### PR TITLE
[MC] Use a variant to hold MCCFIInstruction state (NFC) (#164720)

### DIFF
--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinterDwarf.cpp
@@ -262,32 +262,32 @@ void AsmPrinter::emitCFIInstruction(const MCCFIInstruction &Inst) const {
     break;
   case MCCFIInstruction::OpLLVMRegisterPair: {
     const auto &Fields =
-        Inst.getExtraFields<MCCFIInstruction::RegisterPairExtraFields>();
-    OutStreamer->emitCFILLVMRegisterPair(Inst.getRegister(), Fields.Reg1,
+        Inst.getExtraFields<MCCFIInstruction::RegisterPairFields>();
+    OutStreamer->emitCFILLVMRegisterPair(Fields.Register, Fields.Reg1,
                                          Fields.Reg1SizeInBits, Fields.Reg2,
                                          Fields.Reg2SizeInBits, Loc);
     break;
   }
   case MCCFIInstruction::OpLLVMVectorRegisters: {
     const auto &Fields =
-        Inst.getExtraFields<MCCFIInstruction::VectorRegistersExtraFields>();
-    OutStreamer->emitCFILLVMVectorRegisters(Inst.getRegister(),
+        Inst.getExtraFields<MCCFIInstruction::VectorRegistersFields>();
+    OutStreamer->emitCFILLVMVectorRegisters(Fields.Register,
                                             Fields.VectorRegisters, Loc);
     break;
   }
   case MCCFIInstruction::OpLLVMVectorOffset: {
     const auto &Fields =
-        Inst.getExtraFields<MCCFIInstruction::VectorOffsetExtraFields>();
+        Inst.getExtraFields<MCCFIInstruction::VectorOffsetFields>();
     OutStreamer->emitCFILLVMVectorOffset(
-        Inst.getRegister(), Fields.RegisterSizeInBits, Fields.MaskRegister,
-        Fields.MaskRegisterSizeInBits, Inst.getOffset(), Loc);
+        Fields.Register, Fields.RegisterSizeInBits, Fields.MaskRegister,
+        Fields.MaskRegisterSizeInBits, Fields.Offset, Loc);
     break;
   }
   case MCCFIInstruction::OpLLVMVectorRegisterMask: {
     const auto &Fields =
-        Inst.getExtraFields<MCCFIInstruction::VectorRegisterMaskExtraFields>();
+        Inst.getExtraFields<MCCFIInstruction::VectorRegisterMaskFields>();
     OutStreamer->emitCFILLVMVectorRegisterMask(
-        Inst.getRegister(), Fields.SpillRegister,
+        Fields.Register, Fields.SpillRegister,
         Fields.SpillRegisterLaneSizeInBits, Fields.MaskRegister,
         Fields.MaskRegisterSizeInBits);
     break;

--- a/llvm/lib/CodeGen/MachineOperand.cpp
+++ b/llvm/lib/CodeGen/MachineOperand.cpp
@@ -782,12 +782,12 @@ static void printCFI(raw_ostream &OS, const MCCFIInstruction &CFI,
     break;
   case MCCFIInstruction::OpLLVMRegisterPair: {
     const auto &Fields =
-        CFI.getExtraFields<MCCFIInstruction::RegisterPairExtraFields>();
+        CFI.getExtraFields<MCCFIInstruction::RegisterPairFields>();
 
     OS << "llvm_register_pair ";
     if (MCSymbol *Label = CFI.getLabel())
       MachineOperand::printSymbol(OS, *Label);
-    printCFIRegister(CFI.getRegister(), OS, TRI);
+    printCFIRegister(Fields.Register, OS, TRI);
     OS << ", ";
     printCFIRegister(Fields.Reg1, OS, TRI);
     OS << ", " << Fields.Reg1SizeInBits << ", ";
@@ -797,12 +797,12 @@ static void printCFI(raw_ostream &OS, const MCCFIInstruction &CFI,
   }
   case MCCFIInstruction::OpLLVMVectorRegisters: {
     const auto &Fields =
-        CFI.getExtraFields<MCCFIInstruction::VectorRegistersExtraFields>();
+        CFI.getExtraFields<MCCFIInstruction::VectorRegistersFields>();
 
     OS << "llvm_vector_registers ";
     if (MCSymbol *Label = CFI.getLabel())
       MachineOperand::printSymbol(OS, *Label);
-    printCFIRegister(CFI.getRegister(), OS, TRI);
+    printCFIRegister(Fields.Register, OS, TRI);
     for (auto [Reg, Lane, Size] : Fields.VectorRegisters) {
       OS << ", ";
       printCFIRegister(Reg, OS, TRI);
@@ -812,25 +812,25 @@ static void printCFI(raw_ostream &OS, const MCCFIInstruction &CFI,
   }
   case MCCFIInstruction::OpLLVMVectorOffset: {
     const auto &Fields =
-        CFI.getExtraFields<MCCFIInstruction::VectorOffsetExtraFields>();
+        CFI.getExtraFields<MCCFIInstruction::VectorOffsetFields>();
 
     OS << "llvm_vector_offset ";
     if (MCSymbol *Label = CFI.getLabel())
       MachineOperand::printSymbol(OS, *Label);
-    printCFIRegister(CFI.getRegister(), OS, TRI);
+    printCFIRegister(Fields.Register, OS, TRI);
     OS << ", " << Fields.RegisterSizeInBits << ", ";
     printCFIRegister(Fields.MaskRegister, OS, TRI);
-    OS << ", " << Fields.MaskRegisterSizeInBits << ", " << CFI.getOffset();
+    OS << ", " << Fields.MaskRegisterSizeInBits << ", " << Fields.Offset;
     break;
   }
   case MCCFIInstruction::OpLLVMVectorRegisterMask: {
     const auto &Fields =
-        CFI.getExtraFields<MCCFIInstruction::VectorRegisterMaskExtraFields>();
+        CFI.getExtraFields<MCCFIInstruction::VectorRegisterMaskFields>();
 
     OS << "llvm_vector_register_mask ";
     if (MCSymbol *Label = CFI.getLabel())
       MachineOperand::printSymbol(OS, *Label);
-    printCFIRegister(CFI.getRegister(), OS, TRI);
+    printCFIRegister(Fields.Register, OS, TRI);
     OS << ", ";
     printCFIRegister(Fields.SpillRegister, OS, TRI);
     OS << ", " << Fields.SpillRegisterLaneSizeInBits << ", ";


### PR DESCRIPTION
AMDGPU requires more complex CFI rules, normally these would be expressed with .cfi_escape, however this would make the CFI unreadable and makes it difficult to update registers in CFI instructions (also something AMDGPU requires).

Authored-by: Emma Pilkington <Emma.Pilkington@amd.com>

(cherry picked from commit fd94b410ef60ca0a0494c2164d7897b698315443)


