### PR TITLE
[Comgr] xfail spirv debuginfo test on amd-main

### DIFF
--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
@@ -1,4 +1,8 @@
 // REQUIRES: comgr-has-spirv
+
+// COM: Test not supported on amd-main
+// XFAIL: *
+
 // COM: Generate a debuginfo SPIR-V file from a HIP kernel
 // RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \
 // RUN:    --no-gpu-bundle-output --offload-device-only -O3 %s -o %t.dbg.spv -g


### PR DESCRIPTION
This test only passes on amd-staging, with all of the content from amd-debug branch