### PR TITLE
[AMDGPU][WaveTransform] Update GCNLaneMaskUtils to make it use AMDGPULaneMaskConstants

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULaneMaskUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPULaneMaskUtils.h
@@ -41,7 +41,7 @@ public:
   const unsigned XorOpc;
   const unsigned XorTermOpc;
   const unsigned WQMOpc;
-  const TargetRegisterClass *SRegClass;
+  const TargetRegisterClass *LaneMaskRC;
 
   constexpr LaneMaskConstants(bool IsWave32)
       : ExecReg(IsWave32 ? AMDGPU::EXEC_LO : AMDGPU::EXEC),
@@ -70,7 +70,7 @@ public:
         XorOpc(IsWave32 ? AMDGPU::S_XOR_B32 : AMDGPU::S_XOR_B64),
         XorTermOpc(IsWave32 ? AMDGPU::S_XOR_B32_term : AMDGPU::S_XOR_B64_term),
         WQMOpc(IsWave32 ? AMDGPU::S_WQM_B32 : AMDGPU::S_WQM_B64),
-        SRegClass(IsWave32 ? &AMDGPU::SReg_32RegClass : &AMDGPU::SReg_64RegClass) {}
+        LaneMaskRC(IsWave32 ? &AMDGPU::SReg_32RegClass : &AMDGPU::SReg_64RegClass) {}
 
   static inline const LaneMaskConstants &get(const GCNSubtarget &ST);
 };

--- a/llvm/lib/Target/AMDGPU/AMDGPULaneMaskUtils.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPULaneMaskUtils.h
@@ -36,10 +36,12 @@ public:
   const unsigned MovTermOpc;
   const unsigned OrOpc;
   const unsigned OrTermOpc;
+  const unsigned OrN2Opc;
   const unsigned OrSaveExecOpc;
   const unsigned XorOpc;
   const unsigned XorTermOpc;
   const unsigned WQMOpc;
+  const TargetRegisterClass *SRegClass;
 
   constexpr LaneMaskConstants(bool IsWave32)
       : ExecReg(IsWave32 ? AMDGPU::EXEC_LO : AMDGPU::EXEC),
@@ -62,11 +64,13 @@ public:
         MovTermOpc(IsWave32 ? AMDGPU::S_MOV_B32_term : AMDGPU::S_MOV_B64_term),
         OrOpc(IsWave32 ? AMDGPU::S_OR_B32 : AMDGPU::S_OR_B64),
         OrTermOpc(IsWave32 ? AMDGPU::S_OR_B32_term : AMDGPU::S_OR_B64_term),
+        OrN2Opc(IsWave32 ? AMDGPU::S_ORN2_B32 : AMDGPU::S_ORN2_B64),
         OrSaveExecOpc(IsWave32 ? AMDGPU::S_OR_SAVEEXEC_B32
                                : AMDGPU::S_OR_SAVEEXEC_B64),
         XorOpc(IsWave32 ? AMDGPU::S_XOR_B32 : AMDGPU::S_XOR_B64),
         XorTermOpc(IsWave32 ? AMDGPU::S_XOR_B32_term : AMDGPU::S_XOR_B64_term),
-        WQMOpc(IsWave32 ? AMDGPU::S_WQM_B32 : AMDGPU::S_WQM_B64) {}
+        WQMOpc(IsWave32 ? AMDGPU::S_WQM_B32 : AMDGPU::S_WQM_B64),
+        SRegClass(IsWave32 ? &AMDGPU::SReg_32RegClass : &AMDGPU::SReg_64RegClass) {}
 
   static inline const LaneMaskConstants &get(const GCNSubtarget &ST);
 };

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2137,7 +2137,6 @@ private:
   MachineDominatorTree *DomTree = nullptr;
   // MachineConvergenceInfo ConvergenceInfo;
   MachineCycleInfo *CycleInfo;
-  GCNLaneMaskUtils LMU;
   const SIInstrInfo *TII;
 };
 
@@ -2164,7 +2163,6 @@ bool AMDGPUWaveTransform::runOnMachineFunction(MachineFunction &MF) {
   LLVM_DEBUG(dbgs() << "AMDGPU Wave Transformnsform: " << MF.getName() << '\n');
 
   DomTree = &getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
-  LMU.setFunction(MF);
   TII = MF.getSubtarget<GCNSubtarget>().getInstrInfo();
 
   // ConvergenceInfo = computeMachineConvergenceInfo(MF, *DomTree);

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -1785,13 +1785,14 @@ void ControlFlowRewriter::prepareWaveCfg() {
 /// manipulation.
 void ControlFlowRewriter::rewrite() {
   GCNLaneMaskAnalysis LMA(Function);
+  const AMDGPU::LaneMaskConstants &LMC = LMU.getLaneMaskConsts();
 
   Register RegAllOnes;
   auto getAllOnes = [&]() {
     if (!RegAllOnes) {
       RegAllOnes = LMU.createLaneMaskReg();
       BuildMI(Function.front(), Function.front().getFirstTerminator(), {},
-              TII.get(LMU.consts().MovOpc), RegAllOnes)
+              TII.get(LMC.MovOpc), RegAllOnes)
           .addImm(-1);
     }
     return RegAllOnes;
@@ -1841,12 +1842,12 @@ void ControlFlowRewriter::rewrite() {
         if (!LMA.isSubsetOfExec(CondReg, *Node->Block)) {
           CondReg = LMU.createLaneMaskReg();
           BuildMI(*Node->Block, Node->Block->end(), {},
-                  TII.get(LMU.consts().AndOpc), CondReg)
-              .addReg(LMU.consts().ExecReg)
+                  TII.get(LMC.AndOpc), CondReg)
+              .addReg(LMC.ExecReg)
               .addReg(Info.OrigCondition);
         }
         BuildMI(*Node->Block, Node->Block->end(), {}, TII.get(AMDGPU::COPY),
-                LMU.consts().VccReg)
+                LMC.VccReg)
             .addReg(CondReg);
 
         Opcode = AMDGPU::S_CBRANCH_VCCNZ;
@@ -1924,15 +1925,15 @@ void ControlFlowRewriter::rewrite() {
         if (!LaneOrigin.InvertCondition) {
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().CSelectOpc), CondReg)
-              .addReg(LMU.consts().ExecReg)
+                  TII.get(LMC.CSelectOpc), CondReg)
+              .addReg(LMC.ExecReg)
               .addImm(0);
         } else {
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().CSelectOpc), CondReg)
+                  TII.get(LMC.CSelectOpc), CondReg)
               .addImm(0)
-              .addReg(LMU.consts().ExecReg);
+              .addReg(LMC.ExecReg);
         }
       } else {
         CondReg = LaneOrigin.CondReg;
@@ -1941,8 +1942,8 @@ void ControlFlowRewriter::rewrite() {
           CondReg = LMU.createLaneMaskReg();
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().AndOpc), CondReg)
-              .addReg(LMU.consts().ExecReg)
+                  TII.get(LMC.AndOpc), CondReg)
+              .addReg(LMC.ExecReg)
               .addReg(Prev);
 
           RegMap[std::make_pair(LaneOrigin.Node->Block, LaneOrigin.CondReg)]
@@ -1962,7 +1963,7 @@ void ControlFlowRewriter::rewrite() {
           CondReg = LMU.createLaneMaskReg();
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().XorOpc), CondReg)
+                  TII.get(LMC.XorOpc), CondReg)
               .addReg(LaneOrigin.CondReg)
               .addImm(-1);
 
@@ -1999,7 +2000,7 @@ void ControlFlowRewriter::rewrite() {
                         << '\n');
 
       BuildMI(*OriginNode->Block, OriginNode->Block->end(), {},
-              TII.get(LMU.consts().MovTermOpc), LMU.consts().ExecReg)
+              TII.get(LMC.MovTermOpc), LMC.ExecReg)
           .addReg(OriginCFGNodeInfo.PrimarySuccessorExec);
       BuildMI(*OriginNode->Block, OriginNode->Block->end(), {},
               TII.get(AMDGPU::SI_WAVE_CF_EDGE));
@@ -2046,12 +2047,12 @@ void ControlFlowRewriter::rewrite() {
       Register Rejoin;
 
       if (PrimaryExecDef->getParent() == Pred->Block &&
-          PrimaryExecDef->getOpcode() == LMU.consts().XorOpc &&
+          PrimaryExecDef->getOpcode() == LMC.XorOpc &&
           PrimaryExecDef->getOperand(1).isReg() &&
           PrimaryExecDef->getOperand(2).isReg()) {
-        if (PrimaryExecDef->getOperand(1).getReg() == LMU.consts().ExecReg)
+        if (PrimaryExecDef->getOperand(1).getReg() == LMC.ExecReg)
           Rejoin = PrimaryExecDef->getOperand(2).getReg();
-        else if (PrimaryExecDef->getOperand(2).getReg() == LMU.consts().ExecReg)
+        else if (PrimaryExecDef->getOperand(2).getReg() == LMC.ExecReg)
           Rejoin = PrimaryExecDef->getOperand(1).getReg();
       }
 
@@ -2069,8 +2070,8 @@ void ControlFlowRewriter::rewrite() {
       if (!Rejoin) {
         Rejoin = LMU.createLaneMaskReg();
         BuildMI(*Pred->Block, Pred->Block->getFirstTerminator(), {},
-                TII.get(LMU.consts().XorOpc), Rejoin)
-            .addReg(LMU.consts().ExecReg)
+                TII.get(LMC.XorOpc), Rejoin)
+            .addReg(LMC.ExecReg)
             .addReg(PrimaryExec);
       }
 
@@ -2084,8 +2085,8 @@ void ControlFlowRewriter::rewrite() {
 
     Register Rejoin = Updater.getValueInMiddleOfBlock(*Secondary->Block);
     BuildMI(*Secondary->Block, Secondary->Block->getFirstNonPHI(), {},
-            TII.get(LMU.consts().OrOpc), LMU.consts().ExecReg)
-        .addReg(LMU.consts().ExecReg)
+            TII.get(LMC.OrOpc), LMC.ExecReg)
+        .addReg(LMC.ExecReg)
         .addReg(Rejoin);
 
     LLVM_DEBUG(Function.dump());

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -1791,7 +1791,7 @@ void ControlFlowRewriter::rewrite() {
     if (!RegAllOnes) {
       RegAllOnes = LMU.createLaneMaskReg();
       BuildMI(Function.front(), Function.front().getFirstTerminator(), {},
-              TII.get(LMU.consts().OpMov), RegAllOnes)
+              TII.get(LMU.consts().MovOpc), RegAllOnes)
           .addImm(-1);
     }
     return RegAllOnes;
@@ -1841,12 +1841,12 @@ void ControlFlowRewriter::rewrite() {
         if (!LMA.isSubsetOfExec(CondReg, *Node->Block)) {
           CondReg = LMU.createLaneMaskReg();
           BuildMI(*Node->Block, Node->Block->end(), {},
-                  TII.get(LMU.consts().OpAnd), CondReg)
-              .addReg(LMU.consts().RegExec)
+                  TII.get(LMU.consts().AndOpc), CondReg)
+              .addReg(LMU.consts().ExecReg)
               .addReg(Info.OrigCondition);
         }
         BuildMI(*Node->Block, Node->Block->end(), {}, TII.get(AMDGPU::COPY),
-                LMU.consts().RegVcc)
+                LMU.consts().VccReg)
             .addReg(CondReg);
 
         Opcode = AMDGPU::S_CBRANCH_VCCNZ;
@@ -1924,15 +1924,15 @@ void ControlFlowRewriter::rewrite() {
         if (!LaneOrigin.InvertCondition) {
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().OpCSelect), CondReg)
-              .addReg(LMU.consts().RegExec)
+                  TII.get(LMU.consts().CSelectOpc), CondReg)
+              .addReg(LMU.consts().ExecReg)
               .addImm(0);
         } else {
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().OpCSelect), CondReg)
+                  TII.get(LMU.consts().CSelectOpc), CondReg)
               .addImm(0)
-              .addReg(LMU.consts().RegExec);
+              .addReg(LMU.consts().ExecReg);
         }
       } else {
         CondReg = LaneOrigin.CondReg;
@@ -1941,8 +1941,8 @@ void ControlFlowRewriter::rewrite() {
           CondReg = LMU.createLaneMaskReg();
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().OpAnd), CondReg)
-              .addReg(LMU.consts().RegExec)
+                  TII.get(LMU.consts().AndOpc), CondReg)
+              .addReg(LMU.consts().ExecReg)
               .addReg(Prev);
 
           RegMap[std::make_pair(LaneOrigin.Node->Block, LaneOrigin.CondReg)]
@@ -1962,7 +1962,7 @@ void ControlFlowRewriter::rewrite() {
           CondReg = LMU.createLaneMaskReg();
           BuildMI(*LaneOrigin.Node->Block,
                   LaneOrigin.Node->Block->getFirstTerminator(), {},
-                  TII.get(LMU.consts().OpXor), CondReg)
+                  TII.get(LMU.consts().XorOpc), CondReg)
               .addReg(LaneOrigin.CondReg)
               .addImm(-1);
 
@@ -1999,7 +1999,7 @@ void ControlFlowRewriter::rewrite() {
                         << '\n');
 
       BuildMI(*OriginNode->Block, OriginNode->Block->end(), {},
-              TII.get(LMU.consts().OpMovTerm), LMU.consts().RegExec)
+              TII.get(LMU.consts().MovTermOpc), LMU.consts().ExecReg)
           .addReg(OriginCFGNodeInfo.PrimarySuccessorExec);
       BuildMI(*OriginNode->Block, OriginNode->Block->end(), {},
               TII.get(AMDGPU::SI_WAVE_CF_EDGE));
@@ -2046,12 +2046,12 @@ void ControlFlowRewriter::rewrite() {
       Register Rejoin;
 
       if (PrimaryExecDef->getParent() == Pred->Block &&
-          PrimaryExecDef->getOpcode() == LMU.consts().OpXor &&
+          PrimaryExecDef->getOpcode() == LMU.consts().XorOpc &&
           PrimaryExecDef->getOperand(1).isReg() &&
           PrimaryExecDef->getOperand(2).isReg()) {
-        if (PrimaryExecDef->getOperand(1).getReg() == LMU.consts().RegExec)
+        if (PrimaryExecDef->getOperand(1).getReg() == LMU.consts().ExecReg)
           Rejoin = PrimaryExecDef->getOperand(2).getReg();
-        else if (PrimaryExecDef->getOperand(2).getReg() == LMU.consts().RegExec)
+        else if (PrimaryExecDef->getOperand(2).getReg() == LMU.consts().ExecReg)
           Rejoin = PrimaryExecDef->getOperand(1).getReg();
       }
 
@@ -2069,8 +2069,8 @@ void ControlFlowRewriter::rewrite() {
       if (!Rejoin) {
         Rejoin = LMU.createLaneMaskReg();
         BuildMI(*Pred->Block, Pred->Block->getFirstTerminator(), {},
-                TII.get(LMU.consts().OpXor), Rejoin)
-            .addReg(LMU.consts().RegExec)
+                TII.get(LMU.consts().XorOpc), Rejoin)
+            .addReg(LMU.consts().ExecReg)
             .addReg(PrimaryExec);
       }
 
@@ -2084,8 +2084,8 @@ void ControlFlowRewriter::rewrite() {
 
     Register Rejoin = Updater.getValueInMiddleOfBlock(*Secondary->Block);
     BuildMI(*Secondary->Block, Secondary->Block->getFirstNonPHI(), {},
-            TII.get(LMU.consts().OpOr), LMU.consts().RegExec)
-        .addReg(LMU.consts().RegExec)
+            TII.get(LMU.consts().OrOpc), LMU.consts().ExecReg)
+        .addReg(LMU.consts().ExecReg)
         .addReg(Rejoin);
 
     LLVM_DEBUG(Function.dump());

--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
@@ -16,38 +16,11 @@
 
 using namespace llvm;
 
-/// Obtain a reference to the global wavefront-size dependent constants
-/// based on \p wavefrontSize.
-const GCNLaneMaskConstants *
-GCNLaneMaskUtils::getConsts(unsigned WavefrontSize) {
-  static const GCNLaneMaskConstants Wave32 = {
-      AMDGPU::EXEC_LO,    AMDGPU::VCC_LO,         &AMDGPU::SReg_32RegClass,
-      AMDGPU::S_MOV_B32,  AMDGPU::S_MOV_B32_term, AMDGPU::S_AND_B32,
-      AMDGPU::S_OR_B32,   AMDGPU::S_XOR_B32,      AMDGPU::S_ANDN2_B32,
-      AMDGPU::S_ORN2_B32, AMDGPU::S_CSELECT_B32,
-  };
-  static const GCNLaneMaskConstants Wave64 = {
-      AMDGPU::EXEC,
-      AMDGPU::VCC,
-      &AMDGPU::SReg_64RegClass,
-      AMDGPU::S_MOV_B64,
-      AMDGPU::S_MOV_B64_term,
-      AMDGPU::S_AND_B64,
-      AMDGPU::S_OR_B64,
-      AMDGPU::S_XOR_B64,
-      AMDGPU::S_ANDN2_B64,
-      AMDGPU::S_ORN2_B64,
-      AMDGPU::S_CSELECT_B64,
-  };
-  assert(WavefrontSize == 32 || WavefrontSize == 64);
-  return WavefrontSize == 32 ? &Wave32 : &Wave64;
-}
 
 /// Obtain a reference to the global wavefront-size dependent constants
 /// based on the wavefront-size of \p function.
-const GCNLaneMaskConstants *GCNLaneMaskUtils::getConsts(MachineFunction &MF) {
-  const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
-  return getConsts(ST.getWavefrontSize());
+const AMDGPU::LaneMaskConstants &GCNLaneMaskUtils::getConsts(MachineFunction &MF) {
+  return AMDGPU::LaneMaskConstants::get(MF.getSubtarget<GCNSubtarget>());
 }
 
 /// Check whether the register could be a lane-mask register.
@@ -90,7 +63,7 @@ bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
       return false;
   }
 
-  if (MI->getOpcode() != Constants->OpMov)
+  if (MI->getOpcode() != Constants->MovOpc)
     return false;
 
   if (!MI->getOperand(1).isImm())
@@ -112,7 +85,7 @@ bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
 /// Create a virtual lanemask register.
 Register GCNLaneMaskUtils::createLaneMaskReg() const {
   MachineRegisterInfo &MRI = MF->getRegInfo();
-  return MRI.createVirtualRegister(Constants->RegClass);
+  return MRI.createVirtualRegister(Constants->SRegClass);
 }
 
 /// Insert the moral equivalent of
@@ -155,10 +128,10 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else if (CurVal) {
       // If PrevReg is undef, prefer to propagate a full constant.
       BuildMI(MBB, I, DL, TII->get(AMDGPU::COPY), DstReg)
-          .addReg(PrevReg ? Constants->RegExec : CurReg);
+          .addReg(PrevReg ? Constants->ExecReg : CurReg);
     } else {
-      BuildMI(MBB, I, DL, TII->get(Constants->OpXor), DstReg)
-          .addReg(Constants->RegExec)
+      BuildMI(MBB, I, DL, TII->get(Constants->XorOpc), DstReg)
+          .addReg(Constants->ExecReg)
           .addImm(-1);
     }
     return;
@@ -174,9 +147,9 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else {
       PrevMaskedReg = createLaneMaskReg();
       PrevMaskedBuilt =
-          BuildMI(MBB, I, DL, TII->get(Constants->OpAndN2), PrevMaskedReg)
+          BuildMI(MBB, I, DL, TII->get(Constants->AndN2Opc), PrevMaskedReg)
               .addReg(PrevReg)
-              .addReg(Constants->RegExec);
+              .addReg(Constants->ExecReg);
     }
   }
   if (!CurConstant) {
@@ -186,9 +159,9 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else {
       CurMaskedReg = createLaneMaskReg();
       CurMaskedBuilt =
-          BuildMI(MBB, I, DL, TII->get(Constants->OpAnd), CurMaskedReg)
+          BuildMI(MBB, I, DL, TII->get(Constants->AndOpc), CurMaskedReg)
               .addReg(CurReg)
-              .addReg(Constants->RegExec);
+              .addReg(Constants->ExecReg);
     }
   }
 
@@ -208,13 +181,13 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
       BuildMI(MBB, I, DL, TII->get(AMDGPU::COPY), DstReg).addReg(PrevMaskedReg);
     }
   } else if (PrevConstant && PrevVal) {
-    BuildMI(MBB, I, DL, TII->get(Constants->OpOrN2), DstReg)
+    BuildMI(MBB, I, DL, TII->get(Constants->OrN2Opc), DstReg)
         .addReg(CurMaskedReg)
-        .addReg(Constants->RegExec);
+        .addReg(Constants->ExecReg);
   } else {
-    BuildMI(MBB, I, DL, TII->get(Constants->OpOr), DstReg)
+    BuildMI(MBB, I, DL, TII->get(Constants->OrOpc), DstReg)
         .addReg(PrevMaskedReg)
-        .addReg(CurMaskedReg ? CurMaskedReg : Constants->RegExec);
+        .addReg(CurMaskedReg ? CurMaskedReg : Constants->ExecReg);
   }
 }
 
@@ -229,7 +202,7 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
 
   for (;;) {
     if (!Register::isVirtualRegister(Reg)) {
-      if (Reg == LMU.consts().RegExec &&
+      if (Reg == LMU.consts().ExecReg &&
           (!DefInstr || DefInstr->getParent() == &UseBlock))
         return true;
       return false;
@@ -241,7 +214,7 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
       continue;
     }
 
-    if (DefInstr->getOpcode() == LMU.consts().OpMov) {
+    if (DefInstr->getOpcode() == LMU.consts().MovOpc) {
       if (DefInstr->getOperand(1).isImm() &&
           DefInstr->getOperand(1).getImm() == 0)
         return true;
@@ -268,11 +241,11 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
   if (!RemainingDepth--)
     return false;
 
-  bool LikeOr = DefInstr->getOpcode() == LMU.consts().OpOr ||
-                DefInstr->getOpcode() == LMU.consts().OpXor ||
-                DefInstr->getOpcode() == LMU.consts().OpCSelect;
-  bool IsAnd = DefInstr->getOpcode() == LMU.consts().OpAnd;
-  bool IsAndN2 = DefInstr->getOpcode() == LMU.consts().OpAndN2;
+  bool LikeOr = DefInstr->getOpcode() == LMU.consts().OrOpc ||
+                DefInstr->getOpcode() == LMU.consts().XorOpc ||
+                DefInstr->getOpcode() == LMU.consts().CSelectOpc;
+  bool IsAnd = DefInstr->getOpcode() == LMU.consts().AndOpc;
+  bool IsAndN2 = DefInstr->getOpcode() == LMU.consts().AndN2Opc;
   if ((LikeOr || IsAnd || IsAndN2) &&
       (DefInstr->getOperand(1).isReg() && DefInstr->getOperand(2).isReg())) {
     bool FirstIsSubset = isSubsetOfExec(DefInstr->getOperand(1).getReg(),
@@ -301,7 +274,7 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
 void GCNLaneMaskUpdater::init(Register Reg) {
   Processed = false;
   Blocks.clear();
-  //SSAUpdater.Initialize(LMU.consts().RegClass);
+  //SSAUpdater.Initialize(LMU.consts().SRegClass);
   SSAUpdater.Initialize(Reg);
 }
 
@@ -451,7 +424,7 @@ void GCNLaneMaskUpdater::process() {
   // Prepare an all-zero value for the default and reset in accumulating mode.
   if (Accumulating && !ZeroReg) {
     ZeroReg = LMU.createLaneMaskReg();
-    BuildMI(Entry, Entry.getFirstTerminator(), {}, TII->get(LMU.consts().OpMov),
+    BuildMI(Entry, Entry.getFirstTerminator(), {}, TII->get(LMU.consts().MovOpc),
             ZeroReg)
         .addImm(0);
   }

--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
@@ -63,7 +63,7 @@ bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
       return false;
   }
 
-  if (MI->getOpcode() != Constants->MovOpc)
+  if (MI->getOpcode() != LMC->MovOpc)
     return false;
 
   if (!MI->getOperand(1).isImm())
@@ -85,7 +85,7 @@ bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
 /// Create a virtual lanemask register.
 Register GCNLaneMaskUtils::createLaneMaskReg() const {
   MachineRegisterInfo &MRI = MF->getRegInfo();
-  return MRI.createVirtualRegister(Constants->SRegClass);
+  return MRI.createVirtualRegister(LMC->SRegClass);
 }
 
 /// Insert the moral equivalent of
@@ -128,10 +128,10 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else if (CurVal) {
       // If PrevReg is undef, prefer to propagate a full constant.
       BuildMI(MBB, I, DL, TII->get(AMDGPU::COPY), DstReg)
-          .addReg(PrevReg ? Constants->ExecReg : CurReg);
+          .addReg(PrevReg ? LMC->ExecReg : CurReg);
     } else {
-      BuildMI(MBB, I, DL, TII->get(Constants->XorOpc), DstReg)
-          .addReg(Constants->ExecReg)
+      BuildMI(MBB, I, DL, TII->get(LMC->XorOpc), DstReg)
+          .addReg(LMC->ExecReg)
           .addImm(-1);
     }
     return;
@@ -147,9 +147,9 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else {
       PrevMaskedReg = createLaneMaskReg();
       PrevMaskedBuilt =
-          BuildMI(MBB, I, DL, TII->get(Constants->AndN2Opc), PrevMaskedReg)
+          BuildMI(MBB, I, DL, TII->get(LMC->AndN2Opc), PrevMaskedReg)
               .addReg(PrevReg)
-              .addReg(Constants->ExecReg);
+              .addReg(LMC->ExecReg);
     }
   }
   if (!CurConstant) {
@@ -159,9 +159,9 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else {
       CurMaskedReg = createLaneMaskReg();
       CurMaskedBuilt =
-          BuildMI(MBB, I, DL, TII->get(Constants->AndOpc), CurMaskedReg)
+          BuildMI(MBB, I, DL, TII->get(LMC->AndOpc), CurMaskedReg)
               .addReg(CurReg)
-              .addReg(Constants->ExecReg);
+              .addReg(LMC->ExecReg);
     }
   }
 
@@ -181,13 +181,13 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
       BuildMI(MBB, I, DL, TII->get(AMDGPU::COPY), DstReg).addReg(PrevMaskedReg);
     }
   } else if (PrevConstant && PrevVal) {
-    BuildMI(MBB, I, DL, TII->get(Constants->OrN2Opc), DstReg)
+    BuildMI(MBB, I, DL, TII->get(LMC->OrN2Opc), DstReg)
         .addReg(CurMaskedReg)
-        .addReg(Constants->ExecReg);
+        .addReg(LMC->ExecReg);
   } else {
-    BuildMI(MBB, I, DL, TII->get(Constants->OrOpc), DstReg)
+    BuildMI(MBB, I, DL, TII->get(LMC->OrOpc), DstReg)
         .addReg(PrevMaskedReg)
-        .addReg(CurMaskedReg ? CurMaskedReg : Constants->ExecReg);
+        .addReg(CurMaskedReg ? CurMaskedReg : LMC->ExecReg);
   }
 }
 
@@ -199,10 +199,11 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
                                          unsigned RemainingDepth) {
   MachineRegisterInfo &MRI = LMU.function()->getRegInfo();
   MachineInstr *DefInstr = nullptr;
+  const AMDGPU::LaneMaskConstants &LMC = LMU.getLaneMaskConsts();
 
   for (;;) {
     if (!Register::isVirtualRegister(Reg)) {
-      if (Reg == LMU.consts().ExecReg &&
+      if (Reg == LMC.ExecReg &&
           (!DefInstr || DefInstr->getParent() == &UseBlock))
         return true;
       return false;
@@ -214,7 +215,7 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
       continue;
     }
 
-    if (DefInstr->getOpcode() == LMU.consts().MovOpc) {
+    if (DefInstr->getOpcode() == LMC.MovOpc) {
       if (DefInstr->getOperand(1).isImm() &&
           DefInstr->getOperand(1).getImm() == 0)
         return true;
@@ -241,11 +242,11 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
   if (!RemainingDepth--)
     return false;
 
-  bool LikeOr = DefInstr->getOpcode() == LMU.consts().OrOpc ||
-                DefInstr->getOpcode() == LMU.consts().XorOpc ||
-                DefInstr->getOpcode() == LMU.consts().CSelectOpc;
-  bool IsAnd = DefInstr->getOpcode() == LMU.consts().AndOpc;
-  bool IsAndN2 = DefInstr->getOpcode() == LMU.consts().AndN2Opc;
+  bool LikeOr = DefInstr->getOpcode() == LMC.OrOpc ||
+                DefInstr->getOpcode() == LMC.XorOpc ||
+                DefInstr->getOpcode() == LMC.CSelectOpc;
+  bool IsAnd = DefInstr->getOpcode() == LMC.AndOpc;
+  bool IsAndN2 = DefInstr->getOpcode() == LMC.AndN2Opc;
   if ((LikeOr || IsAnd || IsAndN2) &&
       (DefInstr->getOperand(1).isReg() && DefInstr->getOperand(2).isReg())) {
     bool FirstIsSubset = isSubsetOfExec(DefInstr->getOperand(1).getReg(),
@@ -274,7 +275,7 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
 void GCNLaneMaskUpdater::init(Register Reg) {
   Processed = false;
   Blocks.clear();
-  //SSAUpdater.Initialize(LMU.consts().SRegClass);
+  //SSAUpdater.Initialize(LMU.getLaneMaskConsts().SRegClass);
   SSAUpdater.Initialize(Reg);
 }
 
@@ -424,7 +425,7 @@ void GCNLaneMaskUpdater::process() {
   // Prepare an all-zero value for the default and reset in accumulating mode.
   if (Accumulating && !ZeroReg) {
     ZeroReg = LMU.createLaneMaskReg();
-    BuildMI(Entry, Entry.getFirstTerminator(), {}, TII->get(LMU.consts().MovOpc),
+    BuildMI(Entry, Entry.getFirstTerminator(), {}, TII->get(LMU.getLaneMaskConsts().MovOpc),
             ZeroReg)
         .addImm(0);
   }

--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
@@ -16,20 +16,13 @@
 
 using namespace llvm;
 
-
-/// Obtain a reference to the global wavefront-size dependent constants
-/// based on the wavefront-size of \p function.
-const AMDGPU::LaneMaskConstants &GCNLaneMaskUtils::getConsts(MachineFunction &MF) {
-  return AMDGPU::LaneMaskConstants::get(MF.getSubtarget<GCNSubtarget>());
-}
-
 /// Check whether the register could be a lane-mask register.
 ///
 /// It does not distinguish between lane-masks and scalar registers that happen
 /// to have the right bitsize.
 bool GCNLaneMaskUtils::maybeLaneMask(Register Reg) const {
-  MachineRegisterInfo &MRI = MF->getRegInfo();
-  const GCNSubtarget &ST = MF->getSubtarget<GCNSubtarget>();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   const SIInstrInfo *TII = ST.getInstrInfo();
   return TII->getRegisterInfo().isSGPRReg(MRI, Reg) &&
          TII->getRegisterInfo().getRegSizeInBits(Reg, MRI) ==
@@ -39,7 +32,7 @@ bool GCNLaneMaskUtils::maybeLaneMask(Register Reg) const {
 /// Determine whether the lane-mask register \p Reg is a wave-wide constant.
 /// If so, the value is stored in \p Val.
 bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
-  MachineRegisterInfo &MRI = MF->getRegInfo();
+  MachineRegisterInfo &MRI = MF.getRegInfo();
 
   const MachineInstr *MI;
   for (;;) {
@@ -63,7 +56,7 @@ bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
       return false;
   }
 
-  if (MI->getOpcode() != LMC->MovOpc)
+  if (MI->getOpcode() != LMC.MovOpc)
     return false;
 
   if (!MI->getOperand(1).isImm())
@@ -84,8 +77,8 @@ bool GCNLaneMaskUtils::isConstantLaneMask(Register Reg, bool &Val) const {
 
 /// Create a virtual lanemask register.
 Register GCNLaneMaskUtils::createLaneMaskReg() const {
-  MachineRegisterInfo &MRI = MF->getRegInfo();
-  return MRI.createVirtualRegister(LMC->SRegClass);
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+  return MRI.createVirtualRegister(LMC.LaneMaskRC);
 }
 
 /// Insert the moral equivalent of
@@ -113,7 +106,7 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
                                            Register PrevReg, Register CurReg,
                                            GCNLaneMaskAnalysis *LMA,
                                            bool accumulating) const {
-  const GCNSubtarget &ST = MF->getSubtarget<GCNSubtarget>();
+  const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   const SIInstrInfo *TII = ST.getInstrInfo();
   bool PrevVal = false;
   bool PrevConstant = !PrevReg || isConstantLaneMask(PrevReg, PrevVal);
@@ -128,10 +121,10 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else if (CurVal) {
       // If PrevReg is undef, prefer to propagate a full constant.
       BuildMI(MBB, I, DL, TII->get(AMDGPU::COPY), DstReg)
-          .addReg(PrevReg ? LMC->ExecReg : CurReg);
+          .addReg(PrevReg ? LMC.ExecReg : CurReg);
     } else {
-      BuildMI(MBB, I, DL, TII->get(LMC->XorOpc), DstReg)
-          .addReg(LMC->ExecReg)
+      BuildMI(MBB, I, DL, TII->get(LMC.XorOpc), DstReg)
+          .addReg(LMC.ExecReg)
           .addImm(-1);
     }
     return;
@@ -147,9 +140,9 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else {
       PrevMaskedReg = createLaneMaskReg();
       PrevMaskedBuilt =
-          BuildMI(MBB, I, DL, TII->get(LMC->AndN2Opc), PrevMaskedReg)
+          BuildMI(MBB, I, DL, TII->get(LMC.AndN2Opc), PrevMaskedReg)
               .addReg(PrevReg)
-              .addReg(LMC->ExecReg);
+              .addReg(LMC.ExecReg);
     }
   }
   if (!CurConstant) {
@@ -159,9 +152,9 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
     } else {
       CurMaskedReg = createLaneMaskReg();
       CurMaskedBuilt =
-          BuildMI(MBB, I, DL, TII->get(LMC->AndOpc), CurMaskedReg)
+          BuildMI(MBB, I, DL, TII->get(LMC.AndOpc), CurMaskedReg)
               .addReg(CurReg)
-              .addReg(LMC->ExecReg);
+              .addReg(LMC.ExecReg);
     }
   }
 
@@ -181,13 +174,13 @@ void GCNLaneMaskUtils::buildMergeLaneMasks(MachineBasicBlock &MBB,
       BuildMI(MBB, I, DL, TII->get(AMDGPU::COPY), DstReg).addReg(PrevMaskedReg);
     }
   } else if (PrevConstant && PrevVal) {
-    BuildMI(MBB, I, DL, TII->get(LMC->OrN2Opc), DstReg)
+    BuildMI(MBB, I, DL, TII->get(LMC.OrN2Opc), DstReg)
         .addReg(CurMaskedReg)
-        .addReg(LMC->ExecReg);
+        .addReg(LMC.ExecReg);
   } else {
-    BuildMI(MBB, I, DL, TII->get(LMC->OrOpc), DstReg)
+    BuildMI(MBB, I, DL, TII->get(LMC.OrOpc), DstReg)
         .addReg(PrevMaskedReg)
-        .addReg(CurMaskedReg ? CurMaskedReg : LMC->ExecReg);
+        .addReg(CurMaskedReg ? CurMaskedReg : LMC.ExecReg);
   }
 }
 
@@ -275,7 +268,7 @@ bool GCNLaneMaskAnalysis::isSubsetOfExec(Register Reg,
 void GCNLaneMaskUpdater::init(Register Reg) {
   Processed = false;
   Blocks.clear();
-  //SSAUpdater.Initialize(LMU.getLaneMaskConsts().SRegClass);
+  //SSAUpdater.Initialize(LMU.getLaneMaskConsts().LaneMaskRC);
   SSAUpdater.Initialize(Reg);
 }
 

--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.h
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.h
@@ -15,6 +15,8 @@
 #ifndef LLVM_LIB_TARGET_AMDGPU_GCNLANEMASKUTILS_H
 #define LLVM_LIB_TARGET_AMDGPU_GCNLANEMASKUTILS_H
 
+#include "AMDGPULaneMaskUtils.h"
+
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/CodeGen/MachineBasicBlock.h"
 #include "llvm/CodeGen/MachineDominators.h"
@@ -25,30 +27,14 @@ namespace llvm {
 class GCNLaneMaskAnalysis;
 class MachineFunction;
 
-/// \brief Wavefront-size dependent constants.
-struct GCNLaneMaskConstants {
-  Register RegExec;                    // EXEC / EXEC_LO
-  Register RegVcc;                     // VCC / VCC_LO
-  const TargetRegisterClass *RegClass; // SReg_nnRegClass
-  unsigned OpMov;                      // S_MOV_Bnn
-  unsigned OpMovTerm;                  // S_MOV_Bnn_term
-  unsigned OpAnd;                      // S_AND_Bnn
-  unsigned OpOr;                       // S_OR_Bnn
-  unsigned OpXor;                      // S_XOR_Bnn
-  unsigned OpAndN2;                    // S_ANDN2_Bnn
-  unsigned OpOrN2;                     // S_ORN2_Bnn
-  unsigned OpCSelect;                  // S_CSELECT_Bnn
-};
-
 /// \brief Helper class for lane-mask related tasks.
 class GCNLaneMaskUtils {
 private:
   MachineFunction *MF = nullptr;
-  const GCNLaneMaskConstants *Constants = nullptr;
+  const AMDGPU::LaneMaskConstants *Constants = nullptr;
 
 public:
-  static const GCNLaneMaskConstants *getConsts(unsigned WavefrontSize);
-  static const GCNLaneMaskConstants *getConsts(MachineFunction &MF);
+  static const AMDGPU::LaneMaskConstants &getConsts(MachineFunction &MF);
 
   GCNLaneMaskUtils() = default;
   explicit GCNLaneMaskUtils(MachineFunction &MF) { setFunction(MF); }
@@ -56,10 +42,10 @@ public:
   MachineFunction *function() const { return MF; }
   void setFunction(MachineFunction &Func) {
     MF = &Func;
-    Constants = getConsts(Func);
+    Constants = &getConsts(Func);
   }
 
-  const GCNLaneMaskConstants &consts() const {
+  const AMDGPU::LaneMaskConstants &consts() const {
     assert(Constants);
     return *Constants;
   }

--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.h
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.h
@@ -31,7 +31,7 @@ class MachineFunction;
 class GCNLaneMaskUtils {
 private:
   MachineFunction *MF = nullptr;
-  const AMDGPU::LaneMaskConstants *Constants = nullptr;
+  const AMDGPU::LaneMaskConstants *LMC = nullptr;
 
 public:
   static const AMDGPU::LaneMaskConstants &getConsts(MachineFunction &MF);
@@ -42,12 +42,12 @@ public:
   MachineFunction *function() const { return MF; }
   void setFunction(MachineFunction &Func) {
     MF = &Func;
-    Constants = &getConsts(Func);
+    LMC = &getConsts(Func);
   }
 
-  const AMDGPU::LaneMaskConstants &consts() const {
-    assert(Constants);
-    return *Constants;
+  const AMDGPU::LaneMaskConstants &getLaneMaskConsts() const {
+    assert(LMC);
+    return *LMC;
   }
 
   bool maybeLaneMask(Register Reg) const;

--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.h
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.h
@@ -30,24 +30,17 @@ class MachineFunction;
 /// \brief Helper class for lane-mask related tasks.
 class GCNLaneMaskUtils {
 private:
-  MachineFunction *MF = nullptr;
-  const AMDGPU::LaneMaskConstants *LMC = nullptr;
+  MachineFunction &MF;
+  const AMDGPU::LaneMaskConstants &LMC;
 
 public:
-  static const AMDGPU::LaneMaskConstants &getConsts(MachineFunction &MF);
+  GCNLaneMaskUtils() = delete;
+  explicit GCNLaneMaskUtils(MachineFunction &MF) : MF(MF),  
+    LMC(AMDGPU::LaneMaskConstants::get(MF.getSubtarget<GCNSubtarget>())) {}
 
-  GCNLaneMaskUtils() = default;
-  explicit GCNLaneMaskUtils(MachineFunction &MF) { setFunction(MF); }
-
-  MachineFunction *function() const { return MF; }
-  void setFunction(MachineFunction &Func) {
-    MF = &Func;
-    LMC = &getConsts(Func);
-  }
-
+  MachineFunction *function() const { return &MF; }
   const AMDGPU::LaneMaskConstants &getLaneMaskConsts() const {
-    assert(LMC);
-    return *LMC;
+    return LMC;
   }
 
   bool maybeLaneMask(Register Reg) const;


### PR DESCRIPTION
This patch makes GCNLaneMaskUtils to use LaneMaskConstants defined by globally used AMDGPULaneMaskUtils, instead of GCNLaneMaskConstant eliminating the code duplication.


