### PR TITLE
[OpenMP][omptest] Fix target dependency on runtimes GTest

### DIFF
--- a/openmp/tools/omptest/CMakeLists.txt
+++ b/openmp/tools/omptest/CMakeLists.txt
@@ -82,10 +82,16 @@ if ((NOT LIBOMPTEST_BUILD_STANDALONE) OR LIBOMPTEST_BUILD_UNITTESTS)
     $<TARGET_OBJECTS:default_gtest>
   )
 
-  # Link against the default GTest which at this point primarily pulls in the
-  # include directories and compile definitions. It is important to make these
-  # available to dependant targets, e.g. for unit tests.
-  target_link_libraries(omptest PUBLIC default_gtest)
+  # Add default_gtest's include directories and compile definitions to omptest.
+  # Especially make these available to dependant targets, e.g. for unit tests.
+  # Only use these properties for the build interface, to avoid the target
+  # dependency on default_gtest during installation.
+  target_include_directories(omptest PUBLIC
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:default_gtest,INCLUDE_DIRECTORIES>>
+  )
+  target_compile_definitions(omptest PUBLIC
+    $<BUILD_INTERFACE:$<TARGET_PROPERTY:default_gtest,COMPILE_DEFINITIONS>>
+  )
 
   # Link against Threads (recommended for GTest).
   find_package(Threads REQUIRED)


### PR DESCRIPTION
Fix the implicit dependency from target_link_libraries
 - Only needed during configuration -> BUILD_INTERFACE
 - Only add include directories and compile definitions

Note: Embedding runtimes_gtest / default_gtest may remain unchanged

Known issue:
 - Header file installation is *still broken*


