### PR TITLE
[OMPT] Avoid unused allocations & code clean up

### DIFF
--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -245,18 +245,12 @@ int32_t DeviceTy::submitData(void *TgtPtrBegin, void *HstPtrBegin, int64_t Size,
           RegionInterface.getCallbacks<ompt_target_data_transfer_to_device>(),
           omp_get_initial_device(), HstPtrBegin, DeviceID, TgtPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);
-      // The Profiler can allocate specific data to be used to pass information
-      // from here to lower parts of the runtime system.
-      // NOTE: It is the responsibility of the programmer to ensure type
-      // compatibility and correct usage of the data. The profiler, however,
-      // OWNS the pointer and frees it at an appropriate time.
-      void *ProfData = RTL->getProfiler()->getProfilerSpecificData();
       // Only if 'TracedDeviceId' is actually traced, AsyncInfo->OmptEventInfo
       // is set and a trace record generated. Otherwise: No OMPT device tracing.
       TracerInterfaceRAII TargetDataSubmitTraceRAII(
           RegionInterface
               .getTraceGenerators<ompt_target_data_transfer_to_device>(),
-          AsyncInfo, ProfData, /*TracedDeviceId=*/DeviceID,
+          AsyncInfo, RTL->getProfiler(), /*TracedDeviceId=*/DeviceID,
           /*EventType=*/ompt_callback_target_data_op, omp_get_initial_device(),
           HstPtrBegin, DeviceID, TgtPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
@@ -281,18 +275,12 @@ int32_t DeviceTy::retrieveData(void *HstPtrBegin, void *TgtPtrBegin,
           RegionInterface.getCallbacks<ompt_target_data_transfer_from_device>(),
           DeviceID, TgtPtrBegin, omp_get_initial_device(), HstPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);
-      // The Profiler can allocate specific data to be used to pass information
-      // from here to lower parts of the runtime system.
-      // NOTE: It is the responsibility of the programmer to ensure type
-      // compatibility and correct usage of the data. The profiler, however,
-      // OWNS the pointer and frees it at an appropriate time.
-      void *ProfData = RTL->getProfiler()->getProfilerSpecificData();
       // Only if 'TracedDeviceId' is actually traced, AsyncInfo->OmptEventInfo
       // is set and a trace record generated. Otherwise: No OMPT device tracing.
       TracerInterfaceRAII TargetDataSubmitTraceRAII(
           RegionInterface
               .getTraceGenerators<ompt_target_data_transfer_from_device>(),
-          AsyncInfo, ProfData, /*TracedDeviceId=*/DeviceID,
+          AsyncInfo, RTL->getProfiler(), /*TracedDeviceId=*/DeviceID,
           /*EventType=*/ompt_callback_target_data_op, DeviceID, TgtPtrBegin,
           omp_get_initial_device(), HstPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
@@ -316,18 +304,12 @@ int32_t DeviceTy::dataExchange(void *SrcPtr, DeviceTy &DstDev, void *DstPtr,
           RegionInterface.getCallbacks<ompt_target_data_transfer_from_device>(),
           RTLDeviceID, SrcPtr, DstDev.RTLDeviceID, DstPtr, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);
-      // The Profiler can allocate specific data to be used to pass information
-      // from here to lower parts of the runtime system.
-      // NOTE: It is the responsibility of the programmer to ensure type
-      // compatibility and correct usage of the data. The profiler, however,
-      // OWNS the pointer and frees it at an appropriate time.
-      void *ProfData = RTL->getProfiler()->getProfilerSpecificData();
       // Only if 'TracedDeviceId' is actually traced, AsyncInfo->OmptEventInfo
       // is set and a trace record generated. Otherwise: No OMPT device tracing.
       TracerInterfaceRAII TargetDataExchangeTraceRAII(
           RegionInterface
               .getTraceGenerators<ompt_target_data_transfer_from_device>(),
-          AsyncInfo, ProfData, /*TracedDeviceId=*/RTLDeviceID,
+          AsyncInfo, RTL->getProfiler(), /*TracedDeviceId=*/RTLDeviceID,
           /*EventType=*/ompt_callback_target_data_op, RTLDeviceID, SrcPtr,
           DstDev.RTLDeviceID, DstPtr, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)

--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -2101,13 +2101,6 @@ int target(ident_t *Loc, DeviceTy &Device, void *HostPtr,
     InterfaceRAII TargetSubmitRAII(
         RegionInterface.getCallbacks<ompt_callback_target_submit>(), NumTeams);
 
-    // The Profiler can allocate specific data to be used to pass information
-    // from here to lower parts of the runtime system.
-    // NOTE: It is the responsibility of the programmer to ensure type
-    // compatibility and correct usage of the data. The profiler, however, OWNS
-    // the pointer and frees it at an appropriate time.
-    void *ProfData = Device.RTL->getProfiler()->getProfilerSpecificData();
-
     // Calls "begin" for the OMPT trace record and let the plugin
     // enqueue the stop operation for after the kernel is done. The stop
     // operation completes the trace record entry with the information from
@@ -2116,7 +2109,7 @@ int target(ident_t *Loc, DeviceTy &Device, void *HostPtr,
     // set and a trace record generated. Otherwise: No OMPT device tracing.
     TracerInterfaceRAII TargetTraceRAII(
         RegionInterface.getTraceGenerators<ompt_callback_target_submit>(),
-        AsyncInfo, ProfData, /*TracedDeviceId=*/DeviceId,
+        AsyncInfo, Device.RTL->getProfiler(), /*TracedDeviceId=*/DeviceId,
         /*EventType=*/ompt_callback_target_submit, DeviceId, NumTeams);
 #endif
     Ret = Device.launchKernel(TgtEntryPtr, TgtArgs.data(), TgtOffsets.data(),

--- a/offload/plugins-nextgen/common/OMPT/OmptProfiler.h
+++ b/offload/plugins-nextgen/common/OMPT/OmptProfiler.h
@@ -19,7 +19,6 @@
 
 #include "OmptDeviceTracing.h"
 #include "OpenMP/OMPT/Callback.h"
-#include "OpenMP/OMPT/Interface.h"
 #include "Shared/Debug.h"
 #include "omp-tools.h"
 


### PR DESCRIPTION
This moves the allocation for ProfilerSpecificData into the TraceGeneratorRAII object, thus, it only allocates memory for events that are actually traced.

This is the result of @dhruvachak comment on my previous OMPT PR. While we weren't leaking memory, we would do extra allocations which would accumulate and not be freed. This patch addresses that issue. The allocation is now done inside `TraceInterfaceRAII` in Interface.h when the event has _not_ been filtered.
Tested on single and multi GPU systems.

The way that the higher-level (Interface.h / device.cpp` talks to the lower-level (plugins) is unchanged through this PR and I'm still looking at it / thinking about it.

It also does a bit of NFCI code clean up that can be split out of this commit if desired.