### PR TITLE
device-libs: Remove quo output handling from remquo for nan results

### DIFF
--- a/amd/device-libs/ocml/src/remainderD_base.h
+++ b/amd/device-libs/ocml/src/remainderD_base.h
@@ -122,9 +122,6 @@ MATH_MANGLE(remainder)(double x, double y)
 
     if (!FINITE_ONLY_OPT()) {
         ret = y == 0.0 ? QNAN_F64 : ret;
-#if defined(COMPILING_REMQUO)
-        q7 = y == 0.0 ? 0 : q7;
-#endif
 
         bool c = !BUILTIN_ISNAN_F64(y) && BUILTIN_ISFINITE_F64(x);
         ret = c ? ret : QNAN_F64;

--- a/amd/device-libs/ocml/src/remainderF_base.h
+++ b/amd/device-libs/ocml/src/remainderF_base.h
@@ -143,9 +143,6 @@ MATH_MANGLE(remainder)(float x, float y)
 
     if (!FINITE_ONLY_OPT()) {
         ret = y == 0.0f ? QNAN_F32 : ret;
-#if defined(COMPILING_REMQUO)
-        q7 = y == 0.0f ? 0 : q7;
-#endif
 
         bool c = !BUILTIN_ISNAN_F32(y) && BUILTIN_ISFINITE_F32(x);
         ret = c ? ret : QNAN_F32;

--- a/amd/device-libs/ocml/src/remainderH_base.h
+++ b/amd/device-libs/ocml/src/remainderH_base.h
@@ -124,9 +124,6 @@ MATH_MANGLE(remainder)(half x, half y)
 
     if (!FINITE_ONLY_OPT()) {
         ret = y == 0.0h ? QNAN_F16 : ret;
-#if defined(COMPILING_REMQUO)
-        q7 = y == 0.0h ? 0 : q7;
-#endif
 
         bool c = !BUILTIN_ISNAN_F16(y) && BUILTIN_ISFINITE_F16(x);
         ret = c ? ret : QNAN_F16;


### PR DESCRIPTION
The C standards specify that a nan is returned for y = 0, and *quo is unspecified.

It was also difficult to optimize out this code for known-not-nan cases, since the use isn't floating-point.


