### PR TITLE
[Clang][Flang][AMDGPU] Skip visibility flags when driver is in Flang mode

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -920,7 +920,8 @@ void AMDGPUToolChain::addClangTargetOptions(
   // Default to "hidden" visibility, as object level linking will not be
   // supported for the foreseeable future.
   if (!DriverArgs.hasArg(options::OPT_fvisibility_EQ,
-                         options::OPT_fvisibility_ms_compat)) {
+                         options::OPT_fvisibility_ms_compat) &&
+      !getDriver().IsFlangMode()) {
     CC1Args.push_back("-fvisibility=hidden");
     CC1Args.push_back("-fapply-global-visibility-to-externs");
   }

--- a/flang/test/Lower/AMDGPU/allocate_deallocate_runtime_calls.f90
+++ b/flang/test/Lower/AMDGPU/allocate_deallocate_runtime_calls.f90
@@ -1,6 +1,6 @@
 ! RUN: %flang -target amdgcn-- -mmlir -use-alloc-runtime -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK
 ! RUN: %flang -target amdgcn-- -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK-NO-FLAG
-! XFAIL: *
+
 ! Test to check if usage of flag -use-alloc-runtime results in runtime calls.
 
 subroutine allocate_deallocate()

--- a/flang/test/Lower/AMDGPU/allocate_runtime_alloc_idx.f90
+++ b/flang/test/Lower/AMDGPU/allocate_runtime_alloc_idx.f90
@@ -1,5 +1,5 @@
 ! RUN: %flang -target amdgcn-- -ffast-amd-memory-allocator -S -emit-llvm %s -o - | FileCheck %s --check-prefix=CHECK
-! XFAIL: *
+
 subroutine allocate_deallocate()
   real, allocatable :: x
 ! CHECK: call void @_FortranAAMDAllocatableSetAllocIdx({{.*}}, i32 1)


### PR DESCRIPTION
After commit be1bc283c610 ("[Clang] Permit '--target=amdgcn--' for binaries"), using '-target amdgcn--' with Flang will now route us through the AMDGPUToolChain. This causes addClangTargetOptions() to be called, which adds some unsupported options in Flang to the argument list specifically in the xfail'd test examples the '-fvisibility=hidden' and '-fapply-global-visibility-to-externs' flags. This will then cause compilation failures due to unrecognized arguments.

This patch adds a check for IsFlangMode() to skip adding these visibility flags when the driver is invoked as Flang. This seems to follow what's done elsewhere in the other driver and ToolChain bits (Driver.cpp, Gnu.cpp, Darwin.cpp) to handle Flang-specific behavior.


