### PR TITLE
device-libs: Fix nextafter for daz

### DIFF
--- a/amd/device-libs/ocml/src/nextafterF.cl
+++ b/amd/device-libs/ocml/src/nextafterF.cl
@@ -13,7 +13,7 @@ MATH_MANGLE(nextafter)(float x, float y)
     float up = MATH_MANGLE(succ)(x);
     float down = MATH_MANGLE(pred)(x);
 
-    float ret = y;
+    float ret = DAZ_OPT() ? BUILTIN_CANONICALIZE_F32(y) : y;
     if (x < y)
         ret = up;
     if (x > y)

--- a/amd/device-libs/ocml/src/predF.cl
+++ b/amd/device-libs/ocml/src/predF.cl
@@ -11,7 +11,7 @@ CONSTATTR float
 MATH_MANGLE(pred)(float x)
 {
     int ix = AS_INT(x) + (x > 0.0f ? -1 : 1);
-    float y = x == 0.0f ? -0x1p-149f : AS_FLOAT(ix);
+    float y = x == 0.0f ? (DAZ_OPT() ? -FLT_MIN : -0x1p-149f) : AS_FLOAT(ix);
     return BUILTIN_ISNAN_F32(x) || x == NINF_F32 ? x : y;
 }
 

--- a/amd/device-libs/ocml/src/succF.cl
+++ b/amd/device-libs/ocml/src/succF.cl
@@ -12,5 +12,10 @@ MATH_MANGLE(succ)(float x)
 {
     int y = AS_INT(x + 0.0f);
     int ix = y + (y >= 0 ? 1 : -1);
-    return BUILTIN_ISNAN_F32(x) || x == PINF_F32 ? x : AS_FLOAT(ix);
+
+    float fx = AS_FLOAT(ix);
+    if (DAZ_OPT())
+      fx = x == 0.0f ? FLT_MIN : fx;
+
+    return BUILTIN_ISNAN_F32(x) || x == PINF_F32 ? x : fx;
 }


### PR DESCRIPTION
Implement the standard suggested behavior of returning +/- FLT_MIN for a 0 under DAZ.

Running the conformance test with -z is still not included with any routine testing.


