### PR TITLE
[Comgr] Add LIT test for gfx1250 A0/B0 revision metadata

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -49,5 +49,6 @@ add_comgr_lit_binary(get-version c)
 add_comgr_lit_binary(status-string c)
 add_comgr_lit_binary(data-action c)
 add_comgr_lit_binary(lookup-code-object c)
+add_comgr_lit_binary(check-gfx1250-revision c)
 
 add_dependencies(check-comgr test-lit)

--- a/amd/comgr/test-lit/comgr-sources/check-gfx1250-revision.c
+++ b/amd/comgr/test-lit/comgr-sources/check-gfx1250-revision.c
@@ -1,15 +1,3 @@
-//===- check-gfx1250-revision.c -------------------------------------------===//
-//
-// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
-// amd/comgr/LICENSE.TXT in this repository for license information.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-/// \file
-/// Reads a code object and prints the .gfx1250_revision metadata value
-/// from each kernel's metadata, if present.
-//===----------------------------------------------------------------------===//
-
 #include "amd_comgr.h"
 #include "common.h"
 #include <stdio.h>

--- a/amd/comgr/test-lit/comgr-sources/check-gfx1250-revision.c
+++ b/amd/comgr/test-lit/comgr-sources/check-gfx1250-revision.c
@@ -1,0 +1,61 @@
+//===- check-gfx1250-revision.c -------------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// Reads a code object and prints the .gfx1250_revision metadata value
+/// from each kernel's metadata, if present.
+//===----------------------------------------------------------------------===//
+
+#include "amd_comgr.h"
+#include "common.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    fprintf(stderr, "Usage: %s <code-object>\n", argv[0]);
+    return 1;
+  }
+
+  char *Buf;
+  size_t Size = setBuf(argv[1], &Buf);
+
+  amd_comgr_data_t DataIn;
+  amd_comgr_(create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &DataIn));
+  amd_comgr_(set_data(DataIn, Size, Buf));
+
+  amd_comgr_metadata_node_t RootMeta, KernelsList;
+  amd_comgr_(get_data_metadata(DataIn, &RootMeta));
+  amd_comgr_(metadata_lookup(RootMeta, "amdhsa.kernels", &KernelsList));
+
+  size_t KernelsCount;
+  amd_comgr_(get_metadata_list_size(KernelsList, &KernelsCount));
+
+  for (size_t i = 0; i < KernelsCount; i++) {
+    amd_comgr_metadata_node_t KernelMeta, RevisionMeta;
+    amd_comgr_(index_list_metadata(KernelsList, i, &KernelMeta));
+
+    amd_comgr_status_t Status =
+        amd_comgr_metadata_lookup(KernelMeta, ".gfx1250_revision", &RevisionMeta);
+    if (Status == AMD_COMGR_STATUS_SUCCESS) {
+      char RevisionStr[16];
+      size_t StrSize = sizeof(RevisionStr);
+      amd_comgr_(get_metadata_string(RevisionMeta, &StrSize, RevisionStr));
+      printf("gfx1250_revision: %s\n", RevisionStr);
+      amd_comgr_(destroy_metadata(RevisionMeta));
+    }
+
+    amd_comgr_(destroy_metadata(KernelMeta));
+  }
+
+  amd_comgr_(destroy_metadata(KernelsList));
+  amd_comgr_(destroy_metadata(RootMeta));
+  amd_comgr_(release_data(DataIn));
+  free(Buf);
+
+  return 0;
+}

--- a/amd/comgr/test-lit/gfx1250-b0-specific.hip
+++ b/amd/comgr/test-lit/gfx1250-b0-specific.hip
@@ -1,0 +1,27 @@
+// COM: Test compilation with -amdgpu-gfx1250-b0-specific flag set to 0 (A0) and 1 (B0)
+// COM: and verify the .gfx1250_revision metadata in the resulting code objects.
+
+// COM: Compile for gfx1250 with b0-specific=0 (A0)
+// RUN: %clang --offload-arch=gfx1250 --offload-device-only \
+// RUN:   --no-gpu-bundle-output -nogpulib -nogpuinc \
+// RUN:   -Xclang -mllvm -Xclang -amdgpu-gfx1250-b0-specific=0 \
+// RUN:   %s -o %t.a0.so
+
+// COM: Compile for gfx1250 with b0-specific=1 (B0)
+// RUN: %clang --offload-arch=gfx1250 --offload-device-only \
+// RUN:   --no-gpu-bundle-output -nogpulib -nogpuinc \
+// RUN:   -Xclang -mllvm -Xclang -amdgpu-gfx1250-b0-specific=1 \
+// RUN:   %s -o %t.b0.so
+
+// COM: Check that the A0 code object has .gfx1250_revision: A0
+// RUN: check-gfx1250-revision %t.a0.so | %FileCheck --check-prefix=CHECK-A0 %s
+// CHECK-A0: gfx1250_revision: A0
+
+// COM: Check that the B0 code object has .gfx1250_revision: B0
+// RUN: check-gfx1250-revision %t.b0.so | %FileCheck --check-prefix=CHECK-B0 %s
+// CHECK-B0: gfx1250_revision: B0
+
+__attribute__((global))
+void add(float *A, float *B, float *C) {
+    *C = *A + *B;
+}


### PR DESCRIPTION
Add a test that compiles HIP kernels for gfx1250 with the -amdgpu-gfx1250-b0-specific flag set to 0 (A0) and 1 (B0), then verifies the .gfx1250_revision metadata is correctly set in each code object using the Comgr metadata APIs.