### PR TITLE
[ASan][OpenMP] Fix OpenMP ASan driver and device-rtl build.

### DIFF
--- a/clang/include/clang/Driver/RocmInstallationDetector.h
+++ b/clang/include/clang/Driver/RocmInstallationDetector.h
@@ -141,6 +141,9 @@ private:
   // Asan runtime library
   SmallString<0> AsanRTL;
 
+  // OpenMP ASan runtime library
+  SmallString<0> OpenMPASanRTLPath;
+
   // Libraries swapped based on compile flags.
   ConditionalLibrary WavefrontSize64;
   ConditionalLibrary FiniteOnly;
@@ -174,7 +177,8 @@ private:
 public:
   RocmInstallationDetector(const Driver &D, const llvm::Triple &HostTriple,
                            const llvm::opt::ArgList &Args,
-                           bool DetectHIPRuntime = true);
+                           bool DetectHIPRuntime = true,
+                           bool DetectOpenMPRuntime = true);
 
   /// Get file paths of default bitcode libraries common to AMDGPU based
   /// toolchains.
@@ -236,6 +240,9 @@ public:
   /// Returns empty string of Asan runtime library is not available.
   StringRef getAsanRTLPath() const { return AsanRTL; }
 
+  /// Returns empty string of OpenMP Asan runtime library is not available.
+  StringRef getOpenMPASanRTLPath() const { return OpenMPASanRTLPath; }
+
   StringRef getWavefrontSize64Path(bool Enabled) const {
     return WavefrontSize64.get(Enabled);
   }
@@ -268,6 +275,7 @@ public:
 
   void detectDeviceLibrary();
   void detectHIPRuntime();
+  void detectOpenMPRuntime();
 
   /// Get the values for --rocm-device-lib-path arguments
   ArrayRef<std::string> getRocmDeviceLibPathArg() const {

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1681,6 +1681,8 @@ SanitizerMask ToolChain::getSupportedSanitizers() const {
     Res |= SanitizerKind::MemTag;
   if (getTriple().isBPF())
     Res |= SanitizerKind::KernelAddress;
+  if (getTriple().isAMDGPU())
+    Res |= SanitizerKind::Address;
   return Res;
 }
 

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -313,7 +313,8 @@ RocmInstallationDetector::getInstallationPathCandidates() {
 
 RocmInstallationDetector::RocmInstallationDetector(
     const Driver &D, const llvm::Triple &HostTriple,
-    const llvm::opt::ArgList &Args, bool DetectHIPRuntime)
+    const llvm::opt::ArgList &Args, bool DetectHIPRuntime,
+    bool DetectOpenMPRuntime)
     : D(D) {
   Verbose = Args.hasArg(options::OPT_v);
   RocmPathArg = Args.getLastArgValue(options::OPT_rocm_path_EQ);
@@ -367,6 +368,25 @@ RocmInstallationDetector::RocmInstallationDetector(
 
   if (DetectHIPRuntime)
     detectHIPRuntime();
+  if (DetectOpenMPRuntime)
+    detectOpenMPRuntime();
+}
+
+void RocmInstallationDetector::detectOpenMPRuntime() {
+  assert(OpenMPASanRTLPath.empty());
+  // Set OpenMP ASan library directory path for pre-instrumented device
+  // libraries (e.g., libompdevice.a). This path is used when linking with
+  // -fsanitize=address for OpenMP offloading.
+  OpenMPASanRTLPath = llvm::sys::path::parent_path(D.Dir);
+  llvm::sys::path::append(OpenMPASanRTLPath, "lib", "asan");
+  if (D.getVFS().exists(OpenMPASanRTLPath))
+    return;
+  // Fallback: Search ASan libs in the ROCm tree (e.g. /opt/rocm/llvm/lib/asan).
+  const auto &Candidates = getInstallationPathCandidates();
+  if (Candidates.empty())
+    return;
+  OpenMPASanRTLPath = Candidates.front().Path;
+  llvm::sys::path::append(OpenMPASanRTLPath, "lib", "llvm", "lib", "asan");
 }
 
 void RocmInstallationDetector::detectDeviceLibrary() {
@@ -628,20 +648,6 @@ void amdgpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                  Args.getLastArgValue(options::OPT_mcpu_EQ))));
   }
   addLinkerCompressDebugSectionsOption(getToolChain(), Args, CmdArgs);
-
-  // ASan instrumented OpenMP+Offload libraries are installed in default ROCm
-  // LLVM ASan custom path.
-  // Below code prepends the LLVM ASan custom path to pick ASan instrumented
-  // libompdevice.a.
-  const SanitizerArgs &SanArgs = getToolChain().getSanitizerArgs(Args);
-  if (SanArgs.needsAsanRt()) {
-    const AMDGPUToolChain &AMDGPU =
-        static_cast<const AMDGPUToolChain &>(getToolChain());
-    StringRef ASanPath = Args.MakeArgString(
-        AMDGPU.getRocmInstallationPath().str() + "/lib/llvm/lib/asan");
-    CmdArgs.push_back(Args.MakeArgString("-L" + ASanPath.str()));
-  }
-
   getToolChain().AddFilePathLibArgs(Args, CmdArgs);
   Args.AddAllArgs(CmdArgs, options::OPT_L);
   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
@@ -761,10 +767,24 @@ AMDGPUToolChain::AMDGPUToolChain(const Driver &D, const llvm::Triple &Triple,
   // It is done here to avoid repeated warning or error messages for
   // each tool invocation.
   checkAMDGPUCodeObjectVersion(D, Args);
+  // When ASan is enabled, setup ASan library path configuration early so that
+  // the linker finds ASan-instrumented libraries.
+  checkAndAddAMDGPUSanLibPaths(Args);
 }
 
 Tool *AMDGPUToolChain::buildLinker() const {
   return new tools::amdgpu::Linker(*this);
+}
+
+// Common function to check and add ASan library paths.
+void AMDGPUToolChain::checkAndAddAMDGPUSanLibPaths(const ArgList &Args) {
+  // For OpenMP: when ASan is enabled, prepend the OpenMP ASan library path so
+  // the linker finds ASan-instrumented libraries.
+  if (getSanitizerArgs(Args).needsAsanRt()) {
+    StringRef OmpASanPath = RocmInstallation->getOpenMPASanRTLPath();
+    if (!OmpASanPath.empty() && getVFS().exists(OmpASanPath))
+      getFilePaths().insert(getFilePaths().begin(), OmpASanPath.str());
+  }
 }
 
 DerivedArgList *

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -628,6 +628,20 @@ void amdgpu::Linker::ConstructJob(Compilation &C, const JobAction &JA,
                                  Args.getLastArgValue(options::OPT_mcpu_EQ))));
   }
   addLinkerCompressDebugSectionsOption(getToolChain(), Args, CmdArgs);
+
+  // ASan instrumented OpenMP+Offload libraries are installed in default ROCm
+  // LLVM ASan custom path.
+  // Below code prepends the LLVM ASan custom path to pick ASan instrumented
+  // libompdevice.a.
+  const SanitizerArgs &SanArgs = getToolChain().getSanitizerArgs(Args);
+  if (SanArgs.needsAsanRt()) {
+    const AMDGPUToolChain &AMDGPU =
+        static_cast<const AMDGPUToolChain &>(getToolChain());
+    StringRef ASanPath = Args.MakeArgString(
+        AMDGPU.getRocmInstallationPath().str() + "/lib/llvm/lib/asan");
+    CmdArgs.push_back(Args.MakeArgString("-L" + ASanPath.str()));
+  }
+
   getToolChain().AddFilePathLibArgs(Args, CmdArgs);
   Args.AddAllArgs(CmdArgs, options::OPT_L);
   AddLinkerInputs(getToolChain(), Inputs, Args, CmdArgs, JA);
@@ -1076,16 +1090,17 @@ RocmInstallationDetector::getCommonBitcodeLibs(
       BCLibs.emplace_back(BCLib);
     }
   };
-  auto AddSanBCLibs = [&]() {
-    if (Pref.GPUSan)
-      AddBCLib(getAsanRTLPath(), false);
-  };
 
-  AddSanBCLibs();
+  // For OpenMP, openmp-devicertl(libompdevice.a) already contains ASan GPU
+  // runtime and Ockl functions (via POST_BUILD). Don't add it again at driver
+  // level to avoid duplicates as most of the symbols have USED attribute and
+  // duplicates entries in llvm.compiler.used & llvm.used makes their
+  // duplicate definitions persist even with internalization enabled
+  if (Pref.GPUSan && !Pref.IsOpenMP)
+    // Add Gpu Sanitizer RTL bitcode lib required for AMDGPU Sanitizer
+    AddBCLib(getAsanRTLPath(),false);
   AddBCLib(getOCMLPath());
   if (!Pref.IsOpenMP)
-    AddBCLib(getOCKLPath());
-  else if (Pref.GPUSan && Pref.IsOpenMP)
     AddBCLib(getOCKLPath());
   AddBCLib(getUnsafeMathPath(Pref.UnsafeMathOpt || Pref.FastRelaxedMath));
   AddBCLib(getFiniteOnlyPath(Pref.FiniteOnly || Pref.FastRelaxedMath));

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -141,6 +141,11 @@ public:
     return true;
   }
 
+  /// Get the Rocm Installation path
+  StringRef getRocmInstallationPath() const {
+    return RocmInstallation->getInstallPath();
+  }
+
   /// Needed for translating LTO options.
   const char *getDefaultLinker() const override { return "ld.lld"; }
 

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -141,11 +141,6 @@ public:
     return true;
   }
 
-  /// Get the Rocm Installation path
-  StringRef getRocmInstallationPath() const {
-    return RocmInstallation->getInstallPath();
-  }
-
   /// Needed for translating LTO options.
   const char *getDefaultLinker() const override { return "ld.lld"; }
 
@@ -164,6 +159,8 @@ public:
   /// if unable to find one.
   virtual Expected<SmallVector<std::string>>
   getSystemGPUArchs(const llvm::opt::ArgList &Args) const override;
+
+  void checkAndAddAMDGPUSanLibPaths(const llvm::opt::ArgList &Args);
 
 protected:
   /// Check and diagnose invalid target ID specified by -mcpu.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9552,6 +9552,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   // compilation job.
   const llvm::DenseSet<unsigned> CompilerOptions{
       OPT_v,
+      OPT_fsanitize_EQ,
       OPT_cuda_path_EQ,
       OPT_rocm_path_EQ,
       OPT_hip_path_EQ,

--- a/clang/test/Driver/amdgpu-openmp-sanitize-options.c
+++ b/clang/test/Driver/amdgpu-openmp-sanitize-options.c
@@ -104,12 +104,12 @@
 // HOSTSANCOMBINATION: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address,fuzzer,fuzzer-no-link".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "c".*}}
 // HOSTSANCOMBINATION2: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address,fuzzer,fuzzer-no-link,leak".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "c".*}}
 
-// GPUSAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu".* "-emit-llvm-bc".* "-mlink-bitcode-file" "[^"]*asanrtl.bc".* "-mlink-builtin-bitcode" "[^"]*ockl.bc".* "-target-cpu" "(gfx908|gfx900|gfx1250|gfx1251)".* "-fopenmp".* "-fsanitize=address".* "-x" "c".*}}
+// GPUSAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu".* "-emit-llvm-bc".* "-target-cpu" "(gfx908|gfx900|gfx1250|gfx1251)".* "-fopenmp".* "-fsanitize=address".* "-x" "c".*}}
 // NOGPUSAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu".* "-emit-llvm-bc".* "-target-cpu" "(gfx908|gfx900)".* "-fopenmp".* "-x" "c".*}}
 
 // SAN: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=amdgcn-amd-amdhsa,arch=(gfx908|gfx1250|gfx1251)(:xnack\-|:xnack\+)?,kind=openmp(,feature=(\-xnack|\+xnack))?"}}
 // SAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "ir".*}}
-// SAN: {{"[^"]*clang-linker-wrapper[^"]*".* "--host-triple=x86_64-unknown-linux-gnu".* "--linker-path=[^"]*".* "--whole-archive" "[^"]*(libclang_rt.asan_static.a|libclang_rt.asan_static-x86_64.a)".* "--whole-archive" "[^"]*(libclang_rt.asan.a|libclang_rt.asan-x86_64.a)".*}}
+// SAN: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=amdgcn-amd-amdhsa=-fsanitize=address".* "--host-triple=x86_64-unknown-linux-gnu".* "--linker-path=[^"]*".* "--whole-archive" "[^"]*(libclang_rt.asan_static.a|libclang_rt.asan_static-x86_64.a)".* "--whole-archive" "[^"]*(libclang_rt.asan.a|libclang_rt.asan-x86_64.a)".*}}
 
 // UNSUPPORTEDERROR: error: '-fsanitize=leak' option is not currently supported for target 'amdgcn-amd-amdhsa'
 // XNACKERROR: error: '-fsanitize=address' option for offload arch 'gfx908:xnack-' is not currently supported there. Use it with an offload arch containing 'xnack+' instead

--- a/clang/test/Driver/amdgpu-openmp-sanitize-options.c
+++ b/clang/test/Driver/amdgpu-openmp-sanitize-options.c
@@ -9,7 +9,7 @@
 // RUN:   | FileCheck --check-prefixes=NOTSUPPORTED,FAIL %s
 
 // Memory, Leak, UndefinedBehaviour and Thread Sanitizer are not supported on AMDGPU.
-// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address -fsanitize=leak -fgpu-sanitize --rocm-path=%S/Inputs/rocm -nogpuinc  %s 2>&1 \
+// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address -fsanitize=leak -fgpu-sanitize --rocm-path=%S/Inputs/rocm -nogpuinc  %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=NOTSUPPORTED %s
 
 // GPU ASan Enabled Test Cases
@@ -58,18 +58,18 @@
 // implicitly turns on LLVMs SanitizerCoverage, which the driver then forwards
 // to the device cc1. SanitizerCoverage is not supported on amdgcn.)
 
-// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=fuzzer,address --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=fuzzer,address --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION2 %s
 
 // Do the same for multiple -fsanitize arguments and multi-arch scenarios.
 
-// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ --offload-arch=gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ --offload-arch=gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: not  %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=fuzzer,address -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=fuzzer,address -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION2,NOTSUPPORTED-DAG,INVALIDCOMBINATION2 %s
 
 // Check for -fsanitize-coverage options

--- a/clang/test/Driver/hip-sanitize-options.hip
+++ b/clang/test/Driver/hip-sanitize-options.hip
@@ -58,19 +58,19 @@
 // implicitly turns on LLVMs SanitizerCoverage, which the driver then forwards
 // to the device cc1. SanitizerCoverage is not supported on amdgcn.)
 
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
 // RUN:   -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=INVALIDCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
 // RUN:   -fsanitize=fuzzer,address --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=INVALIDCOMBINATION,INVALIDCOMBINATION2 %s
 
 // Do the same for multiple -fsanitize arguments and multi-arch scenarios.
 
-// RUN:   %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ --offload-arch=gfx908:xnack- \
+// RUN: not %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ --offload-arch=gfx908:xnack- \
 // RUN:   -fsanitize=address,fuzzer -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=MULT1,XNACK2 %s
-// RUN:   %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+,gfx908:xnack- \
+// RUN: not  %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+,gfx908:xnack- \
 // RUN:   -fsanitize=fuzzer,address -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=MULT2,XNACK2 %s
 

--- a/openmp/device/CMakeLists.txt
+++ b/openmp/device/CMakeLists.txt
@@ -52,6 +52,7 @@ if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn" OR
   )
   get_target_property(_ocml_bc ocml IMPORTED_LOCATION)
   get_target_property(_ockl_bc ockl IMPORTED_LOCATION)
+  get_target_property(_asanrtl_bc asanrtl IMPORTED_LOCATION)
 
   if(NOT _ockl_bc)
     message(FATAL_ERROR "Could not find ockl.bc")
@@ -59,7 +60,18 @@ if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn" OR
   if(NOT _ocml_bc)
     message(FATAL_ERROR "Could not find ocml.bc")
   endif()
-  list(APPEND compile_flags "SHELL: -Xclang -mlink-builtin-bitcode -Xclang ${_ockl_bc}")
+  if(NOT _asanrtl_bc)
+    message(FATAL_ERROR "Could not find asanrtl.bc")
+  endif()
+  if(SANITIZER_AMDGPU)
+    list(APPEND compile_flags "SHELL: -DSANITIZER_AMDGPU=1")
+    # For ASan: Don't link asanrtl.bc and ockl.bc at compile time of libompdevice.a
+    # They will be linked once in POST_BUILD step to avoid duplicates symbols
+    # Note: Oclc control constants are provided using Platform.h
+    #
+  else()
+    list(APPEND compile_flags "SHELL: -Xclang -mlink-builtin-bitcode -Xclang ${_ockl_bc}")
+  endif()
   list(APPEND compile_flags "SHELL: -Xclang -mlink-builtin-bitcode -Xclang ${_ocml_bc}")
 endif()
 
@@ -129,6 +141,30 @@ endif()
 if(LLVM_DEFAULT_TARGET_TRIPLE)
   target_link_options(libompdevice PRIVATE "--target=${LLVM_DEFAULT_TARGET_TRIPLE}")
 endif()
+
+# For SANITIZER_AMDGPU: Use llvm-link POST_BUILD to merge ASAN runtime and OCKL
+# into the device library bitcode to resolve all and __asan_* __ockl_* symbols
+if(SANITIZER_AMDGPU)
+  find_program(LLVM_LINK_EXECUTABLE NAMES llvm-link HINTS ${LLVM_TOOLS_BINARY_DIR})
+  if(NOT LLVM_LINK_EXECUTABLE)
+    message(FATAL_ERROR "llvm-link not found")
+  endif()
+  add_custom_command(TARGET libompdevice POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy 
+      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc
+      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc.tmp
+    COMMAND ${LLVM_LINK_EXECUTABLE}
+      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc.tmp
+      ${_asanrtl_bc}
+      ${_ockl_bc}
+      --only-needed
+      -o ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc
+    COMMAND ${CMAKE_COMMAND} -E remove
+      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc.tmp
+    COMMENT "Merging asanrtl.bc and ockl.bc into libomptarget-${target_name}.bc"
+  )
+endif()
+
 install(TARGETS libompdevice
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         DESTINATION ${OPENMP_INSTALL_LIBDIR})

--- a/openmp/device/include/Platform.h
+++ b/openmp/device/include/Platform.h
@@ -21,124 +21,126 @@ namespace platform {
 // define them here.
 extern "C" {
 
+#define USED __attribute__((used))
+
 // Disable unsafe math optimizations in the implementation.
-extern const inline bool __oclc_unsafe_math_opt = 0;
+USED extern const inline bool __oclc_unsafe_math_opt = 0;
 
 // Disable denormalization at zero optimizations in the implementation.
-extern const inline bool __oclc_daz_opt = 0;
+USED extern const inline bool __oclc_daz_opt = 0;
 
 // Disable rounding optimizations for 32-bit square roots.
-extern const inline bool __oclc_correctly_rounded_sqrt32 = 1;
+USED extern const inline bool __oclc_correctly_rounded_sqrt32 = 1;
 
 // Disable finite math optimizations.
-extern const inline bool __oclc_finite_only_opt = 0;
+USED extern const inline bool __oclc_finite_only_opt = 0;
 
 // Spoof this to wave64 since we only compile for a single architecture.
-extern const inline bool __oclc_wavefrontsize64 = 1;
+USED extern const inline bool __oclc_wavefrontsize64 = 1;
 
 // This is only relevant for statically resolving `malloc`, set to COV6.
-extern const inline bool __oclc_ABI_version = 600;
+USED extern const inline bool __oclc_ABI_version = 600;
 
 #if defined(__gfx700__)
-extern const inline unsigned __oclc_ISA_version = 7000;
+USED extern const inline unsigned __oclc_ISA_version = 7000;
 #elif defined(__gfx701__)
-extern const inline unsigned __oclc_ISA_version = 7001;
+USED extern const inline unsigned __oclc_ISA_version = 7001;
 #elif defined(__gfx702__)
-extern const inline unsigned __oclc_ISA_version = 7002;
+USED extern const inline unsigned __oclc_ISA_version = 7002;
 #elif defined(__gfx703__)
-extern const inline unsigned __oclc_ISA_version = 7003;
+USED extern const inline unsigned __oclc_ISA_version = 7003;
 #elif defined(__gfx704__)
-extern const inline unsigned __oclc_ISA_version = 7004;
+USED extern const inline unsigned __oclc_ISA_version = 7004;
 #elif defined(__gfx705__)
-extern const inline unsigned __oclc_ISA_version = 7005;
+USED extern const inline unsigned __oclc_ISA_version = 7005;
 #elif defined(__gfx801__)
-extern const inline unsigned __oclc_ISA_version = 8001;
+USED extern const inline unsigned __oclc_ISA_version = 8001;
 #elif defined(__gfx802__)
-extern const inline unsigned __oclc_ISA_version = 8002;
+USED extern const inline unsigned __oclc_ISA_version = 8002;
 #elif defined(__gfx803__)
-extern const inline unsigned __oclc_ISA_version = 8003;
+USED extern const inline unsigned __oclc_ISA_version = 8003;
 #elif defined(__gfx805__)
-extern const inline unsigned __oclc_ISA_version = 8005;
+USED extern const inline unsigned __oclc_ISA_version = 8005;
 #elif defined(__gfx810__)
-extern const inline unsigned __oclc_ISA_version = 8100;
+USED extern const inline unsigned __oclc_ISA_version = 8100;
 #elif defined(__gfx900__)
-extern const inline unsigned __oclc_ISA_version = 9000;
+USED extern const inline unsigned __oclc_ISA_version = 9000;
 #elif defined(__gfx902__)
-extern const inline unsigned __oclc_ISA_version = 9002;
+USED extern const inline unsigned __oclc_ISA_version = 9002;
 #elif defined(__gfx904__)
-extern const inline unsigned __oclc_ISA_version = 9004;
+USED extern const inline unsigned __oclc_ISA_version = 9004;
 #elif defined(__gfx906__)
-extern const inline unsigned __oclc_ISA_version = 9006;
+USED extern const inline unsigned __oclc_ISA_version = 9006;
 #elif defined(__gfx908__)
-extern const inline unsigned __oclc_ISA_version = 9008;
+USED extern const inline unsigned __oclc_ISA_version = 9008;
 #elif defined(__gfx909__)
-extern const inline unsigned __oclc_ISA_version = 9009;
+USED extern const inline unsigned __oclc_ISA_version = 9009;
 #elif defined(__gfx90a__)
-extern const inline unsigned __oclc_ISA_version = 9010;
+USED extern const inline unsigned __oclc_ISA_version = 9010;
 #elif defined(__gfx90c__)
-extern const inline unsigned __oclc_ISA_version = 9012;
+USED extern const inline unsigned __oclc_ISA_version = 9012;
 #elif defined(__gfx942__)
-extern const inline unsigned __oclc_ISA_version = 9402;
+USED extern const inline unsigned __oclc_ISA_version = 9402;
 #elif defined(__gfx950__)
-extern const inline unsigned __oclc_ISA_version = 9500;
+USED extern const inline unsigned __oclc_ISA_version = 9500;
 #elif defined(__gfx1010__)
-extern const inline unsigned __oclc_ISA_version = 10100;
+USED extern const inline unsigned __oclc_ISA_version = 10100;
 #elif defined(__gfx1011__)
-extern const inline unsigned __oclc_ISA_version = 10101;
+USED extern const inline unsigned __oclc_ISA_version = 10101;
 #elif defined(__gfx1012__)
-extern const inline unsigned __oclc_ISA_version = 10102;
+USED extern const inline unsigned __oclc_ISA_version = 10102;
 #elif defined(__gfx1013__)
-extern const inline unsigned __oclc_ISA_version = 10103;
+USED extern const inline unsigned __oclc_ISA_version = 10103;
 #elif defined(__gfx1030__)
-extern const inline unsigned __oclc_ISA_version = 10300;
+USED extern const inline unsigned __oclc_ISA_version = 10300;
 #elif defined(__gfx1031__)
-extern const inline unsigned __oclc_ISA_version = 10301;
+USED extern const inline unsigned __oclc_ISA_version = 10301;
 #elif defined(__gfx1032__)
-extern const inline unsigned __oclc_ISA_version = 10302;
+USED extern const inline unsigned __oclc_ISA_version = 10302;
 #elif defined(__gfx1033__)
-extern const inline unsigned __oclc_ISA_version = 10303;
+USED extern const inline unsigned __oclc_ISA_version = 10303;
 #elif defined(__gfx1034__)
-extern const inline unsigned __oclc_ISA_version = 10304;
+USED extern const inline unsigned __oclc_ISA_version = 10304;
 #elif defined(__gfx1035__)
-extern const inline unsigned __oclc_ISA_version = 10305;
+USED extern const inline unsigned __oclc_ISA_version = 10305;
 #elif defined(__gfx1036__)
-extern const inline unsigned __oclc_ISA_version = 10306;
+USED extern const inline unsigned __oclc_ISA_version = 10306;
 #elif defined(__gfx1100__)
-extern const inline unsigned __oclc_ISA_version = 11000;
+USED extern const inline unsigned __oclc_ISA_version = 11000;
 #elif defined(__gfx1101__)
-extern const inline unsigned __oclc_ISA_version = 11001;
+USED extern const inline unsigned __oclc_ISA_version = 11001;
 #elif defined(__gfx1102__)
-extern const inline unsigned __oclc_ISA_version = 11002;
+USED extern const inline unsigned __oclc_ISA_version = 11002;
 #elif defined(__gfx1103__)
-extern const inline unsigned __oclc_ISA_version = 11003;
+USED extern const inline unsigned __oclc_ISA_version = 11003;
 #elif defined(__gfx1150__)
-extern const inline unsigned __oclc_ISA_version = 11500;
+USED extern const inline unsigned __oclc_ISA_version = 11500;
 #elif defined(__gfx1151__)
-extern const inline unsigned __oclc_ISA_version = 11501;
+USED extern const inline unsigned __oclc_ISA_version = 11501;
 #elif defined(__gfx1152__)
-extern const inline unsigned __oclc_ISA_version = 11502;
+USED extern const inline unsigned __oclc_ISA_version = 11502;
 #elif defined(__gfx1153__)
-extern const inline unsigned __oclc_ISA_version = 11503;
+USED extern const inline unsigned __oclc_ISA_version = 11503;
 #elif defined(__gfx1200__)
-extern const inline unsigned __oclc_ISA_version = 12000;
+USED extern const inline unsigned __oclc_ISA_version = 12000;
 #elif defined(__gfx1201__)
-extern const inline unsigned __oclc_ISA_version = 12001;
+USED extern const inline unsigned __oclc_ISA_version = 12001;
 #elif defined(__gfx9_generic__)
-extern const inline unsigned __oclc_ISA_version = 9000;
+USED extern const inline unsigned __oclc_ISA_version = 9000;
 #elif defined(__gfx9_4_generic__)
-extern const inline unsigned __oclc_ISA_version = 9402;
+USED extern const inline unsigned __oclc_ISA_version = 9402;
 #elif defined(__gfx10_1_generic__)
-extern const inline unsigned __oclc_ISA_version = 10100;
+USED extern const inline unsigned __oclc_ISA_version = 10100;
 #elif defined(__gfx10_3_generic__)
-extern const inline unsigned __oclc_ISA_version = 10300;
+USED extern const inline unsigned __oclc_ISA_version = 10300;
 #elif defined(__gfx11_generic__)
-extern const inline unsigned __oclc_ISA_version = 11003;
+USED extern const inline unsigned __oclc_ISA_version = 11003;
 #elif defined(__gfx12_generic__)
-extern const inline unsigned __oclc_ISA_version = 12000;
+USED extern const inline unsigned __oclc_ISA_version = 12000;
 #else
 // The only thing this controls that we care about is fast FMA.
 // FIXME: We need to stop relying on the DeviceRTL math libs this way.
-extern const inline unsigned __oclc_ISA_version = 7001;
+USED extern const inline unsigned __oclc_ISA_version = 7001;
 #endif
 }
 


### PR DESCRIPTION
- Update AMDGPU toolchain logic in Clang to account for ASan when building/OpenMP offloading.

- Adjust OpenMP device CMake configuration for ASan-enabled builds.

- Tweak OpenMP device Platform.h and related headers for ASan compatibility on AMDGPU.

SWDEV-551595


