### PR TITLE
device-libs: Use frexp_exp instead of shift and extract

### DIFF
--- a/amd/device-libs/ocml/src/builtins.h
+++ b/amd/device-libs/ocml/src/builtins.h
@@ -241,7 +241,7 @@ static inline half __ocml_priv_rsqrt_f16(half x) {
 #define BUILTIN_FREXP_EXP_F32(X)                                               \
     ({                                                                         \
         int _exp;                                                              \
-        __builtin_frexp(X, &_exp);                                             \
+        __builtin_frexpf(X, &_exp);                                            \
         _exp;                                                                  \
     })
 

--- a/amd/device-libs/ocml/src/trigredlargeF.cl
+++ b/amd/device-libs/ocml/src/trigredlargeF.cl
@@ -12,7 +12,7 @@
 CONSTATTR struct redret
 MATH_PRIVATE(trigredlarge)(float x)
 {
-    int xe = (int)(AS_UINT(x) >> 23) - 127;
+    int xe = BUILTIN_FREXP_EXP_F32(x) - 1;
     uint xm = 0x00800000U | (AS_UINT(x) & 0x7fffffU);
 
     // 224 bits of 2/PI: . A2F9836E 4E441529 FC2757D1 F534DDC0 DB629599 3C439041 FE5163AB


### PR DESCRIPTION
The sub 1 will fold in with the add of constant use below. Saves 4 bytes from avoiding the literals.

Also fixes copy paste error in frexp wrapper macro.


