### PR TITLE
Adopt upstream OpenMP flag improvements (approved in llvm#178914)

### DIFF
--- a/clang/include/clang/Basic/LangOptions.def
+++ b/clang/include/clang/Basic/LangOptions.def
@@ -239,6 +239,7 @@ LANGOPT(OpenMPThreadSubscription  , 1, 0, NotCompatible, "Assume work-shared loo
 LANGOPT(OpenMPTeamSubscription  , 1, 0, NotCompatible, "Assume distributed loops do not have more iterations than participating teams.")
 LANGOPT(OpenMPNoThreadState  , 1, 0, NotCompatible, "Assume that no thread in a parallel region will modify an ICV.")
 LANGOPT(OpenMPNoNestedParallelism  , 1, 0, NotCompatible, "Assume that no thread in a parallel region will encounter a parallel region")
+LANGOPT(OpenMPTargetIgnoreEnvVars, 1, 0, NotCompatible, "Assume that the OpenMP runtime can ignore environment variables during code generation for GPU offload")
 LANGOPT(OpenMPOffloadMandatory  , 1, 0, NotCompatible, "Assert that offloading is mandatory and do not create a host fallback.")
 LANGOPT(OpenMPForceUSM     , 1, 0, NotCompatible, "Enable OpenMP unified shared memory mode via compiler.")
 LANGOPT(NoGPULib  , 1, 0, NotCompatible, "Indicate a build without the standard GPU libraries.")

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3983,23 +3983,9 @@ def fno_openmp_assume_teams_oversubscription : Flag<["-"], "fno-openmp-assume-te
   HelpText<"Do not assume teams oversubscription.">;
 def fno_openmp_assume_threads_oversubscription : Flag<["-"], "fno-openmp-assume-threads-oversubscription">,
   HelpText<"Do not assume threads oversubscription.">;
-def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
-  HelpText<"Assert that a thread in a parallel region may modify an ICV">;
-def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
-  HelpText<"Assert no nested parallel regions in the GPU">,
-  MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
-def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">,
-  HelpText<"Assert that a nested parallel region may be used in the GPU">;
 def fopenmp_assume_no_thread_state : Flag<["-"], "fopenmp-assume-no-thread-state">,
   HelpText<"Assert no thread in a parallel region modifies an ICV">,
   MarshallingInfoFlag<LangOpts<"OpenMPNoThreadState">>;
-def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
-  HelpText<"Assert that a thread in a parallel region may modify an ICV">;
-def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
-  HelpText<"Assert no nested parallel regions in the GPU">,
-  MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
-def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">,
-  HelpText<"Assert that a nested parallel region may be used in the GPU">;
 def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
   HelpText<"Assert that a thread in a parallel region may modify an ICV">;
 def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
@@ -4036,6 +4022,13 @@ def fopenmp_target_ignore_env_vars : Flag<["-"], "fopenmp-target-ignore-env-vars
   HelpText<"Assume that the OpenMP runtime can ignore environment variables during code generation for GPU offload">,
   MarshallingInfoFlag<LangOpts<"OpenMPTargetIgnoreEnvVars">>;
 def fno_openmp_target_ignore_env_vars : Flag<["-"], "fno-openmp-target-ignore-env-vars">,
+  Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
+  Visibility<[ClangOption, CC1Option]>;
+def fopenmp_target_fast : Flag<["-"], "fopenmp-target-fast">,
+  Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Convenience flag to enable aggressive OpenMP GPU optimizations">;
+def fno_openmp_target_fast : Flag<["-"], "fno-openmp-target-fast">,
   Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
   Visibility<[ClangOption, CC1Option]>;
 defm openmp_optimistic_collapse : BoolFOption<"openmp-optimistic-collapse",

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3983,12 +3983,30 @@ def fno_openmp_assume_teams_oversubscription : Flag<["-"], "fno-openmp-assume-te
   HelpText<"Do not assume teams oversubscription.">;
 def fno_openmp_assume_threads_oversubscription : Flag<["-"], "fno-openmp-assume-threads-oversubscription">,
   HelpText<"Do not assume threads oversubscription.">;
-def fopenmp_assume_no_thread_state : Flag<["-"], "fopenmp-assume-no-thread-state">,
-  HelpText<"Assert no thread in a parallel region modifies an ICV">,
-  MarshallingInfoFlag<LangOpts<"OpenMPNoThreadState">>;
+def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
+  HelpText<"Assert that a thread in a parallel region may modify an ICV">;
 def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
   HelpText<"Assert no nested parallel regions in the GPU">,
   MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
+def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">,
+  HelpText<"Assert that a nested parallel region may be used in the GPU">;
+def fopenmp_assume_no_thread_state : Flag<["-"], "fopenmp-assume-no-thread-state">,
+  HelpText<"Assert no thread in a parallel region modifies an ICV">,
+  MarshallingInfoFlag<LangOpts<"OpenMPNoThreadState">>;
+def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
+  HelpText<"Assert that a thread in a parallel region may modify an ICV">;
+def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
+  HelpText<"Assert no nested parallel regions in the GPU">,
+  MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
+def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">,
+  HelpText<"Assert that a nested parallel region may be used in the GPU">;
+def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
+  HelpText<"Assert that a thread in a parallel region may modify an ICV">;
+def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
+  HelpText<"Assert no nested parallel regions in the GPU">,
+  MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
+def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">,
+  HelpText<"Assert that a nested parallel region may be used in the GPU">;
 
 } // let Group = f_Group
 } // let Visibility = [ClangOption, CC1Option, FC1Option]

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -4030,6 +4030,14 @@ def fopenmp_target_new_runtime : Flag<["-"], "fopenmp-target-new-runtime">,
   Group<f_Group>, Flags<[HelpHidden]>, Visibility<[ClangOption, CC1Option]>;
 def fno_openmp_target_new_runtime : Flag<["-"], "fno-openmp-target-new-runtime">,
   Group<f_Group>, Flags<[HelpHidden]>, Visibility<[ClangOption, CC1Option]>;
+def fopenmp_target_ignore_env_vars : Flag<["-"], "fopenmp-target-ignore-env-vars">,
+  Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Assume that the OpenMP runtime can ignore environment variables during code generation for GPU offload">,
+  MarshallingInfoFlag<LangOpts<"OpenMPTargetIgnoreEnvVars">>;
+def fno_openmp_target_ignore_env_vars : Flag<["-"], "fno-openmp-target-ignore-env-vars">,
+  Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
+  Visibility<[ClangOption, CC1Option]>;
 defm openmp_optimistic_collapse : BoolFOption<"openmp-optimistic-collapse",
   LangOpts<"OpenMPOptimisticCollapse">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6725,10 +6725,21 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                        options::OPT_fno_openmp_assume_threads_oversubscription,
                        /*Default=*/false))
         CmdArgs.push_back("-fopenmp-assume-threads-oversubscription");
+      if (Args.hasArg(options::OPT_fopenmp_target_ignore_env_vars))
+        CmdArgs.push_back("-fopenmp-target-ignore-env-vars");
+      else if (Args.hasArg(options::OPT_fno_openmp_target_ignore_env_vars))
+        CmdArgs.push_back("-fno-openmp-target-ignore-env-vars");
+
       if (Args.hasArg(options::OPT_fopenmp_assume_no_thread_state))
         CmdArgs.push_back("-fopenmp-assume-no-thread-state");
+      else if (Args.hasArg(options::OPT_fno_openmp_assume_no_thread_state))
+        CmdArgs.push_back("-fno-openmp-assume-no-thread-state");
+
       if (Args.hasArg(options::OPT_fopenmp_assume_no_nested_parallelism))
         CmdArgs.push_back("-fopenmp-assume-no-nested-parallelism");
+      else if (Args.hasArg(options::OPT_fno_openmp_assume_no_nested_parallelism))
+        CmdArgs.push_back("-fno-openmp-assume-no-nested-parallelism");
+
       if (Args.hasArg(options::OPT_fopenmp_offload_mandatory))
         CmdArgs.push_back("-fopenmp-offload-mandatory");
       if (Args.hasArg(options::OPT_fopenmp_force_usm))

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6675,6 +6675,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                     options::OPT_fno_offload_via_llvm, false) &&
       (JA.isDeviceOffloading(Action::OFK_None) ||
        JA.isDeviceOffloading(Action::OFK_OpenMP))) {
+
+    // Determine if target-fast optimizations should be enabled
+    bool TargetFastUsed =
+        Args.hasFlag(options::OPT_fopenmp_target_fast,
+                     options::OPT_fno_openmp_target_fast, OFastEnabled);
     switch (D.getOpenMPRuntime(Args)) {
     case Driver::OMPRT_OMP:
     case Driver::OMPRT_IOMP5:
@@ -6725,20 +6730,54 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                        options::OPT_fno_openmp_assume_threads_oversubscription,
                        /*Default=*/false))
         CmdArgs.push_back("-fopenmp-assume-threads-oversubscription");
-      if (Args.hasArg(options::OPT_fopenmp_target_ignore_env_vars))
+
+      // Handle -fopenmp-target-fast
+      if (Arg *A = Args.getLastArg(options::OPT_fopenmp_target_fast,
+                                   options::OPT_fno_openmp_target_fast)) {
+        if (A->getOption().matches(options::OPT_fopenmp_target_fast))
+          CmdArgs.push_back("-fopenmp-target-fast");
+        else
+          CmdArgs.push_back("-fno-openmp-target-fast");
+      } else if (OFastEnabled) {
+        CmdArgs.push_back("-fopenmp-target-fast");
+      }
+
+      // Handle -fopenmp-target-ignore-env-vars (implied by target-fast)
+      if (Arg *A =
+              Args.getLastArg(options::OPT_fopenmp_target_ignore_env_vars,
+                              options::OPT_fno_openmp_target_ignore_env_vars)) {
+        if (A->getOption().matches(options::OPT_fopenmp_target_ignore_env_vars))
+          CmdArgs.push_back("-fopenmp-target-ignore-env-vars");
+        else
+          CmdArgs.push_back("-fno-openmp-target-ignore-env-vars");
+      } else if (TargetFastUsed) {
         CmdArgs.push_back("-fopenmp-target-ignore-env-vars");
-      else if (Args.hasArg(options::OPT_fno_openmp_target_ignore_env_vars))
-        CmdArgs.push_back("-fno-openmp-target-ignore-env-vars");
+      }
 
-      if (Args.hasArg(options::OPT_fopenmp_assume_no_thread_state))
+      // Handle -fopenmp-assume-no-thread-state (implied by target-fast)
+      if (Arg *A =
+              Args.getLastArg(options::OPT_fopenmp_assume_no_thread_state,
+                              options::OPT_fno_openmp_assume_no_thread_state)) {
+        if (A->getOption().matches(options::OPT_fopenmp_assume_no_thread_state))
+          CmdArgs.push_back("-fopenmp-assume-no-thread-state");
+        else
+          CmdArgs.push_back("-fno-openmp-assume-no-thread-state");
+      } else if (TargetFastUsed) {
         CmdArgs.push_back("-fopenmp-assume-no-thread-state");
-      else if (Args.hasArg(options::OPT_fno_openmp_assume_no_thread_state))
-        CmdArgs.push_back("-fno-openmp-assume-no-thread-state");
+      }
 
-      if (Args.hasArg(options::OPT_fopenmp_assume_no_nested_parallelism))
+      // Handle -fopenmp-assume-no-nested-parallelism (implied by target-fast)
+      if (Arg *A = Args.getLastArg(
+              options::OPT_fopenmp_assume_no_nested_parallelism,
+              options::OPT_fno_openmp_assume_no_nested_parallelism)) {
+        if (A->getOption().matches(
+                options::OPT_fopenmp_assume_no_nested_parallelism))
+          CmdArgs.push_back("-fopenmp-assume-no-nested-parallelism");
+        else
+          CmdArgs.push_back("-fno-openmp-assume-no-nested-parallelism");
+      } else if (TargetFastUsed) {
         CmdArgs.push_back("-fopenmp-assume-no-nested-parallelism");
-      else if (Args.hasArg(options::OPT_fno_openmp_assume_no_nested_parallelism))
-        CmdArgs.push_back("-fno-openmp-assume-no-nested-parallelism");
+      }
 
       if (Args.hasArg(options::OPT_fopenmp_offload_mandatory))
         CmdArgs.push_back("-fopenmp-offload-mandatory");

--- a/clang/test/Driver/openmp-target-fast-flag.c
+++ b/clang/test/Driver/openmp-target-fast-flag.c
@@ -1,0 +1,48 @@
+// REQUIRES: x86-registered-target, amdgpu-registered-target
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib %s -O0 2>&1 \
+// RUN:   | FileCheck -check-prefixes=DefaultTFast,DefaultEnV,DefaultTState,DefaultNoNestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O0 -fopenmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=TFast,EnV,TState,NestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O3 %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=O3,DefaultTFast,DefaultEnV,DefaultTState,DefaultNoNestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O3 -fno-openmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=O3,NoTFast,DefaultEnV,DefaultTState,DefaultNoNestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -Ofast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=OFast,TFast,EnV,TState,NestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -Ofast -fno-openmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=OFast,NoTFast,DefaultEnV,DefaultTState,DefaultNoNestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -fopenmp-target-fast -fno-openmp-target-ignore-env-vars %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=TFast,NoEnV,TState,NestParallel %s
+
+// RUN:   %clang -### -fopenmp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O0 -fno-openmp-target-fast -fopenmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=TFast,EnV,TState,NestParallel %s
+
+// O3: -O3
+// OFast: -Ofast
+
+// TFast: "-fopenmp-target-fast"
+// TFast-NOT: "-fno-openmp-target-fast"
+// NoTFast: "-fno-openmp-target-fast"
+// NoTFast-NOT: "-fopenmp-target-fast"
+// DefaultTFast-NOT: {{"-f(no-)?openmp-target-fast"}}
+
+// EnV: "-fopenmp-target-ignore-env-vars"
+// EnV-NOT: "-fno-openmp-target-ignore-env-vars"
+// NoEnV: "-fno-openmp-target-ignore-env-vars"
+// NoEnV-NOT: "-fopenmp-target-ignore-env-vars"
+// DefaultEnV-NOT: {{"-f(no-)?openmp-target-ignore-env-vars"}}
+
+// TState: "-fopenmp-assume-no-thread-state"
+// TState-NOT: "-fno-openmp-assume-no-thread-state"
+// DefaultTState-NOT: {{"-f(no-)?openmp-assume-no-thread-state"}}
+
+// NestParallel: "-fopenmp-assume-no-nested-parallelism"
+// NestParallel-NOT: "-fno-openmp-assume-no-nested-parallelism"
+// DefaultNoNestParallel-NOT: {{"-f(-no-)?openmp-assume-no-nested-parallelism"}}


### PR DESCRIPTION
This PR adopts OpenMP flag improvements that have been approved for upstream LLVM (PR #178914) but haven't merged yet.

**Changes**:
- Merges nicebert/openmp-complete-series (approved upstream)
- Replaces ROCm-local implementations with upstream versions
- Uses improved getLastArg() pattern for proper duplicate handling

**Upstream Reference**: https://github.com/llvm/llvm-project/pull/178914