### PR TITLE
[PSDB][Infra] Extend the parameterised github action for multiple PR

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -128,15 +128,9 @@ jobs:
           }
         
           # LLVM PR
-          if [[ -n "$LLVM_PR_URL" ]]; then
-              LLVM_SHA="$(get_pr_sha "$LLVM_PR_URL")"
-              echo "LLVM head SHA: $LLVM_SHA"
-              git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
-          else
-              LLVM_SHA="$(git ls-remote https://github.com/ROCm/llvm-project.git refs/heads/amd-staging | awk '{print $1}')"
-              echo "LLVM PR NOT Passed, defaulting to the amd-staging tip : $LLVM_SHA"
-              git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
-          fi
+          LLVM_SHA="$(get_pr_sha "$LLVM_PR_URL")"
+          echo "LLVM head SHA: $LLVM_SHA"
+          git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
         
           # SPIRV PR
           if [[ -n "$SPIRV_PR_URL" ]]; then

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -132,12 +132,20 @@ jobs:
               LLVM_SHA="$(get_pr_sha "$LLVM_PR_URL")"
               echo "LLVM head SHA: $LLVM_SHA"
               git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
+          else
+              LLVM_SHA="$(git ls-remote https://github.com/ROCm/llvm-project.git refs/heads/amd-staging | awk '{print $1}')"
+              echo "LLVM PR NOT Passed, defaulting to the amd-staging tip : $LLVM_SHA"
+              git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
           fi
         
           # SPIRV PR
           if [[ -n "$SPIRV_PR_URL" ]]; then
               SPIRV_SHA="$(get_pr_sha "$SPIRV_PR_URL")"
               echo "SPIRV head SHA: $SPIRV_SHA"
+              git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
+          else
+              SPIRV_SHA="$(git ls-remote https://github.com/ROCm/SPIRV-LLVM-Translator.git refs/heads/amd-staging | awk '{print $1}')"
+              echo "SPIRV PR NOT Passed, defaulting to the amd-staging tip : $SPIRV_SHA"
               git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
           fi
 
@@ -146,12 +154,16 @@ jobs:
               HIPIFY_SHA="$(get_pr_sha "$HIPIFY_PR_URL")"
               echo "HIPIFY head SHA: $HIPIFY_SHA"
               git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
+          else
+              HIPIFY_SHA="$(git ls-remote https://github.com/ROCm/HIPIFY.git refs/heads/amd-staging | awk '{print $1}')"
+              echo "HIPIFY PR NOT Passed, defaulting to the amd-staging tip : $HIPIFY_SHA"
+              git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
           fi
           git config --global user.email "z1-cciauto@amd.com"
           git config --global user.name "Z1 cciauto"
           git commit -m "Update submodule references from PR URLs"
           git submodule status
-          git submodule          
+          git submodule
  
       - name: Install python deps
         run: |

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -130,6 +130,10 @@ jobs:
               LLVM_SHA="$(get_pr_sha "$LLVM_PR_URL")"
               echo "LLVM head SHA: $LLVM_SHA"
               git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
+          else
+              LLVM_SHA="$(git ls-remote https://github.com/ROCm/llvm-project.git refs/heads/amd-staging | awk '{print $1}')"
+              echo "LLVM PR NOT Passed, defaulting to the amd-staging tip : $LLVM_SHA"
+              git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
           fi
 
           # SPIRV PR
@@ -137,12 +141,20 @@ jobs:
               SPIRV_SHA="$(get_pr_sha "$SPIRV_PR_URL")"
               echo "SPIRV head SHA: $SPIRV_SHA"
               git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
+          else
+              SPIRV_SHA="$(git ls-remote https://github.com/ROCm/SPIRV-LLVM-Translator.git refs/heads/amd-staging | awk '{print $1}')"
+              echo "SPIRV PR NOT Passed, defaulting to the amd-staging tip : $SPIRV_SHA"
+              git update-index --cacheinfo 160000,"$SPIRV_SHA","compiler/spirv-llvm-translator"
           fi
 
           # HIPIFY PR
           if [[ -n "$HIPIFY_PR_URL" ]]; then
               HIPIFY_SHA="$(get_pr_sha "$HIPIFY_PR_URL")"
               echo "HIPIFY head SHA: $HIPIFY_SHA"
+              git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
+          else
+              HIPIFY_SHA="$(git ls-remote https://github.com/ROCm/HIPIFY.git refs/heads/amd-staging | awk '{print $1}')"
+              echo "HIPIFY PR NOT Passed, defaulting to the amd-staging tip : $HIPIFY_SHA"
               git update-index --cacheinfo 160000,"$HIPIFY_SHA","compiler/hipify"
           fi
           git config --global user.email "z1-cciauto@amd.com"

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -126,15 +126,9 @@ jobs:
           }
 
           # LLVM PR
-          if [[ -n "$LLVM_PR_URL" ]]; then
-              LLVM_SHA="$(get_pr_sha "$LLVM_PR_URL")"
-              echo "LLVM head SHA: $LLVM_SHA"
-              git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
-          else
-              LLVM_SHA="$(git ls-remote https://github.com/ROCm/llvm-project.git refs/heads/amd-staging | awk '{print $1}')"
-              echo "LLVM PR NOT Passed, defaulting to the amd-staging tip : $LLVM_SHA"
-              git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
-          fi
+          LLVM_SHA="$(get_pr_sha "$LLVM_PR_URL")"
+          echo "LLVM head SHA: $LLVM_SHA"
+          git update-index --cacheinfo 160000,"$LLVM_SHA","compiler/amd-llvm"
 
           # SPIRV PR
           if [[ -n "$SPIRV_PR_URL" ]]; then


### PR DESCRIPTION
Added fallback behavior: if no PR URL is specified, default to the tip of the amd-staging branch for determining the commit SHA. 

This will allow the users to build the artifact with 1 or 2 PR urls