### PR TITLE
[Nightly][Infra] Temp bump of rocm-libraries to 080aa34

### DIFF
--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -100,6 +100,17 @@ jobs:
           git submodule status
           git submodule
 
+      - name: Temp - Pin rocm-libraries submodule checkout for nightly 
+        if: ${{ github.event_name != 'pull_request' && inputs.test_type == 'full' }}
+        run: |
+          git config --global --add safe.directory "$PWD"
+          git update-index --cacheinfo 160000,080aa34e798c4b33803036aca6c66aae666a76dd,rocm-libraries
+          git config --global user.email "z1-cciauto@amd.com"
+          git config --global user.name "Z1 cciauto"
+          git commit -m "Pin rocm-libraries to 080aa34e798c4b33803036aca6c66aae666a76dd"
+          git submodule status rocm-libraries || true
+          
+
       - name: Download LLVM, SPIRV and HIPIFY PR's stored in file
         if: ${{ github.event_name == 'workflow_dispatch' }}
         continue-on-error: true 

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -232,10 +232,11 @@ jobs:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
-          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          extra_cmake_options: '-DCMAKE_CXX_FLAGS="-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions" ${{ inputs.extra_cmake_options }}'
+          extra_cmake_options: ${{ inputs.extra_cmake_options }}
           BUILD_DIR: build
         run: |
+          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
+          echo 'CXXFLAGS=-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions' >> "$GITHUB_ENV"
           python3 build_tools/github_actions/build_configure.py --manylinux
 
       - name: Build therock-archives and therock-dist

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -236,7 +236,7 @@ jobs:
           BUILD_DIR: build
         run: |
           # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          echo 'CXXFLAGS=-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions' >> "$GITHUB_ENV"
+          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions +-Wno-unused-but-set-variable' >> "$GITHUB_ENV"
           python3 build_tools/github_actions/build_configure.py --manylinux
 
       - name: Build therock-archives and therock-dist

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -233,9 +233,10 @@ jobs:
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
           extra_cmake_options: ${{ inputs.extra_cmake_options }} 
-          CCC_OVERRIDE_OPTIONS: "+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions"
           BUILD_DIR: build
         run: |
+          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
+          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions' >> "$GITHUB_ENV"
           python3 build_tools/github_actions/build_configure.py --manylinux
 
       - name: Build therock-archives and therock-dist

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -232,11 +232,10 @@ jobs:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
-          extra_cmake_options: ${{ inputs.extra_cmake_options }} 
+          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
+          extra_cmake_options: '-DCMAKE_CXX_FLAGS="-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions" ${{ inputs.extra_cmake_options }}'
           BUILD_DIR: build
         run: |
-          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions' >> "$GITHUB_ENV"
           python3 build_tools/github_actions/build_configure.py --manylinux
 
       - name: Build therock-archives and therock-dist

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -232,7 +232,8 @@ jobs:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
-          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          extra_cmake_options: ${{ inputs.extra_cmake_options }} 
+          CCC_OVERRIDE_OPTIONS: "+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions"
           BUILD_DIR: build
         run: |
           python3 build_tools/github_actions/build_configure.py --manylinux

--- a/.github/workflows/build_portable_linux_artifacts.yml
+++ b/.github/workflows/build_portable_linux_artifacts.yml
@@ -246,8 +246,6 @@ jobs:
           extra_cmake_options: ${{ inputs.extra_cmake_options }}
           BUILD_DIR: build
         run: |
-          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions +-Wno-unused-but-set-variable' >> "$GITHUB_ENV"
           python3 build_tools/github_actions/build_configure.py --manylinux
 
       - name: Build therock-archives and therock-dist

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -111,7 +111,18 @@ jobs:
           # Verify the pointer update
           git submodule status
           git submodule
-          
+
+      - name: Temp - Pin rocm-libraries submodule checkout for nightly
+        if: ${{ github.event_name != 'pull_request' && inputs.test_type == 'full' }}
+        run: |
+          git config --global --add safe.directory "$PWD"
+          git update-index --cacheinfo 160000,080aa34e798c4b33803036aca6c66aae666a76dd,rocm-libraries
+          git config --global user.email "z1-cciauto@amd.com"
+          git config --global user.name "Z1 cciauto"
+          git commit -m "Pin rocm-libraries to 080aa34e798c4b33803036aca6c66aae666a76dd"
+          git submodule status rocm-libraries || true
+
+
       - name: Download LLVM, SPIRV and HIPIFY PR's stored in file
         if: ${{ github.event_name == 'workflow_dispatch' }}
         continue-on-error: true

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -280,9 +280,10 @@ jobs:
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
           extra_cmake_options: ${{ inputs.extra_cmake_options }}
-          CCC_OVERRIDE_OPTIONS: "+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions"
         run: |
           # clear cache before build and after download
+          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
+          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions' >>"%GITHUB_ENV%"
           cd L:
           ccache -z
           cmake -B 'B:\build' -GNinja -S 'L:\' --preset windows-release -DTHEROCK_AMDGPU_FAMILIES=gfx1151 '-DCMAKE_C_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_CXX_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_LINKER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/link.exe' -DTHEROCK_BACKGROUND_BUILD_JOBS=4

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -279,11 +279,10 @@ jobs:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
-          extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
+          extra_cmake_options: '-DCMAKE_CXX_FLAGS="-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions" ${{ inputs.extra_cmake_options }}'
         run: |
           # clear cache before build and after download
-          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions' >>"%GITHUB_ENV%"
           cd L:
           ccache -z
           cmake -B 'B:\build' -GNinja -S 'L:\' --preset windows-release -DTHEROCK_AMDGPU_FAMILIES=gfx1151 '-DCMAKE_C_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_CXX_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_LINKER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/link.exe' -DTHEROCK_BACKGROUND_BUILD_JOBS=4

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -279,10 +279,11 @@ jobs:
           cmake_preset: ${{ inputs.build_variant_cmake_preset }}
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
-          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          extra_cmake_options: '-DCMAKE_CXX_FLAGS="-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions" ${{ inputs.extra_cmake_options }}'
+          extra_cmake_options: ${{ inputs.extra_cmake_options }}
         run: |
           # clear cache before build and after download
+          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
+          echo 'CXXFLAGS=-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions' >> "$GITHUB_ENV"
           cd L:
           ccache -z
           cmake -B 'B:\build' -GNinja -S 'L:\' --preset windows-release -DTHEROCK_AMDGPU_FAMILIES=gfx1151 '-DCMAKE_C_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_CXX_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_LINKER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/link.exe' -DTHEROCK_BACKGROUND_BUILD_JOBS=4

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -280,6 +280,7 @@ jobs:
           amdgpu_families: ${{ inputs.amdgpu_families }}
           package_version: ${{ inputs.package_version }}
           extra_cmake_options: ${{ inputs.extra_cmake_options }}
+          CCC_OVERRIDE_OPTIONS: "+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions"
         run: |
           # clear cache before build and after download
           cd L:

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -293,8 +293,6 @@ jobs:
           extra_cmake_options: ${{ inputs.extra_cmake_options }}
         run: |
           # clear cache before build and after download
-          # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions +-Wno-unused-but-set-variable' >> "$GITHUB_ENV"
           cd L:
           ccache -z
           cmake -B 'B:\build' -GNinja -S 'L:\' --preset windows-release -DTHEROCK_AMDGPU_FAMILIES=gfx1151 '-DCMAKE_C_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_CXX_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_LINKER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/link.exe' -DTHEROCK_BACKGROUND_BUILD_JOBS=4

--- a/.github/workflows/build_windows_artifacts.yml
+++ b/.github/workflows/build_windows_artifacts.yml
@@ -283,7 +283,7 @@ jobs:
         run: |
           # clear cache before build and after download
           # The below CCC is temp fix for CK build. This will/shall be removed when fix gets added
-          echo 'CXXFLAGS=-Wno-lifetime-safety-intra-tu-suggestions -Wno-lifetime-safety-cross-tu-suggestions' >> "$GITHUB_ENV"
+          echo 'CCC_OVERRIDE_OPTIONS=+-Wno-lifetime-safety-intra-tu-suggestions +-Wno-lifetime-safety-cross-tu-suggestions +-Wno-unused-but-set-variable' >> "$GITHUB_ENV"
           cd L:
           ccache -z
           cmake -B 'B:\build' -GNinja -S 'L:\' --preset windows-release -DTHEROCK_AMDGPU_FAMILIES=gfx1151 '-DCMAKE_C_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_CXX_COMPILER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/cl.exe' '-DCMAKE_LINKER=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\MSVC\14.44.35207\/bin/Hostx64/x64/link.exe' -DTHEROCK_BACKGROUND_BUILD_JOBS=4


### PR DESCRIPTION
This is a temporary infra chance on nightly to bump the rocm-libraries to get the CK fix

verification run : https://github.com/ROCm/llvm-project/actions/runs/23853493950/job/69539971341