### PR TITLE
[Comgr] Fix versioning in exportmap

### DIFF
--- a/amd/comgr/src/exportmap.in
+++ b/amd/comgr/src/exportmap.in
@@ -92,6 +92,6 @@ global: amd_comgr_action_info_set_bundle_entry_ids;
 global: amd_comgr_action_info_set_device_lib_linking;
 } @amd_comgr_NAME@_2.8;
 
-@amd_comgr_NAME@3.1 {
+@amd_comgr_NAME@_3.1 {
 global: amd_comgr_action_info_set_vfs;
 } @amd_comgr_NAME@_2.9;


### PR DESCRIPTION
This now matches the convention set by other versions.