### PR TITLE
[AMDGPU] Add .gfx1250_revision kernel note

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -733,6 +733,10 @@ void MetadataStreamerMsgPackV5::emitKernelAttrs(const AMDGPUTargetMachine &TM,
   const Function &Func = MF.getFunction();
   if (Func.hasFnAttribute("uniform-work-group-size"))
     Kern[".uniform_work_group_size"] = Kern.getDocument()->getNode(1);
+
+  const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
+  if (ST.hasGFX1250Insts())
+    Kern[".gfx1250_revision"] = ST.hasGFX1250A0() ? "A0" : "B0";
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -972,7 +972,9 @@ public:
     return HasGFX1250Insts && getGeneration() == GFX12;
   }
 
-  bool hasGFX1250A0() const { return HasGFX1250Insts && !HasGFX1250B0; }
+  bool hasGFX1250A0() const {
+    return getGeneration() == GFX12 && HasGFX1250Insts && !HasGFX1250B0;
+  }
 
   // TODO: Remove this when we replace all A0 GFX1250 with B0.
   // DS_READ2 and DS_WRITE2 instructions must have addresses aligned to the


### PR DESCRIPTION
This is to distinguish code for A0 and B0. Revert when we switch to B0.


