### PR TITLE
[OpenMP][AMDGPU] Ensure slab allocation 2MB aligned

### DIFF
--- a/openmp/device/src/DeviceMemInit.cpp
+++ b/openmp/device/src/DeviceMemInit.cpp
@@ -8,9 +8,9 @@ __attribute__((amdgpu_kernel, amdgpu_flat_work_group_size(256, 256),
 __omp_dm_init_kernel(unsigned long heap_ptr, unsigned long slab_ptr) {
 
   unsigned int HEAP_BYTES = 1;
-  unsigned int NUM_SLABS = 256;
+  unsigned int NUM_SLABS = 4;
 
-  // Use 256 * 2MB = 512MB for GPU memory allocation.
+  // Use 4 * 2MB = 8MB for GPU memory allocation.
   __ockl_dm_init_v1(heap_ptr, slab_ptr, HEAP_BYTES, NUM_SLABS);
 }
 }


### PR DESCRIPTION
This PR made following changes:
- Add logic to ensure the slab is 2MB aligned. 
- Following Brian's suggestion, lower the allocated slab to 8MB (4 blocks).
- Improved the logic in `preAllocateDeviceMemoryPool()`. Make it return early after setting up the first coarse-grained memory that's the existing code is designed. 