### PR TITLE
device-libs: Use f32 denormal check in rtn f64->f32 conversions

### DIFF
--- a/amd/device-libs/ocml/src/convert.cl
+++ b/amd/device-libs/ocml/src/convert.cl
@@ -197,12 +197,11 @@ OCML_MANGLE_F64(cvtrtn_f32)(double a)
     v = e == 1151 ? i : v;
     return as_float(s | v);
 #else
-    float r = (float)a;
-    float p = OCML_MANGLE_F32(pred)(r);
-    r = (double)r > a ? p : r;
+    float fa = (float)a;
+    float p = OCML_MANGLE_F32(pred)(fa);
+    float r = (double)fa > a ? p : fa;
     if (DAZ_OPT()) {
-        float z = BUILTIN_COPYSIGN_F32(0.0f, r);
-        r = a >= -0x1.fffffcp-127 && a < 0x1.0p-126 ? z : r;
+        r = fa == 0.0f ? fa : r;
     }
     return r;
 #endif
@@ -229,12 +228,11 @@ OCML_MANGLE_F64(cvtrtp_f32)(double a)
     v = e == 1151 ? i : v;
     return as_float(s | v);
 #else
-    float r = (float)a;
-    float s = OCML_MANGLE_F32(succ)(r);
-    r = (double)r < a ? s : r;
+    float fa = (float)a;
+    float s = OCML_MANGLE_F32(succ)(fa);
+    float r = (double)fa < a ? s : fa;
     if (DAZ_OPT()) {
-        float z = BUILTIN_COPYSIGN_F32(0.0f, r);
-        r = a <= 0x1.fffffcp-127 && a > -0x1.0p-126 ? z : r;
+        r = fa == 0.0f ? fa : r;
     }
     return r;
 #endif


### PR DESCRIPTION
Instead of doing a range check for whether the converted value will be in the denormal range, with the off by one for the direction, just check if the converted value is equal to 0.

This does have a small behavior change. Neither version canonicalizes the results on the pred path, so this changes which denormal results are flushed to 0 or left uncanonicalized.

This saves 5 instructions, mostly from materializing the 64-bit constants.