### PR TITLE
[clang][OpenMP] Add OpenMP GPU optimization flag framework (#178914)

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3954,8 +3954,6 @@ def fopenmp_gpu_threads_per_team_EQ : Joined<["-"], "fopenmp-gpu-threads-per-tea
   Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option]>;
 def fopenmp_target_xteam_reduction_blocksize_EQ : Joined<["-"], "fopenmp-target-xteam-reduction-blocksize=">, Group<f_Group>,
   Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option, FlangOption]>;
-def fopenmp_target_fast : Flag<["-"], "fopenmp-target-fast">, Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option, FlangOption]>;
-def fno_openmp_target_fast : Flag<["-"], "fno-openmp-target-fast">, Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option, FlangOption]>;
 def fopenmp_target_ignore_env_vars : Flag<["-"], "fopenmp-target-ignore-env-vars">, Group<f_Group>, 
   Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option, FlangOption]>,
   HelpText<"Assert that device related environment variables can be ignored while generating code">,
@@ -4092,20 +4090,16 @@ def fno_openmp_assume_teams_oversubscription : Flag<["-"], "fno-openmp-assume-te
   HelpText<"Do not assume teams oversubscription.">;
 def fno_openmp_assume_threads_oversubscription : Flag<["-"], "fno-openmp-assume-threads-oversubscription">,
   HelpText<"Do not assume threads oversubscription.">;
-def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">, Group<f_Group>,
-  Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Assert that a thread in a parallel region may modify an ICV">,
-  MarshallingInfoFlag<LangOpts<"OpenMPNoThreadState">>;
 def fopenmp_assume_no_thread_state : Flag<["-"], "fopenmp-assume-no-thread-state">,
   HelpText<"Assert no thread in a parallel region modifies an ICV">,
   MarshallingInfoFlag<LangOpts<"OpenMPNoThreadState">>;
+def fno_openmp_assume_no_thread_state : Flag<["-"], "fno-openmp-assume-no-thread-state">,
+  HelpText<"Assert that a thread in a parallel region may modify an ICV">;
 def fopenmp_assume_no_nested_parallelism : Flag<["-"], "fopenmp-assume-no-nested-parallelism">,
   HelpText<"Assert no nested parallel regions in the GPU">,
   MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
-def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">, Group<f_Group>,
-  Flags<[NoArgumentUnused, HelpHidden]>, Visibility<[ClangOption, CC1Option]>,
-  HelpText<"Assert that a nested parallel region may be used in the GPU">,
-  MarshallingInfoFlag<LangOpts<"OpenMPNoNestedParallelism">>;
+def fno_openmp_assume_no_nested_parallelism : Flag<["-"], "fno-openmp-assume-no-nested-parallelism">,
+  HelpText<"Assert that a nested parallel region may be used in the GPU">;
 
 } // let Group = f_Group
 } // let Visibility = [ClangOption, CC1Option, FC1Option]
@@ -4129,6 +4123,13 @@ def fopenmp_target_new_runtime : Flag<["-"], "fopenmp-target-new-runtime">,
   Group<f_Group>, Flags<[HelpHidden]>, Visibility<[ClangOption, CC1Option]>;
 def fno_openmp_target_new_runtime : Flag<["-"], "fno-openmp-target-new-runtime">,
   Group<f_Group>, Flags<[HelpHidden]>, Visibility<[ClangOption, CC1Option]>;
+def fopenmp_target_fast : Flag<["-"], "fopenmp-target-fast">,
+  Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
+  Visibility<[ClangOption, CC1Option, FlangOption]>,
+  HelpText<"Assert common GPU usage patterns to enable OpenMP runtime optimizations">;
+def fno_openmp_target_fast : Flag<["-"], "fno-openmp-target-fast">,
+  Group<f_Group>, Flags<[NoArgumentUnused, HelpHidden]>,
+  Visibility<[ClangOption, CC1Option, FlangOption]>;
 defm openmp_optimistic_collapse : BoolFOption<"openmp-optimistic-collapse",
   LangOpts<"OpenMPOptimisticCollapse">, DefaultFalse,
   PosFlag<SetTrue, [], [ClangOption, CC1Option]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6759,6 +6759,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                     options::OPT_fno_offload_via_llvm, false) &&
       (JA.isDeviceOffloading(Action::OFK_None) ||
        JA.isDeviceOffloading(Action::OFK_OpenMP))) {
+
+    // Determine if target-fast optimizations should be enabled
+    bool TargetFastUsed =
+        Args.hasFlag(options::OPT_fopenmp_target_fast,
+                     options::OPT_fno_openmp_target_fast, OFastEnabled);
     switch (D.getOpenMPRuntime(Args)) {
     case Driver::OMPRT_OMP:
     case Driver::OMPRT_IOMP5:
@@ -6875,19 +6880,17 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                        /*Default=*/false))
         CmdArgs.push_back("-fopenmp-assume-threads-oversubscription");
 
+      // Handle -fopenmp-assume-no-thread-state (implied by target-fast)
       if (Args.hasFlag(options::OPT_fopenmp_assume_no_thread_state,
                        options::OPT_fno_openmp_assume_no_thread_state,
-                       isTargetFastUsed(Args)))
+                       /*Default=*/TargetFastUsed))
         CmdArgs.push_back("-fopenmp-assume-no-thread-state");
-      else
-        CmdArgs.push_back("-fno-openmp-assume-no-thread-state");
 
+      // Handle -fopenmp-assume-no-nested-parallelism (implied by target-fast)
       if (Args.hasFlag(options::OPT_fopenmp_assume_no_nested_parallelism,
                        options::OPT_fno_openmp_assume_no_nested_parallelism,
-                       isTargetFastUsed(Args)))
+                       /*Default=*/TargetFastUsed))
         CmdArgs.push_back("-fopenmp-assume-no-nested-parallelism");
-      else
-        CmdArgs.push_back("-fno-openmp-assume-no-nested-parallelism");
 
       if (Args.hasArg(options::OPT_fopenmp_offload_mandatory))
         CmdArgs.push_back("-fopenmp-offload-mandatory");

--- a/clang/test/Driver/openmp-target-fast-flag.c
+++ b/clang/test/Driver/openmp-target-fast-flag.c
@@ -1,46 +1,35 @@
-// REQUIRES: amdgpu-registered-target
+// REQUIRES: x86-registered-target, amdgpu-registered-target
 
-// RUN: %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a %s -O0 2>&1 \
-// RUN:   | FileCheck -check-prefixes=NoTFast,NoEnV,NoTState,NoNestParallel %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib %s -O0 2>&1 \
+// RUN:   | FileCheck -check-prefixes=DefaultTFast,DefaultTState,DefaultNoNestParallel %s
 
-// RUN:  %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -O0 -fopenmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=TFast,EnV,TState,NestParallel %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O0 -fopenmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=TState,NestParallel %s
 
-// RUN: %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -O4 %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=O4,NoTFast,NoEnV,NoTState,NoNestParallel %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O3 %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=O3,DefaultTFast,DefaultTState,DefaultNoNestParallel %s
 
-// RUN: %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -O4 -fno-openmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=O4,NoTFast,NoEnV,NoTState,NoNestParallel %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O3 -fno-openmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=O3,DefaultTState,DefaultNoNestParallel %s
 
-// RUN: %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -Ofast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=OFast,TFast,EnV,TState,NestParallel %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -Ofast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=OFast,TState,NestParallel %s
 
-// RUN: %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -Ofast -fno-openmp-target-fast %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=OFast,NoTFast,NoEnV,NoTState,NoNestParallel %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -Ofast -fno-openmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=OFast,DefaultTState,DefaultNoNestParallel %s
 
-// RUN: %clang -### -fopenmp -nogpuinc -nogpulib  -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -fopenmp-target-fast -fno-openmp-target-ignore-env-vars %s 2>&1 \
-// RUN:   | FileCheck -check-prefixes=TFast,NoEnV,TState,NestParallel,O3 %s
+// RUN:   %clang -### -fopenmp=libomp -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a -nogpulib -O0 -fno-openmp-target-fast -fopenmp-target-fast %s 2>&1 \
+// RUN:   | FileCheck -check-prefixes=TState,NestParallel %s
 
-// O4: -O4
-// OFast: -Ofast
 // O3: -O3
+// OFast: -Ofast
 
-// TFast: -fopenmp-target-fast
-// TFast-NOT: -fno-openmp-target-fast
-// NoTFast: -fno-openmp-target-fast
-// NoTFast-NOT: -fopenmp-target-fast
+// DefaultTFast-NOT: {{"-fopenmp-target-fast"}}
 
-// EnV: -fopenmp-target-ignore-env-vars
-// EnV-NOT: -fno-openmp-target-ignore-env-vars
-// NoEnV: -fno-openmp-target-ignore-env-vars
-// NoEnV-NOT: -fopenmp-target-ignore-env-vars
+// TState: "-fopenmp-assume-no-thread-state"
+// TState-NOT: "-fno-openmp-assume-no-thread-state"
+// DefaultTState-NOT: {{"-f(no-)?openmp-assume-no-thread-state"}}
 
-// TState: -fopenmp-assume-no-thread-state
-// TState-NOT: -fno-openmp-assume-no-thread-state
-// NoTState: -fno-openmp-assume-no-thread-state
-// NoTState-NOT: -fopenmp-assume-no-thread-state
-
-// NestParallel: -fopenmp-assume-no-nested-parallelism
-// NestParallel-NOT: -fno-openmp-assume-no-nested-parallelism
-// NoNestParallel: -fno-openmp-assume-no-nested-parallelism
-// NoNestParallel-NOT: -fopenmp-assume-no-nested-parallelism
+// NestParallel: "-fopenmp-assume-no-nested-parallelism"
+// NestParallel-NOT: "-fno-openmp-assume-no-nested-parallelism"
+// DefaultNoNestParallel-NOT: {{"-f(-no-)?openmp-assume-no-nested-parallelism"}}


### PR DESCRIPTION
This patch series adds a framework of OpenMP GPU optimization flags to enable more efficient code generation for GPU offloading. The series consists of three patches:

1. Add negative flag variants (-fno-*) for existing assume options to allow explicit disabling of optimizations.

2. Add -fopenmp-target-ignore-env-vars flag to indicate that OpenMP runtime can ignore environment variables during code generation, enabling optimizations like skipping runtime checks and eliminating conditional branches.

3. Add -fopenmp-target-fast meta-flag that implies the above optimization flags. This convenience flag is automatically enabled by -Ofast and provides a simple interface for aggressive GPU optimizations.

The flags benefit all GPU targets (NVPTX, AMDGPU, Intel GPU) by providing a standard way to enable common GPU optimization patterns. Individual flags can be selectively overridden while keeping others enabled.


