### PR TITLE
[WaveTransform] Compute liveins for all blocks at end of Wave Transform

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2339,16 +2339,14 @@ bool AMDGPUWaveTransform::runOnMachineFunction(MachineFunction &MF) {
   // ConvergenceInfo.clear();
   DomTree = nullptr;
 
-  // Update the LiveIns of flow blocks.
+  // Update the LiveIns for all blocks.
   ReversePostOrderTraversal<MachineFunction *> RPOT(&MF);
   for (MachineBasicBlock *MBB : reverse(RPOT)) {
-    if (is_contained(FlowBlocks, MBB)){
-      for (const MachineBasicBlock *Succ : MBB->successors()) {
-        for (const auto &LI : Succ->liveins())
-          MBB->addLiveIn(LI);
-      }
-      MBB->sortUniqueLiveIns();
+    for (const MachineBasicBlock *Succ : MBB->successors()) {
+      for (const auto &LI : Succ->liveins())
+        MBB->addLiveIn(LI);
     }
+    MBB->sortUniqueLiveIns();
   }
 
 

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
@@ -637,7 +637,7 @@ body:             |
   ; POSTWT-LABEL: name: if_then_else_nested_divergent_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.8(0x40000000)
-  ; POSTWT-NEXT:   liveins: $vgpr0, $sgpr1, $sgpr2
+  ; POSTWT-NEXT:   liveins: $sgpr1, $sgpr2, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
@@ -255,7 +255,7 @@ body:             |
   ; POSTWT-LABEL: name: two_backedges_divergent_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $vgpr0, $sgpr1
+  ; POSTWT-NEXT:   liveins: $sgpr1, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1
@@ -1194,7 +1194,7 @@ body:             |
   ; POSTWT-LABEL: name: multi_backedge_exits_divergent_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $vgpr0, $sgpr1, $sgpr2
+  ; POSTWT-NEXT:   liveins: $sgpr1, $sgpr2, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
@@ -365,7 +365,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_3
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.10(0x40000000)
-  ; POSTWT-NEXT:   liveins: $vgpr0, $sgpr0, $vgpr1
+  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
@@ -546,7 +546,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_4
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.9(0x40000000)
-  ; POSTWT-NEXT:   liveins: $vgpr0, $vgpr1, $sgpr0
+  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
@@ -730,7 +730,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_5
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.10(0x40000000)
-  ; POSTWT-NEXT:   liveins: $vgpr0, $sgpr0, $sgpr1
+  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
@@ -915,7 +915,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_6
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr0, $sgpr1
+  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0


### PR DESCRIPTION
Initially we only recomputed liveins for flow blocks, we want to do it for all blocks.
This is because an update in liveins of flow block can cause update in liveins of other non-flow blocks.