### PR TITLE
[Comgr] Forward ISA offload arch to SPIR-V translator

### DIFF
--- a/amd/comgr/include/amd_comgr.h.in
+++ b/amd/comgr/include/amd_comgr.h.in
@@ -1810,6 +1810,9 @@ typedef enum amd_comgr_action_kind_s {
    * @llvm.cmdline variable. Finally, we compile the bitcode to a reloctable,
    * appending any extracted flags.
    *
+   * If @p isa name is set in @p info, the GPU architecture (e.g. gfx900) is
+   * forwarded to the SPIR-V translator for feature predicate resolution.
+   *
    * Return @p AMD_COMGR_STATUS_ERROR if any translation, flag extraction, or
    * compilation fails.
    *
@@ -1820,9 +1823,12 @@ typedef enum amd_comgr_action_kind_s {
 
    /**
    * Translate each source SPIR-V object in @p input into LLVM IR Bitcode.
-   * For each successful translation, add a bc object to @p result   *
+   * For each successful translation, add a bc object to @p result.
    *
-   * Return @p AMD_COMGR_STATUS_ERROR if any translation fails
+   * If @p isa name is set in @p info, the GPU architecture (e.g. gfx900) is
+   * forwarded to the SPIR-V translator for feature predicate resolution.
+   *
+   * Return @p AMD_COMGR_STATUS_ERROR if any translation fails.
    *
    * Return @p AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT
    * if any input is not SPIR-V.

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -2247,6 +2247,17 @@ AMDGPUCompiler::translateSpirvToBitcodeImpl(DataSet *SpirvInSet,
     return Status;
   }
 
+  // Extract GPU processor from ISA name if set, for SPIR-V feature predicate
+  // resolution. TODO: Make ISA name required for this action once users have
+  // migrated.
+  StringRef OffloadArch;
+  TargetIdentifier Ident;
+  if (ActionInfo->IsaName) {
+    if (auto Status = parseTargetIdentifier(ActionInfo->IsaName, Ident))
+      return Status;
+    OffloadArch = Ident.Processor;
+  }
+
   auto Cache = CommandCache::get(LogS);
 
   for (auto *Input : SpirvInSet->DataObjects) {
@@ -2262,7 +2273,7 @@ AMDGPUCompiler::translateSpirvToBitcodeImpl(DataSet *SpirvInSet,
     }
 
     SmallString<0> OutBuf;
-    SPIRVCommand SPIRV(Input, OutBuf);
+    SPIRVCommand SPIRV(Input, OutBuf, OffloadArch);
 
     amd_comgr_status_t Status;
     if (!Cache) {

--- a/amd/comgr/src/comgr-spirv-command.cpp
+++ b/amd/comgr/src/comgr-spirv-command.cpp
@@ -57,6 +57,9 @@ amd_comgr_status_t SPIRVCommand::execute(raw_ostream &LogS) {
   Opts.setDesiredBIsRepresentation(SPIRV::BIsRepresentation::OpenCL20);
   Opts.setPreserveAuxData(true);
 
+  if (!OffloadArch.empty())
+    Opts.setAMDGCNSPIRVOffloadArch(OffloadArch);
+
   if (!readSpirv(Context, Opts, ISS, M, Err)) {
     LogS << "Failed to load SPIR-V as LLVM Module: " << Err << '\n';
     return AMD_COMGR_STATUS_ERROR;
@@ -78,9 +81,9 @@ SPIRVCommand::ActionClass SPIRVCommand::getClass() const {
   return clang::driver::Action::ActionClass::JobClassLast + 1;
 }
 
-void SPIRVCommand::addOptionsIdentifier(HashAlgorithm &) const {
-  // do nothing, there are no options
-  return;
+void SPIRVCommand::addOptionsIdentifier(HashAlgorithm &H) const {
+  if (!OffloadArch.empty())
+    addString(H, OffloadArch);
 }
 
 Error SPIRVCommand::addInputIdentifier(HashAlgorithm &H) const {

--- a/amd/comgr/src/comgr-spirv-command.h
+++ b/amd/comgr/src/comgr-spirv-command.h
@@ -17,10 +17,13 @@ class SPIRVCommand : public CachedCommandAdaptor {
 public:
   llvm::StringRef InputBuffer;
   llvm::SmallVectorImpl<char> &OutputBuffer;
+  std::string OffloadArch;
 
 public:
-  SPIRVCommand(DataObject *Input, llvm::SmallVectorImpl<char> &OutputBuffer)
-      : InputBuffer(Input->Data, Input->Size), OutputBuffer(OutputBuffer) {}
+  SPIRVCommand(DataObject *Input, llvm::SmallVectorImpl<char> &OutputBuffer,
+               llvm::StringRef OffloadArch = "")
+      : InputBuffer(Input->Data, Input->Size), OutputBuffer(OutputBuffer),
+        OffloadArch(OffloadArch) {}
 
   bool canCache() const final { return true; }
   llvm::Error writeExecuteOutput(llvm::StringRef CachedBuffer) final;

--- a/amd/comgr/test-lit/comgr-sources/spirv-translator.c
+++ b/amd/comgr/test-lit/comgr-sources/spirv-translator.c
@@ -14,6 +14,7 @@
 
 // Tests the AMD_COMGR_ACTION_TRANSLATE_SPIRV_TO_BC action
 //     Accepts one or more .spv files, and returns one or more .bc files
+//     Optional: --isa <isa_name> to set the ISA for offload arch forwarding
 
 int main(int argc, char *argv[]) {
   char *BufSpirv;
@@ -23,12 +24,40 @@ int main(int argc, char *argv[]) {
   amd_comgr_action_info_t DataAction;
   size_t Count;
 
-  if (argc != 4) {
-    fprintf(stderr, "Usage: spirv-translator file.spv -o file.spv.bc\n");
+  // Parse arguments: spirv-translator [--isa <name>] file.spv -o file.bc
+  const char *IsaName = NULL;
+  const char *InputFile = NULL;
+  const char *OutputFile = NULL;
+
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--isa") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "--isa requires an argument\n");
+        exit(1);
+      }
+      IsaName = argv[++i];
+    } else if (strcmp(argv[i], "-o") == 0) {
+      if (i + 1 >= argc) {
+        fprintf(stderr, "-o requires an argument\n");
+        exit(1);
+      }
+      OutputFile = argv[++i];
+    } else if (!InputFile) {
+      InputFile = argv[i];
+    } else {
+      fprintf(stderr,
+              "Usage: spirv-translator [--isa <name>] file.spv -o file.bc\n");
+      exit(1);
+    }
+  }
+
+  if (!InputFile || !OutputFile) {
+    fprintf(stderr,
+            "Usage: spirv-translator [--isa <name>] file.spv -o file.bc\n");
     exit(1);
   }
 
-  SizeSpirv = setBuf(argv[1], &BufSpirv);
+  SizeSpirv = setBuf(InputFile, &BufSpirv);
 
   amd_comgr_(create_data_set(&DataSetSpirv));
   amd_comgr_(create_data(AMD_COMGR_DATA_KIND_SPIRV, &DataSpirv));
@@ -37,6 +66,10 @@ int main(int argc, char *argv[]) {
   amd_comgr_(data_set_add(DataSetSpirv, DataSpirv));
 
   amd_comgr_(create_action_info(&DataAction));
+
+  if (IsaName)
+    amd_comgr_(action_info_set_isa_name(DataAction, IsaName));
+
   amd_comgr_(create_data_set(&DataSetBc));
 
   amd_comgr_(do_action(AMD_COMGR_ACTION_TRANSLATE_SPIRV_TO_BC, DataAction,
@@ -57,7 +90,7 @@ int main(int argc, char *argv[]) {
   amd_comgr_(
       action_data_get_data(DataSetBc, AMD_COMGR_DATA_KIND_BC, 0, &DataSpirvBc));
 
-  dumpData(DataSpirvBc, argv[3]);
+  dumpData(DataSpirvBc, OutputFile);
 
   amd_comgr_(release_data(DataSpirv));
   amd_comgr_(release_data(DataSpirvBc));

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator-offload-arch.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator-offload-arch.hip
@@ -1,0 +1,31 @@
+// REQUIRES: comgr-has-spirv-translator && comgr-has-spirv-backend
+
+// COM: Compile to SPIR-V via the LLVM SPIR-V backend (handles the
+// COM: __builtin_amdgcn_processor_is predicate as a spec constant)
+// RUN: %clang --offload-device-only --offload-arch=amdgcnspirv \
+// RUN:   --no-gpu-bundle-output -nogpuinc -use-spirv-backend \
+// RUN:   -c %s -o %t.spv
+
+// COM: Translate with --isa gfx900: predicate resolves to true,
+// COM: gfx900 path is kept, fallback is folded away
+// RUN: spirv-translator --isa amdgcn-amd-amdhsa--gfx900 %t.spv -o %t.gfx900.bc
+// RUN: %llvm-dis %t.gfx900.bc -o - | %FileCheck --check-prefix=GFX900 %s
+
+// COM: Translate with --isa gfx1010: predicate resolves to false,
+// COM: gfx900 path is folded away, fallback is kept
+// RUN: spirv-translator --isa amdgcn-amd-amdhsa--gfx1010 %t.spv -o %t.gfx1010.bc
+// RUN: %llvm-dis %t.gfx1010.bc -o - | %FileCheck --check-prefix=GFX1010 %s
+
+// GFX900: define {{.*}}void @foo
+// GFX900: call {{.*}}void @llvm.trap
+// GFX900-NOT: ret void{{$}}
+
+// GFX1010: define {{.*}}void @foo
+// GFX1010-NOT: call {{.*}}void @llvm.trap
+// GFX1010: ret void
+
+extern "C" __attribute__((device))
+void foo() {
+    if (__builtin_amdgcn_processor_is("gfx900"))
+        __builtin_trap();
+}


### PR DESCRIPTION
## Summary
- When ISA name is set on the action info, extract the GPU processor (e.g. `gfx900`) and forward it to the SPIR-V translator via `TranslatorOpts::setAMDGCNSPIRVOffloadArch()` for feature predicate resolution.
- Applies to `AMD_COMGR_ACTION_TRANSLATE_SPIRV_TO_BC` and `AMD_COMGR_ACTION_COMPILE_SPIRV_TO_RELOCATABLE`.
- ISA name is optional for now to avoid breaking existing users. Will be made required in a follow-up once users have migrated.
- Updates `spirv-translator` lit test tool to accept an optional `--isa` flag.

## Dependencies
- Requires ROCm/SPIRV-LLVM-Translator#144 for the `TranslatorOpts::setAMDGCNSPIRVOffloadArch()` API.