### PR TITLE
device-libs: Replace nextafter implementations

### DIFF
--- a/amd/device-libs/ocml/src/nextafterD.cl
+++ b/amd/device-libs/ocml/src/nextafterD.cl
@@ -10,23 +10,15 @@
 CONSTATTR double
 MATH_MANGLE(nextafter)(double x, double y)
 {
-    long ix = AS_LONG(x);
-    long mx = SIGNBIT_DP64 - ix;
-    mx = ix < 0 ? mx : ix;
-    long iy = AS_LONG(y);
-    long my = SIGNBIT_DP64 - iy;
-    my = iy < 0 ? my : iy;
-    long t = mx + (mx < my ? 1 : -1);
-    long r = SIGNBIT_DP64 - t;
-    r = t < 0 ? r : t;
-    r = (mx == -1L && mx < my) ? SIGNBIT_DP64 : r;
+    double up = MATH_MANGLE(succ)(x);
+    double down = MATH_MANGLE(pred)(x);
 
-    if (!FINITE_ONLY_OPT()) {
-        r = BUILTIN_ISNAN_F64(x) ? ix : r;
-        r = BUILTIN_ISNAN_F64(y) ? iy : r;
-    }
+    double ret = y;
+    if (x < y)
+        ret = up;
+    if (x > y)
+        ret = down;
 
-    r = (ix == iy || (AS_LONG(BUILTIN_ABS_F64(x)) | AS_LONG(BUILTIN_ABS_F64(y))) == 0L) ? iy : r;
-    return AS_DOUBLE(r);
+    return BUILTIN_ISUNORDERED_F64(x, y) ? QNAN_F64 : ret;
 }
 

--- a/amd/device-libs/ocml/src/nextafterF.cl
+++ b/amd/device-libs/ocml/src/nextafterF.cl
@@ -10,23 +10,14 @@
 CONSTATTR float
 MATH_MANGLE(nextafter)(float x, float y)
 {
-    int ix = AS_INT(x);
-    int mx = SIGNBIT_SP32 - ix;
-    mx = ix < 0 ? mx : ix;
-    int iy = AS_INT(y);
-    int my = SIGNBIT_SP32 - iy;
-    my = iy < 0 ? my : iy;
-    int t = mx + (mx < my ? 1 : -1);
-    int r = SIGNBIT_SP32 - t;
-    r = t < 0 ? r : t;
-    r = (mx == -1 && mx < my) ? SIGNBIT_SP32 : r;
+    float up = MATH_MANGLE(succ)(x);
+    float down = MATH_MANGLE(pred)(x);
 
-    if (!FINITE_ONLY_OPT()) {
-        r = BUILTIN_ISNAN_F32(x) ? ix : r;
-        r = BUILTIN_ISNAN_F32(y) ? iy : r;
-    }
+    float ret = y;
+    if (x < y)
+        ret = up;
+    if (x > y)
+        ret = down;
 
-    r = (ix == iy || (AS_INT(BUILTIN_ABS_F32(x)) | AS_INT(BUILTIN_ABS_F32(y))) == 0) ? iy : r;
-    return AS_FLOAT(r);
+    return BUILTIN_ISUNORDERED_F32(x, y) ? QNAN_F32 : ret;
 }
-

--- a/amd/device-libs/ocml/src/nextafterH.cl
+++ b/amd/device-libs/ocml/src/nextafterH.cl
@@ -12,23 +12,15 @@ CONSTATTR BGEN(nextafter)
 CONSTATTR half
 MATH_MANGLE(nextafter)(half x, half y)
 {
-    short ix = AS_SHORT(x);
-    short mx = (short)SIGNBIT_HP16 - ix;
-    mx = ix < (short)0 ? mx : ix;
-    short iy = AS_SHORT(y);
-    short my = (short)SIGNBIT_HP16 - iy;
-    my = iy < (short)0 ? my : iy;
-    short t = mx + (mx < my ? (short)1 : (short)-1);
-    short r = (short)SIGNBIT_HP16 - t;
-    r = t < (short)0 ? r : t;
-    r = (mx == (short)-1 && mx < my) ? (short)SIGNBIT_HP16 : r;
+    half up = MATH_MANGLE(succ)(x);
+    half down = MATH_MANGLE(pred)(x);
 
-    if (!FINITE_ONLY_OPT()) {
-        r = BUILTIN_ISNAN_F16(x) ? ix : r;
-        r = BUILTIN_ISNAN_F16(y) ? iy : r;
-    }
+    half ret = y;
+    if (x < y)
+        ret = up;
+    if (x > y)
+        ret = down;
 
-    r = (ix == iy || (AS_SHORT(BUILTIN_ABS_F16(x)) | AS_SHORT(BUILTIN_ABS_F16(y))) == (short)0) ? iy : r;
-    return AS_HALF(r);
+    return BUILTIN_ISUNORDERED_F16(x, y) ? QNAN_F16 : ret;
 }
 


### PR DESCRIPTION
Reimplement in terms of of succ and pred. Allows
finite only value tracking optimizations to auto-delete 
the edge case checks.

Also reduces instruction count. Saves 44 bytes for float, 
24 for double, and 52 for half.


