### PR TITLE
[AMDGPU] Do not reassign scale source operands in amdgpu-rewrite-agpr…

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPURewriteAGPRCopyMFMA.cpp
@@ -302,6 +302,10 @@ bool AMDGPURewriteAGPRCopyMFMAImpl::attemptReassignmentsToAGPR(
     const TargetRegisterClass *EquivalentAGPRRegClass =
         TRI.getEquivalentAGPRClass(MRI.getRegClass(InterferingReg));
 
+    // Do not reassign scale source operands
+    if (EquivalentAGPRRegClass == &AMDGPU::AGPR_32RegClass)
+      return false;
+
     MCPhysReg Assignable = AMDGPU::NoRegister;
     if (EquivalentAGPRRegClass->contains(PrefPhysReg) &&
         LRM.checkInterference(ReassignLI, PrefPhysReg) ==


### PR DESCRIPTION
[AMDGPU] Do not reassign scale source operands in amdgpu-rewrite-agpr-copy-mfma

Testing this seems difficult, as there has to be sufficient register pressure and live range overlapping to trigger the reassignment of the scale source operands.

Manually verified that this prevents a CK compilation failure from SWDEV-564511
v_mfma_scale_f32_16x16x128_f8f6f4 a[80:83], a[72:75], a[44:47], a[80:83], v41, a0/*Invalid register, operand has 'VGPR_32' register class*/ op_sel_hi:[0,0,0] cbsz:4 blgp:4


