### PR TITLE
[Comgr] Fix memory leak in source-to-spirv test

### DIFF
--- a/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
+++ b/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
@@ -50,6 +50,7 @@ int main(int argc, char *argv[]) {
   dumpData(DataSpirv, argv[2]);
 
   amd_comgr_(release_data(DataSource));
+  amd_comgr_(release_data(DataSpirv));
   amd_comgr_(destroy_data_set(DataSetSource));
   amd_comgr_(destroy_data_set(DataSetSpirv));
   amd_comgr_(destroy_action_info(DataAction));


### PR DESCRIPTION
Add missing release_data call for DataSpirv, fixing ASAN-detected memory leak when running source-to-spirv.hip LIT test.


