### PR TITLE
[Comgr] Add manifest rc files for embedding comgr version information for Windows DLLs

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -84,6 +84,30 @@ set(SOURCES
   src/comgr-unbundle-command.cpp
   src/time-stat/time-stat.cpp)
 
+if(WIN32)
+  # TODO: Evaluate whether this should be set from the super-project?
+  # NOTE: This is quite ugly and requires some hacks as of now.
+  #       Eventually, we would like for the DLL name to be set uniformly across all build platforms.
+  if (DEFINED THEROCK_HIP_MAJOR_VERSION AND DEFINED THEROCK_HIP_MINOR_VERSION)
+    set(AMD_COMGR_BUILD_SOURCE "TheRock")
+    set(COMGR_DLL_NAME "amd_comgr0${THEROCK_HIP_MAJOR_VERSION}0${THEROCK_HIP_MINOR_VERSION}.dll")
+  else()
+    set(AMD_COMGR_BUILD_SOURCE "Driver")
+    set(COMGR_DLL_NAME "amd_comgr_${amd_comgr_VERSION_MAJOR}.dll")
+  endif()
+  string(TIMESTAMP COMGR_BUILD_YEAR "%Y")
+
+  # Add Windows resource file for version info
+  set(COMGR_MANIFEST_NAME "AMD.ROCM.Comgr")
+  configure_file(
+    cmake/${COMGR_MANIFEST_NAME}.MANIFEST.in
+    cmake/${COMGR_MANIFEST_NAME}.MANIFEST @ONLY)
+  configure_file(
+    cmake/comgr.rc.in
+    cmake/comgr.rc @ONLY)
+  list(APPEND SOURCES "${CMAKE_CURRENT_BINARY_DIR}/cmake/comgr.rc")
+endif()
+
 if(COMGR_BUILD_SHARED_LIBS)
   add_library(amd_comgr SHARED ${SOURCES})
   # Windows doesn't have a strip utility, so CMAKE_STRIP won't be set.
@@ -246,6 +270,9 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     "/wd4146" #[[Suppress 'unary minus operator applied to unsigned type, result still unsigned]]
     "/Zc:preprocessor" #[[Enable standards conforming preprocessor - https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor]])
   list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS _HAS_EXCEPTIONS=0)
+  # disable automatic manifest embedding to avoid duplicate resource errors
+  # (CVT1100/LNK1123) - the manifest is already embedded via comgr.rc
+  list(APPEND AMD_COMGR_PRIVATE_LINKER_OPTIONS "/MANIFEST:NO")
 endif()
 
 # Windows is strict about visibility of exports in shared libraries, so we ask
@@ -352,6 +379,14 @@ else()
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
+# Install the manifest file alongside the DLL for Windows SxS
+if(WIN32)
+  install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/${COMGR_MANIFEST_NAME}.MANIFEST"
+    COMPONENT amd-comgr
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 install(FILES

--- a/amd/comgr/cmake/AMD.ROCM.Comgr.MANIFEST.in
+++ b/amd/comgr/cmake/AMD.ROCM.Comgr.MANIFEST.in
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    type="win32"
+    name="@COMGR_MANIFEST_NAME@"
+    version="@amd_comgr_VERSION_MAJOR@.@amd_comgr_VERSION_MINOR@.@amd_comgr_VERSION_PATCH@.0"
+    processorArchitecture="amd64"/>
+  <description>AMD Code Object Manager</description>
+  <file name="@COMGR_DLL_NAME@"/>
+</assembly>

--- a/amd/comgr/cmake/comgr.rc.in
+++ b/amd/comgr/cmake/comgr.rc.in
@@ -1,0 +1,35 @@
+#include <windows.h>
+
+// Resource ID 2 is used for DLLs (1 is for EXEs)
+#define DLL_MANIFEST_ID 2
+
+DLL_MANIFEST_ID RT_MANIFEST "@COMGR_MANIFEST_NAME@.MANIFEST"
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     @amd_comgr_VERSION_MAJOR@,@amd_comgr_VERSION_MINOR@,@amd_comgr_VERSION_PATCH@,0
+PRODUCTVERSION  @amd_comgr_VERSION_MAJOR@,@amd_comgr_VERSION_MINOR@,@amd_comgr_VERSION_PATCH@,0
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       0
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     VFT2_UNKNOWN
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+            VALUE "CompanyName", "Advanced Micro Devices, Inc.\0"
+            VALUE "FileDescription", "AMD Code Object Manager (Commit Hash: @AMD_COMGR_GIT_COMMIT@, Build Type: @AMD_COMGR_BUILD_SOURCE@)\0"
+            VALUE "FileVersion", "@amd_comgr_VERSION_MAJOR@.@amd_comgr_VERSION_MINOR@.@amd_comgr_VERSION_PATCH@.0\0"
+            VALUE "InternalName", "amd_comgr\0"
+            VALUE "LegalCopyright", "Copyright (C) @COMGR_BUILD_YEAR@ Advanced Micro Devices, Inc.\0"
+            VALUE "OriginalFilename", "@COMGR_DLL_NAME@\0"
+            VALUE "ProductName", "AMD Comgr\0"
+            VALUE "ProductVersion", "@amd_comgr_VERSION_MAJOR@.@amd_comgr_VERSION_MINOR@.@amd_comgr_VERSION_PATCH@.0\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
Requested for ROCM-3843

This adds versioning information for Comgr DLLs on Windows

Original PRs:

https://github.com/ROCm/llvm-project/pull/1167

https://github.com/ROCm/llvm-project/pull/1281
