### PR TITLE
device-libs: Avoid bithacking in f32 and f16 trig functions

### DIFF
--- a/amd/device-libs/ocml/src/cosH.cl
+++ b/amd/device-libs/ocml/src/cosH.cl
@@ -18,13 +18,15 @@ MATH_MANGLE(cos)(half x)
     struct scret sc = MATH_PRIVATE(sincosred)(r.hi);
     sc.s = -sc.s;
 
-    short c =  AS_SHORT((r.i & 1) == (short)0 ? sc.c : sc.s);
-    c ^= r.i > 1 ? (short)0x8000 : (short)0;
+    half c = (r.i & 1) == (short)0 ? sc.c : sc.s;
+
+    short flip = r.i > 1 ? (short)SIGNBIT_HP16 : 0;
+    c = AS_HALF((short)(AS_SHORT(c) ^ flip));
 
     if (!FINITE_ONLY_OPT()) {
-        c = BUILTIN_ISFINITE_F16(ax) ? c : (short)QNANBITPATT_HP16;
+        c = BUILTIN_ISFINITE_F16(ax) ? c : QNAN_F16;
     }
 
-    return AS_HALF(c);
+    return c;
 }
 

--- a/amd/device-libs/ocml/src/sinH.cl
+++ b/amd/device-libs/ocml/src/sinH.cl
@@ -17,11 +17,13 @@ MATH_MANGLE(sin)(half x)
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc =  MATH_PRIVATE(sincosred)(r.hi);
 
-    short s = AS_SHORT((r.i & (short)1) == (short)0 ? sc.s : sc.c);
-    s ^= (r.i > (short)1 ? (short)0x8000 : (short)0) ^ (AS_SHORT(x) & (short)0x8000);
+    half s = (r.i & (short)1) == (short)0 ? sc.s : sc.c;
+    short flip = r.i > (short)1 ? (short)SIGNBIT_HP16 : (short)0;
+
+    s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ (AS_SHORT(x) & (short)SIGNBIT_HP16))));
 
     if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F16(ax) ? s : (short)QNANBITPATT_HP16;
+        s = BUILTIN_ISFINITE_F16(ax) ? s : QNAN_F16;
     }
 
     return AS_HALF(s);

--- a/amd/device-libs/ocml/src/sincosH.cl
+++ b/amd/device-libs/ocml/src/sincosH.cl
@@ -26,21 +26,23 @@ MATH_MANGLE(sincos)(half x, __private half *cp)
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred)(r.hi);
 
-    short flip = r.i > (short)1 ? (short)0x8000 : (short)0;
+    short flip = r.i > (short)1 ? (short)SIGNBIT_HP16 : (short)0;
     bool odd = (r.i & (short)1) != (short)0;
-    short s = AS_SHORT(odd ? sc.c : sc.s);
-    s ^= flip ^ (AS_SHORT(x) & (short)0x8000);
+    half s = odd ? sc.c : sc.s;
+
+    s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ AS_SHORT(x) & (short)SIGNBIT_HP16)));
+
     sc.s = -sc.s;
-    short c = AS_SHORT(odd ? sc.s : sc.c);
-    c ^= flip;
+    half c = odd ? sc.s : sc.c;
+    c = AS_HALF((short)(AS_SHORT(c) ^ flip));
 
     if (!FINITE_ONLY_OPT()) {
         bool finite = BUILTIN_ISFINITE_F16(ax);
-        c = finite ? c : (short)QNANBITPATT_HP16;
-        s = finite ? s : (short)QNANBITPATT_HP16;
+        c = finite ? c : QNAN_F16;
+        s = finite ? s : QNAN_F16;
     }
 
-    *cp = AS_HALF(c);
-    return AS_HALF(s);
+    *cp = c;
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/sincospiH.cl
+++ b/amd/device-libs/ocml/src/sincospiH.cl
@@ -26,21 +26,22 @@ MATH_MANGLE(sincospi)(half x, __private half *cp)
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
-    short flip = r.i > (short)1 ? (short)0x8000 : (short)0;
+    short flip = r.i > (short)1 ? (short)SIGNBIT_HP16 : (short)0;
     bool odd = (r.i & (short)1) != (short)0;
-    short s = AS_SHORT(odd ? sc.c : sc.s);
-    s ^= flip ^ (AS_SHORT(x) & (short)0x8000);
+    half s = odd ? sc.c : sc.s;
+
+    s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ AS_SHORT(x) & (short)SIGNBIT_HP16)));
+
     sc.s = -sc.s;
-    short c = AS_SHORT(odd ? sc.s : sc.c);
-    c ^= flip;
+    half c = AS_HALF((short)(AS_SHORT(odd ? sc.s : sc.c) ^ flip));
 
     if (!FINITE_ONLY_OPT()) {
         bool finite = BUILTIN_ISFINITE_F16(x);
-        c = finite ? c : (short)QNANBITPATT_HP16;
-        s = finite ? s : (short)QNANBITPATT_HP16;
+        c = finite ? c : QNAN_F16;
+        s = finite ? s : QNAN_F16;
     }
 
-    *cp = AS_HALF(c);
-    return AS_HALF(s);
+    *cp = c;
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/sinpiH.cl
+++ b/amd/device-libs/ocml/src/sinpiH.cl
@@ -16,13 +16,15 @@ MATH_MANGLE(sinpi)(half x)
     struct redret r =  MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
-    short s = AS_SHORT((r.i & (short)1) == (short)0 ? sc.s : sc.c);
-    s ^= (r.i > (short)1 ? (short)0x8000 : (short)0) ^ (AS_SHORT(x) & (short)0x8000);
+    half s = (r.i & (short)1) == (short)0 ? sc.s : sc.c;
+    short flip = r.i > (short)1 ? (short)SIGNBIT_HP16 : (short)0;
+
+    s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ (AS_SHORT(x) ^ (short)SIGNBIT_HP16))));
 
     if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F16(x) ? s : (short)QNANBITPATT_HP16;
+        s = BUILTIN_ISFINITE_F16(x) ? s : QNAN_F16;
     }
 
-    return AS_HALF(s);
+    return s;
 }
 

--- a/amd/device-libs/ocml/src/tanH.cl
+++ b/amd/device-libs/ocml/src/tanH.cl
@@ -15,13 +15,14 @@ MATH_MANGLE(tan)(half x)
 {
     half ax = BUILTIN_ABS_F16(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
-    short t = AS_SHORT(MATH_PRIVATE(tanred)(r.hi, r.i & (short)1));
-    t ^= AS_SHORT(x) & (short)0x8000;
+    half t = MATH_PRIVATE(tanred)(r.hi, r.i & (short)1);
+
+    t = AS_HALF((short)(AS_SHORT(t) ^ (AS_SHORT(x) & SIGNBIT_HP16)));
 
     if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F16(ax) ? t : (short)QNANBITPATT_HP16;
+        t = BUILTIN_ISFINITE_F16(ax) ? t : QNAN_F16;
     }
 
-    return AS_HALF(t);
+    return t;
 }
 

--- a/amd/device-libs/ocml/src/tanpiF.cl
+++ b/amd/device-libs/ocml/src/tanpiF.cl
@@ -12,14 +12,14 @@ CONSTATTR float
 MATH_MANGLE(tanpi)(float x)
 {
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F32(x));
-    int t = AS_INT(MATH_PRIVATE(tanpired)(r.hi, r.i & 1));
-    t ^= (((r.i == 1) | (r.i == 2)) & (r.hi == 0.0f)) ? (int)0x80000000 : 0;
-    t ^= AS_INT(x) & (int)0x80000000;
+    float t = MATH_PRIVATE(tanpired)(r.hi, r.i & 1);
+    int flip = (((r.i == 1) | (r.i == 2)) & (r.hi == 0.0f)) ? SIGNBIT_SP32 : 0;
+    t = AS_FLOAT((AS_INT(t) ^ flip) ^ (AS_INT(x) & SIGNBIT_SP32));
 
     if (!FINITE_ONLY_OPT()) {
-        t =  BUILTIN_ISFINITE_F32(x) ? t : QNANBITPATT_SP32;
+        t = BUILTIN_ISFINITE_F32(x) ? t : QNAN_F32;
     }
 
-    return AS_FLOAT(t);
+    return t;
 }
 

--- a/amd/device-libs/ocml/src/tanpiH.cl
+++ b/amd/device-libs/ocml/src/tanpiH.cl
@@ -14,14 +14,15 @@ CONSTATTR half
 MATH_MANGLE(tanpi)(half x)
 {
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
-    short t = AS_SHORT(MATH_PRIVATE(tanpired)(r.hi, r.i & (short)1));
-    t ^= (((r.i == (short)1) | (r.i == (short)2)) & (r.hi == 0.0h)) ? (short)0x8000 : (short)0;
-    t ^= AS_SHORT(x) & (short)0x8000;
+
+    half t = MATH_PRIVATE(tanpired)(r.hi, r.i & (short)1);
+    short flip = (((r.i == (short)1) | (r.i == (short)2)) & (r.hi == 0.0h)) ? (short)SIGNBIT_HP16 : (short)0;
+    t = AS_HALF((short)((AS_SHORT(t) ^ flip) ^ (AS_SHORT(x) & (short)SIGNBIT_HP16)));
 
     if (!FINITE_ONLY_OPT()) {
-        t =  BUILTIN_ISFINITE_F16(x) ? t : (short)QNANBITPATT_HP16;
+        t = BUILTIN_ISFINITE_F16(x) ? t : QNAN_F16;
     }
 
-    return AS_HALF(t);
+    return t;
 }
 


### PR DESCRIPTION
Avoid vectors and keep special cases as FP type or equivalent sized integer.