### PR TITLE
amd-device-libs: Respect ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW in AMDDeviceLibsConfig.cmake

### DIFF
--- a/amd/device-libs/cmake/Packages.cmake
+++ b/amd/device-libs/cmake/Packages.cmake
@@ -15,9 +15,6 @@ configure_file(AMDDeviceLibsConfig.cmake.in
   ${PACKAGE_PREFIX}/AMDDeviceLibsConfig.cmake
   @ONLY)
 
-
-set(install_path_suffix "amdgcn/bitcode")
-
 # Generate the install-tree package.
 # We do not know the absolute path to the intall tree until we are installed,
 # so we calculate it dynamically in AMD_DEVICE_LIBS_PREFIX_CODE and use
@@ -38,7 +35,7 @@ foreach(target ${AMDGCN_LIB_LIST})
   set(AMD_DEVICE_LIBS_TARGET_CODE "${AMD_DEVICE_LIBS_TARGET_CODE}
 add_library(${target} STATIC IMPORTED)
 set_target_properties(${target} PROPERTIES
-  IMPORTED_LOCATION \"\${AMD_DEVICE_LIBS_PREFIX}/${install_path_suffix}/${target_prefix}${target_name}${target_suffix}\")")
+  IMPORTED_LOCATION \"\${AMD_DEVICE_LIBS_PREFIX}/${INSTALL_ROOT_SUFFIX}/${target_prefix}${target_name}${target_suffix}\")")
 endforeach()
 configure_file(AMDDeviceLibsConfig.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/AMDDeviceLibsConfig.cmake.install


### PR DESCRIPTION
## Motivation

When the `ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW` variable is specified, the install location of bytecode changes, but this change is not reflected in the `AMDDeviceLibsConfig.cmake` file, that still points to the default install location. This PR fixes this by respecting the  `ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW` when generating the `AMDDeviceLibsConfig.cmake` file.

## Technical Details

The `Packages.cmake` was redefining a `install_path_suffix` variable with the hardcoded install value, but a similar variable `INSTALL_ROOT_SUFFIX` (that respects  `ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW` was already defined in `OCL.cmake`, so as `OCL` is included before `Packages`, we can just get rid of `install_path_suffix` and use  `INSTALL_ROOT_SUFFIX` .

This removes the need for patches or workarounds used in downstream packaging, see:
* https://github.com/gentoo/gentoo/blob/86548b8f3404ab51d5dfc1e3e84b266d77dd77f5/dev-libs/rocm-device-libs/rocm-device-libs-6.4.3.ebuild#L61-L63
* https://github.com/conda-forge/rocm-device-libs-feedstock/blob/main/recipe/patches/0001-Use-a-folder-inside-lib-for-bitcode-instead-of-top-l.patch

## Test Plan

I configured the `amd/device-libs` folder in standalone mode, and specified a custom install location with `ROCM_DEVICE_LIBS_BITCODE_INSTALL_LOC_NEW`, and I verified manually that `AMDDeviceLibsConfig.cmake` was correctly updated.

## Test Result

See Test Plan.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
