### PR TITLE
[Comgr] Fix memory leak in test.

### DIFF
--- a/amd/comgr/test-lit/comgr-sources/unbundle.c
+++ b/amd/comgr/test-lit/comgr-sources/unbundle.c
@@ -73,6 +73,7 @@ int main(int argc, char *argv[]) {
   amd_comgr_(destroy_action_info(DataAction));
   amd_comgr_(destroy_data_set(OutputBitcode));
   amd_comgr_(destroy_data_set(InputBundles));
+  free(BundleData);
 
   return 0;
 }

--- a/amd/comgr/test/file_map.c
+++ b/amd/comgr/test/file_map.c
@@ -47,6 +47,9 @@ int main(int argc, char *argv[]) {
   Status = amd_comgr_get_data(DataObject, &SliceLength, Slice);
   checkError(Status, "amd_comgr_get_data");
 
+  Status = amd_comgr_release_data(DataObject);
+  checkError(Status, "amd_comgr_release_data");
+
   if (SliceLength != Length - Offset) {
     fail("File Slice Length incorrect");
   }

--- a/amd/comgr/test/map_elf_virtual_address_test.c
+++ b/amd/comgr/test/map_elf_virtual_address_test.c
@@ -148,8 +148,9 @@ int main(int argc, char *argv[]) {
   }
 
   // Test rocm 5.7 elf virtual address mapping
+  amd_comgr_data_t DataExec2;
   Status = amd_comgr_action_data_get_data(
-      DataSetExec, AMD_COMGR_DATA_KIND_EXECUTABLE, 1, &DataExec);
+      DataSetExec, AMD_COMGR_DATA_KIND_EXECUTABLE, 1, &DataExec2);
   ElfVirtualAddress = 0x60;
   CodeObjectOffset = -1;
   // phdr.p_vaddr:   0
@@ -161,7 +162,7 @@ int main(int argc, char *argv[]) {
   // nobits = phdr.p_vaddr >= phdr.p_filesz
   // slizesize = phdr.p_memsz - (elfVirtualAddress - phdr.p_vaddr);
   Status = amd_comgr_map_elf_virtual_address_to_code_object_offset(
-      DataExec, ElfVirtualAddress, &CodeObjectOffset, &SliceSize, &Nobits);
+      DataExec2, ElfVirtualAddress, &CodeObjectOffset, &SliceSize, &Nobits);
   checkError(Status, "amd_comgr_map_elf_virtual_address_to_code_object_offset");
 
   if (CodeObjectOffset != 0x60 || Nobits != 0 || SliceSize != 0x860) {
@@ -184,7 +185,7 @@ int main(int argc, char *argv[]) {
   // nobits = phdr.p_vaddr >= phdr.p_filesz
   // slizesize = phdr.p_memsz - (elfVirtualAddress - phdr.p_vaddr);
   Status = amd_comgr_map_elf_virtual_address_to_code_object_offset(
-      DataExec, ElfVirtualAddress, &CodeObjectOffset, &SliceSize, &Nobits);
+      DataExec2, ElfVirtualAddress, &CodeObjectOffset, &SliceSize, &Nobits);
   checkError(Status, "amd_comgr_map_elf_virtual_address_to_code_object_offset");
 
   if (CodeObjectOffset != 0xa00 || Nobits != 0 || SliceSize != 0x480) {
@@ -207,7 +208,7 @@ int main(int argc, char *argv[]) {
   // nobits = phdr.p_vaddr >= phdr.p_filesz
   // slizesize = phdr.p_memsz - (elfVirtualAddress - phdr.p_vaddr);
   Status = amd_comgr_map_elf_virtual_address_to_code_object_offset(
-      DataExec, ElfVirtualAddress, &CodeObjectOffset, &SliceSize, &Nobits);
+      DataExec2, ElfVirtualAddress, &CodeObjectOffset, &SliceSize, &Nobits);
   checkError(Status, "amd_comgr_map_elf_virtual_address_to_code_object_offset");
 
   if (CodeObjectOffset != 0xe90 || Nobits != 0 || SliceSize != 0x60) {
@@ -237,6 +238,8 @@ int main(int argc, char *argv[]) {
   Status = amd_comgr_release_data(DataSource2);
   checkError(Status, "amd_comgr_release_data");
   Status = amd_comgr_release_data(DataExec);
+  checkError(Status, "amd_comgr_release_data");
+  Status = amd_comgr_release_data(DataExec2);
   checkError(Status, "amd_comgr_release_data");
   Status = amd_comgr_destroy_data_set(DataSetExec);
   checkError(Status, "amd_comgr_destroy_data_set");

--- a/amd/comgr/test/name_expression_map_test.c
+++ b/amd/comgr/test/name_expression_map_test.c
@@ -376,6 +376,10 @@ int main(int argc, char *argv[]) {
   checkError(Status, "amd_comgr_release_data");
   Status = amd_comgr_release_data(DataExec);
   checkError(Status, "amd_comgr_release_data");
+  Status = amd_comgr_release_data(DataExec2);
+  checkError(Status, "amd_comgr_release_data");
+  Status = amd_comgr_release_data(DataReloc2);
+  checkError(Status, "amd_comgr_release_data");
   Status = amd_comgr_destroy_data_set(DataSetIn);
   checkError(Status, "amd_comgr_destroy_data_set");
   Status = amd_comgr_destroy_data_set(DataSetBc);


### PR DESCRIPTION
Some data structures were missing calls to amd_comgr_release_data.