### PR TITLE
[Comgr] Fix metadata merge failure when multiple notes have amdhsa.printf

### DIFF
--- a/amd/comgr/src/comgr-metadata.cpp
+++ b/amd/comgr/src/comgr-metadata.cpp
@@ -61,9 +61,13 @@ getELFObjectFileBase(DataObject *DataP) {
 
 // Try to merge "amdhsa.kernels" from DocNode @p From to @p To.
 // The merge is allowed only if
-// 1. "amdhsa.printf" record is not existing in either of the nodes.
-// 2. "amdhsa.version" exists and is same.
-// 3. "amdhsa.kernels" exists in both nodes.
+// 1. "amdhsa.version" exists and is same.
+// 2. "amdhsa.kernels" exists in both nodes.
+//
+// "amdhsa.printf" is copied from @p From if @p To doesn't have it.
+// If both have it, the merge is allowed only if they are identical
+// (as expected from LTO partitions sharing the same module-level
+// llvm.printf.fmts metadata).
 //
 // If merge is possible the function merges Kernel records
 // to @p To and returns @c true.
@@ -83,13 +87,12 @@ bool mergeNoteRecords(llvm::msgpack::DocNode &From, llvm::msgpack::DocNode &To,
   assert(To.isMap());
 
   if (From.getMap().find(PrintfStrKey) != From.getMap().end()) {
-    /* Check if both have Printf records */
     if (To.getMap().find(PrintfStrKey) != To.getMap().end()) {
-      return false;
+      if (From.getMap()[PrintfStrKey] != To.getMap()[PrintfStrKey])
+        return false;
+    } else {
+      To.getMap()[PrintfStrKey] = From.getMap()[PrintfStrKey];
     }
-
-    /* Add Printf record for 'To' */
-    To.getMap()[PrintfStrKey] = From.getMap()[PrintfStrKey];
   }
 
   auto &FromMapNode = From.getMap();


### PR DESCRIPTION
With the new offload driver, LLD uses --lto-partitions=8, splitting the device module into multiple LTO partitions. Each partition is compiled independently by the AMDGPU backend, producing its own NT_AMDGPU_METADATA note. When -mprintf-kind=buffered is used, every note contains an amdhsa.printf section.

The amdhsa.printf content is identical across all partitions because SplitModule uses CloneModule, which copies all named metadata (including llvm.printf.fmts) to every partition. The AMDGPU backend's emitPrintf() then emits the full format string list into each partition's note.

mergeNoteRecords() previously rejected the merge when both the accumulated root and the incoming note had amdhsa.printf, causing only the first partition's kernel to be visible. All subsequent kernels triggered "Cannot find Symbol" at runtime.

Fix by allowing the merge when both notes have identical amdhsa.printf, and rejecting only when they differ to preserve correctness.

Fixes: LCOMPILER-553

Continuation of #1665 (moved branch to ROCm repo for RockCI compatibility). Previously approved by @lamb-j.
