### PR TITLE
[Comgr] Fix -fPIC missing on embedded header/resource OBJECT libraries

### DIFF
--- a/amd/comgr/cmake/DeviceLibs.cmake
+++ b/amd/comgr/cmake/DeviceLibs.cmake
@@ -91,7 +91,8 @@ add_library(embed-resource-dir-lib OBJECT)
 set_target_properties(embed-resource-dir-lib PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
-  CXX_EXTENSIONS No)
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 add_dependencies(embed-resource-dir-lib embed-resource-dir)
 target_sources(embed-resource-dir-lib PRIVATE ${GEN_RESOURCE_DIR_FILE})
 

--- a/amd/comgr/cmake/LibcxxHeaders.cmake
+++ b/amd/comgr/cmake/LibcxxHeaders.cmake
@@ -121,7 +121,8 @@ add_library(embed-libcxx-headers-lib OBJECT)
 set_target_properties(embed-libcxx-headers-lib PROPERTIES
   CXX_STANDARD 17
   CXX_STANDARD_REQUIRED Yes
-  CXX_EXTENSIONS No)
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 add_dependencies(embed-libcxx-headers-lib embed-libcxx-headers)
 target_sources(embed-libcxx-headers-lib PRIVATE ${GEN_LIBCXX_FILE})
 


### PR DESCRIPTION
[Comgr] Fix -fPIC missing on embedded header/resource OBJECT libraries

The embed-libcxx-headers-lib and embed-resource-dir-lib OBJECT libraries
are linked into libamd_comgr.so (shared library) but were not compiled
with position-independent code. This caused link failures on standalone
builds where CMAKE_POSITION_INDEPENDENT_CODE is not globally set:

  ld.lld: error: relocation R_X86_64_32 cannot be used against local
  symbol; recompile with -fPIC

Add POSITION_INDEPENDENT_CODE ON to both OBJECT library targets.

