### PR TITLE
[Offload][OMPT] De-type profiler data in API

### DIFF
--- a/offload/plugins-nextgen/common/OMPT/OmptProfiler.cpp
+++ b/offload/plugins-nextgen/common/OMPT/OmptProfiler.cpp
@@ -90,7 +90,7 @@ void llvm::omp::target::ompt::OmptProfilerTy::handlePreKernelLaunch(
 void llvm::omp::target::ompt::OmptProfilerTy::handleKernelCompletion(
     uint64_t StartNanos, uint64_t EndNanos, void *Data) {
 
-  if (!shouldEnableProfiling())
+  if (!isProfilingEnabled())
     return;
 
   DP("OMPT-Async: Time kernel for asynchronous execution (Plugin): Start %lu "
@@ -112,7 +112,7 @@ void llvm::omp::target::ompt::OmptProfilerTy::handleKernelCompletion(
 void llvm::omp::target::ompt::OmptProfilerTy::handleDataTransfer(
     uint64_t StartNanos, uint64_t EndNanos, void *Data) {
 
-  if (!shouldEnableProfiling())
+  if (!isProfilingEnabled())
     return;
 
   auto OmptEventInfo = reinterpret_cast<ompt::OmptEventInfoTy *>(Data);
@@ -126,7 +126,7 @@ void llvm::omp::target::ompt::OmptProfilerTy::handleDataTransfer(
   freeProfilerDataEntry(OmptEventInfo);
 }
 
-bool llvm::omp::target::ompt::OmptProfilerTy::shouldEnableProfiling() {
+bool llvm::omp::target::ompt::OmptProfilerTy::isProfilingEnabled() {
   return llvm::omp::target::ompt::TracingActive;
 }
 

--- a/offload/plugins-nextgen/common/OMPT/OmptProfiler.h
+++ b/offload/plugins-nextgen/common/OMPT/OmptProfiler.h
@@ -80,7 +80,7 @@ public:
 #undef bindOmptTracingFunction
   }
 
-  bool shouldEnableProfiling() override;
+  bool isProfilingEnabled() override;
 
   void handleInit(plugin::GenericDeviceTy *Device,
                   plugin::GenericPluginTy *Plugin) override;

--- a/offload/plugins-nextgen/common/include/GenericProfiler.h
+++ b/offload/plugins-nextgen/common/include/GenericProfiler.h
@@ -60,7 +60,7 @@ public:
   /// Obtain a pointer to profiler-specific data, if any.
   virtual void *getProfilerSpecificData() { return nullptr; }
 
-  virtual bool shouldEnableProfiling() { return false; }
+  virtual bool isProfilingEnabled() { return false; }
 
   /// Set the factors which are used to interpolate the device clock compared to
   /// the host clock. This follows a simple linear interpolation: Slope * <time>


### PR DESCRIPTION
The data type used in many API functions was still OMPT specific. This patch changes the type to vodi * to remove this OMPT specific data type from the interfaces.


