### PR TITLE
[comgr] Remove fixed flag for SPIR-V code generation and register the SPIRV-V backend.

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -220,12 +220,20 @@ option(COMGR_USE_INCBIN "Use the gnu .incbin assembler directive" ${default_use_
 
 option(COMGR_DISABLE_SPIRV "To disable SPIRV in Comgr" OFF)
 
-if (NOT COMGR_DISABLE_SPIRV)
-  if (NOT "SPIRV" IN_LIST LLVM_TARGETS_TO_BUILD)
-    message("-- LLVM SPIRV target not found, disabling Comgr SPIRV")
+set(COMGR_SPIRV_TRANSLATOR_AVAILABLE OFF)
+set(COMGR_SPIRV_BACKEND_AVAILABLE OFF)
+
+if (COMGR_DISABLE_SPIRV)
+  message("-- Comgr SPIRV disabled (-DCOMGR_DISABLE_SPIRV)")
+  list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS "COMGR_DISABLE_SPIRV")
+else()
+  if ("SPIRV" IN_LIST LLVM_TARGETS_TO_BUILD)
+    set(COMGR_SPIRV_BACKEND_AVAILABLE ON)
+    message("-- LLVM SPIRV target found (SPIRV backend available in Comgr)")
+  else()
+    message("-- LLVM SPIRV target not found (SPIRV backend unavailable in Comgr)")
     message("-- LLVM targets configured: ${LLVM_TARGETS_TO_BUILD}")
     message("-- SPIRV must be set in -DLLVM_TARGETS_TO_BUILD when building LLVM")
-    set(COMGR_DISABLE_SPIRV ON)
   endif()
 
   # Candidate include paths for LLVMSPIRVLib.h:
@@ -241,24 +249,30 @@ if (NOT COMGR_DISABLE_SPIRV)
       "${CMAKE_SOURCE_DIR}/projects/SPIRV-LLVM-Translator/include"
     NO_DEFAULT_PATH
   )
-  if (NOT EXISTS "${FOUND_SPIRV_INCLUDE_DIR}/LLVMSPIRVLib.h")
-    message("-- LLVMSPIRVLib/LLVMSPIRVLib.h not found")
-    set(COMGR_DISABLE_SPIRV ON)
+  if (EXISTS "${FOUND_SPIRV_INCLUDE_DIR}/LLVMSPIRVLib.h")
+    set(COMGR_SPIRV_TRANSLATOR_AVAILABLE ON)
+    message("-- LLVMSPIRVLib/LLVMSPIRVLib.h found at ${FOUND_SPIRV_INCLUDE_DIR} (SPIRV translator available in Comgr)")
   else()
-    message("-- LLVMSPIRVLib/LLVMSPIRVLib.h found at ${FOUND_SPIRV_INCLUDE_DIR}")
+    message("-- LLVMSPIRVLib/LLVMSPIRVLib.h not found (SPIRV translator unavailable in Comgr)")
   endif()
+
+  if (COMGR_SPIRV_TRANSLATOR_AVAILABLE)
+    target_include_directories(amd_comgr
+        PRIVATE
+          "${FOUND_SPIRV_INCLUDE_DIR}")
+  endif()
+
 endif()
 
-if(${COMGR_DISABLE_SPIRV})
-    list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS "COMGR_DISABLE_SPIRV")
-  message("-- Comgr SPIRV Disabled")
-else()
-  message("-- Comgr SPIRV Enabled")
-  target_include_directories(amd_comgr
-      PRIVATE
-        "${FOUND_SPIRV_INCLUDE_DIR}")
-endif()
+message("-- COMGR_SPIRV_TRANSLATOR_AVAILABLE: ${COMGR_SPIRV_TRANSLATOR_AVAILABLE}")
+message("-- COMGR_SPIRV_BACKEND_AVAILABLE: ${COMGR_SPIRV_BACKEND_AVAILABLE}")
 
+if (COMGR_SPIRV_TRANSLATOR_AVAILABLE)
+  list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS "COMGR_SPIRV_TRANSLATOR_AVAILABLE")
+endif()
+if (COMGR_SPIRV_BACKEND_AVAILABLE)
+  list(APPEND AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS "COMGR_SPIRV_BACKEND_AVAILABLE")
+endif()
 
 if (UNIX)
   list(APPEND AMD_COMGR_PRIVATE_COMPILE_OPTIONS
@@ -487,12 +501,12 @@ set(LLD_LIBS
   lldELF
   lldCommon)
 
-if (${COMGR_DISABLE_SPIRV})
-  set(SPIRV_DYNAMIC_LIB "")
-  set(SPIRV_STATIC_LIB "")
-else()
+if (${COMGR_SPIRV_TRANSLATOR_AVAILABLE})
   set(SPIRV_DYNAMIC_LIB "LLVMSPIRVAMDLib")
   set(SPIRV_STATIC_LIB "SPIRVAMDLib")
+else()
+  set(SPIRV_DYNAMIC_LIB "")
+  set(SPIRV_STATIC_LIB "")
 endif()
 
 if (LLVM_LINK_LLVM_DYLIB)

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -221,6 +221,13 @@ option(COMGR_USE_INCBIN "Use the gnu .incbin assembler directive" ${default_use_
 option(COMGR_DISABLE_SPIRV "To disable SPIRV in Comgr" OFF)
 
 if (NOT COMGR_DISABLE_SPIRV)
+  if (NOT "SPIRV" IN_LIST LLVM_TARGETS_TO_BUILD)
+    message("-- LLVM SPIRV target not found, disabling Comgr SPIRV")
+    message("-- LLVM targets configured: ${LLVM_TARGETS_TO_BUILD}")
+    message("-- SPIRV must be set in -DLLVM_TARGETS_TO_BUILD when building LLVM")
+    set(COMGR_DISABLE_SPIRV ON)
+  endif()
+
   # Candidate include paths for LLVMSPIRVLib.h:
   # 1. ${LLVM_INCLUDE_DIRS}/LLVMSPIRVLib (standalone build)
   # 2. ${LLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR}/include (external project)

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -102,8 +102,8 @@ only Comgr CMake option for SPIR-V.
 Comgr SPIRV-related APIs can be disabled by passing
 `-DCOMGR_DISABLE_SPIRV=1` during the Comgr `cmake` step. This removes any
 dependency on LLVM SPIRV libraries, the llvm-spirv tool or the SPIRV backend in LLVM.
-If `-DCOMGR_DISABLE_SPIRV=0` is set, Comgr will have the SPIR-V backend available
-when `SPIRV` is included in `-DLLVM_TARGETS_TO_BUILD` (for example
+If `-DCOMGR_DISABLE_SPIRV` is unset or set to zero, Comgr will have the SPIR-V backend
+available when `SPIRV` is included in `-DLLVM_TARGETS_TO_BUILD` (for example
 `-DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV"` when configuring LLVM). That does
 not yet make the SPIR-V backend the default path for SPIR-V code generation in
 Comgr, even when it is found; by default, SPIR-V code generation still uses the

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -94,13 +94,20 @@ step (e.g., `-DCOMGR_DLL_NAME=amd_comgr_3.dll`).
 `llvm/projects` or `llvm/tools` and build using the above instructions, with the
 exception that the `-DCMAKE_PREFIX_PATH` for llvm-project must be an install
 path (specified with `-DCMAKE_INSTALL_PREFIX=/path/to/install/dir` and populated
-with `make install`) rather than the build path.
+with `make install`) rather than the build path. Minimal SPIRV support requires
+that the translator be found when configuring Comgr. At configure time Comgr
+detects translator and backend independently, and `-DCOMGR_DISABLE_SPIRV` is the
+only Comgr CMake option for SPIR-V.
 
 Comgr SPIRV-related APIs can be disabled by passing
 `-DCOMGR_DISABLE_SPIRV=1` during the Comgr `cmake` step. This removes any
 dependency on LLVM SPIRV libraries, the llvm-spirv tool or the SPIRV backend in LLVM.
-If `-DCOMGR_DISABLE_SPIRV=0` is set, the LLVM build must include the SPIRV backend
-(-DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" when configuring LLVM).
+If `-DCOMGR_DISABLE_SPIRV=0` is set, Comgr will have the SPIR-V backend available
+when `SPIRV` is included in `-DLLVM_TARGETS_TO_BUILD` (for example
+`-DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV"` when configuring LLVM). That does
+not yet make the SPIR-V backend the default path for SPIR-V code generation in
+Comgr, even when it is found; by default, SPIR-V code generation still uses the
+translator path.
 
 **Code Coverage Instrumentation:** Comgr supports source-based [code coverage
 via clang](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html), and

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -99,6 +99,8 @@ with `make install`) rather than the build path.
 Comgr SPIRV-related APIs can be disabled by passing
 `-DCOMGR_DISABLE_SPIRV=1` during the Comgr `cmake` step. This removes any
 dependency on LLVM SPIRV libraries or the llvm-spirv tool.
+If `-DCOMGR_DISABLE_SPIRV=1` is set, the LLVM build must include the SPIR-V backend
+(-DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" when configuring LLVM).
 
 **Code Coverage Instrumentation:** Comgr supports source-based [code coverage
 via clang](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html), and

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -98,8 +98,8 @@ with `make install`) rather than the build path.
 
 Comgr SPIRV-related APIs can be disabled by passing
 `-DCOMGR_DISABLE_SPIRV=1` during the Comgr `cmake` step. This removes any
-dependency on LLVM SPIRV libraries or the llvm-spirv tool.
-If `-DCOMGR_DISABLE_SPIRV=1` is set, the LLVM build must include the SPIR-V backend
+dependency on LLVM SPIRV libraries, the llvm-spirv tool or the SPIRV backend in LLVM.
+If `-DCOMGR_DISABLE_SPIRV=0` is set, the LLVM build must include the SPIRV backend
 (-DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" when configuring LLVM).
 
 **Code Coverage Instrumentation:** Comgr supports source-based [code coverage

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -71,7 +71,7 @@
 
 #include "time-stat/ts-interface.h"
 
-#ifndef COMGR_DISABLE_SPIRV
+#ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
 #include <LLVMSPIRVLib.h>
 #endif
 
@@ -689,7 +689,7 @@ amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
   return AMD_COMGR_STATUS_SUCCESS;
 }
 
-#ifndef COMGR_DISABLE_SPIRV
+#ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
 // Execute amd-llvm-spirv in-process using writeSpirv
 // Args format: [options...] <input.bc> -o <output.spv>
 amd_comgr_status_t executeSPIRVTranslator(ArrayRef<const char *> Args,
@@ -845,7 +845,7 @@ executeCommand(const Command &Job, raw_ostream &LogS,
       }
       return executeLLVMLink(Arguments, LogS);
     }
-#ifndef COMGR_DISABLE_SPIRV
+#ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
     if (ExeName.contains("llvm-spirv")) {
       if (env::shouldEmitVerboseLogs()) {
         logArgv(LogS, "llvm-spirv", Argv);
@@ -2232,10 +2232,15 @@ amd_comgr_status_t AMDGPUCompiler::translateSpirvToBitcode() {
 amd_comgr_status_t
 AMDGPUCompiler::translateSpirvToBitcodeImpl(DataSet *SpirvInSet,
                                             DataSet *BcOutSet) {
+#ifndef COMGR_SPIRV_TRANSLATOR_AVAILABLE
 #ifdef COMGR_DISABLE_SPIRV
   LogS << "Calling AMDGPUCompiler::translateSpirvToBitcodeImpl() not "
-       << "supported. Comgr is built with -DCOMGR_DISABLE_SPIRV. Re-build LLVM "
-       << "and Comgr with LLVM-SPIRV-Translator support to continue.\n";
+       << "supported. Comgr was built with -DCOMGR_DISABLE_SPIRV=ON.\n";
+#else
+  LogS << "Calling AMDGPUCompiler::translateSpirvToBitcodeImpl() not "
+       << "supported. The LLVM-SPIRV-Translator was not found when Comgr "
+       << "was configured.\n";
+#endif
   return AMD_COMGR_STATUS_ERROR;
 #else
   if (auto Status = createTmpDirs()) {

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -2369,8 +2369,6 @@ amd_comgr_status_t AMDGPUCompiler::compileSourceToSpirv() {
   // Add SPIRV-specific compilation flags
   Args.push_back("--offload-arch=amdgcnspirv");
   Args.push_back("--no-gpu-bundle-output");
-  Args.push_back("-c");
-
 
 #if _WIN32
   Args.push_back("-fshort-wchar");

--- a/amd/comgr/src/comgr-spirv-command.cpp
+++ b/amd/comgr/src/comgr-spirv-command.cpp
@@ -14,7 +14,7 @@
 
 #include "comgr-spirv-command.h"
 
-#ifndef COMGR_DISABLE_SPIRV
+#ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
 #include "comgr-diagnostic-handler.h"
 
 #include <LLVMSPIRVLib.h>
@@ -39,7 +39,7 @@ Expected<StringRef> SPIRVCommand::readExecuteOutput() {
 }
 
 amd_comgr_status_t SPIRVCommand::execute(raw_ostream &LogS) {
-#ifndef COMGR_DISABLE_SPIRV
+#ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
   LLVMContext Context;
   Context.setDiagnosticHandler(
       std::make_unique<AMDGPUCompilerDiagnosticHandler>(LogS), true);

--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -293,7 +293,7 @@ void COMGR::ensureLLVMInitialized() {
     LLVMInitializeAMDGPUDisassembler();
     LLVMInitializeAMDGPUAsmParser();
     LLVMInitializeAMDGPUAsmPrinter();
-#ifndef COMGR_DISABLE_SPIRV
+#ifdef COMGR_SPIRV_BACKEND_AVAILABLE
     LLVMInitializeSPIRVTarget();
     LLVMInitializeSPIRVTargetInfo();
     LLVMInitializeSPIRVTargetMC();

--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -274,7 +274,7 @@ amd_comgr_status_t COMGR::parseTargetIdentifier(StringRef IdentStr,
 
 void COMGR::ensureLLVMInitialized() {
 
-  // LLVMInitializeAMDGPUTargetInfo calls TargetRegistry.cpp:RegisterTarget()
+  // LLVMInitialize<...>TargetInfo calls TargetRegistry.cpp:RegisterTarget()
   // This function is not thread safe. There may be thread safety issues
   // with the other LLVMInitialize functions as well. For completeness, we
   // include all of these initialization functions in mutual exclusion region
@@ -293,6 +293,12 @@ void COMGR::ensureLLVMInitialized() {
     LLVMInitializeAMDGPUDisassembler();
     LLVMInitializeAMDGPUAsmParser();
     LLVMInitializeAMDGPUAsmPrinter();
+#ifndef COMGR_DISABLE_SPIRV
+    LLVMInitializeSPIRVTarget();
+    LLVMInitializeSPIRVTargetInfo();
+    LLVMInitializeSPIRVTargetMC();
+    LLVMInitializeSPIRVAsmPrinter();
+#endif
     LLVMInitialized = true;
   }
 }

--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -1,4 +1,4 @@
-function(cannonicalize_cmake_boolean var)
+function(canonicalize_cmake_boolean var)
     if(${var})
         set(${var} 1 PARENT_SCOPE)
     else()
@@ -6,7 +6,8 @@ function(cannonicalize_cmake_boolean var)
     endif()
 endfunction()
 
-cannonicalize_cmake_boolean(COMGR_DISABLE_SPIRV)
+canonicalize_cmake_boolean(COMGR_SPIRV_BACKEND_AVAILABLE)
+canonicalize_cmake_boolean(COMGR_SPIRV_TRANSLATOR_AVAILABLE)
 
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 

--- a/amd/comgr/test-lit/cache-tests/spirv-translator-cached.cl
+++ b/amd/comgr/test-lit/cache-tests/spirv-translator-cached.cl
@@ -1,4 +1,4 @@
-// REQUIRES: comgr-has-spirv
+// REQUIRES: comgr-has-spirv-translator
 // COM: Same as spirv-translator but with the cache
 // RUN: rm -fr %t.cache
 

--- a/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
+++ b/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
@@ -27,7 +27,7 @@ int main(int argc, const char *argv[]) {
   }
 
   if (argc > 3) {
-    Options = (const char **)&argv[1];
+    Options = &argv[1];
     OptionsCount = (size_t)(argc - 3);
   }
 

--- a/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
+++ b/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
@@ -12,25 +12,33 @@
 #include <stdlib.h>
 #include <string.h>
 
-int main(int argc, char *argv[]) {
+int main(int argc, const char *argv[]) {
   char *BufSource;
   size_t SizeSource;
   amd_comgr_data_t DataSource;
   amd_comgr_data_set_t DataSetSource, DataSetSpirv;
   amd_comgr_action_info_t DataAction;
-  const char *Options[] = {"-nogpuinc"};
-  size_t OptionsCount = sizeof(Options) / sizeof(Options[0]);
+  const char **Options = NULL;
+  size_t OptionsCount = 0;
 
-  if (argc != 3) {
-    fprintf(stderr, "Usage: source-to-spirv file.hip file.spv\n");
+  if (argc < 3) {
+    fprintf(stderr, "Usage: source-to-spirv [options] file.hip file.spv\n");
     exit(1);
   }
 
-  SizeSource = setBuf(argv[1], &BufSource);
+  if (argc > 3) {
+    Options = (const char **)&argv[1];
+    OptionsCount = (size_t)(argc - 3);
+  }
+
+  const char *InputPath = argv[argc - 2];
+  const char *OutputPath = argv[argc - 1];
+
+  SizeSource = setBuf(InputPath, &BufSource);
 
   amd_comgr_(create_data(AMD_COMGR_DATA_KIND_SOURCE, &DataSource));
   amd_comgr_(set_data(DataSource, SizeSource, BufSource));
-  amd_comgr_(set_data_name(DataSource, "file.hip"));
+  amd_comgr_(set_data_name(DataSource, InputPath));
 
   amd_comgr_(create_data_set(&DataSetSource));
   amd_comgr_(data_set_add(DataSetSource, DataSource));
@@ -47,7 +55,7 @@ int main(int argc, char *argv[]) {
   amd_comgr_data_t DataSpirv;
   amd_comgr_(action_data_get_data(DataSetSpirv, AMD_COMGR_DATA_KIND_SPIRV, 0,
                                   &DataSpirv));
-  dumpData(DataSpirv, argv[2]);
+  dumpData(DataSpirv, OutputPath);
 
   amd_comgr_(release_data(DataSource));
   amd_comgr_(release_data(DataSpirv));

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -12,8 +12,10 @@ config.excludes = ["comgr-sources"]
 config.test_source_root = os.path.dirname(__file__)
 config.test_exec_root = config.my_obj_root
 
-if not config.comgr_disable_spirv:
-    config.available_features.add("comgr-has-spirv")
+if config.comgr_spirv_backend_available:
+    config.available_features.add("comgr-has-spirv-backend")
+if config.comgr_spirv_translator_available:
+    config.available_features.add("comgr-has-spirv-translator")
 
 if platform.system() == "Windows":
     config.available_features.add("system-windows")

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -7,7 +7,8 @@ def _fwd(p):
 config.my_src_root = _fwd(r'@CMAKE_CURRENT_SOURCE_DIR@')
 config.my_obj_root = _fwd(r'@CMAKE_CURRENT_BINARY_DIR@')
 
-config.comgr_disable_spirv = @COMGR_DISABLE_SPIRV@
+config.comgr_spirv_backend_available = @COMGR_SPIRV_BACKEND_AVAILABLE@
+config.comgr_spirv_translator_available = @COMGR_SPIRV_TRANSLATOR_AVAILABLE@
 
 config.llvm_tools_dir = _fwd(r'@LLVM_TOOLS_BINARY_DIR@')
 config.comgr_obj_dir = config.my_obj_root

--- a/amd/comgr/test-lit/spirv-tests/source-to-spirv-spirv-backend.hip
+++ b/amd/comgr/test-lit/spirv-tests/source-to-spirv-spirv-backend.hip
@@ -1,21 +1,9 @@
-// REQUIRES: comgr-has-spirv-translator
+// REQUIRES: comgr-has-spirv-translator && comgr-has-spirv-backend
 
-// COM: Validate flags for SPIR-V codegen via the translator path (no LLVM SPIR-V backend).
+// COM: Validate -use-spirv-backend for SPIR-V codegen (needs LLVM SPIR-V target).
 
-// COM: === Setting 1: source-to-spirv -nogpuinc (link / default output) ===
-// RUN: source-to-spirv -nogpuinc %s %t.spv
-
-// COM: Verify the SPIR-V file was created and is non-empty
-// RUN: test -s %t.spv
-
-// COM: Translate SPIR-V back to LLVM IR bitcode
-// RUN: spirv-translator %t.spv -o %t.bc
-
-// COM: Disassemble LLVM IR bitcode to text
-// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,TRANSLATOR
-
-// COM: === Setting 2: source-to-spirv -nogpuinc -c (compile only) ===
-// RUN: source-to-spirv -nogpuinc -c %s %t.spv
+// COM: === Setting 1: source-to-spirv -nogpuinc -use-spirv-backend ===
+// RUN: source-to-spirv -nogpuinc -use-spirv-backend %s %t.spv
 
 // COM: Verify the SPIR-V file was created and is non-empty
 // RUN: test -s %t.spv
@@ -24,11 +12,23 @@
 // RUN: spirv-translator %t.spv -o %t.bc
 
 // COM: Disassemble LLVM IR bitcode to text
-// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,TRANSLATOR
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,SPIRVBE
+
+// COM: === Setting 2: source-to-spirv -nogpuinc -c -use-spirv-backend ===
+// RUN: source-to-spirv -nogpuinc -c -use-spirv-backend %s %t.spv
+
+// COM: Verify the SPIR-V file was created and is non-empty
+// RUN: test -s %t.spv
+
+// COM: Translate SPIR-V back to LLVM IR bitcode
+// RUN: spirv-translator %t.spv -o %t.bc
+
+// COM: Disassemble LLVM IR bitcode to text
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,SPIRVBE
 
 // COM: Verify LLVM IR contains expected functions and target triple
 // CHECK: target triple = "amdgcn-amd-amdhsa"
-// TRANSLATOR: define void @_Z11clean_valuePf
+// SPIRVBE: define internal void @_Z11clean_valuePf
 // CHECK: define amdgpu_kernel void @_Z9add_valuePfS_S_
 
 __attribute__((device))

--- a/amd/comgr/test-lit/spirv-tests/source-to-spirv-spirv-backend.hip
+++ b/amd/comgr/test-lit/spirv-tests/source-to-spirv-spirv-backend.hip
@@ -28,7 +28,7 @@
 
 // COM: Verify LLVM IR contains expected functions and target triple
 // CHECK: target triple = "amdgcn-amd-amdhsa"
-// SPIRVBE: define internal void @_Z11clean_valuePf
+// SPIRVBE: define void @_Z11clean_valuePf
 // CHECK: define amdgpu_kernel void @_Z9add_valuePfS_S_
 
 __attribute__((device))

--- a/amd/comgr/test-lit/spirv-tests/source-to-spirv.hip
+++ b/amd/comgr/test-lit/spirv-tests/source-to-spirv.hip
@@ -1,4 +1,4 @@
-// REQUIRES: comgr-has-spirv
+// REQUIRES: comgr-has-spirv-translator && comgr-has-spirv-backend
 
 // COM: Validate different set of flags that could be used in comgr for SPIR-V code generation.
 // COM: In particular, test that they work with the translator or the SPIR-V backend in LLVM.

--- a/amd/comgr/test-lit/spirv-tests/source-to-spirv.hip
+++ b/amd/comgr/test-lit/spirv-tests/source-to-spirv.hip
@@ -1,7 +1,10 @@
 // REQUIRES: comgr-has-spirv
 
-// COM: Compile HIP source to SPIR-V using Comgr
-// RUN: source-to-spirv %s %t.spv
+// COM: Validate different set of flags that could be used in comgr for SPIR-V code generation.
+// COM: In particular, test that they work with the translator or the SPIR-V backend in LLVM.
+
+// COM: === Setting 1: source-to-spirv -nogpuinc (link / default output) ===
+// RUN: source-to-spirv -nogpuinc %s %t.spv
 
 // COM: Verify the SPIR-V file was created and is non-empty
 // RUN: test -s %t.spv
@@ -10,11 +13,48 @@
 // RUN: spirv-translator %t.spv -o %t.bc
 
 // COM: Disassemble LLVM IR bitcode to text
-// RUN: llvm-dis %t.bc -o - | %FileCheck %s
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,TRANSLATOR
+
+// COM: === Setting 2: source-to-spirv -nogpuinc -c (compile only, same path as Setting 1) ===
+// RUN: source-to-spirv -nogpuinc -c %s %t.spv
+
+// COM: Verify the SPIR-V file was created and is non-empty
+// RUN: test -s %t.spv
+
+// COM: Translate SPIR-V back to LLVM IR bitcode
+// RUN: spirv-translator %t.spv -o %t.bc
+
+// COM: Disassemble LLVM IR bitcode to text
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,TRANSLATOR
+
+// COM: === Setting 3: source-to-spirv -nogpuinc -use-spirv-backend ===
+// RUN: source-to-spirv -nogpuinc -use-spirv-backend %s %t.spv
+
+// COM: Verify the SPIR-V file was created and is non-empty
+// RUN: test -s %t.spv
+
+// COM: Translate SPIR-V back to LLVM IR bitcode
+// RUN: spirv-translator %t.spv -o %t.bc
+
+// COM: Disassemble LLVM IR bitcode to text
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,SPIRVBE
+
+// COM: === Setting 4: source-to-spirv -nogpuinc -c -use-spirv-backend ===
+// RUN: source-to-spirv -nogpuinc -c -use-spirv-backend %s %t.spv
+
+// COM: Verify the SPIR-V file was created and is non-empty
+// RUN: test -s %t.spv
+
+// COM: Translate SPIR-V back to LLVM IR bitcode
+// RUN: spirv-translator %t.spv -o %t.bc
+
+// COM: Disassemble LLVM IR bitcode to text
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s --check-prefixes=CHECK,SPIRVBE
 
 // COM: Verify LLVM IR contains expected functions and target triple
 // CHECK: target triple = "amdgcn-amd-amdhsa"
-// CHECK: define void @_Z11clean_valuePf
+// TRANSLATOR: define void @_Z11clean_valuePf
+// SPIRVBE: define internal void @_Z11clean_valuePf
 // CHECK: define amdgpu_kernel void @_Z9add_valuePfS_S_
 
 __attribute__((device))

--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
@@ -1,4 +1,4 @@
-// REQUIRES: comgr-has-spirv
+// REQUIRES: comgr-has-spirv-translator
 
 
 // COM: Generate a debuginfo SPIR-V file from a HIP kernel

--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc.hip
@@ -1,4 +1,4 @@
-// REQUIRES: comgr-has-spirv
+// REQUIRES: comgr-has-spirv-translator
 // COM: Generate a SPIR-V file from a HIP kernel
 // RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
 // RUN:    --no-gpu-bundle-output --offload-device-only -O3 %s -o %t.spv \

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator.cl
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator.cl
@@ -1,4 +1,4 @@
-// REQUIRES: comgr-has-spirv
+// REQUIRES: comgr-has-spirv-translator
 // COM: Generate a spirv-targeted LLVM IR file from an OpenCL kernel
 // RUN: %clang -c -emit-llvm --target=spirv64 %s -o %t.bc
 

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator.hip
@@ -1,4 +1,4 @@
-// REQUIRES: comgr-has-spirv
+// REQUIRES: comgr-has-spirv-translator
 // COM: Generate a SPIRV file from a HIP kernel
 // RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
 // RUN:    --no-gpu-bundle-output --offload-device-only -O3 %s -o %t.spv


### PR DESCRIPTION
The PR introduces the following changes:

1. It removes `-c` when building SPIR-V code because it is not strictly necessary.
2. Extends the `source-to-spirv` testing utility so it can receive compiler flags in its CLI and added new tests.
3. Register the SPIR-V backend so it is available if -use-spirv-backend is forwarded.

The SPIR-V backend is not yet used by default for generating the SPIR-V code. This would only happen if it is explicitly set (`-use-spirv-backend` or the clang driver switches to that as the default mode).

`COMGR_DISABLE_SPIRV` is internally split into one flag for the translator and another for the backend. 