### PR TITLE
[infra][linux] using env github variables fails sporadically

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -81,7 +81,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_STAGING_REF }}
+          ref: 'compiler/amd-staging'
           
       - name: Update Submodule Pointer to the PR
         run: |

--- a/.github/workflows/build_portable_linux_python_packages.yml
+++ b/.github/workflows/build_portable_linux_python_packages.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_STAGING_REF }}
+          ref: 'compiler/amd-staging'
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.12'

--- a/.github/workflows/build_windows_python_packages.yml
+++ b/.github/workflows/build_windows_python_packages.yml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_STAGING_REF }}
+          ref: 'compiler/amd-staging'
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
         with:
           python-version: '3.12'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_CI_REF }}
           fetch-depth: 10
       - uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -39,9 +39,8 @@ permissions:
 jobs:
   setup:
     runs-on: ubuntu-24.04
-    environment: rock-ci
     env:
-      BASE_REF:  ${{ vars.THEROCK_CI_REF }}
+      BASE_REF: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
     outputs:
       enable_build_jobs: true
       linux_variants: >
@@ -57,8 +56,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          #fetch-depth: 10
-          ref: ${{ vars.THEROCK_CI_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
       - name: SHA of TheRock
         run: |
              git rev-parse HEAD

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -60,8 +60,8 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
           sparse-checkout: build_tools
-          ref: ${{ secrets.THEROCK_CI_REF }}
           path: "prejob"
 
       # Checkout failure is possible on Windows, as it's the first job on a GPU test runner.
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_CI_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
 
       - name: Setting up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_CI_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_CI_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
 
       - name: Run setup test environment workflow
         uses: './.github/actions/setup_test_environment'

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: ${{ secrets.THEROCK_CI_REF }}
+          ref: '5a23b542e1d03fbb515e014a7d9635c8884b12e6'
 
       - name: Pre-job cleanup Docker containers on Linux
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
  - github env variable like THEROCK_CI_REF substitution is failing intermittently
  - values for the CI sha is hardcoded as an interim fix


