### PR TITLE
device-libs: Use f64 exp intrinsic for expep

### DIFF
--- a/amd/device-libs/ocml/src/builtins.h
+++ b/amd/device-libs/ocml/src/builtins.h
@@ -173,6 +173,7 @@
 
 #define BUILTIN_EXP_F32 __builtin_expf
 #define BUILTIN_EXP10_F32 __builtin_exp10f
+#define BUILTIN_EXP_F64 __builtin_exp
 
 #define BUILTIN_AMDGPU_LOG2_F32 __builtin_amdgcn_logf
 #define BUILTIN_LOG2_F32 __builtin_log2f

--- a/amd/device-libs/ocml/src/builtins.h
+++ b/amd/device-libs/ocml/src/builtins.h
@@ -171,6 +171,7 @@
 
 #define BUILTIN_EXP_F32 __builtin_expf
 #define BUILTIN_EXP10_F32 __builtin_exp10f
+#define BUILTIN_EXP_F64 __builtin_exp
 
 #define BUILTIN_AMDGPU_LOG2_F32 __builtin_amdgcn_logf
 #define BUILTIN_LOG2_F32 __builtin_log2f

--- a/amd/device-libs/ocml/src/expepD.cl
+++ b/amd/device-libs/ocml/src/expepD.cl
@@ -33,7 +33,7 @@ MATH_PRIVATE(expep)(double2 x)
     z = x.hi > 710.0 ? PINF_F64 : z;
     z = x.hi < -745.0 ? 0.0 : z;
 #else
-    double z = MATH_MANGLE(exp)(x.hi);
+    double z = BUILTIN_EXP_F64(x.hi);
     double zz = MATH_MAD(z, x.lo, z);
     z = BUILTIN_ISINF_F64(z)? z : zz;
 #endif


### PR DESCRIPTION
This previously would call the inlined library function. The function is too big for the value tracking recursion depth limit. Use the intrinsic so the optimizer can easily handle it.

This eliminates the remaining codegen differences in the f64 pow functions when FINITE_ONLY_OPT is removed.


