### PR TITLE
[AMDGPU] Improve waitcnt preheader flush with per-counter queue sim

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/Sequence.h"
 #include "llvm/Analysis/AliasAnalysis.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
+#include "llvm/CodeGen/MachineDominators.h"
 #include "llvm/CodeGen/MachineLoopInfo.h"
 #include "llvm/CodeGen/MachinePassManager.h"
 #include "llvm/CodeGen/MachinePostDominators.h"
@@ -511,6 +512,7 @@ class SIInsertWaitcnts {
   DenseMap<const Value *, MachineBasicBlock *> SLoadAddresses;
   DenseMap<MachineBasicBlock *, PreheaderFlushFlags> PreheadersToFlush;
   MachineLoopInfo &MLI;
+  MachineDominatorTree &MDT;
   MachinePostDominatorTree &PDT;
   AliasAnalysis *AA = nullptr;
   MachineFunction &MF;
@@ -546,9 +548,11 @@ public:
   AMDGPU::InstCounterType MaxCounter;
   bool IsExpertMode = false;
 
-  SIInsertWaitcnts(MachineLoopInfo &MLI, MachinePostDominatorTree &PDT,
+  SIInsertWaitcnts(MachineLoopInfo &MLI, MachineDominatorTree &MDT,
+                   MachinePostDominatorTree &PDT,
                    AliasAnalysis *AA, MachineFunction &MF)
-      : MLI(MLI), PDT(PDT), AA(AA), MF(MF), ST(MF.getSubtarget<GCNSubtarget>()),
+      : MLI(MLI), MDT(MDT), PDT(PDT), AA(AA), MF(MF),
+        ST(MF.getSubtarget<GCNSubtarget>()),
         TII(*ST.getInstrInfo()), TRI(TII.getRegisterInfo()),
         MRI(MF.getRegInfo()) {
     (void)ForceExpCounter;
@@ -565,6 +569,9 @@ public:
   bool isVMEMOrFlatVMEM(const MachineInstr &MI) const;
   bool isDSRead(const MachineInstr &MI) const;
   bool mayStoreIncrementingDSCNT(const MachineInstr &MI) const;
+  bool isGuardingBranchLoopInvariant(
+      MachineBasicBlock *UseMBB, MachineLoop *ML,
+      const DenseSet<MCRegUnit> &AllDefsInLoop) const;
   bool run();
 
   void setForceEmitWaitcnt() {
@@ -1057,6 +1064,7 @@ public:
   void getAnalysisUsage(AnalysisUsage &AU) const override {
     AU.setPreservesCFG();
     AU.addRequired<MachineLoopInfoWrapperPass>();
+    AU.addRequired<MachineDominatorTreeWrapperPass>();
     AU.addRequired<MachinePostDominatorTreeWrapperPass>();
     AU.addUsedIfAvailable<AAResultsWrapperPass>();
     AU.addPreserved<AAResultsWrapperPass>();
@@ -1726,6 +1734,7 @@ bool WaitcntBrackets::counterOutOfOrder(AMDGPU::InstCounterType T) const {
 INITIALIZE_PASS_BEGIN(SIInsertWaitcntsLegacy, DEBUG_TYPE, "SI Insert Waitcnts",
                       false, false)
 INITIALIZE_PASS_DEPENDENCY(MachineLoopInfoWrapperPass)
+INITIALIZE_PASS_DEPENDENCY(MachineDominatorTreeWrapperPass)
 INITIALIZE_PASS_DEPENDENCY(MachinePostDominatorTreeWrapperPass)
 INITIALIZE_PASS_END(SIInsertWaitcntsLegacy, DEBUG_TYPE, "SI Insert Waitcnts",
                     false, false)
@@ -3474,6 +3483,76 @@ bool SIInsertWaitcnts::mayStoreIncrementingDSCNT(const MachineInstr &MI) const {
   return MI.mayStore() && SIInstrInfo::isDS(MI);
 }
 
+// Branch invariance heuristic for multi-block loops.
+//
+// When an outside-loaded register is used in a block that does NOT dominate all
+// loop back edges, the use is conditional (executed only on some iterations).
+// Flushing in the preheader has an upfront iter-0 cost, amortized across
+// iterations where the use is reached.  If the branch condition is
+// loop-invariant the same path is taken every iteration, so either:
+//   (a) the use is always reached — but then the block dominates all paths
+//       that matter, and the check above already handles it, OR
+//   (b) the use is never reached — flushing is pure cost with no benefit.
+// In either case there is no amortization opportunity, so we skip the flush.
+//
+// If the branch condition varies across iterations, different iterations may
+// take different paths.  When the use IS reached, the preheader flush helps;
+// when it is NOT reached, the flush was a harmless no-op (already waited).
+// On average the benefit outweighs the one-time iter-0 cost, so we flush.
+//
+// Implementation: find the conditional branch in the immediate dominator of
+// UseMBB, identify the comparison that sets the condition register (SCC/VCC),
+// and check whether its input operands are all defined outside the loop.
+bool SIInsertWaitcnts::isGuardingBranchLoopInvariant(
+    MachineBasicBlock *UseMBB, MachineLoop *ML,
+    const DenseSet<MCRegUnit> &AllDefsInLoop) const {
+  MachineDomTreeNode *Node = MDT.getNode(UseMBB);
+  if (!Node || !Node->getIDom())
+    return false;
+  MachineBasicBlock *IDom = Node->getIDom()->getBlock();
+  if (!IDom || !ML->contains(IDom))
+    return false;
+
+  MachineBasicBlock *TBB = nullptr, *FBB = nullptr;
+  SmallVector<MachineOperand, 4> Cond;
+  if (TII.analyzeBranch(*IDom, TBB, FBB, Cond, /*AllowModify=*/false) ||
+      Cond.size() < 2 || !Cond[1].isReg())
+    return false;
+
+  // EXEC-based branches guard divergent control flow; conservatively treat
+  // them as varying (the EXEC mask is almost always modified in-loop).
+  MCRegister CondReg = Cond[1].getReg().asMCReg();
+  if (CondReg == AMDGPU::EXEC || CondReg == AMDGPU::EXEC_LO)
+    return false;
+
+  // Walk backward from the branch to find the instruction that defines
+  // CondReg (the comparison / test that produces the branch condition).
+  MachineInstr *CondDef = nullptr;
+  for (auto I = std::prev(IDom->getFirstTerminator()), E = IDom->begin();;
+       --I) {
+    if (I->modifiesRegister(CondReg, &TRI)) {
+      CondDef = &*I;
+      break;
+    }
+    if (I == E)
+      break;
+  }
+  if (!CondDef)
+    return false;
+
+  // The condition is loop-invariant iff every register input of the defining
+  // instruction is NOT defined anywhere inside the loop.
+  for (const MachineOperand &Op : CondDef->all_uses()) {
+    if (!Op.isReg() || !Op.getReg().isValid())
+      continue;
+    for (MCRegUnit RU : TRI.regunits(Op.getReg().asMCReg())) {
+      if (AllDefsInLoop.contains(RU))
+        return false;
+    }
+  }
+  return true;
+}
+
 // Return flags indicating which counters should be flushed in the preheader of
 // the given loop. We currently decide to flush in the following situations:
 // For VMEM (FlushVmCnt):
@@ -3525,10 +3604,20 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
   bool TrackDSFlushPoint = ST.hasExtendedWaitCounts() && IsSingleBlock;
   unsigned LastDSFlushPosition = 0;
 
-  // Preheader hoist simulation: for single-block loops, simulate counter
-  // queues on iter 1+ to check if loop-invariant registers benefit from
-  // flushing. Tracks both LOAD_CNT and DS_CNT independently.
-  bool TrackHoist = IsSingleBlock;
+  // Preheader hoist simulation: simulate counter queues on iter 1+ to check
+  // if loop-invariant registers benefit from flushing.  Tracks both LOAD_CNT
+  // and DS_CNT independently.
+  //
+  // For multi-block loops, event counts aggregate across all blocks in the
+  // linear walk order.  This overcounts C (the outstanding-events metric)
+  // relative to any single execution path, but overcounting only causes
+  // extra flushes (a harmless one-time iter-0 cost), never missed flushes.
+  //
+  // Nested-loop guard: if the preheader is inside another loop, skip the
+  // analysis to avoid intermediate flushes from inner to outer loop body.
+  // The outer loop's own preheader analysis handles outer-level invariants.
+  MachineBasicBlock *Preheader = ML->getLoopPreheader();
+  bool TrackHoist = Preheader && !MLI.getLoopFor(Preheader);
   bool HasInLoopVMEMDefUse = false;
   bool HasInLoopDSDefUse = false;
   unsigned LoadCntEvents = 0;
@@ -3538,8 +3627,15 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
     unsigned InstrPos;
     unsigned LoadCntEventsAt;
     unsigned DSCntEventsAt;
+    MachineBasicBlock *UseMBB;
   };
   DenseMap<MCRegUnit, OutsideRegUseInfo> OutsideLoadUseInfo;
+
+  // For multi-block loops: collect all register defs inside the loop so the
+  // branch invariance heuristic can quickly test whether a comparison operand
+  // is loop-invariant.
+  bool TrackBranchInvariance = TrackHoist && !IsSingleBlock;
+  DenseSet<MCRegUnit> AllDefsInLoop;
 
   for (MachineBasicBlock *MBB : ML->blocks()) {
     for (MachineInstr &MI : *MBB) {
@@ -3645,8 +3741,8 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
           }
           if (TrackHoist && (HasPendingLoadCnt || HasPendingDSCnt))
             OutsideLoadUseInfo.try_emplace(
-                RU,
-                OutsideRegUseInfo{HoistInstrPos, LoadCntEvents, DSCntEvents});
+                RU, OutsideRegUseInfo{HoistInstrPos, LoadCntEvents,
+                                      DSCntEvents, MBB});
         }
       }
 
@@ -3689,6 +3785,16 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
         }
       }
 
+      // Collect all register defs for the branch invariance heuristic.
+      if (TrackBranchInvariance) {
+        for (const MachineOperand &Op : MI.all_defs()) {
+          if (!Op.isReg() || !Op.getReg().isValid())
+            continue;
+          for (MCRegUnit RU : TRI.regunits(Op.getReg().asMCReg()))
+            AllDefsInLoop.insert(RU);
+        }
+      }
+
       // Update hoist tracking counters after processing the instruction.
       if (IsLoadCntEvent)
         ++LoadCntEvents;
@@ -3705,8 +3811,8 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
        (HasVMemLoad && ST.hasVmemWriteVgprInOrder())))
     Flags.FlushVmCnt = 0;
 
-  // Preheader hoist for single-block loops: simulate the counter queue state
-  // on iter 1+ to check if loop-invariant registers benefit from flushing.
+  // Preheader hoist: simulate the counter queue state on iter 1+ to check
+  // if loop-invariant registers benefit from flushing.
   //
   // For each invariant (outside-loaded, not redefined in-loop) on counter T:
   //   N = preheader UB(T) - register score(T)  (the waitcnt target)
@@ -3717,11 +3823,46 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
   // (drain point), the counter resets to EventsAt(drain). For points before
   // the first drain, C = TotalEvents + EventsAt(point).
   //
+  // For multi-block loops, TotalEvents is the sum of events across all blocks
+  // (an overcount for any single path, but overcounting C leads to more
+  // flushes, never fewer — a safe conservative direction).
+  //
   // Bail when in-loop-defined loads are consumed in-loop (def-before-use),
   // since those create drain points we can't easily model.
   // TODO: Model drain points from in-loop loads used in-loop to handle
   // mixed reload + in-loop-compute patterns.
   if (TrackHoist && !OutsideLoadUseInfo.empty()) {
+    // Branch invariance filter (multi-block only): remove uses in conditional
+    // blocks whose guarding branch has a loop-invariant condition.
+    // See isGuardingBranchLoopInvariant() for the full rationale.
+    if (TrackBranchInvariance) {
+      MachineBasicBlock *Header = ML->getHeader();
+      SmallVector<MachineBasicBlock *, 4> Latches;
+      for (MachineBasicBlock *Pred : Header->predecessors())
+        if (ML->contains(Pred))
+          Latches.push_back(Pred);
+
+      SmallVector<MCRegUnit, 4> ToRemove;
+      for (const auto &[RU, Info] : OutsideLoadUseInfo) {
+        if (Info.UseMBB == Header)
+          continue;
+
+        bool DomAllLatches = true;
+        for (MachineBasicBlock *Latch : Latches) {
+          if (!MDT.dominates(Info.UseMBB, Latch)) {
+            DomAllLatches = false;
+            break;
+          }
+        }
+        if (DomAllLatches)
+          continue;
+
+        if (isGuardingBranchLoopInvariant(Info.UseMBB, ML, AllDefsInLoop))
+          ToRemove.push_back(RU);
+      }
+      for (MCRegUnit RU : ToRemove)
+        OutsideLoadUseInfo.erase(RU);
+    }
     // Helper: run the C > N profitability check for one counter.
     // Returns the flush value (UB - HighestProfitableScore) or nullopt.
     auto checkCounter = [&](AMDGPU::InstCounterType T, unsigned TotalEvents,
@@ -3805,25 +3946,27 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
 
 bool SIInsertWaitcntsLegacy::runOnMachineFunction(MachineFunction &MF) {
   auto &MLI = getAnalysis<MachineLoopInfoWrapperPass>().getLI();
+  auto &MDT = getAnalysis<MachineDominatorTreeWrapperPass>().getDomTree();
   auto &PDT =
       getAnalysis<MachinePostDominatorTreeWrapperPass>().getPostDomTree();
   AliasAnalysis *AA = nullptr;
   if (auto *AAR = getAnalysisIfAvailable<AAResultsWrapperPass>())
     AA = &AAR->getAAResults();
 
-  return SIInsertWaitcnts(MLI, PDT, AA, MF).run();
+  return SIInsertWaitcnts(MLI, MDT, PDT, AA, MF).run();
 }
 
 PreservedAnalyses
 SIInsertWaitcntsPass::run(MachineFunction &MF,
                           MachineFunctionAnalysisManager &MFAM) {
   auto &MLI = MFAM.getResult<MachineLoopAnalysis>(MF);
+  auto &MDT = MFAM.getResult<MachineDominatorTreeAnalysis>(MF);
   auto &PDT = MFAM.getResult<MachinePostDominatorTreeAnalysis>(MF);
   auto *AA = MFAM.getResult<FunctionAnalysisManagerMachineFunctionProxy>(MF)
                  .getManager()
                  .getCachedResult<AAManager>(MF.getFunction());
 
-  if (!SIInsertWaitcnts(MLI, PDT, AA, MF).run())
+  if (!SIInsertWaitcnts(MLI, MDT, PDT, AA, MF).run())
     return PreservedAnalyses::all();
 
   return getMachineFunctionPassPreservedAnalyses()

--- a/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInsertWaitcnts.cpp
@@ -500,9 +500,11 @@ public:
 };
 
 // Flags indicating which counters should be flushed in a loop preheader.
+// When set, the optional value is the waitcnt target (e.g. FlushVmCnt = 0
+// means emit vmcnt(0); FlushVmCnt = 1 means emit vmcnt(1)).
 struct PreheaderFlushFlags {
-  bool FlushVmCnt = false;
-  bool FlushDsCnt = false;
+  std::optional<unsigned> FlushVmCnt;
+  std::optional<unsigned> FlushDsCnt;
 };
 
 class SIInsertWaitcnts {
@@ -707,6 +709,8 @@ public:
 // wait count may get decreased out of order, therefore we need to put in
 // "s_waitcnt 0" before use.
 class WaitcntBrackets {
+  friend class SIInsertWaitcnts;
+
 public:
   WaitcntBrackets(const SIInsertWaitcnts *Context) : Context(Context) {
     assert(Context->TRI.getNumRegUnits() < REGUNITS_END);
@@ -2446,8 +2450,9 @@ bool WaitcntGeneratorGFX12Plus::createNewWaitcnt(
 ///  and if so what the value of each counter is.
 ///  The "score bracket" is bound by the lower bound and upper bound
 ///  scores (*_score_LB and *_score_ub respectively).
-///  If FlushFlags.FlushVmCnt is true, we want to flush the vmcnt counter here.
-///  If FlushFlags.FlushDsCnt is true, we want to flush the dscnt counter here
+///  If FlushFlags.FlushVmCnt has a value, we want to flush the vmcnt counter
+///  here to the specified target.
+///  If FlushFlags.FlushDsCnt has a value, we want to flush the dscnt counter
 ///  (GFX12+ only, where DS_CNT is a separate counter).
 bool SIInsertWaitcnts::generateWaitcntInstBefore(
     MachineInstr &MI, WaitcntBrackets &ScoreBrackets,
@@ -2733,11 +2738,11 @@ bool SIInsertWaitcnts::generateWaitcntInstBefore(
   if (FlushFlags.FlushVmCnt) {
     for (AMDGPU::InstCounterType T :
          {AMDGPU::LOAD_CNT, AMDGPU::SAMPLE_CNT, AMDGPU::BVH_CNT})
-      Wait.set(T, 0);
+      Wait.set(T, *FlushFlags.FlushVmCnt);
   }
 
   if (FlushFlags.FlushDsCnt && ScoreBrackets.hasPendingEvent(AMDGPU::DS_CNT))
-    Wait.set(AMDGPU::DS_CNT, 0);
+    Wait.set(AMDGPU::DS_CNT, *FlushFlags.FlushDsCnt);
 
   if (ForceEmitZeroLoadFlag && Wait.get(AMDGPU::LOAD_CNT) != ~0u)
     Wait.set(AMDGPU::LOAD_CNT, 0);
@@ -3370,14 +3375,14 @@ bool SIInsertWaitcnts::insertWaitcntInBlock(MachineFunction &MF,
     PreheaderFlushFlags FlushFlags = isPreheaderToFlush(Block, ScoreBrackets);
     if (FlushFlags.FlushVmCnt) {
       if (ScoreBrackets.hasPendingEvent(AMDGPU::LOAD_CNT))
-        Wait.set(AMDGPU::LOAD_CNT, 0);
+        Wait.set(AMDGPU::LOAD_CNT, *FlushFlags.FlushVmCnt);
       if (ScoreBrackets.hasPendingEvent(AMDGPU::SAMPLE_CNT))
-        Wait.set(AMDGPU::SAMPLE_CNT, 0);
+        Wait.set(AMDGPU::SAMPLE_CNT, *FlushFlags.FlushVmCnt);
       if (ScoreBrackets.hasPendingEvent(AMDGPU::BVH_CNT))
-        Wait.set(AMDGPU::BVH_CNT, 0);
+        Wait.set(AMDGPU::BVH_CNT, *FlushFlags.FlushVmCnt);
     }
     if (FlushFlags.FlushDsCnt && ScoreBrackets.hasPendingEvent(AMDGPU::DS_CNT))
-      Wait.set(AMDGPU::DS_CNT, 0);
+      Wait.set(AMDGPU::DS_CNT, *FlushFlags.FlushDsCnt);
   }
 
   // Combine or remove any redundant waitcnts at the end of the block.
@@ -3520,18 +3525,63 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
   bool TrackDSFlushPoint = ST.hasExtendedWaitCounts() && IsSingleBlock;
   unsigned LastDSFlushPosition = 0;
 
+  // Preheader hoist simulation: for single-block loops, simulate counter
+  // queues on iter 1+ to check if loop-invariant registers benefit from
+  // flushing. Tracks both LOAD_CNT and DS_CNT independently.
+  bool TrackHoist = IsSingleBlock;
+  bool HasInLoopVMEMDefUse = false;
+  bool HasInLoopDSDefUse = false;
+  unsigned LoadCntEvents = 0;
+  unsigned DSCntEvents = 0;
+  unsigned HoistInstrPos = 0;
+  struct OutsideRegUseInfo {
+    unsigned InstrPos;
+    unsigned LoadCntEventsAt;
+    unsigned DSCntEventsAt;
+  };
+  DenseMap<MCRegUnit, OutsideRegUseInfo> OutsideLoadUseInfo;
+
   for (MachineBasicBlock *MBB : ML->blocks()) {
     for (MachineInstr &MI : *MBB) {
+      bool IsLoadCntEvent = false;
+      bool IsDSCntEvent = false;
       if (isVMEMOrFlatVMEM(MI)) {
         HasVMemLoad |= MI.mayLoad();
         HasVMemStore |= MI.mayStore();
+        if (TrackHoist) {
+          // Mirror getEventType routing: on GFX10+ atomic-noret goes to
+          // STORE_CNT despite mayLoad, and on GFX12+ image samples / BVH go
+          // to SAMPLE_CNT / BVH_CNT.  Only count events that truly land on
+          // LOAD_CNT.
+          bool IsStoreCntEvent =
+              ST.hasVscnt() && MI.mayStore() &&
+              (!MI.mayLoad() || SIInstrInfo::isAtomicNoRet(MI));
+          if (!IsStoreCntEvent) {
+            bool IsSampleOrBVH = false;
+            if (ST.hasExtendedWaitCounts() && !TII.isFLAT(MI)) {
+              VmemType V = getVmemType(MI);
+              IsSampleOrBVH = (V == VMEM_SAMPLER || V == VMEM_BVH);
+            }
+            if (!IsSampleOrBVH)
+              IsLoadCntEvent = true;
+          }
+        }
+      }
+      if (TrackHoist) {
+        if (isDSRead(MI) || mayStoreIncrementingDSCNT(MI))
+          IsDSCntEvent = true;
+        // FLAT that may access LDS: conservatively count as DS_CNT event
+        // (it increments exactly one counter, but we don't know which).
+        if (TII.isFLAT(MI) && TII.mayAccessLDSThroughFlat(MI) &&
+            (MI.mayLoad() || MI.mayStore()))
+          IsDSCntEvent = true;
       }
       // TODO: Can we relax DSStore check? There may be cases where
       // these DS stores are drained prior to the end of MBB (or loop).
       if (mayStoreIncrementingDSCNT(MI)) {
         // Early exit if none of the optimizations are feasible.
         // Otherwise, set tracking status appropriately and continue.
-        if (VMemInvalidated)
+        if (VMemInvalidated && !TrackHoist)
           return Flags;
         TrackSimpleDSOpt = false;
         TrackDSFlushPoint = false;
@@ -3560,15 +3610,20 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
         for (MCRegUnit RU : TRI.regunits(Op.getReg().asMCReg())) {
           // If we find a register that is loaded inside the loop, 1. and 2.
           // are invalidated.
-          if (VgprDefVMEM.contains(RU))
+          if (VgprDefVMEM.contains(RU)) {
             VMemInvalidated = true;
+            HasInLoopVMEMDefUse = true;
+          }
 
           // Check for DS reads used inside the loop
-          if (VgprDefDS.contains(RU))
+          if (VgprDefDS.contains(RU)) {
             TrackSimpleDSOpt = false;
+            HasInLoopDSDefUse = true;
+          }
 
           // Early exit if all optimizations are invalidated
-          if (VMemInvalidated && !TrackSimpleDSOpt && !TrackDSFlushPoint)
+          if (VMemInvalidated && !TrackHoist &&
+              !TrackSimpleDSOpt && !TrackDSFlushPoint)
             return Flags;
 
           // Check for flush points (DS read used in same iteration)
@@ -3578,15 +3633,20 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
           // Check if this register has a pending VMEM load from outside the
           // loop (value loaded outside and used inside).
           VMEMID ID = toVMEMID(RU);
-          if (Brackets.hasPendingVMEM(ID, AMDGPU::LOAD_CNT) ||
+          bool HasPendingLoadCnt =
+              Brackets.hasPendingVMEM(ID, AMDGPU::LOAD_CNT) ||
               Brackets.hasPendingVMEM(ID, AMDGPU::SAMPLE_CNT) ||
-              Brackets.hasPendingVMEM(ID, AMDGPU::BVH_CNT))
+              Brackets.hasPendingVMEM(ID, AMDGPU::BVH_CNT);
+          bool HasPendingDSCnt = Brackets.hasPendingVMEM(ID, AMDGPU::DS_CNT);
+          if (HasPendingLoadCnt) {
             UsesVgprVMEMLoadedOutside = true;
-          // Check if loaded outside the loop via DS (not VMEM/FLAT).
-          // Only consider it a DS read if there's no pending VMEM load for
-          // this register, since FLAT can set both counters.
-          else if (Brackets.hasPendingVMEM(ID, AMDGPU::DS_CNT))
+          } else if (HasPendingDSCnt) {
             UsesVgprDSReadOutside = true;
+          }
+          if (TrackHoist && (HasPendingLoadCnt || HasPendingDSCnt))
+            OutsideLoadUseInfo.try_emplace(
+                RU,
+                OutsideRegUseInfo{HoistInstrPos, LoadCntEvents, DSCntEvents});
         }
       }
 
@@ -3602,7 +3662,8 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
           }
         }
         // Early exit if all optimizations are invalidated
-        if (VMemInvalidated && !TrackSimpleDSOpt && !TrackDSFlushPoint)
+        if (VMemInvalidated && !TrackHoist &&
+            !TrackSimpleDSOpt && !TrackDSFlushPoint)
           return Flags;
       }
 
@@ -3613,22 +3674,28 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
       // in preheader so iteration 1 doesn't need to wait inside the loop.
       // Only invalidate when DEF comes before USE (same-iteration consumption,
       // checked above when processing uses).
-      if (IsDSRead || TrackDSFlushPoint) {
+      if (IsDSCntEvent || TrackDSFlushPoint) {
         for (const MachineOperand &Op : MI.all_defs()) {
           if (!TRI.isVectorRegister(MRI, Op.getReg()))
             continue;
           for (MCRegUnit RU : TRI.regunits(Op.getReg().asMCReg())) {
-            // Check for overwrite of pending DS read (flush point) by any
-            // instruction
             updateDSReadFlushTracking(RU);
-            if (IsDSRead) {
+            if (IsDSCntEvent) {
               VgprDefDS.insert(RU);
-              if (TrackDSFlushPoint)
-                LastDSReadPositionMap[RU] = DSReadPosition;
             }
+            if (IsDSRead && TrackDSFlushPoint)
+              LastDSReadPositionMap[RU] = DSReadPosition;
           }
         }
       }
+
+      // Update hoist tracking counters after processing the instruction.
+      if (IsLoadCntEvent)
+        ++LoadCntEvents;
+      if (IsDSCntEvent)
+        ++DSCntEvents;
+      if (TrackHoist)
+        ++HoistInstrPos;
     }
   }
 
@@ -3636,7 +3703,88 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
   if (!VMemInvalidated && UsesVgprVMEMLoadedOutside &&
       ((!ST.hasVscnt() && HasVMemStore && !HasVMemLoad) ||
        (HasVMemLoad && ST.hasVmemWriteVgprInOrder())))
-    Flags.FlushVmCnt = true;
+    Flags.FlushVmCnt = 0;
+
+  // Preheader hoist for single-block loops: simulate the counter queue state
+  // on iter 1+ to check if loop-invariant registers benefit from flushing.
+  //
+  // For each invariant (outside-loaded, not redefined in-loop) on counter T:
+  //   N = preheader UB(T) - register score(T)  (the waitcnt target)
+  //   C = outstanding events on T at the register's use on iter 1+
+  // If C > N, the invariant's in-loop wait stalls on back-edge traffic.
+  //
+  // C is computed from a simple model: after any use of a reloaded register
+  // (drain point), the counter resets to EventsAt(drain). For points before
+  // the first drain, C = TotalEvents + EventsAt(point).
+  //
+  // Bail when in-loop-defined loads are consumed in-loop (def-before-use),
+  // since those create drain points we can't easily model.
+  // TODO: Model drain points from in-loop loads used in-loop to handle
+  // mixed reload + in-loop-compute patterns.
+  if (TrackHoist && !OutsideLoadUseInfo.empty()) {
+    // Helper: run the C > N profitability check for one counter.
+    // Returns the flush value (UB - HighestProfitableScore) or nullopt.
+    auto checkCounter = [&](AMDGPU::InstCounterType T, unsigned TotalEvents,
+                            bool HasDefUse,
+                            const DenseSet<MCRegUnit> &DefSet)
+        -> std::optional<unsigned> {
+      if (HasDefUse)
+        return std::nullopt;
+
+      unsigned EarliestReloadUsePos = UINT_MAX;
+      for (const auto &[RU, Info] : OutsideLoadUseInfo) {
+        if (DefSet.contains(RU) && Info.InstrPos < EarliestReloadUsePos)
+          EarliestReloadUsePos = Info.InstrPos;
+      }
+
+      unsigned UB = Brackets.getScoreUB(T);
+      unsigned LB = Brackets.getScoreLB(T);
+      unsigned HighestProfitableScore = 0;
+      bool HasProfitable = false;
+
+      for (const auto &[RU, Info] : OutsideLoadUseInfo) {
+        if (DefSet.contains(RU))
+          continue;
+
+        VMEMID ID = toVMEMID(RU);
+        unsigned S = Brackets.getVMemScore(ID, T);
+        if (S <= LB)
+          continue;
+        unsigned N = UB - S;
+
+        unsigned EventsAt = (T == AMDGPU::LOAD_CNT) ? Info.LoadCntEventsAt
+                                             : Info.DSCntEventsAt;
+        bool HasDrainBefore = EarliestReloadUsePos < Info.InstrPos;
+        unsigned C =
+            HasDrainBefore ? EventsAt : TotalEvents + EventsAt;
+
+        if (C > N) {
+          if (!HasProfitable || S > HighestProfitableScore) {
+            HighestProfitableScore = S;
+            HasProfitable = true;
+          }
+        }
+      }
+
+      if (HasProfitable)
+        return UB - HighestProfitableScore;
+      return std::nullopt;
+    };
+
+    // LOAD_CNT check (VMEM / FLAT-VMEM path)
+    if (!Flags.FlushVmCnt && VMemInvalidated) {
+      if (auto Val = checkCounter(AMDGPU::LOAD_CNT, LoadCntEvents,
+                                  HasInLoopVMEMDefUse, VgprDefVMEM))
+        Flags.FlushVmCnt = *Val;
+    }
+
+    // DS_CNT check (DS / FLAT-LDS path)
+    if (!Flags.FlushDsCnt) {
+      if (auto Val = checkCounter(AMDGPU::DS_CNT, DSCntEvents,
+                                  HasInLoopDSDefUse, VgprDefDS))
+        Flags.FlushDsCnt = *Val;
+    }
+  }
 
   // DS flush decision:
   // Simple DS Opt: flush if loop uses DS read values from outside
@@ -3650,7 +3798,7 @@ SIInsertWaitcnts::getPreheaderFlushFlags(MachineLoop *ML,
       TrackDSFlushPoint && UsesVgprDSReadOutside && HasUnflushedDSReads;
 
   if (SimpleDSOpt || DSFlushPointPrefetch)
-    Flags.FlushDsCnt = true;
+    Flags.FlushDsCnt = 0;
 
   return Flags;
 }

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-loop-ds-store-barrier.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-loop-ds-store-barrier.mir
@@ -2,22 +2,17 @@
 # RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1250 -run-pass=si-insert-waitcnts -o - %s | FileCheck %s
 # RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1200 -run-pass=si-insert-waitcnts -o - %s | FileCheck %s
 
-# Test for the fix that removed the incorrect S_BARRIER check for DS stores.
-# Previously, the code would reset SeenDSStoreInCurrMBB when encountering an
-# S_BARRIER, incorrectly assuming that stores postdominated by a barrier would
-# be waited at the barrier. This was wrong because:
-# 1. S_BARRIER without AutoWaitcntBeforeBarrier does not automatically wait for DS stores to complete
-# 2. S_BARRIER with BackOffBarrier feature does not later flush memory ops by adding ZERO waitcnt
-#
-# This test ensures that when a loop has a DS store followed by S_BARRIER,
-# the preheader flush optimization is NOT applied (no S_WAIT_DSCNT in preheader).
-# The wait should happen inside the loop instead.
+# Test for DS store followed by S_BARRIER in loop.
+# Previously, DS stores would prevent preheader flush entirely. With the
+# queue simulation, the DS_CNT flush is correctly hoisted to the preheader
+# because the back-edge DS store traffic would stall the invariant's wait.
+# S_BARRIER with BackOffBarrier does not affect this decision.
 
 ---
 # Test: DS store followed by S_BARRIER in loop.
 # DS load in preheader, value used in loop.
-# The preheader should NOT have S_WAIT_DSCNT because SeenDSStoreInLoop = true.
-# Instead, the wait should be inside the loop.
+# The preheader hoist simulation detects that the DS store's back-edge traffic
+# stalls the invariant, so S_WAIT_DSCNT is flushed in the preheader.
 name: ds_store_barrier_no_preheader_flush
 tracksRegLiveness: true
 machineFunctionInfo:
@@ -29,15 +24,15 @@ body: |
   ; CHECK-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1, $vgpr2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   $vgpr10_vgpr11_vgpr12_vgpr13 = DS_READ_B128 $vgpr0, 0, 0, implicit $m0, implicit $exec
-  ; Verify NO S_WAIT_DSCNT in preheader - the wait must be inside the loop
-  ; CHECK-NOT:    S_WAIT_DSCNT
+  ; DS_CNT flush hoisted to preheader by queue simulation
+  ; CHECK-NEXT:   S_WAIT_DSCNT 0
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
   ; CHECK-NEXT:   successors: %bb.1(0x40000000), %bb.2(0x40000000)
   ; CHECK-NEXT:   liveins: $sgpr0, $vgpr0, $vgpr1, $vgpr2, $vgpr10
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   S_WAIT_DSCNT 0
+  ; No S_WAIT_DSCNT here - already resolved in preheader
   ; CHECK-NEXT:   $vgpr30 = V_ADD_F32_e32 $vgpr10, $vgpr1, implicit $mode, implicit $exec
   ; CHECK-NEXT:   DS_WRITE_B32 $vgpr2, $vgpr30, 0, 0, implicit $m0, implicit $exec
   ; With BackOffBarrier, no S_WAIT_DSCNT needed before S_BARRIER

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop-hoist-multiblock.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop-hoist-multiblock.mir
@@ -1,0 +1,226 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -verify-machineinstrs -run-pass si-insert-waitcnts -o - %s | FileCheck %s
+
+---
+
+# Multi-block variant of "variant2": invariant v1 (score 2, newest) is used
+# first in the header, reloaded v0 (score 1) is used second.  The loop body
+# is split across two blocks (bb.1 = header, bb.2 = latch).  Hoist simulation
+# sees 1 LOAD_CNT event (reload), so C = 1 > N = 0 => flush in preheader.
+
+# CHECK-LABEL: name: multiblock_header_use_do_flush
+# CHECK-LABEL: bb.0:
+# CHECK:         S_WAIT_LOADCNT_DSCNT 0
+# CHECK:         $vgpr0 = GLOBAL_LOAD_DWORD
+# CHECK:         $vgpr1 = GLOBAL_LOAD_DWORD
+# CHECK:         S_WAIT_LOADCNT 0
+# CHECK:         S_BRANCH %bb.1
+# CHECK-LABEL: bb.1:
+# CHECK-NOT:     S_WAIT_LOADCNT
+# CHECK:         $vgpr3 = V_ADD_U32_e32 $vgpr1
+# CHECK:         S_WAIT_LOADCNT 0
+# CHECK-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+name:            multiblock_header_use_do_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.2:
+    successors: %bb.1, %bb.3
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_CMP_LG_U32 $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit $scc
+    S_BRANCH %bb.3
+
+  bb.3:
+    S_ENDPGM 0
+
+...
+---
+
+# Diamond CFG: invariant v1 used only in bb.2 (a conditional block), with
+# a varying branch condition (sgpr3 modified in-loop by S_ADD_U32).
+# bb.2 does NOT dominate the latch (bb.4).  The branch invariance heuristic
+# finds sgpr3 in AllDefsInLoop => condition varies => keep the use => flush.
+
+# CHECK-LABEL: name: multiblock_branch_varying_do_flush
+# CHECK-LABEL: bb.0:
+# CHECK:         S_WAIT_LOADCNT_DSCNT 0
+# CHECK:         $vgpr0 = GLOBAL_LOAD_DWORD
+# CHECK:         $vgpr1 = GLOBAL_LOAD_DWORD
+# CHECK:         S_WAIT_LOADCNT 0
+# CHECK:         S_BRANCH %bb.1
+# CHECK-LABEL: bb.1:
+
+name:            multiblock_branch_varying_do_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+
+    S_CMP_LG_U32 $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.4
+
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.3:
+    successors: %bb.4
+
+    $vgpr6 = V_MOV_B32_e32 0, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.4:
+    successors: %bb.1, %bb.5
+
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $sgpr3 = S_ADD_U32 $sgpr3, 1, implicit-def $scc
+    S_CMP_LG_U32 $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit $scc
+    S_BRANCH %bb.5
+
+  bb.5:
+    S_ENDPGM 0
+
+...
+---
+
+# Same diamond CFG, but the branch condition in the header uses sgpr10/sgpr11
+# which are NOT defined inside the loop => loop-invariant condition.
+# The branch invariance heuristic removes v1's use from OutsideLoadUseInfo,
+# so no preheader flush is emitted.  The wait for v1 stays in-loop (bb.2).
+
+# CHECK-LABEL: name: multiblock_branch_invariant_no_flush
+# CHECK-LABEL: bb.0:
+# CHECK:         S_WAIT_LOADCNT_DSCNT 0
+# CHECK:         $vgpr0 = GLOBAL_LOAD_DWORD
+# CHECK:         $vgpr1 = GLOBAL_LOAD_DWORD
+# CHECK-NOT:     S_WAIT_LOADCNT
+# CHECK:         S_BRANCH %bb.1
+# CHECK-LABEL: bb.2:
+# CHECK:         S_WAIT_LOADCNT 0
+# CHECK-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+
+name:            multiblock_branch_invariant_no_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+
+    S_CMP_LG_U32 $sgpr10, $sgpr11, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.4
+
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.3:
+    successors: %bb.4
+
+    $vgpr6 = V_MOV_B32_e32 0, implicit $exec
+    S_BRANCH %bb.4
+
+  bb.4:
+    successors: %bb.1, %bb.5
+
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_CMP_LG_U32 $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit $scc
+    S_BRANCH %bb.5
+
+  bb.5:
+    S_ENDPGM 0
+
+...
+---
+
+# Nested loop: inner loop (bb.2) has preheader bb.1 inside the outer loop.
+# The nested-loop guard (MLI.getLoopFor(preheader) != null) prevents flush
+# analysis for the inner loop.  The outer loop's preheader (bb.0) analysis
+# sees v1 used in bb.1 (outer header, dominates all outer back edges) and
+# computes C > N => flush in bb.0.
+# Key check: flush in bb.0, NO flush in bb.1 (inner preheader).
+
+# CHECK-LABEL: name: nested_outer_flush_inner_no_flush
+# CHECK-LABEL: bb.0:
+# CHECK:         S_WAIT_LOADCNT_DSCNT 0
+# CHECK:         $vgpr0 = GLOBAL_LOAD_DWORD
+# CHECK:         $vgpr1 = GLOBAL_LOAD_DWORD
+# CHECK:         S_WAIT_LOADCNT 0
+# CHECK:         S_BRANCH %bb.1
+# CHECK-LABEL: bb.1:
+# CHECK-NOT:     S_WAIT_LOADCNT 0
+# CHECK:         $vgpr3 = V_ADD_U32_e32 $vgpr1
+# CHECK:         S_BRANCH %bb.2
+# CHECK-LABEL: bb.2:
+# CHECK:         S_WAIT_LOADCNT 0
+# CHECK-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+name:            nested_outer_flush_inner_no_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2
+
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    S_BRANCH %bb.2
+
+  bb.2:
+    successors: %bb.2, %bb.3
+
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_CMP_LG_U32 $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.2, implicit $scc
+    S_BRANCH %bb.3
+
+  bb.3:
+    successors: %bb.1, %bb.4
+
+    S_CMP_LG_U32 $sgpr5, $sgpr6, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit $scc
+    S_BRANCH %bb.4
+
+  bb.4:
+    S_ENDPGM 0
+
+...

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop-hoist.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop-hoist.mir
@@ -1,0 +1,189 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx900 -verify-machineinstrs -run-pass si-insert-waitcnts -o - %s | FileCheck -check-prefix=GFX9 %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -verify-machineinstrs -run-pass si-insert-waitcnts -o - %s | FileCheck -check-prefix=GFX10 %s
+# RUN: llc -mtriple=amdgcn -mcpu=gfx1200 -verify-machineinstrs -run-pass si-insert-waitcnts -o - %s | FileCheck -check-prefix=GFX12 %s
+
+---
+
+# Variant 1: v0 is reloaded in loop, v1 is loop-invariant.
+# Use v0 first (reloaded register), then v1 (invariant).
+# On iter 1+, the wait for v0 (vmcnt(0)) covers v1, so v1 needs no separate
+# wait. Flushing v1 in the preheader would kill latency hiding with no benefit.
+# We do NOT expect a preheader flush.
+
+# GFX9-LABEL: name: hoist_variant1_no_flush
+# GFX9-LABEL: bb.0:
+# GFX9:         S_WAITCNT 0
+# GFX9-NOT:     S_WAITCNT
+# GFX9-LABEL: bb.1:
+# GFX9:         S_WAITCNT 3952
+# GFX9-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+# GFX9:         S_WAITCNT 3952
+# GFX9-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+
+# GFX10-LABEL: name: hoist_variant1_no_flush
+# GFX10-LABEL: bb.0:
+# GFX10:         S_WAITCNT 0
+# GFX10-NOT:     S_WAITCNT
+# GFX10-LABEL: bb.1:
+# GFX10:         S_WAITCNT 16240
+# GFX10-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+# GFX10:         S_WAITCNT 16240
+# GFX10-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+
+# GFX12-LABEL: name: hoist_variant1_no_flush
+# GFX12-LABEL: bb.0:
+# GFX12:         S_WAIT_LOADCNT_DSCNT 0
+# GFX12-NOT:     S_WAIT_LOADCNT
+# GFX12-LABEL: bb.1:
+# GFX12:         S_WAIT_LOADCNT 0
+# GFX12-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+# GFX12:         S_WAIT_LOADCNT 0
+# GFX12-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+
+name:            hoist_variant1_no_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_CMP_LG_U32 killed $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+---
+
+# Variant 2: v0 is reloaded in loop (score 1), v1 is loop-invariant (score 2).
+# Use v1 first (invariant), then v0 (reloaded).
+# On iter 1+, v1's wait (vmcnt(0) since v1 is newest) drains the v0 reload
+# prematurely. Flushing vmcnt(0) in the preheader eliminates v1's in-loop wait.
+# v0's wait (vmcnt(0)) stays in the loop body for iter 1+.
+# We DO expect a preheader flush.
+
+# GFX9-LABEL: name: hoist_variant2_do_flush
+# GFX9-LABEL: bb.0:
+# GFX9:         S_WAITCNT 0
+# GFX9:         S_WAITCNT 3952
+# GFX9-LABEL: bb.1:
+# GFX9-NOT:     S_WAITCNT
+# GFX9:         $vgpr3 = V_ADD_U32_e32 $vgpr1
+# GFX9:         S_WAITCNT 3952
+# GFX9-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+# GFX10-LABEL: name: hoist_variant2_do_flush
+# GFX10-LABEL: bb.0:
+# GFX10:         S_WAITCNT 0
+# GFX10:         S_WAITCNT 16240
+# GFX10-LABEL: bb.1:
+# GFX10-NOT:     S_WAITCNT
+# GFX10:         $vgpr3 = V_ADD_U32_e32 $vgpr1
+# GFX10:         S_WAITCNT 16240
+# GFX10-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+# GFX12-LABEL: name: hoist_variant2_do_flush
+# GFX12-LABEL: bb.0:
+# GFX12:         S_WAIT_LOADCNT_DSCNT 0
+# GFX12:         S_WAIT_LOADCNT 0
+# GFX12-LABEL: bb.1:
+# GFX12-NOT:     S_WAIT_LOADCNT
+# GFX12:         $vgpr3 = V_ADD_U32_e32 $vgpr1
+# GFX12:         S_WAIT_LOADCNT 0
+# GFX12-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+name:            hoist_variant2_do_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_CMP_LG_U32 killed $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...
+---
+
+# Variant 3: v1 is loop-invariant (score 1, oldest), v0 is reloaded (score 2).
+# Use v1 first (invariant), then v0 (reloaded).
+# v1's wait is vmcnt(1), which on iter 1+ allows 1 outstanding (the v0 reload).
+# Since cycle traffic = 1 event (v0 reload) and N = 1, 1 > 1 is false.
+# No stall, no benefit from flushing.
+# We do NOT expect a preheader flush.
+
+# GFX9-LABEL: name: hoist_variant3_no_flush
+# GFX9-LABEL: bb.0:
+# GFX9:         S_WAITCNT 0
+# GFX9-NOT:     S_WAITCNT
+# GFX9-LABEL: bb.1:
+# GFX9:         S_WAITCNT 3953
+# GFX9-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+# GFX9:         S_WAITCNT 3952
+# GFX9-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+# GFX10-LABEL: name: hoist_variant3_no_flush
+# GFX10-LABEL: bb.0:
+# GFX10:         S_WAITCNT 0
+# GFX10-NOT:     S_WAITCNT
+# GFX10-LABEL: bb.1:
+# GFX10:         S_WAITCNT 16241
+# GFX10-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+# GFX10:         S_WAITCNT 16240
+# GFX10-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+# GFX12-LABEL: name: hoist_variant3_no_flush
+# GFX12-LABEL: bb.0:
+# GFX12:         S_WAIT_LOADCNT_DSCNT 0
+# GFX12-NOT:     S_WAIT_LOADCNT
+# GFX12-LABEL: bb.1:
+# GFX12:         S_WAIT_LOADCNT 1
+# GFX12-NEXT:    $vgpr3 = V_ADD_U32_e32 $vgpr1
+# GFX12:         S_WAIT_LOADCNT 0
+# GFX12-NEXT:    $vgpr2 = V_ADD_U32_e32 $vgpr0
+
+name:            hoist_variant3_no_flush
+body:             |
+  bb.0:
+    successors: %bb.1
+
+    $vgpr1 = GLOBAL_LOAD_DWORD $vgpr12_vgpr13, 0, 0, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.1, %bb.2
+
+    $vgpr3 = V_ADD_U32_e32 $vgpr1, $vgpr5, implicit $exec
+    $vgpr2 = V_ADD_U32_e32 $vgpr0, $vgpr5, implicit $exec
+    $vgpr0 = GLOBAL_LOAD_DWORD $vgpr10_vgpr11, 0, 0, implicit $exec
+    S_CMP_LG_U32 killed $sgpr3, $sgpr4, implicit-def $scc
+    S_CBRANCH_SCC1 %bb.1, implicit killed $scc
+    S_BRANCH %bb.2
+
+  bb.2:
+    S_ENDPGM 0
+
+...

--- a/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop.mir
+++ b/llvm/test/CodeGen/AMDGPU/waitcnt-vmcnt-loop.mir
@@ -771,28 +771,32 @@ body:             |
 ...
 ---
 
-# Same as above case, but use flat memory instructions instead
+# Same as above case, but use flat memory instructions instead.
+# FLAT loads set scores on both LOAD_CNT and DS_CNT. The preheader hoist
+# simulation detects that the DS_CNT (lgkmcnt) wait would stall on back-edge
+# traffic from the FLAT store, and flushes it in the preheader.
+# On GFX9 this combines with the existing vmcnt(0) flush into a single wait.
 
 # GFX9-LABEL: waitcnt_vm_loop_flat_mem
 # GFX9-LABEL: bb.0:
-# GFX9: S_WAITCNT 39
+# GFX9: S_WAITCNT 112
 # GFX9-LABEL: bb.1:
-# GFX9-NOT: S_WAITCNT 39
+# GFX9-NOT: S_WAITCNT
 # GFX9-LABEL: bb.2:
 
 # GFX10-LABEL: waitcnt_vm_loop_flat_mem
 # GFX10-LABEL: bb.0:
-# GFX10-NOT: S_WAITCNT 11
+# GFX10: S_WAITCNT 49279
 # GFX10-LABEL: bb.1:
-# GFX10: S_WAITCNT 11
+# GFX10: S_WAITCNT 16240
 # GFX10-LABEL: bb.2:
 
 # GFX12-LABEL: waitcnt_vm_loop_flat_mem
 # GFX12-LABEL: bb.0:
 # GFX12: FLAT_LOAD_DWORD
-# GFX12-NOT: S_WAIT_LOADCNT_DSCNT 0
+# GFX12: S_WAIT_DSCNT 0
 # GFX12-LABEL: bb.1:
-# GFX12: S_WAIT_LOADCNT_DSCNT 0
+# GFX12: S_WAIT_LOADCNT 0
 # GFX12-LABEL: bb.2:
 name:            waitcnt_vm_loop_flat_mem
 body:             |


### PR DESCRIPTION
The existing preheader flush in SIInsertWaitcnts uses conservative heuristics (e.g. VMemInvalidated flag, SimpleDSOpt) to decide whether to hoist waitcnts out of single-block loops. This misses profitable cases where loop-invariant register waits stall on unrelated back-edge traffic.

Add a queue simulation that models counter state on iteration 1+ for both LOAD_CNT and DS_CNT independently:
- For each loop-invariant register, compute N (the waitcnt target from the preheader brackets) and C (outstanding events at the register's use on iter 1+, accounting for drain points from reloaded registers).
- If C > N, the invariant's wait stalls on back-edge traffic and flushing to the preheader is profitable.

Key changes:
- PreheaderFlushFlags: bool -> std::optional<unsigned> to carry precise waitcnt targets (e.g. vmcnt(1) instead of always vmcnt(0)).
- Track events on both LOAD_CNT and DS_CNT during the loop scan.
- FLAT instructions conservatively counted on both counters.
- Generic checkCounter lambda handles both counter types uniformly.
- WaitcntBrackets: expose getScoreLB/UB/Range/VMemScore as public.

The simulation is currently limited to single-block loops and bails when in-loop-defined loads are consumed in the same iteration (def-before-use pattern). Multi-block loop support is future work.

Assisted-by: Claude Opus


