### PR TITLE
device-libs: Remove daz_opt control libraries

### DIFF
--- a/amd/device-libs/cmake/OCL.cmake
+++ b/amd/device-libs/cmake/OCL.cmake
@@ -218,7 +218,6 @@ endfunction()
 
 set(OCLC_DEFAULT_LIBS
   oclc_correctly_rounded_sqrt_off
-  oclc_daz_opt_off
   oclc_finite_only_off
   oclc_isa_version_803
   oclc_unsafe_math_off)

--- a/amd/device-libs/doc/OCKL.md
+++ b/amd/device-libs/doc/OCKL.md
@@ -41,7 +41,6 @@ The currently supported control are
   * `finite_only_opt` - floating point Inf and NaN are never expected to be consumed or produced
   * `unsafe_math_opt` - lower accuracy results may be produced with higher performance
   * `ISA_version` - an integer representation of the ISA version of the target device
-  * `daz_opt` - unused and deprecated. Will be removed in the future.
   * `correctly_rounded_sqrt32` - unused and deprecated. Will be removed in the future.
 
 ### Versioning

--- a/amd/device-libs/doc/OCML.md
+++ b/amd/device-libs/doc/OCML.md
@@ -42,13 +42,11 @@ OCML (and a few other device libraries) requires a number of control variables d
 The currently supported control `<name>`s and values `N` are
   * `finite_only_opt` - floating point Inf and NaN are never expected to be consumed or produced.  `N` may be 1 (on/true/enabled), or 0 (off/false/disabled).
   * `unsafe_math_opt` - lower accuracy results may be produced with higher performance.  `N` may be 1 (on/true/enabled) or 0 (off/false/disabled).
-  * `daz_opt` - subnormal values consumed and produced may be flushed to zero.  `N`may be 1 (on/true/enabled) or 0 (off/false/disabled).
   * `wavefrontsize64` - the wave front size is 64.  `N` may be 1 (on/true/enabled) or 0 (off/false/disabled).  Very few current devices support a value of 0.
   * `ISA_version` - an integer representation of the ISA version of the target device
 
 The language runtime can link a specific set of OCLC control libraries to properly configure OCML and other device libraries which also use the controls.  If linking OCLC libraries is used to define the control variables, then the runtime must link in:
 
-- Exactly one of `oclc_daz_opt_on.amdgcn.bc` or `oclc_daz_opt_off.amdgcn.bc` depending on the kernel's requirements
 - Exactly one of `oclc_finite_only_on.amdgcn.bc` or `oclc_finite_only_off.amdgcn.bc` depending on the kernel's requirements
 - Exactly one of `oclc_unsafe_math_on.amdgcn.bc` or `oclc_unsafe_math_off.amdgcn.bc` depending on the kernel's requirements
 - Exactly one of `oclc_wavefrontsize64_on.amdgcn.bc` or `oclc_wavefrontsize64_off.amdgcn.bc` depending on the kernel's requirements

--- a/amd/device-libs/oclc/src/daz_opt_off.cl
+++ b/amd/device-libs/oclc/src/daz_opt_off.cl
@@ -1,8 +1,0 @@
-/*===--------------------------------------------------------------------------
- *                   ROCm Device Libraries
- *
- * This file is distributed under the University of Illinois Open Source
- * License. See LICENSE.TXT for details.
- *===------------------------------------------------------------------------*/
-
-// Placeholder until clang stops looking for this library

--- a/amd/device-libs/oclc/src/daz_opt_on.cl
+++ b/amd/device-libs/oclc/src/daz_opt_on.cl
@@ -1,9 +1,0 @@
-/*===--------------------------------------------------------------------------
- *                   ROCm Device Libraries
- *
- * This file is distributed under the University of Illinois Open Source
- * License. See LICENSE.TXT for details.
- *===------------------------------------------------------------------------*/
-
-// Placeholder until clang stops looking for this library
-


### PR DESCRIPTION
These haven't done anything in a while and clang no longer looks for them.


