### PR TITLE
BC to SPIRV Comgr action

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -78,6 +78,7 @@ set(SOURCES
   src/comgr-env.cpp
   src/comgr-metadata.cpp
   src/comgr-signal.cpp
+  src/comgr-bc-to-spirv-command.cpp
   src/comgr-spirv-command.cpp
   src/comgr-symbol.cpp
   src/comgr-symbolizer.cpp

--- a/amd/comgr/include/amd_comgr.h.in
+++ b/amd/comgr/include/amd_comgr.h.in
@@ -1839,9 +1839,22 @@ typedef enum amd_comgr_action_kind_s {
   AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV = 0x14,
 
   /**
+   * Translate each source LLVM IR Bitcode object in @p input into SPIR-V.
+   * For each successful translation, add a SPIR-V object to @p result.
+   *
+   * This action uses the amd-llvm-spirv translator to convert LLVM bitcode
+   * to SPIR-V bytecode suitable for use with HIP runtime compilation.
+   *
+   * Return @p AMD_COMGR_STATUS_ERROR if any translation fails
+   *
+   * Skip any input that is not LLVM IR Bitcode.
+   */
+  AMD_COMGR_ACTION_TRANSLATE_BC_TO_SPIRV = 0x15,
+
+  /**
    * Marker for last valid action kind.
    */
-  AMD_COMGR_ACTION_LAST = AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV
+  AMD_COMGR_ACTION_LAST = AMD_COMGR_ACTION_TRANSLATE_BC_TO_SPIRV
 } amd_comgr_action_kind_t;
 
 /**

--- a/amd/comgr/src/comgr-bc-to-spirv-command.cpp
+++ b/amd/comgr/src/comgr-bc-to-spirv-command.cpp
@@ -1,0 +1,91 @@
+//===- comgr-bc-to-spirv-command.cpp - BCToSPIRVCommand implementation ----===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file implements the CacheCommandAdaptor interface for the LLVM
+/// Bitcode to SPIR-V conversion.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-bc-to-spirv-command.h"
+
+#ifndef COMGR_DISABLE_SPIRV
+#include "comgr-diagnostic-handler.h"
+
+#include <LLVMSPIRVLib.h>
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/Support/MemoryBuffer.h>
+
+#include <sstream>
+#endif
+
+namespace COMGR {
+using namespace llvm;
+
+Error BCToSPIRVCommand::writeExecuteOutput(StringRef CachedBuffer) {
+  assert(OutputBuffer.empty());
+  OutputBuffer.reserve(CachedBuffer.size());
+  OutputBuffer.insert(OutputBuffer.end(), CachedBuffer.begin(),
+                      CachedBuffer.end());
+  return Error::success();
+}
+
+Expected<StringRef> BCToSPIRVCommand::readExecuteOutput() {
+  return StringRef(OutputBuffer.data(), OutputBuffer.size());
+}
+
+amd_comgr_status_t BCToSPIRVCommand::execute(raw_ostream &LogS) {
+#ifndef COMGR_DISABLE_SPIRV
+  LLVMContext Context;
+  Context.setDiagnosticHandler(
+      std::make_unique<AMDGPUCompilerDiagnosticHandler>(LogS), true);
+
+  // Llvm bc -> Llvm module
+  auto MemBuf = MemoryBuffer::getMemBuffer(InputBuffer, "", false);
+  Expected<std::unique_ptr<Module>> ModuleOrErr =
+      parseBitcodeFile(MemBuf->getMemBufferRef(), Context);
+  if (!ModuleOrErr)
+    return AMD_COMGR_STATUS_ERROR;
+
+  // Llvm module -> Spirv
+  std::unique_ptr<Module> M = std::move(*ModuleOrErr);
+  std::ostringstream OSS;
+  std::string Err;
+  SPIRV::TranslatorOpts Opts;
+  Opts.enableAllExtensions();
+  if (!writeSpirv(M.get(), Opts, OSS, Err)) {
+    LogS << "Failed to translate LLVM IR to SPIR-V: " << Err << '\n';
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  std::string Result = OSS.str();
+  OutputBuffer.assign(Result.begin(), Result.end());
+  return AMD_COMGR_STATUS_SUCCESS;
+#else
+  return AMD_COMGR_STATUS_ERROR;
+#endif
+}
+
+BCToSPIRVCommand::ActionClass BCToSPIRVCommand::getClass() const {
+  // return an action class that is not allocated to distinguish it from any
+  // clang action
+  return clang::driver::Action::ActionClass::JobClassLast + 2;
+}
+
+void BCToSPIRVCommand::addOptionsIdentifier(HashAlgorithm &) const {
+  // do nothing, there are no options
+  return;
+}
+
+Error BCToSPIRVCommand::addInputIdentifier(HashAlgorithm &H) const {
+  addString(H, InputBuffer);
+  return Error::success();
+}
+} // namespace COMGR

--- a/amd/comgr/src/comgr-bc-to-spirv-command.h
+++ b/amd/comgr/src/comgr-bc-to-spirv-command.h
@@ -1,0 +1,39 @@
+//===- comgr-bc-to-spirv-command.h - BCToSPIRVCommand implementation ------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_BC_TO_SPIRV_COMMAND_H
+#define COMGR_BC_TO_SPIRV_COMMAND_H
+
+#include "comgr-cache-command.h"
+#include "comgr.h"
+
+namespace COMGR {
+class BCToSPIRVCommand : public CachedCommandAdaptor {
+public:
+  llvm::StringRef InputBuffer;
+  llvm::SmallVectorImpl<char> &OutputBuffer;
+
+public:
+  BCToSPIRVCommand(DataObject *Input, llvm::SmallVectorImpl<char> &OutputBuffer)
+      : InputBuffer(Input->Data, Input->Size), OutputBuffer(OutputBuffer) {}
+
+  bool canCache() const final { return true; }
+  llvm::Error writeExecuteOutput(llvm::StringRef CachedBuffer) final;
+  llvm::Expected<llvm::StringRef> readExecuteOutput() final;
+  amd_comgr_status_t execute(llvm::raw_ostream &LogS) final;
+
+  ~BCToSPIRVCommand() override = default;
+
+protected:
+  ActionClass getClass() const override;
+  void addOptionsIdentifier(HashAlgorithm &) const override;
+  llvm::Error addInputIdentifier(HashAlgorithm &) const override;
+};
+} // namespace COMGR
+
+#endif

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "comgr-compiler.h"
+#include "comgr-bc-to-spirv-command.h"
 #include "comgr-cache.h"
 #include "comgr-clang-command.h"
 #include "comgr-device-libs.h"
@@ -33,6 +34,7 @@
 #include "clang/Frontend/TextDiagnosticPrinter.h"
 #include "clang/FrontendTool/Utils.h"
 #include "clang/Options/Options.h"
+#include "llvm/ADT/ScopeExit.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Constants.h"
@@ -2122,7 +2124,6 @@ amd_comgr_status_t AMDGPUCompiler::compileSpirvToRelocatable() {
       return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
-  // Translate .spv to .bc
   amd_comgr_data_set_t TranslatedSpirvT;
   if (auto Status = amd_comgr_create_data_set(&TranslatedSpirvT))
     return Status;
@@ -2191,6 +2192,72 @@ amd_comgr_status_t AMDGPUCompiler::compileSourceToSpirv() {
   }
 
   return processFiles(AMD_COMGR_DATA_KIND_SPIRV, ".spv");
+}
+
+amd_comgr_status_t AMDGPUCompiler::translateBitcodeToSpirv() {
+#ifdef COMGR_DISABLE_SPIRV
+  LogS << "Calling AMDGPUCompiler::translateBitcodeToSpirv() not "
+       << "supported. Comgr is built with -DCOMGR_DISABLE_SPIRV. Re-build LLVM "
+       << "and Comgr with LLVM-SPIRV-Translator support to continue.\n";
+  return AMD_COMGR_STATUS_ERROR;
+#else
+  if (auto Status = createTmpDirs()) {
+    return Status;
+  }
+
+  auto Cache = CommandCache::get(LogS);
+
+  for (auto *Input : InSet->DataObjects) {
+    if (Input->DataKind != AMD_COMGR_DATA_KIND_BC)
+      continue;
+
+    if (env::shouldSaveTemps())
+      if (auto Status = outputToFile(Input, getFilePath(Input, InputDir)))
+        return Status;
+
+    SmallString<0> OutBuf;
+    BCToSPIRVCommand BcToSpirv(Input, OutBuf);
+
+    amd_comgr_status_t Status;
+    if (!Cache) {
+      Status = BcToSpirv.execute(LogS);
+    } else {
+      Status = Cache->execute(BcToSpirv, LogS);
+    }
+
+    if (Status) {
+      return Status;
+    }
+
+    amd_comgr_data_t OutputT;
+    if (auto Status = amd_comgr_create_data(AMD_COMGR_DATA_KIND_SPIRV, &OutputT)) {
+      return Status;
+    }
+
+    ScopedDataObjectReleaser SDOR(OutputT);
+
+    DataObject *Output = DataObject::convert(OutputT);
+    Output->setName(std::string(Input->Name) + std::string(".spv"));
+    Output->setData(OutBuf);
+
+    if (auto Status = amd_comgr_data_set_add(OutSetT, OutputT))
+      return Status;
+
+    if (env::shouldEmitVerboseLogs()) {
+      LogS << "BC to SPIR-V Translation: amd-llvm-spirv "
+           << getFilePath(Input, InputDir) << " -o "
+           << getFilePath(Output, OutputDir) << " (command line equivalent)\n";
+    }
+
+    if (env::shouldSaveTemps()) {
+      if (auto Status = outputToFile(Output, getFilePath(Output, OutputDir))) {
+        return Status;
+      }
+    }
+  }
+
+  return AMD_COMGR_STATUS_SUCCESS;
+#endif
 }
 
 AMDGPUCompiler::AMDGPUCompiler(DataAction *ActionInfo, DataSet *InSet,

--- a/amd/comgr/src/comgr-compiler.h
+++ b/amd/comgr/src/comgr-compiler.h
@@ -82,6 +82,7 @@ public:
   amd_comgr_status_t compileSpirvToRelocatable();
   amd_comgr_status_t translateSpirvToBitcode();
   amd_comgr_status_t compileSourceToSpirv();
+  amd_comgr_status_t translateBitcodeToSpirv();
 
   amd_comgr_language_t getLanguage() const { return ActionInfo->Language; }
 };

--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -104,6 +104,8 @@ amd_comgr_status_t dispatchCompilerAction(amd_comgr_action_kind_t ActionKind,
     return Compiler.translateSpirvToBitcode();
   case AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV:
     return Compiler.compileSourceToSpirv();
+  case AMD_COMGR_ACTION_TRANSLATE_BC_TO_SPIRV:
+    return Compiler.translateBitcodeToSpirv();
 
   default:
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
@@ -197,6 +199,8 @@ StringRef getActionKindName(amd_comgr_action_kind_t ActionKind) {
     return "AMD_COMGR_ACTION_TRANSLATE_SPIRV_TO_BC";
   case AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV:
     return "AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV";
+  case AMD_COMGR_ACTION_TRANSLATE_BC_TO_SPIRV:
+    return "AMD_COMGR_ACTION_TRANSLATE_BC_TO_SPIRV";
   }
 
   llvm_unreachable("invalid action");
@@ -1307,6 +1311,7 @@ amd_comgr_status_t AMD_COMGR_API
     case AMD_COMGR_ACTION_COMPILE_SPIRV_TO_RELOCATABLE:
     case AMD_COMGR_ACTION_TRANSLATE_SPIRV_TO_BC:
     case AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV:
+    case AMD_COMGR_ACTION_TRANSLATE_BC_TO_SPIRV:
       ActionStatus = dispatchCompilerAction(ActionKind, ActionInfoP, InputSetP,
                                             ResultSetP, *LogP);
       break;


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number

Resolves [SWDEV-537768](https://ontrack-internal.amd.com/browse/SWDEV-537768).

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?

Add a Comgr action of translating BC to SPIRV.

## Why are these changes needed?

To support SPIRV in hiprtc `-offload-arch=amdgcnspirv` path.

## Updated CHANGELOG?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Added/Updated documentation?

- [ ] Yes
- [x] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.