### PR TITLE
[WaveTransform] Fix implicit operand vcc for S_CBRANCH_VCCNZ instruction

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -1929,8 +1929,10 @@ void ControlFlowRewriter::rewrite() {
         Opcode = AMDGPU::S_CBRANCH_VCCNZ;
       }
 
-      BuildMI(*Node->Block, MBBINodeEnd, {}, TII.get(Opcode))
-          .addMBB(LaneSucc->Wave->Block);
+      MachineInstr *CondBrMI =
+          BuildMI(*Node->Block, MBBINodeEnd, {}, TII.get(Opcode))
+              .addMBB(LaneSucc->Wave->Block);
+      TII.fixImplicitOperands(*CondBrMI);
 
       // The _other_ successor may be a flow block instead of an original
       // successor.


### PR DESCRIPTION
On Wave32, S_CBRANCH_VCCNZ should have implicit $vcc_lo operand.
