### PR TITLE
[OpenMPOpt] Add option to disable spmd conversion. 

### DIFF
--- a/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
+++ b/llvm/lib/Transforms/IPO/OpenMPOpt.cpp
@@ -104,6 +104,12 @@ static cl::opt<bool> DisableOpenMPOptSPMDization(
     cl::desc("Disable OpenMP optimizations involving SPMD-ization."),
     cl::Hidden, cl::init(false));
 
+static cl::opt<bool> DisableOpenMPOptCallbackSPMDization(
+    "openmp-opt-disable-callback-spmdization",
+    cl::desc("Disable OpenMP optimizations involving SPMD-ization in runtime "
+             "functions taking callbacks."),
+    cl::Hidden, cl::init(true));
+
 static cl::opt<bool> DisableOpenMPOptFolding(
     "openmp-opt-disable-folding",
     cl::desc("Disable OpenMP optimizations involving folding."), cl::Hidden,
@@ -5131,6 +5137,10 @@ struct AAKernelInfoCallSite : AAKernelInfo {
       case OMPRTL___kmpc_for_static_loop_4u:
       case OMPRTL___kmpc_for_static_loop_8:
       case OMPRTL___kmpc_for_static_loop_8u:
+        if (DisableOpenMPOptCallbackSPMDization) {
+          SPMDCompatibilityTracker.indicatePessimisticFixpoint();
+          SPMDCompatibilityTracker.insert(&CB);
+        }
         break;
       default:
         // Unknown OpenMP runtime calls cannot be executed in SPMD-mode,

--- a/llvm/test/Transforms/OpenMP/callback_guards.ll
+++ b/llvm/test/Transforms/OpenMP/callback_guards.ll
@@ -1,4 +1,4 @@
-; RUN: opt -passes=openmp-opt -S < %s | FileCheck %s
+; RUN: opt -passes=openmp-opt -openmp-opt-disable-callback-spmdization=false -S < %s | FileCheck %s
 
 %struct.ident_t = type { i32, i32, i32, i32, ptr }
 %struct.DynamicEnvironmentTy = type { i16 }


### PR DESCRIPTION
Previously the generic to spmd conversion was explicitly disabled for new OpenMP runtime functions that are used with `distribute `in `flang`. In commit `8176194f36b9809165a7a77c8a4eaea285998d4e`, I allowed generic to spmd conversion for these functions. It has mostly worked ok but we have seen some apps where it can cause problem.

In this PR, we are putting this under an option (with default disabled) for now. This is for some new OpenMP runtime functions used in `flang`. Normal spmd conversion works as before.


