### PR TITLE
device-libs: Use frexp builtin instead of frexp_exp + frexp_mant

### DIFF
--- a/amd/device-libs/ocml/src/builtins.h
+++ b/amd/device-libs/ocml/src/builtins.h
@@ -259,24 +259,6 @@ static inline half __ocml_priv_rsqrt_f16(half x) {
         _exp;                                                                  \
     })
 
-#define BUILTIN_FREXP_MANT_F32(X)                                              \
-    ({                                                                         \
-        int _exp;                                                              \
-        __builtin_frexpf(X, &_exp);                                            \
-    })
-
-#define BUILTIN_FREXP_MANT_F64(X)                                              \
-    ({                                                                         \
-        int _exp;                                                              \
-        __builtin_frexp(X, &_exp);                                             \
-    })
-
-#define BUILTIN_FREXP_MANT_F16(X)                                              \
-    ({                                                                         \
-        int _exp;                                                              \
-        __builtin_frexpf16(X, &_exp);                                          \
-    })
-
 #define BUILTIN_CMAX_F32 __builtin_fmaxf
 #define BUILTIN_CMAX_F64 __builtin_fmax
 #define BUILTIN_CMAX_F16 __builtin_fmaxf16

--- a/amd/device-libs/ocml/src/eplnD.cl
+++ b/amd/device-libs/ocml/src/eplnD.cl
@@ -13,10 +13,11 @@
 CONSTATTR double2
 MATH_PRIVATE(epln)(double a)
 {
-    double m = BUILTIN_FREXP_MANT_F64(a);
+    int a_exp;
+    double m = BUILTIN_FREXP_F64(a, &a_exp);
     int b = m < (2.0/3.0);
     m = BUILTIN_FLDEXP_F64(m, b);
-    int e = BUILTIN_FREXP_EXP_F64(a) - b;
+    int e = a_exp - b;
 
     double2 x = div(m - 1.0, fadd(1.0, m));
     double2 s = sqr(x);

--- a/amd/device-libs/ocml/src/eplnF.cl
+++ b/amd/device-libs/ocml/src/eplnF.cl
@@ -13,10 +13,11 @@
 CONSTATTR float2
 MATH_PRIVATE(epln)(float a)
 {
-    float m = BUILTIN_FREXP_MANT_F32(a);
+    int a_exp;
+    float m = BUILTIN_FREXP_F32(a, &a_exp);
     int b = m < (2.0f/3.0f);
     m = BUILTIN_FLDEXP_F32(m, b);
-    int e = BUILTIN_FREXP_EXP_F32(a) - b;
+    int e = a_exp - b;
 
     float2 x = div(m - 1.0f, fadd(1.0f, m));
     float2 s = sqr(x);

--- a/amd/device-libs/ocml/src/lnepD.cl
+++ b/amd/device-libs/ocml/src/lnepD.cl
@@ -13,8 +13,11 @@
 CONSTATTR double
 MATH_PRIVATE(lnep)(double2 a, int ea)
 {
-    int b = BUILTIN_FREXP_MANT_F64(a.hi) < (2.0/3.0);
-    int e = BUILTIN_FREXP_EXP_F64(a.hi) - b;
+    int a_hi_exp;
+    double m_hi = BUILTIN_FREXP_F64(a.hi, &a_hi_exp);
+
+    int b = m_hi < (2.0/3.0);
+    int e = a_hi_exp - b;
     double2 m = ldx(a, -e);
     double2 x = div(fadd(-1.0, m), fadd(1.0, m));
     double s = x.hi * x.hi;

--- a/amd/device-libs/ocml/src/lnepF.cl
+++ b/amd/device-libs/ocml/src/lnepF.cl
@@ -13,8 +13,10 @@
 CONSTATTR float
 MATH_PRIVATE(lnep)(float2 a, int ea)
 {
-    int b = BUILTIN_FREXP_MANT_F32(a.hi) < (2.0f/3.0f);
-    int e = BUILTIN_FREXP_EXP_F32(a.hi) - b;
+    int a_hi_exp;
+    float a_hi_m = BUILTIN_FREXP_F32(a.hi, &a_hi_exp);
+    int b = a_hi_m < (2.0f/3.0f);
+    int e = a_hi_exp - b;
     float2 m = ldx(a, -e);
     float2 x = div(fadd(-1.0f, m), fadd(1.0f, m));
     float s = x.hi * x.hi;

--- a/amd/device-libs/ocml/src/logD_base.h
+++ b/amd/device-libs/ocml/src/logD_base.h
@@ -19,10 +19,11 @@ MATH_MANGLE(log10)(double a)
 MATH_MANGLE(log)(double a)
 #endif
 {
-    double m = BUILTIN_FREXP_MANT_F64(a);
+    int a_exp;
+    double m = BUILTIN_FREXP_F64(a, &a_exp);
     int b = m < (2.0/3.0);
     m = BUILTIN_FLDEXP_F64(m, b);
-    int e = BUILTIN_FREXP_EXP_F64(a) - b;
+    int e = a_exp - b;
 
     double2 x = div(m - 1.0, fadd(1.0, m));
     double s = x.hi * x.hi;

--- a/amd/device-libs/ocml/src/remainderD_base.h
+++ b/amd/device-libs/ocml/src/remainderD_base.h
@@ -37,10 +37,14 @@ MATH_MANGLE(remainder)(double x, double y)
     if (ax > ay) {
         int ex, ey;
 
-        ex = BUILTIN_FREXP_EXP_F64(ax) - 1;
-        ax = BUILTIN_FLDEXP_F64(BUILTIN_FREXP_MANT_F64(ax), bits);
-        ey = BUILTIN_FREXP_EXP_F64(ay) - 1;
-        ay = BUILTIN_FLDEXP_F64(BUILTIN_FREXP_MANT_F64(ay), 1);
+        double mx = BUILTIN_FREXP_F64(ax, &ex);
+        --ex;
+
+        double my = BUILTIN_FREXP_F64(ay, &ey);
+        --ey;
+
+        ax = BUILTIN_FLDEXP_F64(mx, bits);
+        ay = BUILTIN_FLDEXP_F64(my, 1);
 
         int nb = ex - ey;
         double ayinv = MATH_RCP(ay);

--- a/amd/device-libs/ocml/src/remainderF_base.h
+++ b/amd/device-libs/ocml/src/remainderF_base.h
@@ -57,10 +57,14 @@ MATH_MANGLE(remainder)(float x, float y)
     if (ax > ay) {
         int ex, ey;
 
-        ex = BUILTIN_FREXP_EXP_F32(ax) - 1;
-        ax = BUILTIN_FLDEXP_F32(BUILTIN_FREXP_MANT_F32(ax), bits);
-        ey = BUILTIN_FREXP_EXP_F32(ay) - 1;
-        ay = BUILTIN_FLDEXP_F32(BUILTIN_FREXP_MANT_F32(ay), 1);
+        float mx = BUILTIN_FREXP_F32(ax, &ex);
+        --ex;
+
+        float my = BUILTIN_FREXP_F32(ay, &ey);
+        --ey;
+
+        ax = BUILTIN_FLDEXP_F32(mx, bits);
+        ay = BUILTIN_FLDEXP_F32(my, 1);
 
         int nb = ex - ey;
         float ayinv = MATH_FAST_RCP(ay);

--- a/amd/device-libs/ocml/src/remainderH_base.h
+++ b/amd/device-libs/ocml/src/remainderH_base.h
@@ -35,10 +35,13 @@ MATH_MANGLE(remainder)(half x, half y)
     if (ax > ay) {
         int ex, ey;
 
-        ex = BUILTIN_FREXP_EXP_F32(ax) - 1;
-        ax = BUILTIN_FLDEXP_F32(BUILTIN_FREXP_MANT_F32(ax), bits);
-        ey = BUILTIN_FREXP_EXP_F32(ay) - 1;
-        ay = BUILTIN_FLDEXP_F32(BUILTIN_FREXP_MANT_F32(ay), 1);
+        float mx = BUILTIN_FREXP_F32(ax, &ex);
+        --ex;
+        float my = BUILTIN_FREXP_F32(ay, &ey);
+        --ey;
+
+        ax = BUILTIN_FLDEXP_F32(mx, bits);
+        ay = BUILTIN_FLDEXP_F32(my, 1);
 
         int nb = ex - ey;
 


### PR DESCRIPTION
All instances of BUILTIN_FREXP_MANT also use BUILTIN_FREXP_EXP, so this can be simplified to just use one frexp call.


