### PR TITLE
[WaveTransform] Avoid the use of SI_BRCOND_UNIFORM in lit tests

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
@@ -203,10 +203,8 @@ body:             |
   ; POSTWT-NEXT:   liveins: $sgpr0
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY:%[0-9]+]]:sgpr_32 = COPY $sgpr0
-  ; POSTWT-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 [[COPY]], killed [[S_MOV_B32_]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_EQ_U32_e64_]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 [[COPY]], 0, implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
@@ -226,9 +224,8 @@ body:             |
     liveins: $sgpr0
 
     %8:sgpr_32 = COPY $sgpr0
-    %15:sreg_32 = S_MOV_B32 0
-    %16:sreg_32 = V_CMP_EQ_U32_e64 %8, killed %15, implicit $exec
-    SI_BRCOND_UNIFORM %bb.2, killed %16
+    S_CMP_EQ_U32 %8, 0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.1
 
   bb.1:
@@ -469,8 +466,7 @@ body:             |
   ; POSTWT-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr2
   ; POSTWT-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY]], [[S_MOV_B32_]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_EQ_U32_e64_]]
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY]], [[S_MOV_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -478,15 +474,15 @@ body:             |
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.9(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY1]], [[S_MOV_B32_]], implicit $exec
-  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[V_CMP_EQ_U32_e64_1]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_1]], -1, implicit-def $scc
+  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY1]], [[S_MOV_B32_]], implicit $exec
+  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[V_CMP_EQ_U32_e64_]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_]], -1, implicit-def $scc
   ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_1:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_1]], implicit-def $scc
@@ -501,11 +497,11 @@ body:             |
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.8(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
-  ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_2]], -1, implicit-def $scc
+  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
+  ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_1]], -1, implicit-def $scc
   ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[S_AND_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[V_CMP_EQ_U32_e64_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[V_CMP_EQ_U32_e64_1]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_3]], implicit-def $scc
@@ -579,8 +575,8 @@ body:             |
     %9:vgpr_32 = COPY $vgpr1
     %10:vgpr_32 = COPY $vgpr2
     %15:sreg_32 = S_MOV_B32 0
-    %16:sreg_32 = V_CMP_EQ_U32_e64 killed %8, %15, implicit $exec
-    SI_BRCOND_UNIFORM %bb.2, killed %16
+    S_CMP_EQ_U32 killed %8, %15, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.1
 
   bb.1:
@@ -663,9 +659,8 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY1]], [[S_MOV_B32_]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_EQ_U32_e64_1]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.3, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.3, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.8:
@@ -686,9 +681,8 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.6(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_EQ_U32_e64_2]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.6, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.6, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.5
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -730,15 +724,15 @@ body:             |
   bb.1:
     successors: %bb.3, %bb.4
 
-    %17:sreg_32 = V_CMP_EQ_U32_e64 killed %9, %15, implicit $exec
-    SI_BRCOND_UNIFORM %bb.3, killed %17
+    S_CMP_EQ_U32 %9, %15, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.3, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.2:
     successors: %bb.5, %bb.6
 
-    %18:sreg_32 = V_CMP_EQ_U32_e64 killed %10, %15, implicit $exec
-    SI_BRCOND_UNIFORM %bb.6, killed %18
+    S_CMP_EQ_U32 killed %10, %15, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.6, implicit killed $scc
     S_BRANCH %bb.5
 
   bb.3:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
@@ -681,8 +681,8 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.6(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.6, implicit $scc
+  ; POSTWT-NEXT:   S_CMP_LG_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC0 %bb.6, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.5
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -731,8 +731,8 @@ body:             |
   bb.2:
     successors: %bb.5, %bb.6
 
-    S_CMP_EQ_U32 killed %10, %15, implicit-def $scc
-    S_CBRANCH_SCC1 %bb.6, implicit killed $scc
+    S_CMP_LG_U32 killed %10, %15, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.6, implicit killed $scc
     S_BRANCH %bb.5
 
   bb.3:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
@@ -396,8 +396,8 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
-  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC0 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
@@ -430,8 +430,8 @@ body:             |
 
   bb.3:
     %10:sreg_32 = COPY %20
-    S_CMP_LG_U32 %20, %2, implicit-def $scc
-    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_CMP_EQ_U32 %20, %2, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.1, implicit killed $scc
     S_BRANCH %bb.2
 
   bb.4:
@@ -627,8 +627,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_1:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY2]], 1, implicit-def $scc
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_1]]
-  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_1]], [[COPY]], implicit-def $scc
-  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 [[S_ADD_U32_1]], [[COPY]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC0 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
@@ -662,8 +662,8 @@ body:             |
   bb.3:
     %30:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %10:sreg_32 = COPY %30
-    S_CMP_LG_U32 %30, %0, implicit-def $scc
-    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_CMP_EQ_U32 %30, %0, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.1, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.4:
@@ -1264,11 +1264,11 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
   ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_2]], $exec_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_5]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
   ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_3]], $exec_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_6]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.9
@@ -1362,8 +1362,8 @@ body:             |
     successors: %bb.1, %bb.5
 
     %10:sreg_32 = COPY %11
-    S_CMP_LG_U32 %11, %2, implicit-def $scc
-    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_CMP_EQ_U32 %11, %2, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.1, implicit killed $scc
     S_BRANCH %bb.5
 
   bb.4:
@@ -1421,8 +1421,8 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
-  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
+  ; POSTWT-NEXT:   S_CMP_EQ_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC0 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -1468,8 +1468,8 @@ body:             |
     successors: %bb.1, %bb.4
 
     %10:sreg_32 = COPY %11
-    S_CMP_LG_U32 %11, %1, implicit-def $scc
-    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_CMP_EQ_U32 %11, %1, implicit-def $scc
+    S_CBRANCH_SCC0 %bb.1, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
@@ -190,19 +190,18 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY2]], 1, implicit-def $scc
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY]], implicit $exec
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_]]
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.1, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.3(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
+  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_NE_U32_e64_1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_NE_U32_e64_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[S_AND_B32_]], implicit-def $scc
@@ -230,9 +229,9 @@ body:             |
     successors: %bb.1, %bb.2
 
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
-    %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND_UNIFORM %bb.1, killed %12
+    S_CMP_LG_U32 %11, %0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.2
 
   bb.2:
@@ -293,9 +292,11 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.4(0x80000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_NE_U32_e64_1]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
@@ -303,8 +304,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -338,9 +339,9 @@ body:             |
   bb.2:
     successors: %bb.1, %bb.3
 
-    %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND_UNIFORM %bb.1, killed %20
+    S_CMP_LG_U32 %11, %1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.3:
@@ -379,27 +380,24 @@ body:             |
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[COPY3]], [[COPY]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[COPY3]], [[COPY]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_1]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.3, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.3, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY2]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_2]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.1, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
@@ -418,22 +416,22 @@ body:             |
   bb.1:
     successors: %bb.2, %bb.4
 
-    %11:sreg_32 = V_CMP_NE_U32_e64 %10, %0, implicit $exec
-    SI_BRCOND_UNIFORM %bb.2, killed %11
+    S_CMP_LG_U32 %10, %0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.2:
     successors: %bb.3, %bb.4
 
     %20:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
-    %21:sreg_32 = V_CMP_NE_U32_e64 %20, %1, implicit $exec
-    SI_BRCOND_UNIFORM %bb.3, killed %21
+    S_CMP_LG_U32 %20, %1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.3, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:
-    %30:sreg_32 = V_CMP_NE_U32_e64 %20, %2, implicit $exec
     %10:sreg_32 = COPY %20
-    SI_BRCOND_UNIFORM %bb.1, killed %30
+    S_CMP_LG_U32 %20, %2, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.2
 
   bb.4:
@@ -619,20 +617,18 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.3(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_1:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY2]], 1, implicit-def $scc
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_1]], [[COPY]], implicit $exec
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_1]]
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_1]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.1, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_1]], [[COPY]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
@@ -658,16 +654,16 @@ body:             |
     successors: %bb.2, %bb.3
 
     %21:sreg_32 = S_ADD_U32 %20, 1, implicit-def $scc
-    %22:sreg_32 = V_CMP_NE_U32_e64 %21, %1, implicit $exec
     %20:sreg_32 = COPY %21
-    SI_BRCOND_UNIFORM %bb.2, killed %22
+    S_CMP_LG_U32 %21, %1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.3:
     %30:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
-    %31:sreg_32 = V_CMP_NE_U32_e64 %30, %0, implicit $exec
     %10:sreg_32 = COPY %30
-    SI_BRCOND_UNIFORM %bb.1, killed %31
+    S_CMP_LG_U32 %30, %0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.4:
@@ -1041,8 +1037,8 @@ body:             |
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
   ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
@@ -1141,7 +1137,8 @@ body:             |
 
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
-    SI_BRCOND_UNIFORM %bb.2, killed %12
+    S_CMP_LG_U32 %11, %0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.2:
@@ -1238,21 +1235,23 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.10(0x80000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_NE_U32_e64_1]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_NE_U32_e64_1]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_1]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.10
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.10:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.9(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_7]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_3]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_4]]
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -1264,21 +1263,23 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.9(0x80000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY2]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_NE_U32_e64_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_4:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_NE_U32_e64_2]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_2:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_3:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_6]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.9
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.7:
   ; POSTWT-NEXT:   successors: %bb.4(0x40000000), %bb.6(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_10]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_6]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_11:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_11]], [[S_AND_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_6]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_7:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_11:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_11]], [[S_AND_B32_7]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_6]]
   ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -1296,9 +1297,9 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.8(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_8]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_6:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_6]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_6]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_4:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_8:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_8]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -1310,9 +1311,9 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.7(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_9]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_7:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_7:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_7]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_10]], [[S_AND_B32_7]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_9:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_10:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_10]], [[S_AND_B32_9]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_5]]
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -1352,17 +1353,17 @@ body:             |
   bb.2:
     successors: %bb.1, %bb.4
 
-    %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND_UNIFORM %bb.1, killed %20
+    S_CMP_LG_U32 %11, %1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:
     successors: %bb.1, %bb.5
 
-    %30:sreg_32 = V_CMP_NE_U32_e64 %11, %2, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND_UNIFORM %bb.1, killed %30
+    S_CMP_LG_U32 %11, %2, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.5
 
   bb.4:
@@ -1412,27 +1413,24 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.2(0x40000000), %bb.3(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_ADD_U32_:%[0-9]+]]:sreg_32 = S_ADD_U32 [[COPY3]], 1, implicit-def $scc
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY]], implicit $exec
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY1]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_1]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.1, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY1]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
   ; POSTWT-NEXT:   successors: %bb.1(0x40000000), %bb.5(0x40000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[S_ADD_U32_]], [[COPY2]], implicit $exec
   ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY [[S_ADD_U32_]]
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[V_CMP_NE_U32_e64_2]]
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.1, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CMP_LG_U32 [[S_ADD_U32_]], [[COPY2]], implicit-def $scc
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.1, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.5
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.4:
@@ -1462,24 +1460,24 @@ body:             |
     successors: %bb.2, %bb.3
 
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
-    %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
-    SI_BRCOND_UNIFORM %bb.2, killed %12
+    S_CMP_LG_U32 %11, %0, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.2:
     successors: %bb.1, %bb.4
 
-    %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND_UNIFORM %bb.1, killed %20
+    S_CMP_LG_U32 %11, %1, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:
     successors: %bb.1, %bb.5
 
-    %30:sreg_32 = V_CMP_NE_U32_e64 %11, %2, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND_UNIFORM %bb.1, killed %30
+    S_CMP_LG_U32 %11, %2, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
     S_BRANCH %bb.5
 
   bb.4:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
@@ -208,16 +208,13 @@ body:             |
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; POSTWT-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
@@ -225,12 +222,12 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY1]], [[S_MOV_B32_]], implicit $exec
   ; POSTWT-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[S_AND_B32_1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[S_AND_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_EQ_U32_e64_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_1:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_1]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_1]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_1]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_1]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_1]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   SI_WAVE_CF_EDGE implicit-def $scc
@@ -242,12 +239,12 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_1]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_3]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_AND_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[V_CMP_EQ_U32_e64_1]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   SI_WAVE_CF_EDGE implicit-def $scc
@@ -265,8 +262,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_4:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -285,8 +282,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_3]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_6]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_6]], [[S_AND_B32_5]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_3]]
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -313,8 +310,7 @@ body:             |
     %3:vgpr_32 = COPY $vgpr1
     %4:sreg_32 = S_MOV_B32 0
     S_CMP_EQ_U32 killed %1, %4, implicit-def $scc
-    %5:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.2, killed %5
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.1
 
   bb.1:
@@ -397,11 +393,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_]]
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.7, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.7, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.10:
@@ -409,8 +402,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_6]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_7]], [[S_AND_B32_1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_7]], [[S_AND_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -424,8 +417,8 @@ body:             |
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
   ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_1]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_1]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[V_CMP_EQ_U32_e64_1]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.9
   ; POSTWT-NEXT: {{  $}}
@@ -439,8 +432,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_7]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_4:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_3]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_4]]
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -459,8 +452,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_8]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_5]]
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -482,8 +475,8 @@ body:             |
   ; POSTWT-NEXT: bb.7:
   ; POSTWT-NEXT:   successors: %bb.10(0x80000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_MOV_B32_3]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_MOV_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.10
   bb.0:
     successors: %bb.1, %bb.2
@@ -501,8 +494,7 @@ body:             |
     successors: %bb.3, %bb.4
 
     S_CMP_EQ_U32 killed %2, %4, implicit-def $scc
-    %6:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.4, killed %6
+    S_CBRANCH_SCC1 %bb.4, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.2:
@@ -610,13 +602,12 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 [[COPY3]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_3]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_1]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.8
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -629,9 +620,9 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.4(0x40000000), %bb.7(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_7]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_6:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_6]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_6]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_5]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_4]]
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -649,9 +640,9 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.6(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_8]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_7:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_7:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_7]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_7]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_6:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_6]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_6]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_5]]
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -692,8 +683,7 @@ body:             |
     successors: %bb.4, %bb.5
 
     S_CMP_EQ_U32 killed %3, %4, implicit-def $scc
-    %7:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.5, killed %7
+    S_CBRANCH_SCC1 %bb.5, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:
@@ -762,11 +752,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_]]
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.7, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.7, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.10:
@@ -774,8 +761,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_6]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_7]], [[S_AND_B32_1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_7]], [[S_AND_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_6:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -788,13 +775,12 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 [[COPY4]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_3]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_CSELECT_B32_1:%[0-9]+]]:sreg_32 = S_CSELECT_B32 $exec_lo, 0, implicit $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_CSELECT_B32_1]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_5]], [[S_AND_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.9
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -806,9 +792,9 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.4(0x40000000), %bb.8(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_7]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_4:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_3:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_8]], [[S_AND_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_4]]
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_7:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -826,9 +812,9 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.5(0x40000000), %bb.6(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_8]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_XOR_B32_5:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_6:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_5]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_6]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_XOR_B32_4:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_5]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_4]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_9:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_9]], [[S_AND_B32_4]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_5]]
   ; POSTWT-NEXT:   [[S_MOV_B32_5:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_8:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -850,8 +836,8 @@ body:             |
   ; POSTWT-NEXT: bb.7:
   ; POSTWT-NEXT:   successors: %bb.10(0x80000000)
   ; POSTWT-NEXT: {{  $}}
-  ; POSTWT-NEXT:   [[S_AND_B32_7:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_MOV_B32_3]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_7]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_5:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_MOV_B32_3]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_5]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.10
   bb.0:
     successors: %bb.1, %bb.2
@@ -869,16 +855,14 @@ body:             |
     successors: %bb.3, %bb.4
 
     S_CMP_EQ_U32 killed %2, %4, implicit-def $scc
-    %6:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.4, killed %6
+    S_CBRANCH_SCC1 %bb.4, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.2:
     successors: %bb.4, %bb.5
 
     S_CMP_EQ_U32 killed %3, %4, implicit-def $scc
-    %7:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.5, killed %7
+    S_CBRANCH_SCC1 %bb.5, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:
@@ -922,14 +906,11 @@ body:             |
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:sgpr_32 = COPY $sgpr1
   ; POSTWT-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
@@ -937,12 +918,12 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY1]], [[S_MOV_B32_]], implicit $exec
   ; POSTWT-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[S_AND_B32_1]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[S_AND_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_EQ_U32_e64_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_1:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_1]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_1]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_1]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[S_AND_B32_1]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_1]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   SI_WAVE_CF_EDGE implicit-def $scc
@@ -953,11 +934,8 @@ body:             |
   ; POSTWT-NEXT:   successors: %bb.4(0x40000000), %bb.5(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY2]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY4]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_3]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.5, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.5, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -971,8 +949,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -1004,8 +982,7 @@ body:             |
     %3:sgpr_32 = COPY $sgpr1
     %4:sreg_32 = S_MOV_B32 0
     S_CMP_EQ_U32 killed %1, %4, implicit-def $scc
-    %5:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.2, killed %5
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.1
 
   bb.1:
@@ -1019,8 +996,7 @@ body:             |
     successors: %bb.4, %bb.5
 
     S_CMP_EQ_U32 killed %3, %4, implicit-def $scc
-    %7:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.5, killed %7
+    S_CBRANCH_SCC1 %bb.5, implicit killed $scc
     S_BRANCH %bb.4
 
   bb.3:
@@ -1064,25 +1040,19 @@ body:             |
   ; POSTWT-NEXT:   [[COPY2:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; POSTWT-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY3:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY3]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.2, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.2, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.1
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.1:
   ; POSTWT-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   S_CMP_EQ_U32 killed [[COPY1]], [[S_MOV_B32_]], implicit-def $scc
-  ; POSTWT-NEXT:   [[COPY4:%[0-9]+]]:sreg_32 = COPY $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 $exec_lo, [[COPY4]], implicit-def $scc
-  ; POSTWT-NEXT:   $vcc_lo = COPY [[S_AND_B32_1]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
-  ; POSTWT-NEXT:   S_CBRANCH_VCCNZ %bb.4, implicit $vcc_lo
+  ; POSTWT-NEXT:   S_CBRANCH_SCC1 %bb.4, implicit $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
@@ -1090,12 +1060,12 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 killed [[COPY2]], [[S_MOV_B32_]], implicit $exec
   ; POSTWT-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 [[V_CMP_EQ_U32_e64_]], -1, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[S_AND_B32_2]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_1]], [[S_AND_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[V_CMP_EQ_U32_e64_]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_1:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_1]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_3:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_1]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[S_AND_B32_3]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_1:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_1]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_3]], [[S_AND_B32_1]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_1]]
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   SI_WAVE_CF_EDGE implicit-def $scc
@@ -1118,8 +1088,8 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   $exec_lo = S_OR_B32 $exec_lo, [[S_MOV_B32_3]], implicit-def $scc
   ; POSTWT-NEXT:   [[S_XOR_B32_2:%[0-9]+]]:sreg_32 = S_XOR_B32 $exec_lo, [[S_MOV_B32_2]], implicit-def $scc
-  ; POSTWT-NEXT:   [[S_AND_B32_4:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
-  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_4]], implicit-def $scc
+  ; POSTWT-NEXT:   [[S_AND_B32_2:%[0-9]+]]:sreg_32 = S_AND_B32 [[S_XOR_B32_2]], $exec_lo, implicit-def $scc
+  ; POSTWT-NEXT:   [[S_MOV_B32_4:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_4]], [[S_AND_B32_2]], implicit-def $scc
   ; POSTWT-NEXT:   $exec_lo = S_MOV_B32 [[S_MOV_B32_2]]
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   [[S_MOV_B32_3:%[0-9]+]]:sreg_32 = S_MOV_B32 0
@@ -1146,16 +1116,14 @@ body:             |
     %3:vgpr_32 = COPY $vgpr0
     %4:sreg_32 = S_MOV_B32 0
     S_CMP_EQ_U32 killed %1, %4, implicit-def $scc
-    %5:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.2, killed %5
+    S_CBRANCH_SCC1 %bb.2, implicit killed $scc
     S_BRANCH %bb.1
 
   bb.1:
     successors: %bb.3, %bb.4
 
     S_CMP_EQ_U32 killed %2, %4, implicit-def $scc
-    %6:sreg_32 = COPY $scc
-    SI_BRCOND_UNIFORM %bb.4, killed %6
+    S_CBRANCH_SCC1 %bb.4, implicit killed $scc
     S_BRANCH %bb.3
 
   bb.2:


### PR DESCRIPTION
Update WaveTransform test expectations to use hardware branch instructions instead of SI_BRCOND_UNIFORM pseudo-instruction. The SI_BRCOND_UNIFORM and SI_BRCOND_UNIFORM_Z opcodes are not needed any more and will be removed in a follow-up patch.


