### PR TITLE
device-libs: Move trig edge case to input

### DIFF
--- a/amd/device-libs/ocml/src/cosD.cl
+++ b/amd/device-libs/ocml/src/cosD.cl
@@ -11,7 +11,11 @@
 double
 MATH_MANGLE(cos)(double x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
+
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred2)(r.hi, r.lo);
     sc.s = -sc.s;
@@ -19,12 +23,6 @@ MATH_MANGLE(cos)(double x)
     long c = AS_LONG((r.i & 1) != 0 ? sc.s : sc.c);
     c ^= r.i > 1 ? SIGNBIT_DP64 : 0;
 
-    double s = AS_DOUBLE(c);
-
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F64(ax) ? s : QNAN_F64;
-    }
-
-    return s;
+    return AS_DOUBLE(c);
 }
 

--- a/amd/device-libs/ocml/src/cosF.cl
+++ b/amd/device-libs/ocml/src/cosF.cl
@@ -11,6 +11,9 @@
 float
 MATH_MANGLE(cos)(float x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
 
     struct redret r = MATH_PRIVATE(trigred)(ax);
@@ -25,10 +28,5 @@ MATH_MANGLE(cos)(float x)
     float c =  (r.i & 1) != 0 ? sc.s : sc.c;
     c = AS_FLOAT(AS_INT(c) ^ (r.i > 1 ? SIGNBIT_SP32 : 0));
 
-    if (!FINITE_ONLY_OPT()) {
-        c = BUILTIN_ISFINITE_F32(ax) ? c : QNAN_F32;
-    }
-
     return c;
 }
-

--- a/amd/device-libs/ocml/src/cosH.cl
+++ b/amd/device-libs/ocml/src/cosH.cl
@@ -13,6 +13,9 @@ UGEN(cos)
 half
 MATH_MANGLE(cos)(half x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     half ax = BUILTIN_ABS_F16(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred)(r.hi);
@@ -22,10 +25,6 @@ MATH_MANGLE(cos)(half x)
 
     short flip = r.i > 1 ? (short)SIGNBIT_HP16 : 0;
     c = AS_HALF((short)(AS_SHORT(c) ^ flip));
-
-    if (!FINITE_ONLY_OPT()) {
-        c = BUILTIN_ISFINITE_F16(ax) ? c : QNAN_F16;
-    }
 
     return c;
 }

--- a/amd/device-libs/ocml/src/cospiD.cl
+++ b/amd/device-libs/ocml/src/cospiD.cl
@@ -11,6 +11,9 @@
 double
 MATH_MANGLE(cospi)(double x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
     struct redret r = MATH_PRIVATE(trigpired)(ax);
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
@@ -19,12 +22,6 @@ MATH_MANGLE(cospi)(double x)
     long c = AS_LONG((r.i & 1) != 0 ? sc.s : sc.c);
     c ^= r.i > 1 ? SIGNBIT_DP64 : 0;
 
-    double s = AS_DOUBLE(c);
-
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F64(ax) ? s : QNAN_F64;
-    }
-
-    return s;
+    return AS_DOUBLE(c);
 }
 

--- a/amd/device-libs/ocml/src/cospiF.cl
+++ b/amd/device-libs/ocml/src/cospiF.cl
@@ -11,6 +11,9 @@
 CONSTATTR float
 MATH_MANGLE(cospi)(float x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
     struct redret r = MATH_PRIVATE(trigpired)(ax);
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
@@ -18,10 +21,6 @@ MATH_MANGLE(cospi)(float x)
 
     float c = (r.i & 1) != 0 ? sc.s : sc.c;
     c = r.i > 1 ? -c : c;
-
-    if (!FINITE_ONLY_OPT() && !BUILTIN_ISFINITE_F32(ax)) {
-        c = QNAN_F32;
-    }
 
     return c;
 }

--- a/amd/device-libs/ocml/src/cospiH.cl
+++ b/amd/device-libs/ocml/src/cospiH.cl
@@ -13,6 +13,9 @@ UGEN(cospi)
 half
 MATH_MANGLE(cospi)(half x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     half ax = BUILTIN_ABS_F16(x);
     struct redret r = MATH_PRIVATE(trigpired)(ax);
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
@@ -20,10 +23,6 @@ MATH_MANGLE(cospi)(half x)
 
     half c = (r.i & (short)1) == (short)0 ? sc.c : sc.s;
     c = r.i > (short)1 ? -c : c;
-
-    if (!FINITE_ONLY_OPT() && !BUILTIN_ISFINITE_F16(ax)) {
-        c = QNAN_F16;
-    }
 
     return c;
 }

--- a/amd/device-libs/ocml/src/sinD.cl
+++ b/amd/device-libs/ocml/src/sinD.cl
@@ -11,7 +11,11 @@
 CONSTATTR double
 MATH_MANGLE(sin)(double x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
+
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred2)(r.hi, r.lo);
 
@@ -19,9 +23,6 @@ MATH_MANGLE(sin)(double x)
 
     s = AS_DOUBLE(AS_LONG(s) ^ (r.i > 1 ? SIGNBIT_DP64 : 0) ^
                   (AS_LONG(x) ^ AS_LONG(ax)));
-
-    if (!FINITE_ONLY_OPT())
-        s = BUILTIN_ISFINITE_F64(ax) ? s : QNAN_F64;
 
     return s;
 }

--- a/amd/device-libs/ocml/src/sinF.cl
+++ b/amd/device-libs/ocml/src/sinF.cl
@@ -11,6 +11,9 @@
 float
 MATH_MANGLE(sin)(float x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
 
     struct redret r = MATH_PRIVATE(trigred)(ax);
@@ -25,10 +28,5 @@ MATH_MANGLE(sin)(float x)
     s = AS_FLOAT(AS_INT(s) ^ (r.i > 1 ? SIGNBIT_SP32 : 0) ^
                  (AS_INT(x) ^ AS_INT(ax)));
 
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F32(ax) ? s : QNAN_F32;
-    }
-
     return s;
 }
-

--- a/amd/device-libs/ocml/src/sinH.cl
+++ b/amd/device-libs/ocml/src/sinH.cl
@@ -13,6 +13,9 @@ UGEN(sin)
 half
 MATH_MANGLE(sin)(half x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     half ax = BUILTIN_ABS_F16(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc =  MATH_PRIVATE(sincosred)(r.hi);
@@ -21,10 +24,6 @@ MATH_MANGLE(sin)(half x)
     short flip = r.i > (short)1 ? (short)SIGNBIT_HP16 : (short)0;
 
     s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ (AS_SHORT(x) & (short)SIGNBIT_HP16))));
-
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F16(ax) ? s : QNAN_F16;
-    }
 
     return AS_HALF(s);
 }

--- a/amd/device-libs/ocml/src/sincosD.cl
+++ b/amd/device-libs/ocml/src/sincosD.cl
@@ -11,6 +11,9 @@
 double
 MATH_MANGLE(sincos)(double x, __private double * cp)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred2)(r.hi, r.lo);
@@ -24,12 +27,6 @@ MATH_MANGLE(sincos)(double x, __private double * cp)
 
     double c = odd ? sc.s : sc.c;
     c = AS_DOUBLE(AS_LONG(c) ^ flip);
-
-    if (!FINITE_ONLY_OPT()) {
-        bool finite = BUILTIN_ISFINITE_F64(x);
-        s = finite ? s : QNAN_F64;
-        c = finite ? c : QNAN_F64;
-    }
 
     *cp = c;
     return s;

--- a/amd/device-libs/ocml/src/sincosF.cl
+++ b/amd/device-libs/ocml/src/sincosF.cl
@@ -11,6 +11,9 @@
 float
 MATH_MANGLE(sincos)(float x, __private float *cp)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
 
     struct redret r = MATH_PRIVATE(trigred)(ax);
@@ -28,12 +31,6 @@ MATH_MANGLE(sincos)(float x, __private float *cp)
     sc.s = -sc.s;
     float c = odd ? sc.s : sc.c;
     c = AS_FLOAT(AS_INT(c) ^ flip);
-
-    if (!FINITE_ONLY_OPT()) {
-        bool finite = BUILTIN_ISFINITE_F32(ax);
-        c = finite ? c : QNAN_F32;
-        s = finite ? s : QNAN_F32;
-    }
 
     *cp = c;
     return s;

--- a/amd/device-libs/ocml/src/sincosH.cl
+++ b/amd/device-libs/ocml/src/sincosH.cl
@@ -22,6 +22,9 @@ MATH_MANGLE2(sincos)(half2 x, __private half2 *cp)
 CONSTATTR half
 MATH_MANGLE(sincos)(half x, __private half *cp)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     half ax = BUILTIN_ABS_F16(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
     struct scret sc = MATH_PRIVATE(sincosred)(r.hi);
@@ -35,12 +38,6 @@ MATH_MANGLE(sincos)(half x, __private half *cp)
     sc.s = -sc.s;
     half c = odd ? sc.s : sc.c;
     c = AS_HALF((short)(AS_SHORT(c) ^ flip));
-
-    if (!FINITE_ONLY_OPT()) {
-        bool finite = BUILTIN_ISFINITE_F16(ax);
-        c = finite ? c : QNAN_F16;
-        s = finite ? s : QNAN_F16;
-    }
 
     *cp = c;
     return s;

--- a/amd/device-libs/ocml/src/sincospiD.cl
+++ b/amd/device-libs/ocml/src/sincospiD.cl
@@ -11,6 +11,9 @@
 double
 MATH_MANGLE(sincospi)(double x, __private double * cp)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F64(x));
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
@@ -24,12 +27,6 @@ MATH_MANGLE(sincospi)(double x, __private double * cp)
 
     double c = odd ? sc.s : sc.c;
     c = AS_DOUBLE(AS_LONG(c) ^ flip);
-
-    if (!FINITE_ONLY_OPT()) {
-        bool finite = BUILTIN_ISFINITE_F64(x);
-        s = finite ? s : QNAN_F64;
-        c = finite ? c : QNAN_F64;
-    }
 
     *cp = c;
     return s;

--- a/amd/device-libs/ocml/src/sincospiF.cl
+++ b/amd/device-libs/ocml/src/sincospiF.cl
@@ -11,6 +11,9 @@
 float
 MATH_MANGLE(sincospi)(float x, __private float *cp)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
 
     struct redret r = MATH_PRIVATE(trigpired)(ax);
@@ -23,12 +26,6 @@ MATH_MANGLE(sincospi)(float x, __private float *cp)
     sc.s = -sc.s;
     float c = odd ? sc.s : sc.c;
     c = AS_FLOAT(AS_INT(c) ^ flip);
-
-    if (!FINITE_ONLY_OPT()) {
-        bool finite = BUILTIN_ISFINITE_F32(ax);
-        c = finite ? c : QNAN_F32;
-        s = finite ? s : QNAN_F32;
-    }
 
     *cp = c;
     return s;

--- a/amd/device-libs/ocml/src/sincospiH.cl
+++ b/amd/device-libs/ocml/src/sincospiH.cl
@@ -23,6 +23,9 @@ MATH_MANGLE2(sincospi)(half2 x, __private half2 *cp)
 half
 MATH_MANGLE(sincospi)(half x, __private half *cp)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
@@ -34,12 +37,6 @@ MATH_MANGLE(sincospi)(half x, __private half *cp)
 
     sc.s = -sc.s;
     half c = AS_HALF((short)(AS_SHORT(odd ? sc.s : sc.c) ^ flip));
-
-    if (!FINITE_ONLY_OPT()) {
-        bool finite = BUILTIN_ISFINITE_F16(x);
-        c = finite ? c : QNAN_F16;
-        s = finite ? s : QNAN_F16;
-    }
 
     *cp = c;
     return s;

--- a/amd/device-libs/ocml/src/sinpiD.cl
+++ b/amd/device-libs/ocml/src/sinpiD.cl
@@ -11,6 +11,9 @@
 double
 MATH_MANGLE(sinpi)(double x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
     struct redret r = MATH_PRIVATE(trigpired)(ax);
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
@@ -19,9 +22,6 @@ MATH_MANGLE(sinpi)(double x)
 
     s = AS_DOUBLE(AS_LONG(s) ^ (r.i > 1 ? SIGNBIT_DP64 : 0) ^
                   (AS_LONG(x) ^ AS_LONG(ax)));
-
-    if (!FINITE_ONLY_OPT())
-        s = BUILTIN_ISFINITE_F64(x) ? s : QNAN_F64;
 
     return s;
 }

--- a/amd/device-libs/ocml/src/sinpiF.cl
+++ b/amd/device-libs/ocml/src/sinpiF.cl
@@ -11,16 +11,15 @@
 CONSTATTR float
 MATH_MANGLE(sinpi)(float x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
     struct redret r = MATH_PRIVATE(trigpired)(ax);
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
     float s = (r.i & 1) == 0 ? sc.s : sc.c;
     s = AS_FLOAT(AS_INT(s) ^ (r.i > 1 ? SIGNBIT_SP32 : 0) ^ (AS_INT(x) ^ AS_INT(ax)));
-
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F32(ax) ? s : QNAN_F32;
-    }
 
     return s;
 }

--- a/amd/device-libs/ocml/src/sinpiH.cl
+++ b/amd/device-libs/ocml/src/sinpiH.cl
@@ -13,17 +13,16 @@ UGEN(sinpi)
 half
 MATH_MANGLE(sinpi)(half x)
 {
-    struct redret r =  MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
+    struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
     struct scret sc = MATH_PRIVATE(sincospired)(r.hi);
 
     half s = (r.i & (short)1) == (short)0 ? sc.s : sc.c;
     short flip = r.i > (short)1 ? (short)SIGNBIT_HP16 : (short)0;
 
     s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ (AS_SHORT(x) ^ (short)SIGNBIT_HP16))));
-
-    if (!FINITE_ONLY_OPT()) {
-        s = BUILTIN_ISFINITE_F16(x) ? s : QNAN_F16;
-    }
 
     return s;
 }

--- a/amd/device-libs/ocml/src/tanD.cl
+++ b/amd/device-libs/ocml/src/tanD.cl
@@ -11,15 +11,15 @@
 CONSTATTR double
 MATH_MANGLE(tan)(double x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
+
     struct redret r = MATH_PRIVATE(trigred)(ax);
 
     double t = MATH_PRIVATE(tanred2)(r.hi, r.lo, r.i & 1);
     t = AS_DOUBLE(AS_LONG(t) ^ (AS_LONG(x) & SIGNBIT_DP64));
-
-    if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F64(ax) ? t : QNAN_F64;
-    }
 
     return AS_DOUBLE(t);
 }

--- a/amd/device-libs/ocml/src/tanF.cl
+++ b/amd/device-libs/ocml/src/tanF.cl
@@ -11,6 +11,9 @@
 float
 MATH_MANGLE(tan)(float x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     float ax = BUILTIN_ABS_F32(x);
 
     struct redret r = MATH_PRIVATE(trigred)(ax);
@@ -22,10 +25,6 @@ MATH_MANGLE(tan)(float x)
 #endif
 
     t = AS_FLOAT(AS_INT(t) ^ (AS_INT(x) ^ AS_INT(ax)));
-
-    if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F32(ax) ? t : QNAN_F32;
-    }
 
     return t;
 }

--- a/amd/device-libs/ocml/src/tanH.cl
+++ b/amd/device-libs/ocml/src/tanH.cl
@@ -13,15 +13,14 @@ UGEN(tan)
 half
 MATH_MANGLE(tan)(half x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     half ax = BUILTIN_ABS_F16(x);
     struct redret r = MATH_PRIVATE(trigred)(ax);
     half t = MATH_PRIVATE(tanred)(r.hi, r.i & (short)1);
 
     t = AS_HALF((short)(AS_SHORT(t) ^ (AS_SHORT(x) & SIGNBIT_HP16)));
-
-    if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F16(ax) ? t : QNAN_F16;
-    }
 
     return t;
 }

--- a/amd/device-libs/ocml/src/tanpiD.cl
+++ b/amd/device-libs/ocml/src/tanpiD.cl
@@ -11,18 +11,15 @@
 CONSTATTR double
 MATH_MANGLE(tanpi)(double x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
+
     double ax = BUILTIN_ABS_F64(x);
     struct redret r = MATH_PRIVATE(trigpired)(ax);
     double t = MATH_PRIVATE(tanpired)(r.hi, r.i & 1);
 
     long flip = (((r.i == 1) | (r.i == 2)) & (r.hi == 0.0)) ? SIGNBIT_DP64 : 0;
 
-    t = AS_DOUBLE((AS_LONG(t) ^ flip) ^ (AS_LONG(x) & SIGNBIT_DP64));
-
-    if (!FINITE_ONLY_OPT()) {
-        t =  BUILTIN_ISFINITE_F64(x) ? t : QNAN_F64;
-    }
-
-    return t;
+    return AS_DOUBLE((AS_LONG(t) ^ flip) ^ (AS_LONG(x) & SIGNBIT_DP64));
 }
 

--- a/amd/device-libs/ocml/src/tanpiF.cl
+++ b/amd/device-libs/ocml/src/tanpiF.cl
@@ -11,14 +11,13 @@
 CONSTATTR float
 MATH_MANGLE(tanpi)(float x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
+
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F32(x));
     float t = MATH_PRIVATE(tanpired)(r.hi, r.i & 1);
     int flip = (((r.i == 1) | (r.i == 2)) & (r.hi == 0.0f)) ? SIGNBIT_SP32 : 0;
     t = AS_FLOAT((AS_INT(t) ^ flip) ^ (AS_INT(x) & SIGNBIT_SP32));
-
-    if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F32(x) ? t : QNAN_F32;
-    }
 
     return t;
 }

--- a/amd/device-libs/ocml/src/tanpiH.cl
+++ b/amd/device-libs/ocml/src/tanpiH.cl
@@ -13,15 +13,14 @@ CONSTATTR UGEN(tanpi)
 CONSTATTR half
 MATH_MANGLE(tanpi)(half x)
 {
+    if (!FINITE_ONLY_OPT())
+        x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
+
     struct redret r = MATH_PRIVATE(trigpired)(BUILTIN_ABS_F16(x));
 
     half t = MATH_PRIVATE(tanpired)(r.hi, r.i & (short)1);
     short flip = (((r.i == (short)1) | (r.i == (short)2)) & (r.hi == 0.0h)) ? (short)SIGNBIT_HP16 : (short)0;
     t = AS_HALF((short)((AS_SHORT(t) ^ flip) ^ (AS_SHORT(x) & (short)SIGNBIT_HP16)));
-
-    if (!FINITE_ONLY_OPT()) {
-        t = BUILTIN_ISFINITE_F16(x) ? t : QNAN_F16;
-    }
 
     return t;
 }


### PR DESCRIPTION
Clamp infinities to nan on the input, instead of at the result. This allows the use code to see it doesn't need to handle infinities. This also reduces instruction count in the sincos cases.


