### PR TITLE
device-libs: Reorder f16 and f64 cbrt edge case check

### DIFF
--- a/amd/device-libs/ocml/src/cbrtD.cl
+++ b/amd/device-libs/ocml/src/cbrtD.cl
@@ -17,7 +17,7 @@ MATH_MANGLE(cbrt)(double x)
 
     if (!FINITE_ONLY_OPT()) {
         // Is normal or subnormal.
-        c = ((x != 0.0) & BUILTIN_ISFINITE_F64(x)) ? c : x;
+        c = x == 0.0 || BUILTIN_ISINF_F64(x) ? x : c;
     }
 
     return BUILTIN_COPYSIGN_F64(c, x);

--- a/amd/device-libs/ocml/src/cbrtH.cl
+++ b/amd/device-libs/ocml/src/cbrtH.cl
@@ -16,6 +16,6 @@ MATH_MANGLE(cbrt)(half x)
     ret = BUILTIN_COPYSIGN_F16(ret, x);
 
     // Is normal or subnormal.
-    return ((x != 0.0h) & BUILTIN_ISFINITE_F16(x)) ? ret : x;
+    return x == 0.0h || BUILTIN_ISINF_F16(x) ? x : ret;
 }
 


### PR DESCRIPTION
Change these to match the change made for f32 in
236d0c5c3c98560f3b3a43dd901fb6eb1b08eedd


