### PR TITLE
[Comgr] Add COMGR_STATIC_LLVM option for static LLVM linking

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -158,6 +158,15 @@ else()
   endif()
 endif()
 
+# Allow the super-project to force static linking of LLVM/Clang into comgr.
+# When ON, LLVM symbols are hidden by comgr's version script (local: *;),
+# avoiding symbol interposition issues without requiring namespace isolation.
+option(COMGR_STATIC_LLVM "Statically link LLVM/Clang into comgr (hides LLVM symbols)" OFF)
+if(COMGR_STATIC_LLVM)
+  set(LLVM_LINK_LLVM_DYLIB OFF)
+  set(CLANG_LINK_CLANG_DYLIB OFF)
+endif()
+
 target_include_directories(amd_comgr
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src)

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -80,6 +80,11 @@ may be enabled during development via `-DADDRESS_SANITIZER=On` during the Comgr
 **Static Comgr:** Comgr can be built as a static library by passing
 `-DCOMGR_BUILD_SHARED_LIBS=OFF` during the Comgr `cmake` step.
 
+**Static LLVM Linking:** When building Comgr as a shared library within a
+super-project, you can statically link LLVM/Clang into Comgr by passing
+`-DCOMGR_STATIC_LLVM=ON`. By default (`OFF`), Comgr respects the existing
+`LLVM_LINK_LLVM_DYLIB` and `CLANG_LINK_CLANG_DYLIB` settings.
+
 **SPIRV Support:** To enable SPIRV support, checkout
 [SPIRV-LLVM-Translator](https://github.com/ROCm/SPIRV-LLVM-Translator) in
 `llvm/projects` or `llvm/tools` and build using the above instructions, with the


### PR DESCRIPTION
Add a COMGR_STATIC_LLVM CMake option that, when enabled, forces comgr to statically link LLVM and Clang component libraries instead of using libLLVM.so and libclang-cpp.so.

Combined with comgr's existing -fvisibility=hidden and version script (local: *;), this hides all LLVM symbols inside libamd_comgr.so, preventing symbol interposition issues without requiring namespace isolation via dlmopen.

This is needed because the delay-load stub approach (using dlmopen for linker namespace isolation) is being turned off by default and re-investigated due to insufficient glibc namespace support across supported distributions.

The option defaults to OFF, preserving existing behavior. When LLVM is built with LLVM_BUILD_LLVM_DYLIB=ON and BUILD_SHARED_LIBS=OFF (as in TheRock), both the monolithic libLLVM.so and individual PIC-enabled static .a component libraries are produced, so comgr can link the static libraries while tools continue using libLLVM.so.

See: https://github.com/ROCm/TheRock/issues/3729