### PR TITLE
[Comgr] Fix use-after-free in metadata merge for multiple notes

### DIFF
--- a/amd/comgr/src/comgr-metadata.cpp
+++ b/amd/comgr/src/comgr-metadata.cpp
@@ -169,16 +169,32 @@ bool processNote(const Elf_Note<ELFT> &Note, DataMeta *MetaP,
     MetaP->MetaDoc->EmitIntegerBooleans = true;
     MetaP->MetaDoc->RawDocumentList.push_back(std::string(DescString));
 
-    /* TODO add support for merge using readFromBlob merge function */
-    auto &Document = MetaP->MetaDoc->Document;
-
-    Document.clear();
-    if (!Document.readFromBlob(MetaP->MetaDoc->RawDocumentList.back(), false)) {
-      return false;
+    if (Root.isEmpty()) {
+      // First note: parse directly into the main Document and set Root.
+      auto &Document = MetaP->MetaDoc->Document;
+      Document.clear();
+      if (!Document.readFromBlob(MetaP->MetaDoc->RawDocumentList.back(),
+                                 false)) {
+        return false;
+      }
+      return mergeNoteRecords(Document.getRoot(), Root, "amdhsa.version",
+                              "amdhsa.printf", "amdhsa.kernels");
+    } else {
+      // Subsequent notes: parse into a separate document to avoid
+      // invalidating Root (which points into the main Document's memory).
+      // The document is stored in MergedDocuments to persist for the
+      // lifetime of MetaDoc, since merged DocNodes reference its memory.
+      auto MergedDoc = std::make_unique<llvm::msgpack::Document>();
+      if (!MergedDoc->readFromBlob(MetaP->MetaDoc->RawDocumentList.back(),
+                                   false)) {
+        return false;
+      }
+      bool Result = mergeNoteRecords(MergedDoc->getRoot(), Root,
+                                     "amdhsa.version", "amdhsa.printf",
+                                     "amdhsa.kernels");
+      MetaP->MetaDoc->MergedDocuments.push_back(std::move(MergedDoc));
+      return Result;
     }
-
-    return mergeNoteRecords(Document.getRoot(), Root, "amdhsa.version",
-                            "amdhsa.printf", "amdhsa.kernels");
   }
   return false;
 }

--- a/amd/comgr/src/comgr.h
+++ b/amd/comgr/src/comgr.h
@@ -228,6 +228,10 @@ struct MetaDocument {
   // The MsgPack parser is zero-copy, so we retain a copy of the input buffer.
   std::string RawDocument;
   std::vector<std::string> RawDocumentList;
+  // Additional documents for parsed notes. When merging multiple notes,
+  // DocNodes from these documents may be referenced by the main Document's
+  // root, so they must persist for the lifetime of the MetaDocument.
+  std::vector<std::unique_ptr<llvm::msgpack::Document>> MergedDocuments;
   // The old YAML parser would produce the strings "true" and "false" for
   // booleans, whereas the old MsgPack parser produced "0" and "1". The new
   // universal parser produces "true" and "false", but we need to remain


### PR DESCRIPTION
When processing multiple NT_AMDGPU_METADATA notes, we called Document.clear() before parsing each subsequent note. This invalidated the memory that the accumulated Root DocNode was pointing to, causing a use-after-free when mergeNoteRecords() accessed Root.getMap().

Fix by parsing subsequent notes into separate documents stored in MergedDocuments, which persist for the lifetime of MetaDocument. This ensures all DocNode references remain valid.


