### PR TITLE
device-libs: Use small trig range reduction for nans

### DIFF
--- a/amd/device-libs/ocml/src/trigredD.cl
+++ b/amd/device-libs/ocml/src/trigredD.cl
@@ -11,9 +11,11 @@
 CONSTATTR struct redret
 MATH_PRIVATE(trigred)(double x)
 {
-    if (x < 0x1.0p+30)
-        return MATH_PRIVATE(trigredsmall)(x);
-    else
+    // Prefer nans use the small path. The large path has elidable nan checks
+    // implied by the condition and the small does not.
+    if (x >= 0x1.0p+30)
         return MATH_PRIVATE(trigredlarge)(x);
+    else
+        return MATH_PRIVATE(trigredsmall)(x);
 }
 

--- a/amd/device-libs/ocml/src/trigredF.cl
+++ b/amd/device-libs/ocml/src/trigredF.cl
@@ -11,9 +11,11 @@
 CONSTATTR struct redret
 MATH_PRIVATE(trigred)(float x)
 {
-    if (x < SMALL_BOUND)
-        return MATH_PRIVATE(trigredsmall)(x);
-    else
+    // Prefer nans use the small path. The large path has elidable nan checks
+    // implied by the condition and the small does not.
+    if (x >= SMALL_BOUND)
         return MATH_PRIVATE(trigredlarge)(x);
+    else
+        return MATH_PRIVATE(trigredsmall)(x);
 }
 


### PR DESCRIPTION
The large range path has a FINITE_ONLY_OPT check hidden in the expansion for BUILTIN_FRACTION_F64. Reorder this so that no-nan input is implied by the dominating condition.


