### PR TITLE
[WaveTransform] Utilzing S_AND for S_CBRANCH_VCC handling as implicitBranchOpc in rewrite()

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2046,22 +2046,22 @@ void ControlFlowRewriter::rewrite() {
         }
         case AMDGPU::S_CBRANCH_VCCNZ:
         case AMDGPU::S_CBRANCH_VCCZ: {
-          // S_AND_B* VCC, VCC sets SCC (if VCC != 0)
+          // S_AND_B* VCC, VCC sets SCC (SCC = VCC != 0)
           BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm, {},
                   TII.get(LMC.AndOpc), LMC.VccReg)
               .addReg(LMC.VccReg)
               .addReg(LMC.VccReg);
 
-          // SCC has VCCNZ sense; flip CSELECT operands for VCCZ.
+          // SCC gets set when VCC!=0, implyng equivalence to VCCNZ branch;
+          // so we should flip CSELECT operands for VCCZ branch equivalent.
           bool FlipForVCCZ =
               (LaneOrigin.ImplicitBranchOpc == AMDGPU::S_CBRANCH_VCCZ);
-          bool InvertCond = LaneOrigin.InvertCondition ^ FlipForVCCZ;
 
           CondReg = LMU.createLaneMaskReg();
           auto MIB =
               BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm, {},
                       TII.get(LMC.CSelectOpc), CondReg);
-          if (!InvertCond)
+          if (LaneOrigin.InvertCondition == FlipForVCCZ)
             MIB.addReg(LMC.ExecReg).addImm(0);
           else
             MIB.addImm(0).addReg(LMC.ExecReg);

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2046,18 +2046,22 @@ void ControlFlowRewriter::rewrite() {
         }
         case AMDGPU::S_CBRANCH_VCCNZ:
         case AMDGPU::S_CBRANCH_VCCZ: {
-          BuildMI(
-              *LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm, {},
-              TII.get(LaneOrigin.ImplicitBranchOpc == AMDGPU::S_CBRANCH_VCCNZ
-                          ? AMDGPU::S_CMP_LG_U32
-                          : AMDGPU::S_CMP_EQ_U32))
+          // S_AND_B* VCC, VCC sets SCC (if VCC != 0)
+          BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm, {},
+                  TII.get(LMC.AndOpc), LMC.VccReg)
               .addReg(LMC.VccReg)
-              .addImm(0);
+              .addReg(LMC.VccReg);
+
+          // SCC has VCCNZ sense; flip CSELECT operands for VCCZ.
+          bool FlipForVCCZ =
+              (LaneOrigin.ImplicitBranchOpc == AMDGPU::S_CBRANCH_VCCZ);
+          bool InvertCond = LaneOrigin.InvertCondition ^ FlipForVCCZ;
+
           CondReg = LMU.createLaneMaskReg();
           auto MIB =
               BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm, {},
                       TII.get(LMC.CSelectOpc), CondReg);
-          if (!LaneOrigin.InvertCondition)
+          if (!InvertCond)
             MIB.addReg(LMC.ExecReg).addImm(0);
           else
             MIB.addImm(0).addReg(LMC.ExecReg);

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
@@ -849,7 +849,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[S_MOV_B32_1:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; POSTWT-NEXT:   $vcc = COPY [[COPY1]]
-  ; POSTWT-NEXT:   S_CMP_LG_U32 $vcc_lo, 0, implicit-def $scc
+  ; POSTWT-NEXT:   $vcc_lo = S_AND_B32 $vcc_lo, $vcc_lo, implicit-def $scc
   ; POSTWT-NEXT:   [[S_CSELECT_B32_:%[0-9]+]]:sreg_32 = S_CSELECT_B32 0, $exec_lo, implicit $scc
   ; POSTWT-NEXT:   [[S_MOV_B32_2:%[0-9]+]]:sreg_32 = S_OR_B32 [[S_MOV_B32_2]], [[S_CSELECT_B32_]], implicit-def $scc
   ; POSTWT-NEXT:   S_BRANCH %bb.4


### PR DESCRIPTION
This patch replaces usage of S_CMP with S_AND as the former is not available for all SubTragets in AMDGPU unlike the latter, in the identification of VCC==0 in the rewrite function of AMDGPUWaveTransform. It depends on the fact that S_AND is performed on VCC with itself and result is stored back into VCC. Then, not only the VCC remain preserved, it sets SCC (when resultant VCC != 0), which then can be used with S_CSELECT like before!


