### PR TITLE
[OpenMP][offload] Fix map-type order

### DIFF
--- a/offload/test/mapping/map_type_order.cpp
+++ b/offload/test/mapping/map_type_order.cpp
@@ -1,0 +1,56 @@
+// RUN: %libomptarget-compilexx-run-and-check-generic
+
+#include <cstdio>
+#include <omp.h>
+
+int main() {
+  int i;
+
+  i = -1;
+#pragma omp target map(to : i) map(from : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(from : i) map(to : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(alloc : i) map(to : i) map(from : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(alloc : i) map(from : i) map(to : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(to : i) map(alloc : i) map(from : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(from : i) map(alloc : i) map(to : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(to : i) map(from : i) map(alloc : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+
+  i = -1;
+#pragma omp target map(from : i) map(to : i) map(alloc : i)
+  i += 2;
+  printf("%d\n", i);
+  // CHECK: 1
+}


### PR DESCRIPTION
Reorder mappers such that
- on target entry: "from" mappers are handled at the end, where they only act as decayed alloc/storage mappers.
- on target exit: "to" mappers are handled first so that they can act as decayed release/storage mappers and decrement the reference count.

This avoids that map to+from or from+to result in different outcomes than mapping with a tofrom mapper. The previous behavior:
- `target map(to: ptr[0:size]) map(from: ptr[0:size])`: the from-mapper was hindered from copying the data back to the host because it was handled first on target exit which means that the to-mapper hadn't been able to decrement the reference count first.
- `target map(from: ptr[0:size]) map(to: ptr[0:size])`: the to-mapper was hindered from copying the data to the device because it was handled second on target entry which means that the reference count had already been incremented by the decayed alloc/storage operation of the from-mapper.


