### PR TITLE
[CODEOWNERS] Cleanup CODEOWNERS for non-AMD specific components

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,70 +11,7 @@
 # See https://llvm.org/docs/DeveloperPolicy.html#maintainers as well as the
 # Maintainers.* files in the the respective subproject directories.
 
-# AMDGPU buffer pointer lowerings
-/llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp @krzysz00
-
-# MLIR Interfaces.
-/mlir/include/mlir/Interfaces/TilingInterface.* @MaheshRavishankar
-/mlir/lib/Interfaces/TilingInterface.* @MaheshRavishankar
-
-# AMDGPU and ROCDL dialects in MLIR.
-/mlir/include/mlir/Dialect/AMDGPU @krzysz00 @kuhar
-/mlir/lib/Dialect/AMDGPU @krzysz00 @kuhar
-/mlir/lib/Conversion/*AMDGPU* @krzysz00 @kuhar
-/mlir/lib/Conversion/*ToROCDL @krzysz00 @kuhar
-/mlir/include/mlir/Dialect/LLVMIR/ROCDL* @krzysz00 @kuhar
-
-# Arith dialect in MLIR.
-/mlir/include/mlir/Dialect/Arith @kuhar
-/mlir/lib/Dialect/Arith @kuhar
-/mlir/lib/Conversion/ArithTo* @kuhar
-
-# Linalg Dialect in MLIR.
-/mlir/lib/Dialect/Linalg/Transforms/DecomposeLinalgOps.cpp @MaheshRavishankar
-/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp @MaheshRavishankar
-/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp @MaheshRavishankar
-/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp @Groverkss
-
-# MemRef Dialect in MLIR.
-/mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp @MaheshRavishankar
-
-# Vector Dialect in MLIR.
-/mlir/include/mlir/Dialect/Vector @Groverkss
-/mlir/include/mlir/Dialect/Vector/IR @kuhar
-/mlir/lib/Dialect/Vector @Groverkss
-/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @MaheshRavishankar
-
-# Presburger library in MLIR
-/mlir/**/*Presburger* @Groverkss
-
-# Transform Dialect in MLIR.
-/mlir/include/mlir/Dialect/Transform/* @ftynse
-/mlir/lib/Dialect/Transform/* @ftynse
-/mlir/**/*TransformOps* @ftynse
-
-# SPIR-V Dialect in MLIR.
-/mlir/**/SPIRV/ @antiagainst @kuhar @IgWod
-/mlir/**/SPIRVTo*/ @antiagainst @kuhar @IgWod
-/mlir/**/*ToSPIRV/ @antiagainst @kuhar @IgWod
-/mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp @antiagainst @kuhar @IgWod
-
-# MLIR Python Bindings
-/mlir/test/python/ @ftynse @stellaraccident
-/mlir/python/ @ftynse @stellaraccident
-
 # AMD-specific projects.
 /amd/comgr/ @lamb-j @chinmaydd
 /amd/device-libs/ @b-sumner @lamb-j
 /amd/hipcc/ @david-salinas @lamb-j
-
-# AMDGPU assembler and disassembler
-/llvm-project/llvm/lib/Target/AMDGPU/AsmParser/AMDGPUAsmParser.cpp @jwanggit86 
-/llvm-project/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp @jwanggit86 
- 
-# Clang Driver
-/clang/lib/Driver/ToolChains/AMDGPU.cpp @lamb-j
-/clang/lib/Driver/OffloadBundler.cpp @lamb-j @david-salinas
-
-# GlobalIsel
-/llvm/lib/Target/AMDGPU/AMDGPURegBankLegalize* @vangthao95

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,53 +11,12 @@
 # See https://llvm.org/docs/DeveloperPolicy.html#maintainers as well as the
 # Maintainers.* files in the the respective subproject directories.
 
-/libcxx/ @llvm/reviewers-libcxx
-/libcxxabi/ @llvm/reviewers-libcxxabi
-/libunwind/ @llvm/reviewers-libunwind
-/runtimes/ @llvm/reviewers-libcxx
-
-/llvm/lib/Analysis/BasicAliasAnalysis.cpp @nikic
-/llvm/lib/Analysis/HashRecognize.cpp @artagnon @pfusik
-/llvm/lib/Analysis/InstructionSimplify.cpp @nikic
-/llvm/lib/Analysis/LazyValueInfo.cpp @nikic
-/llvm/lib/Analysis/ScalarEvolution.cpp @nikic
-/llvm/lib/Analysis/ValueTracking.cpp @nikic
-/llvm/lib/IR/ConstantRange.cpp @nikic
-/llvm/lib/IR/Core.cpp @nikic
-/llvm/lib/Transforms/Scalar/CorrelatedValuePropagation.cpp @nikic
-/llvm/lib/Transforms/Scalar/MemCpyOptimizer.cpp @nikic
-/llvm/lib/Transforms/InstCombine/ @nikic
-
 # AMDGPU buffer pointer lowerings
 /llvm/lib/Target/AMDGPU/AMDGPULowerBufferFatPointers.cpp @krzysz00
 
-/clang/test/CXX/drs/ @Endilll
-/clang/www/cxx_dr_status.html @Endilll
-/clang/www/make_cxx_dr_status @Endilll
-
-/clang/include/clang/CIR @lanza @bcardosolopes @xlauko @andykaylor
-/clang/lib/CIR @lanza @bcardosolopes @xlauko @andykaylor
-/clang/lib/CIR/CodeGen/CIRGenBuiltinAArch64.cpp @lanza @bcardosolopes @xlauko @andykaylor @banach-space
-/clang/tools/cir-* @lanza @bcardosolopes @xlauko @andykaylor
-
-/lldb/ @JDevlieghere
-/lldb/**/*FreeBSD* @mchoo7
-
 # MLIR Interfaces.
-/mlir/include/mlir/Interfaces/TilingInterface.* @MaheshRavishankar @nicolasvasilache
-/mlir/lib/Interfaces/TilingInterface.* @MaheshRavishankar @nicolasvasilache
-/mlir/include/mlir/Interfaces/ValueBoundsOpInterface.* @matthias-springer
-/mlir/lib/Interfaces/ValueBoundsOpInterface.* @matthias-springer
-/mlir/**/ValueBoundsOpInterfaceImpl.* @matthias-springer
-/mlir/include/mlir/Interfaces/RuntimeVerifiableOpInterface.* @matthias-springer
-/mlir/lib/Interfaces/RuntimeVerifiableOpInterface.* @matthias-springer
-/mlir/**/RuntimeVerifiableOpInterfaceImpl.* @matthias-springer
-/mlir/include/mlir/Interfaces/SubsetOpInterface.* @matthias-springer
-/mlir/lib/Interfaces/SubsetOpInterface.* @matthias-springer
-/mlir/**/SubsetOpInterfaceImpl.* @matthias-springer
-/mlir/include/mlir/Interfaces/DestinationStyleOpInterface.* @matthias-springer
-/mlir/lib/Interfaces/DestinationStyleOpInterface.* @matthias-springer
-/mlir/**/Interfaces/ControlFlowInterfaces.* @matthias-springer
+/mlir/include/mlir/Interfaces/TilingInterface.* @MaheshRavishankar
+/mlir/lib/Interfaces/TilingInterface.* @MaheshRavishankar
 
 # AMDGPU and ROCDL dialects in MLIR.
 /mlir/include/mlir/Dialect/AMDGPU @krzysz00 @kuhar
@@ -71,68 +30,28 @@
 /mlir/lib/Dialect/Arith @kuhar
 /mlir/lib/Conversion/ArithTo* @kuhar
 
-# XeGPU and XeVM dialects in MLIR.
-/mlir/include/mlir/Dialect/XeGPU @charithaintc @Jianhui-Li
-/mlir/lib/Dialect/XeGPU @charithaintc @Jianhui-Li
-/mlir/lib/Conversion/*XeGPU* @charithaintc @Jianhui-Li
-/mlir/include/mlir/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li
-/mlir/lib/Dialect/XeGPU/Transforms @charithaintc @Jianhui-Li
-/mlir/include/mlir/Dialect/XeGPU/TransformOps @charithaintc @Jianhui-Li @tkarna
-/mlir/lib/Dialect/XeGPU/TransformOps @charithaintc @Jianhui-Li @tkarna
-/mlir/include/mlir/Dialect/LLVMIR/XeVM* @silee2
-/mlir/lib/Dialect/LLVMIR/IR/XeVM @silee2
-/mlir/lib/Conversion/*XeVM* @silee2
-
-# Bufferization Dialect in MLIR.
-/mlir/include/mlir/Dialect/Bufferization @matthias-springer
-/mlir/lib/Dialect/Bufferization @matthias-springer
-/mlir/**/BufferizableOpInterfaceImpl.* @matthias-springer
-/mlir/Dialect/*/Transforms/Bufferize.cpp @matthias-springer
-
-# DLTI Dialect in MLIR
-/mlir/**/Dialect/DLTI @rolfmorel
-/mlir/**/DataLayoutInterfaces.* @rolfmorel
-
 # Linalg Dialect in MLIR.
-/mlir/include/mlir/Dialect/Linalg @dcaballe @nicolasvasilache @rengolin
-/mlir/lib/Dialect/Linalg @dcaballe @nicolasvasilache @rengolin
-/mlir/lib/Dialect/Linalg/Transforms/DecomposeLinalgOps.cpp @MaheshRavishankar @nicolasvasilache
-/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp @dcaballe @MaheshRavishankar @nicolasvasilache
-/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp @MaheshRavishankar @nicolasvasilache
-/mlir/lib/Dialect/Linalg/Transforms/DataLayoutPropagation.cpp @nicolasvasilache
-/mlir/lib/Dialect/Linalg/Transforms/Transforms.cpp @dcaballe @nicolasvasilache
-/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp @banach-space @dcaballe @nicolasvasilache @Groverkss
+/mlir/lib/Dialect/Linalg/Transforms/DecomposeLinalgOps.cpp @MaheshRavishankar
+/mlir/lib/Dialect/Linalg/Transforms/DropUnitDims.cpp @MaheshRavishankar
+/mlir/lib/Dialect/Linalg/Transforms/ElementwiseOpFusion.cpp @MaheshRavishankar
+/mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp @Groverkss
 
 # MemRef Dialect in MLIR.
 /mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp @MaheshRavishankar @nicolasvasilache
 
 # Vector Dialect in MLIR.
-/mlir/**/*AMX* @aartbik @dcaballe
-/mlir/**/*Neon* @banach-space @dcaballe @nicolasvasilache
-/mlir/**/*SME* @banach-space @dcaballe @nicolasvasilache
-/mlir/**/*SVE* @banach-space @dcaballe @nicolasvasilache
-/mlir/**/*VectorInterfaces* @dcaballe @nicolasvasilache
-/mlir/**/*VectorToSCF* @banach-space @dcaballe @matthias-springer @nicolasvasilache
-/mlir/**/*VectorToLLVM* @banach-space @dcaballe @nicolasvasilache
-/mlir/**/*X86Vector* @aartbik @dcaballe @nicolasvasilache
-/mlir/include/mlir/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
+/mlir/include/mlir/Dialect/Vector @Groverkss
 /mlir/include/mlir/Dialect/Vector/IR @kuhar
-/mlir/lib/Dialect/Vector @banach-space @dcaballe @nicolasvasilache @Groverkss
-/mlir/lib/Dialect/Vector/Transforms/* @banach-space @dcaballe @nicolasvasilache
-/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @banach-space @dcaballe @MaheshRavishankar @nicolasvasilache
-/mlir/**/*EmulateNarrowType* @dcaballe
+/mlir/lib/Dialect/Vector @Groverkss
+/mlir/lib/Dialect/Vector/Transforms/VectorEmulateNarrowType.cpp @MaheshRavishankar
 
 # Presburger library in MLIR
-/mlir/**/*Presburger* @Groverkss @Superty
-
-# Tensor Dialect in MLIR.
-/mlir/lib/Dialect/Tensor/IR/TensorTilingInterfaceImpl.cpp @nicolasvasilache
-/mlir/lib/Dialect/Tensor/Transforms/* @nicolasvasilache
+/mlir/**/*Presburger* @Groverkss
 
 # Transform Dialect in MLIR.
-/mlir/include/mlir/Dialect/Transform/* @ftynse @nicolasvasilache @rolfmorel
-/mlir/lib/Dialect/Transform/* @ftynse @nicolasvasilache @rolfmorel
-/mlir/**/*TransformOps* @ftynse @nicolasvasilache @rolfmorel
+/mlir/include/mlir/Dialect/Transform/* @ftynse
+/mlir/lib/Dialect/Transform/* @ftynse
+/mlir/**/*TransformOps* @ftynse
 
 # SPIR-V Dialect in MLIR.
 /mlir/**/SPIRV/ @antiagainst @kuhar @IgWod
@@ -140,57 +59,9 @@
 /mlir/**/*ToSPIRV/ @antiagainst @kuhar @IgWod
 /mlir/tools/mlir-tblgen/SPIRVUtilsGen.cpp @antiagainst @kuhar @IgWod
 
-# MLIR Sparsifier.
-/mlir/**/*SparseTensor*/ @aartbik @PeimingLiu @yinying-lisa-li @matthias-springer
-
-# MLIR NVGPU Dialect
-/mlir/**/NVGPU*/ @grypp
-/mlir/test/**/CUDA/ @grypp
-
-# MLIR GPU Dialect
-/mlir/**/GPU*/ @fabianmcg
-
-# MLIR NVVM Dialect in MLIR
-/mlir/**/LLVMIR/**/BasicPtxBuilderInterface* @grypp
-/mlir/**/NVVM* @grypp
-
-# MLIR Index Dialect
-/mlir/**/Index* @mogball
-
 # MLIR Python Bindings
-/mlir/test/python/ @ftynse @makslevental @stellaraccident @rolfmorel
-/mlir/python/ @ftynse @makslevental @stellaraccident @rolfmorel
-/mlir/lib/Bindings/Python @makslevental @rolfmorel
-/mlir/include/Bindings/Python @makslevental @rolfmorel
-
-# MLIR Mem2Reg/SROA
-/mlir/**/Transforms/Mem2Reg.* @moxinilian
-/mlir/**/Transforms/SROA.* @moxinilian
-
-# MLIR IRDL-related
-/mlir/**/*IRDL* @moxinilian
-
-# BOLT
-/bolt/ @aaupov @maksfb @rafaelauler @ayermolo @yota9 @paschalis-mpeis @yozhu @yavtuk
-
-# Bazel build system.
-/utils/bazel/ @rupprecht @keith @aaronmondal
-
-# InstallAPI and TextAPI
-/llvm/**/TextAPI/ @cyndyishida
-/clang/**/InstallAPI/ @cyndyishida
-/clang/tools/clang-installapi/ @cyndyishida
-
-# ExtractAPI
-/clang/**/ExtractAPI @QuietMisdreavus @snprajwal
-
-# DWARFLinker, dwarfutil, dsymutil
-/llvm/**/DWARFLinker/ @JDevlieghere
-/llvm/**/dsymutil/ @JDevlieghere
-/llvm/**/llvm-dwarfutil/ @JDevlieghere
-
-# libclang/Python bindings
-/clang/bindings/python @DeinAlptraum
+/mlir/test/python/ @ftynse @stellaraccident
+/mlir/python/ @ftynse @stellaraccident
 
 # AMD-specific projects.
 /amd/comgr/ @lamb-j @chinmaydd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@
 /mlir/lib/Dialect/Linalg/Transforms/Vectorization.cpp @Groverkss
 
 # MemRef Dialect in MLIR.
-/mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp @MaheshRavishankar @nicolasvasilache
+/mlir/lib/Dialect/MemRef/Transforms/EmulateNarrowType.cpp @MaheshRavishankar
 
 # Vector Dialect in MLIR.
 /mlir/include/mlir/Dialect/Vector @Groverkss


### PR DESCRIPTION
Updates to llvm components generated for merges often sends notifications to upstream (non-AMD) codeowners. This should be avoided as part of our fork.