### PR TITLE
[flang][MLIR] Un-xfail `omp-map-info-finalization-usm.fir` and `omptarget-device-shared-memory.mlir`

### DIFF
--- a/flang/test/Transforms/omp-map-info-finalization-usm.fir
+++ b/flang/test/Transforms/omp-map-info-finalization-usm.fir
@@ -1,5 +1,4 @@
 // RUN: fir-opt --split-input-file --omp-map-info-finalization %s | FileCheck %s
-// XFAIL: *
 // Test that the 'close' map flag is cleared from member maps if the parent map
 // (derived type) does not have the 'close' flag. This typically happens in
 // Unified Shared Memory (USM) mode where the parent is in USM (no close) but
@@ -19,6 +18,6 @@ module attributes {omp.requires = #omp<clause_requires unified_shared_memory>} {
 }
 
 // CHECK-LABEL: func.func @test_usm_close_flag_cleanup
-// CHECK: %[[MEMBER:.*]] = omp.map.info {{.*}} map_clauses(always, to) {{.*}} {name = "parent.a.implicit_map"}
+// CHECK: %[[MEMBER:.*]] = omp.map.info {{.*}} map_clauses(always, descriptor, to) {{.*}} {name = "parent.a.implicit_map"}
 // CHECK: %[[PARENT:.*]] = omp.map.info {{.*}} map_clauses(to) {{.*}} members(%[[MEMBER]], {{.*}}) {{.*}} {name = "parent", {{.*}}}
 // CHECK-NOT: close

--- a/mlir/test/Target/LLVMIR/omptarget-device-shared-memory.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-device-shared-memory.mlir
@@ -1,5 +1,4 @@
 // RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
-// XFAIL: *
 // This test checks that, when compiling for an offloading target, device shared
 // memory will be used in place of allocas for certain private variables.
 
@@ -59,8 +58,6 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memo
     // CHECK-NEXT: call void @[[OUTLINED_TEAMS:__omp_offloading_[A-Za-z0-9_.]*]](ptr %structArg.ascast)
 
     // CHECK: [[REDUCE_FINALIZE_BB:reduce\.finalize.*]]:
-    // CHECK-NEXT: %{{.*}} = call i32 @__kmpc_global_thread_num
-    // CHECK-NEXT: call void @__kmpc_barrier
     // CHECK-NEXT: call void @__kmpc_free_shared(ptr %[[X_PRIV]], i64 4)
 
     // CHECK: define internal void @[[OUTLINED_TEAMS]]


### PR DESCRIPTION
Un-xfails 2 tests that were disabled with the latest merge.


