### PR TITLE
[Flang][OpenMP] Fix unintended write-back shown in SWDEV-579431

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -5205,9 +5205,6 @@ processIndividualMap(llvm::IRBuilderBase &builder,
                        llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH) ==
                       llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH);
 
-  if (isPtrTy && mapData.IsDeclareTarget[mapDataIdx])
-    mapFlag |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_PTR_AND_OBJ;
-
   if (isTargetParam &&
       (targetDirective == TargetDirectiveEnumTy::Target &&
        !mapData.IsDeclareTarget[mapDataIdx]) &&
@@ -5226,8 +5223,16 @@ processIndividualMap(llvm::IRBuilderBase &builder,
   // the host, and then expect it to not be updated in a subsequent impliict map
   // (such as an implicit map on a target).
   if (memberOfFlag != llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_NONE) {
-    if (!isPtrTy && !isAttachMap)
+    // If we are in a declare mapper, we apply MEMBER_OF even if it's an attach
+    // or pointer map, this is to make the MEMBER_OF flag uniform across all
+    // maps within the declare mapper, as even if we do not apply it here on
+    // nestings greater than the first layer we will have a member of flag
+    // applied automatically. So, we canonicalize it here, which keeps the
+    // behaviour of pointer/data maps consistent across layers.
+    if ((!isPtrTy && !isAttachMap) ||
+        mapInfoOp->getParentOfType<omp::DeclareMapperOp>()) {
       ompBuilder.setCorrectMemberOfFlag(mapFlag, memberOfFlag);
+    }
 
     // The return parameter should be the over-riding parent in cases where we
     // have a return parameter that is echoed to all members, the main case of
@@ -5237,13 +5242,25 @@ processIndividualMap(llvm::IRBuilderBase &builder,
     mapFlag &= ~llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_RETURN_PARAM;
   }
 
+  // We apply MAP_PTR_AND_OBJ when within a declare mapper object as it enforces
+  // MEMBER_OF mappings on maps that are passed the initial nesting depth, which
+  // includes pointed to data and attach members, both of which are technically
+  // not part of the main object. This has the side-affect of causing early
+  // map-backs in certain cases where an implicit declare mapepr has been
+  // emitted for a target region. Applying MAP_PTR_AND_OBJ in these situations
+  // circumvents this.
+  if (isPtrTy && !isAttachMap && (mapData.IsDeclareTarget[mapDataIdx] ||
+                  mapInfoOp->getParentOfType<omp::DeclareMapperOp>()))
+    mapFlag |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_PTR_AND_OBJ;
+
   // if we're provided a mapDataParentIdx, then the data being mapped is
   // part of a larger object (in a parent <-> member mapping) and in this
   // case our BasePointer should be the parent. Except in the edge case
   // where we are mapping pointee data, in this case we try stay close to
   // what Clang currently does and utilise the regular base pointer of the
   // data.
-  if (mapDataParentIdx >= 0 &&
+  if (!mapInfoOp->getParentOfType<omp::DeclareMapperOp>() &&
+      mapDataParentIdx >= 0 &&
       !(checkHasClauseMapFlag(mapInfoOp.getMapType(),
                               omp::ClauseMapFlags::ref_ptee) ||
         (checkHasClauseMapFlag(mapInfoOp.getMapType(),

--- a/mlir/test/Target/LLVMIR/omptarget-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-llvm.mlir
@@ -603,7 +603,7 @@ module attributes {omp.target_triples = ["amdgcn-amd-amdhsa"]} {
 // CHECK:         br label %[[VAL_42]]
 // CHECK:       omp.type.end:                                     ; preds = %[[VAL_59]], %[[VAL_56]], %[[VAL_55]], %[[VAL_51]]
 // CHECK:         %[[VAL_61:.*]] = phi i64 [ %[[VAL_53]], %[[VAL_51]] ], [ %[[VAL_57]], %[[VAL_55]] ], [ %[[VAL_60]], %[[VAL_59]] ], [ %[[VAL_48]], %[[VAL_56]] ]
-// CHECK:         call void @__tgt_push_mapper_component(ptr %[[VAL_37]], ptr %[[VAL_43]], ptr %[[VAL_45]], i64 4, i64 %[[VAL_61]], ptr @2)
+// CHECK:         call void @__tgt_push_mapper_component(ptr %[[VAL_37]], ptr %[[VAL_45]], ptr %[[VAL_45]], i64 4, i64 %[[VAL_61]], ptr @2)
 // CHECK:         %[[VAL_44]] = getelementptr %[[VAL_18]], ptr %[[VAL_43]], i32 1
 // CHECK:         %[[VAL_62:.*]] = icmp eq ptr %[[VAL_44]], %[[VAL_17]]
 // CHECK:         br i1 %[[VAL_62]], label %[[VAL_63:.*]], label %[[VAL_41]]


### PR DESCRIPTION
The implicit declare mapper will enforce the addition of the MEMBER_OF map-type binding pointed to data to the rest of the derived type/record type. This can cause early write-backs to be triggered in certain cases where the object is implciitly mapped to device in a target region, and then released at the end, which triggers the runtime to map back the data as it's now considered part of the object and the remaining piece on device. To avoid this apply OMP_MAP_PTR_AND_OBJ.

Another facet of the issue is that declare mapper only ever applies the MEMBER_OF mapping to the pointer data when it's considered a secondary layer of the object by the mapper infrastructure. Which only triggers at the moment for 1-layer record types when the record is a descriptor type. This causes a weird issue where applying OMP_MAP_PTR_AND_OBJ in these cases then becomes incorrect and provides incorrect results. So, to address this we "canonicalize" the mapping ourselves by applying MEMBER_OF in these cases as well, ensuring all declare mapper elements are appropriately MEMBER_OF marked.


