### PR TITLE
[OpenMP] Fix small merge artifact in OpenMP device runtime

### DIFF
--- a/openmp/device/src/Allocator.cpp
+++ b/openmp/device/src/Allocator.cpp
@@ -98,7 +98,7 @@ void allocator::free(void *Ptr) {
 #elif defined(__AMDGPU__) && !defined(OMPTARGET_HAS_LIBC)
   __ockl_dm_dealloc(reinterpret_cast<uint64_t>(Ptr));
 #else
-  ::free(Size);
+  ::free(Ptr);
 #endif
 }
 


### PR DESCRIPTION
We're currently using a variable/parameter that no longer exists in the scope of the function, so we get a compilation error. Fix to align with the upstream PR and use Ptr.


