### PR TITLE
[ocml] Route log(float) through the lnep polynomial path (3 ULP → 2 ULP expected)

### DIFF
--- a/amd/device-libs/ocml/src/logF.cl
+++ b/amd/device-libs/ocml/src/logF.cl
@@ -7,7 +7,21 @@
 
 #include "mathF.h"
 
+#define FLOAT_SPECIALIZATION
+#include "ep.h"
+
+extern CONSTATTR float MATH_PRIVATE(lnep)(float2 a, int ea);
+
 CONSTATTR float
-MATH_MANGLE(log)(float x) {
-    return BUILTIN_LOG_F32(x);
+MATH_MANGLE(log)(float x)
+{
+    float z = MATH_PRIVATE(lnep)(con(x, 0.0f), 0);
+
+    if (!FINITE_ONLY_OPT()) {
+        z = BUILTIN_ISINF_F32(x) ? x : z;
+        z = x < 0.0f ? QNAN_F32 : z;
+        z = x == 0.0f ? NINF_F32 : z;
+    }
+
+    return z;
 }

--- a/amd/device-libs/test/compile/CMakeLists.txt
+++ b/amd/device-libs/test/compile/CMakeLists.txt
@@ -100,6 +100,10 @@ foreach(gpu gfx600 gfx700 gfx803)
   add_isa_test(native_rsqrt ${gpu})
   add_isa_test(native_log ${gpu})
   add_isa_test(native_exp ${gpu})
+  # Verify __ocml_log_f32 compiles through the polynomial extended-
+  # precision path (MATH_PRIVATE(lnep)) rather than the hardware
+  # v_log_f32 primitive that native_log uses.
+  add_isa_test(log ${gpu})
 endforeach()
 
 foreach(gpu gfx803 gfx900 gfx90a gfx1030 gfx1100 gfx1200)

--- a/amd/device-libs/test/compile/log.cl
+++ b/amd/device-libs/test/compile/log.cl
@@ -1,0 +1,22 @@
+
+// Verify that ocml's log(float) is lowered through the extended-precision
+// polynomial path (via MATH_PRIVATE(lnep)) rather than the hardware
+// v_log_f32 primitive. The native path is available separately via
+// __ocml_native_log_f32 (see test/compile/native_log.cl).
+
+// CHECK-LABEL: {{^}}test_log_f32:
+
+// The polynomial path starts with frexp to split mantissa/exponent.
+// CHECK: v_frexp_mant_f32
+
+// The polynomial evaluation is a sequence of fmas.
+// CHECK: v_fma_f32
+
+// The primary log hardware instruction must NOT appear in the generated
+// ISA — that would mean ocml_log has regressed back to the fast path
+// that matches __ocml_native_log_f32.
+// CHECK-NOT: v_log_f32
+
+float test_log_f32(float arg) {
+    return log(arg);
+}


### PR DESCRIPTION
## Summary

`__ocml_log_f32` currently reduces to `__builtin_logf`, which lowers to the hardware `v_log_f32 * ln(2)` sequence — the same code path taken by `__ocml_native_log_f32`. OCML's own documentation ([`amd/device-libs/doc/OCML.md`](../blob/amd-staging/amd/device-libs/doc/OCML.md)) lists this at **3 ULP** for f32, which is 2 ULPs looser than the 1-ULP budget XLA and other consumers expect by default from a non-`native_` log function.

This PR routes `__ocml_log_f32` through `MATH_PRIVATE(lnep)` — the extended-precision polynomial kernel that `__ocml_log1p_f32` already uses, and which is structurally equivalent to the `logD_base.h` approach for f64. OCML docs list `log1p` f32 at **2 ULP**, so this change should bring `log` f32 in line with `log1p` f32 at a minimum (3 → 2 ULP), possibly closer to 1 ULP if `lnep`'s actual bound is tighter than documented.

The fast hardware path remains available via `__ocml_native_log_f32` (unchanged). Callers who explicitly want the fast approximation keep it; callers who call `log` get the accurate version without any source change.

## Before / after

**Before** (`ocml/src/logF.cl`):

```c
CONSTATTR float
MATH_MANGLE(log)(float x) {
    return BUILTIN_LOG_F32(x);
}
```

`BUILTIN_LOG_F32` is `__builtin_logf`, which clang lowers to `llvm.log.f32` → AMDGPU backend emits `v_log_f32` followed by a `v_mul_f32` with `ln(2)`. Identical ISA to `__ocml_native_log_f32`.

**After**:

```c
extern CONSTATTR float MATH_PRIVATE(lnep)(float2 a, int ea);

CONSTATTR float
MATH_MANGLE(log)(float x)
{
    float z = MATH_PRIVATE(lnep)(con(x, 0.0f), 0);

    if (!FINITE_ONLY_OPT()) {
        z = BUILTIN_ISINF_F32(x) ? x : z;
        z = x < 0.0f ? QNAN_F32 : z;
        z = x == 0.0f ? NINF_F32 : z;
    }

    return z;
}
```

Matches the structure of `log1pF.cl` exactly, with special-value handling adapted from `logD_base.h`.

## Test coverage

Added `test/compile/log.cl` as a FileCheck ISA test:

```c
// CHECK-LABEL: {{^}}test_log_f32:
// CHECK: v_frexp_mant_f32
// CHECK: v_fma_f32
// CHECK-NOT: v_log_f32
float test_log_f32(float arg) { return log(arg); }
```

This asserts the new implementation:
1. Starts with `v_frexp_mant_f32` (the entry point of `lnep`'s mantissa/exponent split)
2. Contains at least one `v_fma_f32` (polynomial evaluation)
3. Does NOT contain `v_log_f32` anywhere — the whole point of the PR is that we've moved off that instruction, and this is a regression guard

Registered for `gfx600`, `gfx700`, and `gfx803` alongside the existing `native_*` tests in `test/compile/CMakeLists.txt`.

## Scope

- **In scope:** `ocml/src/logF.cl` + test + CMakeLists registration.
- **Explicitly out of scope:** `log2F.cl`, `log10F.cl`, and the OCML.md docs table. They share the same fast-hardware-shortcut pattern and would benefit from the same treatment (`log2 = lnep / ln(2)`, `log10 = lnep / ln(10)`), but doing them together would expand review surface. I'd rather land this one narrowly first and file a follow-up once a maintainer is comfortable with the approach. The docs table should also be updated in a follow-up once AMD's accuracy CI confirms the new bound.
- **Not touched:** native\_log, native\_log2, native\_log10 (`native_logF.cl`) — those remain the fast-hardware path, unchanged.

## Verification requested

**I do not have access to an AMD GPU** and therefore cannot run OCML's numerical accuracy test suite against this change. What I can verify:

- ✅ The compile test asserts the ISA takes the polynomial path (no `v_log_f32`, uses `v_frexp_mant_f32` + `v_fma_f32`).
- ✅ The source structurally mirrors existing patterns in the same codebase (`log1pF.cl`, `logD_base.h`).
- ✅ Special-value handling mirrors `logD_base.h`'s f64 variant exactly.
- ❌ **I cannot confirm the numerical ULP bound.** The OCML docs list log1p f32 at 2 ULP, and `lnep` is what log1p uses, so the expectation is log f32 drops from 3 ULP → 2 ULP. But this needs to be run against your internal accuracy test suite before merging.

If the numerical sweep shows:
- **≤ 2 ULP** (matching log1p): merge as-is; optionally update OCML.md table in a follow-up.
- **= 3 ULP** (no improvement): something unexpected in how `lnep` handles `con(x, 0.0f)` vs `add(1.0f, x-1.0f)`; needs a small adjustment — happy to revise.
- **> 3 ULP** (regression): revert; I missed something.

Marking as **draft** until numerical verification can happen.

## Motivation

This gap was identified during an accuracy audit of XLA's `accuracy_budget.h`. That header has this override:

```cpp
constexpr AccuracyBudget kLogF32Budget = {
    /*cpu=*/{/*regular=*/1, /*subnormal=*/0},
    /*gpu=*/{/*regular=*/1, /*subnormal=*/0},
    /*rocm_gpu=*/UlpBudget{/*regular=*/3, /*subnormal=*/0},  // ← this one
};
```

Making ROCm the only backend where the f32 log budget is 2 ULPs looser than parity. After this change, that override should be unnecessary.

Related audit context:
- openxla/xla#40844 (f64 rsqrt CPU precision fix)
- openxla/xla#40862 (f64 rsqrt GPU budget audit, Blackwell)
