### PR TITLE
[OpenMP][OMPT] Wait for any outstanding flushes to complete during shutdown.

### DIFF
--- a/offload/libomptarget/OpenMP/OMPT/OmptTracingBuffer.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/OmptTracingBuffer.cpp
@@ -741,6 +741,8 @@ void OmptTracingBufferMgr::flushAndShutdownHelperThreads() {
   // Flush buffers for all devices.
   if (OMPX_FlushOnShutdown)
     flushAllBuffers(MAX_NUM_DEVICES);
+  else
+    waitForFlushCompletion(); // Dont initiate but wait for outstanding flushes.
   shutdownHelperThreads();
 }
 


### PR DESCRIPTION
The wait should be performed even if new flushes are not initiated.