### PR TITLE
[Comgr] Add dependency on amd_comgr in Comgr lit tests

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -24,6 +24,7 @@ message("-- LLVM_LIT_PATH: ${LLVM_LIT_PATH}")
 
 add_custom_target(test-lit COMMAND "${LLVM_LIT_PATH}"
                   "${CMAKE_CURRENT_BINARY_DIR}" -v)
+add_dependencies(test-lit amd_comgr)
 
 macro(add_comgr_lit_binary name lang)
   add_executable("${name}" "comgr-sources/${name}.${lang}")


### PR DESCRIPTION
The PR adds dependency on `amd_comgr` in `Comgr` lit tests. 

This is important for correct parallel building in `TheRock CI`. In TheRock CI the `test-lit` target runs `llvm-lit` during the build phase. Without this dependency, ninja may schedule it in parallel with a re-link of `libamd_comgr` triggered by the always-dirty "Embedding clang resource directory" step. Test executables that load the shared library would then see a partially-written file.