### PR TITLE
device-libs: Remove correctly_rounded_sqrt control libraries

### DIFF
--- a/amd/comgr/test-lit/vfs-tests/vfs-tests.cl
+++ b/amd/comgr/test-lit/vfs-tests/vfs-tests.cl
@@ -36,7 +36,6 @@
 
 extern const __constant bool __oclc_finite_only_opt;
 extern const __constant bool __oclc_unsafe_math_opt;
-extern const __constant bool __oclc_correctly_rounded_sqrt32;
 extern const __constant bool __oclc_wavefrontsize64;
 extern const __constant int __oclc_ISA_version;
 extern const __constant int __oclc_ABI_version;
@@ -45,7 +44,6 @@ void kernel device_libs(__global float *status) {
 
   if (__oclc_finite_only_opt)            status[0] = 1.0;
   if (__oclc_unsafe_math_opt)            status[1] = 1.0;
-  if (__oclc_correctly_rounded_sqrt32)   status[3] = 1.0;
   if (__oclc_wavefrontsize64)            status[4] = 1.0;
   if (__oclc_ISA_version)                status[5] = 1.0;
   if (__oclc_ABI_version)                status[6] = 1.0;

--- a/amd/device-libs/README.md
+++ b/amd/device-libs/README.md
@@ -88,7 +88,6 @@ like as follows:
         -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/opencl/opencl.bc \
         -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/ocml/ocml.bc \
         -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/ockl/ockl.bc \
-        -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/oclc/oclc_correctly_rounded_sqrt_off.bc \
         -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/oclc/oclc_finite_only_off.bc \
         -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/oclc/oclc_unsafe_math_off.bc \
         -Xclang -mlink-bitcode-file -Xclang /srv/git/ROCm-Device-Libs/build/dist/amdgcn/bitcode/oclc/oclc_wavefrontsize64_on.bc \

--- a/amd/device-libs/cmake/OCL.cmake
+++ b/amd/device-libs/cmake/OCL.cmake
@@ -217,7 +217,6 @@ function(clang_opencl_code name dir)
 endfunction()
 
 set(OCLC_DEFAULT_LIBS
-  oclc_correctly_rounded_sqrt_off
   oclc_finite_only_off
   oclc_isa_version_803
   oclc_unsafe_math_off)

--- a/amd/device-libs/doc/OCKL.md
+++ b/amd/device-libs/doc/OCKL.md
@@ -41,7 +41,6 @@ The currently supported control are
   * `finite_only_opt` - floating point Inf and NaN are never expected to be consumed or produced
   * `unsafe_math_opt` - lower accuracy results may be produced with higher performance
   * `ISA_version` - an integer representation of the ISA version of the target device
-  * `correctly_rounded_sqrt32` - unused and deprecated. Will be removed in the future.
 
 ### Versioning
 

--- a/amd/device-libs/oclc/src/correctly_rounded_sqrt_off.cl
+++ b/amd/device-libs/oclc/src/correctly_rounded_sqrt_off.cl
@@ -1,1 +1,0 @@
-// Placeholder until clang stops trying to link this

--- a/amd/device-libs/oclc/src/correctly_rounded_sqrt_on.cl
+++ b/amd/device-libs/oclc/src/correctly_rounded_sqrt_on.cl
@@ -1,1 +1,0 @@
-// Placeholder until clang stops trying to link this


### PR DESCRIPTION
These haven't done anything for almost a year.


