### PR TITLE
[AMDGPU] Change A0/B0 commentary to only affect gfx1250

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPU.td
+++ b/llvm/lib/Target/AMDGPU/AMDGPU.td
@@ -2696,11 +2696,9 @@ def NotHasIEEEMinimumMaximumInsts : Predicate<"!Subtarget->hasIEEEMinimumMaximum
 
 def NotHasCvtFP8VOP1Bug : Predicate<"!Subtarget->hasCvtFP8VOP1Bug()">;
 
-def HasUnalignedDS2Bug : Predicate<"Subtarget->hasUnalignedDS2Bug()">,
- AssemblerPredicate<(all_of FeatureGFX1250Insts, (not FeatureGFX1250B0))>;
+def HasUnalignedDS2Bug : Predicate<"Subtarget->hasUnalignedDS2Bug()">;
 
-def NotHasUnalignedDS2Bug : Predicate<"!Subtarget->hasUnalignedDS2Bug()">,
- AssemblerPredicate<(any_of (not FeatureGFX1250Insts), (not FeatureGFX1250B0))>;
+def NotHasUnalignedDS2Bug : Predicate<"!Subtarget->hasUnalignedDS2Bug()">;
 
 def NeedsAlignedVGPRs : Predicate<"Subtarget->needsAlignedVGPRs()">,
                       AssemblerPredicate<(all_of FeatureRequiresAlignedVGPRs)>;

--- a/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUHSAMetadataStreamer.cpp
@@ -735,7 +735,7 @@ void MetadataStreamerMsgPackV5::emitKernelAttrs(const AMDGPUTargetMachine &TM,
     Kern[".uniform_work_group_size"] = Kern.getDocument()->getNode(1);
 
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
-  if (ST.hasGFX1250Insts())
+  if (ST.hasGFX1250A0() || ST.hasGFX1250B0())
     Kern[".gfx1250_revision"] = ST.hasGFX1250A0() ? "A0" : "B0";
 }
 


### PR DESCRIPTION
Also remove AssemblerPredicate from the [Not]HasUnalignedDS2Bug, it is unused.


