### PR TITLE
fix Linux ROCK CI trigger

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -81,16 +81,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: "compiler/amd-mainline"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
           fetch-depth: 10
-
-      - name: SHA of TheRock
-        run: |
-             git config --global --add safe.directory /__w/llvm-project/llvm-project
-             git log -1
-             cd compiler/amd-llvm
-             git log -3
-             cd -
 
       - name: Install python deps
         run: |
@@ -129,14 +121,37 @@ jobs:
         with:
           path: compiler/amd-llvm
 
+      - name: "Checking out repository for spriv-llvm-translator"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/spirv-llvm-translator"
+          path: compiler/spirv-llvm-translator
+          ref: ${{ secrets.SPIRV_LLVM_TRANSLATOR_MAINLINE_REF }}
+
+      - name: "Checking out repository for hipify"
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: "ROCm/hipify"
+          path: compiler/hipify
+          ref: ${{ secrets.HIPIFY_MAINLINE_REF }}
+
       - name: Apply patches
         run: |
              cp -v patches/amd-mainline/llvm-project/*.patch compiler/amd-llvm
              cd compiler/amd-llvm
-             git config --global --add safe.directory /__w/llvm-project/llvm-project
+             git log -10
+             git config --global --add safe.directory $PWD
              find . -type f -name '*.patch' -exec git apply --check {} \;
              find . -type f -name '*.patch' -exec git apply {} \;
              git log -15
+             cd -
+
+      - name: TheRock and llvm SHA
+        run: |
+             git config --global --add safe.directory $PWD
+             git log -1
+             cd compiler/amd-llvm/llvm
+             git log -3
              cd -
 
       - name: Configure Projects

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: "compiler/amd-mainline"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.12'

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: "compiler/amd-mainline"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
           fetch-depth: 10
 
       - name: SHA of TheRock

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: "compiler/amd-mainline"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.12'

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: "compiler/amd-mainline"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
           fetch-depth: 10
       - name: SHA of TheRock
         run: |
@@ -68,7 +68,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
-          echo "PR_LABELS=$(gh pr view ${PR_NUMBER} --json labels)" >> $GITHUB_ENV
+          echo "PR_LABELS=$(gh pr view ${PR_NUMBER} --repo ROCm/llvm-project --json labels)" >> $GITHUB_ENV
 
       - name: Configuring CI options
         id: configure

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           repository: "ROCm/TheRock"
           sparse-checkout: build_tools
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
           path: "prejob"
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
@@ -74,6 +75,8 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
+
 
       - name: Setting up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -53,6 +53,8 @@ jobs:
       - name: "Fetch 'build_tools' from repository"
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          repository: "ROCm/TheRock"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -65,6 +67,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
+          ref: ${{ secrets.THEROCK_MAINLINE_REF }}
 
       - name: Pre-job cleanup Docker containers on Linux
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
   - added secret variables to configure sha's for spirv and hipify
   - added secret variable to configure theROCK sha
   - added fix for setting up PR_LABEL used in the CI framework
   - Removed hardcoded  path /__w/llvm-project/llvm-project


