### PR TITLE
[HeterogeneousDWARF] Stop emitting DW_AT_address_class on pointer types

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/DwarfUnit.cpp
@@ -899,12 +899,8 @@ void DwarfUnit::constructTypeDIE(DIE &Buffer, const DIDerivedType *DTy) {
   // If DWARF address space value is other than None, add it.  The IR
   // verifier checks that DWARF address space only exists for pointer
   // or reference types.
-  if (auto AS = DTy->getDWARFAddressSpace()) {
-    // TODO: Drop address_class once the debugger adopts address_space
-    for (auto ASTag :
-         {dwarf::DW_AT_address_class, dwarf::DW_AT_LLVM_address_space})
-      addUInt(Buffer, ASTag, dwarf::DW_FORM_data4, *AS);
-  }
+  if (auto AS = DTy->getDWARFAddressSpace())
+    addUInt(Buffer, dwarf::DW_AT_LLVM_address_space, dwarf::DW_FORM_data4, *AS);
 
   // Add template alias template parameters.
   if (Tag == dwarf::DW_TAG_template_alias)

--- a/llvm/test/DebugInfo/AMDGPU/heterogeneous-dwarf-diop-diexpression-address-spaces.ll
+++ b/llvm/test/DebugInfo/AMDGPU/heterogeneous-dwarf-diop-diexpression-address-spaces.ll
@@ -123,7 +123,6 @@ attributes #0 = { "frame-pointer"="all" }
 
 ; CHECK: [[PTR_AS_3]]: DW_TAG_pointer_type
 ; CHECK-NEXT: DW_AT_type
-; CHECK-NEXT: DW_AT_address_class (0x00000003)
 ; CHECK-NEXT: DW_AT_LLVM_address_space (0x00000003 "DW_ASPACE_LLVM_AMDGPU_local")
 
 ; CHECK: [[PTR_AS_NONE]]: DW_TAG_pointer_type
@@ -132,7 +131,6 @@ attributes #0 = { "frame-pointer"="all" }
 
 ; CHECK: [[PTR_AS_5]]: DW_TAG_pointer_type
 ; CHECK-NEXT: DW_AT_type
-; CHECK-NEXT: DW_AT_address_class (0x00000005)
 ; CHECK-NEXT: DW_AT_LLVM_address_space (0x00000005 "DW_ASPACE_LLVM_AMDGPU_private_lane")
 
 !llvm.dbg.cu = !{!0}

--- a/llvm/test/DebugInfo/AMDGPU/pointer-address-space.ll
+++ b/llvm/test/DebugInfo/AMDGPU/pointer-address-space.ll
@@ -50,13 +50,11 @@
 
 ; CHECK:      0x[[LOCAL]]: DW_TAG_pointer_type
 ; CHECK-NEXT:                DW_AT_type
-; CHECK-NEXT:                DW_AT_address_class [DW_FORM_data4] (0x00000002)
 ; CHECK-NEXT:                DW_AT_LLVM_address_space [DW_FORM_data4] (0x00000002 "DW_ASPACE_LLVM_AMDGPU_region")
 ; CHECK-NEXT:                DW_AT_LLVM_memory_space [DW_FORM_data4] (DW_MSPACE_LLVM_group)
 
 ; CHECK:      0x[[PRIVATE]]: DW_TAG_pointer_type
 ; CHECK-NEXT:                  DW_AT_type
-; CHECK-NEXT:                  DW_AT_address_class [DW_FORM_data4] (0x00000001)
 ; CHECK-NEXT:                  DW_AT_LLVM_address_space [DW_FORM_data4] (0x00000001 "DW_ASPACE_LLVM_AMDGPU_generic")
 ; CHECK-NEXT:                  DW_AT_LLVM_memory_space [DW_FORM_data4] (DW_MSPACE_LLVM_private)
 

--- a/llvm/test/DebugInfo/Generic/address_space_rvalue.ll
+++ b/llvm/test/DebugInfo/Generic/address_space_rvalue.ll
@@ -6,7 +6,8 @@
 
 ; CHECK: DW_TAG_rvalue_reference_type
 ; CHECK-NOT: DW_TAG
-; CHECK: DW_AT_address_class	(0x00000001)
+; CHECK-NOT: DW_AT_address_class
+; CHECK: DW_AT_LLVM_address_space (0x00000001)
 
 @y = global ptr null, align 8, !dbg !0
 


### PR DESCRIPTION
This attribute isn't fully supported GDB and it's usage was leading to some errors. Fixes SWDEV-565489


