### PR TITLE
device-libs: Remove DAZ_OPT check in atan2/atan2pi

### DIFF
--- a/amd/device-libs/ocml/src/atan2F.cl
+++ b/amd/device-libs/ocml/src/atan2F.cl
@@ -22,13 +22,7 @@ MATH_MANGLE(atan2)(float y, float x)
     float v = BUILTIN_MIN_F32(ax, ay);
     float u = BUILTIN_MAX_F32(ax, ay);
 
-    float vbyu;
-    if (DAZ_OPT()) {
-        float s = u > 0x1.0p+96f ? 0x1.0p-32f : 1.0f;
-        vbyu = s * MATH_FAST_DIV(v, s*u);
-    } else {
-        vbyu = MATH_DIV(v, u);
-    }
+    float vbyu = MATH_DIV(v, u);
 
     float a = MATH_PRIVATE(atanred)(vbyu);
 

--- a/amd/device-libs/ocml/src/atan2piF.cl
+++ b/amd/device-libs/ocml/src/atan2piF.cl
@@ -19,13 +19,7 @@ MATH_MANGLE(atan2pi)(float y, float x)
     float v = BUILTIN_MIN_F32(ax, ay);
     float u = BUILTIN_MAX_F32(ax, ay);
 
-    float vbyu;
-    if (DAZ_OPT()) {
-        float s = u > 0x1.0p+96f ? 0x1.0p-32f : 1.0f;
-        vbyu = s * MATH_FAST_DIV(v, s*u);
-    } else {
-        vbyu = MATH_DIV(v, u);
-    }
+    float vbyu = MATH_DIV(v, u);
 
     float a = MATH_PRIVATE(atanpired)(vbyu);
 


### PR DESCRIPTION
The compiler knows how to select the right division path depending on the 
denormal mode (and based on the implied 2.5 ulp limit by the OpenCL defaults).

This results in almost identical code. Currently the new result has a code 
size regression due to an unnecessary use of a droppable fabs modifier 
(which https://github.com/llvm/llvm-project/pull/172553 avoids).


