### PR TITLE
[openmp] - Add LIBOMP_HWLOC_INSTALL_DIR/include to openmp runtime.

### DIFF
--- a/openmp/runtime/CMakeLists.txt
+++ b/openmp/runtime/CMakeLists.txt
@@ -378,8 +378,15 @@ endif()
 set(LIBOMP_OMPX_TASKGRAPH FALSE CACHE BOOL "OMPX-taskgraph (task record & replay)?")
 
 # Error check hwloc support after config-ix has run
-if(LIBOMP_USE_HWLOC AND (NOT LIBOMP_HAVE_HWLOC))
-  libomp_error_say("Hwloc requested but not available")
+if(${LIBOMP_USE_HWLOC})
+  set(CMAKE_REQUIRED_INCLUDES ${LIBOMP_HWLOC_INSTALL_DIR}/include)
+  check_include_file(hwloc.h LIBOMP_HAVE_HWLOC_H)
+  set(CMAKE_REQUIRED_INCLUDES)
+  if(NOT LIBOMP_HAVE_HWLOC_H)
+    libomp_error_say("Hwloc requested but not available")
+  else()
+    include_directories(${LIBOMP_HWLOC_INSTALL_DIR}/include)
+  endif()
 endif()
 
 # Hierarchical scheduling support


### PR DESCRIPTION
When LIBOMP_USE_HWLOC is on openmp runtime requires hwloc.h. Use include_directories to add the path to the compiler search path. This was not noticed before due to some systems already having hwloc installed at the system level.


