### PR TITLE
[Comgr] Set default path when LLVM_PATH is unset

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -749,7 +749,10 @@ AMDGPUCompiler::executeInProcessDriver(ArrayRef<const char *> Args) {
 
   ProcessWarningOptions(Diags, *DiagOpts, *OverlayFS, /*ReportDiags=*/false);
 
-  Driver TheDriver((Twine(env::getLLVMPath()) + "/bin/clang").str(),
+  SmallString<256> ClangBinaryPath(env::getLLVMPath());
+  sys::path::append(ClangBinaryPath, "bin", "clang");
+
+  Driver TheDriver(std::string(ClangBinaryPath),
                    llvm::sys::getDefaultTargetTriple(), Diags,
                    "AMDGPU Code Object Manager", OverlayFS);
   TheDriver.setCheckInputsExist(false);

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -18,6 +18,10 @@
 
 using namespace llvm;
 
+namespace {
+const char *DefaultLLVMPath = "/opt/rocm";
+} // anonymous namespace
+
 namespace COMGR {
 namespace env {
 
@@ -66,7 +70,9 @@ bool shouldEmitVerboseLogs() {
 
 llvm::StringRef getLLVMPath() {
   static const char *EnvLLVMPath = std::getenv("LLVM_PATH");
-  return EnvLLVMPath;
+  if (EnvLLVMPath)
+    return EnvLLVMPath;
+  return DefaultLLVMPath;
 }
 
 StringRef getCachePolicy() {


### PR DESCRIPTION
This was a subtle issue that was brought to notice by Matt.

`env::getLLVMPath()` returns the value stored in environment variable `LLVM_PATH`. If this is unset, this caused a discrepancy in the paths for the clang binary and the resource directory between the clang driver and comgr.

Specifically, the clang driver [thinks](https://github.com/ROCm/llvm-project/blob/amd-staging/amd/comgr/src/comgr-compiler.cpp#L752) its at `/bin/clang`

`Driver TheDriver((Twine(env::getLLVMPath()) + "/bin/clang").str(),`

Whereas comgr [thinks](https://github.com/ROCm/llvm-project/blob/amd-staging/amd/comgr/src/comgr-compiler.cpp#L1130) its at `bin/clang` (notice the missing `/` in the front)

`sys::path::append(ClangBinaryPath, "bin", "clang");`

This PR attempts to solve that issue by setting a synthetic default of `/opt/rocm` if the LLVM_PATH is unset. This should not impact existing users that set LLVM_PATH when invoking comgr.

The choice of `/opt/rocm` as the default can be debated upon, but I believe its a sane one.