### PR TITLE
[Comgr] Fix metadata merge crash when both notes have amdhsa.printf

### DIFF
--- a/amd/comgr/src/comgr-metadata.cpp
+++ b/amd/comgr/src/comgr-metadata.cpp
@@ -65,9 +65,9 @@ getELFObjectFileBase(DataObject *DataP) {
 // 2. "amdhsa.kernels" exists in both nodes.
 //
 // "amdhsa.printf" is copied from @p From if @p To doesn't have it.
-// If both have it, the merge is allowed only if they are identical
-// (as expected from LTO partitions sharing the same module-level
-// llvm.printf.fmts metadata).
+// If both have it, the merge assumes they are identical (as expected
+// from LTO partitions sharing the same module-level llvm.printf.fmts
+// metadata) and keeps To's copy.
 //
 // If merge is possible the function merges Kernel records
 // to @p To and returns @c true.
@@ -86,11 +86,10 @@ bool mergeNoteRecords(llvm::msgpack::DocNode &From, llvm::msgpack::DocNode &To,
 
   assert(To.isMap());
 
+  // Copy printf from From if To doesn't have it. If both have it, keep To's
+  // copy (they are assumed identical from LTO partitions).
   if (From.getMap().find(PrintfStrKey) != From.getMap().end()) {
-    if (To.getMap().find(PrintfStrKey) != To.getMap().end()) {
-      if (From.getMap()[PrintfStrKey] != To.getMap()[PrintfStrKey])
-        return false;
-    } else {
+    if (To.getMap().find(PrintfStrKey) == To.getMap().end()) {
       To.getMap()[PrintfStrKey] = From.getMap()[PrintfStrKey];
     }
   }


### PR DESCRIPTION
The comparison `From.getMap()[PrintfStrKey] != To.getMap()[PrintfStrKey]` added in 1947bd64fefe crashes when comparing Array-typed DocNodes from the same Document. DocNode::operator< was designed only for map key comparison (scalars), and hits llvm_unreachable for Array/Map types.

Since amdhsa.printf content is identical across LTO partitions (they share the same llvm.printf.fmts metadata via CloneModule), we can simplify the logic: copy printf from From only if To doesn't have it, otherwise keep To's copy.

This avoids the problematic comparison entirely while preserving the intended merge behavior for LTO partitions.


