### PR TITLE
[psdb] use latest rock CI backend

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -40,7 +40,7 @@ jobs:
   setup:
     runs-on: ubuntu-24.04
     env:
-      BASE_REF: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+      BASE_REF: '0efc7532e43c16b532fdd2887e00aec8eb69e10f'
     outputs:
       enable_build_jobs: true
       linux_variants: >
@@ -56,7 +56,9 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+          ref: 'compiler/amd-staging'
+          fetch-depth: 0
+
       - name: SHA of TheRock
         run: |
              git rev-parse HEAD

--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+          ref: 'compiler/amd-staging'
           sparse-checkout: build_tools
           path: "prejob"
 
@@ -84,7 +84,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           repository: "ROCm/TheRock"
-          ref: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+          ref: 'compiler/amd-staging'
 
       - name: Setting up Python
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - name: "Fetch 'build_tools' from repository"
         if: ${{ runner.os == 'Windows' }}
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: build_tools
           path: "prejob"
@@ -52,10 +52,10 @@ jobs:
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
       - name: "Checking out repository"
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setting up Python
-        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548 # v6.1.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -18,6 +18,10 @@ on:
         type: string
       test_retry_count:
         type: number
+      default_container_image:
+        type: string
+        default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
+
 
 permissions:
   contents: read
@@ -26,13 +30,20 @@ jobs:
   test_component:
     name: >-
       Test ${{ fromJSON(inputs.component).job_name }}
-      (shard ${{ matrix.shard }} of ${{ fromJSON(inputs.component).total_shards }})
+      (shard ${{ matrix.shard }}/${{ fromJSON(inputs.component).total_shards }})
+      (${{ inputs.amdgpu_families }})
       ${{ fromJSON(inputs.component).expect_failure == true && '(xfail)' || '' }}
     runs-on: ${{ inputs.test_runs_on }}
     continue-on-error: ${{ fromJSON(inputs.component).expect_failure == true }}
     timeout-minutes: 210
     container:
-      image: ${{ inputs.platform == 'linux' && 'ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98' || null }}
+      # If the component has specified an alternate image, honor that option.
+      # Otherwise use the default image.
+      image: >-
+        ${{ inputs.platform == 'linux' &&
+            (fromJSON(inputs.component).container_image || inputs.default_container_image)
+            || null
+        }}
       # --ulimit memlock=-1:-1 - Prevents memory allocation issues with ROCm inside container
       # --security-opt seccomp=unconfined - enables memory mapping, and is recommended for containers running in HPC environments
       # --env-file /etc/podinfo/gha-gpu-isolation-settings - Required for GPU isolation on OSSCI MIXXX runners
@@ -41,6 +52,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
+        --group-add 992
         --group-add 110
         --ulimit memlock=-1:-1
         --security-opt seccomp=unconfined
@@ -61,6 +73,8 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: "./build"
       THEROCK_BIN_DIR: "./build/bin"
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
+      ARTIFACT_GROUP: ${{ inputs.artifact_group }}
       # Benchmark results database API endpoints for performance metrics collection
       # NOTE: These secrets are only required for benchmark results submission in nightly CI runs.
       # For PR/push workflows, secret retrieval will fail gracefully and benchmarks will skip API submission.
@@ -68,29 +82,32 @@ jobs:
       BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     steps:
       - name: "Fetch 'build_tools' from repository"
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+          ref: 'compiler/amd-staging'
           sparse-checkout: build_tools
           path: "prejob"
 
       - name: Pre-job cleanup processes on Windows
         if: ${{ runner.os == 'Windows' }}
+        timeout-minutes: 5
         shell: powershell
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+          ref: 'compiler/amd-staging'
 
       - name: Run setup test environment workflow
+        timeout-minutes: 15
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
-          ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          ARTIFACT_GROUP: ${{ inputs.amdgpu_families }}
+          AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: ${{ fromJSON(inputs.component).fetch_artifact_args }}
@@ -107,6 +124,7 @@ jobs:
           python ./build_tools/health_status.py
 
       - name: Driver / GPU sanity check
+        timeout-minutes: 3
         run: |
           python ./build_tools/print_driver_gpu_info.py
 
@@ -144,5 +162,6 @@ jobs:
       # and will fail to clean up orphan processes.
       - name: Post-job cleanup processes on Windows
         if: ${{ always() && runner.os == 'Windows' }}
+        timeout-minutes: 5
         shell: powershell
         run: . '${{ github.workspace }}\build_tools\github_actions\cleanup_processes.ps1'

--- a/.github/workflows/test_sanity_check.yml
+++ b/.github/workflows/test_sanity_check.yml
@@ -11,6 +11,9 @@ on:
       amdgpu_families:
         type: string
         default: ""
+      amdgpu_targets:
+        type: string
+        default: ""
       test_runs_on:
         type: string
       platform:
@@ -23,6 +26,9 @@ on:
         type: string
         default: ""
       amdgpu_families:
+        type: string
+        default: ""
+      amdgpu_targets:
         type: string
         default: ""
       test_runs_on:
@@ -38,7 +44,7 @@ permissions:
 
 jobs:
   test_sanity_check:
-    name: "Sanity ROCM Test"
+    name: "Sanity ROCM Test (${{ inputs.amdgpu_families }})"
     runs-on: ${{ inputs.test_runs_on }}
     # Running docker with cap-add and -v /lib/modiles, by recommendation of Github: https://rocm.docs.amd.com/projects/amdsmi/en/amd-staging/how-to/setup-docker-container.html
     container:
@@ -51,6 +57,7 @@ jobs:
         --group-add video
         --device /dev/kfd
         --device /dev/dri
+        --group-add 992
         --group-add 110
         --cap-add SYS_MODULE
         -v /lib/modules:/lib/modules
@@ -67,27 +74,31 @@ jobs:
       OUTPUT_ARTIFACTS_DIR: ${{ github.workspace }}/build
       THEROCK_BIN_DIR: ${{ github.workspace }}/build/bin
       AMDGPU_FAMILIES: ${{ inputs.amdgpu_families }}
+      AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
+      ARTIFACT_GROUP: ${{ inputs.artifact_group }}
     steps:
       - name: "Fetch 'build_tools' from repository"
         if: ${{ runner.os == 'Windows' }}
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: build_tools
           path: prejob
 
       - name: Pre-job cleanup processes on Windows
         if: ${{ runner.os == 'Windows' }}
+        timeout-minutes: 5
         shell: powershell
         run: . '${{ github.workspace }}\prejob\build_tools\github_actions\cleanup_processes.ps1'
 
       - name: Checkout Repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "ROCm/TheRock"
-          ref: 'c3d5aeef808e099b9de06fc901af2de24d0b143d'
+          ref: 'compiler/amd-staging'
 
       - name: Pre-job cleanup Docker containers on Linux
         if: ${{ runner.os == 'Linux' }}
+        timeout-minutes: 5
         shell: bash
         run: |
           # Remove any stopped containers
@@ -96,18 +107,29 @@ jobs:
           docker network prune -f || true
 
       - name: Run setup test environment workflow
+        timeout-minutes: 15
         uses: './.github/actions/setup_test_environment'
         with:
           ARTIFACT_GROUP: ${{ inputs.artifact_group }}
+          AMDGPU_TARGETS: ${{ inputs.amdgpu_targets }}
           ARTIFACT_RUN_ID: ${{ env.ARTIFACT_RUN_ID }}
           OUTPUT_ARTIFACTS_DIR: ${{ env.OUTPUT_ARTIFACTS_DIR }}
           VENV_DIR: ${{ env.VENV_DIR }}
           FETCH_ARTIFACT_ARGS: "--base-only"
           IS_PR_FROM_FORK: ${{ github.event.pull_request.head.repo.fork }}
 
-      - name: Set HIP_CLANG_PATH for windows
+      # The sanity checks run tools like 'offload-arch' which may search for
+      # DLLs on multiple search paths (PATH, CWD, system32, etc.).
+      # For typical "installs" of ROCm, the rocm/bin/ dir can be expected to be
+      # added to PATH, so we do that here. If we don't do this, DLLs on test
+      # runners in system32 may be picked up instead and the tests may not be
+      # representative, see https://github.com/ROCm/TheRock/issues/2019 and
+      # https://github.com/ROCm/TheRock/pull/3230#issuecomment-3844854922.
+      - name: Set PATH and HIP_CLANG_PATH for windows
         if: ${{ runner.os == 'Windows' }}
-        run: echo "HIP_CLANG_PATH=${OUTPUT_ARTIFACTS_DIR}\lib\llvm\bin" >> $GITHUB_ENV
+        run: |
+          echo "HIP_CLANG_PATH=${OUTPUT_ARTIFACTS_DIR}\lib\llvm\bin" >> $GITHUB_ENV
+          echo "${OUTPUT_ARTIFACTS_DIR}\bin" >> $GITHUB_PATH
 
       - name: Driver / GPU sanity check
         timeout-minutes: 3
@@ -125,5 +147,6 @@ jobs:
 
       - name: Post-job cleanup processes on Windows
         if: ${{ always() && runner.os == 'Windows' }}
+        timeout-minutes: 5
         shell: powershell
         run: . '${{ github.workspace }}\build_tools\github_actions\cleanup_processes.ps1'


### PR DESCRIPTION
 - fixes an aws configuration issue for uploading artifacts
 - rock CI backend is going to be current with compiler/amd-staging branch going forward
 - The only sha that we have hardcoded here is for BASE_REF in setup.yml, which is used to
    bypass a rock CI which calculates whether builds have to be run or not.   It is not applicable 
    for compiler CI needs. 