### PR TITLE
[Comgr] Remove cov5 default for SPIRV compilation

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -2192,9 +2192,6 @@ amd_comgr_status_t AMDGPUCompiler::extractSpirvFlags(DataSet *BcSet) {
       }
     }
 
-    // COV5 required for SPIR-V
-    Bc->SpirvFlags.push_back("-mcode-object-version=5");
-
     if (env::shouldEmitVerboseLogs()) {
       LogS << "        SPIR-V Flags: " << Bc->Name << "\n";
       for (auto Flag : Bc->SpirvFlags)

--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc.hip
@@ -14,7 +14,6 @@
 // RUN: grep '\-fexceptions' spirv-flags.txt
 // RUN: grep '\-fcolor-diagnostics' spirv-flags.txt
 // RUN: grep '\-O3' spirv-flags.txt
-// RUN: grep '\-mcode-object-version=5' spirv-flags.txt
 
 // RUN: rm spirv-flags.txt
 


### PR DESCRIPTION
We no longer need to enforce this, and can use the default set in the original clang invocation.


