### PR TITLE
device-libs: Split nonfinite edge case handling of fract usage

### DIFF
--- a/amd/device-libs/ocml/src/builtins.h
+++ b/amd/device-libs/ocml/src/builtins.h
@@ -102,16 +102,31 @@
     _f;                                                         \
 })
 
-#define BUILTIN_FRACTION_F64(X) ({                                      \
-    const double _x = X;                                                \
-    const double _floor_x = BUILTIN_FLOOR_F64(_x);                       \
-    double _f = BUILTIN_MIN_F64(_x - _floor_x, 0x1.fffffffffffffp-1);   \
-    if (!FINITE_ONLY_OPT()) {                                           \
-        _f = BUILTIN_ISNAN_F64(_x) ? _x : _f;                            \
-        _f = BUILTIN_ISINF_F64(_x) ? 0.0 : _f;                           \
-    }                                                                   \
-    _f;                                                                 \
-})
+// Perform the non-finite component of fract
+#define BUILTIN_FRACTION_F64_IMPL(X)                                                                                   \
+    ({                                                                                                                 \
+        const double _x = X;                                                                                           \
+        const double _floor_x = BUILTIN_FLOOR_F64(_x);                                                                 \
+        double _f = BUILTIN_MIN_F64(_x - _floor_x, 0x1.fffffffffffffp-1);                                              \
+        _f;                                                                                                            \
+    })
+
+// Apply the edge case fixups of BUILTIN_FRACTION_F64. \p F should be the result
+// of BUILTIN_FRACTION_F64_IMPL, \p X should be a value that is known to have
+// the same finiteness as \p F. i.e., if isnan(X) == isnan(F), and isinf(X) ==
+// isinf(F).
+#define BUILTIN_FRACTION_F64_FIXUP(F, X)                                                                               \
+    ({                                                                                                                 \
+        const double _x = X;                                                                                           \
+        double _f = F;                                                                                                 \
+        if (!FINITE_ONLY_OPT()) {                                                                                      \
+            _f = BUILTIN_ISNAN_F64(_x) ? _x : _f;                                                                      \
+            _f = BUILTIN_ISINF_F64(_x) ? 0.0 : _f;                                                                     \
+        }                                                                                                              \
+        _f;                                                                                                            \
+    })
+
+#define BUILTIN_FRACTION_F64(X) BUILTIN_FRACTION_F64_FIXUP(BUILTIN_FRACTION_F64_IMPL(X), X)
 
 #define BUILTIN_FRACTION_F16(X) ({                                      \
     const half _x = X;                                                  \

--- a/amd/device-libs/ocml/src/trigredlargeD.cl
+++ b/amd/device-libs/ocml/src/trigredlargeD.cl
@@ -73,7 +73,7 @@ MATH_PRIVATE(trigredlarge)(double x)
     double f2, f1, f0;
     EVALUATE(x, p2, p1, p0, f2, f1, f0);
 
-    f2 = BUILTIN_FLDEXP_F64(BUILTIN_FRACTION_F64(BUILTIN_FLDEXP_F64(f2, -2)), 2);
+    f2 = BUILTIN_FLDEXP_F64(BUILTIN_FRACTION_F64_FIXUP(BUILTIN_FRACTION_F64_IMPL(BUILTIN_FLDEXP_F64(f2, -2)), x), 2);
     f2 += f2+f1 < 0.0 ? 4.0 : 0.0;
 
     int i = (int)(f2 + f1);


### PR DESCRIPTION
Break the builtin macro usage into the main sequence and the edge case fixup part. Perform the edge case checks on the original argument value, rather than the result of the earlier computation. We know this sequence cannot introduce inf or nan. This enables value tracking to trivially use the knowledge that the argument isn't inf or nan. The current sequence is 2 instructions too deep for the default value tracking recursion depth limit.

This eliminates codegen differences in the remaining trig functions when FINITE_ONLY_OPT is deleted.


