### PR TITLE
[Comgr] Handle AMDGCN::Linker jobs for SOURCE_TO_SPIRV action

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -631,6 +631,7 @@ amd_comgr_status_t linkWithLLD(llvm::ArrayRef<const char *> Args,
 
 // Execute llvm-link in-process using llvm::Linker
 // Args format: -o <output.bc> <input1.bc> <input2.bc> ...
+// TODO: refactor this implementation to use a shared infra with linkBitcodeToBitcode()
 amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
                                    raw_ostream &LogS) {
   // Parse args: find -o <output> and collect input .bc files

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -69,6 +69,10 @@
 
 #include "time-stat/ts-interface.h"
 
+#ifndef COMGR_DISABLE_SPIRV
+#include <LLVMSPIRVLib.h>
+#endif
+
 #include <csignal>
 #include <sstream>
 
@@ -625,6 +629,127 @@ amd_comgr_status_t linkWithLLD(llvm::ArrayRef<const char *> Args,
   return AMD_COMGR_STATUS_SUCCESS;
 }
 
+// Execute llvm-link in-process using llvm::Linker
+// Args format: -o <output.bc> <input1.bc> <input2.bc> ...
+amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
+                                   raw_ostream &LogS) {
+  // Parse args: find -o <output> and collect input .bc files
+  StringRef OutputPath;
+  SmallVector<StringRef, 4> InputPaths;
+
+  for (size_t I = 0; I < Args.size(); ++I) {
+    StringRef Arg(Args[I]);
+    if (Arg == "-o" && I + 1 < Args.size()) {
+      OutputPath = Args[++I];
+    } else if (Arg.ends_with(".bc")) {
+      InputPaths.push_back(Arg);
+    }
+  }
+
+  if (OutputPath.empty() || InputPaths.empty()) {
+    LogS << "llvm-link: missing input or output files\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  // Create composite module and linker
+  LLVMContext Context;
+  auto Composite = std::make_unique<llvm::Module>("llvm-link", Context);
+  Linker L(*Composite);
+
+  // Link each input BC
+  for (StringRef InputPath : InputPaths) {
+    auto BufOrErr = MemoryBuffer::getFile(InputPath);
+    if (!BufOrErr) {
+      LogS << "llvm-link: failed to read: " << InputPath << "\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    SMDiagnostic Err;
+    auto Mod = parseIR(BufOrErr->get()->getMemBufferRef(), Err, Context);
+    if (!Mod) {
+      Err.print("llvm-link", LogS);
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    if (L.linkInModule(std::move(Mod))) {
+      LogS << "llvm-link: linking failed for: " << InputPath << "\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+  }
+
+  // Write linked BC to output file
+  std::error_code EC;
+  raw_fd_ostream OS(OutputPath, EC);
+  if (EC) {
+    LogS << "llvm-link: failed to open output: " << OutputPath << "\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+  WriteBitcodeToFile(*Composite, OS);
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+#ifndef COMGR_DISABLE_SPIRV
+// Execute amd-llvm-spirv in-process using writeSpirv
+// Args format: [options...] <input.bc> -o <output.spv>
+amd_comgr_status_t executeSPIRVTranslator(ArrayRef<const char *> Args,
+                                          raw_ostream &LogS) {
+  // Parse args: find input .bc and -o <output>
+  StringRef InputPath, OutputPath;
+
+  for (size_t I = 0; I < Args.size(); ++I) {
+    StringRef Arg(Args[I]);
+    if (Arg == "-o" && I + 1 < Args.size()) {
+      OutputPath = Args[++I];
+    } else if (Arg.ends_with(".bc")) {
+      InputPath = Arg;
+    }
+  }
+
+  if (InputPath.empty() || OutputPath.empty()) {
+    LogS << "spirv-translator: missing input or output files\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  // Read input bitcode
+  auto BufOrErr = MemoryBuffer::getFile(InputPath);
+  if (!BufOrErr) {
+    LogS << "spirv-translator: failed to read: " << InputPath << "\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  LLVMContext Context;
+  SMDiagnostic Err;
+  auto Mod = parseIR(BufOrErr->get()->getMemBufferRef(), Err, Context);
+  if (!Mod) {
+    Err.print("spirv-translator", LogS);
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  // Configure SPIRV translator options (match amd-llvm-spirv defaults)
+  SPIRV::TranslatorOpts Opts;
+  Opts.enableAllExtensions();
+  Opts.setPreserveAuxData(true);
+  Opts.setSPIRVAllowUnknownIntrinsics({"llvm.amdgcn"});
+
+  // Translate to SPIRV
+  std::string ErrMsg;
+  std::ostringstream OSS;
+  if (!writeSpirv(Mod.get(), Opts, OSS, ErrMsg)) {
+    LogS << "spirv-translator: translation failed: " << ErrMsg << "\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  // Write SPIRV to output file
+  std::error_code EC;
+  raw_fd_ostream OS(OutputPath, EC);
+  if (EC) {
+    LogS << "spirv-translator: failed to open output: " << OutputPath << "\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+  std::string Result = OSS.str();
+  OS.write(Result.data(), Result.size());
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+#endif
+
 void logArgv(raw_ostream &OS, StringRef ProgramName,
              ArrayRef<const char *> Argv) {
   OS << "     Driver Job Args: " << ProgramName;
@@ -707,6 +832,27 @@ executeCommand(const Command &Job, raw_ostream &LogS,
       return Status;
     }
   } else {
+    // Check executable name for additional tools (e.g., from AMDGCN::Linker)
+    StringRef Executable = Job.getExecutable();
+    StringRef ExeName = sys::path::filename(Executable);
+
+    if (ExeName.contains("llvm-link")) {
+      if (env::shouldEmitVerboseLogs()) {
+        logArgv(LogS, "llvm-link", Argv);
+      }
+      return executeLLVMLink(Arguments, LogS);
+    }
+#ifndef COMGR_DISABLE_SPIRV
+    if (ExeName.contains("llvm-spirv")) {
+      if (env::shouldEmitVerboseLogs()) {
+        logArgv(LogS, "llvm-spirv", Argv);
+      }
+      return executeSPIRVTranslator(Arguments, LogS);
+    }
+#endif
+
+    LogS << "     Unhandled Job: " << Job.getCreator().getName()
+         << " (executable: " << ExeName << ")\n";
     return AMD_COMGR_STATUS_ERROR;
   }
   return AMD_COMGR_STATUS_SUCCESS;

--- a/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
+++ b/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
@@ -18,7 +18,8 @@ int main(int argc, char *argv[]) {
   amd_comgr_data_t DataSource;
   amd_comgr_data_set_t DataSetSource, DataSetSpirv;
   amd_comgr_action_info_t DataAction;
-  size_t Count;
+  const char *Options[] = {"-nogpuinc"};
+  size_t OptionsCount = sizeof(Options) / sizeof(Options[0]);
 
   if (argc != 3) {
     fprintf(stderr, "Usage: source-to-spirv file.hip file.spv\n");
@@ -36,14 +37,16 @@ int main(int argc, char *argv[]) {
 
   amd_comgr_(create_action_info(&DataAction));
   amd_comgr_(action_info_set_language(DataAction, AMD_COMGR_LANGUAGE_HIP));
+  amd_comgr_(action_info_set_option_list(DataAction, Options, OptionsCount));
 
   amd_comgr_(create_data_set(&DataSetSpirv));
-  amd_comgr_(do_action(AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV,
-                       DataAction, DataSetSource, DataSetSpirv));
+
+  amd_comgr_(do_action(AMD_COMGR_ACTION_COMPILE_SOURCE_TO_SPIRV, DataAction,
+                       DataSetSource, DataSetSpirv));
 
   amd_comgr_data_t DataSpirv;
-  amd_comgr_(action_data_get_data(DataSetSpirv, AMD_COMGR_DATA_KIND_SPIRV,
-                                  0, &DataSpirv));
+  amd_comgr_(action_data_get_data(DataSetSpirv, AMD_COMGR_DATA_KIND_SPIRV, 0,
+                                  &DataSpirv));
   dumpData(DataSpirv, argv[2]);
 
   amd_comgr_(release_data(DataSource));
@@ -52,4 +55,3 @@ int main(int argc, char *argv[]) {
   amd_comgr_(destroy_action_info(DataAction));
   free(BufSource);
 }
-

--- a/amd/comgr/test-lit/spirv-tests/source-to-spirv.hip
+++ b/amd/comgr/test-lit/spirv-tests/source-to-spirv.hip
@@ -1,0 +1,28 @@
+// REQUIRES: comgr-has-spirv
+
+// COM: Compile HIP source to SPIR-V using Comgr
+// RUN: source-to-spirv %s %t.spv
+
+// COM: Verify the SPIR-V file was created and is non-empty
+// RUN: test -s %t.spv
+
+// COM: Translate SPIR-V back to LLVM IR bitcode
+// RUN: spirv-translator %t.spv -o %t.bc
+
+// COM: Disassemble LLVM IR bitcode to text
+// RUN: llvm-dis %t.bc -o - | %FileCheck %s
+
+// COM: Verify LLVM IR contains expected functions and target triple
+// CHECK: target triple = "amdgcn-amd-amdhsa"
+// CHECK: define void @_Z11clean_valuePf
+// CHECK: define amdgpu_kernel void @_Z9add_valuePfS_S_
+
+__attribute__((device))
+void clean_value(float* ptr) { *ptr = 0; }
+
+__attribute__((global))
+void add_value(float* a, float* b, float* res) {
+    *res = *a + *b;
+
+    clean_value(a);
+}


### PR DESCRIPTION
The clang driver creates AMDGCN::Linker jobs when compiling HIP source to SPIRV. These jobs invoke llvm-link and amd-llvm-spirv executables. This change handles them in-process by:

- Adding executeLLVMLink() using llvm::Linker API
- Adding executeSPIRVTranslator() using writeSpirv() from LLVMSPIRVLib
- Dispatching based on executable name in executeCommand()

Co-authored-by: Marcos Maronas <maarquitos14@users.noreply.github.com>

