### PR TITLE
[WaveTransform] Fine-tune shouldCoalesce target hook

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIRegisterInfo.cpp
@@ -3968,26 +3968,14 @@ bool SIRegisterInfo::shouldCoalesce(MachineInstr *MI,
                                     unsigned DstSubReg,
                                     const TargetRegisterClass *NewRC,
                                     LiveIntervals &LIS) const {
-  auto MFI = MI->getMF()->getInfo<SIMachineFunctionInfo>();
-  if (!MFI->isWaveCFG()) {
-    // Do not coalesce any SGPR copy before WaveTransform.
-    // Note that we also need a separate pass to deal with phi-node for
-    // vector-i1 values stored in SGPRs.
-    if (isSGPRClass(SrcRC) || isSGPRClass(DstRC) || isSGPRClass(NewRC))
-      return false;
-    // Check all register operands of the CopyMI. If any vgpr is marked
-    // with WWM flag, we do not want to coalesce them before WaveTransform.
-    // This assumes that we have set the WWM flag properly before coalescer.
-    const MachineRegisterInfo &MRI = MI->getMF()->getRegInfo();
-    for (auto opnd : MI->operands()) {
-      if (!opnd.isReg())
-        continue;
-      auto Reg = opnd.getReg();
-      const TargetRegisterClass *RC = MRI.getRegClass(Reg);
-      if (isVectorSuperClass(RC) &&
-          MFI->checkFlag(Reg, AMDGPU::VirtRegFlag::WWM_REG))
-        return false;
-    }
+  const SIMachineFunctionInfo *MFI =
+      MI->getMF()->getInfo<SIMachineFunctionInfo>();
+  // Do not coalesce any SGPR copy before WaveTransform.
+  // Note that we also need a separate pass to deal with phi-node for
+  // vector-i1 values stored in SGPRs.
+  if (!MFI->isWaveCFG() &&
+      (isSGPRClass(SrcRC) || isSGPRClass(DstRC) || isSGPRClass(NewRC))) {
+    return false;
   }
 
   return TargetRegisterInfo::shouldCoalesce(MI, SrcRC, SubReg, DstRC, DstSubReg,


### PR DESCRIPTION
With upstream PR 168988 the AMDGPU-specific implementation of shouldCoalesce has been removed and the default implementation is now used during register coalescing.

In the wave-transform pipeline, the coalescer is invoked twice. First invocation is immediately after the two-address instruction pass and the next one after the wave-transform pass. This ensure that the scalar registers and the WWM values are not coalesced before the wave transform. It gives us an upper hand as the wave-transform pass may insert additional SGPR copies which can then be optimized by the second coalescer invocation.
To achieve this a register class based filtering mechanism is already available in the feature branch. However, at this stage, the WWM virtual registers are not introduced before SGPR spill lowering, so the filtering for them can be safely removed. We should reinstate this check when WWM values are introduced earlier in the pipeline.


