### PR TITLE
[Comgr] Fix memory leak in comgr for TranslatedSpirvT

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1884,6 +1884,7 @@ amd_comgr_status_t AMDGPUCompiler::compileSpirvToRelocatable() {
   amd_comgr_data_set_t TranslatedSpirvT;
   if (auto Status = amd_comgr_create_data_set(&TranslatedSpirvT))
     return Status;
+  ScopedDataSetReleaser SDSR(TranslatedSpirvT);
   DataSet *TranslatedSpirv = DataSet::convert(TranslatedSpirvT);
 
   if (auto Status = translateSpirvToBitcodeImpl(InSet, TranslatedSpirv))

--- a/amd/comgr/src/comgr.h
+++ b/amd/comgr/src/comgr.h
@@ -133,6 +133,15 @@ public:
   ~ScopedDataObjectReleaser() { Obj->release(); }
 };
 
+class ScopedDataSetReleaser {
+  amd_comgr_data_set_t Set;
+
+public:
+  ScopedDataSetReleaser(amd_comgr_data_set_t Set) : Set(Set) {}
+
+  ~ScopedDataSetReleaser() { amd_comgr_destroy_data_set(Set); }
+};
+
 struct DataSet {
 
   DataSet();


### PR DESCRIPTION
`rocm-examples/Libraries/rocSOLVER/syev_batched` and `rocm-examples/Libraries/hipSOLVER/syevj_batched` will otherwise have memory leaks.