### PR TITLE
[ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1400,41 +1400,36 @@ DECLARE_REAL(hsa_status_t, hsa_amd_ipc_memory_attach,
 DECLARE_REAL(hsa_status_t, hsa_amd_ipc_memory_detach, void *mapped_ptr)
 DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_reserve_align, void** ptr,
              size_t size, uint64_t address, uint64_t alignment, uint64_t flags)
-<<<<<<< HEAD
 DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size)
 DECLARE_REAL(hsa_status_t, hsa_amd_pointer_info, const void* ptr,
              hsa_amd_pointer_info_t* info, void* (*alloc)(size_t),
              uint32_t* num_agents_accessible, hsa_agent_t** accessible)
-||||||| parent of f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
-DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size);
-=======
-DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size);
 DECLARE_REAL(hsa_status_t, hsa_amd_register_system_event_handler,
              hsa_amd_system_event_callback_t, void*)
->>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
 
 namespace __asan {
 // Always align to page boundary to match current ROCr behavior
 static const size_t kPageSize_ = 4096;
 
 hsa_status_t asan_hsa_amd_memory_pool_allocate(
-    hsa_amd_memory_pool_t memory_pool, size_t size, uint32_t flags, void** ptr,
-    BufferedStackTrace* stack) {
+  hsa_amd_memory_pool_t memory_pool, size_t size, uint32_t flags, void **ptr,
+  BufferedStackTrace *stack) {
   AmdgpuAllocationInfo aa_info;
   aa_info.alloc_func =
-      reinterpret_cast<void*>(asan_hsa_amd_memory_pool_allocate);
+    reinterpret_cast<void *>(asan_hsa_amd_memory_pool_allocate);
   aa_info.memory_pool = memory_pool;
   aa_info.size = size;
   aa_info.flags = flags;
   aa_info.ptr = nullptr;
-  SetErrnoOnNull(*ptr = instance.Allocate(size, kPageSize_, stack, FROM_MALLOC,
-                                          false, &aa_info));
+  SetErrnoOnNull(*ptr = instance.Allocate(size, kPageSize_, stack,
+                                          FROM_MALLOC, false, &aa_info));
   return aa_info.status;
 }
 
-hsa_status_t asan_hsa_amd_memory_pool_free(void* ptr,
-                                           BufferedStackTrace* stack) {
-  void* p = get_allocator().GetBlockBegin(ptr);
+hsa_status_t asan_hsa_amd_memory_pool_free(
+  void *ptr,
+  BufferedStackTrace *stack) {
+  void *p = get_allocator().GetBlockBegin(ptr);
   if (p) {
     instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC);
     return HSA_STATUS_SUCCESS;
@@ -1442,12 +1437,11 @@ hsa_status_t asan_hsa_amd_memory_pool_free(void* ptr,
   return REAL(hsa_amd_memory_pool_free)(ptr);
 }
 
-hsa_status_t asan_hsa_amd_agents_allow_access(uint32_t num_agents,
-                                              const hsa_agent_t* agents,
-                                              const uint32_t* flags,
-                                              const void* ptr,
-                                              BufferedStackTrace* stack) {
-  void* p = get_allocator().GetBlockBegin(ptr);
+hsa_status_t asan_hsa_amd_agents_allow_access(
+  uint32_t num_agents, const hsa_agent_t *agents, const uint32_t *flags,
+  const void *ptr,
+  BufferedStackTrace *stack) {
+  void *p = get_allocator().GetBlockBegin(ptr);
   return REAL(hsa_amd_agents_allow_access)(num_agents, agents, flags,
                                            p ? p : ptr);
 }
@@ -1457,12 +1451,13 @@ hsa_status_t asan_hsa_amd_agents_allow_access(uint32_t num_agents,
 // is always one kPageSize_
 // IPC calls use static_assert to make sure kMetadataSize = 0
 //
-#  if SANITIZER_CAN_USE_ALLOCATOR64
+#if SANITIZER_CAN_USE_ALLOCATOR64
 static struct AP64<LocalAddressSpaceView> AP_;
-#  else
+#else
 static struct AP32<LocalAddressSpaceView> AP_;
-#  endif
+#endif
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
                                             hsa_amd_ipc_memory_t* handle) {
@@ -1481,10 +1476,20 @@ hsa_status_t asan_hsa_amd_ipc_memory_create(void *ptr, size_t len,
 hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
                                             hsa_amd_ipc_memory_t* handle) {
   void* ptr_;
+||||||| parent of b03bb8d0297e (Fix clang-format noise.)
+hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
+                                            hsa_amd_ipc_memory_t* handle) {
+  void* ptr_;
+=======
+hsa_status_t asan_hsa_amd_ipc_memory_create(void *ptr, size_t len,
+  hsa_amd_ipc_memory_t * handle) {
+  void *ptr_;
+>>>>>>> b03bb8d0297e (Fix clang-format noise.)
   size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr);
   if (len_) {
 >>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
     static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
+<<<<<<< HEAD
 <<<<<<< HEAD
     uptr p = reinterpret_cast<uptr>(ptr);
     uptr p_ = reinterpret_cast<uptr>(ptr_);
@@ -1499,6 +1504,11 @@ hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
     len_ = len;
 =======
     ptr_ = reinterpret_cast<void*>(reinterpret_cast<uptr>(ptr) - kPageSize_);
+||||||| parent of b03bb8d0297e (Fix clang-format noise.)
+    ptr_ = reinterpret_cast<void*>(reinterpret_cast<uptr>(ptr) - kPageSize_);
+=======
+    ptr_ = reinterpret_cast<void *>(reinterpret_cast<uptr>(ptr) - kPageSize_);
+>>>>>>> b03bb8d0297e (Fix clang-format noise.)
   } else {
     ptr_ = ptr;
     len_ = len;
@@ -1507,25 +1517,24 @@ hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
   return REAL(hsa_amd_ipc_memory_create)(ptr, len, handle);
 }
 
-hsa_status_t asan_hsa_amd_ipc_memory_attach(const hsa_amd_ipc_memory_t* handle,
-                                            size_t len, uint32_t num_agents,
-                                            const hsa_agent_t* mapping_agents,
-                                            void** mapped_ptr) {
+hsa_status_t asan_hsa_amd_ipc_memory_attach(const hsa_amd_ipc_memory_t *handle,
+  size_t len, uint32_t num_agents, const hsa_agent_t *mapping_agents,
+  void **mapped_ptr) {
   static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
   size_t len_ = len + kPageSize_;
   hsa_status_t status = REAL(hsa_amd_ipc_memory_attach)(
-      handle, len_, num_agents, mapping_agents, mapped_ptr);
+    handle, len_, num_agents, mapping_agents, mapped_ptr);
   if (status == HSA_STATUS_SUCCESS && mapped_ptr) {
-    *mapped_ptr = reinterpret_cast<void*>(reinterpret_cast<uptr>(*mapped_ptr) +
-                                          kPageSize_);
+    *mapped_ptr = reinterpret_cast<void *>(reinterpret_cast<uptr>(*mapped_ptr) +
+                                           kPageSize_);
   }
   return status;
 }
 
-hsa_status_t asan_hsa_amd_ipc_memory_detach(void* mapped_ptr) {
+hsa_status_t asan_hsa_amd_ipc_memory_detach(void *mapped_ptr) {
   static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
-  void* mapped_ptr_ =
-      reinterpret_cast<void*>(reinterpret_cast<uptr>(mapped_ptr) - kPageSize_);
+  void *mapped_ptr_ =
+      reinterpret_cast<void *>(reinterpret_cast<uptr>(mapped_ptr) - kPageSize_);
   return REAL(hsa_amd_ipc_memory_detach)(mapped_ptr_);
 }
 

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1385,6 +1385,7 @@ int __asan_update_allocation_context(void* addr) {
 }
 
 #if SANITIZER_AMDGPU
+DECLARE_REAL(hsa_status_t, hsa_init);
 DECLARE_REAL(hsa_status_t, hsa_amd_agents_allow_access, uint32_t num_agents,
   const hsa_agent_t *agents, const uint32_t *flags, const void *ptr)
 DECLARE_REAL(hsa_status_t, hsa_amd_memory_pool_allocate,
@@ -1399,35 +1400,41 @@ DECLARE_REAL(hsa_status_t, hsa_amd_ipc_memory_attach,
 DECLARE_REAL(hsa_status_t, hsa_amd_ipc_memory_detach, void *mapped_ptr)
 DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_reserve_align, void** ptr,
              size_t size, uint64_t address, uint64_t alignment, uint64_t flags)
+<<<<<<< HEAD
 DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size)
 DECLARE_REAL(hsa_status_t, hsa_amd_pointer_info, const void* ptr,
              hsa_amd_pointer_info_t* info, void* (*alloc)(size_t),
              uint32_t* num_agents_accessible, hsa_agent_t** accessible)
+||||||| parent of f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
+DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size);
+=======
+DECLARE_REAL(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size);
+DECLARE_REAL(hsa_status_t, hsa_amd_register_system_event_handler,
+             hsa_amd_system_event_callback_t, void*)
+>>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
 
 namespace __asan {
-
 // Always align to page boundary to match current ROCr behavior
 static const size_t kPageSize_ = 4096;
 
 hsa_status_t asan_hsa_amd_memory_pool_allocate(
-  hsa_amd_memory_pool_t memory_pool, size_t size, uint32_t flags, void **ptr,
-  BufferedStackTrace *stack) {
+    hsa_amd_memory_pool_t memory_pool, size_t size, uint32_t flags, void** ptr,
+    BufferedStackTrace* stack) {
   AmdgpuAllocationInfo aa_info;
   aa_info.alloc_func =
-    reinterpret_cast<void *>(asan_hsa_amd_memory_pool_allocate);
+      reinterpret_cast<void*>(asan_hsa_amd_memory_pool_allocate);
   aa_info.memory_pool = memory_pool;
   aa_info.size = size;
   aa_info.flags = flags;
   aa_info.ptr = nullptr;
-  SetErrnoOnNull(*ptr = instance.Allocate(size, kPageSize_, stack,
-                                          FROM_MALLOC, false, &aa_info));
+  SetErrnoOnNull(*ptr = instance.Allocate(size, kPageSize_, stack, FROM_MALLOC,
+                                          false, &aa_info));
   return aa_info.status;
 }
 
-hsa_status_t asan_hsa_amd_memory_pool_free(
-  void *ptr,
-  BufferedStackTrace *stack) {
-  void *p = get_allocator().GetBlockBegin(ptr);
+hsa_status_t asan_hsa_amd_memory_pool_free(void* ptr,
+                                           BufferedStackTrace* stack) {
+  void* p = get_allocator().GetBlockBegin(ptr);
   if (p) {
     instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC);
     return HSA_STATUS_SUCCESS;
@@ -1435,11 +1442,12 @@ hsa_status_t asan_hsa_amd_memory_pool_free(
   return REAL(hsa_amd_memory_pool_free)(ptr);
 }
 
-hsa_status_t asan_hsa_amd_agents_allow_access(
-  uint32_t num_agents, const hsa_agent_t *agents, const uint32_t *flags,
-  const void *ptr,
-  BufferedStackTrace *stack) {
-  void *p = get_allocator().GetBlockBegin(ptr);
+hsa_status_t asan_hsa_amd_agents_allow_access(uint32_t num_agents,
+                                              const hsa_agent_t* agents,
+                                              const uint32_t* flags,
+                                              const void* ptr,
+                                              BufferedStackTrace* stack) {
+  void* p = get_allocator().GetBlockBegin(ptr);
   return REAL(hsa_amd_agents_allow_access)(num_agents, agents, flags,
                                            p ? p : ptr);
 }
@@ -1449,12 +1457,13 @@ hsa_status_t asan_hsa_amd_agents_allow_access(
 // is always one kPageSize_
 // IPC calls use static_assert to make sure kMetadataSize = 0
 //
-#if SANITIZER_CAN_USE_ALLOCATOR64
+#  if SANITIZER_CAN_USE_ALLOCATOR64
 static struct AP64<LocalAddressSpaceView> AP_;
-#else
+#  else
 static struct AP32<LocalAddressSpaceView> AP_;
-#endif
+#  endif
 
+<<<<<<< HEAD
 hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
                                             hsa_amd_ipc_memory_t* handle) {
   void* ptr_ = get_allocator().GetBlockBegin(ptr);
@@ -1462,35 +1471,61 @@ hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
                      ? instance.GetAsanChunkByAddr(reinterpret_cast<uptr>(ptr_))
                      : nullptr;
   if (ptr_ && m) {
+||||||| parent of f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
+hsa_status_t asan_hsa_amd_ipc_memory_create(void *ptr, size_t len,
+  hsa_amd_ipc_memory_t * handle) {
+  void *ptr_;
+  size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr);
+  if (len_) {
+=======
+hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
+                                            hsa_amd_ipc_memory_t* handle) {
+  void* ptr_;
+  size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr);
+  if (len_) {
+>>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
     static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
+<<<<<<< HEAD
     uptr p = reinterpret_cast<uptr>(ptr);
     uptr p_ = reinterpret_cast<uptr>(ptr_);
     if (p == p_ + kPageSize_ && len == m->UsedSize()) {
       size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr_);
       return REAL(hsa_amd_ipc_memory_create)(ptr_, len_, handle);
     }
+||||||| parent of f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
+    ptr_ = reinterpret_cast<void *>(reinterpret_cast<uptr>(ptr) - kPageSize_);
+  } else {
+    ptr_ = ptr;
+    len_ = len;
+=======
+    ptr_ = reinterpret_cast<void*>(reinterpret_cast<uptr>(ptr) - kPageSize_);
+  } else {
+    ptr_ = ptr;
+    len_ = len;
+>>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
   }
   return REAL(hsa_amd_ipc_memory_create)(ptr, len, handle);
 }
 
-hsa_status_t asan_hsa_amd_ipc_memory_attach(const hsa_amd_ipc_memory_t *handle,
-  size_t len, uint32_t num_agents, const hsa_agent_t *mapping_agents,
-  void **mapped_ptr) {
+hsa_status_t asan_hsa_amd_ipc_memory_attach(const hsa_amd_ipc_memory_t* handle,
+                                            size_t len, uint32_t num_agents,
+                                            const hsa_agent_t* mapping_agents,
+                                            void** mapped_ptr) {
   static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
   size_t len_ = len + kPageSize_;
   hsa_status_t status = REAL(hsa_amd_ipc_memory_attach)(
-    handle, len_, num_agents, mapping_agents, mapped_ptr);
+      handle, len_, num_agents, mapping_agents, mapped_ptr);
   if (status == HSA_STATUS_SUCCESS && mapped_ptr) {
-    *mapped_ptr = reinterpret_cast<void *>(reinterpret_cast<uptr>(*mapped_ptr) +
-                                           kPageSize_);
+    *mapped_ptr = reinterpret_cast<void*>(reinterpret_cast<uptr>(*mapped_ptr) +
+                                          kPageSize_);
   }
   return status;
 }
 
-hsa_status_t asan_hsa_amd_ipc_memory_detach(void *mapped_ptr) {
+hsa_status_t asan_hsa_amd_ipc_memory_detach(void* mapped_ptr) {
   static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
-  void *mapped_ptr_ =
-      reinterpret_cast<void *>(reinterpret_cast<uptr>(mapped_ptr) - kPageSize_);
+  void* mapped_ptr_ =
+      reinterpret_cast<void*>(reinterpret_cast<uptr>(mapped_ptr) - kPageSize_);
   return REAL(hsa_amd_ipc_memory_detach)(mapped_ptr_);
 }
 
@@ -1576,6 +1611,13 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
   }
   return REAL(hsa_amd_pointer_info)(ptr, info, alloc, num_agents_accessible,
                                     accessible);
+}
+
+hsa_status_t asan_hsa_init() {
+  hsa_status_t status = REAL(hsa_init)();
+  if (status == HSA_STATUS_SUCCESS)
+    __sanitizer::AmdgpuMemFuncs::RegisterSystemEventHandlers();
+  return status;
 }
 
 }  // namespace __asan

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1457,8 +1457,6 @@ static struct AP64<LocalAddressSpaceView> AP_;
 static struct AP32<LocalAddressSpaceView> AP_;
 #endif
 
-<<<<<<< HEAD
-<<<<<<< HEAD
 hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
                                             hsa_amd_ipc_memory_t* handle) {
   void* ptr_ = get_allocator().GetBlockBegin(ptr);
@@ -1466,53 +1464,13 @@ hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
                      ? instance.GetAsanChunkByAddr(reinterpret_cast<uptr>(ptr_))
                      : nullptr;
   if (ptr_ && m) {
-||||||| parent of f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
-hsa_status_t asan_hsa_amd_ipc_memory_create(void *ptr, size_t len,
-  hsa_amd_ipc_memory_t * handle) {
-  void *ptr_;
-  size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr);
-  if (len_) {
-=======
-hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
-                                            hsa_amd_ipc_memory_t* handle) {
-  void* ptr_;
-||||||| parent of b03bb8d0297e (Fix clang-format noise.)
-hsa_status_t asan_hsa_amd_ipc_memory_create(void* ptr, size_t len,
-                                            hsa_amd_ipc_memory_t* handle) {
-  void* ptr_;
-=======
-hsa_status_t asan_hsa_amd_ipc_memory_create(void *ptr, size_t len,
-  hsa_amd_ipc_memory_t * handle) {
-  void *ptr_;
->>>>>>> b03bb8d0297e (Fix clang-format noise.)
-  size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr);
-  if (len_) {
->>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
     static_assert(AP_.kMetadataSize == 0, "Expression below requires this");
-<<<<<<< HEAD
-<<<<<<< HEAD
     uptr p = reinterpret_cast<uptr>(ptr);
     uptr p_ = reinterpret_cast<uptr>(ptr_);
     if (p == p_ + kPageSize_ && len == m->UsedSize()) {
       size_t len_ = get_allocator().GetActuallyAllocatedSize(ptr_);
       return REAL(hsa_amd_ipc_memory_create)(ptr_, len_, handle);
     }
-||||||| parent of f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
-    ptr_ = reinterpret_cast<void *>(reinterpret_cast<uptr>(ptr) - kPageSize_);
-  } else {
-    ptr_ = ptr;
-    len_ = len;
-=======
-    ptr_ = reinterpret_cast<void*>(reinterpret_cast<uptr>(ptr) - kPageSize_);
-||||||| parent of b03bb8d0297e (Fix clang-format noise.)
-    ptr_ = reinterpret_cast<void*>(reinterpret_cast<uptr>(ptr) - kPageSize_);
-=======
-    ptr_ = reinterpret_cast<void *>(reinterpret_cast<uptr>(ptr) - kPageSize_);
->>>>>>> b03bb8d0297e (Fix clang-format noise.)
-  } else {
-    ptr_ = ptr;
-    len_ = len;
->>>>>>> f3f3213e9b22 ([ASan][Compiler-rt] Support Gracefull hsa-runtime shutdown.)
   }
   return REAL(hsa_amd_ipc_memory_create)(ptr, len, handle);
 }

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -346,6 +346,7 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
                                        void* (*alloc)(size_t),
                                        uint32_t* num_agents_accessible,
                                        hsa_agent_t** accessible);
+hsa_status_t asan_hsa_init();
 } // namespace __asan
 #endif
 

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -957,7 +957,13 @@ INTERCEPTOR(hsa_status_t, hsa_amd_pointer_info, const void* ptr,
                                    accessible);
 }
 
+INTERCEPTOR(hsa_status_t, hsa_init) {
+  AsanInitFromRtl();
+  return asan_hsa_init();
+}
+
 void InitializeAmdgpuInterceptors() {
+  ASAN_INTERCEPT_FUNC(hsa_init);
   ASAN_INTERCEPT_FUNC(hsa_memory_copy);
   ASAN_INTERCEPT_FUNC(hsa_amd_memory_pool_allocate);
   ASAN_INTERCEPT_FUNC(hsa_amd_memory_pool_free);
@@ -975,7 +981,7 @@ void InitializeAmdgpuInterceptors() {
 }
 
 void ENSURE_HSA_INITED() {
-  if (!REAL(hsa_memory_copy))
+  if (!REAL(hsa_init))
     InitializeAmdgpuInterceptors();
 }
 #endif

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -959,6 +959,7 @@ INTERCEPTOR(hsa_status_t, hsa_amd_pointer_info, const void* ptr,
 
 INTERCEPTOR(hsa_status_t, hsa_init) {
   AsanInitFromRtl();
+  ENSURE_HSA_INITED();
   return asan_hsa_init();
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -43,7 +43,14 @@ static const size_t kPageSize_ = 4096;
 static atomic_uint8_t amdgpu_runtime_shutdown{0};
 static atomic_uint8_t amdgpu_event_registered{0};
 
-// Check if AMDGPU runtime shutdown state
+#  define LOAD_HSA_FUNC_WITH_ERROR_CHECK(func, name, success)         \
+    func = (decltype(func))dlsym(RTLD_NEXT, name);                    \
+    if (!func) {                                                      \
+      VReport(2, "Amdgpu Init: Failed to load " #name " function\n"); \
+      success = false;                                                \
+    }
+
+// Check AMDGPU runtime shutdown state
 bool AmdgpuMemFuncs::IsAmdgpuRuntimeShutdown() {
   return static_cast<bool>(
       atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire));
@@ -54,38 +61,43 @@ void AmdgpuMemFuncs::NotifyAmdgpuRuntimeShutdown() {
   uint8_t shutdown = 0;
   if (atomic_compare_exchange_strong(&amdgpu_runtime_shutdown, &shutdown, 1,
                                      memory_order_acq_rel)) {
-    VReport(1, " Amdgpu Allocator: AMDGPU runtime shutdown detected\n");
+    VReport(2, "Amdgpu Allocator: AMDGPU runtime shutdown detected\n");
   }
 }
 
 bool AmdgpuMemFuncs::Init() {
-  hsa_amd.memory_pool_allocate =
-      (decltype(hsa_amd.memory_pool_allocate))dlsym(
-          RTLD_NEXT, "hsa_amd_memory_pool_allocate");
-  hsa_amd.memory_pool_free = (decltype(hsa_amd.memory_pool_free))dlsym(
-      RTLD_NEXT, "hsa_amd_memory_pool_free");
-  hsa_amd.pointer_info = (decltype(hsa_amd.pointer_info))dlsym(
-      RTLD_NEXT, "hsa_amd_pointer_info");
-  hsa_amd.vmem_address_reserve_align =
-      (decltype(hsa_amd.vmem_address_reserve_align))dlsym(
-          RTLD_NEXT, "hsa_amd_vmem_address_reserve_align");
-  hsa_amd.vmem_address_free = (decltype(hsa_amd.vmem_address_free))dlsym(
-      RTLD_NEXT, "hsa_amd_vmem_address_free");
-  hsa_amd.register_system_event_handler =
-      (decltype(hsa_amd.register_system_event_handler))dlsym(
-          RTLD_NEXT, "hsa_amd_register_system_event_handler");
-  if (!hsa_amd.memory_pool_allocate || !hsa_amd.memory_pool_free ||
-      !hsa_amd.pointer_info || !hsa_amd.vmem_address_reserve_align ||
-      !hsa_amd.vmem_address_free || !hsa_amd.register_system_event_handler)
+  bool success = true;
+  LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.memory_pool_allocate,
+                                 "hsa_amd_memory_pool_allocate", success);
+  LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.memory_pool_free,
+                                 "hsa_amd_memory_pool_free", success);
+  LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.pointer_info, "hsa_amd_pointer_info",
+                                 success);
+  LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.vmem_address_reserve_align,
+                                 "hsa_amd_vmem_address_reserve_align", success);
+  LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.vmem_address_free,
+                                 "hsa_amd_vmem_address_free", success);
+  LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.register_system_event_handler,
+                                 "hsa_amd_register_system_event_handler",
+                                 success);
+  if (!success) {
+    VReport(1, "Amdgpu Init: Failed to load AMDGPU runtime functions\n");
     return false;
+  }
   return true;
 }
 
 void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
                                DeviceAllocationInfo *da_info) {
   // Do not allocate if AMDGPU runtime is shutdown
-  if (IsAmdgpuRuntimeShutdown())
+  if (IsAmdgpuRuntimeShutdown()) {
+    VReport(1,
+            "Amdgpu Allocate: Runtime shutdown, skipping allocation for size "
+            "%zu alignment %zu\n",
+            size, alignment);
     return nullptr;
+  }
+
   AmdgpuAllocationInfo *aa_info =
       reinterpret_cast<AmdgpuAllocationInfo *>(da_info);
   if (!aa_info->memory_pool.handle) {
@@ -104,8 +116,14 @@ void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
 
 void AmdgpuMemFuncs::Deallocate(void *p) {
   // Deallocate does nothing after AMDGPU runtime shutdown
-  if (IsAmdgpuRuntimeShutdown())
+  if (IsAmdgpuRuntimeShutdown()) {
+    VReport(
+        1,
+        "Amdgpu Deallocate: Runtime shutdown, skipping deallocation for %p\n",
+        reinterpret_cast<void*>(p));
     return;
+  }
+
   DevicePointerInfo DevPtrInfo;
   if (AmdgpuMemFuncs::GetPointerInfo(reinterpret_cast<uptr>(p), &DevPtrInfo)) {
     if (DevPtrInfo.type == HSA_EXT_POINTER_TYPE_HSA) {
@@ -118,6 +136,14 @@ void AmdgpuMemFuncs::Deallocate(void *p) {
 }
 
 bool AmdgpuMemFuncs::GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info) {
+  // GetPointerInfo returns false after AMDGPU runtime shutdown
+  if (IsAmdgpuRuntimeShutdown()) {
+    VReport(1,
+            "Amdgpu GetPointerInfo: Runtime shutdown, skipping query for %p\n",
+            reinterpret_cast<void*>(ptr));
+    return false;
+  }
+
   hsa_amd_pointer_info_t info;
   info.size = sizeof(hsa_amd_pointer_info_t);
   hsa_status_t status =
@@ -138,9 +164,11 @@ bool AmdgpuMemFuncs::GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info) {
  // Register shutdown system event handler only once
  // TODO: Register multiple event handlers if needed in future
 void AmdgpuMemFuncs::RegisterSystemEventHandlers() {
-  // Check if already registered
-  if (atomic_load(&amdgpu_event_registered, memory_order_acquire) == 0) {
-    // Callback to just detect runtime shutdown
+  uint8_t registered = 0;
+  // Check if shutdown event handler is already registered
+  if (atomic_compare_exchange_strong(&amdgpu_event_registered, &registered, 1,
+                                     memory_order_acq_rel)) {
+    // Callback to detect and notify AMDGPU runtime shutdown
     hsa_amd_system_event_callback_t callback = [](const hsa_amd_event_t* event,
                                                   void* data) {
       if (!event)
@@ -149,12 +177,20 @@ void AmdgpuMemFuncs::RegisterSystemEventHandlers() {
         AmdgpuMemFuncs::NotifyAmdgpuRuntimeShutdown();
       return HSA_STATUS_SUCCESS;
     };
-    // Register the callback
+    // Register the event callback
     hsa_status_t status =
         hsa_amd.register_system_event_handler(callback, nullptr);
-    // Mark as registered if successful
+    // Check as registered if successful
     if (status == HSA_STATUS_SUCCESS)
-      atomic_store(&amdgpu_event_registered, 1, memory_order_release);
+      VReport(
+          1,
+          "Amdgpu RegisterSystemEventHandlers: Registered shutdown event \n");
+    else {
+      VReport(1,
+              "Amdgpu RegisterSystemEventHandlers: Failed to register shutdown "
+              "event \n");
+      atomic_store(&amdgpu_event_registered, 0, memory_order_release);
+    }
   }
 }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -90,7 +90,7 @@ bool AmdgpuMemFuncs::Init() {
 void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
                                DeviceAllocationInfo *da_info) {
   // Do not allocate if AMDGPU runtime is shutdown
-  if (IsAmdgpuRuntimeShutdown()) {
+  if (UNLIKELY(IsAmdgpuRuntimeShutdown())) {
     VReport(1,
             "Amdgpu Allocate: Runtime shutdown, skipping allocation for size "
             "%zu alignment %zu\n",
@@ -116,7 +116,7 @@ void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
 
 void AmdgpuMemFuncs::Deallocate(void *p) {
   // Deallocate does nothing after AMDGPU runtime shutdown
-  if (IsAmdgpuRuntimeShutdown()) {
+  if (UNLIKELY(IsAmdgpuRuntimeShutdown())) {
     VReport(
         1,
         "Amdgpu Deallocate: Runtime shutdown, skipping deallocation for %p\n",
@@ -137,7 +137,7 @@ void AmdgpuMemFuncs::Deallocate(void *p) {
 
 bool AmdgpuMemFuncs::GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info) {
   // GetPointerInfo returns false after AMDGPU runtime shutdown
-  if (IsAmdgpuRuntimeShutdown()) {
+  if (UNLIKELY(IsAmdgpuRuntimeShutdown())) {
     VReport(1,
             "Amdgpu GetPointerInfo: Runtime shutdown, skipping query for %p\n",
             reinterpret_cast<void*>(ptr));

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -11,28 +11,43 @@
 //===----------------------------------------------------------------------===//
 #if SANITIZER_AMDGPU
 #  include <dlfcn.h>  // For dlsym
+
 #  include "sanitizer_allocator.h"
+#  include "sanitizer_atomic.h"
 
 namespace __sanitizer {
-struct HsaMemoryFunctions {
+struct HsaFunctions {
+  // ---------------- Memory Functions ----------------
   hsa_status_t (*memory_pool_allocate)(hsa_amd_memory_pool_t memory_pool,
-                                       size_t size, uint32_t flags, void **ptr);
-  hsa_status_t (*memory_pool_free)(void *ptr);
-  hsa_status_t (*pointer_info)(void *ptr, hsa_amd_pointer_info_t *info,
-                               void *(*alloc)(size_t),
-                               uint32_t *num_agents_accessible,
-                               hsa_agent_t **accessible);
+                                       size_t size, uint32_t flags, void** ptr);
+  hsa_status_t (*memory_pool_free)(void* ptr);
+  hsa_status_t (*pointer_info)(void* ptr, hsa_amd_pointer_info_t* info,
+                               void* (*alloc)(size_t),
+                               uint32_t* num_agents_accessible,
+                               hsa_agent_t** accessible);
   hsa_status_t (*vmem_address_reserve_align)(void** ptr, size_t size,
                                              uint64_t address,
                                              uint64_t alignment,
                                              uint64_t flags);
   hsa_status_t (*vmem_address_free)(void* ptr, size_t size);
+
+  // ----------------Event Functions ----------------
+  hsa_status_t (*register_system_event_handler)(
+      hsa_amd_system_event_callback_t callback, void* data);
 };
 
-static HsaMemoryFunctions hsa_amd;
+static HsaFunctions hsa_amd;
 
 // Always align to page boundary to match current ROCr behavior
 static const size_t kPageSize_ = 4096;
+
+static atomic_uint8_t amdgpu_runtime_shutdown{0};
+static atomic_uint8_t amdgpu_event_registered{0};
+
+bool AmdgpuMemFuncs::GetAmdgpuRuntimeShutdown() {
+  return static_cast<bool>(
+      atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire));
+}
 
 bool AmdgpuMemFuncs::Init() {
   hsa_amd.memory_pool_allocate =
@@ -47,15 +62,20 @@ bool AmdgpuMemFuncs::Init() {
           RTLD_NEXT, "hsa_amd_vmem_address_reserve_align");
   hsa_amd.vmem_address_free = (decltype(hsa_amd.vmem_address_free))dlsym(
       RTLD_NEXT, "hsa_amd_vmem_address_free");
+  hsa_amd.register_system_event_handler =
+      (decltype(hsa_amd.register_system_event_handler))dlsym(
+          RTLD_NEXT, "hsa_amd_register_system_event_handler");
   if (!hsa_amd.memory_pool_allocate || !hsa_amd.memory_pool_free ||
       !hsa_amd.pointer_info || !hsa_amd.vmem_address_reserve_align ||
-      !hsa_amd.vmem_address_free)
+      !hsa_amd.vmem_address_free || !hsa_amd.register_system_event_handler)
     return false;
   return true;
 }
 
 void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
                                DeviceAllocationInfo *da_info) {
+  if (atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire))
+    return nullptr;
   AmdgpuAllocationInfo *aa_info =
       reinterpret_cast<AmdgpuAllocationInfo *>(da_info);
   if (!aa_info->memory_pool.handle) {
@@ -73,6 +93,8 @@ void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
 }
 
 void AmdgpuMemFuncs::Deallocate(void *p) {
+  if (atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire))
+    return;
   DevicePointerInfo DevPtrInfo;
   if (AmdgpuMemFuncs::GetPointerInfo(reinterpret_cast<uptr>(p), &DevPtrInfo)) {
     if (DevPtrInfo.type == HSA_EXT_POINTER_TYPE_HSA) {
@@ -101,6 +123,30 @@ bool AmdgpuMemFuncs::GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info) {
   ptr_info->type = reinterpret_cast<hsa_amd_pointer_type_t>(info.type);
 
   return true;
+}
+
+void AmdgpuMemFuncs::RegisterSystemEventHandlers() {
+  // Register shutdown system event handler only once
+  if (atomic_load(&amdgpu_event_registered, memory_order_acquire) == 0) {
+    // Callback to just detect runtime shutdown
+    hsa_amd_system_event_callback_t callback = [](const hsa_amd_event_t* event,
+                                                  void* data) {
+      if (!event)
+        return HSA_STATUS_ERROR_INVALID_ARGUMENT;
+      if (event->event_type == HSA_AMD_SYSTEM_SHUTDOWN_EVENT) {
+        uint8_t shutdown = 0;
+        if (atomic_compare_exchange_strong(&amdgpu_runtime_shutdown, &shutdown,
+                                           1, memory_order_acq_rel)) {
+          // Evict all allocations (add purge logic here).
+        }
+      }
+      return HSA_STATUS_SUCCESS;
+    };
+    hsa_status_t status =
+        hsa_amd.register_system_event_handler(callback, nullptr);
+    if (status == HSA_STATUS_SUCCESS)
+      atomic_store(&amdgpu_event_registered, 1, memory_order_release);
+  }
 }
 
 uptr AmdgpuMemFuncs::GetPageSize() { return kPageSize_; }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 #if SANITIZER_AMDGPU
 #  include <dlfcn.h>  // For dlsym
-
 #  include "sanitizer_allocator.h"
 #  include "sanitizer_atomic.h"
 
@@ -19,21 +18,21 @@ namespace __sanitizer {
 struct HsaFunctions {
   // ---------------- Memory Functions ----------------
   hsa_status_t (*memory_pool_allocate)(hsa_amd_memory_pool_t memory_pool,
-                                       size_t size, uint32_t flags, void** ptr);
-  hsa_status_t (*memory_pool_free)(void* ptr);
-  hsa_status_t (*pointer_info)(void* ptr, hsa_amd_pointer_info_t* info,
-                               void* (*alloc)(size_t),
-                               uint32_t* num_agents_accessible,
-                               hsa_agent_t** accessible);
+                                       size_t size, uint32_t flags, void **ptr);
+  hsa_status_t (*memory_pool_free)(void *ptr);
+  hsa_status_t (*pointer_info)(void *ptr, hsa_amd_pointer_info_t *info,
+                               void *(*alloc)(size_t),
+                               uint32_t *num_agents_accessible,
+                               hsa_agent_t **accessible);
   hsa_status_t (*vmem_address_reserve_align)(void** ptr, size_t size,
                                              uint64_t address,
                                              uint64_t alignment,
                                              uint64_t flags);
-  hsa_status_t (*vmem_address_free)(void* ptr, size_t size);
+  hsa_status_t (*vmem_address_free)(void *ptr, size_t size);
 
   // ----------------Event Functions ----------------
   hsa_status_t (*register_system_event_handler)(
-      hsa_amd_system_event_callback_t callback, void* data);
+      hsa_amd_system_event_callback_t callback, void *data);
 };
 
 static HsaFunctions hsa_amd;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -43,9 +43,19 @@ static const size_t kPageSize_ = 4096;
 static atomic_uint8_t amdgpu_runtime_shutdown{0};
 static atomic_uint8_t amdgpu_event_registered{0};
 
-bool AmdgpuMemFuncs::GetAmdgpuRuntimeShutdown() {
+// Check if AMDGPU runtime shutdown state
+bool AmdgpuMemFuncs::IsAmdgpuRuntimeShutdown() {
   return static_cast<bool>(
       atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire));
+}
+
+// Notify AMDGPU runtime shutdown to allocator
+void AmdgpuMemFuncs::NotifyAmdgpuRuntimeShutdown() {
+  uint8_t shutdown = 0;
+  if (atomic_compare_exchange_strong(&amdgpu_runtime_shutdown, &shutdown, 1,
+                                     memory_order_acq_rel)) {
+    VReport(1, " Amdgpu Allocator: AMDGPU runtime shutdown detected\n");
+  }
 }
 
 bool AmdgpuMemFuncs::Init() {
@@ -73,7 +83,8 @@ bool AmdgpuMemFuncs::Init() {
 
 void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
                                DeviceAllocationInfo *da_info) {
-  if (atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire))
+  // Do not allocate if AMDGPU runtime is shutdown
+  if (IsAmdgpuRuntimeShutdown())
     return nullptr;
   AmdgpuAllocationInfo *aa_info =
       reinterpret_cast<AmdgpuAllocationInfo *>(da_info);
@@ -92,7 +103,8 @@ void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
 }
 
 void AmdgpuMemFuncs::Deallocate(void *p) {
-  if (atomic_load(&amdgpu_runtime_shutdown, memory_order_acquire))
+  // Deallocate does nothing after AMDGPU runtime shutdown
+  if (IsAmdgpuRuntimeShutdown())
     return;
   DevicePointerInfo DevPtrInfo;
   if (AmdgpuMemFuncs::GetPointerInfo(reinterpret_cast<uptr>(p), &DevPtrInfo)) {
@@ -123,26 +135,24 @@ bool AmdgpuMemFuncs::GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info) {
 
   return true;
 }
-
+ // Register shutdown system event handler only once
+ // TODO: Register multiple event handlers if needed in future
 void AmdgpuMemFuncs::RegisterSystemEventHandlers() {
-  // Register shutdown system event handler only once
+  // Check if already registered
   if (atomic_load(&amdgpu_event_registered, memory_order_acquire) == 0) {
     // Callback to just detect runtime shutdown
     hsa_amd_system_event_callback_t callback = [](const hsa_amd_event_t* event,
                                                   void* data) {
       if (!event)
         return HSA_STATUS_ERROR_INVALID_ARGUMENT;
-      if (event->event_type == HSA_AMD_SYSTEM_SHUTDOWN_EVENT) {
-        uint8_t shutdown = 0;
-        if (atomic_compare_exchange_strong(&amdgpu_runtime_shutdown, &shutdown,
-                                           1, memory_order_acq_rel)) {
-          // Evict all allocations (add purge logic here).
-        }
-      }
+      if (event->event_type == HSA_AMD_SYSTEM_SHUTDOWN_EVENT)
+        AmdgpuMemFuncs::NotifyAmdgpuRuntimeShutdown();
       return HSA_STATUS_SUCCESS;
     };
+    // Register the callback
     hsa_status_t status =
         hsa_amd.register_system_event_handler(callback, nullptr);
+    // Mark as registered if successful
     if (status == HSA_STATUS_SUCCESS)
       atomic_store(&amdgpu_event_registered, 1, memory_order_release);
   }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -16,7 +16,7 @@
 
 namespace __sanitizer {
 struct HsaFunctions {
-  // ---------------- Memory Functions ----------------
+  // -------------- Memory Allocate/Deallocate Functions ----------------
   hsa_status_t (*memory_pool_allocate)(hsa_amd_memory_pool_t memory_pool,
                                        size_t size, uint32_t flags, void **ptr);
   hsa_status_t (*memory_pool_free)(void *ptr);
@@ -30,7 +30,7 @@ struct HsaFunctions {
                                              uint64_t flags);
   hsa_status_t (*vmem_address_free)(void *ptr, size_t size);
 
-  // ----------------Event Functions ----------------
+  // ----------------- System Event Register Function -------------------
   hsa_status_t (*register_system_event_handler)(
       hsa_amd_system_event_callback_t callback, void *data);
 };

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.h
@@ -22,6 +22,8 @@ class AmdgpuMemFuncs {
   static void Deallocate(void *p);
   static bool GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info);
   static uptr GetPageSize();
+  static void RegisterSystemEventHandlers();
+  static bool GetAmdgpuRuntimeShutdown();
 };
 
 struct AmdgpuAllocationInfo : public DeviceAllocationInfo {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.h
@@ -23,7 +23,10 @@ class AmdgpuMemFuncs {
   static bool GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info);
   static uptr GetPageSize();
   static void RegisterSystemEventHandlers();
-  static bool GetAmdgpuRuntimeShutdown();
+  static bool IsAmdgpuRuntimeShutdown();
+
+ private:
+  static void NotifyAmdgpuRuntimeShutdown();
 };
 
 struct AmdgpuAllocationInfo : public DeviceAllocationInfo {

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
@@ -316,7 +316,7 @@ class DeviceAllocatorT {
       // If GetPointerInfo() fails, we don't assume the runtime is unloaded yet.
       // We just return a conservative single-page header. Here mark/check the
       // runtime shutdown state
-      dev_runtime_unloaded_ = DeviceMemFuncs::GetAmdgpuRuntimeShutdown();
+      dev_runtime_unloaded_ = DeviceMemFuncs::IsAmdgpuRuntimeShutdown();
     }
     // If we reach here, device runtime is unloaded.
     // Fallback: conservative single-page header

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
@@ -122,7 +122,7 @@ class DeviceAllocatorT {
       CHECK_EQ(chunks_[idx], p_);
       CHECK_LT(idx, n_chunks_);
       h = GetHeader(chunks_[idx], &header);
-      if (dev_runtime_unloaded_)
+      if (UNLIKELY(dev_runtime_unloaded_))
         return;
       chunks_[idx] = chunks_[--n_chunks_];
       chunks_sorted_ = false;
@@ -141,7 +141,7 @@ class DeviceAllocatorT {
     uptr res = 0;
     for (uptr i = 0; i < n_chunks_; i++) {
       Header *h = GetHeader(chunks_[i], &header);
-      if (dev_runtime_unloaded_)
+      if (UNLIKELY(dev_runtime_unloaded_))
         return 0;
       res += RoundUpMapSize(h->map_size);
     }
@@ -310,7 +310,7 @@ class DeviceAllocatorT {
     // Device allocator has dependency on device runtime. If device runtime
     // is unloaded, GetPointerInfo() will fail. For such case, we can still
     // return a valid value for map_beg, map_size will be limited to one page
-    if (!dev_runtime_unloaded_) {
+    if (LIKELY(!dev_runtime_unloaded_)) {
       if (DeviceMemFuncs::GetPointerInfo(chunk, h))
         return h;
       // If GetPointerInfo() fails, we don't assume the runtime is unloaded yet.

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
@@ -122,7 +122,8 @@ class DeviceAllocatorT {
       CHECK_EQ(chunks_[idx], p_);
       CHECK_LT(idx, n_chunks_);
       h = GetHeader(chunks_[idx], &header);
-      CHECK(!dev_runtime_unloaded_);
+      if (dev_runtime_unloaded_)
+        return;
       chunks_[idx] = chunks_[--n_chunks_];
       chunks_sorted_ = false;
       stats.n_frees++;
@@ -140,7 +141,8 @@ class DeviceAllocatorT {
     uptr res = 0;
     for (uptr i = 0; i < n_chunks_; i++) {
       Header *h = GetHeader(chunks_[i], &header);
-      CHECK(!dev_runtime_unloaded_);
+      if (dev_runtime_unloaded_)
+        return 0;
       res += RoundUpMapSize(h->map_size);
     }
     return res;
@@ -188,7 +190,6 @@ class DeviceAllocatorT {
       CHECK_LT(nearest_chunk, h->map_beg + h->map_size);
       CHECK_LE(nearest_chunk, p);
       if (h->map_beg + h->map_size <= p) {
-        CHECK(!dev_runtime_unloaded_);
         return nullptr;
       }
     }
@@ -306,14 +307,21 @@ class DeviceAllocatorT {
   }
 
   Header* GetHeader(uptr chunk, Header* h) const {
-    if (dev_runtime_unloaded_ || !DeviceMemFuncs::GetPointerInfo(chunk, h)) {
-      // Device allocator has dependency on device runtime. If device runtime
-      // is unloaded, GetPointerInfo() will fail. For such case, we can still
-      // return a valid value for map_beg, map_size will be limited to one page
-      h->map_beg = chunk;
-      h->map_size = page_size_;
-      dev_runtime_unloaded_ = true;
+    // Device allocator has dependency on device runtime. If device runtime
+    // is unloaded, GetPointerInfo() will fail. For such case, we can still
+    // return a valid value for map_beg, map_size will be limited to one page
+    if (!dev_runtime_unloaded_) {
+      if (DeviceMemFuncs::GetPointerInfo(chunk, h))
+        return h;
+      // If GetPointerInfo() fails, we don't assume the runtime is unloaded yet.
+      // We just return a conservative single-page header. Here mark/check the
+      // runtime shutdown state
+      dev_runtime_unloaded_ = DeviceMemFuncs::GetAmdgpuRuntimeShutdown();
     }
+    // If we reach here, device runtime is unloaded.
+    // Fallback: conservative single-page header
+    h->map_beg = chunk;
+    h->map_size = page_size_;
     return h;
   }
 

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
@@ -122,8 +122,6 @@ class DeviceAllocatorT {
       CHECK_EQ(chunks_[idx], p_);
       CHECK_LT(idx, n_chunks_);
       h = GetHeader(chunks_[idx], &header);
-      if (UNLIKELY(dev_runtime_unloaded_))
-        return;
       chunks_[idx] = chunks_[--n_chunks_];
       chunks_sorted_ = false;
       stats.n_frees++;
@@ -141,8 +139,6 @@ class DeviceAllocatorT {
     uptr res = 0;
     for (uptr i = 0; i < n_chunks_; i++) {
       Header *h = GetHeader(chunks_[i], &header);
-      if (UNLIKELY(dev_runtime_unloaded_))
-        return 0;
       res += RoundUpMapSize(h->map_size);
     }
     return res;


### PR DESCRIPTION
Summary:
  - Track runtime shutdown via AmdgpuMemFuncs::IsAmdgpuRuntimeShutdown()
    and gate further hsa_amd_pointer_info calls.
  - Add interception of 'hsa_init' api call.
  - Add registration of hsa-runtime associated system events via
    'hsa_amd_register_system_event_handler'.
    - HSA event registered is 'HSA_AMD_SYSTEM_SHUTDOWN_EVENT'


