### PR TITLE
[1/1]: Reapply "[MC] Use a variant to hold MCCFIInstruction state (NFC)" (#170342)

### DIFF
--- a/llvm/include/llvm/MC/MCDwarf.h
+++ b/llvm/include/llvm/MC/MCDwarf.h
@@ -571,10 +571,20 @@ public:
 
   // Held in ExtraFields for most common OpTypes, exceptions follow.
   struct CommonFields {
-    unsigned Register = std::numeric_limits<unsigned>::max();
-    int64_t Offset = 0;
-    unsigned Register2 = std::numeric_limits<unsigned>::max();
-    unsigned AddressSpace = 0;
+    unsigned Register;
+    int64_t Offset;
+    unsigned Register2;
+    unsigned AddressSpace;
+    // FIXME: Workaround for GCC7 bug with nested class used as std::variant
+    // alternative where the compiler really wants a user-defined default
+    // constructor. Once we no longer support GCC7 these constructors can be
+    // replaced with default member initializers and aggregate initialization.
+    CommonFields(unsigned Reg, int64_t Off = 0,
+                 unsigned Reg2 = std::numeric_limits<unsigned>::max(),
+                 unsigned AddrSpace = 0)
+        : Register(Reg), Offset(Off), Register2(Reg2), AddressSpace(AddrSpace) {
+    }
+    CommonFields() : CommonFields(std::numeric_limits<unsigned>::max()) {}
   };
   // Held in ExtraFields when OpEscape.
   struct EscapeFields {


### PR DESCRIPTION
This reverts commit 8217c6415ab76c2a0f06705100c76207cd1e6bc0.

I asked Claude Sonnet 4.5 to hazard a guess at what was causing the
buildbot failure, and it seems to have correctly pinned it on a bug in
GCC7, although it didn't give a working fix.

I worked out of a `gcc:7.4` docker container and moved code around until
`MCDwarf.cpp.o` compiled without errors or warnings, so hopefully that's
sufficient to fix the bot.

(cherry picked from commit 8fa29f845733fd4611b606c00bbaab0b979bbc20)

Change-Id: I86c82503d3000f7dcd66042a5bc080b340099192

---

**Stack**:
- #1658⬅
- `amd-staging`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
