### PR TITLE
Enable Lintian Support hipcc

### DIFF
--- a/amd/hipcc/CMakeLists.txt
+++ b/amd/hipcc/CMakeLists.txt
@@ -8,6 +8,14 @@ project(hipcc VERSION "1.1.1" LANGUAGES C CXX)
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
 
+include( utils.cmake )
+set( HIPCC "hipcc" )
+set( HIPCC_NVIDIA "hipcc-nvidia")
+set( COMP_TYPE "AMD" )
+set( COMP_TYPE_NVIDIA "NVIDIA" )
+set( BUILD_ENABLE_LINTIAN_OVERRIDES ON CACHE BOOL "Enable/Disable Lintian Overrides" )
+set( BUILD_DEBIAN_PKGING_FLAG ON CACHE BOOL "Internal Status Flag to indicate Debian Packaging Build" )
+
 # Generate static package, when BUILD_SHARED_LIBS is set to OFF.
 # Default to ON
 option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
@@ -48,11 +56,13 @@ endif()
 file(COPY ${PROJECT_SOURCE_DIR}/bin/ DESTINATION ${PROJECT_BINARY_DIR})
 
 # Packaging:
+set(PKG_MAINTAINER_NM  "ROCm Compiler Support")
+set(PKG_MAINTAINER_EMAIL  "rocm.compiler.support@amd.com")
 set(CPACK_RPM_COMPONENT_INSTALL ON)
 set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
 set(CPACK_COMPONENTS_ALL AMD NVIDIA)
 set(CPACK_GENERATOR "DEB;RPM;ZIP" CACHE STRING "Default packaging generators")
-set(CPACK_PACKAGE_CONTACT "ROCm Compiler Support <rocm.compiler.support@amd.com>")
+set(CPACK_PACKAGE_CONTACT "${PKG_MAINTAINER_NM} <${PKG_MAINTAINER_EMAIL}>")
 set(CPACK_PACKAGE_DESCRIPTION "HIP Compiler Driver")
 set(CPACK_PACKAGE_NAME "${PROJECT_NAME}")
 set(CPACK_PACKAGE_VENDOR "Advanced Micro Devices, Inc.")
@@ -174,6 +184,8 @@ install(TARGETS ${HIPCONFIG_BIN}
         COMPONENT AMD
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+configure_pkg( ${HIPCC} ${COMP_TYPE} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL} )
+
 # NVIDIA specific.
 install(FILES
   "LICENSE.txt"
@@ -186,6 +198,8 @@ install(TARGETS ${HIPCC_BIN}
 install(TARGETS ${HIPCONFIG_BIN}
         COMPONENT NVIDIA
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+configure_pkg( ${HIPCC_NVIDIA} ${COMP_TYPE_NVIDIA} ${CPACK_PACKAGE_VERSION} ${PKG_MAINTAINER_NM} ${PKG_MAINTAINER_EMAIL} )
 
 # TODO: WIN32 check need to be removed if backward
 # compatibility is required for WIN32.

--- a/amd/hipcc/DEBIAN/changelog.in
+++ b/amd/hipcc/DEBIAN/changelog.in
@@ -1,0 +1,5 @@
+@DEB_PACKAGE_NAME@ (@DEB_PACKAGE_VERSION@) stable; urgency=low
+
+  * ROCm Runtime software stack Base Package.
+ -- @DEB_MAINTAINER_NAME@ <@DEB_MAINTAINER_EMAIL@>  @DEB_TIMESTAMP@
+

--- a/amd/hipcc/DEBIAN/copyright.in
+++ b/amd/hipcc/DEBIAN/copyright.in
@@ -1,0 +1,25 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: @DEB_PACKAGE_NAME@
+Upstream-Contact: @DEB_MAINTAINER_NAME@ <@DEB_MAINTAINER_EMAIL@>
+Source: https://github.com/ROCm/@DEB_PACKAGE_NAME@
+Files: *
+License: @DEB_LICENSE@
+Copyright: @DEB_COPYRIGHT_YEAR@ Advanced Micro Devices, Inc. All rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/amd/hipcc/DEBIAN/overrides.in
+++ b/amd/hipcc/DEBIAN/overrides.in
@@ -1,0 +1,3 @@
+@DEB_OVERRIDES_INSTALL_FILENM@: no-copyright-file
+@DEB_OVERRIDES_INSTALL_FILENM@: debian-changelog-file-missing
+@DEB_OVERRIDES_INSTALL_FILENM@: dir-or-file-in-opt

--- a/amd/hipcc/DEBIAN/overrides.in
+++ b/amd/hipcc/DEBIAN/overrides.in
@@ -1,3 +1,0 @@
-@DEB_OVERRIDES_INSTALL_FILENM@: no-copyright-file
-@DEB_OVERRIDES_INSTALL_FILENM@: debian-changelog-file-missing
-@DEB_OVERRIDES_INSTALL_FILENM@: dir-or-file-in-opt

--- a/amd/hipcc/utils.cmake
+++ b/amd/hipcc/utils.cmake
@@ -29,18 +29,6 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
         @ONLY
       )
 
-      if( BUILD_ENABLE_LINTIAN_OVERRIDES )
-        set( DEB_OVERRIDES_INSTALL_FILENM
-          "${DEB_OVERRIDES_INSTALL_FILENM}" CACHE STRING "Debian Package Lintian Override File Name" FORCE)
-              # Configure the changelog file
-              configure_file(
-                "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
-                "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
-          FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-                @ONLY
-              )
-      endif()
-
       # Install Change Log 
       find_program ( DEB_GZIP_EXEC gzip )
       if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian" )
@@ -57,14 +45,6 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
         install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
                   DESTINATION ${CMAKE_INSTALL_DOCDIR}
                   COMPONENT ${COMPONENT_NAME_T})
-      endif()
-
-      # Install lintian overrides
-      if( BUILD_ENABLE_LINTIAN_OVERRIDES STREQUAL "ON" AND BUILD_DEBIAN_PKGING_FLAG STREQUAL "ON")
-        set( OVERRIDE_FILE "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}" )
-        install ( FILES ${OVERRIDE_FILE}
-            DESTINATION ${DEB_OVERRIDES_INSTALL_PATH}
-            COMPONENT ${COMPONENT_NAME_T})
       endif()
 
     endif()

--- a/amd/hipcc/utils.cmake
+++ b/amd/hipcc/utils.cmake
@@ -30,28 +30,15 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
       )
 
       if( BUILD_ENABLE_LINTIAN_OVERRIDES )
-	if(NOT ${BUILD_SHARED_LIBS})
-	  string(FIND ${DEB_OVERRIDES_INSTALL_FILENM} "static" OUT_VAR1)
-	  if(OUT_VAR1 EQUAL -1)
-	    set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_OVERRIDES_INSTALL_FILENM}-static" )
-          endif()
-	else()
-          if(ENABLE_ASAN_PACKAGING)
-	    string( FIND ${DEB_OVERRIDES_INSTALL_FILENM} "asan" OUT_VAR2)
-	    if(OUT_VAR2 EQUAL -1)
-	      set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_OVERRIDES_INSTALL_FILENM}-asan" )
-	    endif()
-          endif()
-	endif()
-	set( DEB_OVERRIDES_INSTALL_FILENM
-		"${DEB_OVERRIDES_INSTALL_FILENM}" CACHE STRING "Debian Package Lintian Override File Name" FORCE)
-        # Configure the changelog file
-        configure_file(
-          "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
-          "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
-	   FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
-          @ONLY
-        )
+        set( DEB_OVERRIDES_INSTALL_FILENM
+          "${DEB_OVERRIDES_INSTALL_FILENM}" CACHE STRING "Debian Package Lintian Override File Name" FORCE)
+              # Configure the changelog file
+              configure_file(
+                "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
+                "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
+          FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+                @ONLY
+              )
       endif()
 
       # Install Change Log 
@@ -72,19 +59,14 @@ function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTA
                   COMPONENT ${COMPONENT_NAME_T})
       endif()
 
-    # Install lintian overrides
-    if( BUILD_ENABLE_LINTIAN_OVERRIDES STREQUAL "ON" AND BUILD_DEBIAN_PKGING_FLAG STREQUAL "ON")
-      set( OVERRIDE_FILE "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}" )
-      install ( FILES ${OVERRIDE_FILE}
-          DESTINATION ${DEB_OVERRIDES_INSTALL_PATH}
-          COMPONENT ${COMPONENT_NAME_T})
-    endif()
-
-    else()
-        # License file
-        install ( FILES ${LICENSE_FILE}
-            DESTINATION ${CMAKE_INSTALL_DOCDIR} RENAME LICENSE.txt
+      # Install lintian overrides
+      if( BUILD_ENABLE_LINTIAN_OVERRIDES STREQUAL "ON" AND BUILD_DEBIAN_PKGING_FLAG STREQUAL "ON")
+        set( OVERRIDE_FILE "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}" )
+        install ( FILES ${OVERRIDE_FILE}
+            DESTINATION ${DEB_OVERRIDES_INSTALL_PATH}
             COMPONENT ${COMPONENT_NAME_T})
+      endif()
+
     endif()
 endfunction()
 
@@ -123,3 +105,4 @@ function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DE
     message(STATUS "DEB_TIMESTAMP                : ${DEB_TIMESTAMP}" )
     message(STATUS "DEB_CHANGELOG_INSTALL_FILENM : ${DEB_CHANGELOG_INSTALL_FILENM}" )
 endfunction()
+

--- a/amd/hipcc/utils.cmake
+++ b/amd/hipcc/utils.cmake
@@ -1,0 +1,125 @@
+## Configure Copyright File for Debian Package
+function( configure_pkg PACKAGE_NAME_T COMPONENT_NAME_T PACKAGE_VERSION_T MAINTAINER_NM_T MAINTAINER_EMAIL_T)
+    # Check If Debian Platform
+    find_file (DEBIAN debian_version debconf.conf PATHS /etc)
+    if(DEBIAN)
+      set( BUILD_DEBIAN_PKGING_FLAG ON CACHE BOOL "Internal Status Flag to indicate Debian Packaging Build" FORCE )
+      set_debian_pkg_cmake_flags( ${PACKAGE_NAME_T} ${PACKAGE_VERSION_T}
+                                  ${MAINTAINER_NM_T} ${MAINTAINER_EMAIL_T} )
+
+      # Create debian directory in build tree
+      file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN")
+
+      # Configure the copyright file
+      configure_file(
+        "${CMAKE_SOURCE_DIR}/DEBIAN/copyright.in"
+        "${CMAKE_BINARY_DIR}/DEBIAN/copyright"
+        @ONLY
+      )
+
+      # Install copyright file
+      install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/copyright"
+	        DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+	        COMPONENT ${COMPONENT_NAME_T} )
+
+      # Configure the changelog file
+      configure_file(
+        "${CMAKE_SOURCE_DIR}/DEBIAN/changelog.in"
+        "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+        @ONLY
+      )
+
+      if( BUILD_ENABLE_LINTIAN_OVERRIDES )
+	if(NOT ${BUILD_SHARED_LIBS})
+	  string(FIND ${DEB_OVERRIDES_INSTALL_FILENM} "static" OUT_VAR1)
+	  if(OUT_VAR1 EQUAL -1)
+	    set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_OVERRIDES_INSTALL_FILENM}-static" )
+          endif()
+	else()
+          if(ENABLE_ASAN_PACKAGING)
+	    string( FIND ${DEB_OVERRIDES_INSTALL_FILENM} "asan" OUT_VAR2)
+	    if(OUT_VAR2 EQUAL -1)
+	      set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_OVERRIDES_INSTALL_FILENM}-asan" )
+	    endif()
+          endif()
+	endif()
+	set( DEB_OVERRIDES_INSTALL_FILENM
+		"${DEB_OVERRIDES_INSTALL_FILENM}" CACHE STRING "Debian Package Lintian Override File Name" FORCE)
+        # Configure the changelog file
+        configure_file(
+          "${CMAKE_SOURCE_DIR}/DEBIAN/overrides.in"
+          "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}"
+	   FILE_PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+          @ONLY
+        )
+      endif()
+
+      # Install Change Log 
+      find_program ( DEB_GZIP_EXEC gzip )
+      if(EXISTS "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian" )
+        execute_process(
+          COMMAND ${DEB_GZIP_EXEC} -f -n -9 "${CMAKE_BINARY_DIR}/DEBIAN/changelog.Debian"
+          WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/DEBIAN"
+          RESULT_VARIABLE result
+          OUTPUT_VARIABLE output
+          ERROR_VARIABLE error
+        )
+        if(NOT ${result} EQUAL 0)
+          message(FATAL_ERROR "Failed to compress: ${error}")
+        endif()
+        install ( FILES "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_CHANGELOG_INSTALL_FILENM}"
+                  DESTINATION ${CMAKE_INSTALL_DOCDIR}
+                  COMPONENT ${COMPONENT_NAME_T})
+      endif()
+
+    # Install lintian overrides
+    if( BUILD_ENABLE_LINTIAN_OVERRIDES STREQUAL "ON" AND BUILD_DEBIAN_PKGING_FLAG STREQUAL "ON")
+      set( OVERRIDE_FILE "${CMAKE_BINARY_DIR}/DEBIAN/${DEB_OVERRIDES_INSTALL_FILENM}" )
+      install ( FILES ${OVERRIDE_FILE}
+          DESTINATION ${DEB_OVERRIDES_INSTALL_PATH}
+          COMPONENT ${COMPONENT_NAME_T})
+    endif()
+
+    else()
+        # License file
+        install ( FILES ${LICENSE_FILE}
+            DESTINATION ${CMAKE_INSTALL_DOCDIR} RENAME LICENSE.txt
+            COMPONENT ${COMPONENT_NAME_T})
+    endif()
+endfunction()
+
+# Set variables for changelog and copyright
+# For Debian specific Packages 
+function( set_debian_pkg_cmake_flags DEB_PACKAGE_NAME_T DEB_PACKAGE_VERSION_T DEB_MAINTAINER_NM_T DEB_MAINTAINER_EMAIL_T )
+    # Setting configure flags
+    set( DEB_PACKAGE_NAME             "${DEB_PACKAGE_NAME_T}" CACHE STRING "Debian Package Name" FORCE )
+    set( DEB_PACKAGE_VERSION          "${DEB_PACKAGE_VERSION_T}" CACHE STRING "Debian Package Version String" )
+    set( DEB_MAINTAINER_NAME          "${DEB_MAINTAINER_NM_T}" CACHE STRING "Debian Package Maintainer Name" )
+    set( DEB_MAINTAINER_EMAIL         "${DEB_MAINTAINER_EMAIL_T}" CACHE STRING "Debian Package Maintainer Email" )
+    set( DEB_COPYRIGHT_YEAR           "2025" CACHE STRING "Debian Package Copyright Year" )
+    set( DEB_LICENSE                  "MIT" CACHE STRING "Debian Package License Type" )
+    set( DEB_CHANGELOG_INSTALL_FILENM "changelog.Debian.gz" CACHE STRING "Debian Package ChangeLog File Name" ) 
+
+    if( BUILD_ENABLE_LINTIAN_OVERRIDES )
+      set( DEB_OVERRIDES_INSTALL_FILENM "${DEB_PACKAGE_NAME}" CACHE STRING "Debian Package Lintian Override File Name" FORCE )
+      set( DEB_OVERRIDES_INSTALL_PATH   "/usr/share/lintian/overrides/" CACHE STRING "Deb Pkg Lintian Override Install Loc" )
+    endif()
+
+    # Get TimeStamp
+    find_program( DEB_DATE_TIMESTAMP_EXEC date )
+    set ( DEB_TIMESTAMP_FORMAT_OPTION "-R" )
+    execute_process (
+        COMMAND ${DEB_DATE_TIMESTAMP_EXEC} ${DEB_TIMESTAMP_FORMAT_OPTION}
+        OUTPUT_VARIABLE TIMESTAMP_T
+    )
+    set( DEB_TIMESTAMP                "${TIMESTAMP_T}" CACHE STRING "Current Time Stamp for Copyright/Changelog" )
+
+    message(STATUS "DEB_PACKAGE_NAME             : ${DEB_PACKAGE_NAME}" )
+    message(STATUS "DEB_PACKAGE_VERSION          : ${DEB_PACKAGE_VERSION}" )
+    message(STATUS "DEB_MAINTAINER_NAME          : ${DEB_MAINTAINER_NAME}" )
+    message(STATUS "DEB_MAINTAINER_EMAIL         : ${DEB_MAINTAINER_EMAIL}" )
+    message(STATUS "DEB_COPYRIGHT_YEAR           : ${DEB_COPYRIGHT_YEAR}" )
+    message(STATUS "DEB_LICENSE                  : ${DEB_LICENSE}" )
+    message(STATUS "DEB_TIMESTAMP                : ${DEB_TIMESTAMP}" )
+    message(STATUS "DEB_CHANGELOG_INSTALL_FILENM : ${DEB_CHANGELOG_INSTALL_FILENM}" )
+endfunction()


### PR DESCRIPTION
Added function configure_pkg to install changelog, copyright, and lintian override for debian.
Install changelog, copyright, and lintian override files to fix lintian errors:
no-copyright-file
debian-changelog-file-missing
dir-or-file-in-opt

