### PR TITLE
[Clang][Driver] Deprecate -parallel-jobs= in favor of --offload-jobs=

### DIFF
--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -182,6 +182,10 @@ New Compiler Flags
 Deprecated Compiler Flags
 -------------------------
 
+- ``-parallel-jobs=`` has been deprecated. Use ``--offload-jobs=`` instead, which
+  controls the number of threads used for device offloading tasks during
+  compilation.
+
 Modified Compiler Flags
 -----------------------
 - The `-mno-outline` and `-moutline` compiler flags are now allowed on RISC-V and X86, which both support the machine outliner.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9767,6 +9767,13 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
   addOffloadCompressArgs(Args, CmdArgs);
 
+  if (Arg *A = Args.getLastArg(options::OPT_offload_jobs_EQ))
+    if (StringRef(Args.getArgString(A->getIndex()))
+            .starts_with("-parallel-jobs="))
+      C.getDriver().Diag(diag::warn_drv_deprecated_arg)
+          << A->getAsString(Args) << /*hasReplacement=*/true
+          << "--offload-jobs=<N>";
+
   if (Arg *A = Args.getLastArg(options::OPT_offload_jobs_EQ)) {
     StringRef Val = A->getValue();
 

--- a/clang/test/Driver/hip-options.hip
+++ b/clang/test/Driver/hip-options.hip
@@ -261,3 +261,10 @@
 // RUN:   FileCheck -check-prefix=JOBSV %s
 // JOBSV: clang-linker-wrapper{{.*}} "--wrapper-jobs=jobserver"
 
+// Check -parallel-jobs= emits deprecation warning and forwards to --wrapper-jobs.
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -nogpuinc -nogpulib \
+// RUN:   --offload-arch=gfx1100 --offload-new-driver -parallel-jobs=4 %s 2>&1 | \
+// RUN:   FileCheck -check-prefix=PJOBS %s
+// PJOBS: warning: argument '-parallel-jobs=4' is deprecated, use '--offload-jobs=<N>' instead
+// PJOBS: clang-linker-wrapper{{.*}} "--wrapper-jobs=4"
+


### PR DESCRIPTION
[Clang][Driver] Deprecate -parallel-jobs= in favor of --offload-jobs=

Emit a deprecation warning when -parallel-jobs= is used, directing
users to --offload-jobs= instead. The option continues to work as
an alias so existing builds are not broken.

