### PR TITLE
device-libs: Replace succ implementations

### DIFF
--- a/amd/device-libs/ocml/src/succD.cl
+++ b/amd/device-libs/ocml/src/succD.cl
@@ -10,13 +10,8 @@
 CONSTATTR double
 MATH_MANGLE(succ)(double x)
 {
-    long ix = AS_LONG(x);
-    long mx = SIGNBIT_DP64 - ix;
-    mx = ix < 0 ? mx : ix;
-    long t = mx + (x != PINF_F64 && !BUILTIN_ISNAN_F64(x));
-    long r = SIGNBIT_DP64 - t;
-    r = t < 0 ? r : t;
-    r = mx == -1L ? SIGNBIT_DP64 : r;
-    return AS_DOUBLE(r);
+    long y = AS_LONG(x + 0.0);
+    long ix = y + (y >= 0 ? 1l : -1l);
+    return BUILTIN_ISNAN_F64(x) || x == PINF_F64 ? x : AS_DOUBLE(ix);
 }
 

--- a/amd/device-libs/ocml/src/succF.cl
+++ b/amd/device-libs/ocml/src/succF.cl
@@ -10,13 +10,7 @@
 CONSTATTR float
 MATH_MANGLE(succ)(float x)
 {
-    int ix = AS_INT(x);
-    int mx = SIGNBIT_SP32 - ix;
-    mx = ix < 0 ? mx : ix;
-    int t = mx + (x != PINF_F32 && !BUILTIN_ISNAN_F32(x));
-    int r = SIGNBIT_SP32 - t;
-    r = t < 0 ? r : t;
-    r = mx == -1 ? SIGNBIT_SP32 : r;
-    return AS_FLOAT(r);
+    int y = AS_INT(x + 0.0f);
+    int ix = y + (y >= 0 ? 1 : -1);
+    return BUILTIN_ISNAN_F32(x) || x == PINF_F32 ? x : AS_FLOAT(ix);
 }
-

--- a/amd/device-libs/ocml/src/succH.cl
+++ b/amd/device-libs/ocml/src/succH.cl
@@ -10,13 +10,8 @@
 CONSTATTR half
 MATH_MANGLE(succ)(half x)
 {
-    short ix = AS_SHORT(x);
-    short mx = (short)SIGNBIT_HP16 - ix;
-    mx = ix < (short)0 ? mx : ix;
-    short t = mx + (short)(x != PINF_F16 && !BUILTIN_ISNAN_F16(x));
-    short r = (short)SIGNBIT_HP16 - t;
-    r = t < (short)0 ? r : t;
-    r = mx == (short)-1 ? (short)SIGNBIT_HP16 : r;
-    return AS_HALF(r);
+    short y = AS_SHORT(x + 0.0h);
+    short ix = y + (y >= 0 ? (short)1 : (short)-1);
+    return BUILTIN_ISNAN_F16(x) || x == PINF_F16 ? x : AS_HALF(ix);
 }
 


### PR DESCRIPTION
This is the mirror change of fbdc7a2cf03 and 3765a4f15e. Saves 6 instructions for f16, 5 for f32, and 10 for f64.

https://alive2.llvm.org/ce/z/qmWcJ6


