### PR TITLE
Keep LLVM temporary files if AMD_COMGR_SAVE_LLVM_TEMPS=1.

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -2220,7 +2220,9 @@ AMDGPUCompiler::AMDGPUCompiler(DataAction *ActionInfo, DataSet *InSet,
 }
 
 AMDGPUCompiler::~AMDGPUCompiler() {
-  if (!env::shouldSaveTemps()) {
+  // LLVM temps get saved in the same directory as regular temps. We can only
+  // call `removeTmpDirs` if none of the env vars is enabled.
+  if (!env::shouldSaveTemps() && !env::shouldSaveLLVMTemps()) {
     removeTmpDirs();
   }
 }


### PR DESCRIPTION
COMGR's destructor only checks `AMD_COMGR_SAVE_TEMPS`, not `AMD_COMGR_SAVE_LLVM_TEMPS`. When `AMD_COMGR_SAVE_LLVM_TEMPS=1` , it passes `-save-temps=obj` to clang, which writes intermediate files to `OutputDir` (inside the temp directory `TmpDir`). However, the destructor still deletes `TmpDir`, removing all the intermediate files the user wanted to save. We can only call `removeTmpDirs()` if neither `AMD_COMGR_SAVE_TEMPS` nor `AMD_COMGR_SAVE_LLVM_TEMPS` are enabled.