### PR TITLE
[AMDDevicelibs] Fix linking issues.

### DIFF
--- a/amd/device-libs/ockl/src/dm.cl
+++ b/amd/device-libs/ockl/src/dm.cl
@@ -1280,7 +1280,7 @@ __ockl_dm_hinfo(ulong *rp)
 #if defined NON_SLAB_TRACKING
 // return a snapshot of the current number of nonslab allocations
 // which haven't been deallocated
-__attribute__((cold)) ulong
+__attribute__((cold,weak)) ulong
 __ockl_dm_nna(void)
 {
     __global heap_t *hp = get_heap_ptr();

--- a/amd/device-libs/utils/prepare-builtins/prepare-builtins.cpp
+++ b/amd/device-libs/utils/prepare-builtins/prepare-builtins.cpp
@@ -73,28 +73,6 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  // Set linkage of every external definition to linkonce_odr.
-  for (Module::iterator i = M->begin(), e = M->end(); i != e; ++i) {
-    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
-        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
-    }
-  }
-
-  for (Module::global_iterator i = M->global_begin(), e = M->global_end();
-       i != e; ++i) {
-    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
-        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
-    }
-  }
-
-  for (Module::alias_iterator i = M->alias_begin(), e = M->alias_end();
-       i != e; ++i) {
-    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
-        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
-    }
-  }
-
-
   if (OutputFilename.empty()) {
     errs() << "no output file\n";
     return 1;


### PR DESCRIPTION
  - Remove force conversion of global symbols to 'linkonce_odr' from prepare_builtins.cpp.
  - Add weak attribute to '__ockl_dm_nna' symbol due to multiply defined in both asanrtl.bc and ockl.bc.


