### PR TITLE
[WaveTransform] Fix sentinel dereference for terminator-less blocks

### DIFF
--- a/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/GCNLaneMaskUtils.cpp
@@ -471,7 +471,7 @@ void GCNLaneMaskUpdater::insertAccumulatorResets() {
     // ResetAtEnd
     MachineBasicBlock::iterator EndInsertPt;
     EndInsertPt = B->getFirstTerminator();
-    if (EndInsertPt->getOpcode() == LMU.getLaneMaskConsts().MovTermOpc &&
+    if (EndInsertPt != B->end() && EndInsertPt->getOpcode() == LMU.getLaneMaskConsts().MovTermOpc &&
         EndInsertPt->getOperand(0).getReg() ==
             LMU.getLaneMaskConsts().ExecReg) {
       EndInsertPt->setDesc(TII->get(LMU.getLaneMaskConsts().MovOpc));


### PR DESCRIPTION
`getFirstTerminator()` returns `end()` for blocks without a terminator (e.g., blocks lowered from unreachable). Guard against dereferencing the sentinel iterator before checking the opcode.