### PR TITLE
[AMDGPU] Handle empty-except-for-DI regions in PreRARematerialize

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNSchedStrategy.cpp
@@ -2093,7 +2093,9 @@ void PreRARematStage::rematerialize() {
       MF.getInfo<SIMachineFunctionInfo>()->getDynamicVGPRBlockSize();
   AchievedOcc = MFI.getMaxWavesPerEU();
   for (auto &[I, OriginalRP] : ImpactedRegions) {
-    bool IsEmptyRegion = DAG.Regions[I].first == DAG.Regions[I].second;
+    auto NonDbgMBBI = skipDebugInstructionsForward(DAG.Regions[I].first,
+                                                   DAG.Regions[I].second);
+    bool IsEmptyRegion = NonDbgMBBI == DAG.Regions[I].second;
     RescheduleRegions[I] = !IsEmptyRegion;
     if (!RecomputeRP.contains(I))
       continue;
@@ -2103,16 +2105,9 @@ void PreRARematStage::rematerialize() {
       RP = getRegPressure(DAG.MRI, DAG.LiveIns[I]);
     } else {
       GCNDownwardRPTracker RPT(*DAG.LIS);
-      auto *NonDbgMI = &*skipDebugInstructionsForward(DAG.Regions[I].first,
-                                                      DAG.Regions[I].second);
-      if (NonDbgMI == DAG.Regions[I].second) {
-        // Region is non-empty but contains only debug instructions.
-        RP = getRegPressure(DAG.MRI, DAG.LiveIns[I]);
-      } else {
-        RPT.reset(*NonDbgMI, &DAG.LiveIns[I]);
-        RPT.advance(DAG.Regions[I].second);
-        RP = RPT.moveMaxPressure();
-      }
+      RPT.reset(*NonDbgMBBI, &DAG.LiveIns[I]);
+      RPT.advance(DAG.Regions[I].second);
+      RP = RPT.moveMaxPressure();
     }
     DAG.Pressure[I] = RP;
     AchievedOcc =


### PR DESCRIPTION
[AMDGPU] Handle empty-except-for-DI regions in PreRARematerialize      
                                                                       
The existing check for this case only comes after a derefence of what  
can be an iterator sentinel (leading to an assert).                    
                                                                       
This may not be purely NFC in that it also avoids queuing the          
effectively-empty region for rescheduling, but AFAICT this should be   
purely an optimization.                                                
                                                                       
Testing this seems difficult, as the high-level scheduler avoids       
scheduling these "empty" regions. This means a reproducer has to depend
on behavior of the scheduler passes before PreRARematStage in order to 
craft a region which triggers the bug.                                 
                                                                       
Since this is a release blocker I am posting a PR now, as both Shore   
Shen and I have manually verified that this resolves the particular    
crash from SWDEV-564142 but I am still working on making a reasonable  
test.                                                                  