### PR TITLE
device-libs: Fix f64 sincospi

### DIFF
--- a/amd/device-libs/ocml/src/sincospiD.cl
+++ b/amd/device-libs/ocml/src/sincospiD.cl
@@ -20,6 +20,7 @@ MATH_MANGLE(sincospi)(double x, __private double * cp)
     double s = odd ? sc.c : sc.s;
 
     s = AS_DOUBLE(AS_LONG(s) ^ flip ^ (AS_LONG(x) & SIGNBIT_DP64));
+    sc.s = -sc.s;
 
     double c = odd ? sc.s : sc.c;
     c = AS_DOUBLE(AS_LONG(c) ^ flip);


### PR DESCRIPTION
Fix regression from 78f48b63f4a2a8f8b8be192110ff9cb8ca1b91bb. The negation of s.s got lost. This is the case not covered by the OpenCL conformance test.
