### PR TITLE
device-libs: Replace f16 and f64 pred implementations

### DIFF
--- a/amd/device-libs/ocml/src/predD.cl
+++ b/amd/device-libs/ocml/src/predD.cl
@@ -10,12 +10,8 @@
 CONSTATTR double
 MATH_MANGLE(pred)(double x)
 {
-    long ix = AS_LONG(x);
-    long mx = SIGNBIT_DP64 - ix;
-    mx = ix < 0 ? mx : ix;
-    long t = mx - (x != NINF_F64 && !BUILTIN_ISNAN_F64(x));
-    long r = SIGNBIT_DP64 - t;
-    r = t < 0 ? r : t;
-    return AS_DOUBLE(r);
+    long ix = AS_LONG(x) + (x > 0.0 ? -1L : 1L);
+    double y = x == 0.0 ? -0x1p-1074 : AS_DOUBLE(ix);
+    return BUILTIN_ISNAN_F64(x) || x == NINF_F64 ? x : y;
 }
 

--- a/amd/device-libs/ocml/src/predH.cl
+++ b/amd/device-libs/ocml/src/predH.cl
@@ -10,12 +10,8 @@
 CONSTATTR half
 MATH_MANGLE(pred)(half x)
 {
-    short ix = AS_SHORT(x);
-    short mx = (short)SIGNBIT_HP16 - ix;
-    mx = ix < (short)0 ? mx : ix;
-    short t = mx - (short)(x != NINF_F16 && !BUILTIN_ISNAN_F16(x));
-    short r = (short)SIGNBIT_HP16 - t;
-    r = t < (short)0 ? r : t;
-    return AS_HALF(r);
+    short ix = AS_SHORT(x) + (x > 0.0h ? (short)-1 : (short)1);
+    half y = x == 0.0h ? -0x1p-24h : AS_HALF(ix);
+    return BUILTIN_ISNAN_F16(x) || x == NINF_F16 ? x : y;
 }
 


### PR DESCRIPTION
Same as for the float case. Saves 8 bytes for each function.


