### PR TITLE
[AMDGPU] comgr: cherry-pick HotSwap rewriting API (stub) to amd-main

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -76,6 +76,7 @@ set(SOURCES
   src/comgr-diagnostic-handler.cpp
   src/comgr-disassembly.cpp
   src/comgr-env.cpp
+  src/comgr-hotswap.cpp
   src/comgr-libcxx-headers.cpp
   src/comgr-metadata.cpp
   src/comgr-signal.cpp

--- a/amd/comgr/include/amd_comgr.h.in
+++ b/amd/comgr/include/amd_comgr.h.in
@@ -237,6 +237,12 @@ extern "C" {
  */
 #define AMD_COMGR_VERSION_3_1
 
+/**
+ * The function was introduced or changed in version 3.2 of the interface
+ * and has the symbol version string of ``"@amd_comgr_NAME@_3.2"``.
+ */
+#define AMD_COMGR_VERSION_3_2
+
 /** @} */
 
 /**
@@ -2670,6 +2676,61 @@ amd_comgr_map_elf_virtual_address_to_code_object_offset(
     uint64_t *code_object_offset,
     uint64_t *slice_size,
     bool *nobits) AMD_COMGR_VERSION_2_7;
+
+/** @} */
+
+/**
+ * \defgroup hotswap HotSwap ISA Rewriting
+ * @{
+ *
+ * APIs for load-time GPU ISA binary rewriting and transpilation.
+ */
+
+/**
+ * @brief Rewrite a code object from one ISA to another.
+ *
+ * Rewrites GPU instructions in the ELF code object so that it can execute
+ * on a different target ISA. This includes both same-family stepping
+ * patches (e.g. B0 to A0) and cross-family transpilation.
+ * The input ELF is not modified; a new data object is created and returned.
+ *
+ * If no patches are needed, the output is a copy of the input.
+ *
+ * Currently supported transformations:
+ *   - GFX1250 B0 to A0
+ *
+ * Additional source/target ISA pairs may be added in future releases.
+ * Unsupported @p source_isa_name / @p target_isa_name combinations return
+ * @c AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT.
+ *
+ * @param[in] input A data object of kind @p AMD_COMGR_DATA_KIND_EXECUTABLE
+ *   containing the input ELF code object bytes.
+ * @param[in] source_isa_name A null terminated string that is the isa name
+ *   the code object was compiled for. The isa name is defined as the Code
+ *   Object Target Identification string, described at
+ *   https://llvm.org/docs/AMDGPUUsage.html#code-object-target-identification
+ * @param[in] target_isa_name A null terminated string that is the isa name
+ *   of the target GPU.
+ * @param[out] output A handle to a data object of kind @p
+ *   AMD_COMGR_DATA_KIND_EXECUTABLE containing the rewritten ELF. The caller
+ *   must release this handle using @c amd_comgr_release_data when done.
+ *   @p output is not modified on failure.
+ *
+ * @retval ::AMD_COMGR_STATUS_SUCCESS Patching completed successfully.
+ * @retval ::AMD_COMGR_STATUS_ERROR An internal error occurred.
+ * @retval ::AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT @p input is an invalid
+ *   data object, is not of kind @p AMD_COMGR_DATA_KIND_EXECUTABLE, does not
+ *   contain data bytes, or @p source_isa_name or @p target_isa_name is NULL,
+ *   or the source/target isa name combination is not supported.
+ * @retval ::AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES Unable to allocate
+ *   the output data object.
+ */
+amd_comgr_status_t AMD_COMGR_API
+amd_comgr_hotswap_rewrite(
+    amd_comgr_data_t input,
+    const char *source_isa_name,
+    const char *target_isa_name,
+    amd_comgr_data_t *output) AMD_COMGR_VERSION_3_2;
 
 /** @} */
 

--- a/amd/comgr/src/comgr-hotswap.cpp
+++ b/amd/comgr/src/comgr-hotswap.cpp
@@ -1,0 +1,47 @@
+//===- comgr-hotswap.cpp - HotSwap ISA stepping rewrite (stub) -----------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "amd_comgr.h"
+#include "comgr.h"
+
+using namespace COMGR;
+
+amd_comgr_status_t AMD_COMGR_API amd_comgr_hotswap_rewrite(
+    amd_comgr_data_t input,
+    const char *source_isa_name, const char *target_isa_name,
+    amd_comgr_data_t *output) {
+  DataObject *InputP = DataObject::convert(input);
+  if (!InputP || !InputP->Data ||
+      InputP->DataKind != AMD_COMGR_DATA_KIND_EXECUTABLE ||
+      !source_isa_name || !target_isa_name || !output)
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  // Validate and parse both ISA names.
+  TargetIdentifier SourceIdent, TargetIdent;
+  if (parseTargetIdentifier(source_isa_name, SourceIdent) ||
+      parseTargetIdentifier(target_isa_name, TargetIdent))
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  // Currently only GFX1250 B0-to-A0 is supported.
+  if (SourceIdent.Processor != "gfx1250" || TargetIdent.Processor != "gfx1250")
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+
+  // Stub: return a copy of the input unchanged.
+  // Full B0-to-A0 patching implementation follows in subsequent commits.
+  DataObject *OutputP = DataObject::allocate(AMD_COMGR_DATA_KIND_EXECUTABLE);
+  if (!OutputP)
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+
+  if (auto Status =
+          OutputP->setData(llvm::StringRef(InputP->Data, InputP->Size))) {
+    OutputP->release();
+    return Status;
+  }
+
+  *output = DataObject::convert(OutputP);
+  return AMD_COMGR_STATUS_SUCCESS;
+}

--- a/amd/comgr/src/exportmap.in
+++ b/amd/comgr/src/exportmap.in
@@ -95,3 +95,7 @@ global: amd_comgr_action_info_set_device_lib_linking;
 @amd_comgr_NAME@3.1 {
 global: amd_comgr_action_info_set_vfs;
 } @amd_comgr_NAME@_2.9;
+
+@amd_comgr_NAME@_3.2 {
+global: amd_comgr_hotswap_rewrite;
+} @amd_comgr_NAME@3.1;

--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -52,5 +52,6 @@ add_comgr_lit_binary(get-version c)
 add_comgr_lit_binary(status-string c)
 add_comgr_lit_binary(data-action c)
 add_comgr_lit_binary(lookup-code-object c)
+add_comgr_lit_binary(hotswap-rewrite c)
 
 add_dependencies(check-comgr test-lit)

--- a/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
@@ -1,0 +1,76 @@
+//===- hotswap-rewrite.c - Test HotSwap rewrite API ----------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "amd_comgr.h"
+#include "common.h"
+
+int main(int argc, char *argv[]) {
+  if (argc < 2) {
+    amd_comgr_data_t dummy_output;
+    amd_comgr_data_t dummy_input = {0};
+    amd_comgr_status_t Status =
+        amd_comgr_hotswap_rewrite(dummy_input, NULL, NULL, &dummy_output);
+    if (Status != AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT)
+      fail("rewrite with NULL args: expected INVALID_ARGUMENT");
+    printf("NULL_ARGS: INVALID_ARGUMENT\n");
+    return 0;
+  }
+
+  if (argc < 4)
+    fail("usage: hotswap-rewrite <elf_file> <source_isa> <target_isa> [--zero-size]");
+
+  const char *ElfFile = argv[1];
+  const char *SourceISA = argv[2];
+  const char *TargetISA = argv[3];
+  int ZeroSize = (argc > 4 && strcmp(argv[4], "--zero-size") == 0);
+
+  char *ElfBuf;
+  size_t ElfSize = (size_t)setBuf(ElfFile, &ElfBuf);
+
+  amd_comgr_data_t InputData;
+  amd_comgr_(create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &InputData));
+  if (!ZeroSize) {
+    amd_comgr_(set_data(InputData, ElfSize, ElfBuf));
+  }
+
+  amd_comgr_data_t OutputData;
+  amd_comgr_status_t Status =
+      amd_comgr_hotswap_rewrite(InputData, SourceISA, TargetISA, &OutputData);
+
+  if (Status == AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT) {
+    printf("RESULT: INVALID_ARGUMENT\n");
+    amd_comgr_(release_data(InputData));
+    free(ElfBuf);
+    return 0;
+  }
+
+  if (Status != AMD_COMGR_STATUS_SUCCESS)
+    fail("unexpected error status %d", (int)Status);
+
+  size_t OutSize = 0;
+  amd_comgr_(get_data(OutputData, &OutSize, NULL));
+
+  if (OutSize != ElfSize)
+    fail("output size %zu != input size %zu", OutSize, ElfSize);
+
+  char *OutBuf = (char *)malloc(OutSize);
+  if (!OutBuf)
+    fail("malloc failed");
+  amd_comgr_(get_data(OutputData, &OutSize, OutBuf));
+
+  if (memcmp(OutBuf, ElfBuf, ElfSize) != 0)
+    fail("output content differs from input");
+
+  free(OutBuf);
+  amd_comgr_(release_data(OutputData));
+  amd_comgr_(release_data(InputData));
+  free(ElfBuf);
+
+  printf("RESULT: SUCCESS\n");
+  return 0;
+}

--- a/amd/comgr/test-lit/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/hotswap-rewrite.c
@@ -1,0 +1,28 @@
+// COM: Test HotSwap rewrite API
+
+// COM: Create a minimal test ELF file
+// RUN: printf '\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00' > %t.elf
+
+// COM: NULL-argument validation (no args)
+// RUN: hotswap-rewrite | %FileCheck --check-prefix=NULL %s
+// NULL: NULL_ARGS: INVALID_ARGUMENT
+
+// COM: Unsupported ISA pair
+// RUN: hotswap-rewrite %t.elf amdgcn-amd-amdhsa--gfx942 amdgcn-amd-amdhsa--gfx942 \
+// RUN:   | %FileCheck --check-prefix=INVALID %s
+// INVALID: RESULT: INVALID_ARGUMENT
+
+// COM: Invalid ISA string
+// RUN: hotswap-rewrite %t.elf not-a-valid-isa also-not-valid \
+// RUN:   | %FileCheck --check-prefix=BADISA %s
+// BADISA: RESULT: INVALID_ARGUMENT
+
+// COM: Zero-size input with supported ISA
+// RUN: hotswap-rewrite %t.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --zero-size \
+// RUN:   | %FileCheck --check-prefix=ZEROSIZE %s
+// ZEROSIZE: RESULT: INVALID_ARGUMENT
+
+// COM: Supported GFX1250 pair (stub returns input unchanged)
+// RUN: hotswap-rewrite %t.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   | %FileCheck --check-prefix=SUPPORTED %s
+// SUPPORTED: RESULT: SUCCESS


### PR DESCRIPTION
## Summary
Cherry-pick of #1975 from amd-staging to amd-main. Adds the `amd_comgr_hotswap_rewrite_b0a0` API stub for GFX1250 B0-to-A0 stepping patches.

Original author: @harsh-nod