### PR TITLE
Re-apply "[mlir][Parser] Fix use-after-free when parsing invalid reference to nested definition (#127778)"

### DIFF
--- a/mlir/lib/AsmParser/Parser.cpp
+++ b/mlir/lib/AsmParser/Parser.cpp
@@ -860,6 +860,12 @@ private:
   /// their first reference, to allow checking for use of undefined values.
   DenseMap<Value, SMLoc> forwardRefPlaceholders;
 
+  /// Operations that define the placeholders. These are kept until the end of
+  /// of the lifetime of the parser because some custom parsers may store
+  /// references to them in local state and use them after forward references
+  /// have been resolved.
+  DenseSet<Operation *> forwardRefOps;
+
   /// Deffered locations: when parsing `loc(#loc42)` we add an entry to this
   /// map. After parsing the definition `#loc42 = ...` we'll patch back users
   /// of this location.
@@ -887,11 +893,11 @@ OperationParser::OperationParser(ParserState &state, ModuleOp topLevelOp)
 }
 
 OperationParser::~OperationParser() {
-  for (auto &fwd : forwardRefPlaceholders) {
+  for (Operation *op : forwardRefOps) {
     // Drop all uses of undefined forward declared reference and destroy
     // defining operation.
-    fwd.first.dropAllUses();
-    fwd.first.getDefiningOp()->destroy();
+    op->dropAllUses();
+    op->destroy();
   }
   for (const auto &scope : forwardRef) {
     for (const auto &fwd : scope) {
@@ -1047,7 +1053,6 @@ ParseResult OperationParser::addDefinition(UnresolvedOperand useInfo,
     // the actual definition instead, delete the forward ref, and remove it
     // from our set of forward references we track.
     existing.replaceAllUsesWith(value);
-    existing.getDefiningOp()->destroy();
     forwardRefPlaceholders.erase(existing);
 
     // If a definition of the value already exists, replace it in the assembly
@@ -1234,6 +1239,7 @@ Value OperationParser::createForwardRefPlaceholder(SMLoc loc, Type type) {
       /*attributes=*/NamedAttrList(), /*properties=*/nullptr,
       /*successors=*/{}, /*numRegions=*/0);
   forwardRefPlaceholders[op->getResult(0)] = loc;
+  forwardRefOps.insert(op);
   return op->getResult(0);
 }
 

--- a/mlir/test/IR/print-unsafe-null-operand.mlir
+++ b/mlir/test/IR/print-unsafe-null-operand.mlir
@@ -1,5 +1,4 @@
 // RUN: mlir-opt %s --mlir-very-unsafe-disable-verifier-on-parsing 2>&1 | FileCheck %s
-// XFAIL: *
 // Regression test for https://github.com/llvm/llvm-project/issues/182747
 // Verify that printing does not crash when an operation has a null operand
 // due to an unresolvable forward reference created with


### PR DESCRIPTION
We seem to have dropped this upstream commit at some point by accident, this is leading to a compiler crash in print-unsafe-null-operand.mlir, to address this it seems correct to reapply this PR. Not sure what the history behind not having this in amd-staging is though, perhaps just some odd merge problem!

Original commit message below.

=========================

This commit fixes a use-after-free crash when parsing the following invalid IR:
```mlir
scf.for ... iter_args(%var = %foo) -> tensor<?xf32> {
  %foo = "test.inner"() : () -> (tensor<?xf32>)
  scf.yield %arg0 : tensor<?xf32>
}
```

The `scf.for` parser was implemented as follows:
1. Resolve operands (including `%foo`).
2. Parse the region.

During operand resolution, a forward reference
(`unrealized_conversion_cast`) is added by the parser because `%foo` has not been defined yet. During region parsing, the definition of `%foo` is found and the forward reference is replaced with the actual definition. (And the forward reference is deleted.) However, the operand of the `scf.for` op is not updated because the `scf.for` op has not been created yet; all we have is an `OperationState` object.

All parsers should be written in such a way that they first parse the region and then resolve the operands. That way, no forward reference is inserted in the first place. Before parsing the region, it may be necessary to set the argument types if they are defined as part of the assembly format of the op (as is the case with `scf.for`). Note: Ops in generic format are parsed in the same way.

To make the parsing infrastructure more robust, this commit also delays the erase of forward references until the end of the lifetime of the parser. Instead of a use-after-free crash, users will then see more descriptive error messages such as:
```
error: operation's operand is unlinked
```

Note: The proper way to fix the parser is to first parse the region, then resolve the operands. The change to `Parser.cpp` is merely to help users finding the root cause of the problem.


