### PR TITLE
[1/1]: [HeterogeneousDWARF] Fix bugs in SILowerSGPRSpills

### DIFF
--- a/llvm/include/llvm/IR/DebugInfoMetadata.h
+++ b/llvm/include/llvm/IR/DebugInfoMetadata.h
@@ -4594,6 +4594,8 @@ public:
                   [](auto &&E) { return std::holds_alternative<T>(E); });
   }
 
+  LLVMContext &getContext() const { return C; }
+
   /// Update the expression to reflect the removal of one level of indirection
   /// from the value acting as the referrer.
   ///

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
@@ -85,8 +85,6 @@ public:
   void determineRegsForWWMAllocation(MachineFunction &MF, BitVector &RegMask);
   void updateDbgValueInst(MachineInstr &MI, const BitVector &SpillFIs);
   void updateDbgValueInsts(MIVector &Insts, const BitVector &SpillFIs);
-  void updateDbgValueArg(MachineInstr &MI, uint32_t FIOpndIdx,
-                         const SIRegisterInfo::SpilledReg &vgpr);
 };
 
 class SILowerSGPRSpillsLegacy : public MachineFunctionPass {
@@ -427,42 +425,6 @@ bool SILowerSGPRSpillsLegacy::runOnMachineFunction(MachineFunction &MF) {
   return SILowerSGPRSpills(LIS, Indexes, MDT, MCI).run(MF);
 }
 
-// Replace an FI argument in DBG_VALUE or DBG_VALUE_LIST
-// with corresponding VGPR lane. The argument if identified by FIOpndIdx.
-void SILowerSGPRSpills::updateDbgValueArg(MachineInstr &MI,
-                                          uint32_t FIOpndIdx,
-                                          const SIRegisterInfo::SpilledReg &vgpr) {
-  const DIExpression *Expr = MI.getDebugExpression();
-  DIExprBuilder EBuilder(*Expr);
-  assert(Expr->holdsNewElements());
-
-  // Find corresponding DIOpArg in the DIExpression.
-  for (auto &&I = EBuilder.begin(); I != EBuilder.end(); ) {
-    if (auto *Arg = std::get_if<DIOp::Arg>(&*I++)) {
-      // We expect DIOpArg be followed by DIOpDeref
-      if (Arg->getIndex() == FIOpndIdx &&
-          I != EBuilder.end() && std::get_if<DIOp::Deref>(&*I)) {
-        // Change the type of DIOpArg and replace the following DIOpDeref
-        // with DIOpConstant + DIOpByteOfset.
-        IntegerType *TypeInt8  = IntegerType::get(Expr->getContext(), 8);
-        IntegerType *TypeInt32 = IntegerType::get(Expr->getContext(), 32);
-        Arg->setResultType(TypeInt32);
-        ConstantData *C = ConstantInt::get(TypeInt8, vgpr.Lane * 8, true);
-        EBuilder.insert(EBuilder.erase(I),
-                        {DIOp::Constant(C), DIOp::ByteOffset(TypeInt32)});
-        // Replace stack (frame index) argument of MI with VGPR
-        if (MI.isDebugValueList())
-          FIOpndIdx += 2;
-        MI.getOperand(FIOpndIdx).ChangeToRegister(vgpr.VGPR, false);
-        MI.getDebugExpressionOp().setMetadata(EBuilder.intoExpression());
-      }
-      else {
-        MI.eraseFromParent();
-      }
-    }
-  }
-}
-
 // Replace frame index in a DBG_VALUE or DBG_VALUE_LIST instruction with VGPR lane.
 void SILowerSGPRSpills::updateDbgValueInst(MachineInstr &MI,
                                            const BitVector &SpillFIs) {
@@ -470,44 +432,54 @@ void SILowerSGPRSpills::updateDbgValueInst(MachineInstr &MI,
   const MachineFunction *MF = MI.getParent()->getParent();
   auto *FuncInfo = MF->getInfo<SIMachineFunctionInfo>();
   const auto &FrInfo = MF->getFrameInfo();
-  ArrayRef<SIRegisterInfo::SpilledReg> VGPRSpills;
 
-  auto WasOpndSpilled = [&](const MachineOperand &Opnd, bool IsValueList) {
-    int FrObjIdx = (IsValueList ? Opnd.getIndex() : 0);
-    return (Opnd.isFI() && !FrInfo.isFixedObjectIndex(FrObjIdx) &&
+  auto WasOpndSpilled = [&](const MachineOperand &Opnd) {
+    return (Opnd.isFI() && !FrInfo.isFixedObjectIndex(Opnd.getIndex()) &&
             SpillFIs[Opnd.getIndex()]);
   };
-  
+
   if (MI.getDebugExpression()->holdsOldElements()) {
-    // For old-style DIExpressions, just replace the frame index
-    // argument with empty register.
+    // For old-style DIExpressions, just do nothing and we will drop all
+    // spilled FIs below.
     // FIXME: We should instead, update it with the
     // correct register value. It should be worked out later.
-    auto &FIOpnd = MI.getOperand(MI.isDebugValueList() ? 2 : 0);
-    if (WasOpndSpilled(FIOpnd, true)) {
-      FIOpnd.ChangeToRegister(Register(), false /*isDef*/);
-    }
-  } else if (MI.isDebugValueList()) {
-    // Walk over DIOpArg nodes in the DIExpression and check
-    // if corresponding DBG_VALUE_LIST arguments have been spilled to VGPR lanes.
-    for (DIOp::Variant Elem : *MI.getDebugExpression()->getNewElementsRef()) {
-      if (auto *Arg = std::get_if<DIOp::Arg>(&Elem)) {
-        auto &FIOpnd = MI.getOperand(Arg->getIndex() + 2);
-        if (WasOpndSpilled(FIOpnd, true)) {
-          VGPRSpills = FuncInfo->getSGPRSpillToVirtualVGPRLanes(FIOpnd.getIndex());
-          updateDbgValueArg(MI, Arg->getIndex(), VGPRSpills[0]);
+  } else {
+    DIExprBuilder Builder(*MI.getDebugExpression());
+    IntegerType *TypeInt8 = IntegerType::get(Builder.getContext(), 8);
+    IntegerType *TypeInt32 = IntegerType::get(Builder.getContext(), 32);
+    for (auto &&I = Builder.begin(); I != Builder.end();) {
+      if (auto *Arg = std::get_if<DIOp::Arg>(&*I++)) {
+        MachineOperand &MO = MI.getDebugOperand(Arg->getIndex());
+        if (!WasOpndSpilled(MO))
+          continue;
+        ArrayRef<SIRegisterInfo::SpilledReg> VGPRSpills =
+            FuncInfo->getSGPRSpillToVirtualVGPRLanes(MO.getIndex());
+        // FIXME: This is a very narrow pattern to match, we could handle much
+        // more, both intervening ops and multi-lane spills
+        if (I != Builder.end() && std::get_if<DIOp::Deref>(&*I) &&
+            VGPRSpills.size() == 1) {
+          const SIRegisterInfo::SpilledReg &VGPRSpill = VGPRSpills.front();
+          // Change the type of DIOpArg and replace the following DIOpDeref
+          // with DIOpConstant + DIOpByteOfset.
+          Arg->setResultType(TypeInt32);
+          ConstantData *C =
+              ConstantInt::get(TypeInt8, VGPRSpill.Lane * 8, true);
+          const std::initializer_list<DIOp::Variant> Ops = {
+              DIOp::Constant(C), DIOp::ByteOffset(TypeInt32)};
+          I = Builder.insert(Builder.erase(I), Ops) + Ops.size();
+          // Replace stack (frame index) argument of MI with VGPR
+          MO.ChangeToRegister(VGPRSpill.VGPR, false);
+        } else {
+          MO.ChangeToRegister(Register(), /*isDef=*/false);
         }
       }
     }
-  } else {
-    assert(MI.isNonListDebugValue());
-    // Check if the 1st argument of DBG_VALUE is a frame index (FI)
-    // which have been spilled to a VGPR lane.
-    auto &FIOpnd = MI.getOperand(0);
-    if (WasOpndSpilled(FIOpnd, false)) {
-      VGPRSpills = FuncInfo->getSGPRSpillToVirtualVGPRLanes(FIOpnd.getIndex());
-      updateDbgValueArg(MI, 0, VGPRSpills[0]);
-    }
+    MI.getDebugExpressionOp().setMetadata(Builder.intoExpression());
+  }
+  // Any spilled FIs we haven't handled by this point should just be dropped.
+  for (MachineOperand &Op : MI.debug_operands()) {
+    if (WasOpndSpilled(Op))
+      Op.ChangeToRegister(Register(), /*isDef=*/false);
   }
 }
 

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-list.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-list.mir
@@ -42,12 +42,25 @@ body:             |
   ; CHECK-LABEL: name: test
   ; CHECK: bb.0:
   ; CHECK:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr10, 0, [[DEF]]
-  ; CHECK-NEXT:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, i32), DIOpConstant(i8 0), DIOpByteOffset(i32)), [[DEF]], 0, {{.*}}
 
   bb.0:
     renamable $sgpr10 = IMPLICIT_DEF
     SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    ; Test the path we expect to work (Arg followed immediately by Deref)
+    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, i32), DIOpConstant(i8 0), DIOpByteOffset(i32)), [[DEF]], 0, {{.*}}
     DBG_VALUE_LIST !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(i32)), %stack.0, 0, debug-location !9
+    S_NOP 0
+    ; Test that we replace unhandled stack indexes with $noreg
+    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32)), $noreg, 0, {{.*}}
+    DBG_VALUE_LIST !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32)), %stack.0, 0, debug-location !9
+    S_NOP 0
+    ; Test that we replace unhandled stack indexes with $noreg even if they are not referenced by a DIOpArg
+    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32)), $noreg, $noreg, 0, {{.*}}
+    DBG_VALUE_LIST !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32)), %stack.0, %stack.0, 0, debug-location !9
+    S_NOP 0
+    ; Test that we handle multiple such unhandled stack indexes
+    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32), DIOpArg(1, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32)), $noreg, $noreg, 0, {{.*}}
+    DBG_VALUE_LIST !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32), DIOpArg(1, ptr addrspace(5)), DIOpRead(), DIOpDeref(i32)), %stack.0, %stack.0, 0, debug-location !9
 
   bb.1:
     renamable $sgpr10 = SI_SPILL_S32_RESTORE %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32


### PR DESCRIPTION
The previous code had a few bugs:

* It actually deleted the DBG_VALUE* instruction if it could not update
  an operand, which could extend the lifetime of other DBG_VALUE*
  instructions mistakenly.
* When it did delete those instructions, the outer loop was unaware and
  could continue if there were more operands left to be checked at the time
  the inner function deleted the functions.
* It assumed the size of the spill to be a single register, and so would
  produce incorrect info for wider spills.

Address each of these and simplify the code to make it eaiser to verify
that they are now handled correctly. Namely:

Factor out the $noreg fallback path so it is shared between expressions
with old and new elements. This is really the same behavior in both
cases, we just don't handle any cases for old and handle some cases for
new.

For the case we want to actually handle, tighten the conditions to match
what we actually implement. Namely, require the spill be of a single
lane.

Work in terms of only DIExprBuilder iterators, and use the iterator
returned by insert to avoid rewalking the expression multiple times.

Use getDebugOperand where appropriate to avoid juggling "+ 2" terms,
which is error prone and difficult to read.

(cherry picked from review against amd-debug)

Change-Id: I3428c6e9257318a2170762508767cbc7cae70ae1

---

**Stack**:
- #2117⬅
- `amd-staging`

<sub>(Note: Closed and merged PRs may not be reflected here and PR numbering is not stable.)</sub>
