### PR TITLE
device-libs: Remove incorrect finite_only_opt check in cbrt f64

### DIFF
--- a/amd/device-libs/ocml/src/cbrtD.cl
+++ b/amd/device-libs/ocml/src/cbrtD.cl
@@ -15,10 +15,6 @@ MATH_MANGLE(cbrt)(double x)
 
     c = BUILTIN_FLDEXP_F64(c, e);
 
-    if (!FINITE_ONLY_OPT()) {
-        // Is normal or subnormal.
-        c = x == 0.0 || BUILTIN_ISINF_F64(x) ? x : c;
-    }
-
+    c = x == 0.0 || BUILTIN_ISINF_F64(x) ? x : c;
     return BUILTIN_COPYSIGN_F64(c, x);
 }


### PR DESCRIPTION
This was breaking 0 with finite only. 0 is not an exceptional value, and this should evaluate to a 0 with the same sign. With the finite only option, this would fold to a nan. The float and half versions do not have the equivalent check.


