### PR TITLE
[AMDGPU] Enable saving SHARED_BASE to VCC.

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -899,7 +899,7 @@ void SIInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
     }
 
     if (DestReg == AMDGPU::VCC) {
-      if (AMDGPU::SReg_64RegClass.contains(SrcReg)) {
+      if (AMDGPU::SReg_64_EncodableRegClass.contains(SrcReg)) {
         BuildMI(MBB, MI, DL, get(AMDGPU::S_MOV_B64), AMDGPU::VCC)
           .addReg(SrcReg, getKillRegState(KillSrc));
       } else {

--- a/llvm/test/CodeGen/AMDGPU/sgpr-phys-copy.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-phys-copy.mir
@@ -59,6 +59,15 @@ body:             |
 ...
 
 ---
+name: src_shared_base_to_vcc
+body:             |
+  bb.0:
+    ; GFX9-LABEL: name: src_shared_base_to_vcc
+    ; GFX9: $vcc = S_MOV_B64 $src_shared_base
+    $vcc = COPY $src_shared_base
+...
+
+---
 name: sgpr96_aligned_src_dst
 body:             |
   bb.0:


### PR DESCRIPTION
This patch resolves the following issue : "Illegal instruction detected: incorrect register class when using atomic operations on shared memory (gfx90a)" as described in the below mentioned ticket.

Fixes [SWDEV-574133](https://ontrack-internal.amd.com/browse/SWDEV-574133).