### PR TITLE
[WaveTransform] Fix illegal VGPR to SGPR copy crash

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -321,8 +321,7 @@ bool Vreg1WideningHelper::widenVreg1s() {
         // Convert vgpr_32 back to lane mask in the predecessor block.
         MachineBasicBlock *PredMBB = MI.getOperand(I + 1).getMBB();
         Register LaneMaskReg = MRI->createVirtualRegister(
-            IsWave32 ? &AMDGPU::SReg_32_XM0_XEXECRegClass
-                     : &AMDGPU::SReg_64_XEXECRegClass);
+            TII->getRegisterInfo().getWaveMaskRegClass());
         BuildMI(*PredMBB, PredMBB->getFirstTerminator(), DebugLoc(),
                 TII->get(AMDGPU::V_CMP_NE_U32_e64), LaneMaskReg)
             .addReg(MI.getOperand(I).getReg())

--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -61,6 +61,10 @@ public:
   bool isVreg32(Register Reg) const {
     return Reg.isVirtual() && MRI->getRegClass(Reg) == &AMDGPU::VGPR_32RegClass;
   }
+  bool isLaneMaskReg(Register Reg) const {
+    return Reg.isVirtual() && MRI->getRegClass(Reg) ==
+                                  TII->getRegisterInfo().getWaveMaskRegClass();
+  }
 };
 
 Vreg1WideningHelper::Vreg1WideningHelper(MachineFunction *MF)

--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -308,6 +308,30 @@ bool Vreg1WideningHelper::widenVreg1s() {
       assert(isVreg32(DstReg));
   }
 
+  // Round#2b, fix PHIs with lane mask dst that received widened vgpr_32 operands.
+  for (MachineBasicBlock &MBB : *MF) {
+    for (MachineInstr &MI : MBB.phis()) {
+      // Skip instructions with no lane mask destination register (SGPR).
+      if (!isLaneMaskReg(MI.getOperand(0).getReg()))
+        continue;
+      for (unsigned I = 1; I < MI.getNumOperands(); I += 2) {
+        // Skip operands that were not widened by Round#1.
+        if (!Vreg32Set.count(MI.getOperand(I).getReg()))
+          continue;
+        // Convert vgpr_32 back to lane mask in the predecessor block.
+        MachineBasicBlock *PredMBB = MI.getOperand(I + 1).getMBB();
+        Register LaneMaskReg = MRI->createVirtualRegister(
+            IsWave32 ? &AMDGPU::SReg_32_XM0_XEXECRegClass
+                     : &AMDGPU::SReg_64_XEXECRegClass);
+        BuildMI(*PredMBB, PredMBB->getFirstTerminator(), DebugLoc(),
+                TII->get(AMDGPU::V_CMP_NE_U32_e64), LaneMaskReg)
+            .addReg(MI.getOperand(I).getReg())
+            .addImm(0);
+        MI.getOperand(I).setReg(LaneMaskReg);
+      }
+    }
+  }
+
   for (MachineInstr *MI : DeadCopies)
     MI->eraseFromParent();
   DeadCopies.clear();

--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -314,7 +314,9 @@ bool Vreg1WideningHelper::widenVreg1s() {
       // Skip instructions with no lane mask destination register (SGPR).
       if (!isLaneMaskReg(MI.getOperand(0).getReg()))
         continue;
+
       for (unsigned I = 1; I < MI.getNumOperands(); I += 2) {
+        assert(I + 1 < MI.getNumOperands());
         // Skip operands that were not widened by Round#1.
         if (!Vreg32Set.count(MI.getOperand(I).getReg()))
           continue;

--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -61,9 +61,19 @@ public:
   bool isVreg32(Register Reg) const {
     return Reg.isVirtual() && MRI->getRegClass(Reg) == &AMDGPU::VGPR_32RegClass;
   }
-  bool isLaneMaskReg(Register Reg) const {
-    return Reg.isVirtual() && MRI->getRegClass(Reg) ==
-                                  TII->getRegisterInfo().getWaveMaskRegClass();
+  bool isGenericSreg(Register Reg) const {
+    // return (MRI->getRegClass(Reg) == &AMDGPU::SGPR_32RegClass ||
+    //         MRI->getRegClass(Reg) == &AMDGPU::SGPR_64RegClass);
+    return PhiLoweringHelper::isLaneMaskReg(Reg);
+  }
+  bool isActualLaneMaskReg(Register Reg) const {
+    // return Reg.isVirtual() && MRI->getRegClass(Reg) ==
+    //                               TII->getRegisterInfo().getWaveMaskRegClass();
+    const TargetRegisterClass *WaveMaskRC =
+        TII->getRegisterInfo().getWaveMaskRegClass();
+    if (Reg.isVirtual())
+      return MRI->getRegClass(Reg) == WaveMaskRC;
+    return WaveMaskRC->contains(Reg);
   }
 };
 

--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -61,20 +61,6 @@ public:
   bool isVreg32(Register Reg) const {
     return Reg.isVirtual() && MRI->getRegClass(Reg) == &AMDGPU::VGPR_32RegClass;
   }
-  bool isGenericSreg(Register Reg) const {
-    // return (MRI->getRegClass(Reg) == &AMDGPU::SGPR_32RegClass ||
-    //         MRI->getRegClass(Reg) == &AMDGPU::SGPR_64RegClass);
-    return PhiLoweringHelper::isLaneMaskReg(Reg);
-  }
-  bool isActualLaneMaskReg(Register Reg) const {
-    // return Reg.isVirtual() && MRI->getRegClass(Reg) ==
-    //                               TII->getRegisterInfo().getWaveMaskRegClass();
-    const TargetRegisterClass *WaveMaskRC =
-        TII->getRegisterInfo().getWaveMaskRegClass();
-    if (Reg.isVirtual())
-      return MRI->getRegClass(Reg) == WaveMaskRC;
-    return WaveMaskRC->contains(Reg);
-  }
 };
 
 Vreg1WideningHelper::Vreg1WideningHelper(MachineFunction *MF)

--- a/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
+++ b/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
@@ -41,8 +41,7 @@ define amdgpu_ps void @main(i32 %0, float %1) {
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
 ; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
-; ISA-NEXT:    s_xor_b64 s[0:1], s[0:1], -1
-; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; ISA-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
 ; ISA-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
 ; ISA-NEXT:    s_xor_b64 s[0:1], exec, s[10:11]
 ; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
@@ -83,8 +82,7 @@ define amdgpu_ps void @main(i32 %0, float %1) {
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v1
-; ISA-NEXT:    s_xor_b64 s[0:1], vcc, -1
-; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; ISA-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], s[0:1]
 ; ISA-NEXT:    s_xor_b64 s[0:1], exec, s[4:5]
 ; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
@@ -174,8 +172,7 @@ define amdgpu_ps void @i1_copy_assert(i1 %v4) {
 ; ISA-NEXT:  .LBB1_1: ; %Flow
 ; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; ISA-NEXT:    s_xor_b64 s[10:11], vcc, -1
-; ISA-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; ISA-NEXT:    s_xor_b64 s[10:11], vcc, exec
 ; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
 ; ISA-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
 ; ISA-NEXT:    s_and_b64 s[10:11], s[10:11], exec

--- a/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
+++ b/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
@@ -23,60 +23,58 @@ define amdgpu_ps void @main(i32 %0, float %1) {
 ; ISA-NEXT:    s_mov_b64 s[0:1], -1
 ; ISA-NEXT:    v_interp_p1_f32_e32 v0, v1, attr0.x
 ; ISA-NEXT:    v_cmp_nlt_f32_e32 vcc, 0, v0
-; ISA-NEXT:    v_cndmask_b32_e64 v3, 0, -1, vcc
 ; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[0:1]
 ; ISA-NEXT:    s_mov_b64 s[0:1], 0
-; ISA-NEXT:    s_mov_b64 s[2:3], -1
-; ISA-NEXT:    s_mov_b64 s[2:3], 0
-; ISA-NEXT:    s_mov_b32 s14, 0
+; ISA-NEXT:    v_cndmask_b32_e64 v3, 0, -1, vcc
 ; ISA-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
-; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v3
+; ISA-NEXT:    s_mov_b64 s[0:1], -1
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:    s_mov_b32 s12, 0
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; ISA-NEXT:    s_mov_b64 s[8:9], 0
 ; ISA-NEXT:    s_mov_b64 s[4:5], 0
-; ISA-NEXT:    s_mov_b64 s[12:13], 0
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
 ; ISA-NEXT:    s_mov_b64 s[6:7], 0
 ; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    s_branch .LBB0_2
 ; ISA-NEXT:  .LBB0_1: ; %Flow
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
-; ISA-NEXT:    s_or_b64 exec, exec, s[12:13]
-; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; ISA-NEXT:    s_xor_b64 s[12:13], vcc, -1
-; ISA-NEXT:    s_and_b64 s[12:13], s[12:13], exec
-; ISA-NEXT:    s_or_b64 s[10:11], s[10:11], s[12:13]
-; ISA-NEXT:    s_xor_b64 s[12:13], exec, s[10:11]
-; ISA-NEXT:    s_and_b64 s[12:13], s[12:13], exec
-; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], s[12:13]
+; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
+; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
+; ISA-NEXT:    s_xor_b64 s[0:1], s[0:1], -1
+; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; ISA-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
+; ISA-NEXT:    s_xor_b64 s[0:1], exec, s[10:11]
+; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], s[0:1]
 ; ISA-NEXT:    s_mov_b64 exec, s[10:11]
-; ISA-NEXT:    s_mov_b64 s[12:13], 0
-; ISA-NEXT:    s_mov_b64 s[10:11], 0
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB0_5
 ; ISA-NEXT:  .LBB0_2: ; %loop
 ; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ISA-NEXT:    s_cmp_lt_u32 s14, 32
-; ISA-NEXT:    s_cselect_b64 s[16:17], -1, 0
 ; ISA-NEXT:    s_mov_b64 s[10:11], 0
+; ISA-NEXT:    s_cmp_lt_u32 s12, 32
 ; ISA-NEXT:    v_mov_b32_e32 v4, v1
 ; ISA-NEXT:    v_mov_b32_e32 v3, v1
-; ISA-NEXT:    s_and_b64 vcc, exec, s[16:17]
-; ISA-NEXT:    s_cbranch_vccz .LBB0_1
+; ISA-NEXT:    s_cbranch_scc0 .LBB0_1
 ; ISA-NEXT:  ; %bb.3: ; %endif1
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
-; ISA-NEXT:    s_and_b64 s[16:17], exec, s[0:1]
-; ISA-NEXT:    s_or_b64 s[8:9], s[8:9], s[16:17]
-; ISA-NEXT:    s_xor_b64 s[16:17], exec, s[8:9]
-; ISA-NEXT:    s_and_b64 s[16:17], s[16:17], exec
+; ISA-NEXT:    s_and_b64 s[14:15], exec, vcc
+; ISA-NEXT:    s_or_b64 s[8:9], s[8:9], s[14:15]
+; ISA-NEXT:    s_xor_b64 s[14:15], exec, s[8:9]
+; ISA-NEXT:    s_and_b64 s[14:15], s[14:15], exec
 ; ISA-NEXT:    v_mov_b32_e32 v4, v1
 ; ISA-NEXT:    v_mov_b32_e32 v3, v2
-; ISA-NEXT:    s_or_b64 s[12:13], s[12:13], s[16:17]
+; ISA-NEXT:    s_or_b64 s[0:1], s[0:1], s[14:15]
 ; ISA-NEXT:    s_mov_b64 exec, s[8:9]
 ; ISA-NEXT:    s_mov_b64 s[8:9], 0
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB0_1
 ; ISA-NEXT:  .LBB0_4: ; %endif2
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
-; ISA-NEXT:    s_add_i32 s14, s14, 1
+; ISA-NEXT:    s_add_i32 s12, s12, 1
 ; ISA-NEXT:    v_mov_b32_e32 v4, v2
 ; ISA-NEXT:    v_mov_b32_e32 v3, v2
 ; ISA-NEXT:    s_branch .LBB0_1
@@ -189,13 +187,11 @@ define amdgpu_ps void @i1_copy_assert(i1 %v4) {
 ; ISA-NEXT:    s_cbranch_execz .LBB1_4
 ; ISA-NEXT:  .LBB1_2: ; %loop
 ; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ISA-NEXT:    s_cmp_lg_u32 s8, 0
-; ISA-NEXT:    s_cselect_b64 s[8:9], -1, 0
 ; ISA-NEXT:    s_mov_b64 s[6:7], 0
+; ISA-NEXT:    s_cmp_lg_u32 s8, 0
 ; ISA-NEXT:    v_mov_b32_e32 v2, v1
 ; ISA-NEXT:    s_mov_b64 s[4:5], s[0:1]
-; ISA-NEXT:    s_and_b64 vcc, exec, s[8:9]
-; ISA-NEXT:    s_cbranch_vccz .LBB1_1
+; ISA-NEXT:    s_cbranch_scc0 .LBB1_1
 ; ISA-NEXT:  ; %bb.3: ; %endif1
 ; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
 ; ISA-NEXT:    s_mov_b64 s[4:5], 0

--- a/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
+++ b/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
@@ -4,7 +4,7 @@
 ;       checks are looking for the absence of specific metadata, which
 ;       cannot be expressed reliably by the generated checks.
 
-; RUN: llc -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck %s -check-prefix=ISA
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck %s -check-prefix=ISA
 ; RUN: opt --amdgpu-late-codegenprepare -S %s |  FileCheck %s -check-prefix=UNIFORM
 ; RUN: opt --amdgpu-late-codegenprepare --si-annotate-control-flow -S %s |  FileCheck %s -check-prefix=CONTROLFLOW
 
@@ -20,53 +20,88 @@ define amdgpu_ps void @main(i32 %0, float %1) {
 ; ISA:       ; %bb.0: ; %start
 ; ISA-NEXT:    v_readfirstlane_b32 s0, v0
 ; ISA-NEXT:    s_mov_b32 m0, s0
-; ISA-NEXT:    s_mov_b32 s8, 0
+; ISA-NEXT:    s_mov_b64 s[0:1], -1
 ; ISA-NEXT:    v_interp_p1_f32_e32 v0, v1, attr0.x
 ; ISA-NEXT:    v_cmp_nlt_f32_e32 vcc, 0, v0
+; ISA-NEXT:    v_cndmask_b32_e64 v3, 0, -1, vcc
+; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[0:1]
 ; ISA-NEXT:    s_mov_b64 s[0:1], 0
-; ISA-NEXT:    ; implicit-def: $sgpr4_sgpr5
-; ISA-NEXT:    ; implicit-def: $sgpr2_sgpr3
-; ISA-NEXT:    s_branch .LBB0_3
-; ISA-NEXT:  .LBB0_1: ; %Flow1
-; ISA-NEXT:    ; in Loop: Header=BB0_3 Depth=1
-; ISA-NEXT:    s_or_b64 exec, exec, s[4:5]
-; ISA-NEXT:    s_mov_b64 s[4:5], s[6:7]
+; ISA-NEXT:    s_mov_b64 s[2:3], -1
+; ISA-NEXT:    s_mov_b64 s[2:3], 0
+; ISA-NEXT:    s_mov_b32 s14, 0
+; ISA-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
+; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v3
+; ISA-NEXT:    s_mov_b64 s[8:9], 0
+; ISA-NEXT:    s_mov_b64 s[4:5], 0
+; ISA-NEXT:    s_mov_b64 s[12:13], 0
 ; ISA-NEXT:    s_mov_b64 s[6:7], 0
-; ISA-NEXT:  .LBB0_2: ; %Flow
-; ISA-NEXT:    ; in Loop: Header=BB0_3 Depth=1
-; ISA-NEXT:    s_and_b64 s[10:11], exec, s[4:5]
-; ISA-NEXT:    s_or_b64 s[0:1], s[10:11], s[0:1]
-; ISA-NEXT:    s_andn2_b64 s[2:3], s[2:3], exec
-; ISA-NEXT:    s_and_b64 s[6:7], s[6:7], exec
-; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[6:7]
-; ISA-NEXT:    s_andn2_b64 exec, exec, s[0:1]
-; ISA-NEXT:    s_cbranch_execz .LBB0_7
-; ISA-NEXT:  .LBB0_3: ; %loop
-; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], exec
-; ISA-NEXT:    s_cmp_lt_u32 s8, 32
-; ISA-NEXT:    s_mov_b64 s[6:7], -1
-; ISA-NEXT:    s_cbranch_scc0 .LBB0_6
-; ISA-NEXT:  ; %bb.4: ; %endif1
-; ISA-NEXT:    ; in Loop: Header=BB0_3 Depth=1
-; ISA-NEXT:    s_and_saveexec_b64 s[4:5], vcc
-; ISA-NEXT:    s_cbranch_execz .LBB0_1
-; ISA-NEXT:  ; %bb.5: ; %endif2
-; ISA-NEXT:    ; in Loop: Header=BB0_3 Depth=1
-; ISA-NEXT:    s_add_i32 s8, s8, 1
-; ISA-NEXT:    s_xor_b64 s[6:7], exec, -1
-; ISA-NEXT:    s_branch .LBB0_1
-; ISA-NEXT:  .LBB0_6: ; in Loop: Header=BB0_3 Depth=1
-; ISA-NEXT:    ; implicit-def: $sgpr8
+; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    s_branch .LBB0_2
-; ISA-NEXT:  .LBB0_7: ; %Flow2
-; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
+; ISA-NEXT:  .LBB0_1: ; %Flow
+; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
+; ISA-NEXT:    s_or_b64 exec, exec, s[12:13]
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; ISA-NEXT:    s_xor_b64 s[12:13], vcc, -1
+; ISA-NEXT:    s_and_b64 s[12:13], s[12:13], exec
+; ISA-NEXT:    s_or_b64 s[10:11], s[10:11], s[12:13]
+; ISA-NEXT:    s_xor_b64 s[12:13], exec, s[10:11]
+; ISA-NEXT:    s_and_b64 s[12:13], s[12:13], exec
+; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], s[12:13]
+; ISA-NEXT:    s_mov_b64 exec, s[10:11]
+; ISA-NEXT:    s_mov_b64 s[12:13], 0
+; ISA-NEXT:    s_mov_b64 s[10:11], 0
+; ISA-NEXT:    ; divergent control-flow edge
+; ISA-NEXT:    s_cbranch_execz .LBB0_5
+; ISA-NEXT:  .LBB0_2: ; %loop
+; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
+; ISA-NEXT:    s_cmp_lt_u32 s14, 32
+; ISA-NEXT:    s_cselect_b64 s[16:17], -1, 0
+; ISA-NEXT:    s_mov_b64 s[10:11], 0
+; ISA-NEXT:    v_mov_b32_e32 v4, v1
+; ISA-NEXT:    v_mov_b32_e32 v3, v1
+; ISA-NEXT:    s_and_b64 vcc, exec, s[16:17]
+; ISA-NEXT:    s_cbranch_vccz .LBB0_1
+; ISA-NEXT:  ; %bb.3: ; %endif1
+; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
+; ISA-NEXT:    s_and_b64 s[16:17], exec, s[0:1]
+; ISA-NEXT:    s_or_b64 s[8:9], s[8:9], s[16:17]
+; ISA-NEXT:    s_xor_b64 s[16:17], exec, s[8:9]
+; ISA-NEXT:    s_and_b64 s[16:17], s[16:17], exec
+; ISA-NEXT:    v_mov_b32_e32 v4, v1
+; ISA-NEXT:    v_mov_b32_e32 v3, v2
+; ISA-NEXT:    s_or_b64 s[12:13], s[12:13], s[16:17]
+; ISA-NEXT:    s_mov_b64 exec, s[8:9]
+; ISA-NEXT:    s_mov_b64 s[8:9], 0
+; ISA-NEXT:    ; divergent control-flow edge
+; ISA-NEXT:    s_cbranch_execz .LBB0_1
+; ISA-NEXT:  .LBB0_4: ; %endif2
+; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
+; ISA-NEXT:    s_add_i32 s14, s14, 1
+; ISA-NEXT:    v_mov_b32_e32 v4, v2
+; ISA-NEXT:    v_mov_b32_e32 v3, v2
+; ISA-NEXT:    s_branch .LBB0_1
+; ISA-NEXT:  .LBB0_5: ; %Flow2
+; ISA-NEXT:    s_or_b64 exec, exec, s[6:7]
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v1
+; ISA-NEXT:    s_xor_b64 s[0:1], vcc, -1
+; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], s[0:1]
+; ISA-NEXT:    s_xor_b64 s[0:1], exec, s[4:5]
+; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; ISA-NEXT:    v_mov_b32_e32 v1, 0
-; ISA-NEXT:    s_and_saveexec_b64 s[0:1], s[2:3]
-; ISA-NEXT:  ; %bb.8: ; %if1
+; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
+; ISA-NEXT:    s_mov_b64 exec, s[4:5]
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:    ; divergent control-flow edge
+; ISA-NEXT:    s_cbranch_execz .LBB0_7
+; ISA-NEXT:  .LBB0_6: ; %if1
 ; ISA-NEXT:    v_sqrt_f32_e32 v1, v0
-; ISA-NEXT:  ; %bb.9: ; %endloop
-; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:  .LBB0_7: ; %endloop
+; ISA-NEXT:    s_or_b64 exec, exec, s[2:3]
 ; ISA-NEXT:    exp mrt0, v1, v1, v1, v1 done vm
 ; ISA-NEXT:    s_endpgm
 start:
@@ -128,40 +163,50 @@ define amdgpu_ps void @i1_copy_assert(i1 %v4) {
 ; ISA-LABEL: i1_copy_assert:
 ; ISA:       ; %bb.0: ; %start
 ; ISA-NEXT:    v_and_b32_e32 v0, 1, v0
+; ISA-NEXT:    s_mov_b64 s[0:1], -1
 ; ISA-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
+; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[0:1]
+; ISA-NEXT:    s_mov_b64 s[2:3], -1
+; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    s_mov_b32 s8, 0
-; ISA-NEXT:    s_mov_b64 s[0:1], 0
-; ISA-NEXT:    ; implicit-def: $sgpr4_sgpr5
-; ISA-NEXT:    ; implicit-def: $sgpr2_sgpr3
-; ISA-NEXT:    s_branch .LBB1_3
-; ISA-NEXT:  .LBB1_1: ; %endif1
-; ISA-NEXT:    ; in Loop: Header=BB1_3 Depth=1
-; ISA-NEXT:    s_andn2_b64 s[4:5], s[4:5], exec
-; ISA-NEXT:    s_and_b64 s[8:9], vcc, exec
-; ISA-NEXT:    s_mov_b64 s[6:7], 0
-; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
-; ISA-NEXT:  .LBB1_2: ; %Flow
-; ISA-NEXT:    ; in Loop: Header=BB1_3 Depth=1
-; ISA-NEXT:    s_and_b64 s[8:9], exec, s[4:5]
-; ISA-NEXT:    s_or_b64 s[0:1], s[8:9], s[0:1]
-; ISA-NEXT:    s_andn2_b64 s[2:3], s[2:3], exec
-; ISA-NEXT:    s_and_b64 s[6:7], s[6:7], exec
-; ISA-NEXT:    s_mov_b32 s8, 1
-; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[6:7]
-; ISA-NEXT:    s_andn2_b64 exec, exec, s[0:1]
-; ISA-NEXT:    s_cbranch_execz .LBB1_5
-; ISA-NEXT:  .LBB1_3: ; %loop
-; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], exec
-; ISA-NEXT:    s_cmp_lg_u32 s8, 0
-; ISA-NEXT:    s_cbranch_scc1 .LBB1_1
-; ISA-NEXT:  ; %bb.4: ; in Loop: Header=BB1_3 Depth=1
-; ISA-NEXT:    s_mov_b64 s[6:7], -1
+; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
+; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v1
+; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    s_branch .LBB1_2
-; ISA-NEXT:  .LBB1_5: ; %Flow2
-; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
-; ISA-NEXT:    v_mov_b32_e32 v0, 0
-; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, 1.0, s[2:3]
+; ISA-NEXT:  .LBB1_1: ; %Flow
+; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; ISA-NEXT:    s_xor_b64 s[10:11], vcc, -1
+; ISA-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], s[10:11]
+; ISA-NEXT:    s_xor_b64 s[10:11], exec, s[6:7]
+; ISA-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; ISA-NEXT:    s_mov_b32 s8, 1
+; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[10:11]
+; ISA-NEXT:    s_mov_b64 exec, s[6:7]
+; ISA-NEXT:    s_mov_b64 s[6:7], 0
+; ISA-NEXT:    ; divergent control-flow edge
+; ISA-NEXT:    s_cbranch_execz .LBB1_4
+; ISA-NEXT:  .LBB1_2: ; %loop
+; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
+; ISA-NEXT:    s_cmp_lg_u32 s8, 0
+; ISA-NEXT:    s_cselect_b64 s[8:9], -1, 0
+; ISA-NEXT:    s_mov_b64 s[6:7], 0
+; ISA-NEXT:    v_mov_b32_e32 v2, v1
+; ISA-NEXT:    s_mov_b64 s[4:5], s[0:1]
+; ISA-NEXT:    s_and_b64 vcc, exec, s[8:9]
+; ISA-NEXT:    s_cbranch_vccz .LBB1_1
+; ISA-NEXT:  ; %bb.3: ; %endif1
+; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
+; ISA-NEXT:    s_mov_b64 s[4:5], 0
+; ISA-NEXT:    v_mov_b32_e32 v2, v0
+; ISA-NEXT:    s_branch .LBB1_1
+; ISA-NEXT:  .LBB1_4: ; %Flow2
+; ISA-NEXT:    s_or_b64 exec, exec, s[2:3]
+; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; ISA-NEXT:    v_mov_b32_e32 v1, 0
+; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, 1.0, vcc
 ; ISA-NEXT:    exp mrt0, off, off, off, off
 ; ISA-NEXT:    s_endpgm
 start:


### PR DESCRIPTION
This PR aims to fix the `illegal VGPR to SGPR copy` assertion crash - thrown during register allocation when encountering a PHI node with an SGPR (lane mask) destination register and a VGPR_32 incoming operand.

Ex: `%20:sreg_exec = PHI %100:vgpr_32, %bb.1, %15:sreg_exec, %bb.4`

This is caused by `AMDGPUFinalizeISelWaveTransform` widening all `vreg_1`s to `vgpr_32`s.


This PR fixes the assertion crash for lit case `llvm :: CodeGen/AMDGPU/divergent-branch-uniform-condition.ll` following similar approach [here](https://github.com/ROCm/llvm-project/blob/amd-feature/wave-transform/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp#L185-L206) for COPY instructions by injecting `V_CMP_NE_U32_e64` to convert `vgpr_32` into an SGPR lane mask.


```llvm
bb.1:
  %10:vreg_1 = PHI %5:vreg_1, %bb.0, %8:vreg_1, %bb.2
...

bb.3:
  %20:sreg_64_xexec = PHI %10:vreg_1, %bb.1, %15:sreg_64_xexec, %bb.4
...
```

is replaced with 

```llvm
bb.1:
  %100:vgpr_32 = PHI %50:vgpr_32, %bb.0, %80:vgpr_32, %bb.2
...

bb.3:
  %20:sreg_exec = PHI %100:vgpr_32, %bb.1, %15:sreg_exec, %bb.4
  ;                   ^^^^^^^^^^^ ILLEGAL: vgpr_32 in sreg_64 PHI
```


This patch updates above MIR to

```llvm
bb.1:
  %100:vgpr_32 = PHI %50:vgpr_32, %bb.0, %80:vgpr_32, %bb.2
  %200:sreg_exec = V_CMP_NE_U32_e64 %100:vgpr_32, 0
...

bb.3:
  %20:sreg_exec = PHI %200:sreg_exec, %bb.1, %15:sreg_exec, %bb.4
```