### PR TITLE
[Comgr] Fix the issue with path names on Windows for lit tests

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -11,11 +11,20 @@ cannonicalize_cmake_boolean(COMGR_DISABLE_SPIRV)
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 
 if (NOT DEFINED LLVM_LIT_PATH)
-  # Comgr source build
-  if (EXISTS "${LLVM_TOOLS_BINARY_DIR}/../../bin/llvm-lit")
-    set(LLVM_LIT_PATH "${LLVM_TOOLS_BINARY_DIR}/../../bin/llvm-lit")
-  # LLVM external projects build
-  else()
+  # On Windows, llvm-lit is generated as llvm-lit.py (Python multiprocessing
+  # needs the .py suffix). Also check for .cmd wrapper installed by TheRock.
+  foreach(_lit_suffix "" ".py" ".cmd")
+    foreach(_lit_prefix "${LLVM_TOOLS_BINARY_DIR}/../../bin" "${LLVM_TOOLS_BINARY_DIR}")
+      if (EXISTS "${_lit_prefix}/llvm-lit${_lit_suffix}")
+        set(LLVM_LIT_PATH "${_lit_prefix}/llvm-lit${_lit_suffix}")
+        break()
+      endif()
+    endforeach()
+    if (DEFINED LLVM_LIT_PATH)
+      break()
+    endif()
+  endforeach()
+  if (NOT DEFINED LLVM_LIT_PATH)
     set(LLVM_LIT_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-lit")
   endif()
 endif()

--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -11,20 +11,12 @@ cannonicalize_cmake_boolean(COMGR_DISABLE_SPIRV)
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 
 if (NOT DEFINED LLVM_LIT_PATH)
-  # On Windows, llvm-lit is generated as llvm-lit.py (Python multiprocessing
-  # needs the .py suffix). Also check for .cmd wrapper installed by TheRock.
-  foreach(_lit_suffix "" ".py" ".cmd")
-    foreach(_lit_prefix "${LLVM_TOOLS_BINARY_DIR}/../../bin" "${LLVM_TOOLS_BINARY_DIR}")
-      if (EXISTS "${_lit_prefix}/llvm-lit${_lit_suffix}")
-        set(LLVM_LIT_PATH "${_lit_prefix}/llvm-lit${_lit_suffix}")
-        break()
-      endif()
-    endforeach()
-    if (DEFINED LLVM_LIT_PATH)
-      break()
-    endif()
-  endforeach()
-  if (NOT DEFINED LLVM_LIT_PATH)
+  find_program(LLVM_LIT_PATH
+    NAMES llvm-lit llvm-lit.py llvm-lit.cmd
+    PATHS "${LLVM_TOOLS_BINARY_DIR}/../../bin" "${LLVM_TOOLS_BINARY_DIR}"
+    NO_DEFAULT_PATH
+  )
+  if (NOT LLVM_LIT_PATH)
     set(LLVM_LIT_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-lit")
   endif()
 endif()

--- a/amd/comgr/test-lit/cache-tests/compile-minimal-cached-bad-dir.cl
+++ b/amd/comgr/test-lit/cache-tests/compile-minimal-cached-bad-dir.cl
@@ -9,5 +9,8 @@
 // RUN:     compile-opencl-minimal %S/../compile-minimal.cl %t.bin 1.2
 // RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal.cl
 // RUN: %FileCheck --check-prefix=BAD %s < %t.log
+// COM: The error message differs by platform:
+// COM: Linux:   Comgr cache, when building the add stream callback: Failed to open cache file <path>: Not a directory
+// COM: Windows: Comgr cache, when getting the cached file stream: no such file or directory: AMDGPUCompilerCache: Can't get a temporary file
 // BAD: Comgr cache,
 // BAD-SAME: {{Not a directory|no such file or directory}}

--- a/amd/comgr/test-lit/cache-tests/compile-minimal-cached-bad-dir.cl
+++ b/amd/comgr/test-lit/cache-tests/compile-minimal-cached-bad-dir.cl
@@ -1,4 +1,3 @@
-// UNSUPPORTED: system-windows
 // RUN: export AMD_COMGR_CACHE=1
 //
 // COM: fail to create the cache, but still produce something valid
@@ -10,5 +9,5 @@
 // RUN:     compile-opencl-minimal %S/../compile-minimal.cl %t.bin 1.2
 // RUN: %llvm-objdump -d %t.bin | %FileCheck %S/../compile-minimal.cl
 // RUN: %FileCheck --check-prefix=BAD %s < %t.log
-// BAD: Failed to open cache file
-// BAD-SAME: Not a directory
+// BAD: Comgr cache,
+// BAD-SAME: {{Not a directory|no such file or directory}}

--- a/amd/comgr/test-lit/cache-tests/compile-minimal-cached-bad-dir.cl
+++ b/amd/comgr/test-lit/cache-tests/compile-minimal-cached-bad-dir.cl
@@ -1,3 +1,4 @@
+// UNSUPPORTED: system-windows
 // RUN: export AMD_COMGR_CACHE=1
 //
 // COM: fail to create the cache, but still produce something valid

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -39,15 +39,19 @@ config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-
 config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
 config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))
 
-# Resolve bare tool names used in RUN lines.  On Windows, shell PATH
-# resolution via os.path.join introduces backslashes; resolving here
-# with forward slashes avoids that.
+# Resolve bare tool names to their full paths with forward slashes.
 _tool_dirs = os.pathsep.join([config.llvm_tools_dir, config.comgr_obj_dir])
 
 def _resolve_tool(name):
     path = lit.util.which(name, _tool_dirs)
     if path:
-        return path.replace("\\", "/")
+        path = path.replace("\\", "/")
+        # lit.util.which calls os.path.normcase which lowercases the drive
+        # letter on Windows (B: -> b:).  Git Bash cannot execute paths with
+        # a lowercased drive letter (exit code 127).
+        if len(path) >= 2 and path[1] == ':':
+            path = path[0].upper() + path[1:]
+        return path
     return name
 
 _bare_tools = [

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -1,9 +1,7 @@
 import os
 import platform
-import re
 
 import lit.formats
-import lit.util
 
 config.name = "Comgr"
 config.suffixes = {".hip", ".cl", ".c", ".cpp"}
@@ -38,33 +36,3 @@ config.substitutions.append(('%llvm-dis', _fwd(config.llvm_tools_dir, 'llvm-dis'
 config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-objdump')))
 config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
 config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))
-
-# Resolve bare tool names to their full paths with forward slashes.
-_tool_dirs = os.pathsep.join([config.llvm_tools_dir, config.comgr_obj_dir])
-
-def _resolve_tool(name):
-    path = lit.util.which(name, _tool_dirs)
-    if path:
-        path = path.replace("\\", "/")
-        # lit.util.which calls os.path.normcase which lowercases the drive
-        # letter on Windows (B: -> b:).  Git Bash cannot execute paths with
-        # a lowercased drive letter (exit code 127).
-        if len(path) >= 2 and path[1] == ':':
-            path = path[0].upper() + path[1:]
-        return path
-    return name
-
-_bare_tools = [
-    "unbundle", "source-to-bc-with-dev-libs", "compile-opencl-minimal",
-    "compile-hip-minimal", "spirv-translator", "spirv-to-reloc",
-    "source-to-spirv", "lookup-code-object",
-    "get-version", "status-string", "data-action",
-]
-
-for _name in _bare_tools:
-    _resolved = _resolve_tool(_name)
-    # Match the tool name at word boundaries but NOT when preceded by a path
-    # separator (inside a path) or followed by '.' or '-' (inside a filename
-    # like spirv-translator.cl).  Modeled after LLVM's ToolSubst patterns.
-    _pattern = r"(?<![/\\])\b" + re.escape(_name) + r"\b(?![.-])"
-    config.substitutions.append((_pattern, _resolved))

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import re
 
 import lit.formats
 import lit.util
@@ -15,13 +17,47 @@ config.test_exec_root = config.my_obj_root
 if not config.comgr_disable_spirv:
     config.available_features.add("comgr-has-spirv")
 
+if platform.system() == "Windows":
+    config.available_features.add("system-windows")
+elif platform.system() == "Linux":
+    config.available_features.add("system-linux")
+
 # By default, disable the cache for the tests.
 # Test for the cache must explicitly enable this variable.
 config.environment['AMD_COMGR_CACHE'] = "0"
 
-# Add substitutions for LLVM tools
-config.substitutions.append(('%clang', os.path.join(config.llvm_tools_dir, 'clang')))
-config.substitutions.append(('%llvm-dis', os.path.join(config.llvm_tools_dir, 'llvm-dis')))
-config.substitutions.append(('%llvm-objdump', os.path.join(config.llvm_tools_dir, 'llvm-objdump')))
-config.substitutions.append(('%FileCheck', os.path.join(config.llvm_tools_dir, 'FileCheck')))
-config.substitutions.append(('%amd-llvm-spirv', os.path.join(config.llvm_tools_dir, 'amd-llvm-spirv')))
+# Resolve tool paths at configure time with forward slashes.  On Windows,
+# os.path.join may return paths with backslashes, which break when written
+# into bash scripts (e.g. "bin\clang" -> "binclang").
+def _fwd(*parts):
+    return os.path.join(*parts).replace("\\", "/")
+
+# %-prefixed substitutions for LLVM tools (used as %clang, %llvm-dis, etc.)
+config.substitutions.append(('%clang', _fwd(config.llvm_tools_dir, 'clang')))
+config.substitutions.append(('%llvm-dis', _fwd(config.llvm_tools_dir, 'llvm-dis')))
+config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-objdump')))
+config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
+config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))
+
+# Resolve bare tool names used in RUN lines.  On Windows, shell PATH
+# resolution via os.path.join introduces backslashes; resolving here
+# with forward slashes avoids that.
+_tool_dirs = os.pathsep.join([config.llvm_tools_dir, config.comgr_obj_dir])
+
+def _resolve_tool(name):
+    path = lit.util.which(name, _tool_dirs)
+    if path:
+        return path.replace("\\", "/")
+    return name
+
+_bare_tools = [
+    "unbundle", "source-to-bc-with-dev-libs", "compile-opencl-minimal",
+    "compile-hip-minimal", "spirv-translator", "spirv-to-reloc",
+    "source-to-spirv", "lookup-code-object",
+    "get-version", "status-string", "data-action",
+]
+
+for _name in _bare_tools:
+    _resolved = _resolve_tool(_name)
+    _pattern = r"\b" + re.escape(_name) + r"\b"
+    config.substitutions.append((_pattern, _resolved))

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -59,5 +59,8 @@ _bare_tools = [
 
 for _name in _bare_tools:
     _resolved = _resolve_tool(_name)
-    _pattern = r"\b" + re.escape(_name) + r"\b"
+    # Match the tool name at word boundaries but NOT when preceded by a path
+    # separator (inside a path) or followed by '.' or '-' (inside a filename
+    # like spirv-translator.cl).  Modeled after LLVM's ToolSubst patterns.
+    _pattern = r"(?<![/\\])\b" + re.escape(_name) + r"\b(?![.-])"
     config.substitutions.append((_pattern, _resolved))

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -11,12 +11,17 @@ config.comgr_disable_spirv = @COMGR_DISABLE_SPIRV@
 
 config.llvm_tools_dir = _fwd(r'@LLVM_TOOLS_BINARY_DIR@')
 config.comgr_obj_dir = config.my_obj_root
+config.comgr_lib_dir = _fwd(os.path.dirname(config.my_obj_root))
 
 # Needed for clang, llvm-dis, etc.
 config.environment['PATH'] = os.pathsep.join([config.llvm_tools_dir,
                                               config.environment['PATH']])
 
-# Needed for Comgr binaries
+# Needed for amd_comgr shared library (DLL on Windows)
+config.environment['PATH'] = os.pathsep.join([config.comgr_lib_dir,
+                                              config.environment['PATH']])
+
+# Needed for Comgr test binaries
 config.environment['PATH'] = os.pathsep.join([config.comgr_obj_dir,
                                               config.environment['PATH']])
 

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -1,16 +1,24 @@
 import os
 
-config.my_src_root = r'@CMAKE_CURRENT_SOURCE_DIR@'
-config.my_obj_root = r'@CMAKE_CURRENT_BINARY_DIR@'
+def _fwd(p):
+    """Normalize path to forward slashes so it is safe in bash scripts."""
+    return p.replace("\\", "/")
+
+config.my_src_root = _fwd(r'@CMAKE_CURRENT_SOURCE_DIR@')
+config.my_obj_root = _fwd(r'@CMAKE_CURRENT_BINARY_DIR@')
 
 config.comgr_disable_spirv = @COMGR_DISABLE_SPIRV@
 
-# Needed for Comgr binaries
-config.environment['PATH'] = os.pathsep.join(["@CMAKE_CURRENT_BINARY_DIR@",
+config.llvm_tools_dir = _fwd(r'@LLVM_TOOLS_BINARY_DIR@')
+config.comgr_obj_dir = config.my_obj_root
+
+# Needed for clang, llvm-dis, etc.
+config.environment['PATH'] = os.pathsep.join([config.llvm_tools_dir,
                                               config.environment['PATH']])
 
-# Set path to LLVM tools for substitutions
-config.llvm_tools_dir = r'@LLVM_TOOLS_BINARY_DIR@'
+# Needed for Comgr binaries
+config.environment['PATH'] = os.pathsep.join([config.comgr_obj_dir,
+                                              config.environment['PATH']])
 
 lit_config.load_config(
       config, os.path.join(config.my_src_root, "lit.cfg.py"))

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -25,6 +25,9 @@ endmacro()
 # TEST_INPUT_BITCODES target list.
 set(TEST_INPUT_WCHAR_FLAG)
 if(WIN32)
+  # Match -fshort-wchar used by device libs on Windows (see
+  # amd/device-libs/cmake/OCL.cmake). Without this, linking fails with
+  # conflicting wchar_size module flags.
   set(TEST_INPUT_WCHAR_FLAG -fshort-wchar)
 endif()
 

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -23,11 +23,17 @@ endmacro()
 # Creates target ${name} which depends on a clang command to compile ${input} to
 # ${output}, with any additional arguments from ${ARGN}, and add it to the
 # TEST_INPUT_BITCODES target list.
+set(TEST_INPUT_WCHAR_FLAG)
+if(WIN32)
+  set(TEST_INPUT_WCHAR_FLAG -fshort-wchar)
+endif()
+
 macro(add_test_input_bitcode name input output)
   add_custom_command(
     OUTPUT "${output}"
     COMMAND "$<TARGET_FILE:clang>" -c -emit-llvm -target amdgcn-amd-amdhsa
     -mcpu=gfx900 -nogpulib -nogpuinc
+    ${TEST_INPUT_WCHAR_FLAG}
     ${ARGN} "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
     -o "${output}"
     VERBATIM


### PR DESCRIPTION
Fix `Comgr` lit test failures on Windows caused by backslash path corruption.

On Windows, `os.path.join` produces paths with backslashes (e.g. `B:/build/.../bin\clang`). When lit writes these into bash `.script` files, `bash` interprets `\c` as an escape sequence, turning `bin\clang` into `binclang` — causing all 19 lit tests to fail with "No such file or directory" (exit code 127).

Changes across `test-lit/lit.site.cfg.py.in`, `test-lit/lit.cfg.py`, and `test-lit/CMakeLists.txt`:
- Path normalization: All CMake-substituted paths are normalized to forward slashes at configure time via a `_fwd()` helper, so they are safe for use in bash scripts on any platform.
- Tool substitutions: LLVM tools (`%clang`, `%llvm-dis`, etc.) and comgr test binaries (`unbundle`, `compile-opencl-minimal`, etc.) are resolved to their full paths with forward slashes at lit configuration time, rather than relying on shell `PATH` resolution at runtime.
- LLVM tools on PATH: Added `LLVM_TOOLS_BINARY_DIR` to the test environment `PATH` (previously only comgr binaries were added), so bare tool references also resolve correctly.
- `llvm-lit` discovery on Windows: Extended `CMakeLists.txt` to search for `llvm-lit.py` and `llvm-lit.cmd` in addition to `llvm-lit`, since Windows generates the `.py` variant and TheRock installs a `.cmd` wrapper.
- Platform features: Added `system-windows` and `system-linux` lit features for future use.

Unit tests pass on Windows (both LIT & Ctest). The testing uses `TheRock` CI in https://github.com/ROCm/TheRock/pull/4089, results https://github.com/ROCm/TheRock/actions/runs/23629741692/job/68826432488?pr=4089