### PR TITLE
[openmp] Remove clang resource dir from OpenMP::omp

### DIFF
--- a/openmp/runtime/src/CMakeLists.txt
+++ b/openmp/runtime/src/CMakeLists.txt
@@ -433,7 +433,6 @@ else()
             DESTINATION "${OPENMP_INSTALL_LIBDIR}")
     install(EXPORT openmpTargets FILE openmpTargets.cmake NAMESPACE OpenMP::
             DESTINATION ${OPENMP_INSTALL_CFGDIR}/openmp)
-    target_include_directories(omp PUBLIC $<INSTALL_INTERFACE:${LIBOMP_HEADERS_INSTALL_PATH}>)
   endif()
 
   # Create cmake configuration files


### PR DESCRIPTION
When LLVM is installed into a resource-dir layout, this resolves to lib/clang/<ver>/include, and adding it as -isystem breaks include_next chains (e.g. GCC 14's <cstdint>) during HIP device compilation. The -fopenmp flag already makes clang find omp.h through its built-in resource dir search.


