### PR TITLE
[ASAN][AsmPrinter] Emit sanitized padded global symbols after alignment

### DIFF
--- a/clang/test/CodeGen/asan_globals_symbols.cpp
+++ b/clang/test/CodeGen/asan_globals_symbols.cpp
@@ -2,10 +2,13 @@
 // RUN:   -fsanitize=address -o %t.out %s
 // RUN: FileCheck %s --input-file=%t.out --check-prefix=CHECK-A
 
-// CHECK-A: myGlobal:
-// CHECK-A: .size   myGlobal, 4
-// CHECK-A: myGlobal__sanitized_padded_global:
-// CHECK-A  .size   myGlobal__sanitized_padded_global, 32
+// Verify that alignment comes before both symbols
+// CHECK-A:      .globl myGlobal
+// CHECK-A-NEXT: .p2align
+// CHECK-A-NEXT: myGlobal:
+// CHECK-A-NEXT: .size   myGlobal, 4
+// CHECK-A-NEXT: myGlobal__sanitized_padded_global:
+// CHECK-A:      .size   myGlobal__sanitized_padded_global, 32
 
 int myGlobal;
 

--- a/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
+++ b/llvm/lib/CodeGen/AsmPrinter/AsmPrinter.cpp
@@ -978,23 +978,27 @@ void AsmPrinter::emitGlobalVariable(const GlobalVariable *GV) {
   }
 
   MCSymbol *EmittedInitSym = GVSym;
+  MCSymbol *SanitizedSym = nullptr;
 
   if (GV->hasAttribute(Attribute::SanitizedPaddedGlobal)) {
-    OutStreamer->switchSection(TheSection);
-    emitLinkage(GV, EmittedInitSym);
-    OutStreamer->emitLabel(EmittedInitSym);
-    if (MAI->hasDotTypeDotSizeDirective())
-      OutStreamer->emitELFSize(EmittedInitSym,
-                               MCConstantExpr::create(ActualSize, OutContext));
-    EmittedInitSym = OutContext.getOrCreateSymbol(
+    SanitizedSym = OutContext.getOrCreateSymbol(
         GVSym->getName() + Twine("__sanitized_padded_global"));
-    emitVisibility(EmittedInitSym, GV->getVisibility(), !GV->isDeclaration());
+    emitVisibility(SanitizedSym, GV->getVisibility(), !GV->isDeclaration());
   }
 
   OutStreamer->switchSection(TheSection);
 
   emitLinkage(GV, EmittedInitSym);
   emitAlignment(Alignment, GV);
+
+  // Emit both original and sanitized symbols after alignment
+  if (SanitizedSym) {
+    OutStreamer->emitLabel(EmittedInitSym);
+    if (MAI->hasDotTypeDotSizeDirective())
+      OutStreamer->emitELFSize(EmittedInitSym,
+                               MCConstantExpr::create(ActualSize, OutContext));
+    EmittedInitSym = SanitizedSym;
+  }
 
   OutStreamer->emitLabel(EmittedInitSym);
   MCSymbol *LocalAlias = getSymbolPreferLocal(*GV);


### PR DESCRIPTION
C-P of https://github.com/ROCm/llvm-project/pull/1572 on to amd-compiler-ww-2026-11.

This change ensures both the original symbol and the sanitized padded global symbol are emitted after the alignment directive, maintaining symbol ordering in the generated assembly.


