### PR TITLE
[AMDGPU] Fix missing !noalias metadata on memory-accessing calls with…

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPULowerKernelArguments.cpp
@@ -113,53 +113,67 @@ static void addAliasScopeMetadata(Function &F, const DataLayout &DL,
 
         PtrArgs.push_back(Arg);
       }
-    }
-
-    if (PtrArgs.empty())
+    } else {
       continue;
+    }
 
     // Collect underlying objects of pointer arguments.
     SmallVector<Metadata *, 4u> Scopes;
     SmallPtrSet<const Value *, 4u> ObjSet;
     SmallVector<Metadata *, 4u> NoAliases;
 
-    for (const Value *Val : PtrArgs) {
-      SmallVector<const Value *, 4u> Objects;
-      getUnderlyingObjects(Val, Objects);
-      ObjSet.insert_range(Objects);
-    }
+    if (!PtrArgs.empty()) {
+      for (const Value *Val : PtrArgs) {
+        SmallVector<const Value *, 4u> Objects;
+        getUnderlyingObjects(Val, Objects);
+        ObjSet.insert_range(Objects);
+      }
 
-    bool RequiresNoCaptureBefore = false;
-    bool UsesUnknownObject = false;
-    bool UsesAliasingPtr = false;
+      bool RequiresNoCaptureBefore = false;
+      bool UsesUnknownObject = false;
+      bool UsesAliasingPtr = false;
 
-    for (const Value *Val : ObjSet) {
-      if (isa<ConstantData>(Val))
-        continue;
+      for (const Value *Val : ObjSet) {
+        if (isa<ConstantData>(Val))
+          continue;
 
-      if (const Argument *Arg = dyn_cast<Argument>(Val)) {
-        if (!Arg->hasAttribute(Attribute::NoAlias))
+        if (const Argument *Arg = dyn_cast<Argument>(Val)) {
+          if (!Arg->hasAttribute(Attribute::NoAlias))
+            UsesAliasingPtr = true;
+        } else
           UsesAliasingPtr = true;
-      } else
-        UsesAliasingPtr = true;
 
-      if (isEscapeSource(Val))
-        RequiresNoCaptureBefore = true;
-      else if (!isa<Argument>(Val) && isIdentifiedObject(Val))
-        UsesUnknownObject = true;
-    }
+        if (isEscapeSource(Val))
+          RequiresNoCaptureBefore = true;
+        else if (!isa<Argument>(Val) && isIdentifiedObject(Val))
+          UsesUnknownObject = true;
+      }
 
-    if (UsesUnknownObject)
-      continue;
-
-    // Collect noalias scopes for instruction.
-    for (const Argument *Arg : NoAliasArgs) {
-      if (ObjSet.contains(Arg))
+      if (UsesUnknownObject)
         continue;
 
-      if (!RequiresNoCaptureBefore ||
-          !capturesAnything(PointerMayBeCapturedBefore(
-              Arg, false, I, &DT, false, CaptureComponents::Provenance)))
+      // Collect noalias scopes for instruction.
+      for (const Argument *Arg : NoAliasArgs) {
+        if (ObjSet.contains(Arg))
+          continue;
+
+        if (!RequiresNoCaptureBefore ||
+            !capturesAnything(PointerMayBeCapturedBefore(
+                Arg, false, I, &DT, false, CaptureComponents::Provenance)))
+          NoAliases.push_back(NewScopes[Arg]);
+      }
+
+      // Collect scopes for alias.scope metadata.
+      if (!UsesAliasingPtr)
+        for (const Argument *Arg : NoAliasArgs) {
+          if (ObjSet.count(Arg))
+            Scopes.push_back(NewScopes[Arg]);
+        }
+    } else {
+      // No pointer args but instruction accesses memory (e.g. call without
+      // pointer arguments). It doesn't access memory through any noalias
+      // argument, so add all noalias scopes to !noalias.
+      for (const Argument *Arg : NoAliasArgs)
         NoAliases.push_back(NewScopes[Arg]);
     }
 
@@ -170,13 +184,6 @@ static void addAliasScopeMetadata(Function &F, const DataLayout &DL,
                               MDNode::get(F.getContext(), NoAliases));
       Inst->setMetadata(LLVMContext::MD_noalias, NewMD);
     }
-
-    // Collect scopes for alias.scope metadata.
-    if (!UsesAliasingPtr)
-      for (const Argument *Arg : NoAliasArgs) {
-        if (ObjSet.count(Arg))
-          Scopes.push_back(NewScopes[Arg]);
-      }
 
     // Add alias.scope metadata to instruction.
     if (!Scopes.empty()) {


### PR DESCRIPTION
    After bd9668df0f00 ("Reapply [AMDGPU] Propagate alias information in
    AMDGPULowerKernelArguments"), addAliasScopeMetadata skips instructions
    whose PtrArgs list is empty. This is wrong for CallBase instructions
    that access memory but have no pointer arguments (e.g. threadIdx
    intrinsic wrappers like _ZN25__hip_builtin_threadIdx_t7__get_xEv).

    Because these calls are skipped, they receive no !noalias metadata.
    Alias Analysis then conservatively reports Mod for them, which prevents
    AMDGPUAnnotateUniformValues from marking kernel argument loads as
    !amdgpu.noclobber. Without that annotation the loads are lowered to
    vector global_load instead of scalar s_load, causing ~20% GFLOPS
    regressions in rocFFT on gfx90a (ROCM-20545).

    Fix: instead of skipping the instruction when PtrArgs is empty, add all
    noalias scopes to !noalias — the call does not access memory through any
    noalias argument, so it cannot alias with any of them.

    Assisted-by: Claude Opus
