### PR TITLE
[GCNScheduler] Add memory-type-aware cluster sizing with latency scaling

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -1656,12 +1656,17 @@ public:
   /// cluster if this hook returns true.
   /// \p NumBytes is the number of bytes that will be loaded from all the
   /// clustered loads if this hook returns true.
+  /// \p MaxConsumerLatency is the maximum latency among data-dependent
+  /// consumers of the first memory operation in the cluster (the cluster
+  /// "anchor"). Targets can use this to scale cluster size limits: longer
+  /// consumer pipelines (e.g. MFMA) allow more loads to be pipelined behind
+  /// the consumer, enabling deeper clusters. 0 means unknown/unavailable.
   virtual bool shouldClusterMemOps(ArrayRef<const MachineOperand *> BaseOps1,
                                    int64_t Offset1, bool OffsetIsScalable1,
                                    ArrayRef<const MachineOperand *> BaseOps2,
                                    int64_t Offset2, bool OffsetIsScalable2,
-                                   unsigned ClusterSize,
-                                   unsigned NumBytes) const {
+                                   unsigned ClusterSize, unsigned NumBytes,
+                                   unsigned MaxConsumerLatency = 0) const {
     llvm_unreachable("target did not implement shouldClusterMemOps()");
   }
 

--- a/llvm/lib/CodeGen/MachineScheduler.cpp
+++ b/llvm/lib/CodeGen/MachineScheduler.cpp
@@ -2112,10 +2112,19 @@ void BaseMemOpClusterMutation::clusterNeighboringMemOps(
       CurrentClusterBytes = Bytes + MemOpb.Width.getValue().getKnownMinValue();
     }
 
-    if (!TII->shouldClusterMemOps(MemOpa.BaseOps, MemOpa.Offset,
-                                  MemOpa.OffsetIsScalable, MemOpb.BaseOps,
-                                  MemOpb.Offset, MemOpb.OffsetIsScalable,
-                                  ClusterLength, CurrentClusterBytes))
+    // Compute the maximum latency among data-dependent consumers of the
+    // cluster anchor so targets can scale the cluster budget for pipelining.
+    unsigned MaxConsumerLatency = 0;
+    for (const SDep &Succ : MemOpa.SU->Succs)
+      if (Succ.getKind() == SDep::Data && Succ.getSUnit()->getInstr())
+        MaxConsumerLatency =
+            std::max(MaxConsumerLatency,
+                     static_cast<unsigned>(Succ.getSUnit()->Latency));
+
+    if (!TII->shouldClusterMemOps(
+            MemOpa.BaseOps, MemOpa.Offset, MemOpa.OffsetIsScalable,
+            MemOpb.BaseOps, MemOpb.Offset, MemOpb.OffsetIsScalable,
+            ClusterLength, CurrentClusterBytes, MaxConsumerLatency))
       continue;
 
     SUnit *SUa = MemOpa.SU;

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.cpp
@@ -5331,7 +5331,7 @@ bool AArch64InstrInfo::shouldClusterMemOps(
     ArrayRef<const MachineOperand *> BaseOps1, int64_t OpOffset1,
     bool OffsetIsScalable1, ArrayRef<const MachineOperand *> BaseOps2,
     int64_t OpOffset2, bool OffsetIsScalable2, unsigned ClusterSize,
-    unsigned NumBytes) const {
+    unsigned NumBytes, unsigned MaxConsumerLatency) const {
   assert(BaseOps1.size() == 1 && BaseOps2.size() == 1);
   const MachineOperand &BaseOp1 = *BaseOps1.front();
   const MachineOperand &BaseOp2 = *BaseOps2.front();

--- a/llvm/lib/Target/AArch64/AArch64InstrInfo.h
+++ b/llvm/lib/Target/AArch64/AArch64InstrInfo.h
@@ -350,8 +350,8 @@ public:
                            int64_t Offset1, bool OffsetIsScalable1,
                            ArrayRef<const MachineOperand *> BaseOps2,
                            int64_t Offset2, bool OffsetIsScalable2,
-                           unsigned ClusterSize,
-                           unsigned NumBytes) const override;
+                           unsigned ClusterSize, unsigned NumBytes,
+                           unsigned MaxConsumerLatency = 0) const override;
 
   void copyPhysRegTuple(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                         const DebugLoc &DL, MCRegister DestReg,

--- a/llvm/lib/Target/AMDGPU/GCNSubtarget.h
+++ b/llvm/lib/Target/AMDGPU/GCNSubtarget.h
@@ -925,6 +925,29 @@ public:
                              SDep &Dep,
                              const TargetSchedModel *SchedModel) const override;
 
+  // \returns the maximum number of DWORDs that can be clustered for DS/LDS
+  // memory operations. DS loads are low-latency and benefit from deeper
+  // clusters to pipeline behind long-latency consumers (e.g. MFMA).
+  unsigned getMaxDSClusterDWords() const { return 16; }
+
+  // \returns the maximum number of DWORDs that can be clustered for VMEM
+  // (MUBUF/MTBUF/MIMG) memory operations.
+  unsigned getMaxVMEMClusterDWords() const {
+    return DefaultMemoryClusterDWordsLimit;
+  }
+
+  // \returns the maximum number of DWORDs that can be clustered for SMEM
+  // memory operations.
+  unsigned getMaxSMEMClusterDWords() const {
+    return DefaultMemoryClusterDWordsLimit;
+  }
+
+  // \returns the maximum number of DWORDs that can be clustered for Flat
+  // memory operations.
+  unsigned getMaxFlatClusterDWords() const {
+    return DefaultMemoryClusterDWordsLimit;
+  }
+
   // \returns true if it's beneficial on this subtarget for the scheduler to
   // cluster stores as well as loads.
   bool shouldClusterStores() const { return getGeneration() >= GFX11; }

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -568,23 +568,48 @@ bool SIInstrInfo::shouldClusterMemOps(ArrayRef<const MachineOperand *> BaseOps1,
                                       int64_t Offset1, bool OffsetIsScalable1,
                                       ArrayRef<const MachineOperand *> BaseOps2,
                                       int64_t Offset2, bool OffsetIsScalable2,
-                                      unsigned ClusterSize,
-                                      unsigned NumBytes) const {
+                                      unsigned ClusterSize, unsigned NumBytes,
+                                      unsigned MaxConsumerLatency) const {
+  if (BaseOps1.empty() || BaseOps2.empty())
+    return false;
+
   // If the mem ops (to be clustered) do not have the same base ptr, then they
   // should not be clustered
   unsigned MaxMemoryClusterDWords = DefaultMemoryClusterDWordsLimit;
-  if (!BaseOps1.empty() && !BaseOps2.empty()) {
-    const MachineInstr &FirstLdSt = *BaseOps1.front()->getParent();
-    const MachineInstr &SecondLdSt = *BaseOps2.front()->getParent();
-    if (!memOpsHaveSameBasePtr(FirstLdSt, BaseOps1, SecondLdSt, BaseOps2))
-      return false;
-
-    const SIMachineFunctionInfo *MFI =
-        FirstLdSt.getMF()->getInfo<SIMachineFunctionInfo>();
-    MaxMemoryClusterDWords = MFI->getMaxMemoryClusterDWords();
-  } else if (!BaseOps1.empty() || !BaseOps2.empty()) {
-    // If only one base op is empty, they do not have the same base ptr
+  const MachineInstr &FirstLdSt = *BaseOps1.front()->getParent();
+  const MachineInstr &SecondLdSt = *BaseOps2.front()->getParent();
+  if (!memOpsHaveSameBasePtr(FirstLdSt, BaseOps1, SecondLdSt, BaseOps2))
     return false;
+
+  // Select the cluster DWORD budget based on the memory type. Different
+  // address spaces have different latency profiles and pipelining
+  // characteristics; DS/LDS loads are low-latency and benefit from deeper
+  // clusters to allow the scheduler to pipeline them behind long-latency
+  // consumers like MFMA.
+  const MachineFunction *MF = FirstLdSt.getMF();
+  const GCNSubtarget &ST = MF->getSubtarget<GCNSubtarget>();
+  if (isDS(FirstLdSt))
+    MaxMemoryClusterDWords = ST.getMaxDSClusterDWords();
+  else if (isMUBUF(FirstLdSt) || isMTBUF(FirstLdSt) || isMIMG(FirstLdSt))
+    MaxMemoryClusterDWords = ST.getMaxVMEMClusterDWords();
+  else if (isSMRD(FirstLdSt))
+    MaxMemoryClusterDWords = ST.getMaxSMEMClusterDWords();
+  else if (isFLAT(FirstLdSt))
+    MaxMemoryClusterDWords = ST.getMaxFlatClusterDWords();
+
+  // When consumer latency information is available, scale the cluster budget
+  // to exploit pipelining. If the consumer pipeline is long (e.g. MFMA at
+  // 8-16 cycles), more loads can execute behind it, so allow deeper clusters.
+  if (MaxConsumerLatency > 0) {
+    unsigned MemLatency = SchedModel.computeInstrLatency(&FirstLdSt);
+    if (MemLatency > 0 && MaxConsumerLatency > MemLatency) {
+      unsigned LoadDWords = ((NumBytes / std::max(ClusterSize, 1U)) + 3) / 4;
+      if (LoadDWords > 0) {
+        unsigned PipelineSlots = MaxConsumerLatency / MemLatency;
+        unsigned ScaledLimit = PipelineSlots * LoadDWords * ClusterSize;
+        MaxMemoryClusterDWords = std::max(MaxMemoryClusterDWords, ScaledLimit);
+      }
+    }
   }
 
   // In order to avoid register pressure, on an average, the number of DWORDS

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.h
@@ -283,8 +283,8 @@ public:
                            int64_t Offset1, bool OffsetIsScalable1,
                            ArrayRef<const MachineOperand *> BaseOps2,
                            int64_t Offset2, bool OffsetIsScalable2,
-                           unsigned ClusterSize,
-                           unsigned NumBytes) const override;
+                           unsigned ClusterSize, unsigned NumBytes,
+                           unsigned MaxConsumerLatency = 0) const override;
 
   bool shouldScheduleLoadsNear(SDNode *Load0, SDNode *Load1, int64_t Offset0,
                                int64_t Offset1, unsigned NumLoads) const override;

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.cpp
@@ -2945,7 +2945,7 @@ bool PPCInstrInfo::shouldClusterMemOps(
     ArrayRef<const MachineOperand *> BaseOps1, int64_t OpOffset1,
     bool OffsetIsScalable1, ArrayRef<const MachineOperand *> BaseOps2,
     int64_t OpOffset2, bool OffsetIsScalable2, unsigned ClusterSize,
-    unsigned NumBytes) const {
+    unsigned NumBytes, unsigned MaxConsumerLatency) const {
 
   assert(BaseOps1.size() == 1 && BaseOps2.size() == 1);
   const MachineOperand &BaseOp1 = *BaseOps1.front();

--- a/llvm/lib/Target/PowerPC/PPCInstrInfo.h
+++ b/llvm/lib/Target/PowerPC/PPCInstrInfo.h
@@ -686,8 +686,8 @@ public:
                            int64_t Offset1, bool OffsetIsScalable1,
                            ArrayRef<const MachineOperand *> BaseOps2,
                            int64_t Offset2, bool OffsetIsScalable2,
-                           unsigned ClusterSize,
-                           unsigned NumBytes) const override;
+                           unsigned ClusterSize, unsigned NumBytes,
+                           unsigned MaxConsumerLatency = 0) const override;
 
   /// Return true if two MIs access different memory addresses and false
   /// otherwise

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.cpp
@@ -3494,7 +3494,7 @@ bool RISCVInstrInfo::shouldClusterMemOps(
     ArrayRef<const MachineOperand *> BaseOps1, int64_t Offset1,
     bool OffsetIsScalable1, ArrayRef<const MachineOperand *> BaseOps2,
     int64_t Offset2, bool OffsetIsScalable2, unsigned ClusterSize,
-    unsigned NumBytes) const {
+    unsigned NumBytes, unsigned MaxConsumerLatency) const {
   // If the mem ops (to be clustered) do not have the same base ptr, then they
   // should not be clustered
   if (!BaseOps1.empty() && !BaseOps2.empty()) {

--- a/llvm/lib/Target/RISCV/RISCVInstrInfo.h
+++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.h
@@ -203,8 +203,8 @@ public:
                            int64_t Offset1, bool OffsetIsScalable1,
                            ArrayRef<const MachineOperand *> BaseOps2,
                            int64_t Offset2, bool OffsetIsScalable2,
-                           unsigned ClusterSize,
-                           unsigned NumBytes) const override;
+                           unsigned ClusterSize, unsigned NumBytes,
+                           unsigned MaxConsumerLatency = 0) const override;
 
   bool getMemOperandWithOffsetWidth(const MachineInstr &LdSt,
                                     const MachineOperand *&BaseOp,

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/load-local.128.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/load-local.128.ll
@@ -52,39 +52,38 @@ define <4 x i32> @load_lds_v4i32_align1(ptr addrspace(3) %ptr) {
 ; GFX9-NEXT:    ds_read_u8 v6, v0 offset:5
 ; GFX9-NEXT:    ds_read_u8 v7, v0 offset:6
 ; GFX9-NEXT:    ds_read_u8 v8, v0 offset:7
-; GFX9-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX9-NEXT:    v_lshl_or_b32 v1, v2, 8, v1
-; GFX9-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 24, v4
-; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_or3_b32 v4, v2, v3, v1
-; GFX9-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX9-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX9-NEXT:    ds_read_u8 v10, v0 offset:9
+; GFX9-NEXT:    ds_read_u8 v11, v0 offset:10
+; GFX9-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX9-NEXT:    ds_read_u8 v13, v0 offset:12
+; GFX9-NEXT:    ds_read_u8 v14, v0 offset:13
+; GFX9-NEXT:    ds_read_u8 v15, v0 offset:14
+; GFX9-NEXT:    ds_read_u8 v16, v0 offset:15
+; GFX9-NEXT:    s_waitcnt lgkmcnt(14)
+; GFX9-NEXT:    v_lshl_or_b32 v0, v2, 8, v1
+; GFX9-NEXT:    s_waitcnt lgkmcnt(12)
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 24, v4
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX9-NEXT:    v_or3_b32 v0, v1, v2, v0
+; GFX9-NEXT:    s_waitcnt lgkmcnt(10)
 ; GFX9-NEXT:    v_lshl_or_b32 v1, v6, 8, v5
-; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NEXT:    s_waitcnt lgkmcnt(8)
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 24, v8
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
 ; GFX9-NEXT:    v_or3_b32 v1, v2, v3, v1
-; GFX9-NEXT:    ds_read_u8 v2, v0 offset:8
-; GFX9-NEXT:    ds_read_u8 v3, v0 offset:9
-; GFX9-NEXT:    ds_read_u8 v5, v0 offset:10
-; GFX9-NEXT:    ds_read_u8 v6, v0 offset:11
-; GFX9-NEXT:    ds_read_u8 v7, v0 offset:12
-; GFX9-NEXT:    ds_read_u8 v8, v0 offset:13
-; GFX9-NEXT:    ds_read_u8 v9, v0 offset:14
-; GFX9-NEXT:    ds_read_u8 v0, v0 offset:15
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX9-NEXT:    v_lshl_or_b32 v2, v3, 8, v2
+; GFX9-NEXT:    v_lshl_or_b32 v2, v10, 8, v9
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 24, v6
-; GFX9-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; GFX9-NEXT:    v_or3_b32 v2, v3, v5, v2
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 24, v12
+; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 16, v11
+; GFX9-NEXT:    v_or3_b32 v2, v3, v4, v2
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-NEXT:    v_lshl_or_b32 v3, v8, 8, v7
+; GFX9-NEXT:    v_lshl_or_b32 v3, v14, 8, v13
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 24, v0
-; GFX9-NEXT:    v_lshlrev_b32_e32 v5, 16, v9
-; GFX9-NEXT:    v_or3_b32 v3, v0, v5, v3
-; GFX9-NEXT:    v_mov_b32_e32 v0, v4
+; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 24, v16
+; GFX9-NEXT:    v_lshlrev_b32_e32 v5, 16, v15
+; GFX9-NEXT:    v_or3_b32 v3, v4, v5, v3
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-LABEL: load_lds_v4i32_align1:
@@ -99,47 +98,46 @@ define <4 x i32> @load_lds_v4i32_align1(ptr addrspace(3) %ptr) {
 ; GFX7-NEXT:    ds_read_u8 v6, v0 offset:5
 ; GFX7-NEXT:    ds_read_u8 v7, v0 offset:6
 ; GFX7-NEXT:    ds_read_u8 v8, v0 offset:7
-; GFX7-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
-; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v4
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX7-NEXT:    v_or_b32_e32 v4, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX7-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX7-NEXT:    ds_read_u8 v10, v0 offset:9
+; GFX7-NEXT:    ds_read_u8 v11, v0 offset:10
+; GFX7-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX7-NEXT:    ds_read_u8 v13, v0 offset:12
+; GFX7-NEXT:    ds_read_u8 v14, v0 offset:13
+; GFX7-NEXT:    ds_read_u8 v15, v0 offset:14
+; GFX7-NEXT:    ds_read_u8 v16, v0 offset:15
+; GFX7-NEXT:    s_waitcnt lgkmcnt(14)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(12)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 24, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-NEXT:    s_waitcnt lgkmcnt(10)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v6
-; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_waitcnt lgkmcnt(8)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v8
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
 ; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
 ; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
 ; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    ds_read_u8 v2, v0 offset:8
-; GFX7-NEXT:    ds_read_u8 v3, v0 offset:9
-; GFX7-NEXT:    ds_read_u8 v5, v0 offset:10
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:11
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:12
-; GFX7-NEXT:    ds_read_u8 v8, v0 offset:13
-; GFX7-NEXT:    ds_read_u8 v9, v0 offset:14
-; GFX7-NEXT:    ds_read_u8 v0, v0 offset:15
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
-; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v10
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 24, v6
-; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v5
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 24, v12
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v11
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v9
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v4
 ; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v8
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v14
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 24, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 16, v9
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v7
-; GFX7-NEXT:    v_or_b32_e32 v0, v0, v5
-; GFX7-NEXT:    v_or_b32_e32 v3, v0, v3
-; GFX7-NEXT:    v_mov_b32_e32 v0, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 24, v16
+; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 16, v15
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v13
+; GFX7-NEXT:    v_or_b32_e32 v4, v4, v5
+; GFX7-NEXT:    v_or_b32_e32 v3, v4, v3
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: load_lds_v4i32_align1:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/load-local.96.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/load-local.96.ll
@@ -52,30 +52,28 @@ define <3 x i32> @load_lds_v3i32_align1(ptr addrspace(3) %ptr) {
 ; GFX9-NEXT:    ds_read_u8 v6, v0 offset:5
 ; GFX9-NEXT:    ds_read_u8 v7, v0 offset:6
 ; GFX9-NEXT:    ds_read_u8 v8, v0 offset:7
+; GFX9-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX9-NEXT:    ds_read_u8 v10, v0 offset:9
+; GFX9-NEXT:    ds_read_u8 v11, v0 offset:10
+; GFX9-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX9-NEXT:    s_waitcnt lgkmcnt(10)
+; GFX9-NEXT:    v_lshl_or_b32 v0, v2, 8, v1
+; GFX9-NEXT:    s_waitcnt lgkmcnt(8)
+; GFX9-NEXT:    v_lshlrev_b32_e32 v1, 24, v4
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX9-NEXT:    v_or3_b32 v0, v1, v2, v0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX9-NEXT:    v_lshl_or_b32 v1, v2, 8, v1
-; GFX9-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 24, v4
-; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX9-NEXT:    v_or3_b32 v3, v2, v3, v1
-; GFX9-NEXT:    s_waitcnt lgkmcnt(2)
 ; GFX9-NEXT:    v_lshl_or_b32 v1, v6, 8, v5
-; GFX9-NEXT:    ds_read_u8 v2, v0 offset:8
-; GFX9-NEXT:    ds_read_u8 v4, v0 offset:9
-; GFX9-NEXT:    ds_read_u8 v5, v0 offset:10
-; GFX9-NEXT:    ds_read_u8 v0, v0 offset:11
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v6, 24, v8
-; GFX9-NEXT:    v_lshlrev_b32_e32 v7, 16, v7
+; GFX9-NEXT:    v_lshlrev_b32_e32 v2, 24, v8
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
+; GFX9-NEXT:    v_or3_b32 v1, v2, v3, v1
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-NEXT:    v_lshl_or_b32 v2, v4, 8, v2
-; GFX9-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 16, v5
+; GFX9-NEXT:    v_lshl_or_b32 v2, v10, 8, v9
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 24, v0
-; GFX9-NEXT:    v_or3_b32 v1, v6, v7, v1
-; GFX9-NEXT:    v_or3_b32 v2, v0, v4, v2
-; GFX9-NEXT:    v_mov_b32_e32 v0, v3
+; GFX9-NEXT:    v_lshlrev_b32_e32 v3, 24, v12
+; GFX9-NEXT:    v_lshlrev_b32_e32 v4, 16, v11
+; GFX9-NEXT:    v_or3_b32 v2, v3, v4, v2
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX7-LABEL: load_lds_v3i32_align1:
@@ -90,36 +88,34 @@ define <3 x i32> @load_lds_v3i32_align1(ptr addrspace(3) %ptr) {
 ; GFX7-NEXT:    ds_read_u8 v6, v0 offset:5
 ; GFX7-NEXT:    ds_read_u8 v7, v0 offset:6
 ; GFX7-NEXT:    ds_read_u8 v8, v0 offset:7
+; GFX7-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX7-NEXT:    ds_read_u8 v10, v0 offset:9
+; GFX7-NEXT:    ds_read_u8 v11, v0 offset:10
+; GFX7-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX7-NEXT:    s_waitcnt lgkmcnt(10)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(8)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 24, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
-; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v4
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX7-NEXT:    v_or_b32_e32 v3, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v6
-; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
-; GFX7-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v7
-; GFX7-NEXT:    ds_read_u8 v5, v0 offset:8
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:9
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:10
-; GFX7-NEXT:    ds_read_u8 v0, v0 offset:11
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v8
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
 ; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v6
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v10
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 24, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v7
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v5
-; GFX7-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX7-NEXT:    v_or_b32_e32 v2, v0, v2
-; GFX7-NEXT:    v_mov_b32_e32 v0, v3
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 24, v12
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v11
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v9
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v4
+; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: load_lds_v3i32_align1:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/load-unaligned.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/load-unaligned.ll
@@ -30,47 +30,46 @@ define <4 x i32> @load_lds_v4i32_align1(ptr addrspace(3) %ptr) {
 ; GFX7-NEXT:    ds_read_u8 v6, v0 offset:5
 ; GFX7-NEXT:    ds_read_u8 v7, v0 offset:6
 ; GFX7-NEXT:    ds_read_u8 v8, v0 offset:7
-; GFX7-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
-; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v4
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX7-NEXT:    v_or_b32_e32 v4, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX7-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX7-NEXT:    ds_read_u8 v10, v0 offset:9
+; GFX7-NEXT:    ds_read_u8 v11, v0 offset:10
+; GFX7-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX7-NEXT:    ds_read_u8 v13, v0 offset:12
+; GFX7-NEXT:    ds_read_u8 v14, v0 offset:13
+; GFX7-NEXT:    ds_read_u8 v15, v0 offset:14
+; GFX7-NEXT:    ds_read_u8 v16, v0 offset:15
+; GFX7-NEXT:    s_waitcnt lgkmcnt(14)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(12)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 24, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-NEXT:    s_waitcnt lgkmcnt(10)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v6
-; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    s_waitcnt lgkmcnt(8)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v8
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
 ; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
 ; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
 ; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    ds_read_u8 v2, v0 offset:8
-; GFX7-NEXT:    ds_read_u8 v3, v0 offset:9
-; GFX7-NEXT:    ds_read_u8 v5, v0 offset:10
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:11
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:12
-; GFX7-NEXT:    ds_read_u8 v8, v0 offset:13
-; GFX7-NEXT:    ds_read_u8 v9, v0 offset:14
-; GFX7-NEXT:    ds_read_u8 v0, v0 offset:15
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v3
-; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v10
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 24, v6
-; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 16, v5
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v5
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 24, v12
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v11
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v9
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v4
 ; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v8
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v14
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 24, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 16, v9
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v7
-; GFX7-NEXT:    v_or_b32_e32 v0, v0, v5
-; GFX7-NEXT:    v_or_b32_e32 v3, v0, v3
-; GFX7-NEXT:    v_mov_b32_e32 v0, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 24, v16
+; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 16, v15
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v13
+; GFX7-NEXT:    v_or_b32_e32 v4, v4, v5
+; GFX7-NEXT:    v_or_b32_e32 v3, v4, v3
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: load_lds_v4i32_align1:
@@ -112,36 +111,34 @@ define <3 x i32> @load_lds_v3i32_align1(ptr addrspace(3) %ptr) {
 ; GFX7-NEXT:    ds_read_u8 v6, v0 offset:5
 ; GFX7-NEXT:    ds_read_u8 v7, v0 offset:6
 ; GFX7-NEXT:    ds_read_u8 v8, v0 offset:7
+; GFX7-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX7-NEXT:    ds_read_u8 v10, v0 offset:9
+; GFX7-NEXT:    ds_read_u8 v11, v0 offset:10
+; GFX7-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX7-NEXT:    s_waitcnt lgkmcnt(10)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(8)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 24, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v3
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v2
-; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v4
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
-; GFX7-NEXT:    v_or_b32_e32 v3, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v6
-; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
-; GFX7-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v7
-; GFX7-NEXT:    ds_read_u8 v5, v0 offset:8
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:9
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:10
-; GFX7-NEXT:    ds_read_u8 v0, v0 offset:11
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 24, v8
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v4
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v7
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v3
 ; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v6
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v10
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 24, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v7
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v5
-; GFX7-NEXT:    v_or_b32_e32 v0, v0, v4
-; GFX7-NEXT:    v_or_b32_e32 v2, v0, v2
-; GFX7-NEXT:    v_mov_b32_e32 v0, v3
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 24, v12
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v11
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v9
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v4
+; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX10-LABEL: load_lds_v3i32_align1:

--- a/llvm/test/CodeGen/AMDGPU/GlobalISel/store-local.128.ll
+++ b/llvm/test/CodeGen/AMDGPU/GlobalISel/store-local.128.ll
@@ -237,49 +237,49 @@ define amdgpu_kernel void @store_lds_v4i32_align1(ptr addrspace(3) %out, <4 x i3
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x10
 ; GFX11-NEXT:    s_load_b32 s4, s[4:5], 0x0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_and_b32 s6, 0xffff, s0
 ; GFX11-NEXT:    s_lshr_b32 s5, s0, 16
+; GFX11-NEXT:    s_and_b32 s6, 0xffff, s0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s4
 ; GFX11-NEXT:    s_lshr_b32 s0, s0, 24
-; GFX11-NEXT:    s_lshr_b32 s4, s1, 16
 ; GFX11-NEXT:    s_and_b32 s7, 0xffff, s1
-; GFX11-NEXT:    s_lshr_b32 s6, s6, 8
+; GFX11-NEXT:    s_lshr_b32 s4, s1, 16
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s2
 ; GFX11-NEXT:    s_lshr_b32 s1, s1, 24
+; GFX11-NEXT:    s_and_b32 s9, 0xffff, s2
 ; GFX11-NEXT:    v_dual_mov_b32 v4, s5 :: v_dual_mov_b32 v5, s0
 ; GFX11-NEXT:    s_lshr_b32 s0, s7, 8
-; GFX11-NEXT:    v_dual_mov_b32 v6, s4 :: v_dual_mov_b32 v7, s6
-; GFX11-NEXT:    s_and_b32 s9, 0xffff, s2
-; GFX11-NEXT:    v_dual_mov_b32 v8, s1 :: v_dual_mov_b32 v9, s0
-; GFX11-NEXT:    s_lshr_b32 s0, s2, 24
+; GFX11-NEXT:    s_lshr_b32 s8, s2, 16
+; GFX11-NEXT:    s_lshr_b32 s6, s6, 8
+; GFX11-NEXT:    v_dual_mov_b32 v6, s4 :: v_dual_mov_b32 v7, s1
 ; GFX11-NEXT:    s_lshr_b32 s1, s9, 8
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-NEXT:    v_dual_mov_b32 v10, s0 :: v_dual_mov_b32 v11, s1
+; GFX11-NEXT:    s_and_b32 s0, 0xffff, s3
+; GFX11-NEXT:    v_dual_mov_b32 v8, s8 :: v_dual_mov_b32 v9, s6
+; GFX11-NEXT:    s_lshr_b32 s0, s0, 8
+; GFX11-NEXT:    s_lshr_b32 s2, s2, 24
+; GFX11-NEXT:    s_lshr_b32 s1, s3, 16
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
+; GFX11-NEXT:    v_dual_mov_b32 v14, s0 :: v_dual_mov_b32 v15, s1
+; GFX11-NEXT:    s_lshr_b32 s0, s3, 24
+; GFX11-NEXT:    v_dual_mov_b32 v12, s2 :: v_dual_mov_b32 v13, s3
+; GFX11-NEXT:    v_mov_b32_e32 v16, s0
 ; GFX11-NEXT:    ds_store_b8 v1, v0
-; GFX11-NEXT:    ds_store_b8 v1, v7 offset:1
+; GFX11-NEXT:    ds_store_b8 v1, v9 offset:1
 ; GFX11-NEXT:    ds_store_b8 v1, v4 offset:2
 ; GFX11-NEXT:    ds_store_b8 v1, v5 offset:3
 ; GFX11-NEXT:    ds_store_b8 v1, v2 offset:4
-; GFX11-NEXT:    ds_store_b8 v1, v9 offset:5
+; GFX11-NEXT:    ds_store_b8 v1, v10 offset:5
 ; GFX11-NEXT:    ds_store_b8 v1, v6 offset:6
-; GFX11-NEXT:    ds_store_b8 v1, v8 offset:7
-; GFX11-NEXT:    v_mov_b32_e32 v4, s0
-; GFX11-NEXT:    s_and_b32 s0, 0xffff, s3
-; GFX11-NEXT:    s_lshr_b32 s8, s2, 16
-; GFX11-NEXT:    v_dual_mov_b32 v0, s1 :: v_dual_mov_b32 v5, s3
-; GFX11-NEXT:    s_lshr_b32 s0, s0, 8
-; GFX11-NEXT:    s_lshr_b32 s1, s3, 16
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v2, s8 :: v_dual_mov_b32 v7, s1
-; GFX11-NEXT:    v_mov_b32_e32 v6, s0
-; GFX11-NEXT:    s_lshr_b32 s0, s3, 24
-; GFX11-NEXT:    v_mov_b32_e32 v8, s0
+; GFX11-NEXT:    ds_store_b8 v1, v7 offset:7
 ; GFX11-NEXT:    ds_store_b8 v1, v3 offset:8
-; GFX11-NEXT:    ds_store_b8 v1, v0 offset:9
-; GFX11-NEXT:    ds_store_b8 v1, v2 offset:10
-; GFX11-NEXT:    ds_store_b8 v1, v4 offset:11
-; GFX11-NEXT:    ds_store_b8 v1, v5 offset:12
-; GFX11-NEXT:    ds_store_b8 v1, v6 offset:13
-; GFX11-NEXT:    ds_store_b8 v1, v7 offset:14
-; GFX11-NEXT:    ds_store_b8 v1, v8 offset:15
+; GFX11-NEXT:    ds_store_b8 v1, v11 offset:9
+; GFX11-NEXT:    ds_store_b8 v1, v8 offset:10
+; GFX11-NEXT:    ds_store_b8 v1, v12 offset:11
+; GFX11-NEXT:    ds_store_b8 v1, v13 offset:12
+; GFX11-NEXT:    ds_store_b8 v1, v14 offset:13
+; GFX11-NEXT:    ds_store_b8 v1, v15 offset:14
+; GFX11-NEXT:    ds_store_b8 v1, v16 offset:15
 ; GFX11-NEXT:    s_endpgm
   store <4 x i32> %x, ptr addrspace(3) %out, align 1
   ret void

--- a/llvm/test/CodeGen/AMDGPU/add.ll
+++ b/llvm/test/CodeGen/AMDGPU/add.ll
@@ -575,27 +575,27 @@ define amdgpu_kernel void @s_add_v16i32(ptr addrspace(1) %out, <16 x i32> %a, <1
 ;
 ; GFX9-LABEL: s_add_v16i32:
 ; GFX9:       ; %bb.0: ; %entry
-; GFX9-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x64
-; GFX9-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
+; GFX9-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
+; GFX9-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0x64
 ; GFX9-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    s_add_i32 s4, s9, s37
-; GFX9-NEXT:    s_add_i32 s5, s8, s36
-; GFX9-NEXT:    s_add_i32 s6, s15, s43
-; GFX9-NEXT:    s_add_i32 s7, s14, s42
-; GFX9-NEXT:    s_add_i32 s8, s13, s41
-; GFX9-NEXT:    s_add_i32 s9, s12, s40
-; GFX9-NEXT:    s_add_i32 s12, s17, s45
-; GFX9-NEXT:    s_add_i32 s13, s16, s44
-; GFX9-NEXT:    s_add_i32 s14, s23, s51
-; GFX9-NEXT:    s_add_i32 s15, s22, s50
-; GFX9-NEXT:    s_add_i32 s16, s21, s49
-; GFX9-NEXT:    s_add_i32 s17, s20, s48
-; GFX9-NEXT:    s_add_i32 s2, s11, s39
-; GFX9-NEXT:    s_add_i32 s3, s10, s38
-; GFX9-NEXT:    s_add_i32 s10, s19, s47
-; GFX9-NEXT:    s_add_i32 s11, s18, s46
+; GFX9-NEXT:    s_add_i32 s4, s37, s9
+; GFX9-NEXT:    s_add_i32 s5, s36, s8
+; GFX9-NEXT:    s_add_i32 s6, s43, s15
+; GFX9-NEXT:    s_add_i32 s7, s42, s14
+; GFX9-NEXT:    s_add_i32 s8, s41, s13
+; GFX9-NEXT:    s_add_i32 s9, s40, s12
+; GFX9-NEXT:    s_add_i32 s12, s45, s17
+; GFX9-NEXT:    s_add_i32 s13, s44, s16
+; GFX9-NEXT:    s_add_i32 s14, s51, s23
+; GFX9-NEXT:    s_add_i32 s15, s50, s22
+; GFX9-NEXT:    s_add_i32 s16, s49, s21
+; GFX9-NEXT:    s_add_i32 s17, s48, s20
+; GFX9-NEXT:    s_add_i32 s2, s39, s11
+; GFX9-NEXT:    s_add_i32 s3, s38, s10
+; GFX9-NEXT:    s_add_i32 s10, s47, s19
+; GFX9-NEXT:    s_add_i32 s11, s46, s18
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s17
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s16
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s15
@@ -624,27 +624,27 @@ define amdgpu_kernel void @s_add_v16i32(ptr addrspace(1) %out, <16 x i32> %a, <1
 ; GFX10-LABEL: s_add_v16i32:
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_clause 0x2
-; GFX10-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x64
-; GFX10-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
+; GFX10-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
+; GFX10-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0x64
 ; GFX10-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX10-NEXT:    v_mov_b32_e32 v16, 0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    s_add_i32 s4, s9, s37
-; GFX10-NEXT:    s_add_i32 s5, s8, s36
-; GFX10-NEXT:    s_add_i32 s6, s15, s43
-; GFX10-NEXT:    s_add_i32 s7, s14, s42
-; GFX10-NEXT:    s_add_i32 s8, s13, s41
-; GFX10-NEXT:    s_add_i32 s9, s12, s40
-; GFX10-NEXT:    s_add_i32 s12, s17, s45
-; GFX10-NEXT:    s_add_i32 s13, s16, s44
-; GFX10-NEXT:    s_add_i32 s14, s23, s51
-; GFX10-NEXT:    s_add_i32 s15, s22, s50
-; GFX10-NEXT:    s_add_i32 s16, s20, s48
-; GFX10-NEXT:    s_add_i32 s17, s21, s49
-; GFX10-NEXT:    s_add_i32 s2, s11, s39
-; GFX10-NEXT:    s_add_i32 s3, s10, s38
-; GFX10-NEXT:    s_add_i32 s10, s19, s47
-; GFX10-NEXT:    s_add_i32 s11, s18, s46
+; GFX10-NEXT:    s_add_i32 s4, s37, s9
+; GFX10-NEXT:    s_add_i32 s5, s36, s8
+; GFX10-NEXT:    s_add_i32 s6, s43, s15
+; GFX10-NEXT:    s_add_i32 s7, s42, s14
+; GFX10-NEXT:    s_add_i32 s8, s41, s13
+; GFX10-NEXT:    s_add_i32 s9, s40, s12
+; GFX10-NEXT:    s_add_i32 s12, s45, s17
+; GFX10-NEXT:    s_add_i32 s13, s44, s16
+; GFX10-NEXT:    s_add_i32 s14, s51, s23
+; GFX10-NEXT:    s_add_i32 s15, s50, s22
+; GFX10-NEXT:    s_add_i32 s16, s48, s20
+; GFX10-NEXT:    s_add_i32 s17, s49, s21
+; GFX10-NEXT:    s_add_i32 s2, s39, s11
+; GFX10-NEXT:    s_add_i32 s3, s38, s10
+; GFX10-NEXT:    s_add_i32 s10, s47, s19
+; GFX10-NEXT:    s_add_i32 s11, s46, s18
 ; GFX10-NEXT:    v_mov_b32_e32 v0, s16
 ; GFX10-NEXT:    v_mov_b32_e32 v1, s17
 ; GFX10-NEXT:    v_mov_b32_e32 v2, s15
@@ -670,26 +670,26 @@ define amdgpu_kernel void @s_add_v16i32(ptr addrspace(1) %out, <16 x i32> %a, <1
 ; GFX11-LABEL: s_add_v16i32:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_clause 0x2
-; GFX11-NEXT:    s_load_b512 s[8:23], s[4:5], 0x64
-; GFX11-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4
+; GFX11-NEXT:    s_load_b512 s[8:23], s[4:5], 0xa4
+; GFX11-NEXT:    s_load_b512 s[36:51], s[4:5], 0x64
 ; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_add_i32 s4, s9, s37
-; GFX11-NEXT:    s_add_i32 s5, s8, s36
-; GFX11-NEXT:    s_add_i32 s6, s15, s43
-; GFX11-NEXT:    s_add_i32 s7, s14, s42
-; GFX11-NEXT:    s_add_i32 s8, s13, s41
-; GFX11-NEXT:    s_add_i32 s9, s12, s40
-; GFX11-NEXT:    s_add_i32 s12, s17, s45
-; GFX11-NEXT:    s_add_i32 s13, s16, s44
-; GFX11-NEXT:    s_add_i32 s14, s23, s51
-; GFX11-NEXT:    s_add_i32 s15, s22, s50
-; GFX11-NEXT:    s_add_i32 s16, s20, s48
-; GFX11-NEXT:    s_add_i32 s17, s21, s49
-; GFX11-NEXT:    s_add_i32 s2, s11, s39
-; GFX11-NEXT:    s_add_i32 s3, s10, s38
-; GFX11-NEXT:    s_add_i32 s10, s19, s47
-; GFX11-NEXT:    s_add_i32 s11, s18, s46
+; GFX11-NEXT:    s_add_i32 s4, s37, s9
+; GFX11-NEXT:    s_add_i32 s5, s36, s8
+; GFX11-NEXT:    s_add_i32 s6, s43, s15
+; GFX11-NEXT:    s_add_i32 s7, s42, s14
+; GFX11-NEXT:    s_add_i32 s8, s41, s13
+; GFX11-NEXT:    s_add_i32 s9, s40, s12
+; GFX11-NEXT:    s_add_i32 s12, s45, s17
+; GFX11-NEXT:    s_add_i32 s13, s44, s16
+; GFX11-NEXT:    s_add_i32 s14, s51, s23
+; GFX11-NEXT:    s_add_i32 s15, s50, s22
+; GFX11-NEXT:    s_add_i32 s16, s48, s20
+; GFX11-NEXT:    s_add_i32 s17, s49, s21
+; GFX11-NEXT:    s_add_i32 s2, s39, s11
+; GFX11-NEXT:    s_add_i32 s3, s38, s10
+; GFX11-NEXT:    s_add_i32 s10, s47, s19
+; GFX11-NEXT:    s_add_i32 s11, s46, s18
 ; GFX11-NEXT:    v_dual_mov_b32 v16, 0 :: v_dual_mov_b32 v1, s17
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s16 :: v_dual_mov_b32 v3, s14
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s15 :: v_dual_mov_b32 v5, s12
@@ -709,26 +709,26 @@ define amdgpu_kernel void @s_add_v16i32(ptr addrspace(1) %out, <16 x i32> %a, <1
 ; GFX12-LABEL: s_add_v16i32:
 ; GFX12:       ; %bb.0: ; %entry
 ; GFX12-NEXT:    s_clause 0x2
-; GFX12-NEXT:    s_load_b512 s[8:23], s[4:5], 0x64
-; GFX12-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4
+; GFX12-NEXT:    s_load_b512 s[8:23], s[4:5], 0xa4
+; GFX12-NEXT:    s_load_b512 s[36:51], s[4:5], 0x64
 ; GFX12-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_add_co_i32 s4, s9, s37
-; GFX12-NEXT:    s_add_co_i32 s5, s8, s36
-; GFX12-NEXT:    s_add_co_i32 s6, s15, s43
-; GFX12-NEXT:    s_add_co_i32 s7, s14, s42
-; GFX12-NEXT:    s_add_co_i32 s8, s13, s41
-; GFX12-NEXT:    s_add_co_i32 s9, s12, s40
-; GFX12-NEXT:    s_add_co_i32 s12, s17, s45
-; GFX12-NEXT:    s_add_co_i32 s13, s16, s44
-; GFX12-NEXT:    s_add_co_i32 s14, s23, s51
-; GFX12-NEXT:    s_add_co_i32 s15, s22, s50
-; GFX12-NEXT:    s_add_co_i32 s16, s20, s48
-; GFX12-NEXT:    s_add_co_i32 s17, s21, s49
-; GFX12-NEXT:    s_add_co_i32 s2, s11, s39
-; GFX12-NEXT:    s_add_co_i32 s3, s10, s38
-; GFX12-NEXT:    s_add_co_i32 s10, s19, s47
-; GFX12-NEXT:    s_add_co_i32 s11, s18, s46
+; GFX12-NEXT:    s_add_co_i32 s4, s37, s9
+; GFX12-NEXT:    s_add_co_i32 s5, s36, s8
+; GFX12-NEXT:    s_add_co_i32 s6, s43, s15
+; GFX12-NEXT:    s_add_co_i32 s7, s42, s14
+; GFX12-NEXT:    s_add_co_i32 s8, s41, s13
+; GFX12-NEXT:    s_add_co_i32 s9, s40, s12
+; GFX12-NEXT:    s_add_co_i32 s12, s45, s17
+; GFX12-NEXT:    s_add_co_i32 s13, s44, s16
+; GFX12-NEXT:    s_add_co_i32 s14, s51, s23
+; GFX12-NEXT:    s_add_co_i32 s15, s50, s22
+; GFX12-NEXT:    s_add_co_i32 s16, s48, s20
+; GFX12-NEXT:    s_add_co_i32 s17, s49, s21
+; GFX12-NEXT:    s_add_co_i32 s2, s39, s11
+; GFX12-NEXT:    s_add_co_i32 s3, s38, s10
+; GFX12-NEXT:    s_add_co_i32 s10, s47, s19
+; GFX12-NEXT:    s_add_co_i32 s11, s46, s18
 ; GFX12-NEXT:    v_dual_mov_b32 v16, 0 :: v_dual_mov_b32 v1, s17
 ; GFX12-NEXT:    v_dual_mov_b32 v0, s16 :: v_dual_mov_b32 v3, s14
 ; GFX12-NEXT:    v_dual_mov_b32 v2, s15 :: v_dual_mov_b32 v5, s12

--- a/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.1024bit.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgcn.bitcast.1024bit.ll
@@ -26441,6 +26441,9 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v9
 ; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v12
 ; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_store_dword v55, off, s[0:3], s32 offset:344 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    buffer_load_dword v55, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
@@ -26449,10 +26452,9 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_mov_b32_e32 v37, v36
 ; SI-NEXT:    v_mov_b32_e32 v36, v47
 ; SI-NEXT:    v_mov_b32_e32 v50, v49
-; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
 ; SI-NEXT:    v_mov_b32_e32 v40, v41
 ; SI-NEXT:    s_mov_b64 s[4:5], 0
-; SI-NEXT:    s_waitcnt vmcnt(6)
+; SI-NEXT:    s_waitcnt vmcnt(7)
 ; SI-NEXT:    v_lshr_b64 v[0:1], v[0:1], 16
 ; SI-NEXT:    v_mov_b32_e32 v1, v43
 ; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:328 ; 4-byte Folded Spill
@@ -26503,6 +26505,8 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v44, v45
+; SI-NEXT:    s_waitcnt vmcnt(14)
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
 ; SI-NEXT:    v_mov_b32_e32 v32, v59
 ; SI-NEXT:    s_waitcnt vmcnt(4)
 ; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v9
@@ -26597,6 +26601,9 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v29
 ; SI-NEXT:    v_mov_b32_e32 v39, v62
+; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v58, v56
 ; SI-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
@@ -26611,9 +26618,8 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_lshr_b64 v[21:22], v[22:23], 16
 ; SI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v55
-; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v22
 ; SI-NEXT:    v_lshr_b64 v[22:23], v[37:38], 16
 ; SI-NEXT:    v_lshr_b64 v[23:24], v[46:47], 16
@@ -26623,11 +26629,6 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_lshr_b64 v[27:28], v[42:43], 16
 ; SI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
-; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v45, v44
 ; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:188 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:192 ; 4-byte Folded Reload
@@ -26635,7 +26636,7 @@ define inreg <32 x i32> @bitcast_v64bf16_to_v32i32_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_mov_b32_e32 v36, v37
 ; SI-NEXT:    v_mov_b32_e32 v49, v50
 ; SI-NEXT:    v_mov_b32_e32 v51, v33
-; SI-NEXT:    s_waitcnt vmcnt(4)
+; SI-NEXT:    s_waitcnt vmcnt(2)
 ; SI-NEXT:    v_lshr_b64 v[28:29], v[28:29], 16
 ; SI-NEXT:    v_lshr_b64 v[29:30], v[40:41], 16
 ; SI-NEXT:    v_lshr_b64 v[30:31], v[54:55], 16
@@ -62525,6 +62526,9 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v9
 ; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v12
 ; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_store_dword v55, off, s[0:3], s32 offset:344 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    buffer_load_dword v55, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
@@ -62533,10 +62537,9 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    v_mov_b32_e32 v37, v36
 ; SI-NEXT:    v_mov_b32_e32 v36, v47
 ; SI-NEXT:    v_mov_b32_e32 v50, v49
-; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
 ; SI-NEXT:    v_mov_b32_e32 v40, v41
 ; SI-NEXT:    s_mov_b64 s[4:5], 0
-; SI-NEXT:    s_waitcnt vmcnt(6)
+; SI-NEXT:    s_waitcnt vmcnt(7)
 ; SI-NEXT:    v_lshr_b64 v[0:1], v[0:1], 16
 ; SI-NEXT:    v_mov_b32_e32 v1, v43
 ; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:328 ; 4-byte Folded Spill
@@ -62587,6 +62590,8 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v44, v45
+; SI-NEXT:    s_waitcnt vmcnt(14)
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
 ; SI-NEXT:    v_mov_b32_e32 v32, v59
 ; SI-NEXT:    s_waitcnt vmcnt(4)
 ; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v9
@@ -62681,6 +62686,9 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v29
 ; SI-NEXT:    v_mov_b32_e32 v39, v62
+; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v58, v56
 ; SI-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
@@ -62695,9 +62703,8 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_lshr_b64 v[21:22], v[22:23], 16
 ; SI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v55
-; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v22
 ; SI-NEXT:    v_lshr_b64 v[22:23], v[37:38], 16
 ; SI-NEXT:    v_lshr_b64 v[23:24], v[46:47], 16
@@ -62707,11 +62714,6 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    v_lshr_b64 v[27:28], v[42:43], 16
 ; SI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
-; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v45, v44
 ; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:188 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:192 ; 4-byte Folded Reload
@@ -62719,7 +62721,7 @@ define inreg <32 x float> @bitcast_v64bf16_to_v32f32_scalar(<64 x bfloat> inreg 
 ; SI-NEXT:    v_mov_b32_e32 v36, v37
 ; SI-NEXT:    v_mov_b32_e32 v49, v50
 ; SI-NEXT:    v_mov_b32_e32 v51, v33
-; SI-NEXT:    s_waitcnt vmcnt(4)
+; SI-NEXT:    s_waitcnt vmcnt(2)
 ; SI-NEXT:    v_lshr_b64 v[28:29], v[28:29], 16
 ; SI-NEXT:    v_lshr_b64 v[29:30], v[40:41], 16
 ; SI-NEXT:    v_lshr_b64 v[30:31], v[54:55], 16
@@ -96190,6 +96192,9 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v9
 ; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v12
 ; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_store_dword v55, off, s[0:3], s32 offset:344 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    buffer_load_dword v55, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
@@ -96198,10 +96203,9 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_mov_b32_e32 v37, v36
 ; SI-NEXT:    v_mov_b32_e32 v36, v47
 ; SI-NEXT:    v_mov_b32_e32 v50, v49
-; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
 ; SI-NEXT:    v_mov_b32_e32 v40, v41
 ; SI-NEXT:    s_mov_b64 s[4:5], 0
-; SI-NEXT:    s_waitcnt vmcnt(6)
+; SI-NEXT:    s_waitcnt vmcnt(7)
 ; SI-NEXT:    v_lshr_b64 v[0:1], v[0:1], 16
 ; SI-NEXT:    v_mov_b32_e32 v1, v43
 ; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:328 ; 4-byte Folded Spill
@@ -96252,6 +96256,8 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v44, v45
+; SI-NEXT:    s_waitcnt vmcnt(14)
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
 ; SI-NEXT:    v_mov_b32_e32 v32, v59
 ; SI-NEXT:    s_waitcnt vmcnt(4)
 ; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v9
@@ -96346,6 +96352,9 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v29
 ; SI-NEXT:    v_mov_b32_e32 v39, v62
+; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v58, v56
 ; SI-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
@@ -96360,9 +96369,8 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_lshr_b64 v[21:22], v[22:23], 16
 ; SI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v55
-; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v22
 ; SI-NEXT:    v_lshr_b64 v[22:23], v[37:38], 16
 ; SI-NEXT:    v_lshr_b64 v[23:24], v[46:47], 16
@@ -96372,11 +96380,6 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_lshr_b64 v[27:28], v[42:43], 16
 ; SI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
-; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v45, v44
 ; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:188 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:192 ; 4-byte Folded Reload
@@ -96384,7 +96387,7 @@ define inreg <16 x i64> @bitcast_v64bf16_to_v16i64_scalar(<64 x bfloat> inreg %a
 ; SI-NEXT:    v_mov_b32_e32 v36, v37
 ; SI-NEXT:    v_mov_b32_e32 v49, v50
 ; SI-NEXT:    v_mov_b32_e32 v51, v33
-; SI-NEXT:    s_waitcnt vmcnt(4)
+; SI-NEXT:    s_waitcnt vmcnt(2)
 ; SI-NEXT:    v_lshr_b64 v[28:29], v[28:29], 16
 ; SI-NEXT:    v_lshr_b64 v[29:30], v[40:41], 16
 ; SI-NEXT:    v_lshr_b64 v[30:31], v[54:55], 16
@@ -129259,6 +129262,9 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    v_lshrrev_b32_e32 v24, 16, v9
 ; SI-NEXT:    v_lshrrev_b32_e32 v28, 16, v12
 ; SI-NEXT:    buffer_store_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
+; SI-NEXT:    s_waitcnt expcnt(0)
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_store_dword v55, off, s[0:3], s32 offset:344 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    buffer_load_dword v55, off, s[0:3], s32 offset:120 ; 4-byte Folded Reload
@@ -129267,10 +129273,9 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    v_mov_b32_e32 v37, v36
 ; SI-NEXT:    v_mov_b32_e32 v36, v47
 ; SI-NEXT:    v_mov_b32_e32 v50, v49
-; SI-NEXT:    buffer_store_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Spill
 ; SI-NEXT:    v_mov_b32_e32 v40, v41
 ; SI-NEXT:    s_mov_b64 s[4:5], 0
-; SI-NEXT:    s_waitcnt vmcnt(6)
+; SI-NEXT:    s_waitcnt vmcnt(7)
 ; SI-NEXT:    v_lshr_b64 v[0:1], v[0:1], 16
 ; SI-NEXT:    v_mov_b32_e32 v1, v43
 ; SI-NEXT:    buffer_store_dword v1, off, s[0:3], s32 offset:328 ; 4-byte Folded Spill
@@ -129321,6 +129326,8 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    buffer_load_dword v20, off, s[0:3], s32 offset:100 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v21, off, s[0:3], s32 offset:96 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v44, v45
+; SI-NEXT:    s_waitcnt vmcnt(14)
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
 ; SI-NEXT:    v_mov_b32_e32 v32, v59
 ; SI-NEXT:    s_waitcnt vmcnt(4)
 ; SI-NEXT:    v_lshrrev_b32_e32 v26, 16, v9
@@ -129415,6 +129422,9 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v34, 16, v29
 ; SI-NEXT:    v_mov_b32_e32 v39, v62
+; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
+; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
+; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v58, v56
 ; SI-NEXT:    buffer_store_dword v33, off, s[0:3], s32 offset:60 ; 4-byte Folded Spill
 ; SI-NEXT:    buffer_store_dword v34, off, s[0:3], s32 offset:64 ; 4-byte Folded Spill
@@ -129429,9 +129439,8 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    s_waitcnt expcnt(0)
 ; SI-NEXT:    v_lshr_b64 v[21:22], v[22:23], 16
 ; SI-NEXT:    buffer_load_dword v22, off, s[0:3], s32 offset:128 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:112 ; 4-byte Folded Reload
 ; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v55
-; SI-NEXT:    s_waitcnt vmcnt(1)
+; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    v_lshrrev_b32_e32 v38, 16, v22
 ; SI-NEXT:    v_lshr_b64 v[22:23], v[37:38], 16
 ; SI-NEXT:    v_lshr_b64 v[23:24], v[46:47], 16
@@ -129441,11 +129450,6 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    v_lshr_b64 v[27:28], v[42:43], 16
 ; SI-NEXT:    buffer_load_dword v28, off, s[0:3], s32 offset:60 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v29, off, s[0:3], s32 offset:64 ; 4-byte Folded Reload
-; SI-NEXT:    s_waitcnt vmcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v53
-; SI-NEXT:    v_lshr_b64 v[61:62], v[52:53], 16
-; SI-NEXT:    buffer_load_dword v53, off, s[0:3], s32 offset:340 ; 4-byte Folded Reload
-; SI-NEXT:    buffer_load_dword v62, off, s[0:3], s32 offset:336 ; 4-byte Folded Reload
 ; SI-NEXT:    v_mov_b32_e32 v45, v44
 ; SI-NEXT:    buffer_load_dword v43, off, s[0:3], s32 offset:188 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v44, off, s[0:3], s32 offset:192 ; 4-byte Folded Reload
@@ -129453,7 +129457,7 @@ define inreg <16 x double> @bitcast_v64bf16_to_v16f64_scalar(<64 x bfloat> inreg
 ; SI-NEXT:    v_mov_b32_e32 v36, v37
 ; SI-NEXT:    v_mov_b32_e32 v49, v50
 ; SI-NEXT:    v_mov_b32_e32 v51, v33
-; SI-NEXT:    s_waitcnt vmcnt(4)
+; SI-NEXT:    s_waitcnt vmcnt(2)
 ; SI-NEXT:    v_lshr_b64 v[28:29], v[28:29], 16
 ; SI-NEXT:    v_lshr_b64 v[29:30], v[40:41], 16
 ; SI-NEXT:    v_lshr_b64 v[30:31], v[54:55], 16

--- a/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-idiv.ll
+++ b/llvm/test/CodeGen/AMDGPU/amdgpu-codegenprepare-idiv.ll
@@ -1849,12 +1849,12 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; GFX6-NEXT:    v_cvt_f32_u32_e32 v0, s0
 ; GFX6-NEXT:    s_sub_i32 s1, 0, s0
 ; GFX6-NEXT:    s_xor_b32 s2, s8, s12
+; GFX6-NEXT:    s_ashr_i32 s6, s2, 31
 ; GFX6-NEXT:    v_rcp_iflag_f32_e32 v0, v0
 ; GFX6-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
 ; GFX6-NEXT:    v_cvt_u32_f32_e32 v0, v0
 ; GFX6-NEXT:    v_mul_lo_u32 v1, s1, v0
 ; GFX6-NEXT:    s_abs_i32 s1, s8
-; GFX6-NEXT:    s_ashr_i32 s8, s2, 31
 ; GFX6-NEXT:    v_mul_hi_u32 v1, v0, v1
 ; GFX6-NEXT:    v_add_i32_e32 v0, vcc, v0, v1
 ; GFX6-NEXT:    v_mul_hi_u32 v0, s1, v0
@@ -1872,87 +1872,87 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; GFX6-NEXT:    v_cvt_f32_u32_e32 v2, s2
 ; GFX6-NEXT:    s_sub_i32 s3, 0, s2
 ; GFX6-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX6-NEXT:    s_xor_b32 s6, s9, s13
+; GFX6-NEXT:    s_xor_b32 s7, s9, s13
 ; GFX6-NEXT:    v_rcp_iflag_f32_e32 v2, v2
+; GFX6-NEXT:    s_ashr_i32 s7, s7, 31
 ; GFX6-NEXT:    v_add_i32_e32 v1, vcc, 1, v0
-; GFX6-NEXT:    v_cndmask_b32_e64 v0, v0, v1, s[0:1]
 ; GFX6-NEXT:    v_mul_f32_e32 v2, 0x4f7ffffe, v2
 ; GFX6-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX6-NEXT:    v_xor_b32_e32 v0, s8, v0
+; GFX6-NEXT:    v_cndmask_b32_e64 v0, v0, v1, s[0:1]
+; GFX6-NEXT:    v_xor_b32_e32 v0, s6, v0
 ; GFX6-NEXT:    v_mul_lo_u32 v3, s3, v2
 ; GFX6-NEXT:    s_abs_i32 s3, s9
-; GFX6-NEXT:    s_ashr_i32 s9, s6, 31
 ; GFX6-NEXT:    v_mul_hi_u32 v3, v2, v3
 ; GFX6-NEXT:    v_add_i32_e32 v2, vcc, v2, v3
 ; GFX6-NEXT:    v_mul_hi_u32 v2, s3, v2
-; GFX6-NEXT:    v_readfirstlane_b32 s6, v2
-; GFX6-NEXT:    s_mul_i32 s6, s6, s2
-; GFX6-NEXT:    s_sub_i32 s3, s3, s6
-; GFX6-NEXT:    s_sub_i32 s6, s3, s2
+; GFX6-NEXT:    v_readfirstlane_b32 s8, v2
+; GFX6-NEXT:    s_mul_i32 s8, s8, s2
+; GFX6-NEXT:    s_sub_i32 s3, s3, s8
+; GFX6-NEXT:    s_sub_i32 s8, s3, s2
 ; GFX6-NEXT:    s_cmp_ge_u32 s3, s2
 ; GFX6-NEXT:    v_add_i32_e32 v3, vcc, 1, v2
-; GFX6-NEXT:    s_cselect_b32 s3, s6, s3
+; GFX6-NEXT:    s_cselect_b32 s3, s8, s3
 ; GFX6-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GFX6-NEXT:    s_cmp_ge_u32 s3, s2
 ; GFX6-NEXT:    s_cselect_b64 s[2:3], -1, 0
-; GFX6-NEXT:    s_abs_i32 s6, s14
-; GFX6-NEXT:    v_cvt_f32_u32_e32 v4, s6
-; GFX6-NEXT:    s_sub_i32 s7, 0, s6
+; GFX6-NEXT:    s_abs_i32 s8, s14
+; GFX6-NEXT:    v_cvt_f32_u32_e32 v4, s8
+; GFX6-NEXT:    s_sub_i32 s9, 0, s8
 ; GFX6-NEXT:    v_cndmask_b32_e32 v2, v2, v3, vcc
-; GFX6-NEXT:    v_add_i32_e32 v3, vcc, 1, v2
+; GFX6-NEXT:    s_xor_b32 s4, s10, s14
 ; GFX6-NEXT:    v_rcp_iflag_f32_e32 v4, v4
+; GFX6-NEXT:    v_add_i32_e32 v3, vcc, 1, v2
 ; GFX6-NEXT:    v_mul_f32_e32 v4, 0x4f7ffffe, v4
 ; GFX6-NEXT:    v_cvt_u32_f32_e32 v4, v4
-; GFX6-NEXT:    v_mul_lo_u32 v5, s7, v4
-; GFX6-NEXT:    s_abs_i32 s7, s10
-; GFX6-NEXT:    s_xor_b32 s10, s10, s14
-; GFX6-NEXT:    s_ashr_i32 s10, s10, 31
+; GFX6-NEXT:    v_mul_lo_u32 v5, s9, v4
+; GFX6-NEXT:    s_abs_i32 s9, s10
+; GFX6-NEXT:    s_ashr_i32 s10, s4, 31
 ; GFX6-NEXT:    v_mul_hi_u32 v5, v4, v5
 ; GFX6-NEXT:    v_add_i32_e32 v4, vcc, v4, v5
-; GFX6-NEXT:    v_mul_hi_u32 v4, s7, v4
-; GFX6-NEXT:    v_readfirstlane_b32 s12, v4
-; GFX6-NEXT:    s_mul_i32 s12, s12, s6
-; GFX6-NEXT:    s_sub_i32 s7, s7, s12
-; GFX6-NEXT:    s_sub_i32 s12, s7, s6
-; GFX6-NEXT:    s_cmp_ge_u32 s7, s6
+; GFX6-NEXT:    v_mul_hi_u32 v4, s9, v4
+; GFX6-NEXT:    v_readfirstlane_b32 s4, v4
+; GFX6-NEXT:    s_mul_i32 s4, s4, s8
+; GFX6-NEXT:    s_sub_i32 s4, s9, s4
+; GFX6-NEXT:    s_sub_i32 s5, s4, s8
+; GFX6-NEXT:    s_cmp_ge_u32 s4, s8
 ; GFX6-NEXT:    v_add_i32_e32 v5, vcc, 1, v4
-; GFX6-NEXT:    s_cselect_b32 s7, s12, s7
+; GFX6-NEXT:    s_cselect_b32 s4, s5, s4
 ; GFX6-NEXT:    s_cselect_b64 vcc, -1, 0
-; GFX6-NEXT:    s_cmp_ge_u32 s7, s6
-; GFX6-NEXT:    s_cselect_b64 s[6:7], -1, 0
-; GFX6-NEXT:    s_abs_i32 s12, s15
-; GFX6-NEXT:    v_cvt_f32_u32_e32 v6, s12
-; GFX6-NEXT:    s_sub_i32 s0, 0, s12
+; GFX6-NEXT:    s_cmp_ge_u32 s4, s8
+; GFX6-NEXT:    s_cselect_b64 s[4:5], -1, 0
+; GFX6-NEXT:    s_abs_i32 s8, s15
+; GFX6-NEXT:    v_cvt_f32_u32_e32 v6, s8
+; GFX6-NEXT:    s_sub_i32 s0, 0, s8
 ; GFX6-NEXT:    v_cndmask_b32_e32 v4, v4, v5, vcc
 ; GFX6-NEXT:    v_add_i32_e32 v5, vcc, 1, v4
 ; GFX6-NEXT:    v_rcp_iflag_f32_e32 v1, v6
 ; GFX6-NEXT:    s_abs_i32 s1, s11
-; GFX6-NEXT:    v_subrev_i32_e32 v0, vcc, s8, v0
+; GFX6-NEXT:    v_subrev_i32_e32 v0, vcc, s6, v0
 ; GFX6-NEXT:    v_mul_f32_e32 v1, 0x4f7ffffe, v1
 ; GFX6-NEXT:    v_cvt_u32_f32_e32 v6, v1
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, v2, v3, s[2:3]
-; GFX6-NEXT:    v_cndmask_b32_e64 v3, v4, v5, s[6:7]
-; GFX6-NEXT:    v_xor_b32_e32 v1, s9, v1
+; GFX6-NEXT:    v_cndmask_b32_e64 v3, v4, v5, s[4:5]
+; GFX6-NEXT:    v_xor_b32_e32 v1, s7, v1
 ; GFX6-NEXT:    v_mul_lo_u32 v2, s0, v6
 ; GFX6-NEXT:    s_xor_b32 s0, s11, s15
 ; GFX6-NEXT:    v_xor_b32_e32 v3, s10, v3
 ; GFX6-NEXT:    s_ashr_i32 s0, s0, 31
 ; GFX6-NEXT:    v_mul_hi_u32 v2, v6, v2
-; GFX6-NEXT:    v_subrev_i32_e32 v1, vcc, s9, v1
+; GFX6-NEXT:    v_subrev_i32_e32 v1, vcc, s7, v1
 ; GFX6-NEXT:    v_add_i32_e32 v2, vcc, v6, v2
 ; GFX6-NEXT:    v_mul_hi_u32 v4, s1, v2
 ; GFX6-NEXT:    v_subrev_i32_e32 v2, vcc, s10, v3
 ; GFX6-NEXT:    v_readfirstlane_b32 s2, v4
-; GFX6-NEXT:    s_mul_i32 s2, s2, s12
+; GFX6-NEXT:    s_mul_i32 s2, s2, s8
 ; GFX6-NEXT:    s_sub_i32 s1, s1, s2
-; GFX6-NEXT:    s_sub_i32 s2, s1, s12
+; GFX6-NEXT:    s_sub_i32 s2, s1, s8
 ; GFX6-NEXT:    v_add_i32_e32 v3, vcc, 1, v4
-; GFX6-NEXT:    s_cmp_ge_u32 s1, s12
+; GFX6-NEXT:    s_cmp_ge_u32 s1, s8
 ; GFX6-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v3, v4, v3, vcc
 ; GFX6-NEXT:    s_cselect_b32 s1, s2, s1
 ; GFX6-NEXT:    v_add_i32_e32 v4, vcc, 1, v3
-; GFX6-NEXT:    s_cmp_ge_u32 s1, s12
+; GFX6-NEXT:    s_cmp_ge_u32 s1, s8
 ; GFX6-NEXT:    s_cselect_b64 vcc, -1, 0
 ; GFX6-NEXT:    v_cndmask_b32_e32 v3, v3, v4, vcc
 ; GFX6-NEXT:    v_xor_b32_e32 v3, s0, v3
@@ -2014,66 +2014,66 @@ define amdgpu_kernel void @sdiv_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; GFX9-NEXT:    s_cselect_b32 s1, s6, s1
 ; GFX9-NEXT:    s_add_i32 s6, s0, 1
 ; GFX9-NEXT:    s_cmp_ge_u32 s1, s2
-; GFX9-NEXT:    s_cselect_b32 s0, s6, s0
-; GFX9-NEXT:    s_abs_i32 s1, s14
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v0, s1
-; GFX9-NEXT:    s_xor_b32 s0, s0, s3
-; GFX9-NEXT:    s_sub_i32 s7, 0, s1
-; GFX9-NEXT:    s_sub_i32 s3, s0, s3
+; GFX9-NEXT:    s_cselect_b32 s2, s6, s0
+; GFX9-NEXT:    s_abs_i32 s6, s14
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v0, s6
+; GFX9-NEXT:    s_xor_b32 s2, s2, s3
+; GFX9-NEXT:    s_sub_i32 s7, 0, s6
+; GFX9-NEXT:    s_sub_i32 s2, s2, s3
 ; GFX9-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GFX9-NEXT:    s_abs_i32 s6, s10
-; GFX9-NEXT:    s_xor_b32 s2, s10, s14
-; GFX9-NEXT:    s_ashr_i32 s2, s2, 31
+; GFX9-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9-NEXT:    s_abs_i32 s5, s10
+; GFX9-NEXT:    s_xor_b32 s4, s10, s14
 ; GFX9-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v0, v0
-; GFX9-NEXT:    v_mov_b32_e32 v1, s3
-; GFX9-NEXT:    v_readfirstlane_b32 s0, v0
-; GFX9-NEXT:    s_mul_i32 s7, s7, s0
-; GFX9-NEXT:    s_mul_hi_u32 s7, s0, s7
-; GFX9-NEXT:    s_add_i32 s0, s0, s7
-; GFX9-NEXT:    s_mul_hi_u32 s0, s6, s0
-; GFX9-NEXT:    s_mul_i32 s7, s0, s1
-; GFX9-NEXT:    s_sub_i32 s6, s6, s7
-; GFX9-NEXT:    s_add_i32 s9, s0, 1
-; GFX9-NEXT:    s_sub_i32 s7, s6, s1
-; GFX9-NEXT:    s_cmp_ge_u32 s6, s1
-; GFX9-NEXT:    s_cselect_b32 s0, s9, s0
-; GFX9-NEXT:    s_cselect_b32 s6, s7, s6
-; GFX9-NEXT:    s_add_i32 s7, s0, 1
-; GFX9-NEXT:    s_cmp_ge_u32 s6, s1
-; GFX9-NEXT:    s_cselect_b32 s6, s7, s0
-; GFX9-NEXT:    s_abs_i32 s7, s15
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v2, s7
-; GFX9-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GFX9-NEXT:    s_xor_b32 s5, s6, s2
-; GFX9-NEXT:    s_sub_i32 s6, 0, s7
+; GFX9-NEXT:    s_ashr_i32 s4, s4, 31
+; GFX9-NEXT:    v_mov_b32_e32 v1, s2
+; GFX9-NEXT:    v_readfirstlane_b32 s3, v0
+; GFX9-NEXT:    s_mul_i32 s7, s7, s3
+; GFX9-NEXT:    s_mul_hi_u32 s7, s3, s7
+; GFX9-NEXT:    s_add_i32 s3, s3, s7
+; GFX9-NEXT:    s_mul_hi_u32 s3, s5, s3
+; GFX9-NEXT:    s_mul_i32 s7, s3, s6
+; GFX9-NEXT:    s_sub_i32 s5, s5, s7
+; GFX9-NEXT:    s_add_i32 s9, s3, 1
+; GFX9-NEXT:    s_sub_i32 s7, s5, s6
+; GFX9-NEXT:    s_cmp_ge_u32 s5, s6
+; GFX9-NEXT:    s_cselect_b32 s3, s9, s3
+; GFX9-NEXT:    s_cselect_b32 s5, s7, s5
+; GFX9-NEXT:    s_add_i32 s7, s3, 1
+; GFX9-NEXT:    s_cmp_ge_u32 s5, s6
+; GFX9-NEXT:    s_cselect_b32 s3, s7, s3
+; GFX9-NEXT:    s_abs_i32 s5, s15
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v2, s5
+; GFX9-NEXT:    s_xor_b32 s3, s3, s4
+; GFX9-NEXT:    s_sub_i32 s7, 0, s5
+; GFX9-NEXT:    s_sub_i32 s3, s3, s4
 ; GFX9-NEXT:    v_rcp_iflag_f32_e32 v2, v2
-; GFX9-NEXT:    s_sub_i32 s2, s5, s2
-; GFX9-NEXT:    s_abs_i32 s4, s11
-; GFX9-NEXT:    s_xor_b32 s3, s11, s15
+; GFX9-NEXT:    s_abs_i32 s6, s11
+; GFX9-NEXT:    s_xor_b32 s2, s11, s15
+; GFX9-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX9-NEXT:    v_mul_f32_e32 v2, 0x4f7ffffe, v2
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v2, v2
-; GFX9-NEXT:    v_mov_b32_e32 v0, s8
-; GFX9-NEXT:    s_ashr_i32 s3, s3, 31
-; GFX9-NEXT:    v_readfirstlane_b32 s5, v2
-; GFX9-NEXT:    s_mul_i32 s6, s6, s5
-; GFX9-NEXT:    s_mul_hi_u32 s6, s5, s6
-; GFX9-NEXT:    s_add_i32 s5, s5, s6
-; GFX9-NEXT:    s_mul_hi_u32 s5, s4, s5
-; GFX9-NEXT:    s_mul_i32 s6, s5, s7
-; GFX9-NEXT:    s_sub_i32 s4, s4, s6
-; GFX9-NEXT:    s_add_i32 s8, s5, 1
-; GFX9-NEXT:    s_sub_i32 s6, s4, s7
-; GFX9-NEXT:    s_cmp_ge_u32 s4, s7
-; GFX9-NEXT:    s_cselect_b32 s5, s8, s5
-; GFX9-NEXT:    s_cselect_b32 s4, s6, s4
-; GFX9-NEXT:    s_add_i32 s6, s5, 1
-; GFX9-NEXT:    s_cmp_ge_u32 s4, s7
-; GFX9-NEXT:    s_cselect_b32 s4, s6, s5
-; GFX9-NEXT:    s_xor_b32 s4, s4, s3
-; GFX9-NEXT:    s_sub_i32 s3, s4, s3
-; GFX9-NEXT:    v_mov_b32_e32 v2, s2
-; GFX9-NEXT:    v_mov_b32_e32 v3, s3
+; GFX9-NEXT:    s_ashr_i32 s2, s2, 31
+; GFX9-NEXT:    v_readfirstlane_b32 s4, v2
+; GFX9-NEXT:    s_mul_i32 s7, s7, s4
+; GFX9-NEXT:    s_mul_hi_u32 s7, s4, s7
+; GFX9-NEXT:    s_add_i32 s4, s4, s7
+; GFX9-NEXT:    s_mul_hi_u32 s4, s6, s4
+; GFX9-NEXT:    s_mul_i32 s7, s4, s5
+; GFX9-NEXT:    s_sub_i32 s6, s6, s7
+; GFX9-NEXT:    s_add_i32 s8, s4, 1
+; GFX9-NEXT:    s_sub_i32 s7, s6, s5
+; GFX9-NEXT:    s_cmp_ge_u32 s6, s5
+; GFX9-NEXT:    s_cselect_b32 s4, s8, s4
+; GFX9-NEXT:    s_cselect_b32 s6, s7, s6
+; GFX9-NEXT:    s_add_i32 s7, s4, 1
+; GFX9-NEXT:    s_cmp_ge_u32 s6, s5
+; GFX9-NEXT:    s_cselect_b32 s4, s7, s4
+; GFX9-NEXT:    s_xor_b32 s4, s4, s2
+; GFX9-NEXT:    s_sub_i32 s2, s4, s2
+; GFX9-NEXT:    v_mov_b32_e32 v2, s3
+; GFX9-NEXT:    v_mov_b32_e32 v3, s2
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX9-NEXT:    s_endpgm
@@ -2313,16 +2313,16 @@ define amdgpu_kernel void @srem_v4i32(ptr addrspace(1) %out, <4 x i32> %x, <4 x 
 ; GFX6-NEXT:    s_cselect_b32 s9, s2, s0
 ; GFX6-NEXT:    s_abs_i32 s10, s15
 ; GFX6-NEXT:    v_cvt_f32_u32_e32 v0, s10
-; GFX6-NEXT:    s_sub_i32 s0, 0, s10
-; GFX6-NEXT:    s_mov_b32 s2, -1
+; GFX6-NEXT:    s_sub_i32 s2, 0, s10
+; GFX6-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
+; GFX6-NEXT:    s_abs_i32 s4, s11
 ; GFX6-NEXT:    v_rcp_iflag_f32_e32 v0, v0
+; GFX6-NEXT:    s_ashr_i32 s5, s11, 31
 ; GFX6-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
 ; GFX6-NEXT:    v_cvt_u32_f32_e32 v2, v0
 ; GFX6-NEXT:    v_mov_b32_e32 v0, s7
-; GFX6-NEXT:    v_mul_lo_u32 v1, s0, v2
-; GFX6-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
-; GFX6-NEXT:    s_abs_i32 s4, s11
-; GFX6-NEXT:    s_ashr_i32 s5, s11, 31
+; GFX6-NEXT:    v_mul_lo_u32 v1, s2, v2
+; GFX6-NEXT:    s_mov_b32 s2, -1
 ; GFX6-NEXT:    v_mul_hi_u32 v3, v2, v1
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s6
 ; GFX6-NEXT:    s_xor_b32 s6, s9, s8

--- a/llvm/test/CodeGen/AMDGPU/asyncmark-gfx12plus.ll
+++ b/llvm/test/CodeGen/AMDGPU/asyncmark-gfx12plus.ll
@@ -304,18 +304,19 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; SDAG-LABEL: test_pipelined_loop_with_global:
 ; SDAG:       ; %bb.0: ; %prolog
 ; SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; SDAG-NEXT:    s_clause 0x1
 ; SDAG-NEXT:    s_load_b96 s[8:10], s[4:5], 0x24 nv
-; SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
 ; SDAG-NEXT:    v_mov_b32_e32 v0, 0
+; SDAG-NEXT:    s_clause 0x1
+; SDAG-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
+; SDAG-NEXT:    s_load_b32 s11, s[4:5], 0x44 nv
 ; SDAG-NEXT:    s_wait_kmcnt 0x0
 ; SDAG-NEXT:    s_load_b32 s6, s[8:9], 0x0
 ; SDAG-NEXT:    s_load_b32 s7, s[0:1], 0x0
 ; SDAG-NEXT:    v_mov_b32_e32 v1, s10
-; SDAG-NEXT:    s_add_co_i32 s11, s10, 4
+; SDAG-NEXT:    s_add_co_i32 s4, s10, 4
 ; SDAG-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; SDAG-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_mov_b32 v4, s11
-; SDAG-NEXT:    s_load_b32 s11, s[4:5], 0x44 nv
+; SDAG-NEXT:    v_dual_mov_b32 v3, 4 :: v_dual_mov_b32 v4, s4
+; SDAG-NEXT:    s_add_nc_u64 s[4:5], s[8:9], 8
 ; SDAG-NEXT:    global_load_async_to_lds_b32 v1, v0, s[8:9] offset:4 nv
 ; SDAG-NEXT:    ; asyncmark
 ; SDAG-NEXT:    s_clause 0x1
@@ -323,7 +324,6 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; SDAG-NEXT:    global_load_b32 v2, v0, s[0:1] offset:4
 ; SDAG-NEXT:    s_wait_xcnt 0x0
 ; SDAG-NEXT:    s_add_nc_u64 s[0:1], s[0:1], 8
-; SDAG-NEXT:    s_add_nc_u64 s[4:5], s[8:9], 8
 ; SDAG-NEXT:    s_wait_kmcnt 0x0
 ; SDAG-NEXT:    v_dual_mov_b32 v5, s6 :: v_dual_mov_b32 v6, s7
 ; SDAG-NEXT:    s_mov_b64 s[6:7], s[2:3]
@@ -388,37 +388,35 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; GISEL-LABEL: test_pipelined_loop_with_global:
 ; GISEL:       ; %bb.0: ; %prolog
 ; GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GISEL-NEXT:    s_clause 0x1
+; GISEL-NEXT:    s_clause 0x2
 ; GISEL-NEXT:    s_load_b96 s[8:10], s[4:5], 0x24 nv
 ; GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x34 nv
+; GISEL-NEXT:    s_load_b32 s6, s[4:5], 0x44 nv
 ; GISEL-NEXT:    v_mov_b32_e32 v1, 0
-; GISEL-NEXT:    s_wait_xcnt 0x0
-; GISEL-NEXT:    s_load_b32 s4, s[4:5], 0x44 nv
-; GISEL-NEXT:    s_wait_xcnt 0x0
-; GISEL-NEXT:    s_mov_b32 s5, 2
 ; GISEL-NEXT:    s_wait_kmcnt 0x0
-; GISEL-NEXT:    s_load_b32 s11, s[8:9], 0x0
-; GISEL-NEXT:    s_load_b32 s12, s[0:1], 0x0
+; GISEL-NEXT:    s_load_b32 s7, s[8:9], 0x0
+; GISEL-NEXT:    s_load_b32 s11, s[0:1], 0x0
 ; GISEL-NEXT:    v_mov_b32_e32 v0, s10
-; GISEL-NEXT:    s_add_co_u32 s6, s10, 4
-; GISEL-NEXT:    v_dual_mov_b32 v9, s10 :: v_dual_mov_b32 v11, s5
+; GISEL-NEXT:    s_add_co_u32 s4, s10, 4
 ; GISEL-NEXT:    global_load_async_to_lds_b32 v0, v1, s[8:9] offset:4 nv
 ; GISEL-NEXT:    ; asyncmark
 ; GISEL-NEXT:    s_clause 0x1
 ; GISEL-NEXT:    global_load_b32 v6, v1, s[8:9] offset:4
 ; GISEL-NEXT:    global_load_b32 v7, v1, s[0:1] offset:4
 ; GISEL-NEXT:    s_wait_xcnt 0x0
-; GISEL-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, 4
+; GISEL-NEXT:    v_dual_mov_b32 v0, s4 :: v_dual_mov_b32 v1, 4
 ; GISEL-NEXT:    s_add_co_u32 s0, s0, 8
 ; GISEL-NEXT:    s_add_co_ci_u32 s1, s1, 0
-; GISEL-NEXT:    s_add_co_u32 s6, s8, 8
-; GISEL-NEXT:    s_add_co_ci_u32 s7, s9, 0
+; GISEL-NEXT:    s_add_co_u32 s4, s8, 8
+; GISEL-NEXT:    s_add_co_ci_u32 s5, s9, 0
 ; GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[0:1]
-; GISEL-NEXT:    v_mov_b64_e32 v[2:3], s[6:7]
+; GISEL-NEXT:    v_mov_b64_e32 v[2:3], s[4:5]
 ; GISEL-NEXT:    s_wait_kmcnt 0x0
-; GISEL-NEXT:    v_dual_mov_b32 v13, s11 :: v_dual_mov_b32 v15, s12
+; GISEL-NEXT:    v_dual_mov_b32 v13, s7 :: v_dual_mov_b32 v15, s11
 ; GISEL-NEXT:    global_load_async_to_lds_b32 v0, v1, s[8:9] offset:4 nv
+; GISEL-NEXT:    s_mov_b32 s8, 2
 ; GISEL-NEXT:    v_mov_b64_e32 v[0:1], s[2:3]
+; GISEL-NEXT:    v_dual_mov_b32 v9, s10 :: v_dual_mov_b32 v11, s8
 ; GISEL-NEXT:    s_wait_loadcnt 0x0
 ; GISEL-NEXT:    v_dual_mov_b32 v8, v6 :: v_dual_mov_b32 v12, v7
 ; GISEL-NEXT:    ; asyncmark
@@ -444,7 +442,7 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GISEL-NEXT:    v_add_co_ci_u32_e64 v3, null, 0, v3, vcc_lo
 ; GISEL-NEXT:    v_add_nc_u32_e32 v9, 4, v9
-; GISEL-NEXT:    v_cmp_gt_i32_e32 vcc_lo, s4, v11
+; GISEL-NEXT:    v_cmp_gt_i32_e32 vcc_lo, s6, v11
 ; GISEL-NEXT:    s_wait_dscnt 0x0
 ; GISEL-NEXT:    v_add3_u32 v16, v13, v15, v16
 ; GISEL-NEXT:    v_dual_mov_b32 v13, v6 :: v_dual_mov_b32 v15, v7
@@ -455,7 +453,7 @@ define amdgpu_kernel void @test_pipelined_loop_with_global(ptr addrspace(1) %foo
 ; GISEL-NEXT:    v_add_co_ci_u32_e64 v1, null, 0, v1, s0
 ; GISEL-NEXT:    s_cbranch_vccnz .LBB2_1
 ; GISEL-NEXT:  ; %bb.2: ; %epilog
-; GISEL-NEXT:    s_add_co_i32 s0, s4, -2
+; GISEL-NEXT:    s_add_co_i32 s0, s6, -2
 ; GISEL-NEXT:    ; wait_asyncmark(1)
 ; GISEL-NEXT:    s_wait_asynccnt 0x1
 ; GISEL-NEXT:    s_lshl_b32 s1, s0, 2

--- a/llvm/test/CodeGen/AMDGPU/buffer-fat-pointers-memcpy.ll
+++ b/llvm/test/CodeGen/AMDGPU/buffer-fat-pointers-memcpy.ll
@@ -1201,50 +1201,47 @@ define amdgpu_kernel void @memcpy_known_small(ptr addrspace(7) %src, ptr addrspa
 ; GISEL-GFX942:       ; %bb.0:
 ; GISEL-GFX942-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
 ; GISEL-GFX942-NEXT:    s_load_dword s11, s[4:5], 0x34
+; GISEL-GFX942-NEXT:    s_load_dwordx4 s[12:15], s[4:5], 0x44
 ; GISEL-GFX942-NEXT:    s_waitcnt lgkmcnt(0)
 ; GISEL-GFX942-NEXT:    s_mov_b32 s8, s1
 ; GISEL-GFX942-NEXT:    s_mov_b32 s9, s2
 ; GISEL-GFX942-NEXT:    s_mov_b32 s10, s3
 ; GISEL-GFX942-NEXT:    v_mov_b32_e32 v4, s0
 ; GISEL-GFX942-NEXT:    buffer_load_dwordx4 v[0:3], v4, s[8:11], 0 offen
-; GISEL-GFX942-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x44
-; GISEL-GFX942-NEXT:    s_load_dword s7, s[4:5], 0x54
-; GISEL-GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GISEL-GFX942-NEXT:    s_mov_b32 s4, s1
-; GISEL-GFX942-NEXT:    s_mov_b32 s5, s2
-; GISEL-GFX942-NEXT:    s_mov_b32 s6, s3
-; GISEL-GFX942-NEXT:    v_mov_b32_e32 v5, s0
-; GISEL-GFX942-NEXT:    s_waitcnt vmcnt(0)
-; GISEL-GFX942-NEXT:    buffer_store_dwordx4 v[0:3], v5, s[4:7], 0 offen
+; GISEL-GFX942-NEXT:    s_load_dword s3, s[4:5], 0x54
+; GISEL-GFX942-NEXT:    s_mov_b32 s0, s13
+; GISEL-GFX942-NEXT:    s_mov_b32 s1, s14
+; GISEL-GFX942-NEXT:    s_mov_b32 s2, s15
+; GISEL-GFX942-NEXT:    v_mov_b32_e32 v5, s12
+; GISEL-GFX942-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GISEL-GFX942-NEXT:    buffer_store_dwordx4 v[0:3], v5, s[0:3], 0 offen
 ; GISEL-GFX942-NEXT:    buffer_load_dwordx4 v[0:3], v4, s[8:11], 0 offen offset:16
 ; GISEL-GFX942-NEXT:    s_waitcnt vmcnt(0)
-; GISEL-GFX942-NEXT:    buffer_store_dwordx4 v[0:3], v5, s[4:7], 0 offen offset:16
+; GISEL-GFX942-NEXT:    buffer_store_dwordx4 v[0:3], v5, s[0:3], 0 offen offset:16
 ; GISEL-GFX942-NEXT:    s_endpgm
 ;
 ; GISEL-GFX1100-LABEL: memcpy_known_small:
 ; GISEL-GFX1100:       ; %bb.0:
-; GISEL-GFX1100-NEXT:    s_clause 0x1
+; GISEL-GFX1100-NEXT:    s_clause 0x2
 ; GISEL-GFX1100-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GISEL-GFX1100-NEXT:    s_load_b32 s11, s[4:5], 0x34
+; GISEL-GFX1100-NEXT:    s_load_b128 s[12:15], s[4:5], 0x44
 ; GISEL-GFX1100-NEXT:    s_waitcnt lgkmcnt(0)
 ; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v4, s0
 ; GISEL-GFX1100-NEXT:    s_mov_b32 s8, s1
 ; GISEL-GFX1100-NEXT:    s_mov_b32 s9, s2
 ; GISEL-GFX1100-NEXT:    s_mov_b32 s10, s3
-; GISEL-GFX1100-NEXT:    s_clause 0x1
-; GISEL-GFX1100-NEXT:    s_load_b128 s[0:3], s[4:5], 0x44
-; GISEL-GFX1100-NEXT:    s_load_b32 s7, s[4:5], 0x54
-; GISEL-GFX1100-NEXT:    s_waitcnt lgkmcnt(0)
-; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v5, s0
+; GISEL-GFX1100-NEXT:    v_mov_b32_e32 v5, s12
 ; GISEL-GFX1100-NEXT:    buffer_load_b128 v[0:3], v4, s[8:11], 0 offen
-; GISEL-GFX1100-NEXT:    s_mov_b32 s4, s1
-; GISEL-GFX1100-NEXT:    s_mov_b32 s5, s2
-; GISEL-GFX1100-NEXT:    s_mov_b32 s6, s3
-; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0)
-; GISEL-GFX1100-NEXT:    buffer_store_b128 v[0:3], v5, s[4:7], 0 offen
+; GISEL-GFX1100-NEXT:    s_load_b32 s3, s[4:5], 0x54
+; GISEL-GFX1100-NEXT:    s_mov_b32 s0, s13
+; GISEL-GFX1100-NEXT:    s_mov_b32 s1, s14
+; GISEL-GFX1100-NEXT:    s_mov_b32 s2, s15
+; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GISEL-GFX1100-NEXT:    buffer_store_b128 v[0:3], v5, s[0:3], 0 offen
 ; GISEL-GFX1100-NEXT:    buffer_load_b128 v[0:3], v4, s[8:11], 0 offen offset:16
 ; GISEL-GFX1100-NEXT:    s_waitcnt vmcnt(0)
-; GISEL-GFX1100-NEXT:    buffer_store_b128 v[0:3], v5, s[4:7], 0 offen offset:16
+; GISEL-GFX1100-NEXT:    buffer_store_b128 v[0:3], v5, s[0:3], 0 offen offset:16
 ; GISEL-GFX1100-NEXT:    s_endpgm
   call void @llvm.memcpy.p7.p7.i32(ptr addrspace(7) %dst, ptr addrspace(7) %src, i32 32, i1 false)
   ret void

--- a/llvm/test/CodeGen/AMDGPU/call-argument-types.ll
+++ b/llvm/test/CodeGen/AMDGPU/call-argument-types.ll
@@ -5978,7 +5978,6 @@ define amdgpu_kernel void @test_call_external_void_func_byval_struct_i8_i32() #0
 ; GFX11-TRUE16-NEXT:    s_add_u32 s2, s2, external_void_func_byval_struct_i8_i32@rel32@lo+4
 ; GFX11-TRUE16-NEXT:    s_addc_u32 s3, s3, external_void_func_byval_struct_i8_i32@rel32@hi+12
 ; GFX11-TRUE16-NEXT:    s_mov_b64 s[6:7], s[0:1]
-; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, off
 ; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v1, off offset:4
 ; GFX11-TRUE16-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -5995,7 +5994,6 @@ define amdgpu_kernel void @test_call_external_void_func_byval_struct_i8_i32() #0
 ; GFX11-FAKE16-NEXT:    s_add_u32 s2, s2, external_void_func_byval_struct_i8_i32@rel32@lo+4
 ; GFX11-FAKE16-NEXT:    s_addc_u32 s3, s3, external_void_func_byval_struct_i8_i32@rel32@hi+12
 ; GFX11-FAKE16-NEXT:    s_mov_b64 s[6:7], s[0:1]
-; GFX11-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-FAKE16-NEXT:    scratch_store_b8 off, v0, off
 ; GFX11-FAKE16-NEXT:    scratch_store_b32 off, v1, off offset:4
 ; GFX11-FAKE16-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -6191,7 +6189,6 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
 ; GFX11-TRUE16-NEXT:    s_add_u32 s2, s2, external_void_func_sret_struct_i8_i32_byval_struct_i8_i32@rel32@lo+4
 ; GFX11-TRUE16-NEXT:    s_addc_u32 s3, s3, external_void_func_sret_struct_i8_i32_byval_struct_i8_i32@rel32@hi+12
 ; GFX11-TRUE16-NEXT:    s_mov_b64 s[6:7], s[0:1]
-; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    scratch_store_b8 off, v0, off
 ; GFX11-TRUE16-NEXT:    scratch_store_b32 off, v1, off offset:4
 ; GFX11-TRUE16-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -6199,7 +6196,6 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
 ; GFX11-TRUE16-NEXT:    scratch_store_b64 off, v[0:1], s32
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v0, 8
 ; GFX11-TRUE16-NEXT:    s_swappc_b64 s[30:31], s[2:3]
-; GFX11-TRUE16-NEXT:    s_clause 0x1
 ; GFX11-TRUE16-NEXT:    scratch_load_d16_u8 v0, off, off offset:8
 ; GFX11-TRUE16-NEXT:    scratch_load_b32 v1, off, off offset:12
 ; GFX11-TRUE16-NEXT:    s_mov_b32 s3, 0x31016000
@@ -6222,7 +6218,6 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
 ; GFX11-FAKE16-NEXT:    s_add_u32 s2, s2, external_void_func_sret_struct_i8_i32_byval_struct_i8_i32@rel32@lo+4
 ; GFX11-FAKE16-NEXT:    s_addc_u32 s3, s3, external_void_func_sret_struct_i8_i32_byval_struct_i8_i32@rel32@hi+12
 ; GFX11-FAKE16-NEXT:    s_mov_b64 s[6:7], s[0:1]
-; GFX11-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-FAKE16-NEXT:    scratch_store_b8 off, v0, off
 ; GFX11-FAKE16-NEXT:    scratch_store_b32 off, v1, off offset:4
 ; GFX11-FAKE16-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -6230,7 +6225,6 @@ define amdgpu_kernel void @test_call_external_void_func_sret_struct_i8_i32_byval
 ; GFX11-FAKE16-NEXT:    scratch_store_b64 off, v[0:1], s32
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v0, 8
 ; GFX11-FAKE16-NEXT:    s_swappc_b64 s[30:31], s[2:3]
-; GFX11-FAKE16-NEXT:    s_clause 0x1
 ; GFX11-FAKE16-NEXT:    scratch_load_u8 v0, off, off offset:8
 ; GFX11-FAKE16-NEXT:    scratch_load_b32 v1, off, off offset:12
 ; GFX11-FAKE16-NEXT:    s_mov_b32 s3, 0x31016000

--- a/llvm/test/CodeGen/AMDGPU/cluster-ds-loads.mir
+++ b/llvm/test/CodeGen/AMDGPU/cluster-ds-loads.mir
@@ -1,0 +1,107 @@
+# RUN: llc -mtriple=amdgcn -mcpu=gfx942 -run-pass machine-scheduler -debug-only=machine-scheduler %s -o /dev/null 2> %t
+# RUN: FileCheck %s < %t
+# REQUIRES: asserts
+
+# Verify that DS_READ_B128 instructions (4 DWORDs each) can form clusters
+# of up to 4 ops (16 DWORDs total). With the default limit of 8, only pairs
+# would cluster; the per-memory-type DS limit of 16 enables deeper clusters
+# for better latency hiding behind consumers like MFMA.
+
+# CHECK-LABEL: cluster_ds_read_b128:%bb.0
+# CHECK: Cluster ld/st SU([[L0:[0-9]+]]) - SU([[L1:[0-9]+]])
+# CHECK: Cluster ld/st SU([[L1]]) - SU([[L2:[0-9]+]])
+# CHECK: Cluster ld/st SU([[L2]]) - SU([[L3:[0-9]+]])
+# CHECK-NOT: Cluster ld/st
+
+# Verify that the 5th DS_READ_B128 does NOT cluster with the first 4
+# (would exceed the 16-DWORD limit for DS).
+# CHECK-LABEL: cluster_ds_read_b128_limit:%bb.0
+# CHECK: Cluster ld/st SU([[M0:[0-9]+]]) - SU([[M1:[0-9]+]])
+# CHECK: Cluster ld/st SU([[M1]]) - SU([[M2:[0-9]+]])
+# CHECK: Cluster ld/st SU([[M2]]) - SU([[M3:[0-9]+]])
+# CHECK-NOT: Cluster ld/st SU([[M3]])
+
+# Verify that the subtarget DS cluster limit (16 DWORDs) takes precedence
+# over the per-function maxMemoryClusterDWords attribute for DS operations.
+# CHECK-LABEL: cluster_ds_read_b128_attr_override:%bb.0
+# CHECK: Cluster ld/st SU([[A0:[0-9]+]]) - SU([[A1:[0-9]+]])
+# CHECK: Cluster ld/st SU([[A1]]) - SU([[A2:[0-9]+]])
+# CHECK: Cluster ld/st SU([[A2]]) - SU([[A3:[0-9]+]])
+# CHECK-NOT: Cluster ld/st
+
+---
+name: cluster_ds_read_b128
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg: '$sgpr96_sgpr97_sgpr98_sgpr99'
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    %0:vgpr_32 = COPY $vgpr0
+    %1:vreg_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec :: (load (s128), addrspace 3)
+    %2:vgpr_32 = COPY %1.sub0
+    %3:vreg_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec :: (load (s128), addrspace 3)
+    %4:vgpr_32 = COPY %3.sub0
+    %5:vreg_128_align2 = DS_READ_B128_gfx9 %0, 32, 0, implicit $exec :: (load (s128), addrspace 3)
+    %6:vgpr_32 = COPY %5.sub0
+    %7:vreg_128_align2 = DS_READ_B128_gfx9 %0, 48, 0, implicit $exec :: (load (s128), addrspace 3)
+    %8:vgpr_32 = COPY %7.sub0
+    %9:vgpr_32 = V_ADD_F32_e64 0, %2, 0, %4, 0, 0, implicit $mode, implicit $exec
+    %10:vgpr_32 = V_ADD_F32_e64 0, %6, 0, %8, 0, 0, implicit $mode, implicit $exec
+    %11:vgpr_32 = V_ADD_F32_e64 0, %9, 0, %10, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %11
+
+---
+name: cluster_ds_read_b128_limit
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg: '$sgpr96_sgpr97_sgpr98_sgpr99'
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    %0:vgpr_32 = COPY $vgpr0
+    %1:vreg_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec :: (load (s128), addrspace 3)
+    %2:vgpr_32 = COPY %1.sub0
+    %3:vreg_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec :: (load (s128), addrspace 3)
+    %4:vgpr_32 = COPY %3.sub0
+    %5:vreg_128_align2 = DS_READ_B128_gfx9 %0, 32, 0, implicit $exec :: (load (s128), addrspace 3)
+    %6:vgpr_32 = COPY %5.sub0
+    %7:vreg_128_align2 = DS_READ_B128_gfx9 %0, 48, 0, implicit $exec :: (load (s128), addrspace 3)
+    %8:vgpr_32 = COPY %7.sub0
+    %9:vreg_128_align2 = DS_READ_B128_gfx9 %0, 64, 0, implicit $exec :: (load (s128), addrspace 3)
+    %10:vgpr_32 = COPY %9.sub0
+    %11:vgpr_32 = V_ADD_F32_e64 0, %2, 0, %4, 0, 0, implicit $mode, implicit $exec
+    %12:vgpr_32 = V_ADD_F32_e64 0, %6, 0, %8, 0, 0, implicit $mode, implicit $exec
+    %13:vgpr_32 = V_ADD_F32_e64 0, %10, 0, %11, 0, 0, implicit $mode, implicit $exec
+    %14:vgpr_32 = V_ADD_F32_e64 0, %12, 0, %13, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %14
+
+---
+name: cluster_ds_read_b128_attr_override
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg: '$sgpr96_sgpr97_sgpr98_sgpr99'
+  maxMemoryClusterDWords: 8
+body:             |
+  bb.0:
+    liveins: $vgpr0
+
+    %0:vgpr_32 = COPY $vgpr0
+    %1:vreg_128_align2 = DS_READ_B128_gfx9 %0, 0, 0, implicit $exec :: (load (s128), addrspace 3)
+    %2:vgpr_32 = COPY %1.sub0
+    %3:vreg_128_align2 = DS_READ_B128_gfx9 %0, 16, 0, implicit $exec :: (load (s128), addrspace 3)
+    %4:vgpr_32 = COPY %3.sub0
+    %5:vreg_128_align2 = DS_READ_B128_gfx9 %0, 32, 0, implicit $exec :: (load (s128), addrspace 3)
+    %6:vgpr_32 = COPY %5.sub0
+    %7:vreg_128_align2 = DS_READ_B128_gfx9 %0, 48, 0, implicit $exec :: (load (s128), addrspace 3)
+    %8:vgpr_32 = COPY %7.sub0
+    %9:vgpr_32 = V_ADD_F32_e64 0, %2, 0, %4, 0, 0, implicit $mode, implicit $exec
+    %10:vgpr_32 = V_ADD_F32_e64 0, %6, 0, %8, 0, 0, implicit $mode, implicit $exec
+    %11:vgpr_32 = V_ADD_F32_e64 0, %9, 0, %10, 0, 0, implicit $mode, implicit $exec
+    S_ENDPGM 0, implicit %11
+...

--- a/llvm/test/CodeGen/AMDGPU/coexec-scheduler.ll
+++ b/llvm/test/CodeGen/AMDGPU/coexec-scheduler.ll
@@ -404,70 +404,69 @@ define amdgpu_kernel void @ds_wmma_permute(ptr addrspace(3) %base, ptr addrspace
 ; GCN-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-NEXT:    s_add_co_i32 s7, s2, s6
 ; GCN-NEXT:    s_add_co_i32 s8, s3, s6
-; GCN-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GCN-NEXT:    v_dual_mov_b32 v96, s7 :: v_dual_mov_b32 v97, s8
+; GCN-NEXT:    v_nop
+; GCN-NEXT:    v_nop
+; GCN-NEXT:    v_nop
+; GCN-NEXT:    v_nop
+; GCN-NEXT:    v_dual_mov_b32 v148, s7 :: v_dual_mov_b32 v156, s8
 ; GCN-NEXT:    s_and_b32 vcc_lo, exec_lo, s0
 ; GCN-NEXT:    s_add_co_i32 s6, s6, s1
-; GCN-NEXT:    ds_load_tr16_b128 v[32:35], v96
-; GCN-NEXT:    ds_load_tr16_b128 v[36:39], v96 offset:64
-; GCN-NEXT:    ds_load_tr16_b128 v[40:43], v97
-; GCN-NEXT:    ds_load_tr16_b128 v[44:47], v97 offset:64
-; GCN-NEXT:    ds_load_tr16_b128 v[48:51], v96 offset:256
-; GCN-NEXT:    ds_load_tr16_b128 v[52:55], v96 offset:320
-; GCN-NEXT:    ds_load_tr16_b128 v[56:59], v97 offset:256
-; GCN-NEXT:    ds_load_tr16_b128 v[60:63], v97 offset:320
-; GCN-NEXT:    ds_load_tr16_b128 v[64:67], v96 offset:512
-; GCN-NEXT:    ds_load_tr16_b128 v[68:71], v96 offset:576
-; GCN-NEXT:    ds_load_tr16_b128 v[72:75], v97 offset:512
-; GCN-NEXT:    ds_load_tr16_b128 v[76:79], v97 offset:576
-; GCN-NEXT:    ds_load_tr16_b128 v[80:83], v96 offset:768
-; GCN-NEXT:    ds_load_tr16_b128 v[84:87], v96 offset:832
-; GCN-NEXT:    ds_load_tr16_b128 v[88:91], v97 offset:768
-; GCN-NEXT:    ds_load_tr16_b128 v[92:95], v97 offset:832
-; GCN-NEXT:    s_wait_dscnt 0xc
+; GCN-NEXT:    ds_load_tr16_b128 v[32:35], v148
+; GCN-NEXT:    ds_load_tr16_b128 v[36:39], v148 offset:64
+; GCN-NEXT:    ds_load_tr16_b128 v[40:43], v156
+; GCN-NEXT:    ds_load_tr16_b128 v[44:47], v156 offset:64
+; GCN-NEXT:    ds_load_tr16_b128 v[48:51], v148 offset:256
+; GCN-NEXT:    ds_load_tr16_b128 v[52:55], v148 offset:320
+; GCN-NEXT:    ds_load_tr16_b128 v[56:59], v156 offset:256
+; GCN-NEXT:    ds_load_tr16_b128 v[60:63], v156 offset:320
+; GCN-NEXT:    ds_load_tr16_b128 v[64:67], v148 offset:128
+; GCN-NEXT:    ds_load_tr16_b128 v[68:71], v148 offset:192
+; GCN-NEXT:    ds_load_tr16_b128 v[72:75], v148 offset:512
+; GCN-NEXT:    ds_load_tr16_b128 v[76:79], v148 offset:576
+; GCN-NEXT:    ds_load_tr16_b128 v[80:83], v156 offset:128
+; GCN-NEXT:    ds_load_tr16_b128 v[84:87], v156 offset:192
+; GCN-NEXT:    ds_load_tr16_b128 v[88:91], v156 offset:512
+; GCN-NEXT:    ds_load_tr16_b128 v[112:115], v148 offset:640
+; GCN-NEXT:    ds_load_tr16_b128 v[116:119], v148 offset:704
+; GCN-NEXT:    ds_load_tr16_b128 v[120:123], v148 offset:768
+; GCN-NEXT:    ds_load_tr16_b128 v[128:131], v156 offset:640
+; GCN-NEXT:    ds_load_tr16_b128 v[132:135], v156 offset:704
+; GCN-NEXT:    ds_load_tr16_b128 v[136:139], v156 offset:768
+; GCN-NEXT:    ds_load_tr16_b128 v[140:143], v156 offset:832
+; GCN-NEXT:    ds_load_tr16_b128 v[92:95], v156 offset:576
+; GCN-NEXT:    ds_load_tr16_b128 v[96:99], v148 offset:384
+; GCN-NEXT:    ds_load_tr16_b128 v[100:103], v148 offset:448
+; GCN-NEXT:    ds_load_tr16_b128 v[104:107], v156 offset:384
+; GCN-NEXT:    ds_load_tr16_b128 v[108:111], v156 offset:448
+; GCN-NEXT:    ds_load_tr16_b128 v[124:127], v148 offset:832
+; GCN-NEXT:    ds_load_tr16_b128 v[144:147], v148 offset:896
+; GCN-NEXT:    ds_load_tr16_b128 v[148:151], v148 offset:960
+; GCN-NEXT:    ds_load_tr16_b128 v[152:155], v156 offset:896
+; GCN-NEXT:    ds_load_tr16_b128 v[156:159], v156 offset:960
+; GCN-NEXT:    s_wait_dscnt 0x1c
 ; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; GCN-NEXT:    s_wait_dscnt 0x8
+; GCN-NEXT:    s_wait_dscnt 0x18
 ; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
+; GCN-NEXT:    s_wait_dscnt 0x9
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[72:79], v[88:95], v[8:15]
 ; GCN-NEXT:    s_wait_dscnt 0x4
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[120:127], v[136:143], v[0:7]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[72:79], v[88:95], v[8:15]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[120:127], v[136:143], v[0:7]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[64:71], v[80:87], v[24:31]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[96:103], v[104:111], v[16:23]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[112:119], v[128:135], v[8:15]
 ; GCN-NEXT:    s_wait_dscnt 0x0
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; GCN-NEXT:    ds_load_tr16_b128 v[32:35], v96 offset:128
-; GCN-NEXT:    ds_load_tr16_b128 v[36:39], v96 offset:192
-; GCN-NEXT:    ds_load_tr16_b128 v[40:43], v97 offset:128
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
-; GCN-NEXT:    ds_load_tr16_b128 v[44:47], v97 offset:192
-; GCN-NEXT:    ds_load_tr16_b128 v[48:51], v96 offset:384
-; GCN-NEXT:    ds_load_tr16_b128 v[52:55], v96 offset:448
-; GCN-NEXT:    ds_load_tr16_b128 v[56:59], v97 offset:384
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; GCN-NEXT:    ds_load_tr16_b128 v[60:63], v97 offset:448
-; GCN-NEXT:    ds_load_tr16_b128 v[64:67], v96 offset:640
-; GCN-NEXT:    ds_load_tr16_b128 v[68:71], v96 offset:704
-; GCN-NEXT:    ds_load_tr16_b128 v[72:75], v97 offset:640
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
-; GCN-NEXT:    ds_load_tr16_b128 v[76:79], v97 offset:704
-; GCN-NEXT:    ds_load_tr16_b128 v[80:83], v96 offset:896
-; GCN-NEXT:    ds_load_tr16_b128 v[84:87], v96 offset:960
-; GCN-NEXT:    ds_load_tr16_b128 v[88:91], v97 offset:896
-; GCN-NEXT:    ds_load_tr16_b128 v[92:95], v97 offset:960
-; GCN-NEXT:    s_wait_dscnt 0xc
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; GCN-NEXT:    s_wait_dscnt 0x8
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
-; GCN-NEXT:    s_wait_dscnt 0x4
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; GCN-NEXT:    s_wait_dscnt 0x0
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[32:39], v[40:47], v[24:31]
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[48:55], v[56:63], v[16:23]
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[64:71], v[72:79], v[8:15]
-; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[80:87], v[88:95], v[0:7]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[144:151], v[152:159], v[0:7]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[24:31], v[64:71], v[80:87], v[24:31]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[16:23], v[96:103], v[104:111], v[16:23]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[8:15], v[112:119], v[128:135], v[8:15]
+; GCN-NEXT:    v_wmma_f32_16x16x32_f16 v[0:7], v[144:151], v[152:159], v[0:7]
 ; GCN-NEXT:    s_cbranch_vccnz .LBB1_1
 ; GCN-NEXT:  ; %bb.2: ; %end
 ; GCN-NEXT:    s_load_b64 s[0:1], s[4:5], 0x8 nv
-; GCN-NEXT:    v_nop
 ; GCN-NEXT:    v_mov_b32_e32 v32, 0
 ; GCN-NEXT:    s_wait_kmcnt 0x0
 ; GCN-NEXT:    s_clause 0x7

--- a/llvm/test/CodeGen/AMDGPU/ds-alignment.ll
+++ b/llvm/test/CodeGen/AMDGPU/ds-alignment.ll
@@ -493,27 +493,27 @@ define amdgpu_kernel void @ds12align1(ptr addrspace(3) %in, ptr addrspace(3) %ou
 ; ALIGNED-GISEL-NEXT:    ds_read_u8 v6, v0 offset:5
 ; ALIGNED-GISEL-NEXT:    ds_read_u8 v7, v0 offset:6
 ; ALIGNED-GISEL-NEXT:    ds_read_u8 v8, v0 offset:7
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(6)
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v9, v0 offset:8
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v10, v0 offset:9
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v11, v0 offset:10
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v0, v0 offset:11
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(10)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s2, v2
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s0, v1
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s2, s2, 8
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s0, s2, s0
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(5)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(9)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(4)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(8)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v4
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s3, s3, 24
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s2, s2, 16
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v1, v0 offset:8
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v2, v0 offset:9
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s2, s3, s2
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(4)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(6)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v6
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s0, s2, s0
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s2, v5
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s3, s3, 8
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v3, v0 offset:10
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v0, v0 offset:11
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s2, s3, s2
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(5)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v7
@@ -523,13 +523,13 @@ define amdgpu_kernel void @ds12align1(ptr addrspace(3) %in, ptr addrspace(3) %ou
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s3, s3, 16
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s3, s4, s3
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(2)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v10
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s2, s3, s2
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v1
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v9
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s4, s4, 8
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s3, s4, s3
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(1)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v3
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v11
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v0
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s5, s5, 24
@@ -850,60 +850,60 @@ define amdgpu_kernel void @ds16align1(ptr addrspace(3) %in, ptr addrspace(3) %ou
 ; ALIGNED-GISEL-NEXT:    ds_read_u8 v6, v0 offset:5
 ; ALIGNED-GISEL-NEXT:    ds_read_u8 v7, v0 offset:6
 ; ALIGNED-GISEL-NEXT:    ds_read_u8 v8, v0 offset:7
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(6)
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v9, v0 offset:8
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v10, v0 offset:9
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v11, v0 offset:10
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v12, v0 offset:11
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v13, v0 offset:12
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v14, v0 offset:13
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v15, v0 offset:14
+; ALIGNED-GISEL-NEXT:    ds_read_u8 v0, v0 offset:15
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(14)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s2, v2
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s0, v1
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s2, s2, 8
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s0, s2, s0
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(5)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(13)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s2, v3
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(4)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(12)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v4
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s3, s3, 24
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s2, s2, 16
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s2, s3, s2
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(2)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(10)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v6
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s0, s2, s0
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s2, v5
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s3, s3, 8
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s2, s3, s2
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(1)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(9)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v7
-; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(8)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v8
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s4, s4, 24
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s3, s3, 16
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s3, s4, s3
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v1, v0 offset:8
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v2, v0 offset:9
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v3, v0 offset:10
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v4, v0 offset:11
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v5, v0 offset:12
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v6, v0 offset:13
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v7, v0 offset:14
-; ALIGNED-GISEL-NEXT:    ds_read_u8 v0, v0 offset:15
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(6)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v2
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v10
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s2, s3, s2
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v1
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s3, v9
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s4, s4, 8
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s3, s4, s3
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(5)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v3
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v11
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(4)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v4
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v12
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s5, s5, 24
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s4, s4, 16
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s4, s5, s4
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(2)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v6
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v14
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s3, s4, s3
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v5
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s4, v13
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s5, s5, 8
 ; ALIGNED-GISEL-NEXT:    s_or_b32 s4, s5, s4
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(1)
-; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v7
+; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s5, v15
 ; ALIGNED-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; ALIGNED-GISEL-NEXT:    v_readfirstlane_b32 s6, v0
 ; ALIGNED-GISEL-NEXT:    s_lshl_b32 s6, s6, 24

--- a/llvm/test/CodeGen/AMDGPU/ds_read2-gfx1250.ll
+++ b/llvm/test/CodeGen/AMDGPU/ds_read2-gfx1250.ll
@@ -677,16 +677,17 @@ define amdgpu_kernel void @sgemm_inner_loop_read2_sequence(ptr addrspace(1) %C, 
 ; GFX1250-NEXT:    ds_load_2addr_b32 v[4:5], v4 offset1:1
 ; GFX1250-NEXT:    s_wait_dscnt 0x1
 ; GFX1250-NEXT:    v_dual_lshrrev_b32 v0, 8, v0 :: v_dual_add_f32 v2, v2, v3
-; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_1)
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-NEXT:    v_and_b32_e32 v8, 0xffc, v0
 ; GFX1250-NEXT:    ds_load_2addr_b32 v[0:1], v8 offset1:1
 ; GFX1250-NEXT:    ds_load_2addr_b32 v[6:7], v8 offset0:32 offset1:33
-; GFX1250-NEXT:    s_wait_dscnt 0x2
+; GFX1250-NEXT:    ds_load_2addr_b32 v[8:9], v8 offset0:64 offset1:65
+; GFX1250-NEXT:    s_wait_dscnt 0x3
 ; GFX1250-NEXT:    v_add_f32_e32 v2, v2, v4
-; GFX1250-NEXT:    v_add_f32_e32 v4, v2, v5
-; GFX1250-NEXT:    ds_load_2addr_b32 v[2:3], v8 offset0:64 offset1:65
+; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+; GFX1250-NEXT:    v_add_f32_e32 v2, v2, v5
 ; GFX1250-NEXT:    s_wait_dscnt 0x2
-; GFX1250-NEXT:    v_add_f32_e32 v0, v4, v0
+; GFX1250-NEXT:    v_add_f32_e32 v0, v2, v0
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX1250-NEXT:    v_dual_add_f32 v0, v0, v1 :: v_dual_mov_b32 v1, 0
 ; GFX1250-NEXT:    s_wait_dscnt 0x1
@@ -694,9 +695,9 @@ define amdgpu_kernel void @sgemm_inner_loop_read2_sequence(ptr addrspace(1) %C, 
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
 ; GFX1250-NEXT:    v_add_f32_e32 v0, v0, v7
 ; GFX1250-NEXT:    s_wait_dscnt 0x0
-; GFX1250-NEXT:    v_add_f32_e32 v0, v0, v2
+; GFX1250-NEXT:    v_add_f32_e32 v0, v0, v8
 ; GFX1250-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-NEXT:    v_add_f32_e32 v0, v0, v3
+; GFX1250-NEXT:    v_add_f32_e32 v0, v0, v9
 ; GFX1250-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-NEXT:    global_store_b32 v1, v0, s[0:1]
 ; GFX1250-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/fcopysign.f32.ll
+++ b/llvm/test/CodeGen/AMDGPU/fcopysign.f32.ll
@@ -527,19 +527,19 @@ define amdgpu_kernel void @s_test_copysign_v3f32(ptr addrspace(1) %out, <3 x flo
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0xd
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
-; SI-NEXT:    s_brev_b32 s6, -2
+; SI-NEXT:    s_brev_b32 s4, -2
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v0, s9
 ; SI-NEXT:    v_mov_b32_e32 v1, s13
-; SI-NEXT:    v_bfi_b32 v1, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v1, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s8
 ; SI-NEXT:    v_mov_b32_e32 v2, s12
-; SI-NEXT:    v_bfi_b32 v0, s6, v0, v2
+; SI-NEXT:    v_bfi_b32 v0, s4, v0, v2
 ; SI-NEXT:    v_mov_b32_e32 v2, s10
 ; SI-NEXT:    v_mov_b32_e32 v3, s14
-; SI-NEXT:    v_bfi_b32 v2, s6, v2, v3
+; SI-NEXT:    v_bfi_b32 v2, s4, v2, v3
 ; SI-NEXT:    buffer_store_dword v2, off, s[0:3], 0 offset:8
 ; SI-NEXT:    buffer_store_dwordx2 v[0:1], off, s[0:3], 0
 ; SI-NEXT:    s_endpgm
@@ -588,23 +588,23 @@ define amdgpu_kernel void @s_test_copysign_v4f32(ptr addrspace(1) %out, <4 x flo
 ; SI-LABEL: s_test_copysign_v4f32:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0xd
-; SI-NEXT:    s_brev_b32 s6, -2
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
+; SI-NEXT:    s_brev_b32 s4, -2
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v0, s11
 ; SI-NEXT:    v_mov_b32_e32 v1, s15
-; SI-NEXT:    v_bfi_b32 v3, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v3, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s10
 ; SI-NEXT:    v_mov_b32_e32 v1, s14
-; SI-NEXT:    v_bfi_b32 v2, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v2, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s9
 ; SI-NEXT:    v_mov_b32_e32 v1, s13
-; SI-NEXT:    v_bfi_b32 v1, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v1, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s8
 ; SI-NEXT:    v_mov_b32_e32 v4, s12
-; SI-NEXT:    v_bfi_b32 v0, s6, v0, v4
+; SI-NEXT:    v_bfi_b32 v0, s4, v0, v4
 ; SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; SI-NEXT:    s_endpgm
 ;

--- a/llvm/test/CodeGen/AMDGPU/fcopysign.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/fcopysign.f64.ll
@@ -608,16 +608,16 @@ define amdgpu_kernel void @s_test_copysign_v2f64(ptr addrspace(1) %out, <2 x dou
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0xd
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
-; SI-NEXT:    s_brev_b32 s6, -2
+; SI-NEXT:    s_brev_b32 s4, -2
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v0, s11
 ; SI-NEXT:    v_mov_b32_e32 v1, s15
-; SI-NEXT:    v_bfi_b32 v3, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v3, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s9
 ; SI-NEXT:    v_mov_b32_e32 v1, s13
-; SI-NEXT:    v_bfi_b32 v1, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v1, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s8
 ; SI-NEXT:    v_mov_b32_e32 v2, s10
 ; SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
@@ -667,19 +667,19 @@ define amdgpu_kernel void @s_test_copysign_v3f64(ptr addrspace(1) %out, <3 x dou
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x11
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
-; SI-NEXT:    s_brev_b32 s6, -2
+; SI-NEXT:    s_brev_b32 s4, -2
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v0, s11
 ; SI-NEXT:    v_mov_b32_e32 v1, s19
-; SI-NEXT:    v_bfi_b32 v3, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v3, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s9
 ; SI-NEXT:    v_mov_b32_e32 v1, s17
-; SI-NEXT:    v_bfi_b32 v1, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v1, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s13
 ; SI-NEXT:    v_mov_b32_e32 v2, s21
-; SI-NEXT:    v_bfi_b32 v5, s6, v0, v2
+; SI-NEXT:    v_bfi_b32 v5, s4, v0, v2
 ; SI-NEXT:    v_mov_b32_e32 v4, s12
 ; SI-NEXT:    v_mov_b32_e32 v0, s8
 ; SI-NEXT:    v_mov_b32_e32 v2, s10
@@ -742,23 +742,23 @@ define amdgpu_kernel void @s_test_copysign_v4f64(ptr addrspace(1) %out, <4 x dou
 ; SI-LABEL: s_test_copysign_v4f64:
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x11
-; SI-NEXT:    s_brev_b32 s6, -2
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
+; SI-NEXT:    s_brev_b32 s4, -2
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v0, s11
 ; SI-NEXT:    v_mov_b32_e32 v1, s19
-; SI-NEXT:    v_bfi_b32 v3, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v3, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s9
 ; SI-NEXT:    v_mov_b32_e32 v1, s17
-; SI-NEXT:    v_bfi_b32 v1, s6, v0, v1
+; SI-NEXT:    v_bfi_b32 v1, s4, v0, v1
 ; SI-NEXT:    v_mov_b32_e32 v0, s15
 ; SI-NEXT:    v_mov_b32_e32 v2, s23
-; SI-NEXT:    v_bfi_b32 v7, s6, v0, v2
+; SI-NEXT:    v_bfi_b32 v7, s4, v0, v2
 ; SI-NEXT:    v_mov_b32_e32 v0, s13
 ; SI-NEXT:    v_mov_b32_e32 v2, s21
-; SI-NEXT:    v_bfi_b32 v5, s6, v0, v2
+; SI-NEXT:    v_bfi_b32 v5, s4, v0, v2
 ; SI-NEXT:    v_mov_b32_e32 v4, s12
 ; SI-NEXT:    v_mov_b32_e32 v6, s14
 ; SI-NEXT:    v_mov_b32_e32 v0, s8

--- a/llvm/test/CodeGen/AMDGPU/flat-scratch.ll
+++ b/llvm/test/CodeGen/AMDGPU/flat-scratch.ll
@@ -62,7 +62,6 @@ define amdgpu_kernel void @zero_init_kernel() {
 ; GFX11-NEXT:    s_mov_b32 s3, s0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    s_clause 0x3
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], off offset:48
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], off offset:32
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], off offset:16
@@ -78,7 +77,6 @@ define amdgpu_kernel void @zero_init_kernel() {
 ; GFX12-NEXT:    s_mov_b32 s3, s0
 ; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-NEXT:    s_clause 0x3
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:48
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:32
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:16
@@ -181,7 +179,6 @@ define amdgpu_kernel void @zero_init_kernel() {
 ; GFX11-PAL-NEXT:    s_mov_b32 s3, s0
 ; GFX11-PAL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-PAL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-PAL-NEXT:    s_clause 0x3
 ; GFX11-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:48
 ; GFX11-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:32
 ; GFX11-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:16
@@ -197,7 +194,6 @@ define amdgpu_kernel void @zero_init_kernel() {
 ; GFX12-PAL-NEXT:    s_mov_b32 s3, s0
 ; GFX12-PAL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-PAL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-PAL-NEXT:    s_clause 0x3
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:48
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:32
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:16
@@ -1126,7 +1122,6 @@ define amdgpu_kernel void @zero_init_small_offset_kernel() {
 ; GFX11-NEXT:    s_mov_b32 s3, s0
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-NEXT:    s_clause 0x3
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], off offset:272
 ; GFX11-NEXT:    scratch_store_b128 off, v[0:3], off offset:288
@@ -1144,7 +1139,6 @@ define amdgpu_kernel void @zero_init_small_offset_kernel() {
 ; GFX12-NEXT:    s_mov_b32 s3, s0
 ; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-NEXT:    s_clause 0x3
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:272
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:288
@@ -1257,7 +1251,6 @@ define amdgpu_kernel void @zero_init_small_offset_kernel() {
 ; GFX11-PAL-NEXT:    s_mov_b32 s3, s0
 ; GFX11-PAL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX11-PAL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX11-PAL-NEXT:    s_clause 0x3
 ; GFX11-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:272
 ; GFX11-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:288
@@ -1275,7 +1268,6 @@ define amdgpu_kernel void @zero_init_small_offset_kernel() {
 ; GFX12-PAL-NEXT:    s_mov_b32 s3, s0
 ; GFX12-PAL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-PAL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-PAL-NEXT:    s_clause 0x3
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:272
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:288
@@ -2383,7 +2375,6 @@ define amdgpu_kernel void @zero_init_large_offset_kernel() {
 ; GFX12-NEXT:    s_mov_b32 s3, s0
 ; GFX12-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-NEXT:    s_clause 0x3
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:16384
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:16400
 ; GFX12-NEXT:    scratch_store_b128 off, v[0:3], off offset:16416
@@ -2519,7 +2510,6 @@ define amdgpu_kernel void @zero_init_large_offset_kernel() {
 ; GFX12-PAL-NEXT:    s_mov_b32 s3, s0
 ; GFX12-PAL-NEXT:    v_dual_mov_b32 v0, s0 :: v_dual_mov_b32 v1, s1
 ; GFX12-PAL-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s3
-; GFX12-PAL-NEXT:    s_clause 0x3
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:16384
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:16400
 ; GFX12-PAL-NEXT:    scratch_store_b128 off, v[0:3], off offset:16416

--- a/llvm/test/CodeGen/AMDGPU/freeze.ll
+++ b/llvm/test/CodeGen/AMDGPU/freeze.ll
@@ -12261,40 +12261,40 @@ define void @freeze_v16p3(ptr addrspace(3) %ptra, ptr addrspace(3) %ptrb) {
 ; GFX6-SDAG-LABEL: freeze_v16p3:
 ; GFX6-SDAG:       ; %bb.0:
 ; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v2, vcc, 8, v0
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v4, vcc, 24, v0
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v6, vcc, 16, v0
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v10, vcc, 40, v0
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v12, vcc, 32, v0
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v16, vcc, 56, v0
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v14, vcc, 48, v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v2, vcc, 24, v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v4, vcc, 16, v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v6, vcc, 40, v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v8, vcc, 32, v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v10, vcc, 56, v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v12, vcc, 48, v0
 ; GFX6-SDAG-NEXT:    s_mov_b32 m0, -1
 ; GFX6-SDAG-NEXT:    ds_read_b64 v[2:3], v2
 ; GFX6-SDAG-NEXT:    ds_read_b64 v[4:5], v4
 ; GFX6-SDAG-NEXT:    ds_read_b64 v[6:7], v6
-; GFX6-SDAG-NEXT:    ds_read_b64 v[8:9], v0
+; GFX6-SDAG-NEXT:    ds_read_b64 v[8:9], v8
 ; GFX6-SDAG-NEXT:    ds_read_b64 v[10:11], v10
 ; GFX6-SDAG-NEXT:    ds_read_b64 v[12:13], v12
-; GFX6-SDAG-NEXT:    ds_read_b64 v[14:15], v14
-; GFX6-SDAG-NEXT:    ds_read_b64 v[16:17], v16
+; GFX6-SDAG-NEXT:    ds_read_b64 v[14:15], v0
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 8, v0
+; GFX6-SDAG-NEXT:    ds_read_b64 v[16:17], v0
 ; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 48, v1
-; GFX6-SDAG-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX6-SDAG-NEXT:    ds_write_b64 v1, v[8:9]
 ; GFX6-SDAG-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[14:15]
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 56, v1
-; GFX6-SDAG-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[16:17]
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 32, v1
 ; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[12:13]
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 40, v1
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 56, v1
 ; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[10:11]
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 16, v1
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 32, v1
+; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[8:9]
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 40, v1
 ; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[6:7]
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 24, v1
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 16, v1
 ; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[4:5]
-; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 8, v1
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 24, v1
 ; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[2:3]
+; GFX6-SDAG-NEXT:    v_add_i32_e32 v0, vcc, 8, v1
+; GFX6-SDAG-NEXT:    s_waitcnt lgkmcnt(7)
+; GFX6-SDAG-NEXT:    ds_write_b64 v1, v[14:15]
+; GFX6-SDAG-NEXT:    s_waitcnt lgkmcnt(7)
+; GFX6-SDAG-NEXT:    ds_write_b64 v0, v[16:17]
 ; GFX6-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -12304,19 +12304,19 @@ define void @freeze_v16p3(ptr addrspace(3) %ptra, ptr addrspace(3) %ptrb) {
 ; GFX6-GISEL-NEXT:    v_add_i32_e32 v4, vcc, 8, v0
 ; GFX6-GISEL-NEXT:    v_add_i32_e32 v6, vcc, 16, v0
 ; GFX6-GISEL-NEXT:    v_add_i32_e32 v8, vcc, 24, v0
+; GFX6-GISEL-NEXT:    v_add_i32_e32 v10, vcc, 32, v0
+; GFX6-GISEL-NEXT:    v_add_i32_e32 v12, vcc, 40, v0
+; GFX6-GISEL-NEXT:    v_add_i32_e32 v14, vcc, 48, v0
+; GFX6-GISEL-NEXT:    v_add_i32_e32 v16, vcc, 56, v0
 ; GFX6-GISEL-NEXT:    s_mov_b32 m0, -1
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[2:3], v0
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[4:5], v4
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[6:7], v6
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[8:9], v8
-; GFX6-GISEL-NEXT:    v_add_i32_e32 v10, vcc, 32, v0
-; GFX6-GISEL-NEXT:    v_add_i32_e32 v12, vcc, 40, v0
-; GFX6-GISEL-NEXT:    v_add_i32_e32 v14, vcc, 48, v0
-; GFX6-GISEL-NEXT:    v_add_i32_e32 v0, vcc, 56, v0
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[10:11], v10
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[12:13], v12
 ; GFX6-GISEL-NEXT:    ds_read_b64 v[14:15], v14
-; GFX6-GISEL-NEXT:    ds_read_b64 v[16:17], v0
+; GFX6-GISEL-NEXT:    ds_read_b64 v[16:17], v16
 ; GFX6-GISEL-NEXT:    v_add_i32_e32 v0, vcc, 8, v1
 ; GFX6-GISEL-NEXT:    s_waitcnt lgkmcnt(6)
 ; GFX6-GISEL-NEXT:    ds_write_b64 v0, v[4:5]
@@ -12493,16 +12493,16 @@ define void @freeze_v16p3(ptr addrspace(3) %ptra, ptr addrspace(3) %ptrb) {
 ; GFX11-SDAG-LABEL: freeze_v16p3:
 ; GFX11-SDAG:       ; %bb.0:
 ; GFX11-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX11-SDAG-NEXT:    ds_load_b128 v[2:5], v0 offset:32
-; GFX11-SDAG-NEXT:    ds_load_b128 v[6:9], v0 offset:48
-; GFX11-SDAG-NEXT:    ds_load_b128 v[10:13], v0
+; GFX11-SDAG-NEXT:    ds_load_b128 v[2:5], v0
+; GFX11-SDAG-NEXT:    ds_load_b128 v[6:9], v0 offset:32
+; GFX11-SDAG-NEXT:    ds_load_b128 v[10:13], v0 offset:48
 ; GFX11-SDAG-NEXT:    ds_load_b128 v[14:17], v0 offset:16
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[2:5] offset:32
+; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[2:5]
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[6:9] offset:48
+; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[6:9] offset:32
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[10:13]
+; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[10:13] offset:48
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(3)
 ; GFX11-SDAG-NEXT:    ds_store_b128 v1, v[14:17] offset:16
 ; GFX11-SDAG-NEXT:    s_waitcnt lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/fshr.ll
+++ b/llvm/test/CodeGen/AMDGPU/fshr.ll
@@ -725,29 +725,29 @@ define amdgpu_kernel void @fshr_v4i32(ptr addrspace(1) %in, <4 x i32> %x, <4 x i
 ; SI-LABEL: fshr_v4i32:
 ; SI:       ; %bb.0: ; %entry
 ; SI-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0xd
-; SI-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x15
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
+; SI-NEXT:    s_load_dwordx4 s[4:7], s[4:5], 0x15
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_mov_b32 s4, s15
-; SI-NEXT:    s_mov_b32 s5, s11
-; SI-NEXT:    s_and_b32 s6, s19, 31
-; SI-NEXT:    s_lshr_b64 s[4:5], s[4:5], s6
+; SI-NEXT:    s_mov_b32 s16, s15
+; SI-NEXT:    s_mov_b32 s17, s11
+; SI-NEXT:    s_and_b32 s7, s7, 31
 ; SI-NEXT:    s_mov_b32 s15, s10
-; SI-NEXT:    s_and_b32 s5, s18, 31
-; SI-NEXT:    s_lshr_b64 s[6:7], s[14:15], s5
+; SI-NEXT:    s_and_b32 s6, s6, 31
 ; SI-NEXT:    s_mov_b32 s10, s13
 ; SI-NEXT:    s_mov_b32 s11, s9
-; SI-NEXT:    s_and_b32 s5, s17, 31
-; SI-NEXT:    s_lshr_b64 s[10:11], s[10:11], s5
+; SI-NEXT:    s_and_b32 s5, s5, 31
 ; SI-NEXT:    s_mov_b32 s13, s8
-; SI-NEXT:    s_and_b32 s5, s16, 31
-; SI-NEXT:    s_lshr_b64 s[8:9], s[12:13], s5
-; SI-NEXT:    v_mov_b32_e32 v0, s8
+; SI-NEXT:    s_and_b32 s4, s4, 31
+; SI-NEXT:    s_lshr_b64 s[16:17], s[16:17], s7
+; SI-NEXT:    s_lshr_b64 s[6:7], s[14:15], s6
+; SI-NEXT:    s_lshr_b64 s[10:11], s[10:11], s5
+; SI-NEXT:    s_lshr_b64 s[4:5], s[12:13], s4
+; SI-NEXT:    v_mov_b32_e32 v0, s4
 ; SI-NEXT:    v_mov_b32_e32 v1, s10
 ; SI-NEXT:    v_mov_b32_e32 v2, s6
-; SI-NEXT:    v_mov_b32_e32 v3, s4
+; SI-NEXT:    v_mov_b32_e32 v3, s16
 ; SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0
 ; SI-NEXT:    s_endpgm
 ;
@@ -1083,14 +1083,14 @@ define amdgpu_kernel void @fshr_v4i32_imm_src0(ptr addrspace(1) %in, <4 x i32> %
 ; SI-LABEL: fshr_v4i32_imm_src0:
 ; SI:       ; %bb.0: ; %entry
 ; SI-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0xd
-; SI-NEXT:    s_mov_b32 s7, 33
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
+; SI-NEXT:    s_mov_b32 s5, 33
 ; SI-NEXT:    s_mov_b32 s3, 0xf000
 ; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    s_mov_b32 s6, s11
-; SI-NEXT:    s_and_b32 s4, s15, 31
-; SI-NEXT:    s_lshr_b64 s[4:5], s[6:7], s4
+; SI-NEXT:    s_mov_b32 s4, s11
+; SI-NEXT:    s_and_b32 s6, s15, 31
+; SI-NEXT:    s_lshr_b64 s[4:5], s[4:5], s6
 ; SI-NEXT:    s_mov_b32 s11, 9
 ; SI-NEXT:    s_and_b32 s5, s14, 31
 ; SI-NEXT:    s_lshr_b64 s[6:7], s[10:11], s5
@@ -1139,28 +1139,28 @@ define amdgpu_kernel void @fshr_v4i32_imm_src0(ptr addrspace(1) %in, <4 x i32> %
 ; GFX9-LABEL: fshr_v4i32_imm_src0:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
-; GFX9-NEXT:    s_mov_b32 s1, 33
-; GFX9-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x24
+; GFX9-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9-NEXT:    s_mov_b32 s3, 33
 ; GFX9-NEXT:    s_mov_b32 s7, 7
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    s_mov_b32 s0, s11
+; GFX9-NEXT:    s_mov_b32 s2, s11
 ; GFX9-NEXT:    s_and_b32 s4, s15, 31
-; GFX9-NEXT:    s_lshr_b64 s[0:1], s[0:1], s4
+; GFX9-NEXT:    s_lshr_b64 s[2:3], s[2:3], s4
 ; GFX9-NEXT:    s_mov_b32 s11, 9
-; GFX9-NEXT:    s_and_b32 s1, s14, 31
-; GFX9-NEXT:    s_lshr_b64 s[4:5], s[10:11], s1
+; GFX9-NEXT:    s_and_b32 s3, s14, 31
+; GFX9-NEXT:    s_lshr_b64 s[4:5], s[10:11], s3
 ; GFX9-NEXT:    s_mov_b32 s6, s9
-; GFX9-NEXT:    s_and_b32 s1, s13, 31
-; GFX9-NEXT:    s_lshr_b64 s[6:7], s[6:7], s1
+; GFX9-NEXT:    s_and_b32 s3, s13, 31
+; GFX9-NEXT:    s_lshr_b64 s[6:7], s[6:7], s3
 ; GFX9-NEXT:    s_mov_b32 s9, 1
-; GFX9-NEXT:    s_and_b32 s1, s12, 31
-; GFX9-NEXT:    s_lshr_b64 s[8:9], s[8:9], s1
+; GFX9-NEXT:    s_and_b32 s3, s12, 31
+; GFX9-NEXT:    s_lshr_b64 s[8:9], s[8:9], s3
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s4
-; GFX9-NEXT:    v_mov_b32_e32 v3, s0
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[2:3]
+; GFX9-NEXT:    v_mov_b32_e32 v3, s2
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; R600-LABEL: fshr_v4i32_imm_src0:
@@ -1184,82 +1184,82 @@ define amdgpu_kernel void @fshr_v4i32_imm_src0(ptr addrspace(1) %in, <4 x i32> %
 ; GFX10:       ; %bb.0: ; %entry
 ; GFX10-NEXT:    s_clause 0x1
 ; GFX10-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
-; GFX10-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
-; GFX10-NEXT:    s_mov_b32 s1, 33
-; GFX10-NEXT:    s_mov_b32 s3, 7
+; GFX10-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX10-NEXT:    s_mov_b32 s3, 33
+; GFX10-NEXT:    s_mov_b32 s5, 7
 ; GFX10-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    s_mov_b32 s0, s11
-; GFX10-NEXT:    s_and_b32 s4, s15, 31
+; GFX10-NEXT:    s_mov_b32 s2, s11
+; GFX10-NEXT:    s_and_b32 s6, s15, 31
 ; GFX10-NEXT:    s_mov_b32 s11, 9
-; GFX10-NEXT:    s_and_b32 s5, s14, 31
-; GFX10-NEXT:    s_mov_b32 s2, s9
+; GFX10-NEXT:    s_and_b32 s7, s14, 31
+; GFX10-NEXT:    s_mov_b32 s4, s9
 ; GFX10-NEXT:    s_and_b32 s13, s13, 31
 ; GFX10-NEXT:    s_mov_b32 s9, 1
 ; GFX10-NEXT:    s_and_b32 s12, s12, 31
-; GFX10-NEXT:    s_lshr_b64 s[0:1], s[0:1], s4
-; GFX10-NEXT:    s_lshr_b64 s[4:5], s[10:11], s5
+; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], s6
+; GFX10-NEXT:    s_lshr_b64 s[6:7], s[10:11], s7
 ; GFX10-NEXT:    s_lshr_b64 s[8:9], s[8:9], s12
-; GFX10-NEXT:    s_lshr_b64 s[2:3], s[2:3], s13
+; GFX10-NEXT:    s_lshr_b64 s[4:5], s[4:5], s13
 ; GFX10-NEXT:    v_mov_b32_e32 v0, s8
-; GFX10-NEXT:    v_mov_b32_e32 v1, s2
-; GFX10-NEXT:    v_mov_b32_e32 v2, s4
-; GFX10-NEXT:    v_mov_b32_e32 v3, s0
-; GFX10-NEXT:    global_store_dwordx4 v4, v[0:3], s[6:7]
+; GFX10-NEXT:    v_mov_b32_e32 v1, s4
+; GFX10-NEXT:    v_mov_b32_e32 v2, s6
+; GFX10-NEXT:    v_mov_b32_e32 v3, s2
+; GFX10-NEXT:    global_store_dwordx4 v4, v[0:3], s[0:1]
 ; GFX10-NEXT:    s_endpgm
 ;
 ; GFX11-LABEL: fshr_v4i32_imm_src0:
 ; GFX11:       ; %bb.0: ; %entry
 ; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    s_load_b256 s[8:15], s[4:5], 0x34
-; GFX11-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24
-; GFX11-NEXT:    s_mov_b32 s1, 33
-; GFX11-NEXT:    s_mov_b32 s3, 7
+; GFX11-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX11-NEXT:    s_mov_b32 s3, 33
+; GFX11-NEXT:    s_mov_b32 s5, 7
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_mov_b32 s0, s11
+; GFX11-NEXT:    s_mov_b32 s2, s11
 ; GFX11-NEXT:    s_and_b32 s6, s15, 31
 ; GFX11-NEXT:    s_mov_b32 s11, 9
 ; GFX11-NEXT:    s_and_b32 s7, s14, 31
-; GFX11-NEXT:    s_mov_b32 s2, s9
+; GFX11-NEXT:    s_mov_b32 s4, s9
 ; GFX11-NEXT:    s_and_b32 s13, s13, 31
 ; GFX11-NEXT:    s_mov_b32 s9, 1
 ; GFX11-NEXT:    s_and_b32 s12, s12, 31
-; GFX11-NEXT:    s_lshr_b64 s[0:1], s[0:1], s6
+; GFX11-NEXT:    s_lshr_b64 s[2:3], s[2:3], s6
 ; GFX11-NEXT:    s_lshr_b64 s[6:7], s[10:11], s7
 ; GFX11-NEXT:    s_lshr_b64 s[8:9], s[8:9], s12
-; GFX11-NEXT:    s_lshr_b64 s[2:3], s[2:3], s13
+; GFX11-NEXT:    s_lshr_b64 s[4:5], s[4:5], s13
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_mov_b32 v1, s2
-; GFX11-NEXT:    v_dual_mov_b32 v0, s8 :: v_dual_mov_b32 v3, s0
+; GFX11-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_mov_b32 v1, s4
+; GFX11-NEXT:    v_dual_mov_b32 v0, s8 :: v_dual_mov_b32 v3, s2
 ; GFX11-NEXT:    v_mov_b32_e32 v2, s6
-; GFX11-NEXT:    global_store_b128 v4, v[0:3], s[4:5]
+; GFX11-NEXT:    global_store_b128 v4, v[0:3], s[0:1]
 ; GFX11-NEXT:    s_endpgm
 ;
 ; GFX12-LABEL: fshr_v4i32_imm_src0:
 ; GFX12:       ; %bb.0: ; %entry
 ; GFX12-NEXT:    s_clause 0x1
 ; GFX12-NEXT:    s_load_b256 s[8:15], s[4:5], 0x34
-; GFX12-NEXT:    s_load_b64 s[4:5], s[4:5], 0x24
-; GFX12-NEXT:    s_mov_b32 s1, 33
-; GFX12-NEXT:    s_mov_b32 s3, 7
+; GFX12-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24
+; GFX12-NEXT:    s_mov_b32 s3, 33
+; GFX12-NEXT:    s_mov_b32 s5, 7
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
-; GFX12-NEXT:    s_mov_b32 s0, s11
+; GFX12-NEXT:    s_mov_b32 s2, s11
 ; GFX12-NEXT:    s_and_b32 s6, s15, 31
 ; GFX12-NEXT:    s_mov_b32 s11, 9
 ; GFX12-NEXT:    s_and_b32 s7, s14, 31
-; GFX12-NEXT:    s_mov_b32 s2, s9
+; GFX12-NEXT:    s_mov_b32 s4, s9
 ; GFX12-NEXT:    s_and_b32 s13, s13, 31
 ; GFX12-NEXT:    s_mov_b32 s9, 1
 ; GFX12-NEXT:    s_and_b32 s12, s12, 31
-; GFX12-NEXT:    s_lshr_b64 s[0:1], s[0:1], s6
+; GFX12-NEXT:    s_lshr_b64 s[2:3], s[2:3], s6
 ; GFX12-NEXT:    s_lshr_b64 s[6:7], s[10:11], s7
 ; GFX12-NEXT:    s_lshr_b64 s[8:9], s[8:9], s12
-; GFX12-NEXT:    s_lshr_b64 s[2:3], s[2:3], s13
+; GFX12-NEXT:    s_lshr_b64 s[4:5], s[4:5], s13
 ; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_mov_b32 v1, s2
-; GFX12-NEXT:    v_dual_mov_b32 v0, s8 :: v_dual_mov_b32 v3, s0
+; GFX12-NEXT:    v_dual_mov_b32 v4, 0 :: v_dual_mov_b32 v1, s4
+; GFX12-NEXT:    v_dual_mov_b32 v0, s8 :: v_dual_mov_b32 v3, s2
 ; GFX12-NEXT:    v_mov_b32_e32 v2, s6
-; GFX12-NEXT:    global_store_b128 v4, v[0:3], s[4:5]
+; GFX12-NEXT:    global_store_b128 v4, v[0:3], s[0:1]
 ; GFX12-NEXT:    s_endpgm
 entry:
   %0 = call <4 x i32> @llvm.fshr.v4i32(<4 x i32> <i32 1, i32 7, i32 9, i32 33>, <4 x i32> %x, <4 x i32> %y)

--- a/llvm/test/CodeGen/AMDGPU/global_atomics_scan_fadd.ll
+++ b/llvm/test/CodeGen/AMDGPU/global_atomics_scan_fadd.ll
@@ -1318,7 +1318,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_one_as_scope
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -1346,7 +1345,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_one_as_scope
 ; GFX1132-NEXT:    v_dual_mov_b32 v0, 0x43300000 :: v_dual_mov_b32 v1, s0
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -1538,7 +1536,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_one_as_scope
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -1566,7 +1563,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_one_as_scope
 ; GFX1132-DPP-NEXT:    v_dual_mov_b32 v0, 0x43300000 :: v_dual_mov_b32 v1, s0
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -2545,7 +2541,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_agent_scope_
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -2589,7 +2584,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_agent_scope_
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -2795,7 +2789,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_agent_scope_
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -2839,7 +2832,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_agent_scope_
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -4615,7 +4607,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_default_scop
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -4659,7 +4650,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_default_scop
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -4865,7 +4855,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_default_scop
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -4909,7 +4898,6 @@ define amdgpu_kernel void @global_atomic_fadd_uni_address_uni_value_default_scop
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7314,7 +7302,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_one_a
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7359,7 +7346,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_one_a
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7571,7 +7557,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_one_a
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7616,7 +7601,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_one_a
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -8755,7 +8739,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_agent
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -8800,7 +8783,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_agent
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -9012,7 +8994,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_agent
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -9057,7 +9038,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_agent
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11119,7 +11099,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_defau
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11164,7 +11143,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_defau
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11376,7 +11354,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_defau
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11421,7 +11398,6 @@ define amdgpu_kernel void @global_atomic_fadd_double_uni_address_uni_value_defau
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off

--- a/llvm/test/CodeGen/AMDGPU/global_atomics_scan_fsub.ll
+++ b/llvm/test/CodeGen/AMDGPU/global_atomics_scan_fsub.ll
@@ -1430,7 +1430,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_one_as_scope
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -1474,7 +1473,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_one_as_scope
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -1680,7 +1678,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_one_as_scope
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -1724,7 +1721,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_one_as_scope
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -2769,7 +2765,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_agent_scope_
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -2813,7 +2808,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_agent_scope_
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -3019,7 +3013,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_agent_scope_
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -3063,7 +3056,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_agent_scope_
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -4943,7 +4935,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_default_scop
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -4987,7 +4978,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_default_scop
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -5193,7 +5183,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_default_scop
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -5237,7 +5226,6 @@ define amdgpu_kernel void @global_atomic_fsub_uni_address_uni_value_default_scop
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7642,7 +7630,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_one_a
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7687,7 +7674,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_one_a
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7899,7 +7885,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_one_a
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -7944,7 +7929,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_one_a
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -9082,7 +9066,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_agent
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -9127,7 +9110,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_agent
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -9339,7 +9321,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_agent
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -9384,7 +9365,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_agent
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11445,7 +11425,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_defau
 ; GFX1164-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-NEXT:    s_clause 0x1
 ; GFX1164-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11490,7 +11469,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_defau
 ; GFX1132-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-NEXT:    s_clause 0x1
 ; GFX1132-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11702,7 +11680,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_defau
 ; GFX1164-DPP-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX1164-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1164-DPP-NEXT:    s_mov_b64 s[0:1], exec
-; GFX1164-DPP-NEXT:    s_clause 0x1
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1164-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1164-DPP-NEXT:    scratch_load_b64 v[0:1], off, off
@@ -11747,7 +11724,6 @@ define amdgpu_kernel void @global_atomic_fsub_double_uni_address_uni_value_defau
 ; GFX1132-DPP-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s2, 0
 ; GFX1132-DPP-NEXT:    s_mov_b32 s0, exec_lo
-; GFX1132-DPP-NEXT:    s_clause 0x1
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v0, off offset:4
 ; GFX1132-DPP-NEXT:    scratch_store_b32 off, v1, off
 ; GFX1132-DPP-NEXT:    scratch_load_b64 v[0:1], off, off

--- a/llvm/test/CodeGen/AMDGPU/group-image-instructions.ll
+++ b/llvm/test/CodeGen/AMDGPU/group-image-instructions.ll
@@ -4,7 +4,7 @@
 define amdgpu_ps void @group_image_sample(i32 inreg noundef %globalTable, i32 inreg noundef %userdata6, i32 inreg noundef %userdata7, i32 inreg noundef %userdata8, i32 inreg noundef %PrimMask, <2 x float> noundef %PerspInterpSample, <2 x float> noundef %PerspInterpCenter, <2 x float> noundef %PerspInterpCentroid) #2 {
 ; GFX11-LABEL: group_image_sample:
 ; GFX11:       ; %bb.0: ; %.entry
-; GFX11-NEXT:    s_mov_b32 s33, exec_lo
+; GFX11-NEXT:    s_mov_b32 s24, exec_lo
 ; GFX11-NEXT:    s_wqm_b32 exec_lo, exec_lo
 ; GFX11-NEXT:    s_mov_b32 m0, s4
 ; GFX11-NEXT:    s_getpc_b64 s[4:5]
@@ -21,79 +21,73 @@ define amdgpu_ps void @group_image_sample(i32 inreg noundef %globalTable, i32 in
 ; GFX11-NEXT:    lds_param_load v2, attr0.y wait_vdst:15
 ; GFX11-NEXT:    lds_param_load v3, attr0.x wait_vdst:15
 ; GFX11-NEXT:    s_mov_b32 exec_lo, s16
-; GFX11-NEXT:    v_interp_p10_f32 v4, v2, v0, v2 wait_exp:1
-; GFX11-NEXT:    v_interp_p10_f32 v0, v3, v0, v3 wait_exp:0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_clause 0xf
+; GFX11-NEXT:    s_clause 0x3
 ; GFX11-NEXT:    s_buffer_load_b64 s[16:17], s[12:15], 0x10
 ; GFX11-NEXT:    s_buffer_load_b64 s[18:19], s[12:15], 0x20
 ; GFX11-NEXT:    s_buffer_load_b64 s[20:21], s[12:15], 0x30
 ; GFX11-NEXT:    s_buffer_load_b64 s[22:23], s[12:15], 0x40
-; GFX11-NEXT:    s_buffer_load_b64 s[24:25], s[12:15], 0x50
-; GFX11-NEXT:    s_buffer_load_b64 s[26:27], s[12:15], 0x60
-; GFX11-NEXT:    s_buffer_load_b64 s[28:29], s[12:15], 0x70
-; GFX11-NEXT:    s_buffer_load_b64 s[30:31], s[12:15], 0x80
-; GFX11-NEXT:    s_buffer_load_b64 s[34:35], s[12:15], 0x90
-; GFX11-NEXT:    s_buffer_load_b64 s[36:37], s[12:15], 0xa0
-; GFX11-NEXT:    s_buffer_load_b64 s[38:39], s[12:15], 0xb0
-; GFX11-NEXT:    s_buffer_load_b64 s[40:41], s[12:15], 0xc0
-; GFX11-NEXT:    s_buffer_load_b64 s[42:43], s[12:15], 0xd0
-; GFX11-NEXT:    s_buffer_load_b64 s[44:45], s[12:15], 0xe0
-; GFX11-NEXT:    s_buffer_load_b64 s[46:47], s[12:15], 0xf0
-; GFX11-NEXT:    s_buffer_load_b64 s[12:13], s[12:15], 0x100
-; GFX11-NEXT:    v_interp_p2_f32 v36, v2, v1, v4 wait_exp:7
+; GFX11-NEXT:    v_interp_p10_f32 v4, v2, v0, v2 wait_exp:1
+; GFX11-NEXT:    v_interp_p10_f32 v0, v3, v0, v3 wait_exp:0
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instskip(NEXT) | instid1(VALU_DEP_3)
 ; GFX11-NEXT:    v_interp_p2_f32 v0, v3, v1, v0 wait_exp:7
+; GFX11-NEXT:    v_interp_p2_f32 v1, v2, v1, v4 wait_exp:7
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_add_f32_e32 v5, s17, v36
-; GFX11-NEXT:    v_add_f32_e32 v4, s16, v0
-; GFX11-NEXT:    v_add_f32_e32 v8, s18, v0
-; GFX11-NEXT:    v_add_f32_e32 v9, s19, v36
-; GFX11-NEXT:    v_add_f32_e32 v12, s20, v0
-; GFX11-NEXT:    v_add_f32_e32 v13, s21, v36
-; GFX11-NEXT:    v_add_f32_e32 v16, s22, v0
-; GFX11-NEXT:    v_add_f32_e32 v17, s23, v36
-; GFX11-NEXT:    v_add_f32_e32 v20, s24, v0
-; GFX11-NEXT:    v_add_f32_e32 v21, s25, v36
-; GFX11-NEXT:    v_add_f32_e32 v24, s26, v0
-; GFX11-NEXT:    v_add_f32_e32 v25, s27, v36
-; GFX11-NEXT:    v_add_f32_e32 v28, s28, v0
-; GFX11-NEXT:    v_add_f32_e32 v29, s29, v36
-; GFX11-NEXT:    v_add_f32_e32 v32, s30, v0
-; GFX11-NEXT:    v_add_f32_e32 v33, s31, v36
-; GFX11-NEXT:    s_clause 0x7
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX11-NEXT:    v_dual_add_f32 v4, s16, v0 :: v_dual_add_f32 v5, s17, v1
+; GFX11-NEXT:    v_dual_add_f32 v8, s18, v0 :: v_dual_add_f32 v9, s19, v1
+; GFX11-NEXT:    v_dual_add_f32 v12, s20, v0 :: v_dual_add_f32 v13, s21, v1
+; GFX11-NEXT:    v_dual_add_f32 v16, s22, v0 :: v_dual_add_f32 v17, s23, v1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    s_buffer_load_b64 s[16:17], s[12:15], 0x50
+; GFX11-NEXT:    s_buffer_load_b64 s[18:19], s[12:15], 0x60
+; GFX11-NEXT:    s_buffer_load_b64 s[20:21], s[12:15], 0x70
+; GFX11-NEXT:    s_buffer_load_b64 s[22:23], s[12:15], 0x80
+; GFX11-NEXT:    s_clause 0x3
 ; GFX11-NEXT:    image_sample v[4:7], v[4:5], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[8:11], v[8:9], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[12:15], v[12:13], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[16:19], v[16:17], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-NEXT:    v_dual_add_f32 v20, s16, v0 :: v_dual_add_f32 v21, s17, v1
+; GFX11-NEXT:    v_dual_add_f32 v24, s18, v0 :: v_dual_add_f32 v25, s19, v1
+; GFX11-NEXT:    v_dual_add_f32 v28, s20, v0 :: v_dual_add_f32 v29, s21, v1
+; GFX11-NEXT:    v_dual_add_f32 v32, s22, v0 :: v_dual_add_f32 v33, s23, v1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    s_buffer_load_b64 s[16:17], s[12:15], 0x90
+; GFX11-NEXT:    s_buffer_load_b64 s[18:19], s[12:15], 0xa0
+; GFX11-NEXT:    s_buffer_load_b64 s[20:21], s[12:15], 0xb0
+; GFX11-NEXT:    s_buffer_load_b64 s[22:23], s[12:15], 0xc0
+; GFX11-NEXT:    s_clause 0x3
 ; GFX11-NEXT:    image_sample v[20:23], v[20:21], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[24:27], v[24:25], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[28:31], v[28:29], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[32:35], v[32:33], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
-; GFX11-NEXT:    v_add_f32_e32 v37, s34, v0
-; GFX11-NEXT:    v_add_f32_e32 v38, s35, v36
-; GFX11-NEXT:    v_add_f32_e32 v40, s36, v0
-; GFX11-NEXT:    v_add_f32_e32 v41, s37, v36
-; GFX11-NEXT:    v_add_f32_e32 v44, s38, v0
-; GFX11-NEXT:    v_add_f32_e32 v45, s39, v36
-; GFX11-NEXT:    v_add_f32_e32 v48, s40, v0
-; GFX11-NEXT:    v_add_f32_e32 v49, s41, v36
-; GFX11-NEXT:    v_add_f32_e32 v52, s42, v0
-; GFX11-NEXT:    v_add_f32_e32 v53, s43, v36
-; GFX11-NEXT:    v_add_f32_e32 v56, s44, v0
-; GFX11-NEXT:    v_add_f32_e32 v57, s45, v36
-; GFX11-NEXT:    v_add_f32_e32 v60, s46, v0
-; GFX11-NEXT:    v_add_f32_e32 v61, s47, v36
-; GFX11-NEXT:    v_add_f32_e32 v0, s12, v0
-; GFX11-NEXT:    v_add_f32_e32 v1, s13, v36
-; GFX11-NEXT:    s_and_b32 exec_lo, exec_lo, s33
-; GFX11-NEXT:    s_clause 0x7
-; GFX11-NEXT:    image_sample v[36:39], v[37:38], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-NEXT:    v_dual_add_f32 v36, s16, v0 :: v_dual_add_f32 v37, s17, v1
+; GFX11-NEXT:    v_dual_add_f32 v40, s18, v0 :: v_dual_add_f32 v41, s19, v1
+; GFX11-NEXT:    v_dual_add_f32 v44, s20, v0 :: v_dual_add_f32 v45, s21, v1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    s_buffer_load_b64 s[16:17], s[12:15], 0xd0
+; GFX11-NEXT:    s_buffer_load_b64 s[18:19], s[12:15], 0xe0
+; GFX11-NEXT:    s_buffer_load_b64 s[20:21], s[12:15], 0xf0
+; GFX11-NEXT:    s_buffer_load_b64 s[12:13], s[12:15], 0x100
+; GFX11-NEXT:    v_dual_add_f32 v48, s22, v0 :: v_dual_add_f32 v49, s23, v1
+; GFX11-NEXT:    s_clause 0x3
+; GFX11-NEXT:    image_sample v[36:39], v[36:37], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[40:43], v[40:41], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[44:47], v[44:45], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[48:51], v[48:49], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
+; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-NEXT:    v_dual_add_f32 v52, s16, v0 :: v_dual_add_f32 v53, s17, v1
+; GFX11-NEXT:    v_dual_add_f32 v56, s18, v0 :: v_dual_add_f32 v57, s19, v1
+; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    image_sample v[52:55], v[52:53], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[56:59], v[56:57], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
+; GFX11-NEXT:    v_dual_add_f32 v60, s20, v0 :: v_dual_add_f32 v61, s21, v1
+; GFX11-NEXT:    v_dual_add_f32 v0, s12, v0 :: v_dual_add_f32 v1, s13, v1
+; GFX11-NEXT:    s_and_b32 exec_lo, exec_lo, s24
+; GFX11-NEXT:    s_clause 0x1
 ; GFX11-NEXT:    image_sample v[60:63], v[60:61], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    image_sample v[64:67], v[0:1], s[0:7], s[8:11] dmask:0xf dim:SQ_RSRC_IMG_2D
 ; GFX11-NEXT:    s_waitcnt vmcnt(14)

--- a/llvm/test/CodeGen/AMDGPU/idot4s.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot4s.ll
@@ -3091,15 +3091,15 @@ define amdgpu_kernel void @idot4_4src(ptr addrspace(1) %src1,
 ; GFX9-NODL-LABEL: idot4_4src:
 ; GFX9-NODL:       ; %bb.0: ; %entry
 ; GFX9-NODL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX9-NODL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-NODL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
+; GFX9-NODL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-NODL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NODL-NEXT:    global_load_dword v1, v0, s[8:9]
 ; GFX9-NODL-NEXT:    global_load_dword v2, v0, s[10:11]
 ; GFX9-NODL-NEXT:    global_load_dword v3, v0, s[12:13]
 ; GFX9-NODL-NEXT:    global_load_dword v4, v0, s[14:15]
-; GFX9-NODL-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX9-NODL-NEXT:    s_load_dword s2, s[0:1], 0x0
+; GFX9-NODL-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX9-NODL-NEXT:    s_waitcnt vmcnt(3)
 ; GFX9-NODL-NEXT:    v_mul_i32_i24_sdwa v1, sext(v1), sext(v1) dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:BYTE_1
 ; GFX9-NODL-NEXT:    s_waitcnt vmcnt(2)
@@ -3117,8 +3117,8 @@ define amdgpu_kernel void @idot4_4src(ptr addrspace(1) %src1,
 ; GFX9-DL-LABEL: idot4_4src:
 ; GFX9-DL:       ; %bb.0: ; %entry
 ; GFX9-DL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX9-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-DL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
+; GFX9-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-DL-NEXT:    s_mov_b32 s2, 0xc0c0501
 ; GFX9-DL-NEXT:    s_mov_b32 s3, 0x5010c0c
 ; GFX9-DL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3126,8 +3126,8 @@ define amdgpu_kernel void @idot4_4src(ptr addrspace(1) %src1,
 ; GFX9-DL-NEXT:    global_load_dword v2, v0, s[10:11]
 ; GFX9-DL-NEXT:    global_load_dword v3, v0, s[12:13]
 ; GFX9-DL-NEXT:    global_load_dword v4, v0, s[14:15]
-; GFX9-DL-NEXT:    s_mov_b32 s4, 0xc0c0400
 ; GFX9-DL-NEXT:    s_load_dword s6, s[0:1], 0x0
+; GFX9-DL-NEXT:    s_mov_b32 s4, 0xc0c0400
 ; GFX9-DL-NEXT:    s_mov_b32 s5, 0x4000c0c
 ; GFX9-DL-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX9-DL-NEXT:    s_waitcnt vmcnt(2)
@@ -3145,9 +3145,10 @@ define amdgpu_kernel void @idot4_4src(ptr addrspace(1) %src1,
 ;
 ; GFX10-DL-LABEL: idot4_4src:
 ; GFX10-DL:       ; %bb.0: ; %entry
+; GFX10-DL-NEXT:    s_clause 0x1
 ; GFX10-DL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX10-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX10-DL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
+; GFX10-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX10-DL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-DL-NEXT:    s_clause 0x3
 ; GFX10-DL-NEXT:    global_load_dword v1, v0, s[8:9]
@@ -3172,9 +3173,10 @@ define amdgpu_kernel void @idot4_4src(ptr addrspace(1) %src1,
 ;
 ; GFX11-DL-LABEL: idot4_4src:
 ; GFX11-DL:       ; %bb.0: ; %entry
+; GFX11-DL-NEXT:    s_clause 0x1
 ; GFX11-DL-NEXT:    s_load_b256 s[8:15], s[4:5], 0x24
-; GFX11-DL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x44
+; GFX11-DL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-DL-NEXT:    s_waitcnt lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/idot4u.ll
+++ b/llvm/test/CodeGen/AMDGPU/idot4u.ll
@@ -4633,15 +4633,15 @@ define amdgpu_kernel void @udot4_4src(ptr addrspace(1) %src1,
 ; GFX9-NODL-LABEL: udot4_4src:
 ; GFX9-NODL:       ; %bb.0: ; %entry
 ; GFX9-NODL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX9-NODL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-NODL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
+; GFX9-NODL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-NODL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NODL-NEXT:    global_load_dword v1, v0, s[8:9]
 ; GFX9-NODL-NEXT:    global_load_dword v2, v0, s[10:11]
 ; GFX9-NODL-NEXT:    global_load_dword v3, v0, s[12:13]
 ; GFX9-NODL-NEXT:    global_load_dword v4, v0, s[14:15]
-; GFX9-NODL-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX9-NODL-NEXT:    s_load_dword s2, s[0:1], 0x0
+; GFX9-NODL-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX9-NODL-NEXT:    s_waitcnt vmcnt(3)
 ; GFX9-NODL-NEXT:    v_mul_u32_u24_sdwa v1, v1, v1 dst_sel:DWORD dst_unused:UNUSED_PAD src0_sel:BYTE_0 src1_sel:BYTE_1
 ; GFX9-NODL-NEXT:    s_waitcnt vmcnt(2)
@@ -4659,8 +4659,8 @@ define amdgpu_kernel void @udot4_4src(ptr addrspace(1) %src1,
 ; GFX9-DL-LABEL: udot4_4src:
 ; GFX9-DL:       ; %bb.0: ; %entry
 ; GFX9-DL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX9-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-DL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
+; GFX9-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-DL-NEXT:    s_mov_b32 s2, 0xc0c0501
 ; GFX9-DL-NEXT:    s_mov_b32 s3, 0x5010c0c
 ; GFX9-DL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4668,8 +4668,8 @@ define amdgpu_kernel void @udot4_4src(ptr addrspace(1) %src1,
 ; GFX9-DL-NEXT:    global_load_dword v2, v0, s[10:11]
 ; GFX9-DL-NEXT:    global_load_dword v3, v0, s[12:13]
 ; GFX9-DL-NEXT:    global_load_dword v4, v0, s[14:15]
-; GFX9-DL-NEXT:    s_mov_b32 s4, 0xc0c0400
 ; GFX9-DL-NEXT:    s_load_dword s6, s[0:1], 0x0
+; GFX9-DL-NEXT:    s_mov_b32 s4, 0xc0c0400
 ; GFX9-DL-NEXT:    s_mov_b32 s5, 0x4000c0c
 ; GFX9-DL-NEXT:    v_mov_b32_e32 v0, 0
 ; GFX9-DL-NEXT:    s_waitcnt vmcnt(2)
@@ -4687,9 +4687,10 @@ define amdgpu_kernel void @udot4_4src(ptr addrspace(1) %src1,
 ;
 ; GFX10-DL-LABEL: udot4_4src:
 ; GFX10-DL:       ; %bb.0: ; %entry
+; GFX10-DL-NEXT:    s_clause 0x1
 ; GFX10-DL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX10-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX10-DL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
+; GFX10-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX10-DL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-DL-NEXT:    s_clause 0x3
 ; GFX10-DL-NEXT:    global_load_dword v1, v0, s[8:9]
@@ -4713,9 +4714,10 @@ define amdgpu_kernel void @udot4_4src(ptr addrspace(1) %src1,
 ;
 ; GFX11-DL-LABEL: udot4_4src:
 ; GFX11-DL:       ; %bb.0: ; %entry
+; GFX11-DL-NEXT:    s_clause 0x1
 ; GFX11-DL-NEXT:    s_load_b256 s[8:15], s[4:5], 0x24
-; GFX11-DL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x44
+; GFX11-DL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX11-DL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-DL-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX11-DL-NEXT:    s_waitcnt lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/indirect-addressing-si.ll
+++ b/llvm/test/CodeGen/AMDGPU/indirect-addressing-si.ll
@@ -1428,28 +1428,28 @@ define amdgpu_kernel void @extract_neg_offset_sgpr_loaded(ptr addrspace(1) %out,
 ;
 ; GFX9-IDXMODE-LABEL: extract_neg_offset_sgpr_loaded:
 ; GFX9-IDXMODE:       ; %bb.0: ; %entry
-; GFX9-IDXMODE-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x64
-; GFX9-IDXMODE-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
+; GFX9-IDXMODE-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
+; GFX9-IDXMODE-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0x64
 ; GFX9-IDXMODE-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-IDXMODE-NEXT:    s_load_dword s2, s[4:5], 0xe4
 ; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v16, 0
 ; GFX9-IDXMODE-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-IDXMODE-NEXT:    s_or_b32 s8, s8, s36
-; GFX9-IDXMODE-NEXT:    s_or_b32 s3, s23, s51
-; GFX9-IDXMODE-NEXT:    s_or_b32 s4, s22, s50
-; GFX9-IDXMODE-NEXT:    s_or_b32 s5, s21, s49
-; GFX9-IDXMODE-NEXT:    s_or_b32 s6, s20, s48
-; GFX9-IDXMODE-NEXT:    s_or_b32 s7, s19, s47
-; GFX9-IDXMODE-NEXT:    s_or_b32 s18, s18, s46
-; GFX9-IDXMODE-NEXT:    s_or_b32 s17, s17, s45
-; GFX9-IDXMODE-NEXT:    s_or_b32 s16, s16, s44
-; GFX9-IDXMODE-NEXT:    s_or_b32 s15, s15, s43
-; GFX9-IDXMODE-NEXT:    s_or_b32 s14, s14, s42
-; GFX9-IDXMODE-NEXT:    s_or_b32 s13, s13, s41
-; GFX9-IDXMODE-NEXT:    s_or_b32 s12, s12, s40
-; GFX9-IDXMODE-NEXT:    s_or_b32 s11, s11, s39
-; GFX9-IDXMODE-NEXT:    s_or_b32 s10, s10, s38
-; GFX9-IDXMODE-NEXT:    s_or_b32 s9, s9, s37
+; GFX9-IDXMODE-NEXT:    s_or_b32 s8, s36, s8
+; GFX9-IDXMODE-NEXT:    s_or_b32 s3, s51, s23
+; GFX9-IDXMODE-NEXT:    s_or_b32 s4, s50, s22
+; GFX9-IDXMODE-NEXT:    s_or_b32 s5, s49, s21
+; GFX9-IDXMODE-NEXT:    s_or_b32 s6, s48, s20
+; GFX9-IDXMODE-NEXT:    s_or_b32 s7, s47, s19
+; GFX9-IDXMODE-NEXT:    s_or_b32 s18, s46, s18
+; GFX9-IDXMODE-NEXT:    s_or_b32 s17, s45, s17
+; GFX9-IDXMODE-NEXT:    s_or_b32 s16, s44, s16
+; GFX9-IDXMODE-NEXT:    s_or_b32 s15, s43, s15
+; GFX9-IDXMODE-NEXT:    s_or_b32 s14, s42, s14
+; GFX9-IDXMODE-NEXT:    s_or_b32 s13, s41, s13
+; GFX9-IDXMODE-NEXT:    s_or_b32 s12, s40, s12
+; GFX9-IDXMODE-NEXT:    s_or_b32 s11, s39, s11
+; GFX9-IDXMODE-NEXT:    s_or_b32 s10, s38, s10
+; GFX9-IDXMODE-NEXT:    s_or_b32 s9, s37, s9
 ; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v0, s8
 ; GFX9-IDXMODE-NEXT:    s_addk_i32 s2, 0xfe00
 ; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v1, s9
@@ -6389,22 +6389,20 @@ define amdgpu_kernel void @insert_vgpr_offset_multiple_in_block(ptr addrspace(1)
 ;
 ; SI-MOVREL-LABEL: insert_vgpr_offset_multiple_in_block:
 ; SI-MOVREL:       ; %bb.0: ; %entry
-; SI-MOVREL-NEXT:    s_load_dwordx2 s[8:9], s[4:5], 0xd
+; SI-MOVREL-NEXT:    s_load_dwordx2 s[24:25], s[4:5], 0xd
+; SI-MOVREL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x19
 ; SI-MOVREL-NEXT:    s_mov_b32 s3, 0xf000
-; SI-MOVREL-NEXT:    s_mov_b32 s10, 0
-; SI-MOVREL-NEXT:    s_mov_b32 s11, s3
+; SI-MOVREL-NEXT:    s_mov_b32 s26, 0
+; SI-MOVREL-NEXT:    s_mov_b32 s27, s3
 ; SI-MOVREL-NEXT:    v_lshlrev_b32_e32 v1, 2, v0
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v2, 0
 ; SI-MOVREL-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-MOVREL-NEXT:    buffer_load_dword v14, v[1:2], s[8:11], 0 addr64 glc
+; SI-MOVREL-NEXT:    buffer_load_dword v14, v[1:2], s[24:27], 0 addr64 glc
 ; SI-MOVREL-NEXT:    s_waitcnt vmcnt(0)
-; SI-MOVREL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x19
+; SI-MOVREL-NEXT:    v_mov_b32_e32 v2, s18
 ; SI-MOVREL-NEXT:    ;;#ASMSTART
 ; SI-MOVREL-NEXT:    v_mov_b32 v1, 62
 ; SI-MOVREL-NEXT:    ;;#ASMEND
-; SI-MOVREL-NEXT:    s_mov_b32 s2, -1
-; SI-MOVREL-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-MOVREL-NEXT:    v_mov_b32_e32 v2, s18
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v3, s19
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v4, s12
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v5, s13
@@ -6417,6 +6415,7 @@ define amdgpu_kernel void @insert_vgpr_offset_multiple_in_block(ptr addrspace(1)
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v10, s22
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v11, s23
 ; SI-MOVREL-NEXT:    v_mov_b32_e32 v15, s16
+; SI-MOVREL-NEXT:    s_mov_b32 s2, -1
 ; SI-MOVREL-NEXT:    v_add_i32_e32 v18, vcc, 1, v14
 ; SI-MOVREL-NEXT:    v_cmp_eq_u32_e32 vcc, 10, v14
 ; SI-MOVREL-NEXT:    v_cndmask_b32_e32 v16, v2, v1, vcc
@@ -6635,15 +6634,15 @@ define amdgpu_kernel void @insert_vgpr_offset_multiple_in_block(ptr addrspace(1)
 ; GFX9-IDXMODE-LABEL: insert_vgpr_offset_multiple_in_block:
 ; GFX9-IDXMODE:       ; %bb.0: ; %entry
 ; GFX9-IDXMODE-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x34
-; GFX9-IDXMODE-NEXT:    v_lshlrev_b32_e32 v1, 2, v0
 ; GFX9-IDXMODE-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0x64
+; GFX9-IDXMODE-NEXT:    v_lshlrev_b32_e32 v1, 2, v0
 ; GFX9-IDXMODE-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-IDXMODE-NEXT:    global_load_dword v14, v1, s[0:1] glc
 ; GFX9-IDXMODE-NEXT:    s_waitcnt vmcnt(0)
+; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v2, s18
 ; GFX9-IDXMODE-NEXT:    ;;#ASMSTART
 ; GFX9-IDXMODE-NEXT:    v_mov_b32 v1, 62
 ; GFX9-IDXMODE-NEXT:    ;;#ASMEND
-; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v2, s18
 ; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v3, s19
 ; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v4, s12
 ; GFX9-IDXMODE-NEXT:    v_mov_b32_e32 v5, s13

--- a/llvm/test/CodeGen/AMDGPU/insert_vector_elt.ll
+++ b/llvm/test/CodeGen/AMDGPU/insert_vector_elt.ll
@@ -659,7 +659,6 @@ define amdgpu_kernel void @dynamic_insertelement_v8f32(ptr addrspace(1) %out, <8
 ; SI-NEXT:    s_load_dword s8, s[8:9], 0x10
 ; SI-NEXT:    v_mov_b32_e32 v8, 0x40a00000
 ; SI-NEXT:    s_mov_b32 s15, 0x100f000
-; SI-NEXT:    s_mov_b32 s14, -1
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
 ; SI-NEXT:    v_mov_b32_e32 v0, s0
 ; SI-NEXT:    v_mov_b32_e32 v1, s1
@@ -670,6 +669,7 @@ define amdgpu_kernel void @dynamic_insertelement_v8f32(ptr addrspace(1) %out, <8
 ; SI-NEXT:    v_mov_b32_e32 v6, s6
 ; SI-NEXT:    v_mov_b32_e32 v7, s7
 ; SI-NEXT:    s_mov_b32 m0, s8
+; SI-NEXT:    s_mov_b32 s14, -1
 ; SI-NEXT:    v_movreld_b32_e32 v0, v8
 ; SI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[12:15], 0 offset:16
 ; SI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[12:15], 0
@@ -682,7 +682,6 @@ define amdgpu_kernel void @dynamic_insertelement_v8f32(ptr addrspace(1) %out, <8
 ; VI-NEXT:    s_load_dword s8, s[8:9], 0x40
 ; VI-NEXT:    v_mov_b32_e32 v8, 0x40a00000
 ; VI-NEXT:    s_mov_b32 s15, 0x1100f000
-; VI-NEXT:    s_mov_b32 s14, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-NEXT:    v_mov_b32_e32 v1, s1
@@ -693,6 +692,7 @@ define amdgpu_kernel void @dynamic_insertelement_v8f32(ptr addrspace(1) %out, <8
 ; VI-NEXT:    v_mov_b32_e32 v6, s6
 ; VI-NEXT:    v_mov_b32_e32 v7, s7
 ; VI-NEXT:    s_mov_b32 m0, s8
+; VI-NEXT:    s_mov_b32 s14, -1
 ; VI-NEXT:    v_movreld_b32_e32 v0, v8
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[12:15], 0 offset:16
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[12:15], 0
@@ -736,7 +736,6 @@ define amdgpu_kernel void @dynamic_insertelement_v9f32(ptr addrspace(1) %out, <9
 ; VI-NEXT:    s_load_dword s10, s[8:9], 0x60
 ; VI-NEXT:    v_mov_b32_e32 v9, 0x40a00000
 ; VI-NEXT:    s_mov_b32 s15, 0x1100f000
-; VI-NEXT:    s_mov_b32 s14, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-NEXT:    s_load_dword s0, s[8:9], 0x80
@@ -750,6 +749,7 @@ define amdgpu_kernel void @dynamic_insertelement_v9f32(ptr addrspace(1) %out, <9
 ; VI-NEXT:    v_mov_b32_e32 v8, s10
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    s_mov_b32 m0, s0
+; VI-NEXT:    s_mov_b32 s14, -1
 ; VI-NEXT:    v_movreld_b32_e32 v0, v9
 ; VI-NEXT:    buffer_store_dword v8, off, s[12:15], 0 offset:32
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[12:15], 0 offset:16
@@ -790,13 +790,14 @@ define amdgpu_kernel void @dynamic_insertelement_v10f32(ptr addrspace(1) %out, <
 ;
 ; VI-LABEL: dynamic_insertelement_v10f32:
 ; VI:       ; %bb.0:
-; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
-; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    s_load_dwordx2 s[4:5], s[8:9], 0x60
 ; VI-NEXT:    s_load_dword s6, s[8:9], 0x80
+; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
+; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    v_mov_b32_e32 v10, 0x40a00000
 ; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v8, s4
 ; VI-NEXT:    v_mov_b32_e32 v0, s12
 ; VI-NEXT:    v_mov_b32_e32 v1, s13
 ; VI-NEXT:    v_mov_b32_e32 v2, s14
@@ -805,7 +806,6 @@ define amdgpu_kernel void @dynamic_insertelement_v10f32(ptr addrspace(1) %out, <
 ; VI-NEXT:    v_mov_b32_e32 v5, s17
 ; VI-NEXT:    v_mov_b32_e32 v6, s18
 ; VI-NEXT:    v_mov_b32_e32 v7, s19
-; VI-NEXT:    v_mov_b32_e32 v8, s4
 ; VI-NEXT:    v_mov_b32_e32 v9, s5
 ; VI-NEXT:    s_mov_b32 m0, s6
 ; VI-NEXT:    s_mov_b32 s2, -1
@@ -851,14 +851,15 @@ define amdgpu_kernel void @dynamic_insertelement_v11f32(ptr addrspace(1) %out, <
 ;
 ; VI-LABEL: dynamic_insertelement_v11f32:
 ; VI:       ; %bb.0:
-; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    s_load_dwordx4 s[4:7], s[8:9], 0x60
-; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    s_load_dword s7, s[8:9], 0x80
+; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
+; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    v_mov_b32_e32 v11, 0x40a00000
 ; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    v_mov_b32_e32 v8, s4
+; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s12
 ; VI-NEXT:    v_mov_b32_e32 v1, s13
 ; VI-NEXT:    v_mov_b32_e32 v2, s14
@@ -869,7 +870,6 @@ define amdgpu_kernel void @dynamic_insertelement_v11f32(ptr addrspace(1) %out, <
 ; VI-NEXT:    v_mov_b32_e32 v7, s19
 ; VI-NEXT:    v_mov_b32_e32 v9, s5
 ; VI-NEXT:    v_mov_b32_e32 v10, s6
-; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    s_mov_b32 m0, s7
 ; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    v_movreld_b32_e32 v0, v11
@@ -919,7 +919,6 @@ define amdgpu_kernel void @dynamic_insertelement_v12f32(ptr addrspace(1) %out, <
 ; VI-NEXT:    s_load_dwordx4 s[4:7], s[8:9], 0x60
 ; VI-NEXT:    s_load_dword s8, s[8:9], 0x80
 ; VI-NEXT:    v_mov_b32_e32 v12, 0x40a00000
-; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s12
 ; VI-NEXT:    v_mov_b32_e32 v1, s13
@@ -934,6 +933,7 @@ define amdgpu_kernel void @dynamic_insertelement_v12f32(ptr addrspace(1) %out, <
 ; VI-NEXT:    v_mov_b32_e32 v10, s6
 ; VI-NEXT:    v_mov_b32_e32 v11, s7
 ; VI-NEXT:    s_mov_b32 m0, s8
+; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    v_movreld_b32_e32 v0, v12
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:16
@@ -1285,13 +1285,14 @@ define amdgpu_kernel void @dynamic_insertelement_v10i32(ptr addrspace(1) %out, <
 ;
 ; VI-LABEL: dynamic_insertelement_v10i32:
 ; VI:       ; %bb.0:
-; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
-; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    s_load_dwordx2 s[4:5], s[8:9], 0x60
 ; VI-NEXT:    s_load_dword s6, s[8:9], 0x80
+; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
+; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
+; VI-NEXT:    v_mov_b32_e32 v8, s4
 ; VI-NEXT:    v_mov_b32_e32 v0, s12
 ; VI-NEXT:    v_mov_b32_e32 v1, s13
 ; VI-NEXT:    v_mov_b32_e32 v2, s14
@@ -1300,7 +1301,6 @@ define amdgpu_kernel void @dynamic_insertelement_v10i32(ptr addrspace(1) %out, <
 ; VI-NEXT:    v_mov_b32_e32 v5, s17
 ; VI-NEXT:    v_mov_b32_e32 v6, s18
 ; VI-NEXT:    v_mov_b32_e32 v7, s19
-; VI-NEXT:    v_mov_b32_e32 v8, s4
 ; VI-NEXT:    v_mov_b32_e32 v9, s5
 ; VI-NEXT:    s_mov_b32 m0, s6
 ; VI-NEXT:    v_movreld_b32_e32 v0, 5
@@ -1344,14 +1344,15 @@ define amdgpu_kernel void @dynamic_insertelement_v11i32(ptr addrspace(1) %out, <
 ;
 ; VI-LABEL: dynamic_insertelement_v11i32:
 ; VI:       ; %bb.0:
-; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    s_load_dwordx4 s[4:7], s[8:9], 0x60
-; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    s_load_dword s7, s[8:9], 0x80
+; VI-NEXT:    s_load_dwordx8 s[12:19], s[8:9], 0x40
+; VI-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
 ; VI-NEXT:    s_mov_b32 s3, 0x1100f000
 ; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    v_mov_b32_e32 v8, s4
+; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s12
 ; VI-NEXT:    v_mov_b32_e32 v1, s13
 ; VI-NEXT:    v_mov_b32_e32 v2, s14
@@ -1362,7 +1363,6 @@ define amdgpu_kernel void @dynamic_insertelement_v11i32(ptr addrspace(1) %out, <
 ; VI-NEXT:    v_mov_b32_e32 v7, s19
 ; VI-NEXT:    v_mov_b32_e32 v9, s5
 ; VI-NEXT:    v_mov_b32_e32 v10, s6
-; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    s_mov_b32 m0, s7
 ; VI-NEXT:    v_movreld_b32_e32 v0, 5
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:16
@@ -1410,7 +1410,6 @@ define amdgpu_kernel void @dynamic_insertelement_v12i32(ptr addrspace(1) %out, <
 ; VI-NEXT:    s_load_dwordx4 s[4:7], s[8:9], 0x60
 ; VI-NEXT:    s_load_dword s8, s[8:9], 0x80
 ; VI-NEXT:    s_mov_b32 s3, 0x1100f000
-; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NEXT:    v_mov_b32_e32 v0, s12
 ; VI-NEXT:    v_mov_b32_e32 v1, s13
@@ -1425,6 +1424,7 @@ define amdgpu_kernel void @dynamic_insertelement_v12i32(ptr addrspace(1) %out, <
 ; VI-NEXT:    v_mov_b32_e32 v10, s6
 ; VI-NEXT:    v_mov_b32_e32 v11, s7
 ; VI-NEXT:    s_mov_b32 m0, s8
+; VI-NEXT:    s_mov_b32 s2, -1
 ; VI-NEXT:    v_movreld_b32_e32 v0, 5
 ; VI-NEXT:    buffer_store_dwordx4 v[4:7], off, s[0:3], 0 offset:16
 ; VI-NEXT:    buffer_store_dwordx4 v[0:3], off, s[0:3], 0

--- a/llvm/test/CodeGen/AMDGPU/kernel-args.ll
+++ b/llvm/test/CodeGen/AMDGPU/kernel-args.ll
@@ -2927,20 +2927,20 @@ define amdgpu_kernel void @v8i32_arg(ptr addrspace(1) nocapture %out, <8 x i32> 
 ; GFX9-LABEL: v8i32_arg:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_load_dwordx8 s[0:7], s[8:9], 0x20
+; GFX9-NEXT:    s_load_dwordx2 s[10:11], s[8:9], 0x0
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0x0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s7
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9] offset:16
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11] offset:16
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s3
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9]
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; EG-LABEL: v8i32_arg:
@@ -3038,20 +3038,20 @@ define amdgpu_kernel void @v8f32_arg(ptr addrspace(1) nocapture %out, <8 x float
 ; GFX9-LABEL: v8f32_arg:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_load_dwordx8 s[0:7], s[8:9], 0x20
+; GFX9-NEXT:    s_load_dwordx2 s[10:11], s[8:9], 0x0
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0x0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s7
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9] offset:16
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11] offset:16
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s3
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9]
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; EG-LABEL: v8f32_arg:
@@ -3600,20 +3600,20 @@ define amdgpu_kernel void @v16i16_arg(ptr addrspace(1) %out, <16 x i16> %in) {
 ; GFX9-LABEL: v16i16_arg:
 ; GFX9:       ; %bb.0: ; %entry
 ; GFX9-NEXT:    s_load_dwordx8 s[0:7], s[8:9], 0x20
+; GFX9-NEXT:    s_load_dwordx2 s[10:11], s[8:9], 0x0
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0x0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s5
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s7
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9] offset:16
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11] offset:16
 ; GFX9-NEXT:    s_nop 0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s3
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9]
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; EG-LABEL: v16i16_arg:

--- a/llvm/test/CodeGen/AMDGPU/kernel-argument-dag-lowering.ll
+++ b/llvm/test/CodeGen/AMDGPU/kernel-argument-dag-lowering.ll
@@ -527,8 +527,8 @@ define amdgpu_kernel void @byref_natural_align_constant_v16i32_arg(ptr addrspace
 ; GCN-LABEL: byref_natural_align_constant_v16i32_arg:
 ; GCN:       ; %bb.0:
 ; GCN-NEXT:    s_load_dwordx16 s[12:27], s[8:9], 0x40
-; GCN-NEXT:    s_load_dword s2, s[8:9], 0x80
 ; GCN-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
+; GCN-NEXT:    s_load_dword s2, s[8:9], 0x80
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
 ; GCN-NEXT:    v_mov_b32_e32 v0, s24

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.alignbyte.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.alignbyte.ll
@@ -103,16 +103,15 @@ define amdgpu_kernel void @v_alignbyte_b32_2(ptr addrspace(1) %out, ptr addrspac
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
 ; GFX9-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
+; GFX9-NEXT:    s_load_dword s8, s[4:5], 0x3c
 ; GFX9-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    global_load_dword v1, v0, s[2:3] glc
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    global_load_dword v2, v0, s[6:7] glc
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    s_load_dword s2, s[4:5], 0x3c
 ; GFX9-NEXT:    v_mov_b32_e32 v0, 0
-; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NEXT:    v_alignbyte_b32 v1, v1, v2, s2
+; GFX9-NEXT:    v_alignbyte_b32 v1, v1, v2, s8
 ; GFX9-NEXT:    global_store_dword v0, v1, s[0:1]
 ; GFX9-NEXT:    s_endpgm
 ;
@@ -122,15 +121,14 @@ define amdgpu_kernel void @v_alignbyte_b32_2(ptr addrspace(1) %out, ptr addrspac
 ; GFX10-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x24
 ; GFX10-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x34
 ; GFX10-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
+; GFX10-NEXT:    s_load_dword s4, s[4:5], 0x3c
 ; GFX10-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    global_load_dword v1, v0, s[2:3] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
 ; GFX10-NEXT:    global_load_dword v0, v0, s[6:7] glc dlc
 ; GFX10-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-NEXT:    s_load_dword s2, s[4:5], 0x3c
-; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-NEXT:    v_alignbyte_b32 v0, v1, v0, s2
+; GFX10-NEXT:    v_alignbyte_b32 v0, v1, v0, s4
 ; GFX10-NEXT:    global_store_dword v2, v0, s[0:1]
 ; GFX10-NEXT:    s_endpgm
 ;
@@ -140,6 +138,7 @@ define amdgpu_kernel void @v_alignbyte_b32_2(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-TRUE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-TRUE16-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34
 ; GFX11-TRUE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-TRUE16-NEXT:    s_load_b32 s4, s[4:5], 0x3c
 ; GFX11-TRUE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-TRUE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-TRUE16-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
@@ -148,8 +147,8 @@ define amdgpu_kernel void @v_alignbyte_b32_2(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-TRUE16-NEXT:    global_load_b32 v0, v0, s[6:7] glc dlc
 ; GFX11-TRUE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-TRUE16-NEXT:    s_load_b32 s2, s[4:5], 0x3c
-; GFX11-TRUE16-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-TRUE16-NEXT:    s_mov_b32 s2, s4
+; GFX11-TRUE16-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-TRUE16-NEXT:    v_alignbyte_b32 v0, v1, v0, s2
 ; GFX11-TRUE16-NEXT:    global_store_b32 v2, v0, s[0:1]
 ; GFX11-TRUE16-NEXT:    s_endpgm
@@ -160,6 +159,7 @@ define amdgpu_kernel void @v_alignbyte_b32_2(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-FAKE16-NEXT:    s_load_b128 s[0:3], s[4:5], 0x24
 ; GFX11-FAKE16-NEXT:    s_load_b64 s[6:7], s[4:5], 0x34
 ; GFX11-FAKE16-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX11-FAKE16-NEXT:    s_load_b32 s4, s[4:5], 0x3c
 ; GFX11-FAKE16-NEXT:    v_mov_b32_e32 v2, 0
 ; GFX11-FAKE16-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-FAKE16-NEXT:    v_lshlrev_b32_e32 v0, 2, v0
@@ -168,9 +168,7 @@ define amdgpu_kernel void @v_alignbyte_b32_2(ptr addrspace(1) %out, ptr addrspac
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
 ; GFX11-FAKE16-NEXT:    global_load_b32 v0, v0, s[6:7] glc dlc
 ; GFX11-FAKE16-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-FAKE16-NEXT:    s_load_b32 s2, s[4:5], 0x3c
-; GFX11-FAKE16-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-FAKE16-NEXT:    v_alignbyte_b32 v0, v1, v0, s2
+; GFX11-FAKE16-NEXT:    v_alignbyte_b32 v0, v1, v0, s4
 ; GFX11-FAKE16-NEXT:    global_store_b32 v2, v0, s[0:1]
 ; GFX11-FAKE16-NEXT:    s_endpgm
   %tid = call i32 @llvm.amdgcn.workitem.id.x()

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.mfma.gfx942.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.mfma.gfx942.ll
@@ -1264,16 +1264,16 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x32_f16(ptr addrspace(1) %arg, <
 ; GFX942-GISEL-LABEL: test_smfmac_f32_16x16x32_f16:
 ; GFX942-GISEL:       ; %bb.0: ; %bb
 ; GFX942-GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX942-GISEL-NEXT:    s_load_dword s6, s[4:5], 0x44
+; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[10:11]
+; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[0:1], s[12:13]
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[2:3], s[14:15]
+; GFX942-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[10:11], s[2:3]
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[8:9], s[0:1]
-; GFX942-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX942-GISEL-NEXT:    s_nop 1
 ; GFX942-GISEL-NEXT:    v_smfmac_f32_16x16x32_f16 v[8:11], v[4:5], v[0:3], v6 cbsz:1 abid:2
 ; GFX942-GISEL-NEXT:    v_mov_b32_e32 v0, 0
@@ -1304,16 +1304,16 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x32_f16(ptr addrspace(1) %arg, <
 ; GFX950-GISEL-LABEL: test_smfmac_f32_16x16x32_f16:
 ; GFX950-GISEL:       ; %bb.0: ; %bb
 ; GFX950-GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX950-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX950-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX950-GISEL-NEXT:    s_load_dword s6, s[4:5], 0x44
+; GFX950-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[10:11]
+; GFX950-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[0:1], s[12:13]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[2:3], s[14:15]
+; GFX950-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX950-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[10:11], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[8:9], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX950-GISEL-NEXT:    s_nop 1
 ; GFX950-GISEL-NEXT:    v_smfmac_f32_16x16x32_f16 v[8:11], v[4:5], v[0:3], v6 cbsz:1 abid:2
 ; GFX950-GISEL-NEXT:    v_mov_b32_e32 v0, 0
@@ -1666,16 +1666,16 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x32_bf16(ptr addrspace(1) %arg, 
 ; GFX942-GISEL-LABEL: test_smfmac_f32_16x16x32_bf16:
 ; GFX942-GISEL:       ; %bb.0: ; %bb
 ; GFX942-GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX942-GISEL-NEXT:    s_load_dword s6, s[4:5], 0x44
+; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[10:11]
+; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[0:1], s[12:13]
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[2:3], s[14:15]
+; GFX942-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[10:11], s[2:3]
 ; GFX942-GISEL-NEXT:    v_mov_b64_e32 v[8:9], s[0:1]
-; GFX942-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX942-GISEL-NEXT:    s_nop 1
 ; GFX942-GISEL-NEXT:    v_smfmac_f32_16x16x32_bf16 v[8:11], v[4:5], v[0:3], v6 cbsz:1 abid:2
 ; GFX942-GISEL-NEXT:    v_mov_b32_e32 v0, 0
@@ -1706,16 +1706,16 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x32_bf16(ptr addrspace(1) %arg, 
 ; GFX950-GISEL-LABEL: test_smfmac_f32_16x16x32_bf16:
 ; GFX950-GISEL:       ; %bb.0: ; %bb
 ; GFX950-GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
-; GFX950-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX950-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX950-GISEL-NEXT:    s_load_dword s6, s[4:5], 0x44
+; GFX950-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[4:5], s[10:11]
+; GFX950-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[0:1], s[12:13]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[2:3], s[14:15]
+; GFX950-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX950-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[10:11], s[2:3]
 ; GFX950-GISEL-NEXT:    v_mov_b64_e32 v[8:9], s[0:1]
-; GFX950-GISEL-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX950-GISEL-NEXT:    s_nop 1
 ; GFX950-GISEL-NEXT:    v_smfmac_f32_16x16x32_bf16 v[8:11], v[4:5], v[0:3], v6 cbsz:1 abid:2
 ; GFX950-GISEL-NEXT:    v_mov_b32_e32 v0, 0

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.smfmac.gfx950.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.smfmac.gfx950.ll
@@ -1410,14 +1410,13 @@ define amdgpu_kernel void @test_smfmac_i32_16x16x128_i8__vgpr(ptr addrspace(1) %
 ; SDAG-LABEL: test_smfmac_i32_16x16x128_i8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-NEXT:    v_mov_b32_e32 v10, s10
@@ -1431,8 +1430,8 @@ define amdgpu_kernel void @test_smfmac_i32_16x16x128_i8__vgpr(ptr addrspace(1) %
 ; SDAG-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-NEXT:    s_nop 0
 ; SDAG-NEXT:    v_smfmac_i32_16x16x128_i8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-NEXT:    s_nop 7
 ; SDAG-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -1441,9 +1440,9 @@ define amdgpu_kernel void @test_smfmac_i32_16x16x128_i8__vgpr(ptr addrspace(1) %
 ; GISEL-LABEL: test_smfmac_i32_16x16x128_i8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1466,14 +1465,13 @@ define amdgpu_kernel void @test_smfmac_i32_16x16x128_i8__vgpr(ptr addrspace(1) %
 ; SDAG-VGPR-LABEL: test_smfmac_i32_16x16x128_i8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-VGPR-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v10, s10
@@ -1487,8 +1485,8 @@ define amdgpu_kernel void @test_smfmac_i32_16x16x128_i8__vgpr(ptr addrspace(1) %
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-VGPR-NEXT:    s_nop 0
 ; SDAG-VGPR-NEXT:    v_smfmac_i32_16x16x128_i8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-VGPR-NEXT:    s_nop 7
 ; SDAG-VGPR-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -1497,9 +1495,9 @@ define amdgpu_kernel void @test_smfmac_i32_16x16x128_i8__vgpr(ptr addrspace(1) %
 ; GISEL-VGPR-LABEL: test_smfmac_i32_16x16x128_i8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1701,9 +1699,9 @@ define amdgpu_kernel void @test_smfmac_i32_32x32x64_i8__vgpr(ptr addrspace(1) %a
 ; SDAG-LABEL: test_smfmac_i32_32x32x64_i8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1738,9 +1736,9 @@ define amdgpu_kernel void @test_smfmac_i32_32x32x64_i8__vgpr(ptr addrspace(1) %a
 ; GISEL-LABEL: test_smfmac_i32_32x32x64_i8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1769,9 +1767,9 @@ define amdgpu_kernel void @test_smfmac_i32_32x32x64_i8__vgpr(ptr addrspace(1) %a
 ; SDAG-VGPR-LABEL: test_smfmac_i32_32x32x64_i8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -1806,9 +1804,9 @@ define amdgpu_kernel void @test_smfmac_i32_32x32x64_i8__vgpr(ptr addrspace(1) %a
 ; GISEL-VGPR-LABEL: test_smfmac_i32_32x32x64_i8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2309,14 +2307,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_bf8__vgpr(ptr addrspace
 ; SDAG-LABEL: test_smfmac_f32_16x16x128_bf8_bf8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-NEXT:    v_mov_b32_e32 v10, s10
@@ -2330,8 +2327,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_bf8__vgpr(ptr addrspace
 ; SDAG-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-NEXT:    s_nop 0
 ; SDAG-NEXT:    v_smfmac_f32_16x16x128_bf8_bf8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-NEXT:    s_nop 7
 ; SDAG-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -2340,9 +2337,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_bf8__vgpr(ptr addrspace
 ; GISEL-LABEL: test_smfmac_f32_16x16x128_bf8_bf8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2365,14 +2362,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_bf8__vgpr(ptr addrspace
 ; SDAG-VGPR-LABEL: test_smfmac_f32_16x16x128_bf8_bf8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-VGPR-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v10, s10
@@ -2386,8 +2382,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_bf8__vgpr(ptr addrspace
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-VGPR-NEXT:    s_nop 0
 ; SDAG-VGPR-NEXT:    v_smfmac_f32_16x16x128_bf8_bf8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-VGPR-NEXT:    s_nop 7
 ; SDAG-VGPR-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -2396,9 +2392,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_bf8__vgpr(ptr addrspace
 ; GISEL-VGPR-LABEL: test_smfmac_f32_16x16x128_bf8_bf8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2600,14 +2596,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_fp8__vgpr(ptr addrspace
 ; SDAG-LABEL: test_smfmac_f32_16x16x128_bf8_fp8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-NEXT:    v_mov_b32_e32 v10, s10
@@ -2621,8 +2616,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_fp8__vgpr(ptr addrspace
 ; SDAG-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-NEXT:    s_nop 0
 ; SDAG-NEXT:    v_smfmac_f32_16x16x128_bf8_fp8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-NEXT:    s_nop 7
 ; SDAG-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -2631,9 +2626,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_fp8__vgpr(ptr addrspace
 ; GISEL-LABEL: test_smfmac_f32_16x16x128_bf8_fp8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2656,14 +2651,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_fp8__vgpr(ptr addrspace
 ; SDAG-VGPR-LABEL: test_smfmac_f32_16x16x128_bf8_fp8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-VGPR-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v10, s10
@@ -2677,8 +2671,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_fp8__vgpr(ptr addrspace
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-VGPR-NEXT:    s_nop 0
 ; SDAG-VGPR-NEXT:    v_smfmac_f32_16x16x128_bf8_fp8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-VGPR-NEXT:    s_nop 7
 ; SDAG-VGPR-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -2687,9 +2681,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_bf8_fp8__vgpr(ptr addrspace
 ; GISEL-VGPR-LABEL: test_smfmac_f32_16x16x128_bf8_fp8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2891,14 +2885,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_bf8__vgpr(ptr addrspace
 ; SDAG-LABEL: test_smfmac_f32_16x16x128_fp8_bf8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-NEXT:    v_mov_b32_e32 v10, s10
@@ -2912,8 +2905,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_bf8__vgpr(ptr addrspace
 ; SDAG-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-NEXT:    s_nop 0
 ; SDAG-NEXT:    v_smfmac_f32_16x16x128_fp8_bf8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-NEXT:    s_nop 7
 ; SDAG-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -2922,9 +2915,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_bf8__vgpr(ptr addrspace
 ; GISEL-LABEL: test_smfmac_f32_16x16x128_fp8_bf8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -2947,14 +2940,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_bf8__vgpr(ptr addrspace
 ; SDAG-VGPR-LABEL: test_smfmac_f32_16x16x128_fp8_bf8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-VGPR-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v10, s10
@@ -2968,8 +2960,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_bf8__vgpr(ptr addrspace
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-VGPR-NEXT:    s_nop 0
 ; SDAG-VGPR-NEXT:    v_smfmac_f32_16x16x128_fp8_bf8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-VGPR-NEXT:    s_nop 7
 ; SDAG-VGPR-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -2978,9 +2970,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_bf8__vgpr(ptr addrspace
 ; GISEL-VGPR-LABEL: test_smfmac_f32_16x16x128_fp8_bf8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3182,14 +3174,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_fp8__vgpr(ptr addrspace
 ; SDAG-LABEL: test_smfmac_f32_16x16x128_fp8_fp8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-NEXT:    v_mov_b32_e32 v10, s10
@@ -3203,8 +3194,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_fp8__vgpr(ptr addrspace
 ; SDAG-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-NEXT:    s_nop 0
 ; SDAG-NEXT:    v_smfmac_f32_16x16x128_fp8_fp8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-NEXT:    s_nop 7
 ; SDAG-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -3213,9 +3204,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_fp8__vgpr(ptr addrspace
 ; GISEL-LABEL: test_smfmac_f32_16x16x128_fp8_fp8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3238,14 +3229,13 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_fp8__vgpr(ptr addrspace
 ; SDAG-VGPR-LABEL: test_smfmac_f32_16x16x128_fp8_fp8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
 ; SDAG-VGPR-NEXT:    global_load_dwordx4 v[14:17], v0, s[6:7]
-; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v8, s8
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v9, s9
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v10, s10
@@ -3259,8 +3249,8 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_fp8__vgpr(ptr addrspace
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v6, s2
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v7, s3
 ; SDAG-VGPR-NEXT:    v_mov_b32_e32 v13, s16
+; SDAG-VGPR-NEXT:    v_mov_b32_e32 v12, 0
 ; SDAG-VGPR-NEXT:    s_waitcnt vmcnt(0)
-; SDAG-VGPR-NEXT:    s_nop 0
 ; SDAG-VGPR-NEXT:    v_smfmac_f32_16x16x128_fp8_fp8 v[14:17], v[8:11], v[0:7], v13 cbsz:1 abid:2
 ; SDAG-VGPR-NEXT:    s_nop 7
 ; SDAG-VGPR-NEXT:    global_store_dwordx4 v12, v[14:17], s[6:7]
@@ -3269,9 +3259,9 @@ define amdgpu_kernel void @test_smfmac_f32_16x16x128_fp8_fp8__vgpr(ptr addrspace
 ; GISEL-VGPR-LABEL: test_smfmac_f32_16x16x128_fp8_fp8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v0, 4, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3473,9 +3463,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_bf8__vgpr(ptr addrspace(
 ; SDAG-LABEL: test_smfmac_f32_32x32x64_bf8_bf8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3510,9 +3500,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_bf8__vgpr(ptr addrspace(
 ; GISEL-LABEL: test_smfmac_f32_32x32x64_bf8_bf8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3541,9 +3531,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_bf8__vgpr(ptr addrspace(
 ; SDAG-VGPR-LABEL: test_smfmac_f32_32x32x64_bf8_bf8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -3578,9 +3568,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_bf8__vgpr(ptr addrspace(
 ; GISEL-VGPR-LABEL: test_smfmac_f32_32x32x64_bf8_bf8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4081,9 +4071,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_fp8__vgpr(ptr addrspace(
 ; SDAG-LABEL: test_smfmac_f32_32x32x64_bf8_fp8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4118,9 +4108,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_fp8__vgpr(ptr addrspace(
 ; GISEL-LABEL: test_smfmac_f32_32x32x64_bf8_fp8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4149,9 +4139,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_fp8__vgpr(ptr addrspace(
 ; SDAG-VGPR-LABEL: test_smfmac_f32_32x32x64_bf8_fp8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4186,9 +4176,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_bf8_fp8__vgpr(ptr addrspace(
 ; GISEL-VGPR-LABEL: test_smfmac_f32_32x32x64_bf8_fp8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4689,9 +4679,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_bf8__vgpr(ptr addrspace(
 ; SDAG-LABEL: test_smfmac_f32_32x32x64_fp8_bf8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4726,9 +4716,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_bf8__vgpr(ptr addrspace(
 ; GISEL-LABEL: test_smfmac_f32_32x32x64_fp8_bf8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4757,9 +4747,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_bf8__vgpr(ptr addrspace(
 ; SDAG-VGPR-LABEL: test_smfmac_f32_32x32x64_fp8_bf8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -4794,9 +4784,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_bf8__vgpr(ptr addrspace(
 ; GISEL-VGPR-LABEL: test_smfmac_f32_32x32x64_fp8_bf8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -5297,9 +5287,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_fp8__vgpr(ptr addrspace(
 ; SDAG-LABEL: test_smfmac_f32_32x32x64_fp8_fp8__vgpr:
 ; SDAG:       ; %bb.0: ; %bb
 ; SDAG-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-NEXT:    s_waitcnt lgkmcnt(0)
@@ -5334,9 +5324,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_fp8__vgpr(ptr addrspace(
 ; GISEL-LABEL: test_smfmac_f32_32x32x64_fp8_fp8__vgpr:
 ; GISEL:       ; %bb.0: ; %bb
 ; GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-NEXT:    s_waitcnt lgkmcnt(0)
@@ -5365,9 +5355,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_fp8__vgpr(ptr addrspace(
 ; SDAG-VGPR-LABEL: test_smfmac_f32_32x32x64_fp8_fp8__vgpr:
 ; SDAG-VGPR:       ; %bb.0: ; %bb
 ; SDAG-VGPR-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x24
+; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; SDAG-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; SDAG-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; SDAG-VGPR-NEXT:    s_load_dword s16, s[4:5], 0x64
 ; SDAG-VGPR-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x54
 ; SDAG-VGPR-NEXT:    s_waitcnt lgkmcnt(0)
@@ -5402,9 +5392,9 @@ define amdgpu_kernel void @test_smfmac_f32_32x32x64_fp8_fp8__vgpr(ptr addrspace(
 ; GISEL-VGPR-LABEL: test_smfmac_f32_32x32x64_fp8_fp8__vgpr:
 ; GISEL-VGPR:       ; %bb.0: ; %bb
 ; GISEL-VGPR-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GISEL-VGPR-NEXT:    v_lshlrev_b32_e32 v16, 6, v0
-; GISEL-VGPR-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x34
 ; GISEL-VGPR-NEXT:    s_load_dwordx4 s[16:19], s[4:5], 0x54
 ; GISEL-VGPR-NEXT:    s_load_dword s2, s[4:5], 0x64
 ; GISEL-VGPR-NEXT:    s_waitcnt lgkmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/load-local-i16.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-local-i16.ll
@@ -2078,19 +2078,19 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i32(ptr addrspace(3) %out
 ; SI-NEXT:    s_waitcnt lgkmcnt(3)
 ; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v1
 ; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v0
-; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v3
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v2
 ; SI-NEXT:    v_and_b32_e32 v16, 0xffff, v1
 ; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v0
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v3
-; SI-NEXT:    v_and_b32_e32 v22, 0xffff, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v3
+; SI-NEXT:    v_and_b32_e32 v0, 0xffff, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
+; SI-NEXT:    v_and_b32_e32 v2, 0xffff, v2
 ; SI-NEXT:    s_waitcnt lgkmcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v4
-; SI-NEXT:    v_and_b32_e32 v0, 0xffff, v5
-; SI-NEXT:    v_and_b32_e32 v2, 0xffff, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
-; SI-NEXT:    v_and_b32_e32 v4, 0xffff, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v5
+; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; SI-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v7
+; SI-NEXT:    v_and_b32_e32 v22, 0xffff, v7
 ; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; SI-NEXT:    v_and_b32_e32 v6, 0xffff, v6
 ; SI-NEXT:    s_waitcnt lgkmcnt(1)
@@ -2116,9 +2116,9 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i32(ptr addrspace(3) %out
 ; SI-NEXT:    ds_write2_b64 v32, v[12:13], v[28:29] offset0:12 offset1:13
 ; SI-NEXT:    ds_write2_b64 v32, v[10:11], v[26:27] offset0:10 offset1:11
 ; SI-NEXT:    ds_write2_b64 v32, v[8:9], v[24:25] offset0:8 offset1:9
-; SI-NEXT:    ds_write2_b64 v32, v[6:7], v[4:5] offset0:6 offset1:7
-; SI-NEXT:    ds_write2_b64 v32, v[2:3], v[0:1] offset0:4 offset1:5
-; SI-NEXT:    ds_write2_b64 v32, v[22:23], v[20:21] offset0:2 offset1:3
+; SI-NEXT:    ds_write2_b64 v32, v[6:7], v[22:23] offset0:6 offset1:7
+; SI-NEXT:    ds_write2_b64 v32, v[4:5], v[20:21] offset0:4 offset1:5
+; SI-NEXT:    ds_write2_b64 v32, v[2:3], v[0:1] offset0:2 offset1:3
 ; SI-NEXT:    ds_write2_b64 v32, v[18:19], v[16:17] offset1:1
 ; SI-NEXT:    s_endpgm
 ;
@@ -2127,112 +2127,108 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i32(ptr addrspace(3) %out
 ; VI-NO-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; VI-NO-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_mov_b32_e32 v24, s1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset1:1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v12 offset1:1
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v12 offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[8:11], v12 offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v12 offset0:6 offset1:7
 ; VI-NO-DS128-NEXT:    v_mov_b32_e32 v32, s0
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v3
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v3
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v2
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v2
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v1
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v1
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v0
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v0
+; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v3
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v3
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v7
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v7
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v6
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v6
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v5
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v5
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v4
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v4
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v1
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v1
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v13
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v13
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v1
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v1
 ; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; VI-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v5
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v5
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v3
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v3
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v2
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v7
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v7
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v7
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v7
 ; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; VI-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v6
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[30:31] offset0:12 offset1:13
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[6:7], v[28:29] offset0:14 offset1:15
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[2:3], v[26:27] offset0:10 offset1:11
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[24:25] offset0:8 offset1:9
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[22:23], v[20:21] offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[18:19], v[16:17] offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[12:13] offset1:1
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[8:9] offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v5
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v5
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v9
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v9
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v8
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v8
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v11
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v11
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v10
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v15
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v15
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v14
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[12:13], v[30:31] offset0:12 offset1:13
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[28:29] offset0:14 offset1:15
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[26:27] offset0:10 offset1:11
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[8:9], v[24:25] offset0:8 offset1:9
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[22:23] offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[6:7], v[20:21] offset0:6 offset1:7
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[18:19] offset1:1
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[2:3], v[16:17] offset0:2 offset1:3
 ; VI-NO-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-NO-DS128-LABEL: local_zextload_v32i16_to_v32i32:
 ; GFX9-NO-DS128:       ; %bb.0:
 ; GFX9-NO-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v24, s1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset1:1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v12 offset1:1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v12 offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[8:11], v12 offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v12 offset0:6 offset1:7
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v32, s0
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v3
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v3
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v2
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v2
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v1
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v1
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v0
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v0
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v3
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v3
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v7
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v7
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v6
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v6
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v5
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v5
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v4
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v4
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v1
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v1
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v13
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v13
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v2
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v1
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v1
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v5
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v5
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v3
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v3
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v2
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v7
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v7
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v7
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v7
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v6
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[30:31] offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[6:7], v[28:29] offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[2:3], v[26:27] offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[24:25] offset0:8 offset1:9
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[22:23], v[20:21] offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[18:19], v[16:17] offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[12:13] offset1:1
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[8:9] offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v5
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v5
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v4
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v9
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v9
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v8
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v8
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v11
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v11
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v10
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v15
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v15
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v14
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[12:13], v[30:31] offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[28:29] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[26:27] offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[8:9], v[24:25] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[22:23] offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[6:7], v[20:21] offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[18:19] offset1:1
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[2:3], v[16:17] offset0:2 offset1:3
 ; GFX9-NO-DS128-NEXT:    s_endpgm
 ;
 ; EG-LABEL: local_zextload_v32i16_to_v32i32:
@@ -2437,108 +2433,108 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i32(ptr addrspace(3) %out
 ; VI-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; VI-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_mov_b32_e32 v20, s1
-; VI-DS128-NEXT:    ds_read_b128 v[0:3], v20
-; VI-DS128-NEXT:    ds_read_b128 v[4:7], v20 offset:16
-; VI-DS128-NEXT:    ds_read_b128 v[16:19], v20 offset:32
-; VI-DS128-NEXT:    ds_read_b128 v[20:23], v20 offset:48
+; VI-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; VI-DS128-NEXT:    ds_read_b128 v[0:3], v12
+; VI-DS128-NEXT:    ds_read_b128 v[4:7], v12 offset:16
+; VI-DS128-NEXT:    ds_read_b128 v[8:11], v12 offset:32
+; VI-DS128-NEXT:    ds_read_b128 v[12:15], v12 offset:48
 ; VI-DS128-NEXT:    v_mov_b32_e32 v32, s0
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(3)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; VI-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v3
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v3
+; VI-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v3
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v2
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v23
-; VI-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v23
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
-; VI-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v22
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
-; VI-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v21
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v20
-; VI-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v20
-; VI-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v2
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v15
+; VI-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v15
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
+; VI-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v14
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v13
+; VI-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v13
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
+; VI-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; VI-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v2
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
 ; VI-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v1
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; VI-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v7
-; VI-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v7
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v6
-; VI-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v6
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v7
+; VI-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v7
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v6
+; VI-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v6
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v5
 ; VI-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v5
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; VI-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v19
-; VI-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v19
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v18
-; VI-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v18
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v17
-; VI-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v17
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
-; VI-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v16
-; VI-DS128-NEXT:    ds_write_b128 v32, v[20:23] offset:96
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v11
+; VI-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v11
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
+; VI-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v10
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v9
+; VI-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v9
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v8
+; VI-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v8
+; VI-DS128-NEXT:    ds_write_b128 v32, v[12:15] offset:96
 ; VI-DS128-NEXT:    ds_write_b128 v32, v[28:31] offset:112
-; VI-DS128-NEXT:    ds_write_b128 v32, v[16:19] offset:64
+; VI-DS128-NEXT:    ds_write_b128 v32, v[8:11] offset:64
 ; VI-DS128-NEXT:    ds_write_b128 v32, v[24:27] offset:80
 ; VI-DS128-NEXT:    ds_write_b128 v32, v[4:7] offset:32
-; VI-DS128-NEXT:    ds_write_b128 v32, v[12:15] offset:48
+; VI-DS128-NEXT:    ds_write_b128 v32, v[20:23] offset:48
 ; VI-DS128-NEXT:    ds_write_b128 v32, v[0:3]
-; VI-DS128-NEXT:    ds_write_b128 v32, v[8:11] offset:16
+; VI-DS128-NEXT:    ds_write_b128 v32, v[16:19] offset:16
 ; VI-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-DS128-LABEL: local_zextload_v32i16_to_v32i32:
 ; GFX9-DS128:       ; %bb.0:
 ; GFX9-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v20, s1
-; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v20
-; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v20 offset:16
-; GFX9-DS128-NEXT:    ds_read_b128 v[16:19], v20 offset:32
-; GFX9-DS128-NEXT:    ds_read_b128 v[20:23], v20 offset:48
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v12
+; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v12 offset:16
+; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v12 offset:32
+; GFX9-DS128-NEXT:    ds_read_b128 v[12:15], v12 offset:48
 ; GFX9-DS128-NEXT:    v_mov_b32_e32 v32, s0
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v3
-; GFX9-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v3
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v2
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v3
+; GFX9-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v3
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v2
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v23
-; GFX9-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v23
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v22
-; GFX9-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v22
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v21
-; GFX9-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v21
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v20
-; GFX9-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v20
-; GFX9-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v2
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v15
+; GFX9-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v15
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v14
+; GFX9-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v14
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v13
+; GFX9-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v13
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
+; GFX9-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; GFX9-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v2
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v1
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v1
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v0
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v7
-; GFX9-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v7
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v6
-; GFX9-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v6
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v7
+; GFX9-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v7
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v6
+; GFX9-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v6
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v5
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v5
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v4
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v19
-; GFX9-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v19
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v18
-; GFX9-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v18
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v17
-; GFX9-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v17
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
-; GFX9-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v16
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[20:23] offset:96
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v11
+; GFX9-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v11
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
+; GFX9-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v10
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v9
+; GFX9-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v9
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v8
+; GFX9-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v8
+; GFX9-DS128-NEXT:    ds_write_b128 v32, v[12:15] offset:96
 ; GFX9-DS128-NEXT:    ds_write_b128 v32, v[28:31] offset:112
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[16:19] offset:64
+; GFX9-DS128-NEXT:    ds_write_b128 v32, v[8:11] offset:64
 ; GFX9-DS128-NEXT:    ds_write_b128 v32, v[24:27] offset:80
 ; GFX9-DS128-NEXT:    ds_write_b128 v32, v[4:7] offset:32
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[12:15] offset:48
+; GFX9-DS128-NEXT:    ds_write_b128 v32, v[20:23] offset:48
 ; GFX9-DS128-NEXT:    ds_write_b128 v32, v[0:3]
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[8:11] offset:16
+; GFX9-DS128-NEXT:    ds_write_b128 v32, v[16:19] offset:16
 ; GFX9-DS128-NEXT:    s_endpgm
   %load = load <32 x i16>, ptr addrspace(3) %in
   %ext = zext <32 x i16> %load to <32 x i32>
@@ -2609,112 +2605,108 @@ define amdgpu_kernel void @local_sextload_v32i16_to_v32i32(ptr addrspace(3) %out
 ; VI-NO-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; VI-NO-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_mov_b32_e32 v24, s1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset1:1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v12 offset1:1
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v12 offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[8:11], v12 offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v12 offset0:6 offset1:7
 ; VI-NO-DS128-NEXT:    v_mov_b32_e32 v32, s0
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v3
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v2
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v1
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v0
+; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v3
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v2
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v1
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v7
-; VI-NO-DS128-NEXT:    v_bfe_i32 v8, v3, 0, 16
-; VI-NO-DS128-NEXT:    v_bfe_i32 v10, v2, 0, 16
-; VI-NO-DS128-NEXT:    v_bfe_i32 v12, v1, 0, 16
-; VI-NO-DS128-NEXT:    v_bfe_i32 v14, v0, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v6
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v5
-; VI-NO-DS128-NEXT:    v_bfe_i32 v16, v7, 0, 16
-; VI-NO-DS128-NEXT:    v_bfe_i32 v18, v6, 0, 16
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    v_bfe_i32 v20, v5, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v4
-; VI-NO-DS128-NEXT:    v_bfe_i32 v22, v4, 0, 16
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v1
-; VI-NO-DS128-NEXT:    v_bfe_i32 v24, v1, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v0
-; VI-NO-DS128-NEXT:    v_bfe_i32 v0, v0, 0, 16
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v5
-; VI-NO-DS128-NEXT:    v_bfe_i32 v30, v5, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v13
+; VI-NO-DS128-NEXT:    v_bfe_i32 v30, v13, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v12
+; VI-NO-DS128-NEXT:    v_bfe_i32 v12, v12, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v0
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v7
+; VI-NO-DS128-NEXT:    v_bfe_i32 v16, v3, 0, 16
+; VI-NO-DS128-NEXT:    v_bfe_i32 v18, v2, 0, 16
+; VI-NO-DS128-NEXT:    v_bfe_i32 v20, v1, 0, 16
+; VI-NO-DS128-NEXT:    v_bfe_i32 v22, v0, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v6
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v5
+; VI-NO-DS128-NEXT:    v_bfe_i32 v24, v7, 0, 16
+; VI-NO-DS128-NEXT:    v_bfe_i32 v0, v6, 0, 16
+; VI-NO-DS128-NEXT:    v_bfe_i32 v2, v5, 0, 16
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v4
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v4, v4, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v3
-; VI-NO-DS128-NEXT:    v_bfe_i32 v26, v3, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v2
-; VI-NO-DS128-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v7
-; VI-NO-DS128-NEXT:    v_bfe_i32 v28, v7, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v6
-; VI-NO-DS128-NEXT:    v_bfe_i32 v6, v6, 0, 16
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[30:31] offset0:12 offset1:13
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[6:7], v[28:29] offset0:14 offset1:15
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[2:3], v[26:27] offset0:10 offset1:11
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[24:25] offset0:8 offset1:9
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[22:23], v[20:21] offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[18:19], v[16:17] offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[12:13] offset1:1
-; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[8:9] offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v9
+; VI-NO-DS128-NEXT:    v_bfe_i32 v6, v9, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v8
+; VI-NO-DS128-NEXT:    v_bfe_i32 v8, v8, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v11
+; VI-NO-DS128-NEXT:    v_bfe_i32 v26, v11, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v10
+; VI-NO-DS128-NEXT:    v_bfe_i32 v10, v10, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v15
+; VI-NO-DS128-NEXT:    v_bfe_i32 v28, v15, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v14
+; VI-NO-DS128-NEXT:    v_bfe_i32 v14, v14, 0, 16
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[12:13], v[30:31] offset0:12 offset1:13
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[28:29] offset0:14 offset1:15
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[26:27] offset0:10 offset1:11
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[8:9], v[6:7] offset0:8 offset1:9
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[2:3] offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[24:25] offset0:6 offset1:7
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[22:23], v[20:21] offset1:1
+; VI-NO-DS128-NEXT:    ds_write2_b64 v32, v[18:19], v[16:17] offset0:2 offset1:3
 ; VI-NO-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-NO-DS128-LABEL: local_sextload_v32i16_to_v32i32:
 ; GFX9-NO-DS128:       ; %bb.0:
 ; GFX9-NO-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v24, s1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset1:1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:2 offset1:3
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v32, s0
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v3
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v2
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v1
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v0
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v12 offset1:1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v12 offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[8:11], v12 offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v12 offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v0
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v20, v0, 0, 16
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v7
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v8, v3, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v10, v2, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v12, v1, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v14, v0, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v6
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v5
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v7, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v6, 0, 16
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v24 offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v20, v5, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v4
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v22, v4, 0, 16
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v24 offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v1
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v24, v1, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v0
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v0, v0, 0, 16
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v5
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v30, v5, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v4
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v4, v4, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v3
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v26, v3, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v2
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v7
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v28, v7, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v13
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v32, v13, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v12
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v12, v12, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v3
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v2
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v3, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v2, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v2, 16, v1
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v1, v1, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v7
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v22, v7, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v6
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v6, v6, 0, 16
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[4:5], v[30:31] offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[6:7], v[28:29] offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[2:3], v[26:27] offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[0:1], v[24:25] offset0:8 offset1:9
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[22:23], v[20:21] offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[18:19], v[16:17] offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[14:15], v[12:13] offset1:1
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v32, v[10:11], v[8:9] offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v5
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v24, v5, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v4
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v4, v4, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v9
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v26, v9, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v8
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v8, v8, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v11
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v28, v11, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v10
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v10, v10, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v15
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v30, v15, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v14
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v14, v14, 0, 16
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[12:13], v[32:33] offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[14:15], v[30:31] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[10:11], v[28:29] offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[8:9], v[26:27] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[4:5], v[24:25] offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[6:7], v[22:23] offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[20:21], v[1:2] offset1:1
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[18:19], v[16:17] offset0:2 offset1:3
 ; GFX9-NO-DS128-NEXT:    s_endpgm
 ;
 ; EG-LABEL: local_sextload_v32i16_to_v32i32:
@@ -2938,112 +2930,108 @@ define amdgpu_kernel void @local_sextload_v32i16_to_v32i32(ptr addrspace(3) %out
 ; VI-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; VI-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_mov_b32_e32 v24, s1
-; VI-DS128-NEXT:    ds_read_b128 v[0:3], v24
-; VI-DS128-NEXT:    ds_read_b128 v[4:7], v24 offset:16
-; VI-DS128-NEXT:    ds_read_b128 v[20:23], v24 offset:32
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v3
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v2
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v1
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v0
-; VI-DS128-NEXT:    v_bfe_i32 v10, v3, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v8, v2, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v14, v1, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v12, v0, 0, 16
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
+; VI-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; VI-DS128-NEXT:    ds_read_b128 v[0:3], v12
+; VI-DS128-NEXT:    ds_read_b128 v[4:7], v12 offset:16
+; VI-DS128-NEXT:    ds_read_b128 v[8:11], v12 offset:32
+; VI-DS128-NEXT:    ds_read_b128 v[12:15], v12 offset:48
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v3
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v2
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v1
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v35, 16, v13
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v12
+; VI-DS128-NEXT:    v_bfe_i32 v34, v13, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v32, v12, 0, 16
+; VI-DS128-NEXT:    v_mov_b32_e32 v12, s0
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v0
+; VI-DS128-NEXT:    v_bfe_i32 v18, v3, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v16, v2, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v22, v1, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v20, v0, 0, 16
 ; VI-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v7
 ; VI-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v6
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v5
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v4
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v5
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v4
 ; VI-DS128-NEXT:    v_bfe_i32 v2, v7, 0, 16
 ; VI-DS128-NEXT:    v_bfe_i32 v0, v6, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v18, v5, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v16, v4, 0, 16
-; VI-DS128-NEXT:    ds_read_b128 v[4:7], v24 offset:48
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v26, 16, v23
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v24, 16, v22
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v30, 16, v21
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v28, 16, v20
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v38, 16, v5
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v36, 16, v4
-; VI-DS128-NEXT:    v_bfe_i32 v37, v5, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v35, v4, 0, 16
-; VI-DS128-NEXT:    v_mov_b32_e32 v4, s0
-; VI-DS128-NEXT:    v_bfe_i32 v25, v23, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v23, v22, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v29, v21, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v27, v20, 0, 16
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v34, 16, v7
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v32, 16, v6
-; VI-DS128-NEXT:    v_bfe_i32 v33, v7, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v31, v6, 0, 16
-; VI-DS128-NEXT:    ds_write_b128 v4, v[35:38] offset:96
-; VI-DS128-NEXT:    ds_write_b128 v4, v[31:34] offset:112
-; VI-DS128-NEXT:    ds_write_b128 v4, v[27:30] offset:64
-; VI-DS128-NEXT:    ds_write_b128 v4, v[23:26] offset:80
-; VI-DS128-NEXT:    ds_write_b128 v4, v[16:19] offset:32
-; VI-DS128-NEXT:    ds_write_b128 v4, v[0:3] offset:48
-; VI-DS128-NEXT:    ds_write_b128 v4, v[12:15]
-; VI-DS128-NEXT:    ds_write_b128 v4, v[8:11] offset:16
+; VI-DS128-NEXT:    v_bfe_i32 v26, v5, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v24, v4, 0, 16
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v11
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v10
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v9
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v8
+; VI-DS128-NEXT:    v_bfe_i32 v6, v11, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v4, v10, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v30, v9, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v28, v8, 0, 16
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v15
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v14
+; VI-DS128-NEXT:    v_bfe_i32 v10, v15, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v8, v14, 0, 16
+; VI-DS128-NEXT:    ds_write_b128 v12, v[32:35] offset:96
+; VI-DS128-NEXT:    ds_write_b128 v12, v[8:11] offset:112
+; VI-DS128-NEXT:    ds_write_b128 v12, v[28:31] offset:64
+; VI-DS128-NEXT:    ds_write_b128 v12, v[4:7] offset:80
+; VI-DS128-NEXT:    ds_write_b128 v12, v[24:27] offset:32
+; VI-DS128-NEXT:    ds_write_b128 v12, v[0:3] offset:48
+; VI-DS128-NEXT:    ds_write_b128 v12, v[20:23]
+; VI-DS128-NEXT:    ds_write_b128 v12, v[16:19] offset:16
 ; VI-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-DS128-LABEL: local_sextload_v32i16_to_v32i32:
 ; GFX9-DS128:       ; %bb.0:
 ; GFX9-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v24, s1
-; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v24
-; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v24 offset:16
-; GFX9-DS128-NEXT:    ds_read_b128 v[20:23], v24 offset:32
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v3
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v2
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v1
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v0
-; GFX9-DS128-NEXT:    v_bfe_i32 v10, v3, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v8, v2, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v14, v1, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v12, v0, 0, 16
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v12
+; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v12 offset:16
+; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v12 offset:32
+; GFX9-DS128-NEXT:    ds_read_b128 v[12:15], v12 offset:48
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v3
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v2
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v1
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v35, 16, v13
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v12
+; GFX9-DS128-NEXT:    v_bfe_i32 v34, v13, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v32, v12, 0, 16
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, s0
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v0
+; GFX9-DS128-NEXT:    v_bfe_i32 v18, v3, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v16, v2, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v22, v1, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v20, v0, 0, 16
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v7
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v6
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v5
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v4
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v5
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v4
 ; GFX9-DS128-NEXT:    v_bfe_i32 v2, v7, 0, 16
 ; GFX9-DS128-NEXT:    v_bfe_i32 v0, v6, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v18, v5, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v16, v4, 0, 16
-; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v24 offset:48
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v26, 16, v23
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v24, 16, v22
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v30, 16, v21
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v28, 16, v20
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v38, 16, v5
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v36, 16, v4
-; GFX9-DS128-NEXT:    v_bfe_i32 v37, v5, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v35, v4, 0, 16
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v4, s0
-; GFX9-DS128-NEXT:    v_bfe_i32 v25, v23, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v23, v22, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v29, v21, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v27, v20, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v34, 16, v7
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v32, 16, v6
-; GFX9-DS128-NEXT:    v_bfe_i32 v33, v7, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v31, v6, 0, 16
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[35:38] offset:96
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[31:34] offset:112
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[27:30] offset:64
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[23:26] offset:80
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[16:19] offset:32
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[0:3] offset:48
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[12:15]
-; GFX9-DS128-NEXT:    ds_write_b128 v4, v[8:11] offset:16
+; GFX9-DS128-NEXT:    v_bfe_i32 v26, v5, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v24, v4, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v11
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v10
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v9
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v8
+; GFX9-DS128-NEXT:    v_bfe_i32 v6, v11, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v4, v10, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v30, v9, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v28, v8, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v14
+; GFX9-DS128-NEXT:    v_bfe_i32 v10, v15, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v8, v14, 0, 16
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[32:35] offset:96
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[8:11] offset:112
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[28:31] offset:64
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[4:7] offset:80
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[24:27] offset:32
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[0:3] offset:48
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[20:23]
+; GFX9-DS128-NEXT:    ds_write_b128 v12, v[16:19] offset:16
 ; GFX9-DS128-NEXT:    s_endpgm
   %load = load <32 x i16>, ptr addrspace(3) %in
   %ext = sext <32 x i16> %load to <32 x i32>
@@ -3062,111 +3050,111 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; SI-NEXT:    s_addc_u32 s13, s13, 0
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v24, s1
+; SI-NEXT:    v_mov_b32_e32 v16, s1
 ; SI-NEXT:    s_mov_b32 m0, -1
-; SI-NEXT:    ds_read2_b64 v[0:3], v24 offset0:8 offset1:9
-; SI-NEXT:    ds_read2_b64 v[4:7], v24 offset0:10 offset1:11
-; SI-NEXT:    ds_read2_b64 v[12:15], v24 offset0:12 offset1:13
-; SI-NEXT:    ds_read2_b64 v[8:11], v24 offset0:14 offset1:15
-; SI-NEXT:    ds_read2_b64 v[20:23], v24 offset1:1
-; SI-NEXT:    ds_read2_b64 v[16:19], v24 offset0:2 offset1:3
-; SI-NEXT:    ds_read2_b64 v[34:37], v24 offset0:4 offset1:5
-; SI-NEXT:    ds_read2_b64 v[38:41], v24 offset0:6 offset1:7
+; SI-NEXT:    ds_read2_b64 v[12:15], v16 offset0:8 offset1:9
+; SI-NEXT:    ds_read2_b64 v[8:11], v16 offset0:10 offset1:11
+; SI-NEXT:    ds_read2_b64 v[4:7], v16 offset0:12 offset1:13
+; SI-NEXT:    ds_read2_b64 v[0:3], v16 offset0:14 offset1:15
+; SI-NEXT:    ds_read2_b64 v[28:31], v16 offset1:1
+; SI-NEXT:    ds_read2_b64 v[32:35], v16 offset0:2 offset1:3
+; SI-NEXT:    ds_read2_b64 v[36:39], v16 offset0:4 offset1:5
+; SI-NEXT:    ds_read2_b64 v[40:43], v16 offset0:6 offset1:7
 ; SI-NEXT:    s_waitcnt lgkmcnt(7)
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v0
-; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v3
-; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v2
-; SI-NEXT:    s_waitcnt lgkmcnt(6)
-; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v5
-; SI-NEXT:    v_and_b32_e32 v24, 0xffff, v1
-; SI-NEXT:    buffer_store_dword v24, off, s[12:15], 0 ; 4-byte Folded Spill
-; SI-NEXT:    buffer_store_dword v25, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
-; SI-NEXT:    v_and_b32_e32 v26, 0xffff, v0
-; SI-NEXT:    v_and_b32_e32 v28, 0xffff, v3
-; SI-NEXT:    v_and_b32_e32 v30, 0xffff, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v13
+; SI-NEXT:    v_and_b32_e32 v16, 0xffff, v13
+; SI-NEXT:    buffer_store_dword v16, off, s[12:15], 0 ; 4-byte Folded Spill
+; SI-NEXT:    buffer_store_dword v17, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
 ; SI-NEXT:    s_waitcnt expcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v7
-; SI-NEXT:    v_and_b32_e32 v32, 0xffff, v5
-; SI-NEXT:    v_and_b32_e32 v24, 0xffff, v4
-; SI-NEXT:    v_and_b32_e32 v2, 0xffff, v7
-; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v6
-; SI-NEXT:    v_and_b32_e32 v4, 0xffff, v6
-; SI-NEXT:    s_waitcnt lgkmcnt(5)
-; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v13
-; SI-NEXT:    v_and_b32_e32 v6, 0xffff, v13
-; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
-; SI-NEXT:    v_and_b32_e32 v12, 0xffff, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v15
-; SI-NEXT:    v_and_b32_e32 v42, 0xffff, v15
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v12
+; SI-NEXT:    v_and_b32_e32 v16, 0xffff, v12
+; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v15
+; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v15
 ; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
 ; SI-NEXT:    v_and_b32_e32 v14, 0xffff, v14
-; SI-NEXT:    s_waitcnt lgkmcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v9
-; SI-NEXT:    v_and_b32_e32 v44, 0xffff, v9
-; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v8
-; SI-NEXT:    v_and_b32_e32 v8, 0xffff, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v11
-; SI-NEXT:    v_and_b32_e32 v46, 0xffff, v11
+; SI-NEXT:    s_waitcnt lgkmcnt(6)
+; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v9
+; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v9
+; SI-NEXT:    v_lshrrev_b32_e32 v13, 16, v8
+; SI-NEXT:    v_and_b32_e32 v12, 0xffff, v8
+; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v11
+; SI-NEXT:    v_and_b32_e32 v22, 0xffff, v11
 ; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
 ; SI-NEXT:    v_and_b32_e32 v10, 0xffff, v10
+; SI-NEXT:    s_waitcnt lgkmcnt(5)
+; SI-NEXT:    v_lshrrev_b32_e32 v25, 16, v5
+; SI-NEXT:    v_and_b32_e32 v24, 0xffff, v5
+; SI-NEXT:    v_lshrrev_b32_e32 v9, 16, v4
+; SI-NEXT:    v_and_b32_e32 v8, 0xffff, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v27, 16, v7
+; SI-NEXT:    v_and_b32_e32 v26, 0xffff, v7
+; SI-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; SI-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; SI-NEXT:    s_waitcnt lgkmcnt(4)
+; SI-NEXT:    v_lshrrev_b32_e32 v45, 16, v1
+; SI-NEXT:    v_and_b32_e32 v44, 0xffff, v1
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v0
+; SI-NEXT:    v_and_b32_e32 v4, 0xffff, v0
+; SI-NEXT:    v_lshrrev_b32_e32 v47, 16, v3
+; SI-NEXT:    v_and_b32_e32 v46, 0xffff, v3
+; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
+; SI-NEXT:    v_and_b32_e32 v2, 0xffff, v2
 ; SI-NEXT:    s_waitcnt lgkmcnt(3)
-; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v21
-; SI-NEXT:    v_and_b32_e32 v48, 0xffff, v21
-; SI-NEXT:    v_lshrrev_b32_e32 v21, 16, v20
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v20
-; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v23
-; SI-NEXT:    v_and_b32_e32 v50, 0xffff, v23
-; SI-NEXT:    v_lshrrev_b32_e32 v23, 16, v22
-; SI-NEXT:    v_and_b32_e32 v22, 0xffff, v22
+; SI-NEXT:    v_lshrrev_b32_e32 v49, 16, v29
+; SI-NEXT:    v_and_b32_e32 v48, 0xffff, v29
+; SI-NEXT:    v_lshrrev_b32_e32 v29, 16, v28
+; SI-NEXT:    v_and_b32_e32 v28, 0xffff, v28
+; SI-NEXT:    v_lshrrev_b32_e32 v51, 16, v31
+; SI-NEXT:    v_and_b32_e32 v50, 0xffff, v31
+; SI-NEXT:    v_lshrrev_b32_e32 v31, 16, v30
+; SI-NEXT:    v_and_b32_e32 v30, 0xffff, v30
 ; SI-NEXT:    s_waitcnt lgkmcnt(2)
-; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v17
-; SI-NEXT:    v_and_b32_e32 v52, 0xffff, v17
-; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
-; SI-NEXT:    v_and_b32_e32 v16, 0xffff, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v19
-; SI-NEXT:    v_and_b32_e32 v54, 0xffff, v19
-; SI-NEXT:    v_lshrrev_b32_e32 v19, 16, v18
-; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v18
-; SI-NEXT:    s_waitcnt lgkmcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v35
-; SI-NEXT:    v_and_b32_e32 v56, 0xffff, v35
+; SI-NEXT:    v_lshrrev_b32_e32 v53, 16, v33
+; SI-NEXT:    v_and_b32_e32 v52, 0xffff, v33
+; SI-NEXT:    v_lshrrev_b32_e32 v33, 16, v32
+; SI-NEXT:    v_and_b32_e32 v32, 0xffff, v32
+; SI-NEXT:    v_lshrrev_b32_e32 v55, 16, v35
+; SI-NEXT:    v_and_b32_e32 v54, 0xffff, v35
 ; SI-NEXT:    v_lshrrev_b32_e32 v35, 16, v34
 ; SI-NEXT:    v_and_b32_e32 v34, 0xffff, v34
-; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v37
-; SI-NEXT:    v_and_b32_e32 v58, 0xffff, v37
+; SI-NEXT:    s_waitcnt lgkmcnt(1)
+; SI-NEXT:    v_lshrrev_b32_e32 v57, 16, v37
+; SI-NEXT:    v_and_b32_e32 v56, 0xffff, v37
 ; SI-NEXT:    v_lshrrev_b32_e32 v37, 16, v36
 ; SI-NEXT:    v_and_b32_e32 v36, 0xffff, v36
-; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v39
-; SI-NEXT:    v_and_b32_e32 v60, 0xffff, v39
+; SI-NEXT:    v_lshrrev_b32_e32 v59, 16, v39
+; SI-NEXT:    v_and_b32_e32 v58, 0xffff, v39
 ; SI-NEXT:    v_lshrrev_b32_e32 v39, 16, v38
 ; SI-NEXT:    v_and_b32_e32 v38, 0xffff, v38
-; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v41
-; SI-NEXT:    v_and_b32_e32 v62, 0xffff, v41
+; SI-NEXT:    s_waitcnt lgkmcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v61, 16, v41
+; SI-NEXT:    v_and_b32_e32 v60, 0xffff, v41
 ; SI-NEXT:    v_lshrrev_b32_e32 v41, 16, v40
 ; SI-NEXT:    v_and_b32_e32 v40, 0xffff, v40
+; SI-NEXT:    v_lshrrev_b32_e32 v63, 16, v43
+; SI-NEXT:    v_and_b32_e32 v62, 0xffff, v43
+; SI-NEXT:    v_lshrrev_b32_e32 v43, 16, v42
+; SI-NEXT:    v_and_b32_e32 v42, 0xffff, v42
 ; SI-NEXT:    v_mov_b32_e32 v0, s0
-; SI-NEXT:    ds_write2_b64 v0, v[40:41], v[62:63] offset0:14 offset1:15
-; SI-NEXT:    ds_write2_b64 v0, v[38:39], v[60:61] offset0:12 offset1:13
-; SI-NEXT:    ds_write2_b64 v0, v[36:37], v[58:59] offset0:10 offset1:11
-; SI-NEXT:    ds_write2_b64 v0, v[34:35], v[56:57] offset0:8 offset1:9
-; SI-NEXT:    ds_write2_b64 v0, v[18:19], v[54:55] offset0:6 offset1:7
-; SI-NEXT:    ds_write2_b64 v0, v[16:17], v[52:53] offset0:4 offset1:5
-; SI-NEXT:    ds_write2_b64 v0, v[22:23], v[50:51] offset0:2 offset1:3
-; SI-NEXT:    ds_write2_b64 v0, v[20:21], v[48:49] offset1:1
-; SI-NEXT:    ds_write2_b64 v0, v[10:11], v[46:47] offset0:30 offset1:31
-; SI-NEXT:    ds_write2_b64 v0, v[8:9], v[44:45] offset0:28 offset1:29
-; SI-NEXT:    ds_write2_b64 v0, v[14:15], v[42:43] offset0:26 offset1:27
-; SI-NEXT:    ds_write2_b64 v0, v[12:13], v[6:7] offset0:24 offset1:25
-; SI-NEXT:    ds_write2_b64 v0, v[4:5], v[2:3] offset0:22 offset1:23
-; SI-NEXT:    ds_write2_b64 v0, v[24:25], v[32:33] offset0:20 offset1:21
-; SI-NEXT:    ds_write2_b64 v0, v[30:31], v[28:29] offset0:18 offset1:19
+; SI-NEXT:    ds_write2_b64 v0, v[42:43], v[62:63] offset0:14 offset1:15
+; SI-NEXT:    ds_write2_b64 v0, v[40:41], v[60:61] offset0:12 offset1:13
+; SI-NEXT:    ds_write2_b64 v0, v[38:39], v[58:59] offset0:10 offset1:11
+; SI-NEXT:    ds_write2_b64 v0, v[36:37], v[56:57] offset0:8 offset1:9
+; SI-NEXT:    ds_write2_b64 v0, v[34:35], v[54:55] offset0:6 offset1:7
+; SI-NEXT:    ds_write2_b64 v0, v[32:33], v[52:53] offset0:4 offset1:5
+; SI-NEXT:    ds_write2_b64 v0, v[30:31], v[50:51] offset0:2 offset1:3
+; SI-NEXT:    ds_write2_b64 v0, v[28:29], v[48:49] offset1:1
+; SI-NEXT:    ds_write2_b64 v0, v[2:3], v[46:47] offset0:30 offset1:31
+; SI-NEXT:    ds_write2_b64 v0, v[4:5], v[44:45] offset0:28 offset1:29
+; SI-NEXT:    ds_write2_b64 v0, v[6:7], v[26:27] offset0:26 offset1:27
+; SI-NEXT:    ds_write2_b64 v0, v[8:9], v[24:25] offset0:24 offset1:25
+; SI-NEXT:    ds_write2_b64 v0, v[10:11], v[22:23] offset0:22 offset1:23
+; SI-NEXT:    ds_write2_b64 v0, v[12:13], v[20:21] offset0:20 offset1:21
+; SI-NEXT:    ds_write2_b64 v0, v[14:15], v[18:19] offset0:18 offset1:19
 ; SI-NEXT:    buffer_load_dword v1, off, s[12:15], 0 ; 4-byte Folded Reload
 ; SI-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:4 ; 4-byte Folded Reload
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    ds_write2_b64 v0, v[26:27], v[1:2] offset0:16 offset1:17
+; SI-NEXT:    ds_write2_b64 v0, v[16:17], v[1:2] offset0:16 offset1:17
 ; SI-NEXT:    s_endpgm
 ;
 ; VI-NO-DS128-LABEL: local_zextload_v64i16_to_v64i32:
@@ -3177,111 +3165,107 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-NO-DS128-NEXT:    s_mov_b32 s89, SCRATCH_RSRC_DWORD1
 ; VI-NO-DS128-NEXT:    s_mov_b32 s90, -1
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_mov_b32_e32 v16, s1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[10:13], v16 offset1:1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[17:20], v16 offset0:2 offset1:3
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[21:24], v16 offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    v_mov_b32_e32 v28, s1
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v28 offset1:1
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v28 offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v28 offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:6 offset1:7
 ; VI-NO-DS128-NEXT:    s_mov_b32 s91, 0xe80000
 ; VI-NO-DS128-NEXT:    s_add_u32 s88, s88, s11
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v11
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v10
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v13
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v12
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v18
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v11
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v10
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v13
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v12
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v17
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v20
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v18
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v17
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v20
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v19
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v19
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[17:20], v16 offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v26, 16, v22
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v25, 0xffff, v22
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v28, 16, v21
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v27, 0xffff, v21
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v30, 16, v24
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v29, 0xffff, v24
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v32, 16, v23
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v31, 0xffff, v23
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v34, 16, v18
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v33, 0xffff, v18
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v36, 16, v17
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v35, 0xffff, v17
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v38, 16, v20
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[21:24], v16 offset0:8 offset1:9
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v37, 0xffff, v20
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v40, 16, v19
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v39, 0xffff, v19
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[17:20], v16 offset0:10 offset1:11
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v42, 16, v22
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v41, 0xffff, v22
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v44, 16, v21
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v43, 0xffff, v21
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v46, 16, v24
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v45, 0xffff, v24
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v48, 16, v23
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v47, 0xffff, v23
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v50, 16, v18
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v49, 0xffff, v18
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v52, 16, v17
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v51, 0xffff, v17
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[21:24], v16 offset0:12 offset1:13
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v56, 16, v19
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v55, 0xffff, v19
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v16 offset0:14 offset1:15
 ; VI-NO-DS128-NEXT:    s_addc_u32 s89, s89, 0
+; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v17
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v32, 0xffff, v17
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v16
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v16
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v37, 16, v19
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v19
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v18
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v38, 0xffff, v18
+; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v21
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v21
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v43, 16, v20
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v20
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v45, 16, v23
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v44, 0xffff, v23
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v47, 16, v22
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v28 offset0:8 offset1:9
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v46, 0xffff, v22
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:10 offset1:11
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[24:27], v28 offset0:12 offset1:13
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[28:31], v28 offset0:14 offset1:15
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v5
 ; VI-NO-DS128-NEXT:    buffer_store_dword v0, off, s[88:91], 0 ; 4-byte Folded Spill
 ; VI-NO-DS128-NEXT:    buffer_store_dword v1, off, s[88:91], 0 offset:4 ; 4-byte Folded Spill
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v54, 16, v20
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v53, 0xffff, v20
+; VI-NO-DS128-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v20, 16, v19
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v19, 0xffff, v19
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v18
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v18
-; VI-NO-DS128-NEXT:    v_mov_b32_e32 v18, s0
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v58, 16, v22
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v57, 0xffff, v22
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v22, 16, v21
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v21, 0xffff, v21
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v60, 16, v24
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v59, 0xffff, v24
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v24, 16, v23
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v23, 0xffff, v23
-; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v62, 16, v17
-; VI-NO-DS128-NEXT:    v_and_b32_e32 v61, 0xffff, v17
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v63, 16, v31
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v62, 0xffff, v31
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v30
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v30
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v4
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v4
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v7
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v13
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v13
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v12
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v12
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v15
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v15
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v14
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v49, 16, v17
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v17
 ; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
 ; VI-NO-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v16
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[0:1], v[19:20] offset0:30 offset1:31
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[16:17], v[61:62] offset0:28 offset1:29
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[23:24], v[59:60] offset0:26 offset1:27
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[21:22], v[57:58] offset0:24 offset1:25
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[55:56], v[53:54] offset0:22 offset1:23
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[51:52], v[49:50] offset0:20 offset1:21
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[47:48], v[45:46] offset0:18 offset1:19
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[43:44], v[41:42] offset0:16 offset1:17
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[39:40], v[37:38] offset0:14 offset1:15
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[35:36], v[33:34] offset0:12 offset1:13
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[31:32], v[29:30] offset0:10 offset1:11
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[27:28], v[25:26] offset0:8 offset1:9
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[14:15], v[12:13] offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[10:11], v[8:9] offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[6:7], v[4:5] offset0:2 offset1:3
-; VI-NO-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 ; 4-byte Folded Reload
-; VI-NO-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:4 ; 4-byte Folded Reload
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v19
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v50, 0xffff, v19
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v18
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v18
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v53, 16, v21
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v52, 0xffff, v21
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v20
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v20
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v23
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v54, 0xffff, v23
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v22
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v22
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v57, 16, v25
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v56, 0xffff, v25
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v24
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v24
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v27
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v27
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v26
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v26
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v29
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v29
+; VI-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v28
+; VI-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v28
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[30:31], v[62:63] offset0:30 offset1:31
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[28:29], v[60:61] offset0:28 offset1:29
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[26:27], v[58:59] offset0:26 offset1:27
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[24:25], v[56:57] offset0:24 offset1:25
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[22:23], v[54:55] offset0:22 offset1:23
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[20:21], v[52:53] offset0:20 offset1:21
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[18:19], v[50:51] offset0:18 offset1:19
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[16:17], v[48:49] offset0:16 offset1:17
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[46:47], v[44:45] offset0:14 offset1:15
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[42:43], v[40:41] offset0:12 offset1:13
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[38:39], v[36:37] offset0:10 offset1:11
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[34:35], v[32:33] offset0:8 offset1:9
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[14:15], v[12:13] offset0:6 offset1:7
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[10:11], v[8:9] offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[6:7], v[4:5] offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    buffer_load_dword v4, off, s[88:91], 0 ; 4-byte Folded Reload
+; VI-NO-DS128-NEXT:    buffer_load_dword v5, off, s[88:91], 0 offset:4 ; 4-byte Folded Reload
 ; VI-NO-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-NO-DS128-NEXT:    ds_write2_b64 v18, v[2:3], v[0:1] offset1:1
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[2:3], v[4:5] offset1:1
 ; VI-NO-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-NO-DS128-LABEL: local_zextload_v64i16_to_v64i32:
@@ -3292,104 +3276,101 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-NO-DS128-NEXT:    s_mov_b32 s14, -1
 ; GFX9-NO-DS128-NEXT:    s_mov_b32 s15, 0xe00000
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v56, s1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[10:13], v56 offset1:1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[14:17], v56 offset0:2 offset1:3
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[18:21], v56 offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[22:25], v56 offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v28, s1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v28 offset1:1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v28 offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v28 offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:6 offset1:7
 ; GFX9-NO-DS128-NEXT:    s_add_u32 s12, s12, s11
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v11
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v10
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v13
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v12
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v15
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v11
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v10
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v13
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v12
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v14
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v17
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v15
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v14
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v17
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v16
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v16
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v19
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v19
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v18
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v18
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v21
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v21
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v20
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v32, 0xffff, v20
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v23
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v23
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v37, 16, v22
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v22
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v56 offset0:8 offset1:9
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v56 offset0:10 offset1:11
 ; GFX9-NO-DS128-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v5
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v17
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v32, 0xffff, v17
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v16
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v16
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v37, 16, v19
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v19
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v18
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v38, 0xffff, v18
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v21
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v21
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v43, 16, v20
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v20
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v45, 16, v23
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v44, 0xffff, v23
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v47, 16, v22
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v28 offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v46, 0xffff, v22
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[24:27], v28 offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[28:31], v28 offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v5
 ; GFX9-NO-DS128-NEXT:    buffer_store_dword v0, off, s[12:15], 0 ; 4-byte Folded Spill
 ; GFX9-NO-DS128-NEXT:    s_nop 0
 ; GFX9-NO-DS128-NEXT:    buffer_store_dword v1, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v0, s0
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v17
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v17
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v43, 16, v16
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v16
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v45, 16, v19
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v44, 0xffff, v19
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v47, 16, v18
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v46, 0xffff, v18
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v4
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v49, 16, v21
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v21
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v20
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v50, 0xffff, v20
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v53, 16, v23
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[16:19], v56 offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v52, 0xffff, v23
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v22
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v54, 0xffff, v22
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v56 offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v25
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v38, 0xffff, v25
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v24
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v24
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v63, 16, v23
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v62, 0xffff, v23
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v22
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v22
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v57, 16, v17
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v56, 0xffff, v17
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v63, 16, v31
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v62, 0xffff, v31
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v31, 16, v30
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v30
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v4
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v7
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v6
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v13
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v13
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v12
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v12
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v15
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v15
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v14
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v49, 16, v17
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v17
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v16
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v16
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v19
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v19
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v19
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v50, 0xffff, v19
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v18
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v18
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v21
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v21
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v53, 16, v21
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v52, 0xffff, v21
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v20
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v20
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[22:23], v[62:63] offset0:30 offset1:31
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[20:21], v[60:61] offset0:28 offset1:29
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[18:19], v[58:59] offset0:26 offset1:27
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[16:17], v[56:57] offset0:24 offset1:25
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[54:55], v[52:53] offset0:22 offset1:23
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[50:51], v[48:49] offset0:20 offset1:21
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[46:47], v[44:45] offset0:18 offset1:19
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[42:43], v[40:41] offset0:16 offset1:17
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[24:25], v[38:39] offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[36:37], v[34:35] offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[32:33], v[30:31] offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[28:29], v[26:27] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v23
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v54, 0xffff, v23
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v23, 16, v22
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v22
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v57, 16, v25
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v56, 0xffff, v25
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v24
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v24
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v27
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v27
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v26
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v26
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v29
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v29
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v29, 16, v28
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v28
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[30:31], v[62:63] offset0:30 offset1:31
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[28:29], v[60:61] offset0:28 offset1:29
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[26:27], v[58:59] offset0:26 offset1:27
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[24:25], v[56:57] offset0:24 offset1:25
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[22:23], v[54:55] offset0:22 offset1:23
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[20:21], v[52:53] offset0:20 offset1:21
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[18:19], v[50:51] offset0:18 offset1:19
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[16:17], v[48:49] offset0:16 offset1:17
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[46:47], v[44:45] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[42:43], v[40:41] offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[38:39], v[36:37] offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[34:35], v[32:33] offset0:8 offset1:9
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[14:15], v[12:13] offset0:6 offset1:7
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[10:11], v[8:9] offset0:4 offset1:5
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[6:7], v[4:5] offset0:2 offset1:3
@@ -3794,18 +3775,18 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-DS128-LABEL: local_zextload_v64i16_to_v64i32:
 ; VI-DS128:       ; %bb.0:
 ; VI-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; VI-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-DS128-NEXT:    s_mov_b32 s88, SCRATCH_RSRC_DWORD0
 ; VI-DS128-NEXT:    s_mov_b32 s89, SCRATCH_RSRC_DWORD1
+; VI-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-DS128-NEXT:    s_mov_b32 s90, -1
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-DS128-NEXT:    v_mov_b32_e32 v0, s1
 ; VI-DS128-NEXT:    ds_read_b128 v[8:11], v0
 ; VI-DS128-NEXT:    ds_read_b128 v[16:19], v0 offset:16
-; VI-DS128-NEXT:    s_mov_b32 s91, 0xe80000
-; VI-DS128-NEXT:    s_add_u32 s88, s88, s11
 ; VI-DS128-NEXT:    ds_read_b128 v[20:23], v0 offset:32
 ; VI-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:48
+; VI-DS128-NEXT:    s_mov_b32 s91, 0xe80000
+; VI-DS128-NEXT:    s_add_u32 s88, s88, s11
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(3)
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v11
 ; VI-DS128-NEXT:    s_addc_u32 s89, s89, 0
@@ -3821,17 +3802,13 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v8
 ; VI-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v9
 ; VI-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v8
-; VI-DS128-NEXT:    buffer_store_dword v4, off, s[88:91], 0 offset:16 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    buffer_store_dword v5, off, s[88:91], 0 offset:20 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    buffer_store_dword v6, off, s[88:91], 0 offset:24 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    buffer_store_dword v7, off, s[88:91], 0 offset:28 ; 4-byte Folded Spill
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v4, 16, v19
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v18
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v19
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v18
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v17
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v16
-; VI-DS128-NEXT:    v_and_b32_e32 v3, 0xffff, v19
-; VI-DS128-NEXT:    v_and_b32_e32 v1, 0xffff, v18
+; VI-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v19
+; VI-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v18
 ; VI-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v17
 ; VI-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v16
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
@@ -3849,84 +3826,70 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v25
 ; VI-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
 ; VI-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v27
-; VI-DS128-NEXT:    ds_read_b128 v[36:39], v0 offset:64
 ; VI-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v26
 ; VI-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v25
 ; VI-DS128-NEXT:    v_and_b32_e32 v32, 0xffff, v24
 ; VI-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:80
-; VI-DS128-NEXT:    ds_read_b128 v[55:58], v0 offset:96
-; VI-DS128-NEXT:    buffer_store_dword v1, off, s[88:91], 0 offset:32 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    buffer_store_dword v2, off, s[88:91], 0 offset:36 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    buffer_store_dword v3, off, s[88:91], 0 offset:40 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    buffer_store_dword v4, off, s[88:91], 0 offset:44 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v42, 16, v39
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v40, 16, v38
+; VI-DS128-NEXT:    ds_read_b128 v[40:43], v0 offset:96
+; VI-DS128-NEXT:    ds_read_b128 v[44:47], v0 offset:112
+; VI-DS128-NEXT:    ds_read_b128 v[36:39], v0 offset:64
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v25
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v57, 16, v24
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v50, 16, v27
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v48, 16, v26
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v54, 16, v25
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v52, 16, v24
-; VI-DS128-NEXT:    v_and_b32_e32 v49, 0xffff, v27
-; VI-DS128-NEXT:    v_and_b32_e32 v47, 0xffff, v26
-; VI-DS128-NEXT:    v_and_b32_e32 v53, 0xffff, v25
-; VI-DS128-NEXT:    v_and_b32_e32 v51, 0xffff, v24
-; VI-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:112
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v46, 16, v37
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v44, 16, v36
-; VI-DS128-NEXT:    v_and_b32_e32 v41, 0xffff, v39
-; VI-DS128-NEXT:    v_and_b32_e32 v39, 0xffff, v38
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v45
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v44
+; VI-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v45
+; VI-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v44
+; VI-DS128-NEXT:    v_mov_b32_e32 v44, s0
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v25
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v24
-; VI-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v25
-; VI-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v24
-; VI-DS128-NEXT:    v_mov_b32_e32 v24, s0
-; VI-DS128-NEXT:    v_and_b32_e32 v45, 0xffff, v37
-; VI-DS128-NEXT:    v_and_b32_e32 v43, 0xffff, v36
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v58
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v57
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v56
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v55
-; VI-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v58
-; VI-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v57
-; VI-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v56
-; VI-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v55
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v27
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v26
-; VI-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v27
-; VI-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v26
-; VI-DS128-NEXT:    ds_write_b128 v24, v[0:3] offset:224
-; VI-DS128-NEXT:    ds_write_b128 v24, v[4:7] offset:240
-; VI-DS128-NEXT:    ds_write_b128 v24, v[8:11] offset:192
-; VI-DS128-NEXT:    ds_write_b128 v24, v[58:61] offset:208
-; VI-DS128-NEXT:    ds_write_b128 v24, v[51:54] offset:160
-; VI-DS128-NEXT:    ds_write_b128 v24, v[47:50] offset:176
-; VI-DS128-NEXT:    ds_write_b128 v24, v[43:46] offset:128
-; VI-DS128-NEXT:    ds_write_b128 v24, v[39:42] offset:144
-; VI-DS128-NEXT:    ds_write_b128 v24, v[32:35] offset:96
-; VI-DS128-NEXT:    ds_write_b128 v24, v[20:23] offset:112
-; VI-DS128-NEXT:    ds_write_b128 v24, v[28:31] offset:64
-; VI-DS128-NEXT:    ds_write_b128 v24, v[16:19] offset:80
-; VI-DS128-NEXT:    ds_write_b128 v24, v[12:15] offset:32
-; VI-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 offset:32 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:36 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    buffer_load_dword v2, off, s[88:91], 0 offset:40 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    buffer_load_dword v3, off, s[88:91], 0 offset:44 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-DS128-NEXT:    ds_write_b128 v24, v[0:3] offset:48
-; VI-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 offset:16 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:20 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    buffer_load_dword v2, off, s[88:91], 0 offset:24 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    buffer_load_dword v3, off, s[88:91], 0 offset:28 ; 4-byte Folded Reload
-; VI-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-DS128-NEXT:    ds_write_b128 v24, v[0:3]
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v39
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v49, 16, v38
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v37
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v53, 16, v36
+; VI-DS128-NEXT:    v_and_b32_e32 v50, 0xffff, v39
+; VI-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v38
+; VI-DS128-NEXT:    v_and_b32_e32 v54, 0xffff, v37
+; VI-DS128-NEXT:    v_and_b32_e32 v52, 0xffff, v36
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v27
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v37, 16, v26
+; VI-DS128-NEXT:    v_and_b32_e32 v38, 0xffff, v27
+; VI-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v26
+; VI-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v25
+; VI-DS128-NEXT:    v_and_b32_e32 v56, 0xffff, v24
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v43
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v42
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v63, 16, v41
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v40
+; VI-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v43
+; VI-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v42
+; VI-DS128-NEXT:    v_and_b32_e32 v62, 0xffff, v41
+; VI-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v40
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v43, 16, v47
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v46
+; VI-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v47
+; VI-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v46
+; VI-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:224
+; VI-DS128-NEXT:    ds_write_b128 v44, v[40:43] offset:240
+; VI-DS128-NEXT:    ds_write_b128 v44, v[60:63] offset:192
+; VI-DS128-NEXT:    ds_write_b128 v44, v[24:27] offset:208
+; VI-DS128-NEXT:    ds_write_b128 v44, v[56:59] offset:160
+; VI-DS128-NEXT:    ds_write_b128 v44, v[36:39] offset:176
+; VI-DS128-NEXT:    ds_write_b128 v44, v[52:55] offset:128
+; VI-DS128-NEXT:    ds_write_b128 v44, v[48:51] offset:144
+; VI-DS128-NEXT:    ds_write_b128 v44, v[32:35] offset:96
+; VI-DS128-NEXT:    ds_write_b128 v44, v[20:23] offset:112
+; VI-DS128-NEXT:    ds_write_b128 v44, v[28:31] offset:64
+; VI-DS128-NEXT:    ds_write_b128 v44, v[16:19] offset:80
+; VI-DS128-NEXT:    ds_write_b128 v44, v[12:15] offset:32
+; VI-DS128-NEXT:    ds_write_b128 v44, v[8:11] offset:48
+; VI-DS128-NEXT:    ds_write_b128 v44, v[4:7]
 ; VI-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:4 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v2, off, s[88:91], 0 offset:8 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v3, off, s[88:91], 0 offset:12 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-DS128-NEXT:    ds_write_b128 v24, v[0:3] offset:16
+; VI-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:16
 ; VI-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-DS128-LABEL: local_zextload_v64i16_to_v64i32:
@@ -3940,9 +3903,9 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-DS128-NEXT:    v_mov_b32_e32 v0, s1
 ; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v0
 ; GFX9-DS128-NEXT:    ds_read_b128 v[16:19], v0 offset:16
-; GFX9-DS128-NEXT:    s_add_u32 s12, s12, s11
 ; GFX9-DS128-NEXT:    ds_read_b128 v[20:23], v0 offset:32
 ; GFX9-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:48
+; GFX9-DS128-NEXT:    s_add_u32 s12, s12, s11
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v11
 ; GFX9-DS128-NEXT:    s_addc_u32 s13, s13, 0
@@ -3959,18 +3922,13 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v8
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v9
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v8
-; GFX9-DS128-NEXT:    buffer_store_dword v4, off, s[12:15], 0 offset:16 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    s_nop 0
-; GFX9-DS128-NEXT:    buffer_store_dword v5, off, s[12:15], 0 offset:20 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v6, off, s[12:15], 0 offset:24 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v7, off, s[12:15], 0 offset:28 ; 4-byte Folded Spill
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v4, 16, v19
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v18
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v19
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v18
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v17
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v16
-; GFX9-DS128-NEXT:    v_and_b32_e32 v3, 0xffff, v19
-; GFX9-DS128-NEXT:    v_and_b32_e32 v1, 0xffff, v18
+; GFX9-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v19
+; GFX9-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v18
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v17
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v16
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
@@ -3988,85 +3946,70 @@ define amdgpu_kernel void @local_zextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v25
 ; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v24
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v27
-; GFX9-DS128-NEXT:    ds_read_b128 v[36:39], v0 offset:64
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v26
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v25
 ; GFX9-DS128-NEXT:    v_and_b32_e32 v32, 0xffff, v24
 ; GFX9-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:80
-; GFX9-DS128-NEXT:    ds_read_b128 v[55:58], v0 offset:96
-; GFX9-DS128-NEXT:    buffer_store_dword v1, off, s[12:15], 0 offset:32 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    s_nop 0
-; GFX9-DS128-NEXT:    buffer_store_dword v2, off, s[12:15], 0 offset:36 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v3, off, s[12:15], 0 offset:40 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v4, off, s[12:15], 0 offset:44 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v42, 16, v39
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v40, 16, v38
+; GFX9-DS128-NEXT:    ds_read_b128 v[40:43], v0 offset:96
+; GFX9-DS128-NEXT:    ds_read_b128 v[44:47], v0 offset:112
+; GFX9-DS128-NEXT:    ds_read_b128 v[36:39], v0 offset:64
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v25
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v57, 16, v24
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v50, 16, v27
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v48, 16, v26
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v54, 16, v25
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v52, 16, v24
-; GFX9-DS128-NEXT:    v_and_b32_e32 v49, 0xffff, v27
-; GFX9-DS128-NEXT:    v_and_b32_e32 v47, 0xffff, v26
-; GFX9-DS128-NEXT:    v_and_b32_e32 v53, 0xffff, v25
-; GFX9-DS128-NEXT:    v_and_b32_e32 v51, 0xffff, v24
-; GFX9-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:112
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v46, 16, v37
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v44, 16, v36
-; GFX9-DS128-NEXT:    v_and_b32_e32 v41, 0xffff, v39
-; GFX9-DS128-NEXT:    v_and_b32_e32 v39, 0xffff, v38
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v45
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v44
+; GFX9-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v45
+; GFX9-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v44
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v44, s0
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v25
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v24
-; GFX9-DS128-NEXT:    v_and_b32_e32 v2, 0xffff, v25
-; GFX9-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v24
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v24, s0
-; GFX9-DS128-NEXT:    v_and_b32_e32 v45, 0xffff, v37
-; GFX9-DS128-NEXT:    v_and_b32_e32 v43, 0xffff, v36
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v58
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v59, 16, v57
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v56
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v55
-; GFX9-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v58
-; GFX9-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v57
-; GFX9-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v56
-; GFX9-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v55
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v27
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v26
-; GFX9-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v27
-; GFX9-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v26
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[0:3] offset:224
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[4:7] offset:240
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[8:11] offset:192
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[58:61] offset:208
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[51:54] offset:160
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[47:50] offset:176
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[43:46] offset:128
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[39:42] offset:144
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[32:35] offset:96
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[20:23] offset:112
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[28:31] offset:64
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[16:19] offset:80
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[12:15] offset:32
-; GFX9-DS128-NEXT:    buffer_load_dword v0, off, s[12:15], 0 offset:32 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:36 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:40 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    buffer_load_dword v3, off, s[12:15], 0 offset:44 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[0:3] offset:48
-; GFX9-DS128-NEXT:    buffer_load_dword v0, off, s[12:15], 0 offset:16 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:20 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:24 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    buffer_load_dword v3, off, s[12:15], 0 offset:28 ; 4-byte Folded Reload
-; GFX9-DS128-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[0:3]
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v39
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v49, 16, v38
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v37
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v53, 16, v36
+; GFX9-DS128-NEXT:    v_and_b32_e32 v50, 0xffff, v39
+; GFX9-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v38
+; GFX9-DS128-NEXT:    v_and_b32_e32 v54, 0xffff, v37
+; GFX9-DS128-NEXT:    v_and_b32_e32 v52, 0xffff, v36
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v27
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v37, 16, v26
+; GFX9-DS128-NEXT:    v_and_b32_e32 v38, 0xffff, v27
+; GFX9-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v26
+; GFX9-DS128-NEXT:    v_and_b32_e32 v58, 0xffff, v25
+; GFX9-DS128-NEXT:    v_and_b32_e32 v56, 0xffff, v24
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v43
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v42
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v63, 16, v41
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v61, 16, v40
+; GFX9-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v43
+; GFX9-DS128-NEXT:    v_and_b32_e32 v24, 0xffff, v42
+; GFX9-DS128-NEXT:    v_and_b32_e32 v62, 0xffff, v41
+; GFX9-DS128-NEXT:    v_and_b32_e32 v60, 0xffff, v40
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v43, 16, v47
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v46
+; GFX9-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v47
+; GFX9-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v46
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:224
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[40:43] offset:240
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[60:63] offset:192
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[24:27] offset:208
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[56:59] offset:160
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[36:39] offset:176
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[52:55] offset:128
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[48:51] offset:144
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[32:35] offset:96
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[20:23] offset:112
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[28:31] offset:64
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[16:19] offset:80
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[12:15] offset:32
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[8:11] offset:48
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[4:7]
 ; GFX9-DS128-NEXT:    buffer_load_dword v0, off, s[12:15], 0 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:4 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:8 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v3, off, s[12:15], 0 offset:12 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DS128-NEXT:    ds_write_b128 v24, v[0:3] offset:16
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:16
 ; GFX9-DS128-NEXT:    s_endpgm
   %load = load <64 x i16>, ptr addrspace(3) %in
   %ext = zext <64 x i16> %load to <64 x i32>
@@ -4201,55 +4144,38 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-NO-DS128-NEXT:    s_mov_b32 s90, -1
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NO-DS128-NEXT:    v_mov_b32_e32 v28, s1
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[29:32], v28 offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[33:36], v28 offset0:8 offset1:9
 ; VI-NO-DS128-NEXT:    ds_read2_b64 v[10:13], v28 offset1:1
 ; VI-NO-DS128-NEXT:    ds_read2_b64 v[14:17], v28 offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[29:32], v28 offset0:6 offset1:7
 ; VI-NO-DS128-NEXT:    s_mov_b32 s91, 0xe80000
 ; VI-NO-DS128-NEXT:    s_add_u32 s88, s88, s11
+; VI-NO-DS128-NEXT:    s_addc_u32 s89, s89, 0
 ; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v11
+; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v30
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v24, v30, 0, 16
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v29
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v26, v29, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v38, 16, v32
-; VI-NO-DS128-NEXT:    v_bfe_i32 v37, v32, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v40, 16, v31
-; VI-NO-DS128-NEXT:    v_bfe_i32 v39, v31, 0, 16
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[29:32], v28 offset0:10 offset1:11
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v42, 16, v34
-; VI-NO-DS128-NEXT:    v_bfe_i32 v41, v34, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v44, 16, v33
-; VI-NO-DS128-NEXT:    v_bfe_i32 v43, v33, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v46, 16, v36
-; VI-NO-DS128-NEXT:    v_bfe_i32 v45, v36, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v48, 16, v35
-; VI-NO-DS128-NEXT:    v_bfe_i32 v47, v35, 0, 16
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v50, 16, v30
-; VI-NO-DS128-NEXT:    v_bfe_i32 v49, v30, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v52, 16, v29
-; VI-NO-DS128-NEXT:    v_bfe_i32 v51, v29, 0, 16
-; VI-NO-DS128-NEXT:    ds_read2_b64 v[33:36], v28 offset0:12 offset1:13
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v56, 16, v31
-; VI-NO-DS128-NEXT:    v_bfe_i32 v55, v31, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v45, 16, v32
+; VI-NO-DS128-NEXT:    v_bfe_i32 v44, v32, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v47, 16, v31
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[32:35], v28 offset0:8 offset1:9
+; VI-NO-DS128-NEXT:    v_bfe_i32 v46, v31, 0, 16
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[36:39], v28 offset0:10 offset1:11
+; VI-NO-DS128-NEXT:    ds_read2_b64 v[40:43], v28 offset0:12 offset1:13
 ; VI-NO-DS128-NEXT:    ds_read2_b64 v[28:31], v28 offset0:14 offset1:15
-; VI-NO-DS128-NEXT:    s_addc_u32 s89, s89, 0
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v11
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v0, v11, 0, 16
 ; VI-NO-DS128-NEXT:    buffer_store_dword v0, off, s[88:91], 0 ; 4-byte Folded Spill
 ; VI-NO-DS128-NEXT:    buffer_store_dword v1, off, s[88:91], 0 offset:4 ; 4-byte Folded Spill
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v54, 16, v32
-; VI-NO-DS128-NEXT:    v_bfe_i32 v53, v32, 0, 16
-; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v32, 16, v31
-; VI-NO-DS128-NEXT:    v_bfe_i32 v31, v31, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v30
-; VI-NO-DS128-NEXT:    v_bfe_i32 v0, v30, 0, 16
-; VI-NO-DS128-NEXT:    v_mov_b32_e32 v30, s0
+; VI-NO-DS128-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v10
+; VI-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v63, 16, v31
+; VI-NO-DS128-NEXT:    v_bfe_i32 v62, v31, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v30
+; VI-NO-DS128-NEXT:    v_bfe_i32 v30, v30, 0, 16
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v13
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v12
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v15
@@ -4271,37 +4197,53 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v20, v23, 0, 16
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v22
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v22, v22, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v58, 16, v34
-; VI-NO-DS128-NEXT:    v_bfe_i32 v57, v34, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v34, 16, v33
-; VI-NO-DS128-NEXT:    v_bfe_i32 v33, v33, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v60, 16, v36
-; VI-NO-DS128-NEXT:    v_bfe_i32 v59, v36, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v36, 16, v35
-; VI-NO-DS128-NEXT:    v_bfe_i32 v35, v35, 0, 16
-; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v62, 16, v29
-; VI-NO-DS128-NEXT:    v_bfe_i32 v61, v29, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v49, 16, v33
+; VI-NO-DS128-NEXT:    v_bfe_i32 v48, v33, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v32
+; VI-NO-DS128-NEXT:    v_bfe_i32 v32, v32, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v51, 16, v35
+; VI-NO-DS128-NEXT:    v_bfe_i32 v50, v35, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v35, 16, v34
+; VI-NO-DS128-NEXT:    v_bfe_i32 v34, v34, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v53, 16, v37
+; VI-NO-DS128-NEXT:    v_bfe_i32 v52, v37, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v37, 16, v36
+; VI-NO-DS128-NEXT:    v_bfe_i32 v36, v36, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v55, 16, v39
+; VI-NO-DS128-NEXT:    v_bfe_i32 v54, v39, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v39, 16, v38
+; VI-NO-DS128-NEXT:    v_bfe_i32 v38, v38, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v57, 16, v41
+; VI-NO-DS128-NEXT:    v_bfe_i32 v56, v41, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v41, 16, v40
+; VI-NO-DS128-NEXT:    v_bfe_i32 v40, v40, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v59, 16, v43
+; VI-NO-DS128-NEXT:    v_bfe_i32 v58, v43, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v43, 16, v42
+; VI-NO-DS128-NEXT:    v_bfe_i32 v42, v42, 0, 16
+; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v61, 16, v29
+; VI-NO-DS128-NEXT:    v_bfe_i32 v60, v29, 0, 16
 ; VI-NO-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v28
 ; VI-NO-DS128-NEXT:    v_bfe_i32 v28, v28, 0, 16
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[0:1], v[31:32] offset0:30 offset1:31
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[28:29], v[61:62] offset0:28 offset1:29
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[35:36], v[59:60] offset0:26 offset1:27
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[33:34], v[57:58] offset0:24 offset1:25
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[55:56], v[53:54] offset0:22 offset1:23
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[51:52], v[49:50] offset0:20 offset1:21
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[47:48], v[45:46] offset0:18 offset1:19
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[43:44], v[41:42] offset0:16 offset1:17
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[39:40], v[37:38] offset0:14 offset1:15
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[26:27], v[24:25] offset0:12 offset1:13
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[22:23], v[20:21] offset0:10 offset1:11
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[18:19], v[16:17] offset0:8 offset1:9
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[14:15], v[12:13] offset0:6 offset1:7
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[10:11], v[8:9] offset0:4 offset1:5
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[6:7], v[4:5] offset0:2 offset1:3
-; VI-NO-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 ; 4-byte Folded Reload
-; VI-NO-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:4 ; 4-byte Folded Reload
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[30:31], v[62:63] offset0:30 offset1:31
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[28:29], v[60:61] offset0:28 offset1:29
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[42:43], v[58:59] offset0:26 offset1:27
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[40:41], v[56:57] offset0:24 offset1:25
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[38:39], v[54:55] offset0:22 offset1:23
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[36:37], v[52:53] offset0:20 offset1:21
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[34:35], v[50:51] offset0:18 offset1:19
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[32:33], v[48:49] offset0:16 offset1:17
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[46:47], v[44:45] offset0:14 offset1:15
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[26:27], v[24:25] offset0:12 offset1:13
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[22:23], v[20:21] offset0:10 offset1:11
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[18:19], v[16:17] offset0:8 offset1:9
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[14:15], v[12:13] offset0:6 offset1:7
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[10:11], v[8:9] offset0:4 offset1:5
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[6:7], v[4:5] offset0:2 offset1:3
+; VI-NO-DS128-NEXT:    buffer_load_dword v4, off, s[88:91], 0 ; 4-byte Folded Reload
+; VI-NO-DS128-NEXT:    buffer_load_dword v5, off, s[88:91], 0 offset:4 ; 4-byte Folded Reload
 ; VI-NO-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-NO-DS128-NEXT:    ds_write2_b64 v30, v[2:3], v[0:1] offset1:1
+; VI-NO-DS128-NEXT:    ds_write2_b64 v0, v[2:3], v[4:5] offset1:1
 ; VI-NO-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-NO-DS128-LABEL: local_sextload_v64i16_to_v64i32:
@@ -4313,68 +4255,51 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-NO-DS128-NEXT:    s_mov_b32 s15, 0xe00000
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v28, s1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v28 offset1:1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v28 offset0:2 offset1:3
 ; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[20:23], v28 offset0:4 offset1:5
 ; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[29:32], v28 offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[33:36], v28 offset0:8 offset1:9
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[10:13], v28 offset1:1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[14:17], v28 offset0:2 offset1:3
 ; GFX9-NO-DS128-NEXT:    s_add_u32 s12, s12, s11
 ; GFX9-NO-DS128-NEXT:    s_addc_u32 s13, s13, 0
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v5
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v0, v5, 0, 16
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v30
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v24, v30, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v29
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v26, v29, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v38, 16, v32
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v37, v32, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v40, 16, v31
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v39, v31, 0, 16
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[29:32], v28 offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v42, 16, v34
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v41, v34, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v44, 16, v33
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v43, v33, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v46, 16, v36
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v45, v36, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v48, 16, v35
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v47, v35, 0, 16
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v50, 16, v30
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v49, v30, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v52, 16, v29
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v51, v29, 0, 16
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[33:36], v28 offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v56, 16, v31
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v55, v31, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v45, 16, v32
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v44, v32, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v47, 16, v31
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[32:35], v28 offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v46, v31, 0, 16
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[36:39], v28 offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[40:43], v28 offset0:12 offset1:13
 ; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[28:31], v28 offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v11
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v0, v11, 0, 16
 ; GFX9-NO-DS128-NEXT:    buffer_store_dword v0, off, s[12:15], 0 ; 4-byte Folded Spill
 ; GFX9-NO-DS128-NEXT:    s_nop 0
 ; GFX9-NO-DS128-NEXT:    buffer_store_dword v1, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v54, 16, v32
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v53, v32, 0, 16
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v0, s0
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v4
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v2, v4, 0, 16
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v32, 16, v31
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v31, v31, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v30
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v0, v30, 0, 16
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v30, s0
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v10
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v13
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v12
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v15
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v2, v10, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v4, v13, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v6, v12, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v14
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v17
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v8, v15, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v10, v14, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v12, v17, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v14, v16, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v63, 16, v31
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v62, v31, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v30
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v30, v30, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v7
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v4, v7, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v6
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v6, v6, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v13
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v8, v13, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v12
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v10, v12, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 16, v15
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v12, v15, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v15, 16, v14
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v14, v14, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v21
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v21, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v20
@@ -4383,37 +4308,53 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v20, v23, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v22
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v22, v22, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v58, 16, v34
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v57, v34, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v34, 16, v33
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v33, v33, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v60, 16, v36
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v59, v36, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v36, 16, v35
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v35, v35, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v62, 16, v29
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v61, v29, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v49, 16, v33
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v48, v33, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v32
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v32, v32, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v51, 16, v35
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v50, v35, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v35, 16, v34
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v34, v34, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v53, 16, v37
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v52, v37, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v37, 16, v36
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v36, v36, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v55, 16, v39
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v54, v39, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v39, 16, v38
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v38, v38, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v57, 16, v41
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v56, v41, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v41, 16, v40
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v40, v40, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v59, 16, v43
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v58, v43, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v43, 16, v42
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v42, v42, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v61, 16, v29
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v60, v29, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v28
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v28, v28, 0, 16
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[0:1], v[31:32] offset0:30 offset1:31
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[28:29], v[61:62] offset0:28 offset1:29
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[35:36], v[59:60] offset0:26 offset1:27
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[33:34], v[57:58] offset0:24 offset1:25
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[55:56], v[53:54] offset0:22 offset1:23
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[51:52], v[49:50] offset0:20 offset1:21
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[47:48], v[45:46] offset0:18 offset1:19
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[43:44], v[41:42] offset0:16 offset1:17
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[39:40], v[37:38] offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[26:27], v[24:25] offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[22:23], v[20:21] offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[18:19], v[16:17] offset0:8 offset1:9
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[14:15], v[12:13] offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[10:11], v[8:9] offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[6:7], v[4:5] offset0:2 offset1:3
-; GFX9-NO-DS128-NEXT:    buffer_load_dword v0, off, s[12:15], 0 ; 4-byte Folded Reload
-; GFX9-NO-DS128-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:4 ; 4-byte Folded Reload
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[30:31], v[62:63] offset0:30 offset1:31
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[28:29], v[60:61] offset0:28 offset1:29
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[42:43], v[58:59] offset0:26 offset1:27
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[40:41], v[56:57] offset0:24 offset1:25
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[38:39], v[54:55] offset0:22 offset1:23
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[36:37], v[52:53] offset0:20 offset1:21
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[34:35], v[50:51] offset0:18 offset1:19
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[32:33], v[48:49] offset0:16 offset1:17
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[46:47], v[44:45] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[26:27], v[24:25] offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[22:23], v[20:21] offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[18:19], v[16:17] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[14:15], v[12:13] offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[10:11], v[8:9] offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[6:7], v[4:5] offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    buffer_load_dword v4, off, s[12:15], 0 ; 4-byte Folded Reload
+; GFX9-NO-DS128-NEXT:    buffer_load_dword v5, off, s[12:15], 0 offset:4 ; 4-byte Folded Reload
 ; GFX9-NO-DS128-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v30, v[2:3], v[0:1] offset1:1
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v0, v[2:3], v[4:5] offset1:1
 ; GFX9-NO-DS128-NEXT:    s_endpgm
 ;
 ; EG-LABEL: local_sextload_v64i16_to_v64i32:
@@ -4846,8 +4787,8 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-DS128:       ; %bb.0:
 ; VI-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; VI-DS128-NEXT:    s_mov_b32 s88, SCRATCH_RSRC_DWORD0
-; VI-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-DS128-NEXT:    s_mov_b32 s89, SCRATCH_RSRC_DWORD1
+; VI-DS128-NEXT:    s_mov_b32 m0, -1
 ; VI-DS128-NEXT:    s_mov_b32 s90, -1
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-DS128-NEXT:    v_mov_b32_e32 v32, s1
@@ -4883,91 +4824,91 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
 ; VI-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v27
 ; VI-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v26
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v25
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v24
 ; VI-DS128-NEXT:    v_bfe_i32 v18, v27, 0, 16
 ; VI-DS128-NEXT:    v_bfe_i32 v16, v26, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v22, v25, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v20, v24, 0, 16
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; VI-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v36
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v35
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v34
 ; VI-DS128-NEXT:    v_bfe_i32 v26, v36, 0, 16
-; VI-DS128-NEXT:    ds_read_b128 v[36:39], v32 offset:64
-; VI-DS128-NEXT:    ds_read_b128 v[40:43], v32 offset:80
-; VI-DS128-NEXT:    ds_read_b128 v[56:59], v32 offset:96
+; VI-DS128-NEXT:    v_bfe_i32 v24, v35, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v30, v34, 0, 16
+; VI-DS128-NEXT:    ds_read_b128 v[34:37], v32 offset:64
+; VI-DS128-NEXT:    ds_read_b128 v[38:41], v32 offset:80
+; VI-DS128-NEXT:    ds_read_b128 v[42:45], v32 offset:96
+; VI-DS128-NEXT:    ds_read_b128 v[46:49], v32 offset:112
 ; VI-DS128-NEXT:    buffer_store_dword v3, off, s[88:91], 0 offset:16 ; 4-byte Folded Spill
 ; VI-DS128-NEXT:    buffer_store_dword v4, off, s[88:91], 0 offset:20 ; 4-byte Folded Spill
 ; VI-DS128-NEXT:    buffer_store_dword v5, off, s[88:91], 0 offset:24 ; 4-byte Folded Spill
 ; VI-DS128-NEXT:    buffer_store_dword v6, off, s[88:91], 0 offset:28 ; 4-byte Folded Spill
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v25
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v47, 16, v39
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v45, 16, v38
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v51, 16, v37
-; VI-DS128-NEXT:    v_bfe_i32 v46, v39, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v44, v38, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v50, v37, 0, 16
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v53, 16, v40
-; VI-DS128-NEXT:    v_bfe_i32 v52, v40, 0, 16
-; VI-DS128-NEXT:    ds_read_b128 v[37:40], v32 offset:112
-; VI-DS128-NEXT:    v_mov_b32_e32 v32, s0
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v24
-; VI-DS128-NEXT:    v_bfe_i32 v22, v25, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v20, v24, 0, 16
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v38
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v37
-; VI-DS128-NEXT:    v_bfe_i32 v2, v38, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v0, v37, 0, 16
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v35
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v34
 ; VI-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v33
-; VI-DS128-NEXT:    v_bfe_i32 v24, v35, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v30, v34, 0, 16
 ; VI-DS128-NEXT:    v_bfe_i32 v28, v33, 0, 16
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v49, 16, v36
-; VI-DS128-NEXT:    v_bfe_i32 v48, v36, 0, 16
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v36, 16, v43
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v34, 16, v42
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v55, 16, v41
-; VI-DS128-NEXT:    v_bfe_i32 v35, v43, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v33, v42, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v54, v41, 0, 16
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v62, 16, v59
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v60, 16, v58
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v57
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v56
-; VI-DS128-NEXT:    v_bfe_i32 v61, v59, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v59, v58, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v6, v57, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v4, v56, 0, 16
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v43, 16, v40
-; VI-DS128-NEXT:    v_ashrrev_i32_e32 v41, 16, v39
-; VI-DS128-NEXT:    v_bfe_i32 v42, v40, 0, 16
-; VI-DS128-NEXT:    v_bfe_i32 v40, v39, 0, 16
-; VI-DS128-NEXT:    ds_write_b128 v32, v[0:3] offset:224
-; VI-DS128-NEXT:    ds_write_b128 v32, v[40:43] offset:240
-; VI-DS128-NEXT:    ds_write_b128 v32, v[4:7] offset:192
-; VI-DS128-NEXT:    ds_write_b128 v32, v[59:62] offset:208
-; VI-DS128-NEXT:    ds_write_b128 v32, v[52:55] offset:160
-; VI-DS128-NEXT:    ds_write_b128 v32, v[33:36] offset:176
-; VI-DS128-NEXT:    ds_write_b128 v32, v[48:51] offset:128
-; VI-DS128-NEXT:    ds_write_b128 v32, v[44:47] offset:144
-; VI-DS128-NEXT:    ds_write_b128 v32, v[28:31] offset:96
-; VI-DS128-NEXT:    ds_write_b128 v32, v[24:27] offset:112
-; VI-DS128-NEXT:    ds_write_b128 v32, v[20:23] offset:64
-; VI-DS128-NEXT:    ds_write_b128 v32, v[16:19] offset:80
-; VI-DS128-NEXT:    ds_write_b128 v32, v[12:15] offset:32
-; VI-DS128-NEXT:    ds_write_b128 v32, v[8:11] offset:48
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v53, 16, v37
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v51, 16, v36
+; VI-DS128-NEXT:    v_bfe_i32 v52, v37, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v50, v36, 0, 16
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v37, 16, v44
+; VI-DS128-NEXT:    v_bfe_i32 v36, v44, 0, 16
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v47
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v46
+; VI-DS128-NEXT:    v_bfe_i32 v2, v47, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v0, v46, 0, 16
+; VI-DS128-NEXT:    v_mov_b32_e32 v44, s0
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v57, 16, v35
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v55, 16, v34
+; VI-DS128-NEXT:    v_bfe_i32 v56, v35, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v54, v34, 0, 16
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v35, 16, v41
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v40
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v61, 16, v39
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v59, 16, v38
+; VI-DS128-NEXT:    v_bfe_i32 v34, v41, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v32, v40, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v60, v39, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v58, v38, 0, 16
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v39, 16, v45
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v43
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v42
+; VI-DS128-NEXT:    v_bfe_i32 v38, v45, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v6, v43, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v4, v42, 0, 16
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v43, 16, v49
+; VI-DS128-NEXT:    v_ashrrev_i32_e32 v41, 16, v48
+; VI-DS128-NEXT:    v_bfe_i32 v42, v49, 0, 16
+; VI-DS128-NEXT:    v_bfe_i32 v40, v48, 0, 16
+; VI-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:224
+; VI-DS128-NEXT:    ds_write_b128 v44, v[40:43] offset:240
+; VI-DS128-NEXT:    ds_write_b128 v44, v[4:7] offset:192
+; VI-DS128-NEXT:    ds_write_b128 v44, v[36:39] offset:208
+; VI-DS128-NEXT:    ds_write_b128 v44, v[58:61] offset:160
+; VI-DS128-NEXT:    ds_write_b128 v44, v[32:35] offset:176
+; VI-DS128-NEXT:    ds_write_b128 v44, v[54:57] offset:128
+; VI-DS128-NEXT:    ds_write_b128 v44, v[50:53] offset:144
+; VI-DS128-NEXT:    ds_write_b128 v44, v[28:31] offset:96
+; VI-DS128-NEXT:    ds_write_b128 v44, v[24:27] offset:112
+; VI-DS128-NEXT:    ds_write_b128 v44, v[20:23] offset:64
+; VI-DS128-NEXT:    ds_write_b128 v44, v[16:19] offset:80
+; VI-DS128-NEXT:    ds_write_b128 v44, v[12:15] offset:32
+; VI-DS128-NEXT:    ds_write_b128 v44, v[8:11] offset:48
 ; VI-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 offset:16 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:20 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v2, off, s[88:91], 0 offset:24 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v3, off, s[88:91], 0 offset:28 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-DS128-NEXT:    ds_write_b128 v32, v[0:3]
+; VI-DS128-NEXT:    ds_write_b128 v44, v[0:3]
 ; VI-DS128-NEXT:    buffer_load_dword v0, off, s[88:91], 0 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v1, off, s[88:91], 0 offset:4 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v2, off, s[88:91], 0 offset:8 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    buffer_load_dword v3, off, s[88:91], 0 offset:12 ; 4-byte Folded Reload
 ; VI-DS128-NEXT:    s_waitcnt vmcnt(0)
-; VI-DS128-NEXT:    ds_write_b128 v32, v[0:3] offset:16
+; VI-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:16
 ; VI-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-DS128-LABEL: local_sextload_v64i16_to_v64i32:
@@ -4978,27 +4919,28 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-DS128-NEXT:    s_mov_b32 s14, -1
 ; GFX9-DS128-NEXT:    s_mov_b32 s15, 0xe00000
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v32, s1
-; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v32
-; GFX9-DS128-NEXT:    ds_read_b128 v[16:19], v32 offset:16
-; GFX9-DS128-NEXT:    ds_read_b128 v[24:27], v32 offset:32
-; GFX9-DS128-NEXT:    ds_read_b128 v[33:36], v32 offset:48
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v0, s1
+; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v0
+; GFX9-DS128-NEXT:    ds_read_b128 v[16:19], v0 offset:16
+; GFX9-DS128-NEXT:    ds_read_b128 v[24:27], v0 offset:32
+; GFX9-DS128-NEXT:    ds_read_b128 v[32:35], v0 offset:48
 ; GFX9-DS128-NEXT:    s_add_u32 s12, s12, s11
-; GFX9-DS128-NEXT:    s_addc_u32 s13, s13, 0
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v11
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v10
-; GFX9-DS128-NEXT:    v_bfe_i32 v2, v11, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v0, v10, 0, 16
-; GFX9-DS128-NEXT:    buffer_store_dword v0, off, s[12:15], 0 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    s_addc_u32 s13, s13, 0
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v2, 16, v10
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v4, v3
+; GFX9-DS128-NEXT:    v_bfe_i32 v3, v11, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v1, v10, 0, 16
+; GFX9-DS128-NEXT:    buffer_store_dword v1, off, s[12:15], 0 ; 4-byte Folded Spill
 ; GFX9-DS128-NEXT:    s_nop 0
-; GFX9-DS128-NEXT:    buffer_store_dword v1, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v2, off, s[12:15], 0 offset:8 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v3, off, s[12:15], 0 offset:12 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v6, 16, v9
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v4, 16, v8
-; GFX9-DS128-NEXT:    v_bfe_i32 v5, v9, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v3, v8, 0, 16
+; GFX9-DS128-NEXT:    buffer_store_dword v2, off, s[12:15], 0 offset:4 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    buffer_store_dword v3, off, s[12:15], 0 offset:8 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    buffer_store_dword v4, off, s[12:15], 0 offset:12 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v9
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v8
+; GFX9-DS128-NEXT:    v_bfe_i32 v6, v9, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v4, v8, 0, 16
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(2)
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v11, 16, v19
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v9, 16, v18
@@ -5011,92 +4953,93 @@ define amdgpu_kernel void @local_sextload_v64i16_to_v64i32(ptr addrspace(3) %out
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v19, 16, v27
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v17, 16, v26
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v25
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v24
 ; GFX9-DS128-NEXT:    v_bfe_i32 v18, v27, 0, 16
 ; GFX9-DS128-NEXT:    v_bfe_i32 v16, v26, 0, 16
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v36
-; GFX9-DS128-NEXT:    v_bfe_i32 v26, v36, 0, 16
-; GFX9-DS128-NEXT:    ds_read_b128 v[36:39], v32 offset:64
-; GFX9-DS128-NEXT:    ds_read_b128 v[40:43], v32 offset:80
-; GFX9-DS128-NEXT:    ds_read_b128 v[56:59], v32 offset:96
-; GFX9-DS128-NEXT:    buffer_store_dword v3, off, s[12:15], 0 offset:16 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    s_nop 0
-; GFX9-DS128-NEXT:    buffer_store_dword v4, off, s[12:15], 0 offset:20 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v5, off, s[12:15], 0 offset:24 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    buffer_store_dword v6, off, s[12:15], 0 offset:28 ; 4-byte Folded Spill
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v23, 16, v25
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v47, 16, v39
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v45, 16, v38
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v51, 16, v37
-; GFX9-DS128-NEXT:    v_bfe_i32 v46, v39, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v44, v38, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v50, v37, 0, 16
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v53, 16, v40
-; GFX9-DS128-NEXT:    v_bfe_i32 v52, v40, 0, 16
-; GFX9-DS128-NEXT:    ds_read_b128 v[37:40], v32 offset:112
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v32, s0
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v21, 16, v24
 ; GFX9-DS128-NEXT:    v_bfe_i32 v22, v25, 0, 16
 ; GFX9-DS128-NEXT:    v_bfe_i32 v20, v24, 0, 16
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v38
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v37
-; GFX9-DS128-NEXT:    v_bfe_i32 v2, v38, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v0, v37, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v35
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v34
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v33
-; GFX9-DS128-NEXT:    v_bfe_i32 v24, v35, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v30, v34, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v28, v33, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v49, 16, v36
-; GFX9-DS128-NEXT:    v_bfe_i32 v48, v36, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v36, 16, v43
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v34, 16, v42
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v55, 16, v41
-; GFX9-DS128-NEXT:    v_bfe_i32 v35, v43, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v33, v42, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v54, v41, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v62, 16, v59
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v60, 16, v58
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v57
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v56
-; GFX9-DS128-NEXT:    v_bfe_i32 v61, v59, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v59, v58, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v6, v57, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v4, v56, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v43, 16, v40
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v41, 16, v39
-; GFX9-DS128-NEXT:    v_bfe_i32 v42, v40, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v40, v39, 0, 16
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[0:3] offset:224
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[40:43] offset:240
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[4:7] offset:192
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[59:62] offset:208
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[52:55] offset:160
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[33:36] offset:176
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[48:51] offset:128
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[44:47] offset:144
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[28:31] offset:96
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[24:27] offset:112
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[20:23] offset:64
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[16:19] offset:80
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[12:15] offset:32
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[8:11] offset:48
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v27, 16, v35
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v25, 16, v34
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v31, 16, v33
+; GFX9-DS128-NEXT:    v_bfe_i32 v26, v35, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v24, v34, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v30, v33, 0, 16
+; GFX9-DS128-NEXT:    ds_read_b128 v[33:36], v0 offset:64
+; GFX9-DS128-NEXT:    ds_read_b128 v[37:40], v0 offset:80
+; GFX9-DS128-NEXT:    ds_read_b128 v[41:44], v0 offset:96
+; GFX9-DS128-NEXT:    ds_read_b128 v[45:48], v0 offset:112
+; GFX9-DS128-NEXT:    buffer_store_dword v4, off, s[12:15], 0 offset:16 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    s_nop 0
+; GFX9-DS128-NEXT:    buffer_store_dword v5, off, s[12:15], 0 offset:20 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    buffer_store_dword v6, off, s[12:15], 0 offset:24 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    buffer_store_dword v7, off, s[12:15], 0 offset:28 ; 4-byte Folded Spill
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v29, 16, v32
+; GFX9-DS128-NEXT:    v_bfe_i32 v28, v32, 0, 16
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v54, 16, v33
+; GFX9-DS128-NEXT:    v_bfe_i32 v53, v33, 0, 16
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v33, 16, v39
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v60, 16, v38
+; GFX9-DS128-NEXT:    v_bfe_i32 v32, v39, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v59, v38, 0, 16
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v39, 16, v44
+; GFX9-DS128-NEXT:    v_bfe_i32 v38, v44, 0, 16
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 16, v46
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v1, 16, v45
+; GFX9-DS128-NEXT:    v_bfe_i32 v2, v46, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v0, v45, 0, 16
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v44, s0
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v52, 16, v36
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v50, 16, v35
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v56, 16, v34
+; GFX9-DS128-NEXT:    v_bfe_i32 v51, v36, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v49, v35, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v55, v34, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v35, 16, v40
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v58, 16, v37
+; GFX9-DS128-NEXT:    v_bfe_i32 v34, v40, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v57, v37, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v37, 16, v43
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 16, v42
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 16, v41
+; GFX9-DS128-NEXT:    v_bfe_i32 v36, v43, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v6, v42, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v4, v41, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v43, 16, v48
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v41, 16, v47
+; GFX9-DS128-NEXT:    v_bfe_i32 v42, v48, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v40, v47, 0, 16
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:224
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[40:43] offset:240
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[4:7] offset:192
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[36:39] offset:208
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[57:60] offset:160
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[32:35] offset:176
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[53:56] offset:128
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[49:52] offset:144
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[28:31] offset:96
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[24:27] offset:112
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[20:23] offset:64
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[16:19] offset:80
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[12:15] offset:32
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[8:11] offset:48
 ; GFX9-DS128-NEXT:    buffer_load_dword v0, off, s[12:15], 0 offset:16 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:20 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:24 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v3, off, s[12:15], 0 offset:28 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[0:3]
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[0:3]
 ; GFX9-DS128-NEXT:    buffer_load_dword v0, off, s[12:15], 0 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v1, off, s[12:15], 0 offset:4 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v2, off, s[12:15], 0 offset:8 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    buffer_load_dword v3, off, s[12:15], 0 offset:12 ; 4-byte Folded Reload
 ; GFX9-DS128-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-DS128-NEXT:    ds_write_b128 v32, v[0:3] offset:16
+; GFX9-DS128-NEXT:    ds_write_b128 v44, v[0:3] offset:16
 ; GFX9-DS128-NEXT:    s_endpgm
   %load = load <64 x i16>, ptr addrspace(3) %in
   %ext = sext <64 x i16> %load to <64 x i32>
@@ -7278,79 +7221,79 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v0, s1
+; SI-NEXT:    v_mov_b32_e32 v12, s1
 ; SI-NEXT:    s_mov_b32 m0, -1
-; SI-NEXT:    ds_read2_b64 v[2:5], v0 offset0:2 offset1:3
-; SI-NEXT:    v_mov_b32_e32 v1, 0
-; SI-NEXT:    ds_read2_b64 v[6:9], v0 offset1:1
-; SI-NEXT:    v_mov_b32_e32 v19, v1
-; SI-NEXT:    v_mov_b32_e32 v21, v1
-; SI-NEXT:    v_mov_b32_e32 v22, s0
-; SI-NEXT:    s_waitcnt lgkmcnt(1)
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v5
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v5
-; SI-NEXT:    ds_read2_b64 v[10:13], v0 offset0:4 offset1:5
-; SI-NEXT:    ds_read2_b64 v[14:17], v0 offset0:6 offset1:7
-; SI-NEXT:    ds_write2_b64 v22, v[20:21], v[18:19] offset0:14 offset1:15
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v3
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v3
-; SI-NEXT:    ds_write2_b64 v22, v[20:21], v[18:19] offset0:10 offset1:11
-; SI-NEXT:    s_waitcnt lgkmcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v9
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v9
-; SI-NEXT:    ds_write2_b64 v22, v[20:21], v[18:19] offset0:6 offset1:7
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v7
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v7
-; SI-NEXT:    ds_write2_b64 v22, v[20:21], v[18:19] offset0:2 offset1:3
-; SI-NEXT:    s_waitcnt lgkmcnt(4)
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v17
-; SI-NEXT:    v_and_b32_e32 v20, 0xffff, v17
-; SI-NEXT:    ds_write2_b64 v22, v[20:21], v[18:19] offset0:30 offset1:31
-; SI-NEXT:    v_mov_b32_e32 v18, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v15
-; SI-NEXT:    v_mov_b32_e32 v20, v1
-; SI-NEXT:    v_and_b32_e32 v19, 0xffff, v15
-; SI-NEXT:    ds_write2_b64 v22, v[19:20], v[17:18] offset0:26 offset1:27
-; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v13
-; SI-NEXT:    v_and_b32_e32 v19, 0xffff, v13
-; SI-NEXT:    ds_write2_b64 v22, v[19:20], v[17:18] offset0:22 offset1:23
-; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v4
-; SI-NEXT:    v_mov_b32_e32 v5, v1
-; SI-NEXT:    v_and_b32_e32 v4, 0xffff, v4
-; SI-NEXT:    ds_write2_b64 v22, v[4:5], v[17:18] offset0:12 offset1:13
-; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v2
-; SI-NEXT:    v_mov_b32_e32 v4, v1
-; SI-NEXT:    ds_write2_b64 v22, v[17:18], v[3:4] offset0:8 offset1:9
-; SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v8
-; SI-NEXT:    v_lshrrev_b32_e32 v4, 16, v6
-; SI-NEXT:    v_and_b32_e32 v6, 0xffff, v6
-; SI-NEXT:    v_and_b32_e32 v8, 0xffff, v8
-; SI-NEXT:    v_mov_b32_e32 v9, v1
-; SI-NEXT:    v_mov_b32_e32 v7, v1
-; SI-NEXT:    v_mov_b32_e32 v3, v1
-; SI-NEXT:    v_lshrrev_b32_e32 v0, 16, v11
-; SI-NEXT:    ds_write2_b64 v22, v[8:9], v[2:3] offset0:4 offset1:5
-; SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v8, 16, v10
-; SI-NEXT:    ds_write2_b64 v22, v[6:7], v[4:5] offset1:1
-; SI-NEXT:    v_and_b32_e32 v4, 0xffff, v10
-; SI-NEXT:    v_and_b32_e32 v5, 0xffff, v11
-; SI-NEXT:    v_and_b32_e32 v10, 0xffff, v12
-; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v16
-; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
-; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v14
-; SI-NEXT:    v_and_b32_e32 v19, 0xffff, v16
-; SI-NEXT:    v_mov_b32_e32 v6, v1
-; SI-NEXT:    ds_write2_b64 v22, v[5:6], v[0:1] offset0:18 offset1:19
-; SI-NEXT:    v_mov_b32_e32 v11, v1
-; SI-NEXT:    v_mov_b32_e32 v5, v1
-; SI-NEXT:    v_mov_b32_e32 v13, v1
-; SI-NEXT:    v_mov_b32_e32 v16, v1
-; SI-NEXT:    ds_write2_b64 v22, v[19:20], v[12:13] offset0:28 offset1:29
-; SI-NEXT:    ds_write2_b64 v22, v[17:18], v[15:16] offset0:24 offset1:25
-; SI-NEXT:    ds_write2_b64 v22, v[10:11], v[2:3] offset0:20 offset1:21
-; SI-NEXT:    ds_write2_b64 v22, v[4:5], v[8:9] offset0:16 offset1:17
+; SI-NEXT:    ds_read2_b64 v[0:3], v12 offset0:6 offset1:7
+; SI-NEXT:    ds_read2_b64 v[5:8], v12 offset0:2 offset1:3
+; SI-NEXT:    v_mov_b32_e32 v4, 0
+; SI-NEXT:    v_mov_b32_e32 v17, v4
+; SI-NEXT:    v_mov_b32_e32 v19, v4
+; SI-NEXT:    v_mov_b32_e32 v20, s0
+; SI-NEXT:    s_waitcnt lgkmcnt(0)
+; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v8
+; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v8
+; SI-NEXT:    ds_read2_b64 v[8:11], v12 offset0:4 offset1:5
+; SI-NEXT:    ds_read2_b64 v[12:15], v12 offset1:1
+; SI-NEXT:    ds_write2_b64 v20, v[18:19], v[16:17] offset0:14 offset1:15
+; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v6
+; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v6
+; SI-NEXT:    ds_write2_b64 v20, v[18:19], v[16:17] offset0:10 offset1:11
+; SI-NEXT:    s_waitcnt lgkmcnt(2)
+; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v15
+; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v15
+; SI-NEXT:    ds_write2_b64 v20, v[18:19], v[16:17] offset0:6 offset1:7
+; SI-NEXT:    v_mov_b32_e32 v16, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v13
+; SI-NEXT:    v_mov_b32_e32 v18, v4
+; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v13
+; SI-NEXT:    ds_write2_b64 v20, v[17:18], v[15:16] offset0:2 offset1:3
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v3
+; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v3
+; SI-NEXT:    ds_write2_b64 v20, v[17:18], v[15:16] offset0:30 offset1:31
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v1
+; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v1
+; SI-NEXT:    ds_write2_b64 v20, v[17:18], v[15:16] offset0:26 offset1:27
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v11
+; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v11
+; SI-NEXT:    ds_write2_b64 v20, v[17:18], v[15:16] offset0:22 offset1:23
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v7
+; SI-NEXT:    v_and_b32_e32 v17, 0xffff, v7
+; SI-NEXT:    ds_write2_b64 v20, v[17:18], v[15:16] offset0:12 offset1:13
+; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
+; SI-NEXT:    v_and_b32_e32 v15, 0xffff, v5
+; SI-NEXT:    v_mov_b32_e32 v7, v4
+; SI-NEXT:    ds_write2_b64 v20, v[15:16], v[6:7] offset0:8 offset1:9
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v12
+; SI-NEXT:    v_and_b32_e32 v13, 0xffff, v12
+; SI-NEXT:    v_and_b32_e32 v15, 0xffff, v14
+; SI-NEXT:    v_mov_b32_e32 v14, v4
+; SI-NEXT:    v_mov_b32_e32 v6, v4
+; SI-NEXT:    v_mov_b32_e32 v12, v4
+; SI-NEXT:    v_lshrrev_b32_e32 v3, 16, v9
+; SI-NEXT:    ds_write2_b64 v20, v[15:16], v[5:6] offset0:4 offset1:5
+; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v8
+; SI-NEXT:    ds_write2_b64 v20, v[13:14], v[11:12] offset1:1
+; SI-NEXT:    v_and_b32_e32 v7, 0xffff, v8
+; SI-NEXT:    v_and_b32_e32 v8, 0xffff, v9
+; SI-NEXT:    v_and_b32_e32 v10, 0xffff, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v12, 16, v2
+; SI-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
+; SI-NEXT:    v_and_b32_e32 v16, 0xffff, v0
+; SI-NEXT:    v_and_b32_e32 v18, 0xffff, v2
+; SI-NEXT:    v_mov_b32_e32 v9, v4
+; SI-NEXT:    ds_write2_b64 v20, v[8:9], v[3:4] offset0:18 offset1:19
+; SI-NEXT:    v_mov_b32_e32 v17, v4
+; SI-NEXT:    v_mov_b32_e32 v11, v4
+; SI-NEXT:    v_mov_b32_e32 v8, v4
+; SI-NEXT:    v_mov_b32_e32 v13, v4
+; SI-NEXT:    v_mov_b32_e32 v15, v4
+; SI-NEXT:    v_mov_b32_e32 v2, v4
+; SI-NEXT:    ds_write2_b64 v20, v[18:19], v[12:13] offset0:28 offset1:29
+; SI-NEXT:    ds_write2_b64 v20, v[16:17], v[14:15] offset0:24 offset1:25
+; SI-NEXT:    ds_write2_b64 v20, v[10:11], v[1:2] offset0:20 offset1:21
+; SI-NEXT:    ds_write2_b64 v20, v[7:8], v[5:6] offset0:16 offset1:17
 ; SI-NEXT:    s_endpgm
 ;
 ; VI-NO-DS128-LABEL: local_zextload_v32i16_to_v32i64:
@@ -7442,12 +7385,12 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v21, v5
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v4, s1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[6:9], v4 offset0:4 offset1:5
 ; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v4 offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[6:9], v4 offset1:1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[10:13], v4 offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[14:17], v4 offset0:4 offset1:5
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v22, s0
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[10:13], v4 offset1:1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[14:17], v4 offset0:2 offset1:3
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v20, 16, v2
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v18, 0xffff, v2
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[18:19], v[20:21] offset0:28 offset1:29
@@ -7458,58 +7401,62 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v1, 0xffff, v0
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v18, 16, v0
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[1:2], v[18:19] offset0:24 offset1:25
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v9
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v17
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v1, v5
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v18, 16, v9
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[0:1], v[18:19] offset0:22 offset1:23
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v8
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v9, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[0:1], v[8:9] offset0:20 offset1:21
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v7
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v7
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v8, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[0:1], v[7:8] offset0:18 offset1:19
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v6
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v6
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v7, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[0:1] offset0:16 offset1:17
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v17
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v17
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[0:1] offset0:14 offset1:15
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v16
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v16
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[0:1] offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v15
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v15
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[0:1] offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v14
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v14
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v10
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v10
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[1:2] offset0:8 offset1:9
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v12
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v9, 0xffff, v12
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v10, 16, v13
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v13
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v17
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v18, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[0:1], v[17:18] offset0:22 offset1:23
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v16
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v16
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v17, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[0:1], v[16:17] offset0:20 offset1:21
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v15
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v15
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v16, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[0:1], v[15:16] offset0:18 offset1:19
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v14
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v14
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v15, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[14:15], v[0:1] offset0:16 offset1:17
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v13
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v13, 0xffff, v13
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v14, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[13:14], v[0:1] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v12
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v12
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v13, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[12:13], v[0:1] offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v11
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v11, 0xffff, v11
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v12, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[11:12], v[0:1] offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v10
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v10, 0xffff, v10
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v11, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[10:11], v[1:2] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v8
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v8, 0xffff, v8
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v10, 16, v9
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v12, 0xffff, v9
 ; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v3
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v3
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v14, v5
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v11
-; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v11
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v9, v5
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v3, v5
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v7, 0xffff, v7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[8:9], v[2:3] offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v8, v5
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v2, v5
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v6
+; GFX9-NO-DS128-NEXT:    v_and_b32_e32 v6, 0xffff, v6
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[4:5], v[13:14] offset0:30 offset1:31
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v13, v5
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v11, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[12:13], v[10:11] offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v10, v5
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v3, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[9:10], v[2:3] offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v2, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[1:2] offset0:2 offset1:3
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v9, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[7:8], v[1:2] offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v7, v5
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v1, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[8:9], v[0:1] offset1:1
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[12:13], v[10:11] offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v22, v[6:7], v[0:1] offset1:1
 ; GFX9-NO-DS128-NEXT:    s_endpgm
 ;
 ; EG-LABEL: local_zextload_v32i16_to_v32i64:
@@ -7811,193 +7758,189 @@ define amdgpu_kernel void @local_zextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; VI-DS128:       ; %bb.0:
 ; VI-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; VI-DS128-NEXT:    s_mov_b32 m0, -1
+; VI-DS128-NEXT:    v_mov_b32_e32 v54, 0
+; VI-DS128-NEXT:    v_mov_b32_e32 v50, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v52, v54
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_mov_b32_e32 v1, s1
-; VI-DS128-NEXT:    ds_read_b128 v[3:6], v1
-; VI-DS128-NEXT:    ds_read_b128 v[7:10], v1 offset:16
-; VI-DS128-NEXT:    v_mov_b32_e32 v52, s0
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v6
+; VI-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; VI-DS128-NEXT:    ds_read_b128 v[0:3], v12
+; VI-DS128-NEXT:    ds_read_b128 v[4:7], v12 offset:16
+; VI-DS128-NEXT:    ds_read_b128 v[8:11], v12 offset:32
+; VI-DS128-NEXT:    ds_read_b128 v[12:15], v12 offset:48
+; VI-DS128-NEXT:    v_mov_b32_e32 v47, v54
+; VI-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v0
+; VI-DS128-NEXT:    v_and_b32_e32 v19, 0xffff, v0
+; VI-DS128-NEXT:    v_mov_b32_e32 v0, s0
 ; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v8
-; VI-DS128-NEXT:    v_and_b32_e32 v17, 0xffff, v8
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v22, 16, v7
-; VI-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v7
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
-; VI-DS128-NEXT:    v_and_b32_e32 v23, 0xffff, v10
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v28, 16, v9
-; VI-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v9
-; VI-DS128-NEXT:    ds_read_b128 v[7:10], v1 offset:32
-; VI-DS128-NEXT:    ds_read_b128 v[29:32], v1 offset:48
-; VI-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v6
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; VI-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v38, 16, v7
-; VI-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v7
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v44, 16, v9
-; VI-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v9
-; VI-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v30
-; VI-DS128-NEXT:    v_and_b32_e32 v7, 0xffff, v30
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v50, 16, v32
-; VI-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v32
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v32, 16, v31
-; VI-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v31, 0
-; VI-DS128-NEXT:    v_mov_b32_e32 v49, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v51, v31
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v47, 16, v29
-; VI-DS128-NEXT:    v_and_b32_e32 v45, 0xffff, v29
-; VI-DS128-NEXT:    ds_write_b128 v52, v[48:51] offset:240
-; VI-DS128-NEXT:    v_mov_b32_e32 v46, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v48, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v27, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v29, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[45:48] offset:192
-; VI-DS128-NEXT:    v_mov_b32_e32 v43, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v45, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[26:29] offset:96
-; VI-DS128-NEXT:    v_mov_b32_e32 v24, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v26, v31
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v10
-; VI-DS128-NEXT:    v_and_b32_e32 v39, 0xffff, v10
-; VI-DS128-NEXT:    ds_write_b128 v52, v[42:45] offset:160
-; VI-DS128-NEXT:    v_mov_b32_e32 v40, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v42, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[23:26] offset:112
-; VI-DS128-NEXT:    v_mov_b32_e32 v21, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v23, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[39:42] offset:176
-; VI-DS128-NEXT:    v_mov_b32_e32 v37, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v39, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[20:23] offset:64
-; VI-DS128-NEXT:    v_mov_b32_e32 v18, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v20, v31
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v8
-; VI-DS128-NEXT:    v_and_b32_e32 v33, 0xffff, v8
-; VI-DS128-NEXT:    v_mov_b32_e32 v8, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v10, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[36:39] offset:128
-; VI-DS128-NEXT:    v_mov_b32_e32 v34, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v36, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[17:20] offset:80
-; VI-DS128-NEXT:    v_mov_b32_e32 v15, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v17, v31
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v3
-; VI-DS128-NEXT:    v_and_b32_e32 v11, 0xffff, v3
-; VI-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; VI-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v5
-; VI-DS128-NEXT:    ds_write_b128 v52, v[7:10] offset:208
-; VI-DS128-NEXT:    ds_write_b128 v52, v[33:36] offset:144
-; VI-DS128-NEXT:    v_mov_b32_e32 v5, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v7, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v33, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[14:17] offset:48
-; VI-DS128-NEXT:    v_mov_b32_e32 v12, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v14, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v1, v31
-; VI-DS128-NEXT:    v_mov_b32_e32 v3, v31
-; VI-DS128-NEXT:    ds_write_b128 v52, v[4:7] offset:32
-; VI-DS128-NEXT:    ds_write_b128 v52, v[30:33] offset:224
-; VI-DS128-NEXT:    ds_write_b128 v52, v[11:14]
-; VI-DS128-NEXT:    ds_write_b128 v52, v[0:3] offset:16
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v15
+; VI-DS128-NEXT:    v_and_b32_e32 v49, 0xffff, v15
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v48, 16, v12
+; VI-DS128-NEXT:    v_and_b32_e32 v46, 0xffff, v12
+; VI-DS128-NEXT:    ds_write_b128 v0, v[49:52] offset:240
+; VI-DS128-NEXT:    v_mov_b32_e32 v49, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v45, 16, v13
+; VI-DS128-NEXT:    v_and_b32_e32 v43, 0xffff, v13
+; VI-DS128-NEXT:    ds_write_b128 v0, v[46:49] offset:192
+; VI-DS128-NEXT:    v_mov_b32_e32 v44, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v46, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v42, 16, v11
+; VI-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v11
+; VI-DS128-NEXT:    ds_write_b128 v0, v[43:46] offset:208
+; VI-DS128-NEXT:    v_mov_b32_e32 v41, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v43, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v8
+; VI-DS128-NEXT:    v_and_b32_e32 v37, 0xffff, v8
+; VI-DS128-NEXT:    ds_write_b128 v0, v[40:43] offset:176
+; VI-DS128-NEXT:    v_mov_b32_e32 v38, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v40, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v36, 16, v9
+; VI-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v9
+; VI-DS128-NEXT:    ds_write_b128 v0, v[37:40] offset:128
+; VI-DS128-NEXT:    v_mov_b32_e32 v35, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v37, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v7
+; VI-DS128-NEXT:    v_and_b32_e32 v31, 0xffff, v7
+; VI-DS128-NEXT:    ds_write_b128 v0, v[34:37] offset:144
+; VI-DS128-NEXT:    v_mov_b32_e32 v32, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v34, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v30, 16, v4
+; VI-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v4
+; VI-DS128-NEXT:    ds_write_b128 v0, v[31:34] offset:112
+; VI-DS128-NEXT:    v_mov_b32_e32 v29, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v31, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v5
+; VI-DS128-NEXT:    v_and_b32_e32 v25, 0xffff, v5
+; VI-DS128-NEXT:    ds_write_b128 v0, v[28:31] offset:64
+; VI-DS128-NEXT:    v_mov_b32_e32 v26, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v28, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v24, 16, v3
+; VI-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v3
+; VI-DS128-NEXT:    ds_write_b128 v0, v[25:28] offset:80
+; VI-DS128-NEXT:    v_mov_b32_e32 v23, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v25, v54
+; VI-DS128-NEXT:    ds_write_b128 v0, v[22:25] offset:48
+; VI-DS128-NEXT:    v_mov_b32_e32 v20, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v22, v54
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v18, 16, v1
+; VI-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v1
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
+; VI-DS128-NEXT:    v_and_b32_e32 v1, 0xffff, v2
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; VI-DS128-NEXT:    v_and_b32_e32 v5, 0xffff, v6
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
+; VI-DS128-NEXT:    v_and_b32_e32 v9, 0xffff, v10
+; VI-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v14
+; VI-DS128-NEXT:    v_and_b32_e32 v53, 0xffff, v14
+; VI-DS128-NEXT:    v_mov_b32_e32 v10, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v12, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v6, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v8, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v2, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v4, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v56, v54
+; VI-DS128-NEXT:    ds_write_b128 v0, v[19:22]
+; VI-DS128-NEXT:    v_mov_b32_e32 v17, v54
+; VI-DS128-NEXT:    v_mov_b32_e32 v19, v54
+; VI-DS128-NEXT:    ds_write_b128 v0, v[9:12] offset:160
+; VI-DS128-NEXT:    ds_write_b128 v0, v[5:8] offset:96
+; VI-DS128-NEXT:    ds_write_b128 v0, v[1:4] offset:32
+; VI-DS128-NEXT:    ds_write_b128 v0, v[53:56] offset:224
+; VI-DS128-NEXT:    ds_write_b128 v0, v[16:19] offset:16
 ; VI-DS128-NEXT:    s_endpgm
 ;
 ; GFX9-DS128-LABEL: local_zextload_v32i16_to_v32i64:
 ; GFX9-DS128:       ; %bb.0:
 ; GFX9-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v54, 0
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v50, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v52, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v47, v54
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v1, s1
-; GFX9-DS128-NEXT:    ds_read_b128 v[3:6], v1
-; GFX9-DS128-NEXT:    ds_read_b128 v[7:10], v1 offset:16
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v52, s0
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v6
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, s1
+; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v12
+; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v12 offset:16
+; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v12 offset:32
+; GFX9-DS128-NEXT:    ds_read_b128 v[12:15], v12 offset:48
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v44, v54
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v21, 16, v0
+; GFX9-DS128-NEXT:    v_and_b32_e32 v19, 0xffff, v0
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v19, 16, v8
-; GFX9-DS128-NEXT:    v_and_b32_e32 v17, 0xffff, v8
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v22, 16, v7
-; GFX9-DS128-NEXT:    v_and_b32_e32 v20, 0xffff, v7
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v25, 16, v10
-; GFX9-DS128-NEXT:    v_and_b32_e32 v23, 0xffff, v10
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v28, 16, v9
-; GFX9-DS128-NEXT:    v_and_b32_e32 v26, 0xffff, v9
-; GFX9-DS128-NEXT:    ds_read_b128 v[7:10], v1 offset:32
-; GFX9-DS128-NEXT:    ds_read_b128 v[29:32], v1 offset:48
-; GFX9-DS128-NEXT:    v_and_b32_e32 v14, 0xffff, v6
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v4
-; GFX9-DS128-NEXT:    v_and_b32_e32 v0, 0xffff, v4
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v38, 16, v7
-; GFX9-DS128-NEXT:    v_and_b32_e32 v36, 0xffff, v7
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v44, 16, v9
-; GFX9-DS128-NEXT:    v_and_b32_e32 v42, 0xffff, v9
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v9, 16, v30
-; GFX9-DS128-NEXT:    v_and_b32_e32 v7, 0xffff, v30
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v50, 16, v32
-; GFX9-DS128-NEXT:    v_and_b32_e32 v48, 0xffff, v32
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v32, 16, v31
-; GFX9-DS128-NEXT:    v_and_b32_e32 v30, 0xffff, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v31, 0
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v49, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v51, v31
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v47, 16, v29
-; GFX9-DS128-NEXT:    v_and_b32_e32 v45, 0xffff, v29
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[48:51] offset:240
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v46, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v48, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v27, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v29, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[45:48] offset:192
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v43, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v45, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[26:29] offset:96
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v24, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v26, v31
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v41, 16, v10
-; GFX9-DS128-NEXT:    v_and_b32_e32 v39, 0xffff, v10
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[42:45] offset:160
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v40, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v42, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[23:26] offset:112
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v21, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v23, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[39:42] offset:176
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v37, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v39, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[20:23] offset:64
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v18, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v20, v31
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v35, 16, v8
-; GFX9-DS128-NEXT:    v_and_b32_e32 v33, 0xffff, v8
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v8, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v10, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[36:39] offset:128
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v34, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v36, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[17:20] offset:80
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v15, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v17, v31
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v3
-; GFX9-DS128-NEXT:    v_and_b32_e32 v11, 0xffff, v3
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-DS128-NEXT:    v_and_b32_e32 v4, 0xffff, v5
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[7:10] offset:208
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[33:36] offset:144
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v5, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v7, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v33, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[14:17] offset:48
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v14, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v1, v31
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v3, v31
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[4:7] offset:32
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[30:33] offset:224
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[11:14]
-; GFX9-DS128-NEXT:    ds_write_b128 v52, v[0:3] offset:16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v51, 16, v15
+; GFX9-DS128-NEXT:    v_and_b32_e32 v49, 0xffff, v15
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v48, 16, v12
+; GFX9-DS128-NEXT:    v_and_b32_e32 v46, 0xffff, v12
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[49:52] offset:240
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v49, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v45, 16, v13
+; GFX9-DS128-NEXT:    v_and_b32_e32 v43, 0xffff, v13
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[46:49] offset:192
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v46, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v42, 16, v11
+; GFX9-DS128-NEXT:    v_and_b32_e32 v40, 0xffff, v11
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[43:46] offset:208
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v41, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v43, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v39, 16, v8
+; GFX9-DS128-NEXT:    v_and_b32_e32 v37, 0xffff, v8
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[40:43] offset:176
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v38, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v40, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v36, 16, v9
+; GFX9-DS128-NEXT:    v_and_b32_e32 v34, 0xffff, v9
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[37:40] offset:128
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v35, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v37, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v33, 16, v7
+; GFX9-DS128-NEXT:    v_and_b32_e32 v31, 0xffff, v7
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[34:37] offset:144
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v32, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v34, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v30, 16, v4
+; GFX9-DS128-NEXT:    v_and_b32_e32 v28, 0xffff, v4
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[31:34] offset:112
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v29, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v31, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v27, 16, v5
+; GFX9-DS128-NEXT:    v_and_b32_e32 v25, 0xffff, v5
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[28:31] offset:64
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v26, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v28, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v24, 16, v3
+; GFX9-DS128-NEXT:    v_and_b32_e32 v22, 0xffff, v3
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[25:28] offset:80
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v23, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v25, v54
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[22:25] offset:48
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v20, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v22, v54
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v18, 16, v1
+; GFX9-DS128-NEXT:    v_and_b32_e32 v16, 0xffff, v1
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
+; GFX9-DS128-NEXT:    v_and_b32_e32 v1, 0xffff, v2
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; GFX9-DS128-NEXT:    v_and_b32_e32 v5, 0xffff, v6
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
+; GFX9-DS128-NEXT:    v_and_b32_e32 v9, 0xffff, v10
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v55, 16, v14
+; GFX9-DS128-NEXT:    v_and_b32_e32 v53, 0xffff, v14
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v10, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v6, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v8, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v2, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v4, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v56, v54
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[19:22]
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v17, v54
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v19, v54
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[9:12] offset:160
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[5:8] offset:96
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[1:4] offset:32
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[53:56] offset:224
+; GFX9-DS128-NEXT:    ds_write_b128 v0, v[16:19] offset:16
 ; GFX9-DS128-NEXT:    s_endpgm
   %load = load <32 x i16>, ptr addrspace(3) %in
   %ext = zext <32 x i16> %load to <32 x i64>
@@ -8010,105 +7953,103 @@ define amdgpu_kernel void @local_sextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; SI:       ; %bb.0:
 ; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    v_mov_b32_e32 v12, s1
+; SI-NEXT:    v_mov_b32_e32 v8, s1
 ; SI-NEXT:    s_mov_b32 m0, -1
-; SI-NEXT:    ds_read2_b64 v[4:7], v12 offset0:2 offset1:3
-; SI-NEXT:    ds_read2_b64 v[0:3], v12 offset1:1
-; SI-NEXT:    ds_read2_b64 v[8:11], v12 offset0:6 offset1:7
-; SI-NEXT:    ds_read2_b64 v[12:15], v12 offset0:4 offset1:5
+; SI-NEXT:    ds_read2_b64 v[0:3], v8 offset0:2 offset1:3
+; SI-NEXT:    ds_read2_b64 v[4:7], v8 offset0:6 offset1:7
+; SI-NEXT:    ds_read2_b64 v[12:15], v8 offset0:4 offset1:5
+; SI-NEXT:    ds_read2_b64 v[8:11], v8 offset1:1
 ; SI-NEXT:    s_waitcnt lgkmcnt(3)
-; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v7
-; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v7
-; SI-NEXT:    v_bfe_i32 v18, v7, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    v_mov_b32_e32 v7, s0
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:14 offset1:15
-; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v5
-; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v5
-; SI-NEXT:    v_bfe_i32 v18, v5, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:10 offset1:11
-; SI-NEXT:    s_waitcnt lgkmcnt(4)
 ; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v3
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v3
 ; SI-NEXT:    v_bfe_i32 v18, v3, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:6 offset1:7
+; SI-NEXT:    v_mov_b32_e32 v3, s0
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:14 offset1:15
 ; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v1
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v1
 ; SI-NEXT:    v_bfe_i32 v18, v1, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:2 offset1:3
-; SI-NEXT:    s_waitcnt lgkmcnt(5)
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:10 offset1:11
+; SI-NEXT:    s_waitcnt lgkmcnt(2)
 ; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v11
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v11
 ; SI-NEXT:    v_bfe_i32 v18, v11, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:30 offset1:31
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:6 offset1:7
 ; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v9
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v9
 ; SI-NEXT:    v_bfe_i32 v18, v9, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:26 offset1:27
-; SI-NEXT:    s_waitcnt lgkmcnt(6)
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:2 offset1:3
+; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v7
+; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v7
+; SI-NEXT:    v_bfe_i32 v18, v7, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:30 offset1:31
+; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v5
+; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v5
+; SI-NEXT:    v_bfe_i32 v18, v5, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:26 offset1:27
 ; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v15
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 16, v15
 ; SI-NEXT:    v_bfe_i32 v18, v15, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; SI-NEXT:    ds_write2_b64 v7, v[18:19], v[16:17] offset0:22 offset1:23
+; SI-NEXT:    ds_write2_b64 v3, v[18:19], v[16:17] offset0:22 offset1:23
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 31, v13
 ; SI-NEXT:    v_ashrrev_i32_e32 v15, 16, v13
 ; SI-NEXT:    v_bfe_i32 v17, v13, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
-; SI-NEXT:    ds_write2_b64 v7, v[17:18], v[15:16] offset0:18 offset1:19
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v6
-; SI-NEXT:    v_bfe_i32 v5, v6, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v6, 31, v5
-; SI-NEXT:    v_bfe_i32 v15, v1, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; SI-NEXT:    ds_write2_b64 v7, v[5:6], v[15:16] offset0:12 offset1:13
-; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v4
-; SI-NEXT:    v_lshrrev_b32_e32 v11, 16, v2
-; SI-NEXT:    v_lshrrev_b32_e32 v18, 16, v10
-; SI-NEXT:    v_bfe_i32 v3, v4, 0, 16
-; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v8
-; SI-NEXT:    v_bfe_i32 v5, v1, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v4, 31, v3
-; SI-NEXT:    v_ashrrev_i32_e32 v6, 31, v5
-; SI-NEXT:    ds_write2_b64 v7, v[3:4], v[5:6] offset0:8 offset1:9
-; SI-NEXT:    v_lshrrev_b32_e32 v4, 16, v14
-; SI-NEXT:    v_lshrrev_b32_e32 v6, 16, v12
-; SI-NEXT:    v_bfe_i32 v1, v12, 0, 16
-; SI-NEXT:    v_bfe_i32 v3, v14, 0, 16
-; SI-NEXT:    v_bfe_i32 v5, v8, 0, 16
-; SI-NEXT:    v_bfe_i32 v8, v10, 0, 16
-; SI-NEXT:    v_lshrrev_b32_e32 v14, 16, v0
-; SI-NEXT:    v_bfe_i32 v9, v0, 0, 16
-; SI-NEXT:    v_bfe_i32 v10, v2, 0, 16
-; SI-NEXT:    v_bfe_i32 v12, v11, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
-; SI-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
-; SI-NEXT:    ds_write2_b64 v7, v[10:11], v[12:13] offset0:4 offset1:5
-; SI-NEXT:    v_bfe_i32 v11, v6, 0, 16
+; SI-NEXT:    ds_write2_b64 v3, v[17:18], v[15:16] offset0:18 offset1:19
+; SI-NEXT:    v_lshrrev_b32_e32 v5, 16, v2
+; SI-NEXT:    v_bfe_i32 v1, v2, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
-; SI-NEXT:    v_bfe_i32 v13, v4, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v4, 31, v3
+; SI-NEXT:    v_bfe_i32 v15, v5, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; SI-NEXT:    ds_write2_b64 v3, v[1:2], v[15:16] offset0:12 offset1:13
+; SI-NEXT:    v_lshrrev_b32_e32 v1, 16, v0
+; SI-NEXT:    v_lshrrev_b32_e32 v2, 16, v10
+; SI-NEXT:    v_lshrrev_b32_e32 v20, 16, v6
+; SI-NEXT:    v_bfe_i32 v0, v0, 0, 16
+; SI-NEXT:    v_lshrrev_b32_e32 v17, 16, v4
+; SI-NEXT:    v_bfe_i32 v15, v1, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; SI-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; SI-NEXT:    ds_write2_b64 v3, v[0:1], v[15:16] offset0:8 offset1:9
+; SI-NEXT:    v_lshrrev_b32_e32 v15, 16, v14
+; SI-NEXT:    v_lshrrev_b32_e32 v16, 16, v12
+; SI-NEXT:    v_bfe_i32 v0, v12, 0, 16
+; SI-NEXT:    v_bfe_i32 v5, v14, 0, 16
+; SI-NEXT:    v_bfe_i32 v7, v4, 0, 16
+; SI-NEXT:    v_bfe_i32 v9, v6, 0, 16
+; SI-NEXT:    v_lshrrev_b32_e32 v4, 16, v8
+; SI-NEXT:    v_bfe_i32 v11, v8, 0, 16
+; SI-NEXT:    v_bfe_i32 v1, v10, 0, 16
+; SI-NEXT:    v_bfe_i32 v12, v2, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
+; SI-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
+; SI-NEXT:    ds_write2_b64 v3, v[1:2], v[12:13] offset0:4 offset1:5
+; SI-NEXT:    v_bfe_i32 v13, v16, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
 ; SI-NEXT:    v_bfe_i32 v15, v15, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v6, 31, v5
-; SI-NEXT:    v_bfe_i32 v16, v14, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v10, 31, v9
-; SI-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; SI-NEXT:    ds_write2_b64 v7, v[9:10], v[16:17] offset1:1
-; SI-NEXT:    v_bfe_i32 v17, v18, 0, 16
-; SI-NEXT:    v_ashrrev_i32_e32 v9, 31, v8
+; SI-NEXT:    v_bfe_i32 v17, v17, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v8, 31, v7
+; SI-NEXT:    v_bfe_i32 v18, v4, 0, 16
 ; SI-NEXT:    v_ashrrev_i32_e32 v12, 31, v11
+; SI-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
+; SI-NEXT:    ds_write2_b64 v3, v[11:12], v[18:19] offset1:1
+; SI-NEXT:    v_bfe_i32 v11, v20, 0, 16
+; SI-NEXT:    v_ashrrev_i32_e32 v10, 31, v9
 ; SI-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
 ; SI-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
 ; SI-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
-; SI-NEXT:    ds_write2_b64 v7, v[8:9], v[17:18] offset0:28 offset1:29
-; SI-NEXT:    ds_write2_b64 v7, v[5:6], v[15:16] offset0:24 offset1:25
-; SI-NEXT:    ds_write2_b64 v7, v[3:4], v[13:14] offset0:20 offset1:21
-; SI-NEXT:    ds_write2_b64 v7, v[1:2], v[11:12] offset0:16 offset1:17
+; SI-NEXT:    v_ashrrev_i32_e32 v12, 31, v11
+; SI-NEXT:    ds_write2_b64 v3, v[9:10], v[11:12] offset0:28 offset1:29
+; SI-NEXT:    ds_write2_b64 v3, v[7:8], v[17:18] offset0:24 offset1:25
+; SI-NEXT:    ds_write2_b64 v3, v[5:6], v[15:16] offset0:20 offset1:21
+; SI-NEXT:    ds_write2_b64 v3, v[0:1], v[13:14] offset0:16 offset1:17
 ; SI-NEXT:    s_endpgm
 ;
 ; VI-NO-DS128-LABEL: local_sextload_v32i16_to_v32i64:
@@ -8227,111 +8168,110 @@ define amdgpu_kernel void @local_sextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; GFX9-NO-DS128:       ; %bb.0:
 ; GFX9-NO-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v11, s1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v11 offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v11 offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v8, s1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[12:15], v8 offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[0:3], v8 offset1:1
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[4:7], v8 offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[8:11], v8 offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v15
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v15, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v17, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
 ; GFX9-NO-DS128-NEXT:    v_mov_b32_e32 v15, s0
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v7, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v8, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[7:10], v11 offset1:1
-; GFX9-NO-DS128-NEXT:    ds_read2_b64 v[11:14], v11 offset0:2 offset1:3
 ; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[18:19] offset0:30 offset1:31
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v6
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v16, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v6, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[18:19], v[16:17] offset0:28 offset1:29
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v6, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v5, v5, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v6, 31, v5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[5:6], v[16:17] offset0:26 offset1:27
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v4
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v4, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v17, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(5)
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v4, 16, v3
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[18:19] offset0:24 offset1:25
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v4, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v3, v3, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v4, 31, v3
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[3:4], v[16:17] offset0:22 offset1:23
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v3, v3, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v2, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v4, 31, v3
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v1
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[3:4] offset0:20 offset1:21
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v2, v2, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v1, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[2:3] offset0:18 offset1:19
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v0
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v0, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v17, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[18:19] offset0:16 offset1:17
-; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(8)
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v14
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v16, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v14, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
 ; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v14, 16, v13
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[18:19], v[16:17] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[18:19], v[16:17] offset0:28 offset1:29
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v14, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v13, v13, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[13:14], v[16:17] offset0:12 offset1:13
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v12
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v10
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v13, v13, 0, 16
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[13:14], v[16:17] offset0:26 offset1:27
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v12
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v12, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v12, v0, 0, 16
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v11
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[13:14] offset0:10 offset1:11
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v0, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v11, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v17, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v5, 16, v7
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v20, 16, v8
-; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v9
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[18:19], v[16:17] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v12, 16, v11
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[18:19] offset0:24 offset1:25
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v12, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v11, v11, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v12, 31, v11
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[11:12], v[16:17] offset0:22 offset1:23
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v10
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v11, v11, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v10, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v12, 31, v11
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v10, 16, v9
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[11:12] offset0:20 offset1:21
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v10, v10, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v9, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v9, v10, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v5, v5, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v1, v20, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v3, v3, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v20, v7, 0, 16
-; GFX9-NO-DS128-NEXT:    v_bfe_i32 v7, v8, 0, 16
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v10, 31, v9
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v6, 31, v5
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v2, 31, v1
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v4, 31, v3
-; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v21, 31, v20
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[10:11] offset0:18 offset1:19
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v17, 16, v8
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v8, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v17, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v8, 16, v7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[18:19] offset0:16 offset1:17
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v8, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v7, v7, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v8, 31, v7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[7:8], v[16:17] offset0:14 offset1:15
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v6
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v7, v7, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v6, 0, 16
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v8, 31, v7
 ; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[9:10], v[12:13] offset0:6 offset1:7
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[3:4] offset0:4 offset1:5
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[7:8], v[1:2] offset0:2 offset1:3
-; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[20:21], v[5:6] offset1:1
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[7:8] offset0:12 offset1:13
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v6, v6, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v5, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[6:7] offset0:10 offset1:11
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v7, 16, v4
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v20, 16, v1
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v7, v7, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v16, v4, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v9, v20, 0, 16
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v20, 16, v3
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v8, 31, v7
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v13, 16, v0
+; GFX9-NO-DS128-NEXT:    v_lshrrev_b32_e32 v11, 16, v2
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v5, v20, 0, 16
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[16:17], v[7:8] offset0:8 offset1:9
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v7, v2, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v2, v3, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v13, v13, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v11, v11, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v6, 31, v5
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v18, v0, 0, 16
+; GFX9-NO-DS128-NEXT:    v_bfe_i32 v0, v1, 0, 16
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v10, 31, v9
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v12, 31, v11
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX9-NO-DS128-NEXT:    v_ashrrev_i32_e32 v8, 31, v7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[2:3], v[5:6] offset0:6 offset1:7
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[7:8], v[11:12] offset0:4 offset1:5
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[0:1], v[9:10] offset0:2 offset1:3
+; GFX9-NO-DS128-NEXT:    ds_write2_b64 v15, v[18:19], v[13:14] offset1:1
 ; GFX9-NO-DS128-NEXT:    s_endpgm
 ;
 ; EG-LABEL: local_sextload_v32i16_to_v32i64:
@@ -8793,112 +8733,110 @@ define amdgpu_kernel void @local_sextload_v32i16_to_v32i64(ptr addrspace(3) %out
 ; GFX9-DS128:       ; %bb.0:
 ; GFX9-DS128-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v13, s1
-; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v13 offset:48
-; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v13 offset:32
-; GFX9-DS128-NEXT:    v_mov_b32_e32 v12, s0
-; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v13
-; GFX9-DS128-NEXT:    ds_read_b128 v[18:21], v13 offset:16
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v8, s1
+; GFX9-DS128-NEXT:    ds_read_b128 v[12:15], v8 offset:48
+; GFX9-DS128-NEXT:    ds_read_b128 v[0:3], v8
+; GFX9-DS128-NEXT:    ds_read_b128 v[4:7], v8 offset:16
+; GFX9-DS128-NEXT:    ds_read_b128 v[8:11], v8 offset:32
 ; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX9-DS128-NEXT:    v_bfe_i32 v14, v6, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v6
-; GFX9-DS128-NEXT:    v_bfe_i32 v16, v6, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v15, 31, v14
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v14
+; GFX9-DS128-NEXT:    v_bfe_i32 v18, v16, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v16, v14, 0, 16
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v17, 31, v16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v7
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[14:17] offset:224
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v6, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v7, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v19, 31, v18
+; GFX9-DS128-NEXT:    v_mov_b32_e32 v14, s0
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[16:19] offset:224
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v16, 16, v15
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v16, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v15, 0, 16
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v4
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:240
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v6, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v6, 16, v5
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v4, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v4, v5, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v6, v6, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[4:7] offset:208
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(5)
-; GFX9-DS128-NEXT:    v_bfe_i32 v4, v2, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v2
-; GFX9-DS128-NEXT:    v_bfe_i32 v6, v2, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v2, 16, v3
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[4:7] offset:160
-; GFX9-DS128-NEXT:    v_bfe_i32 v4, v3, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v6, v2, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
-; GFX9-DS128-NEXT:    v_bfe_i32 v2, v0, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[4:7] offset:176
-; GFX9-DS128-NEXT:    v_bfe_i32 v4, v0, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v9
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[2:5] offset:128
-; GFX9-DS128-NEXT:    v_bfe_i32 v4, v0, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v1
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:192
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v1, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v0, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v20
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:144
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v20, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v0, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v21
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:96
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v21, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v0, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v18
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:112
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v18, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v0, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v8
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    v_bfe_i32 v6, v8, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v8, v0, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v19
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:64
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v19, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v0, 0, 16
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v11
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:80
-; GFX9-DS128-NEXT:    v_bfe_i32 v15, v0, 0, 16
-; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v10
-; GFX9-DS128-NEXT:    v_bfe_i32 v17, v10, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v19, v0, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v2, v9, 0, 16
-; GFX9-DS128-NEXT:    v_bfe_i32 v13, v11, 0, 16
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v20, 31, v19
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v5, 31, v4
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:240
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v15, 16, v12
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v15, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v12, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v12, 16, v13
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:192
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v13, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v12, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:208
+; GFX9-DS128-NEXT:    s_waitcnt lgkmcnt(4)
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v10, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v10, 16, v10
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v10, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v10, 16, v11
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:160
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v10, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v10, v8, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v8, 16, v8
+; GFX9-DS128-NEXT:    v_bfe_i32 v12, v8, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v11, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[10:13] offset:128
+; GFX9-DS128-NEXT:    v_bfe_i32 v10, v1, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v1
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    v_bfe_i32 v12, v1, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v9
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:176
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v9, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v1, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v6
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:144
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v6, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v1, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v7
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:96
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v1, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v1, 16, v4
+; GFX9-DS128-NEXT:    v_bfe_i32 v6, v4, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v8, v1, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v7, 0, 16
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v9, 31, v8
-; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v14, 31, v13
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[6:9] offset:64
+; GFX9-DS128-NEXT:    v_bfe_i32 v6, v0, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v0
 ; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[17:20] offset:32
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[13:16] offset:48
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[6:9]
-; GFX9-DS128-NEXT:    ds_write_b128 v12, v[2:5] offset:16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    v_bfe_i32 v8, v0, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v5
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:112
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v5, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v0, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:80
+; GFX9-DS128-NEXT:    v_bfe_i32 v15, v3, 0, 16
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v0, 16, v3
+; GFX9-DS128-NEXT:    v_lshrrev_b32_e32 v3, 16, v2
+; GFX9-DS128-NEXT:    v_bfe_i32 v17, v0, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v0, v2, 0, 16
+; GFX9-DS128-NEXT:    v_bfe_i32 v2, v3, 0, 16
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v1, 31, v0
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v3, 31, v2
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v11, 31, v10
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v13, 31, v12
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v7, 31, v6
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v9, 31, v8
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v16, 31, v15
+; GFX9-DS128-NEXT:    v_ashrrev_i32_e32 v18, 31, v17
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[0:3] offset:32
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[15:18] offset:48
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[6:9]
+; GFX9-DS128-NEXT:    ds_write_b128 v14, v[10:13] offset:16
 ; GFX9-DS128-NEXT:    s_endpgm
   %load = load <32 x i16>, ptr addrspace(3) %in
   %ext = sext <32 x i16> %load to <32 x i64>

--- a/llvm/test/CodeGen/AMDGPU/load-local.128.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-local.128.ll
@@ -96,53 +96,50 @@ define <4 x i32> @load_lds_v4i32_align1(ptr addrspace(3) %ptr) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    s_mov_b32 m0, -1
 ; GFX7-NEXT:    ds_read_u8 v1, v0 offset:1
-; GFX7-NEXT:    ds_read_u8 v2, v0 offset:6
-; GFX7-NEXT:    ds_read_u8 v3, v0 offset:4
-; GFX7-NEXT:    ds_read_u8 v4, v0 offset:2
-; GFX7-NEXT:    ds_read_u8 v5, v0
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:3
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:5
-; GFX7-NEXT:    ds_read_u8 v8, v0 offset:7
-; GFX7-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
-; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 8, v6
-; GFX7-NEXT:    v_or_b32_e32 v4, v5, v4
-; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; GFX7-NEXT:    v_or_b32_e32 v4, v4, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v7
-; GFX7-NEXT:    v_or_b32_e32 v1, v1, v3
-; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v8
+; GFX7-NEXT:    ds_read_u8 v2, v0 offset:3
+; GFX7-NEXT:    ds_read_u8 v3, v0 offset:5
+; GFX7-NEXT:    ds_read_u8 v4, v0 offset:7
 ; GFX7-NEXT:    ds_read_u8 v5, v0 offset:9
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:11
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:13
-; GFX7-NEXT:    ds_read_u8 v8, v0 offset:15
-; GFX7-NEXT:    ds_read_u8 v9, v0 offset:14
-; GFX7-NEXT:    ds_read_u8 v10, v0 offset:12
-; GFX7-NEXT:    ds_read_u8 v11, v0 offset:10
-; GFX7-NEXT:    ds_read_u8 v0, v0 offset:8
-; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
+; GFX7-NEXT:    ds_read_u8 v6, v0 offset:14
+; GFX7-NEXT:    ds_read_u8 v7, v0 offset:12
+; GFX7-NEXT:    ds_read_u8 v8, v0 offset:10
+; GFX7-NEXT:    ds_read_u8 v9, v0 offset:8
+; GFX7-NEXT:    ds_read_u8 v10, v0 offset:6
+; GFX7-NEXT:    ds_read_u8 v11, v0 offset:4
+; GFX7-NEXT:    ds_read_u8 v12, v0 offset:2
+; GFX7-NEXT:    ds_read_u8 v13, v0
+; GFX7-NEXT:    ds_read_u8 v14, v0 offset:11
+; GFX7-NEXT:    ds_read_u8 v15, v0 offset:13
+; GFX7-NEXT:    ds_read_u8 v16, v0 offset:15
+; GFX7-NEXT:    s_waitcnt lgkmcnt(14)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v1
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v2
+; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v12
+; GFX7-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v13
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v4
+; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v3
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v10
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v11
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v14
 ; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(7)
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v5
-; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_or_b32_e32 v0, v2, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v6
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v11
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v8
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v7
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v9
-; GFX7-NEXT:    v_or_b32_e32 v0, v0, v10
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v8
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v9
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v0
-; GFX7-NEXT:    v_mov_b32_e32 v0, v4
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 8, v16
+; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v15
+; GFX7-NEXT:    v_or_b32_e32 v4, v4, v6
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v7
+; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
+; GFX7-NEXT:    v_or_b32_e32 v3, v4, v3
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX6-LABEL: load_lds_v4i32_align1:
@@ -155,6 +152,14 @@ define <4 x i32> @load_lds_v4i32_align1(ptr addrspace(3) %ptr) {
 ; GFX6-NEXT:    v_add_i32_e32 v5, vcc, 9, v0
 ; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 8, v0
 ; GFX6-NEXT:    v_add_i32_e32 v7, vcc, 11, v0
+; GFX6-NEXT:    v_add_i32_e32 v8, vcc, 10, v0
+; GFX6-NEXT:    v_add_i32_e32 v9, vcc, 13, v0
+; GFX6-NEXT:    v_add_i32_e32 v10, vcc, 12, v0
+; GFX6-NEXT:    v_add_i32_e32 v11, vcc, 15, v0
+; GFX6-NEXT:    v_add_i32_e32 v12, vcc, 14, v0
+; GFX6-NEXT:    v_add_i32_e32 v13, vcc, 3, v0
+; GFX6-NEXT:    v_add_i32_e32 v14, vcc, 2, v0
+; GFX6-NEXT:    v_add_i32_e32 v15, vcc, 1, v0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    ds_read_u8 v1, v1
 ; GFX6-NEXT:    ds_read_u8 v2, v2
@@ -163,59 +168,49 @@ define <4 x i32> @load_lds_v4i32_align1(ptr addrspace(3) %ptr) {
 ; GFX6-NEXT:    ds_read_u8 v5, v5
 ; GFX6-NEXT:    ds_read_u8 v6, v6
 ; GFX6-NEXT:    ds_read_u8 v7, v7
-; GFX6-NEXT:    ds_read_u8 v8, v0
-; GFX6-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; GFX6-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX6-NEXT:    v_or_b32_e32 v1, v1, v2
-; GFX6-NEXT:    s_waitcnt lgkmcnt(5)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v3
-; GFX6-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX6-NEXT:    v_or_b32_e32 v2, v2, v4
-; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; GFX6-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX6-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v5
-; GFX6-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX6-NEXT:    v_or_b32_e32 v2, v2, v6
-; GFX6-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v7
-; GFX6-NEXT:    v_add_i32_e32 v4, vcc, 10, v0
-; GFX6-NEXT:    v_add_i32_e32 v5, vcc, 13, v0
-; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 12, v0
-; GFX6-NEXT:    v_add_i32_e32 v7, vcc, 15, v0
-; GFX6-NEXT:    v_add_i32_e32 v9, vcc, 14, v0
-; GFX6-NEXT:    v_add_i32_e32 v10, vcc, 3, v0
-; GFX6-NEXT:    v_add_i32_e32 v11, vcc, 2, v0
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 1, v0
-; GFX6-NEXT:    ds_read_u8 v4, v4
-; GFX6-NEXT:    ds_read_u8 v5, v5
-; GFX6-NEXT:    ds_read_u8 v6, v6
-; GFX6-NEXT:    ds_read_u8 v7, v7
+; GFX6-NEXT:    ds_read_u8 v8, v8
 ; GFX6-NEXT:    ds_read_u8 v9, v9
 ; GFX6-NEXT:    ds_read_u8 v10, v10
 ; GFX6-NEXT:    ds_read_u8 v11, v11
+; GFX6-NEXT:    ds_read_u8 v12, v12
+; GFX6-NEXT:    ds_read_u8 v13, v13
+; GFX6-NEXT:    ds_read_u8 v14, v14
+; GFX6-NEXT:    ds_read_u8 v15, v15
 ; GFX6-NEXT:    ds_read_u8 v0, v0
-; GFX6-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX6-NEXT:    v_or_b32_e32 v3, v3, v4
+; GFX6-NEXT:    s_waitcnt lgkmcnt(14)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX6-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX6-NEXT:    s_waitcnt lgkmcnt(13)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v3
+; GFX6-NEXT:    s_waitcnt lgkmcnt(12)
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v4
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
+; GFX6-NEXT:    s_waitcnt lgkmcnt(9)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v7
+; GFX6-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v5
+; GFX6-NEXT:    s_waitcnt lgkmcnt(8)
+; GFX6-NEXT:    v_or_b32_e32 v3, v3, v8
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v6
 ; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX6-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 8, v7
+; GFX6-NEXT:    s_waitcnt lgkmcnt(5)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 8, v11
 ; GFX6-NEXT:    v_or_b32_e32 v2, v3, v2
-; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v5
-; GFX6-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX6-NEXT:    v_or_b32_e32 v4, v4, v9
-; GFX6-NEXT:    v_or_b32_e32 v3, v3, v6
+; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v9
+; GFX6-NEXT:    s_waitcnt lgkmcnt(4)
+; GFX6-NEXT:    v_or_b32_e32 v4, v4, v12
+; GFX6-NEXT:    v_or_b32_e32 v3, v3, v10
 ; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
 ; GFX6-NEXT:    v_or_b32_e32 v3, v4, v3
+; GFX6-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 8, v13
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 8, v10
+; GFX6-NEXT:    v_or_b32_e32 v4, v4, v14
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX6-NEXT:    v_or_b32_e32 v4, v4, v11
-; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX6-NEXT:    v_lshlrev_b32_e32 v5, 8, v15
 ; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 16, v4
-; GFX6-NEXT:    v_or_b32_e32 v0, v0, v8
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    v_or_b32_e32 v0, v5, v0
 ; GFX6-NEXT:    v_or_b32_e32 v0, v4, v0
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/load-local.96.ll
+++ b/llvm/test/CodeGen/AMDGPU/load-local.96.ll
@@ -87,43 +87,41 @@ define <3 x i32> @load_lds_v3i32_align1(ptr addrspace(3) %ptr) {
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX7-NEXT:    s_mov_b32 m0, -1
 ; GFX7-NEXT:    ds_read_u8 v1, v0 offset:1
-; GFX7-NEXT:    ds_read_u8 v2, v0 offset:6
-; GFX7-NEXT:    ds_read_u8 v4, v0 offset:4
-; GFX7-NEXT:    ds_read_u8 v3, v0 offset:2
-; GFX7-NEXT:    ds_read_u8 v5, v0
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:3
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:5
-; GFX7-NEXT:    ds_read_u8 v8, v0 offset:7
-; GFX7-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX7-NEXT:    v_or_b32_e32 v1, v1, v5
-; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v5, 8, v6
-; GFX7-NEXT:    v_or_b32_e32 v3, v5, v3
-; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX7-NEXT:    v_or_b32_e32 v3, v3, v1
-; GFX7-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v7
-; GFX7-NEXT:    ds_read_u8 v5, v0 offset:9
-; GFX7-NEXT:    ds_read_u8 v6, v0 offset:11
-; GFX7-NEXT:    ds_read_u8 v7, v0 offset:10
-; GFX7-NEXT:    ds_read_u8 v0, v0 offset:8
-; GFX7-NEXT:    v_or_b32_e32 v1, v1, v4
+; GFX7-NEXT:    ds_read_u8 v2, v0 offset:3
+; GFX7-NEXT:    ds_read_u8 v3, v0 offset:5
+; GFX7-NEXT:    ds_read_u8 v4, v0 offset:10
+; GFX7-NEXT:    ds_read_u8 v5, v0 offset:8
+; GFX7-NEXT:    ds_read_u8 v6, v0 offset:6
+; GFX7-NEXT:    ds_read_u8 v7, v0 offset:4
+; GFX7-NEXT:    ds_read_u8 v8, v0 offset:2
+; GFX7-NEXT:    ds_read_u8 v9, v0
+; GFX7-NEXT:    ds_read_u8 v10, v0 offset:7
+; GFX7-NEXT:    ds_read_u8 v11, v0 offset:9
+; GFX7-NEXT:    ds_read_u8 v12, v0 offset:11
+; GFX7-NEXT:    s_waitcnt lgkmcnt(11)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v0, 8, v1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(10)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v2
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v4, 8, v8
-; GFX7-NEXT:    v_or_b32_e32 v2, v4, v2
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v8
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v5
-; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX7-NEXT:    v_or_b32_e32 v0, v2, v0
-; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v6
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v7
+; GFX7-NEXT:    v_or_b32_e32 v0, v0, v9
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 16, v1
+; GFX7-NEXT:    s_waitcnt lgkmcnt(2)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v10
+; GFX7-NEXT:    v_or_b32_e32 v0, v1, v0
+; GFX7-NEXT:    v_lshlrev_b32_e32 v1, 8, v3
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v6
+; GFX7-NEXT:    v_or_b32_e32 v1, v1, v7
 ; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; GFX7-NEXT:    v_or_b32_e32 v2, v2, v0
-; GFX7-NEXT:    v_mov_b32_e32 v0, v3
+; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 8, v12
+; GFX7-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX7-NEXT:    v_lshlrev_b32_e32 v2, 8, v11
+; GFX7-NEXT:    v_or_b32_e32 v3, v3, v4
+; GFX7-NEXT:    v_or_b32_e32 v2, v2, v5
+; GFX7-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
+; GFX7-NEXT:    v_or_b32_e32 v2, v3, v2
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX6-LABEL: load_lds_v3i32_align1:
@@ -136,6 +134,10 @@ define <3 x i32> @load_lds_v3i32_align1(ptr addrspace(3) %ptr) {
 ; GFX6-NEXT:    v_add_i32_e32 v5, vcc, 9, v0
 ; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 8, v0
 ; GFX6-NEXT:    v_add_i32_e32 v7, vcc, 11, v0
+; GFX6-NEXT:    v_add_i32_e32 v8, vcc, 10, v0
+; GFX6-NEXT:    v_add_i32_e32 v9, vcc, 3, v0
+; GFX6-NEXT:    v_add_i32_e32 v10, vcc, 2, v0
+; GFX6-NEXT:    v_add_i32_e32 v11, vcc, 1, v0
 ; GFX6-NEXT:    s_mov_b32 m0, -1
 ; GFX6-NEXT:    ds_read_u8 v1, v1
 ; GFX6-NEXT:    ds_read_u8 v2, v2
@@ -144,43 +146,38 @@ define <3 x i32> @load_lds_v3i32_align1(ptr addrspace(3) %ptr) {
 ; GFX6-NEXT:    ds_read_u8 v5, v5
 ; GFX6-NEXT:    ds_read_u8 v6, v6
 ; GFX6-NEXT:    ds_read_u8 v7, v7
-; GFX6-NEXT:    ds_read_u8 v8, v0
-; GFX6-NEXT:    s_waitcnt lgkmcnt(7)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
-; GFX6-NEXT:    s_waitcnt lgkmcnt(6)
-; GFX6-NEXT:    v_or_b32_e32 v1, v1, v2
-; GFX6-NEXT:    s_waitcnt lgkmcnt(5)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v3
-; GFX6-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX6-NEXT:    v_or_b32_e32 v2, v2, v4
-; GFX6-NEXT:    v_add_i32_e32 v4, vcc, 10, v0
-; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
-; GFX6-NEXT:    ds_read_u8 v4, v4
-; GFX6-NEXT:    v_or_b32_e32 v1, v2, v1
-; GFX6-NEXT:    s_waitcnt lgkmcnt(4)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v5
-; GFX6-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX6-NEXT:    v_or_b32_e32 v2, v2, v6
-; GFX6-NEXT:    v_add_i32_e32 v5, vcc, 3, v0
-; GFX6-NEXT:    v_add_i32_e32 v6, vcc, 2, v0
-; GFX6-NEXT:    v_add_i32_e32 v0, vcc, 1, v0
-; GFX6-NEXT:    ds_read_u8 v5, v5
-; GFX6-NEXT:    ds_read_u8 v6, v6
+; GFX6-NEXT:    ds_read_u8 v8, v8
+; GFX6-NEXT:    ds_read_u8 v9, v9
+; GFX6-NEXT:    ds_read_u8 v10, v10
+; GFX6-NEXT:    ds_read_u8 v11, v11
 ; GFX6-NEXT:    ds_read_u8 v0, v0
+; GFX6-NEXT:    s_waitcnt lgkmcnt(11)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v1, 8, v1
+; GFX6-NEXT:    s_waitcnt lgkmcnt(10)
+; GFX6-NEXT:    v_or_b32_e32 v1, v1, v2
+; GFX6-NEXT:    s_waitcnt lgkmcnt(9)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v3
+; GFX6-NEXT:    s_waitcnt lgkmcnt(8)
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v4
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 16, v2
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(5)
 ; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v7
-; GFX6-NEXT:    s_waitcnt lgkmcnt(3)
-; GFX6-NEXT:    v_or_b32_e32 v3, v3, v4
+; GFX6-NEXT:    v_or_b32_e32 v1, v2, v1
+; GFX6-NEXT:    v_lshlrev_b32_e32 v2, 8, v5
+; GFX6-NEXT:    s_waitcnt lgkmcnt(4)
+; GFX6-NEXT:    v_or_b32_e32 v3, v3, v8
+; GFX6-NEXT:    v_or_b32_e32 v2, v2, v6
 ; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
 ; GFX6-NEXT:    v_or_b32_e32 v2, v3, v2
+; GFX6-NEXT:    s_waitcnt lgkmcnt(3)
+; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v9
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(2)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 8, v5
+; GFX6-NEXT:    v_or_b32_e32 v3, v3, v10
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(1)
-; GFX6-NEXT:    v_or_b32_e32 v3, v3, v6
-; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    v_lshlrev_b32_e32 v0, 8, v0
+; GFX6-NEXT:    v_lshlrev_b32_e32 v4, 8, v11
 ; GFX6-NEXT:    v_lshlrev_b32_e32 v3, 16, v3
-; GFX6-NEXT:    v_or_b32_e32 v0, v0, v8
+; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX6-NEXT:    v_or_b32_e32 v0, v4, v0
 ; GFX6-NEXT:    v_or_b32_e32 v0, v3, v0
 ; GFX6-NEXT:    s_setpc_b64 s[30:31]
 ;

--- a/llvm/test/CodeGen/AMDGPU/lower-buffer-fat-pointers-nontemporal-metadata.ll
+++ b/llvm/test/CodeGen/AMDGPU/lower-buffer-fat-pointers-nontemporal-metadata.ll
@@ -45,21 +45,20 @@ define amdgpu_kernel void @buffer_nontemporal_load_store(ptr addrspace(7) %in, p
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX9-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x10
+; GFX9-GISEL-NEXT:    s_load_dwordx4 s[12:15], s[8:9], 0x20
 ; GFX9-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-GISEL-NEXT:    s_mov_b32 s4, s1
 ; GFX9-GISEL-NEXT:    s_mov_b32 s5, s2
 ; GFX9-GISEL-NEXT:    s_mov_b32 s6, s3
 ; GFX9-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-GISEL-NEXT:    buffer_load_dword v0, v0, s[4:7], 0 offen glc slc
-; GFX9-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x20
-; GFX9-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x30
-; GFX9-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX9-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX9-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, s0
-; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-GISEL-NEXT:    buffer_store_dword v0, v1, s[4:7], 0 offen glc slc
+; GFX9-GISEL-NEXT:    s_load_dword s3, s[8:9], 0x30
+; GFX9-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX9-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX9-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, s12
+; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX9-GISEL-NEXT:    buffer_store_dword v0, v1, s[0:3], 0 offen glc slc
 ; GFX9-GISEL-NEXT:    s_endpgm
 ;
 ; GFX942-SDAG-LABEL: buffer_nontemporal_load_store:
@@ -96,21 +95,20 @@ define amdgpu_kernel void @buffer_nontemporal_load_store(ptr addrspace(7) %in, p
 ; GFX942-GISEL:       ; %bb.0: ; %entry
 ; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x0
 ; GFX942-GISEL-NEXT:    s_load_dword s11, s[4:5], 0x10
+; GFX942-GISEL-NEXT:    s_load_dwordx4 s[12:15], s[4:5], 0x20
 ; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-GISEL-NEXT:    s_mov_b32 s8, s1
 ; GFX942-GISEL-NEXT:    s_mov_b32 s9, s2
 ; GFX942-GISEL-NEXT:    s_mov_b32 s10, s3
 ; GFX942-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX942-GISEL-NEXT:    buffer_load_dword v0, v0, s[8:11], 0 offen nt
-; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x20
-; GFX942-GISEL-NEXT:    s_load_dword s7, s[4:5], 0x30
-; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX942-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX942-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX942-GISEL-NEXT:    v_mov_b32_e32 v1, s0
-; GFX942-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX942-GISEL-NEXT:    buffer_store_dword v0, v1, s[4:7], 0 offen nt
+; GFX942-GISEL-NEXT:    s_load_dword s3, s[4:5], 0x30
+; GFX942-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX942-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX942-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX942-GISEL-NEXT:    v_mov_b32_e32 v1, s12
+; GFX942-GISEL-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX942-GISEL-NEXT:    buffer_store_dword v0, v1, s[0:3], 0 offen nt
 ; GFX942-GISEL-NEXT:    s_endpgm
 ;
 ; GFX10-SDAG-LABEL: buffer_nontemporal_load_store:
@@ -148,26 +146,23 @@ define amdgpu_kernel void @buffer_nontemporal_load_store(ptr addrspace(7) %in, p
 ;
 ; GFX10-GISEL-LABEL: buffer_nontemporal_load_store:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
-; GFX10-GISEL-NEXT:    s_clause 0x1
+; GFX10-GISEL-NEXT:    s_clause 0x2
 ; GFX10-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX10-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x10
+; GFX10-GISEL-NEXT:    s_load_dwordx4 s[12:15], s[8:9], 0x20
 ; GFX10-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX10-GISEL-NEXT:    s_mov_b32 s4, s1
 ; GFX10-GISEL-NEXT:    s_mov_b32 s5, s2
 ; GFX10-GISEL-NEXT:    s_mov_b32 s6, s3
+; GFX10-GISEL-NEXT:    s_load_dword s3, s[8:9], 0x30
 ; GFX10-GISEL-NEXT:    buffer_load_dword v0, v0, s[4:7], 0 offen slc
-; GFX10-GISEL-NEXT:    s_clause 0x1
-; GFX10-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x20
-; GFX10-GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
-; GFX10-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x30
-; GFX10-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_mov_b32_e32 v1, s0
-; GFX10-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX10-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX10-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-GISEL-NEXT:    buffer_store_dword v0, v1, s[4:7], 0 offen glc slc
+; GFX10-GISEL-NEXT:    v_mov_b32_e32 v1, s12
+; GFX10-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX10-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX10-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX10-GISEL-NEXT:    buffer_store_dword v0, v1, s[0:3], 0 offen glc slc
 ; GFX10-GISEL-NEXT:    s_endpgm
 ;
 ; GFX11-SDAG-LABEL: buffer_nontemporal_load_store:
@@ -206,25 +201,23 @@ define amdgpu_kernel void @buffer_nontemporal_load_store(ptr addrspace(7) %in, p
 ;
 ; GFX11-GISEL-LABEL: buffer_nontemporal_load_store:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
-; GFX11-GISEL-NEXT:    s_clause 0x1
+; GFX11-GISEL-NEXT:    s_clause 0x2
 ; GFX11-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
 ; GFX11-GISEL-NEXT:    s_load_b32 s11, s[4:5], 0x10
+; GFX11-GISEL-NEXT:    s_load_b128 s[12:15], s[4:5], 0x20
 ; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-GISEL-NEXT:    s_mov_b32 s8, s1
 ; GFX11-GISEL-NEXT:    s_mov_b32 s9, s2
 ; GFX11-GISEL-NEXT:    s_mov_b32 s10, s3
-; GFX11-GISEL-NEXT:    s_clause 0x1
-; GFX11-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x20
-; GFX11-GISEL-NEXT:    s_load_b32 s7, s[4:5], 0x30
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v1, s0
+; GFX11-GISEL-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX11-GISEL-NEXT:    buffer_load_b32 v0, v0, s[8:11], 0 offen slc dlc
-; GFX11-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX11-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX11-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-NEXT:    buffer_store_b32 v0, v1, s[4:7], 0 offen glc slc dlc
+; GFX11-GISEL-NEXT:    s_load_b32 s3, s[4:5], 0x30
+; GFX11-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX11-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX11-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
+; GFX11-GISEL-NEXT:    buffer_store_b32 v0, v1, s[0:3], 0 offen glc slc dlc
 ; GFX11-GISEL-NEXT:    s_endpgm
 ;
 ; GFX12-SDAG-LABEL: buffer_nontemporal_load_store:
@@ -263,25 +256,24 @@ define amdgpu_kernel void @buffer_nontemporal_load_store(ptr addrspace(7) %in, p
 ;
 ; GFX12-GISEL-LABEL: buffer_nontemporal_load_store:
 ; GFX12-GISEL:       ; %bb.0: ; %entry
-; GFX12-GISEL-NEXT:    s_clause 0x1
+; GFX12-GISEL-NEXT:    s_clause 0x2
 ; GFX12-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
 ; GFX12-GISEL-NEXT:    s_load_b32 s11, s[4:5], 0x10
+; GFX12-GISEL-NEXT:    s_load_b128 s[12:15], s[4:5], 0x20
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX12-GISEL-NEXT:    s_mov_b32 s8, s1
 ; GFX12-GISEL-NEXT:    s_mov_b32 s9, s2
 ; GFX12-GISEL-NEXT:    s_mov_b32 s10, s3
-; GFX12-GISEL-NEXT:    s_clause 0x1
-; GFX12-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x20
-; GFX12-GISEL-NEXT:    s_load_b32 s7, s[4:5], 0x30
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v1, s0
+; GFX12-GISEL-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX12-GISEL-NEXT:    buffer_load_b32 v0, v0, s[8:11], null offen th:TH_LOAD_NT
-; GFX12-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX12-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX12-GISEL-NEXT:    s_mov_b32 s6, s3
+; GFX12-GISEL-NEXT:    s_load_b32 s3, s[4:5], 0x30
+; GFX12-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX12-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX12-GISEL-NEXT:    s_mov_b32 s2, s15
 ; GFX12-GISEL-NEXT:    s_wait_loadcnt 0x0
-; GFX12-GISEL-NEXT:    buffer_store_b32 v0, v1, s[4:7], null offen th:TH_STORE_NT
+; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-NEXT:    buffer_store_b32 v0, v1, s[0:3], null offen th:TH_STORE_NT
 ; GFX12-GISEL-NEXT:    s_endpgm
 entry:
   %val = load i32, ptr addrspace(7) %in, !nontemporal !0
@@ -325,6 +317,7 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ; GFX9-GISEL:       ; %bb.0: ; %entry
 ; GFX9-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX9-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x10
+; GFX9-GISEL-NEXT:    s_load_dwordx4 s[12:15], s[8:9], 0x20
 ; GFX9-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-GISEL-NEXT:    s_mov_b32 s4, s1
 ; GFX9-GISEL-NEXT:    s_mov_b32 s5, s2
@@ -332,14 +325,13 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ; GFX9-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX9-GISEL-NEXT:    buffer_load_dword v0, v0, s[4:7], 0 offen glc
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x20
-; GFX9-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x30
+; GFX9-GISEL-NEXT:    s_load_dword s3, s[8:9], 0x30
+; GFX9-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX9-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX9-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX9-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX9-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX9-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX9-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX9-GISEL-NEXT:    v_mov_b32_e32 v1, s0
-; GFX9-GISEL-NEXT:    buffer_store_dword v0, v1, s[4:7], 0 offen
+; GFX9-GISEL-NEXT:    buffer_store_dword v0, v1, s[0:3], 0 offen
 ; GFX9-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-GISEL-NEXT:    s_endpgm
 ;
@@ -378,6 +370,7 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ; GFX942-GISEL:       ; %bb.0: ; %entry
 ; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x0
 ; GFX942-GISEL-NEXT:    s_load_dword s11, s[4:5], 0x10
+; GFX942-GISEL-NEXT:    s_load_dwordx4 s[12:15], s[4:5], 0x20
 ; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-GISEL-NEXT:    s_mov_b32 s8, s1
 ; GFX942-GISEL-NEXT:    s_mov_b32 s9, s2
@@ -385,14 +378,13 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ; GFX942-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX942-GISEL-NEXT:    buffer_load_dword v0, v0, s[8:11], 0 offen sc0 sc1
 ; GFX942-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX942-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x20
-; GFX942-GISEL-NEXT:    s_load_dword s7, s[4:5], 0x30
+; GFX942-GISEL-NEXT:    s_load_dword s3, s[4:5], 0x30
+; GFX942-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX942-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX942-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX942-GISEL-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX942-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX942-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX942-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX942-GISEL-NEXT:    v_mov_b32_e32 v1, s0
-; GFX942-GISEL-NEXT:    buffer_store_dword v0, v1, s[4:7], 0 offen sc0 sc1
+; GFX942-GISEL-NEXT:    buffer_store_dword v0, v1, s[0:3], 0 offen sc0 sc1
 ; GFX942-GISEL-NEXT:    s_waitcnt vmcnt(0)
 ; GFX942-GISEL-NEXT:    s_endpgm
 ;
@@ -432,26 +424,24 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ;
 ; GFX10-GISEL-LABEL: buffer_nontemporal_and_volatile_load_store:
 ; GFX10-GISEL:       ; %bb.0: ; %entry
-; GFX10-GISEL-NEXT:    s_clause 0x1
+; GFX10-GISEL-NEXT:    s_clause 0x2
 ; GFX10-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x0
 ; GFX10-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x10
+; GFX10-GISEL-NEXT:    s_load_dwordx4 s[12:15], s[8:9], 0x20
 ; GFX10-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX10-GISEL-NEXT:    s_mov_b32 s4, s1
 ; GFX10-GISEL-NEXT:    s_mov_b32 s5, s2
 ; GFX10-GISEL-NEXT:    s_mov_b32 s6, s3
+; GFX10-GISEL-NEXT:    s_load_dword s3, s[8:9], 0x30
 ; GFX10-GISEL-NEXT:    buffer_load_dword v0, v0, s[4:7], 0 offen glc dlc
 ; GFX10-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX10-GISEL-NEXT:    s_clause 0x1
-; GFX10-GISEL-NEXT:    s_load_dwordx4 s[0:3], s[8:9], 0x20
-; GFX10-GISEL-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
-; GFX10-GISEL-NEXT:    s_load_dword s7, s[8:9], 0x30
+; GFX10-GISEL-NEXT:    v_mov_b32_e32 v1, s12
+; GFX10-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX10-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX10-GISEL-NEXT:    s_mov_b32 s2, s15
 ; GFX10-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX10-GISEL-NEXT:    v_mov_b32_e32 v1, s0
-; GFX10-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX10-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX10-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX10-GISEL-NEXT:    buffer_store_dword v0, v1, s[4:7], 0 offen
+; GFX10-GISEL-NEXT:    buffer_store_dword v0, v1, s[0:3], 0 offen
 ; GFX10-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX10-GISEL-NEXT:    s_endpgm
 ;
@@ -492,25 +482,24 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ;
 ; GFX11-GISEL-LABEL: buffer_nontemporal_and_volatile_load_store:
 ; GFX11-GISEL:       ; %bb.0: ; %entry
-; GFX11-GISEL-NEXT:    s_clause 0x1
+; GFX11-GISEL-NEXT:    s_clause 0x2
 ; GFX11-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
 ; GFX11-GISEL-NEXT:    s_load_b32 s11, s[4:5], 0x10
+; GFX11-GISEL-NEXT:    s_load_b128 s[12:15], s[4:5], 0x20
 ; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX11-GISEL-NEXT:    s_mov_b32 s8, s1
 ; GFX11-GISEL-NEXT:    s_mov_b32 s9, s2
 ; GFX11-GISEL-NEXT:    s_mov_b32 s10, s3
-; GFX11-GISEL-NEXT:    s_clause 0x1
-; GFX11-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x20
-; GFX11-GISEL-NEXT:    s_load_b32 s7, s[4:5], 0x30
-; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX11-GISEL-NEXT:    v_mov_b32_e32 v1, s0
+; GFX11-GISEL-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX11-GISEL-NEXT:    buffer_load_b32 v0, v0, s[8:11], 0 offen glc dlc
 ; GFX11-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; GFX11-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX11-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX11-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX11-GISEL-NEXT:    buffer_store_b32 v0, v1, s[4:7], 0 offen dlc
+; GFX11-GISEL-NEXT:    s_load_b32 s3, s[4:5], 0x30
+; GFX11-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX11-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX11-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX11-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX11-GISEL-NEXT:    buffer_store_b32 v0, v1, s[0:3], 0 offen dlc
 ; GFX11-GISEL-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GFX11-GISEL-NEXT:    s_endpgm
 ;
@@ -551,25 +540,24 @@ define amdgpu_kernel void @buffer_nontemporal_and_volatile_load_store(ptr addrsp
 ;
 ; GFX12-GISEL-LABEL: buffer_nontemporal_and_volatile_load_store:
 ; GFX12-GISEL:       ; %bb.0: ; %entry
-; GFX12-GISEL-NEXT:    s_clause 0x1
+; GFX12-GISEL-NEXT:    s_clause 0x2
 ; GFX12-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x0
 ; GFX12-GISEL-NEXT:    s_load_b32 s11, s[4:5], 0x10
+; GFX12-GISEL-NEXT:    s_load_b128 s[12:15], s[4:5], 0x20
 ; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-GISEL-NEXT:    v_mov_b32_e32 v0, s0
 ; GFX12-GISEL-NEXT:    s_mov_b32 s8, s1
 ; GFX12-GISEL-NEXT:    s_mov_b32 s9, s2
 ; GFX12-GISEL-NEXT:    s_mov_b32 s10, s3
-; GFX12-GISEL-NEXT:    s_clause 0x1
-; GFX12-GISEL-NEXT:    s_load_b128 s[0:3], s[4:5], 0x20
-; GFX12-GISEL-NEXT:    s_load_b32 s7, s[4:5], 0x30
-; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
-; GFX12-GISEL-NEXT:    v_mov_b32_e32 v1, s0
+; GFX12-GISEL-NEXT:    v_mov_b32_e32 v1, s12
 ; GFX12-GISEL-NEXT:    buffer_load_b32 v0, v0, s[8:11], null offen th:TH_LOAD_NT scope:SCOPE_SYS
 ; GFX12-GISEL-NEXT:    s_wait_loadcnt 0x0
-; GFX12-GISEL-NEXT:    s_mov_b32 s4, s1
-; GFX12-GISEL-NEXT:    s_mov_b32 s5, s2
-; GFX12-GISEL-NEXT:    s_mov_b32 s6, s3
-; GFX12-GISEL-NEXT:    buffer_store_b32 v0, v1, s[4:7], null offen th:TH_STORE_NT scope:SCOPE_SYS
+; GFX12-GISEL-NEXT:    s_load_b32 s3, s[4:5], 0x30
+; GFX12-GISEL-NEXT:    s_mov_b32 s0, s13
+; GFX12-GISEL-NEXT:    s_mov_b32 s1, s14
+; GFX12-GISEL-NEXT:    s_mov_b32 s2, s15
+; GFX12-GISEL-NEXT:    s_wait_kmcnt 0x0
+; GFX12-GISEL-NEXT:    buffer_store_b32 v0, v1, s[0:3], null offen th:TH_STORE_NT scope:SCOPE_SYS
 ; GFX12-GISEL-NEXT:    s_wait_storecnt 0x0
 ; GFX12-GISEL-NEXT:    s_endpgm
 entry:

--- a/llvm/test/CodeGen/AMDGPU/memcpy-libcall.ll
+++ b/llvm/test/CodeGen/AMDGPU/memcpy-libcall.ll
@@ -264,29 +264,32 @@ define amdgpu_kernel void @memcpy_p0_p3_minsize(ptr %generic) #0 {
 ; CHECK-LABEL: memcpy_p0_p3_minsize:
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
-; CHECK-NEXT:    v_mov_b32_e32 v16, 0
-; CHECK-NEXT:    ds_read2_b64 v[0:3], v16 offset1:1
-; CHECK-NEXT:    ds_read2_b64 v[4:7], v16 offset0:2 offset1:3
-; CHECK-NEXT:    ds_read2_b64 v[8:11], v16 offset0:4 offset1:5
-; CHECK-NEXT:    ds_read2_b64 v[12:15], v16 offset0:6 offset1:7
+; CHECK-NEXT:    v_mov_b32_e32 v18, 0
+; CHECK-NEXT:    ds_read2_b64 v[0:3], v18 offset1:1
+; CHECK-NEXT:    ds_read2_b64 v[4:7], v18 offset0:2 offset1:3
+; CHECK-NEXT:    ds_read2_b64 v[8:11], v18 offset0:4 offset1:5
+; CHECK-NEXT:    ds_read2_b64 v[12:15], v18 offset0:6 offset1:7
 ; CHECK-NEXT:    s_add_u32 flat_scratch_lo, s12, s17
 ; CHECK-NEXT:    s_addc_u32 flat_scratch_hi, s13, 0
 ; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
-; CHECK-NEXT:    v_mov_b32_e32 v21, s1
-; CHECK-NEXT:    v_mov_b32_e32 v20, s0
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[0:3]
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[4:7] offset:16
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[8:11] offset:32
-; CHECK-NEXT:    ds_read2_b64 v[0:3], v16 offset0:8 offset1:9
-; CHECK-NEXT:    ds_read2_b64 v[4:7], v16 offset0:10 offset1:11
-; CHECK-NEXT:    ds_read_b128 v[8:11], v16 offset:96
-; CHECK-NEXT:    ds_read_b128 v[16:19], v16 offset:112
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[12:15] offset:48
+; CHECK-NEXT:    v_mov_b32_e32 v17, s1
+; CHECK-NEXT:    v_mov_b32_e32 v16, s0
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3]
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[4:7] offset:16
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[8:11] offset:32
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[12:15] offset:48
+; CHECK-NEXT:    ds_read2_b64 v[0:3], v18 offset0:8 offset1:9
 ; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[0:3] offset:64
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[4:7] offset:80
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[8:11] offset:96
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[16:19] offset:112
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:64
+; CHECK-NEXT:    ds_read2_b64 v[0:3], v18 offset0:10 offset1:11
+; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:80
+; CHECK-NEXT:    ds_read_b128 v[0:3], v18 offset:96
+; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:96
+; CHECK-NEXT:    ds_read_b128 v[0:3], v18 offset:112
+; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:112
 ; CHECK-NEXT:    s_endpgm
 entry:
   tail call void @llvm.memcpy.p0.p3.i64(ptr %generic, ptr addrspace(3) @shared, i64 128, i1 false)
@@ -552,29 +555,32 @@ define amdgpu_kernel void @memcpy_p0_p3_optsize(ptr %generic) #1 {
 ; CHECK-LABEL: memcpy_p0_p3_optsize:
 ; CHECK:       ; %bb.0: ; %entry
 ; CHECK-NEXT:    s_load_dwordx2 s[0:1], s[8:9], 0x0
-; CHECK-NEXT:    v_mov_b32_e32 v16, 0
-; CHECK-NEXT:    ds_read2_b64 v[0:3], v16 offset1:1
-; CHECK-NEXT:    ds_read2_b64 v[4:7], v16 offset0:2 offset1:3
-; CHECK-NEXT:    ds_read2_b64 v[8:11], v16 offset0:4 offset1:5
-; CHECK-NEXT:    ds_read2_b64 v[12:15], v16 offset0:6 offset1:7
+; CHECK-NEXT:    v_mov_b32_e32 v18, 0
+; CHECK-NEXT:    ds_read2_b64 v[0:3], v18 offset1:1
+; CHECK-NEXT:    ds_read2_b64 v[4:7], v18 offset0:2 offset1:3
+; CHECK-NEXT:    ds_read2_b64 v[8:11], v18 offset0:4 offset1:5
+; CHECK-NEXT:    ds_read2_b64 v[12:15], v18 offset0:6 offset1:7
 ; CHECK-NEXT:    s_add_u32 flat_scratch_lo, s12, s17
 ; CHECK-NEXT:    s_addc_u32 flat_scratch_hi, s13, 0
 ; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
-; CHECK-NEXT:    v_mov_b32_e32 v21, s1
-; CHECK-NEXT:    v_mov_b32_e32 v20, s0
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[0:3]
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[4:7] offset:16
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[8:11] offset:32
-; CHECK-NEXT:    ds_read2_b64 v[0:3], v16 offset0:8 offset1:9
-; CHECK-NEXT:    ds_read2_b64 v[4:7], v16 offset0:10 offset1:11
-; CHECK-NEXT:    ds_read_b128 v[8:11], v16 offset:96
-; CHECK-NEXT:    ds_read_b128 v[16:19], v16 offset:112
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[12:15] offset:48
+; CHECK-NEXT:    v_mov_b32_e32 v17, s1
+; CHECK-NEXT:    v_mov_b32_e32 v16, s0
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3]
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[4:7] offset:16
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[8:11] offset:32
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[12:15] offset:48
+; CHECK-NEXT:    ds_read2_b64 v[0:3], v18 offset0:8 offset1:9
 ; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[0:3] offset:64
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[4:7] offset:80
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[8:11] offset:96
-; CHECK-NEXT:    flat_store_dwordx4 v[20:21], v[16:19] offset:112
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:64
+; CHECK-NEXT:    ds_read2_b64 v[0:3], v18 offset0:10 offset1:11
+; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:80
+; CHECK-NEXT:    ds_read_b128 v[0:3], v18 offset:96
+; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:96
+; CHECK-NEXT:    ds_read_b128 v[0:3], v18 offset:112
+; CHECK-NEXT:    s_waitcnt lgkmcnt(0)
+; CHECK-NEXT:    flat_store_dwordx4 v[16:17], v[0:3] offset:112
 ; CHECK-NEXT:    s_endpgm
 entry:
   tail call void @llvm.memcpy.p0.p3.i64(ptr %generic, ptr addrspace(3) @shared, i64 128, i1 false)

--- a/llvm/test/CodeGen/AMDGPU/memory_clause.ll
+++ b/llvm/test/CodeGen/AMDGPU/memory_clause.ll
@@ -486,7 +486,6 @@ define amdgpu_kernel void @flat_scratch_load_clause(float %a, float %b, <8 x i32
 ; GCN-SCRATCH-NEXT:    s_waitcnt_vscnt null, 0x0
 ; GCN-SCRATCH-NEXT:    ;;#ASMSTART
 ; GCN-SCRATCH-NEXT:    ;;#ASMEND
-; GCN-SCRATCH-NEXT:    s_clause 0x1
 ; GCN-SCRATCH-NEXT:    scratch_load_dword v0, off, off
 ; GCN-SCRATCH-NEXT:    scratch_load_dword v1, off, off offset:4
 ; GCN-SCRATCH-NEXT:    s_waitcnt vmcnt(0)

--- a/llvm/test/CodeGen/AMDGPU/min.ll
+++ b/llvm/test/CodeGen/AMDGPU/min.ll
@@ -390,8 +390,8 @@ define amdgpu_kernel void @s_test_imin_sle_v4i32(ptr addrspace(1) %out, <4 x i32
 ; GFX9-LABEL: s_test_imin_sle_v4i32:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_load_dwordx8 s[0:7], s[8:9], 0x10
+; GFX9-NEXT:    s_load_dwordx2 s[10:11], s[8:9], 0x0
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0x0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    s_min_i32 s3, s3, s7
 ; GFX9-NEXT:    s_min_i32 s2, s2, s6
@@ -401,7 +401,7 @@ define amdgpu_kernel void @s_test_imin_sle_v4i32(ptr addrspace(1) %out, <4 x i32
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s1
 ; GFX9-NEXT:    v_mov_b32_e32 v2, s2
 ; GFX9-NEXT:    v_mov_b32_e32 v3, s3
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9]
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; GFX10-LABEL: s_test_imin_sle_v4i32:
@@ -3835,8 +3835,8 @@ define amdgpu_kernel void @s_test_umin_ult_v8i16(ptr addrspace(1) %out, <8 x i16
 ; GFX9-LABEL: s_test_umin_ult_v8i16:
 ; GFX9:       ; %bb.0:
 ; GFX9-NEXT:    s_load_dwordx8 s[0:7], s[8:9], 0x10
+; GFX9-NEXT:    s_load_dwordx2 s[10:11], s[8:9], 0x0
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
-; GFX9-NEXT:    s_load_dwordx2 s[8:9], s[8:9], 0x0
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s7
 ; GFX9-NEXT:    v_mov_b32_e32 v1, s6
@@ -3846,7 +3846,7 @@ define amdgpu_kernel void @s_test_umin_ult_v8i16(ptr addrspace(1) %out, <8 x i16
 ; GFX9-NEXT:    v_pk_min_u16 v1, s1, v0
 ; GFX9-NEXT:    v_mov_b32_e32 v0, s4
 ; GFX9-NEXT:    v_pk_min_u16 v0, s0, v0
-; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[8:9]
+; GFX9-NEXT:    global_store_dwordx4 v4, v[0:3], s[10:11]
 ; GFX9-NEXT:    s_endpgm
 ;
 ; GFX10-LABEL: s_test_umin_ult_v8i16:

--- a/llvm/test/CodeGen/AMDGPU/packed-fp32.ll
+++ b/llvm/test/CodeGen/AMDGPU/packed-fp32.ll
@@ -188,9 +188,9 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX900-LABEL: fadd_v32_vs:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX900-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; GFX900-NEXT:    v_lshlrev_b32_e32 v0, 7, v0
-; GFX900-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; GFX900-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; GFX900-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; GFX900-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX900-NEXT:    global_load_dwordx4 v[25:28], v0, s[0:1] offset:112
 ; GFX900-NEXT:    global_load_dwordx4 v[29:32], v0, s[0:1] offset:96
@@ -201,43 +201,43 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX900-NEXT:    global_load_dwordx4 v[17:20], v0, s[0:1] offset:80
 ; GFX900-NEXT:    global_load_dwordx4 v[21:24], v0, s[0:1] offset:64
 ; GFX900-NEXT:    s_waitcnt vmcnt(5)
-; GFX900-NEXT:    v_add_f32_e32 v4, s43, v4
-; GFX900-NEXT:    v_add_f32_e32 v3, s42, v3
-; GFX900-NEXT:    v_add_f32_e32 v2, s41, v2
-; GFX900-NEXT:    v_add_f32_e32 v1, s40, v1
-; GFX900-NEXT:    v_add_f32_e32 v32, s19, v32
-; GFX900-NEXT:    v_add_f32_e32 v31, s18, v31
-; GFX900-NEXT:    v_add_f32_e32 v30, s17, v30
-; GFX900-NEXT:    v_add_f32_e32 v29, s16, v29
+; GFX900-NEXT:    v_add_f32_e32 v4, s15, v4
+; GFX900-NEXT:    v_add_f32_e32 v3, s14, v3
+; GFX900-NEXT:    v_add_f32_e32 v2, s13, v2
+; GFX900-NEXT:    v_add_f32_e32 v1, s12, v1
+; GFX900-NEXT:    v_add_f32_e32 v32, s47, v32
+; GFX900-NEXT:    v_add_f32_e32 v31, s46, v31
+; GFX900-NEXT:    v_add_f32_e32 v30, s45, v30
+; GFX900-NEXT:    v_add_f32_e32 v29, s44, v29
 ; GFX900-NEXT:    s_waitcnt vmcnt(4)
-; GFX900-NEXT:    v_add_f32_e32 v8, s39, v8
-; GFX900-NEXT:    v_add_f32_e32 v7, s38, v7
-; GFX900-NEXT:    v_add_f32_e32 v6, s37, v6
-; GFX900-NEXT:    v_add_f32_e32 v5, s36, v5
+; GFX900-NEXT:    v_add_f32_e32 v8, s11, v8
+; GFX900-NEXT:    v_add_f32_e32 v7, s10, v7
+; GFX900-NEXT:    v_add_f32_e32 v6, s9, v6
+; GFX900-NEXT:    v_add_f32_e32 v5, s8, v5
 ; GFX900-NEXT:    s_waitcnt vmcnt(3)
-; GFX900-NEXT:    v_add_f32_e32 v12, s51, v12
-; GFX900-NEXT:    v_add_f32_e32 v11, s50, v11
-; GFX900-NEXT:    v_add_f32_e32 v10, s49, v10
-; GFX900-NEXT:    v_add_f32_e32 v9, s48, v9
+; GFX900-NEXT:    v_add_f32_e32 v12, s23, v12
+; GFX900-NEXT:    v_add_f32_e32 v11, s22, v11
+; GFX900-NEXT:    v_add_f32_e32 v10, s21, v10
+; GFX900-NEXT:    v_add_f32_e32 v9, s20, v9
 ; GFX900-NEXT:    s_waitcnt vmcnt(2)
-; GFX900-NEXT:    v_add_f32_e32 v16, s47, v16
-; GFX900-NEXT:    v_add_f32_e32 v15, s46, v15
-; GFX900-NEXT:    v_add_f32_e32 v14, s45, v14
-; GFX900-NEXT:    v_add_f32_e32 v13, s44, v13
+; GFX900-NEXT:    v_add_f32_e32 v16, s19, v16
+; GFX900-NEXT:    v_add_f32_e32 v15, s18, v15
+; GFX900-NEXT:    v_add_f32_e32 v14, s17, v14
+; GFX900-NEXT:    v_add_f32_e32 v13, s16, v13
 ; GFX900-NEXT:    s_waitcnt vmcnt(1)
-; GFX900-NEXT:    v_add_f32_e32 v20, s15, v20
-; GFX900-NEXT:    v_add_f32_e32 v19, s14, v19
-; GFX900-NEXT:    v_add_f32_e32 v18, s13, v18
-; GFX900-NEXT:    v_add_f32_e32 v17, s12, v17
+; GFX900-NEXT:    v_add_f32_e32 v20, s43, v20
+; GFX900-NEXT:    v_add_f32_e32 v19, s42, v19
+; GFX900-NEXT:    v_add_f32_e32 v18, s41, v18
+; GFX900-NEXT:    v_add_f32_e32 v17, s40, v17
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_add_f32_e32 v24, s11, v24
-; GFX900-NEXT:    v_add_f32_e32 v23, s10, v23
-; GFX900-NEXT:    v_add_f32_e32 v22, s9, v22
-; GFX900-NEXT:    v_add_f32_e32 v21, s8, v21
-; GFX900-NEXT:    v_add_f32_e32 v28, s23, v28
-; GFX900-NEXT:    v_add_f32_e32 v27, s22, v27
-; GFX900-NEXT:    v_add_f32_e32 v26, s21, v26
-; GFX900-NEXT:    v_add_f32_e32 v25, s20, v25
+; GFX900-NEXT:    v_add_f32_e32 v24, s39, v24
+; GFX900-NEXT:    v_add_f32_e32 v23, s38, v23
+; GFX900-NEXT:    v_add_f32_e32 v22, s37, v22
+; GFX900-NEXT:    v_add_f32_e32 v21, s36, v21
+; GFX900-NEXT:    v_add_f32_e32 v28, s51, v28
+; GFX900-NEXT:    v_add_f32_e32 v27, s50, v27
+; GFX900-NEXT:    v_add_f32_e32 v26, s49, v26
+; GFX900-NEXT:    v_add_f32_e32 v25, s48, v25
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[29:32], s[0:1] offset:96
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[25:28], s[0:1] offset:112
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[21:24], s[0:1] offset:64
@@ -251,10 +251,10 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-SDAG-LABEL: fadd_v32_vs:
 ; PACKED-SDAG:       ; %bb.0:
 ; PACKED-SDAG-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; PACKED-SDAG-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; PACKED-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; PACKED-SDAG-NEXT:    v_lshlrev_b32_e32 v32, 7, v0
-; PACKED-SDAG-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; PACKED-SDAG-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; PACKED-SDAG-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; PACKED-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[0:3], v32, s[0:1] offset:16
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[4:7], v32, s[0:1]
@@ -265,26 +265,26 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[24:27], v32, s[0:1] offset:112
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[28:31], v32, s[0:1] offset:96
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(7)
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[0:1], v[0:1], s[40:41]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[2:3], v[2:3], s[42:43]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[0:1], v[0:1], s[12:13]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[2:3], v[2:3], s[14:15]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(6)
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[6:7], v[6:7], s[38:39]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[6:7], v[6:7], s[10:11]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(5)
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[8:9], v[8:9], s[48:49]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[10:11], v[10:11], s[50:51]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[8:9], v[8:9], s[20:21]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[10:11], v[10:11], s[22:23]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(4)
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[16:17], v[16:17], s[44:45]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[18:19], v[18:19], s[46:47]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[16:17], v[16:17], s[16:17]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[18:19], v[18:19], s[18:19]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[28:29], v[28:29], s[16:17]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[30:31], v[30:31], s[18:19]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[20:21], v[20:21], s[12:13]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[22:23], v[22:23], s[14:15]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[14:15], v[14:15], s[10:11]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[24:25], v[24:25], s[20:21]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[26:27], v[26:27], s[22:23]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[4:5], v[4:5], s[36:37]
-; PACKED-SDAG-NEXT:    v_pk_add_f32 v[12:13], v[12:13], s[8:9]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[28:29], v[28:29], s[44:45]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[30:31], v[30:31], s[46:47]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[20:21], v[20:21], s[40:41]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[22:23], v[22:23], s[42:43]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[14:15], v[14:15], s[38:39]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[24:25], v[24:25], s[48:49]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[26:27], v[26:27], s[50:51]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[4:5], v[4:5], s[8:9]
+; PACKED-SDAG-NEXT:    v_pk_add_f32 v[12:13], v[12:13], s[36:37]
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[28:31], s[0:1] offset:96
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[24:27], s[0:1] offset:112
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[12:15], s[0:1] offset:64
@@ -298,10 +298,10 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-GISEL-LABEL: fadd_v32_vs:
 ; PACKED-GISEL:       ; %bb.0:
 ; PACKED-GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; PACKED-GISEL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; PACKED-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; PACKED-GISEL-NEXT:    v_lshlrev_b32_e32 v32, 7, v0
-; PACKED-GISEL-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; PACKED-GISEL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; PACKED-GISEL-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; PACKED-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[0:3], v32, s[0:1]
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[4:7], v32, s[0:1] offset:16
@@ -312,29 +312,29 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[24:27], v32, s[0:1] offset:96
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[28:31], v32, s[0:1] offset:112
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(7)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[0:1], v[0:1], s[36:37]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[2:3], v[2:3], s[38:39]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[0:1], v[0:1], s[8:9]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[2:3], v[2:3], s[10:11]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(6)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[4:5], v[4:5], s[40:41]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[6:7], v[6:7], s[42:43]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[4:5], v[4:5], s[12:13]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[6:7], v[6:7], s[14:15]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(5)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[8:9], v[8:9], s[44:45]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[10:11], v[10:11], s[46:47]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[8:9], v[8:9], s[16:17]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[10:11], v[10:11], s[18:19]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(4)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[12:13], v[12:13], s[48:49]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[14:15], v[14:15], s[50:51]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[12:13], v[12:13], s[20:21]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[14:15], v[14:15], s[22:23]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(3)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[16:17], v[16:17], s[8:9]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[18:19], v[18:19], s[10:11]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[16:17], v[16:17], s[36:37]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[18:19], v[18:19], s[38:39]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(2)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[20:21], v[20:21], s[12:13]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[22:23], v[22:23], s[14:15]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[20:21], v[20:21], s[40:41]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[22:23], v[22:23], s[42:43]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(1)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[24:25], v[24:25], s[16:17]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[26:27], v[26:27], s[18:19]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[24:25], v[24:25], s[44:45]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[26:27], v[26:27], s[46:47]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[28:29], v[28:29], s[20:21]
-; PACKED-GISEL-NEXT:    v_pk_add_f32 v[30:31], v[30:31], s[22:23]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[28:29], v[28:29], s[48:49]
+; PACKED-GISEL-NEXT:    v_pk_add_f32 v[30:31], v[30:31], s[50:51]
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[0:3], s[0:1]
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[4:7], s[0:1] offset:16
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[8:11], s[0:1] offset:32
@@ -348,14 +348,14 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-LABEL: fadd_v32_vs:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-SDAG-NEXT:    s_clause 0x2
+; GFX1250-SDAG-NEXT:    s_clause 0x1
 ; GFX1250-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
-; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
+; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xa4 nv
 ; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xe4 nv
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-SDAG-NEXT:    v_dual_lshlrev_b32 v56, 7, v0 :: v_dual_mov_b32 v32, s40
+; GFX1250-SDAG-NEXT:    v_dual_lshlrev_b32 v56, 7, v0 :: v_dual_mov_b32 v32, s12
 ; GFX1250-SDAG-NEXT:    s_clause 0x7
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v56, s[0:1] offset:16
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[4:7], v56, s[0:1] offset:48
@@ -365,28 +365,28 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[20:23], v56, s[0:1] offset:96
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[24:27], v56, s[0:1] offset:64
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[28:31], v56, s[0:1] offset:112
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v33, s41 :: v_dual_mov_b32 v34, s42
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v35, s43 :: v_dual_mov_b32 v36, s38
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v39, s49 :: v_dual_mov_b32 v40, s50
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v41, s51 :: v_dual_mov_b32 v42, s44
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v37, s39 :: v_dual_mov_b32 v38, s48
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v55, s23 :: v_dual_mov_b32 v51, s11
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v52, s20 :: v_dual_mov_b32 v53, s21
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s22 :: v_dual_mov_b32 v49, s15
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s10 :: v_dual_mov_b32 v45, s47
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v46, s12 :: v_dual_mov_b32 v47, s13
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s14 :: v_dual_mov_b32 v43, s45
-; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v44, s46
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v33, s13 :: v_dual_mov_b32 v34, s14
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v35, s15 :: v_dual_mov_b32 v36, s10
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v39, s21 :: v_dual_mov_b32 v40, s22
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v41, s23 :: v_dual_mov_b32 v42, s16
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v37, s11 :: v_dual_mov_b32 v38, s20
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v55, s51 :: v_dual_mov_b32 v51, s39
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v52, s48 :: v_dual_mov_b32 v53, s49
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s50 :: v_dual_mov_b32 v49, s43
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s38 :: v_dual_mov_b32 v45, s19
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v46, s40 :: v_dual_mov_b32 v47, s41
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s42 :: v_dual_mov_b32 v43, s17
+; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v44, s18
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x7
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[0:1], v[0:1], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[2:3], v[2:3], v[34:35]
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v32, s16 :: v_dual_mov_b32 v33, s17
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v34, s18 :: v_dual_mov_b32 v35, s19
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v32, s44 :: v_dual_mov_b32 v33, s45
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v34, s46 :: v_dual_mov_b32 v35, s47
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x6
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[6:7], v[6:7], v[40:41]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[8:9]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[36:37]
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[4:5], v[4:5], v[38:39]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[36:37]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[8:9]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x2
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[20:21], v[20:21], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_add_f32 v[22:23], v[22:23], v[34:35]
@@ -415,10 +415,10 @@ define amdgpu_kernel void @fadd_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-GISEL-LABEL: fadd_v32_vs:
 ; GFX1250-GISEL:       ; %bb.0:
 ; GFX1250-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-GISEL-NEXT:    s_clause 0x1
+; GFX1250-GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
 ; GFX1250-GISEL-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
+; GFX1250-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-GISEL-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
 ; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-GISEL-NEXT:    v_lshlrev_b32_e32 v56, 7, v0
@@ -1475,9 +1475,9 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX900-LABEL: fmul_v32_vs:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX900-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; GFX900-NEXT:    v_lshlrev_b32_e32 v0, 7, v0
-; GFX900-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; GFX900-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; GFX900-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; GFX900-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX900-NEXT:    global_load_dwordx4 v[25:28], v0, s[0:1] offset:112
 ; GFX900-NEXT:    global_load_dwordx4 v[29:32], v0, s[0:1] offset:96
@@ -1488,43 +1488,43 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX900-NEXT:    global_load_dwordx4 v[17:20], v0, s[0:1] offset:80
 ; GFX900-NEXT:    global_load_dwordx4 v[21:24], v0, s[0:1] offset:64
 ; GFX900-NEXT:    s_waitcnt vmcnt(5)
-; GFX900-NEXT:    v_mul_f32_e32 v4, s43, v4
-; GFX900-NEXT:    v_mul_f32_e32 v3, s42, v3
-; GFX900-NEXT:    v_mul_f32_e32 v2, s41, v2
-; GFX900-NEXT:    v_mul_f32_e32 v1, s40, v1
-; GFX900-NEXT:    v_mul_f32_e32 v32, s19, v32
-; GFX900-NEXT:    v_mul_f32_e32 v31, s18, v31
-; GFX900-NEXT:    v_mul_f32_e32 v30, s17, v30
-; GFX900-NEXT:    v_mul_f32_e32 v29, s16, v29
+; GFX900-NEXT:    v_mul_f32_e32 v4, s15, v4
+; GFX900-NEXT:    v_mul_f32_e32 v3, s14, v3
+; GFX900-NEXT:    v_mul_f32_e32 v2, s13, v2
+; GFX900-NEXT:    v_mul_f32_e32 v1, s12, v1
+; GFX900-NEXT:    v_mul_f32_e32 v32, s47, v32
+; GFX900-NEXT:    v_mul_f32_e32 v31, s46, v31
+; GFX900-NEXT:    v_mul_f32_e32 v30, s45, v30
+; GFX900-NEXT:    v_mul_f32_e32 v29, s44, v29
 ; GFX900-NEXT:    s_waitcnt vmcnt(4)
-; GFX900-NEXT:    v_mul_f32_e32 v8, s39, v8
-; GFX900-NEXT:    v_mul_f32_e32 v7, s38, v7
-; GFX900-NEXT:    v_mul_f32_e32 v6, s37, v6
-; GFX900-NEXT:    v_mul_f32_e32 v5, s36, v5
+; GFX900-NEXT:    v_mul_f32_e32 v8, s11, v8
+; GFX900-NEXT:    v_mul_f32_e32 v7, s10, v7
+; GFX900-NEXT:    v_mul_f32_e32 v6, s9, v6
+; GFX900-NEXT:    v_mul_f32_e32 v5, s8, v5
 ; GFX900-NEXT:    s_waitcnt vmcnt(3)
-; GFX900-NEXT:    v_mul_f32_e32 v12, s51, v12
-; GFX900-NEXT:    v_mul_f32_e32 v11, s50, v11
-; GFX900-NEXT:    v_mul_f32_e32 v10, s49, v10
-; GFX900-NEXT:    v_mul_f32_e32 v9, s48, v9
+; GFX900-NEXT:    v_mul_f32_e32 v12, s23, v12
+; GFX900-NEXT:    v_mul_f32_e32 v11, s22, v11
+; GFX900-NEXT:    v_mul_f32_e32 v10, s21, v10
+; GFX900-NEXT:    v_mul_f32_e32 v9, s20, v9
 ; GFX900-NEXT:    s_waitcnt vmcnt(2)
-; GFX900-NEXT:    v_mul_f32_e32 v16, s47, v16
-; GFX900-NEXT:    v_mul_f32_e32 v15, s46, v15
-; GFX900-NEXT:    v_mul_f32_e32 v14, s45, v14
-; GFX900-NEXT:    v_mul_f32_e32 v13, s44, v13
+; GFX900-NEXT:    v_mul_f32_e32 v16, s19, v16
+; GFX900-NEXT:    v_mul_f32_e32 v15, s18, v15
+; GFX900-NEXT:    v_mul_f32_e32 v14, s17, v14
+; GFX900-NEXT:    v_mul_f32_e32 v13, s16, v13
 ; GFX900-NEXT:    s_waitcnt vmcnt(1)
-; GFX900-NEXT:    v_mul_f32_e32 v20, s15, v20
-; GFX900-NEXT:    v_mul_f32_e32 v19, s14, v19
-; GFX900-NEXT:    v_mul_f32_e32 v18, s13, v18
-; GFX900-NEXT:    v_mul_f32_e32 v17, s12, v17
+; GFX900-NEXT:    v_mul_f32_e32 v20, s43, v20
+; GFX900-NEXT:    v_mul_f32_e32 v19, s42, v19
+; GFX900-NEXT:    v_mul_f32_e32 v18, s41, v18
+; GFX900-NEXT:    v_mul_f32_e32 v17, s40, v17
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_mul_f32_e32 v24, s11, v24
-; GFX900-NEXT:    v_mul_f32_e32 v23, s10, v23
-; GFX900-NEXT:    v_mul_f32_e32 v22, s9, v22
-; GFX900-NEXT:    v_mul_f32_e32 v21, s8, v21
-; GFX900-NEXT:    v_mul_f32_e32 v28, s23, v28
-; GFX900-NEXT:    v_mul_f32_e32 v27, s22, v27
-; GFX900-NEXT:    v_mul_f32_e32 v26, s21, v26
-; GFX900-NEXT:    v_mul_f32_e32 v25, s20, v25
+; GFX900-NEXT:    v_mul_f32_e32 v24, s39, v24
+; GFX900-NEXT:    v_mul_f32_e32 v23, s38, v23
+; GFX900-NEXT:    v_mul_f32_e32 v22, s37, v22
+; GFX900-NEXT:    v_mul_f32_e32 v21, s36, v21
+; GFX900-NEXT:    v_mul_f32_e32 v28, s51, v28
+; GFX900-NEXT:    v_mul_f32_e32 v27, s50, v27
+; GFX900-NEXT:    v_mul_f32_e32 v26, s49, v26
+; GFX900-NEXT:    v_mul_f32_e32 v25, s48, v25
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[29:32], s[0:1] offset:96
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[25:28], s[0:1] offset:112
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[21:24], s[0:1] offset:64
@@ -1538,10 +1538,10 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-SDAG-LABEL: fmul_v32_vs:
 ; PACKED-SDAG:       ; %bb.0:
 ; PACKED-SDAG-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; PACKED-SDAG-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; PACKED-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; PACKED-SDAG-NEXT:    v_lshlrev_b32_e32 v32, 7, v0
-; PACKED-SDAG-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; PACKED-SDAG-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; PACKED-SDAG-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; PACKED-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[0:3], v32, s[0:1] offset:16
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[4:7], v32, s[0:1]
@@ -1552,26 +1552,26 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[24:27], v32, s[0:1] offset:112
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[28:31], v32, s[0:1] offset:96
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(7)
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[0:1], v[0:1], s[40:41]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[2:3], v[2:3], s[42:43]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[0:1], v[0:1], s[12:13]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[2:3], v[2:3], s[14:15]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(6)
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[6:7], v[6:7], s[38:39]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[6:7], v[6:7], s[10:11]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(5)
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[8:9], v[8:9], s[48:49]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[10:11], v[10:11], s[50:51]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[8:9], v[8:9], s[20:21]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[10:11], v[10:11], s[22:23]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(4)
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[16:17], v[16:17], s[44:45]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[18:19], v[18:19], s[46:47]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[16:17], v[16:17], s[16:17]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[18:19], v[18:19], s[18:19]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[28:29], v[28:29], s[16:17]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[30:31], v[30:31], s[18:19]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[20:21], v[20:21], s[12:13]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[22:23], v[22:23], s[14:15]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[14:15], v[14:15], s[10:11]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[24:25], v[24:25], s[20:21]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[26:27], v[26:27], s[22:23]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[4:5], v[4:5], s[36:37]
-; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[12:13], v[12:13], s[8:9]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[28:29], v[28:29], s[44:45]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[30:31], v[30:31], s[46:47]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[20:21], v[20:21], s[40:41]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[22:23], v[22:23], s[42:43]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[14:15], v[14:15], s[38:39]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[24:25], v[24:25], s[48:49]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[26:27], v[26:27], s[50:51]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[4:5], v[4:5], s[8:9]
+; PACKED-SDAG-NEXT:    v_pk_mul_f32 v[12:13], v[12:13], s[36:37]
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[28:31], s[0:1] offset:96
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[24:27], s[0:1] offset:112
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[12:15], s[0:1] offset:64
@@ -1585,10 +1585,10 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-GISEL-LABEL: fmul_v32_vs:
 ; PACKED-GISEL:       ; %bb.0:
 ; PACKED-GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; PACKED-GISEL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; PACKED-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; PACKED-GISEL-NEXT:    v_lshlrev_b32_e32 v32, 7, v0
-; PACKED-GISEL-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; PACKED-GISEL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; PACKED-GISEL-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; PACKED-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[0:3], v32, s[0:1]
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[4:7], v32, s[0:1] offset:16
@@ -1599,29 +1599,29 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[24:27], v32, s[0:1] offset:96
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[28:31], v32, s[0:1] offset:112
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(7)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[0:1], v[0:1], s[36:37]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[2:3], v[2:3], s[38:39]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[0:1], v[0:1], s[8:9]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[2:3], v[2:3], s[10:11]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(6)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[4:5], v[4:5], s[40:41]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[6:7], v[6:7], s[42:43]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[4:5], v[4:5], s[12:13]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[6:7], v[6:7], s[14:15]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(5)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[8:9], v[8:9], s[44:45]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[10:11], v[10:11], s[46:47]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[8:9], v[8:9], s[16:17]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[10:11], v[10:11], s[18:19]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(4)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[12:13], v[12:13], s[48:49]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[14:15], v[14:15], s[50:51]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[12:13], v[12:13], s[20:21]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[14:15], v[14:15], s[22:23]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(3)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[16:17], v[16:17], s[8:9]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[18:19], v[18:19], s[10:11]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[16:17], v[16:17], s[36:37]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[18:19], v[18:19], s[38:39]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(2)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[20:21], v[20:21], s[12:13]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[22:23], v[22:23], s[14:15]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[20:21], v[20:21], s[40:41]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[22:23], v[22:23], s[42:43]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(1)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[24:25], v[24:25], s[16:17]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[26:27], v[26:27], s[18:19]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[24:25], v[24:25], s[44:45]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[26:27], v[26:27], s[46:47]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[28:29], v[28:29], s[20:21]
-; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[30:31], v[30:31], s[22:23]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[28:29], v[28:29], s[48:49]
+; PACKED-GISEL-NEXT:    v_pk_mul_f32 v[30:31], v[30:31], s[50:51]
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[0:3], s[0:1]
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[4:7], s[0:1] offset:16
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[8:11], s[0:1] offset:32
@@ -1635,14 +1635,14 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-LABEL: fmul_v32_vs:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-SDAG-NEXT:    s_clause 0x2
+; GFX1250-SDAG-NEXT:    s_clause 0x1
 ; GFX1250-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
-; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
+; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xa4 nv
 ; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xe4 nv
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
 ; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
-; GFX1250-SDAG-NEXT:    v_dual_lshlrev_b32 v56, 7, v0 :: v_dual_mov_b32 v32, s40
+; GFX1250-SDAG-NEXT:    v_dual_lshlrev_b32 v56, 7, v0 :: v_dual_mov_b32 v32, s12
 ; GFX1250-SDAG-NEXT:    s_clause 0x7
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[0:3], v56, s[0:1] offset:16
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[4:7], v56, s[0:1] offset:48
@@ -1652,28 +1652,28 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[20:23], v56, s[0:1] offset:96
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[24:27], v56, s[0:1] offset:64
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[28:31], v56, s[0:1] offset:112
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v33, s41 :: v_dual_mov_b32 v34, s42
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v35, s43 :: v_dual_mov_b32 v36, s38
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v39, s49 :: v_dual_mov_b32 v40, s50
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v41, s51 :: v_dual_mov_b32 v42, s44
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v37, s39 :: v_dual_mov_b32 v38, s48
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v55, s23 :: v_dual_mov_b32 v51, s11
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v52, s20 :: v_dual_mov_b32 v53, s21
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s22 :: v_dual_mov_b32 v49, s15
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s10 :: v_dual_mov_b32 v45, s47
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v46, s12 :: v_dual_mov_b32 v47, s13
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s14 :: v_dual_mov_b32 v43, s45
-; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v44, s46
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v33, s13 :: v_dual_mov_b32 v34, s14
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v35, s15 :: v_dual_mov_b32 v36, s10
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v39, s21 :: v_dual_mov_b32 v40, s22
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v41, s23 :: v_dual_mov_b32 v42, s16
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v37, s11 :: v_dual_mov_b32 v38, s20
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v55, s51 :: v_dual_mov_b32 v51, s39
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v52, s48 :: v_dual_mov_b32 v53, s49
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v54, s50 :: v_dual_mov_b32 v49, s43
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v50, s38 :: v_dual_mov_b32 v45, s19
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v46, s40 :: v_dual_mov_b32 v47, s41
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v48, s42 :: v_dual_mov_b32 v43, s17
+; GFX1250-SDAG-NEXT:    v_mov_b32_e32 v44, s18
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x7
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[0:1], v[0:1], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[2:3], v[2:3], v[34:35]
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v32, s16 :: v_dual_mov_b32 v33, s17
-; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v34, s18 :: v_dual_mov_b32 v35, s19
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v32, s44 :: v_dual_mov_b32 v33, s45
+; GFX1250-SDAG-NEXT:    v_dual_mov_b32 v34, s46 :: v_dual_mov_b32 v35, s47
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x6
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[6:7], v[6:7], v[40:41]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[8:9]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[36:37]
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[4:5], v[4:5], v[38:39]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[36:37]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[8:9]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x2
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[20:21], v[20:21], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_mul_f32 v[22:23], v[22:23], v[34:35]
@@ -1702,10 +1702,10 @@ define amdgpu_kernel void @fmul_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-GISEL-LABEL: fmul_v32_vs:
 ; GFX1250-GISEL:       ; %bb.0:
 ; GFX1250-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-GISEL-NEXT:    s_clause 0x1
+; GFX1250-GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
 ; GFX1250-GISEL-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
+; GFX1250-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-GISEL-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
 ; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-GISEL-NEXT:    v_lshlrev_b32_e32 v56, 7, v0
@@ -2323,9 +2323,9 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX900-LABEL: fma_v32_vs:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; GFX900-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; GFX900-NEXT:    v_lshlrev_b32_e32 v0, 7, v0
-; GFX900-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; GFX900-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; GFX900-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; GFX900-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX900-NEXT:    global_load_dwordx4 v[25:28], v0, s[0:1] offset:112
 ; GFX900-NEXT:    global_load_dwordx4 v[29:32], v0, s[0:1] offset:96
@@ -2336,43 +2336,43 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX900-NEXT:    global_load_dwordx4 v[17:20], v0, s[0:1] offset:80
 ; GFX900-NEXT:    global_load_dwordx4 v[21:24], v0, s[0:1] offset:64
 ; GFX900-NEXT:    s_waitcnt vmcnt(5)
-; GFX900-NEXT:    v_fma_f32 v4, v4, s43, s43
-; GFX900-NEXT:    v_fma_f32 v3, v3, s42, s42
-; GFX900-NEXT:    v_fma_f32 v2, v2, s41, s41
-; GFX900-NEXT:    v_fma_f32 v1, v1, s40, s40
-; GFX900-NEXT:    v_fma_f32 v32, v32, s19, s19
-; GFX900-NEXT:    v_fma_f32 v31, v31, s18, s18
-; GFX900-NEXT:    v_fma_f32 v30, v30, s17, s17
-; GFX900-NEXT:    v_fma_f32 v29, v29, s16, s16
+; GFX900-NEXT:    v_fma_f32 v4, v4, s15, s15
+; GFX900-NEXT:    v_fma_f32 v3, v3, s14, s14
+; GFX900-NEXT:    v_fma_f32 v2, v2, s13, s13
+; GFX900-NEXT:    v_fma_f32 v1, v1, s12, s12
+; GFX900-NEXT:    v_fma_f32 v32, v32, s47, s47
+; GFX900-NEXT:    v_fma_f32 v31, v31, s46, s46
+; GFX900-NEXT:    v_fma_f32 v30, v30, s45, s45
+; GFX900-NEXT:    v_fma_f32 v29, v29, s44, s44
 ; GFX900-NEXT:    s_waitcnt vmcnt(4)
-; GFX900-NEXT:    v_fma_f32 v8, v8, s39, s39
-; GFX900-NEXT:    v_fma_f32 v7, v7, s38, s38
-; GFX900-NEXT:    v_fma_f32 v6, v6, s37, s37
-; GFX900-NEXT:    v_fma_f32 v5, v5, s36, s36
+; GFX900-NEXT:    v_fma_f32 v8, v8, s11, s11
+; GFX900-NEXT:    v_fma_f32 v7, v7, s10, s10
+; GFX900-NEXT:    v_fma_f32 v6, v6, s9, s9
+; GFX900-NEXT:    v_fma_f32 v5, v5, s8, s8
 ; GFX900-NEXT:    s_waitcnt vmcnt(3)
-; GFX900-NEXT:    v_fma_f32 v12, v12, s51, s51
-; GFX900-NEXT:    v_fma_f32 v11, v11, s50, s50
-; GFX900-NEXT:    v_fma_f32 v10, v10, s49, s49
-; GFX900-NEXT:    v_fma_f32 v9, v9, s48, s48
+; GFX900-NEXT:    v_fma_f32 v12, v12, s23, s23
+; GFX900-NEXT:    v_fma_f32 v11, v11, s22, s22
+; GFX900-NEXT:    v_fma_f32 v10, v10, s21, s21
+; GFX900-NEXT:    v_fma_f32 v9, v9, s20, s20
 ; GFX900-NEXT:    s_waitcnt vmcnt(2)
-; GFX900-NEXT:    v_fma_f32 v16, v16, s47, s47
-; GFX900-NEXT:    v_fma_f32 v15, v15, s46, s46
-; GFX900-NEXT:    v_fma_f32 v14, v14, s45, s45
-; GFX900-NEXT:    v_fma_f32 v13, v13, s44, s44
+; GFX900-NEXT:    v_fma_f32 v16, v16, s19, s19
+; GFX900-NEXT:    v_fma_f32 v15, v15, s18, s18
+; GFX900-NEXT:    v_fma_f32 v14, v14, s17, s17
+; GFX900-NEXT:    v_fma_f32 v13, v13, s16, s16
 ; GFX900-NEXT:    s_waitcnt vmcnt(1)
-; GFX900-NEXT:    v_fma_f32 v20, v20, s15, s15
-; GFX900-NEXT:    v_fma_f32 v19, v19, s14, s14
-; GFX900-NEXT:    v_fma_f32 v18, v18, s13, s13
-; GFX900-NEXT:    v_fma_f32 v17, v17, s12, s12
+; GFX900-NEXT:    v_fma_f32 v20, v20, s43, s43
+; GFX900-NEXT:    v_fma_f32 v19, v19, s42, s42
+; GFX900-NEXT:    v_fma_f32 v18, v18, s41, s41
+; GFX900-NEXT:    v_fma_f32 v17, v17, s40, s40
 ; GFX900-NEXT:    s_waitcnt vmcnt(0)
-; GFX900-NEXT:    v_fma_f32 v24, v24, s11, s11
-; GFX900-NEXT:    v_fma_f32 v23, v23, s10, s10
-; GFX900-NEXT:    v_fma_f32 v22, v22, s9, s9
-; GFX900-NEXT:    v_fma_f32 v21, v21, s8, s8
-; GFX900-NEXT:    v_fma_f32 v28, v28, s23, s23
-; GFX900-NEXT:    v_fma_f32 v27, v27, s22, s22
-; GFX900-NEXT:    v_fma_f32 v26, v26, s21, s21
-; GFX900-NEXT:    v_fma_f32 v25, v25, s20, s20
+; GFX900-NEXT:    v_fma_f32 v24, v24, s39, s39
+; GFX900-NEXT:    v_fma_f32 v23, v23, s38, s38
+; GFX900-NEXT:    v_fma_f32 v22, v22, s37, s37
+; GFX900-NEXT:    v_fma_f32 v21, v21, s36, s36
+; GFX900-NEXT:    v_fma_f32 v28, v28, s51, s51
+; GFX900-NEXT:    v_fma_f32 v27, v27, s50, s50
+; GFX900-NEXT:    v_fma_f32 v26, v26, s49, s49
+; GFX900-NEXT:    v_fma_f32 v25, v25, s48, s48
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[29:32], s[0:1] offset:96
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[25:28], s[0:1] offset:112
 ; GFX900-NEXT:    global_store_dwordx4 v0, v[21:24], s[0:1] offset:64
@@ -2386,10 +2386,10 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-SDAG-LABEL: fma_v32_vs:
 ; PACKED-SDAG:       ; %bb.0:
 ; PACKED-SDAG-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; PACKED-SDAG-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; PACKED-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; PACKED-SDAG-NEXT:    v_lshlrev_b32_e32 v32, 7, v0
-; PACKED-SDAG-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; PACKED-SDAG-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; PACKED-SDAG-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; PACKED-SDAG-NEXT:    s_waitcnt lgkmcnt(0)
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[0:3], v32, s[0:1] offset:16
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[4:7], v32, s[0:1]
@@ -2400,26 +2400,26 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[24:27], v32, s[0:1] offset:112
 ; PACKED-SDAG-NEXT:    global_load_dwordx4 v[28:31], v32, s[0:1] offset:96
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(7)
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[0:1], v[0:1], s[40:41], s[40:41]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[2:3], v[2:3], s[42:43], s[42:43]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[0:1], v[0:1], s[12:13], s[12:13]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[2:3], v[2:3], s[14:15], s[14:15]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(6)
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[6:7], v[6:7], s[38:39], s[38:39]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[6:7], v[6:7], s[10:11], s[10:11]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(5)
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[8:9], v[8:9], s[48:49], s[48:49]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[10:11], v[10:11], s[50:51], s[50:51]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[8:9], v[8:9], s[20:21], s[20:21]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[10:11], v[10:11], s[22:23], s[22:23]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(4)
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[16:17], v[16:17], s[44:45], s[44:45]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[18:19], v[18:19], s[46:47], s[46:47]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[16:17], v[16:17], s[16:17], s[16:17]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[18:19], v[18:19], s[18:19], s[18:19]
 ; PACKED-SDAG-NEXT:    s_waitcnt vmcnt(0)
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[28:29], v[28:29], s[16:17], s[16:17]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[30:31], v[30:31], s[18:19], s[18:19]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[20:21], v[20:21], s[12:13], s[12:13]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[22:23], v[22:23], s[14:15], s[14:15]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[14:15], v[14:15], s[10:11], s[10:11]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[24:25], v[24:25], s[20:21], s[20:21]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[26:27], v[26:27], s[22:23], s[22:23]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[4:5], v[4:5], s[36:37], s[36:37]
-; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[12:13], v[12:13], s[8:9], s[8:9]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[28:29], v[28:29], s[44:45], s[44:45]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[30:31], v[30:31], s[46:47], s[46:47]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[20:21], v[20:21], s[40:41], s[40:41]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[22:23], v[22:23], s[42:43], s[42:43]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[14:15], v[14:15], s[38:39], s[38:39]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[24:25], v[24:25], s[48:49], s[48:49]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[26:27], v[26:27], s[50:51], s[50:51]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[4:5], v[4:5], s[8:9], s[8:9]
+; PACKED-SDAG-NEXT:    v_pk_fma_f32 v[12:13], v[12:13], s[36:37], s[36:37]
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[28:31], s[0:1] offset:96
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[24:27], s[0:1] offset:112
 ; PACKED-SDAG-NEXT:    global_store_dwordx4 v32, v[12:15], s[0:1] offset:64
@@ -2433,10 +2433,10 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-GISEL-LABEL: fma_v32_vs:
 ; PACKED-GISEL:       ; %bb.0:
 ; PACKED-GISEL-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
+; PACKED-GISEL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xa4
 ; PACKED-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; PACKED-GISEL-NEXT:    v_lshlrev_b32_e32 v32, 7, v0
-; PACKED-GISEL-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xa4
-; PACKED-GISEL-NEXT:    s_load_dwordx16 s[8:23], s[4:5], 0xe4
+; PACKED-GISEL-NEXT:    s_load_dwordx16 s[36:51], s[4:5], 0xe4
 ; PACKED-GISEL-NEXT:    s_waitcnt lgkmcnt(0)
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[0:3], v32, s[0:1]
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[4:7], v32, s[0:1] offset:16
@@ -2447,29 +2447,29 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[24:27], v32, s[0:1] offset:96
 ; PACKED-GISEL-NEXT:    global_load_dwordx4 v[28:31], v32, s[0:1] offset:112
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(7)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[0:1], v[0:1], s[36:37], s[36:37]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[2:3], v[2:3], s[38:39], s[38:39]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[0:1], v[0:1], s[8:9], s[8:9]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[2:3], v[2:3], s[10:11], s[10:11]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(6)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[4:5], v[4:5], s[40:41], s[40:41]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[6:7], v[6:7], s[42:43], s[42:43]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[4:5], v[4:5], s[12:13], s[12:13]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[6:7], v[6:7], s[14:15], s[14:15]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(5)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[8:9], v[8:9], s[44:45], s[44:45]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[10:11], v[10:11], s[46:47], s[46:47]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[8:9], v[8:9], s[16:17], s[16:17]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[10:11], v[10:11], s[18:19], s[18:19]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(4)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[12:13], v[12:13], s[48:49], s[48:49]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[14:15], v[14:15], s[50:51], s[50:51]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[12:13], v[12:13], s[20:21], s[20:21]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[14:15], v[14:15], s[22:23], s[22:23]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(3)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[16:17], v[16:17], s[8:9], s[8:9]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[18:19], v[18:19], s[10:11], s[10:11]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[16:17], v[16:17], s[36:37], s[36:37]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[18:19], v[18:19], s[38:39], s[38:39]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(2)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[20:21], v[20:21], s[12:13], s[12:13]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[22:23], v[22:23], s[14:15], s[14:15]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[20:21], v[20:21], s[40:41], s[40:41]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[22:23], v[22:23], s[42:43], s[42:43]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(1)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[24:25], v[24:25], s[16:17], s[16:17]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[26:27], v[26:27], s[18:19], s[18:19]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[24:25], v[24:25], s[44:45], s[44:45]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[26:27], v[26:27], s[46:47], s[46:47]
 ; PACKED-GISEL-NEXT:    s_waitcnt vmcnt(0)
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[28:29], v[28:29], s[20:21], s[20:21]
-; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[30:31], v[30:31], s[22:23], s[22:23]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[28:29], v[28:29], s[48:49], s[48:49]
+; PACKED-GISEL-NEXT:    v_pk_fma_f32 v[30:31], v[30:31], s[50:51], s[50:51]
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[0:3], s[0:1]
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[4:7], s[0:1] offset:16
 ; PACKED-GISEL-NEXT:    global_store_dwordx4 v32, v[8:11], s[0:1] offset:32
@@ -2483,11 +2483,11 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-LABEL: fma_v32_vs:
 ; GFX1250-SDAG:       ; %bb.0:
 ; GFX1250-SDAG-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-SDAG-NEXT:    s_clause 0x1
-; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
-; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
+; GFX1250-SDAG-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
+; GFX1250-SDAG-NEXT:    s_load_b512 s[8:23], s[4:5], 0xa4 nv
+; GFX1250-SDAG-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
+; GFX1250-SDAG-NEXT:    s_load_b512 s[36:51], s[4:5], 0xe4 nv
 ; GFX1250-SDAG-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-SDAG-NEXT:    v_lshlrev_b32_e32 v56, 7, v0
 ; GFX1250-SDAG-NEXT:    s_wait_kmcnt 0x0
@@ -2500,28 +2500,28 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[20:23], v56, s[0:1] offset:96
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[24:27], v56, s[0:1] offset:64
 ; GFX1250-SDAG-NEXT:    global_load_b128 v[28:31], v56, s[0:1] offset:112
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[32:33], s[40:41]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[34:35], s[42:43]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[50:51]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[48:49]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[52:53], s[20:21]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[54:55], s[22:23]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[50:51], s[10:11]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[46:47], s[12:13]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[48:49], s[14:15]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[42:43], s[44:45]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[44:45], s[46:47]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[36:37], s[38:39]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[32:33], s[12:13]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[34:35], s[14:15]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[22:23]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[20:21]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[52:53], s[48:49]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[54:55], s[50:51]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[50:51], s[38:39]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[46:47], s[40:41]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[48:49], s[42:43]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[42:43], s[16:17]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[44:45], s[18:19]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[36:37], s[10:11]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x7
 ; GFX1250-SDAG-NEXT:    v_pk_fma_f32 v[0:1], v[0:1], v[32:33], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_fma_f32 v[2:3], v[2:3], v[34:35], v[34:35]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[32:33], s[16:17]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[34:35], s[18:19]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[32:33], s[44:45]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[34:35], s[46:47]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x6
 ; GFX1250-SDAG-NEXT:    v_pk_fma_f32 v[6:7], v[6:7], v[40:41], v[40:41]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[8:9]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[40:41], s[36:37]
 ; GFX1250-SDAG-NEXT:    v_pk_fma_f32 v[4:5], v[4:5], v[38:39], v[38:39]
-; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[36:37]
+; GFX1250-SDAG-NEXT:    v_mov_b64_e32 v[38:39], s[8:9]
 ; GFX1250-SDAG-NEXT:    s_wait_loadcnt 0x2
 ; GFX1250-SDAG-NEXT:    v_pk_fma_f32 v[20:21], v[20:21], v[32:33], v[32:33]
 ; GFX1250-SDAG-NEXT:    v_pk_fma_f32 v[22:23], v[22:23], v[34:35], v[34:35]
@@ -2550,10 +2550,10 @@ define amdgpu_kernel void @fma_v32_vs(ptr addrspace(1) %a, <32 x float> %x) {
 ; GFX1250-GISEL-LABEL: fma_v32_vs:
 ; GFX1250-GISEL:       ; %bb.0:
 ; GFX1250-GISEL-NEXT:    s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1 ; msbs: dst=0 src0=0 src1=0 src2=0
-; GFX1250-GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
-; GFX1250-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-GISEL-NEXT:    s_clause 0x1
+; GFX1250-GISEL-NEXT:    s_load_b64 s[0:1], s[4:5], 0x24 nv
 ; GFX1250-GISEL-NEXT:    s_load_b512 s[36:51], s[4:5], 0xa4 nv
+; GFX1250-GISEL-NEXT:    v_and_b32_e32 v0, 0x3ff, v0
 ; GFX1250-GISEL-NEXT:    s_load_b512 s[8:23], s[4:5], 0xe4 nv
 ; GFX1250-GISEL-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX1250-GISEL-NEXT:    v_lshlrev_b32_e32 v56, 7, v0

--- a/llvm/test/CodeGen/AMDGPU/reassoc-mul-add-1-to-mad.ll
+++ b/llvm/test/CodeGen/AMDGPU/reassoc-mul-add-1-to-mad.ll
@@ -4019,19 +4019,20 @@ define amdgpu_kernel void @compute_mad(ptr addrspace(4) %i18, ptr addrspace(4) %
 ; GFX67-LABEL: compute_mad:
 ; GFX67:       ; %bb.0: ; %bb
 ; GFX67-NEXT:    s_load_dword s0, s[4:5], 0x6
-; GFX67-NEXT:    s_mov_b32 s3, 0xf000
+; GFX67-NEXT:    s_mov_b32 s7, 0xf000
+; GFX67-NEXT:    s_mov_b32 s6, 0
 ; GFX67-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX67-NEXT:    s_add_i32 s0, s0, 1
 ; GFX67-NEXT:    v_mul_lo_u32 v1, s0, v0
 ; GFX67-NEXT:    v_add_i32_e32 v2, vcc, s0, v1
 ; GFX67-NEXT:    v_mul_lo_u32 v2, v2, v0
 ; GFX67-NEXT:    v_add_i32_e32 v1, vcc, 1, v1
-; GFX67-NEXT:    s_load_dwordx4 s[12:15], s[4:5], 0x0
-; GFX67-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x4
+; GFX67-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x0
+; GFX67-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x4
 ; GFX67-NEXT:    v_mul_lo_u32 v3, v2, v1
 ; GFX67-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX67-NEXT:    s_load_dword s2, s[14:15], 0x1
-; GFX67-NEXT:    s_load_dwordx2 s[4:5], s[12:13], 0x0
+; GFX67-NEXT:    s_load_dword s2, s[2:3], 0x1
+; GFX67-NEXT:    s_load_dwordx2 s[0:1], s[0:1], 0x0
 ; GFX67-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
 ; GFX67-NEXT:    v_mul_lo_u32 v1, v1, v2
 ; GFX67-NEXT:    v_add_i32_e32 v2, vcc, 1, v3
@@ -4042,16 +4043,15 @@ define amdgpu_kernel void @compute_mad(ptr addrspace(4) %i18, ptr addrspace(4) %
 ; GFX67-NEXT:    v_add_i32_e32 v0, vcc, s8, v0
 ; GFX67-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
 ; GFX67-NEXT:    v_mul_lo_u32 v1, v2, v1
-; GFX67-NEXT:    v_mov_b32_e32 v2, s5
-; GFX67-NEXT:    s_mov_b32 s2, 0
+; GFX67-NEXT:    v_mov_b32_e32 v2, s1
 ; GFX67-NEXT:    v_mul_lo_u32 v3, v1, v3
 ; GFX67-NEXT:    v_add_i32_e32 v3, vcc, v3, v1
 ; GFX67-NEXT:    v_mul_lo_u32 v4, v3, v1
-; GFX67-NEXT:    v_add_i32_e32 v0, vcc, s4, v0
+; GFX67-NEXT:    v_add_i32_e32 v0, vcc, s0, v0
 ; GFX67-NEXT:    v_addc_u32_e32 v1, vcc, 0, v2, vcc
 ; GFX67-NEXT:    v_lshl_b64 v[0:1], v[0:1], 2
 ; GFX67-NEXT:    v_add_i32_e32 v2, vcc, v4, v3
-; GFX67-NEXT:    buffer_store_dword v2, v[0:1], s[0:3], 0 addr64
+; GFX67-NEXT:    buffer_store_dword v2, v[0:1], s[4:7], 0 addr64
 ; GFX67-NEXT:    s_endpgm
 ;
 ; GFX8-LABEL: compute_mad:

--- a/llvm/test/CodeGen/AMDGPU/release-vgprs-spill.ll
+++ b/llvm/test/CodeGen/AMDGPU/release-vgprs-spill.ll
@@ -22,9 +22,8 @@ define amdgpu_kernel void @f(ptr %ptr, i32 %arg) "amdgpu-flat-work-group-size"="
 ; CHECK-NEXT:    ;;#ASMEND
 ; CHECK-NEXT:    s_cbranch_scc1 .LBB0_2
 ; CHECK-NEXT:  ; %bb.1: ; %true
-; CHECK-NEXT:    s_clause 0x1 ; 8-byte Folded Reload
-; CHECK-NEXT:    scratch_load_b32 v0, off, off offset:4
-; CHECK-NEXT:    scratch_load_b32 v2, off, off
+; CHECK-NEXT:    scratch_load_b32 v0, off, off offset:4 ; 4-byte Folded Reload
+; CHECK-NEXT:    scratch_load_b32 v2, off, off ; 4-byte Folded Reload
 ; CHECK-NEXT:    s_waitcnt vmcnt(1)
 ; CHECK-NEXT:    v_add_co_u32 v0, s0, s2, v0
 ; CHECK-NEXT:    s_delay_alu instid0(VALU_DEP_1)

--- a/llvm/test/CodeGen/AMDGPU/schedule-regpressure-ilp-metric-spills.mir
+++ b/llvm/test/CodeGen/AMDGPU/schedule-regpressure-ilp-metric-spills.mir
@@ -14,17 +14,12 @@
 # GCN: S_ENDPGM
 
 # GCN-GCNTRACKER-LABEL: name: no_sched_metric_due_to_spills
-# GCN-GCNTRACKER: SI_SPILL_V32_SAVE
-# GCN-GCNTRACKER: SI_SPILL_V32_SAVE
-# GCN-GCNTRACKER: SI_SPILL_V32_SAVE
-# GCN-GCNTRACKER: SI_SPILL_V32_SAVE
-# GCN-GCNTRACKER: SI_SPILL_V32_SAVE
-# GCN-GCNTRACKER: SI_SPILL_V32_SAVE
+# GCN-GCNTRACKER-NOT: SI_SPILL_
 # GCN-GCNTRACKER: S_ENDPGM
 
-# When using the GCN Trackers, the scheduler is able to acieve desired occupancy without running high-RP-reschedule stage. However, the RP is still high,
-# and RA is unable to allocate without spills. By running the high-RP-reschedule schedule we would have furhter decreased RP, which provides increased
-# flexibility for RA.
+# With memory-type-aware clustering (larger DS cluster budgets), the scheduler
+# achieves better DS load pipelining. Combined with the GCN trackers achieving
+# desired occupancy, RA is now able to allocate without spills.
 
 ---
 name:            no_sched_metric_due_to_spills

--- a/llvm/test/CodeGen/AMDGPU/schedule-relaxed-occupancy.ll
+++ b/llvm/test/CodeGen/AMDGPU/schedule-relaxed-occupancy.ll
@@ -7,16 +7,16 @@
 ; Using -amgpu-schedule-relaxed-occupancy allows scheduler to produce better ILP by further relaxing occupancy target
 
 ; CHECK-LABEL: {{^}}load_fma_store:
-; OCC:    NumVgprs: 24
-; OCC-GCNTRACKER:    NumVgprs: 26
-; RELAX:    NumVgprs: 64
-; RELAX-GCNTRACKER:    NumVgprs: 60
-; OCC: NumVGPRsForWavesPerEU: 24
-; OCC-GCNTRACKER: NumVGPRsForWavesPerEU: 26
-; RELAX: NumVGPRsForWavesPerEU: 64
-; RELAX-GCNTRACKER: NumVGPRsForWavesPerEU: 60
-; OCC:    Occupancy: 10
-; OCC-GCNTRACKER:    Occupancy: 9
+; OCC:    NumVgprs: 29
+; OCC-GCNTRACKER:    NumVgprs: 16
+; RELAX:    NumVgprs: 57
+; RELAX-GCNTRACKER:    NumVgprs: 56
+; OCC: NumVGPRsForWavesPerEU: 29
+; OCC-GCNTRACKER: NumVGPRsForWavesPerEU: 16
+; RELAX: NumVGPRsForWavesPerEU: 57
+; RELAX-GCNTRACKER: NumVGPRsForWavesPerEU: 56
+; OCC:    Occupancy: 8
+; OCC-GCNTRACKER:    Occupancy: 10
 ; RELAX: Occupancy: 4
 ; RELAX-GCNTRACKER: Occupancy: 4
 

--- a/llvm/test/CodeGen/AMDGPU/scratch-simple.ll
+++ b/llvm/test/CodeGen/AMDGPU/scratch-simple.ll
@@ -967,7 +967,6 @@ define amdgpu_ps float @ps_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -980,11 +979,9 @@ define amdgpu_ps float @ps_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -1001,13 +998,11 @@ define amdgpu_ps float @ps_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768
@@ -1971,7 +1966,6 @@ define amdgpu_vs float @vs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -1984,11 +1978,9 @@ define amdgpu_vs float @vs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -2005,13 +1997,11 @@ define amdgpu_vs float @vs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768
@@ -2975,7 +2965,6 @@ define amdgpu_cs float @cs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -2988,11 +2977,9 @@ define amdgpu_cs float @cs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -3009,13 +2996,11 @@ define amdgpu_cs float @cs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768
@@ -3976,7 +3961,6 @@ define amdgpu_hs float @hs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -3989,11 +3973,9 @@ define amdgpu_hs float @hs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -4010,13 +3992,11 @@ define amdgpu_hs float @hs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768
@@ -4977,7 +4957,6 @@ define amdgpu_gs float @gs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v6, 0x3eae29dc
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -4990,11 +4969,9 @@ define amdgpu_gs float @gs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -5011,13 +4988,11 @@ define amdgpu_gs float @gs_main(i32 %idx) {
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768
@@ -5989,7 +5964,6 @@ define amdgpu_hs <{i32, i32, i32, float}> @hs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -6002,11 +5976,9 @@ define amdgpu_hs <{i32, i32, i32, float}> @hs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -6023,13 +5995,11 @@ define amdgpu_hs <{i32, i32, i32, float}> @hs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768
@@ -7000,7 +6970,6 @@ define amdgpu_gs <{i32, i32, i32, float}> @gs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v7, 0x3eae29d8
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v8, 0x3e319356
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v9, 0x3e31934f
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[25:28], off offset:304
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[1:4], off offset:288
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v12, 0xbf20e7f5
@@ -7013,11 +6982,9 @@ define amdgpu_gs <{i32, i32, i32, float}> @gs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v2, 0xbe31934f :: v_dual_mov_b32 v31, v11
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v0, 0xb702e758
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v22, 0xbf638e39
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[6:9], off offset:240
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[11:14], off offset:224
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v14, 0x3f20e7f5 :: v_dual_mov_b32 v9, v6
-; GFX11-FLATSCR-NEXT:    s_clause 0x3
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[17:20], off offset:272
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[0:3], off offset:256
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[21:24], off offset:208
@@ -7034,13 +7001,11 @@ define amdgpu_gs <{i32, i32, i32, float}> @gs_ir_uses_scratch_offset(i32 inreg, 
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v23, v25
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v25, v26 :: v_dual_mov_b32 v18, v12
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v20, v17 :: v_dual_mov_b32 v21, v3
-; GFX11-FLATSCR-NEXT:    s_clause 0x1
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[29:32], off offset:752
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[13:16], off offset:736
 ; GFX11-FLATSCR-NEXT:    v_dual_mov_b32 v5, v8 :: v_dual_mov_b32 v14, v17
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v4, v7
 ; GFX11-FLATSCR-NEXT:    v_mov_b32_e32 v13, v19
-; GFX11-FLATSCR-NEXT:    s_clause 0x4
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[7:10], off offset:816
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[18:21], off offset:800
 ; GFX11-FLATSCR-NEXT:    scratch_store_b128 off, v[22:25], off offset:768

--- a/llvm/test/CodeGen/AMDGPU/splitkit-getsubrangeformask.ll
+++ b/llvm/test/CodeGen/AMDGPU/splitkit-getsubrangeformask.ll
@@ -62,13 +62,11 @@ define amdgpu_gs void @_amdgpu_gs_main(i32 inreg %primShaderTableAddrLow, <31 x 
   ; CHECK-NEXT:   undef [[S_ADD_U32_2:%[0-9]+]].sub0:sreg_64 = S_ADD_U32 [[COPY6]], [[S_LSHL_B32_1]], implicit-def $scc
   ; CHECK-NEXT:   [[S_ADD_U32_2:%[0-9]+]].sub1:sreg_64 = S_ADDC_U32 undef %54:sreg_32, [[S_ASHR_I32_1]], implicit-def dead $scc, implicit $scc
   ; CHECK-NEXT:   undef [[S_ADD_U32_3:%[0-9]+]].sub0:sreg_64 = S_ADD_U32 [[COPY6]], [[S_LSHL_B32_2]], implicit-def $scc
-  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM1:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_1]], 64, 0 :: (invariant load (s128) from %ir.89, addrspace 4)
-  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM2:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_2]], 64, 0 :: (invariant load (s128) from %ir.95, addrspace 4)
-  ; CHECK-NEXT:   KILL [[S_ADD_U32_2]].sub0, [[S_ADD_U32_2]].sub1
-  ; CHECK-NEXT:   KILL [[S_ADD_U32_1]].sub0, [[S_ADD_U32_1]].sub1
   ; CHECK-NEXT:   [[S_ADD_U32_3:%[0-9]+]].sub1:sreg_64 = S_ADDC_U32 undef %54:sreg_32, [[S_ASHR_I32_2]], implicit-def dead $scc, implicit $scc
   ; CHECK-NEXT:   [[S_ASHR_I32_3:%[0-9]+]]:sreg_32_xm0 = S_ASHR_I32 undef %174:sreg_32, 31, implicit-def dead $scc
   ; CHECK-NEXT:   undef [[S_ADD_U32_4:%[0-9]+]].sub0:sreg_64 = S_ADD_U32 [[COPY6]], undef %174:sreg_32, implicit-def $scc
+  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM1:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_1]], 64, 0 :: (invariant load (s128) from %ir.89, addrspace 4)
+  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM2:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_2]], 64, 0 :: (invariant load (s128) from %ir.95, addrspace 4)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM3:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_3]], 64, 0 :: (invariant load (s128) from %ir.101, addrspace 4)
   ; CHECK-NEXT:   [[S_ADD_U32_4:%[0-9]+]].sub1:sreg_64 = S_ADDC_U32 undef %54:sreg_32, [[S_ASHR_I32_3]], implicit-def dead $scc, implicit $scc
   ; CHECK-NEXT:   undef [[S_ADD_U32_5:%[0-9]+]].sub0:sreg_64 = S_ADD_U32 [[COPY7]].sub0, [[S_LSHL_B32_]], implicit-def $scc
@@ -118,12 +116,13 @@ define amdgpu_gs void @_amdgpu_gs_main(i32 inreg %primShaderTableAddrLow, <31 x 
   ; CHECK-NEXT:   [[S_BUFFER_LOAD_DWORD_SGPR_IMM6:%[0-9]+]]:sreg_32_xm0_xexec = S_BUFFER_LOAD_DWORD_SGPR_IMM undef %388:sgpr_128, [[S_LSHL4_ADD_U32_]], 0, 0 :: (dereferenceable invariant load (s32))
   ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN5:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM4]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM8:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_5]], 224, 0 :: (invariant load (s128) from %ir.131, addrspace 4)
-  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM9:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY7]], 224, 0 :: (invariant load (s128) from %ir.147, addrspace 4)
-  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM10:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_5]], 576, 0 :: (invariant load (s128) from %ir.152, addrspace 4)
-  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN6:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM5]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
+  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM9:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_8]], 576, 0 :: (invariant load (s128) from %ir.159, addrspace 4)
+  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM10:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_7]], 576, 0 :: (invariant load (s128) from %ir.164, addrspace 4)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM11:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_6]], 224, 0 :: (invariant load (s128) from %ir.136, addrspace 4)
-  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM12:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_7]], 576, 0 :: (invariant load (s128) from %ir.164, addrspace 4)
+  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM12:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_5]], 576, 0 :: (invariant load (s128) from %ir.152, addrspace 4)
+  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN6:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM5]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM13:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_8]], 224, 0 :: (invariant load (s128) from %ir.142, addrspace 4)
+  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM14:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[COPY7]], 224, 0 :: (invariant load (s128) from %ir.147, addrspace 4)
   ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN7:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM6]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
   ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN8:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM7]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
   ; CHECK-NEXT:   [[S_ADD_I32_6:%[0-9]+]]:sreg_32 = S_ADD_I32 [[S_BUFFER_LOAD_DWORD_SGPR_IMM4]], -217, implicit-def dead $scc
@@ -147,10 +146,9 @@ define amdgpu_gs void @_amdgpu_gs_main(i32 inreg %primShaderTableAddrLow, <31 x 
   ; CHECK-NEXT:   undef [[S_ADD_U32_18:%[0-9]+]].sub0:sreg_64 = S_ADD_U32 [[COPY]].sub0, [[S_LSHL_B32_4]], implicit-def $scc
   ; CHECK-NEXT:   [[S_ADD_U32_18:%[0-9]+]].sub1:sreg_64 = S_ADDC_U32 undef %57:sreg_32, [[S_ASHR_I32_5]], implicit-def dead $scc, implicit $scc
   ; CHECK-NEXT:   [[S_LOAD_DWORD_IMM:%[0-9]+]]:sreg_32_xm0_xexec = S_LOAD_DWORD_IMM [[S_ADD_U32_18]], 168, 0 :: (invariant load (s32) from %ir.276, align 8, addrspace 4)
-  ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM14:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_8]], 576, 0 :: (invariant load (s128) from %ir.159, addrspace 4)
   ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN11:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM13]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
-  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN12:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM9]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
-  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN13:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM10]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
+  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN12:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM14]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
+  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN13:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM12]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]].sub3:sgpr_128 = S_MOV_B32 553734060
   ; CHECK-NEXT:   [[S_LOAD_DWORDX2_IMM:%[0-9]+]].sub2:sgpr_128 = S_MOV_B32 -1
   ; CHECK-NEXT:   [[COPY15:%[0-9]+]]:sgpr_128 = COPY [[S_LOAD_DWORDX2_IMM]]
@@ -158,8 +156,8 @@ define amdgpu_gs void @_amdgpu_gs_main(i32 inreg %primShaderTableAddrLow, <31 x 
   ; CHECK-NEXT:   [[COPY15:%[0-9]+]].sub1:sgpr_128 = COPY [[S_MOV_B32_]].sub1
   ; CHECK-NEXT:   [[COPY15:%[0-9]+]].sub0:sgpr_128 = COPY [[S_LOAD_DWORD_IMM]]
   ; CHECK-NEXT:   [[S_BUFFER_LOAD_DWORD_IMM4:%[0-9]+]]:sreg_32_xm0_xexec = S_BUFFER_LOAD_DWORD_IMM [[COPY15]], 0, 0 :: (dereferenceable invariant load (s32))
-  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN14:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM14]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
-  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN15:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM12]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
+  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN14:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM9]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
+  ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN15:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM10]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM16:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_10]], 0, 0 :: (invariant load (s128) from %ir.180, addrspace 4)
   ; CHECK-NEXT:   [[S_LOAD_DWORDX4_IMM17:%[0-9]+]]:sgpr_128 = S_LOAD_DWORDX4_IMM [[S_ADD_U32_11]], 0, 0 :: (invariant load (s128) from %ir.185, addrspace 4)
   ; CHECK-NEXT:   [[BUFFER_LOAD_FORMAT_X_IDXEN16:%[0-9]+]]:vgpr_32 = BUFFER_LOAD_FORMAT_X_IDXEN [[V_MOV_B32_e32_]], [[S_LOAD_DWORDX4_IMM15]], 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s32), align 1, addrspace 8)

--- a/llvm/test/CodeGen/AMDGPU/store-local.128.ll
+++ b/llvm/test/CodeGen/AMDGPU/store-local.128.ll
@@ -279,20 +279,25 @@ define amdgpu_kernel void @store_lds_v4i32_align1(ptr addrspace(3) %out, <4 x i3
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x10
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s3
-; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s1
 ; GFX11-NEXT:    s_lshr_b32 s4, s3, 8
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
 ; GFX11-NEXT:    v_dual_mov_b32 v4, s0 :: v_dual_mov_b32 v5, s4
+; GFX11-NEXT:    v_dual_mov_b32 v2, s2 :: v_dual_mov_b32 v3, s1
+; GFX11-NEXT:    s_lshr_b32 s3, s3, 24
 ; GFX11-NEXT:    s_lshr_b32 s5, s2, 8
 ; GFX11-NEXT:    s_lshr_b32 s2, s2, 24
 ; GFX11-NEXT:    s_lshr_b32 s6, s1, 8
-; GFX11-NEXT:    s_lshr_b32 s3, s3, 24
 ; GFX11-NEXT:    s_lshr_b32 s1, s1, 24
 ; GFX11-NEXT:    s_lshr_b32 s7, s0, 8
 ; GFX11-NEXT:    s_lshr_b32 s0, s0, 24
-; GFX11-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, s6
 ; GFX11-NEXT:    v_dual_mov_b32 v6, s3 :: v_dual_mov_b32 v7, s5
-; GFX11-NEXT:    v_mov_b32_e32 v10, s1
+; GFX11-NEXT:    v_dual_mov_b32 v8, s2 :: v_dual_mov_b32 v9, s6
+; GFX11-NEXT:    v_dual_mov_b32 v10, s1 :: v_dual_mov_b32 v11, s7
+; GFX11-NEXT:    v_mov_b32_e32 v12, s0
+; GFX11-NEXT:    ds_store_b8 v0, v4
+; GFX11-NEXT:    ds_store_b8_d16_hi v0, v4 offset:2
+; GFX11-NEXT:    ds_store_b8 v0, v3 offset:4
+; GFX11-NEXT:    ds_store_b8_d16_hi v0, v3 offset:6
 ; GFX11-NEXT:    ds_store_b8 v0, v2 offset:8
 ; GFX11-NEXT:    ds_store_b8_d16_hi v0, v2 offset:10
 ; GFX11-NEXT:    ds_store_b8 v0, v1 offset:12
@@ -301,15 +306,10 @@ define amdgpu_kernel void @store_lds_v4i32_align1(ptr addrspace(3) %out, <4 x i3
 ; GFX11-NEXT:    ds_store_b8 v0, v6 offset:15
 ; GFX11-NEXT:    ds_store_b8 v0, v7 offset:9
 ; GFX11-NEXT:    ds_store_b8 v0, v8 offset:11
-; GFX11-NEXT:    v_dual_mov_b32 v1, s7 :: v_dual_mov_b32 v2, s0
-; GFX11-NEXT:    ds_store_b8 v0, v4
-; GFX11-NEXT:    ds_store_b8_d16_hi v0, v4 offset:2
-; GFX11-NEXT:    ds_store_b8 v0, v3 offset:4
-; GFX11-NEXT:    ds_store_b8_d16_hi v0, v3 offset:6
 ; GFX11-NEXT:    ds_store_b8 v0, v9 offset:5
 ; GFX11-NEXT:    ds_store_b8 v0, v10 offset:7
-; GFX11-NEXT:    ds_store_b8 v0, v1 offset:1
-; GFX11-NEXT:    ds_store_b8 v0, v2 offset:3
+; GFX11-NEXT:    ds_store_b8 v0, v11 offset:1
+; GFX11-NEXT:    ds_store_b8 v0, v12 offset:3
 ; GFX11-NEXT:    s_endpgm
   store <4 x i32> %x, ptr addrspace(3) %out, align 1
   ret void

--- a/llvm/test/CodeGen/AMDGPU/store-local.96.ll
+++ b/llvm/test/CodeGen/AMDGPU/store-local.96.ll
@@ -239,25 +239,24 @@ define amdgpu_kernel void @store_lds_v3i32_align1(ptr addrspace(3) %out, <3 x i3
 ; GFX11-NEXT:    s_load_b128 s[0:3], s[4:5], 0x10
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_dual_mov_b32 v0, s6 :: v_dual_mov_b32 v1, s2
+; GFX11-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s0
 ; GFX11-NEXT:    s_lshr_b32 s3, s2, 8
 ; GFX11-NEXT:    s_lshr_b32 s2, s2, 24
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v4, s3 :: v_dual_mov_b32 v5, s2
-; GFX11-NEXT:    v_dual_mov_b32 v2, s1 :: v_dual_mov_b32 v3, s0
 ; GFX11-NEXT:    s_lshr_b32 s4, s1, 8
 ; GFX11-NEXT:    s_lshr_b32 s1, s1, 24
 ; GFX11-NEXT:    s_lshr_b32 s5, s0, 8
 ; GFX11-NEXT:    s_lshr_b32 s0, s0, 24
+; GFX11-NEXT:    v_dual_mov_b32 v4, s3 :: v_dual_mov_b32 v5, s2
 ; GFX11-NEXT:    v_dual_mov_b32 v6, s4 :: v_dual_mov_b32 v7, s1
 ; GFX11-NEXT:    v_dual_mov_b32 v8, s5 :: v_dual_mov_b32 v9, s0
-; GFX11-NEXT:    ds_store_b8 v0, v1 offset:8
-; GFX11-NEXT:    ds_store_b8_d16_hi v0, v1 offset:10
-; GFX11-NEXT:    ds_store_b8 v0, v4 offset:9
-; GFX11-NEXT:    ds_store_b8 v0, v5 offset:11
 ; GFX11-NEXT:    ds_store_b8 v0, v3
 ; GFX11-NEXT:    ds_store_b8_d16_hi v0, v3 offset:2
 ; GFX11-NEXT:    ds_store_b8 v0, v2 offset:4
 ; GFX11-NEXT:    ds_store_b8_d16_hi v0, v2 offset:6
+; GFX11-NEXT:    ds_store_b8 v0, v1 offset:8
+; GFX11-NEXT:    ds_store_b8_d16_hi v0, v1 offset:10
+; GFX11-NEXT:    ds_store_b8 v0, v4 offset:9
+; GFX11-NEXT:    ds_store_b8 v0, v5 offset:11
 ; GFX11-NEXT:    ds_store_b8 v0, v6 offset:5
 ; GFX11-NEXT:    ds_store_b8 v0, v7 offset:7
 ; GFX11-NEXT:    ds_store_b8 v0, v8 offset:1

--- a/llvm/test/CodeGen/AMDGPU/urem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/urem64.ll
@@ -694,15 +694,15 @@ define amdgpu_kernel void @s_test_urem23_64_v2i64(ptr addrspace(1) %out, <2 x i6
 ; GCN-NEXT:    s_mov_b32 s3, 0xf000
 ; GCN-NEXT:    s_mov_b32 s2, -1
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_lshr_b32 s6, s13, 1
-; GCN-NEXT:    v_cvt_f32_u32_e32 v0, s6
-; GCN-NEXT:    s_lshr_b32 s4, s15, 9
-; GCN-NEXT:    v_cvt_f32_u32_e32 v1, s4
-; GCN-NEXT:    s_lshr_b32 s5, s11, 9
+; GCN-NEXT:    s_lshr_b32 s4, s13, 1
+; GCN-NEXT:    v_cvt_f32_u32_e32 v0, s4
+; GCN-NEXT:    s_lshr_b32 s5, s15, 9
+; GCN-NEXT:    v_cvt_f32_u32_e32 v1, s5
+; GCN-NEXT:    s_lshr_b32 s6, s11, 9
 ; GCN-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GCN-NEXT:    v_cvt_f32_u32_e32 v2, s5
+; GCN-NEXT:    v_cvt_f32_u32_e32 v2, s6
 ; GCN-NEXT:    v_rcp_iflag_f32_e32 v3, v1
-; GCN-NEXT:    s_sub_i32 s8, 0, s6
+; GCN-NEXT:    s_sub_i32 s8, 0, s4
 ; GCN-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
 ; GCN-NEXT:    v_cvt_u32_f32_e32 v0, v0
 ; GCN-NEXT:    v_mul_f32_e32 v3, v2, v3
@@ -714,20 +714,20 @@ define amdgpu_kernel void @s_test_urem23_64_v2i64(ptr addrspace(1) %out, <2 x i6
 ; GCN-NEXT:    s_lshr_b32 s7, s9, 1
 ; GCN-NEXT:    v_mul_hi_u32 v4, v0, v4
 ; GCN-NEXT:    v_addc_u32_e32 v1, vcc, 0, v3, vcc
-; GCN-NEXT:    v_mul_lo_u32 v1, v1, s4
+; GCN-NEXT:    v_mul_lo_u32 v1, v1, s5
 ; GCN-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
 ; GCN-NEXT:    v_mul_hi_u32 v0, v0, s7
-; GCN-NEXT:    v_sub_i32_e32 v1, vcc, s5, v1
+; GCN-NEXT:    v_sub_i32_e32 v1, vcc, s6, v1
 ; GCN-NEXT:    v_and_b32_e32 v2, 0x7fffff, v1
-; GCN-NEXT:    v_readfirstlane_b32 s4, v0
-; GCN-NEXT:    s_mul_i32 s4, s4, s6
-; GCN-NEXT:    s_sub_i32 s4, s7, s4
-; GCN-NEXT:    s_sub_i32 s5, s4, s6
-; GCN-NEXT:    s_cmp_ge_u32 s4, s6
-; GCN-NEXT:    s_cselect_b32 s4, s5, s4
-; GCN-NEXT:    s_sub_i32 s5, s4, s6
-; GCN-NEXT:    s_cmp_ge_u32 s4, s6
-; GCN-NEXT:    s_cselect_b32 s4, s5, s4
+; GCN-NEXT:    v_readfirstlane_b32 s5, v0
+; GCN-NEXT:    s_mul_i32 s5, s5, s4
+; GCN-NEXT:    s_sub_i32 s5, s7, s5
+; GCN-NEXT:    s_sub_i32 s6, s5, s4
+; GCN-NEXT:    s_cmp_ge_u32 s5, s4
+; GCN-NEXT:    s_cselect_b32 s5, s6, s5
+; GCN-NEXT:    s_sub_i32 s6, s5, s4
+; GCN-NEXT:    s_cmp_ge_u32 s5, s4
+; GCN-NEXT:    s_cselect_b32 s4, s6, s5
 ; GCN-NEXT:    v_mov_b32_e32 v1, 0
 ; GCN-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-NEXT:    v_mov_b32_e32 v3, v1
@@ -741,15 +741,15 @@ define amdgpu_kernel void @s_test_urem23_64_v2i64(ptr addrspace(1) %out, <2 x i6
 ; GCN-IR-NEXT:    s_mov_b32 s3, 0xf000
 ; GCN-IR-NEXT:    s_mov_b32 s2, -1
 ; GCN-IR-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-IR-NEXT:    s_lshr_b32 s6, s13, 1
-; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v0, s6
-; GCN-IR-NEXT:    s_lshr_b32 s4, s15, 9
-; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v1, s4
-; GCN-IR-NEXT:    s_lshr_b32 s5, s11, 9
+; GCN-IR-NEXT:    s_lshr_b32 s4, s13, 1
+; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v0, s4
+; GCN-IR-NEXT:    s_lshr_b32 s5, s15, 9
+; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v1, s5
+; GCN-IR-NEXT:    s_lshr_b32 s6, s11, 9
 ; GCN-IR-NEXT:    v_rcp_iflag_f32_e32 v0, v0
-; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v2, s5
+; GCN-IR-NEXT:    v_cvt_f32_u32_e32 v2, s6
 ; GCN-IR-NEXT:    v_rcp_iflag_f32_e32 v3, v1
-; GCN-IR-NEXT:    s_sub_i32 s8, 0, s6
+; GCN-IR-NEXT:    s_sub_i32 s8, 0, s4
 ; GCN-IR-NEXT:    v_mul_f32_e32 v0, 0x4f7ffffe, v0
 ; GCN-IR-NEXT:    v_cvt_u32_f32_e32 v0, v0
 ; GCN-IR-NEXT:    v_mul_f32_e32 v3, v2, v3
@@ -761,20 +761,20 @@ define amdgpu_kernel void @s_test_urem23_64_v2i64(ptr addrspace(1) %out, <2 x i6
 ; GCN-IR-NEXT:    s_lshr_b32 s7, s9, 1
 ; GCN-IR-NEXT:    v_mul_hi_u32 v4, v0, v4
 ; GCN-IR-NEXT:    v_addc_u32_e32 v1, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    v_mul_lo_u32 v1, v1, s4
+; GCN-IR-NEXT:    v_mul_lo_u32 v1, v1, s5
 ; GCN-IR-NEXT:    v_add_i32_e32 v0, vcc, v0, v4
 ; GCN-IR-NEXT:    v_mul_hi_u32 v0, v0, s7
-; GCN-IR-NEXT:    v_sub_i32_e32 v1, vcc, s5, v1
+; GCN-IR-NEXT:    v_sub_i32_e32 v1, vcc, s6, v1
 ; GCN-IR-NEXT:    v_and_b32_e32 v2, 0x7fffff, v1
-; GCN-IR-NEXT:    v_readfirstlane_b32 s4, v0
-; GCN-IR-NEXT:    s_mul_i32 s4, s4, s6
-; GCN-IR-NEXT:    s_sub_i32 s4, s7, s4
-; GCN-IR-NEXT:    s_sub_i32 s5, s4, s6
-; GCN-IR-NEXT:    s_cmp_ge_u32 s4, s6
-; GCN-IR-NEXT:    s_cselect_b32 s4, s5, s4
-; GCN-IR-NEXT:    s_sub_i32 s5, s4, s6
-; GCN-IR-NEXT:    s_cmp_ge_u32 s4, s6
-; GCN-IR-NEXT:    s_cselect_b32 s4, s5, s4
+; GCN-IR-NEXT:    v_readfirstlane_b32 s5, v0
+; GCN-IR-NEXT:    s_mul_i32 s5, s5, s4
+; GCN-IR-NEXT:    s_sub_i32 s5, s7, s5
+; GCN-IR-NEXT:    s_sub_i32 s6, s5, s4
+; GCN-IR-NEXT:    s_cmp_ge_u32 s5, s4
+; GCN-IR-NEXT:    s_cselect_b32 s5, s6, s5
+; GCN-IR-NEXT:    s_sub_i32 s6, s5, s4
+; GCN-IR-NEXT:    s_cmp_ge_u32 s5, s4
+; GCN-IR-NEXT:    s_cselect_b32 s4, s6, s5
 ; GCN-IR-NEXT:    v_mov_b32_e32 v1, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v0, s4
 ; GCN-IR-NEXT:    v_mov_b32_e32 v3, v1

--- a/llvm/test/CodeGen/AMDGPU/vni8-across-blocks.ll
+++ b/llvm/test/CodeGen/AMDGPU/vni8-across-blocks.ll
@@ -720,9 +720,9 @@ define amdgpu_kernel void @v8i8_multiuse_multiblock(ptr addrspace(1) %src1, ptr 
 ; GFX942-LABEL: v8i8_multiuse_multiblock:
 ; GFX942:       ; %bb.0: ; %entry
 ; GFX942-NEXT:    s_load_dwordx8 s[8:15], s[4:5], 0x24
+; GFX942-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
 ; GFX942-NEXT:    v_and_b32_e32 v2, 0x3ff, v0
 ; GFX942-NEXT:    v_lshlrev_b32_e32 v0, 3, v2
-; GFX942-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x44
 ; GFX942-NEXT:    v_cmp_lt_u32_e64 s[2:3], 14, v2
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-NEXT:    global_load_dwordx2 v[0:1], v0, s[8:9]


### PR DESCRIPTION
Add a `MaxConsumerLatency` parameter to `TargetInstrInfo::shouldClusterMemOps` so targets can scale memory operation cluster budgets based on the latency of data-dependent consumers. The scheduler now computes this by inspecting the successors of the cluster anchor `SUnit` and passes it through.

On AMDGPU, use this to implement two improvements to memory clustering:
- Per-memory-type cluster limits: Instead of a single global DWORD budget, select the cluster limit based on the memory type of the operations being clustered. DS/LDS loads get a deeper budget (16 DWORDs vs the default 8) since they are low-latency and benefit from deeper clusters to pipeline behind long-latency consumers like MFMA.

- Consumer-latency-driven scaling: When consumer latency information is available and exceeds the memory operation latency, dynamically scale the cluster budget to exploit pipelining opportunities. Longer consumer pipelines (e.g. MFMA at 8-16 cycles) allow more loads to execute concurrently behind them.

- These changes eliminate register spills in workloads with interleaved DS loads and MFMA instructions by enabling the scheduler to form deeper load clusters that better hide latency.

- Other targets (AArch64, PowerPC, RISC-V) are updated to accept the new parameter with no behavioral change.


