### PR TITLE
Revert "fix regression in ASAN build for RCCL & rocSHMEM"

### DIFF
--- a/amd/device-libs/utils/prepare-builtins/prepare-builtins.cpp
+++ b/amd/device-libs/utils/prepare-builtins/prepare-builtins.cpp
@@ -73,29 +73,6 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  // Set linkage of every external definition to linkonce_odr.
-  // This is required to avoid duplicate symbol errors when linking
-  // device code from multiple translation units with -fgpu-rdc.
-  for (Module::iterator i = M->begin(), e = M->end(); i != e; ++i) {
-    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
-        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
-    }
-  }
-
-  for (Module::global_iterator i = M->global_begin(), e = M->global_end();
-       i != e; ++i) {
-    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
-        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
-    }
-  }
-
-  for (Module::alias_iterator i = M->alias_begin(), e = M->alias_end();
-       i != e; ++i) {
-    if (!i->isDeclaration() && i->getLinkage() == GlobalValue::ExternalLinkage) {
-        i->setLinkage(GlobalValue::LinkOnceODRLinkage);
-    }
-  }
-
   if (OutputFilename.empty()) {
     errs() << "no output file\n";
     return 1;


### PR DESCRIPTION
Reverts ROCm/llvm-project#1969

This is a risky change, and re-introduces broken behavior wrt how the device libraries are built.

The proper fix can should come from the RCCL CMake