### PR TITLE
Add auto-merge workflows for upstream and amd-main to amd-staging

### DIFF
--- a/.github/workflows/amd-main-to-staging.yml
+++ b/.github/workflows/amd-main-to-staging.yml
@@ -1,0 +1,192 @@
+name: Merge amd-main into amd-staging
+
+on:
+  schedule:
+    # 11am EST (16:00 UTC)
+    - cron: '0 16 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # Push branches
+  pull-requests: write  # Create PRs
+
+jobs:
+  merge-amd-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: amd-staging
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch amd-main
+        run: |
+          git fetch origin amd-main
+
+      - name: Get timestamp
+        id: timestamp
+        run: |
+          echo "datetime=$(TZ='America/New_York' date +'%Y-%m-%d %H:%M %Z')" >> $GITHUB_OUTPUT
+
+      - name: Check for new commits
+        id: check-commits
+        run: |
+          AMD_MAIN_SHA=$(git rev-parse origin/amd-main)
+          if git merge-base --is-ancestor $AMD_MAIN_SHA HEAD; then
+            echo "No new commits on amd-main"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "New amd-main commits found"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create merge branch
+        id: merge
+        if: steps.check-commits.outputs.has_changes == 'true'
+        run: |
+          BRANCH_NAME="amd-main-merge-$(date +%Y%m%d%H%M%S)"
+          PR_TITLE="merge amd-main into amd-staging ${{ steps.timestamp.outputs.datetime }}"
+          git checkout -b $BRANCH_NAME
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+
+          if git merge origin/amd-main --no-edit; then
+            echo "Merge successful"
+            echo "conflict=false" >> $GITHUB_OUTPUT
+          else
+            echo "Merge has conflicts"
+            # Capture conflicting files before aborting
+            CONFLICTS=$(git diff --name-only --diff-filter=U | head -10)
+            CONFLICT_COUNT=$(git diff --name-only --diff-filter=U | wc -l)
+            echo "conflict_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$CONFLICTS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "conflict_count=$CONFLICT_COUNT" >> $GITHUB_OUTPUT
+            git merge --abort
+            echo "conflict=true" >> $GITHUB_OUTPUT
+          fi
+
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Push branch
+        if: steps.merge.outputs.conflict == 'false'
+        run: |
+          git push origin ${{ steps.merge.outputs.branch }}
+
+      - name: Create Pull Request
+        id: create-pr
+        if: steps.merge.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
+            --base amd-staging \
+            --head ${{ steps.merge.outputs.branch }} \
+            --title "${{ steps.merge.outputs.pr_title }}" \
+            --body "$(cat <<'EOF'
+          Automated merge of amd-main into amd-staging.
+
+          This PR was created automatically by the amd-main-to-staging workflow.
+          EOF
+          )")
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+      - name: Notify Teams - PR Created
+        if: steps.merge.outputs.conflict == 'false'
+        run: |
+          curl -H "Content-Type: application/json" -d '{
+            "@type": "MessageCard",
+            "themeColor": "00FF00",
+            "summary": "amd-main to amd-staging PR created",
+            "sections": [{
+              "activityTitle": "✅ amd-main → amd-staging PR Created",
+              "facts": [{
+                "name": "Time",
+                "value": "${{ steps.timestamp.outputs.datetime }}"
+              }, {
+                "name": "Branch",
+                "value": "${{ steps.merge.outputs.branch }}"
+              }],
+              "markdown": true
+            }],
+            "potentialAction": [{
+              "@type": "OpenUri",
+              "name": "View PR",
+              "targets": [{
+                "os": "default",
+                "uri": "${{ steps.create-pr.outputs.pr_url }}"
+              }]
+            }]
+          }' "${{ secrets.TEAMS_WEBHOOK_URL_AMD_MAIN_GARDEN }}"
+
+      - name: Notify Teams - No Changes
+        if: steps.check-commits.outputs.has_changes == 'false'
+        run: |
+          curl -H "Content-Type: application/json" -d '{
+            "@type": "MessageCard",
+            "themeColor": "808080",
+            "summary": "No new amd-main changes",
+            "sections": [{
+              "activityTitle": "ℹ️ No New amd-main Commits",
+              "facts": [{
+                "name": "Time",
+                "value": "${{ steps.timestamp.outputs.datetime }}"
+              }],
+              "text": "amd-staging is already up to date with amd-main.",
+              "markdown": true
+            }]
+          }' "${{ secrets.TEAMS_WEBHOOK_URL_AMD_MAIN_GARDEN }}"
+
+      - name: Notify Teams - Merge Conflict
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          CONFLICT_FILES: ${{ steps.merge.outputs.conflict_files }}
+        run: |
+          # Format conflict files for display (replace newlines with <br>)
+          FORMATTED_FILES=$(echo "$CONFLICT_FILES" | sed ':a;N;$!ba;s/\n/<br>/g')
+          CONFLICT_COUNT="${{ steps.merge.outputs.conflict_count }}"
+
+          # Add note if there are more than 10 files
+          if [ "$CONFLICT_COUNT" -gt 10 ]; then
+            FORMATTED_FILES="${FORMATTED_FILES}<br>... and $((CONFLICT_COUNT - 10)) more"
+          fi
+
+          curl -H "Content-Type: application/json" -d '{
+            "@type": "MessageCard",
+            "themeColor": "FF0000",
+            "summary": "amd-main to amd-staging merge conflict",
+            "sections": [{
+              "activityTitle": "⚠️ Merge Conflicts Detected (amd-main → amd-staging)",
+              "facts": [{
+                "name": "Time",
+                "value": "${{ steps.timestamp.outputs.datetime }}"
+              }, {
+                "name": "Conflicting Files",
+                "value": "'"$FORMATTED_FILES"'"
+              }, {
+                "name": "Total Conflicts",
+                "value": "'"$CONFLICT_COUNT"' file(s)"
+              }],
+              "text": "Automatic merge of amd-main into amd-staging failed due to conflicts. Manual intervention required.",
+              "markdown": true
+            }],
+            "potentialAction": [{
+              "@type": "OpenUri",
+              "name": "View Repository",
+              "targets": [{
+                "os": "default",
+                "uri": "${{ github.server_url }}/${{ github.repository }}"
+              }]
+            }]
+          }' "${{ secrets.TEAMS_WEBHOOK_URL_AMD_MAIN_GARDEN }}"

--- a/.github/workflows/upstream-merge.yml
+++ b/.github/workflows/upstream-merge.yml
@@ -1,0 +1,193 @@
+name: Merge Upstream into amd-main
+
+on:
+  schedule:
+    # 7am, 3pm, 11pm EST (12:00, 20:00, 04:00 UTC)
+    - cron: '0 4,12,20 * * *'
+  workflow_dispatch: # Allow manual triggering
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write       # Push branches
+  pull-requests: write  # Create PRs
+
+jobs:
+  merge-upstream:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: amd-main
+          fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Add upstream remote
+        run: |
+          git remote add upstream https://github.com/llvm/llvm-project.git
+          git fetch upstream main
+
+      - name: Get timestamp
+        id: timestamp
+        run: |
+          echo "datetime=$(TZ='America/New_York' date +'%Y-%m-%d %H:%M %Z')" >> $GITHUB_OUTPUT
+
+      - name: Check for new commits
+        id: check-commits
+        run: |
+          UPSTREAM_SHA=$(git rev-parse upstream/main)
+          if git merge-base --is-ancestor $UPSTREAM_SHA HEAD; then
+            echo "No new upstream commits"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "New upstream commits found"
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create merge branch
+        id: merge
+        if: steps.check-commits.outputs.has_changes == 'true'
+        run: |
+          BRANCH_NAME="upstream_merge_$(date +%Y%m%d%H%M%S)"
+          PR_TITLE="Upstream merge ${{ steps.timestamp.outputs.datetime }}"
+          git checkout -b $BRANCH_NAME
+          echo "pr_title=$PR_TITLE" >> $GITHUB_OUTPUT
+
+          if git merge upstream/main --no-edit; then
+            echo "Merge successful"
+            echo "conflict=false" >> $GITHUB_OUTPUT
+          else
+            echo "Merge has conflicts"
+            # Capture conflicting files before aborting
+            CONFLICTS=$(git diff --name-only --diff-filter=U | head -10)
+            CONFLICT_COUNT=$(git diff --name-only --diff-filter=U | wc -l)
+            echo "conflict_files<<EOF" >> $GITHUB_OUTPUT
+            echo "$CONFLICTS" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "conflict_count=$CONFLICT_COUNT" >> $GITHUB_OUTPUT
+            git merge --abort
+            echo "conflict=true" >> $GITHUB_OUTPUT
+          fi
+
+          echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
+
+      - name: Push branch
+        if: steps.merge.outputs.conflict == 'false'
+        run: |
+          git push origin ${{ steps.merge.outputs.branch }}
+
+      - name: Create Pull Request
+        id: create-pr
+        if: steps.merge.outputs.conflict == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          PR_URL=$(gh pr create \
+            --repo ${{ github.repository }} \
+            --base amd-main \
+            --head ${{ steps.merge.outputs.branch }} \
+            --title "${{ steps.merge.outputs.pr_title }}" \
+            --body "$(cat <<'EOF'
+          Automated merge of upstream llvm/llvm-project main branch.
+
+          This PR was created automatically by the upstream-merge workflow.
+          EOF
+          )")
+          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+      - name: Notify Teams - PR Created
+        if: steps.merge.outputs.conflict == 'false'
+        run: |
+          curl -H "Content-Type: application/json" -d '{
+            "@type": "MessageCard",
+            "themeColor": "00FF00",
+            "summary": "Upstream merge PR created",
+            "sections": [{
+              "activityTitle": "✅ Upstream Merge PR Created",
+              "facts": [{
+                "name": "Time",
+                "value": "${{ steps.timestamp.outputs.datetime }}"
+              }, {
+                "name": "Branch",
+                "value": "${{ steps.merge.outputs.branch }}"
+              }],
+              "markdown": true
+            }],
+            "potentialAction": [{
+              "@type": "OpenUri",
+              "name": "View PR",
+              "targets": [{
+                "os": "default",
+                "uri": "${{ steps.create-pr.outputs.pr_url }}"
+              }]
+            }]
+          }' "${{ secrets.TEAMS_WEBHOOK_URL_AMD_MAIN_GARDEN }}"
+
+      - name: Notify Teams - No Changes
+        if: steps.check-commits.outputs.has_changes == 'false'
+        run: |
+          curl -H "Content-Type: application/json" -d '{
+            "@type": "MessageCard",
+            "themeColor": "808080",
+            "summary": "No upstream changes",
+            "sections": [{
+              "activityTitle": "ℹ️ No New Upstream Commits",
+              "facts": [{
+                "name": "Time",
+                "value": "${{ steps.timestamp.outputs.datetime }}"
+              }],
+              "text": "amd-main is already up to date with upstream main.",
+              "markdown": true
+            }]
+          }' "${{ secrets.TEAMS_WEBHOOK_URL_AMD_MAIN_GARDEN }}"
+
+      - name: Notify Teams - Merge Conflict
+        if: steps.merge.outputs.conflict == 'true'
+        env:
+          CONFLICT_FILES: ${{ steps.merge.outputs.conflict_files }}
+        run: |
+          # Format conflict files for display (replace newlines with <br>)
+          FORMATTED_FILES=$(echo "$CONFLICT_FILES" | sed ':a;N;$!ba;s/\n/<br>/g')
+          CONFLICT_COUNT="${{ steps.merge.outputs.conflict_count }}"
+
+          # Add note if there are more than 10 files
+          if [ "$CONFLICT_COUNT" -gt 10 ]; then
+            FORMATTED_FILES="${FORMATTED_FILES}<br>... and $((CONFLICT_COUNT - 10)) more"
+          fi
+
+          curl -H "Content-Type: application/json" -d '{
+            "@type": "MessageCard",
+            "themeColor": "FF0000",
+            "summary": "Upstream merge conflict",
+            "sections": [{
+              "activityTitle": "⚠️ Merge Conflicts Detected",
+              "facts": [{
+                "name": "Time",
+                "value": "${{ steps.timestamp.outputs.datetime }}"
+              }, {
+                "name": "Conflicting Files",
+                "value": "'"$FORMATTED_FILES"'"
+              }, {
+                "name": "Total Conflicts",
+                "value": "'"$CONFLICT_COUNT"' file(s)"
+              }],
+              "text": "Automatic merge of upstream main into amd-main failed due to conflicts. Manual intervention required.",
+              "markdown": true
+            }],
+            "potentialAction": [{
+              "@type": "OpenUri",
+              "name": "View Repository",
+              "targets": [{
+                "os": "default",
+                "uri": "${{ github.server_url }}/${{ github.repository }}"
+              }]
+            }]
+          }' "${{ secrets.TEAMS_WEBHOOK_URL_AMD_MAIN_GARDEN }}"


### PR DESCRIPTION
Adds two scheduled GitHub Actions workflows:
- upstream-merge.yml: merges llvm/llvm-project main into amd-main at 7am, 3pm, 11pm EST
- amd-main-to-staging.yml: merges amd-main into amd-staging at 11am EST

Both workflows send Teams notifications for all outcomes (PR created, no changes, merge conflicts with file list).


