### PR TITLE
[flang][OpenACC] Un-XFAIL OACC tests due to amd-staging and main divergence

### DIFF
--- a/flang/include/flang/Lower/DirectivesCommon.h
+++ b/flang/include/flang/Lower/DirectivesCommon.h
@@ -263,10 +263,7 @@ genBoundsOps(fir::FirOpBuilder &builder, mlir::Location loc,
         // If it is a scalar subscript, then the upper bound
         // is equal to the lower bound, and the extent is one.
         ubound = lbound;
-        if (treatIndexAsSection)
-          extent = fir::factory::readExtent(builder, loc, dataExv, dimension);
-        else
-          extent = one;
+        extent = one;
       } else {
         asFortran << ':';
         Fortran::semantics::MaybeExpr upper =

--- a/flang/test/Lower/OpenACC/acc-cache.f90
+++ b/flang/test/Lower/OpenACC/acc-cache.f90
@@ -1,5 +1,4 @@
 ! This test checks lowering of OpenACC cache directive.
-! XFAIL: *
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 ! CHECK-LABEL: acc.private.recipe @privatization_ref_i32 : !fir.ref<i32> init {

--- a/flang/test/Lower/OpenACC/acc-enter-data.f90
+++ b/flang/test/Lower/OpenACC/acc-enter-data.f90
@@ -1,5 +1,4 @@
 ! This test checks lowering of OpenACC enter data directive.
-! XFAIL: *
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
 
 module mod1

--- a/flang/test/Lower/OpenACC/acc-use-device-remapping.f90
+++ b/flang/test/Lower/OpenACC/acc-use-device-remapping.f90
@@ -1,6 +1,5 @@
 ! Test remapping of component references in data clauses.
 ! RUN: bbc -fopenacc -emit-hlfir %s -o - | FileCheck %s
-! XFAIL: *
 module mhdata_types
   type t_scalar
       integer :: x


### PR DESCRIPTION
There was divergence between amd-staging and main in `genBoundsOps` (see changes). The divergence comes from the very initial flang commit and the upstream version makes more sense to me. `check-flang` succeeds with the changes in the PR.

Resolves: https://amd-hub.atlassian.net/browse/LCOMPILER-1522.
