### PR TITLE
Add unaligned Blit kernel

### DIFF
--- a/amd/device-libs/opencl/src/misc/amdblit.cl
+++ b/amd/device-libs/opencl/src/misc/amdblit.cl
@@ -470,52 +470,48 @@ __amd_copyBufferExt(
   }
 }
 
-   __kernel void __amd_rocclr_fillBufferUnAligned(__global void* __restrict buf,
-                                                     __constant uchar* __restrict pattern,
-                                                     int body_pattern, ulong2 body_tile_pattern,
-                                                     ulong body_tile_count, ulong body_tile_passes,
-                                                     ulong stride, ulong pattern_size,
-                                                     ulong tail_offset, __global uchar* __restrict body_ptr,
-                                                     __global uchar* __restrict body_tail_ptr,
-                                                     __global uchar* __restrict tail_ptr,
-                                                     __global ulong2* __restrict element_tiled,
-                                                     ushort4 counts, int isAligned) {
-      uint l = __builtin_amdgcn_workitem_id_x();
-      uint g = __builtin_amdgcn_workgroup_id_x();
-      ulong id = (g * 256 + l);
+__attribute__((always_inline)) void __amd_fillBufferUnAligned(__global void* __restrict buf,
+                                                 __constant uchar* __restrict pattern,
+                                                 int body_pattern, ulong2 body_tile_pattern,
+                                                 ulong body_tile_count, ulong body_tile_passes,
+                                                 ulong stride, ulong pattern_size,
+                                                 ulong tail_offset, __global uchar* __restrict body_ptr,
+                                                 __global uchar* __restrict body_tail_ptr,
+                                                 __global uchar* __restrict tail_ptr,
+                                                 __global ulong2* __restrict element_tiled,
+                                                 ushort4 counts, int isAligned) {
+  ulong id = get_global_id(0);
 
-      // Handle head, body and tail - each store in a separate warp to reduce divergence
-      // Skip when buffer is 16-byte aligned (no head/body/body_tail/tail regions)
-      if (!isAligned) {
-        __global uchar* head_ptr = (__global uchar*)buf;
-        const uint wave_64_id = l >> 6;  // warp size 64, block size 256 -> 4 warps
-        if (wave_64_id == 0 && g == 0) {
-          if (id < counts.s0) {
-            head_ptr[id] = pattern[id & (pattern_size - 1)];
-          }
-        } else if (wave_64_id == 1 && g == 0) {
-          if (id < 64 + counts.s1) {
-            ((__global int*)body_ptr)[id - 64] = body_pattern;
-          }
-        } else if (wave_64_id == 2 && g == 0) {
-          if (id < 128 + counts.s2) {
-            ((__global int*)body_tail_ptr)[id - 128] = body_pattern;
-          }
-        } else if (wave_64_id == 3 && g == 0) {
-          if (id < 192 + counts.s3) {
-            const ulong tail_byte_idx = (id - 192);
-            tail_ptr[tail_byte_idx] =
-                pattern[(tail_offset + tail_byte_idx) & (pattern_size - 1)];
-          }
-        }
-      }
+  // Handle head, body and tail in the first warp only.
+  // count values are each <= 4, so all unaligned work fits in 32 lanes.
+  // Skip when buffer is 16-byte aligned (no head/body/body_tail/tail regions).
+  if (!isAligned && id < 32) {
+    __global uchar* head_ptr = (__global uchar*)buf;
+    const uint lane = (uint)id;
+    const uint head_end = (uint)counts.s0;
+    const uint body_end = head_end + (uint)counts.s1;
+    const uint body_tail_end = body_end + (uint)counts.s2;
+    const uint tail_end = body_tail_end + (uint)counts.s3;
 
-      // We pass in the number of passes from the CPU to get the best code-gen
-      // We use the number of passes and the size to get correct behiaviour
-      for (ulong j = 0; (j < body_tile_passes) && (j * stride + id < body_tile_count); ++j) {
-        element_tiled[j * stride + id] = body_tile_pattern;
-      }
+    if (lane < head_end) {
+      head_ptr[lane] = pattern[lane & (pattern_size - 1)];
+    } else if (lane < body_end) {
+      ((__global int*)body_ptr)[lane - head_end] = body_pattern;
+    } else if (lane < body_tail_end) {
+      ((__global int*)body_tail_ptr)[lane - body_end] = body_pattern;
+    } else if (lane < tail_end) {
+      const ulong tail_byte_idx = (ulong)(lane - body_tail_end);
+      tail_ptr[tail_byte_idx] =
+          pattern[(tail_offset + tail_byte_idx) & (pattern_size - 1)];
     }
+  }
+
+  // We pass in the number of passes from the CPU to get the best code-gen
+  // We use the number of passes and the size to get correct behiaviour
+  for (ulong j = 0; (j < body_tile_passes) && (j * stride + id < body_tile_count); ++j) {
+    element_tiled[j * stride + id] = body_tile_pattern;
+  }
+}
 
 __attribute__((always_inline)) void
 __amd_fillBuffer(

--- a/amd/device-libs/opencl/src/misc/amdblit.cl
+++ b/amd/device-libs/opencl/src/misc/amdblit.cl
@@ -470,6 +470,53 @@ __amd_copyBufferExt(
   }
 }
 
+   __kernel void __amd_rocclr_fillBufferUnAligned(__global void* __restrict buf,
+                                                     __constant uchar* __restrict pattern,
+                                                     int body_pattern, ulong2 body_tile_pattern,
+                                                     ulong body_tile_count, ulong body_tile_passes,
+                                                     ulong stride, ulong pattern_size,
+                                                     ulong tail_offset, __global uchar* __restrict body_ptr,
+                                                     __global uchar* __restrict body_tail_ptr,
+                                                     __global uchar* __restrict tail_ptr,
+                                                     __global ulong2* __restrict element_tiled,
+                                                     ushort4 counts, int isAligned) {
+      uint l = __builtin_amdgcn_workitem_id_x();
+      uint g = __builtin_amdgcn_workgroup_id_x();
+      ulong id = (g * 256 + l);
+
+      // Handle head, body and tail - each store in a separate warp to reduce divergence
+      // Skip when buffer is 16-byte aligned (no head/body/body_tail/tail regions)
+      if (!isAligned) {
+        __global uchar* head_ptr = (__global uchar*)buf;
+        const uint wave_64_id = l >> 6;  // warp size 64, block size 256 -> 4 warps
+        if (wave_64_id == 0 && g == 0) {
+          if (id < counts.s0) {
+            head_ptr[id] = pattern[id & (pattern_size - 1)];
+          }
+        } else if (wave_64_id == 1 && g == 0) {
+          if (id < 64 + counts.s1) {
+            ((__global int*)body_ptr)[id - 64] = body_pattern;
+          }
+        } else if (wave_64_id == 2 && g == 0) {
+          if (id < 128 + counts.s2) {
+            ((__global int*)body_tail_ptr)[id - 128] = body_pattern;
+          }
+        } else if (wave_64_id == 3 && g == 0) {
+          if (id < 192 + counts.s3) {
+            const ulong tail_byte_idx = (id - 192);
+            tail_ptr[tail_byte_idx] =
+                pattern[(tail_offset + tail_byte_idx) & (pattern_size - 1)];
+          }
+        }
+      }
+
+      // We pass in the number of passes from the CPU to get the best code-gen
+      // We use the number of passes and the size to get correct behiaviour
+      for (ulong j = 0; (j < body_tile_passes) && (j * stride + id < body_tile_count); ++j) {
+        element_tiled[j * stride + id] = body_tile_pattern;
+      }
+    }
+
 __attribute__((always_inline)) void
 __amd_fillBuffer(
     __global uchar* bufUChar,


### PR DESCRIPTION
Currently we use three separate kernels to implement an unaligned memset operation. This kernel allows us to handle aligned and unaligned cases with one kernel and achieve better performance for the unaligned case, while maintaining aligned perf.

This has been tested inside HIP and will be wired into CLR in a seperate PR.

**Unaligned results:**
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/abeltons/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{mso-header-data:"&L&\0022Aptos\0022&10&K008000 \[Public\]&1\#\000D";
	margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{font-weight:700;
	border:.5pt solid windowtext;}
.xl66
	{font-weight:700;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl67
	{font-weight:700;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl68
	{border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl69
	{border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl70
	{border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl71
	{border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl72
	{font-weight:700;
	mso-number-format:0%;
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl73
	{font-weight:700;
	mso-number-format:0%;
	border-top:.5pt solid windowtext;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
.xl74
	{font-weight:700;
	mso-number-format:0%;
	border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl75
	{font-weight:700;
	mso-number-format:0%;
	border-top:none;
	border-right:.5pt solid windowtext;
	border-bottom:none;
	border-left:none;}
-->

</head>

<body link="#467886" vlink="#96607D">


  | Develop |   | UnalignedKernel |   | Percentage   Change |  
-- | -- | -- | -- | -- | -- | --
Size (fp32 elements) | Time (ns) | Throughput (GiB/s) | Time (ns) | Throughput (GiB/s) | Time (- is better) | Throughput (+ is   better)
512 | 7857 | 0.242758 | 4550 | 0.419198 | -42% | 73%
4096 | 8606 | 1.77304 | 4607 | 3.31209 | -46% | 87%
32768 | 8731 | 13.9813 | 4206 | 29.0229 | -52% | 108%
262144 | 8682 | 112.481 | 4159 | 234.807 | -52% | 109%
2097152 | 8587 | 909.806 | 4748 | 1645.43 | -45% | 81%
16777216 | 15882 | 3935.27 | 11998 | 5209.2 | -24% | 32%
134217728 | 115994 | 4310.57 | 112568 | 4441.76 | -3% | 3%



</body>

</html>
