### PR TITLE
[Comgr] Add AMD_COMGR_DRIVER_OPTIONS_APPEND environment variable

### DIFF
--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -187,14 +187,6 @@ By default, the cache is enabled.
   termination. The string format aligns with [Clang's ThinLTO cache pruning policy](https://clang.llvm.org/docs/ThinLTO.html#cache-pruning).
   The default policy is set as: "prune_interval=1h:prune_expiration=0h:cache_size=75%:cache_size_bytes=30g:cache_size_files=0".
 
-### Compiler Options
-Comgr supports environment variables to modify clang driver invocations:
-
-* `AMD_COMGR_DRIVER_OPTIONS_APPEND`: If set, the space-separated options are
-  appended to all clang driver invocations. This can be used to inject
-  additional compiler flags for debugging or experimentation without modifying
-  the application code.
-
 ### Debugging
 Comgr supports some environment variables to aid in debugging. These
 include:
@@ -215,6 +207,10 @@ include:
   include additional Comgr-specific informational messages.
 * `AMD_COMGR_TIME_STATISTICS`: If this is set, and is not "0", logs will
   include additional Comgr-specific timing information for compilation actions.
+* `AMD_COMGR_DRIVER_OPTIONS_APPEND`: If set, the space-separated options are
+  appended to all clang driver invocations. This can be used to inject
+  additional compiler flags for debugging or experimentation without modifying
+  the application code.
 
 ### VFS
 Comgr implements support for an in-memory, virtual filesystem (VFS) for storing

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -187,6 +187,14 @@ By default, the cache is enabled.
   termination. The string format aligns with [Clang's ThinLTO cache pruning policy](https://clang.llvm.org/docs/ThinLTO.html#cache-pruning).
   The default policy is set as: "prune_interval=1h:prune_expiration=0h:cache_size=75%:cache_size_bytes=30g:cache_size_files=0".
 
+### Compiler Options
+Comgr supports environment variables to modify clang driver invocations:
+
+* `AMD_COMGR_DRIVER_OPTIONS_APPEND`: If set, the space-separated options are
+  appended to all clang driver invocations. This can be used to inject
+  additional compiler flags for debugging or experimentation without modifying
+  the application code.
+
 ### Debugging
 Comgr supports some environment variables to aid in debugging. These
 include:

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1084,9 +1084,8 @@ amd_comgr_status_t AMDGPUCompiler::processFile(DataObject *Input,
   if (!EnvOptions.empty()) {
     SmallVector<StringRef, 8> Options;
     EnvOptions.split(Options, ' ', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
-    for (StringRef Opt : Options) {
+    for (StringRef Opt : Options)
       Argv.push_back(Saver.save(Opt).data());
-    }
   }
 
   Argv.push_back(InputFilePath);

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1078,6 +1078,17 @@ amd_comgr_status_t AMDGPUCompiler::processFile(DataObject *Input,
   Argv.push_back("-Xclang");
   Argv.push_back("-no-disable-free");
 
+  // Append options from AMD_COMGR_DRIVER_OPTIONS_APPEND environment variable.
+  // Options are space-separated and appended after all other options.
+  StringRef EnvOptions = env::getDriverOptionsAppend();
+  if (!EnvOptions.empty()) {
+    SmallVector<StringRef, 8> Options;
+    EnvOptions.split(Options, ' ', /*MaxSplit=*/-1, /*KeepEmpty=*/false);
+    for (StringRef Opt : Options) {
+      Argv.push_back(Saver.save(Opt).data());
+    }
+  }
+
   Argv.push_back(InputFilePath);
 
   Argv.push_back("-o");

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -98,5 +98,10 @@ StringRef getCacheDirectory() {
   return "";
 }
 
+StringRef getDriverOptionsAppend() {
+  static const char *Options = std::getenv("AMD_COMGR_DRIVER_OPTIONS_APPEND");
+  return Options ? Options : "";
+}
+
 } // namespace env
 } // namespace COMGR

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -42,6 +42,10 @@ llvm::StringRef getCachePolicy();
 /// $HOME/.cache/comgr_cache (depends on XDG_CACHE_HOME)
 llvm::StringRef getCacheDirectory();
 
+/// If environment variable AMD_COMGR_DRIVER_OPTIONS_APPEND is set, return the
+/// space-separated options to append to clang driver invocations.
+llvm::StringRef getDriverOptionsAppend();
+
 } // namespace env
 } // namespace COMGR
 

--- a/amd/comgr/test-lit/driver-options-append.hip
+++ b/amd/comgr/test-lit/driver-options-append.hip
@@ -1,0 +1,18 @@
+// COM: Test the AMD_COMGR_DRIVER_OPTIONS_APPEND environment variable
+// COM: This test verifies that options set via the environment variable
+// COM: are appended to clang driver invocations.
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:     AMD_COMGR_REDIRECT_LOGS=stdout \
+// RUN:     AMD_COMGR_DRIVER_OPTIONS_APPEND="-DTEST_MACRO=123 -Wno-extra" \
+// RUN:     compile-hip-minimal %s %t.bin | \
+// RUN:     %FileCheck %s
+
+// CHECK: Compilation Args:
+// CHECK-SAME: "-DTEST_MACRO=123"
+// CHECK-SAME: "-Wno-extra"
+
+__attribute__((global))
+void test(int *out) {
+  out[0] = 42;
+}


### PR DESCRIPTION
Add support for appending additional options to clang driver invocations via the AMD_COMGR_DRIVER_OPTIONS_APPEND environment variable. This allows users to inject compiler flags for debugging or experimentation without modifying application code.


