### PR TITLE
[Flang] Add switch for disabling implicit linking of Flang GPU

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6143,6 +6143,8 @@ def : Flag<["-"], "nogpulib">,
 def : Flag<["-"], "nocudalib">, Alias<no_offloadlib>;
 def gpulibc : Flag<["-"], "gpulibc">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>,
   HelpText<"Link the LLVM C Library for GPUs">;
+def fgpu_flang_rt : Flag<["-"], "fgpu-flang-rt">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
+def fno_gpu_flang_rt : Flag<["-"], "fno-gpu-flang-rt">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 def nogpulibc : Flag<["-"], "nogpulibc">, Visibility<[ClangOption, CC1Option, FlangOption, FC1Option]>;
 def nodefaultlibs : Flag<["-"], "nodefaultlibs">,
   Visibility<[ClangOption, FlangOption]>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9450,7 +9450,9 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
             Args.MakeArgString("--device-linker=" + TC.getTripleString() + "=" +
                                "-lclang_rt.builtins"));
       bool HasFlangRT = HasCompilerRT && C.getDriver().IsFlangMode();
-      if (HasFlangRT)
+      bool UseFlangRT = Args.hasFlag(options::OPT_fgpu_flang_rt,
+                                     options::OPT_fno_gpu_flang_rt, true);
+      if (HasFlangRT && UseFlangRT)
         CmdArgs.push_back(
             Args.MakeArgString("--device-linker=" + TC.getTripleString() + "=" +
                                "-lflang_rt.runtime"));


### PR DESCRIPTION
User can disable implicit linking Flang GPU runtime by setting `-fno-gpu-flang-rt` flag.