### PR TITLE
Fix Integer Type Errors

### DIFF
--- a/clang/lib/Headers/__clang_hip_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_hip_runtime_wrapper.h
@@ -48,9 +48,7 @@ extern "C" {
   }
 }
 
-#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
 #undef _GLIBCXX_USE_C99_INTTYPES_TR1
-#endif
 
 #endif //__cplusplus
 
@@ -116,7 +114,6 @@ __attribute__((weak)) inline __device__ void free(void *__ptr) {
 #endif //__cplusplus
 
 #if !defined(__HIPCC_RTC__)
-#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
 namespace std
 {
   typedef unsigned long int size_t;
@@ -127,7 +124,6 @@ typedef unsigned int uint32_t;
 typedef unsigned short uint16_t;
 typedef unsigned char uint8_t;
 #define __SIZE_TYPE__ size_t
-#endif
 #include <cmath>
 #include <stdlib.h>
 #if __has_include("hip/hip_version.h")
@@ -164,7 +160,6 @@ typedef unsigned char uint8_t;
 #include <__clang_hip_cmath.h>
 #include <__clang_cuda_complex_builtins.h>
 #include <algorithm>
-#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
 #define int_least8_t __int_least8_t
 #define int_least16_t __int_least16_t
 #define int_least32_t __int_least32_t
@@ -192,7 +187,6 @@ typedef unsigned char uint8_t;
 #define SCNu64 "lu"
 #include <complex>
 #include <new>
-#endif
 
 #endif // __HIPCC_RTC__
 

--- a/clang/lib/Headers/__clang_hip_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_hip_runtime_wrapper.h
@@ -47,6 +47,11 @@ extern "C" {
     __builtin_trap();
   }
 }
+
+#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
+#undef _GLIBCXX_USE_C99_INTTYPES_TR1
+#endif
+
 #endif //__cplusplus
 
 #if !defined(__HIPCC_RTC__)
@@ -111,14 +116,25 @@ __attribute__((weak)) inline __device__ void free(void *__ptr) {
 #endif //__cplusplus
 
 #if !defined(__HIPCC_RTC__)
+#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
+namespace std
+{
+  typedef unsigned long int size_t;
+}
+using std::size_t;
+typedef unsigned long int uint64_t;
+typedef unsigned int uint32_t;
+typedef unsigned short uint16_t;
+typedef unsigned char uint8_t;
+#define __SIZE_TYPE__ size_t
+#endif
 #include <cmath>
-#include <cstdlib>
 #include <stdlib.h>
 #if __has_include("hip/hip_version.h")
 #include "hip/hip_version.h"
 #endif // __has_include("hip/hip_version.h")
 #else
-typedef __SIZE_TYPE__ size_t;
+#define __SIZE_TYPE__ size_t
 // Define macros which are needed to declare HIP device API's without standard
 // C/C++ headers. This is for readability so that these API's can be written
 // the same way as non-hipRTC use case. These macros need to be popped so that
@@ -148,8 +164,36 @@ typedef __SIZE_TYPE__ size_t;
 #include <__clang_hip_cmath.h>
 #include <__clang_cuda_complex_builtins.h>
 #include <algorithm>
+#if __GLIBC__ < 3 && __GLIBC__MINOR__ < 39
+#define int_least8_t __int_least8_t
+#define int_least16_t __int_least16_t
+#define int_least32_t __int_least32_t
+#define int_least64_t __int_least64_t
+#define uint_least8_t __uint_least8_t 
+#define uint_least16_t __uint_least16_t 
+#define uint_least32_t __uint_least32_t 
+#define uint_least64_t __uint_least64_t 
+#define int_fast8_t __int_least8_t
+#define int_fast16_t __int_least16_t
+#define int_fast32_t __int_least32_t
+#define int_fast64_t __int_least64_t
+#define uint_fast8_t __uint_least8_t 
+#define uint_fast16_t __uint_least16_t 
+#define uint_fast32_t __uint_least32_t 
+#define uint_fast64_t __uint_least64_t
+#define intmax_t __intmax_t
+#define uintmax_t __uintmax_t
+#define intptr_t int64_t
+#define uintptr_t uint64_t
+#define UINTPTR_MAX 0xFFFFFFFFFFFFFFFFUL
+#define SCNd32 "d"
+#define SCNu32 "u"
+#define SCNd64 "l"
+#define SCNu64 "lu"
 #include <complex>
 #include <new>
+#endif
+
 #endif // __HIPCC_RTC__
 
 #define __CLANG_HIP_RUNTIME_WRAPPER_INCLUDED__ 1


### PR DESCRIPTION
A recent change to LLVM is causing missing integer type errors on Linux with GCC 12, GCC 15, and probably other versions.  This is part of a series of PRs to address that issue.

The root cause is probably the fact that we partially-but-not-completely have our own C standard library separate from the host library, but that's not something that can be avoided.

The #if guards are probably unnecessary; will fix if there's interest in pursuing this.