### PR TITLE
InstCombine: Use SimplifyDemandedFPClass on fmul

### DIFF
--- a/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
+++ b/llvm/lib/Transforms/InstCombine/InstCombineInternal.h
@@ -623,6 +623,8 @@ public:
                                FPClassTest DemandedMask, KnownFPClass &Known,
                                unsigned Depth = 0);
 
+  bool SimplifyDemandedInstructionFPClass(Instruction &Inst);
+
   /// Common transforms for add / disjoint or
   Instruction *foldAddLikeCommutative(Value *LHS, Value *RHS, bool NSW,
                                       bool NUW);

--- a/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineMulDivRem.cpp
@@ -989,19 +989,8 @@ Instruction *InstCombinerImpl::visitFMul(BinaryOperator &I) {
   if (match(Op1, m_SpecificFP(-1.0)))
     return UnaryOperator::CreateFNegFMF(Op0, &I);
 
-  // With no-nans/no-infs:
-  // X * 0.0 --> copysign(0.0, X)
-  // X * -0.0 --> copysign(0.0, -X)
-  const APFloat *FPC;
-  if (match(Op1, m_APFloatAllowPoison(FPC)) && FPC->isZero() &&
-      ((I.hasNoInfs() && isKnownNeverNaN(Op0, SQ.getWithInstruction(&I))) ||
-       isKnownNeverNaN(&I, SQ.getWithInstruction(&I)))) {
-    if (FPC->isNegative())
-      Op0 = Builder.CreateFNegFMF(Op0, &I);
-    CallInst *CopySign = Builder.CreateIntrinsic(Intrinsic::copysign,
-                                                 {I.getType()}, {Op1, Op0}, &I);
-    return replaceInstUsesWith(I, CopySign);
-  }
+  if (SimplifyDemandedInstructionFPClass(I))
+    return &I;
 
   // -X * C --> X * -C
   Value *X, *Y;

--- a/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
+++ b/llvm/lib/Transforms/InstCombine/InstCombineSimplifyDemanded.cpp
@@ -148,6 +148,19 @@ bool InstCombinerImpl::SimplifyDemandedInstructionBits(Instruction &Inst) {
   return SimplifyDemandedInstructionBits(Inst, Known);
 }
 
+bool InstCombinerImpl::SimplifyDemandedInstructionFPClass(Instruction &Inst) {
+  KnownFPClass Known;
+
+  Value *V =
+      SimplifyDemandedUseFPClass(&Inst, fcAllFlags, Known, /*CtxI=*/&Inst);
+  if (!V)
+    return false;
+  if (V == &Inst)
+    return true;
+  replaceInstUsesWith(Inst, V);
+  return true;
+}
+
 /// This form of SimplifyDemandedBits simplifies the specified instruction
 /// operand if possible, updating it in place. It returns true if it made any
 /// change and false otherwise.
@@ -2189,7 +2202,6 @@ Value *InstCombinerImpl::SimplifyDemandedUseFPClass(Instruction *I,
                                                     unsigned Depth) {
   assert(Depth <= MaxAnalysisRecursionDepth && "Limit Search Depth");
   assert(Known == KnownFPClass() && "expected uninitialized state");
-  assert(I->hasOneUse() && "wrong version called");
 
   Type *VTy = I->getType();
 

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pown.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-simplify-libcall-pown.ll
@@ -1063,8 +1063,7 @@ define float @test_pown_afn_ninf_nnan_f32__x_known_positive(float nofpclass(ninf
 ; CHECK-LABEL: define float @test_pown_afn_ninf_nnan_f32__x_known_positive
 ; CHECK-SAME: (float nofpclass(ninf nsub nnorm) [[X:%.*]], i32 [[Y:%.*]]) {
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[__FABS:%.*]] = call nnan ninf afn float @llvm.fabs.f32(float [[X]])
-; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[__FABS]])
+; CHECK-NEXT:    [[__LOG2:%.*]] = call nnan ninf afn float @llvm.log2.f32(float [[X]])
 ; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to float
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul nnan ninf afn float [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call nnan ninf afn float @llvm.exp2.f32(float [[__YLOGX]])
@@ -1142,8 +1141,7 @@ define float @test_fast_pown_f32_known_positive_y_known_even(float nofpclass(nin
 ; CHECK-SAME: (float nofpclass(ninf nsub nnorm) [[X:%.*]], i32 [[Y_ARG:%.*]]) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[Y:%.*]] = shl i32 [[Y_ARG]], 1
-; CHECK-NEXT:    [[__FABS:%.*]] = call fast float @llvm.fabs.f32(float [[X]])
-; CHECK-NEXT:    [[__LOG2:%.*]] = call fast float @llvm.log2.f32(float [[__FABS]])
+; CHECK-NEXT:    [[__LOG2:%.*]] = call fast float @llvm.log2.f32(float [[X]])
 ; CHECK-NEXT:    [[POWNI2F:%.*]] = sitofp i32 [[Y]] to float
 ; CHECK-NEXT:    [[__YLOGX:%.*]] = fmul fast float [[__LOG2]], [[POWNI2F]]
 ; CHECK-NEXT:    [[__EXP2:%.*]] = call fast float @llvm.exp2.f32(float [[__YLOGX]])

--- a/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
+++ b/llvm/test/Transforms/InstCombine/AMDGPU/fmul_legacy.ll
@@ -44,7 +44,7 @@ define float @test_finite(i32 %x, i32 %y) {
 ; CHECK-LABEL: @test_finite(
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i32 [[X:%.*]] to float
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i32 [[Y:%.*]] to float
-; CHECK-NEXT:    [[CALL:%.*]] = fmul float [[XF]], [[YF]]
+; CHECK-NEXT:    [[CALL:%.*]] = fmul nnan float [[XF]], [[YF]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %xf = sitofp i32 %x to float
@@ -62,7 +62,7 @@ define float @test_finite_assumed(float %x, float %y) {
 ; CHECK-NEXT:    [[IS_FINITE_Y:%.*]] = fcmp one float [[FABS_Y]], 0x7FF0000000000000
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_X]])
 ; CHECK-NEXT:    call void @llvm.assume(i1 [[IS_FINITE_Y]])
-; CHECK-NEXT:    [[CALL:%.*]] = fmul float [[X]], [[Y]]
+; CHECK-NEXT:    [[CALL:%.*]] = fmul nnan float [[X]], [[Y]]
 ; CHECK-NEXT:    ret float [[CALL]]
 ;
   %fabs.x = call float @llvm.fabs.f32(float %x)

--- a/llvm/test/Transforms/InstCombine/binop-itofp.ll
+++ b/llvm/test/Transforms/InstCombine/binop-itofp.ll
@@ -284,7 +284,7 @@ define half @test_ui_ui_i8_mul_C_fail_overlow(i8 noundef %x_in) {
 ; CHECK-LABEL: @test_ui_ui_i8_mul_C_fail_overlow(
 ; CHECK-NEXT:    [[X:%.*]] = and i8 [[X_IN:%.*]], 14
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i8 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], 0xH4CC0
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 0xH4CC0
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = and i8 %x_in, 14
@@ -317,7 +317,7 @@ define half @test_si_si_i8_mul_fail_maybe_zero(i8 noundef %x_in, i8 noundef %y_i
 ; CHECK-NEXT:    [[Y:%.*]] = or i8 [[Y_IN:%.*]], -8
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i8 [[X]] to half
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i8 [[Y]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], [[YF]]
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = and i8 %x_in, 7
@@ -333,7 +333,7 @@ define half @test_si_si_i8_mul_C_fail_no_repr(i8 noundef %x_in) {
 ; CHECK-NEXT:    [[XX:%.*]] = and i8 [[X_IN:%.*]], 6
 ; CHECK-NEXT:    [[X:%.*]] = or disjoint i8 [[XX]], 1
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i8 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], 0xHC780
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 0xHC780
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %xx = and i8 %x_in, 6
@@ -348,7 +348,7 @@ define half @test_si_si_i8_mul_C_fail_overflow(i8 noundef %x_in) {
 ; CHECK-NEXT:    [[XX:%.*]] = and i8 [[X_IN:%.*]], 6
 ; CHECK-NEXT:    [[X:%.*]] = or disjoint i8 [[XX]], 1
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i8 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], 0xHCCC0
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 0xHCCC0
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %xx = and i8 %x_in, 6
@@ -403,7 +403,7 @@ define half @test_ui_si_i8_mul_fail_signed(i8 noundef %x_in, i8 noundef %y_in) {
 ; CHECK-NEXT:    [[Y:%.*]] = or i8 [[Y_IN:%.*]], -4
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i8 [[X]] to half
 ; CHECK-NEXT:    [[YF:%.*]] = uitofp i8 [[Y]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], [[YF]]
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %xx = and i8 %x_in, 7
@@ -661,7 +661,7 @@ define half @test_si_si_i16_mul_C_fail_overflow(i16 noundef %x_in) {
 ; CHECK-LABEL: @test_si_si_i16_mul_C_fail_overflow(
 ; CHECK-NEXT:    [[X:%.*]] = or i16 [[X_IN:%.*]], -129
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i16 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], 0xH5800
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 0xH5800
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = or i16 %x_in, -129
@@ -674,7 +674,7 @@ define half @test_si_si_i16_mul_C_fail_no_promotion(i16 noundef %x_in) {
 ; CHECK-LABEL: @test_si_si_i16_mul_C_fail_no_promotion(
 ; CHECK-NEXT:    [[X:%.*]] = or i16 [[X_IN:%.*]], -4097
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i16 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], 0xH4500
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 0xH4500
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = or i16 %x_in, -4097
@@ -917,7 +917,7 @@ define half @test_si_si_i12_mul_fail_overflow(i12 noundef %x_in, i12 noundef %y_
 ; CHECK-NEXT:    [[Y:%.*]] = or i12 [[Y_IN:%.*]], -128
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i12 [[X]] to half
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i12 [[Y]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], [[YF]]
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %xx = and i12 %x_in, 30
@@ -935,7 +935,7 @@ define half @test_si_si_i12_mul_fail_maybe_non_zero(i12 noundef %x_in, i12 nound
 ; CHECK-NEXT:    [[Y:%.*]] = or i12 [[Y_IN:%.*]], -128
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg i12 [[X]] to half
 ; CHECK-NEXT:    [[YF:%.*]] = sitofp i12 [[Y]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], [[YF]]
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = and i12 %x_in, 30
@@ -963,7 +963,7 @@ define half @test_si_si_i12_mul_C_fail_overflow(i12 noundef %x_in) {
 ; CHECK-LABEL: @test_si_si_i12_mul_C_fail_overflow(
 ; CHECK-NEXT:    [[X:%.*]] = or i12 [[X_IN:%.*]], -64
 ; CHECK-NEXT:    [[XF:%.*]] = sitofp i12 [[X]] to half
-; CHECK-NEXT:    [[R:%.*]] = fmul half [[XF]], 0xHD400
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan half [[XF]], 0xHD400
 ; CHECK-NEXT:    ret half [[R]]
 ;
   %x = or i12 %x_in, -64
@@ -1071,7 +1071,7 @@ define <2 x half> @test_ui_ui_i8_mul_vec(<2 x i8> noundef %x_in, <2 x i8> nounde
 ; CHECK-NEXT:    [[Y:%.*]] = and <2 x i8> [[Y_IN:%.*]], splat (i8 15)
 ; CHECK-NEXT:    [[XF:%.*]] = uitofp nneg <2 x i8> [[X]] to <2 x half>
 ; CHECK-NEXT:    [[YF:%.*]] = uitofp nneg <2 x i8> [[Y]] to <2 x half>
-; CHECK-NEXT:    [[R:%.*]] = fmul <2 x half> [[XF]], [[YF]]
+; CHECK-NEXT:    [[R:%.*]] = fmul nnan <2 x half> [[XF]], [[YF]]
 ; CHECK-NEXT:    ret <2 x half> [[R]]
 ;
   %x = and <2 x i8> %x_in, splat (i8 15)
@@ -1110,7 +1110,7 @@ define <2 x float> @nonzero_check_on_constant_for_si_fmul_nz_vec_w_poison(i1 %c,
 ; CHECK-NEXT:    [[CONV_I_V:%.*]] = insertelement <2 x i16> poison, i16 [[CONV_I_S]], i64 0
 ; CHECK-NEXT:    [[CONV_I:%.*]] = shufflevector <2 x i16> [[CONV_I_V]], <2 x i16> poison, <2 x i32> zeroinitializer
 ; CHECK-NEXT:    [[MUL3_I_I:%.*]] = sitofp <2 x i16> [[CONV_I]] to <2 x float>
-; CHECK-NEXT:    [[MUL3_I_I1:%.*]] = fmul <2 x float> [[MUL3_I_I]], <float poison, float 1.000000e+00>
+; CHECK-NEXT:    [[MUL3_I_I1:%.*]] = fmul nnan <2 x float> [[MUL3_I_I]], <float poison, float 1.000000e+00>
 ; CHECK-NEXT:    store i32 [[SEL]], ptr [[G_2345:%.*]], align 4
 ; CHECK-NEXT:    ret <2 x float> [[MUL3_I_I1]]
 ;

--- a/llvm/test/Transforms/InstCombine/binop-select.ll
+++ b/llvm/test/Transforms/InstCombine/binop-select.ll
@@ -368,11 +368,9 @@ define <2 x half> @fmul_sel_op1(i1 %b, <2 x half> %p) {
 
 define <2 x half> @fmul_sel_op1_use(i1 %b, <2 x half> %p) {
 ; CHECK-LABEL: @fmul_sel_op1_use(
-; CHECK-NEXT:    [[X:%.*]] = fadd <2 x half> [[P:%.*]], <half 0xH3C00, half 0xH4000>
 ; CHECK-NEXT:    [[S:%.*]] = select i1 [[B:%.*]], <2 x half> zeroinitializer, <2 x half> splat (half 0xHFFFF)
 ; CHECK-NEXT:    call void @use_v2f16(<2 x half> [[S]])
-; CHECK-NEXT:    [[R:%.*]] = fmul nnan nsz <2 x half> [[X]], [[S]]
-; CHECK-NEXT:    ret <2 x half> [[R]]
+; CHECK-NEXT:    ret <2 x half> zeroinitializer
 ;
   %x = fadd <2 x half> %p, <half 1.0, half 2.0> ; thwart complexity-based canonicalization
   %s = select i1 %b, <2 x half> zeroinitializer, <2 x half> <half 0xHffff, half 0xHffff>

--- a/llvm/test/Transforms/InstCombine/fast-math.ll
+++ b/llvm/test/Transforms/InstCombine/fast-math.ll
@@ -18,7 +18,7 @@ define float @fold(float %a) {
 define float @notfold(float %a) {
 ; CHECK-LABEL: @notfold(
 ; CHECK-NEXT:    [[MUL:%.*]] = fmul fast float [[A:%.*]], 0x3FF3333340000000
-; CHECK-NEXT:    [[MUL1:%.*]] = fmul float [[MUL]], 0x4002666660000000
+; CHECK-NEXT:    [[MUL1:%.*]] = fmul nnan float [[MUL]], 0x4002666660000000
 ; CHECK-NEXT:    ret float [[MUL1]]
 ;
   %mul = fmul fast float %a, 0x3FF3333340000000
@@ -728,7 +728,7 @@ define double @sqrt_intrinsic_three_args6(double %x, ptr %yp) {
 
 define double @sqrt_intrinsic_not_so_fast(double %x, double %y) {
 ; CHECK-LABEL: @sqrt_intrinsic_not_so_fast(
-; CHECK-NEXT:    [[MUL:%.*]] = fmul double [[X:%.*]], [[X]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan ninf double [[X:%.*]], [[X]]
 ; CHECK-NEXT:    [[MUL2:%.*]] = fmul fast double [[MUL]], [[Y:%.*]]
 ; CHECK-NEXT:    [[SQRT:%.*]] = call fast double @llvm.sqrt.f64(double [[MUL2]])
 ; CHECK-NEXT:    ret double [[SQRT]]

--- a/llvm/test/Transforms/InstCombine/fmul-sqrt.ll
+++ b/llvm/test/Transforms/InstCombine/fmul-sqrt.ll
@@ -72,10 +72,10 @@ define double @sqrt_a_sqrt_b_reassoc(double %a, double %b) {
 
 define double @sqrt_a_sqrt_b_sqrt_c_sqrt_d_reassoc(double %a, double %b, double %c, double %d) {
 ; CHECK-LABEL: @sqrt_a_sqrt_b_sqrt_c_sqrt_d_reassoc(
-; CHECK-NEXT:    [[TMP1:%.*]] = fmul reassoc nnan arcp double [[A:%.*]], [[B:%.*]]
-; CHECK-NEXT:    [[TMP2:%.*]] = fmul reassoc nnan double [[TMP1]], [[C:%.*]]
+; CHECK-NEXT:    [[TMP2:%.*]] = fmul reassoc nnan ninf arcp double [[A:%.*]], [[B:%.*]]
 ; CHECK-NEXT:    [[TMP3:%.*]] = fmul reassoc nnan ninf double [[TMP2]], [[D:%.*]]
-; CHECK-NEXT:    [[MUL2:%.*]] = call reassoc nnan ninf double @llvm.sqrt.f64(double [[TMP3]])
+; CHECK-NEXT:    [[TMP4:%.*]] = fmul reassoc nnan ninf double [[TMP3]], [[D1:%.*]]
+; CHECK-NEXT:    [[MUL2:%.*]] = call reassoc nnan ninf double @llvm.sqrt.f64(double [[TMP4]])
 ; CHECK-NEXT:    ret double [[MUL2]]
 ;
   %1 = call double @llvm.sqrt.f64(double %a)

--- a/llvm/test/Transforms/InstCombine/fmul.ll
+++ b/llvm/test/Transforms/InstCombine/fmul.ll
@@ -1401,7 +1401,7 @@ entry:
 define <3 x float> @mul_mixed_zero_nnan_ninf_vec(<3 x float> nofpclass(inf nan) %a) {
 ; CHECK-LABEL: @mul_mixed_zero_nnan_ninf_vec(
 ; CHECK-NEXT:  entry:
-; CHECK-NEXT:    [[RET:%.*]] = fmul <3 x float> [[A:%.*]], <float -0.000000e+00, float 0.000000e+00, float poison>
+; CHECK-NEXT:    [[RET:%.*]] = fmul nnan ninf <3 x float> [[A:%.*]], <float -0.000000e+00, float 0.000000e+00, float poison>
 ; CHECK-NEXT:    ret <3 x float> [[RET]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/fsqrtdiv-transform.ll
+++ b/llvm/test/Transforms/InstCombine/fsqrtdiv-transform.ll
@@ -80,7 +80,7 @@ define void @bb_constraint_case3(double %a, i32 %d) {
 ; CHECK-NEXT:    [[D_NOT:%.*]] = icmp eq i32 [[D]], 0
 ; CHECK-NEXT:    br i1 [[D_NOT]], label [[IF_END:%.*]], label [[IF_THEN:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    store double [[MUL]], ptr @r1, align 8
 ; CHECK-NEXT:    [[DIV1:%.*]] = fdiv reassoc double [[A]], [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV1]], ptr @r2, align 8
@@ -117,7 +117,7 @@ define void @bb_constraint_case4(double %a, i32 %c, i32 %d) {
 ; CHECK-NEXT:    [[C_NOT:%.*]] = icmp eq i32 [[C]], 0
 ; CHECK-NEXT:    br i1 [[C_NOT]], label [[IF_END:%.*]], label [[IF_THEN:%.*]]
 ; CHECK:       if.then:
-; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    store double [[MUL]], ptr @r1, align 8
 ; CHECK-NEXT:    br label [[IF_END]]
 ; CHECK:       if.end:
@@ -172,7 +172,7 @@ define void @bb_constraint_case5(double %a, i32 %c) {
 ; CHECK:       if.end:
 ; CHECK-NEXT:    [[SQRT:%.*]] = phi double [ [[TMP0]], [[IF_THEN]] ], [ [[TMP1]], [[IF_ELSE]] ]
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc ninf arcp double 1.000000e+00, [[SQRT]]
-; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    store double [[MUL]], ptr @r1, align 8
 ; CHECK-NEXT:    [[DIV1:%.*]] = fdiv reassoc double [[A]], [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV1]], ptr @r2, align 8
@@ -267,7 +267,7 @@ define void @bb_constraint_case7(double %a, i32 %c, i32 %d) {
 ; CHECK-NEXT:    [[TMP1:%.*]] = fdiv double 2.000000e+00, [[A]]
 ; CHECK-NEXT:    br label [[IF_END]]
 ; CHECK:       if.else1:
-; CHECK-NEXT:    [[TMP2:%.*]] = fmul reassoc double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[TMP2:%.*]] = fmul reassoc nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    br label [[IF_END]]
 ; CHECK:       if.end:
 ; CHECK-NEXT:    [[MUL:%.*]] = phi double [ [[TMP1]], [[IF_THEN1]] ], [ [[TMP2]], [[IF_ELSE1]] ], [ [[TMP0]], [[IF_THEN]] ]
@@ -382,7 +382,7 @@ define void @missing_arcp_flag_on_div(double %a) {
 ; CHECK-NEXT:    [[SQRT:%.*]] = call reassoc nnan ninf nsz double @llvm.sqrt.f64(double [[A]])
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc ninf double 1.000000e+00, [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV]], ptr @x, align 8
-; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    store double [[MUL]], ptr @r1, align 8
 ; CHECK-NEXT:    [[DIV1:%.*]] = fdiv reassoc double [[A]], [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV1]], ptr @r2, align 8
@@ -407,7 +407,7 @@ define void @missing_reassoc_flag_on_mul(double %a) {
 ; CHECK-NEXT:    [[SQRT:%.*]] = call reassoc nnan ninf nsz double @llvm.sqrt.f64(double [[A]])
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc ninf arcp double 1.000000e+00, [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV]], ptr @x, align 8
-; CHECK-NEXT:    [[MUL:%.*]] = fmul double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    store double [[MUL]], ptr @r1, align 8
 ; CHECK-NEXT:    [[DIV1:%.*]] = fdiv reassoc double [[A]], [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV1]], ptr @r2, align 8
@@ -432,7 +432,7 @@ define void @missing_reassoc_flag_on_div1(double %a) {
 ; CHECK-NEXT:    [[SQRT:%.*]] = call reassoc nnan ninf nsz double @llvm.sqrt.f64(double [[A]])
 ; CHECK-NEXT:    [[DIV:%.*]] = fdiv reassoc ninf arcp double 1.000000e+00, [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV]], ptr @x, align 8
-; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc double [[DIV]], [[DIV]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul reassoc nnan double [[DIV]], [[DIV]]
 ; CHECK-NEXT:    store double [[MUL]], ptr @r1, align 8
 ; CHECK-NEXT:    [[DIV1:%.*]] = fdiv double [[A]], [[SQRT]]
 ; CHECK-NEXT:    store double [[DIV1]], ptr @r2, align 8
@@ -626,6 +626,8 @@ declare <2 x double> @llvm.sqrt.v2f64(<2 x double>)
 !1 = !{float 3.5}
 !2 = !{float 4.5}
 !3 = !{float 5.5}
+;.
 ; CHECK: [[META0]] = !{float 5.500000e+00}
 ; CHECK: [[META1]] = !{float 4.500000e+00}
 ; CHECK: [[META2]] = !{float 3.500000e+00}
+;.

--- a/llvm/test/Transforms/InstCombine/pow-to-ldexp.ll
+++ b/llvm/test/Transforms/InstCombine/pow-to-ldexp.ll
@@ -54,7 +54,7 @@ define float @pow_sitofp_f32_const_base_4(i32 %x) {
 ; LDEXP-EXP2-LABEL: define float @pow_sitofp_f32_const_base_4(
 ; LDEXP-EXP2-SAME: i32 [[X:%.*]]) {
 ; LDEXP-EXP2-NEXT:    [[ITOFP:%.*]] = sitofp i32 [[X]] to float
-; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul float [[ITOFP]], 2.000000e+00
+; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul nnan float [[ITOFP]], 2.000000e+00
 ; LDEXP-EXP2-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; LDEXP-EXP2-NEXT:    ret float [[EXP2]]
 ;
@@ -67,7 +67,7 @@ define float @pow_sitofp_f32_const_base_4(i32 %x) {
 ; NOLDEXP-LABEL: define float @pow_sitofp_f32_const_base_4(
 ; NOLDEXP-SAME: i32 [[X:%.*]]) {
 ; NOLDEXP-NEXT:    [[ITOFP:%.*]] = sitofp i32 [[X]] to float
-; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul float [[ITOFP]], 2.000000e+00
+; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul nnan float [[ITOFP]], 2.000000e+00
 ; NOLDEXP-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; NOLDEXP-NEXT:    ret float [[EXP2]]
 ;
@@ -80,7 +80,7 @@ define float @pow_sitofp_f32_const_base_16(i32 %x) {
 ; LDEXP-EXP2-LABEL: define float @pow_sitofp_f32_const_base_16(
 ; LDEXP-EXP2-SAME: i32 [[X:%.*]]) {
 ; LDEXP-EXP2-NEXT:    [[ITOFP:%.*]] = sitofp i32 [[X]] to float
-; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul float [[ITOFP]], 4.000000e+00
+; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul nnan float [[ITOFP]], 4.000000e+00
 ; LDEXP-EXP2-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; LDEXP-EXP2-NEXT:    ret float [[EXP2]]
 ;
@@ -93,7 +93,7 @@ define float @pow_sitofp_f32_const_base_16(i32 %x) {
 ; NOLDEXP-LABEL: define float @pow_sitofp_f32_const_base_16(
 ; NOLDEXP-SAME: i32 [[X:%.*]]) {
 ; NOLDEXP-NEXT:    [[ITOFP:%.*]] = sitofp i32 [[X]] to float
-; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul float [[ITOFP]], 4.000000e+00
+; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul nnan float [[ITOFP]], 4.000000e+00
 ; NOLDEXP-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; NOLDEXP-NEXT:    ret float [[EXP2]]
 ;
@@ -139,7 +139,7 @@ define <2 x float> @pow_sitofp_v2f32_const_base_8(<2 x i32> %x) {
 ; LDEXP-EXP2-LABEL: define <2 x float> @pow_sitofp_v2f32_const_base_8(
 ; LDEXP-EXP2-SAME: <2 x i32> [[X:%.*]]) {
 ; LDEXP-EXP2-NEXT:    [[ITOFP:%.*]] = sitofp <2 x i32> [[X]] to <2 x float>
-; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul <2 x float> [[ITOFP]], splat (float 3.000000e+00)
+; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul nnan <2 x float> [[ITOFP]], splat (float 3.000000e+00)
 ; LDEXP-EXP2-NEXT:    [[EXP2:%.*]] = tail call <2 x float> @llvm.exp2.v2f32(<2 x float> [[MUL]])
 ; LDEXP-EXP2-NEXT:    ret <2 x float> [[EXP2]]
 ;
@@ -152,7 +152,7 @@ define <2 x float> @pow_sitofp_v2f32_const_base_8(<2 x i32> %x) {
 ; NOLDEXP-LABEL: define <2 x float> @pow_sitofp_v2f32_const_base_8(
 ; NOLDEXP-SAME: <2 x i32> [[X:%.*]]) {
 ; NOLDEXP-NEXT:    [[ITOFP:%.*]] = sitofp <2 x i32> [[X]] to <2 x float>
-; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul <2 x float> [[ITOFP]], splat (float 3.000000e+00)
+; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul nnan <2 x float> [[ITOFP]], splat (float 3.000000e+00)
 ; NOLDEXP-NEXT:    [[EXP2:%.*]] = tail call <2 x float> @llvm.exp2.v2f32(<2 x float> [[MUL]])
 ; NOLDEXP-NEXT:    ret <2 x float> [[EXP2]]
 ;
@@ -228,7 +228,7 @@ define <2 x half> @pow_sitofp_v2f16_const_base_8(<2 x i32> %x) {
 ; LDEXP-EXP2-LABEL: define <2 x half> @pow_sitofp_v2f16_const_base_8(
 ; LDEXP-EXP2-SAME: <2 x i32> [[X:%.*]]) {
 ; LDEXP-EXP2-NEXT:    [[ITOFP:%.*]] = sitofp <2 x i32> [[X]] to <2 x half>
-; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul <2 x half> [[ITOFP]], splat (half 0xH4200)
+; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul nnan <2 x half> [[ITOFP]], splat (half 0xH4200)
 ; LDEXP-EXP2-NEXT:    [[EXP2:%.*]] = tail call <2 x half> @llvm.exp2.v2f16(<2 x half> [[MUL]])
 ; LDEXP-EXP2-NEXT:    ret <2 x half> [[EXP2]]
 ;
@@ -241,7 +241,7 @@ define <2 x half> @pow_sitofp_v2f16_const_base_8(<2 x i32> %x) {
 ; NOLDEXP-LABEL: define <2 x half> @pow_sitofp_v2f16_const_base_8(
 ; NOLDEXP-SAME: <2 x i32> [[X:%.*]]) {
 ; NOLDEXP-NEXT:    [[ITOFP:%.*]] = sitofp <2 x i32> [[X]] to <2 x half>
-; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul <2 x half> [[ITOFP]], splat (half 0xH4200)
+; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul nnan <2 x half> [[ITOFP]], splat (half 0xH4200)
 ; NOLDEXP-NEXT:    [[EXP2:%.*]] = tail call <2 x half> @llvm.exp2.v2f16(<2 x half> [[MUL]])
 ; NOLDEXP-NEXT:    ret <2 x half> [[EXP2]]
 ;
@@ -261,7 +261,7 @@ define <2 x double> @pow_sitofp_v2f64_const_base_8(<2 x i32> %x) {
 ; LDEXP-EXP2-LABEL: define <2 x double> @pow_sitofp_v2f64_const_base_8(
 ; LDEXP-EXP2-SAME: <2 x i32> [[X:%.*]]) {
 ; LDEXP-EXP2-NEXT:    [[ITOFP:%.*]] = sitofp <2 x i32> [[X]] to <2 x double>
-; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul <2 x double> [[ITOFP]], splat (double 3.000000e+00)
+; LDEXP-EXP2-NEXT:    [[MUL:%.*]] = fmul nnan <2 x double> [[ITOFP]], splat (double 3.000000e+00)
 ; LDEXP-EXP2-NEXT:    [[EXP2:%.*]] = tail call <2 x double> @llvm.exp2.v2f64(<2 x double> [[MUL]])
 ; LDEXP-EXP2-NEXT:    ret <2 x double> [[EXP2]]
 ;
@@ -274,7 +274,7 @@ define <2 x double> @pow_sitofp_v2f64_const_base_8(<2 x i32> %x) {
 ; NOLDEXP-LABEL: define <2 x double> @pow_sitofp_v2f64_const_base_8(
 ; NOLDEXP-SAME: <2 x i32> [[X:%.*]]) {
 ; NOLDEXP-NEXT:    [[ITOFP:%.*]] = sitofp <2 x i32> [[X]] to <2 x double>
-; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul <2 x double> [[ITOFP]], splat (double 3.000000e+00)
+; NOLDEXP-NEXT:    [[MUL:%.*]] = fmul nnan <2 x double> [[ITOFP]], splat (double 3.000000e+00)
 ; NOLDEXP-NEXT:    [[EXP2:%.*]] = tail call <2 x double> @llvm.exp2.v2f64(<2 x double> [[MUL]])
 ; NOLDEXP-NEXT:    ret <2 x double> [[EXP2]]
 ;

--- a/llvm/test/Transforms/InstCombine/pow_fp_int.ll
+++ b/llvm/test/Transforms/InstCombine/pow_fp_int.ll
@@ -72,7 +72,7 @@ define double @pow_sitofp_double_const_base_power_of_2_fast(i32 %x) {
 ; CHECK-LABEL: define double @pow_sitofp_double_const_base_power_of_2_fast(
 ; CHECK-SAME: i32 [[X:%.*]]) {
 ; CHECK-NEXT:    [[SUBFP:%.*]] = sitofp i32 [[X]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul afn float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan afn float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call afn float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]
@@ -101,7 +101,7 @@ define double @pow_uitofp_const_base_power_of_2_fast(i31 %x) {
 ; CHECK-LABEL: define double @pow_uitofp_const_base_power_of_2_fast(
 ; CHECK-SAME: i31 [[X:%.*]]) {
 ; CHECK-NEXT:    [[SUBFP:%.*]] = uitofp i31 [[X]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul afn float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan afn float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call afn float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]
@@ -387,7 +387,7 @@ define double @pow_sitofp_const_base_power_of_2_no_fast(i32 %x) {
 ; CHECK-LABEL: define double @pow_sitofp_const_base_power_of_2_no_fast(
 ; CHECK-SAME: i32 [[X:%.*]]) {
 ; CHECK-NEXT:    [[SUBFP:%.*]] = sitofp i32 [[X]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]
@@ -416,7 +416,7 @@ define double @pow_uitofp_const_base_power_of_2_no_fast(i32 %x) {
 ; CHECK-LABEL: define double @pow_uitofp_const_base_power_of_2_no_fast(
 ; CHECK-SAME: i32 [[X:%.*]]) {
 ; CHECK-NEXT:    [[SUBFP:%.*]] = uitofp i32 [[X]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]

--- a/llvm/test/Transforms/InstCombine/pow_fp_int16.ll
+++ b/llvm/test/Transforms/InstCombine/pow_fp_int16.ll
@@ -64,7 +64,7 @@ define double @pow_sitofp_double_const_base_2_fast(i16 %x) {
 define double @pow_sitofp_double_const_base_power_of_2_fast(i16 %x) {
 ; CHECK-LABEL: @pow_sitofp_double_const_base_power_of_2_fast(
 ; CHECK-NEXT:    [[SUBFP:%.*]] = sitofp i16 [[X:%.*]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul afn float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan afn float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call afn float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]
@@ -91,7 +91,7 @@ define double @pow_uitofp_const_base_2_fast(i15 %x) {
 define double @pow_uitofp_const_base_power_of_2_fast(i15 %x) {
 ; CHECK-LABEL: @pow_uitofp_const_base_power_of_2_fast(
 ; CHECK-NEXT:    [[SUBFP:%.*]] = uitofp i15 [[X:%.*]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul afn float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan afn float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call afn float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]
@@ -326,7 +326,7 @@ define double @pow_sitofp_const_base_2_no_fast(i16 %x) {
 define double @pow_sitofp_const_base_power_of_2_no_fast(i16 %x) {
 ; CHECK-LABEL: @pow_sitofp_const_base_power_of_2_no_fast(
 ; CHECK-NEXT:    [[SUBFP:%.*]] = sitofp i16 [[X:%.*]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]
@@ -353,7 +353,7 @@ define double @pow_uitofp_const_base_2_no_fast(i16 %x) {
 define double @pow_uitofp_const_base_power_of_2_no_fast(i16 %x) {
 ; CHECK-LABEL: @pow_uitofp_const_base_power_of_2_no_fast(
 ; CHECK-NEXT:    [[SUBFP:%.*]] = uitofp i16 [[X:%.*]] to float
-; CHECK-NEXT:    [[MUL:%.*]] = fmul float [[SUBFP]], 4.000000e+00
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan float [[SUBFP]], 4.000000e+00
 ; CHECK-NEXT:    [[EXP2:%.*]] = tail call float @llvm.exp2.f32(float [[MUL]])
 ; CHECK-NEXT:    [[RES:%.*]] = fpext float [[EXP2]] to double
 ; CHECK-NEXT:    ret double [[RES]]

--- a/llvm/test/Transforms/InstCombine/powi.ll
+++ b/llvm/test/Transforms/InstCombine/powi.ll
@@ -207,7 +207,7 @@ define double @powi_fmul_powi_fast_on_powi(double %x, i32 %y, i32 %z) {
 ; CHECK-NEXT:  entry:
 ; CHECK-NEXT:    [[P1:%.*]] = tail call fast double @llvm.powi.f64.i32(double [[X:%.*]], i32 [[Y:%.*]])
 ; CHECK-NEXT:    [[P2:%.*]] = tail call fast double @llvm.powi.f64.i32(double [[X]], i32 [[Z:%.*]])
-; CHECK-NEXT:    [[MUL:%.*]] = fmul double [[P2]], [[P1]]
+; CHECK-NEXT:    [[MUL:%.*]] = fmul nnan double [[P2]], [[P1]]
 ; CHECK-NEXT:    ret double [[MUL]]
 ;
 entry:

--- a/llvm/test/Transforms/InstCombine/select_arithmetic.ll
+++ b/llvm/test/Transforms/InstCombine/select_arithmetic.ll
@@ -49,7 +49,7 @@ define float @test2(i1 zeroext %arg) #0 {
 
 define float @test3(i1 zeroext %arg) #0 {
 ; CHECK-LABEL: @test3(
-; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[ARG:%.*]], float 5.000000e+00, float 5.400000e+01
+; CHECK-NEXT:    [[TMP2:%.*]] = select nnan i1 [[ARG:%.*]], float 5.000000e+00, float 5.400000e+01
 ; CHECK-NEXT:    ret float [[TMP2]]
 ;
   %tmp = select i1 %arg, float 5.000000e+00, float 6.000000e+00
@@ -66,7 +66,7 @@ declare void @use_float(float)
 define float @test4(i1 zeroext %arg) #0 {
 ; CHECK-LABEL: @test4(
 ; CHECK-NEXT:    [[TMP:%.*]] = select i1 [[ARG:%.*]], float 5.000000e+00, float 6.000000e+00
-; CHECK-NEXT:    [[TMP2:%.*]] = select i1 [[ARG]], float 5.000000e+00, float 5.400000e+01
+; CHECK-NEXT:    [[TMP2:%.*]] = select nnan i1 [[ARG]], float 5.000000e+00, float 5.400000e+01
 ; CHECK-NEXT:    call void @use_float(float [[TMP]])
 ; CHECK-NEXT:    ret float [[TMP2]]
 ;

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass-fmul.ll
@@ -657,7 +657,7 @@ define nofpclass(nan) float @ret_no_nan_result__known_pzero__fmul__not_inf(float
 define nofpclass(nan) float @ret_no_nan_result__not_inf_or_nan__fmul__known_pzero_or_nan(float nofpclass(inf) %not.inf.or.nan, float nofpclass(inf sub norm nzero) %pzero.or.nan) {
 ; CHECK-LABEL: define nofpclass(nan) float @ret_no_nan_result__not_inf_or_nan__fmul__known_pzero_or_nan(
 ; CHECK-SAME: float nofpclass(inf) [[NOT_INF_OR_NAN:%.*]], float nofpclass(inf nzero sub norm) [[PZERO_OR_NAN:%.*]]) {
-; CHECK-NEXT:    [[MUL:%.*]] = call float @llvm.copysign.f32(float 0.000000e+00, float [[NOT_INF_OR_NAN]])
+; CHECK-NEXT:    [[MUL:%.*]] = call ninf float @llvm.copysign.f32(float 0.000000e+00, float [[NOT_INF_OR_NAN]])
 ; CHECK-NEXT:    ret float [[MUL]]
 ;
   %mul = fmul float %not.inf.or.nan, %pzero.or.nan

--- a/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
+++ b/llvm/test/Transforms/InstCombine/simplify-demanded-fpclass.ll
@@ -1300,7 +1300,7 @@ define nofpclass(nan inf) float @pow_f32(float nofpclass(nan inf) %arg, float no
 ; CHECK-NEXT:    [[I5:%.*]] = tail call nofpclass(ninf nzero nsub nnorm) float @llvm.fabs.f32(float noundef [[ARG1]])
 ; CHECK-NEXT:    [[I6:%.*]] = tail call float @llvm.trunc.f32(float noundef [[I5]])
 ; CHECK-NEXT:    [[I7:%.*]] = fcmp oeq float [[I6]], [[I5]]
-; CHECK-NEXT:    [[I8:%.*]] = fmul float [[I5]], 5.000000e-01
+; CHECK-NEXT:    [[I8:%.*]] = fmul nnan float [[I5]], 5.000000e-01
 ; CHECK-NEXT:    [[I9:%.*]] = tail call float @llvm.trunc.f32(float noundef [[I8]])
 ; CHECK-NEXT:    [[I10:%.*]] = fcmp une float [[I9]], [[I8]]
 ; CHECK-NEXT:    [[I11:%.*]] = and i1 [[I7]], [[I10]]

--- a/llvm/test/Transforms/LoopVectorize/scalable-inductions.ll
+++ b/llvm/test/Transforms/LoopVectorize/scalable-inductions.ll
@@ -251,13 +251,13 @@ define void @add_unique_indf32(ptr noalias nocapture %a, i64 %n) {
 ; CHECK-NEXT:    [[N_MOD_VF:%.*]] = urem i64 [[N]], [[TMP3]]
 ; CHECK-NEXT:    [[N_VEC:%.*]] = sub i64 [[N]], [[N_MOD_VF]]
 ; CHECK-NEXT:    [[DOTCAST:%.*]] = sitofp i64 [[N_VEC]] to float
-; CHECK-NEXT:    [[TMP4:%.*]] = fmul float [[DOTCAST]], 2.000000e+00
+; CHECK-NEXT:    [[TMP4:%.*]] = fmul nnan float [[DOTCAST]], 2.000000e+00
 ; CHECK-NEXT:    [[IND_END:%.*]] = fadd float [[TMP4]], 0.000000e+00
 ; CHECK-NEXT:    [[TMP7:%.*]] = call <vscale x 4 x i32> @llvm.stepvector.nxv4i32()
 ; CHECK-NEXT:    [[TMP8:%.*]] = uitofp <vscale x 4 x i32> [[TMP7]] to <vscale x 4 x float>
-; CHECK-NEXT:    [[TMP9:%.*]] = fmul <vscale x 4 x float> [[TMP8]], splat (float 2.000000e+00)
+; CHECK-NEXT:    [[TMP9:%.*]] = fmul nnan <vscale x 4 x float> [[TMP8]], splat (float 2.000000e+00)
 ; CHECK-NEXT:    [[TMP12:%.*]] = uitofp i64 [[TMP3]] to float
-; CHECK-NEXT:    [[TMP13:%.*]] = fmul float [[TMP12]], 2.000000e+00
+; CHECK-NEXT:    [[TMP13:%.*]] = fmul nnan float [[TMP12]], 2.000000e+00
 ; CHECK-NEXT:    [[DOTSPLATINSERT:%.*]] = insertelement <vscale x 4 x float> poison, float [[TMP13]], i64 0
 ; CHECK-NEXT:    [[DOTSPLAT:%.*]] = shufflevector <vscale x 4 x float> [[DOTSPLATINSERT]], <vscale x 4 x float> poison, <vscale x 4 x i32> zeroinitializer
 ; CHECK-NEXT:    br label [[VECTOR_BODY:%.*]]


### PR DESCRIPTION
Start trying to use SimplifyDemandedFPClass on instructions, starting with fmul. This subsumes the old transform on multiply of 0. The main change is the introduction of nnan/ninf. I do not think anywhere was systematically trying to introduce fast math flags before, though a few odd transforms would set them.

Previously we only called SimplifyDemandedFPClass on function returns with nofpclass annotations. Start following the pattern of SimplifyDemandedBits, where this will be called from relevant root instructions.

I was wondering if this should go into InstCombineAggressive, but that apparently does not make use of InstCombineInternal's worklist.


