### PR TITLE
  [SWDEV-563823][Compiler-rt][ASan] Simplify API Logic 'asan_hsa_amd_…

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -341,6 +341,11 @@ hsa_status_t asan_hsa_amd_vmem_address_reserve_align(void** ptr, size_t size,
                                                      BufferedStackTrace* stack);
 hsa_status_t asan_hsa_amd_vmem_address_free(void* ptr, size_t size,
                                             BufferedStackTrace* stack);
+hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
+                                       hsa_amd_pointer_info_t* info,
+                                       void* (*alloc)(size_t),
+                                       uint32_t* num_agents_accessible,
+                                       hsa_agent_t** accessible);
 } // namespace __asan
 #endif
 

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -913,6 +913,15 @@ INTERCEPTOR(hsa_status_t, hsa_amd_vmem_address_free, void* ptr, size_t size) {
   return asan_hsa_amd_vmem_address_free(ptr, size, &stack);
 }
 
+INTERCEPTOR(hsa_status_t, hsa_amd_pointer_info, const void* ptr,
+            hsa_amd_pointer_info_t* info, void* (*alloc)(size_t),
+            uint32_t* num_agents_accessible, hsa_agent_t** accessible) {
+  AsanInitFromRtl();
+  ENSURE_HSA_INITED();
+  return asan_hsa_amd_pointer_info(ptr, info, alloc, num_agents_accessible,
+                                   accessible);
+}
+
 void InitializeAmdgpuInterceptors() {
   ASAN_INTERCEPT_FUNC(hsa_memory_copy);
   ASAN_INTERCEPT_FUNC(hsa_amd_memory_pool_allocate);
@@ -927,6 +936,7 @@ void InitializeAmdgpuInterceptors() {
   ASAN_INTERCEPT_FUNC(hsa_amd_ipc_memory_detach);
   ASAN_INTERCEPT_FUNC(hsa_amd_vmem_address_reserve_align);
   ASAN_INTERCEPT_FUNC(hsa_amd_vmem_address_free);
+  ASAN_INTERCEPT_FUNC(hsa_amd_pointer_info);
 }
 
 void ENSURE_HSA_INITED() {


### PR DESCRIPTION
…ipc_memory_create'. (#475)

- Use reinterpret_cast<uptr> for pointer arithmetic.
 - Add sanitizer interception logic for api 'hsa_amd_pointer_info'.
 - Allow only valid values of ptr and len in non-ASan mode.
    - ptr == Actual agentBaseAddress && len == original_len_used_in_alloc
 - Allow only valid values of ptr and len in ASan mode.
    - Here pinfo is retrieved from external hsa_amd_pointer_info(not internal device allocator function AmdgpuMemFuncs::GetPointerInfo) - ptr == pinfo.agentBaseAddress && len == pinfo.sizeInBytes
    - ptr == original_ptr_returned_by_ASAN && len == original_len_used_in_alloc


