### PR TITLE
fix regression in ASAN build for RCCL & rocSHMEM

### DIFF
--- a/amd/device-libs/utils/prepare-builtins/prepare-builtins.cpp
+++ b/amd/device-libs/utils/prepare-builtins/prepare-builtins.cpp
@@ -73,6 +73,29 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+  // Set linkage of every external definition to linkonce_odr.
+  // This is required to avoid duplicate symbol errors when linking
+  // device code from multiple translation units with -fgpu-rdc.
+  for (Module::iterator i = M->begin(), e = M->end(); i != e; ++i) {
+    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
+        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
+    }
+  }
+
+  for (Module::global_iterator i = M->global_begin(), e = M->global_end();
+       i != e; ++i) {
+    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
+        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
+    }
+  }
+
+  for (Module::alias_iterator i = M->alias_begin(), e = M->alias_end();
+       i != e; ++i) {
+    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
+        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
+    }
+  }
+
   if (OutputFilename.empty()) {
     errs() << "no output file\n";
     return 1;


### PR DESCRIPTION
Cherry-pick of 2c6ccd1c53d1 from `amd-staging` to `amd-main`.

## Summary
- Reverts the change from commit `01bb749c38f1` (2026-01-27) that caused duplicate symbol linker errors when building AMDGPU code with both `-fsanitize=address` (ASan) and `-fgpu-rdc` (relocatable device code)
- Fixes ASAN builds for RCCL & rocSHMEM

ROCM-20881
ROCM-20490