### PR TITLE
[AMDGPU] Precommit test for issue in amdgpu-rewrite-agpr-copy-mfma,

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/rewrite-vgpr-mfma-scale-to-agpr.mir
+++ b/llvm/test/CodeGen/AMDGPU/rewrite-vgpr-mfma-scale-to-agpr.mir
@@ -1,0 +1,33 @@
+# RUN: not llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -run-pass=greedy,amdgpu-rewrite-agpr-copy-mfma -verify-machineinstrs -o - %s 2>&1 | FileCheck %s
+# CHECK: Illegal virtual register for instruction
+# CHECK: Expected a VGPR_32 register, but got a AGPR_32 register
+ 
+# Test for issue in amdgpu-rewrite-agpr-copy-mfma, which reassigns scale operand
+# in vgpr_32 register to agpr_32, not permitted by instruction format.
+---
+name:            test
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    liveins:
+ 
+    %0:vgpr_32 = IMPLICIT_DEF
+    %1:av_128_align2 = IMPLICIT_DEF
+    undef %2.sub0:vreg_128_align2 = IMPLICIT_DEF
+ 
+  bb.1:
+    liveins:
+ 
+    %3:vgpr_32 = IMPLICIT_DEF
+    %4:av_128_align2 = IMPLICIT_DEF
+    %5:vreg_128_align2 = V_MFMA_SCALE_F32_16X16X128_F8F6F4_f4_f4_vgprcd_e64 %4, %1, %2, 4, 4, %3, %0, 4, 0, implicit $mode, implicit $exec
+    %6:agpr_32 = IMPLICIT_DEF
+    %0:vgpr_32 = COPY %6
+    S_CBRANCH_SCC1 %bb.1, implicit undef $scc
+    S_BRANCH %bb.2
+ 
+  bb.2:
+    liveins:
+ 
+    S_ENDPGM 0
+...


### PR DESCRIPTION
which reassigns scale operand in vgpr_32 register to agpr_32, not permitted by instruction format. Reduced from ck.


