### PR TITLE
device-libs: Avoid using fract for is integer idiom

### DIFF
--- a/amd/device-libs/ocml/src/lgamma_rD.cl
+++ b/amd/device-libs/ocml/src/lgamma_rD.cl
@@ -271,7 +271,7 @@ MATH_MANGLE(lgamma_r_impl)(double x)
             double t = MATH_MANGLE(sinpi)(x);
             double negadj = MATH_MANGLE(log)(MATH_DIV(pi, BUILTIN_ABS_F64(t * x)));
             ret = negadj - ret;
-            bool z = BUILTIN_FRACTION_F64(x) == 0.0;
+            bool z = BUILTIN_TRUNC_F64(x) == x;
             ret = z ? PINF_F64 : ret;
             s = t < 0.0 ? -1 : 1;
             s = z ? 0 : s;

--- a/amd/device-libs/ocml/src/lgamma_rF.cl
+++ b/amd/device-libs/ocml/src/lgamma_rF.cl
@@ -266,7 +266,7 @@ MATH_MANGLE(lgamma_r_impl)(float x)
             float t = MATH_MANGLE(sinpi)(x);
             float negadj = MATH_MANGLE(log)(MATH_DIV(pi, BUILTIN_ABS_F32(t * x)));
             ret = negadj - ret;
-            bool z = BUILTIN_FRACTION_F32(x) == 0.0f;
+            bool z = BUILTIN_TRUNC_F32(x) == x;
             ret = z ? PINF_F32 : ret;
             s = t < 0.0f ? -1 : 1;
             s = z ? 0 : s;

--- a/amd/device-libs/ocml/src/tgammaD.cl
+++ b/amd/device-libs/ocml/src/tgammaD.cl
@@ -59,7 +59,7 @@ MATH_MANGLE(tgamma)(double x)
 
         ret = MATH_DIV(n, MATH_MAD(d, y*qt, d));
         ret = x == 0.0 ? BUILTIN_COPYSIGN_F64(PINF_F64, x) : ret;
-        ret = x < 0.0 && BUILTIN_FRACTION_F64(x) == 0.0 ? QNAN_F64 : ret;
+        ret = x < 0.0 && BUILTIN_TRUNC_F64(x) == x ? QNAN_F64 : ret;
     } else {
         const double sqrt2pi = 0x1.40d931ff62706p+1;
         const double sqrtpiby2 = 0x1.40d931ff62706p+0;
@@ -88,7 +88,7 @@ MATH_MANGLE(tgamma)(double x)
                 ret = MATH_DIV(MATH_DIV(sqrtpiby2, MATH_MAD(d, xr*pt, d)), s*t1);
             } else
                 ret = BUILTIN_COPYSIGN_F64(0.0, s);
-            ret = BUILTIN_FRACTION_F64(x) == 0.0 || BUILTIN_ISNAN_F64(x) ? QNAN_F64 : ret;
+            ret = BUILTIN_TRUNC_F64(x) == x || BUILTIN_ISNAN_F64(x) ? QNAN_F64 : ret;
         }
     }
 

--- a/amd/device-libs/ocml/src/tgammaF.cl
+++ b/amd/device-libs/ocml/src/tgammaF.cl
@@ -51,7 +51,7 @@ MATH_MANGLE(tgamma)(float x)
                        -0x1.5810f2p-5f), -0x1.4fcfd6p-1f), 0x1.2788ccp-1f);
         ret = MATH_DIV(n, MATH_MAD(d, y*qt, d));
         ret = x == 0.0f ? BUILTIN_COPYSIGN_F32(PINF_F32, x) : ret;
-        ret = x < 0.0f && BUILTIN_FRACTION_F32(x) == 0.0f ? QNAN_F32 : ret;
+        ret = x < 0.0f && BUILTIN_TRUNC_F32(x) == x ? QNAN_F32 : ret;
     } else {
         const float sqrt2pi = 0x1.40d932p+1f;
         const float sqrtpiby2 = 0x1.40d932p+0f;
@@ -71,7 +71,7 @@ MATH_MANGLE(tgamma)(float x)
                 ret = MATH_DIV(MATH_DIV(sqrtpiby2, t2*t1*p), s*t1);
             else
                 ret = BUILTIN_COPYSIGN_F32(0.0f, s);
-            ret = BUILTIN_FRACTION_F32(x) == 0.0f || BUILTIN_ISNAN_F32(x) ? QNAN_F32 : ret;
+            ret = BUILTIN_TRUNC_F32(x) == x || BUILTIN_ISNAN_F32(x) ? QNAN_F32 : ret;
         }
     }
 


### PR DESCRIPTION
Fract is mechanically more complicated, and doesn't have a first class intrinsic. trunc is simpler and well understood. The fract pattern can lose the non-nan knowledge, and this cannot. Saves several instructions in each function.


