### PR TITLE
[Offload] Fix incorrect size used in llvm-offload-device-info tool

### DIFF
--- a/offload/tools/deviceinfo/llvm-offload-device-info.cpp
+++ b/offload/tools/deviceinfo/llvm-offload-device-info.cpp
@@ -137,7 +137,7 @@ ol_result_t printDeviceValue(std::ostream &S, ol_device_handle_t Dev,
     size_t Size;
     OFFLOAD_ERR(olGetDeviceInfoSize(Dev, Info, &Size));
     Val.resize(Size);
-    OFFLOAD_ERR(olGetDeviceInfo(Dev, Info, sizeof(Val), Val.data()));
+    OFFLOAD_ERR(olGetDeviceInfo(Dev, Info, Size, Val.data()));
     doWrite<T, PK>(S, reinterpret_cast<T>(Val.data()));
   } else {
     T Val;


### PR DESCRIPTION
Summary:
This was not using the size previously queried and would fail when the implementation actually verified it.

--------------

This is a cherry-pick of https://github.com/llvm/llvm-project/commit/786358a3d70561f2b2cf7d7ec239c1058818236b

