### PR TITLE
[WaveTransform] Recompute liveins using fullyRecomputeLiveIns at end of wave transform pass

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2341,10 +2341,11 @@ bool AMDGPUWaveTransform::runOnMachineFunction(MachineFunction &MF) {
   DomTree = nullptr;
 
   // Recompute LiveIns for all blocks.
-  SmallVector<MachineBasicBlock *, 16> AllBlocks;
-  for (MachineBasicBlock &MBB : MF)
-    AllBlocks.push_back(&MBB);
-  fullyRecomputeLiveIns(AllBlocks);
+  ReversePostOrderTraversal<MachineFunction *> RPOT(&MF);
+  SmallVector<MachineBasicBlock *, 16> PostOrder;
+  for (auto MBB : reverse(RPOT))
+    PostOrder.push_back(MBB);
+  fullyRecomputeLiveIns(PostOrder);
 
   MF.getInfo<SIMachineFunctionInfo>()->setWaveCFG(true);
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -82,12 +82,13 @@
 #include "SIMachineFunctionInfo.h"
 #include "llvm/ADT/IntEqClasses.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/PostOrderIterator.h"
+#include "llvm/CodeGen/LivePhysRegs.h"
 #include "llvm/CodeGen/MachineCycleAnalysis.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/ADT/PostOrderIterator.h"
 
 using namespace llvm;
 
@@ -2339,16 +2340,11 @@ bool AMDGPUWaveTransform::runOnMachineFunction(MachineFunction &MF) {
   // ConvergenceInfo.clear();
   DomTree = nullptr;
 
-  // Update the LiveIns for all blocks.
-  ReversePostOrderTraversal<MachineFunction *> RPOT(&MF);
-  for (MachineBasicBlock *MBB : reverse(RPOT)) {
-    for (const MachineBasicBlock *Succ : MBB->successors()) {
-      for (const auto &LI : Succ->liveins())
-        MBB->addLiveIn(LI);
-    }
-    MBB->sortUniqueLiveIns();
-  }
-
+  // Recompute LiveIns for all blocks.
+  SmallVector<MachineBasicBlock *, 16> AllBlocks;
+  for (MachineBasicBlock &MBB : MF)
+    AllBlocks.push_back(&MBB);
+  fullyRecomputeLiveIns(AllBlocks);
 
   MF.getInfo<SIMachineFunctionInfo>()->setWaveCFG(true);
 

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
@@ -200,7 +200,7 @@ body:             |
   ; POSTWT-LABEL: name: if_then_else_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -463,7 +463,7 @@ body:             |
   ; POSTWT-LABEL: name: if_then_else_nested_uniform_divergent
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr1, $vgpr2
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $vgpr1, $vgpr2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
@@ -637,7 +637,7 @@ body:             |
   ; POSTWT-LABEL: name: if_then_else_nested_divergent_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.8(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr1, $sgpr2, $vgpr0
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr1, $sgpr2, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1
@@ -661,6 +661,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY1]], [[S_MOV_B32_]], implicit $exec
@@ -670,6 +671,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.8:
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.7(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
@@ -684,6 +686,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.6(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
@@ -693,11 +696,13 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.8(0x80000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   S_BRANCH %bb.8
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
   ; POSTWT-NEXT:   successors: %bb.8(0x80000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   S_BRANCH %bb.8
   ; POSTWT-NEXT: {{  $}}

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
@@ -173,7 +173,7 @@ body:             |
   ; POSTWT-LABEL: name: two_backedges_uniform_divergent
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr1
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $vgpr1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
@@ -187,6 +187,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY2]], 1, implicit-def $scc
@@ -199,6 +200,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
@@ -367,7 +369,7 @@ body:             |
   ; POSTWT-LABEL: name: nested_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $sgpr2
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $sgpr1, $sgpr2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1
@@ -378,6 +380,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.4(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[COPY3]], [[COPY]], implicit $exec
   ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_]]
@@ -386,6 +389,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
@@ -395,6 +399,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY2]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
@@ -600,7 +605,7 @@ body:             |
   ; POSTWT-LABEL: name: nested2_uniform_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $sgpr1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1
@@ -610,6 +615,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.2(0x80000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_MOV_B32_1]]
@@ -617,6 +623,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.3(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
@@ -627,6 +634,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.4(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_1:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY2]], 1, implicit-def $scc
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_1]], [[COPY]], implicit $exec
@@ -1018,7 +1026,7 @@ body:             |
   ; POSTWT-LABEL: name: multi_backedge_exits_uniform_divergent
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr1, $vgpr2
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $vgpr1, $vgpr2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
@@ -1037,6 +1045,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.3(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
@@ -1047,6 +1056,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.8(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
@@ -1065,6 +1075,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.8(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY2]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
@@ -1399,7 +1410,7 @@ body:             |
   ; POSTWT-LABEL: name: multi_backedge_exits_uniform_uniform
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x80000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $sgpr2
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $sgpr1, $sgpr2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1
@@ -1410,6 +1421,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.3(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY]], implicit $exec
@@ -1419,6 +1431,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.4(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
@@ -1428,6 +1441,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.5(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY2]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
@@ -201,7 +201,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_2
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $vgpr0, $vgpr1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
@@ -365,7 +365,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_3
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.10(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $vgpr0, $vgpr1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
@@ -394,6 +394,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.7(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
@@ -730,7 +731,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_5
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.10(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $sgpr1, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr0
@@ -759,6 +760,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.7(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
@@ -915,7 +917,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_6
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $sgpr1, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
@@ -951,6 +953,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.4(0x40000000), %bb.5(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY $scc
@@ -1057,7 +1060,7 @@ body:             |
   ; POSTWT-LABEL: name: partial_join_7
   ; POSTWT: bb.0:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
-  ; POSTWT-NEXT:   liveins: $sgpr0, $sgpr1, $vgpr0
+  ; POSTWT-NEXT:   liveins: $vcc_hi, $sgpr0, $sgpr1, $vgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:sgpr_32 = COPY $sgpr1
@@ -1076,6 +1079,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
+  ; POSTWT-NEXT:   liveins: $vcc_hi
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY $scc


### PR DESCRIPTION
Current implementation iterates over CFG and updates the livein.
This updates the liveins for the entry block as well, which is incorrect.
In case of loops, we need to update liveins until we reach a fixed point. 

Replacing the same with already present functionality to compute liveins : `fullyRecomputeLiveIns()`