### PR TITLE
device-libs: Split powF into separate fast entry points

### DIFF
--- a/amd/device-libs/doc/OCML.md
+++ b/amd/device-libs/doc/OCML.md
@@ -161,8 +161,11 @@ The following table contains a list of {function} currently supported by OCML, a
 | nearbyint | round to nearest integer (see also rint) | 0 | 0 | 0 |
 | nextafter | next closest value above or below | 0 | 0 | 0 |
 | pow | general power | 16 | 16 | 4 |
+| pow_fast | general power | 178 | n/a | n/a |
 | pown | power with integral exponent | 16 | 16 | 4 |
+| pown_fast | power with integral exponent | 209.01 | n/a | n/a |
 | powr | power with positive floating point exponent | 16 | 16 | 4 |
+| powr_fast | power with positive floating point exponent | 206.25 | n/a | n/a |
 | pred | predecessor | c | c | c |
 | rcbrt | reciprocal cube root | 2 | 2 | 2 |
 | remainder | floating point remainder | 0 | 0 | 0 |
@@ -172,6 +175,7 @@ The following table contains a list of {function} currently supported by OCML, a
 | rlen3 | reciprocal len3 | 2 | 2 | 2 |
 | rlen4 | reciprocal len4 | 2 | 2 | 2 |
 | rootn | nth root | 16 | 16 | 4 |
+| rootn_fast | nth root | 88 | n/a | n/a |
 | round | round to integer, always away from 0 | c | c | c |
 | rsqrt | reciprocal square root | 2 | 2 | 1 |
 | scalb | multiply by 2 raised to a power | c | c | c |

--- a/amd/device-libs/ocml/inc/ocml.h
+++ b/amd/device-libs/ocml/inc/ocml.h
@@ -183,9 +183,13 @@ DECL_CONST_OCML_UNARY_F32(ncdfinv)
 DECL_CONST_OCML_UNARY_F32(nearbyint)
 DECL_CONST_OCML_BINARY_F32(nextafter)
 DECL_CONST_OCML_BINARY_F32(pow)
+DECL_CONST_OCML_BINARY_F32(pow_fast)
 DECL_CONST_OCML_BINARY_F32(powr)
+DECL_CONST_OCML_BINARY_F32(powr_fast)
 extern __attribute__((pure)) float OCML_MANGLE_F32(pown)(float, int);
+extern __attribute__((pure)) float OCML_MANGLE_F32(pown_fast)(float, int);
 extern __attribute__((pure)) float OCML_MANGLE_F32(rootn)(float, int);
+extern __attribute__((pure)) float OCML_MANGLE_F32(rootn_fast)(float, int);
 DECL_CONST_OCML_UNARY_F32(pred)
 DECL_CONST_OCML_BINARY_F32(remainder)
 

--- a/amd/device-libs/ocml/src/powF_base.h
+++ b/amd/device-libs/ocml/src/powF_base.h
@@ -23,9 +23,6 @@ fast_expylnx(float x, float y)
 static float
 compute_expylnx_int(float x, int ny)
 {
-    if (UNSAFE_MATH_OPT())
-        return fast_expylnx(x, (float)ny);
-
     float ax = BUILTIN_ABS_F32(x);
     int nyh = ny & 0xffff0000;
     float2 y = fadd((float)nyh, (float)(ny - nyh));
@@ -37,11 +34,6 @@ static float
 compute_exp_inverse_y_lnx_int(float x, int ny)
 {
     float ax = BUILTIN_ABS_F32(x);
-    if (UNSAFE_MATH_OPT()) {
-        float y = MATH_FAST_RCP((float)ny);
-        return fast_expylnx(ax, y);
-    }
-
     int nyh = ny & 0xffff0000;
     float2 y = fadd((float)nyh, (float)(ny - nyh));
     y = rcp(y);
@@ -51,9 +43,6 @@ compute_exp_inverse_y_lnx_int(float x, int ny)
 static float
 compute_expylnx_float(float x, float y)
 {
-    if (UNSAFE_MATH_OPT())
-        return fast_expylnx(x, y);
-
     float ax = BUILTIN_ABS_F32(x);
     return MATH_PRIVATE(expep)(omul(y, MATH_PRIVATE(epln)(ax)));
 }
@@ -108,13 +97,27 @@ pow_fixup(float x, float y, float expylnx)
 CONSTATTR float
 MATH_MANGLE(pow)(float x, float y)
 {
+    if (UNSAFE_MATH_OPT())
+        return MATH_MANGLE(pow_fast)(x, y);
+
     if (x == 1.0f)
         y = 1.0f;
     if (y == 0.0f)
         x = 1.0f;
 
     float expylnx = compute_expylnx_float(x, y);
+    return pow_fixup(x, y, expylnx);
+}
 
+CONSTATTR float
+MATH_MANGLE(pow_fast)(float x, float y)
+{
+    if (x == 1.0f)
+        y = 1.0f;
+    if (y == 0.0f)
+        x = 1.0f;
+
+    float expylnx = fast_expylnx(x, y);
     return pow_fixup(x, y, expylnx);
 }
 
@@ -148,10 +151,23 @@ powr_fixup(float x, float y, float expylnx)
 CONSTATTR float
 MATH_MANGLE(powr)(float x, float y)
 {
+    if (UNSAFE_MATH_OPT())
+        return MATH_MANGLE(powr_fast)(x, y);
+
     if (x < 0.0f)
         x = QNAN_F32;
 
     float expylnx = compute_expylnx_float(x, y);
+    return powr_fixup(x, y, expylnx);
+}
+
+CONSTATTR float
+MATH_MANGLE(powr_fast)(float x, float y)
+{
+    if (x < 0.0f)
+        x = QNAN_F32;
+
+    float expylnx = fast_expylnx(x, y);
     return powr_fixup(x, y, expylnx);
 }
 
@@ -175,10 +191,23 @@ pown_fixup(float x, int ny, float expylnx)
 CONSTATTR float
 MATH_MANGLE(pown)(float x, int ny)
 {
+    if (UNSAFE_MATH_OPT())
+        return MATH_MANGLE(pown_fast)(x, ny);
+
     if (ny == 0)
         x = 1.0f;
 
     float expylnx = compute_expylnx_int(x, ny);
+    return pown_fixup(x, ny, expylnx);
+}
+
+CONSTATTR float
+MATH_MANGLE(pown_fast)(float x, int ny)
+{
+    if (ny == 0)
+        x = 1.0f;
+
+    float expylnx = fast_expylnx(x, (float)ny);
     return pown_fixup(x, ny, expylnx);
 }
 
@@ -206,7 +235,18 @@ rootn_fixup(float x, int ny, float expylnx)
 CONSTATTR float
 MATH_MANGLE(rootn)(float x, int ny)
 {
+    if (UNSAFE_MATH_OPT())
+        return MATH_MANGLE(rootn_fast)(x, ny);
+
     float expylnx = compute_exp_inverse_y_lnx_int(x, ny);
+    return rootn_fixup(x, ny, expylnx);
+}
+
+CONSTATTR float
+MATH_MANGLE(rootn_fast)(float x, int ny)
+{
+    float y = MATH_FAST_RCP((float)ny);
+    float expylnx = fast_expylnx(x, y);
     return rootn_fixup(x, ny, expylnx);
 }
 

--- a/amd/device-libs/opencl/src/math/wrapb.cl
+++ b/amd/device-libs/opencl/src/math/wrapb.cl
@@ -41,6 +41,9 @@ F(T##N x, T##N y) \
     return (T##N) ( SLST##N(F,T) ); \
 }
 
+#define SWRAPNT_EXT(N, F, T)                                                   \
+    ATTR T##N C(__, F)(T##N x, T##N y) { return (T##N)(SLST##N(F, T)); }
+
 #define PWRAPNT(N,F,T) \
 ATTR T##N \
 F(T##N x, T##N y) \
@@ -54,6 +57,9 @@ F(T x, T y) \
 { \
     return SNAME(F,T)(x, y); \
 }
+
+#define WRAP1T_EXT(F, T)                                                       \
+    ATTR T C(__, F)(T x, T y) { return SNAME(F, T)(x, y); }
 
 #define WRAP2T(F,T) \
 ATTR T##2 \
@@ -91,6 +97,14 @@ F(T##2 x, T##2 y) \
     WRAP2T(F,half)
 #endif
 
+#define SWRAPT_EXT(F, T)                                                       \
+    SWRAPNT_EXT(16, F, T)                                                      \
+    SWRAPNT_EXT(8, F, T)                                                       \
+    SWRAPNT_EXT(4, F, T)                                                       \
+    SWRAPNT_EXT(3, F, T)                                                       \
+    SWRAPNT_EXT(2, F, T)                                                       \
+    WRAP1T_EXT(F, T)
+
 WRAP(atan2)
 WRAP(atan2pi)
 WRAP(fdim)
@@ -102,6 +116,9 @@ WRAP(nextafter)
 WRAP(pow)
 WRAP(powr)
 WRAP(remainder)
+
+SWRAPT_EXT(pow_fast, float)
+SWRAPT_EXT(powr_fast, float)
 
 #define WRAP_ELEMENTWISE_TYPE(F, T, N, B)                                      \
     ATTR T##N F(T##N x, T##N y) { return B(x, y); }

--- a/amd/device-libs/opencl/src/math/wrapbs.cl
+++ b/amd/device-libs/opencl/src/math/wrapbs.cl
@@ -53,6 +53,9 @@ F(TX##N x, TY##N y) \
     return (TX##N) ( SLST##N(F,TX) ); \
 }
 
+#define SWRAPTN_EXT(N, F, TX, TY)                                              \
+    ATTR TX##N C(__, F)(TX##N x, TY##N y) { return (TX##N)(SLST##N(F, TX)); }
+
 #define SWRAPSTN(N,F,TX,TY) \
 ATTR TX##N \
 F(TX##N x, TY y) \
@@ -82,6 +85,9 @@ F(TX x, TY y) \
     return SNAME(F,TX)(x, y); \
 }
 
+#define WRAPT1_EXT(F, TX, TY)                                                  \
+    ATTR TX C(__, F)(TX x, TY y) { return SNAME(F, TX)(x, y); }
+
 #define WRAPT2(F,TX,TY) \
 ATTR TX##2 \
 F(TX##2 x, TY##2 y) \
@@ -103,6 +109,14 @@ F(TX##2 x, TY y) \
     SWRAPTN(3,F,TX,TY) \
     SWRAPTN(2,F,TX,TY) \
     WRAPT1(F,TX,TY)
+
+#define SWRAPT_EXT(F, TX, TY)                                                  \
+    SWRAPTN_EXT(16, F, TX, TY)                                                 \
+    SWRAPTN_EXT(8, F, TX, TY)                                                  \
+    SWRAPTN_EXT(4, F, TX, TY)                                                  \
+    SWRAPTN_EXT(3, F, TX, TY)                                                  \
+    SWRAPTN_EXT(2, F, TX, TY)                                                  \
+    WRAPT1_EXT(F, TX, TY)
 
 #define SWRAPST(F,TX,TY) \
     SWRAPTN(16,F,TX,TY) \
@@ -161,6 +175,9 @@ PWRAPT(pown,half,int)
 SWRAPT(rootn,float,int)
 SWRAPT(rootn,double,int)
 PWRAPT(rootn,half,int)
+
+SWRAPT_EXT(pown_fast, float, int)
+SWRAPT_EXT(rootn_fast, float, int)
 
 #define WRAP_ELEMENTWISE_TYPE(F, T, N, B)                                      \
     ATTR T##N F(T##N x, int##N y) { return B(x, y); }                          \


### PR DESCRIPTION
The compiler needs to make the contextual decision to switch a particular call to the fast version based on the fast math flags. The global option is inflexible, requires the whole translation unit to use the same version and requires duplicating the function into every translation unit. The compiler needs a separate entry point to do this.

Give pow, powr, pown, and rootn _fast suffixed variants to call. This will now define __ocml_pow_fast_f32 __ocml_powr_fast_f32, __ocml_pown_fast_f32, and __ocml_rootn_fast_f32 as the implementation fast entry points.

Additionally, the opencl library now defines __pow_fast, __powr_fast, __pown_fast, and __rootn_fast overloads as the public entry points.

For now leave the UNSAFE_MATH_OPT check and redirect to the fast version from the base function to stage the change to avoid commit order dependence between the library and compiler.

Document the worst case ulp values. I extracted these by hacking up the conformance test to report better information in the fast cases. This was more painful than I expected because
  - test_bruteforce only tests pow with relaxed math and doesn't verify the ulp, so I had to force it to report values and also handle powr/pown/rootn.
  - Relaxed testing is done with -cl-fast-relaxed-math instead of -cl-unsafe-math-optimizations, so nans were breaking even though these implementations do not depend on finite only.


