### PR TITLE
[OMPT] Fix assertion in per-device-enabled tracing

### DIFF
--- a/offload/plugins-nextgen/common/OMPT/OmptProfiler.cpp
+++ b/offload/plugins-nextgen/common/OMPT/OmptProfiler.cpp
@@ -93,6 +93,11 @@ void llvm::omp::target::ompt::OmptProfilerTy::handleKernelCompletion(
   if (!isProfilingEnabled())
     return;
 
+  /// Empty data means no tracing in OMPT
+  /// offload/include/OpenMP/OMPT/Interface.h line 492
+  if (!Data)
+    return;
+
   DP("OMPT-Async: Time kernel for asynchronous execution (Plugin): Start %lu "
      "End %lu\n",
      StartNanos, EndNanos);
@@ -113,6 +118,11 @@ void llvm::omp::target::ompt::OmptProfilerTy::handleDataTransfer(
     uint64_t StartNanos, uint64_t EndNanos, void *Data) {
 
   if (!isProfilingEnabled())
+    return;
+
+  /// Empty data means no tracing in OMPT
+  /// offload/include/OpenMP/OMPT/Interface.h line 492
+  if (!Data)
     return;
 
   auto OmptEventInfo = reinterpret_cast<ompt::OmptEventInfoTy *>(Data);


### PR DESCRIPTION
OpenMP allows to disable trace events on a per-device basis. https://github.com/ROCm/llvm-project/pull/340 at the latest introduced a bug which does not respect the disabling of specific trace events.

This fix adds checks whether the required data has been set when creating the OMPT info before dispatching the actual operation on the plugins.


