### PR TITLE
[Comgr] Add LLVM tool substitutions to lit configuration

### DIFF
--- a/amd/comgr/test-lit/cache-tests/compile-minimal-test-cached-bad-dir.cl
+++ b/amd/comgr/test-lit/cache-tests/compile-minimal-test-cached-bad-dir.cl
@@ -7,7 +7,7 @@
 // RUN:   AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
 // RUN:   AMD_COMGR_REDIRECT_LOGS=%t.log \
 // RUN:     compile-opencl-minimal %S/../compile-minimal-test.cl %t.bin 1.2
-// RUN: llvm-objdump -d %t.bin | FileCheck %S/../compile-minimal-test.cl
-// RUN: FileCheck --check-prefix=BAD %s < %t.log
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal-test.cl
+// RUN: %FileCheck --check-prefix=BAD %s < %t.log
 // BAD: Failed to open cache file
 // BAD-SAME: Not a directory

--- a/amd/comgr/test-lit/cache-tests/compile-minimal-test-cached-bad-policy.cl
+++ b/amd/comgr/test-lit/cache-tests/compile-minimal-test-cached-bad-policy.cl
@@ -7,8 +7,8 @@
 // RUN:   AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
 // RUN:   AMD_COMGR_REDIRECT_LOGS=%t.log \
 // RUN:     compile-opencl-minimal %S/../compile-minimal-test.cl %t.bin 1.2
-// RUN: llvm-objdump -d %t.bin | FileCheck %S/../compile-minimal-test.cl
-// RUN: FileCheck --check-prefix=BAD %s < %t.log
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal-test.cl
+// RUN: %FileCheck --check-prefix=BAD %s < %t.log
 // BAD: when parsing the cache policy: Unknown key: 'foo'
 //
 // COM: the cache has not been created since we couldn't parse the policy

--- a/amd/comgr/test-lit/cache-tests/compile-minimal-test-cached.cl
+++ b/amd/comgr/test-lit/cache-tests/compile-minimal-test-cached.cl
@@ -7,20 +7,20 @@
 // COM: Check the default behavior of AMD_COMGR_CACHE
 // RUN: unset AMD_COMGR_CACHE
 // RUN: AMD_COMGR_CACHE_DIR=%t.cache compile-opencl-minimal \
-// RUN:    %S/../compile-minimal-test.cl %t.bin 1.2 | FileCheck --check-prefix=STORED %s
-// RUN: llvm-objdump -d %t.bin | FileCheck %S/../compile-minimal-test.cl
+// RUN:    %S/../compile-minimal-test.cl %t.bin 1.2 | %FileCheck --check-prefix=STORED %s
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal-test.cl
 // RUN: [ -d %t.cache ]
 //
 // RUN: AMD_COMGR_CACHE_DIR=%t.cache compile-opencl-minimal \
-// RUN:    %S/../compile-minimal-test.cl %t.bin 1.2 | FileCheck --check-prefix=FOUND %s
-// RUN: llvm-objdump -d %t.bin | FileCheck %S/../compile-minimal-test.cl
+// RUN:    %S/../compile-minimal-test.cl %t.bin 1.2 | %FileCheck --check-prefix=FOUND %s
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal-test.cl
 //
 // RUN: rm -fr %t.cache
 //
 // RUN: export AMD_COMGR_CACHE=0
 // RUN: AMD_COMGR_CACHE_DIR=%t.cache compile-opencl-minimal \
 // RUN:    %S/../compile-minimal-test.cl %t.bin 1.2
-// RUN: llvm-objdump -d %t.bin | FileCheck %S/../compile-minimal-test.cl
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal-test.cl
 // RUN: [ ! -d %t.cache ]
 //
 // RUN: export AMD_COMGR_CACHE=1
@@ -29,8 +29,8 @@
 // COM     1 element (one for the cache tag, one or more for the cached
 // COM:    commands)
 // RUN: AMD_COMGR_CACHE_DIR=%t.cache compile-opencl-minimal \
-// RUN:    %S/../compile-minimal-test.cl %t_a.bin 1.2 | FileCheck --check-prefix=STORED %s
-// RUN: llvm-objdump -d %t_a.bin | FileCheck %S/../compile-minimal-test.cl
+// RUN:    %S/../compile-minimal-test.cl %t_a.bin 1.2 | %FileCheck --check-prefix=STORED %s
+// RUN: %llvm-objdump -d %t_a.bin | %FileCheck %S/../compile-minimal-test.cl
 // RUN: COUNT_BEFORE=$(ls "%t.cache" | wc -l)
 
 // COM: One element for the tag, one for cli->bc, one for bc->obj another
@@ -38,8 +38,8 @@
 // RUN: [ 4 -eq $COUNT_BEFORE ]
 //
 // RUN: AMD_COMGR_CACHE_DIR=%t.cache compile-opencl-minimal \
-// RUN:    %S/../compile-minimal-test.cl %t_b.bin 1.2 | FileCheck --check-prefix=FOUND %s
-// RUN: llvm-objdump -d %t_b.bin | FileCheck %S/../compile-minimal-test.cl
+// RUN:    %S/../compile-minimal-test.cl %t_b.bin 1.2 | %FileCheck --check-prefix=FOUND %s
+// RUN: %llvm-objdump -d %t_b.bin | %FileCheck %S/../compile-minimal-test.cl
 // RUN: COUNT_AFTER=$(ls "%t.cache" | wc -l)
 // RUN: [ $COUNT_AFTER = $COUNT_BEFORE ]
 //

--- a/amd/comgr/test-lit/cache-tests/spirv-translator-cached.cl
+++ b/amd/comgr/test-lit/cache-tests/spirv-translator-cached.cl
@@ -3,10 +3,10 @@
 // RUN: rm -fr %t.cache
 
 // COM: Generate a spirv-targeted LLVM IR file from an OpenCL kernel
-// RUN: clang -c -emit-llvm --target=spirv64 %S/../spirv-tests/spirv-translator.cl -o %t.bc
+// RUN: %clang -c -emit-llvm --target=spirv64 %S/../spirv-tests/spirv-translator.cl -o %t.bc
 
 // COM: Translate LLVM IR to SPIRV format
-// RUN: amd-llvm-spirv --spirv-target-env=CL2.0 %t.bc -o %t.spv
+// RUN: %amd-llvm-spirv --spirv-target-env=CL2.0 %t.bc -o %t.spv
 
 // COM: Run Comgr Translator to covert SPIRV back to LLVM IR
 // RUN: export AMD_COMGR_CACHE=1
@@ -21,4 +21,4 @@
 // RUN: [ 2 -eq $COUNT ]
 
 // COM: Dissasemble LLVM IR bitcode to LLVM IR text
-// RUN: llvm-dis %t.translated.bc -o - | FileCheck %S/../spirv-tests/spirv-translator.cl
+// RUN: %llvm-dis %t.translated.bc -o - | %FileCheck %S/../spirv-tests/spirv-translator.cl

--- a/amd/comgr/test-lit/cache-tests/unbundle-test-cached.hip
+++ b/amd/comgr/test-lit/cache-tests/unbundle-test-cached.hip
@@ -1,5 +1,5 @@
 // Create compressed bitcode bundle (add --offload-compress flag)
-// RUN: clang -c -x hip --offload-arch=gfx900 --offload-arch=gfx1030 \
+// RUN: %clang -c -x hip --offload-arch=gfx900 --offload-arch=gfx1030 \
 // RUN:    -nogpulib -nogpuinc \
 // RUN:    --gpu-bundle-output --offload-device-only \
 // RUN:    -emit-llvm \
@@ -14,21 +14,21 @@
 // RUN: export AMD_COMGR_CACHE_DIR=%t.cache
 // RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx900 \
 // RUN:    %t.cache_1.bc
-// RUN: llvm-dis %t.cache_1.bc -o - | FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: %llvm-dis %t.cache_1.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 2 -eq $COUNT ]
 //
 // If there is a re-run, the cache contents remain the same
 // RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx900 \
 // RUN:    %t.cache_2.bc
-// RUN: llvm-dis %t.cache_2.bc -o - | FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: %llvm-dis %t.cache_2.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 2 -eq $COUNT ]
 //
 // A run with different input options results in new contents in the cache
 // RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1030 \
 // RUN:    %t.cache_3.bc
-// RUN: llvm-dis %t.cache_3.bc -o - | FileCheck --check-prefixes=BOTH,GFX10 %s
+// RUN: %llvm-dis %t.cache_3.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 3 -eq $COUNT ]
 

--- a/amd/comgr/test-lit/compile-minimal-test.cl
+++ b/amd/comgr/test-lit/compile-minimal-test.cl
@@ -3,7 +3,7 @@
 // RUN: compile-opencl-minimal %s %t.bin 1.2
 
 // COM: Dissasemble
-// RUN: llvm-objdump -d %t.bin | FileCheck %s
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %s
 // CHECK: <add>:
 // CHECK: s_endpgm
 

--- a/amd/comgr/test-lit/compile-opencl-2.cl
+++ b/amd/comgr/test-lit/compile-opencl-2.cl
@@ -3,7 +3,7 @@
 // RUN: compile-opencl-minimal %s %t.bin 2.0
 
 // COM: Dissasemble
-// RUN: llvm-objdump -d %t.bin | FileCheck %s
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %s
 // CHECK: <add>:
 // CHECK: s_endpgm
 

--- a/amd/comgr/test-lit/device-lib-linking.cl
+++ b/amd/comgr/test-lit/device-lib-linking.cl
@@ -3,7 +3,7 @@
 // RUN: source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc
 
 // COM: Dissasemble LLVM IR bitcode to LLVM IR text
-// RUN: llvm-dis %t-with-dev-libs.bc -o - | FileCheck %s
+// RUN: %llvm-dis %t-with-dev-libs.bc -o - | %FileCheck %s
 
 // COM: Verify LLVM IR text file
 // CHECK: target triple = "amdgcn-amd-amdhsa"

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -2,7 +2,7 @@ import os
 
 import lit.formats
 import lit.util
-
+from lit.llvm import llvm_config
 config.name = "Comgr"
 config.suffixes = {".hip", ".cl", ".c", ".cpp"}
 config.test_format = lit.formats.ShTest(True)

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -23,3 +23,5 @@ config.environment['AMD_COMGR_CACHE'] = "0"
 config.substitutions.append(('%clang', os.path.join(config.llvm_tools_dir, 'clang')))
 config.substitutions.append(('%llvm-dis', os.path.join(config.llvm_tools_dir, 'llvm-dis')))
 config.substitutions.append(('%llvm-objdump', os.path.join(config.llvm_tools_dir, 'llvm-objdump')))
+config.substitutions.append(('%FileCheck', os.path.join(config.llvm_tools_dir, 'FileCheck')))
+config.substitutions.append(('%amd-llvm-spirv', os.path.join(config.llvm_tools_dir, 'amd-llvm-spirv')))

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -20,8 +20,5 @@ if not config.comgr_disable_spirv:
 config.environment['AMD_COMGR_CACHE'] = "0"
 
 # Add substitutions for LLVM tools
-config.substitutions.append(('%clang', os.path.join(config.llvm_tools_dir, 'clang')))
-config.substitutions.append(('%llvm-dis', os.path.join(config.llvm_tools_dir, 'llvm-dis')))
-config.substitutions.append(('%llvm-objdump', os.path.join(config.llvm_tools_dir, 'llvm-objdump')))
-config.substitutions.append(('%FileCheck', os.path.join(config.llvm_tools_dir, 'FileCheck')))
-config.substitutions.append(('%amd-llvm-spirv', os.path.join(config.llvm_tools_dir, 'amd-llvm-spirv')))
+tools = ["clang", "llvm-dis", "llvm-objdump", "FileCheck", "amd-llvm-spirv"]
+llvm_config.add_tool_substitutions(tools, config.llvm_tools_dir)

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -20,5 +20,8 @@ if not config.comgr_disable_spirv:
 config.environment['AMD_COMGR_CACHE'] = "0"
 
 # Add substitutions for LLVM tools
-tools = ["clang", "llvm-dis", "llvm-objdump", "FileCheck", "amd-llvm-spirv"]
-llvm_config.add_tool_substitutions(tools, config.llvm_tools_dir)
+config.substitutions.append(('%clang', os.path.join(config.llvm_tools_dir, 'clang')))
+config.substitutions.append(('%llvm-dis', os.path.join(config.llvm_tools_dir, 'llvm-dis')))
+config.substitutions.append(('%llvm-objdump', os.path.join(config.llvm_tools_dir, 'llvm-objdump')))
+config.substitutions.append(('%FileCheck', os.path.join(config.llvm_tools_dir, 'FileCheck')))
+config.substitutions.append(('%amd-llvm-spirv', os.path.join(config.llvm_tools_dir, 'amd-llvm-spirv')))

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -2,7 +2,7 @@ import os
 
 import lit.formats
 import lit.util
-from lit.llvm import llvm_config
+
 config.name = "Comgr"
 config.suffixes = {".hip", ".cl", ".c", ".cpp"}
 config.test_format = lit.formats.ShTest(True)

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -18,3 +18,8 @@ if not config.comgr_disable_spirv:
 # By default, disable the cache for the tests.
 # Test for the cache must explicitly enable this variable.
 config.environment['AMD_COMGR_CACHE'] = "0"
+
+# Add substitutions for LLVM tools
+config.substitutions.append(('%clang', os.path.join(config.llvm_tools_dir, 'clang')))
+config.substitutions.append(('%llvm-dis', os.path.join(config.llvm_tools_dir, 'llvm-dis')))
+config.substitutions.append(('%llvm-objdump', os.path.join(config.llvm_tools_dir, 'llvm-objdump')))

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -5,10 +5,6 @@ config.my_obj_root = r'@CMAKE_CURRENT_BINARY_DIR@'
 
 config.comgr_disable_spirv = @COMGR_DISABLE_SPIRV@
 
-# Needed for clang, llvm-dis, etc.
-config.environment['PATH'] = os.pathsep.join(["@LLVM_TOOLS_BINARY_DIR@",
-                                              config.environment['PATH']])
-
 # Needed for Comgr binaries
 config.environment['PATH'] = os.pathsep.join(["@CMAKE_CURRENT_BINARY_DIR@",
                                               config.environment['PATH']])

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -13,5 +13,8 @@ config.environment['PATH'] = os.pathsep.join(["@LLVM_TOOLS_BINARY_DIR@",
 config.environment['PATH'] = os.pathsep.join(["@CMAKE_CURRENT_BINARY_DIR@",
                                               config.environment['PATH']])
 
+# Set path to LLVM tools for substitutions
+config.llvm_tools_dir = r'@LLVM_TOOLS_BINARY_DIR@'
+
 lit_config.load_config(
       config, os.path.join(config.my_src_root, "lit.cfg.py"))

--- a/amd/comgr/test-lit/lookup-code-object.hip
+++ b/amd/comgr/test-lit/lookup-code-object.hip
@@ -1,8 +1,8 @@
 // COM: Create fatbin (executable)
-// RUN: clang --offload-arch=gfx900 --offload-device-only \
+// RUN: %clang --offload-arch=gfx900 --offload-device-only \
 // RUN:  --no-gpu-bundle-output -nogpulib -nogpuinc %s -o %t.so
 
-// RUN: lookup-code-object %t.so 0 | FileCheck --check-prefixes=EXEC %s
+// RUN: lookup-code-object %t.so 0 | %FileCheck --check-prefixes=EXEC %s
 
 // EXEC: ObjectInfo[0].isa: amdgcn-amd-amdhsa--gfx900
 // EXEC: ObjectInfo[0].size: {{[1-9][0-9]*}}
@@ -15,11 +15,11 @@
 // EXEC: ObjectInfo[2].offset: 0
 
 // COM: Create offload bundle
-// RUN: clang --offload-arch=gfx900,gfx942 --offload-device-only \
+// RUN: %clang --offload-arch=gfx900,gfx942 --offload-device-only \
 // RUN:   --gpu-bundle-output -nogpulib -nogpuinc \
 // RUN:   %s -o %t.bundle
 
-// RUN: lookup-code-object %t.bundle 1 | FileCheck --check-prefixes=BUNDLE %s
+// RUN: lookup-code-object %t.bundle 1 | %FileCheck --check-prefixes=BUNDLE %s
 
 // BUNDLE: ObjectInfo[0].isa: amdgcn-amd-amdhsa--gfx900
 // BUNDLE: ObjectInfo[0].size: {{[1-9][0-9]*}}

--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
@@ -1,11 +1,11 @@
 // REQUIRES: comgr-has-spirv
 // COM: Generate a debuginfo SPIR-V file from a HIP kernel
-// RUN: clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
+// RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
 // RUN:    --no-gpu-bundle-output --offload-device-only -O3 %s -o %t.dbg.spv -g
 
 // COM: Compile debuginfo SPIR-V source to a relocatable
 // RUN: AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_REDIRECT_LOGS=stdout \
-// RUN:   spirv-to-reloc %t.dbg.spv %t.dbg.o | FileCheck --dump-input-filter all \
+// RUN:   spirv-to-reloc %t.dbg.spv %t.dbg.o | %FileCheck --dump-input-filter all \
 // RUN:   -check-prefix=CHECK-DBG %s
 
 // COM: Check that debuginfo SPIR-V flags are correctly extracted

--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc.hip
@@ -1,6 +1,6 @@
 // REQUIRES: comgr-has-spirv
 // COM: Generate a SPIR-V file from a HIP kernel
-// RUN: clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
+// RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
 // RUN:    --no-gpu-bundle-output --offload-device-only -O3 %s -o %t.spv \
 // RUN:    -fvisibility=hidden -fno-autolink -fexceptions -fcolor-diagnostics
 

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator.cl
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator.cl
@@ -1,15 +1,15 @@
 // REQUIRES: comgr-has-spirv
 // COM: Generate a spirv-targeted LLVM IR file from an OpenCL kernel
-// RUN: clang -c -emit-llvm --target=spirv64 %s -o %t.bc
+// RUN: %clang -c -emit-llvm --target=spirv64 %s -o %t.bc
 
 // COM: Translate LLVM IR to SPIRV format
-// RUN: amd-llvm-spirv --spirv-target-env=CL2.0 %t.bc -o %t.spv
+// RUN: %amd-llvm-spirv --spirv-target-env=CL2.0 %t.bc -o %t.spv
 
 // COM: Run Comgr Translator to covert SPIRV back to LLVM IR
 // RUN: spirv-translator %t.spv -o %t.translated.bc
 
 // COM: Dissasemble LLVM IR bitcode to LLVM IR text
-// RUN: llvm-dis %t.translated.bc -o - | FileCheck %s
+// RUN: %llvm-dis %t.translated.bc -o - | %FileCheck %s
 
 // COM: Verify LLVM IR text
 // CHECK: target triple = "spir64-unknown-unknown"

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator.hip
@@ -1,13 +1,13 @@
 // REQUIRES: comgr-has-spirv
 // COM: Generate a SPIRV file from a HIP kernel
-// RUN: clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
+// RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
 // RUN:    --no-gpu-bundle-output --offload-device-only -O3 %s -o %t.spv
 
 // COM: Run Comgr Translator to covert SPIRV back to LLVM IR
 // RUN: spirv-translator %t.spv -o %t.translated.bc
 
 // COM: Dissasemble LLVM IR bitcode to LLVM IR text
-// RUN: llvm-dis %t.translated.bc -o - | FileCheck %s
+// RUN: %llvm-dis %t.translated.bc -o - | %FileCheck %s
 
 // COM: Verify LLVM IR text
 // CHECK: target triple = "amdgcn-amd-amdhsa"

--- a/amd/comgr/test-lit/unbundle-test.hip
+++ b/amd/comgr/test-lit/unbundle-test.hip
@@ -1,11 +1,11 @@
 // Create bitcode bundle
-// RUN: clang -c -x hip --offload-arch=gfx900 --offload-arch=gfx1030 \
+// RUN: %clang -c -x hip --offload-arch=gfx900 --offload-arch=gfx1030 \
 // RUN:    -nogpulib -nogpuinc -emit-llvm \
 // RUN:    --gpu-bundle-output --offload-device-only \
 // RUN:    %s -o %t.bundle.bc
 //
 // Create compressed bitcode bundle (add --offload-compress flag)
-// RUN: clang -c -x hip --offload-arch=gfx900 --offload-arch=gfx1030 \
+// RUN: %clang -c -x hip --offload-arch=gfx900 --offload-arch=gfx1030 \
 // RUN:    -nogpulib -nogpuinc -emit-llvm \
 // RUN:    --gpu-bundle-output --offload-device-only \
 // RUN:    --offload-compress \
@@ -13,10 +13,10 @@
 //
 // Extract using Comgr
 // RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx900 %t.gfx900.bc
-// RUN: llvm-dis %t.gfx900.bc -o - | FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: %llvm-dis %t.gfx900.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
 //
 // RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1030 %t.compressed.gfx1030.bc
-// RUN: llvm-dis %t.compressed.gfx1030.bc -o - | FileCheck --check-prefixes=BOTH,GFX10 %s
+// RUN: %llvm-dis %t.compressed.gfx1030.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
 //
 // BOTH: target triple = "amdgcn-amd-amdhsa"
 // GFX9: "target-cpu"="gfx900"

--- a/amd/comgr/test-lit/vfs-tests/vfs-tests.cl
+++ b/amd/comgr/test-lit/vfs-tests/vfs-tests.cl
@@ -1,24 +1,24 @@
 // COM: Prefixes follow pattern (AMD_COMGR_SAVETEMPS)-(AMD_COMGR_USE_VFS)-(DataAction API)
 
 // COM: Default behavior right now is to use the real file system
-// RUN: source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-NA-NA %s
+// RUN: source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-NA-NA %s
 
 // COM: AMD_COMGR_USE_VFS=1 should force the compiler to use VFS, irrespective of the option provided via the DataAction API
-// RUN: env AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s --novfs -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-VFS-NOVFS %s
-// RUN: env AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-VFS-NA %s
+// RUN: env AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s --novfs -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-VFS-NOVFS %s
+// RUN: env AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-VFS-NA %s
 
 // COM: AMD_COMGR_USE_VFS=0 should force the compiler to not use VFS, irrespective of the option provided via the DataAction API
-// RUN: env AMD_COMGR_USE_VFS=0 source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-NOVFS-VFS %s
-// RUN: env AMD_COMGR_USE_VFS=0 source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-NOVFS-NA %s
+// RUN: env AMD_COMGR_USE_VFS=0 source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-NOVFS-VFS %s
+// RUN: env AMD_COMGR_USE_VFS=0 source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-NOVFS-NA %s
 
 // COM: No value for AMD_COMGR_USE_VFS should respect option provided via the DataAction API
-// RUN: source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-NA-VFS %s
-// RUN: source-to-bc-with-dev-libs %s --novfs -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-NA-NA-NOVFS %s
+// RUN: source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-NA-VFS %s
+// RUN: source-to-bc-with-dev-libs %s --novfs -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-NA-NA-NOVFS %s
 
-// COM: AMD_COMGR_SAVE_TEMPS=1 should override all options and always use the real file system 
-// RUN: env AMD_COMGR_SAVE_TEMPS=1 source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-SAVETEMPS-NA-VFS %s
-// RUN: env AMD_COMGR_SAVE_TEMPS=1 AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-SAVETEMPS-VFS-NA %s
-// RUN: env AMD_COMGR_SAVE_TEMPS=1 AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | FileCheck --check-prefixes=STATUS,OUT-SAVETEMPS-VFS-VFS %s
+// COM: AMD_COMGR_SAVE_TEMPS=1 should override all options and always use the real file system
+// RUN: env AMD_COMGR_SAVE_TEMPS=1 source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-SAVETEMPS-NA-VFS %s
+// RUN: env AMD_COMGR_SAVE_TEMPS=1 AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-SAVETEMPS-VFS-NA %s
+// RUN: env AMD_COMGR_SAVE_TEMPS=1 AMD_COMGR_USE_VFS=1 source-to-bc-with-dev-libs %s --vfs -o %t-with-dev-libs.bc | %FileCheck --check-prefixes=STATUS,OUT-SAVETEMPS-VFS-VFS %s
 
 // OUT-NA-NA-NA: File System: VFS
 // OUT-NA-VFS-NOVFS: File System: VFS


### PR DESCRIPTION
Add substitutions for common LLVM tools (%clang, %llvm-dis, %llvm-objdump) to the lit test configuration.


