### PR TITLE
[OpenMP] Remove NVPTX local addrspace on parameters (#183195)

### DIFF
--- a/clang/lib/CodeGen/CGDecl.cpp
+++ b/clang/lib/CodeGen/CGDecl.cpp
@@ -2704,6 +2704,9 @@ void CodeGenFunction::EmitParmDecl(const VarDecl &D, ParamValue Arg,
     Arg.getAnyValue()->setName(D.getName());
 
   QualType Ty = D.getType();
+  assert((getLangOpts().OpenCL || Ty.getAddressSpace() == LangAS::Default
+         || (CGM.getContext().getTargetInfo().getTriple().isAMDGCN()))
+         && "parameter has non-default address space in non-OpenCL mode");
 
   // Use better IR generation for certain implicit parameters.
   if (auto IPD = dyn_cast<ImplicitParamDecl>(&D)) {

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -2035,8 +2035,6 @@ CGOpenMPRuntimeGPU::translateParameter(const FieldDecl *FD,
   }
   ArgType = CGM.getContext().getPointerType(PointeeTy);
   QC.addRestrict();
-  enum { NVPTX_local_addr = 5 };
-  QC.addAddressSpace(getLangASFromTargetAS(NVPTX_local_addr));
   ArgType = QC.apply(CGM.getContext(), ArgType);
   if (isa<ImplicitParamDecl>(NativeParam))
     return ImplicitParamDecl::Create(


### PR DESCRIPTION
In CGOpenMPRuntimeGPU::translateParameter, reference-type captured variables were translated to pointer parameters with two address-space annotations:

1. LangAS::opencl_global on the pointee (for map'd variables), which correctly produces ptr addrspace(1) in NVPTX IR.
2. getLangASFromTargetAS(NVPTX_local_addr=5) on the pointer itself, annotating the parameter as living in NVPTX local (stack) memory.

The second annotation is incorrect at the Clang type-system level: EmitParmDecl only supports parameters to be in LangAS::Default (or the special cases for OpenCL).

Temporarily add an assert in EmitParmDecl that catches parameters with non-default address spaces in non-OpenCL compilations, and fix the violation by dropping the NVPTX_local_addr addAddressSpace call.

Should fix the issue noticed in

https://github.com/llvm/llvm-project/pull/181256#discussion_r2821894122, allowing removing that special case there for OpenMP, though I haven't tested the combination yet. That PR would fix EmitParmDecl to actually support non-default address spaces from Sema, and will remove this assert again.


