### PR TITLE
[OpenMP][MI-300][Runtime] Handling crash with `OMP_TARGET_OFFLOAD=DISABLED` and invoking `omp_get_default_device()`

### DIFF
--- a/openmp/runtime/src/kmp_ftn_entry.h
+++ b/openmp/runtime/src/kmp_ftn_entry.h
@@ -1213,14 +1213,6 @@ int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_TEAM_NUM)(void) {
 #endif
 }
 
-int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_DEFAULT_DEVICE)(void) {
-#if KMP_MIC || KMP_OS_DARWIN || defined(KMP_STUB)
-  return 0;
-#else
-  return __kmp_entry_thread()->th.th_current_task->td_icvs.default_device;
-#endif
-}
-
 void FTN_STDCALL KMP_EXPAND_NAME(FTN_SET_DEFAULT_DEVICE)(int KMP_DEREF arg) {
 #if KMP_MIC || KMP_OS_DARWIN || defined(KMP_STUB)
 // Nothing.
@@ -1265,6 +1257,17 @@ int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_INITIAL_DEVICE)(void)
 int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_INITIAL_DEVICE)(void) {
   // same as omp_get_num_devices()
   return KMP_EXPAND_NAME(FTN_GET_NUM_DEVICES)();
+}
+
+int FTN_STDCALL KMP_EXPAND_NAME(FTN_GET_DEFAULT_DEVICE)(void) {
+#if KMP_MIC || KMP_OS_DARWIN || defined(KMP_STUB)
+  return 0;
+#else
+  // When offloading is disabled, return the initial device (host)
+  if (__kmp_target_offload == tgt_disabled)
+    return KMP_EXPAND_NAME(FTN_GET_INITIAL_DEVICE)();
+  return __kmp_entry_thread()->th.th_current_task->td_icvs.default_device;
+#endif
 }
 
 #if defined(KMP_STUB)


### PR DESCRIPTION
Fix a crash in `omp_get_default_device()` when `OMP_TARGET_OFFLOAD=DISABLED` is set together with a non-zero `OMP_DEFAULT_DEVICE` value.

When users set both:

`OMP_TARGET_OFFLOAD=DISABLED` (to disable GPU offloading)
`OMP_DEFAULT_DEVICE=N` (where N > 0)
The application would crash with:

`omptarget fatal error 2: "invalid value" device number 'N' out of range, only 0 devices available`

Reason: This occurs because `omp_get_default_device()` returned the value from `OMP_DEFAULT_DEVICE` (or from `omp_set_default_device()`) even when offloading was disabled, causing program to execute the code associated with the non-existent devices.

The solution ensures that when offloading is disabled, all device-related functions return values consistent with host-only execution by returning the initial device value.

Testing: testing with the smoke test with PR [1787](https://github.com/ROCm/aomp/pull/1787)