### PR TITLE
device-libs: Avoid bithacking edge case checks in f64 trig functions

### DIFF
--- a/amd/device-libs/ocml/src/cosD.cl
+++ b/amd/device-libs/ocml/src/cosD.cl
@@ -16,13 +16,15 @@ MATH_MANGLE(cos)(double x)
     struct scret sc = MATH_PRIVATE(sincosred2)(r.hi, r.lo);
     sc.s = -sc.s;
 
-    int2 c = AS_INT2((r.i & 1) != 0 ? sc.s : sc.c);
-    c.hi ^= r.i > 1 ? (int)0x80000000 : 0;
+    long c = AS_LONG((r.i & 1) != 0 ? sc.s : sc.c);
+    c ^= r.i > 1 ? SIGNBIT_DP64 : 0;
+
+    double s = AS_DOUBLE(c);
 
     if (!FINITE_ONLY_OPT()) {
-        c = BUILTIN_ISFINITE_F64(ax) ? c : AS_INT2(QNANBITPATT_DP64);
+        s = BUILTIN_ISFINITE_F64(ax) ? s : QNAN_F64;
     }
 
-    return AS_DOUBLE(c);
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/cospiD.cl
+++ b/amd/device-libs/ocml/src/cospiD.cl
@@ -16,13 +16,15 @@ MATH_MANGLE(cospi)(double x)
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
     sc.s = -sc.s;
 
-    double c = (r.i & 1) == 0 ? sc.c : sc.s;
-    c = r.i > 1 ? -c : c;
+    long c = AS_LONG((r.i & 1) != 0 ? sc.s : sc.c);
+    c ^= r.i > 1 ? SIGNBIT_DP64 : 0;
 
-    if (!FINITE_ONLY_OPT() && !BUILTIN_ISFINITE_F64(ax)) {
-        c = QNAN_F64;
+    double s = AS_DOUBLE(c);
+
+    if (!FINITE_ONLY_OPT()) {
+        s = BUILTIN_ISFINITE_F64(ax) ? s : QNAN_F64;
     }
 
-    return c;
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/sincosD.cl
+++ b/amd/device-libs/ocml/src/sincosD.cl
@@ -15,22 +15,23 @@ MATH_MANGLE(sincos)(double x, __private double * cp)
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred2)(r.hi, r.lo);
 
-    int flip = r.i > 1 ? (int)0x80000000 : 0;
+    long flip = r.i > 1 ? SIGNBIT_DP64 : 0;
     bool odd = (r.i & 1) != 0;
 
-    int2 s = AS_INT2(odd ? sc.c : sc.s);
-    s.hi ^= flip ^ (AS_INT2(x).hi &(int)0x80000000);
+    double s = odd ? sc.c : sc.s;
+    s = AS_DOUBLE(AS_LONG(s) ^ flip ^ (AS_LONG(x) & SIGNBIT_DP64));
     sc.s = -sc.s;
-    int2 c = AS_INT2(odd ? sc.s : sc.c);
-    c.hi ^= flip;
+
+    double c = odd ? sc.s : sc.c;
+    c = AS_DOUBLE(AS_LONG(c) ^ flip);
 
     if (!FINITE_ONLY_OPT()) {
         bool finite = BUILTIN_ISFINITE_F64(x);
-        s = finite ? s : AS_INT2(QNANBITPATT_DP64);
-        c = finite ? c : AS_INT2(QNANBITPATT_DP64);
+        s = finite ? s : QNAN_F64;
+        c = finite ? c : QNAN_F64;
     }
 
-    *cp = AS_DOUBLE(c);
-    return AS_DOUBLE(s);
+    *cp = c;
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/sincospiD.cl
+++ b/amd/device-libs/ocml/src/sincospiD.cl
@@ -14,22 +14,23 @@ MATH_MANGLE(sincospi)(double x, __private double * cp)
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F64(x));
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
-    int flip = r.i > 1 ? (int)0x80000000 : 0;
+    long flip = r.i > 1 ? SIGNBIT_DP64 : 0;
     bool odd = (r.i & 1) != 0;
 
-    int2 s = AS_INT2(odd ? sc.c : sc.s);
-    s.hi ^= flip ^ (AS_INT2(x).hi & 0x80000000);
-    sc.s = -sc.s;
-    int2 c = AS_INT2(odd ? sc.s : sc.c);
-    c.hi ^= flip;
+    double s = odd ? sc.c : sc.s;
+
+    s = AS_DOUBLE(AS_LONG(s) ^ flip ^ (AS_LONG(x) & SIGNBIT_DP64));
+
+    double c = odd ? sc.s : sc.c;
+    c = AS_DOUBLE(AS_LONG(c) ^ flip);
 
     if (!FINITE_ONLY_OPT()) {
         bool finite = BUILTIN_ISFINITE_F64(x);
-        s = finite ? s : AS_INT2(QNANBITPATT_DP64);
-        c = finite ? c : AS_INT2(QNANBITPATT_DP64);
+        s = finite ? s : QNAN_F64;
+        c = finite ? c : QNAN_F64;
     }
 
-    *cp = AS_DOUBLE(c);
-    return AS_DOUBLE(s);
+    *cp = c;
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/sinpiD.cl
+++ b/amd/device-libs/ocml/src/sinpiD.cl
@@ -11,16 +11,18 @@
 double
 MATH_MANGLE(sinpi)(double x)
 {
-    struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F64(x));
+    double ax = BUILTIN_ABS_F64(x);
+    struct redret r = MATH_PRIVATE(trigpired)(ax);
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
-    int2 s = AS_INT2((r.i & 1) == 0 ? sc.s : sc.c);
-    s.hi ^= (r.i > 1 ? 0x80000000 : 0) ^ (AS_INT2(x).hi & 0x80000000);
+    double s = (r.i & 1) == 0 ? sc.s : sc.c;
 
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F64(x) ? s : AS_INT2(QNANBITPATT_DP64);
-    }
+    s = AS_DOUBLE(AS_LONG(s) ^ (r.i > 1 ? SIGNBIT_DP64 : 0) ^
+                  (AS_LONG(x) ^ AS_LONG(ax)));
 
-    return AS_DOUBLE(s);
+    if (!FINITE_ONLY_OPT())
+        s = BUILTIN_ISFINITE_F64(x) ? s : QNAN_F64;
+
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/tanD.cl
+++ b/amd/device-libs/ocml/src/tanD.cl
@@ -14,11 +14,11 @@ MATH_MANGLE(tan)(double x)
     double ax = BUILTIN_ABS_F64(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
 
-    int2 t = AS_INT2(MATH_PRIVATE(tanred2)(r.hi, r.lo, r.i & 1));
-    t.hi ^= AS_INT2(x).hi & (int)0x80000000;
+    double t = MATH_PRIVATE(tanred2)(r.hi, r.lo, r.i & 1);
+    t = AS_DOUBLE(AS_LONG(t) ^ (AS_LONG(x) & SIGNBIT_DP64));
 
     if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F64(ax) ? t : AS_INT2(QNANBITPATT_DP64);
+        t = BUILTIN_ISFINITE_F64(ax) ? t : QNAN_F64;
     }
 
     return AS_DOUBLE(t);

--- a/amd/device-libs/ocml/src/tanpiD.cl
+++ b/amd/device-libs/ocml/src/tanpiD.cl
@@ -11,15 +11,18 @@
 CONSTATTR double
 MATH_MANGLE(tanpi)(double x)
 {
-    struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F64(x));
-    int2 t = AS_INT2(MATH_PRIVATE(tanpired)(r.hi, r.i & 1));
-    t.hi ^= (((r.i == 1) | (r.i == 2)) & (r.hi == 0.0)) ? 0x80000000 : 0;
-    t.hi ^= AS_INT2(x).hi & (int)0x80000000;
+    double ax = BUILTIN_ABS_F64(x);
+    struct redret r = MATH_PRIVATE(trigpired)(ax);
+    double t = MATH_PRIVATE(tanpired)(r.hi, r.i & 1);
+
+    long flip = (((r.i == 1) | (r.i == 2)) & (r.hi == 0.0)) ? SIGNBIT_DP64 : 0;
+
+    t = AS_DOUBLE((AS_LONG(t) ^ flip) ^ (AS_LONG(x) & SIGNBIT_DP64));
 
     if (!FINITE_ONLY_OPT()) {
-        t =  BUILTIN_ISFINITE_F64(x) ? t : AS_INT2(QNANBITPATT_DP64);
+        t =  BUILTIN_ISFINITE_F64(x) ? t : QNAN_F64;
     }
 
-    return AS_DOUBLE(t);
+    return t;
 }
 


### PR DESCRIPTION
Keep as much directly in the double type as possible, trying to keep nan constants properly typed. Improves value tracking, though the compiler should manage to reassemble these (as https://github.com/llvm/llvm-project/pull/179042 does)