### PR TITLE
[flang-rt] Fix OpenMP/offload build for NVPTX

### DIFF
--- a/flang-rt/lib/runtime/CMakeLists.txt
+++ b/flang-rt/lib/runtime/CMakeLists.txt
@@ -45,7 +45,6 @@ set(supported_sources
   internal-unit.cpp
   io-api.cpp
   io-api-minimal.cpp
-  io-error.cpp
   io-stmt.cpp
   iostat.cpp
   matmul-transpose.cpp
@@ -83,6 +82,7 @@ set(host_sources
   exceptions.cpp
   execute.cpp
   extensions.cpp
+  io-error.cpp
   main.cpp
   random.cpp
   reduce.cpp

--- a/flang-rt/lib/runtime/stop.cpp
+++ b/flang-rt/lib/runtime/stop.cpp
@@ -23,7 +23,7 @@
 #include <thread>
 #endif
 
-#ifdef HAVE_BACKTRACE
+#if defined(HAVE_BACKTRACE) && !defined(__AMDGPU__) && !defined(__NVPTX__)
 #include BACKTRACE_HEADER
 #endif
 
@@ -219,7 +219,7 @@ void RTNAME(RegisterFailImageCallback)(void (*callback)(void)) {
 }
 
 static RT_NOINLINE_ATTR void PrintBacktrace() {
-#ifdef HAVE_BACKTRACE
+#if defined(HAVE_BACKTRACE) && !defined(__AMDGPU__) && !defined(__NVPTX__)
   // TODO: Need to parse DWARF information to print function line numbers
   constexpr int MAX_CALL_STACK{999};
   void *buffer[MAX_CALL_STACK];

--- a/openmp/device/src/Synchronization.cpp
+++ b/openmp/device/src/Synchronization.cpp
@@ -167,17 +167,6 @@ void namedBarrier() {
 void syncThreadsAligned(atomic::OrderingTy Ordering) { __syncthreads(); }
 
 constexpr uint32_t OMP_SPIN = 1000;
-constexpr uint32_t UNSET = 0;
-constexpr uint32_t SET = 1;
-
-void unsetLock(omp_lock_t *Lock) {
-  [[maybe_unused]] uint32_t before = atomicExchange(
-      reinterpret_cast<uint32_t *>(Lock), UNSET, atomic::seq_cst);
-}
-
-int testLock(omp_lock_t *Lock) {
-  return atomic::add(reinterpret_cast<uint32_t *>(Lock), 0u, atomic::seq_cst);
-}
 
 void initLock(omp_lock_t *Lock) { unsetLock(Lock); }
 

--- a/openmp/device/src/Synchronization.cpp
+++ b/openmp/device/src/Synchronization.cpp
@@ -167,6 +167,17 @@ void namedBarrier() {
 void syncThreadsAligned(atomic::OrderingTy Ordering) { __syncthreads(); }
 
 constexpr uint32_t OMP_SPIN = 1000;
+constexpr uint32_t UNSET = 0;
+constexpr uint32_t SET = 1;
+
+void unsetLock(omp_lock_t *Lock) {
+  [[maybe_unused]] uint32_t before = atomicExchange(
+      reinterpret_cast<uint32_t *>(Lock), UNSET, atomic::seq_cst);
+}
+
+int testLock(omp_lock_t *Lock) {
+  return atomic::add(reinterpret_cast<uint32_t *>(Lock), 0u, atomic::seq_cst);
+}
 
 void initLock(omp_lock_t *Lock) { unsetLock(Lock); }
 


### PR DESCRIPTION
Due to the downstream flag EMBED_FLANG_RT_GPU_LLVM_IR, we compiled io-error.cpp and stop.cpp also for GPU.
For io-error.cpp, we already decided upstream that this doesn't make sense (see https://github.com/llvm/llvm-project/pull/180530). Thus, we should also move it from supported_sources to host_sources. For stop.cpp, we need to guard HAVE_BACKTRACE.


