### PR TITLE
Fix failing LLVM and MLIR LIT tests

### DIFF
--- a/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
+++ b/llvm/unittests/Frontend/OpenMPIRBuilderTest.cpp
@@ -5971,14 +5971,8 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
   EXPECT_TRUE(isa<AllocaInst>(Alloca2));
   auto *Store2 = Alloca2->getNextNode();
   EXPECT_TRUE(isa<StoreInst>(Store2));
-  auto *Alloca3 = Store2->getNextNode();
-  EXPECT_TRUE(isa<AllocaInst>(Alloca3));
-  auto *Store3 = Alloca3->getNextNode();
-  EXPECT_TRUE(isa<StoreInst>(Store3));
-  auto *Load1 = Store3->getNextNode();
-  EXPECT_TRUE(isa<LoadInst>(Load1));
 
-  auto *InitCall = dyn_cast<CallInst>(Load1->getNextNode());
+  auto *InitCall = dyn_cast<CallInst>(Store2->getNextNode());
   EXPECT_NE(InitCall, nullptr);
   EXPECT_EQ(InitCall->getCalledFunction()->getName(), "__kmpc_target_init");
   EXPECT_EQ(InitCall->arg_size(), 2U);
@@ -6002,12 +5996,12 @@ TEST_F(OpenMPIRBuilderTest, TargetRegionDevice) {
   // Check user code block
   auto *UserCodeBlock = EntryBlockBranch->getSuccessor(0);
   EXPECT_EQ(UserCodeBlock->getName(), "user_code.entry");
-  auto *Load2 = UserCodeBlock->getFirstNonPHI();
+  auto *Load1 = UserCodeBlock->getFirstNonPHI();
+  EXPECT_TRUE(isa<LoadInst>(Load1));
+  auto *Load2 = Load1->getNextNode();
   EXPECT_TRUE(isa<LoadInst>(Load2));
-  auto *Load3 = Load2->getNextNode();
-  EXPECT_TRUE(isa<LoadInst>(Load3));
 
-  auto *Value1 = Load3->getNextNode();
+  auto *Value1 = Load2->getNextNode();
   EXPECT_EQ(Value1, Value);
   EXPECT_EQ(Value1->getNextNode(), TargetStore);
   auto *Deinit = TargetStore->getNextNode();

--- a/mlir/test/Target/LLVMIR/omptarget-parallel-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-parallel-llvm.mlir
@@ -63,11 +63,7 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memo
 // CHECK:         %[[TMP3:.*]] = alloca ptr, align 8, addrspace(5)
 // CHECK:         %[[TMP4:.*]] = addrspacecast ptr addrspace(5) %[[TMP3]] to ptr
 // CHECK:         store ptr %[[TMP0]], ptr %[[TMP4]], align 8
-// CHECK:         %[[KERNEL_LAUNCH_ENV_TMP:.*]] = alloca ptr, align 8, addrspace(5)
-// CHECK:         %[[KERNEL_LAUNCH_ENV_TMP_CAST:.*]] = addrspacecast ptr addrspace(5) %[[KERNEL_LAUNCH_ENV_TMP]] to ptr
-// CHECK:         store ptr %[[TMP]], ptr %[[KERNEL_LAUNCH_ENV_TMP_CAST]], align 8
-// CHECK:         %[[KERNEL_LAUNCH_ENV:.*]] = load ptr, ptr %[[KERNEL_LAUNCH_ENV_TMP_CAST]], align 8
-// CHECK:         %[[TMP5:.*]] = call i32 @__kmpc_target_init(ptr addrspacecast (ptr addrspace(1) @{{.*}} to ptr), ptr %[[KERNEL_LAUNCH_ENV]])
+// CHECK:         %[[TMP5:.*]] = call i32 @__kmpc_target_init(ptr addrspacecast (ptr addrspace(1) @{{.*}} to ptr), ptr %[[TMP]])
 // CHECK:         %[[EXEC_USER_CODE:.*]] = icmp eq i32 %[[TMP5]], -1
 // CHECK:         br i1 %[[EXEC_USER_CODE]], label %[[USER_CODE_ENTRY:.*]], label %[[WORKER_EXIT:.*]]
 // CHECK:         %[[TMP6:.*]] = load ptr, ptr %[[TMP4]], align 8

--- a/mlir/test/Target/LLVMIR/omptarget-region-device-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-region-device-llvm.mlir
@@ -38,10 +38,7 @@ module attributes {llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_target_devic
 // CHECK:        store ptr %[[ADDR_B]], ptr %[[TMP_B]], align 8
 // CHECK:        %[[TMP_C:.*]] = alloca ptr, align 8
 // CHECK:        store ptr %[[ADDR_C]], ptr %[[TMP_C]], align 8
-// CHECK:        %[[KERNEL_LAUNCH_ENV_TMP:.*]] = alloca ptr, align 8
-// CHECK:        store ptr %[[DYN_PTR]], ptr %[[KERNEL_LAUNCH_ENV_TMP]], align 8
-// CHECK:        %[[KERNEL_LAUNCH_ENV:.*]] = load ptr, ptr %[[KERNEL_LAUNCH_ENV_TMP]], align 8
-// CHECK:        %[[INIT:.*]] = call i32 @__kmpc_target_init(ptr @[[KERNEL_ENV]], ptr %[[KERNEL_LAUNCH_ENV]])
+// CHECK:        %[[INIT:.*]] = call i32 @__kmpc_target_init(ptr @[[KERNEL_ENV]], ptr %[[DYN_PTR]])
 // CHECK-NEXT:   %[[CMP:.*]] = icmp eq i32 %[[INIT]], -1
 // CHECK-NEXT:   br i1 %[[CMP]], label %[[LABEL_ENTRY:.*]], label %[[LABEL_EXIT:.*]]
 // CHECK:        [[LABEL_ENTRY]]:


### PR DESCRIPTION
PR #21 resulted in these broken tests due to changes in the produced IR. This patch updates the tests to expect the new IR.