### PR TITLE
[Comgr] Add missing clangOptions to Comgr link libraries

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -410,6 +410,7 @@ if(TARGET clangFrontendTool)
   set(CLANG_LIBS
     clangBasic
     clangDriver
+    clangOptions
     clangSerialization
     clangFrontend
     clangFrontendTool)


### PR DESCRIPTION
Fixes error when compiling with `-DBUILD_SHARED_LIBS=ON`:

```
  /usr/bin/ld:
  tools/comgr/CMakeFiles/amd_comgr.dir/src/comgr-compiler.cpp.o: in
  function
  `COMGR::AMDGPUCompiler::executeInProcessDriver(llvm::ArrayRef<char
  const*>)':
  amd/comgr/src/comgr-compiler.cpp:739:
  undefined reference to `clang::getDriverOptTable()'
  collect2: error: ld returned 1 exit status
  ninja: build stopped: subcommand failed.
```

Related to #167374
