### PR TITLE
device-libs: Reorder cbrt edge case check

### DIFF
--- a/amd/device-libs/ocml/src/cbrtF.cl
+++ b/amd/device-libs/ocml/src/cbrtF.cl
@@ -31,7 +31,7 @@ MATH_MANGLE(cbrt)(float x)
     }
 
     // Is normal or subnormal.
-    z = ((x != 0.0f) & BUILTIN_ISFINITE_F32(x)) ? z : x;
+    z = x == 0.0f || BUILTIN_ISINF_F32(x) ? x : z;
     return BUILTIN_COPYSIGN_F32(z, x);
 }
 


### PR DESCRIPTION
The special case is preserving the sign of 0/inf; the is finite check was too broad. For the nan case, we can just take the nan propagated through the other operations.


