### PR TITLE
[psdb] enable rock CI windows build for debug branches

### DIFF
--- a/.github/workflows/rockci-windows-debug-support.yml
+++ b/.github/workflows/rockci-windows-debug-support.yml
@@ -1,0 +1,124 @@
+# This CI workflow is triggered by:
+#   - on push to amd/compiler/win-debug/**
+#   - workflow dispatch
+#
+#   - Windows: Builds on gfx1151
+#
+
+name: ROCK CI Windows Debug Support
+
+on:
+  push:
+    branches:
+      - amd/compiler/win-debug/**
+  workflow_dispatch:
+    inputs:
+      linux_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Linux GPU families to build and test. ex: gfx94X, gfx1201X"
+        default: ""
+      linux_test_labels:
+        type: string
+        description: "If enabled, reduce test set on Linux to the list of labels prefixed with 'test:'. ex: test:rocprim, test:hipcub"
+        default: ""
+      linux_use_prebuilt_artifacts:
+        type: boolean
+        description: "If enabled, the CI will pull Linux artifacts using artifact_run_id and only run tests"
+      windows_amdgpu_families:
+        type: string
+        description: "Insert comma-separated list of Windows GPU families to build and test. ex: gfx94X, gfx1201X"
+        default: ""
+      windows_test_labels:
+        type: string
+        description: "If enabled, reduce test set on Windows to the list of labels prefixed with 'test:' ex: test:rocprim, test:hipcub"
+        default: ""
+      windows_use_prebuilt_artifacts:
+        type: boolean
+        description: "If enabled, the CI will pull Windows artifacts using artifact_run_id and only run tests"
+      artifact_run_id:
+        type: string
+        description: "If provided, the tests will run on this artifact ID"
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  # A PR number if a pull request and otherwise the commit hash. This cancels
+  # queued and in-progress runs for the same PR (presubmit) or commit
+  # (postsubmit). The workflow name is prepended to avoid conflicts between
+  # different workflows.
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  setup:
+    uses: ./.github/workflows/setup.yml
+    with:
+      build_variant: "release"
+
+  windows_build_and_test:
+    name: Windows::${{ matrix.variant.family }}::${{ matrix.variant.build_variant_label }}
+    needs: setup
+    if: >-
+      ${{
+        needs.setup.outputs.windows_variants != '[]'
+      }}
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: ${{ fromJSON(needs.setup.outputs.windows_variants) }}
+    uses: ./.github/workflows/ci_windows.yml
+    with:
+      amdgpu_families: ${{ matrix.variant.family }}
+      artifact_group: ${{ matrix.variant.artifact_group }}
+      test_runs_on: ${{ matrix.variant.test-runs-on }}
+      build_variant_label: ${{ matrix.variant.build_variant_label }}
+      build_variant_suffix: ${{ matrix.variant.build_variant_suffix }}
+      build_variant_cmake_preset: ${{ matrix.variant.build_variant_cmake_preset }}
+      test_labels: ${{ needs.setup.outputs.windows_test_labels }}
+      artifact_run_id: ${{ inputs.artifact_run_id }}
+      expect_failure: ${{ matrix.variant.expect_failure == true }}
+      use_prebuilt_artifacts: ${{ inputs.windows_use_prebuilt_artifacts == true && 'true' || 'false' }}
+      rocm_package_version: ${{ needs.setup.outputs.rocm_package_version }}
+      test_type: 'smoke'
+      sanity_check_only_for_family: ${{ matrix.variant.sanity_check_only_for_family == true }}
+    permissions:
+      contents: read
+      id-token: write
+
+  # build_python_packages:
+  #   name: Build Python Packages
+  #   uses: ./.github/workflows/build_python_packages.yml
+
+  ci_summary:
+    name: CI Summary
+    if: always()
+    needs:
+      - setup
+      - windows_build_and_test
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Output failed jobs
+        run: |
+          echo '${{ toJson(needs) }}'
+
+          # Build a list of failed jobs, but ignore those marked continue-on-error
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
+            | jq --raw-output '
+              to_entries
+              | map(select(
+                  (.value.result != "success" and .value.result != "skipped")
+                  and (.value.outputs.continue_on_error | not)
+                ))
+              | map(.key)
+              | join(",")
+            ' \
+          )"
+
+          if [[ -n "${FAILED_JOBS}" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
+            exit 1
+          else
+            echo "All required jobs succeeded (continue-on-error jobs ignored)."
+          fi


### PR DESCRIPTION
     - feature branches that matches amd/compiler/win-debug/** triggers
       gfx1151 rock ci windows build
     - No PR creation needed. Just push your branch and go to "Actions" to see your run
       matching your commit message


