### PR TITLE
[ASan][Compiler-rt] Reset AMDGPU shutdown state on hsa_init() re-init

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1644,8 +1644,10 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
 
 hsa_status_t asan_hsa_init() {
   hsa_status_t status = REAL(hsa_init)();
-  if (status == HSA_STATUS_SUCCESS)
+  if (status == HSA_STATUS_SUCCESS) {
+    __sanitizer::AmdgpuMemFuncs::ClearAmdgpuRuntimeShutdownState();
     __sanitizer::AmdgpuMemFuncs::RegisterSystemEventHandlers();
+  }
   return status;
 }
 

--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1645,7 +1645,10 @@ hsa_status_t asan_hsa_amd_pointer_info(const void* ptr,
 hsa_status_t asan_hsa_init() {
   hsa_status_t status = REAL(hsa_init)();
   if (status == HSA_STATUS_SUCCESS) {
-    __sanitizer::AmdgpuMemFuncs::ClearAmdgpuRuntimeShutdownState();
+    // Only clear state when recovering from a prior shutdown (avoids clearing
+    // amdgpu_event_registered on every refcount bump and re-registering).
+    if (__sanitizer::AmdgpuMemFuncs::IsAmdgpuRuntimeShutdown())
+      __sanitizer::AmdgpuMemFuncs::ClearAmdgpuRuntimeShutdownState();
     __sanitizer::AmdgpuMemFuncs::RegisterSystemEventHandlers();
   }
   return status;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -65,6 +65,15 @@ void AmdgpuMemFuncs::NotifyAmdgpuRuntimeShutdown() {
   }
 }
 
+// Clear shutdown state when hsa_init() succeeds again (re-init after shutdown).
+// Resets amdgpu_runtime_shutdown so allocator operations are enabled, and
+// amdgpu_event_registered so RegisterSystemEventHandlers() will register the
+// shutdown callback for the new runtime instance.
+void AmdgpuMemFuncs::ClearAmdgpuRuntimeShutdownState() {
+  atomic_store(&amdgpu_runtime_shutdown, 0, memory_order_release);
+  atomic_store(&amdgpu_event_registered, 0, memory_order_release);
+}
+
 bool AmdgpuMemFuncs::Init() {
   bool success = true;
   LOAD_HSA_FUNC_WITH_ERROR_CHECK(hsa_amd.memory_pool_allocate,

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.h
@@ -24,6 +24,7 @@ class AmdgpuMemFuncs {
   static uptr GetPageSize();
   static void RegisterSystemEventHandlers();
   static bool IsAmdgpuRuntimeShutdown();
+  static void ClearAmdgpuRuntimeShutdownState();
 
  private:
   static void NotifyAmdgpuRuntimeShutdown();


### PR DESCRIPTION
After hsa_shut_down(), amdgpu_runtime_shutdown was set and never cleared.A later successful hsa_init() left the allocator in shutdown state, so Allocate/Deallocate/GetPointerInfo stayed disabled and GPU ASan could be silently disabled for the rest of the process (e.g. rocrtst Concurrent_Init_Shutdown_Test with many concurrent inits/shutdowns).

- Add AmdgpuMemFuncs::ClearAmdgpuRuntimeShutdownState() to clear both amdgpu_runtime_shutdown and amdgpu_event_registered on re-init.
- Call it from asan_hsa_init() on HSA_STATUS_SUCCESS before RegisterSystemEventHandlers(), so the allocator is re-enabled and the shutdown callback is re-registered for the new runtime instance.


