### PR TITLE
[OpenMP][offload] Remove XFAIL from test/mapping/lambda_mapping.cpp

### DIFF
--- a/offload/test/mapping/lambda_mapping.cpp
+++ b/offload/test/mapping/lambda_mapping.cpp
@@ -1,5 +1,4 @@
 // Unonptimized, we need 24000000 bytes heap
-// XFAIL: amdgcn-amd-amdhsa
 // RUN: %libomptarget-compilexx-generic
 // RUN: env LIBOMPTARGET_HEAP_SIZE=24000000 \
 // RUN: %libomptarget-run-generic 2>&1 | %fcheck-generic


### PR DESCRIPTION
Isn't present upstream and doesn't actually fail for downstream, either.


