### PR TITLE
[OpenMP] Fix xteam reduction fast atomic path for USM

### DIFF
--- a/openmp/device/src/Xteamr.cpp
+++ b/openmp/device/src/Xteamr.cpp
@@ -314,8 +314,14 @@ __attribute__((flatten, always_inline)) void _xteam_reduction(
   }
 
   if (_IS_FAST) {
-    if (omp_thread_num == 0)
-      ompx::atomic::add(r_ptr, xwave_lds[0], ompx::atomic::seq_cst, Scope);
+    if (omp_thread_num == 0) {
+      // Force fine-grained remote memory to cover the USM case where we need to
+      // sync the result to the host.
+      [[clang::atomic(fine_grained_memory, remote_memory)]] {
+        __scoped_atomic_fetch_add(r_ptr, xwave_lds[0], ompx::atomic::seq_cst,
+                                  Scope);
+      }
+    }
   } else {
     // No sync needed here from last reduction in LDS loop
     // because we only need xwave_lds[0] correct on thread 0.


### PR DESCRIPTION
https://github.com/llvm/llvm-project/pull/114841 introduced clang atomic attributes for fine grained and remote memory (see https://llvm.org/docs/AMDGPUUsage.html#amdgpu-no-fine-grained-memory-metadata and
https://llvm.org/docs/AMDGPUUsage.html#amdgpu-no-remote-memory-metadata) and set corresponding defaults.
If used together with -fopenmp-target-fast-reduction and -fopenmp-force-usm and HSA_XNACK=1, the atomic add in the fast path of the xteam reduction wouldn't propagate to the host.
Adding compiler flags such as -fatomic-fine-grained-memory for the compilation of the affected application won't help since the xteam reduction device code is built during the compiler build itself.
This patch adds the necessary atomic attributes to the atomic add in the xteam reduction fast path code.


