### PR TITLE
device-libs: Remove range check in log1p result

### DIFF
--- a/amd/device-libs/ocml/src/log1pF.cl
+++ b/amd/device-libs/ocml/src/log1pF.cl
@@ -23,6 +23,6 @@ MATH_MANGLE(log1p)(float x)
         z = x == -1.0f ? NINF_F32 : z;
     }
 
-    return BUILTIN_ABS_F32(x) < 0x1.0p-24f ? x : z;
+    return z;
 }
 


### PR DESCRIPTION
I can't figure out why this would be here, and the double version doesn't have a similar check (which is otherwise identical). Passes conformance without it.


