### PR TITLE
[OpenMP][Offload] fix xteam_scan_2/3.c and race condition in Xteams.cpp

### DIFF
--- a/offload/test/offloading/xteam_scan_2.c
+++ b/offload/test/offloading/xteam_scan_2.c
@@ -3,7 +3,8 @@
 // of the Xteam Scan Kernel. 
 // It verifies that the reduction kernel is of Xteam-Scan type 
 // and is launched with 85x256 and 85x512 combinations for teamsXthrds. 
-// It also verifies the output without the num_teams() and num_threads() clauses.
+// It also verifies the output without the num_teams() and num_threads() clauses,
+// where the workgroup size is determined by the runtime (captured as ConstWGSize).
 // 
 
 // RUN: %libomptarget-compile-generic -fopenmp-target-ignore-env-vars -fopenmp-target-xteam-scan -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state -lm -latomic
@@ -164,35 +165,35 @@ int main() {
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK: args:10 teamsXthrds:( 85X 256)
-/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l49
+/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l50
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK: args:10 teamsXthrds:( 85X 256)
-/// CHECK: n:__omp_offloading_[[MANGLED]]_with_clauses_l49_1
+/// CHECK: n:__omp_offloading_[[MANGLED]]_with_clauses_l50_1
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK: args:10 teamsXthrds:( 85X 256)
-/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l73
+/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l74
 
 /// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK: args:10 teamsXthrds:( 85X 256)
-/// CHECK: n:__omp_offloading_[[MANGLED]]_with_clauses_l73_1
+/// CHECK: n:__omp_offloading_[[MANGLED]]_with_clauses_l74_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_without_clauses_l109
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE:[0-9]+]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS:[0-9]+]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_without_clauses_l110
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: n:__omp_offloading_[[MANGLED]]_without_clauses_l109_1
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: n:__omp_offloading_[[MANGLED]]_without_clauses_l110_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_without_clauses_l133
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: n:__omp_offloading_[[MANGLED:.*]]_without_clauses_l134
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: n:__omp_offloading_[[MANGLED]]_without_clauses_l133_1
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: n:__omp_offloading_[[MANGLED]]_without_clauses_l134_1
 
 /// CHECK: Inclusive Scan: Success!
 /// CHECK: Exclusive Scan: Success!
@@ -201,19 +202,19 @@ int main() {
 
 /// CHECK-512WGSize: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK-512WGSize: args:10 teamsXthrds:( 85X 512)
-/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l49
+/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l50
 
 /// CHECK-512WGSize: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK-512WGSize: args:10 teamsXthrds:( 85X 512)
-/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED]]_with_clauses_l49_1
+/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED]]_with_clauses_l50_1
 
 /// CHECK-512WGSize: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK-512WGSize: args:10 teamsXthrds:( 85X 512)
-/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l73
+/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED:.*]]_with_clauses_l74
 
 /// CHECK-512WGSize: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
 /// CHECK-512WGSize: args:10 teamsXthrds:( 85X 512)
-/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED]]_with_clauses_l73_1
+/// CHECK-512WGSize: n:__omp_offloading_[[MANGLED]]_with_clauses_l74_1
 
 /// CHECK-512WGSize: Inclusive Scan: Success!
 /// CHECK-512WGSize: Exclusive Scan: Success!

--- a/offload/test/offloading/xteam_scan_3.cpp
+++ b/offload/test/offloading/xteam_scan_3.cpp
@@ -1,7 +1,7 @@
 // clang-format off
 // This test verifies the output of inclusive and exclusive scan computed using the Xteam Scan Kernel
-// for various datatypes for both Segmented(default) Scan and No-Loop Scan kernel variants
-// 
+// for various datatypes for both Segmented(default) Scan and No-Loop Scan kernel variants.
+// For the default (segmented) variant, workgroup size is determined by the runtime (captured as ConstWGSize).
 
 // RUN: %libomptarget-compile-generic -fopenmp-target-ignore-env-vars -fopenmp-target-xteam-scan -fopenmp-assume-no-nested-parallelism -fopenmp-assume-no-thread-state -lm -latomic
 // RUN: env LIBOMPTARGET_KERNEL_TRACE=1 \
@@ -114,123 +114,123 @@ int main() {
 }
 // clang-format off
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:8200B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE:[0-9]+]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS:[0-9]+]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:4104B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*i.*]]_l50
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l50_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:8200B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:4104B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*i.*]]_l74
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l74_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:8200B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:4104B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*j.*]]_l50
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l50_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:8200B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:4104B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*j.*]]_l74
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l74_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:16400B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:8208B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*m.*]]_l50
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l50_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:16400B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:8208B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*m.*]]_l74
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l74_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:16400B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:8208B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*l.*]]_l50
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l50_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:16400B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:8208B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*l.*]]_l74
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l74_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:16400B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:8208B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*d.*]]_l50
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l50_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:16400B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:8208B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*d.*]]_l74
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l74_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:8200B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:4104B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*f.*]]_l50
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l50_1
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
-/// CHECK: lds_usage:8200B
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
+/// CHECK: lds_usage:4104B
 /// CHECK: n:__omp_offloading_[[MANGLED:.*f.*]]_l74
 
-/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8
-/// CHECK: args:10 teamsXthrds:( 104X1024)
+/// CHECK: DEVID:[[S:[ ]*]][[DEVID:[0-9]+]] SGN:8 ConstWGSize:[[WGSIZE]]
+/// CHECK: args:10 teamsXthrds:({{[ ]*}}[[TEAMS]]X{{[ ]*}}[[WGSIZE]])
 /// CHECK: lds_usage:0B
 /// CHECK: n:__omp_offloading_[[MANGLED]]_l74_1
 

--- a/openmp/device/src/Xteams.cpp
+++ b/openmp/device/src/Xteams.cpp
@@ -123,7 +123,11 @@ __attribute__((flatten, always_inline)) void _xteam_scan(
   // The offset value which is required to access the computed team-wise scan 
   // based upon the workgroup size.
   uint32_t offset = is_odd_power(_NT) ? total_num_threads : 0;
-  storage[k] = storage[offset + k];  
+  storage[k] = storage[offset + k];
+
+  // Thread 0 reads storage[..._NT-1] below, which was written by thread _NT-1
+  // above.
+  ompx::synchronize::threadsAligned(ompx::atomic::seq_cst);
 
   // The teams_done_ptr will be read using this
   static __XTEAM_SHARED_LDS uint32_t td;


### PR DESCRIPTION
Fix `offload/test/offloading/xteam_scan_2.c` and `xteam_scan_3.c` by making them more hardware independent.

Fix a race condition in Xteams.cpp, which also caused a failure in `xteam_scan_3.c`.


