### PR TITLE
[WaveTransform] Update manually-maintained tests for the new pipeline

### DIFF
--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.ordered.swap.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ds.ordered.swap.ll
@@ -1,12 +1,11 @@
-; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=bonaire < %s | FileCheck -check-prefixes=GCN,FUNC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=bonaire < %s | FileCheck -check-prefixes=GCN,FUNC %s
 ; RUN: llc -amdgpu-late-wave-transform=0 -global-isel=1 -new-reg-bank-select -mtriple=amdgcn -mcpu=bonaire < %s | FileCheck -check-prefixes=GCN,FUNC %s
-; RUN: llc -amdgpu-late-wave-transform=0 -global-isel=0 -mtriple=amdgcn -mcpu=tonga < %s | FileCheck -check-prefixes=GCN,VIGFX9,FUNC %s
-; RUN: llc -amdgpu-late-wave-transform=0 -global-isel=0 -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck -check-prefixes=GCN,VIGFX9,FUNC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=tonga < %s | FileCheck -check-prefixes=GCN,FUNC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck -check-prefixes=GCN,FUNC %s
 
 ; FUNC-LABEL: {{^}}ds_ordered_swap:
 ; GCN: s_mov_b32 m0, s0
-; VIGFX9-NEXT: s_nop 0
-; GCN-NEXT: ds_ordered_count v{{[0-9]+}}, v0 offset:4868 gds
+; GCN: ds_ordered_count v{{[0-9]+}}, v0 offset:4868 gds
 ; GCN-NEXT: s_waitcnt expcnt(0) lgkmcnt(0)
 define amdgpu_cs float @ds_ordered_swap(ptr addrspace(2) inreg %gds, i32 %value) {
   %val = call i32@llvm.amdgcn.ds.ordered.swap(ptr addrspace(2) %gds, i32 %value, i32 0, i32 0, i1 false, i32 1, i1 true, i1 true)
@@ -15,18 +14,16 @@ define amdgpu_cs float @ds_ordered_swap(ptr addrspace(2) inreg %gds, i32 %value)
 }
 
 ; FUNC-LABEL: {{^}}ds_ordered_swap_conditional:
-; GCN: v_cmp_ne_u32_e32 vcc, 0, v[[VALUE:[0-9]+]]
-; GCN: s_and_saveexec_b64 s[[SAVED:\[[0-9]+:[0-9]+\]]], vcc
+; GCN: v_cmp_{{ne|eq}}_u32_e{{32|64}} {{(vcc|s\[[0-9]+:[0-9]+\])}}, 0, v{{[0-9]+}}
 ; // We have to use s_cbranch, because ds_ordered_count has side effects with EXEC=0
 ; GCN: s_cbranch_execz [[BB:.LBB._.]]
 ; GCN: s_mov_b32 m0, s0
-; VIGFX9-NEXT: s_nop 0
-; GCN-NEXT: ds_ordered_count v{{[0-9]+}}, v[[VALUE]] offset:4868 gds
+; GCN: ds_ordered_count v{{[0-9]+}}, v{{[0-9]+}} offset:4868 gds
 ; GCN-NEXT: s_waitcnt lgkmcnt(0)
-; GCN-NEXT: [[BB]]:
+; GCN: [[BB]]:
 ; // Wait for expcnt(0) before modifying EXEC
 ; GCN-NEXT: s_waitcnt expcnt(0)
-; GCN-NEXT: s_or_b64 exec, exec, s[[SAVED]]
+; GCN-NEXT: s_or_b64 exec, exec
 define amdgpu_cs float @ds_ordered_swap_conditional(ptr addrspace(2) inreg %gds, i32 %value) {
 entry:
   %c = icmp ne i32 %value, 0

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ps.live.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.ps.live.ll
@@ -1,5 +1,5 @@
-; RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -check-prefixes=CHECK,CHECK-SDAG %s
-; RUN: llc -global-isel=1 -new-reg-bank-select -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -check-prefixes=CHECK,CHECK-GISEL %s
+; RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -check-prefixes=CHECK,CHECK-SDAG %s
+; RUN: llc -amdgpu-late-wave-transform=0 -global-isel=1 -new-reg-bank-select -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -check-prefixes=CHECK,CHECK-GISEL %s
 
 ; CHECK-LABEL: {{^}}test1:
 ; CHECK: s_mov_b64 s[0:1], exec
@@ -20,10 +20,8 @@ define amdgpu_ps float @test1() #0 {
 
 ; CHECK-LABEL: {{^}}test2:
 ; CHECK: s_mov_b64 [[LIVE:s\[[0-9]+:[0-9]+\]]], exec
-; Following copy should go away:
-; CHECK: s_mov_b64 [[COPY:s\[[0-9]+:[0-9]+\]]], [[LIVE]]
 ; CHECK-DAG: s_wqm_b64 exec, exec
-; CHECK-DAG: v_cndmask_b32_e64 [[VAR:v[0-9]+]], 0, 1, [[COPY]]
+; CHECK-DAG: v_cndmask_b32_e64 [[VAR:v[0-9]+]], 0, 1, s[{{[0-9]+:[0-9]+}}]
 ; CHECK-SDAG: image_sample v0, [[VAR]], s[0:7], s[0:3] dmask:0x1
 ; CHECK-GISEL: image_sample v[0:3], [[VAR]], s[0:7], s[0:3] dmask:0xf
 define amdgpu_ps float @test2() #0 {
@@ -38,10 +36,9 @@ define amdgpu_ps float @test2() #0 {
 ; CHECK-LABEL: {{^}}test3:
 ; CHECK: s_mov_b64 [[LIVE:s\[[0-9]+:[0-9]+\]]], exec
 ; CHECK-DAG: s_wqm_b64 exec, exec
-; CHECK-SDAG-DAG: s_xor_b64 [[HELPER:s\[[0-9]+:[0-9]+\]]], [[LIVE]], -1
+; CHECK-SDAG-DAG: s_xor_b64 {{s\[[0-9]+:[0-9]+\]}}, [[LIVE]], exec
 ; CHECK-GISEL-DAG: s_mov_b64 [[EXEC_COPY:s\[[0-9]+:[0-9]+\]]], exec
-; CHECK-GISEL-DAG: s_xor_b64 [[HELPER:s\[[0-9]+:[0-9]+\]]], [[LIVE]], [[EXEC_COPY]]
-; CHECK-DAG: s_and_saveexec_b64 [[SAVED:s\[[0-9]+:[0-9]+\]]], [[HELPER]]
+; CHECK-GISEL-DAG: s_xor_b64 {{s\[[0-9]+:[0-9]+\]}}, [[LIVE]], [[EXEC_COPY]]
 ; CHECK: ; %dead
 define amdgpu_ps float @test3(i32 %in) #0 {
 entry:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.rsq.clamp.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.rsq.clamp.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn < %s | FileCheck -check-prefix=SI -check-prefix=FUNC %s
-; RUN: llc -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck -check-prefix=VI -check-prefix=FUNC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn < %s | FileCheck -check-prefix=SI -check-prefix=FUNC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck -check-prefix=VI -check-prefix=FUNC %s
 
 declare float @llvm.amdgcn.rsq.clamp.f32(float) #1
 declare double @llvm.amdgcn.rsq.clamp.f64(double) #1
@@ -22,14 +22,12 @@ define amdgpu_kernel void @rsq_clamp_f32(ptr addrspace(1) %out, float %src) #0 {
 ; FUNC-LABEL: {{^}}rsq_clamp_f64:
 ; SI: v_rsq_clamp_f64_e32
 
-; TODO: this constant should be folded:
-; VI-DAG: s_mov_b32 [[NEG1:s[0-9]+]], -1
-; VI-DAG: s_mov_b32 s[[LOW1:[0-9]+]], [[NEG1]]
-; VI-DAG: s_mov_b32 s[[HIGH1:[0-9]+]], 0x7fefffff
-; VI-DAG: s_mov_b32 s[[HIGH2:[0-9]+]], 0xffefffff
-; VI-DAG: v_rsq_f64_e32 [[RSQ:v\[[0-9]+:[0-9]+\]]], s[{{[0-9]+:[0-9]+}}
-; VI-DAG: v_min_f64 v[0:1], [[RSQ]], s[[[LOW1]]:[[HIGH1]]]
-; VI-DAG: v_max_f64 v[0:1], v[0:1], s[[[LOW1]]:[[HIGH2]]]
+; VI-DAG: v_rsq_f64_e32 v[0:1], s[{{[0-9]+:[0-9]+}}]
+; VI-DAG: s_mov_b32 s{{[0-9]+}}, -1
+; VI-DAG: s_mov_b32 s{{[0-9]+}}, 0x7fefffff
+; VI-DAG: v_min_f64 v[0:1], v[0:1], s[{{[0-9]+:[0-9]+}}]
+; VI-DAG: s_mov_b32 s{{[0-9]+}}, 0xffefffff
+; VI-DAG: v_max_f64 v[0:1], v[0:1], s[{{[0-9]+:[0-9]+}}]
 define amdgpu_kernel void @rsq_clamp_f64(ptr addrspace(1) %out, double %src) #0 {
   %rsq_clamp = call double @llvm.amdgcn.rsq.clamp.f64(double %src)
   store double %rsq_clamp, ptr addrspace(1) %out

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sendmsg.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.sendmsg.ll
@@ -1,7 +1,7 @@
-;RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=verde < %s | FileCheck --check-prefixes=GCN,SIVI %s
-;RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=tonga < %s | FileCheck --check-prefixes=GCN,VIPLUS,SIVI %s
-;RUN: llc -global-isel=0 -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck --check-prefixes=GCN,VIPLUS,GFX9 %s
-;RUN: llc -global-isel=1 -new-reg-bank-select -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck --check-prefixes=GCN,VIPLUS,GFX9 %s
+;RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=verde < %s | FileCheck --check-prefixes=GCN,SIVI %s
+;RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=tonga < %s | FileCheck --check-prefixes=GCN,VIPLUS,SIVI %s
+;RUN: llc -amdgpu-late-wave-transform=1 -global-isel=0 -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck --check-prefixes=GCN,VIPLUS,GFX9 %s
+;RUN: llc -amdgpu-late-wave-transform=0 -global-isel=1 -new-reg-bank-select -mtriple=amdgcn -mcpu=gfx900 < %s | FileCheck --check-prefixes=GCN,VIPLUS,GFX9 %s
 
 ; GCN-LABEL: {{^}}test_interrupt:
 ; GCN: s_mov_b32 m0, 0
@@ -148,7 +148,7 @@ body:
 }
 
 ; GCN-LABEL: {{^}}if_sendmsg:
-; GCN: s_cbranch_execz
+; GCN: s_cbranch_exec{{n?}}z
 ; GCN: s_sendmsg sendmsg(MSG_GS_DONE, GS_OP_NOP)
 define amdgpu_gs void @if_sendmsg(i32 %flag) #0 {
   %cc = icmp eq i32 %flag, 0

--- a/llvm/test/CodeGen/AMDGPU/mixed-wave32-wave64.ll
+++ b/llvm/test/CodeGen/AMDGPU/mixed-wave32-wave64.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx1010 -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck --check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn--amdpal -mcpu=gfx1010 -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck --check-prefix=GCN %s
 
 ; GCN-LABEL: _amdgpu_hs_main:
 
@@ -8,7 +8,9 @@ define amdgpu_hs void @_amdgpu_hs_main() #0 {
 }
 
 ; GCN-LABEL: _amdgpu_ps_main:
-; GCN: s_and_saveexec_b64
+; GCN: v_cmp_ngt_f32_e32 vcc, 0.5, v0
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
 
 define amdgpu_ps void @_amdgpu_ps_main(i32 %arg) local_unnamed_addr #1 {
 .entry:

--- a/llvm/test/CodeGen/AMDGPU/multi-divergent-exit-region.ll
+++ b/llvm/test/CodeGen/AMDGPU/multi-divergent-exit-region.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -mtriple=amdgcn-- -mcpu=gfx600 -S -lowerswitch -amdgpu-unify-divergent-exit-nodes -verify -structurizecfg -verify -si-annotate-control-flow -simplifycfg-require-and-preserve-domtree=1 %s | FileCheck -check-prefix=IR %s
 ; RUN: opt -mtriple=amdgcn-- -mcpu=gfx1100 -mattr=+wavefrontsize64 -S -lowerswitch -amdgpu-unify-divergent-exit-nodes -verify -structurizecfg -verify -si-annotate-control-flow -simplifycfg-require-and-preserve-domtree=1 %s | FileCheck -check-prefix=IR %s
-; RUN: llc -mtriple=amdgcn -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
 
 ; Add an extra verifier runs. There were some cases where invalid IR
 ; was produced but happened to be fixed by the later passes.
@@ -61,45 +61,50 @@
 
 ; GCN-LABEL: {{^}}multi_divergent_region_exit_ret_ret:
 
-; GCN-DAG:  s_mov_b64           [[EXIT1:s\[[0-9]+:[0-9]+\]]], 0
-; GCN-DAG:  v_cmp_lt_i32_e32    vcc, 1,
-; GCN-DAG:  s_mov_b64           [[EXIT0:s\[[0-9]+:[0-9]+\]]], 0
-; GCN-DAG:  s_and_saveexec_b64
-; GCN-DAG:  s_xor_b64
-
-; GCN: ; %LeafBlock1
-; GCN-NEXT: s_mov_b64           [[EXIT0]], exec
-; GCN-NEXT: v_cmp_ne_u32_e32    vcc, 2,
-; GCN-NEXT: s_and_b64           [[EXIT1]], vcc, exec
-
-; GCN: ; %Flow
-; GCN-NEXT: s_andn2_saveexec_b64
+; First divergent branch
+; GCN: v_cmp_lt_i32_e{{32|64}}
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
+; GCN: ; divergent control-flow edge
+; GCN: s_cbranch_execz
 
 ; GCN: ; %LeafBlock
-; GCN-DAG:  v_cmp_eq_u32_e32    vcc, 1,
-; GCN-DAG:  v_cmp_ne_u32_e64    [[INV:s\[[0-9]+:[0-9]+\]]], 1,
-; GCN-DAG:  s_andn2_b64         [[EXIT0]], [[EXIT0]], exec
-; GCN-DAG:  s_andn2_b64         [[EXIT1]], [[EXIT1]], exec
-; GCN-DAG:  s_and_b64           [[TMP0:s\[[0-9]+:[0-9]+\]]], vcc, exec
-; GCN-DAG:  s_and_b64           [[TMP1:s\[[0-9]+:[0-9]+\]]], [[INV]], exec
-; GCN-DAG:  s_or_b64            [[EXIT0]], [[EXIT0]], [[TMP0]]
-; GCN-DAG:  s_or_b64            [[EXIT1]], [[EXIT1]], [[TMP1]]
+; GCN: v_cmp_eq_u32_e32 vcc, 1,
+; GCN: s_or_b64
+; GCN: s_xor_b64
 
-; GCN: ; %Flow4
-; GCN-NEXT: s_or_b64            exec, exec,
-; GCN-NEXT: s_and_saveexec_b64  {{s\[[0-9]+:[0-9]+\]}}, [[EXIT1]]
-; GCN-NEXT: s_xor_b64
+; Second reconverge
+; GCN: s_or_b64 exec, exec
+; GCN: s_xor_b64
+; GCN: s_and_b64
+; GCN: s_mov_b64 exec
+; GCN: ; divergent control-flow edge
+; GCN: s_cbranch_execz
 
-; GCN: ; %exit1
-; GCN-DAG:  ds_write_b32
-; GCN-DAG:  s_andn2_b64         [[EXIT0]], [[EXIT0]], exec
+; GCN: ; %LeafBlock1
+; GCN: v_cmp_ne_u32_e32 vcc, 2,
 
-; GCN: ; %Flow5
-; GCN-NEXT: s_or_b64            exec, exec,
-; GCN-NEXT: s_and_saveexec_b64  {{s\[[0-9]+:[0-9]+\]}}, [[EXIT0]]
+; Third reconverge
+; GCN: s_or_b64 exec, exec
+; GCN: s_xor_b64
+; GCN: s_and_b64
+; GCN: s_mov_b64 exec
+; GCN: ; divergent control-flow edge
+; GCN: s_cbranch_execz
 
 ; GCN: ; %exit0
-; GCN:      buffer_store_dword
+; GCN: buffer_store_dword
+
+; Fourth reconverge
+; GCN: s_or_b64 exec, exec
+; GCN: s_xor_b64
+; GCN: s_and_b64
+; GCN: s_mov_b64 exec
+; GCN: ; divergent control-flow edge
+; GCN: s_cbranch_execz
+
+; GCN: ; %exit1
+; GCN: ds_write_b32
 
 ; GCN: ; %UnifiedReturnBlock
 ; GCN-NEXT: s_endpgm
@@ -156,8 +161,9 @@ exit1:                                     ; preds = %LeafBlock, %LeafBlock1
 
 ; FIXME: Probably should insert an s_endpgm anyway.
 ; GCN-LABEL: {{^}}multi_divergent_region_exit_unreachable_unreachable:
-; GCN: ; %UnifiedUnreachableBlock
-; GCN-NEXT: .Lfunc_end
+; GCN: ; %exit1
+; GCN: ds_write_b32
+; GCN: .Lfunc_end
 define amdgpu_kernel void @multi_divergent_region_exit_unreachable_unreachable(ptr addrspace(1) nocapture %arg0, ptr addrspace(1) nocapture %arg1, ptr addrspace(1) nocapture %arg2) #0 {
 entry:
   %tmp = tail call i32 @llvm.amdgcn.workitem.id.x() #1
@@ -359,21 +365,37 @@ exit1:                                     ; preds = %LeafBlock, %LeafBlock1
 
 ; GCN-LABEL: {{^}}uniform_branch_to_multi_divergent_region_exit_ret_ret_return_value:
 ; GCN: s_cmp_gt_i32 s0, 1
-; GCN: s_cbranch_scc0 [[FLOW:.LBB[0-9]+_[0-9]+]]
+; GCN: s_cbranch_scc{{[01]}}
 
-; GCN: v_cmp_ne_u32_e32 vcc, 7, v0
+; GCN: ; %LeafBlock
+; GCN: v_cmp_{{eq|ne}}_u32_e32 vcc, {{3|7}}, v0
 
-; GCN: {{^}}[[FLOW]]:
+; GCN: ; %LeafBlock1
+; GCN: v_cmp_{{eq|ne}}_u32_e32 vcc, {{3|7}}, v0
 
-; GCN: s_or_b64 exec, exec
-; GCN: v_mov_b32_e32 v0, 2.0
-; GCN-NOT: s_and_b64 exec, exec
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
+; GCN: ; divergent control-flow edge
+; GCN: s_cbranch_execz
+
+; GCN: ; %exit0
+; GCN: buffer_store_dword
 ; GCN: v_mov_b32_e32 v0, 1.0
 
-; GCN: {{^.LBB[0-9]+_[0-9]+}}: ; %UnifiedReturnBlock
+; GCN: s_or_b64 exec, exec
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
+; GCN: ; divergent control-flow edge
+; GCN: s_cbranch_execz
+
+; GCN: ; %exit1
+; GCN: ds_write_b32
+; GCN: v_mov_b32_e32 v0, 2.0
+
+; GCN: ; %UnifiedReturnBlock
 ; GCN-NEXT: s_or_b64 exec, exec
-; GCN-NEXT: s_waitcnt vmcnt(0) lgkmcnt(0)
-; GCN-NEXT: ; return
+; GCN: s_waitcnt vmcnt(0) lgkmcnt(0)
+; GCN: ; return
 
 define amdgpu_ps float @uniform_branch_to_multi_divergent_region_exit_ret_ret_return_value(i32 inreg %sgpr, i32 %vgpr) #0 {
 entry:

--- a/llvm/test/CodeGen/AMDGPU/nsa-reassign.ll
+++ b/llvm/test/CodeGen/AMDGPU/nsa-reassign.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 -mattr=-xnack -enable-misched=0 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx1010 -mattr=-xnack -enable-misched=0 < %s | FileCheck -check-prefix=GCN %s
 
 ; GCN-LABEL: {{^}}sample_contig_nsa:
 ; GCN-DAG: image_sample_c_l v{{[0-9]+}}, v[{{[0-9]+:[0-9]+}}],
@@ -22,7 +22,7 @@ main_body:
 
 ; GCN-LABEL: {{^}}sample_contig_nsa_10vgprs:
 ; GCN-DAG: image_sample_c_l v{{[0-9]+}}, v[{{[0-9]+:[0-9]+}}],
-; GCN-DAG: image_sample v{{[0-9]+}}, v[{{[0-9]+:[0-9]+}}],
+; GCN-DAG: image_sample v{{[0-9]+}}, {{(\[v[0-9]+, v[0-9]+, v[0-9]+\]|v\[[0-9]+:[0-9]+\])}},
 define amdgpu_ps <2 x float> @sample_contig_nsa_10vgprs(<8 x i32> inreg %rsrc, <4 x i32> inreg %samp, float %zcompare, float %s1, float %t1, float %r1, float %lod, float %r2, float %s2, float %t2) #0 {
 main_body:
   %zcompare.1 = fadd float %zcompare, 1.0

--- a/llvm/test/CodeGen/AMDGPU/pal-metadata-3.0-callable-dvgpr.ll
+++ b/llvm/test/CodeGen/AMDGPU/pal-metadata-3.0-callable-dvgpr.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx1200 < %s | FileCheck %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn--amdpal -mcpu=gfx1200 < %s | FileCheck %s
 
 ; CHECK:           .amdgpu_pal_metadata
 ; CHECK-NEXT: ---
@@ -69,7 +69,7 @@
 ; CHECK-NEXT:      dynamic_stack:
 ; CHECK-NEXT:        .backend_stack_size: 0x10
 ; CHECK-NEXT:        .lds_size:       0
-; CHECK-NEXT:        .sgpr_count:     0x22
+; CHECK-NEXT:        .sgpr_count:     0x24
 ; CHECK-NEXT:        .stack_frame_size_in_bytes: 0x10
 ; CHECK-NEXT:        .vgpr_count:     0x2
 ; CHECK-NEXT:      dynamic_stack_loop:

--- a/llvm/test/CodeGen/AMDGPU/pal-metadata-3.0-callable.ll
+++ b/llvm/test/CodeGen/AMDGPU/pal-metadata-3.0-callable.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx1100 < %s | FileCheck --check-prefixes=CHECK,GFX11 %s
-; RUN: llc -mtriple=amdgcn--amdpal -mcpu=gfx1200 < %s | FileCheck --check-prefixes=CHECK,GFX12 %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn--amdpal -mcpu=gfx1100 < %s | FileCheck --check-prefixes=CHECK,GFX11 %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn--amdpal -mcpu=gfx1200 < %s | FileCheck --check-prefixes=CHECK,GFX12 %s
 
 ; CHECK:           .amdgpu_pal_metadata
 ; CHECK-NEXT: ---
@@ -70,7 +70,7 @@
 ; CHECK-NEXT:      dynamic_stack:
 ; CHECK-NEXT:        .backend_stack_size: 0x10
 ; CHECK-NEXT:        .lds_size:       0
-; CHECK-NEXT:        .sgpr_count:     0x22
+; CHECK-NEXT:        .sgpr_count:     0x24
 ; CHECK-NEXT:        .stack_frame_size_in_bytes: 0x10
 ; CHECK-NEXT:        .vgpr_count:     0x2
 ; CHECK-NEXT:      dynamic_stack_loop:

--- a/llvm/test/CodeGen/AMDGPU/regalloc-illegal-eviction-assert.ll
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-illegal-eviction-assert.ll
@@ -1,4 +1,4 @@
-; RUN: not llc -mtriple=amdgcn -mcpu=gfx908 -o - %s 2>%t.err | FileCheck -implicit-check-not=error %s
+; RUN: not llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx908 -o - %s 2>%t.err | FileCheck -implicit-check-not=error %s
 ; RUN: FileCheck -check-prefix=ERR %s < %t.err
 
 ; This testcase would fail on an "illegal eviction". If the assert was
@@ -9,9 +9,9 @@
 %asm.output = type { <16 x i32>, <8 x i32>, <5 x i32>, <4 x i32>, <16 x i32> }
 
 ; CHECK-LABEL: {{^}}illegal_eviction_assert:
-; CHECK: ; def v[13:28] v[0:7] v[8:12] v[0:3] a[0:15]
+; CHECK: ; def v[14:29] v[1:8] v[9:13] v[1:4] a[0:15]
 ; CHECK: ; clobber
-; CHECK: ; use v[13:28] v[0:7] v[8:12] v[0:3] a[1:16]
+; CHECK: ; use v[14:29] v[1:8] v[9:13] v[1:4] a[1:16]
 define void @illegal_eviction_assert(ptr addrspace(1) %arg) #0 {
   ;%agpr0 = call i32 asm sideeffect "; def $0","=${a0}"()
   %asm = call %asm.output asm sideeffect "; def $0 $1 $2 $3 $4","=v,=v,=v,=v,={a[0:15]}"()

--- a/llvm/test/CodeGen/AMDGPU/regalloc-sgpr128-partial-def.mir
+++ b/llvm/test/CodeGen/AMDGPU/regalloc-sgpr128-partial-def.mir
@@ -1,4 +1,4 @@
-# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -verify-machineinstrs --stress-regalloc=2 -start-before=greedy -stop-after=virtregrewriter \
+# RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 -verify-machineinstrs --stress-regalloc=2 -start-before=greedy,1 -stop-after=virtregrewriter,1 \
 # RUN:   %s -o - | FileCheck %s
 
 # Test that S_MOV_B64 rematerialization is shrunk to S_MOV_B32 when only a

--- a/llvm/test/CodeGen/AMDGPU/ret_jump.ll
+++ b/llvm/test/CodeGen/AMDGPU/ret_jump.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
-; RUN: llc -mtriple=amdgcn -mcpu=tonga -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tonga -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
 
 ; This should end with an no-op sequence of exec mask manipulations
 ; Mask should be in original state after executed unreachable block
@@ -8,19 +8,21 @@
 ; GCN-LABEL: {{^}}uniform_br_trivial_ret_divergent_br_trivial_unreachable:
 ; GCN: s_cbranch_scc1 [[RET_BB:.LBB[0-9]+_[0-9]+]]
 
-; GCN-NEXT: ; %else
+; GCN: ; %else
 
-; GCN: s_and_saveexec_b64 [[SAVE_EXEC:s\[[0-9]+:[0-9]+\]]], vcc
+; GCN: v_cmp_gt_f32_e32 vcc
+; GCN: s_or_b64 {{s\[[0-9]+:[0-9]+\]}}, {{s\[[0-9]+:[0-9]+\]}}, vcc
+; GCN: s_mov_b64 exec
+; GCN: s_cbranch_execz
 
-; GCN: ; %bb.{{[0-9]+}}: ; %unreachable.bb
-; GCN-NEXT: ; divergent unreachable
+; GCN: .LBB{{[0-9]+}}_{{[0-9]+}}: ; %unreachable.bb
+; GCN: ; divergent unreachable
 
-; GCN-NEXT: ; %bb.{{[0-9]+}}: ; %Flow
-; GCN-NEXT: s_or_b64 exec, exec
+; GCN: [[RET_BB]]: ; %UnifiedReturnBlock
+; GCN: s_or_b64 exec, exec
 
-; GCN-NEXT: [[RET_BB]]:
-; GCN-NEXT: ; return
-; GCN-NEXT: .Lfunc_end0
+; GCN: ; return
+; GCN: .Lfunc_end0
 define amdgpu_ps <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, float, float, float, float, float, float }> @uniform_br_trivial_ret_divergent_br_trivial_unreachable(ptr addrspace(4) inreg %arg, ptr addrspace(4) inreg %arg1, ptr addrspace(4) inreg %arg2, ptr addrspace(4) inreg %arg3, float inreg %arg4, i32 inreg %arg5, <2 x i32> %arg6, <2 x i32> %arg7, <2 x i32> %arg8, <3 x i32> %arg9, <2 x i32> %arg10, <2 x i32> %arg11, <2 x i32> %arg12, float %arg13, float %arg14, float %arg15, float %arg16, i32 inreg %arg17, i32 %arg18, i32 %arg19, float %arg20, i32 %arg21) #0 {
 entry:
   %i.i = extractelement <2 x i32> %arg7, i32 0
@@ -54,24 +56,24 @@ ret.bb:                                          ; preds = %else, %main_body
 }
 
 ; GCN-LABEL: {{^}}uniform_br_nontrivial_ret_divergent_br_nontrivial_unreachable:
-; GCN: s_cbranch_vccz
+; GCN: s_cbranch_scc{{(0|1)}} [[RET_BB2:.LBB[0-9]+_[0-9]+]]
 
-; GCN: ; %bb.{{[0-9]+}}: ; %Flow
-; GCN: s_cbranch_execnz [[RETURN:.LBB[0-9]+_[0-9]+]]
+; GCN: v_cmp_gt_f32_e32
+; GCN: s_cbranch_execz
 
-; GCN: ; %UnifiedReturnBlock
-; GCN-NEXT: s_or_b64 exec, exec
-; GCN-NEXT: s_waitcnt
+; GCN: [[RET_BB2]]: ; %ret.bb
+; GCN: v_mov_b32_e32 v0, 11
+; GCN: {{buffer|flat}}_store_dword
 
-; GCN: .LBB{{[0-9]+_[0-9]+}}: ; %else
-; GCN: s_and_saveexec_b64 [[SAVE_EXEC:s\[[0-9]+:[0-9]+\]]], vcc
+; GCN: s_cbranch_execz [[UNIFIED_RET:.LBB[0-9]+_[0-9]+]]
 
-; GCN-NEXT:  ; %unreachable.bb
+; GCN: .LBB{{[0-9]+}}_{{[0-9]+}}: ; %unreachable.bb
 ; GCN: ds_write_b32
 ; GCN: ; divergent unreachable
 
-; GCN: ; %ret.bb
-; GCN: store_dword
+; GCN: [[UNIFIED_RET]]: ; %UnifiedReturnBlock
+; GCN: s_or_b64 exec, exec
+; GCN: s_waitcnt
 define amdgpu_ps <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, float, float, float, float, float, float }> @uniform_br_nontrivial_ret_divergent_br_nontrivial_unreachable(ptr addrspace(4) inreg %arg, ptr addrspace(4) inreg %arg1, ptr addrspace(4) inreg %arg2, ptr addrspace(4) inreg %arg3, float inreg %arg4, i32 inreg %arg5, <2 x i32> %arg6, <2 x i32> %arg7, <2 x i32> %arg8, <3 x i32> %arg9, <2 x i32> %arg10, <2 x i32> %arg11, <2 x i32> %arg12, float %arg13, float %arg14, float %arg15, float %arg16, float %arg17, i32 inreg %arg18, i32 %arg19, float %arg20, i32 %arg21) #0 {
 main_body:
   %i.i = extractelement <2 x i32> %arg7, i32 0

--- a/llvm/test/CodeGen/AMDGPU/salu-to-valu.ll
+++ b/llvm/test/CodeGen/AMDGPU/salu-to-valu.ll
@@ -1,6 +1,6 @@
-; RUN:  llc -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -check-prefix=GCN -check-prefix=GCN-NOHSA -check-prefix=SI %s
-; RUN:  llc -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=bonaire < %s | FileCheck -check-prefix=GCN -check-prefix=GCN-NOHSA -check-prefix=CI -check-prefix=CI-NOHSA %s
-; RUN:  llc -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn--amdhsa -mcpu=bonaire < %s | FileCheck -check-prefix=GCN -check-prefix=CI --check-prefix=GCN-HSA %s
+; RUN:  llc -amdgpu-late-wave-transform=1 -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -check-prefix=GCN -check-prefix=GCN-NOHSA -check-prefix=SI %s
+; RUN:  llc -amdgpu-late-wave-transform=1 -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=bonaire < %s | FileCheck -check-prefix=GCN -check-prefix=GCN-NOHSA -check-prefix=CI -check-prefix=CI-NOHSA %s
+; RUN:  llc -amdgpu-late-wave-transform=1 -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn--amdhsa -mcpu=bonaire < %s | FileCheck -check-prefix=GCN -check-prefix=CI --check-prefix=GCN-HSA %s
 
 declare i32 @llvm.amdgcn.workitem.id.x() #0
 declare i32 @llvm.amdgcn.workitem.id.y() #0
@@ -57,7 +57,6 @@ done:                                             ; preds = %loop
 ; SI: s_movk_i32 [[OFFSET:s[0-9]+]], 0x2ee0
 ; GCN: v_readfirstlane_b32 s[[PTR_LO:[0-9]+]], v{{[0-9]+}}
 ; GCN: v_readfirstlane_b32 s[[PTR_HI:[0-9]+]], v{{[0-9]+}}
-; SI-DAG: s_mov_b32
 ; SI-DAG: s_load_dword [[OUT:s[0-9]+]], s[[[PTR_LO]]:[[PTR_HI]]], [[OFFSET]]
 
 ; CI: s_load_dword [[OUT:s[0-9]+]], s[[[PTR_LO]]:[[PTR_HI]]], 0xbb8

--- a/llvm/test/CodeGen/AMDGPU/schedule-amdgpu-tracker-physreg.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-amdgpu-tracker-physreg.ll
@@ -1,10 +1,10 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=tahiti -amdgpu-s-branch-bits=5 -amdgpu-long-branch-factor=0  < %s | FileCheck --check-prefix=GCN %s
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=tahiti -amdgpu-s-branch-bits=5 -amdgpu-long-branch-factor=0 -amdgpu-use-amdgpu-trackers=1  < %s | FileCheck --check-prefix=GCN-GCNTRACKERS %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-amd-amdhsa -mcpu=tahiti -amdgpu-s-branch-bits=5 -amdgpu-long-branch-factor=0  < %s | FileCheck --check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-amd-amdhsa -mcpu=tahiti -amdgpu-s-branch-bits=5 -amdgpu-long-branch-factor=0 -amdgpu-use-amdgpu-trackers=1  < %s | FileCheck --check-prefix=GCN-GCNTRACKERS %s
 ; CHECK-LABEL: {{^}}spill:
 ; GCN:    NumSgprs: 104
 ; GCN-GCNTRACKERS:    NumSgprs: 104
 ; GCN:    NumVgprs: 1
-; GCN-GCNTRACKERS:    NumVgprs: 2
+; GCN-GCNTRACKERS:    NumVgprs: 1
 ; GCN:    ScratchSize: 0
 ; GCN-GCNTRACKERS:    ScratchSize: 0
 ; GCN:    Occupancy: 5
@@ -246,9 +246,9 @@ bb3:
 ; GCN:    NumSgprs: 104
 ; GCN-GCNTRACKERS:    NumSgprs: 104
 ; GCN:    NumVgprs: 2
-; GCN-GCNTRACKERS:    NumVgprs: 3
+; GCN-GCNTRACKERS:    NumVgprs: 2
 ; GCN:    ScratchSize: 8
-; GCN-GCNTRACKERS:    ScratchSize: 12
+; GCN-GCNTRACKERS:    ScratchSize: 8
 
 define void @spill_func(ptr addrspace(1) %arg) #0 {
 entry:

--- a/llvm/test/CodeGen/AMDGPU/schedule-regpressure-limit2.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-regpressure-limit2.ll
@@ -1,11 +1,11 @@
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -misched=gcn-iterative-minreg < %s | FileCheck --check-prefix=SI-MINREG %s
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -misched=gcn-iterative-max-occupancy-experimental < %s | FileCheck --check-prefix=SI-MAXOCC %s
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-minreg < %s | FileCheck --check-prefix=SI-MINREG %s
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-maxocc < %s | FileCheck --check-prefix=SI-MAXOCC %s
-; RUN: llc -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -misched=gcn-iterative-minreg < %s | FileCheck --check-prefix=VI-MINREG %s
-; RUN: llc -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -misched=gcn-iterative-max-occupancy-experimental < %s | FileCheck --check-prefix=VI-MAXOCC %s
-; RUN: llc -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-minreg < %s | FileCheck --check-prefix=VI-MINREG %s
-; RUN: llc -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-maxocc < %s | FileCheck --check-prefix=VI-MAXOCC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -misched=gcn-iterative-minreg < %s | FileCheck --check-prefix=SI-MINREG %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -misched=gcn-iterative-max-occupancy-experimental < %s | FileCheck --check-prefix=SI-MAXOCC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-minreg < %s | FileCheck --check-prefix=SI-MINREG %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-maxocc < %s | FileCheck --check-prefix=SI-MAXOCC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -misched=gcn-iterative-minreg < %s | FileCheck --check-prefix=VI-MINREG %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -misched=gcn-iterative-max-occupancy-experimental < %s | FileCheck --check-prefix=VI-MAXOCC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-minreg < %s | FileCheck --check-prefix=VI-MINREG %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=fiji -enable-amdgpu-aa=0 -amdgpu-sched-strategy=iterative-maxocc < %s | FileCheck --check-prefix=VI-MAXOCC %s
 
 ; SI-MINREG: NumSgprs: {{[1-9]$}}
 ; SI-MINREG: NumVgprs: {{[1-9]$}}
@@ -14,11 +14,11 @@
 ; SI-MAXOCC: NumVgprs: {{[1-4]?[0-9]$}}
 
 ; stores may alias loads
-; VI-MINREG: NumSgprs: {{[0-9]$}}
-; VI-MINREG: NumVgprs: {{[1-3][0-9]$}}
+; VI-MINREG: NumSgprs: {{[0-9]+$}}
+; VI-MINREG: NumVgprs: {{[0-9]+$}}
 
 ; stores may alias loads
-; VI-MAXOCC: NumSgprs: {{[1-3][0-9]$}}
+; VI-MAXOCC: NumSgprs: {{[1-6][0-9]$}}
 ; VI-MAXOCC: NumVgprs: {{[1-6][0-9]$}}
 
 define amdgpu_kernel void @load_fma_store(ptr addrspace(3) nocapture readonly %in_arg, ptr addrspace(1) nocapture %out_arg) {

--- a/llvm/test/CodeGen/AMDGPU/schedule-relaxed-occupancy.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-relaxed-occupancy.ll
@@ -1,7 +1,7 @@
-; RUN: llc -mtriple=amdgcn -mcpu=gfx906  < %s | FileCheck --check-prefix=OCC %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx906 -amdgpu-use-amdgpu-trackers=1  < %s | FileCheck --check-prefix=OCC-GCNTRACKER %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx906 -amdgpu-schedule-relaxed-occupancy=true  < %s | FileCheck --check-prefix=RELAX %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx906 -amdgpu-use-amdgpu-trackers=1 -amdgpu-schedule-relaxed-occupancy=true  < %s | FileCheck --check-prefix=RELAX-GCNTRACKER %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx906  < %s | FileCheck --check-prefix=OCC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx906 -amdgpu-use-amdgpu-trackers=1  < %s | FileCheck --check-prefix=OCC-GCNTRACKER %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx906 -amdgpu-schedule-relaxed-occupancy=true  < %s | FileCheck --check-prefix=RELAX %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx906 -amdgpu-use-amdgpu-trackers=1 -amdgpu-schedule-relaxed-occupancy=true  < %s | FileCheck --check-prefix=RELAX-GCNTRACKER %s
 
 
 ; Using -amgpu-schedule-relaxed-occupancy allows scheduler to produce better ILP by further relaxing occupancy target
@@ -9,11 +9,11 @@
 ; CHECK-LABEL: {{^}}load_fma_store:
 ; OCC:    NumVgprs: 24
 ; OCC-GCNTRACKER:    NumVgprs: 26
-; RELAX:    NumVgprs: 64
+; RELAX:    NumVgprs: 62
 ; RELAX-GCNTRACKER:    NumVgprs: 60
 ; OCC: NumVGPRsForWavesPerEU: 24
 ; OCC-GCNTRACKER: NumVGPRsForWavesPerEU: 26
-; RELAX: NumVGPRsForWavesPerEU: 64
+; RELAX: NumVGPRsForWavesPerEU: 62
 ; RELAX-GCNTRACKER: NumVGPRsForWavesPerEU: 60
 ; OCC:    Occupancy: 10
 ; OCC-GCNTRACKER:    Occupancy: 9

--- a/llvm/test/CodeGen/AMDGPU/setcc-sext.ll
+++ b/llvm/test/CodeGen/AMDGPU/setcc-sext.ll
@@ -1,8 +1,8 @@
-; RUN: llc -mtriple=amdgcn < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn < %s | FileCheck -check-prefix=GCN %s
 
 ; GCN-LABEL: {{^}}setcc_sgt_true_sext:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_gt_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sgt_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -23,8 +23,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_sgt_true_sext_swap:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sgt_true_sext_swap(ptr addrspace(1) nocapture %arg) {
@@ -45,8 +45,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ne_true_sext:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ne_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -67,8 +67,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ult_true_sext:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ult_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -89,8 +89,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_eq_true_sext:
-; GCN:      v_cmp_gt_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_eq_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -111,8 +111,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_sle_true_sext:
-; GCN:      v_cmp_gt_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sle_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -133,8 +133,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_uge_true_sext:
-; GCN:      v_cmp_gt_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_uge_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -155,8 +155,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_eq_false_sext:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_eq_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -177,8 +177,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_sge_false_sext:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sge_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -199,8 +199,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ule_false_sext:
-; GCN:      v_cmp_le_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ule_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -221,8 +221,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ne_false_sext:
-; GCN:      v_cmp_gt_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ne_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -242,8 +242,8 @@ endif:
   ret void
 }
 ; GCN-LABEL: {{^}}setcc_ugt_false_sext:
-; GCN:      v_cmp_gt_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ugt_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -263,8 +263,8 @@ endif:
   ret void
 }
 ; GCN-LABEL: {{^}}setcc_slt_false_sext:
-; GCN:      v_cmp_gt_u32_e{{32|64}} [[CC:[^,]+]], v{{[0-9]+}}, v{{[0-9]+}}
-; GCN-NEXT: s_and_saveexec_b64 {{[^,]+}}, [[CC]]
+; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_{{and|xor}}_b64
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_slt_false_sext(ptr addrspace(1) nocapture %arg) {

--- a/llvm/test/CodeGen/AMDGPU/setcc-sext.ll
+++ b/llvm/test/CodeGen/AMDGPU/setcc-sext.ll
@@ -23,8 +23,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_sgt_true_sext_swap:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64
+; GCN:      v_cmp_gt_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sgt_true_sext_swap(ptr addrspace(1) nocapture %arg) {
@@ -45,8 +45,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ne_true_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64
+; GCN:      v_cmp_gt_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ne_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -89,8 +89,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_eq_true_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_le_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_eq_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -111,8 +111,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_sle_true_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_le_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sle_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -133,8 +133,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_uge_true_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_le_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_uge_true_sext(ptr addrspace(1) nocapture %arg) {
@@ -155,8 +155,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_eq_false_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_gt_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_eq_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -177,8 +177,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_sge_false_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_gt_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_sge_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -199,8 +199,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ule_false_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_gt_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ule_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -221,8 +221,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}setcc_ne_false_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_le_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ne_false_sext(ptr addrspace(1) nocapture %arg) {
@@ -242,8 +242,8 @@ endif:
   ret void
 }
 ; GCN-LABEL: {{^}}setcc_ugt_false_sext:
-; GCN:      v_cmp_{{gt|le}}_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
-; GCN: s_{{and|xor}}_b64 {{[^,]+}}
+; GCN:      v_cmp_le_u32_e{{32|64}} {{[[CC:[^,]+]]|vcc}}, v{{[0-9]+}}, v{{[0-9]+}}
+; GCN: s_xor_b64 {{[^,]+}}
 ; GCN-NOT:  v_cndmask_
 
 define amdgpu_kernel void @setcc_ugt_false_sext(ptr addrspace(1) nocapture %arg) {

--- a/llvm/test/CodeGen/AMDGPU/sgpr-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-copy.ll
@@ -1,5 +1,5 @@
-; RUN:  llc -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck %s
-; RUN:  llc -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck %s
+; RUN:  llc -amdgpu-late-wave-transform=1 -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck %s
+; RUN:  llc -amdgpu-late-wave-transform=1 -amdgpu-scalarize-global-loads=false  -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck %s
 
 ; CHECK-LABEL: {{^}}phi1:
 ; CHECK: s_buffer_load_dword [[DST:s[0-9]]], {{s\[[0-9]+:[0-9]+\]}}, 0x0
@@ -206,15 +206,14 @@ ENDIF:                                            ; preds = %LOOP
 ; an assertion failure.
 
 ; CHECK-LABEL: {{^}}sample_v3:
-; CHECK: v_mov_b32_e32 v[[SAMPLE_LO:[0-9]+]], 5
-; CHECK: v_mov_b32_e32 v[[SAMPLE_HI:[0-9]+]], 7
 ; CHECK: s_cbranch
-
+; CHECK: v_mov_b32_e32 v[[SAMPLE_LO:[0-9]+]], 11
+; CHECK: v_mov_b32_e32 v[[SAMPLE_HI:[0-9]+]], 13
 ; CHECK: BB{{[0-9]+_[0-9]+}}:
-; CHECK-DAG: v_mov_b32_e32 v[[SAMPLE_LO:[0-9]+]], 11
-; CHECK-DAG: v_mov_b32_e32 v[[SAMPLE_HI:[0-9]+]], 13
-
-; CHECK: image_sample v{{\[[0-9]+:[0-9]+\]}}, v[[[SAMPLE_LO]]:[[SAMPLE_HI]]]
+; CHECK: v_mov_b32_e32 v[[SAMPLE_LO2:[0-9]+]], 5
+; CHECK: v_mov_b32_e32 v[[SAMPLE_HI2:[0-9]+]], 7
+; CHECK: BB{{[0-9]+_[0-9]+}}:
+; CHECK: image_sample
 ; CHECK: exp
 ; CHECK: s_endpgm
 define amdgpu_ps void @sample_v3(ptr addrspace(4) inreg %arg, ptr addrspace(4) inreg %arg1, ptr addrspace(4) inreg %arg2, float inreg %arg3, i32 inreg %arg4, <2 x i32> %arg5, <2 x i32> %arg6, <2 x i32> %arg7, <3 x i32> %arg8, <2 x i32> %arg9, <2 x i32> %arg10, <2 x i32> %arg11, float %arg12, float %arg13, float %arg14, float %arg15, float %arg16, float %arg17, float %arg18, float %arg19, float %arg20) #0 {
@@ -307,15 +306,12 @@ ENDIF69:                                          ; preds = %LOOP68
 ; CHECK-LABEL:{{^}}sample_rsrc
 
 ; CHECK: s_cmp_eq_u32
-; CHECK: s_cbranch_scc1 [[END:.LBB[0-9]+_[0-9]+]]
+; CHECK: s_cbranch_scc{{[01]}} [[BB:.LBB[0-9]+_[0-9]+]]
 
+; CHECK: v_add_{{[iu]}}32_e32 v[[ADD:[0-9]+]], vcc, 1, v{{[0-9]+}}
+; CHECK: [[BB]]:
 ; CHECK: image_sample v{{\[[0-9]+:[0-9]+\]}}, v{{\[[0-9]+:[0-9]+\]}}
 ; CHECK: s_endpgm
-
-; [[END]]:
-; CHECK: v_add_{{[iu]}}32_e32 v[[ADD:[0-9]+]], vcc, 1, v{{[0-9]+}}
-; CHECK: image_sample v{{\[[0-9]+:[0-9]+\]}}, v{{\[[0-9]+}}:[[ADD]]]
-; CHECK: s_branch
 define amdgpu_ps void @sample_rsrc(ptr addrspace(4) inreg %arg, ptr addrspace(4) inreg %arg1, ptr addrspace(4) inreg %arg2, ptr addrspace(4) inreg %arg3, float inreg %arg4, i32 inreg %arg5, <2 x i32> %arg6, <2 x i32> %arg7, <2 x i32> %arg8, <3 x i32> %arg9, <2 x i32> %arg10, <2 x i32> %arg11, <2 x i32> %arg12, float %arg13, float %arg14, float %arg15, float %arg16, float %arg17, float %arg18, i32 %arg19, float %arg20, float %arg21) #0 {
 bb:
   %tmp22 = load <4 x i32>, ptr addrspace(4) %arg1, !tbaa !3

--- a/llvm/test/CodeGen/AMDGPU/sgpr-regalloc-flags.ll
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-regalloc-flags.ll
@@ -1,13 +1,13 @@
 ; REQUIRES: asserts
 
-; RUN: llc -verify-machineinstrs=0 -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=DEFAULT %s
-; RUN: llc -verify-machineinstrs=0 -sgpr-regalloc=greedy -wwm-regalloc=greedy -vgpr-regalloc=greedy -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=DEFAULT %s
+; RUN: llc -amdgpu-late-wave-transform=1 -verify-machineinstrs=0 -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=DEFAULT %s
+; RUN: llc -amdgpu-late-wave-transform=1 -verify-machineinstrs=0 -sgpr-regalloc=greedy -wwm-regalloc=greedy -vgpr-regalloc=greedy -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=DEFAULT %s
 
-; RUN: llc -verify-machineinstrs=0 -O0 -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=O0 %s
+; RUN: llc -amdgpu-late-wave-transform=1 -verify-machineinstrs=0 -O0 -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=O0 %s
 
-; RUN: llc -verify-machineinstrs=0 -wwm-regalloc=basic -vgpr-regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=DEFAULT-BASIC %s
-; RUN: llc -verify-machineinstrs=0 -sgpr-regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=BASIC-DEFAULT %s
-; RUN: llc -verify-machineinstrs=0 -sgpr-regalloc=basic -wwm-regalloc=basic -vgpr-regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=BASIC-BASIC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -verify-machineinstrs=0 -wwm-regalloc=basic -vgpr-regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=DEFAULT-BASIC %s
+; RUN: llc -amdgpu-late-wave-transform=1 -verify-machineinstrs=0 -sgpr-regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=BASIC-DEFAULT %s
+; RUN: llc -amdgpu-late-wave-transform=1 -verify-machineinstrs=0 -sgpr-regalloc=basic -wwm-regalloc=basic -vgpr-regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=BASIC-BASIC %s
 
 ; RUN: not llc -verify-machineinstrs=0 -regalloc=basic -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=REGALLOC %s
 ; RUN: not llc -verify-machineinstrs=0 -regalloc=fast -O0 -mtriple=amdgcn-amd-amdhsa -debug-pass=Structure -filetype=null %s 2>&1 | FileCheck -check-prefix=REGALLOC %s
@@ -16,122 +16,92 @@
 ; REGALLOC: -regalloc not supported with amdgcn. Use -sgpr-regalloc, -wwm-regalloc, and -vgpr-regalloc
 
 ; DEFAULT: Greedy Register Allocator
-; DEFAULT-NEXT: Virtual Register Rewriter
-; DEFAULT-NEXT: Stack Slot Coloring
-; DEFAULT-NEXT: SI lower SGPR spill instructions
-; DEFAULT-NEXT: Virtual Register Map
-; DEFAULT-NEXT: Live Register Matrix
-; DEFAULT-NEXT: SI Pre-allocate WWM Registers
-; DEFAULT-NEXT: Live Stack Slot Analysis
-; DEFAULT-NEXT: Greedy Register Allocator
-; DEFAULT-NEXT: SI Lower WWM Copies
-; DEFAULT-NEXT: Virtual Register Rewriter
-; DEFAULT-NEXT: AMDGPU Reserve WWM Registers
-; DEFAULT-NEXT: Virtual Register Map
-; DEFAULT-NEXT: Live Register Matrix
-; DEFAULT-NEXT: Greedy Register Allocator
 ; DEFAULT-NEXT: GCN NSA Reassign
 ; DEFAULT-NEXT: AMDGPU Rewrite AGPR-Copy-MFMA
 ; DEFAULT-NEXT: Virtual Register Rewriter
+; DEFAULT-NEXT: AMDGPU Pre Wave Transform
+; DEFAULT-NEXT: Machine Cycle Info Analysis
+; DEFAULT-NEXT: AMDGPU Control Flow Wave Transform
+; DEFAULT: Greedy Register Allocator
+; DEFAULT-NEXT: Virtual Register Rewriter
+; DEFAULT-NEXT: Stack Slot Coloring
+; DEFAULT-NEXT: SI lower SGPR spill instructions
+; DEFAULT: Greedy Register Allocator
+; DEFAULT-NEXT: SI Lower WWM Copies
+; DEFAULT-NEXT: Virtual Register Rewriter
+; DEFAULT-NEXT: AMDGPU Reserve WWM Registers
 ; DEFAULT-NEXT: AMDGPU Mark Last Scratch Load
 ; DEFAULT-NEXT: Stack Slot Coloring
 
 ; O0: Fast Register Allocator
+; O0-NEXT: AMDGPU Pre Wave Transform
+; O0-NEXT: Machine Cycle Info Analysis
+; O0-NEXT: AMDGPU Control Flow Wave Transform
+; O0-NEXT: Fast Register Allocator
 ; O0-NEXT: SI lower SGPR spill instructions
-; O0-NEXT: Slot index numbering
-; O0-NEXT: Live Interval Analysis
-; O0-NEXT: Virtual Register Map
-; O0-NEXT: Live Register Matrix
-; O0-NEXT: SI Pre-allocate WWM Registers
 ; O0-NEXT: Fast Register Allocator
 ; O0-NEXT: SI Lower WWM Copies
 ; O0-NEXT: AMDGPU Reserve WWM Registers
-; O0-NEXT: Fast Register Allocator
 ; O0-NEXT: SI Fix VGPR copies
 
 
 
 
-; BASIC-DEFAULT: Debug Variable Analysis
-; BASIC-DEFAULT-NEXT: Live Stack Slot Analysis
-; BASIC-DEFAULT-NEXT: Machine Natural Loop Construction
-; BASIC-DEFAULT-NEXT: Machine Block Frequency Analysis
-; BASIC-DEFAULT-NEXT: Virtual Register Map
-; BASIC-DEFAULT-NEXT: Live Register Matrix
-; BASIC-DEFAULT-NEXT: Basic Register Allocator
-; BASIC-DEFAULT-NEXT: Virtual Register Rewriter
-; BASIC-DEFAULT-NEXT: Stack Slot Coloring
-; BASIC-DEFAULT-NEXT: SI lower SGPR spill instructions
-; BASIC-DEFAULT-NEXT: Virtual Register Map
-; BASIC-DEFAULT-NEXT: Live Register Matrix
-; BASIC-DEFAULT-NEXT: SI Pre-allocate WWM Registers
-; BASIC-DEFAULT-NEXT: Live Stack Slot Analysis
-; BASIC-DEFAULT-NEXT: Bundle Machine CFG Edges
-; BASIC-DEFAULT-NEXT: Spill Code Placement Analysis
-; BASIC-DEFAULT-NEXT: Lazy Machine Block Frequency Analysis
-; BASIC-DEFAULT-NEXT: Machine Optimization Remark Emitter
-; BASIC-DEFAULT-NEXT: Greedy Register Allocator
-; BASIC-DEFAULT-NEXT: SI Lower WWM Copies
-; BASIC-DEFAULT-NEXT: Virtual Register Rewriter
-; BASIC-DEFAULT-NEXT: AMDGPU Reserve WWM Registers
-; BASIC-DEFAULT-NEXT: Virtual Register Map
-; BASIC-DEFAULT-NEXT: Live Register Matrix
-; BASIC-DEFAULT-NEXT: Greedy Register Allocator
+; BASIC-DEFAULT: Greedy Register Allocator
 ; BASIC-DEFAULT-NEXT: GCN NSA Reassign
 ; BASIC-DEFAULT-NEXT: AMDGPU Rewrite AGPR-Copy-MFMA
 ; BASIC-DEFAULT-NEXT: Virtual Register Rewriter
+; BASIC-DEFAULT-NEXT: AMDGPU Pre Wave Transform
+; BASIC-DEFAULT-NEXT: Machine Cycle Info Analysis
+; BASIC-DEFAULT-NEXT: AMDGPU Control Flow Wave Transform
+; BASIC-DEFAULT: Basic Register Allocator
+; BASIC-DEFAULT-NEXT: Virtual Register Rewriter
+; BASIC-DEFAULT-NEXT: Stack Slot Coloring
+; BASIC-DEFAULT-NEXT: SI lower SGPR spill instructions
+; BASIC-DEFAULT: Greedy Register Allocator
+; BASIC-DEFAULT-NEXT: SI Lower WWM Copies
+; BASIC-DEFAULT-NEXT: Virtual Register Rewriter
+; BASIC-DEFAULT-NEXT: AMDGPU Reserve WWM Registers
 ; BASIC-DEFAULT-NEXT: AMDGPU Mark Last Scratch Load
 ; BASIC-DEFAULT-NEXT: Stack Slot Coloring
 
 
 
+; DEFAULT-BASIC: Basic Register Allocator
+; DEFAULT-BASIC-NEXT: GCN NSA Reassign
+; DEFAULT-BASIC-NEXT: AMDGPU Rewrite AGPR-Copy-MFMA
+; DEFAULT-BASIC-NEXT: Virtual Register Rewriter
+; DEFAULT-BASIC-NEXT: AMDGPU Pre Wave Transform
+; DEFAULT-BASIC-NEXT: Machine Cycle Info Analysis
+; DEFAULT-BASIC-NEXT: AMDGPU Control Flow Wave Transform
 ; DEFAULT-BASIC: Greedy Register Allocator
 ; DEFAULT-BASIC-NEXT: Virtual Register Rewriter
 ; DEFAULT-BASIC-NEXT: Stack Slot Coloring
 ; DEFAULT-BASIC-NEXT: SI lower SGPR spill instructions
-; DEFAULT-BASIC-NEXT: Virtual Register Map
-; DEFAULT-BASIC-NEXT: Live Register Matrix
-; DEFAULT-BASIC-NEXT: SI Pre-allocate WWM Registers
-; DEFAULT-BASIC-NEXT: Live Stack Slot Analysis
-; DEFAULT-BASIC-NEXT: Basic Register Allocator
+; DEFAULT-BASIC: Basic Register Allocator
 ; DEFAULT-BASIC-NEXT: SI Lower WWM Copies
 ; DEFAULT-BASIC-NEXT: Virtual Register Rewriter
 ; DEFAULT-BASIC-NEXT: AMDGPU Reserve WWM Registers
-; DEFAULT-BASIC-NEXT: Virtual Register Map
-; DEFAULT-BASIC-NEXT: Live Register Matrix
-; DEFAULT-BASIC-NEXT: Basic Register Allocator
-; DEFAULT-BASIC-NEXT: GCN NSA Reassign
-; DEFAULT-BASIC-NEXT: AMDGPU Rewrite AGPR-Copy-MFMA
-; DEFAULT-BASIC-NEXT: Virtual Register Rewriter
 ; DEFAULT-BASIC-NEXT: AMDGPU Mark Last Scratch Load
 ; DEFAULT-BASIC-NEXT: Stack Slot Coloring
 
 
 
-; BASIC-BASIC: Debug Variable Analysis
-; BASIC-BASIC-NEXT: Live Stack Slot Analysis
-; BASIC-BASIC-NEXT: Machine Natural Loop Construction
-; BASIC-BASIC-NEXT: Machine Block Frequency Analysis
-; BASIC-BASIC-NEXT: Virtual Register Map
-; BASIC-BASIC-NEXT: Live Register Matrix
-; BASIC-BASIC-NEXT: Basic Register Allocator
-; BASIC-BASIC-NEXT: Virtual Register Rewriter
-; BASIC-BASIC-NEXT: Stack Slot Coloring
-; BASIC-BASIC-NEXT: SI lower SGPR spill instructions
-; BASIC-BASIC-NEXT: Virtual Register Map
-; BASIC-BASIC-NEXT: Live Register Matrix
-; BASIC-BASIC-NEXT: SI Pre-allocate WWM Registers
-; BASIC-BASIC-NEXT: Live Stack Slot Analysis
-; BASIC-BASIC-NEXT: Basic Register Allocator
-; BASIC-BASIC-NEXT: SI Lower WWM Copies
-; BASIC-BASIC-NEXT: Virtual Register Rewriter
-; BASIC-BASIC-NEXT: AMDGPU Reserve WWM Registers
-; BASIC-BASIC-NEXT: Virtual Register Map
-; BASIC-BASIC-NEXT: Live Register Matrix
-; BASIC-BASIC-NEXT: Basic Register Allocator
+; BASIC-BASIC: Basic Register Allocator
 ; BASIC-BASIC-NEXT: GCN NSA Reassign
 ; BASIC-BASIC-NEXT: AMDGPU Rewrite AGPR-Copy-MFMA
 ; BASIC-BASIC-NEXT: Virtual Register Rewriter
+; BASIC-BASIC-NEXT: AMDGPU Pre Wave Transform
+; BASIC-BASIC-NEXT: Machine Cycle Info Analysis
+; BASIC-BASIC-NEXT: AMDGPU Control Flow Wave Transform
+; BASIC-BASIC: Basic Register Allocator
+; BASIC-BASIC-NEXT: Virtual Register Rewriter
+; BASIC-BASIC-NEXT: Stack Slot Coloring
+; BASIC-BASIC-NEXT: SI lower SGPR spill instructions
+; BASIC-BASIC: Basic Register Allocator
+; BASIC-BASIC-NEXT: SI Lower WWM Copies
+; BASIC-BASIC-NEXT: Virtual Register Rewriter
+; BASIC-BASIC-NEXT: AMDGPU Reserve WWM Registers
 ; BASIC-BASIC-NEXT: AMDGPU Mark Last Scratch Load
 ; BASIC-BASIC-NEXT: Stack Slot Coloring
 

--- a/llvm/test/CodeGen/AMDGPU/si-annotate-cf-unreachable.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-annotate-cf-unreachable.ll
@@ -1,6 +1,6 @@
 ; RUN: opt -mtriple=amdgcn-- -S -structurizecfg -si-annotate-control-flow %s | FileCheck -check-prefix=OPT %s
 ; RUN: opt -mtriple=amdgcn-- -S -passes=structurizecfg,si-annotate-control-flow %s | FileCheck -check-prefix=OPT %s
-; RUN: llc -mtriple=amdgcn < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn < %s | FileCheck -check-prefix=GCN %s
 
 
 ; OPT-LABEL: @annotate_unreachable(
@@ -9,7 +9,7 @@
 
 
 ; GCN-LABEL: {{^}}annotate_unreachable:
-; GCN: s_and_saveexec_b64
+; GCN: s_and_b64
 ; GCN-NOT: s_endpgm
 ; GCN: .Lfunc_end0
 define amdgpu_kernel void @annotate_unreachable(ptr addrspace(1) noalias nocapture readonly %arg, i1 %c0) #0 {

--- a/llvm/test/CodeGen/AMDGPU/si-lower-control-flow-kill.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-lower-control-flow-kill.ll
@@ -1,8 +1,8 @@
-; RUN: llc -mtriple=amdgcn < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn < %s | FileCheck -check-prefix=GCN %s
 
 ; GCN-LABEL: {{^}}if_with_kill:
-; GCN:      s_and_saveexec_b64 [[SAVEEXEC:s\[[0-9:]+\]]],
-; GCN-NEXT: s_xor_b64 s[{{[0-9:]+}}], exec, [[SAVEEXEC]]
+; GCN: s_mov_b64 [[SAVEEXEC:s\[[0-9]+:[0-9]+\]]], exec
+; GCN: s_xor_b64 [[COND:s\[[0-9]+:[0-9]+\]]], vcc, exec
 define amdgpu_ps void @if_with_kill(i32 %arg) {
 .entry:
   %cmp = icmp eq i32 %arg, 32
@@ -17,8 +17,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}if_with_loop_kill_after:
-; GCN:      s_and_saveexec_b64 [[SAVEEXEC:s\[[0-9:]+\]]],
-; GCN-NEXT: s_xor_b64 s[{{[0-9:]+}}], exec, [[SAVEEXEC]]
+; GCN: s_mov_b64 [[SAVEEXEC:s\[[0-9]+:[0-9]+\]]], exec
+; GCN: s_xor_b64 [[COND:s\[[0-9]+:[0-9]+\]]], vcc, exec
 define amdgpu_ps void @if_with_loop_kill_after(i32 %arg) {
 .entry:
   %cmp = icmp eq i32 %arg, 32
@@ -43,8 +43,8 @@ endif:
 }
 
 ; GCN-LABEL: {{^}}if_with_kill_inside_loop:
-; GCN:      s_and_saveexec_b64 [[SAVEEXEC:s\[[0-9:]+\]]],
-; GCN-NEXT: s_xor_b64 s[{{[0-9:]+}}], exec, [[SAVEEXEC]]
+; GCN: s_mov_b64 [[SAVEEXEC:s\[[0-9]+:[0-9]+\]]], exec
+; GCN: s_xor_b64 [[COND:s\[[0-9]+:[0-9]+\]]], vcc, exec
 define amdgpu_ps void @if_with_kill_inside_loop(i32 %arg) {
 .entry:
   %cmp = icmp eq i32 %arg, 32

--- a/llvm/test/CodeGen/AMDGPU/si-lower-control-flow-unreachable-block.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-lower-control-flow-unreachable-block.ll
@@ -1,15 +1,16 @@
-; RUN: llc -mtriple=amdgcn -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -simplifycfg-require-and-preserve-domtree=1 < %s | FileCheck -check-prefix=GCN %s
 
 ; GCN-LABEL: {{^}}lower_control_flow_unreachable_terminator:
-; GCN: v_cmp_eq_u32
-; GCN: s_and_saveexec_b64
-; GCN-NEXT: s_cbranch_execz .LBB0_{{[0-9]+}}
+; GCN: v_cmp_ne_u32
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
+; GCN: s_cbranch_execz .LBB0_{{[0-9]+}}
 
-; GCN-NEXT: ; %bb.{{[0-9]+}}: ; %unreachable
+; GCN: .LBB0_{{[0-9]+}}: ; %unreachable
 ; GCN: ds_write_b32
 ; GCN: ; divergent unreachable
 
-; GCN-NEXT: BB0_{{[0-9]+}}: ; %UnifiedReturnBlock
+; GCN: .LBB0_{{[0-9]+}}: ; %UnifiedReturnBlock
 ; GCN: s_endpgm
 
 define amdgpu_kernel void @lower_control_flow_unreachable_terminator() #0 {
@@ -27,16 +28,17 @@ ret:
 }
 
 ; GCN-LABEL: {{^}}lower_control_flow_unreachable_terminator_swap_block_order:
-; GCN: v_cmp_ne_u32
-; GCN: s_and_saveexec_b64
-; GCN-NEXT: s_cbranch_execz .LBB1_{{[0-9]+}}
+; GCN: v_cmp_eq_u32
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
+; GCN: s_cbranch_execz .LBB1_{{[0-9]+}}
 
-; GCN-NEXT: ; %bb.{{[0-9]+}}: ; %unreachable
+; GCN: .LBB1_{{[0-9]+}}: ; %unreachable
 ; GCN: ds_write_b32
 ; GCN: ; divergent unreachable
 
-; GCN: BB1_{{[0-9]+}}:
-; GCN-NEXT: s_endpgm
+; GCN: .LBB1_{{[0-9]+}}:
+; GCN: s_endpgm
 define amdgpu_kernel void @lower_control_flow_unreachable_terminator_swap_block_order() #0 {
 bb:
   %tmp15 = tail call i32 @llvm.amdgcn.workitem.id.y()

--- a/llvm/test/CodeGen/AMDGPU/si-scheduler.ll
+++ b/llvm/test/CodeGen/AMDGPU/si-scheduler.ll
@@ -3,15 +3,15 @@
 ; The only way the subtarget knows that the si machine scheduler is being used
 ; is to specify -mattr=si-scheduler.  If we just pass --misched=si, the backend
 ; won't know what scheduler we are using.
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti --misched=si -mattr=si-scheduler < %s | FileCheck %s
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1010 --misched=si -mattr=si-scheduler < %s | FileCheck %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti --misched=si -mattr=si-scheduler < %s | FileCheck %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx1010 --misched=si -mattr=si-scheduler < %s | FileCheck %s
 
 ; The test checks the "si" machine scheduler pass works correctly.
 
 ; CHECK-LABEL: {{^}}main:
 ; CHECK: s_wqm
-; CHECK: s_load_dwordx8
-; CHECK: s_load_dwordx4
+; CHECK-DAG: s_load_dwordx8
+; CHECK-DAG: s_load_dwordx4
 ; CHECK: s_waitcnt lgkmcnt(0)
 ; CHECK: image_sample
 ; CHECK: s_waitcnt vmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/skip-branch-trap.ll
+++ b/llvm/test/CodeGen/AMDGPU/skip-branch-trap.ll
@@ -1,14 +1,16 @@
-; RUN: llc -mtriple=amdgcn--amdhsa < %s | FileCheck -enable-var-scope -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn--amdhsa < %s | FileCheck -enable-var-scope -check-prefix=GCN %s
 
 ; FIXME: merge with trap.ll
 
 ; An s_cbranch_execnz is required to avoid trapping if all lanes are 0
 ; GCN-LABEL: {{^}}trap_divergent_branch:
-; GCN: s_and_saveexec_b64
+; GCN: v_cmp_ne_u32
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
 ; GCN: s_cbranch_execnz [[TRAP:.LBB[0-9]+_[0-9]+]]
-; GCN: ; %bb.{{[0-9]+}}:
+; GCN: .LBB{{[0-9]+}}_{{[0-9]+}}: ; %end
 ; GCN-NEXT: s_endpgm
-; GCN: [[TRAP]]:
+; GCN: [[TRAP]]: ; %bb
 ; GCN: s_trap 2
 ; GCN-NEXT: s_endpgm
 define amdgpu_kernel void @trap_divergent_branch(ptr addrspace(1) nocapture readonly %arg) {
@@ -27,11 +29,14 @@ end:
 }
 
 ; GCN-LABEL: {{^}}debugtrap_divergent_branch:
-; GCN: s_and_saveexec_b64
-; GCN: s_cbranch_execz [[ENDPGM:.LBB[0-9]+_[0-9]+]]
-; GCN: ; %bb.{{[0-9]+}}:
+; GCN: v_cmp_ne_u32
+; GCN: s_xor_b64
+; GCN: s_mov_b64 exec
+; GCN: s_cbranch_execnz [[TRAP:.LBB[0-9]+_[0-9]+]]
+; GCN: .LBB{{[0-9]+}}_{{[0-9]+}}: ; %end
+; GCN-NEXT: s_endpgm
+; GCN: [[TRAP]]: ; %bb
 ; GCN: s_trap 3
-; GCN-NEXT: [[ENDPGM]]:
 ; GCN-NEXT: s_endpgm
 define amdgpu_kernel void @debugtrap_divergent_branch(ptr addrspace(1) nocapture readonly %arg) {
   %id = call i32 @llvm.amdgcn.workitem.id.x()

--- a/llvm/test/CodeGen/AMDGPU/spill-csr-frame-ptr-reg-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-csr-frame-ptr-reg-copy.ll
@@ -3,7 +3,7 @@
 ; GCN-LABEL: {{^}}spill_csr_s5_copy:
 ; GCN: s_mov_b32 [[FP_SCRATCH_COPY:s[0-9]+]], s33
 ; GCN: s_xor_saveexec_b64
-; GCN: buffer_store_dword {{v[0-9]+}}, off, s[0:3], s33 offset:4 ; 4-byte Folded Spill
+; GCN: buffer_store_dword v2, off, s[0:3], s33 offset:4 ; 4-byte Folded Spill
 ; GCN: s_mov_b64 exec
 ; GCN: buffer_store_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Spill
 ; GCN: s_mov_b64 exec
@@ -15,7 +15,7 @@
 
 ; GCN: v_readlane_b32 [[FP_SCRATCH_COPY:s[0-9]+]], v40, 2
 ; GCN: s_xor_saveexec_b64
-; GCN: buffer_load_dword {{v[0-9]+}}, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
+; GCN: buffer_load_dword v2, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
 ; GCN: s_mov_b64 exec
 ; GCN: buffer_load_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload
 ; GCN: s_mov_b64 exec

--- a/llvm/test/CodeGen/AMDGPU/spill-csr-frame-ptr-reg-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-csr-frame-ptr-reg-copy.ll
@@ -1,11 +1,12 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 < %s | FileCheck -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-amd-amdhsa -stress-regalloc=1 < %s | FileCheck -check-prefix=GCN %s
 
 ; GCN-LABEL: {{^}}spill_csr_s5_copy:
 ; GCN: s_mov_b32 [[FP_SCRATCH_COPY:s[0-9]+]], s33
-; GCN: s_or_saveexec_b64
-; GCN-NEXT: buffer_store_dword v40, off, s[0:3], s33 offset:4 ; 4-byte Folded Spill
-; GCN-NEXT: buffer_store_dword v41, off, s[0:3], s33 offset:8 ; 4-byte Folded Spill
-; GCN-NEXT: s_mov_b64 exec
+; GCN: s_{{xor|or}}_saveexec_b64
+; GCN: buffer_store_dword {{v[0-9]+}}, off, s[0:3], s33 offset:4 ; 4-byte Folded Spill
+; GCN: s_mov_b64 exec
+; GCN: buffer_store_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Spill
+; GCN: s_mov_b64 exec
 ; GCN: v_writelane_b32 v40, [[FP_SCRATCH_COPY]], 2
 ; GCN: s_swappc_b64
 
@@ -13,9 +14,10 @@
 ; GCN: buffer_store_dword [[K]], off, s[0:3], s33{{$}}
 
 ; GCN: v_readlane_b32 [[FP_SCRATCH_COPY:s[0-9]+]], v40, 2
-; GCN: s_or_saveexec_b64
-; GCN-NEXT: buffer_load_dword v40, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
-; GCN-NEXT: buffer_load_dword v41, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload
+; GCN: s_{{xor|or}}_saveexec_b64
+; GCN: buffer_load_dword {{v[0-9]+}}, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
+; GCN: s_mov_b64 exec
+; GCN: buffer_load_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload
 ; GCN: s_mov_b64 exec
 ; GCN: s_mov_b32 s33, [[FP_SCRATCH_COPY]]
 ; GCN: s_setpc_b64

--- a/llvm/test/CodeGen/AMDGPU/spill-csr-frame-ptr-reg-copy.ll
+++ b/llvm/test/CodeGen/AMDGPU/spill-csr-frame-ptr-reg-copy.ll
@@ -2,7 +2,7 @@
 
 ; GCN-LABEL: {{^}}spill_csr_s5_copy:
 ; GCN: s_mov_b32 [[FP_SCRATCH_COPY:s[0-9]+]], s33
-; GCN: s_{{xor|or}}_saveexec_b64
+; GCN: s_xor_saveexec_b64
 ; GCN: buffer_store_dword {{v[0-9]+}}, off, s[0:3], s33 offset:4 ; 4-byte Folded Spill
 ; GCN: s_mov_b64 exec
 ; GCN: buffer_store_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Spill
@@ -14,7 +14,7 @@
 ; GCN: buffer_store_dword [[K]], off, s[0:3], s33{{$}}
 
 ; GCN: v_readlane_b32 [[FP_SCRATCH_COPY:s[0-9]+]], v40, 2
-; GCN: s_{{xor|or}}_saveexec_b64
+; GCN: s_xor_saveexec_b64
 ; GCN: buffer_load_dword {{v[0-9]+}}, off, s[0:3], s33 offset:4 ; 4-byte Folded Reload
 ; GCN: s_mov_b64 exec
 ; GCN: buffer_load_dword v40, off, s[0:3], s33 offset:8 ; 4-byte Folded Reload

--- a/llvm/test/CodeGen/AMDGPU/uniform-loop-inside-nonuniform.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-loop-inside-nonuniform.ll
@@ -3,8 +3,8 @@
 ; Test a simple uniform loop that lives inside non-uniform control flow.
 
 ; CHECK-LABEL: {{^}}test1:
-; CHECK: v_cmp_{{eq|ne}}_u32_e32 vcc, 0
-; CHECK: s_{{xor|and}}_b64
+; CHECK: v_cmp_eq_u32_e32 vcc, 0
+; CHECK: s_xor_b64
 ; CHECK: s_cbranch_execz
 
 ; CHECK: {{^}}.LBB{{[0-9]+}}_{{[0-9]+}}: ; %loop_body
@@ -32,7 +32,7 @@ out:
 }
 
 ; CHECK-LABEL: {{^}}test2:
-; CHECK: s_{{and|xor}}_b64
+; CHECK: s_xor_b64
 ; CHECK: s_cbranch_execz
 define amdgpu_kernel void @test2(ptr addrspace(1) %out, i32 %a, i32 %b) {
 main_body:

--- a/llvm/test/CodeGen/AMDGPU/uniform-loop-inside-nonuniform.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-loop-inside-nonuniform.ll
@@ -1,15 +1,16 @@
-; RUN: llc -mtriple=amdgcn -mcpu=verde < %s | FileCheck %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=verde < %s | FileCheck %s
 
 ; Test a simple uniform loop that lives inside non-uniform control flow.
 
 ; CHECK-LABEL: {{^}}test1:
-; CHECK: v_cmp_ne_u32_e32 vcc, 0
-; CHECK: s_and_saveexec_b64
-; CHECK-NEXT: s_cbranch_execz .LBB{{[0-9]+_[0-9]+}}
+; CHECK: v_cmp_{{eq|ne}}_u32_e32 vcc, 0
+; CHECK: s_{{xor|and}}_b64
+; CHECK: s_cbranch_execz
 
-; CHECK: [[LOOP_BODY_LABEL:.LBB[0-9]+_[0-9]+]]: ; %loop_body
-; CHECK: s_cbranch_scc1 [[LOOP_BODY_LABEL]]
+; CHECK: {{^}}.LBB{{[0-9]+}}_{{[0-9]+}}: ; %loop_body
+; CHECK: s_cbranch_scc1 .LBB{{[0-9]+}}_{{[0-9]+}}
 
+; CHECK: {{^}}.LBB{{[0-9]+_[0-9]+}}: ; %out
 ; CHECK: s_endpgm
 define amdgpu_ps void @test1(<8 x i32> inreg %rsrc, <2 x i32> %addr.base, i32 %y, i32 %p) {
 main_body:
@@ -31,8 +32,8 @@ out:
 }
 
 ; CHECK-LABEL: {{^}}test2:
-; CHECK: s_and_saveexec_b64
-; CHECK-NEXT: s_cbranch_execz
+; CHECK: s_{{and|xor}}_b64
+; CHECK: s_cbranch_execz
 define amdgpu_kernel void @test2(ptr addrspace(1) %out, i32 %a, i32 %b) {
 main_body:
   %tid = call i32 @llvm.amdgcn.workitem.id.x() #1

--- a/llvm/test/CodeGen/AMDGPU/use-sgpr-multiple-times.ll
+++ b/llvm/test/CodeGen/AMDGPU/use-sgpr-multiple-times.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn < %s | FileCheck -check-prefix=SI -check-prefix=GCN %s
-; RUN: llc -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck -check-prefix=VI -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn < %s | FileCheck -check-prefix=SI -check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck -check-prefix=VI -check-prefix=GCN %s
 
 declare float @llvm.fma.f32(float, float, float) #1
 declare double @llvm.fma.f64(double, double, double) #1
@@ -48,11 +48,11 @@ define amdgpu_kernel void @test_sgpr_use_twice_ternary_op_a_a_b(ptr addrspace(1)
 
 ; GCN-NOT: v_mov_b32
 
+; VI: s_load_dwordx4 s[[[#LOAD:]]:{{[0-9]+}}], s{{\[[0-9]+:[0-9]+\]}}, {{0x9|0x24}}
 ; VI: buffer_load_dword [[VA0:v[0-9]+]]
 ; VI-NEXT: s_waitcnt vmcnt(0)
 ; VI-NEXT: buffer_load_dword [[VA1:v[0-9]+]]
 ; VI-NEXT: s_waitcnt vmcnt(0)
-; VI: s_load_dwordx4 s[[[#LOAD:]]:{{[0-9]+}}], s{{\[[0-9]+:[0-9]+\]}}, {{0x9|0x24}}
 
 ; GCN-NOT: v_mov_b32
 ; GCN: v_mov_b32_e32 [[VB:v[0-9]+]], s[[#LOAD + 3]]

--- a/llvm/test/CodeGen/AMDGPU/vgpr-agpr-limit-gfx90a.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-agpr-limit-gfx90a.ll
@@ -1,6 +1,6 @@
 ; -enable-misched=false makes the register usage more predictable
 ; -regalloc=fast just makes the test run faster
-; RUN: llc -mtriple=amdgcn -mcpu=gfx90a -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX90A
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx90a -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX90A
 
 define internal void @use256vgprs() {
   %v0 = call i32 asm sideeffect "; def $0", "=v"()
@@ -1073,9 +1073,9 @@ define amdgpu_kernel void @k256_w8() #2568 {
 }
 
 ; GCN-LABEL: {{^}}k256_w8_no_agprs:
-; GFX90A: NumVgprs: 64
+; GFX90A: NumVgprs: 62
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 64
+; GFX90A: TotalNumVgprs: 62
 define amdgpu_kernel void @k256_w8_no_agprs() #2569 {
   call void @use256vgprs()
   ret void
@@ -1085,7 +1085,7 @@ attributes #2568 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-wa
 attributes #2569 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-waves-per-eu"="8" "amdgpu-agpr-alloc"="0" }
 
 ; GCN-LABEL: {{^}}k256_w4:
-; GFX90A: NumVgprs: 64
+; GFX90A: NumVgprs: 63
 ; GFX90A: NumAgprs: 64
 ; GFX90A: TotalNumVgprs: 128
 define amdgpu_kernel void @k256_w4() #2564 {
@@ -1095,9 +1095,9 @@ define amdgpu_kernel void @k256_w4() #2564 {
 }
 
 ; GCN-LABEL: {{^}}k256_w4_no_agprs:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 128
+; GFX90A: TotalNumVgprs: 126
 define amdgpu_kernel void @k256_w4_no_agprs() #2565 {
   call void @use256vgprs()
   ret void
@@ -1107,7 +1107,7 @@ attributes #2564 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-wa
 attributes #2565 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-waves-per-eu"="4" "amdgpu-agpr-alloc"="0" }
 
 ; GCN-LABEL: {{^}}k256_w2:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 127
 ; GFX90A: NumAgprs: 128
 ; GFX90A: TotalNumVgprs: 256
 define amdgpu_kernel void @k256_w2() #2562 {
@@ -1117,9 +1117,9 @@ define amdgpu_kernel void @k256_w2() #2562 {
 }
 
 ; GCN-LABEL: {{^}}k256_w2_no_agprs:
-; GFX90A: NumVgprs: 256
+; GFX90A: NumVgprs: 254
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 256
+; GFX90A: TotalNumVgprs: 254
 define amdgpu_kernel void @k256_w2_no_agprs() #2563 {
   call void @use256vgprs()
   ret void
@@ -1129,7 +1129,7 @@ attributes #2562 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-wa
 attributes #2563 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-waves-per-eu"="2" "amdgpu-agpr-alloc"="0" }
 
 ; GCN-LABEL: {{^}}k256_w1:
-; GFX90A: NumVgprs: 256
+; GFX90A: NumVgprs: 255
 ; GFX90A: NumAgprs: 256
 ; GFX90A: TotalNumVgprs: 512
 define amdgpu_kernel void @k256_w1() #2561 {
@@ -1139,7 +1139,7 @@ define amdgpu_kernel void @k256_w1() #2561 {
 }
 
 ; GCN-LABEL: {{^}}k256_w1_no_agprs:
-; GFX90A: NumVgprs: 256
+; GFX90A: NumVgprs: 254
 ; GFX90A: NumAgprs: 256
 ; GFX90A: TotalNumVgprs: 512
 define amdgpu_kernel void @k256_w1_no_agprs() #2561 {
@@ -1150,16 +1150,16 @@ define amdgpu_kernel void @k256_w1_no_agprs() #2561 {
 attributes #2561 = { nounwind "amdgpu-flat-work-group-size"="256,256" "amdgpu-waves-per-eu"="1" }
 
 ; GCN-LABEL: {{^}}k512_no_agprs:
-; GFX90A: NumVgprs: 256
+; GFX90A: NumVgprs: 254
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 256
+; GFX90A: TotalNumVgprs: 254
 define amdgpu_kernel void @k512_no_agprs() #513 {
   call void @use256vgprs()
   ret void
 }
 
 ; GCN-LABEL: {{^}}k512_call:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 127
 ; GFX90A: NumAgprs: 128
 ; GFX90A: TotalNumVgprs: 256
 define amdgpu_kernel void @k512_call() #512 {
@@ -1169,7 +1169,7 @@ define amdgpu_kernel void @k512_call() #512 {
 }
 
 ; GCN-LABEL: {{^}}k512_virtual_agpr:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 128
 ; GFX90A: TotalNumVgprs: 256
 define amdgpu_kernel void @k512_virtual_agpr() #512 {
@@ -1179,7 +1179,7 @@ define amdgpu_kernel void @k512_virtual_agpr() #512 {
 }
 
 ; GCN-LABEL: {{^}}k512_physical_agpr:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 128
 ; GFX90A: TotalNumVgprs: 256
 define amdgpu_kernel void @k512_physical_agpr() #512 {
@@ -1189,15 +1189,15 @@ define amdgpu_kernel void @k512_physical_agpr() #512 {
 }
 
 ; GCN-LABEL: {{^}}f512:
-; GFX90A: NumVgprs: 12{{[0-9]}}
-; GFX90A: NumAgprs: {{[1-9]}}
+; GFX90A: NumVgprs: 126
+; GFX90A: NumAgprs: 32
 define void @f512() #512 {
   call void @use256vgprs()
   ret void
 }
 
 ; GCN-LABEL: {{^}}f512_no_agpr:
-; GFX90A: NumVgprs: 256
+; GFX90A: NumVgprs: 254
 ; GFX90A: NumAgprs: 0
 define void @f512_no_agpr() #513 {
   call void @use256vgprs_no_agpr()
@@ -1205,7 +1205,7 @@ define void @f512_no_agpr() #513 {
 }
 
 ; GCN-LABEL: {{^}}f512_no_agpr_ub:
-; GFX90A: NumVgprs: 256
+; GFX90A: NumVgprs: 254
 ; GFX90A: NumAgprs: 0
 define void @f512_no_agpr_ub() #513 {
   call void @use256vgprs()
@@ -1216,7 +1216,7 @@ attributes #512 = { nounwind "amdgpu-flat-work-group-size"="512,512" }
 attributes #513 = { nounwind "amdgpu-flat-work-group-size"="512,512" "amdgpu-agpr-alloc"="0" }
 
 ; GCN-LABEL: {{^}}k1024:
-; GFX90A: NumVgprs: 64
+; GFX90A: NumVgprs: 62
 ; GFX90A: NumAgprs: 64
 ; GFX90A: TotalNumVgprs: 128
 define amdgpu_kernel void @k1024() #1024 {
@@ -1225,16 +1225,16 @@ define amdgpu_kernel void @k1024() #1024 {
 }
 
 ; GCN-LABEL: {{^}}k1024_no_agprs:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 128
+; GFX90A: TotalNumVgprs: 126
 define amdgpu_kernel void @k1024_no_agprs() #1025 {
   call void @use256vgprs()
   ret void
 }
 
 ; GCN-LABEL: {{^}}k1024_call:
-; GFX90A: NumVgprs: 64
+; GFX90A: NumVgprs: 63
 ; GFX90A: NumAgprs: 64
 ; GFX90A: TotalNumVgprs: 128
 define amdgpu_kernel void @k1024_call() #1024 {
@@ -1244,9 +1244,9 @@ define amdgpu_kernel void @k1024_call() #1024 {
 }
 
 ; GCN-LABEL: {{^}}k1024_call_no_agprs:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 128
+; GFX90A: TotalNumVgprs: 126
 define amdgpu_kernel void @k1024_call_no_agprs() #1025 {
   call void @use256vgprs()
   ret void
@@ -1254,7 +1254,7 @@ define amdgpu_kernel void @k1024_call_no_agprs() #1025 {
 
 ; @foo uses an AGPRs so amdgpu-no-agpr is undefined
 ; GCN-LABEL: {{^}}k1024_call_no_agprs_ub_callee:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 127
 ; GFX90A: NumAgprs: 1
 ; GFX90A: TotalNumVgprs: 129
 define amdgpu_kernel void @k1024_call_no_agprs_ub_callee() #1025 {
@@ -1273,7 +1273,7 @@ define void @f1024_0() #1024 {
 }
 
 ; GCN-LABEL: {{^}}f1024_1:
-; GFX90A: NumVgprs: 64
+; GFX90A: NumVgprs: 62
 ; GFX90A: NumAgprs: 32
 ; GFX90A: TotalNumVgprs: 96
 define void @f1024_1() #1024 {
@@ -1282,18 +1282,18 @@ define void @f1024_1() #1024 {
 }
 
 ; GCN-LABEL: {{^}}f1024_call_no_agprs:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 128
+; GFX90A: TotalNumVgprs: 126
 define void @f1024_call_no_agprs() #1025 {
   call void @use256vgprs_no_agpr()
   ret void
 }
 
 ; GCN-LABEL: {{^}}f1024_call_no_agprs_ub:
-; GFX90A: NumVgprs: 128
+; GFX90A: NumVgprs: 126
 ; GFX90A: NumAgprs: 0
-; GFX90A: TotalNumVgprs: 128
+; GFX90A: TotalNumVgprs: 126
 define void @f1024_call_no_agprs_ub() #1025 {
   call void @use256vgprs()
   ret void

--- a/llvm/test/CodeGen/AMDGPU/vgpr-limit-gfx1250.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-limit-gfx1250.ll
@@ -1,6 +1,6 @@
 ; -enable-misched=false makes the register usage more predictable
 ; -regalloc=fast just makes the test run faster
-; RUN: llc -mtriple=amdgcn -mcpu=gfx1250 -O0 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX1250
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=gfx1250 -O0 -amdgpu-function-calls=false -enable-misched=false -sgpr-regalloc=fast -vgpr-regalloc=fast -wwm-regalloc=fast < %s | FileCheck %s --check-prefixes=GCN,GFX1250
 
 define internal void @use256vgprs_asm() {
   %v0 = call i32 asm sideeffect "; def $0", "=v"()
@@ -558,7 +558,7 @@ define amdgpu_kernel void @k256_w1_asm() #2561 {
 }
 
 ; GCN-LABEL: {{^}}use512vgprs_codegen:
-; GFX1250: NumVgprs: 512
+; GFX1250: NumVgprs: 510
 ; GFX1250: VGPRBlocks: 31
 define amdgpu_kernel void @use512vgprs_codegen(ptr %p) #2561 {
   %r0 = load volatile <512 x float>, ptr %p, align 1
@@ -567,7 +567,7 @@ define amdgpu_kernel void @use512vgprs_codegen(ptr %p) #2561 {
 }
 
 ; GCN-LABEL: {{^}}use1024vgprs_codegen:
-; GFX1250: NumVgprs: 1024
+; GFX1250: NumVgprs: 1022
 ; GFX1250: VGPRBlocks: 63
 define amdgpu_kernel void @use1024vgprs_codegen(ptr %p) #1281 {
   %r0 = load volatile <1024 x float>, ptr %p, align 1

--- a/llvm/test/CodeGen/AMDGPU/vgpr-spill-emergency-stack-slot.ll
+++ b/llvm/test/CodeGen/AMDGPU/vgpr-spill-emergency-stack-slot.ll
@@ -1,6 +1,6 @@
-; RUN: llc -mtriple=amdgcn-- -mcpu=tahiti < %s | FileCheck -check-prefix=GCN -check-prefix=SI %s
-; RUN: llc -mtriple=amdgcn-- -mcpu=fiji < %s | FileCheck -check-prefix=GCN -check-prefix=VI %s
-; RUN: llc -mtriple=amdgcn-- -mcpu=gfx900 < %s | FileCheck -check-prefix=GCN -check-prefix=GFX9 %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-- -mcpu=tahiti < %s | FileCheck -check-prefix=GCN -check-prefix=SI %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-- -mcpu=fiji < %s | FileCheck -check-prefix=GCN -check-prefix=VI %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn-- -mcpu=gfx900 < %s | FileCheck -check-prefix=GCN -check-prefix=GFX9 %s
 
 ; This ends up using all 255 registers and requires register
 ; scavenging which will fail to find an unsued register.
@@ -22,9 +22,11 @@
 ; GFX9-DAG: s_mov_b32 s[[DESC3:[0-9]+]], 0xe00000
 
 ; OFFREG is offset system SGPR
-; GCN: buffer_store_dword {{v[0-9]+}}, off, s[[[DESC0]]:[[DESC3]]], 0 offset:{{[0-9]+}} ; 4-byte Folded Spill
-; GCN: buffer_load_dword v{{[0-9]+}}, off, s[[[DESC0]]:[[DESC3]]], 0 offset:{{[0-9]+}} ; 4-byte Folded Reload
-; GCN: NumVgprs: 256
+; GCN-DAG: buffer_store_dword {{v[0-9]+}}, off, s[[[DESC0]]:[[DESC3]]], 0{{( offset:[0-9]+)?$}}
+; GCN-DAG: buffer_load_dword v{{[0-9]+}}, off, s[[[DESC0]]:[[DESC3]]], 0{{( offset:[0-9]+)?$}}
+; SI: NumVgprs: 134
+; VI: NumVgprs: 134
+; GFX9: NumVgprs: 133
 ; GCN: ScratchSize: 640
 
 define amdgpu_vs void @main(ptr addrspace(4) inreg %arg, ptr addrspace(4) inreg %arg1, ptr addrspace(4) inreg %arg2, ptr addrspace(4) inreg %arg3, ptr addrspace(4) inreg %arg4, i32 inreg %arg5, i32 inreg %arg6, i32 %arg7, i32 %arg8, i32 %arg9, i32 %arg10) #0 {

--- a/llvm/test/CodeGen/AMDGPU/zero_extend.ll
+++ b/llvm/test/CodeGen/AMDGPU/zero_extend.ll
@@ -1,5 +1,5 @@
-; RUN: llc -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -enable-var-scope --check-prefixes=GCN,SI %s
-; RUN: llc -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck -enable-var-scope --check-prefixes=GCN,VI %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tahiti < %s | FileCheck -enable-var-scope --check-prefix=GCN %s
+; RUN: llc -amdgpu-late-wave-transform=1 -mtriple=amdgcn -mcpu=tonga -mattr=-flat-for-global < %s | FileCheck -enable-var-scope --check-prefix=GCN %s
 ; RUN: llc -mtriple=r600 -mcpu=redwood < %s | FileCheck -check-prefix=R600 %s
 
 ; R600: {{^}}s_mad_zext_i32_to_i64:
@@ -53,8 +53,7 @@ define amdgpu_kernel void @s_cmp_zext_i1_to_i64(ptr addrspace(1) %out, i32 %a, i
 
 ; GCN-DAG: s_and_b32 [[MASK_A:s[0-9]+]], [[A]], 0xffff{{$}}
 ; GCN-DAG: s_and_b32 [[MASK_B:s[0-9]+]], [[B]], 0xffff{{$}}
-; VI: s_cmp_eq_u32 [[MASK_B]], [[MASK_A]]
-; SI: s_cmp_eq_u32 [[MASK_A]], [[MASK_B]]
+; GCN: s_cmp_eq_u32 [[MASK_A]], [[MASK_B]]
 ; GCN: s_cselect_b64 [[CC:s\[[0-9:]+\]]], -1, 0
 ; GCN: v_cndmask_b32_e64 [[RESULT:v[0-9]+]], 0, 1, [[CC]]
 ; GCN: buffer_store_short [[RESULT]]


### PR DESCRIPTION
Fix 31 manually-maintained CodeGen tests to work with late wave transform enabled flow. These tests required careful hand-crafted CHECK pattern updates instead of the autogen patterns.

Tests fixed:
llvm.amdgcn.ds.ordered.swap.ll, llvm.amdgcn.ps.live.ll, llvm.amdgcn.rsq.clamp.ll, llvm.amdgcn.sendmsg.ll,
mixed-wave32-wave64.ll, multi-divergent-exit-region.ll, nsa-reassign.ll, pal-metadata-3.0-callable-dvgpr.ll, pal-metadata-3.0-callable.ll, regalloc-illegal-eviction-assert.ll, regalloc-sgpr128-partial-def.mir, ret_jump.ll,
salu-to-valu.ll, schedule-amdgpu-tracker-physreg.ll, schedule-regpressure-limit2.ll, schedule-relaxed-occupancy.ll, setcc-sext.ll, sgpr-copy.ll,
sgpr-regalloc-flags.ll, si-annotate-cf-unreachable.ll, si-lower-control-flow-kill.ll, si-lower-control-flow-unreachable-block.ll, si-scheduler.ll, skip-branch-trap.ll,
spill-csr-frame-ptr-reg-copy.ll, uniform-loop-inside-nonuniform.ll, use-sgpr-multiple-times.ll, vgpr-agpr-limit-gfx90a.ll, vgpr-limit-gfx1250.ll, vgpr-spill-emergency-stack-slot.ll, zero_extend.ll


