### PR TITLE
[WaveTransform] Refreshes the cached reserved register state after AMDGPUReserveWWMRegs pass

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUReserveWWMRegs.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUReserveWWMRegs.cpp
@@ -108,5 +108,14 @@ bool AMDGPUReserveWWMRegs::run(MachineFunction &MF) {
   // Now clear the VGPR register allocation mask.
   MFI->clearVGPRAllocMask();
 
+  // Refresh the cached reserved register set to reflect the newly reserved
+  // WWM registers and cleared VGPRAllocMask. Without this, passes like PEI
+  // that check MRI.isAllocatable() would see stale reservation state when
+  // no subsequent register allocation round refreshes it for the late WT flow.
+  //
+  // In the structurizer-enabled flow, this is harmless as the subsequent
+  // perlane VGPRregister allocation round would refresh it anyway.
+  MF.getRegInfo().freezeReservedRegs();
+
   return Changed;
 }

--- a/llvm/test/CodeGen/AMDGPU/preserve-wwm-copy-dst-reg.ll
+++ b/llvm/test/CodeGen/AMDGPU/preserve-wwm-copy-dst-reg.ll
@@ -15,17 +15,17 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    s_or_saveexec_b64 s[18:19], -1
 ; GFX906-NEXT:    buffer_store_dword v41, off, s[0:3], s33 offset:148 ; 4-byte Folded Spill
 ; GFX906-NEXT:    s_mov_b64 exec, s[18:19]
-; GFX906-NEXT:    v_mov_b32_e32 v36, s16
-; GFX906-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:152 ; 4-byte Folded Spill
+; GFX906-NEXT:    v_mov_b32_e32 v2, s16
+; GFX906-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:152 ; 4-byte Folded Spill
 ; GFX906-NEXT:    s_addk_i32 s32, 0x2800
 ; GFX906-NEXT:    buffer_store_dword v40, off, s[0:3], s33 ; 4-byte Folded Spill
 ; GFX906-NEXT:    s_mov_b64 s[16:17], exec
 ; GFX906-NEXT:    s_mov_b64 exec, 3
-; GFX906-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:156
-; GFX906-NEXT:    v_writelane_b32 v36, s30, 0
-; GFX906-NEXT:    v_writelane_b32 v36, s31, 1
-; GFX906-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:140 ; 4-byte Folded Spill
-; GFX906-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:156
+; GFX906-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:156
+; GFX906-NEXT:    v_writelane_b32 v2, s30, 0
+; GFX906-NEXT:    v_writelane_b32 v2, s31, 1
+; GFX906-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:140 ; 4-byte Folded Spill
+; GFX906-NEXT:    buffer_load_dword v2, off, s[0:3], s33 offset:156
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
 ; GFX906-NEXT:    s_mov_b64 exec, s[16:17]
 ; GFX906-NEXT:    s_mov_b32 s21, s15
@@ -136,15 +136,15 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX906-NEXT:    v_writelane_b32 v41, s10, 22
 ; GFX906-NEXT:    v_writelane_b32 v41, s11, 23
-; GFX906-NEXT:    v_mov_b32_e32 v40, v32
 ; GFX906-NEXT:    v_readlane_b32 s16, v41, 22
 ; GFX906-NEXT:    s_mov_b32 s12, s24
 ; GFX906-NEXT:    s_mov_b32 s13, s23
 ; GFX906-NEXT:    s_mov_b32 s14, s22
-; GFX906-NEXT:    v_mov_b32_e32 v31, v40
+; GFX906-NEXT:    v_mov_b32_e32 v31, v32
 ; GFX906-NEXT:    s_mov_b32 s15, s21
 ; GFX906-NEXT:    s_mov_b64 s[10:11], s[26:27]
 ; GFX906-NEXT:    v_readlane_b32 s17, v41, 23
+; GFX906-NEXT:    v_mov_b32_e32 v40, v32
 ; GFX906-NEXT:    s_swappc_b64 s[30:31], s[16:17]
 ; GFX906-NEXT:    v_readlane_b32 s11, v41, 12
 ; GFX906-NEXT:    ;;#ASMSTART
@@ -353,19 +353,19 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX906-NEXT:    flat_store_dwordx4 v[2:3], v[4:7]
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
 ; GFX906-NEXT:    s_mov_b64 exec, 3
-; GFX906-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:156
-; GFX906-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:140 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:156
+; GFX906-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:140 ; 4-byte Folded Reload
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
-; GFX906-NEXT:    v_readlane_b32 s30, v36, 0
-; GFX906-NEXT:    v_readlane_b32 s31, v36, 1
-; GFX906-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:156
+; GFX906-NEXT:    v_readlane_b32 s30, v0, 0
+; GFX906-NEXT:    v_readlane_b32 s31, v0, 1
+; GFX906-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:156
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
 ; GFX906-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX906-NEXT:    buffer_load_dword v40, off, s[0:3], s33 ; 4-byte Folded Reload
-; GFX906-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:152 ; 4-byte Folded Reload
+; GFX906-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:152 ; 4-byte Folded Reload
 ; GFX906-NEXT:    s_mov_b32 s32, s33
 ; GFX906-NEXT:    s_waitcnt vmcnt(0)
-; GFX906-NEXT:    v_readfirstlane_b32 s4, v36
+; GFX906-NEXT:    v_readfirstlane_b32 s4, v0
 ; GFX906-NEXT:    s_or_saveexec_b64 s[6:7], -1
 ; GFX906-NEXT:    buffer_load_dword v41, off, s[0:3], s33 offset:148 ; 4-byte Folded Reload
 ; GFX906-NEXT:    s_mov_b64 exec, s[6:7]
@@ -381,21 +381,21 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    s_xor_saveexec_b64 s[18:19], -1
 ; GFX908-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:152 ; 4-byte Folded Spill
 ; GFX908-NEXT:    s_mov_b64 exec, s[18:19]
-; GFX908-NEXT:    v_mov_b32_e32 v37, s16
-; GFX908-NEXT:    buffer_store_dword v37, off, s[0:3], s33 offset:164 ; 4-byte Folded Spill
-; GFX908-NEXT:    v_mov_b32_e32 v37, s34
-; GFX908-NEXT:    buffer_store_dword v37, off, s[0:3], s33 offset:156 ; 4-byte Folded Spill
-; GFX908-NEXT:    v_mov_b32_e32 v37, s35
-; GFX908-NEXT:    buffer_store_dword v37, off, s[0:3], s33 offset:160 ; 4-byte Folded Spill
+; GFX908-NEXT:    v_mov_b32_e32 v2, s16
+; GFX908-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:164 ; 4-byte Folded Spill
+; GFX908-NEXT:    v_mov_b32_e32 v2, s34
+; GFX908-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:156 ; 4-byte Folded Spill
+; GFX908-NEXT:    v_mov_b32_e32 v2, s35
+; GFX908-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:160 ; 4-byte Folded Spill
 ; GFX908-NEXT:    s_addk_i32 s32, 0x2c00
 ; GFX908-NEXT:    buffer_store_dword v40, off, s[0:3], s33 ; 4-byte Folded Spill
 ; GFX908-NEXT:    s_mov_b64 s[16:17], exec
 ; GFX908-NEXT:    s_mov_b64 exec, 3
-; GFX908-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:168
-; GFX908-NEXT:    v_writelane_b32 v36, s30, 0
-; GFX908-NEXT:    v_writelane_b32 v36, s31, 1
-; GFX908-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:140 ; 4-byte Folded Spill
-; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:168
+; GFX908-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:168
+; GFX908-NEXT:    v_writelane_b32 v2, s30, 0
+; GFX908-NEXT:    v_writelane_b32 v2, s31, 1
+; GFX908-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:140 ; 4-byte Folded Spill
+; GFX908-NEXT:    buffer_load_dword v2, off, s[0:3], s33 offset:168
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
 ; GFX908-NEXT:    s_mov_b64 exec, s[16:17]
 ; GFX908-NEXT:    s_mov_b32 s21, s15
@@ -511,15 +511,15 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
 ; GFX908-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:148 ; 4-byte Folded Spill
 ; GFX908-NEXT:    s_mov_b64 exec, s[34:35]
-; GFX908-NEXT:    v_mov_b32_e32 v40, v32
 ; GFX908-NEXT:    v_readlane_b32 s16, v36, 22
 ; GFX908-NEXT:    s_mov_b32 s12, s24
 ; GFX908-NEXT:    s_mov_b32 s13, s23
 ; GFX908-NEXT:    s_mov_b32 s14, s22
-; GFX908-NEXT:    v_mov_b32_e32 v31, v40
+; GFX908-NEXT:    v_mov_b32_e32 v31, v32
 ; GFX908-NEXT:    s_mov_b32 s15, s21
 ; GFX908-NEXT:    s_mov_b64 s[10:11], s[26:27]
 ; GFX908-NEXT:    v_readlane_b32 s17, v36, 23
+; GFX908-NEXT:    v_mov_b32_e32 v40, v32
 ; GFX908-NEXT:    s_swappc_b64 s[30:31], s[16:17]
 ; GFX908-NEXT:    s_or_saveexec_b64 s[34:35], -1
 ; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:148 ; 4-byte Folded Reload
@@ -739,25 +739,25 @@ define void @preserve_wwm_copy_dstreg(ptr %parg0, ptr %parg1, ptr %parg2) #0 {
 ; GFX908-NEXT:    flat_store_dwordx4 v[2:3], v[4:7]
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
 ; GFX908-NEXT:    s_mov_b64 exec, 3
-; GFX908-NEXT:    buffer_store_dword v36, off, s[0:3], s33 offset:168
-; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:140 ; 4-byte Folded Reload
+; GFX908-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:168
+; GFX908-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:140 ; 4-byte Folded Reload
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
-; GFX908-NEXT:    v_readlane_b32 s30, v36, 0
-; GFX908-NEXT:    v_readlane_b32 s31, v36, 1
-; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:168
+; GFX908-NEXT:    v_readlane_b32 s30, v0, 0
+; GFX908-NEXT:    v_readlane_b32 s31, v0, 1
+; GFX908-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:168
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
 ; GFX908-NEXT:    s_mov_b64 exec, s[4:5]
-; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:164 ; 4-byte Folded Reload
+; GFX908-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:164 ; 4-byte Folded Reload
 ; GFX908-NEXT:    buffer_load_dword v40, off, s[0:3], s33 ; 4-byte Folded Reload
 ; GFX908-NEXT:    s_mov_b32 s32, s33
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
-; GFX908-NEXT:    v_readfirstlane_b32 s4, v36
-; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:156 ; 4-byte Folded Reload
+; GFX908-NEXT:    v_readfirstlane_b32 s4, v0
+; GFX908-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:156 ; 4-byte Folded Reload
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
-; GFX908-NEXT:    v_readfirstlane_b32 s34, v36
-; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:160 ; 4-byte Folded Reload
+; GFX908-NEXT:    v_readfirstlane_b32 s34, v0
+; GFX908-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:160 ; 4-byte Folded Reload
 ; GFX908-NEXT:    s_waitcnt vmcnt(0)
-; GFX908-NEXT:    v_readfirstlane_b32 s35, v36
+; GFX908-NEXT:    v_readfirstlane_b32 s35, v0
 ; GFX908-NEXT:    s_xor_saveexec_b64 s[6:7], -1
 ; GFX908-NEXT:    buffer_load_dword v36, off, s[0:3], s33 offset:152 ; 4-byte Folded Reload
 ; GFX908-NEXT:    s_mov_b64 exec, s[6:7]

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-overlap-wwm-reserve.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-overlap-wwm-reserve.mir
@@ -28,7 +28,7 @@ body:             |
   ; GCN-LABEL: name: test_main
   ; GCN: bb.0:
   ; GCN-NEXT:   successors: %bb.1(0x80000000)
-  ; GCN-NEXT:   liveins: $vcc_hi, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $sgpr8, $sgpr9, $sgpr10, $sgpr11, $sgpr12, $sgpr13, $sgpr14, $sgpr15, $sgpr16, $sgpr17, $sgpr18, $sgpr19, $sgpr20, $sgpr21, $sgpr22, $sgpr23, $sgpr24, $sgpr25, $sgpr26, $sgpr27, $sgpr28, $sgpr29, $sgpr64, $sgpr65, $sgpr66, $sgpr67, $sgpr68, $sgpr69, $sgpr70, $sgpr71, $sgpr72, $sgpr73, $sgpr74, $sgpr75, $sgpr76, $sgpr77, $sgpr78, $sgpr79, $sgpr80, $sgpr81, $sgpr82, $sgpr83, $sgpr84, $sgpr85, $sgpr86, $sgpr87, $sgpr88, $sgpr89, $sgpr90, $sgpr91, $sgpr92, $sgpr93, $sgpr94, $sgpr95, $sgpr96, $sgpr97, $sgpr98, $sgpr99, $sgpr100, $sgpr101, $sgpr102, $sgpr103, $vgpr0, $vgpr2, $sgpr30_sgpr31
+  ; GCN-NEXT:   liveins: $vcc_hi, $sgpr4, $sgpr5, $sgpr6, $sgpr7, $sgpr8, $sgpr9, $sgpr10, $sgpr11, $sgpr12, $sgpr13, $sgpr14, $sgpr15, $sgpr16, $sgpr17, $sgpr18, $sgpr19, $sgpr20, $sgpr21, $sgpr22, $sgpr23, $sgpr24, $sgpr25, $sgpr26, $sgpr27, $sgpr28, $sgpr29, $sgpr64, $sgpr65, $sgpr66, $sgpr67, $sgpr68, $sgpr69, $sgpr70, $sgpr71, $sgpr72, $sgpr73, $sgpr74, $sgpr75, $sgpr76, $sgpr77, $sgpr78, $sgpr79, $sgpr80, $sgpr81, $sgpr82, $sgpr83, $sgpr84, $sgpr85, $sgpr86, $sgpr87, $sgpr88, $sgpr89, $sgpr90, $sgpr91, $sgpr92, $sgpr93, $sgpr94, $sgpr95, $sgpr96, $sgpr97, $sgpr98, $sgpr99, $sgpr100, $sgpr101, $sgpr102, $sgpr103, $vgpr0, $sgpr30_sgpr31
   ; GCN-NEXT: {{  $}}
   ; GCN-NEXT:   frame-setup CFI_INSTRUCTION escape 0x0f, 0x09, 0x90, 0x40, 0x94, 0x04, 0x35, 0x24, 0x36, 0xe9, 0x02
   ; GCN-NEXT:   frame-setup CFI_INSTRUCTION llvm_register_pair $pc_reg, $sgpr30, 32, $sgpr31, 32
@@ -79,7 +79,7 @@ body:             |
   ; GCN-NEXT:   $sgpr0 = S_XOR_SAVEEXEC_B32 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
   ; GCN-NEXT:   SCRATCH_STORE_DWORD_SADDR killed $vgpr1, $sgpr33, 0, 0, implicit $exec, implicit $flat_scr :: ("amdgpu-thread-private" store (s32) into %stack.68, addrspace 5)
   ; GCN-NEXT:   frame-setup CFI_INSTRUCTION offset $vgpr1, 0
-  ; GCN-NEXT:   SCRATCH_STORE_DWORD_SADDR $vgpr2, $sgpr33, 4, 0, implicit $exec, implicit $flat_scr :: ("amdgpu-thread-private" store (s32) into %stack.69, addrspace 5)
+  ; GCN-NEXT:   SCRATCH_STORE_DWORD_SADDR killed $vgpr2, $sgpr33, 4, 0, implicit $exec, implicit $flat_scr :: ("amdgpu-thread-private" store (s32) into %stack.69, addrspace 5)
   ; GCN-NEXT:   frame-setup CFI_INSTRUCTION offset $vgpr2, 128
   ; GCN-NEXT:   SCRATCH_STORE_DWORD_SADDR killed $vgpr3, $sgpr33, 8, 0, implicit $exec, implicit $flat_scr :: ("amdgpu-thread-private" store (s32) into %stack.70, addrspace 5)
   ; GCN-NEXT:   frame-setup CFI_INSTRUCTION offset $vgpr3, 256

--- a/llvm/test/CodeGen/AMDGPU/spill-reg-tuple-super-reg-use.mir
+++ b/llvm/test/CodeGen/AMDGPU/spill-reg-tuple-super-reg-use.mir
@@ -24,24 +24,25 @@ body:             |
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION llvm_def_aspace_cfa $sgpr32, 0, 6
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION llvm_register_pair $pc_reg, $sgpr30, 32, $sgpr31, 32
+    ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $vgpr0
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr0
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr1
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr2
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr3
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr8
-    ; GCN-NEXT: $sgpr8_sgpr9 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
-    ; GCN-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr63, $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" store (s32) into %stack.1, addrspace 5)
-    ; GCN-NEXT: frame-setup CFI_INSTRUCTION offset $vgpr63, 0
+    ; GCN-NEXT: $sgpr8_sgpr9 = S_XOR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
+    ; GCN-NEXT: BUFFER_STORE_DWORD_OFFSET $vgpr0, $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" store (s32) into %stack.1, addrspace 5)
+    ; GCN-NEXT: frame-setup CFI_INSTRUCTION offset $vgpr0, 0
     ; GCN-NEXT: $exec = S_MOV_B64 killed $sgpr8_sgpr9
     ; GCN-NEXT: renamable $sgpr1 = COPY $sgpr2
-    ; GCN-NEXT: $vgpr63 = IMPLICIT_DEF
-    ; GCN-NEXT: $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr0, 0, killed $vgpr63, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3
-    ; GCN-NEXT: $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr1, 1, killed $vgpr63
-    ; GCN-NEXT: $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr2, 2, killed $vgpr63
-    ; GCN-NEXT: dead $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr3, 3, killed $vgpr63, implicit $sgpr0_sgpr1_sgpr2_sgpr3
+    ; GCN-NEXT: $vgpr0 = IMPLICIT_DEF
+    ; GCN-NEXT: $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr0, 0, killed $vgpr0, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3
+    ; GCN-NEXT: $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr1, 1, killed $vgpr0
+    ; GCN-NEXT: $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr2, 2, killed $vgpr0
+    ; GCN-NEXT: dead $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr3, 3, killed $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3
     ; GCN-NEXT: renamable $sgpr8 = COPY renamable $sgpr1
-    ; GCN-NEXT: $sgpr0_sgpr1 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
-    ; GCN-NEXT: $vgpr63 = BUFFER_LOAD_DWORD_OFFSET $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" load (s32) from %stack.1, addrspace 5)
+    ; GCN-NEXT: $sgpr0_sgpr1 = S_XOR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
+    ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" load (s32) from %stack.1, addrspace 5)
     ; GCN-NEXT: $exec = S_MOV_B64 killed $sgpr0_sgpr1
     ; GCN-NEXT: S_ENDPGM 0, implicit $sgpr8
     renamable $sgpr1 = COPY $sgpr2
@@ -70,22 +71,23 @@ body:             |
     ; GCN-NEXT: {{  $}}
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION llvm_def_aspace_cfa $sgpr32, 0, 6
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION llvm_register_pair $pc_reg, $sgpr30, 32, $sgpr31, 32
+    ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $vgpr0
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr0
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr1
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr2
     ; GCN-NEXT: frame-setup CFI_INSTRUCTION undefined $sgpr3
-    ; GCN-NEXT: $sgpr8_sgpr9 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
-    ; GCN-NEXT: BUFFER_STORE_DWORD_OFFSET killed $vgpr63, $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" store (s32) into %stack.1, addrspace 5)
-    ; GCN-NEXT: frame-setup CFI_INSTRUCTION offset $vgpr63, 0
+    ; GCN-NEXT: $sgpr8_sgpr9 = S_XOR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
+    ; GCN-NEXT: BUFFER_STORE_DWORD_OFFSET $vgpr0, $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" store (s32) into %stack.1, addrspace 5)
+    ; GCN-NEXT: frame-setup CFI_INSTRUCTION offset $vgpr0, 0
     ; GCN-NEXT: $exec = S_MOV_B64 killed $sgpr8_sgpr9
     ; GCN-NEXT: renamable $sgpr1 = COPY $sgpr2
-    ; GCN-NEXT: $vgpr63 = IMPLICIT_DEF
-    ; GCN-NEXT: $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr0, 0, killed $vgpr63, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3
-    ; GCN-NEXT: $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr1, 1, killed $vgpr63
-    ; GCN-NEXT: $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr2, 2, killed $vgpr63
-    ; GCN-NEXT: dead $vgpr63 = SI_SPILL_S32_TO_VGPR $sgpr3, 3, killed $vgpr63, implicit $sgpr0_sgpr1_sgpr2_sgpr3
-    ; GCN-NEXT: $sgpr0_sgpr1 = S_OR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
-    ; GCN-NEXT: $vgpr63 = BUFFER_LOAD_DWORD_OFFSET $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" load (s32) from %stack.1, addrspace 5)
+    ; GCN-NEXT: $vgpr0 = IMPLICIT_DEF
+    ; GCN-NEXT: $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr0, 0, killed $vgpr0, implicit-def $sgpr0_sgpr1_sgpr2_sgpr3, implicit $sgpr0_sgpr1_sgpr2_sgpr3
+    ; GCN-NEXT: $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr1, 1, killed $vgpr0
+    ; GCN-NEXT: $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr2, 2, killed $vgpr0
+    ; GCN-NEXT: dead $vgpr0 = SI_SPILL_S32_TO_VGPR $sgpr3, 3, killed $vgpr0, implicit $sgpr0_sgpr1_sgpr2_sgpr3
+    ; GCN-NEXT: $sgpr0_sgpr1 = S_XOR_SAVEEXEC_B64 -1, implicit-def $exec, implicit-def dead $scc, implicit $exec
+    ; GCN-NEXT: $vgpr0 = BUFFER_LOAD_DWORD_OFFSET $sgpr100_sgpr101_sgpr102_sgpr103, $sgpr32, 0, 0, 0, implicit $exec :: ("amdgpu-thread-private" load (s32) from %stack.1, addrspace 5)
     ; GCN-NEXT: $exec = S_MOV_B64 killed $sgpr0_sgpr1
     ; GCN-NEXT: S_ENDPGM 0
     renamable $sgpr1 = COPY $sgpr2

--- a/llvm/test/CodeGen/AMDGPU/whole-wave-register-spill.ll
+++ b/llvm/test/CodeGen/AMDGPU/whole-wave-register-spill.ll
@@ -21,16 +21,16 @@ define void @test() #0 {
 ; GCN-NEXT:    s_or_saveexec_b64 s[18:19], -1
 ; GCN-NEXT:    buffer_store_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Spill
 ; GCN-NEXT:    s_mov_b64 exec, s[18:19]
-; GCN-NEXT:    v_mov_b32_e32 v2, s16
-; GCN-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:12 ; 4-byte Folded Spill
+; GCN-NEXT:    v_mov_b32_e32 v0, s16
+; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:12 ; 4-byte Folded Spill
 ; GCN-NEXT:    s_addk_i32 s32, 0x800
 ; GCN-NEXT:    s_mov_b64 s[16:17], exec
 ; GCN-NEXT:    s_mov_b64 exec, 3
-; GCN-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:16
-; GCN-NEXT:    v_writelane_b32 v2, s30, 0
-; GCN-NEXT:    v_writelane_b32 v2, s31, 1
-; GCN-NEXT:    buffer_store_dword v2, off, s[0:3], s33 ; 4-byte Folded Spill
-; GCN-NEXT:    buffer_load_dword v2, off, s[0:3], s33 offset:16
+; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:16
+; GCN-NEXT:    v_writelane_b32 v0, s30, 0
+; GCN-NEXT:    v_writelane_b32 v0, s31, 1
+; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], s33 ; 4-byte Folded Spill
+; GCN-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:16
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_mov_b64 exec, s[16:17]
 ; GCN-NEXT:    ;;#ASMSTART
@@ -50,18 +50,18 @@ define void @test() #0 {
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_mov_b64 s[4:5], exec
 ; GCN-NEXT:    s_mov_b64 exec, 3
-; GCN-NEXT:    buffer_store_dword v2, off, s[0:3], s33 offset:16
-; GCN-NEXT:    buffer_load_dword v2, off, s[0:3], s33 ; 4-byte Folded Reload
+; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:16
+; GCN-NEXT:    buffer_load_dword v0, off, s[0:3], s33 ; 4-byte Folded Reload
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NEXT:    v_readlane_b32 s30, v2, 0
-; GCN-NEXT:    v_readlane_b32 s31, v2, 1
-; GCN-NEXT:    buffer_load_dword v2, off, s[0:3], s33 offset:16
+; GCN-NEXT:    v_readlane_b32 s30, v0, 0
+; GCN-NEXT:    v_readlane_b32 s31, v0, 1
+; GCN-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:16
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_mov_b64 exec, s[4:5]
-; GCN-NEXT:    buffer_load_dword v2, off, s[0:3], s33 offset:12 ; 4-byte Folded Reload
+; GCN-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:12 ; 4-byte Folded Reload
 ; GCN-NEXT:    s_mov_b32 s32, s33
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NEXT:    v_readfirstlane_b32 s4, v2
+; GCN-NEXT:    v_readfirstlane_b32 s4, v0
 ; GCN-NEXT:    s_or_saveexec_b64 s[6:7], -1
 ; GCN-NEXT:    buffer_load_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload
 ; GCN-NEXT:    s_mov_b64 exec, s[6:7]
@@ -85,11 +85,11 @@ define void @test() #0 {
 ; GCN-O0-NEXT:    s_add_i32 s32, s32, 0x800
 ; GCN-O0-NEXT:    s_mov_b64 s[16:17], exec
 ; GCN-O0-NEXT:    s_mov_b64 exec, 3
-; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s33 offset:20
-; GCN-O0-NEXT:    v_writelane_b32 v3, s30, 0
-; GCN-O0-NEXT:    v_writelane_b32 v3, s31, 1
-; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s33 ; 4-byte Folded Spill
-; GCN-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s33 offset:20
+; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:20
+; GCN-O0-NEXT:    v_writelane_b32 v0, s30, 0
+; GCN-O0-NEXT:    v_writelane_b32 v0, s31, 1
+; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s33 ; 4-byte Folded Spill
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:20
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[16:17]
 ; GCN-O0-NEXT:    ;;#ASMSTART
@@ -123,12 +123,12 @@ define void @test() #0 {
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_mov_b64 s[4:5], exec
 ; GCN-O0-NEXT:    s_mov_b64 exec, 3
-; GCN-O0-NEXT:    buffer_store_dword v3, off, s[0:3], s33 offset:20
-; GCN-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s33 ; 4-byte Folded Reload
+; GCN-O0-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:20
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s33 ; 4-byte Folded Reload
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
-; GCN-O0-NEXT:    v_readlane_b32 s30, v3, 0
-; GCN-O0-NEXT:    v_readlane_b32 s31, v3, 1
-; GCN-O0-NEXT:    buffer_load_dword v3, off, s[0:3], s33 offset:20
+; GCN-O0-NEXT:    v_readlane_b32 s30, v0, 0
+; GCN-O0-NEXT:    v_readlane_b32 s31, v0, 1
+; GCN-O0-NEXT:    buffer_load_dword v0, off, s[0:3], s33 offset:20
 ; GCN-O0-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-O0-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-O0-NEXT:    s_mov_b32 s32, s33


### PR DESCRIPTION
The invocation of freezeReservedRegs() is necessarily needed after AMDGPUReserveWWMRegs pass to get rid of stale reservation state in LWT flow, as no subsequent RA happens to refresh it as in default flow (perlane VGPR RA). Without this other passes like PEI, would see a stale cache of reserved registers to use from.

It resolves the LLVM ERRORS for the following LIT test :

1. CodeGen/AMDGPU/fold-reload-into-exec.mir
2. CodeGen/AMDGPU/fold-reload-into-m0.mir


