### PR TITLE
[Flang] Provide option to use heap allocation for private adjustable arrays

### DIFF
--- a/flang/lib/Lower/Support/PrivateReductionUtils.cpp
+++ b/flang/lib/Lower/Support/PrivateReductionUtils.cpp
@@ -27,8 +27,14 @@
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "flang/Optimizer/Support/FatalError.h"
 #include "flang/Semantics/symbol.h"
+#include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Location.h"
+
+static llvm::cl::opt<bool> enableGPUHeapAlloc("enable-gpu-heap-alloc",
+    llvm::cl::desc(
+        "Allow to use heap alloc for adjustable arrays on GPU"),
+    llvm::cl::init(false));
 
 static bool hasFinalization(const Fortran::semantics::Symbol &sym) {
   if (sym.has<Fortran::semantics::ObjectEntityDetails>())
@@ -383,7 +389,7 @@ private:
     return loadedMoldArg;
   }
 
-  bool shouldAllocateTempOnStack() const;
+  bool shouldAllocateTempOnStack(fir::BaseBoxType boxTy) const;
 };
 
 } // namespace
@@ -446,7 +452,7 @@ void PopulateInitAndCleanupRegionsHelper::initAndCleanupBoxedScalar(
     builder.setInsertionPointToStart(&ifUnallocated.getElseRegion().front());
   }
 
-  bool shouldAllocateOnStack = shouldAllocateTempOnStack();
+  bool shouldAllocateOnStack = shouldAllocateTempOnStack(boxTy);
   mlir::Value valAlloc =
       (shouldAllocateOnStack)
           ? builder.createTemporary(loc, innerTy, /*name=*/{},
@@ -477,12 +483,21 @@ void PopulateInitAndCleanupRegionsHelper::initAndCleanupBoxedScalar(
   createYield(allocatedPrivVarArg);
 }
 
-bool PopulateInitAndCleanupRegionsHelper::shouldAllocateTempOnStack() const {
-  // On the GPU, always allocate on the stack since heap allocatins are very
-  // expensive.
+bool PopulateInitAndCleanupRegionsHelper::shouldAllocateTempOnStack(fir::BaseBoxType boxTy) const {
   auto offloadMod =
       llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(*builder.getModule());
-  return offloadMod && offloadMod.getIsGPU();
+  // On the GPU, always allocate on the stack unless the user explicitly
+  // specifies otherwise since heap allocatins are very expensive.
+  bool isGPU = offloadMod && offloadMod.getIsGPU();
+  if (isGPU && enableGPUHeapAlloc) {
+     // Check if it is adjustable array
+     if(auto seqTy = mlir::dyn_cast<fir::SequenceType>(boxTy.getEleTy())) {
+        if (seqTy.hasUnknownShape()|| seqTy.hasDynamicExtents()) {
+           return false;
+        }
+     }
+  }
+  return isGPU;
 }
 
 void PopulateInitAndCleanupRegionsHelper::initAndCleanupBoxedArray(
@@ -527,7 +542,7 @@ void PopulateInitAndCleanupRegionsHelper::initAndCleanupBoxedArray(
   // TODO: Allocate on the heap if the whole reduction/privatization is nested
   // inside of a loop
   auto temp = [&]() {
-    if (shouldAllocateTempOnStack())
+    if (shouldAllocateTempOnStack(boxTy))
       return createStackTempFromMold(loc, builder, source);
 
     auto [temp, needsDealloc] = createTempFromMold(loc, builder, source);

--- a/flang/lib/Lower/Support/PrivateReductionUtils.cpp
+++ b/flang/lib/Lower/Support/PrivateReductionUtils.cpp
@@ -27,13 +27,13 @@
 #include "flang/Optimizer/HLFIR/HLFIROps.h"
 #include "flang/Optimizer/Support/FatalError.h"
 #include "flang/Semantics/symbol.h"
-#include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
 #include "mlir/IR/Location.h"
+#include "llvm/Support/CommandLine.h"
 
-static llvm::cl::opt<bool> enableGPUHeapAlloc("enable-gpu-heap-alloc",
-    llvm::cl::desc(
-        "Allow to use heap alloc for adjustable arrays on GPU"),
+static llvm::cl::opt<bool> enableGPUHeapAlloc(
+    "enable-gpu-heap-alloc",
+    llvm::cl::desc("Allow to use heap alloc for adjustable arrays on GPU"),
     llvm::cl::init(false));
 
 static bool hasFinalization(const Fortran::semantics::Symbol &sym) {
@@ -483,19 +483,20 @@ void PopulateInitAndCleanupRegionsHelper::initAndCleanupBoxedScalar(
   createYield(allocatedPrivVarArg);
 }
 
-bool PopulateInitAndCleanupRegionsHelper::shouldAllocateTempOnStack(fir::BaseBoxType boxTy) const {
+bool PopulateInitAndCleanupRegionsHelper::shouldAllocateTempOnStack(
+    fir::BaseBoxType boxTy) const {
   auto offloadMod =
       llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(*builder.getModule());
   // On the GPU, always allocate on the stack unless the user explicitly
   // specifies otherwise since heap allocatins are very expensive.
   bool isGPU = offloadMod && offloadMod.getIsGPU();
   if (isGPU && enableGPUHeapAlloc) {
-     // Check if it is adjustable array
-     if(auto seqTy = mlir::dyn_cast<fir::SequenceType>(boxTy.getEleTy())) {
-        if (seqTy.hasUnknownShape()|| seqTy.hasDynamicExtents()) {
-           return false;
-        }
-     }
+    // Check if it is adjustable array
+    if (auto seqTy = mlir::dyn_cast<fir::SequenceType>(boxTy.getEleTy())) {
+      if (seqTy.hasUnknownShape() || seqTy.hasDynamicExtents()) {
+        return false;
+      }
+    }
   }
   return isGPU;
 }


### PR DESCRIPTION
The size of adjustable Fortran arrays is not known at compilation time. Using limited GPU stack memory may cause hard-to-debug errors. On the other hand, switching to heap memory allocation may lead to missed optimization opportunities and significantly increased kernel execution time.

Adding the option `-mmlir --enable-gpu-heap-alloc` allows the user to generate valid code for adjustable Fortran arrays. The flag is off by default, so there is no efficiency penalty for code that does not use adjustable arrays.