### PR TITLE
device-libs: Use ldexp builtin directly

### DIFF
--- a/amd/device-libs/ocml/src/scalbH.cl
+++ b/amd/device-libs/ocml/src/scalbH.cl
@@ -13,7 +13,7 @@ CONSTATTR half
 MATH_MANGLE(scalb)(half x, half y)
 {
     half t = BUILTIN_MIN_F16(BUILTIN_MAX_F16(y, -0x1.0p+6h), 0x1.0p+6h);
-    half ret = MATH_MANGLE(ldexp)(x, (int)BUILTIN_RINT_F16(t));
+    half ret = BUILTIN_FLDEXP_F16(x, (int)BUILTIN_RINT_F16(t));
 
     if (!FINITE_ONLY_OPT()) {
         ret = BUILTIN_ISUNORDERED_F16(x, y) ? QNAN_F16 : ret;

--- a/amd/device-libs/ocml/src/scalbnH.cl
+++ b/amd/device-libs/ocml/src/scalbnH.cl
@@ -10,12 +10,12 @@
 CONSTATTR half2
 MATH_MANGLE2(scalbn)(half2 x, int2 n)
 {
-    return (half2)(MATH_MANGLE(ldexp)(x.lo, n.lo), MATH_MANGLE(ldexp)(x.hi, n.hi));
+    return BUILTIN_FLDEXP_2F16(x, n);
 }
 
 CONSTATTR half
 MATH_MANGLE(scalbn)(half x, int n)
 {
-    return MATH_MANGLE(ldexp)(x, n);
+    return BUILTIN_FLDEXP_F16(x, n);
 }
 


### PR DESCRIPTION
Avoid going through the ocml wrapper, which should be deprecated.


