### PR TITLE
[WaveTransform] Handle Uniform BRCOND during SelectionDAG Isel in the LateWaveTransform pipeline

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUISelDAGToDAG.cpp
@@ -2844,19 +2844,17 @@ static SDValue combineBallotPattern(SDValue VCMP, bool &Negate) {
 void AMDGPUDAGToDAGISel::SelectBRCOND(SDNode *N) {
   SDValue Cond = N->getOperand(1);
 
-  if (EnableLateWaveTransform) {
-    auto Opc =
-        Cond->isDivergent() ? AMDGPU::SI_BRCOND : AMDGPU::SI_BRCOND_UNIFORM;
-    CurDAG->SelectNodeTo(N, Opc, MVT::Other,
-                         N->getOperand(2),  // true basic block
-                         Cond,              // condition
-                         N->getOperand(0)); // chain
-    return;
-  }
-
   if (Cond.isUndef()) {
     CurDAG->SelectNodeTo(N, AMDGPU::SI_BR_UNDEF, MVT::Other,
                          N->getOperand(2), N->getOperand(0));
+    return;
+  }
+
+  if (EnableLateWaveTransform && Cond->isDivergent()) {
+    CurDAG->SelectNodeTo(N, AMDGPU::SI_BRCOND, MVT::Other,
+                         N->getOperand(2),  // true basic block
+                         Cond,              // condition
+                         N->getOperand(0)); // chain
     return;
   }
 

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
@@ -83,7 +83,7 @@ define void @divergent_i1_phi_used_outside_loop_larger_loop_body(float %val, ptr
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_]], %bb.0, %6, %bb.3
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vreg_64 = PHI [[COPY4]], %bb.0, %5, %bb.3
-  ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:vgpr_32 = PHI [[V_CNDMASK_B32_e64_]], %bb.0, %54, %bb.3
+  ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:vgpr_32 = PHI [[V_CNDMASK_B32_e64_]], %bb.0, %52, %bb.3
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 0, [[PHI2]], implicit $exec
   ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_CMP_NE_U32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 1, killed [[V_CNDMASK_B32_e64_1]], implicit $exec
@@ -102,12 +102,11 @@ define void @divergent_i1_phi_used_outside_loop_larger_loop_body(float %val, ptr
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI3:%[0-9]+]]:vgpr_32 = PHI [[PHI2]], %bb.1, [[V_CNDMASK_B32_e64_2]], %bb.2
   ; CHECK-NEXT:   [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[PHI1]].sub0, 4, 0, implicit $exec
-  ; CHECK-NEXT:   %57:vgpr_32, dead $sgpr_null = V_ADDC_U32_e64 0, killed [[PHI1]].sub1, killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed %57, %subreg.sub1
+  ; CHECK-NEXT:   %55:vgpr_32, dead $sgpr_null = V_ADDC_U32_e64 0, killed [[PHI1]].sub1, killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+  ; CHECK-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed %55, %subreg.sub1
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = nsw S_ADD_I32 killed [[PHI]], 1, implicit-def dead $scc
   ; CHECK-NEXT:   S_CMP_GT_I32 [[S_ADD_I32_]], 9, implicit-def $scc
-  ; CHECK-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit killed $scc
-  ; CHECK-NEXT:   SI_BRCOND_UNIFORM %bb.1, killed [[S_CSELECT_B32_]]
+  ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit killed $scc
   ; CHECK-NEXT:   S_BRANCH %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.exit:
@@ -542,8 +541,8 @@ define amdgpu_cs void @loop_with_1break(ptr addrspace(1) %x, ptr addrspace(1) %a
   ; CHECK-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[PHI]], %subreg.sub0, killed [[S_ASHR_I32_]], %subreg.sub1
   ; CHECK-NEXT:   [[S_LSHL_B64_:%[0-9]+]]:sreg_64 = nsw S_LSHL_B64 [[REG_SEQUENCE3]], 2, implicit-def dead $scc
   ; CHECK-NEXT:   [[V_ADD_CO_U32_e64_:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[REG_SEQUENCE1]].sub0, [[S_LSHL_B64_]].sub0, 0, implicit $exec
-  ; CHECK-NEXT:   %55:vgpr_32, dead $sgpr_null = V_ADDC_U32_e64 [[S_LSHL_B64_]].sub1, [[REG_SEQUENCE1]].sub1, killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed %55, %subreg.sub1
+  ; CHECK-NEXT:   %53:vgpr_32, dead $sgpr_null = V_ADDC_U32_e64 [[S_LSHL_B64_]].sub1, [[REG_SEQUENCE1]].sub1, killed [[V_ADD_CO_U32_e64_1]], 0, implicit $exec
+  ; CHECK-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed %53, %subreg.sub1
   ; CHECK-NEXT:   [[GLOBAL_LOAD_DWORD:%[0-9]+]]:vgpr_32 = GLOBAL_LOAD_DWORD killed [[REG_SEQUENCE4]], 0, 0, implicit $exec :: (load (s32) from %ir.a.plus.counter, addrspace 1)
   ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 0, killed [[GLOBAL_LOAD_DWORD]], implicit $exec
   ; CHECK-NEXT:   SI_BRCOND %bb.5, killed [[V_CMP_EQ_U32_e64_]]
@@ -560,15 +559,14 @@ define amdgpu_cs void @loop_with_1break(ptr addrspace(1) %x, ptr addrspace(1) %a
   ; CHECK-NEXT:   successors: %bb.5(0x04000000), %bb.1(0x7c000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[V_ADD_CO_U32_e64_2:%[0-9]+]]:vgpr_32, [[V_ADD_CO_U32_e64_3:%[0-9]+]]:sreg_32_xm0_xexec = V_ADD_CO_U32_e64 [[REG_SEQUENCE2]].sub0, [[S_LSHL_B64_]].sub0, 0, implicit $exec
-  ; CHECK-NEXT:   %63:vgpr_32, dead $sgpr_null = V_ADDC_U32_e64 killed [[S_LSHL_B64_]].sub1, [[REG_SEQUENCE2]].sub1, killed [[V_ADD_CO_U32_e64_3]], 0, implicit $exec
-  ; CHECK-NEXT:   [[REG_SEQUENCE5:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_2]], %subreg.sub0, killed %63, %subreg.sub1
+  ; CHECK-NEXT:   %61:vgpr_32, dead $sgpr_null = V_ADDC_U32_e64 killed [[S_LSHL_B64_]].sub1, [[REG_SEQUENCE2]].sub1, killed [[V_ADD_CO_U32_e64_3]], 0, implicit $exec
+  ; CHECK-NEXT:   [[REG_SEQUENCE5:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_2]], %subreg.sub0, killed %61, %subreg.sub1
   ; CHECK-NEXT:   [[GLOBAL_LOAD_DWORD1:%[0-9]+]]:vgpr_32 = GLOBAL_LOAD_DWORD [[REG_SEQUENCE5]], 0, 0, implicit $exec :: (load (s32) from %ir.x.plus.counter, addrspace 1)
   ; CHECK-NEXT:   [[V_ADD_U32_e64_:%[0-9]+]]:vgpr_32 = V_ADD_U32_e64 1, killed [[GLOBAL_LOAD_DWORD1]], 0, implicit $exec
   ; CHECK-NEXT:   GLOBAL_STORE_DWORD killed [[REG_SEQUENCE5]], killed [[V_ADD_U32_e64_]], 0, 0, implicit $exec :: (store (s32) into %ir.x.plus.counter, addrspace 1)
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 [[REG_SEQUENCE3]].sub0, 1, implicit-def dead $scc
   ; CHECK-NEXT:   S_CMP_LT_U32 killed [[REG_SEQUENCE3]].sub0, 100, implicit-def $scc
-  ; CHECK-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit killed $scc
-  ; CHECK-NEXT:   SI_BRCOND_UNIFORM %bb.5, killed [[S_CSELECT_B32_]]
+  ; CHECK-NEXT:   S_CBRANCH_SCC1 %bb.5, implicit killed $scc
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.exit:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/global-atomic-fadd.f32-rtn.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/global-atomic-fadd.f32-rtn.ll
@@ -244,10 +244,10 @@ define amdgpu_ps float @global_atomic_fadd_f32_saddr_rtn_atomicrmw(ptr addrspace
   ; ITERATE-NEXT: bb.3 (%ir-block.6):
   ; ITERATE-NEXT:   successors: %bb.4(0x80000000)
   ; ITERATE-NEXT: {{  $}}
-  ; ITERATE-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI %33, %bb.6, [[GLOBAL_ATOMIC_ADD_F32_SADDR_RTN]], %bb.2
+  ; ITERATE-NEXT:   [[PHI:%[0-9]+]]:vgpr_32 = PHI %32, %bb.6, [[GLOBAL_ATOMIC_ADD_F32_SADDR_RTN]], %bb.2
   ; ITERATE-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 [[PHI]], implicit $exec
   ; ITERATE-NEXT:   [[V_ADD_F32_e64_:%[0-9]+]]:vgpr_32 = nofpexcept V_ADD_F32_e64 0, [[V_READFIRSTLANE_B32_]], 0, %11, 0, 0, implicit $mode, implicit $exec
-  ; ITERATE-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %43, 0, implicit $exec
+  ; ITERATE-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %41, 0, implicit $exec
   ; ITERATE-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, killed [[V_ADD_F32_e64_]], 0, [[V_READFIRSTLANE_B32_]], [[V_CMP_NE_U32_e64_1]], implicit $exec
   ; ITERATE-NEXT: {{  $}}
   ; ITERATE-NEXT: bb.4 (%ir-block.11):
@@ -270,9 +270,7 @@ define amdgpu_ps float @global_atomic_fadd_f32_saddr_rtn_atomicrmw(ptr addrspace
   ; ITERATE-NEXT:   [[S_ANDN2_B32_:%[0-9]+]]:sreg_32 = S_ANDN2_B32 [[PHI4]], killed [[S_LSHL_B32_]], implicit-def dead $scc
   ; ITERATE-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; ITERATE-NEXT:   S_CMP_LG_U32 [[S_ANDN2_B32_]], killed [[S_MOV_B32_3]], implicit-def $scc
-  ; ITERATE-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; ITERATE-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_]]
-  ; ITERATE-NEXT:   SI_BRCOND_UNIFORM %bb.5, killed [[COPY7]]
+  ; ITERATE-NEXT:   S_CBRANCH_SCC1 %bb.5, implicit $scc
   ; ITERATE-NEXT:   S_BRANCH %bb.6
   ; ITERATE-NEXT: {{  $}}
   ; ITERATE-NEXT: bb.6.ComputeEnd:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/loop-mix-i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/loop-mix-i1.ll
@@ -58,20 +58,18 @@ define amdgpu_kernel void @loop_mix_i1(ptr addrspace(1) %filter.coerce, ptr addr
   ; GFX90A-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
   ; GFX90A-NEXT:   [[COPY6:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_]]
   ; GFX90A-NEXT:   [[S_XOR_B64_:%[0-9]+]]:sreg_64_xexec = S_XOR_B64 [[PHI1]], killed [[COPY6]], implicit-def dead $scc
+  ; GFX90A-NEXT:   [[S_MOV_B64_1:%[0-9]+]]:sreg_64 = S_MOV_B64 64
+  ; GFX90A-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[PHI]].sub0
+  ; GFX90A-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[PHI]].sub1
+  ; GFX90A-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_MOV_B64_1]].sub0
+  ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_MOV_B64_1]].sub1
+  ; GFX90A-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY7]], [[COPY9]], implicit-def $scc
+  ; GFX90A-NEXT:   [[S_ADDC_U32_:%[0-9]+]]:sreg_32 = S_ADDC_U32 [[COPY8]], [[COPY10]], implicit-def $scc, implicit $scc
+  ; GFX90A-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[S_ADD_U32_]], %subreg.sub0, [[S_ADDC_U32_]], %subreg.sub1
   ; GFX90A-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 11
   ; GFX90A-NEXT:   S_CMP_GT_I32 [[S_LOAD_DWORD_IMM]], killed [[S_MOV_B32_3]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_1:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY7:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_1]]
-  ; GFX90A-NEXT:   [[S_MOV_B64_1:%[0-9]+]]:sreg_64 = S_MOV_B64 64
-  ; GFX90A-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[PHI]].sub0
-  ; GFX90A-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[PHI]].sub1
-  ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_MOV_B64_1]].sub0
-  ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[S_MOV_B64_1]].sub1
-  ; GFX90A-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY8]], [[COPY10]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_ADDC_U32_:%[0-9]+]]:sreg_32 = S_ADDC_U32 [[COPY9]], [[COPY11]], implicit-def $scc, implicit $scc
-  ; GFX90A-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:sreg_64 = REG_SEQUENCE [[S_ADD_U32_]], %subreg.sub0, [[S_ADDC_U32_]], %subreg.sub1
   ; GFX90A-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, -1, [[S_XOR_B64_]], implicit $exec
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.2, killed [[COPY7]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.4
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.3.if.else:
@@ -97,9 +95,9 @@ define amdgpu_kernel void @loop_mix_i1(ptr addrspace(1) %filter.coerce, ptr addr
   ; GFX90A-NEXT: bb.5.if.then11:
   ; GFX90A-NEXT:   successors: %bb.6(0x80000000)
   ; GFX90A-NEXT: {{  $}}
-  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
-  ; GFX90A-NEXT:   [[COPY13:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
-  ; GFX90A-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64_xexec_xnull = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1
+  ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+  ; GFX90A-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64_xexec_xnull = REG_SEQUENCE killed [[COPY12]], %subreg.sub0, killed [[COPY11]], %subreg.sub1
   ; GFX90A-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX90A-NEXT:   [[V_LSHLREV_B32_e64_1:%[0-9]+]]:vgpr_32 = nuw nsw V_LSHLREV_B32_e64 killed [[S_MOV_B32_6]], [[COPY5]], implicit $exec
   ; GFX90A-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_LSHLREV_B32_e64_1]], [[COPY5]], killed [[REG_SEQUENCE2]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx13, addrspace 1)
@@ -138,12 +136,11 @@ define amdgpu_kernel void @loop_mix_i1(ptr addrspace(1) %filter.coerce, ptr addr
   ; GFX1200-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit killed $scc
   ; GFX1200-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY killed [[COPY4]]
   ; GFX1200-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_XOR_B32 killed [[COPY6]], killed [[S_CSELECT_B32_]], implicit-def dead $scc
-  ; GFX1200-NEXT:   S_CMP_GT_I32 killed [[S_LOAD_DWORD_IMM]], 11, implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit killed $scc
   ; GFX1200-NEXT:   [[S_ADD_U64_:%[0-9]+]]:sreg_64 = S_ADD_U64 killed [[COPY5]], 64
+  ; GFX1200-NEXT:   S_CMP_GT_I32 killed [[S_LOAD_DWORD_IMM]], 11, implicit-def $scc
   ; GFX1200-NEXT:   [[COPY3:%[0-9]+]]:sreg_64 = COPY killed [[S_ADD_U64_]]
   ; GFX1200-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY [[S_XOR_B32_]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.2, killed [[S_CSELECT_B32_1]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit killed $scc
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.3:
   ; GFX1200-NEXT:   successors: %bb.5(0x80000000)

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/switch-uniform-i1.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/switch-uniform-i1.ll
@@ -54,9 +54,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORD_IMM1]]
   ; GFX90A-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GFX90A-NEXT:   S_CMP_LT_I32 [[S_LOAD_DWORD_IMM]], killed [[S_MOV_B32_2]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_]]
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.4, killed [[COPY10]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.2
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.2.NodeBlock:
@@ -65,9 +63,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64 = S_MOV_B64 0
   ; GFX90A-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX90A-NEXT:   S_CMP_LT_I32 [[COPY3]], killed [[S_MOV_B32_3]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_1:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_1]]
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.6, killed [[COPY11]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.6, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.3
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.3.LeafBlock4:
@@ -76,9 +72,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT:   [[S_MOV_B64_1:%[0-9]+]]:sreg_64 = S_MOV_B64 0
   ; GFX90A-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX90A-NEXT:   S_CMP_EQ_U32 [[COPY3]], killed [[S_MOV_B32_4]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_2:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_2]]
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.7, killed [[COPY12]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.7, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.8
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.4.LeafBlock:
@@ -86,9 +80,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GFX90A-NEXT:   S_CMP_LG_U32 [[COPY3]], killed [[S_MOV_B32_5]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_3:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY13:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_3]]
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.8, killed [[COPY13]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.8, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.5
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.5.sw.bb:
@@ -96,19 +88,19 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 3
   ; GFX90A-NEXT:   S_CMP_GT_I32 [[COPY9]], killed [[S_MOV_B32_6]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_4:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY14:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_4]]
-  ; GFX90A-NEXT:   [[COPY15:%[0-9]+]]:sreg_64 = COPY [[COPY14]]
+  ; GFX90A-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
+  ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_]]
+  ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:sreg_64 = COPY [[COPY10]]
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.6.sw.bb4:
   ; GFX90A-NEXT:   successors: %bb.7(0x80000000)
   ; GFX90A-NEXT: {{  $}}
-  ; GFX90A-NEXT:   [[PHI:%[0-9]+]]:sreg_64 = PHI [[S_MOV_B64_]], %bb.2, [[COPY15]], %bb.5
+  ; GFX90A-NEXT:   [[PHI:%[0-9]+]]:sreg_64 = PHI [[S_MOV_B64_]], %bb.2, [[COPY11]], %bb.5
   ; GFX90A-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 5
   ; GFX90A-NEXT:   S_CMP_GT_I32 [[COPY9]], killed [[S_MOV_B32_7]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_5:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY16:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_5]]
-  ; GFX90A-NEXT:   [[S_OR_B64_:%[0-9]+]]:sreg_64 = S_OR_B64 killed [[COPY16]], [[PHI]], implicit-def dead $scc
+  ; GFX90A-NEXT:   [[S_CSELECT_B64_1:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
+  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_1]]
+  ; GFX90A-NEXT:   [[S_OR_B64_:%[0-9]+]]:sreg_64 = S_OR_B64 killed [[COPY12]], [[PHI]], implicit-def dead $scc
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.7.sw.bb12:
   ; GFX90A-NEXT:   successors: %bb.9(0x80000000)
@@ -116,9 +108,9 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT:   [[PHI1:%[0-9]+]]:sreg_64 = PHI [[S_MOV_B64_1]], %bb.3, [[S_OR_B64_]], %bb.6
   ; GFX90A-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 7
   ; GFX90A-NEXT:   S_CMP_GT_I32 [[COPY9]], killed [[S_MOV_B32_8]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_6:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY17:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_6]]
-  ; GFX90A-NEXT:   [[S_OR_B64_1:%[0-9]+]]:sreg_64 = S_OR_B64 killed [[COPY17]], [[PHI1]], implicit-def dead $scc
+  ; GFX90A-NEXT:   [[S_CSELECT_B64_2:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
+  ; GFX90A-NEXT:   [[COPY13:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_2]]
+  ; GFX90A-NEXT:   [[S_OR_B64_1:%[0-9]+]]:sreg_64 = S_OR_B64 killed [[COPY13]], [[PHI1]], implicit-def dead $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.9
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.8.sw.default:
@@ -126,38 +118,39 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_MOV_B32 11
   ; GFX90A-NEXT:   S_CMP_GT_I32 [[COPY9]], killed [[S_MOV_B32_9]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_7:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY18:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_7]]
-  ; GFX90A-NEXT:   [[COPY19:%[0-9]+]]:sreg_64 = COPY [[COPY18]]
+  ; GFX90A-NEXT:   [[S_CSELECT_B64_3:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
+  ; GFX90A-NEXT:   [[COPY14:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_3]]
+  ; GFX90A-NEXT:   [[COPY15:%[0-9]+]]:sreg_64 = COPY [[COPY14]]
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.9.sw.epilog:
   ; GFX90A-NEXT:   successors: %bb.10(0x40000000), %bb.11(0x40000000)
   ; GFX90A-NEXT: {{  $}}
-  ; GFX90A-NEXT:   [[PHI2:%[0-9]+]]:sreg_64_xexec = PHI [[COPY19]], %bb.8, [[S_OR_B64_1]], %bb.7
+  ; GFX90A-NEXT:   [[PHI2:%[0-9]+]]:sreg_64_xexec = PHI [[COPY15]], %bb.8, [[S_OR_B64_1]], %bb.7
   ; GFX90A-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, [[PHI2]], implicit $exec
   ; GFX90A-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GFX90A-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_64_xexec = V_CMP_NE_U32_e64 [[V_CNDMASK_B32_e64_]], killed [[S_MOV_B32_10]], implicit $exec
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.11, killed [[V_CMP_NE_U32_e64_]]
+  ; GFX90A-NEXT:   $vcc = S_AND_B64 $exec, [[V_CMP_NE_U32_e64_]], implicit-def $scc
+  ; GFX90A-NEXT:   S_CBRANCH_VCCNZ %bb.11, implicit $vcc
   ; GFX90A-NEXT:   S_BRANCH %bb.10
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.10.if.then:
   ; GFX90A-NEXT:   successors: %bb.11(0x80000000)
   ; GFX90A-NEXT: {{  $}}
-  ; GFX90A-NEXT:   [[COPY20:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
-  ; GFX90A-NEXT:   [[COPY21:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
-  ; GFX90A-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY21]], %subreg.sub0, killed [[COPY20]], %subreg.sub1
+  ; GFX90A-NEXT:   [[COPY16:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+  ; GFX90A-NEXT:   [[COPY17:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+  ; GFX90A-NEXT:   [[REG_SEQUENCE3:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY17]], %subreg.sub0, killed [[COPY16]], %subreg.sub1
   ; GFX90A-NEXT:   [[S_MOV_B32_11:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX90A-NEXT:   [[S_LSHL_B64_1:%[0-9]+]]:sreg_64 = nuw nsw S_LSHL_B64 [[COPY4]], killed [[S_MOV_B32_11]], implicit-def dead $scc
-  ; GFX90A-NEXT:   [[COPY22:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE3]].sub0
-  ; GFX90A-NEXT:   [[COPY23:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE3]].sub1
-  ; GFX90A-NEXT:   [[COPY24:%[0-9]+]]:sreg_32 = COPY [[S_LSHL_B64_1]].sub0
-  ; GFX90A-NEXT:   [[COPY25:%[0-9]+]]:sreg_32 = COPY [[S_LSHL_B64_1]].sub1
-  ; GFX90A-NEXT:   [[S_ADD_U32_1:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY22]], [[COPY24]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_ADDC_U32_1:%[0-9]+]]:sreg_32 = S_ADDC_U32 [[COPY23]], [[COPY25]], implicit-def $scc, implicit $scc
+  ; GFX90A-NEXT:   [[COPY18:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE3]].sub0
+  ; GFX90A-NEXT:   [[COPY19:%[0-9]+]]:sreg_32 = COPY [[REG_SEQUENCE3]].sub1
+  ; GFX90A-NEXT:   [[COPY20:%[0-9]+]]:sreg_32 = COPY [[S_LSHL_B64_1]].sub0
+  ; GFX90A-NEXT:   [[COPY21:%[0-9]+]]:sreg_32 = COPY [[S_LSHL_B64_1]].sub1
+  ; GFX90A-NEXT:   [[S_ADD_U32_1:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY18]], [[COPY20]], implicit-def $scc
+  ; GFX90A-NEXT:   [[S_ADDC_U32_1:%[0-9]+]]:sreg_32 = S_ADDC_U32 [[COPY19]], [[COPY21]], implicit-def $scc, implicit $scc
   ; GFX90A-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:sreg_64_xexec_xnull = REG_SEQUENCE [[S_ADD_U32_1]], %subreg.sub0, [[S_ADDC_U32_1]], %subreg.sub1
   ; GFX90A-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; GFX90A-NEXT:   [[COPY26:%[0-9]+]]:av_32 = COPY [[COPY9]]
-  ; GFX90A-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_]], [[COPY26]], killed [[REG_SEQUENCE4]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx29, addrspace 1)
+  ; GFX90A-NEXT:   [[COPY22:%[0-9]+]]:av_32 = COPY [[COPY9]]
+  ; GFX90A-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_]], [[COPY22]], killed [[REG_SEQUENCE4]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx29, addrspace 1)
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.11.if.end:
   ; GFX90A-NEXT:   S_ENDPGM 0
@@ -188,9 +181,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORD_IMM1]]
   ; GFX1200-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GFX1200-NEXT:   S_CMP_LT_I32 [[S_LOAD_DWORD_IMM]], killed [[S_MOV_B32_2]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.4, killed [[COPY6]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.2
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.2.NodeBlock:
@@ -199,9 +190,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GFX1200-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX1200-NEXT:   S_CMP_LT_I32 [[COPY3]], killed [[S_MOV_B32_4]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_1]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.6, killed [[COPY7]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.6, implicit $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.3
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.3.LeafBlock4:
@@ -210,9 +199,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GFX1200-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX1200-NEXT:   S_CMP_EQ_U32 [[COPY3]], killed [[S_MOV_B32_6]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_2]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.7, killed [[COPY8]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.7, implicit $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.8
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.4.LeafBlock:
@@ -220,9 +207,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GFX1200-NEXT:   S_CMP_LG_U32 [[COPY3]], killed [[S_MOV_B32_7]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_3]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.8, killed [[COPY9]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.8, implicit $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.5
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.5.sw.bb:
@@ -230,19 +215,19 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 3
   ; GFX1200-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_8]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_4:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_4]]
-  ; GFX1200-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[COPY10]]
+  ; GFX1200-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GFX1200-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_]]
+  ; GFX1200-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[COPY6]]
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.6.sw.bb4:
   ; GFX1200-NEXT:   successors: %bb.7(0x80000000)
   ; GFX1200-NEXT: {{  $}}
-  ; GFX1200-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_3]], %bb.2, [[COPY11]], %bb.5
+  ; GFX1200-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_3]], %bb.2, [[COPY7]], %bb.5
   ; GFX1200-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_MOV_B32 5
   ; GFX1200-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_9]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_5:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_5]]
-  ; GFX1200-NEXT:   [[S_OR_B32_:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY12]], [[PHI]], implicit-def dead $scc
+  ; GFX1200-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GFX1200-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_1]]
+  ; GFX1200-NEXT:   [[S_OR_B32_:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY8]], [[PHI]], implicit-def dead $scc
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.7.sw.bb12:
   ; GFX1200-NEXT:   successors: %bb.9(0x80000000)
@@ -250,9 +235,9 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT:   [[PHI1:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_5]], %bb.3, [[S_OR_B32_]], %bb.6
   ; GFX1200-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_MOV_B32 7
   ; GFX1200-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_10]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_6:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY13:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_6]]
-  ; GFX1200-NEXT:   [[S_OR_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY13]], [[PHI1]], implicit-def dead $scc
+  ; GFX1200-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GFX1200-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_2]]
+  ; GFX1200-NEXT:   [[S_OR_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY9]], [[PHI1]], implicit-def dead $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.9
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.8.sw.default:
@@ -260,32 +245,33 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT:   [[S_MOV_B32_11:%[0-9]+]]:sreg_32 = S_MOV_B32 11
   ; GFX1200-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_11]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_7:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY14:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_7]]
-  ; GFX1200-NEXT:   [[COPY15:%[0-9]+]]:sreg_32 = COPY [[COPY14]]
+  ; GFX1200-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GFX1200-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_3]]
+  ; GFX1200-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[COPY10]]
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.9.sw.epilog:
   ; GFX1200-NEXT:   successors: %bb.10(0x40000000), %bb.11(0x40000000)
   ; GFX1200-NEXT: {{  $}}
-  ; GFX1200-NEXT:   [[PHI2:%[0-9]+]]:sreg_32_xm0_xexec = PHI [[COPY15]], %bb.8, [[S_OR_B32_1]], %bb.7
+  ; GFX1200-NEXT:   [[PHI2:%[0-9]+]]:sreg_32_xm0_xexec = PHI [[COPY11]], %bb.8, [[S_OR_B32_1]], %bb.7
   ; GFX1200-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, [[PHI2]], implicit $exec
   ; GFX1200-NEXT:   [[S_MOV_B32_12:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GFX1200-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[V_CNDMASK_B32_e64_]], killed [[S_MOV_B32_12]], implicit $exec
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.11, killed [[V_CMP_NE_U32_e64_]]
+  ; GFX1200-NEXT:   $vcc_lo = S_AND_B32 $exec_lo, [[V_CMP_NE_U32_e64_]], implicit-def $scc
+  ; GFX1200-NEXT:   S_CBRANCH_VCCNZ %bb.11, implicit $vcc_lo
   ; GFX1200-NEXT:   S_BRANCH %bb.10
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.10.if.then:
   ; GFX1200-NEXT:   successors: %bb.11(0x80000000)
   ; GFX1200-NEXT: {{  $}}
-  ; GFX1200-NEXT:   [[COPY16:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
-  ; GFX1200-NEXT:   [[COPY17:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
-  ; GFX1200-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY17]], %subreg.sub0, killed [[COPY16]], %subreg.sub1
+  ; GFX1200-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+  ; GFX1200-NEXT:   [[COPY13:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+  ; GFX1200-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1
   ; GFX1200-NEXT:   [[S_MOV_B32_13:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GFX1200-NEXT:   [[S_LSHL_B64_1:%[0-9]+]]:sreg_64 = nuw nsw S_LSHL_B64 [[COPY4]], killed [[S_MOV_B32_13]], implicit-def dead $scc
   ; GFX1200-NEXT:   [[S_ADD_U64_1:%[0-9]+]]:sreg_64_xexec_xnull = S_ADD_U64 killed [[REG_SEQUENCE2]], killed [[S_LSHL_B64_1]]
   ; GFX1200-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; GFX1200-NEXT:   [[COPY18:%[0-9]+]]:vgpr_32 = COPY [[COPY5]]
-  ; GFX1200-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_]], [[COPY18]], killed [[S_ADD_U64_1]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx29, addrspace 1)
+  ; GFX1200-NEXT:   [[COPY14:%[0-9]+]]:vgpr_32 = COPY [[COPY5]]
+  ; GFX1200-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_]], [[COPY14]], killed [[S_ADD_U64_1]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx29, addrspace 1)
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.11.if.end:
   ; GFX1200-NEXT:   S_ENDPGM 0
@@ -316,9 +302,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT:   [[COPY5:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORD_IMM1]]
   ; GISEL-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GISEL-NEXT:   S_CMP_LT_I32 [[S_LOAD_DWORD_IMM]], killed [[S_MOV_B32_2]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_]]
-  ; GISEL-NEXT:   SI_BRCOND_UNIFORM %bb.4, killed [[COPY6]]
+  ; GISEL-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
   ; GISEL-NEXT:   S_BRANCH %bb.2
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.2.NodeBlock:
@@ -327,9 +311,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GISEL-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GISEL-NEXT:   S_CMP_LT_I32 [[COPY3]], killed [[S_MOV_B32_4]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_1]]
-  ; GISEL-NEXT:   SI_BRCOND_UNIFORM %bb.6, killed [[COPY7]]
+  ; GISEL-NEXT:   S_CBRANCH_SCC1 %bb.6, implicit $scc
   ; GISEL-NEXT:   S_BRANCH %bb.3
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.3.LeafBlock4:
@@ -338,9 +320,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GISEL-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GISEL-NEXT:   S_CMP_EQ_U32 [[COPY3]], killed [[S_MOV_B32_6]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_2]]
-  ; GISEL-NEXT:   SI_BRCOND_UNIFORM %bb.7, killed [[COPY8]]
+  ; GISEL-NEXT:   S_CBRANCH_SCC1 %bb.7, implicit $scc
   ; GISEL-NEXT:   S_BRANCH %bb.8
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.4.LeafBlock:
@@ -348,9 +328,7 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; GISEL-NEXT:   S_CMP_LG_U32 [[COPY3]], killed [[S_MOV_B32_7]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_3]]
-  ; GISEL-NEXT:   SI_BRCOND_UNIFORM %bb.8, killed [[COPY9]]
+  ; GISEL-NEXT:   S_CBRANCH_SCC1 %bb.8, implicit $scc
   ; GISEL-NEXT:   S_BRANCH %bb.5
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.5.sw.bb:
@@ -358,19 +336,19 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 3
   ; GISEL-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_8]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_4:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_4]]
-  ; GISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[COPY10]]
+  ; GISEL-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GISEL-NEXT:   [[COPY6:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_]]
+  ; GISEL-NEXT:   [[COPY7:%[0-9]+]]:sreg_32 = COPY [[COPY6]]
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.6.sw.bb4:
   ; GISEL-NEXT:   successors: %bb.7(0x80000000)
   ; GISEL-NEXT: {{  $}}
-  ; GISEL-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_3]], %bb.2, [[COPY11]], %bb.5
+  ; GISEL-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_3]], %bb.2, [[COPY7]], %bb.5
   ; GISEL-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_MOV_B32 5
   ; GISEL-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_9]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_5:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_5]]
-  ; GISEL-NEXT:   [[S_OR_B32_:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY12]], [[PHI]], implicit-def dead $scc
+  ; GISEL-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GISEL-NEXT:   [[COPY8:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_1]]
+  ; GISEL-NEXT:   [[S_OR_B32_:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY8]], [[PHI]], implicit-def dead $scc
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.7.sw.bb12:
   ; GISEL-NEXT:   successors: %bb.9(0x80000000)
@@ -378,9 +356,9 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT:   [[PHI1:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_5]], %bb.3, [[S_OR_B32_]], %bb.6
   ; GISEL-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_MOV_B32 7
   ; GISEL-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_10]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_6:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY13:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_6]]
-  ; GISEL-NEXT:   [[S_OR_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY13]], [[PHI1]], implicit-def dead $scc
+  ; GISEL-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GISEL-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_2]]
+  ; GISEL-NEXT:   [[S_OR_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 killed [[COPY9]], [[PHI1]], implicit-def dead $scc
   ; GISEL-NEXT:   S_BRANCH %bb.9
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.8.sw.default:
@@ -388,32 +366,33 @@ define amdgpu_kernel void @switch_uniform_i1(ptr addrspace(1) %filter.coerce, pt
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT:   [[S_MOV_B32_11:%[0-9]+]]:sreg_32 = S_MOV_B32 11
   ; GISEL-NEXT:   S_CMP_GT_I32 [[COPY5]], killed [[S_MOV_B32_11]], implicit-def $scc
-  ; GISEL-NEXT:   [[S_CSELECT_B32_7:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GISEL-NEXT:   [[COPY14:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_7]]
-  ; GISEL-NEXT:   [[COPY15:%[0-9]+]]:sreg_32 = COPY [[COPY14]]
+  ; GISEL-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
+  ; GISEL-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_3]]
+  ; GISEL-NEXT:   [[COPY11:%[0-9]+]]:sreg_32 = COPY [[COPY10]]
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.9.sw.epilog:
   ; GISEL-NEXT:   successors: %bb.10(0x40000000), %bb.11(0x40000000)
   ; GISEL-NEXT: {{  $}}
-  ; GISEL-NEXT:   [[PHI2:%[0-9]+]]:sreg_32_xm0_xexec = PHI [[COPY15]], %bb.8, [[S_OR_B32_1]], %bb.7
+  ; GISEL-NEXT:   [[PHI2:%[0-9]+]]:sreg_32_xm0_xexec = PHI [[COPY11]], %bb.8, [[S_OR_B32_1]], %bb.7
   ; GISEL-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, [[PHI2]], implicit $exec
   ; GISEL-NEXT:   [[S_MOV_B32_12:%[0-9]+]]:sreg_32 = S_MOV_B32 1
   ; GISEL-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[V_CNDMASK_B32_e64_]], killed [[S_MOV_B32_12]], implicit $exec
-  ; GISEL-NEXT:   SI_BRCOND_UNIFORM %bb.11, killed [[V_CMP_NE_U32_e64_]]
+  ; GISEL-NEXT:   $vcc_lo = S_AND_B32 $exec_lo, [[V_CMP_NE_U32_e64_]], implicit-def $scc
+  ; GISEL-NEXT:   S_CBRANCH_VCCNZ %bb.11, implicit $vcc_lo
   ; GISEL-NEXT:   S_BRANCH %bb.10
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.10.if.then:
   ; GISEL-NEXT:   successors: %bb.11(0x80000000)
   ; GISEL-NEXT: {{  $}}
-  ; GISEL-NEXT:   [[COPY16:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
-  ; GISEL-NEXT:   [[COPY17:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
-  ; GISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY17]], %subreg.sub0, killed [[COPY16]], %subreg.sub1
+  ; GISEL-NEXT:   [[COPY12:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub3
+  ; GISEL-NEXT:   [[COPY13:%[0-9]+]]:sreg_32 = COPY [[S_LOAD_DWORDX4_IMM]].sub2
+  ; GISEL-NEXT:   [[REG_SEQUENCE2:%[0-9]+]]:sreg_64 = REG_SEQUENCE killed [[COPY13]], %subreg.sub0, killed [[COPY12]], %subreg.sub1
   ; GISEL-NEXT:   [[S_MOV_B32_13:%[0-9]+]]:sreg_32 = S_MOV_B32 2
   ; GISEL-NEXT:   [[S_LSHL_B64_1:%[0-9]+]]:sreg_64 = nuw nsw S_LSHL_B64 [[COPY4]], killed [[S_MOV_B32_13]], implicit-def dead $scc
   ; GISEL-NEXT:   [[S_ADD_U64_1:%[0-9]+]]:sreg_64_xexec_xnull = S_ADD_U64 killed [[REG_SEQUENCE2]], killed [[S_LSHL_B64_1]]
   ; GISEL-NEXT:   [[V_MOV_B32_e32_:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 0, implicit $exec
-  ; GISEL-NEXT:   [[COPY18:%[0-9]+]]:vgpr_32 = COPY [[COPY5]]
-  ; GISEL-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_]], [[COPY18]], killed [[S_ADD_U64_1]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx29, addrspace 1)
+  ; GISEL-NEXT:   [[COPY14:%[0-9]+]]:vgpr_32 = COPY [[COPY5]]
+  ; GISEL-NEXT:   GLOBAL_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_]], [[COPY14]], killed [[S_ADD_U64_1]], 0, 0, implicit $exec :: (store (s32) into %ir.arrayidx29, addrspace 1)
   ; GISEL-NEXT: {{  $}}
   ; GISEL-NEXT: bb.11.if.end:
   ; GISEL-NEXT:   S_ENDPGM 0

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/unstructured-cfg-def-use-issue.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/unstructured-cfg-def-use-issue.ll
@@ -22,7 +22,8 @@ define hidden void @widget() {
   ; GFX90A-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 [[GLOBAL_LOAD_DWORD]], implicit $exec
   ; GFX90A-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 21
   ; GFX90A-NEXT:   [[V_CMP_LT_I32_e64_:%[0-9]+]]:sreg_64_xexec = V_CMP_LT_I32_e64 [[GLOBAL_LOAD_DWORD]], killed [[S_MOV_B32_]], implicit $exec
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.2, killed [[V_CMP_LT_I32_e64_]]
+  ; GFX90A-NEXT:   $vcc = S_AND_B64 $exec, [[V_CMP_LT_I32_e64_]], implicit-def $scc
+  ; GFX90A-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc
   ; GFX90A-NEXT:   S_BRANCH %bb.1
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.1.bb2:
@@ -30,9 +31,7 @@ define hidden void @widget() {
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 21
   ; GFX90A-NEXT:   S_CMP_EQ_U32 [[V_READFIRSTLANE_B32_]], killed [[S_MOV_B32_1]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY9:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_]]
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.5, killed [[COPY9]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.5, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.4
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.2.bb4:
@@ -40,9 +39,7 @@ define hidden void @widget() {
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 9
   ; GFX90A-NEXT:   S_CMP_LG_U32 [[V_READFIRSTLANE_B32_]], killed [[S_MOV_B32_2]], implicit-def $scc
-  ; GFX90A-NEXT:   [[S_CSELECT_B64_1:%[0-9]+]]:sreg_64_xexec = S_CSELECT_B64 -1, 0, implicit $scc
-  ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:sreg_64 = COPY [[S_CSELECT_B64_1]]
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.4, killed [[COPY10]]
+  ; GFX90A-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
   ; GFX90A-NEXT:   S_BRANCH %bb.3
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.3.bb7:
@@ -50,6 +47,27 @@ define hidden void @widget() {
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
   ; GFX90A-NEXT:   [[SI_PC_ADD_REL_OFFSET:%[0-9]+]]:sreg_64 = SI_PC_ADD_REL_OFFSET target-flags(amdgpu-rel32-lo) @wibble, target-flags(amdgpu-rel32-hi) @wibble, implicit-def dead $scc
+  ; GFX90A-NEXT:   [[COPY9:%[0-9]+]]:sgpr_128 = COPY $sgpr0_sgpr1_sgpr2_sgpr3
+  ; GFX90A-NEXT:   $sgpr4_sgpr5 = COPY [[COPY8]]
+  ; GFX90A-NEXT:   $sgpr6_sgpr7 = COPY [[COPY7]]
+  ; GFX90A-NEXT:   $sgpr8_sgpr9 = COPY [[COPY6]]
+  ; GFX90A-NEXT:   $sgpr10_sgpr11 = COPY [[COPY5]]
+  ; GFX90A-NEXT:   $sgpr12 = COPY [[COPY4]]
+  ; GFX90A-NEXT:   $sgpr13 = COPY [[COPY3]]
+  ; GFX90A-NEXT:   $sgpr14 = COPY [[COPY2]]
+  ; GFX90A-NEXT:   $sgpr15 = COPY [[COPY1]]
+  ; GFX90A-NEXT:   $vgpr31 = COPY [[COPY]]
+  ; GFX90A-NEXT:   $sgpr0_sgpr1_sgpr2_sgpr3 = COPY [[COPY9]]
+  ; GFX90A-NEXT:   $sgpr30_sgpr31 = SI_CALL killed [[SI_PC_ADD_REL_OFFSET]], @wibble, csr_amdgpu_gfx90ainsts, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit-def $vgpr0
+  ; GFX90A-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
+  ; GFX90A-NEXT:   [[COPY10:%[0-9]+]]:av_32 = COPY $vgpr0
+  ; GFX90A-NEXT:   S_BRANCH %bb.6
+  ; GFX90A-NEXT: {{  $}}
+  ; GFX90A-NEXT: bb.4.bb9:
+  ; GFX90A-NEXT:   successors: %bb.6(0x40000000), %bb.5(0x40000000)
+  ; GFX90A-NEXT: {{  $}}
+  ; GFX90A-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
+  ; GFX90A-NEXT:   [[SI_PC_ADD_REL_OFFSET1:%[0-9]+]]:sreg_64 = SI_PC_ADD_REL_OFFSET target-flags(amdgpu-rel32-lo) @wibble, target-flags(amdgpu-rel32-hi) @wibble, implicit-def dead $scc
   ; GFX90A-NEXT:   [[COPY11:%[0-9]+]]:sgpr_128 = COPY $sgpr0_sgpr1_sgpr2_sgpr3
   ; GFX90A-NEXT:   $sgpr4_sgpr5 = COPY [[COPY8]]
   ; GFX90A-NEXT:   $sgpr6_sgpr7 = COPY [[COPY7]]
@@ -61,32 +79,11 @@ define hidden void @widget() {
   ; GFX90A-NEXT:   $sgpr15 = COPY [[COPY1]]
   ; GFX90A-NEXT:   $vgpr31 = COPY [[COPY]]
   ; GFX90A-NEXT:   $sgpr0_sgpr1_sgpr2_sgpr3 = COPY [[COPY11]]
-  ; GFX90A-NEXT:   $sgpr30_sgpr31 = SI_CALL killed [[SI_PC_ADD_REL_OFFSET]], @wibble, csr_amdgpu_gfx90ainsts, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit-def $vgpr0
-  ; GFX90A-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
-  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:av_32 = COPY $vgpr0
-  ; GFX90A-NEXT:   S_BRANCH %bb.6
-  ; GFX90A-NEXT: {{  $}}
-  ; GFX90A-NEXT: bb.4.bb9:
-  ; GFX90A-NEXT:   successors: %bb.6(0x40000000), %bb.5(0x40000000)
-  ; GFX90A-NEXT: {{  $}}
-  ; GFX90A-NEXT:   ADJCALLSTACKUP 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
-  ; GFX90A-NEXT:   [[SI_PC_ADD_REL_OFFSET1:%[0-9]+]]:sreg_64 = SI_PC_ADD_REL_OFFSET target-flags(amdgpu-rel32-lo) @wibble, target-flags(amdgpu-rel32-hi) @wibble, implicit-def dead $scc
-  ; GFX90A-NEXT:   [[COPY13:%[0-9]+]]:sgpr_128 = COPY $sgpr0_sgpr1_sgpr2_sgpr3
-  ; GFX90A-NEXT:   $sgpr4_sgpr5 = COPY [[COPY8]]
-  ; GFX90A-NEXT:   $sgpr6_sgpr7 = COPY [[COPY7]]
-  ; GFX90A-NEXT:   $sgpr8_sgpr9 = COPY [[COPY6]]
-  ; GFX90A-NEXT:   $sgpr10_sgpr11 = COPY [[COPY5]]
-  ; GFX90A-NEXT:   $sgpr12 = COPY [[COPY4]]
-  ; GFX90A-NEXT:   $sgpr13 = COPY [[COPY3]]
-  ; GFX90A-NEXT:   $sgpr14 = COPY [[COPY2]]
-  ; GFX90A-NEXT:   $sgpr15 = COPY [[COPY1]]
-  ; GFX90A-NEXT:   $vgpr31 = COPY [[COPY]]
-  ; GFX90A-NEXT:   $sgpr0_sgpr1_sgpr2_sgpr3 = COPY [[COPY13]]
   ; GFX90A-NEXT:   $sgpr30_sgpr31 = SI_CALL killed [[SI_PC_ADD_REL_OFFSET1]], @wibble, csr_amdgpu_gfx90ainsts, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit $sgpr0_sgpr1_sgpr2_sgpr3, implicit-def $vgpr0
   ; GFX90A-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
-  ; GFX90A-NEXT:   [[COPY14:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+  ; GFX90A-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX90A-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sgpr_32 = S_MOV_B32 0
-  ; GFX90A-NEXT:   [[V_CMP_GT_F32_e64_:%[0-9]+]]:sreg_64 = nsz nofpexcept V_CMP_GT_F32_e64 0, [[COPY14]], 0, killed [[S_MOV_B32_3]], 0, implicit $mode, implicit $exec
+  ; GFX90A-NEXT:   [[V_CMP_GT_F32_e64_:%[0-9]+]]:sreg_64 = nsz nofpexcept V_CMP_GT_F32_e64 0, [[COPY12]], 0, killed [[S_MOV_B32_3]], 0, implicit $mode, implicit $exec
   ; GFX90A-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_GT_F32_e64_]]
   ; GFX90A-NEXT:   S_BRANCH %bb.5
   ; GFX90A-NEXT: {{  $}}
@@ -119,7 +116,8 @@ define hidden void @widget() {
   ; GFX1200-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 [[GLOBAL_LOAD_DWORD]], implicit $exec
   ; GFX1200-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 21
   ; GFX1200-NEXT:   [[V_CMP_LT_I32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_LT_I32_e64 [[GLOBAL_LOAD_DWORD]], killed [[S_MOV_B32_]], implicit $exec
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.2, killed [[V_CMP_LT_I32_e64_]]
+  ; GFX1200-NEXT:   $vcc_lo = S_AND_B32 $exec_lo, [[V_CMP_LT_I32_e64_]], implicit-def $scc
+  ; GFX1200-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
   ; GFX1200-NEXT:   S_BRANCH %bb.1
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.1.bb2:
@@ -127,9 +125,7 @@ define hidden void @widget() {
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 21
   ; GFX1200-NEXT:   S_CMP_EQ_U32 [[V_READFIRSTLANE_B32_]], killed [[S_MOV_B32_1]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY9:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.5, killed [[COPY9]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.5, implicit $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.4
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.2.bb4:
@@ -137,9 +133,7 @@ define hidden void @widget() {
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 9
   ; GFX1200-NEXT:   S_CMP_LG_U32 [[V_READFIRSTLANE_B32_]], killed [[S_MOV_B32_2]], implicit-def $scc
-  ; GFX1200-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32_xm0_xexec = S_CSELECT_B32 -1, 0, implicit $scc
-  ; GFX1200-NEXT:   [[COPY10:%[0-9]+]]:sreg_32 = COPY [[S_CSELECT_B32_1]]
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.4, killed [[COPY10]]
+  ; GFX1200-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
   ; GFX1200-NEXT:   S_BRANCH %bb.3
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.3.bb7:
@@ -158,7 +152,7 @@ define hidden void @widget() {
   ; GFX1200-NEXT:   $vgpr31 = COPY [[COPY]]
   ; GFX1200-NEXT:   $sgpr30_sgpr31 = SI_CALL killed [[SI_PC_ADD_REL_OFFSET]], @wibble, csr_amdgpu, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit-def $vgpr0
   ; GFX1200-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
-  ; GFX1200-NEXT:   [[COPY11:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+  ; GFX1200-NEXT:   [[COPY9:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX1200-NEXT:   S_BRANCH %bb.6
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.4.bb9:
@@ -177,9 +171,9 @@ define hidden void @widget() {
   ; GFX1200-NEXT:   $vgpr31 = COPY [[COPY]]
   ; GFX1200-NEXT:   $sgpr30_sgpr31 = SI_CALL killed [[SI_PC_ADD_REL_OFFSET1]], @wibble, csr_amdgpu, implicit $sgpr4_sgpr5, implicit $sgpr6_sgpr7, implicit $sgpr8_sgpr9, implicit $sgpr10_sgpr11, implicit $sgpr12, implicit $sgpr13, implicit $sgpr14, implicit $sgpr15, implicit $vgpr31, implicit-def $vgpr0
   ; GFX1200-NEXT:   ADJCALLSTACKDOWN 0, 0, implicit-def dead $scc, implicit-def $sgpr32, implicit $sgpr32
-  ; GFX1200-NEXT:   [[COPY12:%[0-9]+]]:vgpr_32 = COPY $vgpr0
+  ; GFX1200-NEXT:   [[COPY10:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; GFX1200-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sgpr_32 = S_MOV_B32 0
-  ; GFX1200-NEXT:   [[V_CMP_GT_F32_e64_:%[0-9]+]]:sreg_32 = nsz nofpexcept V_CMP_GT_F32_e64 0, [[COPY12]], 0, killed [[S_MOV_B32_3]], 0, implicit $mode, implicit $exec
+  ; GFX1200-NEXT:   [[V_CMP_GT_F32_e64_:%[0-9]+]]:sreg_32 = nsz nofpexcept V_CMP_GT_F32_e64 0, [[COPY10]], 0, killed [[S_MOV_B32_3]], 0, implicit $mode, implicit $exec
   ; GFX1200-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_GT_F32_e64_]]
   ; GFX1200-NEXT:   S_BRANCH %bb.5
   ; GFX1200-NEXT: {{  $}}
@@ -323,7 +317,9 @@ define hidden void @blam() {
   ; GFX90A-NEXT:   [[V_MOV_B32_e32_3:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 2143289344, implicit $exec
   ; GFX90A-NEXT:   BUFFER_STORE_DWORD_OFFSET killed [[V_MOV_B32_e32_3]], $sgpr0_sgpr1_sgpr2_sgpr3, 0, 0, 0, 0, implicit $exec :: (store (s32) into `ptr addrspace(5) null`, align 16, addrspace 5)
   ; GFX90A-NEXT:   [[S_MOV_B64_:%[0-9]+]]:sreg_64 = S_MOV_B64 0
-  ; GFX90A-NEXT:   SI_BRCOND_UNIFORM %bb.10, killed [[S_MOV_B64_]]
+  ; GFX90A-NEXT:   [[S_AND_B64_:%[0-9]+]]:sreg_64 = S_AND_B64 $exec, killed [[S_MOV_B64_]], implicit-def dead $scc
+  ; GFX90A-NEXT:   $vcc = COPY [[S_AND_B64_]]
+  ; GFX90A-NEXT:   S_CBRANCH_VCCNZ %bb.10, implicit $vcc
   ; GFX90A-NEXT:   S_BRANCH %bb.8
   ; GFX90A-NEXT: {{  $}}
   ; GFX90A-NEXT: bb.8.bb17:
@@ -440,7 +436,9 @@ define hidden void @blam() {
   ; GFX1200-NEXT:   [[V_MOV_B32_e32_2:%[0-9]+]]:vgpr_32 = V_MOV_B32_e32 2143289344, implicit $exec
   ; GFX1200-NEXT:   SCRATCH_STORE_DWORD_SADDR killed [[V_MOV_B32_e32_2]], killed [[S_MOV_B32_9]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s32) into `ptr addrspace(5) null`, align 16, addrspace 5)
   ; GFX1200-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; GFX1200-NEXT:   SI_BRCOND_UNIFORM %bb.10, killed [[S_MOV_B32_10]]
+  ; GFX1200-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, killed [[S_MOV_B32_10]], implicit-def dead $scc
+  ; GFX1200-NEXT:   $vcc_lo = COPY [[S_AND_B32_]]
+  ; GFX1200-NEXT:   S_CBRANCH_VCCNZ %bb.10, implicit $vcc_lo
   ; GFX1200-NEXT:   S_BRANCH %bb.8
   ; GFX1200-NEXT: {{  $}}
   ; GFX1200-NEXT: bb.8.bb17:

--- a/llvm/test/CodeGen/AMDGPU/s-cluster-barrier.ll
+++ b/llvm/test/CodeGen/AMDGPU/s-cluster-barrier.ll
@@ -10,9 +10,8 @@ define amdgpu_kernel void @kernel1() #0 {
 ; GFX12-NEXT:    s_barrier_signal_isfirst -1
 ; GFX12-NEXT:    s_barrier_wait -1
 ; GFX12-NEXT:    s_cselect_b32 s0, -1, 0
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(VALU_DEP_1)
-; GFX12-NEXT:    v_cndmask_b32_e64 v0, 0, 1, s0
-; GFX12-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 1, v0
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX12-NEXT:    s_and_not1_b32 vcc_lo, exec_lo, s0
 ; GFX12-NEXT:    s_cbranch_vccnz .LBB0_2
 ; GFX12-NEXT:  ; %bb.1:
 ; GFX12-NEXT:    s_barrier_signal -3


### PR DESCRIPTION
For uniform conditional branches, instead of spawning SI_BRCOND_UNIFORM (to be handled later at the AMDGPUWaveTransform), we are now allowing them to be lowered down into target-specific branching instructions based on the analysis done in the SelectBRCOND.


