### PR TITLE
Add HIP_CLANG_LAUNCHER for launching Clang through a wrapper executable

### DIFF
--- a/amd/hipcc/bin/hipcc.pl
+++ b/amd/hipcc/bin/hipcc.pl
@@ -44,6 +44,9 @@ use Cwd 'abs_path';
 # HIP_ROCCLR_HOME : Path to HIP/ROCclr directory. Used on AMD platforms only.
 # HIP_CLANG_PATH : Path to HIP-Clang (default to ../../llvm/bin relative to this
 #                  script's abs_path). Used on AMD platforms only.
+# HIP_CLANG_LAUNCHER: Path to an executable to launch HIP-Clang with.
+#                     Analogous to CMAKE_C_COMPILER_LAUNCHER, this is commonly
+#                     used for launching HIP-Clang through a compiler cache.
 
 if(scalar @ARGV == 0){
     print "No Arguments passed, exiting ...\n";
@@ -82,6 +85,8 @@ $HIP_LIB_PATH=$ENV{'HIP_LIB_PATH'};
 $DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'};
 $HIP_CLANG_HCC_COMPAT_MODE=$ENV{'HIP_CLANG_HCC_COMPAT_MODE'}; # HCC compatibility mode
 $HIP_COMPILE_CXX_AS_HIP=$ENV{'HIP_COMPILE_CXX_AS_HIP'} // "1";
+
+$HIP_CLANG_LAUNCHER=$ENV{'HIP_CLANG_LAUNCHER'};
 
 #---
 # Temporary directories
@@ -193,6 +198,7 @@ if ($HIP_PLATFORM eq "amd") {
         print ("HIP_LIB_PATH=$HIP_LIB_PATH\n");
         print ("DEVICE_LIB_PATH=$DEVICE_LIB_PATH\n");
         print ("HIP_CLANG_RT_LIB=$HIP_CLANG_RT_LIB\n");
+        print ("HIP_CLANG_LAUNCHER=$HIP_CLANG_LAUNCHER\n");
     }
 
     if ($HIP_CLANG_HCC_COMPAT_MODE) {
@@ -593,6 +599,10 @@ if ($HIPCC_LINK_FLAGS_APPEND) {
 
 # TODO: convert CMD to an array rather than a string
 my $CMD="$HIPCC";
+
+if ($HIP_CLANG_LAUNCHER) {
+    $CMD = "\"$HIP_CLANG_LAUNCHER\" \"$CMD\"";
+}
 
 if ($needCFLAGS) {
     $CMD .= " $HIPCFLAGS";

--- a/amd/hipcc/src/hipBin_amd.h
+++ b/amd/hipcc/src/hipBin_amd.h
@@ -878,6 +878,11 @@ void HipBinAmd::executeHipCCCmd(vector<string> argv) {
   string compiler;
   compiler = getHipCC();
   string CMD = compiler;
+
+  if (!var.hipClangLauncher_.empty()) {
+    CMD = "\"" + var.hipClangLauncher_ + "\" \"" + compiler + "\"";
+  }
+
   if (needCFLAGS) {
     CMD += " " + HIPCFLAGS;
   }

--- a/amd/hipcc/src/hipBin_base.h
+++ b/amd/hipcc/src/hipBin_base.h
@@ -50,6 +50,7 @@ THE SOFTWARE.
 # define HIP_COMPILE_CXX_AS_HIP         "HIP_COMPILE_CXX_AS_HIP"
 # define HIPCC_VERBOSE                  "HIPCC_VERBOSE"
 # define HCC_AMDGPU_TARGET              "HCC_AMDGPU_TARGET"
+# define HIP_CLANG_LAUNCHER             "HIP_CLANG_LAUNCHER"
 
 # define HIP_BASE_VERSION_MAJOR     "6"
 # define HIP_BASE_VERSION_MINOR     "0"
@@ -157,6 +158,7 @@ struct EnvVariables {
   string hipClangHccCompactModeEnv_ = "";
   string hipCompileCxxAsHipEnv_ = "";
   string hccAmdGpuTargetEnv_ = "";
+  string hipClangLauncher_ = "";
   friend std::ostream& operator <<(std::ostream& os, const EnvVariables& var) {
     os << "Path: "                           << var.path_ << endl;
     os << "Hip Path: "                       << var.hipPathEnv_ << endl;
@@ -181,6 +183,7 @@ struct EnvVariables {
     os << "Hip Compile Cxx as Hip: "         <<
            var.hipCompileCxxAsHipEnv_ << endl;
     os << "Hcc Amd Gpu Target: "             << var.hccAmdGpuTargetEnv_ << endl;
+    os << "Hip Clang launcher: "             << var.hipClangLauncher_ << endl;
     return os;
   }
 };
@@ -316,6 +319,8 @@ void HipBinBase::readEnvVariables() {
     envVariables_.hipClangHccCompactModeEnv_ = hipClangHccCompactMode;
   if (const char* hipCompileCxxAsHip = std::getenv(HIP_COMPILE_CXX_AS_HIP))
     envVariables_.hipCompileCxxAsHipEnv_ = hipCompileCxxAsHip;
+  if (const char* hipClangLuancher = std::getenv(HIP_CLANG_LAUNCHER))
+    envVariables_.hipClangLauncher_ = hipClangLuancher;
 }
 
 // constructs the HIP path


### PR DESCRIPTION
Fixes ROCm/llvm-project#72. Moved from ROCm/HIPCC#148.

This allows Clang to be called through a compiler wrapper/launcher. This is most commonly used to run clang through a compiler launcher that can cache compilations, such as ccache and sccache, to allow caching of compilation artifacts.

For a more detailed motivation and description, please see ROCm/ROCm#2817.

