### PR TITLE
[WaveTransform] Support S_SUBVECTOR_LOOP terminators in the WT.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -1782,8 +1782,7 @@ void ControlFlowRewriter::prepareWaveCfg() {
                  Opcode == AMDGPU::S_CBRANCH_VCCZ ||
                  Opcode == AMDGPU::S_CBRANCH_VCCNZ ||
                  Opcode == AMDGPU::S_CBRANCH_SCC0 ||
-                 Opcode == AMDGPU::S_CBRANCH_SCC1 ||
-                 isHardwareManagedBranch(Terminator)) {
+                 Opcode == AMDGPU::S_CBRANCH_SCC1) {
         assert(!Info.OrigCondition);
         assert(!Info.ImplicitBranchOpc);
         assert(!Info.OrigSuccCond);

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -111,6 +111,16 @@ static cl::opt<bool>
 
 namespace {
 
+static bool isHardwareManagedBranch(MachineInstr &MI) {
+  switch (MI.getOpcode()) {
+  case AMDGPU::S_SUBVECTOR_LOOP_BEGIN:
+  case AMDGPU::S_SUBVECTOR_LOOP_END:
+    return true;
+  default:
+    return false;
+  }
+}
+
 static bool isArtificialTerminator(MachineInstr &MI) {
   // Return true for instructions that are marked as terminators to support
   // special exec management.
@@ -1772,7 +1782,8 @@ void ControlFlowRewriter::prepareWaveCfg() {
                  Opcode == AMDGPU::S_CBRANCH_VCCZ ||
                  Opcode == AMDGPU::S_CBRANCH_VCCNZ ||
                  Opcode == AMDGPU::S_CBRANCH_SCC0 ||
-                 Opcode == AMDGPU::S_CBRANCH_SCC1) {
+                 Opcode == AMDGPU::S_CBRANCH_SCC1 ||
+                 isHardwareManagedBranch(Terminator)) {
         assert(!Info.OrigCondition);
         assert(!Info.ImplicitBranchOpc);
         assert(!Info.OrigSuccCond);
@@ -1785,10 +1796,6 @@ void ControlFlowRewriter::prepareWaveCfg() {
       } else if (Terminator.isReturn()) {
         assert(!Info.OrigCondition);
         Info.OrigExit = true;
-      } else {
-        assert(Opcode != AMDGPU::S_SUBVECTOR_LOOP_BEGIN &&
-               Opcode != AMDGPU::S_SUBVECTOR_LOOP_END &&
-               "wave-transform: unhandled branch opcode");
       }
     }
 
@@ -1949,9 +1956,12 @@ void ControlFlowRewriter::rewrite() {
     MachineBasicBlock::iterator MBBINodeEnd = Node->Block->end();
 
     if (!Info.OrigExit) {
-      // Remove original terminators.
+      // Remove original terminators, preserving artificial terminators
+      // (EXEC management ops) and hardware-managed branches (e.g.
+      // S_SUBVECTOR_LOOP) that pass through to assembly unchanged.
       while (!Node->Block->empty() && Node->Block->back().isTerminator() &&
-             !isArtificialTerminator(Node->Block->back()))
+             !isArtificialTerminator(Node->Block->back()) &&
+             !isHardwareManagedBranch(Node->Block->back()))
         Node->Block->back().eraseFromParent();
     }
 
@@ -2000,6 +2010,12 @@ void ControlFlowRewriter::rewrite() {
     }
 
     assert(Node->Successors.size() == 2);
+
+    // Hardware-managed branches handle their own EXEC and control flow
+    // atomically — no new branches needed.
+    if (!Node->Block->empty() && Node->Block->back().isBranch() &&
+        isHardwareManagedBranch(Node->Block->back()))
+      continue;
 
     if (!Node->IsDivergent) {
       // Uniform block with two successors: we must have had two original

--- a/llvm/test/CodeGen/AMDGPU/subvector-test.mir
+++ b/llvm/test/CodeGen/AMDGPU/subvector-test.mir
@@ -1,5 +1,5 @@
-# RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -start-before=greedy -verify-machineinstrs -o - %s | FileCheck -check-prefix=GCN %s
-# RUN: llc -mtriple=amdgcn -mcpu=gfx1100 -start-before=greedy -verify-machineinstrs -o - %s | FileCheck -check-prefix=GCN %s
+# RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx1010 -start-before=greedy -verify-machineinstrs -o - %s | FileCheck -check-prefix=GCN %s
+# RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx1100 -start-before=greedy -verify-machineinstrs -o - %s | FileCheck -check-prefix=GCN %s
 ...
 # GCN-LABEL: {{^}}"subvector-basic-bb"
 # GCN: s_subvector_loop_begin [[RS:s[0-9]]], .LBB0_2


### PR DESCRIPTION
Handles the S_SUBVECTOR_LOOP_BEGIN/S_SUBVECTOR_LOOP_END terminators in the AMDGPUWaveTransform pass. MBB having this terminators need to ignore it for processing, leaving it unchanged as they occur within a SESE region which undergoes no structural changes and also these terminators need to translate as it is in the final assembly. 