### PR TITLE
device-libs: Replace f32 pred implementation

### DIFF
--- a/amd/device-libs/ocml/src/predF.cl
+++ b/amd/device-libs/ocml/src/predF.cl
@@ -10,12 +10,8 @@
 CONSTATTR float
 MATH_MANGLE(pred)(float x)
 {
-    int ix = AS_INT(x);
-    int mx = SIGNBIT_SP32 - ix;
-    mx = ix < 0 ? mx : ix;
-    int t = mx - (x != NINF_F32 && !BUILTIN_ISNAN_F32(x));
-    int r = SIGNBIT_SP32 - t;
-    r = t < 0 ? r : t;
-    return AS_FLOAT(r);
+    int ix = AS_INT(x) + (x > 0.0f ? -1 : 1);
+    float y = x == 0.0f ? -0x1p-149f : AS_FLOAT(ix);
+    return BUILTIN_ISNAN_F32(x) || x == NINF_F32 ? x : y;
 }
 


### PR DESCRIPTION
This version is more straightforward and relies less on bithacking. It generates an equivalent instruction count and code size. It does increase the vgpr use from 2 to 3. With -ffinite-only, this saves an instruction.

This also fixes a bug with the value 0x1p-149f. The old implementation returned -0, instead of +0 as other nextdown implementations do.