### PR TITLE
[WaveTransform][NFC] Remove SI_BRCOND_UNIFORM opcodes

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -1724,9 +1724,7 @@ void ControlFlowRewriter::prepareWaveCfg() {
       unsigned Opcode = Terminator.getOpcode();
 
       assert(!Info.OrigSuccFinal);
-      if (Opcode == AMDGPU::SI_BRCOND || Opcode == AMDGPU::SI_BRCOND_UNIFORM ||
-          Opcode == AMDGPU::SI_BRCOND_Z ||
-          Opcode == AMDGPU::SI_BRCOND_UNIFORM_Z) {
+      if (Opcode == AMDGPU::SI_BRCOND || Opcode == AMDGPU::SI_BRCOND_Z) {
         assert(!Info.OrigCondition);
         Info.OrigCondition = Terminator.getOperand(1).getReg();
         Info.OrigConditionUndef = Terminator.getOperand(1).isUndef();
@@ -1940,7 +1938,7 @@ void ControlFlowRewriter::rewrite() {
       assert(LaneSucc != Node->LaneSuccessors.end());
 
       unsigned Opcode = Info.ImplicitBranchOpc;
-      if (!Opcode) { // SI_BRCOND_UNIFORM SI_BRCOND_UNIFORM_Z
+      if (!Opcode) { // For uniform branch cases.
         assert(Info.OrigCondition);
 
         if (Info.OrigCondition == AMDGPU::SCC) {

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3221,10 +3221,6 @@ unsigned SIInstrInfo::getBranchOpcode(SIInstrInfo::BranchPredicate Cond) {
     return AMDGPU::S_CBRANCH_EXECNZ;
   case SIInstrInfo::EXECZ:
     return AMDGPU::S_CBRANCH_EXECZ;
-  case SIInstrInfo::UNIFORM_NZ:
-    return AMDGPU::SI_BRCOND_UNIFORM;
-  case SIInstrInfo::UNIFORM_Z:
-    return AMDGPU::SI_BRCOND_UNIFORM_Z;
   case SIInstrInfo::DIVERGE_NZ:
     return AMDGPU::SI_BRCOND;
   case SIInstrInfo::DIVERGE_Z:
@@ -3252,10 +3248,6 @@ SIInstrInfo::BranchPredicate SIInstrInfo::getBranchPredicate(unsigned Opcode) {
     return DIVERGE_NZ;
   case AMDGPU::SI_BRCOND_Z:
     return DIVERGE_Z;
-  case AMDGPU::SI_BRCOND_UNIFORM:
-    return UNIFORM_NZ;
-  case AMDGPU::SI_BRCOND_UNIFORM_Z:
-    return UNIFORM_Z;
   default:
     return INVALID_BR;
   }
@@ -3393,9 +3385,7 @@ unsigned SIInstrInfo::insertBranch(MachineBasicBlock &MBB,
       BuildMI(&MBB, DL, get(Opcode))
       .addMBB(TBB);
 
-    if (Opcode == AMDGPU::SI_BRCOND_UNIFORM ||
-        Opcode == AMDGPU::SI_BRCOND_UNIFORM_Z || Opcode == AMDGPU::SI_BRCOND ||
-        Opcode == AMDGPU::SI_BRCOND_Z) {
+    if (Opcode == AMDGPU::SI_BRCOND || Opcode == AMDGPU::SI_BRCOND_Z) {
       assert(Cond.size() == 2 && "Branch should have two operands");
       CondBr->addOperand(Cond[1]); // Add the condition register.
     }
@@ -3413,9 +3403,7 @@ unsigned SIInstrInfo::insertBranch(MachineBasicBlock &MBB,
   MachineInstr *CondBr =
     BuildMI(&MBB, DL, get(Opcode))
     .addMBB(TBB);
-  if (Opcode == AMDGPU::SI_BRCOND_UNIFORM ||
-      Opcode == AMDGPU::SI_BRCOND_UNIFORM_Z || Opcode == AMDGPU::SI_BRCOND ||
-      Opcode == AMDGPU::SI_BRCOND_Z) {
+  if (Opcode == AMDGPU::SI_BRCOND || Opcode == AMDGPU::SI_BRCOND_Z) {
     assert(Cond.size() == 2 && "Branch should have two operands");
     CondBr->addOperand(Cond[1]); // Add the condition register.
   }

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -110,10 +110,8 @@ private:
     VCCZ = -2,
     EXECNZ = -3,
     EXECZ = 3,
-    UNIFORM_NZ = 4,
-    UNIFORM_Z = -4,
-    DIVERGE_NZ = 5,
-    DIVERGE_Z = -5
+    DIVERGE_NZ = 4,
+    DIVERGE_Z = -4
   };
 
   using SetVectorType = SmallSetVector<MachineInstr *, 32>;

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -690,32 +690,6 @@ def SI_BRCOND_Z
   // let usesCustomInserter = 1;
   let isBranch = 1;
 }
-// Pseudo wave-level conditional branch used in WaveTransform mode.
-// It takes a virtual scalar register as the condition. Semantically,
-// a wave jumps to the target if its condition is NOT zero,
-// falls through if its condition is zero. This pseudo-op is lowered
-// to the real AMDGPU branch instruction during WaveTransform.
-// It does NOT affect exec-mask.
-def SI_BRCOND_UNIFORM
-    : SPseudoInstSI<(outs), (ins SOPPBrTarget:$target, SReg_1:$cond)> {
-  let isTerminator = 1;
-  // let usesCustomInserter = 1;
-  let isBranch = 1;
-}
-// Mirror of SI_BRCOND_UNIFORM for flipping branch during MIR optimization.
-// Pseudo wave-level conditional branch used in WaveTransform mode.
-// It takes a virtual scalar register as the condition. Semantically,
-// a wave jumps to the target if its condition is zero,
-// falls through if its condition is NOT zero. This pseudo-op is lowered
-// to the real AMDGPU branch instruction during WaveTransform.
-// It does NOT affect exec-mask.
-def SI_BRCOND_UNIFORM_Z
-    : SPseudoInstSI<(outs), (ins SOPPBrTarget:$target, SReg_1:$cond)> {
-  let isTerminator = 1;
-  // let usesCustomInserter = 1;
-  let isBranch = 1;
-}
-
 def SI_PS_LIVE : PseudoInstSI <
   (outs SReg_1:$dst), (ins),
   [(set i1:$dst, (int_amdgcn_ps_live))]> {


### PR DESCRIPTION
Remove SI_BRCOND_UNIFORM and SI_BRCOND_UNIFORM_Z
pseudo-instructions as they are no longer needed.
These opcodes were intermediate representations
for uniform branches that will now be lowered to
actual hardware branch instructions earlier in
the pipeline.


