### PR TITLE
[OpenMP][flang] Fix crash in host offload (upstream #187847)

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -8053,7 +8053,8 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
   }
 
   // Set the grid value in the config needed for lowering later on
-  Config.setGridValue(getGridValue(T, Kernel));
+  if (hasGridValue(T))
+    Config.setGridValue(getGridValue(T, Kernel));
 
   // Manifest the launch configuration in the metadata matching the kernel
   // environment.

--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -169,6 +169,10 @@ static void restoreIPandDebugLoc(llvm::IRBuilderBase &Builder,
     Builder.SetCurrentDebugLocation(BB->back().getStableDebugLoc());
 }
 
+static bool hasGridValue(const Triple &T) {
+  return T.isAMDGPU() || T.isNVPTX() || T.isSPIRV();
+}
+
 static const omp::GV &getGridValue(const Triple &T, Function *Kernel) {
   if (T.isAMDGPU()) {
     StringRef Features =
@@ -8059,9 +8063,15 @@ OpenMPIRBuilder::InsertPointTy OpenMPIRBuilder::createTargetInit(
   int32_t MaxThreadsVal = Attrs.MaxThreads.front();
   // If MaxThreads not set, select the maximum between the default workgroup
   // size and the MinThreads value.
-  if (MaxThreadsVal < 0)
-    MaxThreadsVal = std::max(
-        int32_t(getGridValue(T, Kernel).GV_Default_WG_Size), Attrs.MinThreads);
+  if (MaxThreadsVal < 0) {
+    if (hasGridValue(T)) {
+      MaxThreadsVal =
+          std::max(int32_t(getGridValue(T, Kernel).GV_Default_WG_Size),
+                   Attrs.MinThreads);
+    } else {
+      MaxThreadsVal = Attrs.MinThreads;
+    }
+  }
 
   if (MaxThreadsVal > 0)
     writeThreadBoundsForKernel(T, *Kernel, Attrs.MinThreads, MaxThreadsVal);

--- a/mlir/test/Target/LLVMIR/omptarget-region-host-device-llvm.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-region-host-device-llvm.mlir
@@ -1,0 +1,14 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// Verify that host offloading doesn't crash the OMPIRBuilder.
+module attributes {llvm.target_triple = "x86_64-unknown-linux-gnu", omp.is_target_device = true} {
+  llvm.func @omp_target_region_host_device() {
+    omp.target {
+      omp.terminator
+    }
+    llvm.return
+  }
+}
+
+// CHECK:      define void @omp_target_region_host_device()
+// CHECK:      define weak_odr protected void @__omp_offloading_{{[^_]+}}_{{[^_]+}}_omp_target_region_host_device_l{{[0-9]+}}(ptr %[[ADDR_A:.*]])


### PR DESCRIPTION
Land upstream PR https://github.com/llvm/llvm-project/pull/187847 with guard for an additional call to `getGridValue` that is not present in upstream code.
Fixes issue in https://github.com/ROCm/llvm-project/pull/1908