### PR TITLE
[Clang][Driver] Replace --parallel-jobs with alias to --offload-jobs

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -371,9 +371,6 @@ private:
   /// stored in it, and will clean them up when torn down.
   mutable llvm::StringMap<std::unique_ptr<ToolChain>> ToolChains;
 
-  /// Number of parallel jobs.
-  unsigned NumParallelJobs;
-
 private:
   /// TranslateInputArgs - Create a new derived argument list from the input
   /// arguments, after applying the standard argument translations.
@@ -758,12 +755,6 @@ public:
 
   /// Get the specific kind of offload LTO being performed.
   LTOKind getOffloadLTOMode() const { return OffloadLTOMode; }
-
-  /// Get the number of parallel jobs.
-  unsigned getNumberOfParallelJobs() const { return NumParallelJobs; }
-
-  /// Set the number of parallel jobs.
-  void setNumberOfParallelJobs(unsigned N) { NumParallelJobs = N; }
 
   /// Get the CUID option.
   const CUIDOptions &getCUIDOpts() const { return CUIDOpts; }

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -858,8 +858,6 @@ def P : Flag<["-"], "P">,
   Group<Preprocessor_Group>,
   HelpText<"Disable linemarker output in -E mode">,
   MarshallingInfoNegativeFlag<PreprocessorOutputOpts<"ShowLineMarkers">>;
-def parallel_jobs_EQ : Joined<["-"], "parallel-jobs=">, Flags<[NoXarchOption]>,
-  HelpText<"Number of parallel jobs">;
 def Qy : Flag<["-"], "Qy">, Visibility<[ClangOption, CC1Option]>,
   HelpText<"Emit metadata containing compiler name and version">;
 def Qn : Flag<["-"], "Qn">, Visibility<[ClangOption, CC1Option]>,
@@ -1274,6 +1272,8 @@ def offload_jobs_EQ : Joined<["--"], "offload-jobs=">,
   HelpText<"Specify the number of threads to use for device offloading tasks "
            "during compilation. Can be a positive integer or the string "
            "'jobserver' to use the make-style jobserver from the environment.">;
+def parallel_jobs_EQ : Joined<["-"], "parallel-jobs=">,
+  Alias<offload_jobs_EQ>;
 
 defm offload_via_llvm : BoolFOption<"offload-via-llvm",
   LangOpts<"OffloadViaLLVM">, DefaultFalse,

--- a/clang/lib/Driver/Compilation.cpp
+++ b/clang/lib/Driver/Compilation.cpp
@@ -21,12 +21,8 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 #include <cassert>
-#include <chrono>
-#include <functional>
-#include <mutex>
 #include <string>
 #include <system_error>
-#include <thread>
 #include <utility>
 
 using namespace clang;
@@ -236,101 +232,6 @@ static bool ActionFailed(const Action *A,
   return false;
 }
 
-namespace {
-class JobScheduler {
-public:
-  enum JobState { JS_WAIT, JS_RUN, JS_DONE, JS_FAIL };
-  JobScheduler(const JobList &Jobs, size_t NJobs = 1)
-      : Jobs(Jobs), NumJobs(NJobs) {
-#if !LLVM_ENABLE_THREADS
-    NumJobs = 1;
-#endif
-    for (auto &Job : Jobs) {
-      JState[&Job] = JS_WAIT;
-      for (const auto *AI : Job.getDependentActions()) {
-        for (const auto *CI : ActToCmds[AI]) {
-          DependentCmds[&Job].push_back(CI);
-        }
-      }
-      for (const auto *CI : ActToCmds[&Job.getSource()]) {
-        DependentCmds[&Job].push_back(CI);
-      }
-      ActToCmds[&Job.getSource()].push_back(&Job);
-    }
-  }
-  /// \return true if all jobs are done. Otherwise, \p Next contains the
-  /// the next job ready to be executed if it is not null pointer. Otherwise
-  /// all jobs are running or waiting.
-  bool IsDone(const Command *&Next) {
-    std::lock_guard<std::mutex> lock(Mutex);
-    Next = nullptr;
-    unsigned Done = 0;
-    unsigned Running = 0;
-    for (auto &Cmd : Jobs) {
-      switch (JState[&Cmd]) {
-      case JS_RUN:
-        ++Running;
-        break;
-      case JS_DONE:
-      case JS_FAIL:
-        ++Done;
-        break;
-      case JS_WAIT: {
-        bool InputsReady = true;
-        for (const auto *CI : DependentCmds[&Cmd]) {
-          if (JState[CI] == JS_FAIL) {
-            JState[&Cmd] = JS_FAIL;
-            ++Done;
-            InputsReady = false;
-            break;
-          }
-          if (JState[CI] != JS_DONE) {
-            InputsReady = false;
-            break;
-          }
-        }
-        if (!Next && InputsReady) {
-          Next = &Cmd;
-        }
-        break;
-      }
-      }
-    }
-    if (Running >= NumJobs)
-      Next = nullptr;
-    return Done == Jobs.size();
-  }
-
-  void setJobState(const Command *Cmd, JobState JS) {
-    std::lock_guard<std::mutex> lock(Mutex);
-    JState[Cmd] = JS;
-  }
-
-  void launch(std::function<void()> Work) {
-#if LLVM_ENABLE_THREADS
-    if (NumJobs == 1) {
-      Work();
-      return;
-    }
-    std::thread Th(Work);
-    Th.detach();
-#else
-    Work();
-#endif
-  }
-
-private:
-  std::mutex Mutex;
-  const JobList &Jobs;
-  llvm::DenseMap<const Command *, JobState> JState;
-  llvm::DenseMap<const Action *, llvm::SmallVector<const Command *, 4>>
-      ActToCmds;
-  llvm::DenseMap<const Command *, llvm::SmallVector<const Command *, 4>>
-      DependentCmds;
-  size_t NumJobs; // Number of parallel jobs to run
-};
-} // namespace
-
 void Compilation::ExecuteJobs(const JobList &Jobs,
                               FailingCommandList &FailingCommands,
                               bool LogOnly) const {
@@ -338,35 +239,16 @@ void Compilation::ExecuteJobs(const JobList &Jobs,
   // inputs on the command line even one of them failed.
   // In all but CLMode, execute all the jobs unless the necessary inputs for the
   // job is missing due to previous failures.
-  JobScheduler JS(Jobs, getDriver().getNumberOfParallelJobs());
-
-  const Command *Next = nullptr;
-  while (!JS.IsDone(Next)) {
-    if (!Next) {
-      // sleep, rather than yield so we do not busy wait.
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  for (const auto &Job : Jobs) {
+    if (ActionFailed(&Job.getSource(), FailingCommands))
       continue;
-    }
-
-    if (ActionFailed(&Next->getSource(), FailingCommands)) {
-      JS.setJobState(Next, JobScheduler::JS_FAIL);
+    const Command *FailingCommand = nullptr;
+    if (int Res = ExecuteCommand(Job, FailingCommand, LogOnly)) {
+      FailingCommands.push_back(std::make_pair(Res, FailingCommand));
       // Bail as soon as one command fails in cl driver mode.
       if (TheDriver.IsCLMode())
         return;
-      continue;
     }
-
-    JS.setJobState(Next, JobScheduler::JS_RUN);
-    auto Work = [&, Next]() {
-      const Command *FailingCommand = nullptr;
-      if (int Res = ExecuteCommand(*Next, FailingCommand, LogOnly)) {
-        FailingCommands.push_back(std::make_pair(Res, FailingCommand));
-        JS.setJobState(Next, JobScheduler::JS_FAIL);
-      } else {
-        JS.setJobState(Next, JobScheduler::JS_DONE);
-      }
-    };
-    JS.launch(Work);
   }
 }
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -185,8 +185,7 @@ Driver::Driver(StringRef ClangExecutable, StringRef TargetTriple,
       CCPrintProcessStats(false), CCPrintInternalStats(false),
       TargetTriple(TargetTriple), Saver(Alloc), PrependArg(nullptr),
       PreferredLinker(CLANG_DEFAULT_LINKER), CheckInputsExist(true),
-      ProbePrecompiled(true), SuppressMissingInputWarning(false),
-      NumParallelJobs(1) {
+      ProbePrecompiled(true), SuppressMissingInputWarning(false) {
   // Provide a sane fallback if no VFS is specified.
   if (!this->VFS)
     this->VFS = llvm::vfs::getRealFileSystem();
@@ -1690,13 +1689,6 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
     } else
       BitcodeEmbed = static_cast<BitcodeEmbedMode>(Model);
   }
-
-  // Force -parallel-jobs=1 when verbose is set to avoid corrupted output
-  if (Args.hasArg(options::OPT_v))
-    setNumberOfParallelJobs(1);
-  else
-    setNumberOfParallelJobs(
-        getLastArgIntValue(Args, options::OPT_parallel_jobs_EQ, 1, Diags));
 
   // Remove existing compilation database so that each job can append to it.
   if (Arg *A = Args.getLastArg(options::OPT_MJ))

--- a/clang/lib/Driver/README_amd_driver_trunk_diffs
+++ b/clang/lib/Driver/README_amd_driver_trunk_diffs
@@ -19,9 +19,6 @@ These are the areas where amd-staging differs from the trunk:
 - Support for legacy/classic flang driver.  This will eventually go away
   when llvm flang (flang) is in production. 
 
-- Support for the generation of parallel jobs. Unless someone upstreams 
-  this support, this difference will remain.
-
 - Support for --opaque-offload-linker. This using the same offload driver, actions
   and phases. It is only an alternative command generator in ToolChains/Clang.cpp 
   LinerWrapper:ConstructJob. Instead of the driver generating four commands

--- a/clang/tools/driver/driver.cpp
+++ b/clang/tools/driver/driver.cpp
@@ -207,13 +207,6 @@ static void FixupDiagPrefixExeName(TextDiagnosticPrinter *DiagClient,
   DiagClient->setPrefix(std::string(ExeBasename));
 }
 
-static void PopulateArgsOpts(ArrayRef<const char *> argv,
-                             InputArgList &Args) {
-  unsigned MissingArgIndex, MissingArgCount;
-  Args = getDriverOptTable().ParseArgs(argv.slice(1), MissingArgIndex,
-                                       MissingArgCount);
-}
-
 static int ExecuteCC1Tool(SmallVectorImpl<const char *> &ArgV,
                           const llvm::ToolContext &ToolContext,
                           IntrusiveRefCntPtr<llvm::vfs::FileSystem> VFS) {
@@ -342,9 +335,6 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
                            .Case("-fintegrated-cc1", false)
                            .Default(UseNewCC1Process);
 
-  InputArgList ArgList;
-  PopulateArgsOpts(Args, ArgList);
-
   std::unique_ptr<DiagnosticOptions> DiagOpts = CreateAndPopulateDiagOpts(Args);
   // Driver's diagnostics don't use suppression mappings, so don't bother
   // parsing them. CC1 still receives full args, so this doesn't impact other
@@ -356,13 +346,6 @@ int clang_main(int Argc, char **Argv, const llvm::ToolContext &ToolContext) {
   FixupDiagPrefixExeName(DiagClient, ProgName);
 
   DiagnosticsEngine Diags(DiagnosticIDs::create(), *DiagOpts, DiagClient);
-
-  unsigned NumParallelJobs =
-      getLastArgIntValue(ArgList, options::OPT_parallel_jobs_EQ, 1, Diags);
-  UseNewCC1Process =
-      ArgList.hasFlag(clang::options::OPT_fno_integrated_cc1,
-                      clang::options::OPT_fintegrated_cc1,
-                      /*Default=*/NumParallelJobs > 1 ? true : CLANG_SPAWN_CC1);
 
   if (!DiagOpts->DiagnosticSerializationFile.empty()) {
     auto SerializedConsumer =


### PR DESCRIPTION
Remove the downstream --parallel-jobs implementation (driver-level parallel cc1 execution via JobScheduler) and make --parallel-jobs a simple alias to --offload-jobs, which is the upstream equivalent that controls thread count in clang-linker-wrapper.

This reduces the downstream diff by ~155 lines.


