### PR TITLE
[flang-rt] Guard executionEnvironment usage in Descriptor::Allocate for GPU builds

### DIFF
--- a/flang-rt/lib/runtime/descriptor.cpp
+++ b/flang-rt/lib/runtime/descriptor.cpp
@@ -12,7 +12,9 @@
 #endif
 #include "flang-rt/runtime/allocator-registry.h"
 #include "flang-rt/runtime/derived.h"
+#if !defined(RT_DEVICE_COMPILATION) && !defined(RT_GPU_TARGET)
 #include "flang-rt/runtime/environment.h"
+#endif
 #include "flang-rt/runtime/memory.h"
 #include "flang-rt/runtime/stat.h"
 #include "flang-rt/runtime/terminator.h"
@@ -180,9 +182,11 @@ RT_API_ATTRS int Descriptor::Allocate(std::int64_t *asyncObject) {
   // descriptor must be allocated/associated. Since std::malloc(0)
   // result is implementation defined, always allocate at least one byte.
   if (byteSize < 1) {
+#if !defined(RT_DEVICE_COMPILATION) && !defined(RT_GPU_TARGET)
     if (executionEnvironment.noEmptyAllocation) {
       return CFI_ERROR_MEM_ALLOCATION;
     }
+#endif
     byteSize = 1;
   }
   void *p{alloc(byteSize, asyncObject)};


### PR DESCRIPTION
Commit `a10e77b1a52f [flang][runtime] Conditionally fail empty ALLOCATE` (#182918) added a reference to executionEnvironment in
`Descriptor::Allocate`, which is compiled for the GPU device. However, `executionEnvironment` is not defined for GPU targets because environment.cpp is excluded by a file-level guard in native GPU builds.

Guard the reference with `!defined(RT_DEVICE_COMPILATION) && !defined(RT_GPU_TARGET)` to cover all GPU compilation paths (OpenMP offload, CUDA, and native GPU).

This was the error I was seeing

```
ld.lld: error: undefined symbol: Fortran::runtime::executionEnvironment
>>> referenced by ...:(Fortran::runtime::FinalizeTicket::Begin(Fortran::runtime::WorkQueue&))
>>> referenced by ...:(Fortran::runtime::FinalizeTicket::Begin(Fortran::runtime::WorkQueue&))
>>> referenced by ...:(Fortran::runtime::DerivedAssignTicket<false>::Continue(Fortran::runtime::WorkQueue&))
>>> referenced 11 more times
```

