### PR TITLE
device-libs: Add struct returning variants of sincos and sincospi

### DIFF
--- a/amd/comgr/test-lit/device-lib-linking.cl
+++ b/amd/comgr/test-lit/device-lib-linking.cl
@@ -7,13 +7,13 @@
 
 // COM: Verify LLVM IR text file
 // CHECK: target triple = "amdgcn-amd-amdhsa"
-// CHECK: define internal float @_Z4powrff
-// CHECK: define internal float @_Z6sincosfPU3AS5f
-// CHECK: define internal float @_Z4cbrtf
-// CHECK: define internal float @__ocml_sincos_f32
-// CHECK: define internal float @__ocml_powr_f32
-// CHECK: define internal noundef float @__ocml_exp_f32
-// CHECK: define internal ptr addrspace(1) @__printf_alloc
+// CHECK-DAG: define internal float @_Z4powrff
+// CHECK-DAG: define internal float @_Z6sincosfPU3AS5f
+// CHECK-DAG: define internal float @_Z4cbrtf
+// CHECK-DAG: define internal float @__ocml_sincos_f32
+// CHECK-DAG: define internal float @__ocml_powr_f32
+// CHECK-DAG: define internal noundef float @__ocml_exp_f32
+// CHECK-DAG: define internal ptr addrspace(1) @__printf_alloc
 
 extern const __constant bool __oclc_finite_only_opt;
 extern const __constant bool __oclc_unsafe_math_opt;

--- a/amd/device-libs/ocml/inc/ocml.h
+++ b/amd/device-libs/ocml/inc/ocml.h
@@ -213,6 +213,14 @@ DECL_CONST_OCML_UNARY_F32(sinh)
 DECL_CONST_OCML_UNARY_F32(sinpi)
 extern float OCML_MANGLE_F32(sincos)(float, __private float *);
 extern float OCML_MANGLE_F32(sincospi)(float, __private float *);
+
+typedef struct __ocml_sincos_f32_result {
+    float __sin, __cos;
+} __ocml_sincos_f32_result;
+
+extern __ocml_sincos_f32_result OCML_MANGLE_F32(sincos_stret)(float);
+extern __ocml_sincos_f32_result OCML_MANGLE_F32(sincospi_stret)(float);
+
 DECL_CONST_OCML_UNARY_F32(sqrt)
 DECL_CONST_OCML_UNARY_F32(succ)
 DECL_OCML_UNARY_F32(tan)
@@ -352,6 +360,14 @@ DECL_CONST_OCML_UNARYPRED_F64(signbit)
 DECL_CONST_OCML_UNARY_F64(sin)
 extern double OCML_MANGLE_F64(sincos)(double, __private double *);
 extern double OCML_MANGLE_F64(sincospi)(double, __private double *);
+
+typedef struct __ocml_sincos_f64_result {
+    double __sin, __cos;
+} __ocml_sincos_f64_result;
+
+extern __ocml_sincos_f64_result OCML_MANGLE_F64(sincos_stret)(double);
+extern __ocml_sincos_f64_result OCML_MANGLE_F64(sincospi_stret)(double);
+
 DECL_CONST_OCML_UNARY_F64(sinh)
 DECL_CONST_OCML_UNARY_F64(sinpi)
 DECL_CONST_OCML_UNARY_F64(sqrt)
@@ -526,6 +542,14 @@ DECL_CONST_OCML_UNARY_F16(sinh)
 DECL_CONST_OCML_UNARY_F16(sinpi)
 extern half OCML_MANGLE_F16(sincos)(half, __private half *);
 extern half OCML_MANGLE_F16(sincospi)(half, __private half *);
+
+typedef struct __ocml_sincos_f16_result {
+    half __sin, __cos;
+} __ocml_sincos_f16_result;
+
+extern __ocml_sincos_f16_result OCML_MANGLE_F16(sincos_stret)(half);
+extern __ocml_sincos_f16_result OCML_MANGLE_F16(sincospi_stret)(half);
+
 DECL_CONST_OCML_UNARY_F16(sqrt)
 DECL_CONST_OCML_UNARY_F16(sqrt_rte)
 DECL_CONST_OCML_UNARY_F16(sqrt_rtp)

--- a/amd/device-libs/ocml/src/ccoshD.cl
+++ b/amd/device-libs/ocml/src/ccoshD.cl
@@ -21,8 +21,10 @@ MATH_MANGLE(ccosh)(double2 z)
     er = ldx(er, -4);
     double2 cx = fadd(e, er);
     double2 sx = fsub(e, er);
-    double cy;
-    double sy = MATH_MANGLE(sincos)(z.y, &cy);
+
+    __ocml_sincos_f64_result scy = MATH_MANGLE(sincos_stret)(z.y);
+    double sy = scy.__sin;
+    double cy = scy.__cos;
 
     double cxhi, sxhi;
     if (FINITE_ONLY_OPT()) {

--- a/amd/device-libs/ocml/src/ccoshF.cl
+++ b/amd/device-libs/ocml/src/ccoshF.cl
@@ -21,8 +21,10 @@ MATH_MANGLE(ccosh)(float2 z)
     er = ldx(er, -4);
     float2 cx = fadd(e, er);
     float2 sx = fsub(e, er);
-    float cy;
-    float sy = MATH_MANGLE(sincos)(z.y, &cy);
+
+    __ocml_sincos_f32_result scy = MATH_MANGLE(sincos_stret)(z.y);
+    float sy = scy.__sin;
+    float cy = scy.__cos;
 
     float cxhi, sxhi;
     if (FINITE_ONLY_OPT()) {

--- a/amd/device-libs/ocml/src/cexpD.cl
+++ b/amd/device-libs/ocml/src/cexpD.cl
@@ -12,8 +12,11 @@ MATH_MANGLE(cexp)(double2 z)
 {
     double x = z.s0;
     double y = z.s1;
-    double cy;
-    double sy = MATH_MANGLE(sincos)(y, &cy);
+
+    __ocml_sincos_f64_result scy = MATH_MANGLE(sincos_stret)(y);
+    double sy = scy.__sin;
+    double cy = scy.__cos;
+
     bool g = x > 709.0;
     double ex = MATH_MANGLE(exp)(x - (g ? 1.0f : 0.0f));
     const double e1 =  0x1.5bf0a8b145769p+1;

--- a/amd/device-libs/ocml/src/cexpF.cl
+++ b/amd/device-libs/ocml/src/cexpF.cl
@@ -12,8 +12,11 @@ MATH_MANGLE(cexp)(float2 z)
 {
     float x = z.s0;
     float y = z.s1;
-    float cy;
-    float sy = MATH_MANGLE(sincos)(y, &cy);
+
+    __ocml_sincos_f32_result scy = MATH_MANGLE(sincos_stret)(y);
+    float sy = scy.__sin;
+    float cy = scy.__cos;
+
     bool g = x > 88.0f;
     float ex = MATH_MANGLE(exp)(x - (g ? 1.0f : 0.0f));
     const float e1 =  0x1.5bf0a8p+1f;

--- a/amd/device-libs/ocml/src/csinhD.cl
+++ b/amd/device-libs/ocml/src/csinhD.cl
@@ -21,8 +21,10 @@ MATH_MANGLE(csinh)(double2 z)
     er = ldx(er, -4);
     double2 cx = fadd(e, er);
     double2 sx = fsub(e, er);
-    double cy;
-    double sy = MATH_MANGLE(sincos)(z.y, &cy);
+
+    __ocml_sincos_f64_result scy = MATH_MANGLE(sincos_stret)(z.y);
+    double sy = scy.__sin;
+    double cy = scy.__cos;
 
     double cxhi = cx.hi;
     double sxhi = sx.hi;

--- a/amd/device-libs/ocml/src/csinhF.cl
+++ b/amd/device-libs/ocml/src/csinhF.cl
@@ -21,8 +21,10 @@ MATH_MANGLE(csinh)(float2 z)
     er = ldx(er, -4);
     float2 cx = fadd(e, er);
     float2 sx = fsub(e, er);
-    float cy;
-    float sy = MATH_MANGLE(sincos)(z.y, &cy);
+
+    __ocml_sincos_f32_result scy = MATH_MANGLE(sincos_stret)(z.y);
+    float sy = scy.__sin;
+    float cy = scy.__cos;
 
     float cxhi = cx.hi;
     float sxhi = sx.hi;

--- a/amd/device-libs/ocml/src/ctanhD.cl
+++ b/amd/device-libs/ocml/src/ctanhD.cl
@@ -15,8 +15,10 @@ extern CONSTATTR double2 MATH_PRIVATE(epexpep)(double2 z);
 CONSTATTR double2
 MATH_MANGLE(ctanh)(double2 z)
 {
-    double cy;
-    double sy = MATH_MANGLE(sincos)(z.y, &cy);
+    __ocml_sincos_f64_result scy = MATH_MANGLE(sincos_stret)(z.y);
+    double sy = scy.__sin;
+    double cy = scy.__cos;
+
     double cysy = cy*sy;
     double x = BUILTIN_ABS_F64(z.x);
 

--- a/amd/device-libs/ocml/src/ctanhF.cl
+++ b/amd/device-libs/ocml/src/ctanhF.cl
@@ -15,8 +15,10 @@ extern CONSTATTR float2 MATH_PRIVATE(epexpep)(float2 z);
 CONSTATTR float2
 MATH_MANGLE(ctanh)(float2 z)
 {
-    float cy;
-    float sy = MATH_MANGLE(sincos)(z.y, &cy);
+    __ocml_sincos_f32_result scy = MATH_MANGLE(sincos_stret)(z.y);
+    float sy = scy.__sin;
+    float cy = scy.__cos;
+
     float cysy = cy*sy;
     float x = BUILTIN_ABS_F32(z.x);
 

--- a/amd/device-libs/ocml/src/sincosD.cl
+++ b/amd/device-libs/ocml/src/sincosD.cl
@@ -8,8 +8,8 @@
 #include "mathD.h"
 #include "trigredD.h"
 
-double
-MATH_MANGLE(sincos)(double x, __private double * cp)
+__ocml_sincos_f64_result
+MATH_MANGLE(sincos_stret)(double x)
 {
     if (!FINITE_ONLY_OPT())
         x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
@@ -28,7 +28,14 @@ MATH_MANGLE(sincos)(double x, __private double * cp)
     double c = odd ? sc.s : sc.c;
     c = AS_DOUBLE(AS_LONG(c) ^ flip);
 
-    *cp = c;
-    return s;
+    __ocml_sincos_f64_result result = {s, c};
+    return result;
 }
 
+double
+MATH_MANGLE(sincos)(double x, __private double *cp)
+{
+    __ocml_sincos_f64_result result = MATH_MANGLE(sincos_stret)(x);
+    *cp = result.__cos;
+    return result.__sin;
+}

--- a/amd/device-libs/ocml/src/sincosF.cl
+++ b/amd/device-libs/ocml/src/sincosF.cl
@@ -8,8 +8,8 @@
 #include "mathF.h"
 #include "trigredF.h"
 
-float
-MATH_MANGLE(sincos)(float x, __private float *cp)
+__ocml_sincos_f32_result
+MATH_MANGLE(sincos_stret)(float x)
 {
     if (!FINITE_ONLY_OPT())
         x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
@@ -32,7 +32,14 @@ MATH_MANGLE(sincos)(float x, __private float *cp)
     float c = odd ? sc.s : sc.c;
     c = AS_FLOAT(AS_INT(c) ^ flip);
 
-    *cp = c;
-    return s;
+    __ocml_sincos_f32_result result = {s, c};
+    return result;
 }
 
+float
+MATH_MANGLE(sincos)(float x, __private float *cp)
+{
+    __ocml_sincos_f32_result result = MATH_MANGLE(sincos_stret)(x);
+    *cp = result.__cos;
+    return result.__sin;
+}

--- a/amd/device-libs/ocml/src/sincosH.cl
+++ b/amd/device-libs/ocml/src/sincosH.cl
@@ -19,8 +19,8 @@ MATH_MANGLE2(sincos)(half2 x, __private half2 *cp)
     return s;
 }
 
-CONSTATTR half
-MATH_MANGLE(sincos)(half x, __private half *cp)
+CONSTATTR __ocml_sincos_f16_result
+MATH_MANGLE(sincos_stret)(half x)
 {
     if (!FINITE_ONLY_OPT())
         x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
@@ -39,7 +39,14 @@ MATH_MANGLE(sincos)(half x, __private half *cp)
     half c = odd ? sc.s : sc.c;
     c = AS_HALF((short)(AS_SHORT(c) ^ flip));
 
-    *cp = c;
-    return s;
+    __ocml_sincos_f16_result result = {s, c};
+    return result;
 }
 
+CONSTATTR half
+MATH_MANGLE(sincos)(half x, __private half *cp)
+{
+    __ocml_sincos_f16_result result = MATH_MANGLE(sincos_stret)(x);
+    *cp = result.__cos;
+    return result.__sin;
+}

--- a/amd/device-libs/ocml/src/sincospiD.cl
+++ b/amd/device-libs/ocml/src/sincospiD.cl
@@ -8,8 +8,8 @@
 #include "mathD.h"
 #include "trigpiredD.h"
 
-double
-MATH_MANGLE(sincospi)(double x, __private double * cp)
+__ocml_sincos_f64_result
+MATH_MANGLE(sincospi_stret)(double x)
 {
     if (!FINITE_ONLY_OPT())
         x = BUILTIN_ISINF_F64(x) ? QNAN_F64 : x;
@@ -28,7 +28,14 @@ MATH_MANGLE(sincospi)(double x, __private double * cp)
     double c = odd ? sc.s : sc.c;
     c = AS_DOUBLE(AS_LONG(c) ^ flip);
 
-    *cp = c;
-    return s;
+    __ocml_sincos_f64_result result = {s, c};
+    return result;
 }
 
+double
+MATH_MANGLE(sincospi)(double x, __private double *cp)
+{
+    __ocml_sincos_f64_result result = MATH_MANGLE(sincospi_stret)(x);
+    *cp = result.__cos;
+    return result.__sin;
+}

--- a/amd/device-libs/ocml/src/sincospiF.cl
+++ b/amd/device-libs/ocml/src/sincospiF.cl
@@ -8,8 +8,8 @@
 #include "mathF.h"
 #include "trigpiredF.h"
 
-float
-MATH_MANGLE(sincospi)(float x, __private float *cp)
+__ocml_sincos_f32_result
+MATH_MANGLE(sincospi_stret)(float x)
 {
     if (!FINITE_ONLY_OPT())
         x = BUILTIN_ISINF_F32(x) ? QNAN_F32 : x;
@@ -27,7 +27,14 @@ MATH_MANGLE(sincospi)(float x, __private float *cp)
     float c = odd ? sc.s : sc.c;
     c = AS_FLOAT(AS_INT(c) ^ flip);
 
-    *cp = c;
-    return s;
+    __ocml_sincos_f32_result result = {s, c};
+    return result;
 }
 
+float
+MATH_MANGLE(sincospi)(float x, __private float *cp)
+{
+    __ocml_sincos_f32_result result = MATH_MANGLE(sincospi_stret)(x);
+    *cp = result.__cos;
+    return result.__sin;
+}

--- a/amd/device-libs/ocml/src/sincospiH.cl
+++ b/amd/device-libs/ocml/src/sincospiH.cl
@@ -20,8 +20,8 @@ MATH_MANGLE2(sincospi)(half2 x, __private half2 *cp)
     return s;
 }
 
-half
-MATH_MANGLE(sincospi)(half x, __private half *cp)
+__ocml_sincos_f16_result
+MATH_MANGLE(sincospi_stret)(half x)
 {
     if (!FINITE_ONLY_OPT())
         x = BUILTIN_ISINF_F16(x) ? QNAN_F16 : x;
@@ -38,7 +38,14 @@ MATH_MANGLE(sincospi)(half x, __private half *cp)
     sc.s = -sc.s;
     half c = AS_HALF((short)(AS_SHORT(odd ? sc.s : sc.c) ^ flip));
 
-    *cp = c;
-    return s;
+    __ocml_sincos_f16_result result = {s, c};
+    return result;
 }
 
+CONSTATTR half
+MATH_MANGLE(sincospi)(half x, __private half *cp)
+{
+    __ocml_sincos_f16_result result = MATH_MANGLE(sincospi_stret)(x);
+    *cp = result.__cos;
+    return result.__sin;
+}


### PR DESCRIPTION
Out arguments should be avoided. In addition to the direct cost of the load and store to some scratch memory, tracking the value through memory adds extra complications. In particular the nofpclass attribute can't directly apply to the pointer argument, and has to be attached to the load and store which is not handled.

This was preventing elimination of finite only checks in the complex functions.


