### PR TITLE
[AMDGPU] comgr: add HotSwap B0-to-A0 ISA rewriting infrastructure

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -66,6 +66,12 @@ endif()
 option(COMGR_BUILD_SHARED_LIBS "Build the shared library"
        ${build_shared_libs_default})
 
+set(HOTSWAP_SOURCES
+  src/comgr-hotswap.cpp
+  src/comgr-hotswap-b0a0.cpp
+  src/comgr-hotswap-elf.cpp
+  src/comgr-hotswap-llvm.cpp)
+
 set(SOURCES
   src/comgr-cache.cpp
   src/comgr-cache-command.cpp
@@ -76,10 +82,6 @@ set(SOURCES
   src/comgr-diagnostic-handler.cpp
   src/comgr-disassembly.cpp
   src/comgr-env.cpp
-  src/comgr-hotswap.cpp
-  src/comgr-hotswap-b0a0.cpp
-  src/comgr-hotswap-elf.cpp
-  src/comgr-hotswap-llvm.cpp
   src/comgr-libcxx-headers.cpp
   src/comgr-metadata.cpp
   src/comgr-signal.cpp
@@ -87,7 +89,8 @@ set(SOURCES
   src/comgr-symbol.cpp
   src/comgr-symbolizer.cpp
   src/comgr-unbundle-command.cpp
-  src/time-stat/time-stat.cpp)
+  src/time-stat/time-stat.cpp
+  ${HOTSWAP_SOURCES})
 
 # Add Windows resource file for version info
 if(WIN32)
@@ -561,6 +564,27 @@ if(BUILD_TESTING)
   endif()
   add_subdirectory(test)
   add_subdirectory(test-lit)
+
+  if(TARGET llvm_gtest)
+    add_library(comgr_hotswap_obj OBJECT ${HOTSWAP_SOURCES})
+    set_target_properties(comgr_hotswap_obj PROPERTIES
+      CXX_STANDARD 17
+      CXX_STANDARD_REQUIRED Yes
+      CXX_EXTENSIONS No
+      POSITION_INDEPENDENT_CODE ON)
+    target_include_directories(comgr_hotswap_obj PRIVATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/src
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
+    if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+      target_include_directories(comgr_hotswap_obj PRIVATE
+        ${LLVM_INCLUDE_DIRS} ${CLANG_INCLUDE_DIRS} ${LLD_INCLUDE_DIRS})
+    endif()
+    target_compile_options(comgr_hotswap_obj
+      PRIVATE "${AMD_COMGR_PRIVATE_COMPILE_OPTIONS}")
+    target_compile_definitions(comgr_hotswap_obj
+      PRIVATE "${AMD_COMGR_PRIVATE_COMPILE_DEFINITIONS}")
+    add_subdirectory(unittests)
+  endif()
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -77,6 +77,9 @@ set(SOURCES
   src/comgr-disassembly.cpp
   src/comgr-env.cpp
   src/comgr-hotswap.cpp
+  src/comgr-hotswap-b0a0.cpp
+  src/comgr-hotswap-elf.cpp
+  src/comgr-hotswap-llvm.cpp
   src/comgr-libcxx-headers.cpp
   src/comgr-metadata.cpp
   src/comgr-signal.cpp

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -168,7 +168,9 @@ endif()
 
 target_include_directories(amd_comgr
   PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  ${CMAKE_CURRENT_SOURCE_DIR}/src
+  ${LLVM_MAIN_SRC_DIR}/lib/Target/AMDGPU
+  ${LLVM_BINARY_DIR}/lib/Target/AMDGPU)
 
 message("")
 message("------------LLVM_DIR: ${LLVM_DIR}")
@@ -574,6 +576,8 @@ if(BUILD_TESTING)
       POSITION_INDEPENDENT_CODE ON)
     target_include_directories(comgr_hotswap_obj PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/src
+      ${LLVM_MAIN_SRC_DIR}/lib/Target/AMDGPU
+      ${LLVM_BINARY_DIR}/lib/Target/AMDGPU
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
     if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       target_include_directories(comgr_hotswap_obj PRIVATE

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -168,9 +168,7 @@ endif()
 
 target_include_directories(amd_comgr
   PRIVATE
-  ${CMAKE_CURRENT_SOURCE_DIR}/src
-  ${LLVM_MAIN_SRC_DIR}/lib/Target/AMDGPU
-  ${LLVM_BINARY_DIR}/lib/Target/AMDGPU)
+  ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 message("")
 message("------------LLVM_DIR: ${LLVM_DIR}")
@@ -576,8 +574,6 @@ if(BUILD_TESTING)
       POSITION_INDEPENDENT_CODE ON)
     target_include_directories(comgr_hotswap_obj PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/src
-      ${LLVM_MAIN_SRC_DIR}/lib/Target/AMDGPU
-      ${LLVM_BINARY_DIR}/lib/Target/AMDGPU
       $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
     if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
       target_include_directories(comgr_hotswap_obj PRIVATE

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -266,7 +266,7 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
     MallocBuffer copy(elf_size);
     if (!copy)
       return AMD_COMGR_STATUS_ERROR;
-    std::memcpy(copy.data, elf_data, elf_size);
+    std::memcpy(copy.get(), elf_data, elf_size);
     *out_size = elf_size;
     *out_data = copy.release();
     return AMD_COMGR_STATUS_SUCCESS;
@@ -330,11 +330,11 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
                               elf_info.text_section_idx))
       HotswapLog(HotswapLogLevel::Error)
           << "hotswap: WARNING: AddTrampolineSymbols failed\n";
-    PatchDebugRanges(new_buf.data, new_buf.size, elf_info.text_addr,
+    PatchDebugRanges(new_buf.get(), new_buf.size, elf_info.text_addr,
                      elf_info.text_size, tramp_total);
-    PatchDebugInfo(new_buf.data, new_buf.size, elf_info.text_addr,
+    PatchDebugInfo(new_buf.get(), new_buf.size, elf_info.text_addr,
                    elf_info.text_size, tramp_total);
-    PatchDebugFrame(new_buf.data, new_buf.size, elf_info.text_addr,
+    PatchDebugFrame(new_buf.get(), new_buf.size, elf_info.text_addr,
                     elf_info.text_size, tramp_total);
     if (!PatchDebugLine(new_buf, deferred, elf_info.text_size,
                         elf_info.text_addr))
@@ -347,7 +347,7 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
     MallocBuffer out(elf_size);
     if (!out)
       return AMD_COMGR_STATUS_ERROR;
-    std::memcpy(out.data, buf.data(), elf_size);
+    std::memcpy(out.get(), buf.data(), elf_size);
     *out_data = out.release();
     *out_size = elf_size;
   }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1,0 +1,369 @@
+//===- comgr-hotswap-b0a0.cpp - GFX1250 B0-to-A0 patch dispatcher --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Dispatcher for B0-to-A0 silicon stepping patches and the
+/// RetargetCodeObjectB0A0 orchestrator that drives the full pipeline:
+/// decode → patch → trampoline growth → DWARF update.
+///
+/// Patch entry points are declared as weak symbols returning 0. Each
+/// comgr-hotswap-patch-*.cpp file provides a strong override, allowing
+/// patches to land as independent PRs with no merge conflicts.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+// ── Weak-symbol patch stubs ──────────────────────────────────────────────────
+//
+// The linker picks strong definitions from patch .cpp files when present;
+// otherwise these no-op stubs keep the build green.
+
+__attribute__((weak)) uint32_t ApplyInPlacePatches(PatchContext &, size_t) {
+  return 0;
+}
+__attribute__((weak)) uint32_t ApplyTrampolinePatches(PatchContext &, size_t) {
+  return 0;
+}
+__attribute__((weak)) uint32_t ApplyWmmaHazardPatch(PatchContext &) {
+  return 0;
+}
+__attribute__((weak)) uint32_t ApplyWmmaSplitPatches(PatchContext &, size_t) {
+  return 0;
+}
+__attribute__((weak)) uint32_t ApplyScratchPatches(PatchContext &, size_t) {
+  return 0;
+}
+
+// ── Weak-symbol liveness stubs ───────────────────────────────────────────────
+//
+// Conservative defaults: all 256 VGPRs reported live. ScratchAllocator
+// will allocate above KD count (correct but suboptimal until
+// comgr-hotswap-liveness.cpp lands with real analysis).
+
+__attribute__((weak)) CFG
+BuildCFG(const std::vector<InternalDecodedInst> &decoded,
+         const llvm::MCInstrInfo &) {
+  (void)decoded;
+  return CFG{};
+}
+
+__attribute__((weak)) LivenessInfo
+ComputeLiveness(const std::vector<InternalDecodedInst> &decoded,
+                const CFG &, const llvm::MCInstrInfo &,
+                const llvm::MCRegisterInfo &) {
+  LivenessInfo info;
+  llvm::BitVector all_live(256);
+  all_live.set(0, 256);
+  info.live_before.resize(decoded.size(), all_live);
+  info.live_after.resize(decoded.size(), all_live);
+  info.converged = true;
+  return info;
+}
+
+__attribute__((weak)) RegDefUse
+GetInstRegDefUse(const llvm::MCInst &, const llvm::MCInstrInfo &,
+                 const llvm::MCRegisterInfo &) {
+  return {};
+}
+
+__attribute__((weak)) int64_t GetBranchImm(const llvm::MCInst &) { return 0; }
+
+__attribute__((weak)) bool
+VerifyPatchCorrectness(const uint8_t *, uint64_t, const LLVMState &,
+                       const std::vector<ScratchPatchInfo> &) {
+  return true;
+}
+
+// ── Weak-symbol DWARF stubs ──────────────────────────────────────────────────
+
+__attribute__((weak)) uint8_t *FindSectionHeader(uint8_t *, size_t,
+                                                 const char *, int *) {
+  return nullptr;
+}
+__attribute__((weak)) bool
+AddTrampolineSymbols(MallocBuffer &, const std::vector<Trampoline> &,
+                     uint64_t, int) {
+  return true;
+}
+__attribute__((weak)) bool
+PatchDebugLine(MallocBuffer &, const std::vector<Trampoline> &, uint64_t,
+               uint64_t) {
+  return true;
+}
+__attribute__((weak)) void PatchDebugRanges(uint8_t *, size_t, uint64_t,
+                                            uint64_t, uint64_t) {}
+__attribute__((weak)) void PatchDebugInfo(uint8_t *, size_t, uint64_t,
+                                          uint64_t, uint64_t) {}
+__attribute__((weak)) void PatchDebugFrame(uint8_t *, size_t, uint64_t,
+                                           uint64_t, uint64_t) {}
+
+// ── NOP sled scanning ────────────────────────────────────────────────────────
+
+static std::vector<NopSled>
+BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded,
+                const llvm::MCInstrInfo &MCII) {
+  std::vector<NopSled> sleds;
+  size_t i = 0;
+  while (i < decoded.size()) {
+    if (decoded[i].mnemonic == "s_nop") {
+      uint64_t start = decoded[i].offset;
+      uint64_t end = start;
+      while (i < decoded.size() && decoded[i].mnemonic == "s_nop") {
+        end = decoded[i].offset + decoded[i].size;
+        ++i;
+      }
+      if (end - start >= 8)
+        sleds.push_back({start, end, start});
+    } else {
+      ++i;
+    }
+  }
+  return sleds;
+}
+
+// ── Sled-or-trampoline code emission ─────────────────────────────────────────
+
+[[nodiscard]] static bool EmitReplacementCode(
+    PatchContext &ctx, uint64_t inst_offset, uint32_t inst_size,
+    const std::vector<uint8_t> &replacement, const char *desc = nullptr) {
+  uint64_t needed = replacement.size() + 4;
+  NopSled *sled = FindNearestSled(ctx.nop_sleds, inst_offset, needed);
+
+  if (sled && replacement.size() + 4 <= sled->end - sled->write_pos) {
+    std::memcpy(ctx.text + sled->write_pos, replacement.data(),
+                replacement.size());
+    uint8_t br_back[4];
+    if (!EncodeSBranch(sled->write_pos + replacement.size(),
+                       inst_offset + inst_size, br_back, true))
+      return false;
+    std::memcpy(ctx.text + sled->write_pos + replacement.size(), br_back, 4);
+
+    uint8_t br_fwd[4];
+    if (!EncodeSBranch(inst_offset, sled->write_pos, br_fwd, true))
+      return false;
+    std::memcpy(ctx.text + inst_offset, br_fwd, 4);
+    for (uint32_t i = 4; i < inst_size; i += 4) {
+      uint8_t nop[4];
+      EncodeSNop(nop);
+      std::memcpy(ctx.text + inst_offset + i, nop, 4);
+    }
+    sled->write_pos += replacement.size() + 4;
+    return true;
+  }
+
+  uint64_t tramp_offset = ctx.text_size;
+  for (auto &t : ctx.out_trampolines)
+    tramp_offset += t.bytes.size();
+
+  Trampoline t;
+  t.original_offset = inst_offset;
+  t.original_size = inst_size;
+  t.bytes.insert(t.bytes.end(), replacement.begin(), replacement.end());
+
+  uint8_t br_back[4];
+  if (!EncodeSBranch(tramp_offset + t.bytes.size(), inst_offset + inst_size,
+                     br_back, true))
+    return false;
+  t.bytes.insert(t.bytes.end(), br_back, br_back + 4);
+
+  ctx.out_trampolines.push_back(std::move(t));
+  return true;
+}
+
+// ── ApplyGfx1250B0toA0Rules ──────────────────────────────────────────────────
+
+static uint32_t
+ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
+                        uint8_t *text, uint64_t text_size,
+                        const LLVMState &llvm_state,
+                        std::vector<Trampoline> &out_trampolines,
+                        uint8_t *elf_data, size_t elf_size,
+                        const ElfInfo &elf_info,
+                        std::vector<ScratchPatchInfo> &out_scratch_patches) {
+  uint32_t patched = 0;
+  std::vector<NopSled> nop_sleds = BuildNopSledMap(decoded, *llvm_state.MCII);
+
+  CFG cfg = BuildCFG(decoded, *llvm_state.MCII);
+  LivenessInfo liveness =
+      ComputeLiveness(decoded, cfg, *llvm_state.MCII, *llvm_state.MRI);
+
+  if (!liveness.converged) {
+    HotswapLog(HotswapLogLevel::Error)
+        << "hotswap: WARNING: liveness analysis did not converge, "
+           "using conservative all-VGPRs-live fallback\n";
+    llvm::BitVector all_vgprs(256);
+    all_vgprs.set(0, 256);
+    for (size_t i = 0; i < liveness.live_before.size(); ++i) {
+      liveness.live_before[i] = all_vgprs;
+      liveness.live_after[i] = all_vgprs;
+    }
+  }
+
+  std::unordered_map<std::string, KernelPatchStats> kernel_stats;
+
+  PatchContext ctx{decoded,     text,
+                   text_size,   llvm_state,
+                   out_trampolines, nop_sleds,
+                   elf_data,    elf_size,
+                   elf_info,    liveness,
+                   kernel_stats, out_scratch_patches};
+
+  for (size_t idx = 0; idx < decoded.size(); ++idx) {
+    auto &di = decoded[idx];
+    if (di.mnemonic == "<unknown>" || di.mnemonic == "<replaced>")
+      continue;
+
+    uint32_t p = 0;
+    p += ApplyInPlacePatches(ctx, idx);
+    if (p) { patched += p; continue; }
+    p += ApplyTrampolinePatches(ctx, idx);
+    if (p) { patched += p; continue; }
+    p += ApplyWmmaSplitPatches(ctx, idx);
+    if (p) { patched += p; continue; }
+    p += ApplyScratchPatches(ctx, idx);
+    if (p) { patched += p; continue; }
+  }
+
+  patched += ApplyWmmaHazardPatch(ctx);
+
+  for (const auto &kv : kernel_stats) {
+    const std::string &kname = kv.first;
+    const auto &stats = kv.second;
+    if (kname.empty())
+      continue;
+    int vgprs_before =
+        GetKernelVgprCount(elf_data, elf_size, elf_info, kname);
+    if (stats.extra_vgprs > 0)
+      UpdateKernelDescriptor(elf_data, elf_size, elf_info, kname,
+                             stats.extra_vgprs, 0);
+    int vgprs_after =
+        GetKernelVgprCount(elf_data, elf_size, elf_info, kname);
+    HotswapLog(HotswapLogLevel::Info)
+        << "hotswap: liveness: kernel " << kname
+        << ": vgprs_before=" << vgprs_before
+        << ", vgprs_after=" << vgprs_after
+        << ", scratch_reused=" << stats.scratch_reused
+        << ", scratch_above_kd=" << stats.scratch_above_kd << "\n";
+  }
+
+  return patched;
+}
+
+// ── RetargetCodeObjectB0A0 ───────────────────────────────────────────────────
+
+amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
+                                          size_t elf_size, void **out_data,
+                                          size_t *out_size) {
+  const std::string isa = "amdgcn-amd-amdhsa--gfx1250";
+
+  ElfInfo elf_info;
+  const uint8_t *elf = static_cast<const uint8_t *>(elf_data);
+  if (!ParseElfInfo(elf, elf_size, elf_info) || elf_info.text_size == 0) {
+    MallocBuffer copy(elf_size);
+    if (!copy)
+      return AMD_COMGR_STATUS_ERROR;
+    std::memcpy(copy.data, elf_data, elf_size);
+    *out_size = elf_size;
+    *out_data = copy.release();
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
+
+  LLVMState llvm_state = InitLLVMCached(isa);
+  if (!llvm_state.valid)
+    return AMD_COMGR_STATUS_ERROR;
+
+  std::vector<uint8_t> buf(elf, elf + elf_size);
+  uint8_t *text = buf.data() + elf_info.text_offset;
+
+  std::vector<InternalDecodedInst> decoded;
+  if (!DecodeTextSection(text, elf_info.text_size, llvm_state, decoded))
+    return AMD_COMGR_STATUS_ERROR;
+
+  std::vector<Trampoline> deferred;
+  std::vector<ScratchPatchInfo> scratch_patches;
+  uint32_t count =
+      ApplyGfx1250B0toA0Rules(decoded, text, elf_info.text_size, llvm_state,
+                              deferred, buf.data(), buf.size(), elf_info,
+                              scratch_patches);
+
+  HotswapLog(HotswapLogLevel::Info)
+      << "hotswap: applied " << count << " B0-to-A0 patches\n";
+
+  if (!deferred.empty()) {
+    uint64_t tramp_text_offset = elf_info.text_size;
+    for (auto &t : deferred) {
+      uint64_t tp = tramp_text_offset;
+      tramp_text_offset += t.bytes.size();
+
+      uint8_t br_back[4];
+      uint64_t br_from = tp + t.bytes.size() - 4;
+      uint64_t br_to = t.original_offset + t.original_size;
+      if (!EncodeSBranch(br_from, br_to, br_back, true))
+        continue;
+      std::memcpy(t.bytes.data() + t.bytes.size() - 4, br_back, 4);
+
+      uint8_t br_fwd[4];
+      if (!EncodeSBranch(t.original_offset, tp, br_fwd, true))
+        continue;
+      std::memcpy(text + t.original_offset, br_fwd, 4);
+      for (uint32_t i = 4; i < t.original_size; i += 4) {
+        uint8_t nop[4];
+        EncodeSNop(nop);
+        std::memcpy(text + t.original_offset + i, nop, 4);
+      }
+    }
+
+    MallocBuffer new_buf =
+        GrowElfWithTrampolines(buf.data(), elf_size, elf_info, deferred);
+    if (!new_buf)
+      return AMD_COMGR_STATUS_ERROR;
+
+    size_t tramp_total = 0;
+    for (auto &t : deferred)
+      tramp_total += t.bytes.size();
+
+    AddTrampolineSymbols(new_buf, deferred, elf_info.text_size,
+                         elf_info.text_section_idx);
+    PatchDebugRanges(new_buf.data, new_buf.size, elf_info.text_addr,
+                     elf_info.text_size, tramp_total);
+    PatchDebugInfo(new_buf.data, new_buf.size, elf_info.text_addr,
+                   elf_info.text_size, tramp_total);
+    PatchDebugFrame(new_buf.data, new_buf.size, elf_info.text_addr,
+                    elf_info.text_size, tramp_total);
+    PatchDebugLine(new_buf, deferred, elf_info.text_size,
+                   elf_info.text_addr);
+
+    *out_size = new_buf.size;
+    *out_data = new_buf.release();
+  } else {
+    MallocBuffer out(elf_size);
+    if (!out)
+      return AMD_COMGR_STATUS_ERROR;
+    std::memcpy(out.data, buf.data(), elf_size);
+    *out_data = out.release();
+    *out_size = elf_size;
+  }
+
+  if (!scratch_patches.empty()) {
+    ElfInfo verify_elf_info;
+    const uint8_t *verify_elf = static_cast<const uint8_t *>(*out_data);
+    if (ParseElfInfo(verify_elf, *out_size, verify_elf_info) &&
+        verify_elf_info.text_size > 0) {
+      bool ok = VerifyPatchCorrectness(
+          verify_elf + verify_elf_info.text_offset,
+          verify_elf_info.text_size, llvm_state, scratch_patches);
+      if (!ok) {
+        HotswapLog(HotswapLogLevel::Error)
+            << "hotswap: WARNING: post-patch verification detected "
+               "possible scratch conflicts\n";
+      }
+    }
+  }
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -147,36 +147,37 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
 
 // ── Sled-or-trampoline code emission ─────────────────────────────────────────
 
-[[nodiscard]] static bool EmitReplacementCode(
-    PatchContext &ctx, uint64_t inst_offset, uint32_t inst_size,
-    const std::vector<uint8_t> &replacement, const char *desc = nullptr) {
+[[nodiscard]] static bool EmitToNopSled(
+    PatchContext &ctx, NopSled &sled, uint64_t inst_offset, uint32_t inst_size,
+    const std::vector<uint8_t> &replacement) {
   const auto &cfg = ctx.config;
-  uint64_t needed = replacement.size() + 4;
-  NopSled *sled = FindNearestSled(ctx.nop_sleds, inst_offset, needed);
+  std::memcpy(ctx.text + sled.write_pos, replacement.data(),
+              replacement.size());
 
-  if (sled && replacement.size() + 4 <= sled->end - sled->write_pos) {
-    std::memcpy(ctx.text + sled->write_pos, replacement.data(),
-                replacement.size());
-    uint8_t br_back[4];
-    if (!EncodeSBranch(sled->write_pos + replacement.size(),
-                       inst_offset + inst_size, br_back, cfg.s_branch_opcode))
-      return false;
-    std::memcpy(ctx.text + sled->write_pos + replacement.size(), br_back, 4);
+  uint8_t br_back[4];
+  if (!EncodeSBranch(sled.write_pos + replacement.size(),
+                     inst_offset + inst_size, br_back, cfg.s_branch_opcode))
+    return false;
+  std::memcpy(ctx.text + sled.write_pos + replacement.size(), br_back, 4);
 
-    uint8_t br_fwd[4];
-    if (!EncodeSBranch(inst_offset, sled->write_pos, br_fwd,
-                       cfg.s_branch_opcode))
-      return false;
-    std::memcpy(ctx.text + inst_offset, br_fwd, 4);
-    for (uint32_t i = 4; i < inst_size; i += 4) {
-      uint8_t nop[4];
-      EncodeSNop(nop, cfg.s_nop_opcode);
-      std::memcpy(ctx.text + inst_offset + i, nop, 4);
-    }
-    sled->write_pos += replacement.size() + 4;
-    return true;
+  uint8_t br_fwd[4];
+  if (!EncodeSBranch(inst_offset, sled.write_pos, br_fwd,
+                     cfg.s_branch_opcode))
+    return false;
+  std::memcpy(ctx.text + inst_offset, br_fwd, 4);
+
+  for (uint32_t i = 4; i < inst_size; i += 4) {
+    uint8_t nop[4];
+    EncodeSNop(nop, cfg.s_nop_opcode);
+    std::memcpy(ctx.text + inst_offset + i, nop, 4);
   }
+  sled.write_pos += replacement.size() + 4;
+  return true;
+}
 
+[[nodiscard]] static bool EmitToTrampoline(
+    PatchContext &ctx, uint64_t inst_offset, uint32_t inst_size,
+    const std::vector<uint8_t> &replacement) {
   uint64_t tramp_offset = ctx.text_size;
   for (auto &t : ctx.out_trampolines)
     tramp_offset += t.bytes.size();
@@ -188,12 +189,24 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
 
   uint8_t br_back[4];
   if (!EncodeSBranch(tramp_offset + t.bytes.size(), inst_offset + inst_size,
-                     br_back, cfg.s_branch_opcode))
+                     br_back, ctx.config.s_branch_opcode))
     return false;
   t.bytes.insert(t.bytes.end(), br_back, br_back + 4);
 
   ctx.out_trampolines.push_back(std::move(t));
   return true;
+}
+
+[[nodiscard]] static bool EmitReplacementCode(
+    PatchContext &ctx, uint64_t inst_offset, uint32_t inst_size,
+    const std::vector<uint8_t> &replacement, const char *desc = nullptr) {
+  uint64_t needed = replacement.size() + 4;
+  NopSled *sled = FindNearestSled(ctx.nop_sleds, inst_offset, needed);
+
+  if (sled && replacement.size() + 4 <= sled->end - sled->write_pos)
+    return EmitToNopSled(ctx, *sled, inst_offset, inst_size, replacement);
+
+  return EmitToTrampoline(ctx, inst_offset, inst_size, replacement);
 }
 
 // ── ApplyGfx1250B0toA0Rules ──────────────────────────────────────────────────
@@ -276,6 +289,73 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
   return patched;
 }
 
+// ── RetargetCodeObjectB0A0 — helpers ─────────────────────────────────────────
+
+static void FixupTrampolineBranches(
+    std::vector<Trampoline> &trampolines, uint8_t *text,
+    uint64_t text_size, const RewriteConfig &config) {
+  uint64_t tramp_text_offset = text_size;
+  for (auto &t : trampolines) {
+    uint64_t tp = tramp_text_offset;
+    tramp_text_offset += t.bytes.size();
+
+    uint8_t br_back[4];
+    if (!EncodeSBranch(tp + t.bytes.size() - 4,
+                       t.original_offset + t.original_size, br_back,
+                       config.s_branch_opcode))
+      continue;
+    std::memcpy(t.bytes.data() + t.bytes.size() - 4, br_back, 4);
+
+    uint8_t br_fwd[4];
+    if (!EncodeSBranch(t.original_offset, tp, br_fwd,
+                       config.s_branch_opcode))
+      continue;
+    std::memcpy(text + t.original_offset, br_fwd, 4);
+    for (uint32_t i = 4; i < t.original_size; i += 4) {
+      uint8_t nop[4];
+      EncodeSNop(nop, config.s_nop_opcode);
+      std::memcpy(text + t.original_offset + i, nop, 4);
+    }
+  }
+}
+
+static void PatchDebugSections(MallocBuffer &elf_buf,
+                               const std::vector<Trampoline> &trampolines,
+                               const ElfInfo &elf_info,
+                               size_t tramp_total) {
+  if (!AddTrampolineSymbols(elf_buf, trampolines, elf_info.text_size,
+                            elf_info.text_section_idx))
+    HotswapLog(HotswapLogLevel::Error)
+        << "hotswap: WARNING: AddTrampolineSymbols failed\n";
+  PatchDebugRanges(elf_buf.get(), elf_buf.size, elf_info.text_addr,
+                   elf_info.text_size, tramp_total);
+  PatchDebugInfo(elf_buf.get(), elf_buf.size, elf_info.text_addr,
+                 elf_info.text_size, tramp_total);
+  PatchDebugFrame(elf_buf.get(), elf_buf.size, elf_info.text_addr,
+                  elf_info.text_size, tramp_total);
+  if (!PatchDebugLine(elf_buf, trampolines, elf_info.text_size,
+                      elf_info.text_addr))
+    HotswapLog(HotswapLogLevel::Error)
+        << "hotswap: WARNING: PatchDebugLine failed\n";
+}
+
+static void RunScratchVerification(
+    const void *out_data, size_t out_size, const LLVMState &llvm_state,
+    const std::vector<ScratchPatchInfo> &scratch_patches,
+    unsigned max_vgprs) {
+  ElfInfo verify_elf_info;
+  const uint8_t *verify_elf = static_cast<const uint8_t *>(out_data);
+  if (!ParseElfInfo(verify_elf, out_size, verify_elf_info) ||
+      verify_elf_info.text_size == 0)
+    return;
+  if (!VerifyPatchCorrectness(verify_elf + verify_elf_info.text_offset,
+                              verify_elf_info.text_size, llvm_state,
+                              scratch_patches, max_vgprs))
+    HotswapLog(HotswapLogLevel::Error)
+        << "hotswap: WARNING: post-patch verification detected "
+           "possible scratch conflicts\n";
+}
+
 // ── RetargetCodeObjectB0A0 ───────────────────────────────────────────────────
 
 amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
@@ -285,8 +365,7 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
   const uint8_t *elf = static_cast<const uint8_t *>(elf_data);
   if (!ParseElfInfo(elf, elf_size, elf_info) || elf_info.text_size == 0) {
     MallocBuffer copy(elf_size);
-    if (!copy)
-      return AMD_COMGR_STATUS_ERROR;
+    if (!copy) return AMD_COMGR_STATUS_ERROR;
     std::memcpy(copy.get(), elf_data, elf_size);
     *out_size = elf_size;
     *out_data = copy.release();
@@ -295,8 +374,7 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
 
   const std::string isa = "amdgcn-amd-amdhsa--gfx1250";
   LLVMState llvm_state = InitLLVMCached(isa);
-  if (!llvm_state.valid)
-    return AMD_COMGR_STATUS_ERROR;
+  if (!llvm_state.valid) return AMD_COMGR_STATUS_ERROR;
 
   RewriteConfig config = MakeGfx1250B0A0Config(llvm_state);
 
@@ -315,84 +393,33 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
                               scratch_patches, config);
 
   HotswapLog(HotswapLogLevel::Info)
-      << "hotswap: applied " << count << " B0-to-A0 patches\n";
+      << "hotswap: applied " << count << " patches\n";
 
   if (!deferred.empty()) {
-    uint64_t tramp_text_offset = elf_info.text_size;
-    for (auto &t : deferred) {
-      uint64_t tp = tramp_text_offset;
-      tramp_text_offset += t.bytes.size();
-
-      uint8_t br_back[4];
-      uint64_t br_from = tp + t.bytes.size() - 4;
-      uint64_t br_to = t.original_offset + t.original_size;
-      if (!EncodeSBranch(br_from, br_to, br_back, config.s_branch_opcode))
-        continue;
-      std::memcpy(t.bytes.data() + t.bytes.size() - 4, br_back, 4);
-
-      uint8_t br_fwd[4];
-      if (!EncodeSBranch(t.original_offset, tp, br_fwd,
-                         config.s_branch_opcode))
-        continue;
-      std::memcpy(text + t.original_offset, br_fwd, 4);
-      for (uint32_t i = 4; i < t.original_size; i += 4) {
-        uint8_t nop[4];
-        EncodeSNop(nop, config.s_nop_opcode);
-        std::memcpy(text + t.original_offset + i, nop, 4);
-      }
-    }
+    FixupTrampolineBranches(deferred, text, elf_info.text_size, config);
 
     MallocBuffer new_buf =
         GrowElfWithTrampolines(buf.data(), elf_size, elf_info, deferred);
-    if (!new_buf)
-      return AMD_COMGR_STATUS_ERROR;
+    if (!new_buf) return AMD_COMGR_STATUS_ERROR;
 
     size_t tramp_total = 0;
-    for (auto &t : deferred)
-      tramp_total += t.bytes.size();
+    for (auto &t : deferred) tramp_total += t.bytes.size();
 
-    if (!AddTrampolineSymbols(new_buf, deferred, elf_info.text_size,
-                              elf_info.text_section_idx))
-      HotswapLog(HotswapLogLevel::Error)
-          << "hotswap: WARNING: AddTrampolineSymbols failed\n";
-    PatchDebugRanges(new_buf.get(), new_buf.size, elf_info.text_addr,
-                     elf_info.text_size, tramp_total);
-    PatchDebugInfo(new_buf.get(), new_buf.size, elf_info.text_addr,
-                   elf_info.text_size, tramp_total);
-    PatchDebugFrame(new_buf.get(), new_buf.size, elf_info.text_addr,
-                    elf_info.text_size, tramp_total);
-    if (!PatchDebugLine(new_buf, deferred, elf_info.text_size,
-                        elf_info.text_addr))
-      HotswapLog(HotswapLogLevel::Error)
-          << "hotswap: WARNING: PatchDebugLine failed\n";
+    PatchDebugSections(new_buf, deferred, elf_info, tramp_total);
 
     *out_size = new_buf.size;
     *out_data = new_buf.release();
   } else {
     MallocBuffer out(elf_size);
-    if (!out)
-      return AMD_COMGR_STATUS_ERROR;
+    if (!out) return AMD_COMGR_STATUS_ERROR;
     std::memcpy(out.get(), buf.data(), elf_size);
     *out_data = out.release();
     *out_size = elf_size;
   }
 
-  if (!scratch_patches.empty()) {
-    ElfInfo verify_elf_info;
-    const uint8_t *verify_elf = static_cast<const uint8_t *>(*out_data);
-    if (ParseElfInfo(verify_elf, *out_size, verify_elf_info) &&
-        verify_elf_info.text_size > 0) {
-      bool ok = VerifyPatchCorrectness(
-          verify_elf + verify_elf_info.text_offset,
-          verify_elf_info.text_size, llvm_state, scratch_patches,
-          config.max_vgprs);
-      if (!ok) {
-        HotswapLog(HotswapLogLevel::Error)
-            << "hotswap: WARNING: post-patch verification detected "
-               "possible scratch conflicts\n";
-      }
-    }
-  }
+  if (!scratch_patches.empty())
+    RunScratchVerification(*out_data, *out_size, llvm_state, scratch_patches,
+                           config.max_vgprs);
 
   return AMD_COMGR_STATUS_SUCCESS;
 }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -105,8 +105,7 @@ __attribute__((weak)) void PatchDebugFrame(uint8_t *, size_t, uint64_t,
 // ── NOP sled scanning ────────────────────────────────────────────────────────
 
 static std::vector<NopSled>
-BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded,
-                const llvm::MCInstrInfo &MCII) {
+BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
   std::vector<NopSled> sleds;
   size_t i = 0;
   while (i < decoded.size()) {
@@ -186,7 +185,7 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
                         const ElfInfo &elf_info,
                         std::vector<ScratchPatchInfo> &out_scratch_patches) {
   uint32_t patched = 0;
-  std::vector<NopSled> nop_sleds = BuildNopSledMap(decoded, *llvm_state.MCII);
+  std::vector<NopSled> nop_sleds = BuildNopSledMap(decoded);
 
   CFG cfg = BuildCFG(decoded, *llvm_state.MCII);
   LivenessInfo liveness =
@@ -215,7 +214,7 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
 
   for (size_t idx = 0; idx < decoded.size(); ++idx) {
     auto &di = decoded[idx];
-    if (di.mnemonic == "<unknown>" || di.mnemonic == "<replaced>")
+    if (di.mnemonic == "<unknown>")
       continue;
 
     uint32_t p = 0;
@@ -327,16 +326,20 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
     for (auto &t : deferred)
       tramp_total += t.bytes.size();
 
-    AddTrampolineSymbols(new_buf, deferred, elf_info.text_size,
-                         elf_info.text_section_idx);
+    if (!AddTrampolineSymbols(new_buf, deferred, elf_info.text_size,
+                              elf_info.text_section_idx))
+      HotswapLog(HotswapLogLevel::Error)
+          << "hotswap: WARNING: AddTrampolineSymbols failed\n";
     PatchDebugRanges(new_buf.data, new_buf.size, elf_info.text_addr,
                      elf_info.text_size, tramp_total);
     PatchDebugInfo(new_buf.data, new_buf.size, elf_info.text_addr,
                    elf_info.text_size, tramp_total);
     PatchDebugFrame(new_buf.data, new_buf.size, elf_info.text_addr,
                     elf_info.text_size, tramp_total);
-    PatchDebugLine(new_buf, deferred, elf_info.text_size,
-                   elf_info.text_addr);
+    if (!PatchDebugLine(new_buf, deferred, elf_info.text_size,
+                        elf_info.text_addr))
+      HotswapLog(HotswapLogLevel::Error)
+          << "hotswap: WARNING: PatchDebugLine failed\n";
 
     *out_size = new_buf.size;
     *out_data = new_buf.release();

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -8,7 +8,7 @@
 /// \file
 /// Dispatcher for B0-to-A0 silicon stepping patches and the
 /// RetargetCodeObjectB0A0 orchestrator that drives the full pipeline:
-/// decode → patch → trampoline growth → DWARF update.
+/// decode -> patch -> trampoline growth -> DWARF update.
 ///
 /// Patch entry points are declared as weak symbols returning 0. Each
 /// comgr-hotswap-patch-*.cpp file provides a strong override, allowing
@@ -17,6 +17,24 @@
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
+
+#include "Utils/AMDGPUBaseInfo.h"
+
+// ── GFX1250 B0-to-A0 constants ──────────────────────────────────────────────
+
+static constexpr uint32_t kSBranchGFX12 = 0xBFA00000u;
+static constexpr uint32_t kSNopOpcode = 0xBF800000u;
+
+static RewriteConfig MakeGfx1250B0A0Config(const LLVMState &state) {
+  unsigned max_vgprs =
+      llvm::AMDGPU::IsaInfo::getTotalNumVGPRs(state.STI.get());
+  return {"amdgcn-amd-amdhsa--gfx1250",
+          "amdgcn-amd-amdhsa--gfx1250",
+          "gfx1250",
+          kSBranchGFX12,
+          kSNopOpcode,
+          max_vgprs};
+}
 
 // ── Weak-symbol patch stubs ──────────────────────────────────────────────────
 //
@@ -41,7 +59,7 @@ __attribute__((weak)) uint32_t ApplyScratchPatches(PatchContext &, size_t) {
 
 // ── Weak-symbol liveness stubs ───────────────────────────────────────────────
 //
-// Conservative defaults: all 256 VGPRs reported live. ScratchAllocator
+// Conservative defaults: all VGPRs reported live. ScratchAllocator
 // will allocate above KD count (correct but suboptimal until
 // comgr-hotswap-liveness.cpp lands with real analysis).
 
@@ -55,10 +73,11 @@ BuildCFG(const std::vector<InternalDecodedInst> &decoded,
 __attribute__((weak)) LivenessInfo
 ComputeLiveness(const std::vector<InternalDecodedInst> &decoded,
                 const CFG &, const llvm::MCInstrInfo &,
-                const llvm::MCRegisterInfo &) {
+                const llvm::MCRegisterInfo &,
+                unsigned max_vgprs) {
   LivenessInfo info;
-  llvm::BitVector all_live(256);
-  all_live.set(0, 256);
+  llvm::BitVector all_live(max_vgprs);
+  all_live.set(0, max_vgprs);
   info.live_before.resize(decoded.size(), all_live);
   info.live_after.resize(decoded.size(), all_live);
   info.converged = true;
@@ -75,7 +94,8 @@ __attribute__((weak)) int64_t GetBranchImm(const llvm::MCInst &) { return 0; }
 
 __attribute__((weak)) bool
 VerifyPatchCorrectness(const uint8_t *, uint64_t, const LLVMState &,
-                       const std::vector<ScratchPatchInfo> &) {
+                       const std::vector<ScratchPatchInfo> &,
+                       unsigned) {
   return true;
 }
 
@@ -130,6 +150,7 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
 [[nodiscard]] static bool EmitReplacementCode(
     PatchContext &ctx, uint64_t inst_offset, uint32_t inst_size,
     const std::vector<uint8_t> &replacement, const char *desc = nullptr) {
+  const auto &cfg = ctx.config;
   uint64_t needed = replacement.size() + 4;
   NopSled *sled = FindNearestSled(ctx.nop_sleds, inst_offset, needed);
 
@@ -138,17 +159,18 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
                 replacement.size());
     uint8_t br_back[4];
     if (!EncodeSBranch(sled->write_pos + replacement.size(),
-                       inst_offset + inst_size, br_back, true))
+                       inst_offset + inst_size, br_back, cfg.s_branch_opcode))
       return false;
     std::memcpy(ctx.text + sled->write_pos + replacement.size(), br_back, 4);
 
     uint8_t br_fwd[4];
-    if (!EncodeSBranch(inst_offset, sled->write_pos, br_fwd, true))
+    if (!EncodeSBranch(inst_offset, sled->write_pos, br_fwd,
+                       cfg.s_branch_opcode))
       return false;
     std::memcpy(ctx.text + inst_offset, br_fwd, 4);
     for (uint32_t i = 4; i < inst_size; i += 4) {
       uint8_t nop[4];
-      EncodeSNop(nop);
+      EncodeSNop(nop, cfg.s_nop_opcode);
       std::memcpy(ctx.text + inst_offset + i, nop, 4);
     }
     sled->write_pos += replacement.size() + 4;
@@ -166,7 +188,7 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
 
   uint8_t br_back[4];
   if (!EncodeSBranch(tramp_offset + t.bytes.size(), inst_offset + inst_size,
-                     br_back, true))
+                     br_back, cfg.s_branch_opcode))
     return false;
   t.bytes.insert(t.bytes.end(), br_back, br_back + 4);
 
@@ -183,20 +205,21 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
                         std::vector<Trampoline> &out_trampolines,
                         uint8_t *elf_data, size_t elf_size,
                         const ElfInfo &elf_info,
-                        std::vector<ScratchPatchInfo> &out_scratch_patches) {
+                        std::vector<ScratchPatchInfo> &out_scratch_patches,
+                        const RewriteConfig &config) {
   uint32_t patched = 0;
   std::vector<NopSled> nop_sleds = BuildNopSledMap(decoded);
 
   CFG cfg = BuildCFG(decoded, *llvm_state.MCII);
-  LivenessInfo liveness =
-      ComputeLiveness(decoded, cfg, *llvm_state.MCII, *llvm_state.MRI);
+  LivenessInfo liveness = ComputeLiveness(
+      decoded, cfg, *llvm_state.MCII, *llvm_state.MRI, config.max_vgprs);
 
   if (!liveness.converged) {
     HotswapLog(HotswapLogLevel::Error)
         << "hotswap: WARNING: liveness analysis did not converge, "
            "using conservative all-VGPRs-live fallback\n";
-    llvm::BitVector all_vgprs(256);
-    all_vgprs.set(0, 256);
+    llvm::BitVector all_vgprs(config.max_vgprs);
+    all_vgprs.set(0, config.max_vgprs);
     for (size_t i = 0; i < liveness.live_before.size(); ++i) {
       liveness.live_before[i] = all_vgprs;
       liveness.live_after[i] = all_vgprs;
@@ -205,11 +228,11 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
 
   std::unordered_map<std::string, KernelPatchStats> kernel_stats;
 
-  PatchContext ctx{decoded,     text,
-                   text_size,   llvm_state,
+  PatchContext ctx{config,       decoded,     text,
+                   text_size,    llvm_state,
                    out_trampolines, nop_sleds,
-                   elf_data,    elf_size,
-                   elf_info,    liveness,
+                   elf_data,     elf_size,
+                   elf_info,     liveness,
                    kernel_stats, out_scratch_patches};
 
   for (size_t idx = 0; idx < decoded.size(); ++idx) {
@@ -258,8 +281,6 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
 amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
                                           size_t elf_size, void **out_data,
                                           size_t *out_size) {
-  const std::string isa = "amdgcn-amd-amdhsa--gfx1250";
-
   ElfInfo elf_info;
   const uint8_t *elf = static_cast<const uint8_t *>(elf_data);
   if (!ParseElfInfo(elf, elf_size, elf_info) || elf_info.text_size == 0) {
@@ -272,9 +293,12 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
     return AMD_COMGR_STATUS_SUCCESS;
   }
 
+  const std::string isa = "amdgcn-amd-amdhsa--gfx1250";
   LLVMState llvm_state = InitLLVMCached(isa);
   if (!llvm_state.valid)
     return AMD_COMGR_STATUS_ERROR;
+
+  RewriteConfig config = MakeGfx1250B0A0Config(llvm_state);
 
   std::vector<uint8_t> buf(elf, elf + elf_size);
   uint8_t *text = buf.data() + elf_info.text_offset;
@@ -288,7 +312,7 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
   uint32_t count =
       ApplyGfx1250B0toA0Rules(decoded, text, elf_info.text_size, llvm_state,
                               deferred, buf.data(), buf.size(), elf_info,
-                              scratch_patches);
+                              scratch_patches, config);
 
   HotswapLog(HotswapLogLevel::Info)
       << "hotswap: applied " << count << " B0-to-A0 patches\n";
@@ -302,17 +326,18 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
       uint8_t br_back[4];
       uint64_t br_from = tp + t.bytes.size() - 4;
       uint64_t br_to = t.original_offset + t.original_size;
-      if (!EncodeSBranch(br_from, br_to, br_back, true))
+      if (!EncodeSBranch(br_from, br_to, br_back, config.s_branch_opcode))
         continue;
       std::memcpy(t.bytes.data() + t.bytes.size() - 4, br_back, 4);
 
       uint8_t br_fwd[4];
-      if (!EncodeSBranch(t.original_offset, tp, br_fwd, true))
+      if (!EncodeSBranch(t.original_offset, tp, br_fwd,
+                         config.s_branch_opcode))
         continue;
       std::memcpy(text + t.original_offset, br_fwd, 4);
       for (uint32_t i = 4; i < t.original_size; i += 4) {
         uint8_t nop[4];
-        EncodeSNop(nop);
+        EncodeSNop(nop, config.s_nop_opcode);
         std::memcpy(text + t.original_offset + i, nop, 4);
       }
     }
@@ -359,7 +384,8 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
         verify_elf_info.text_size > 0) {
       bool ok = VerifyPatchCorrectness(
           verify_elf + verify_elf_info.text_offset,
-          verify_elf_info.text_size, llvm_state, scratch_patches);
+          verify_elf_info.text_size, llvm_state, scratch_patches,
+          config.max_vgprs);
       if (!ok) {
         HotswapLog(HotswapLogLevel::Error)
             << "hotswap: WARNING: post-patch verification detected "

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -136,7 +136,7 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
         end = decoded[i].offset + decoded[i].size;
         ++i;
       }
-      if (end - start >= 8)
+      if (end - start >= kMinNopSledSize)
         sleds.push_back({start, end, start});
     } else {
       ++i;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -293,9 +293,10 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
 
 // ── RetargetCodeObjectB0A0 — helpers ─────────────────────────────────────────
 
-static void FixupTrampolineBranches(
+[[nodiscard]] static bool FixupTrampolineBranches(
     std::vector<Trampoline> &trampolines, uint8_t *text,
     uint64_t text_size, const RewriteConfig &config) {
+  bool all_ok = true;
   uint64_t tramp_text_offset = text_size;
   for (auto &t : trampolines) {
     uint64_t tp = tramp_text_offset;
@@ -304,15 +305,25 @@ static void FixupTrampolineBranches(
     uint8_t br_back[kMinInstSize];
     if (!EncodeSBranch(tp + t.bytes.size() - kMinInstSize,
                        t.original_offset + t.original_size, br_back,
-                       config.s_branch_opcode))
+                       config.s_branch_opcode)) {
+      HotswapLog(HotswapLogLevel::Error)
+          << "hotswap: WARNING: trampoline branch-back encoding failed at 0x"
+          << llvm::utohexstr(t.original_offset) << "\n";
+      all_ok = false;
       continue;
+    }
     std::memcpy(t.bytes.data() + t.bytes.size() - kMinInstSize, br_back,
                 kMinInstSize);
 
     uint8_t br_fwd[kMinInstSize];
     if (!EncodeSBranch(t.original_offset, tp, br_fwd,
-                       config.s_branch_opcode))
+                       config.s_branch_opcode)) {
+      HotswapLog(HotswapLogLevel::Error)
+          << "hotswap: WARNING: trampoline branch-fwd encoding failed at 0x"
+          << llvm::utohexstr(t.original_offset) << "\n";
+      all_ok = false;
       continue;
+    }
     std::memcpy(text + t.original_offset, br_fwd, kMinInstSize);
     for (uint32_t i = kMinInstSize; i < t.original_size; i += kMinInstSize) {
       uint8_t nop[kMinInstSize];
@@ -320,6 +331,7 @@ static void FixupTrampolineBranches(
       std::memcpy(text + t.original_offset + i, nop, kMinInstSize);
     }
   }
+  return all_ok;
 }
 
 static void PatchDebugSections(MallocBuffer &elf_buf,
@@ -399,7 +411,9 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
       << "hotswap: applied " << count << " patches\n";
 
   if (!deferred.empty()) {
-    FixupTrampolineBranches(deferred, text, elf_info.text_size, config);
+    if (!FixupTrampolineBranches(deferred, text, elf_info.text_size, config))
+      HotswapLog(HotswapLogLevel::Error)
+          << "hotswap: WARNING: some trampolines could not be fixed up\n";
 
     MallocBuffer new_buf =
         GrowElfWithTrampolines(buf.data(), elf_size, elf_info, deferred);

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -18,22 +18,21 @@
 
 #include "comgr-hotswap-internal.h"
 
-#include "Utils/AMDGPUBaseInfo.h"
+#include "llvm/ADT/StringExtras.h"
 
 // ── GFX1250 B0-to-A0 constants ──────────────────────────────────────────────
 
 static constexpr uint32_t kSBranchGFX12 = 0xBFA00000u;
 static constexpr uint32_t kSNopOpcode = 0xBF800000u;
+static constexpr unsigned kGfx1250MaxVGPRs = 256;
 
-static RewriteConfig MakeGfx1250B0A0Config(const LLVMState &state) {
-  unsigned max_vgprs =
-      llvm::AMDGPU::IsaInfo::getTotalNumVGPRs(state.STI.get());
+static RewriteConfig MakeGfx1250B0A0Config() {
   return {"amdgcn-amd-amdhsa--gfx1250",
           "amdgcn-amd-amdhsa--gfx1250",
           "gfx1250",
           kSBranchGFX12,
           kSNopOpcode,
-          max_vgprs};
+          kGfx1250MaxVGPRs};
 }
 
 // ── Weak-symbol patch stubs ──────────────────────────────────────────────────
@@ -391,7 +390,7 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
   LLVMState llvm_state = InitLLVMCached(isa);
   if (!llvm_state.valid) return AMD_COMGR_STATUS_ERROR;
 
-  RewriteConfig config = MakeGfx1250B0A0Config(llvm_state);
+  RewriteConfig config = MakeGfx1250B0A0Config();
 
   std::vector<uint8_t> buf(elf, elf + elf_size);
   uint8_t *text = buf.data() + elf_info.text_offset;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -154,24 +154,25 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
   std::memcpy(ctx.text + sled.write_pos, replacement.data(),
               replacement.size());
 
-  uint8_t br_back[4];
+  uint8_t br_back[kMinInstSize];
   if (!EncodeSBranch(sled.write_pos + replacement.size(),
                      inst_offset + inst_size, br_back, cfg.s_branch_opcode))
     return false;
-  std::memcpy(ctx.text + sled.write_pos + replacement.size(), br_back, 4);
+  std::memcpy(ctx.text + sled.write_pos + replacement.size(), br_back,
+              kMinInstSize);
 
-  uint8_t br_fwd[4];
+  uint8_t br_fwd[kMinInstSize];
   if (!EncodeSBranch(inst_offset, sled.write_pos, br_fwd,
                      cfg.s_branch_opcode))
     return false;
-  std::memcpy(ctx.text + inst_offset, br_fwd, 4);
+  std::memcpy(ctx.text + inst_offset, br_fwd, kMinInstSize);
 
-  for (uint32_t i = 4; i < inst_size; i += 4) {
-    uint8_t nop[4];
+  for (uint32_t i = kMinInstSize; i < inst_size; i += kMinInstSize) {
+    uint8_t nop[kMinInstSize];
     EncodeSNop(nop, cfg.s_nop_opcode);
-    std::memcpy(ctx.text + inst_offset + i, nop, 4);
+    std::memcpy(ctx.text + inst_offset + i, nop, kMinInstSize);
   }
-  sled.write_pos += replacement.size() + 4;
+  sled.write_pos += replacement.size() + kMinInstSize;
   return true;
 }
 
@@ -187,11 +188,11 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
   t.original_size = inst_size;
   t.bytes.insert(t.bytes.end(), replacement.begin(), replacement.end());
 
-  uint8_t br_back[4];
+  uint8_t br_back[kMinInstSize];
   if (!EncodeSBranch(tramp_offset + t.bytes.size(), inst_offset + inst_size,
                      br_back, ctx.config.s_branch_opcode))
     return false;
-  t.bytes.insert(t.bytes.end(), br_back, br_back + 4);
+  t.bytes.insert(t.bytes.end(), br_back, br_back + kMinInstSize);
 
   ctx.out_trampolines.push_back(std::move(t));
   return true;
@@ -200,10 +201,10 @@ BuildNopSledMap(const std::vector<InternalDecodedInst> &decoded) {
 [[nodiscard]] static bool EmitReplacementCode(
     PatchContext &ctx, uint64_t inst_offset, uint32_t inst_size,
     const std::vector<uint8_t> &replacement, const char *desc = nullptr) {
-  uint64_t needed = replacement.size() + 4;
+  uint64_t needed = replacement.size() + kMinInstSize;
   NopSled *sled = FindNearestSled(ctx.nop_sleds, inst_offset, needed);
 
-  if (sled && replacement.size() + 4 <= sled->end - sled->write_pos)
+  if (sled && replacement.size() + kMinInstSize <= sled->end - sled->write_pos)
     return EmitToNopSled(ctx, *sled, inst_offset, inst_size, replacement);
 
   return EmitToTrampoline(ctx, inst_offset, inst_size, replacement);
@@ -299,22 +300,23 @@ static void FixupTrampolineBranches(
     uint64_t tp = tramp_text_offset;
     tramp_text_offset += t.bytes.size();
 
-    uint8_t br_back[4];
-    if (!EncodeSBranch(tp + t.bytes.size() - 4,
+    uint8_t br_back[kMinInstSize];
+    if (!EncodeSBranch(tp + t.bytes.size() - kMinInstSize,
                        t.original_offset + t.original_size, br_back,
                        config.s_branch_opcode))
       continue;
-    std::memcpy(t.bytes.data() + t.bytes.size() - 4, br_back, 4);
+    std::memcpy(t.bytes.data() + t.bytes.size() - kMinInstSize, br_back,
+                kMinInstSize);
 
-    uint8_t br_fwd[4];
+    uint8_t br_fwd[kMinInstSize];
     if (!EncodeSBranch(t.original_offset, tp, br_fwd,
                        config.s_branch_opcode))
       continue;
-    std::memcpy(text + t.original_offset, br_fwd, 4);
-    for (uint32_t i = 4; i < t.original_size; i += 4) {
-      uint8_t nop[4];
+    std::memcpy(text + t.original_offset, br_fwd, kMinInstSize);
+    for (uint32_t i = kMinInstSize; i < t.original_size; i += kMinInstSize) {
+      uint8_t nop[kMinInstSize];
       EncodeSNop(nop, config.s_nop_opcode);
-      std::memcpy(text + t.original_offset + i, nop, 4);
+      std::memcpy(text + t.original_offset + i, nop, kMinInstSize);
     }
   }
 }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -240,7 +240,7 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
     }
   }
 
-  std::unordered_map<std::string, KernelPatchStats> kernel_stats;
+  llvm::StringMap<KernelPatchStats> kernel_stats;
 
   PatchContext ctx{config,       decoded,     text,
                    text_size,    llvm_state,
@@ -268,17 +268,18 @@ ApplyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &decoded,
   patched += ApplyWmmaHazardPatch(ctx);
 
   for (const auto &kv : kernel_stats) {
-    const std::string &kname = kv.first;
+    llvm::StringRef kname = kv.first();
     const auto &stats = kv.second;
     if (kname.empty())
       continue;
+    std::string kname_str = kname.str();
     int vgprs_before =
-        GetKernelVgprCount(elf_data, elf_size, elf_info, kname);
+        GetKernelVgprCount(elf_data, elf_size, elf_info, kname_str);
     if (stats.extra_vgprs > 0)
-      UpdateKernelDescriptor(elf_data, elf_size, elf_info, kname,
+      UpdateKernelDescriptor(elf_data, elf_size, elf_info, kname_str,
                              stats.extra_vgprs, 0);
     int vgprs_after =
-        GetKernelVgprCount(elf_data, elf_size, elf_info, kname);
+        GetKernelVgprCount(elf_data, elf_size, elf_info, kname_str);
     HotswapLog(HotswapLogLevel::Info)
         << "hotswap: liveness: kernel " << kname
         << ": vgprs_before=" << vgprs_before

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -1,0 +1,422 @@
+//===- comgr-hotswap-elf.cpp - ELF types, parsing, and binary helpers -----===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+// ── s_branch / s_nop encoding ────────────────────────────────────────────────
+
+[[nodiscard]] bool EncodeSBranch(uint64_t from_offset, uint64_t to_offset,
+                          uint8_t out_bytes[4], bool gfx12) {
+  int64_t byte_delta = static_cast<int64_t>(to_offset) -
+                       static_cast<int64_t>(from_offset) - 4;
+  if (byte_delta % 4 != 0) return false;
+  int64_t dword_offset = byte_delta / 4;
+  if (dword_offset < -32768 || dword_offset > 32767) return false;
+  uint32_t opcode = gfx12 ? S_BRANCH_GFX12 : S_BRANCH_GFX9;
+  uint32_t encoded = opcode | (static_cast<uint16_t>(dword_offset) & 0xFFFF);
+  std::memcpy(out_bytes, &encoded, 4);
+  return true;
+}
+
+void EncodeSNop(uint8_t out_bytes[4]) {
+  uint32_t encoded = S_NOP_OPCODE;
+  std::memcpy(out_bytes, &encoded, 4);
+}
+
+// ── ExtractCPU ───────────────────────────────────────────────────────────────
+
+std::string ExtractCPU(const std::string &isa_name) {
+  size_t pos = isa_name.rfind("gfx");
+  if (pos != std::string::npos) {
+    std::string cpu;
+    for (size_t i = pos; i < isa_name.size(); ++i) {
+      char c = isa_name[i];
+      if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+          (c >= 'A' && c <= 'Z'))
+        cpu += c;
+      else
+        break;
+    }
+    return cpu;
+  }
+  return "";
+}
+
+// ── ELF parsing ──────────────────────────────────────────────────────────────
+
+[[nodiscard]] bool ParseElfInfo(const uint8_t *elf, size_t elf_size, ElfInfo &info) {
+  using ELFT = llvm::object::ELF64LE;
+  auto elf_or_err = llvm::object::ELFFile<ELFT>::create(
+      llvm::StringRef(reinterpret_cast<const char *>(elf), elf_size));
+  if (!elf_or_err) {
+    llvm::consumeError(elf_or_err.takeError());
+    return false;
+  }
+  const auto &elf_file = *elf_or_err;
+
+  auto sections_or_err = elf_file.sections();
+  if (!sections_or_err) {
+    llvm::consumeError(sections_or_err.takeError());
+    return false;
+  }
+  auto shdrs = *sections_or_err;
+
+  for (const auto &shdr : shdrs) {
+    ElfSection sec;
+    sec.type = shdr.sh_type;
+    sec.offset = shdr.sh_offset;
+    sec.size = shdr.sh_size;
+    sec.addr = shdr.sh_addr;
+    sec.name_idx = shdr.sh_name;
+
+    auto name_or_err = elf_file.getSectionName(shdr);
+    if (name_or_err)
+      sec.name = name_or_err->str();
+    else
+      llvm::consumeError(name_or_err.takeError());
+
+    if (sec.name == ".text" && sec.offset + sec.size <= elf_size) {
+      info.text_section_idx = static_cast<int>(info.sections.size());
+      info.text_idx = info.text_section_idx;
+      info.text_offset = sec.offset;
+      info.text_size = sec.size;
+      info.text_addr = sec.addr;
+    }
+
+    info.sections.push_back(std::move(sec));
+  }
+
+  size_t num_sections = info.sections.size();
+  for (size_t i = 0; i < num_sections; ++i) {
+    if (info.sections[i].type != 2 && info.sections[i].type != 11)
+      continue;
+
+    const auto &sym_shdr = *(shdrs.begin() + i);
+
+    auto syms_or_err = elf_file.symbols(&sym_shdr);
+    if (!syms_or_err) {
+      llvm::consumeError(syms_or_err.takeError());
+      continue;
+    }
+
+    auto strtab_or_err = elf_file.getStringTableForSymtab(sym_shdr, shdrs);
+    if (!strtab_or_err) {
+      llvm::consumeError(strtab_or_err.takeError());
+      continue;
+    }
+
+    for (const auto &sym : *syms_or_err) {
+      ElfSymbol esym;
+      esym.info = sym.st_info;
+      esym.shndx = sym.st_shndx;
+      esym.value = sym.st_value;
+      esym.size = sym.st_size;
+
+      auto sym_name_or_err = sym.getName(*strtab_or_err);
+      if (sym_name_or_err)
+        esym.name = sym_name_or_err->str();
+      else
+        llvm::consumeError(sym_name_or_err.takeError());
+
+      info.symbols.push_back(std::move(esym));
+    }
+  }
+
+  return info.text_section_idx >= 0;
+}
+
+std::string FindKernelAtOffset(const ElfInfo &elf_info,
+                                      uint64_t text_offset) {
+  for (auto &sym : elf_info.symbols) {
+    uint8_t sym_type = sym.info & 0xf;
+    if (sym_type != 2 && sym_type != 10)
+      continue;
+    if (sym.shndx != static_cast<uint16_t>(elf_info.text_section_idx))
+      continue;
+    uint64_t sym_start = sym.value;
+    uint64_t sym_end = sym.value + sym.size;
+    if (text_offset >= sym_start && text_offset < sym_end)
+      return sym.name;
+  }
+  return "";
+}
+
+// ── ApplyByteReplace ─────────────────────────────────────────────────────────
+
+[[nodiscard]] bool ApplyByteReplace(const RewriteRule &rule, uint64_t inst_offset,
+                             uint32_t inst_size, uint8_t *text,
+                             uint64_t text_size) {
+  if (inst_offset + inst_size > text_size) return false;
+  if (rule.replace_bytes.size() > inst_size) return false;
+  std::memcpy(text + inst_offset, rule.replace_bytes.data(),
+              rule.replace_bytes.size());
+  uint32_t remaining =
+      inst_size - static_cast<uint32_t>(rule.replace_bytes.size());
+  uint64_t pad_offset = inst_offset + rule.replace_bytes.size();
+  while (remaining >= 4) {
+    uint8_t nop[4];
+    EncodeSNop(nop);
+    std::memcpy(text + pad_offset, nop, 4);
+    pad_offset += 4;
+    remaining -= 4;
+  }
+  return true;
+}
+
+// ── UpdateKernelDescriptor ───────────────────────────────────────────────────
+
+void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
+                                   const ElfInfo &elf_info,
+                                   const std::string &kernel_name,
+                                   int32_t extra_vgprs, int32_t extra_sgprs) {
+  std::string kd_name = kernel_name + ".kd";
+  for (auto &sym : elf_info.symbols) {
+    if (sym.name != kd_name)
+      continue;
+    if (sym.shndx >= elf_info.sections.size())
+      continue;
+    auto &sec = elf_info.sections[sym.shndx];
+    if (sym.value < sec.addr) continue;
+    uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
+    if (kd_file_offset + 64 > elf_size)
+      continue;
+    uint8_t *kd = elf_data + kd_file_offset;
+    uint32_t rsrc1;
+    std::memcpy(&rsrc1, kd + 48, 4);
+    if (extra_vgprs > 0) {
+      uint32_t current = rsrc1 & KD_RSRC1_VGPR_MASK;
+      uint32_t extra_granules =
+          (static_cast<uint32_t>(extra_vgprs) + 3) / 4;
+      uint32_t new_val = current + extra_granules;
+      if (new_val > 63) new_val = 63;
+      rsrc1 = (rsrc1 & ~KD_RSRC1_VGPR_MASK) | new_val;
+    }
+    if (extra_sgprs > 0) {
+      uint32_t current = (rsrc1 >> KD_RSRC1_SGPR_SHIFT) & KD_RSRC1_SGPR_MASK;
+      uint32_t extra_granules =
+          (static_cast<uint32_t>(extra_sgprs) + 7) / 8;
+      uint32_t new_val = current + extra_granules;
+      if (new_val > 15) new_val = 15;
+      rsrc1 = (rsrc1 & ~(KD_RSRC1_SGPR_MASK << KD_RSRC1_SGPR_SHIFT)) | (new_val << KD_RSRC1_SGPR_SHIFT);
+    }
+    std::memcpy(kd + 48, &rsrc1, 4);
+    return;
+  }
+}
+
+// ── NOP sled management ─────────────────────────────────────────────────────
+
+NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
+                                uint64_t needed) {
+  NopSled *best = nullptr;
+  int64_t best_dist = INT64_MAX;
+  for (auto &sled : sleds) {
+    if (sled.write_pos + needed > sled.end) continue;
+    int64_t dist = std::abs(static_cast<int64_t>(sled.write_pos) -
+                            static_cast<int64_t>(offset));
+    if (dist < 131072 && dist < best_dist) {
+      best = &sled;
+      best_dist = dist;
+    }
+  }
+  return best;
+}
+
+// ── GrowElfWithTrampolines ──────────────────────────────────────────────────
+
+MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
+                                            const ElfInfo &elf_info,
+                                            const std::vector<Trampoline> &trampolines) {
+  size_t tramp_total = 0;
+  for (auto &t : trampolines)
+    tramp_total += t.bytes.size();
+  if (tramp_total == 0)
+    return {};
+  if (tramp_total > SIZE_MAX - elf_size)
+    return {};
+
+  size_t new_elf_size = elf_size + tramp_total;
+  MallocBuffer buf(new_elf_size);
+  if (!buf)
+    return {};
+
+  uint8_t *new_elf = buf.data;
+
+  uint64_t text_end = elf_info.text_offset + elf_info.text_size;
+  std::memcpy(new_elf, elf, text_end);
+
+  uint64_t tramp_pos = text_end;
+  for (auto &t : trampolines) {
+    std::memcpy(new_elf + tramp_pos, t.bytes.data(), t.bytes.size());
+    tramp_pos += t.bytes.size();
+  }
+
+  if (text_end < elf_size)
+    std::memcpy(new_elf + tramp_pos, elf + text_end, elf_size - text_end);
+
+  uint64_t e_shoff;
+  uint16_t e_shentsize;
+  std::memcpy(&e_shoff, new_elf + 40, 8);
+  std::memcpy(&e_shentsize, new_elf + 58, 2);
+
+  if (e_shoff >= text_end) {
+    uint64_t new_shoff = e_shoff + tramp_total;
+    std::memcpy(new_elf + 40, &new_shoff, 8);
+    e_shoff = new_shoff;
+  }
+
+  uint16_t e_shnum;
+  std::memcpy(&e_shnum, new_elf + 60, 2);
+
+  for (uint16_t i = 0; i < e_shnum; ++i) {
+    uint8_t *sh = new_elf + e_shoff + i * e_shentsize;
+    uint64_t sh_offset;
+    std::memcpy(&sh_offset, sh + 24, 8);
+
+    if (sh_offset == elf_info.text_offset) {
+      uint64_t new_text_size = elf_info.text_size + tramp_total;
+      std::memcpy(sh + 32, &new_text_size, 8);
+    } else if (sh_offset > elf_info.text_offset) {
+      uint64_t new_offset = sh_offset + tramp_total;
+      std::memcpy(sh + 24, &new_offset, 8);
+    }
+  }
+
+  uint64_t e_phoff;
+  uint16_t e_phentsize, e_phnum;
+  std::memcpy(&e_phoff, new_elf + 32, 8);
+  std::memcpy(&e_phentsize, new_elf + 54, 2);
+  std::memcpy(&e_phnum, new_elf + 56, 2);
+
+  for (uint16_t i = 0; i < e_phnum; ++i) {
+    uint8_t *ph = new_elf + e_phoff + i * e_phentsize;
+    uint64_t p_offset, p_filesz, p_memsz;
+    std::memcpy(&p_offset, ph + 8, 8);
+    std::memcpy(&p_filesz, ph + 32, 8);
+    std::memcpy(&p_memsz, ph + 40, 8);
+
+    if (p_offset <= elf_info.text_offset &&
+        p_offset + p_filesz >= text_end) {
+      p_filesz += tramp_total;
+      p_memsz += tramp_total;
+      std::memcpy(ph + 32, &p_filesz, 8);
+      std::memcpy(ph + 40, &p_memsz, 8);
+    } else if (p_offset > elf_info.text_offset) {
+      p_offset += tramp_total;
+      std::memcpy(ph + 8, &p_offset, 8);
+    }
+  }
+
+  return buf;
+}
+
+// ── PatchElfIsa ──────────────────────────────────────────────────────────────
+
+bool PatchElfIsa(uint8_t *elf, size_t elf_size,
+                 const std::string &target_cpu) {
+  if (elf_size < 64) return false;
+  if (elf[0] != 0x7f || elf[1] != 'E' || elf[2] != 'L' || elf[3] != 'F')
+    return false;
+  if (elf[4] != 2) return false;
+
+  struct GfxMach { const char *name; uint32_t mach; };
+  static const GfxMach gfx_mach_map[] = {
+      {"gfx900", 0x02c},  {"gfx906", 0x02f},  {"gfx908", 0x030},
+      {"gfx90a", 0x03f},  {"gfx940", 0x04a},  {"gfx941", 0x04b},
+      {"gfx942", 0x04c},  {"gfx950", 0x04f},  {"gfx1010", 0x033},
+      {"gfx1030", 0x036}, {"gfx1100", 0x041},  {"gfx1200", 0x048},
+      {"gfx1201", 0x04a}, {"gfx1250", 0x049},  {nullptr, 0}};
+
+  uint32_t target_mach = 0;
+  for (auto *p = gfx_mach_map; p->name; ++p) {
+    if (target_cpu == p->name) {
+      target_mach = p->mach;
+      break;
+    }
+  }
+  if (target_mach == 0) return false;
+
+  uint32_t e_flags;
+  std::memcpy(&e_flags, elf + 48, 4);
+  e_flags = (e_flags & ~0xFFu) | (target_mach & 0xFF);
+  std::memcpy(elf + 48, &e_flags, 4);
+
+  uint64_t e_shoff;
+  uint16_t e_shentsize, e_shnum;
+  std::memcpy(&e_shoff, elf + 40, 8);
+  std::memcpy(&e_shentsize, elf + 58, 2);
+  std::memcpy(&e_shnum, elf + 60, 2);
+  if (e_shoff == 0 || e_shnum == 0) return true;
+
+  for (uint16_t i = 0; i < e_shnum; ++i) {
+    const uint8_t *sh = elf + e_shoff + i * e_shentsize;
+    uint32_t sh_type;
+    std::memcpy(&sh_type, sh + 4, 4);
+    if (sh_type != 7) continue;
+    uint64_t sh_offset, sh_size;
+    std::memcpy(&sh_offset, sh + 24, 8);
+    std::memcpy(&sh_size, sh + 32, 8);
+    if (sh_offset + sh_size > elf_size) continue;
+    uint64_t pos = sh_offset;
+    while (pos + 12 <= sh_offset + sh_size) {
+      uint32_t namesz, descsz, type;
+      std::memcpy(&namesz, elf + pos, 4);
+      std::memcpy(&descsz, elf + pos + 4, 4);
+      std::memcpy(&type, elf + pos + 8, 4);
+      uint32_t namesz_aligned = (namesz + 3) & ~3u;
+      uint32_t descsz_aligned = (descsz + 3) & ~3u;
+      uint64_t note_total = 12 + namesz_aligned + descsz_aligned;
+      if (pos + note_total > sh_offset + sh_size) break;
+      if (type == 27 && namesz > 0) {
+        const char *owner = reinterpret_cast<const char *>(elf + pos + 12);
+        if (std::strncmp(owner, "AMDGPU", 6) == 0) {
+          uint8_t *desc = elf + pos + 12 + namesz_aligned;
+          std::string orig_isa(reinterpret_cast<const char *>(desc), descsz);
+          size_t gfx_pos = orig_isa.find("gfx");
+          if (gfx_pos != std::string::npos) {
+            size_t gfx_end = gfx_pos;
+            while (gfx_end < orig_isa.size() && orig_isa[gfx_end] != ':' &&
+                   orig_isa[gfx_end] != '\0')
+              ++gfx_end;
+            std::string orig_gfx =
+                orig_isa.substr(gfx_pos, gfx_end - gfx_pos);
+            if (target_cpu.size() <= orig_gfx.size()) {
+              std::memcpy(desc + gfx_pos, target_cpu.c_str(),
+                          target_cpu.size());
+              for (size_t j = target_cpu.size(); j < orig_gfx.size(); ++j)
+                desc[gfx_pos + j] = '\0';
+            }
+          }
+        }
+      }
+      pos += note_total;
+    }
+  }
+  return true;
+}
+
+// ── GetKernelVgprCount ───────────────────────────────────────────────────────
+
+int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
+                       const ElfInfo &elf_info,
+                       const std::string &kernel_name) {
+  std::string kd_name = kernel_name + ".kd";
+  for (const auto &sym : elf_info.symbols) {
+    if (sym.name != kd_name) continue;
+    if (sym.shndx >= elf_info.sections.size()) continue;
+    const auto &sec = elf_info.sections[sym.shndx];
+    if (sym.value < sec.addr) continue;
+    uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
+    if (kd_file_offset + 64 > elf_size) continue;
+    uint32_t rsrc1;
+    std::memcpy(&rsrc1, elf_data + kd_file_offset + 48, 4);
+    uint32_t granulated = rsrc1 & KD_RSRC1_VGPR_MASK;
+    return static_cast<int>((granulated + 1) * 8);
+  }
+  return 256;
+}

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -173,46 +173,51 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
   return true;
 }
 
+// ── Kernel descriptor lookup ─────────────────────────────────────────────────
+
+static uint8_t *FindKernelDescriptor(uint8_t *elf_data, size_t elf_size,
+                                     const ElfInfo &elf_info,
+                                     const std::string &kernel_name) {
+  std::string kd_name = kernel_name + ".kd";
+  for (const auto &sym : elf_info.symbols) {
+    if (sym.name != kd_name) continue;
+    if (sym.shndx >= elf_info.sections.size()) continue;
+    const auto &sec = elf_info.sections[sym.shndx];
+    if (sym.value < sec.addr) continue;
+    uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
+    if (kd_file_offset + kKdSize > elf_size) continue;
+    return elf_data + kd_file_offset;
+  }
+  return nullptr;
+}
+
 // ── UpdateKernelDescriptor ───────────────────────────────────────────────────
 
 void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
                             const ElfInfo &elf_info,
                             const std::string &kernel_name,
                             int32_t extra_vgprs, int32_t extra_sgprs) {
-  std::string kd_name = kernel_name + ".kd";
-  for (auto &sym : elf_info.symbols) {
-    if (sym.name != kd_name)
-      continue;
-    if (sym.shndx >= elf_info.sections.size())
-      continue;
-    auto &sec = elf_info.sections[sym.shndx];
-    if (sym.value < sec.addr) continue;
-    uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
-    if (kd_file_offset + kKdSize > elf_size)
-      continue;
-    uint8_t *kd = elf_data + kd_file_offset;
-    uint32_t rsrc1;
-    std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
-    if (extra_vgprs > 0) {
-      uint32_t current = rsrc1 & KD_RSRC1_VGPR_MASK;
-      uint32_t extra_granules =
-          (static_cast<uint32_t>(extra_vgprs) + 3) / 4;
-      uint32_t new_val = current + extra_granules;
-      if (new_val > 63) new_val = 63;
-      rsrc1 = (rsrc1 & ~KD_RSRC1_VGPR_MASK) | new_val;
-    }
-    if (extra_sgprs > 0) {
-      uint32_t current = (rsrc1 >> KD_RSRC1_SGPR_SHIFT) & KD_RSRC1_SGPR_MASK;
-      uint32_t extra_granules =
-          (static_cast<uint32_t>(extra_sgprs) + 7) / 8;
-      uint32_t new_val = current + extra_granules;
-      if (new_val > 15) new_val = 15;
-      rsrc1 = (rsrc1 & ~(KD_RSRC1_SGPR_MASK << KD_RSRC1_SGPR_SHIFT)) |
-              (new_val << KD_RSRC1_SGPR_SHIFT);
-    }
-    std::memcpy(kd + kKdRsrc1Offset, &rsrc1, 4);
-    return;
+  uint8_t *kd = FindKernelDescriptor(elf_data, elf_size, elf_info, kernel_name);
+  if (!kd) return;
+
+  uint32_t rsrc1;
+  std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
+  if (extra_vgprs > 0) {
+    uint32_t current = rsrc1 & KD_RSRC1_VGPR_MASK;
+    uint32_t extra_granules = (static_cast<uint32_t>(extra_vgprs) + 3) / 4;
+    uint32_t new_val = current + extra_granules;
+    if (new_val > 63) new_val = 63;
+    rsrc1 = (rsrc1 & ~KD_RSRC1_VGPR_MASK) | new_val;
   }
+  if (extra_sgprs > 0) {
+    uint32_t current = (rsrc1 >> KD_RSRC1_SGPR_SHIFT) & KD_RSRC1_SGPR_MASK;
+    uint32_t extra_granules = (static_cast<uint32_t>(extra_sgprs) + 7) / 8;
+    uint32_t new_val = current + extra_granules;
+    if (new_val > 15) new_val = 15;
+    rsrc1 = (rsrc1 & ~(KD_RSRC1_SGPR_MASK << KD_RSRC1_SGPR_SHIFT)) |
+            (new_val << KD_RSRC1_SGPR_SHIFT);
+  }
+  std::memcpy(kd + kKdRsrc1Offset, &rsrc1, 4);
 }
 
 // ── NOP sled management ──────────────────────────────────────────────────────
@@ -235,93 +240,99 @@ NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
 
 // ── GrowElfWithTrampolines ──────────────────────────────────────────────────
 
+static void AdjustSectionHeaders(uint8_t *elf, uint64_t text_offset,
+                                 uint64_t text_size, size_t tramp_total) {
+  using Ehdr = llvm::ELF::Elf64_Ehdr;
+  using Shdr = llvm::ELF::Elf64_Shdr;
+
+  uint64_t text_end = text_offset + text_size;
+  uint64_t e_shoff;
+  uint16_t e_shentsize, e_shnum;
+  std::memcpy(&e_shoff, elf + offsetof(Ehdr, e_shoff), 8);
+  std::memcpy(&e_shentsize, elf + offsetof(Ehdr, e_shentsize), 2);
+
+  if (e_shoff >= text_end) {
+    uint64_t new_shoff = e_shoff + tramp_total;
+    std::memcpy(elf + offsetof(Ehdr, e_shoff), &new_shoff, 8);
+    e_shoff = new_shoff;
+  }
+
+  std::memcpy(&e_shnum, elf + offsetof(Ehdr, e_shnum), 2);
+
+  for (uint16_t i = 0; i < e_shnum; ++i) {
+    uint8_t *sh = elf + e_shoff + i * e_shentsize;
+    uint64_t sh_offset;
+    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), 8);
+
+    if (sh_offset == text_offset) {
+      uint64_t new_text_size = text_size + tramp_total;
+      std::memcpy(sh + offsetof(Shdr, sh_size), &new_text_size, 8);
+    } else if (sh_offset > text_offset) {
+      uint64_t new_offset = sh_offset + tramp_total;
+      std::memcpy(sh + offsetof(Shdr, sh_offset), &new_offset, 8);
+    }
+  }
+}
+
+static void AdjustProgramHeaders(uint8_t *elf, uint64_t text_offset,
+                                 uint64_t text_size, size_t tramp_total) {
+  using Ehdr = llvm::ELF::Elf64_Ehdr;
+  using Phdr = llvm::ELF::Elf64_Phdr;
+
+  uint64_t text_end = text_offset + text_size;
+  uint64_t e_phoff;
+  uint16_t e_phentsize, e_phnum;
+  std::memcpy(&e_phoff, elf + offsetof(Ehdr, e_phoff), 8);
+  std::memcpy(&e_phentsize, elf + offsetof(Ehdr, e_phentsize), 2);
+  std::memcpy(&e_phnum, elf + offsetof(Ehdr, e_phnum), 2);
+
+  for (uint16_t i = 0; i < e_phnum; ++i) {
+    uint8_t *ph = elf + e_phoff + i * e_phentsize;
+    uint64_t p_offset, p_filesz, p_memsz;
+    std::memcpy(&p_offset, ph + offsetof(Phdr, p_offset), 8);
+    std::memcpy(&p_filesz, ph + offsetof(Phdr, p_filesz), 8);
+    std::memcpy(&p_memsz, ph + offsetof(Phdr, p_memsz), 8);
+
+    if (p_offset <= text_offset && p_offset + p_filesz >= text_end) {
+      p_filesz += tramp_total;
+      p_memsz += tramp_total;
+      std::memcpy(ph + offsetof(Phdr, p_filesz), &p_filesz, 8);
+      std::memcpy(ph + offsetof(Phdr, p_memsz), &p_memsz, 8);
+    } else if (p_offset > text_offset) {
+      p_offset += tramp_total;
+      std::memcpy(ph + offsetof(Phdr, p_offset), &p_offset, 8);
+    }
+  }
+}
+
 MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
                                     const ElfInfo &elf_info,
                                     const std::vector<Trampoline> &trampolines) {
   size_t tramp_total = 0;
   for (auto &t : trampolines)
     tramp_total += t.bytes.size();
-  if (tramp_total == 0)
-    return {};
-  if (tramp_total > SIZE_MAX - elf_size)
+  if (tramp_total == 0 || tramp_total > SIZE_MAX - elf_size)
     return {};
 
-  size_t new_elf_size = elf_size + tramp_total;
-  MallocBuffer buf(new_elf_size);
-  if (!buf)
-    return {};
+  MallocBuffer buf(elf_size + tramp_total);
+  if (!buf) return {};
 
-  uint8_t *new_elf = buf.get();
-
+  uint8_t *out = buf.get();
   uint64_t text_end = elf_info.text_offset + elf_info.text_size;
-  std::memcpy(new_elf, elf, text_end);
 
-  uint64_t tramp_pos = text_end;
+  std::memcpy(out, elf, text_end);
+  uint64_t pos = text_end;
   for (auto &t : trampolines) {
-    std::memcpy(new_elf + tramp_pos, t.bytes.data(), t.bytes.size());
-    tramp_pos += t.bytes.size();
+    std::memcpy(out + pos, t.bytes.data(), t.bytes.size());
+    pos += t.bytes.size();
   }
-
   if (text_end < elf_size)
-    std::memcpy(new_elf + tramp_pos, elf + text_end, elf_size - text_end);
+    std::memcpy(out + pos, elf + text_end, elf_size - text_end);
 
-  using Ehdr = llvm::ELF::Elf64_Ehdr;
-  using Shdr = llvm::ELF::Elf64_Shdr;
-  using Phdr = llvm::ELF::Elf64_Phdr;
-
-  uint64_t e_shoff;
-  uint16_t e_shentsize;
-  std::memcpy(&e_shoff, new_elf + offsetof(Ehdr, e_shoff), 8);
-  std::memcpy(&e_shentsize, new_elf + offsetof(Ehdr, e_shentsize), 2);
-
-  if (e_shoff >= text_end) {
-    uint64_t new_shoff = e_shoff + tramp_total;
-    std::memcpy(new_elf + offsetof(Ehdr, e_shoff), &new_shoff, 8);
-    e_shoff = new_shoff;
-  }
-
-  uint16_t e_shnum;
-  std::memcpy(&e_shnum, new_elf + offsetof(Ehdr, e_shnum), 2);
-
-  for (uint16_t i = 0; i < e_shnum; ++i) {
-    uint8_t *sh = new_elf + e_shoff + i * e_shentsize;
-    uint64_t sh_offset;
-    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), 8);
-
-    if (sh_offset == elf_info.text_offset) {
-      uint64_t new_text_size = elf_info.text_size + tramp_total;
-      std::memcpy(sh + offsetof(Shdr, sh_size), &new_text_size, 8);
-    } else if (sh_offset > elf_info.text_offset) {
-      uint64_t new_offset = sh_offset + tramp_total;
-      std::memcpy(sh + offsetof(Shdr, sh_offset), &new_offset, 8);
-    }
-  }
-
-  uint64_t e_phoff;
-  uint16_t e_phentsize, e_phnum;
-  std::memcpy(&e_phoff, new_elf + offsetof(Ehdr, e_phoff), 8);
-  std::memcpy(&e_phentsize, new_elf + offsetof(Ehdr, e_phentsize), 2);
-  std::memcpy(&e_phnum, new_elf + offsetof(Ehdr, e_phnum), 2);
-
-  for (uint16_t i = 0; i < e_phnum; ++i) {
-    uint8_t *ph = new_elf + e_phoff + i * e_phentsize;
-    uint64_t p_offset, p_filesz, p_memsz;
-    std::memcpy(&p_offset, ph + offsetof(Phdr, p_offset), 8);
-    std::memcpy(&p_filesz, ph + offsetof(Phdr, p_filesz), 8);
-    std::memcpy(&p_memsz, ph + offsetof(Phdr, p_memsz), 8);
-
-    if (p_offset <= elf_info.text_offset &&
-        p_offset + p_filesz >= text_end) {
-      p_filesz += tramp_total;
-      p_memsz += tramp_total;
-      std::memcpy(ph + offsetof(Phdr, p_filesz), &p_filesz, 8);
-      std::memcpy(ph + offsetof(Phdr, p_memsz), &p_memsz, 8);
-    } else if (p_offset > elf_info.text_offset) {
-      p_offset += tramp_total;
-      std::memcpy(ph + offsetof(Phdr, p_offset), &p_offset, 8);
-    }
-  }
-
+  AdjustSectionHeaders(out, elf_info.text_offset, elf_info.text_size,
+                        tramp_total);
+  AdjustProgramHeaders(out, elf_info.text_offset, elf_info.text_size,
+                        tramp_total);
   return buf;
 }
 
@@ -404,18 +415,11 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
 int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
                        const ElfInfo &elf_info,
                        const std::string &kernel_name) {
-  std::string kd_name = kernel_name + ".kd";
-  for (const auto &sym : elf_info.symbols) {
-    if (sym.name != kd_name) continue;
-    if (sym.shndx >= elf_info.sections.size()) continue;
-    const auto &sec = elf_info.sections[sym.shndx];
-    if (sym.value < sec.addr) continue;
-    uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
-    if (kd_file_offset + kKdSize > elf_size) continue;
-    uint32_t rsrc1;
-    std::memcpy(&rsrc1, elf_data + kd_file_offset + kKdRsrc1Offset, 4);
-    uint32_t granulated = rsrc1 & KD_RSRC1_VGPR_MASK;
-    return static_cast<int>((granulated + 1) * 8);
-  }
-  return -1;
+  const uint8_t *kd = FindKernelDescriptor(
+      const_cast<uint8_t *>(elf_data), elf_size, elf_info, kernel_name);
+  if (!kd) return -1;
+  uint32_t rsrc1;
+  std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
+  uint32_t granulated = rsrc1 & KD_RSRC1_VGPR_MASK;
+  return static_cast<int>((granulated + 1) * 8);
 }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -8,24 +8,26 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "MCTargetDesc/AMDGPUTargetStreamer.h"
+
 // ── s_branch / s_nop encoding ────────────────────────────────────────────────
 
 [[nodiscard]] bool EncodeSBranch(uint64_t from_offset, uint64_t to_offset,
-                          uint8_t out_bytes[4], bool gfx12) {
+                                 uint8_t out_bytes[4],
+                                 uint32_t s_branch_opcode) {
   int64_t byte_delta = static_cast<int64_t>(to_offset) -
                        static_cast<int64_t>(from_offset) - 4;
   if (byte_delta % 4 != 0) return false;
   int64_t dword_offset = byte_delta / 4;
   if (dword_offset < -32768 || dword_offset > 32767) return false;
-  uint32_t opcode = gfx12 ? S_BRANCH_GFX12 : S_BRANCH_GFX9;
-  uint32_t encoded = opcode | (static_cast<uint16_t>(dword_offset) & 0xFFFF);
+  uint32_t encoded =
+      s_branch_opcode | (static_cast<uint16_t>(dword_offset) & 0xFFFF);
   std::memcpy(out_bytes, &encoded, 4);
   return true;
 }
 
-void EncodeSNop(uint8_t out_bytes[4]) {
-  uint32_t encoded = S_NOP_OPCODE;
-  std::memcpy(out_bytes, &encoded, 4);
+void EncodeSNop(uint8_t out_bytes[4], uint32_t s_nop_opcode) {
+  std::memcpy(out_bytes, &s_nop_opcode, 4);
 }
 
 // ── ExtractCPU ───────────────────────────────────────────────────────────────
@@ -49,7 +51,8 @@ std::string ExtractCPU(const std::string &isa_name) {
 
 // ── ELF parsing ──────────────────────────────────────────────────────────────
 
-[[nodiscard]] bool ParseElfInfo(const uint8_t *elf, size_t elf_size, ElfInfo &info) {
+[[nodiscard]] bool ParseElfInfo(const uint8_t *elf, size_t elf_size,
+                                ElfInfo &info) {
   using ELFT = llvm::object::ELF64LE;
   auto elf_or_err = llvm::object::ELFFile<ELFT>::create(
       llvm::StringRef(reinterpret_cast<const char *>(elf), elf_size));
@@ -93,7 +96,8 @@ std::string ExtractCPU(const std::string &isa_name) {
 
   size_t num_sections = info.sections.size();
   for (size_t i = 0; i < num_sections; ++i) {
-    if (info.sections[i].type != 2 && info.sections[i].type != 11)
+    if (info.sections[i].type != llvm::ELF::SHT_SYMTAB &&
+        info.sections[i].type != llvm::ELF::SHT_DYNSYM)
       continue;
 
     const auto &sym_shdr = *(shdrs.begin() + i);
@@ -134,7 +138,7 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
                                uint64_t text_offset) {
   for (auto &sym : elf_info.symbols) {
     uint8_t sym_type = sym.info & 0xf;
-    if (sym_type != 2 && sym_type != 10)
+    if (sym_type != llvm::ELF::STT_FUNC && sym_type != llvm::ELF::STT_GNU_IFUNC)
       continue;
     if (sym.shndx != static_cast<uint16_t>(elf_info.text_section_idx))
       continue;
@@ -150,7 +154,8 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
 
 [[nodiscard]] bool ApplyByteReplace(const RewriteRule &rule,
                                     uint64_t inst_offset, uint32_t inst_size,
-                                    uint8_t *text, uint64_t text_size) {
+                                    uint8_t *text, uint64_t text_size,
+                                    uint32_t s_nop_opcode) {
   if (inst_offset + inst_size > text_size) return false;
   if (rule.replace_bytes.size() > inst_size) return false;
   std::memcpy(text + inst_offset, rule.replace_bytes.data(),
@@ -160,7 +165,7 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
   uint64_t pad_offset = inst_offset + rule.replace_bytes.size();
   while (remaining >= 4) {
     uint8_t nop[4];
-    EncodeSNop(nop);
+    EncodeSNop(nop, s_nop_opcode);
     std::memcpy(text + pad_offset, nop, 4);
     pad_offset += 4;
     remaining -= 4;
@@ -183,11 +188,11 @@ void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
     auto &sec = elf_info.sections[sym.shndx];
     if (sym.value < sec.addr) continue;
     uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
-    if (kd_file_offset + 64 > elf_size)
+    if (kd_file_offset + kKdSize > elf_size)
       continue;
     uint8_t *kd = elf_data + kd_file_offset;
     uint32_t rsrc1;
-    std::memcpy(&rsrc1, kd + 48, 4);
+    std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
     if (extra_vgprs > 0) {
       uint32_t current = rsrc1 & KD_RSRC1_VGPR_MASK;
       uint32_t extra_granules =
@@ -202,14 +207,15 @@ void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
           (static_cast<uint32_t>(extra_sgprs) + 7) / 8;
       uint32_t new_val = current + extra_granules;
       if (new_val > 15) new_val = 15;
-      rsrc1 = (rsrc1 & ~(KD_RSRC1_SGPR_MASK << KD_RSRC1_SGPR_SHIFT)) | (new_val << KD_RSRC1_SGPR_SHIFT);
+      rsrc1 = (rsrc1 & ~(KD_RSRC1_SGPR_MASK << KD_RSRC1_SGPR_SHIFT)) |
+              (new_val << KD_RSRC1_SGPR_SHIFT);
     }
-    std::memcpy(kd + 48, &rsrc1, 4);
+    std::memcpy(kd + kKdRsrc1Offset, &rsrc1, 4);
     return;
   }
 }
 
-// ── NOP sled management ─────────────────────────────────────────────────────
+// ── NOP sled management ──────────────────────────────────────────────────────
 
 NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
                          uint64_t needed) {
@@ -219,7 +225,7 @@ NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
     if (sled.write_pos + needed > sled.end) continue;
     int64_t dist = std::abs(static_cast<int64_t>(sled.write_pos) -
                             static_cast<int64_t>(offset));
-    if (dist < 131072 && dist < best_dist) {
+    if (dist < kMaxSledDistance && dist < best_dist) {
       best = &sled;
       best_dist = dist;
     }
@@ -259,56 +265,60 @@ MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
   if (text_end < elf_size)
     std::memcpy(new_elf + tramp_pos, elf + text_end, elf_size - text_end);
 
+  using Ehdr = llvm::ELF::Elf64_Ehdr;
+  using Shdr = llvm::ELF::Elf64_Shdr;
+  using Phdr = llvm::ELF::Elf64_Phdr;
+
   uint64_t e_shoff;
   uint16_t e_shentsize;
-  std::memcpy(&e_shoff, new_elf + 40, 8);
-  std::memcpy(&e_shentsize, new_elf + 58, 2);
+  std::memcpy(&e_shoff, new_elf + offsetof(Ehdr, e_shoff), 8);
+  std::memcpy(&e_shentsize, new_elf + offsetof(Ehdr, e_shentsize), 2);
 
   if (e_shoff >= text_end) {
     uint64_t new_shoff = e_shoff + tramp_total;
-    std::memcpy(new_elf + 40, &new_shoff, 8);
+    std::memcpy(new_elf + offsetof(Ehdr, e_shoff), &new_shoff, 8);
     e_shoff = new_shoff;
   }
 
   uint16_t e_shnum;
-  std::memcpy(&e_shnum, new_elf + 60, 2);
+  std::memcpy(&e_shnum, new_elf + offsetof(Ehdr, e_shnum), 2);
 
   for (uint16_t i = 0; i < e_shnum; ++i) {
     uint8_t *sh = new_elf + e_shoff + i * e_shentsize;
     uint64_t sh_offset;
-    std::memcpy(&sh_offset, sh + 24, 8);
+    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), 8);
 
     if (sh_offset == elf_info.text_offset) {
       uint64_t new_text_size = elf_info.text_size + tramp_total;
-      std::memcpy(sh + 32, &new_text_size, 8);
+      std::memcpy(sh + offsetof(Shdr, sh_size), &new_text_size, 8);
     } else if (sh_offset > elf_info.text_offset) {
       uint64_t new_offset = sh_offset + tramp_total;
-      std::memcpy(sh + 24, &new_offset, 8);
+      std::memcpy(sh + offsetof(Shdr, sh_offset), &new_offset, 8);
     }
   }
 
   uint64_t e_phoff;
   uint16_t e_phentsize, e_phnum;
-  std::memcpy(&e_phoff, new_elf + 32, 8);
-  std::memcpy(&e_phentsize, new_elf + 54, 2);
-  std::memcpy(&e_phnum, new_elf + 56, 2);
+  std::memcpy(&e_phoff, new_elf + offsetof(Ehdr, e_phoff), 8);
+  std::memcpy(&e_phentsize, new_elf + offsetof(Ehdr, e_phentsize), 2);
+  std::memcpy(&e_phnum, new_elf + offsetof(Ehdr, e_phnum), 2);
 
   for (uint16_t i = 0; i < e_phnum; ++i) {
     uint8_t *ph = new_elf + e_phoff + i * e_phentsize;
     uint64_t p_offset, p_filesz, p_memsz;
-    std::memcpy(&p_offset, ph + 8, 8);
-    std::memcpy(&p_filesz, ph + 32, 8);
-    std::memcpy(&p_memsz, ph + 40, 8);
+    std::memcpy(&p_offset, ph + offsetof(Phdr, p_offset), 8);
+    std::memcpy(&p_filesz, ph + offsetof(Phdr, p_filesz), 8);
+    std::memcpy(&p_memsz, ph + offsetof(Phdr, p_memsz), 8);
 
     if (p_offset <= elf_info.text_offset &&
         p_offset + p_filesz >= text_end) {
       p_filesz += tramp_total;
       p_memsz += tramp_total;
-      std::memcpy(ph + 32, &p_filesz, 8);
-      std::memcpy(ph + 40, &p_memsz, 8);
+      std::memcpy(ph + offsetof(Phdr, p_filesz), &p_filesz, 8);
+      std::memcpy(ph + offsetof(Phdr, p_memsz), &p_memsz, 8);
     } else if (p_offset > elf_info.text_offset) {
       p_offset += tramp_total;
-      std::memcpy(ph + 8, &p_offset, 8);
+      std::memcpy(ph + offsetof(Phdr, p_offset), &p_offset, 8);
     }
   }
 
@@ -319,45 +329,34 @@ MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
 
 bool PatchElfIsa(uint8_t *elf, size_t elf_size,
                  const std::string &target_cpu) {
-  if (elf_size < 64) return false;
+  if (elf_size < kMinElfSize) return false;
   if (elf[0] != 0x7f || elf[1] != 'E' || elf[2] != 'L' || elf[3] != 'F')
     return false;
-  if (elf[4] != 2) return false;
+  if (elf[llvm::ELF::EI_CLASS] != llvm::ELF::ELFCLASS64) return false;
 
-  struct GfxMach { const char *name; uint32_t mach; };
-  static const GfxMach gfx_mach_map[] = {
-      {"gfx900", 0x02c},  {"gfx906", 0x02f},  {"gfx908", 0x030},
-      {"gfx90a", 0x03f},  {"gfx940", 0x04a},  {"gfx941", 0x04b},
-      {"gfx942", 0x04c},  {"gfx950", 0x04f},  {"gfx1010", 0x033},
-      {"gfx1030", 0x036}, {"gfx1100", 0x041},  {"gfx1200", 0x048},
-      {"gfx1201", 0x04a}, {"gfx1250", 0x049},  {nullptr, 0}};
+  unsigned target_mach =
+      llvm::AMDGPUTargetStreamer::getElfMach(llvm::StringRef(target_cpu));
+  if (target_mach == llvm::ELF::EF_AMDGPU_MACH_NONE) return false;
 
-  uint32_t target_mach = 0;
-  for (auto *p = gfx_mach_map; p->name; ++p) {
-    if (target_cpu == p->name) {
-      target_mach = p->mach;
-      break;
-    }
-  }
-  if (target_mach == 0) return false;
+  using Ehdr = llvm::ELF::Elf64_Ehdr;
 
   uint32_t e_flags;
-  std::memcpy(&e_flags, elf + 48, 4);
+  std::memcpy(&e_flags, elf + offsetof(Ehdr, e_flags), 4);
   e_flags = (e_flags & ~0xFFu) | (target_mach & 0xFF);
-  std::memcpy(elf + 48, &e_flags, 4);
+  std::memcpy(elf + offsetof(Ehdr, e_flags), &e_flags, 4);
 
   uint64_t e_shoff;
   uint16_t e_shentsize, e_shnum;
-  std::memcpy(&e_shoff, elf + 40, 8);
-  std::memcpy(&e_shentsize, elf + 58, 2);
-  std::memcpy(&e_shnum, elf + 60, 2);
+  std::memcpy(&e_shoff, elf + offsetof(Ehdr, e_shoff), 8);
+  std::memcpy(&e_shentsize, elf + offsetof(Ehdr, e_shentsize), 2);
+  std::memcpy(&e_shnum, elf + offsetof(Ehdr, e_shnum), 2);
   if (e_shoff == 0 || e_shnum == 0) return true;
 
   for (uint16_t i = 0; i < e_shnum; ++i) {
     const uint8_t *sh = elf + e_shoff + i * e_shentsize;
     uint32_t sh_type;
     std::memcpy(&sh_type, sh + 4, 4);
-    if (sh_type != 7) continue;
+    if (sh_type != llvm::ELF::SHT_NOTE) continue;
     uint64_t sh_offset, sh_size;
     std::memcpy(&sh_offset, sh + 24, 8);
     std::memcpy(&sh_size, sh + 32, 8);
@@ -372,7 +371,7 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
       uint32_t descsz_aligned = (descsz + 3) & ~3u;
       uint64_t note_total = 12 + namesz_aligned + descsz_aligned;
       if (pos + note_total > sh_offset + sh_size) break;
-      if (type == 27 && namesz > 0) {
+      if (type == kNoteTypeIsaVersion && namesz > 0) {
         const char *owner = reinterpret_cast<const char *>(elf + pos + 12);
         if (std::strncmp(owner, "AMDGPU", 6) == 0) {
           uint8_t *desc = elf + pos + 12 + namesz_aligned;
@@ -412,11 +411,11 @@ int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
     const auto &sec = elf_info.sections[sym.shndx];
     if (sym.value < sec.addr) continue;
     uint64_t kd_file_offset = sec.offset + (sym.value - sec.addr);
-    if (kd_file_offset + 64 > elf_size) continue;
+    if (kd_file_offset + kKdSize > elf_size) continue;
     uint32_t rsrc1;
-    std::memcpy(&rsrc1, elf_data + kd_file_offset + 48, 4);
+    std::memcpy(&rsrc1, elf_data + kd_file_offset + kKdRsrc1Offset, 4);
     uint32_t granulated = rsrc1 & KD_RSRC1_VGPR_MASK;
     return static_cast<int>((granulated + 1) * 8);
   }
-  return 256;
+  return -1;
 }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -338,6 +338,28 @@ MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
 
 // ── PatchElfIsa ──────────────────────────────────────────────────────────────
 
+static constexpr uint32_t kEFlagsMachMask = 0xFFu;
+static constexpr size_t kNoteHeaderSize = 12;
+
+static void PatchIsaInNote(uint8_t *desc, uint32_t descsz,
+                           const std::string &target_cpu) {
+  std::string orig_isa(reinterpret_cast<const char *>(desc), descsz);
+  size_t gfx_pos = orig_isa.find("gfx");
+  if (gfx_pos == std::string::npos) return;
+
+  size_t gfx_end = gfx_pos;
+  while (gfx_end < orig_isa.size() && orig_isa[gfx_end] != ':' &&
+         orig_isa[gfx_end] != '\0')
+    ++gfx_end;
+
+  size_t orig_len = gfx_end - gfx_pos;
+  if (target_cpu.size() > orig_len) return;
+
+  std::memcpy(desc + gfx_pos, target_cpu.c_str(), target_cpu.size());
+  for (size_t j = target_cpu.size(); j < orig_len; ++j)
+    desc[gfx_pos + j] = '\0';
+}
+
 bool PatchElfIsa(uint8_t *elf, size_t elf_size,
                  const std::string &target_cpu) {
   if (elf_size < kMinElfSize) return false;
@@ -350,10 +372,12 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
   if (target_mach == llvm::ELF::EF_AMDGPU_MACH_NONE) return false;
 
   using Ehdr = llvm::ELF::Elf64_Ehdr;
+  using Shdr = llvm::ELF::Elf64_Shdr;
+  using Nhdr = llvm::ELF::Elf64_Nhdr;
 
   uint32_t e_flags;
   std::memcpy(&e_flags, elf + offsetof(Ehdr, e_flags), 4);
-  e_flags = (e_flags & ~0xFFu) | (target_mach & 0xFF);
+  e_flags = (e_flags & ~kEFlagsMachMask) | (target_mach & kEFlagsMachMask);
   std::memcpy(elf + offsetof(Ehdr, e_flags), &e_flags, 4);
 
   uint64_t e_shoff;
@@ -366,43 +390,31 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
   for (uint16_t i = 0; i < e_shnum; ++i) {
     const uint8_t *sh = elf + e_shoff + i * e_shentsize;
     uint32_t sh_type;
-    std::memcpy(&sh_type, sh + 4, 4);
+    std::memcpy(&sh_type, sh + offsetof(Shdr, sh_type), 4);
     if (sh_type != llvm::ELF::SHT_NOTE) continue;
+
     uint64_t sh_offset, sh_size;
-    std::memcpy(&sh_offset, sh + 24, 8);
-    std::memcpy(&sh_size, sh + 32, 8);
+    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), 8);
+    std::memcpy(&sh_size, sh + offsetof(Shdr, sh_size), 8);
     if (sh_offset + sh_size > elf_size) continue;
+
     uint64_t pos = sh_offset;
-    while (pos + 12 <= sh_offset + sh_size) {
+    while (pos + kNoteHeaderSize <= sh_offset + sh_size) {
       uint32_t namesz, descsz, type;
-      std::memcpy(&namesz, elf + pos, 4);
-      std::memcpy(&descsz, elf + pos + 4, 4);
-      std::memcpy(&type, elf + pos + 8, 4);
+      std::memcpy(&namesz, elf + pos + offsetof(Nhdr, n_namesz), 4);
+      std::memcpy(&descsz, elf + pos + offsetof(Nhdr, n_descsz), 4);
+      std::memcpy(&type, elf + pos + offsetof(Nhdr, n_type), 4);
       uint32_t namesz_aligned = (namesz + 3) & ~3u;
       uint32_t descsz_aligned = (descsz + 3) & ~3u;
-      uint64_t note_total = 12 + namesz_aligned + descsz_aligned;
+      uint64_t note_total = kNoteHeaderSize + namesz_aligned + descsz_aligned;
       if (pos + note_total > sh_offset + sh_size) break;
+
       if (type == kNoteTypeIsaVersion && namesz > 0) {
-        const char *owner = reinterpret_cast<const char *>(elf + pos + 12);
-        if (std::strncmp(owner, "AMDGPU", 6) == 0) {
-          uint8_t *desc = elf + pos + 12 + namesz_aligned;
-          std::string orig_isa(reinterpret_cast<const char *>(desc), descsz);
-          size_t gfx_pos = orig_isa.find("gfx");
-          if (gfx_pos != std::string::npos) {
-            size_t gfx_end = gfx_pos;
-            while (gfx_end < orig_isa.size() && orig_isa[gfx_end] != ':' &&
-                   orig_isa[gfx_end] != '\0')
-              ++gfx_end;
-            std::string orig_gfx =
-                orig_isa.substr(gfx_pos, gfx_end - gfx_pos);
-            if (target_cpu.size() <= orig_gfx.size()) {
-              std::memcpy(desc + gfx_pos, target_cpu.c_str(),
-                          target_cpu.size());
-              for (size_t j = target_cpu.size(); j < orig_gfx.size(); ++j)
-                desc[gfx_pos + j] = '\0';
-            }
-          }
-        }
+        const char *owner =
+            reinterpret_cast<const char *>(elf + pos + kNoteHeaderSize);
+        if (std::strncmp(owner, "AMDGPU", 6) == 0)
+          PatchIsaInNote(elf + pos + kNoteHeaderSize + namesz_aligned,
+                         descsz, target_cpu);
       }
       pos += note_total;
     }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -131,7 +131,7 @@ std::string ExtractCPU(const std::string &isa_name) {
 }
 
 std::string FindKernelAtOffset(const ElfInfo &elf_info,
-                                      uint64_t text_offset) {
+                               uint64_t text_offset) {
   for (auto &sym : elf_info.symbols) {
     uint8_t sym_type = sym.info & 0xf;
     if (sym_type != 2 && sym_type != 10)
@@ -148,9 +148,9 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
 
 // ── ApplyByteReplace ─────────────────────────────────────────────────────────
 
-[[nodiscard]] bool ApplyByteReplace(const RewriteRule &rule, uint64_t inst_offset,
-                             uint32_t inst_size, uint8_t *text,
-                             uint64_t text_size) {
+[[nodiscard]] bool ApplyByteReplace(const RewriteRule &rule,
+                                    uint64_t inst_offset, uint32_t inst_size,
+                                    uint8_t *text, uint64_t text_size) {
   if (inst_offset + inst_size > text_size) return false;
   if (rule.replace_bytes.size() > inst_size) return false;
   std::memcpy(text + inst_offset, rule.replace_bytes.data(),
@@ -171,9 +171,9 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
 // ── UpdateKernelDescriptor ───────────────────────────────────────────────────
 
 void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
-                                   const ElfInfo &elf_info,
-                                   const std::string &kernel_name,
-                                   int32_t extra_vgprs, int32_t extra_sgprs) {
+                            const ElfInfo &elf_info,
+                            const std::string &kernel_name,
+                            int32_t extra_vgprs, int32_t extra_sgprs) {
   std::string kd_name = kernel_name + ".kd";
   for (auto &sym : elf_info.symbols) {
     if (sym.name != kd_name)
@@ -212,7 +212,7 @@ void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
 // ── NOP sled management ─────────────────────────────────────────────────────
 
 NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
-                                uint64_t needed) {
+                         uint64_t needed) {
   NopSled *best = nullptr;
   int64_t best_dist = INT64_MAX;
   for (auto &sled : sleds) {
@@ -230,8 +230,8 @@ NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
 // ── GrowElfWithTrampolines ──────────────────────────────────────────────────
 
 MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
-                                            const ElfInfo &elf_info,
-                                            const std::vector<Trampoline> &trampolines) {
+                                    const ElfInfo &elf_info,
+                                    const std::vector<Trampoline> &trampolines) {
   size_t tramp_total = 0;
   for (auto &t : trampolines)
     tramp_total += t.bytes.size();
@@ -245,7 +245,7 @@ MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
   if (!buf)
     return {};
 
-  uint8_t *new_elf = buf.data;
+  uint8_t *new_elf = buf.get();
 
   uint64_t text_end = elf_info.text_offset + elf_info.text_size;
   std::memcpy(new_elf, elf, text_end);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -16,18 +16,19 @@
                                  uint8_t out_bytes[4],
                                  uint32_t s_branch_opcode) {
   int64_t byte_delta = static_cast<int64_t>(to_offset) -
-                       static_cast<int64_t>(from_offset) - 4;
-  if (byte_delta % 4 != 0) return false;
-  int64_t dword_offset = byte_delta / 4;
-  if (dword_offset < -32768 || dword_offset > 32767) return false;
-  uint32_t encoded =
-      s_branch_opcode | (static_cast<uint16_t>(dword_offset) & 0xFFFF);
-  std::memcpy(out_bytes, &encoded, 4);
+                       static_cast<int64_t>(from_offset) - kMinInstSize;
+  if (byte_delta % kMinInstSize != 0) return false;
+  int64_t dword_offset = byte_delta / kMinInstSize;
+  if (dword_offset < kBranchOffsetMin || dword_offset > kBranchOffsetMax)
+    return false;
+  uint32_t encoded = s_branch_opcode |
+                     (static_cast<uint16_t>(dword_offset) & kBranchOffsetMask);
+  std::memcpy(out_bytes, &encoded, kMinInstSize);
   return true;
 }
 
 void EncodeSNop(uint8_t out_bytes[4], uint32_t s_nop_opcode) {
-  std::memcpy(out_bytes, &s_nop_opcode, 4);
+  std::memcpy(out_bytes, &s_nop_opcode, kMinInstSize);
 }
 
 // ── ExtractCPU ───────────────────────────────────────────────────────────────
@@ -163,12 +164,12 @@ std::string FindKernelAtOffset(const ElfInfo &elf_info,
   uint32_t remaining =
       inst_size - static_cast<uint32_t>(rule.replace_bytes.size());
   uint64_t pad_offset = inst_offset + rule.replace_bytes.size();
-  while (remaining >= 4) {
-    uint8_t nop[4];
+  while (remaining >= kMinInstSize) {
+    uint8_t nop[kMinInstSize];
     EncodeSNop(nop, s_nop_opcode);
-    std::memcpy(text + pad_offset, nop, 4);
-    pad_offset += 4;
-    remaining -= 4;
+    std::memcpy(text + pad_offset, nop, kMinInstSize);
+    pad_offset += kMinInstSize;
+    remaining -= kMinInstSize;
   }
   return true;
 }
@@ -367,7 +368,10 @@ static void PatchIsaInNote(uint8_t *desc, uint32_t descsz,
 bool PatchElfIsa(uint8_t *elf, size_t elf_size,
                  const std::string &target_cpu) {
   if (elf_size < kMinElfSize) return false;
-  if (elf[0] != 0x7f || elf[1] != 'E' || elf[2] != 'L' || elf[3] != 'F')
+  if (elf[llvm::ELF::EI_MAG0] != llvm::ELF::ElfMagic[0] ||
+      elf[llvm::ELF::EI_MAG1] != llvm::ELF::ElfMagic[1] ||
+      elf[llvm::ELF::EI_MAG2] != llvm::ELF::ElfMagic[2] ||
+      elf[llvm::ELF::EI_MAG3] != llvm::ELF::ElfMagic[3])
     return false;
   if (elf[llvm::ELF::EI_CLASS] != llvm::ELF::ELFCLASS64) return false;
 
@@ -408,15 +412,17 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
       std::memcpy(&namesz, elf + pos + offsetof(Nhdr, n_namesz), 4);
       std::memcpy(&descsz, elf + pos + offsetof(Nhdr, n_descsz), 4);
       std::memcpy(&type, elf + pos + offsetof(Nhdr, n_type), 4);
-      uint32_t namesz_aligned = (namesz + 3) & ~3u;
-      uint32_t descsz_aligned = (descsz + 3) & ~3u;
+      uint32_t namesz_aligned =
+          (namesz + kNoteAlign - 1) & ~(kNoteAlign - 1);
+      uint32_t descsz_aligned =
+          (descsz + kNoteAlign - 1) & ~(kNoteAlign - 1);
       uint64_t note_total = kNoteHeaderSize + namesz_aligned + descsz_aligned;
       if (pos + note_total > sh_offset + sh_size) break;
 
       if (type == kNoteTypeIsaVersion && namesz > 0) {
         const char *owner =
             reinterpret_cast<const char *>(elf + pos + kNoteHeaderSize);
-        if (std::strncmp(owner, "AMDGPU", 6) == 0)
+        if (std::strncmp(owner, kAmdgpuNoteOwner, kAmdgpuNoteOwnerLen) == 0)
           PatchIsaInNote(elf + pos + kNoteHeaderSize + namesz_aligned,
                          descsz, target_cpu);
       }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -8,9 +8,9 @@
 
 #include "comgr-hotswap-internal.h"
 
-#include "MCTargetDesc/AMDGPUTargetStreamer.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/MathExtras.h"
+#include "llvm/TargetParser/TargetParser.h"
 
 // ── s_branch / s_nop encoding ────────────────────────────────────────────────
 
@@ -378,8 +378,14 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
     return false;
   if (elf[llvm::ELF::EI_CLASS] != llvm::ELF::ELFCLASS64) return false;
 
-  unsigned target_mach =
-      llvm::AMDGPUTargetStreamer::getElfMach(llvm::StringRef(target_cpu));
+  auto ak = llvm::AMDGPU::parseArchAMDGCN(target_cpu);
+  if (ak == llvm::AMDGPU::GPUKind::GK_NONE) return false;
+  unsigned target_mach = llvm::ELF::EF_AMDGPU_MACH_NONE;
+#define X(VAL, ENUM, NAME)                                                     \
+  if (llvm::StringRef(NAME) == target_cpu)                                     \
+    target_mach = llvm::ELF::ENUM;
+  AMDGPU_MACH_LIST(X)
+#undef X
   if (target_mach == llvm::ELF::EF_AMDGPU_MACH_NONE) return false;
 
   using Ehdr = llvm::ELF::Elf64_Ehdr;

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -9,6 +9,8 @@
 #include "comgr-hotswap-internal.h"
 
 #include "MCTargetDesc/AMDGPUTargetStreamer.h"
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/MathExtras.h"
 
 // ── s_branch / s_nop encoding ────────────────────────────────────────────────
 
@@ -38,10 +40,8 @@ std::string ExtractCPU(const std::string &isa_name) {
   if (pos != std::string::npos) {
     std::string cpu;
     for (size_t i = pos; i < isa_name.size(); ++i) {
-      char c = isa_name[i];
-      if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
-          (c >= 'A' && c <= 'Z'))
-        cpu += c;
+      if (llvm::isAlnum(isa_name[i]))
+        cpu += isa_name[i];
       else
         break;
     }
@@ -344,7 +344,6 @@ MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
 // ── PatchElfIsa ──────────────────────────────────────────────────────────────
 
 static constexpr uint32_t kEFlagsMachMask = 0xFFu;
-static constexpr size_t kNoteHeaderSize = 12;
 
 static void PatchIsaInNote(uint8_t *desc, uint32_t descsz,
                            const std::string &target_cpu) {
@@ -407,23 +406,21 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
     if (sh_offset + sh_size > elf_size) continue;
 
     uint64_t pos = sh_offset;
-    while (pos + kNoteHeaderSize <= sh_offset + sh_size) {
+    while (pos + sizeof(Nhdr) <= sh_offset + sh_size) {
       uint32_t namesz, descsz, type;
       std::memcpy(&namesz, elf + pos + offsetof(Nhdr, n_namesz), 4);
       std::memcpy(&descsz, elf + pos + offsetof(Nhdr, n_descsz), 4);
       std::memcpy(&type, elf + pos + offsetof(Nhdr, n_type), 4);
-      uint32_t namesz_aligned =
-          (namesz + kNoteAlign - 1) & ~(kNoteAlign - 1);
-      uint32_t descsz_aligned =
-          (descsz + kNoteAlign - 1) & ~(kNoteAlign - 1);
-      uint64_t note_total = kNoteHeaderSize + namesz_aligned + descsz_aligned;
+      uint32_t namesz_aligned = llvm::alignTo(namesz, kNoteAlign);
+      uint32_t descsz_aligned = llvm::alignTo(descsz, kNoteAlign);
+      uint64_t note_total = sizeof(Nhdr) + namesz_aligned + descsz_aligned;
       if (pos + note_total > sh_offset + sh_size) break;
 
       if (type == kNoteTypeIsaVersion && namesz > 0) {
         const char *owner =
-            reinterpret_cast<const char *>(elf + pos + kNoteHeaderSize);
+            reinterpret_cast<const char *>(elf + pos + sizeof(Nhdr));
         if (std::strncmp(owner, kAmdgpuNoteOwner, kAmdgpuNoteOwnerLen) == 0)
-          PatchIsaInNote(elf + pos + kNoteHeaderSize + namesz_aligned,
+          PatchIsaInNote(elf + pos + sizeof(Nhdr) + namesz_aligned,
                          descsz, target_cpu);
       }
       pos += note_total;

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -202,7 +202,7 @@ void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
   if (!kd) return;
 
   uint32_t rsrc1;
-  std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
+  std::memcpy(&rsrc1, kd + kKdRsrc1Offset, sizeof(rsrc1));
   if (extra_vgprs > 0) {
     uint32_t current = rsrc1 & kKdRsrc1VgprMask;
     uint32_t extra_granules =
@@ -222,7 +222,7 @@ void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
     rsrc1 = (rsrc1 & ~(kKdRsrc1SgprMask << kKdRsrc1SgprShift)) |
             (new_val << kKdRsrc1SgprShift);
   }
-  std::memcpy(kd + kKdRsrc1Offset, &rsrc1, 4);
+  std::memcpy(kd + kKdRsrc1Offset, &rsrc1, sizeof(rsrc1));
 }
 
 // ── NOP sled management ──────────────────────────────────────────────────────
@@ -253,28 +253,31 @@ static void AdjustSectionHeaders(uint8_t *elf, uint64_t text_offset,
   uint64_t text_end = text_offset + text_size;
   uint64_t e_shoff;
   uint16_t e_shentsize, e_shnum;
-  std::memcpy(&e_shoff, elf + offsetof(Ehdr, e_shoff), 8);
-  std::memcpy(&e_shentsize, elf + offsetof(Ehdr, e_shentsize), 2);
+  std::memcpy(&e_shoff, elf + offsetof(Ehdr, e_shoff), sizeof(e_shoff));
+  std::memcpy(&e_shentsize, elf + offsetof(Ehdr, e_shentsize),
+              sizeof(e_shentsize));
 
   if (e_shoff >= text_end) {
     uint64_t new_shoff = e_shoff + tramp_total;
-    std::memcpy(elf + offsetof(Ehdr, e_shoff), &new_shoff, 8);
+    std::memcpy(elf + offsetof(Ehdr, e_shoff), &new_shoff, sizeof(new_shoff));
     e_shoff = new_shoff;
   }
 
-  std::memcpy(&e_shnum, elf + offsetof(Ehdr, e_shnum), 2);
+  std::memcpy(&e_shnum, elf + offsetof(Ehdr, e_shnum), sizeof(e_shnum));
 
   for (uint16_t i = 0; i < e_shnum; ++i) {
     uint8_t *sh = elf + e_shoff + i * e_shentsize;
     uint64_t sh_offset;
-    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), 8);
+    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), sizeof(sh_offset));
 
     if (sh_offset == text_offset) {
       uint64_t new_text_size = text_size + tramp_total;
-      std::memcpy(sh + offsetof(Shdr, sh_size), &new_text_size, 8);
+      std::memcpy(sh + offsetof(Shdr, sh_size), &new_text_size,
+                  sizeof(new_text_size));
     } else if (sh_offset > text_offset) {
       uint64_t new_offset = sh_offset + tramp_total;
-      std::memcpy(sh + offsetof(Shdr, sh_offset), &new_offset, 8);
+      std::memcpy(sh + offsetof(Shdr, sh_offset), &new_offset,
+                  sizeof(new_offset));
     }
   }
 }
@@ -287,25 +290,26 @@ static void AdjustProgramHeaders(uint8_t *elf, uint64_t text_offset,
   uint64_t text_end = text_offset + text_size;
   uint64_t e_phoff;
   uint16_t e_phentsize, e_phnum;
-  std::memcpy(&e_phoff, elf + offsetof(Ehdr, e_phoff), 8);
-  std::memcpy(&e_phentsize, elf + offsetof(Ehdr, e_phentsize), 2);
-  std::memcpy(&e_phnum, elf + offsetof(Ehdr, e_phnum), 2);
+  std::memcpy(&e_phoff, elf + offsetof(Ehdr, e_phoff), sizeof(e_phoff));
+  std::memcpy(&e_phentsize, elf + offsetof(Ehdr, e_phentsize),
+              sizeof(e_phentsize));
+  std::memcpy(&e_phnum, elf + offsetof(Ehdr, e_phnum), sizeof(e_phnum));
 
   for (uint16_t i = 0; i < e_phnum; ++i) {
     uint8_t *ph = elf + e_phoff + i * e_phentsize;
     uint64_t p_offset, p_filesz, p_memsz;
-    std::memcpy(&p_offset, ph + offsetof(Phdr, p_offset), 8);
-    std::memcpy(&p_filesz, ph + offsetof(Phdr, p_filesz), 8);
-    std::memcpy(&p_memsz, ph + offsetof(Phdr, p_memsz), 8);
+    std::memcpy(&p_offset, ph + offsetof(Phdr, p_offset), sizeof(p_offset));
+    std::memcpy(&p_filesz, ph + offsetof(Phdr, p_filesz), sizeof(p_filesz));
+    std::memcpy(&p_memsz, ph + offsetof(Phdr, p_memsz), sizeof(p_memsz));
 
     if (p_offset <= text_offset && p_offset + p_filesz >= text_end) {
       p_filesz += tramp_total;
       p_memsz += tramp_total;
-      std::memcpy(ph + offsetof(Phdr, p_filesz), &p_filesz, 8);
-      std::memcpy(ph + offsetof(Phdr, p_memsz), &p_memsz, 8);
+      std::memcpy(ph + offsetof(Phdr, p_filesz), &p_filesz, sizeof(p_filesz));
+      std::memcpy(ph + offsetof(Phdr, p_memsz), &p_memsz, sizeof(p_memsz));
     } else if (p_offset > text_offset) {
       p_offset += tramp_total;
-      std::memcpy(ph + offsetof(Phdr, p_offset), &p_offset, 8);
+      std::memcpy(ph + offsetof(Phdr, p_offset), &p_offset, sizeof(p_offset));
     }
   }
 }
@@ -383,34 +387,37 @@ bool PatchElfIsa(uint8_t *elf, size_t elf_size,
   using Nhdr = llvm::ELF::Elf64_Nhdr;
 
   uint32_t e_flags;
-  std::memcpy(&e_flags, elf + offsetof(Ehdr, e_flags), 4);
+  std::memcpy(&e_flags, elf + offsetof(Ehdr, e_flags), sizeof(e_flags));
   e_flags = (e_flags & ~kEFlagsMachMask) | (target_mach & kEFlagsMachMask);
-  std::memcpy(elf + offsetof(Ehdr, e_flags), &e_flags, 4);
+  std::memcpy(elf + offsetof(Ehdr, e_flags), &e_flags, sizeof(e_flags));
 
   uint64_t e_shoff;
   uint16_t e_shentsize, e_shnum;
-  std::memcpy(&e_shoff, elf + offsetof(Ehdr, e_shoff), 8);
-  std::memcpy(&e_shentsize, elf + offsetof(Ehdr, e_shentsize), 2);
-  std::memcpy(&e_shnum, elf + offsetof(Ehdr, e_shnum), 2);
+  std::memcpy(&e_shoff, elf + offsetof(Ehdr, e_shoff), sizeof(e_shoff));
+  std::memcpy(&e_shentsize, elf + offsetof(Ehdr, e_shentsize),
+              sizeof(e_shentsize));
+  std::memcpy(&e_shnum, elf + offsetof(Ehdr, e_shnum), sizeof(e_shnum));
   if (e_shoff == 0 || e_shnum == 0) return true;
 
   for (uint16_t i = 0; i < e_shnum; ++i) {
     const uint8_t *sh = elf + e_shoff + i * e_shentsize;
     uint32_t sh_type;
-    std::memcpy(&sh_type, sh + offsetof(Shdr, sh_type), 4);
+    std::memcpy(&sh_type, sh + offsetof(Shdr, sh_type), sizeof(sh_type));
     if (sh_type != llvm::ELF::SHT_NOTE) continue;
 
     uint64_t sh_offset, sh_size;
-    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), 8);
-    std::memcpy(&sh_size, sh + offsetof(Shdr, sh_size), 8);
+    std::memcpy(&sh_offset, sh + offsetof(Shdr, sh_offset), sizeof(sh_offset));
+    std::memcpy(&sh_size, sh + offsetof(Shdr, sh_size), sizeof(sh_size));
     if (sh_offset + sh_size > elf_size) continue;
 
     uint64_t pos = sh_offset;
     while (pos + sizeof(Nhdr) <= sh_offset + sh_size) {
       uint32_t namesz, descsz, type;
-      std::memcpy(&namesz, elf + pos + offsetof(Nhdr, n_namesz), 4);
-      std::memcpy(&descsz, elf + pos + offsetof(Nhdr, n_descsz), 4);
-      std::memcpy(&type, elf + pos + offsetof(Nhdr, n_type), 4);
+      std::memcpy(&namesz, elf + pos + offsetof(Nhdr, n_namesz),
+                  sizeof(namesz));
+      std::memcpy(&descsz, elf + pos + offsetof(Nhdr, n_descsz),
+                  sizeof(descsz));
+      std::memcpy(&type, elf + pos + offsetof(Nhdr, n_type), sizeof(type));
       uint32_t namesz_aligned = llvm::alignTo(namesz, kNoteAlign);
       uint32_t descsz_aligned = llvm::alignTo(descsz, kNoteAlign);
       uint64_t note_total = sizeof(Nhdr) + namesz_aligned + descsz_aligned;
@@ -438,7 +445,7 @@ int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
       const_cast<uint8_t *>(elf_data), elf_size, elf_info, kernel_name);
   if (!kd) return -1;
   uint32_t rsrc1;
-  std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
+  std::memcpy(&rsrc1, kd + kKdRsrc1Offset, sizeof(rsrc1));
   uint32_t granulated = rsrc1 & kKdRsrc1VgprMask;
   return static_cast<int>((granulated + 1) * kVgprGranularity);
 }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -137,7 +137,7 @@ std::string ExtractCPU(const std::string &isa_name) {
 std::string FindKernelAtOffset(const ElfInfo &elf_info,
                                uint64_t text_offset) {
   for (auto &sym : elf_info.symbols) {
-    uint8_t sym_type = sym.info & 0xf;
+    uint8_t sym_type = sym.info & kElfStTypeMask;
     if (sym_type != llvm::ELF::STT_FUNC && sym_type != llvm::ELF::STT_GNU_IFUNC)
       continue;
     if (sym.shndx != static_cast<uint16_t>(elf_info.text_section_idx))
@@ -203,19 +203,23 @@ void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
   uint32_t rsrc1;
   std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
   if (extra_vgprs > 0) {
-    uint32_t current = rsrc1 & KD_RSRC1_VGPR_MASK;
-    uint32_t extra_granules = (static_cast<uint32_t>(extra_vgprs) + 3) / 4;
+    uint32_t current = rsrc1 & kKdRsrc1VgprMask;
+    uint32_t extra_granules =
+        (static_cast<uint32_t>(extra_vgprs) + kVgprGranuleSize - 1) /
+        kVgprGranuleSize;
     uint32_t new_val = current + extra_granules;
-    if (new_val > 63) new_val = 63;
-    rsrc1 = (rsrc1 & ~KD_RSRC1_VGPR_MASK) | new_val;
+    if (new_val > kKdRsrc1VgprMaxGranule) new_val = kKdRsrc1VgprMaxGranule;
+    rsrc1 = (rsrc1 & ~kKdRsrc1VgprMask) | new_val;
   }
   if (extra_sgprs > 0) {
-    uint32_t current = (rsrc1 >> KD_RSRC1_SGPR_SHIFT) & KD_RSRC1_SGPR_MASK;
-    uint32_t extra_granules = (static_cast<uint32_t>(extra_sgprs) + 7) / 8;
+    uint32_t current = (rsrc1 >> kKdRsrc1SgprShift) & kKdRsrc1SgprMask;
+    uint32_t extra_granules =
+        (static_cast<uint32_t>(extra_sgprs) + kSgprGranuleSize - 1) /
+        kSgprGranuleSize;
     uint32_t new_val = current + extra_granules;
-    if (new_val > 15) new_val = 15;
-    rsrc1 = (rsrc1 & ~(KD_RSRC1_SGPR_MASK << KD_RSRC1_SGPR_SHIFT)) |
-            (new_val << KD_RSRC1_SGPR_SHIFT);
+    if (new_val > kKdRsrc1SgprMaxGranule) new_val = kKdRsrc1SgprMaxGranule;
+    rsrc1 = (rsrc1 & ~(kKdRsrc1SgprMask << kKdRsrc1SgprShift)) |
+            (new_val << kKdRsrc1SgprShift);
   }
   std::memcpy(kd + kKdRsrc1Offset, &rsrc1, 4);
 }
@@ -432,6 +436,6 @@ int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
   if (!kd) return -1;
   uint32_t rsrc1;
   std::memcpy(&rsrc1, kd + kKdRsrc1Offset, 4);
-  uint32_t granulated = rsrc1 & KD_RSRC1_VGPR_MASK;
-  return static_cast<int>((granulated + 1) * 8);
+  uint32_t granulated = rsrc1 & kKdRsrc1VgprMask;
+  return static_cast<int>((granulated + 1) * kVgprGranularity);
 }

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -183,24 +183,10 @@ struct NopSled {
 
 // ── Rewrite-rule types (used by ApplyByteReplace / ApplyMnemonicSwap) ────────
 
-struct OperandMatch {
-  enum class Kind { Wildcard, Immediate, RegClass };
-  Kind kind = Kind::Wildcard;
-  int64_t imm_value = 0;
-};
-
 struct RewriteRule {
-  std::string name;
-  std::string match_mnemonic;
-  std::string match_kernel;
-  int64_t match_offset = -1;
-  std::vector<OperandMatch> operands;
   std::string replace_mnemonic;
   bool preserve_operands = true;
-  std::vector<std::string> replace_asm;
   std::vector<uint8_t> replace_bytes;
-  int32_t extra_vgprs = 0;
-  int32_t extra_sgprs = 0;
 };
 
 // ── s_branch / s_nop constants ───────────────────────────────────────────────

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -185,7 +185,6 @@ struct NopSled {
 
 struct RewriteRule {
   std::string replace_mnemonic;
-  bool preserve_operands = true;
   std::vector<uint8_t> replace_bytes;
 };
 
@@ -436,10 +435,30 @@ amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
 // Patch .cpp files provide strong definitions that override the stubs at link
 // time, allowing patches to land as independent PRs.
 
+/// Per-instruction patches that rewrite in place without changing code size:
+///  - cluster_load → global_load mnemonic swap
+///  - s_clause → s_nop byte overwrite
 uint32_t ApplyInPlacePatches(PatchContext &ctx, size_t idx);
+
+/// Per-instruction patches that expand one instruction into multiple via NOP
+/// sled or trampoline: ds_2addr stride64 expansion and tensor_load_to_lds
+/// s_pack_hh prepend.
 uint32_t ApplyTrampolinePatches(PatchContext &ctx, size_t idx);
+
+/// Whole-kernel pass: detect WMMA/SWMMAC followed by VALU with overlapping
+/// VGPR ranges and insert v_nop instructions to resolve the co-execution
+/// hazard. Runs after all per-instruction patches.
 uint32_t ApplyWmmaHazardPatch(PatchContext &ctx);
+
+/// Per-instruction decomposition of unsupported WMMA variants into narrower
+/// operations: split 16x16x128 FP8/BF8 WMMA into two 16x16x64 halves and
+/// split 32x16x128_f4 WMMA into two 16x16x128 f8f6f4 WMMAs with FP4 format
+/// modifiers.
 uint32_t ApplyWmmaSplitPatches(PatchContext &ctx, size_t idx);
+
+/// Per-instruction patches requiring dynamically allocated VGPRs via
+/// ScratchAllocator backed by backward liveness analysis: CVT E5M3 CLAMP
+/// emulation (4 scratch VGPRs) and Scale16 decomposition (2 scratch VGPRs).
 uint32_t ApplyScratchPatches(PatchContext &ctx, size_t idx);
 
 #endif // COMGR_HOTSWAP_INTERNAL_H

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -14,7 +14,7 @@
 ///   comgr-hotswap-dwarf.cpp     — DWARF debug section patching
 ///   comgr-hotswap-llvm.cpp      — LLVM MC infrastructure (disasm/asm/encode)
 ///   comgr-hotswap-liveness.cpp  — CFG, backward liveness, scratch allocator
-///   comgr-hotswap-b0a0.cpp      — GFX1250 B0-to-A0 silicon stepping patches
+///   comgr-hotswap-b0a0.cpp      — ISA rewrite policy (e.g., GFX1250 B0-to-A0)
 ///   comgr-hotswap.cpp           — Public C API entry points
 ///
 //===----------------------------------------------------------------------===//
@@ -36,21 +36,21 @@
 #include <vector>
 
 #include "llvm/ADT/BitVector.h"
-#include "llvm/MC/MCInstrDesc.h"
-#include "llvm/MC/MCInstrInfo.h"
-#include "llvm/MC/MCRegisterInfo.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Object/ELF.h"
-#include "llvm/Object/ELFTypes.h"
-#include "llvm/Support/raw_ostream.h"
-
+#include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Object/ELFTypes.h"
+#include "llvm/Support/raw_ostream.h"
 
 // ── MallocBuffer ─────────────────────────────────────────────────────────────
 
@@ -101,6 +101,21 @@ inline llvm::raw_ostream &HotswapLog(HotswapLogLevel level) {
     return llvm::errs();
   return llvm::nulls();
 }
+
+// ── RewriteConfig ────────────────────────────────────────────────────────────
+//
+// ISA-specific parameters that drive the generic rewriting infrastructure.
+// Constructed by the policy layer (e.g., b0a0.cpp for GFX1250) and threaded
+// through PatchContext so infrastructure code has zero ISA assumptions.
+
+struct RewriteConfig {
+  std::string source_isa;
+  std::string target_isa;
+  std::string target_cpu;
+  uint32_t s_branch_opcode;
+  uint32_t s_nop_opcode;
+  unsigned max_vgprs;
+};
 
 // ── ELF types ────────────────────────────────────────────────────────────────
 
@@ -154,17 +169,18 @@ struct RewriteRule {
   std::vector<uint8_t> replace_bytes;
 };
 
-// ── s_branch / s_nop constants ───────────────────────────────────────────────
+// ── ELF / KD named constants ─────────────────────────────────────────────────
 
-inline constexpr uint32_t S_BRANCH_GFX9 = 0xBF820000u;
-inline constexpr uint32_t S_BRANCH_GFX12 = 0xBFA00000u;
-inline constexpr uint32_t S_NOP_OPCODE = 0xBF800000u;
-
-// ── AMDGPU Kernel Descriptor RSRC1 bit fields ───────────────────────────────
-
+static constexpr uint64_t kMinElfSize = sizeof(llvm::ELF::Elf64_Ehdr);
+static constexpr uint64_t kKdSize = 64;
+static constexpr uint64_t kKdRsrc1Offset = 48;
 static constexpr uint32_t KD_RSRC1_VGPR_MASK = 0x3Fu;
 static constexpr uint32_t KD_RSRC1_SGPR_SHIFT = 6;
 static constexpr uint32_t KD_RSRC1_SGPR_MASK = 0xFu;
+static constexpr int64_t kMaxSledDistance = 131072;
+
+// AMDGPU code-object-v3 ISA version note type (not in llvm::ELF enum)
+static constexpr uint32_t kNoteTypeIsaVersion = 27;
 
 // ── DWARF types ──────────────────────────────────────────────────────────────
 
@@ -203,8 +219,8 @@ struct InternalDecodedInst {
 // ── VGPR liveness types ──────────────────────────────────────────────────────
 
 struct RegDefUse {
-  llvm::BitVector defs{256};
-  llvm::BitVector uses{256};
+  llvm::BitVector defs;
+  llvm::BitVector uses;
 };
 
 struct BasicBlock {
@@ -230,11 +246,12 @@ struct ScratchAllocator {
   llvm::BitVector live_at_point;
   int kd_allocated_vgprs;
   int next_above_kd;
+  int max_vgprs;
   int extra_allocated = 0;
 
-  ScratchAllocator(const llvm::BitVector &live, int kd_vgprs)
+  ScratchAllocator(const llvm::BitVector &live, int kd_vgprs, int max)
       : live_at_point(live), kd_allocated_vgprs(kd_vgprs),
-        next_above_kd(kd_vgprs) {}
+        next_above_kd(kd_vgprs), max_vgprs(max) {}
 
   int Alloc() {
     for (int v = kd_allocated_vgprs - 1; v >= 0; --v) {
@@ -243,7 +260,7 @@ struct ScratchAllocator {
         return v;
       }
     }
-    if (next_above_kd >= 256)
+    if (next_above_kd >= max_vgprs)
       return -1;
     int v = next_above_kd++;
     extra_allocated++;
@@ -256,10 +273,10 @@ struct ScratchAllocator {
 
 struct ScratchPatchInfo {
   uint64_t offset;
-  llvm::BitVector scratch_regs{256};
+  llvm::BitVector scratch_regs;
 };
 
-// ── B0-to-A0 types ──────────────────────────────────────────────────────────
+// ── Patch types ──────────────────────────────────────────────────────────────
 
 struct WmmaNopReq {
   int b0_nops;
@@ -281,6 +298,7 @@ struct KernelPatchStats {
 };
 
 struct PatchContext {
+  const RewriteConfig &config;
   std::vector<InternalDecodedInst> &decoded;
   uint8_t *text;
   uint64_t text_size;
@@ -299,15 +317,17 @@ struct PatchContext {
 
 // elf
 [[nodiscard]] bool EncodeSBranch(uint64_t from_offset, uint64_t to_offset,
-                                 uint8_t out_bytes[4], bool gfx12 = false);
-void EncodeSNop(uint8_t out_bytes[4]);
+                                 uint8_t out_bytes[4],
+                                 uint32_t s_branch_opcode);
+void EncodeSNop(uint8_t out_bytes[4], uint32_t s_nop_opcode);
 std::string ExtractCPU(const std::string &isa_name);
 [[nodiscard]] bool ParseElfInfo(const uint8_t *elf, size_t elf_size,
                                 ElfInfo &info);
 std::string FindKernelAtOffset(const ElfInfo &elf_info, uint64_t text_offset);
 [[nodiscard]] bool ApplyByteReplace(const RewriteRule &rule,
                                     uint64_t inst_offset, uint32_t inst_size,
-                                    uint8_t *text, uint64_t text_size);
+                                    uint8_t *text, uint64_t text_size,
+                                    uint32_t s_nop_opcode);
 void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
                             const ElfInfo &elf_info,
                             const std::string &kernel_name,
@@ -354,7 +374,7 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
 Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
                            uint64_t original_offset, uint32_t original_size,
                            uint64_t trampoline_text_offset,
-                           const std::string &cpu,
+                           const RewriteConfig &config,
                            const LLVMState &llvm_state);
 std::string PrintInst(const InternalDecodedInst &di,
                       const LLVMState &llvm_state);
@@ -378,17 +398,19 @@ CFG BuildCFG(const std::vector<InternalDecodedInst> &decoded,
              const llvm::MCInstrInfo &MCII);
 LivenessInfo ComputeLiveness(const std::vector<InternalDecodedInst> &decoded,
                              const CFG &cfg, const llvm::MCInstrInfo &MCII,
-                             const llvm::MCRegisterInfo &MRI);
+                             const llvm::MCRegisterInfo &MRI,
+                             unsigned max_vgprs);
 [[nodiscard]] bool VerifyPatchCorrectness(
     const uint8_t *text, uint64_t text_size, const LLVMState &llvm_state,
-    const std::vector<ScratchPatchInfo> &scratch_patches);
+    const std::vector<ScratchPatchInfo> &scratch_patches,
+    unsigned max_vgprs);
 
-// b0a0 — dispatcher
+// policy — dispatcher
 amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
                                           size_t elf_size, void **out_data,
                                           size_t *out_size);
 
-// b0a0 — patch entry points (weak stubs in b0a0.cpp)
+// policy — patch entry points (weak stubs in b0a0.cpp)
 //
 // Each group is defined as a weak symbol in comgr-hotswap-b0a0.cpp returning 0.
 // Patch .cpp files provide strong definitions that override the stubs at link

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -39,7 +39,6 @@
 #include <utility>
 #include <vector>
 
-#include "llvm/Config/llvm-config.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAsmInfo.h"

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -28,82 +28,55 @@
 #include <charconv>
 #include <cstdlib>
 #include <cstring>
-#include <iomanip>
-#include <iostream>
 #include <memory>
 #include <mutex>
-#include <sstream>
 #include <string>
-#include <string_view>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "llvm/ADT/BitVector.h"
-#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Object/ELFTypes.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCInstPrinter.h"
-#include "llvm/MC/MCInstrDesc.h"
-#include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCObjectFileInfo.h"
-#include "llvm/MC/MCObjectWriter.h"
-#include "llvm/MC/MCParser/MCAsmParser.h"
-#include "llvm/MC/MCParser/MCTargetAsmParser.h"
-#include "llvm/MC/MCRegisterInfo.h"
-#include "llvm/MC/MCStreamer.h"
 #include "llvm/MC/MCSubtargetInfo.h"
-#include "llvm/Support/MemoryBuffer.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/LEB128.h"
-#include "llvm/Object/ELF.h"
-#include "llvm/Object/ELFTypes.h"
-#include "llvm/Support/raw_ostream.h"
-#include "llvm/MC/TargetRegistry.h"
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// Types
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── MallocBuffer ─────────────────────────────────────────────────────────────
 
-// ── MallocBuffer RAII wrapper ────────────────────────────────────────────────
+struct FreeDeleter {
+  void operator()(uint8_t *p) const { std::free(p); }
+};
 
 struct MallocBuffer {
-  uint8_t *data = nullptr;
+  std::unique_ptr<uint8_t[], FreeDeleter> data;
   size_t size = 0;
 
   MallocBuffer() = default;
-  MallocBuffer(size_t n)
+  explicit MallocBuffer(size_t n)
       : data(static_cast<uint8_t *>(std::malloc(n))), size(data ? n : 0) {}
-  ~MallocBuffer() { std::free(data); }
 
-  MallocBuffer(MallocBuffer &&o) noexcept : data(o.data), size(o.size) {
-    o.data = nullptr;
-    o.size = 0;
-  }
+  MallocBuffer(MallocBuffer &&o) noexcept
+      : data(std::move(o.data)), size(std::exchange(o.size, 0)) {}
   MallocBuffer &operator=(MallocBuffer &&o) noexcept {
-    if (this != &o) {
-      std::free(data);
-      data = o.data;
-      size = o.size;
-      o.data = nullptr;
-      o.size = 0;
-    }
+    data = std::move(o.data);
+    size = std::exchange(o.size, 0);
     return *this;
   }
 
-  MallocBuffer(const MallocBuffer &) = delete;
-  MallocBuffer &operator=(const MallocBuffer &) = delete;
-
   explicit operator bool() const { return data != nullptr; }
-  uint8_t *release() {
-    uint8_t *p = data;
-    data = nullptr;
-    size = 0;
-    return p;
-  }
+  uint8_t *get() const { return data.get(); }
+  uint8_t *release() { size = 0; return data.release(); }
 };
 
 // ── Logging ──────────────────────────────────────────────────────────────────
@@ -123,16 +96,10 @@ inline HotswapLogLevel GetHotswapLogLevel() {
   return level;
 }
 
-inline std::ostream &HotswapLog(HotswapLogLevel level) {
-  class NullBuf : public std::streambuf {
-  protected:
-    int overflow(int c) override { return c; }
-  };
-  static NullBuf null_buf;
-  static std::ostream null_stream(&null_buf);
+inline llvm::raw_ostream &HotswapLog(HotswapLogLevel level) {
   if (static_cast<int>(level) <= static_cast<int>(GetHotswapLogLevel()))
-    return std::cerr;
-  return null_stream;
+    return llvm::errs();
+  return llvm::nulls();
 }
 
 // ── ELF types ────────────────────────────────────────────────────────────────
@@ -180,7 +147,7 @@ struct NopSled {
   uint64_t write_pos;
 };
 
-// ── Rewrite-rule types (used by ApplyByteReplace / ApplyMnemonicSwap) ────────
+// ── Rewrite-rule types ───────────────────────────────────────────────────────
 
 struct RewriteRule {
   std::string replace_mnemonic;
@@ -224,7 +191,7 @@ struct LLVMState {
   bool valid = false;
 };
 
-// ── Decoded instruction with MCInst ──────────────────────────────────────────
+// ── Decoded instruction ──────────────────────────────────────────────────────
 
 struct InternalDecodedInst {
   uint64_t offset;
@@ -233,7 +200,7 @@ struct InternalDecodedInst {
   std::string mnemonic;
 };
 
-// ── Per-point VGPR liveness types ────────────────────────────────────────────
+// ── VGPR liveness types ──────────────────────────────────────────────────────
 
 struct RegDefUse {
   llvm::BitVector defs{256};
@@ -328,12 +295,9 @@ struct PatchContext {
   std::vector<ScratchPatchInfo> &out_scratch_patches;
 };
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// Function declarations (cross-file)
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── Function declarations ────────────────────────────────────────────────────
 
-// ── elf ──────────────────────────────────────────────────────────────────────
-
+// elf
 [[nodiscard]] bool EncodeSBranch(uint64_t from_offset, uint64_t to_offset,
                                  uint8_t out_bytes[4], bool gfx12 = false);
 void EncodeSNop(uint8_t out_bytes[4]);
@@ -358,8 +322,7 @@ int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
                        const ElfInfo &elf_info,
                        const std::string &kernel_name);
 
-// ── dwarf ────────────────────────────────────────────────────────────────────
-
+// dwarf
 uint8_t *FindSectionHeader(uint8_t *elf, size_t elf_size, const char *name,
                            int *out_idx = nullptr);
 [[nodiscard]] bool AddTrampolineSymbols(
@@ -376,8 +339,7 @@ void PatchDebugInfo(uint8_t *elf, size_t elf_size, uint64_t text_addr,
 void PatchDebugFrame(uint8_t *elf, size_t elf_size, uint64_t text_addr,
                      uint64_t text_size_before, uint64_t tramp_total);
 
-// ── llvm ─────────────────────────────────────────────────────────────────────
-
+// llvm
 LLVMState InitLLVMImpl(const std::string &isa_name,
                        const llvm::Target *cached_target = nullptr);
 LLVMState InitLLVMCached(const std::string &isa_name);
@@ -407,8 +369,7 @@ bool CheckVgprOverlap(const llvm::MCInst &wmma_inst,
                       const llvm::MCInst &valu_inst,
                       const llvm::MCRegisterInfo &MRI);
 
-// ── liveness ─────────────────────────────────────────────────────────────────
-
+// liveness
 RegDefUse GetInstRegDefUse(const llvm::MCInst &inst,
                            const llvm::MCInstrInfo &MCII,
                            const llvm::MCRegisterInfo &MRI);
@@ -422,21 +383,20 @@ LivenessInfo ComputeLiveness(const std::vector<InternalDecodedInst> &decoded,
     const uint8_t *text, uint64_t text_size, const LLVMState &llvm_state,
     const std::vector<ScratchPatchInfo> &scratch_patches);
 
-// ── b0a0 — dispatcher and entry point ────────────────────────────────────────
-
+// b0a0 — dispatcher
 amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
                                           size_t elf_size, void **out_data,
                                           size_t *out_size);
 
-// ── b0a0 — patch entry points (weak stubs in b0a0.cpp) ──────────────────────
+// b0a0 — patch entry points (weak stubs in b0a0.cpp)
 //
 // Each group is defined as a weak symbol in comgr-hotswap-b0a0.cpp returning 0.
 // Patch .cpp files provide strong definitions that override the stubs at link
 // time, allowing patches to land as independent PRs.
 
 /// Per-instruction patches that rewrite in place without changing code size:
-///  - cluster_load → global_load mnemonic swap
-///  - s_clause → s_nop byte overwrite
+///  - cluster_load -> global_load mnemonic swap
+///  - s_clause -> s_nop byte overwrite
 uint32_t ApplyInPlacePatches(PatchContext &ctx, size_t idx);
 
 /// Per-instruction patches that expand one instruction into multiple via NOP

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -77,7 +77,7 @@ struct MallocBuffer {
 
   MallocBuffer() = default;
   MallocBuffer(size_t n)
-      : data(static_cast<uint8_t *>(std::malloc(n))), size(n) {}
+      : data(static_cast<uint8_t *>(std::malloc(n))), size(data ? n : 0) {}
   ~MallocBuffer() { std::free(data); }
 
   MallocBuffer(MallocBuffer &&o) noexcept : data(o.data), size(o.size) {
@@ -125,7 +125,12 @@ inline HotswapLogLevel GetHotswapLogLevel() {
 }
 
 inline std::ostream &HotswapLog(HotswapLogLevel level) {
-  static std::ostream null_stream(nullptr);
+  class NullBuf : public std::streambuf {
+  protected:
+    int overflow(int c) override { return c; }
+  };
+  static NullBuf null_buf;
+  static std::ostream null_stream(&null_buf);
   if (static_cast<int>(level) <= static_cast<int>(GetHotswapLogLevel()))
     return std::cerr;
   return null_stream;
@@ -178,11 +183,18 @@ struct NopSled {
 
 // ── Rewrite-rule types (used by ApplyByteReplace / ApplyMnemonicSwap) ────────
 
+struct OperandMatch {
+  enum class Kind { Wildcard, Immediate, RegClass };
+  Kind kind = Kind::Wildcard;
+  int64_t imm_value = 0;
+};
+
 struct RewriteRule {
   std::string name;
   std::string match_mnemonic;
   std::string match_kernel;
   int64_t match_offset = -1;
+  std::vector<OperandMatch> operands;
   std::string replace_mnemonic;
   bool preserve_operands = true;
   std::vector<std::string> replace_asm;
@@ -223,7 +235,7 @@ struct LLVMState {
   std::unique_ptr<llvm::MCObjectFileInfo> MOFI;
   std::unique_ptr<llvm::MCDisassembler> disasm;
   std::unique_ptr<llvm::MCInstPrinter> printer;
-  llvm::MCCodeEmitter *CE = nullptr;
+  std::unique_ptr<llvm::MCCodeEmitter> CE;
   std::string cpu;
   bool valid = false;
 };

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1,0 +1,447 @@
+//===- comgr-hotswap-internal.h - HotSwap internal types and declarations -===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Internal header for the HotSwap ISA rewriting subsystem. Shared by all
+/// comgr-hotswap-*.cpp compilation units. Not part of the public COMGR API.
+///
+/// Module structure:
+///   comgr-hotswap-elf.cpp       — ELF parsing, binary helpers, trampoline growth
+///   comgr-hotswap-dwarf.cpp     — DWARF debug section patching
+///   comgr-hotswap-llvm.cpp      — LLVM MC infrastructure (disasm/asm/encode)
+///   comgr-hotswap-liveness.cpp  — CFG, backward liveness, scratch allocator
+///   comgr-hotswap-b0a0.cpp      — GFX1250 B0-to-A0 silicon stepping patches
+///   comgr-hotswap.cpp           — Public C API entry points
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_HOTSWAP_INTERNAL_H
+#define COMGR_HOTSWAP_INTERNAL_H
+
+#include "amd_comgr.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "llvm/Config/llvm-config.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCCodeEmitter.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDisassembler/MCDisassembler.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCObjectFileInfo.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCParser/MCAsmParser.h"
+#include "llvm/MC/MCParser/MCTargetAsmParser.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/LEB128.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Object/ELFTypes.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/MC/TargetRegistry.h"
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Types
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ── MallocBuffer RAII wrapper ────────────────────────────────────────────────
+
+struct MallocBuffer {
+  uint8_t *data = nullptr;
+  size_t size = 0;
+
+  MallocBuffer() = default;
+  MallocBuffer(size_t n)
+      : data(static_cast<uint8_t *>(std::malloc(n))), size(n) {}
+  ~MallocBuffer() { std::free(data); }
+
+  MallocBuffer(MallocBuffer &&o) noexcept : data(o.data), size(o.size) {
+    o.data = nullptr;
+    o.size = 0;
+  }
+  MallocBuffer &operator=(MallocBuffer &&o) noexcept {
+    if (this != &o) {
+      std::free(data);
+      data = o.data;
+      size = o.size;
+      o.data = nullptr;
+      o.size = 0;
+    }
+    return *this;
+  }
+
+  MallocBuffer(const MallocBuffer &) = delete;
+  MallocBuffer &operator=(const MallocBuffer &) = delete;
+
+  explicit operator bool() const { return data != nullptr; }
+  uint8_t *release() {
+    uint8_t *p = data;
+    data = nullptr;
+    size = 0;
+    return p;
+  }
+};
+
+// ── Logging ──────────────────────────────────────────────────────────────────
+
+enum class HotswapLogLevel : int { Silent = 0, Error = 1, Info = 2, Debug = 3 };
+
+inline HotswapLogLevel GetHotswapLogLevel() {
+  static HotswapLogLevel level = []() {
+    const char *env = std::getenv("HSA_HOTSWAP_LOG_LEVEL");
+    if (env) {
+      int v = std::atoi(env);
+      if (v >= 0 && v <= 3)
+        return static_cast<HotswapLogLevel>(v);
+    }
+    return HotswapLogLevel::Info;
+  }();
+  return level;
+}
+
+inline std::ostream &HotswapLog(HotswapLogLevel level) {
+  static std::ostream null_stream(nullptr);
+  if (static_cast<int>(level) <= static_cast<int>(GetHotswapLogLevel()))
+    return std::cerr;
+  return null_stream;
+}
+
+// ── ELF types ────────────────────────────────────────────────────────────────
+
+struct ElfSection {
+  uint32_t name_idx;
+  std::string name;
+  uint32_t type;
+  uint64_t offset;
+  uint64_t size;
+  uint64_t addr;
+};
+
+struct ElfSymbol {
+  std::string name;
+  uint64_t value;
+  uint64_t size;
+  uint8_t info;
+  uint16_t shndx;
+};
+
+struct ElfInfo {
+  std::vector<ElfSection> sections;
+  std::vector<ElfSymbol> symbols;
+  int text_section_idx = -1;
+  int text_idx = -1;
+  uint64_t text_offset = 0;
+  uint64_t text_size = 0;
+  uint64_t text_addr = 0;
+};
+
+// ── Trampoline ───────────────────────────────────────────────────────────────
+
+struct Trampoline {
+  uint64_t original_offset;
+  uint32_t original_size;
+  std::vector<uint8_t> bytes;
+};
+
+// ── NOP sled ─────────────────────────────────────────────────────────────────
+
+struct NopSled {
+  uint64_t start;
+  uint64_t end;
+  uint64_t write_pos;
+};
+
+// ── Rewrite-rule types (used by ApplyByteReplace / ApplyMnemonicSwap) ────────
+
+struct RewriteRule {
+  std::string name;
+  std::string match_mnemonic;
+  std::string match_kernel;
+  int64_t match_offset = -1;
+  std::string replace_mnemonic;
+  bool preserve_operands = true;
+  std::vector<std::string> replace_asm;
+  std::vector<uint8_t> replace_bytes;
+  int32_t extra_vgprs = 0;
+  int32_t extra_sgprs = 0;
+};
+
+// ── s_branch / s_nop constants ───────────────────────────────────────────────
+
+inline constexpr uint32_t S_BRANCH_GFX9 = 0xBF820000u;
+inline constexpr uint32_t S_BRANCH_GFX12 = 0xBFA00000u;
+inline constexpr uint32_t S_NOP_OPCODE = 0xBF800000u;
+
+// ── AMDGPU Kernel Descriptor RSRC1 bit fields ───────────────────────────────
+
+static constexpr uint32_t KD_RSRC1_VGPR_MASK = 0x3Fu;
+static constexpr uint32_t KD_RSRC1_SGPR_SHIFT = 6;
+static constexpr uint32_t KD_RSRC1_SGPR_MASK = 0xFu;
+
+// ── DWARF types ──────────────────────────────────────────────────────────────
+
+struct DebugLineRow {
+  uint64_t address;
+  uint32_t file;
+  int32_t line;
+};
+
+// ── LLVM MC Context ──────────────────────────────────────────────────────────
+
+struct LLVMState {
+  const llvm::Target *target = nullptr;
+  std::unique_ptr<llvm::MCRegisterInfo> MRI;
+  std::unique_ptr<const llvm::MCAsmInfo> MAI;
+  std::unique_ptr<llvm::MCInstrInfo> MCII;
+  std::unique_ptr<llvm::MCSubtargetInfo> STI;
+  std::unique_ptr<llvm::MCContext> Ctx;
+  std::unique_ptr<llvm::MCObjectFileInfo> MOFI;
+  std::unique_ptr<llvm::MCDisassembler> disasm;
+  std::unique_ptr<llvm::MCInstPrinter> printer;
+  llvm::MCCodeEmitter *CE = nullptr;
+  std::string cpu;
+  bool valid = false;
+};
+
+// ── Decoded instruction with MCInst ──────────────────────────────────────────
+
+struct InternalDecodedInst {
+  uint64_t offset;
+  uint32_t size;
+  llvm::MCInst inst;
+  std::string mnemonic;
+};
+
+// ── Per-point VGPR liveness types ────────────────────────────────────────────
+
+struct RegDefUse {
+  llvm::BitVector defs{256};
+  llvm::BitVector uses{256};
+};
+
+struct BasicBlock {
+  uint64_t start_offset = 0;
+  uint64_t end_offset = 0;
+  std::vector<size_t> inst_indices;
+  std::vector<int> successors;
+  std::vector<int> predecessors;
+};
+
+struct CFG {
+  std::vector<BasicBlock> blocks;
+  std::unordered_map<uint64_t, int> offset_to_block;
+};
+
+struct LivenessInfo {
+  std::vector<llvm::BitVector> live_before;
+  std::vector<llvm::BitVector> live_after;
+  bool converged = false;
+};
+
+struct ScratchAllocator {
+  llvm::BitVector live_at_point;
+  int kd_allocated_vgprs;
+  int next_above_kd;
+  int extra_allocated = 0;
+
+  ScratchAllocator(const llvm::BitVector &live, int kd_vgprs)
+      : live_at_point(live), kd_allocated_vgprs(kd_vgprs),
+        next_above_kd(kd_vgprs) {}
+
+  int Alloc() {
+    for (int v = kd_allocated_vgprs - 1; v >= 0; --v) {
+      if (!live_at_point.test(v)) {
+        live_at_point.set(v);
+        return v;
+      }
+    }
+    if (next_above_kd >= 256)
+      return -1;
+    int v = next_above_kd++;
+    extra_allocated++;
+    live_at_point.set(v);
+    return v;
+  }
+
+  int ExtraVgprsNeeded() const { return extra_allocated; }
+};
+
+struct ScratchPatchInfo {
+  uint64_t offset;
+  llvm::BitVector scratch_regs{256};
+};
+
+// ── B0-to-A0 types ──────────────────────────────────────────────────────────
+
+struct WmmaNopReq {
+  int b0_nops;
+  int a0_nops;
+};
+
+struct WmmaHazard {
+  size_t wmma_idx;
+  size_t valu_idx;
+  int existing_nops;
+  int needed_nops;
+  int deficit;
+};
+
+struct KernelPatchStats {
+  int extra_vgprs = 0;
+  int scratch_reused = 0;
+  int scratch_above_kd = 0;
+};
+
+struct PatchContext {
+  std::vector<InternalDecodedInst> &decoded;
+  uint8_t *text;
+  uint64_t text_size;
+  const LLVMState &llvm_state;
+  std::vector<Trampoline> &out_trampolines;
+  std::vector<NopSled> &nop_sleds;
+  uint8_t *elf_data;
+  size_t elf_size;
+  const ElfInfo &elf_info;
+  const LivenessInfo &liveness;
+  std::unordered_map<std::string, KernelPatchStats> &kernel_stats;
+  std::vector<ScratchPatchInfo> &out_scratch_patches;
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Function declarations (cross-file)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+// ── elf ──────────────────────────────────────────────────────────────────────
+
+[[nodiscard]] bool EncodeSBranch(uint64_t from_offset, uint64_t to_offset,
+                                 uint8_t out_bytes[4], bool gfx12 = false);
+void EncodeSNop(uint8_t out_bytes[4]);
+std::string ExtractCPU(const std::string &isa_name);
+[[nodiscard]] bool ParseElfInfo(const uint8_t *elf, size_t elf_size,
+                                ElfInfo &info);
+std::string FindKernelAtOffset(const ElfInfo &elf_info, uint64_t text_offset);
+[[nodiscard]] bool ApplyByteReplace(const RewriteRule &rule,
+                                    uint64_t inst_offset, uint32_t inst_size,
+                                    uint8_t *text, uint64_t text_size);
+void UpdateKernelDescriptor(uint8_t *elf_data, size_t elf_size,
+                            const ElfInfo &elf_info,
+                            const std::string &kernel_name,
+                            int32_t extra_vgprs, int32_t extra_sgprs);
+NopSled *FindNearestSled(std::vector<NopSled> &sleds, uint64_t offset,
+                         uint64_t needed);
+MallocBuffer GrowElfWithTrampolines(const uint8_t *elf, size_t elf_size,
+                                    const ElfInfo &elf_info,
+                                    const std::vector<Trampoline> &trampolines);
+bool PatchElfIsa(uint8_t *elf, size_t elf_size, const std::string &target_cpu);
+int GetKernelVgprCount(const uint8_t *elf_data, size_t elf_size,
+                       const ElfInfo &elf_info,
+                       const std::string &kernel_name);
+
+// ── dwarf ────────────────────────────────────────────────────────────────────
+
+uint8_t *FindSectionHeader(uint8_t *elf, size_t elf_size, const char *name,
+                           int *out_idx = nullptr);
+[[nodiscard]] bool AddTrampolineSymbols(
+    MallocBuffer &elf_buf, const std::vector<Trampoline> &trampolines,
+    uint64_t text_size_before, int text_section_idx);
+[[nodiscard]] bool PatchDebugLine(MallocBuffer &elf_buf,
+                                  const std::vector<Trampoline> &trampolines,
+                                  uint64_t text_size_before,
+                                  uint64_t text_addr);
+void PatchDebugRanges(uint8_t *elf, size_t elf_size, uint64_t text_addr,
+                      uint64_t text_size_before, uint64_t tramp_total);
+void PatchDebugInfo(uint8_t *elf, size_t elf_size, uint64_t text_addr,
+                    uint64_t text_size_before, uint64_t tramp_total);
+void PatchDebugFrame(uint8_t *elf, size_t elf_size, uint64_t text_addr,
+                     uint64_t text_size_before, uint64_t tramp_total);
+
+// ── llvm ─────────────────────────────────────────────────────────────────────
+
+LLVMState InitLLVMImpl(const std::string &isa_name,
+                       const llvm::Target *cached_target = nullptr);
+LLVMState InitLLVMCached(const std::string &isa_name);
+[[nodiscard]] bool DecodeTextSection(const uint8_t *text, uint64_t text_size,
+                                     const LLVMState &llvm_state,
+                                     std::vector<InternalDecodedInst> &decoded);
+std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
+                                        const LLVMState &llvm_state);
+[[nodiscard]] bool ApplyMnemonicSwap(const RewriteRule &rule,
+                                     InternalDecodedInst &inst, uint8_t *text,
+                                     const LLVMState &llvm_state);
+Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
+                           uint64_t original_offset, uint32_t original_size,
+                           uint64_t trampoline_text_offset,
+                           const std::string &cpu,
+                           const LLVMState &llvm_state);
+std::string PrintInst(const InternalDecodedInst &di,
+                      const LLVMState &llvm_state);
+int GetVgprNum(unsigned reg, const llvm::MCRegisterInfo &MRI);
+std::pair<int, int> GetVgprRange(unsigned reg,
+                                 const llvm::MCRegisterInfo &MRI);
+std::pair<int, int> GetOperandVgprRange(const llvm::MCInst &inst,
+                                        unsigned op_idx,
+                                        const llvm::MCRegisterInfo &MRI);
+bool RangesOverlap(int base1, int count1, int base2, int count2);
+bool CheckVgprOverlap(const llvm::MCInst &wmma_inst,
+                      const llvm::MCInst &valu_inst,
+                      const llvm::MCRegisterInfo &MRI);
+
+// ── liveness ─────────────────────────────────────────────────────────────────
+
+RegDefUse GetInstRegDefUse(const llvm::MCInst &inst,
+                           const llvm::MCInstrInfo &MCII,
+                           const llvm::MCRegisterInfo &MRI);
+int64_t GetBranchImm(const llvm::MCInst &inst);
+CFG BuildCFG(const std::vector<InternalDecodedInst> &decoded,
+             const llvm::MCInstrInfo &MCII);
+LivenessInfo ComputeLiveness(const std::vector<InternalDecodedInst> &decoded,
+                             const CFG &cfg, const llvm::MCInstrInfo &MCII,
+                             const llvm::MCRegisterInfo &MRI);
+[[nodiscard]] bool VerifyPatchCorrectness(
+    const uint8_t *text, uint64_t text_size, const LLVMState &llvm_state,
+    const std::vector<ScratchPatchInfo> &scratch_patches);
+
+// ── b0a0 — dispatcher and entry point ────────────────────────────────────────
+
+amd_comgr_status_t RetargetCodeObjectB0A0(const void *elf_data,
+                                          size_t elf_size, void **out_data,
+                                          size_t *out_size);
+
+// ── b0a0 — patch entry points (weak stubs in b0a0.cpp) ──────────────────────
+//
+// Each group is defined as a weak symbol in comgr-hotswap-b0a0.cpp returning 0.
+// Patch .cpp files provide strong definitions that override the stubs at link
+// time, allowing patches to land as independent PRs.
+
+uint32_t ApplyInPlacePatches(PatchContext &ctx, size_t idx);
+uint32_t ApplyTrampolinePatches(PatchContext &ctx, size_t idx);
+uint32_t ApplyWmmaHazardPatch(PatchContext &ctx);
+uint32_t ApplyWmmaSplitPatches(PatchContext &ctx, size_t idx);
+uint32_t ApplyScratchPatches(PatchContext &ctx, size_t idx);
+
+#endif // COMGR_HOTSWAP_INTERNAL_H

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -174,13 +174,23 @@ struct RewriteRule {
 static constexpr uint64_t kMinElfSize = sizeof(llvm::ELF::Elf64_Ehdr);
 static constexpr uint64_t kKdSize = 64;
 static constexpr uint64_t kKdRsrc1Offset = 48;
-static constexpr uint32_t KD_RSRC1_VGPR_MASK = 0x3Fu;
-static constexpr uint32_t KD_RSRC1_SGPR_SHIFT = 6;
-static constexpr uint32_t KD_RSRC1_SGPR_MASK = 0xFu;
+static constexpr uint32_t kKdRsrc1VgprMask = 0x3Fu;
+static constexpr uint32_t kKdRsrc1VgprMaxGranule = 63;
+static constexpr uint32_t kKdRsrc1SgprShift = 6;
+static constexpr uint32_t kKdRsrc1SgprMask = 0xFu;
+static constexpr uint32_t kKdRsrc1SgprMaxGranule = 15;
+static constexpr uint32_t kVgprGranularity = 8;
+static constexpr uint32_t kVgprGranuleSize = 4;
+static constexpr uint32_t kSgprGranuleSize = 8;
 static constexpr int64_t kMaxSledDistance = 131072;
+static constexpr uint64_t kMinNopSledSize = 8;
+static constexpr uint32_t kMinInstSize = 4;
 
 // AMDGPU code-object-v3 ISA version note type (not in llvm::ELF enum)
 static constexpr uint32_t kNoteTypeIsaVersion = 27;
+
+// ELF symbol type extraction mask
+static constexpr uint8_t kElfStTypeMask = 0xf;
 
 // ── DWARF types ──────────────────────────────────────────────────────────────
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -192,6 +192,18 @@ static constexpr uint32_t kNoteTypeIsaVersion = 27;
 // ELF symbol type extraction mask
 static constexpr uint8_t kElfStTypeMask = 0xf;
 
+// s_branch encoding limits (16-bit signed dword offset field)
+static constexpr int64_t kBranchOffsetMin = -32768;
+static constexpr int64_t kBranchOffsetMax = 32767;
+static constexpr uint32_t kBranchOffsetMask = 0xFFFF;
+
+// AMDGPU ELF note owner
+static constexpr const char *kAmdgpuNoteOwner = "AMDGPU";
+static constexpr size_t kAmdgpuNoteOwnerLen = 6;
+
+// ELF note alignment
+static constexpr uint32_t kNoteAlign = 4;
+
 // ── DWARF types ──────────────────────────────────────────────────────────────
 
 struct DebugLineRow {

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -31,11 +31,13 @@
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCCodeEmitter.h"
@@ -151,7 +153,7 @@ struct ElfInfo {
 struct Trampoline {
   uint64_t original_offset;
   uint32_t original_size;
-  std::vector<uint8_t> bytes;
+  llvm::SmallVector<uint8_t, 16> bytes;
 };
 
 // ── NOP sled ─────────────────────────────────────────────────────────────────
@@ -166,7 +168,7 @@ struct NopSled {
 
 struct RewriteRule {
   std::string replace_mnemonic;
-  std::vector<uint8_t> replace_bytes;
+  llvm::SmallVector<uint8_t, 16> replace_bytes;
 };
 
 // ── ELF / KD named constants ─────────────────────────────────────────────────
@@ -255,7 +257,7 @@ struct BasicBlock {
 
 struct CFG {
   std::vector<BasicBlock> blocks;
-  std::unordered_map<uint64_t, int> offset_to_block;
+  llvm::DenseMap<uint64_t, int> offset_to_block;
 };
 
 struct LivenessInfo {
@@ -331,7 +333,7 @@ struct PatchContext {
   size_t elf_size;
   const ElfInfo &elf_info;
   const LivenessInfo &liveness;
-  std::unordered_map<std::string, KernelPatchStats> &kernel_stats;
+  llvm::StringMap<KernelPatchStats> &kernel_stats;
   std::vector<ScratchPatchInfo> &out_scratch_patches;
 };
 
@@ -388,8 +390,8 @@ LLVMState InitLLVMCached(const std::string &isa_name);
 [[nodiscard]] bool DecodeTextSection(const uint8_t *text, uint64_t text_size,
                                      const LLVMState &llvm_state,
                                      std::vector<InternalDecodedInst> &decoded);
-std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
-                                        const LLVMState &llvm_state);
+llvm::SmallVector<uint8_t, 16> AssembleSingleInst(const std::string &asm_str,
+                                                  const LLVMState &llvm_state);
 [[nodiscard]] bool ApplyMnemonicSwap(const RewriteRule &rule,
                                      InternalDecodedInst &inst, uint8_t *text,
                                      const LLVMState &llvm_state);

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -273,42 +273,6 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
   return result;
 }
 
-// ── MatchRule ────────────────────────────────────────────────────────────────
-
-[[nodiscard]] bool MatchRule(const RewriteRule &rule, const InternalDecodedInst &inst,
-                      const ElfInfo &elf_info) {
-  if (!rule.match_mnemonic.empty() && rule.match_mnemonic != inst.mnemonic)
-    return false;
-  if (rule.match_offset >= 0 &&
-      static_cast<uint64_t>(rule.match_offset) != inst.offset)
-    return false;
-  if (!rule.match_kernel.empty()) {
-    std::string kernel = FindKernelAtOffset(elf_info, inst.offset);
-    if (kernel != rule.match_kernel) return false;
-  }
-  if (!rule.operands.empty()) {
-    if (rule.operands.size() >
-        static_cast<size_t>(inst.inst.getNumOperands()))
-      return false;
-    for (size_t i = 0; i < rule.operands.size(); ++i) {
-      auto &match = rule.operands[i];
-      auto &operand = inst.inst.getOperand(static_cast<unsigned>(i));
-      switch (match.kind) {
-      case OperandMatch::Kind::Wildcard:
-        break;
-      case OperandMatch::Kind::Immediate:
-        if (!operand.isImm() || operand.getImm() != match.imm_value)
-          return false;
-        break;
-      case OperandMatch::Kind::RegClass:
-        if (!operand.isReg()) return false;
-        break;
-      }
-    }
-  }
-  return true;
-}
-
 // ── VGPR introspection ───────────────────────────────────────────────────────
 
 int GetVgprNum(unsigned reg, const llvm::MCRegisterInfo &MRI) {

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -102,6 +102,24 @@ LLVMState InitLLVMCached(const std::string &isa_name) {
   return InitLLVMImpl(isa_name, tgt);
 }
 
+// ── Instruction helpers ──────────────────────────────────────────────────────
+
+static std::string ExtractMnemonic(const std::string &printed) {
+  size_t s = printed.find_first_not_of(" \t");
+  if (s == std::string::npos) return "";
+  size_t e = printed.find_first_of(" \t", s);
+  return printed.substr(s, e - s);
+}
+
+static std::string PrintInstStr(const llvm::MCInst &inst,
+                                const LLVMState &llvm_state) {
+  std::string str;
+  llvm::raw_string_ostream rso(str);
+  llvm_state.printer->printInst(&inst, 0, "", *llvm_state.STI, rso);
+  rso.flush();
+  return str;
+}
+
 // ── Instruction decode ───────────────────────────────────────────────────────
 
 [[nodiscard]] bool DecodeTextSection(const uint8_t *text, uint64_t text_size,
@@ -124,19 +142,10 @@ LLVMState InitLLVMCached(const std::string &isa_name) {
       pos += 4;
     } else {
       di.size = static_cast<uint32_t>(inst_size);
-      if (llvm_state.printer) {
-        std::string str;
-        llvm::raw_string_ostream rso(str);
-        llvm_state.printer->printInst(&di.inst, 0, "", *llvm_state.STI, rso);
-        rso.flush();
-        size_t s = str.find_first_not_of(" \t");
-        if (s != std::string::npos) {
-          size_t e = str.find_first_of(" \t", s);
-          di.mnemonic = str.substr(s, e - s);
-        }
-      } else {
+      if (llvm_state.printer)
+        di.mnemonic = ExtractMnemonic(PrintInstStr(di.inst, llvm_state));
+      else
         di.mnemonic = llvm_state.MCII->getName(di.inst.getOpcode()).str();
-      }
       pos += inst_size;
     }
     decoded.push_back(std::move(di));
@@ -212,20 +221,14 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
                                      const LLVMState &llvm_state) {
   if (!llvm_state.printer) return false;
 
-  std::string orig_str;
-  llvm::raw_string_ostream rso(orig_str);
-  llvm_state.printer->printInst(&inst.inst, 0, "", *llvm_state.STI, rso);
-  rso.flush();
-
-  size_t start = orig_str.find_first_not_of(" \t");
+  std::string printed = PrintInstStr(inst.inst, llvm_state);
+  size_t start = printed.find_first_not_of(" \t");
   if (start == std::string::npos) return false;
-  size_t end = orig_str.find_first_of(" \t", start);
+  size_t end = printed.find_first_of(" \t", start);
 
-  std::string new_asm;
-  if (end != std::string::npos)
-    new_asm = rule.replace_mnemonic + orig_str.substr(end);
-  else
-    new_asm = rule.replace_mnemonic;
+  std::string new_asm = (end != std::string::npos)
+                            ? rule.replace_mnemonic + printed.substr(end)
+                            : rule.replace_mnemonic;
 
   auto bytes = AssembleSingleInst(new_asm, llvm_state);
   if (bytes.empty() || bytes.size() != inst.size) return false;
@@ -319,13 +322,9 @@ GetOperandVgprRange(const llvm::MCInst &inst, unsigned op_idx,
 
 std::string PrintInst(const InternalDecodedInst &di,
                       const LLVMState &llvm_state) {
-  std::string inst_str;
-  if (llvm_state.printer) {
-    llvm::raw_string_ostream rso(inst_str);
-    llvm_state.printer->printInst(&di.inst, 0, "", *llvm_state.STI, rso);
-    rso.flush();
-  }
-  return inst_str;
+  if (llvm_state.printer)
+    return PrintInstStr(di.inst, llvm_state);
+  return "";
 }
 
 bool RangesOverlap(int base1, int count1, int base2, int count2) {

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -262,7 +262,8 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
   uint64_t branch_back_to = original_offset + original_size;
 
   uint8_t branch_bytes[4];
-  bool is_gfx12 = !(cpu.find("gfx9") == 0 || cpu.find("gfx10") == 0);
+  llvm::StringRef cpu_ref(cpu);
+  bool is_gfx12 = !(cpu_ref.starts_with("gfx9") || cpu_ref.starts_with("gfx10"));
   if (!EncodeSBranch(branch_back_from, branch_back_to, branch_bytes,
                      is_gfx12)) {
     result.bytes.clear();
@@ -278,35 +279,34 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
 int GetVgprNum(unsigned reg, const llvm::MCRegisterInfo &MRI) {
   const char *name = MRI.getName(reg);
   if (!name) return -1;
-  std::string rname(name);
-  if (rname.find("VGPR") == 0) {
-    size_t numstart = 4;
-    size_t underscore = rname.find('_', numstart);
-    std::string numstr = rname.substr(
-        numstart, underscore == std::string::npos ? std::string::npos
-                                                  : underscore - numstart);
-    int val = -1;
-    std::from_chars(numstr.data(), numstr.data() + numstr.size(), val);
-    return val;
-  }
-  return -1;
+  llvm::StringRef rname(name);
+  if (!rname.starts_with("VGPR")) return -1;
+  llvm::StringRef numpart = rname.drop_front(4);
+  size_t underscore = numpart.find('_');
+  if (underscore != llvm::StringRef::npos)
+    numpart = numpart.take_front(underscore);
+  int val = -1;
+  auto [ptr, ec] =
+      std::from_chars(numpart.data(), numpart.data() + numpart.size(), val);
+  if (ec != std::errc()) return -1;
+  return val;
 }
 
 std::pair<int, int> GetVgprRange(unsigned reg,
                                         const llvm::MCRegisterInfo &MRI) {
   const char *name = MRI.getName(reg);
   if (!name) return {-1, 0};
-  std::string rname(name);
-  if (rname.find("VGPR") != 0) return {-1, 0};
+  llvm::StringRef rname(name);
+  if (!rname.starts_with("VGPR")) return {-1, 0};
   int count = 1;
   for (char c : rname)
     if (c == '_') count++;
-  size_t numstart = 4;
-  size_t numend = rname.find_first_not_of("0123456789", numstart);
-  if (numend == std::string::npos) numend = rname.size();
-  std::string numstr = rname.substr(numstart, numend - numstart);
+  llvm::StringRef numpart = rname.drop_front(4);
+  size_t numend = numpart.find_first_not_of("0123456789");
+  if (numend != llvm::StringRef::npos)
+    numpart = numpart.take_front(numend);
   int base = -1;
-  auto [p, ec] = std::from_chars(numstr.data(), numstr.data() + numstr.size(), base);
+  auto [p, ec] = std::from_chars(numpart.data(), numpart.data() + numpart.size(), base);
   if (ec != std::errc())
     return {-1, 0};
   return {base, count};

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -8,6 +8,15 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/MC/MCAsmBackend.h"
+#include "llvm/MC/MCObjectWriter.h"
+#include "llvm/MC/MCParser/MCAsmParser.h"
+#include "llvm/MC/MCParser/MCTargetAsmParser.h"
+#include "llvm/MC/MCStreamer.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+
 namespace {
 std::once_flag g_llvm_init_flag;
 std::mutex g_target_cache_mutex;
@@ -22,7 +31,7 @@ static void InitLLVMTargets() {
 }
 
 LLVMState InitLLVMImpl(const std::string &isa_name,
-                              const llvm::Target *cached_target) {
+                       const llvm::Target *cached_target) {
   std::call_once(g_llvm_init_flag, InitLLVMTargets);
 
   LLVMState state;
@@ -97,8 +106,8 @@ LLVMState InitLLVMCached(const std::string &isa_name) {
 // ── Instruction decode ───────────────────────────────────────────────────────
 
 [[nodiscard]] bool DecodeTextSection(const uint8_t *text, uint64_t text_size,
-                              const LLVMState &llvm_state,
-                              std::vector<InternalDecodedInst> &decoded) {
+                                     const LLVMState &llvm_state,
+                                     std::vector<InternalDecodedInst> &decoded) {
   uint64_t pos = 0;
   while (pos < text_size) {
     InternalDecodedInst di;
@@ -139,7 +148,7 @@ LLVMState InitLLVMCached(const std::string &isa_name) {
 // ── AssembleSingleInst ───────────────────────────────────────────────────────
 
 std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
-                                               const LLVMState &llvm_state) {
+                                        const LLVMState &llvm_state) {
   llvm_state.Ctx->reset();
 
   std::string full_asm = ".text\n" + asm_str;
@@ -201,8 +210,8 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
 // ── ApplyMnemonicSwap ────────────────────────────────────────────────────────
 
 [[nodiscard]] bool ApplyMnemonicSwap(const RewriteRule &rule,
-                              InternalDecodedInst &inst, uint8_t *text,
-                              const LLVMState &llvm_state) {
+                                     InternalDecodedInst &inst, uint8_t *text,
+                                     const LLVMState &llvm_state) {
   if (!llvm_state.printer) return false;
 
   std::string orig_str;
@@ -230,11 +239,11 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
 // ── BuildTrampoline ──────────────────────────────────────────────────────────
 
 Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
-                                  uint64_t original_offset,
-                                  uint32_t original_size,
-                                  uint64_t trampoline_text_offset,
-                                  const std::string &cpu,
-                                  const LLVMState &llvm_state) {
+                           uint64_t original_offset,
+                           uint32_t original_size,
+                           uint64_t trampoline_text_offset,
+                           const std::string &cpu,
+                           const LLVMState &llvm_state) {
   Trampoline result;
   result.original_offset = original_offset;
   result.original_size = original_size;
@@ -283,7 +292,7 @@ int GetVgprNum(unsigned reg, const llvm::MCRegisterInfo &MRI) {
 }
 
 std::pair<int, int> GetVgprRange(unsigned reg,
-                                        const llvm::MCRegisterInfo &MRI) {
+                                 const llvm::MCRegisterInfo &MRI) {
   const char *name = MRI.getName(reg);
   if (!name) return {-1, 0};
   llvm::StringRef rname(name);
@@ -312,7 +321,7 @@ GetOperandVgprRange(const llvm::MCInst &inst, unsigned op_idx,
 }
 
 std::string PrintInst(const InternalDecodedInst &di,
-                              const LLVMState &llvm_state) {
+                      const LLVMState &llvm_state) {
   std::string inst_str;
   if (llvm_state.printer) {
     llvm::raw_string_ostream rso(inst_str);
@@ -330,8 +339,8 @@ bool RangesOverlap(int base1, int count1, int base2, int count2) {
 // ── WMMA co-execution hazard overlap check ──────────────────────────────────
 
 bool CheckVgprOverlap(const llvm::MCInst &wmma_inst,
-                             const llvm::MCInst &valu_inst,
-                             const llvm::MCRegisterInfo &MRI) {
+                      const llvm::MCInst &valu_inst,
+                      const llvm::MCRegisterInfo &MRI) {
   std::vector<std::pair<int, int>> wmma_input_ranges;
   for (unsigned i = 0; i < wmma_inst.getNumOperands(); ++i) {
     const auto &op = wmma_inst.getOperand(i);

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -162,22 +162,12 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
 
   if (!ce || !mab) return {};
 
-#if LLVM_VERSION_MAJOR > 20
   auto streamer = std::unique_ptr<llvm::MCStreamer>(
       llvm_state.target->createMCObjectStreamer(
           triple, *llvm_state.Ctx,
           std::unique_ptr<llvm::MCAsmBackend>(mab),
           mab->createObjectWriter(*bos),
           std::unique_ptr<llvm::MCCodeEmitter>(ce), *llvm_state.STI));
-#else
-  auto streamer = std::unique_ptr<llvm::MCStreamer>(
-      llvm_state.target->createMCObjectStreamer(
-          triple, *llvm_state.Ctx,
-          std::unique_ptr<llvm::MCAsmBackend>(mab),
-          mab->createObjectWriter(*bos),
-          std::unique_ptr<llvm::MCCodeEmitter>(ce), *llvm_state.STI,
-          mc_opts.MCRelaxAll, mc_opts.MCIncrementalLinkerCompatible, false));
-#endif
 
   if (!streamer) return {};
 

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -70,7 +70,7 @@ LLVMState InitLLVMImpl(const std::string &isa_name,
   state.printer.reset(state.target->createMCInstPrinter(
       triple, asm_variant, *state.MAI, *state.MCII, *state.MRI));
 
-  state.CE = state.target->createMCCodeEmitter(*state.MCII, *state.Ctx);
+  state.CE.reset(state.target->createMCCodeEmitter(*state.MCII, *state.Ctx));
 
   state.valid = true;
   return state;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -1,0 +1,401 @@
+//===- comgr-hotswap-llvm.cpp - LLVM MC infrastructure, decode/encode -----===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+namespace {
+std::once_flag g_llvm_init_flag;
+std::mutex g_target_cache_mutex;
+const llvm::Target *g_cached_target = nullptr;
+} // namespace
+
+static void InitLLVMTargets() {
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTargetMC();
+  LLVMInitializeAMDGPUAsmParser();
+  LLVMInitializeAMDGPUDisassembler();
+}
+
+LLVMState InitLLVMImpl(const std::string &isa_name,
+                              const llvm::Target *cached_target) {
+  std::call_once(g_llvm_init_flag, InitLLVMTargets);
+
+  LLVMState state;
+  state.cpu = ExtractCPU(isa_name);
+  if (state.cpu.empty()) return state;
+
+  llvm::Triple triple("amdgcn-amd-amdhsa");
+
+  if (cached_target) {
+    state.target = cached_target;
+  } else {
+    std::string error;
+    state.target = llvm::TargetRegistry::lookupTarget("amdgcn", triple, error);
+  }
+  if (!state.target) return state;
+
+  state.MRI.reset(
+      state.target->createMCRegInfo(llvm::Triple("amdgcn-amd-amdhsa")));
+  if (!state.MRI) return state;
+
+  llvm::MCTargetOptions mc_opts;
+  state.MAI.reset(state.target->createMCAsmInfo(
+      *state.MRI, llvm::Triple("amdgcn-amd-amdhsa"), mc_opts));
+  if (!state.MAI) return state;
+
+  state.MCII.reset(state.target->createMCInstrInfo());
+  if (!state.MCII) return state;
+
+  state.STI.reset(state.target->createMCSubtargetInfo(
+      llvm::Triple("amdgcn-amd-amdhsa"), state.cpu, ""));
+  if (!state.STI || !state.STI->isCPUStringValid(state.cpu)) return state;
+
+  state.Ctx = std::make_unique<llvm::MCContext>(triple, state.MAI.get(),
+                                                state.MRI.get(),
+                                                state.STI.get());
+  state.MOFI = std::make_unique<llvm::MCObjectFileInfo>();
+  state.MOFI->initMCObjectFileInfo(*state.Ctx, false);
+  state.Ctx->setObjectFileInfo(state.MOFI.get());
+
+  state.disasm.reset(
+      state.target->createMCDisassembler(*state.STI, *state.Ctx));
+  if (!state.disasm) return state;
+
+  unsigned asm_variant = state.MAI->getAssemblerDialect();
+  state.printer.reset(state.target->createMCInstPrinter(
+      triple, asm_variant, *state.MAI, *state.MCII, *state.MRI));
+
+  state.CE = state.target->createMCCodeEmitter(*state.MCII, *state.Ctx);
+
+  state.valid = true;
+  return state;
+}
+
+LLVMState InitLLVMCached(const std::string &isa_name) {
+  std::call_once(g_llvm_init_flag, InitLLVMTargets);
+
+  const llvm::Target *tgt;
+  {
+    std::lock_guard<std::mutex> lock(g_target_cache_mutex);
+    if (!g_cached_target) {
+      std::string error;
+      llvm::Triple triple("amdgcn-amd-amdhsa");
+      g_cached_target =
+          llvm::TargetRegistry::lookupTarget("amdgcn", triple, error);
+    }
+    tgt = g_cached_target;
+  }
+
+  return InitLLVMImpl(isa_name, tgt);
+}
+
+// ── Instruction decode ───────────────────────────────────────────────────────
+
+[[nodiscard]] bool DecodeTextSection(const uint8_t *text, uint64_t text_size,
+                              const LLVMState &llvm_state,
+                              std::vector<InternalDecodedInst> &decoded) {
+  uint64_t pos = 0;
+  while (pos < text_size) {
+    InternalDecodedInst di;
+    di.offset = pos;
+
+    llvm::ArrayRef<uint8_t> bytes(text + pos, text_size - pos);
+    uint64_t inst_size = 0;
+
+    auto status = llvm_state.disasm->getInstruction(di.inst, inst_size, bytes,
+                                                    pos, llvm::nulls());
+
+    if (status == llvm::MCDisassembler::Fail) {
+      di.size = 4;
+      di.mnemonic = "<unknown>";
+      pos += 4;
+    } else {
+      di.size = static_cast<uint32_t>(inst_size);
+      if (llvm_state.printer) {
+        std::string str;
+        llvm::raw_string_ostream rso(str);
+        llvm_state.printer->printInst(&di.inst, 0, "", *llvm_state.STI, rso);
+        rso.flush();
+        size_t s = str.find_first_not_of(" \t");
+        if (s != std::string::npos) {
+          size_t e = str.find_first_of(" \t", s);
+          di.mnemonic = str.substr(s, e - s);
+        }
+      } else {
+        di.mnemonic = llvm_state.MCII->getName(di.inst.getOpcode()).str();
+      }
+      pos += inst_size;
+    }
+    decoded.push_back(std::move(di));
+  }
+  return true;
+}
+
+// ── AssembleSingleInst ───────────────────────────────────────────────────────
+
+std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
+                                               const LLVMState &llvm_state) {
+  llvm_state.Ctx->reset();
+
+  std::string full_asm = ".text\n" + asm_str;
+  llvm::StringRef asm_ref(full_asm);
+  auto buf = llvm::MemoryBuffer::getMemBuffer(asm_ref, "", false);
+  llvm::SourceMgr src_mgr;
+  src_mgr.AddNewSourceBuffer(std::move(buf), llvm::SMLoc());
+
+  std::string data;
+  auto data_stream = std::make_unique<llvm::raw_string_ostream>(data);
+  auto bos = std::make_unique<llvm::buffer_ostream>(*data_stream);
+
+  llvm::MCTargetOptions mc_opts;
+  llvm::Triple triple("amdgcn-amd-amdhsa");
+
+  llvm::MCCodeEmitter *ce =
+      llvm_state.target->createMCCodeEmitter(*llvm_state.MCII, *llvm_state.Ctx);
+  llvm::MCAsmBackend *mab = llvm_state.target->createMCAsmBackend(
+      *llvm_state.STI, *llvm_state.MRI, mc_opts);
+
+  if (!ce || !mab) return {};
+
+#if LLVM_VERSION_MAJOR > 20
+  auto streamer = std::unique_ptr<llvm::MCStreamer>(
+      llvm_state.target->createMCObjectStreamer(
+          triple, *llvm_state.Ctx,
+          std::unique_ptr<llvm::MCAsmBackend>(mab),
+          mab->createObjectWriter(*bos),
+          std::unique_ptr<llvm::MCCodeEmitter>(ce), *llvm_state.STI));
+#else
+  auto streamer = std::unique_ptr<llvm::MCStreamer>(
+      llvm_state.target->createMCObjectStreamer(
+          triple, *llvm_state.Ctx,
+          std::unique_ptr<llvm::MCAsmBackend>(mab),
+          mab->createObjectWriter(*bos),
+          std::unique_ptr<llvm::MCCodeEmitter>(ce), *llvm_state.STI,
+          mc_opts.MCRelaxAll, mc_opts.MCIncrementalLinkerCompatible, false));
+#endif
+
+  if (!streamer) return {};
+
+  auto parser = std::unique_ptr<llvm::MCAsmParser>(
+      llvm::createMCAsmParser(src_mgr, *llvm_state.Ctx, *streamer,
+                              *llvm_state.MAI));
+  auto tap = std::unique_ptr<llvm::MCTargetAsmParser>(
+      llvm_state.target->createMCAsmParser(*llvm_state.STI, *parser,
+                                           *llvm_state.MCII, mc_opts));
+  if (!tap) return {};
+  parser->setTargetParser(*tap);
+
+  if (parser->Run(true)) return {};
+
+  bos.reset();
+  data_stream->flush();
+
+  const uint8_t *elf_bytes = reinterpret_cast<const uint8_t *>(data.data());
+  size_t elf_sz = data.size();
+  if (elf_sz < 64) return {};
+
+  ElfInfo asm_elf;
+  if (!ParseElfInfo(elf_bytes, elf_sz, asm_elf)) return {};
+  if (asm_elf.text_size == 0) return {};
+
+  return std::vector<uint8_t>(elf_bytes + asm_elf.text_offset,
+                              elf_bytes + asm_elf.text_offset +
+                                  asm_elf.text_size);
+}
+
+// ── ApplyMnemonicSwap ────────────────────────────────────────────────────────
+
+[[nodiscard]] bool ApplyMnemonicSwap(const RewriteRule &rule,
+                              InternalDecodedInst &inst, uint8_t *text,
+                              const LLVMState &llvm_state) {
+  if (!llvm_state.printer) return false;
+
+  std::string orig_str;
+  llvm::raw_string_ostream rso(orig_str);
+  llvm_state.printer->printInst(&inst.inst, 0, "", *llvm_state.STI, rso);
+  rso.flush();
+
+  size_t start = orig_str.find_first_not_of(" \t");
+  if (start == std::string::npos) return false;
+  size_t end = orig_str.find_first_of(" \t", start);
+
+  std::string new_asm;
+  if (end != std::string::npos)
+    new_asm = rule.replace_mnemonic + orig_str.substr(end);
+  else
+    new_asm = rule.replace_mnemonic;
+
+  auto bytes = AssembleSingleInst(new_asm, llvm_state);
+  if (bytes.empty() || bytes.size() != inst.size) return false;
+
+  std::memcpy(text + inst.offset, bytes.data(), inst.size);
+  return true;
+}
+
+// ── BuildTrampoline ──────────────────────────────────────────────────────────
+
+Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
+                                  uint64_t original_offset,
+                                  uint32_t original_size,
+                                  uint64_t trampoline_text_offset,
+                                  const std::string &cpu,
+                                  const LLVMState &llvm_state) {
+  Trampoline result;
+  result.original_offset = original_offset;
+  result.original_size = original_size;
+
+  std::string asm_source = ".text\n";
+  for (auto &line : asm_lines)
+    asm_source += line + "\n";
+
+  auto bytes = AssembleSingleInst(asm_source.substr(6), llvm_state);
+  if (bytes.empty()) return result;
+
+  result.bytes = std::move(bytes);
+
+  uint64_t branch_back_from = trampoline_text_offset + result.bytes.size();
+  uint64_t branch_back_to = original_offset + original_size;
+
+  uint8_t branch_bytes[4];
+  bool is_gfx12 = !(cpu.find("gfx9") == 0 || cpu.find("gfx10") == 0);
+  if (!EncodeSBranch(branch_back_from, branch_back_to, branch_bytes,
+                     is_gfx12)) {
+    result.bytes.clear();
+    return result;
+  }
+
+  result.bytes.insert(result.bytes.end(), branch_bytes, branch_bytes + 4);
+  return result;
+}
+
+// ── MatchRule ────────────────────────────────────────────────────────────────
+
+[[nodiscard]] bool MatchRule(const RewriteRule &rule, const InternalDecodedInst &inst,
+                      const ElfInfo &elf_info) {
+  if (!rule.match_mnemonic.empty() && rule.match_mnemonic != inst.mnemonic)
+    return false;
+  if (rule.match_offset >= 0 &&
+      static_cast<uint64_t>(rule.match_offset) != inst.offset)
+    return false;
+  if (!rule.match_kernel.empty()) {
+    std::string kernel = FindKernelAtOffset(elf_info, inst.offset);
+    if (kernel != rule.match_kernel) return false;
+  }
+  if (!rule.operands.empty()) {
+    if (rule.operands.size() >
+        static_cast<size_t>(inst.inst.getNumOperands()))
+      return false;
+    for (size_t i = 0; i < rule.operands.size(); ++i) {
+      auto &match = rule.operands[i];
+      auto &operand = inst.inst.getOperand(static_cast<unsigned>(i));
+      switch (match.kind) {
+      case OperandMatch::Kind::Wildcard:
+        break;
+      case OperandMatch::Kind::Immediate:
+        if (!operand.isImm() || operand.getImm() != match.imm_value)
+          return false;
+        break;
+      case OperandMatch::Kind::RegClass:
+        if (!operand.isReg()) return false;
+        break;
+      }
+    }
+  }
+  return true;
+}
+
+// ── VGPR introspection ───────────────────────────────────────────────────────
+
+int GetVgprNum(unsigned reg, const llvm::MCRegisterInfo &MRI) {
+  const char *name = MRI.getName(reg);
+  if (!name) return -1;
+  std::string rname(name);
+  if (rname.find("VGPR") == 0) {
+    size_t numstart = 4;
+    size_t underscore = rname.find('_', numstart);
+    std::string numstr = rname.substr(
+        numstart, underscore == std::string::npos ? std::string::npos
+                                                  : underscore - numstart);
+    int val = -1;
+    std::from_chars(numstr.data(), numstr.data() + numstr.size(), val);
+    return val;
+  }
+  return -1;
+}
+
+std::pair<int, int> GetVgprRange(unsigned reg,
+                                        const llvm::MCRegisterInfo &MRI) {
+  const char *name = MRI.getName(reg);
+  if (!name) return {-1, 0};
+  std::string rname(name);
+  if (rname.find("VGPR") != 0) return {-1, 0};
+  int count = 1;
+  for (char c : rname)
+    if (c == '_') count++;
+  size_t numstart = 4;
+  size_t numend = rname.find_first_not_of("0123456789", numstart);
+  if (numend == std::string::npos) numend = rname.size();
+  std::string numstr = rname.substr(numstart, numend - numstart);
+  int base = -1;
+  auto [p, ec] = std::from_chars(numstr.data(), numstr.data() + numstr.size(), base);
+  if (ec != std::errc())
+    return {-1, 0};
+  return {base, count};
+}
+
+std::pair<int, int>
+GetOperandVgprRange(const llvm::MCInst &inst, unsigned op_idx,
+                    const llvm::MCRegisterInfo &MRI) {
+  if (op_idx >= inst.getNumOperands()) return {-1, 0};
+  const auto &op = inst.getOperand(op_idx);
+  if (!op.isReg()) return {-1, 0};
+  return GetVgprRange(op.getReg(), MRI);
+}
+
+std::string PrintInst(const InternalDecodedInst &di,
+                              const LLVMState &llvm_state) {
+  std::string inst_str;
+  if (llvm_state.printer) {
+    llvm::raw_string_ostream rso(inst_str);
+    llvm_state.printer->printInst(&di.inst, 0, "", *llvm_state.STI, rso);
+    rso.flush();
+  }
+  return inst_str;
+}
+
+bool RangesOverlap(int base1, int count1, int base2, int count2) {
+  if (base1 < 0 || base2 < 0) return false;
+  return base1 < base2 + count2 && base2 < base1 + count1;
+}
+
+// ── WMMA co-execution hazard overlap check ──────────────────────────────────
+
+bool CheckVgprOverlap(const llvm::MCInst &wmma_inst,
+                             const llvm::MCInst &valu_inst,
+                             const llvm::MCRegisterInfo &MRI) {
+  std::vector<std::pair<int, int>> wmma_input_ranges;
+  for (unsigned i = 0; i < wmma_inst.getNumOperands(); ++i) {
+    const auto &op = wmma_inst.getOperand(i);
+    if (!op.isReg()) continue;
+    auto range = GetVgprRange(op.getReg(), MRI);
+    if (range.first >= 0) wmma_input_ranges.push_back(range);
+  }
+  if (wmma_input_ranges.empty()) return false;
+
+  if (valu_inst.getNumOperands() == 0) return false;
+  const auto &dest_op = valu_inst.getOperand(0);
+  if (!dest_op.isReg()) return false;
+  auto valu_dest = GetVgprRange(dest_op.getReg(), MRI);
+  if (valu_dest.first < 0) return false;
+
+  for (const auto &wr : wmma_input_ranges) {
+    if (RangesOverlap(wr.first, wr.second, valu_dest.first, valu_dest.second))
+      return true;
+  }
+  return false;
+}

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -17,6 +17,8 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/TargetSelect.h"
 
+static const llvm::Triple kAMDGPUTriple("amdgcn-amd-amdhsa");
+
 namespace {
 std::once_flag g_llvm_init_flag;
 std::mutex g_target_cache_mutex;
@@ -38,35 +40,32 @@ LLVMState InitLLVMImpl(const std::string &isa_name,
   state.cpu = ExtractCPU(isa_name);
   if (state.cpu.empty()) return state;
 
-  llvm::Triple triple("amdgcn-amd-amdhsa");
-
   if (cached_target) {
     state.target = cached_target;
   } else {
     std::string error;
+    llvm::Triple triple(kAMDGPUTriple);
     state.target = llvm::TargetRegistry::lookupTarget("amdgcn", triple, error);
   }
   if (!state.target) return state;
 
-  state.MRI.reset(
-      state.target->createMCRegInfo(llvm::Triple("amdgcn-amd-amdhsa")));
+  state.MRI.reset(state.target->createMCRegInfo(kAMDGPUTriple));
   if (!state.MRI) return state;
 
   llvm::MCTargetOptions mc_opts;
-  state.MAI.reset(state.target->createMCAsmInfo(
-      *state.MRI, llvm::Triple("amdgcn-amd-amdhsa"), mc_opts));
+  state.MAI.reset(
+      state.target->createMCAsmInfo(*state.MRI, kAMDGPUTriple, mc_opts));
   if (!state.MAI) return state;
 
   state.MCII.reset(state.target->createMCInstrInfo());
   if (!state.MCII) return state;
 
-  state.STI.reset(state.target->createMCSubtargetInfo(
-      llvm::Triple("amdgcn-amd-amdhsa"), state.cpu, ""));
+  state.STI.reset(
+      state.target->createMCSubtargetInfo(kAMDGPUTriple, state.cpu, ""));
   if (!state.STI || !state.STI->isCPUStringValid(state.cpu)) return state;
 
-  state.Ctx = std::make_unique<llvm::MCContext>(triple, state.MAI.get(),
-                                                state.MRI.get(),
-                                                state.STI.get());
+  state.Ctx = std::make_unique<llvm::MCContext>(
+      kAMDGPUTriple, state.MAI.get(), state.MRI.get(), state.STI.get());
   state.MOFI = std::make_unique<llvm::MCObjectFileInfo>();
   state.MOFI->initMCObjectFileInfo(*state.Ctx, false);
   state.Ctx->setObjectFileInfo(state.MOFI.get());
@@ -77,7 +76,7 @@ LLVMState InitLLVMImpl(const std::string &isa_name,
 
   unsigned asm_variant = state.MAI->getAssemblerDialect();
   state.printer.reset(state.target->createMCInstPrinter(
-      triple, asm_variant, *state.MAI, *state.MCII, *state.MRI));
+      kAMDGPUTriple, asm_variant, *state.MAI, *state.MCII, *state.MRI));
 
   state.CE.reset(state.target->createMCCodeEmitter(*state.MCII, *state.Ctx));
 
@@ -93,7 +92,7 @@ LLVMState InitLLVMCached(const std::string &isa_name) {
     std::lock_guard<std::mutex> lock(g_target_cache_mutex);
     if (!g_cached_target) {
       std::string error;
-      llvm::Triple triple("amdgcn-amd-amdhsa");
+      llvm::Triple triple(kAMDGPUTriple);
       g_cached_target =
           llvm::TargetRegistry::lookupTarget("amdgcn", triple, error);
     }
@@ -162,7 +161,6 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
   auto bos = std::make_unique<llvm::buffer_ostream>(*data_stream);
 
   llvm::MCTargetOptions mc_opts;
-  llvm::Triple triple("amdgcn-amd-amdhsa");
 
   llvm::MCCodeEmitter *ce =
       llvm_state.target->createMCCodeEmitter(*llvm_state.MCII, *llvm_state.Ctx);
@@ -173,7 +171,7 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
 
   auto streamer = std::unique_ptr<llvm::MCStreamer>(
       llvm_state.target->createMCObjectStreamer(
-          triple, *llvm_state.Ctx,
+          kAMDGPUTriple, *llvm_state.Ctx,
           std::unique_ptr<llvm::MCAsmBackend>(mab),
           mab->createObjectWriter(*bos),
           std::unique_ptr<llvm::MCCodeEmitter>(ce), *llvm_state.STI));
@@ -196,7 +194,7 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
 
   const uint8_t *elf_bytes = reinterpret_cast<const uint8_t *>(data.data());
   size_t elf_sz = data.size();
-  if (elf_sz < 64) return {};
+  if (elf_sz < kMinElfSize) return {};
 
   ElfInfo asm_elf;
   if (!ParseElfInfo(elf_bytes, elf_sz, asm_elf)) return {};
@@ -242,7 +240,7 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
                            uint64_t original_offset,
                            uint32_t original_size,
                            uint64_t trampoline_text_offset,
-                           const std::string &cpu,
+                           const RewriteConfig &config,
                            const LLVMState &llvm_state) {
   Trampoline result;
   result.original_offset = original_offset;
@@ -261,10 +259,8 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
   uint64_t branch_back_to = original_offset + original_size;
 
   uint8_t branch_bytes[4];
-  llvm::StringRef cpu_ref(cpu);
-  bool is_gfx12 = !(cpu_ref.starts_with("gfx9") || cpu_ref.starts_with("gfx10"));
   if (!EncodeSBranch(branch_back_from, branch_back_to, branch_bytes,
-                     is_gfx12)) {
+                     config.s_branch_opcode)) {
     result.bytes.clear();
     return result;
   }
@@ -305,7 +301,8 @@ std::pair<int, int> GetVgprRange(unsigned reg,
   if (numend != llvm::StringRef::npos)
     numpart = numpart.take_front(numend);
   int base = -1;
-  auto [p, ec] = std::from_chars(numpart.data(), numpart.data() + numpart.size(), base);
+  auto [p, ec] =
+      std::from_chars(numpart.data(), numpart.data() + numpart.size(), base);
   if (ec != std::errc())
     return {-1, 0};
   return {base, count};

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -249,11 +249,13 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
   result.original_offset = original_offset;
   result.original_size = original_size;
 
-  std::string asm_source = ".text\n";
+  static constexpr llvm::StringLiteral kTextDirective(".text\n");
+  std::string asm_source(kTextDirective);
   for (auto &line : asm_lines)
     asm_source += line + "\n";
 
-  auto bytes = AssembleSingleInst(asm_source.substr(6), llvm_state);
+  auto bytes = AssembleSingleInst(
+      asm_source.substr(kTextDirective.size()), llvm_state);
   if (bytes.empty()) return result;
 
   result.bytes = std::move(bytes);
@@ -261,14 +263,15 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
   uint64_t branch_back_from = trampoline_text_offset + result.bytes.size();
   uint64_t branch_back_to = original_offset + original_size;
 
-  uint8_t branch_bytes[4];
+  uint8_t branch_bytes[kMinInstSize];
   if (!EncodeSBranch(branch_back_from, branch_back_to, branch_bytes,
                      config.s_branch_opcode)) {
     result.bytes.clear();
     return result;
   }
 
-  result.bytes.insert(result.bytes.end(), branch_bytes, branch_bytes + 4);
+  result.bytes.insert(result.bytes.end(), branch_bytes,
+                      branch_bytes + kMinInstSize);
   return result;
 }
 
@@ -348,8 +351,9 @@ bool CheckVgprOverlap(const llvm::MCInst &wmma_inst,
   }
   if (wmma_input_ranges.empty()) return false;
 
+  static constexpr unsigned kDestOperandIdx = 0;
   if (valu_inst.getNumOperands() == 0) return false;
-  const auto &dest_op = valu_inst.getOperand(0);
+  const auto &dest_op = valu_inst.getOperand(kDestOperandIdx);
   if (!dest_op.isReg()) return false;
   auto valu_dest = GetVgprRange(dest_op.getReg(), MRI);
   if (valu_dest.first < 0) return false;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -155,8 +155,8 @@ static std::string PrintInstStr(const llvm::MCInst &inst,
 
 // ── AssembleSingleInst ───────────────────────────────────────────────────────
 
-std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
-                                        const LLVMState &llvm_state) {
+llvm::SmallVector<uint8_t, 16> AssembleSingleInst(const std::string &asm_str,
+                                                  const LLVMState &llvm_state) {
   llvm_state.Ctx->reset();
 
   std::string full_asm = ".text\n" + asm_str;
@@ -209,9 +209,9 @@ std::vector<uint8_t> AssembleSingleInst(const std::string &asm_str,
   if (!ParseElfInfo(elf_bytes, elf_sz, asm_elf)) return {};
   if (asm_elf.text_size == 0) return {};
 
-  return std::vector<uint8_t>(elf_bytes + asm_elf.text_offset,
-                              elf_bytes + asm_elf.text_offset +
-                                  asm_elf.text_size);
+  return llvm::SmallVector<uint8_t, 16>(elf_bytes + asm_elf.text_offset,
+                                       elf_bytes + asm_elf.text_offset +
+                                           asm_elf.text_size);
 }
 
 // ── ApplyMnemonicSwap ────────────────────────────────────────────────────────

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -137,9 +137,9 @@ static std::string PrintInstStr(const llvm::MCInst &inst,
                                                     pos, llvm::nulls());
 
     if (status == llvm::MCDisassembler::Fail) {
-      di.size = 4;
+      di.size = kMinInstSize;
       di.mnemonic = "<unknown>";
-      pos += 4;
+      pos += kMinInstSize;
     } else {
       di.size = static_cast<uint32_t>(inst_size);
       if (llvm_state.printer)
@@ -274,12 +274,14 @@ Trampoline BuildTrampoline(const std::vector<std::string> &asm_lines,
 
 // ── VGPR introspection ───────────────────────────────────────────────────────
 
+static constexpr llvm::StringLiteral kVgprPrefix("VGPR");
+
 int GetVgprNum(unsigned reg, const llvm::MCRegisterInfo &MRI) {
   const char *name = MRI.getName(reg);
   if (!name) return -1;
   llvm::StringRef rname(name);
-  if (!rname.starts_with("VGPR")) return -1;
-  llvm::StringRef numpart = rname.drop_front(4);
+  if (!rname.starts_with(kVgprPrefix)) return -1;
+  llvm::StringRef numpart = rname.drop_front(kVgprPrefix.size());
   size_t underscore = numpart.find('_');
   if (underscore != llvm::StringRef::npos)
     numpart = numpart.take_front(underscore);
@@ -295,11 +297,11 @@ std::pair<int, int> GetVgprRange(unsigned reg,
   const char *name = MRI.getName(reg);
   if (!name) return {-1, 0};
   llvm::StringRef rname(name);
-  if (!rname.starts_with("VGPR")) return {-1, 0};
+  if (!rname.starts_with(kVgprPrefix)) return {-1, 0};
   int count = 1;
   for (char c : rname)
     if (c == '_') count++;
-  llvm::StringRef numpart = rname.drop_front(4);
+  llvm::StringRef numpart = rname.drop_front(kVgprPrefix.size());
   size_t numend = numpart.find_first_not_of("0123456789");
   if (numend != llvm::StringRef::npos)
     numpart = numpart.take_front(numend);

--- a/amd/comgr/src/comgr-hotswap.cpp
+++ b/amd/comgr/src/comgr-hotswap.cpp
@@ -1,4 +1,4 @@
-//===- comgr-hotswap.cpp - HotSwap ISA stepping rewrite (stub) -----------===//
+//===- comgr-hotswap.cpp - HotSwap ISA rewriting — public API bridge ------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -7,6 +7,7 @@
 
 #include "amd_comgr.h"
 #include "comgr.h"
+#include "comgr-hotswap-internal.h"
 
 using namespace COMGR;
 
@@ -20,28 +21,36 @@ amd_comgr_status_t AMD_COMGR_API amd_comgr_hotswap_rewrite(
       !source_isa_name || !target_isa_name || !output)
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Validate and parse both ISA names.
   TargetIdentifier SourceIdent, TargetIdent;
   if (parseTargetIdentifier(source_isa_name, SourceIdent) ||
       parseTargetIdentifier(target_isa_name, TargetIdent))
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Currently only GFX1250 B0-to-A0 is supported.
   if (SourceIdent.Processor != "gfx1250" || TargetIdent.Processor != "gfx1250")
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Stub: return a copy of the input unchanged.
-  // Full B0-to-A0 patching implementation follows in subsequent commits.
-  DataObject *OutputP = DataObject::allocate(AMD_COMGR_DATA_KIND_EXECUTABLE);
-  if (!OutputP)
-    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
-
-  if (auto Status =
-          OutputP->setData(llvm::StringRef(InputP->Data, InputP->Size))) {
-    OutputP->release();
+  void *out_data = nullptr;
+  size_t out_size = 0;
+  amd_comgr_status_t Status = RetargetCodeObjectB0A0(
+      InputP->Data, InputP->Size, &out_data, &out_size);
+  if (Status != AMD_COMGR_STATUS_SUCCESS)
     return Status;
+
+  DataObject *OutputP = DataObject::allocate(AMD_COMGR_DATA_KIND_EXECUTABLE);
+  if (!OutputP) {
+    std::free(out_data);
+    return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
+  if (auto SetStatus =
+          OutputP->setData(llvm::StringRef(static_cast<char *>(out_data),
+                                           out_size))) {
+    std::free(out_data);
+    OutputP->release();
+    return SetStatus;
+  }
+
+  std::free(out_data);
   *output = DataObject::convert(OutputP);
   return AMD_COMGR_STATUS_SUCCESS;
 }

--- a/amd/comgr/unittests/CMakeLists.txt
+++ b/amd/comgr/unittests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsDisassemblers
   AllTargetsInfos
   AllTargetsMCAs
+  AMDGPUUtils
   )
 
 add_unittest(check-comgr HotswapTests
@@ -17,4 +18,6 @@ add_unittest(check-comgr HotswapTests
 
 target_include_directories(HotswapTests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  ${LLVM_MAIN_SRC_DIR}/lib/Target/AMDGPU
+  ${LLVM_BINARY_DIR}/lib/Target/AMDGPU
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)

--- a/amd/comgr/unittests/CMakeLists.txt
+++ b/amd/comgr/unittests/CMakeLists.txt
@@ -1,0 +1,20 @@
+set(LLVM_LINK_COMPONENTS
+  MC
+  MCDisassembler
+  MCParser
+  Object
+  Support
+  TargetParser
+  AllTargetsDescs
+  AllTargetsDisassemblers
+  AllTargetsInfos
+  AllTargetsMCAs
+  )
+
+add_unittest(check-comgr HotswapTests
+  HotswapTest.cpp
+  $<TARGET_OBJECTS:comgr_hotswap_obj>)
+
+target_include_directories(HotswapTests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)

--- a/amd/comgr/unittests/CMakeLists.txt
+++ b/amd/comgr/unittests/CMakeLists.txt
@@ -9,7 +9,6 @@ set(LLVM_LINK_COMPONENTS
   AllTargetsDisassemblers
   AllTargetsInfos
   AllTargetsMCAs
-  AMDGPUUtils
   )
 
 add_unittest(check-comgr HotswapTests
@@ -18,6 +17,4 @@ add_unittest(check-comgr HotswapTests
 
 target_include_directories(HotswapTests PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/../src
-  ${LLVM_MAIN_SRC_DIR}/lib/Target/AMDGPU
-  ${LLVM_BINARY_DIR}/lib/Target/AMDGPU
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)

--- a/amd/comgr/unittests/HotswapTest.cpp
+++ b/amd/comgr/unittests/HotswapTest.cpp
@@ -10,11 +10,15 @@
 #include "gtest/gtest.h"
 #include <cstring>
 
+static constexpr uint32_t kTestBranchGFX9 = 0xBF820000u;
+static constexpr uint32_t kTestBranchGFX12 = 0xBFA00000u;
+static constexpr uint32_t kTestNopOpcode = 0xBF800000u;
+
 // ── EncodeSBranch ────────────────────────────────────────────────────────────
 
 TEST(EncodeSBranch, ForwardBranchGFX9) {
   uint8_t out[4] = {};
-  ASSERT_TRUE(EncodeSBranch(0, 8, out, /*gfx12=*/false));
+  ASSERT_TRUE(EncodeSBranch(0, 8, out, kTestBranchGFX9));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
   EXPECT_EQ(encoded, 0xBF820001u);
@@ -22,7 +26,7 @@ TEST(EncodeSBranch, ForwardBranchGFX9) {
 
 TEST(EncodeSBranch, BackwardBranchGFX9) {
   uint8_t out[4] = {};
-  ASSERT_TRUE(EncodeSBranch(16, 0, out, /*gfx12=*/false));
+  ASSERT_TRUE(EncodeSBranch(16, 0, out, kTestBranchGFX9));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
   EXPECT_EQ(encoded, 0xBF82FFFBu);
@@ -30,7 +34,7 @@ TEST(EncodeSBranch, BackwardBranchGFX9) {
 
 TEST(EncodeSBranch, ForwardBranchGFX12) {
   uint8_t out[4] = {};
-  ASSERT_TRUE(EncodeSBranch(0, 8, out, /*gfx12=*/true));
+  ASSERT_TRUE(EncodeSBranch(0, 8, out, kTestBranchGFX12));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
   EXPECT_EQ(encoded, 0xBFA00001u);
@@ -38,30 +42,30 @@ TEST(EncodeSBranch, ForwardBranchGFX12) {
 
 TEST(EncodeSBranch, UnalignedDeltaFails) {
   uint8_t out[4] = {};
-  EXPECT_FALSE(EncodeSBranch(0, 7, out));
+  EXPECT_FALSE(EncodeSBranch(0, 7, out, kTestBranchGFX9));
 }
 
 TEST(EncodeSBranch, OutOfRangeFails) {
   uint8_t out[4] = {};
-  EXPECT_FALSE(EncodeSBranch(0, 500000, out));
+  EXPECT_FALSE(EncodeSBranch(0, 500000, out, kTestBranchGFX9));
 }
 
 TEST(EncodeSBranch, ZeroOffsetBranch) {
   uint8_t out[4] = {};
-  ASSERT_TRUE(EncodeSBranch(0, 4, out, /*gfx12=*/false));
+  ASSERT_TRUE(EncodeSBranch(0, 4, out, kTestBranchGFX9));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
-  EXPECT_EQ(encoded, S_BRANCH_GFX9);
+  EXPECT_EQ(encoded, kTestBranchGFX9);
 }
 
 // ── EncodeSNop ───────────────────────────────────────────────────────────────
 
 TEST(EncodeSNop, ProducesCorrectEncoding) {
   uint8_t out[4] = {};
-  EncodeSNop(out);
+  EncodeSNop(out, kTestNopOpcode);
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
-  EXPECT_EQ(encoded, S_NOP_OPCODE);
+  EXPECT_EQ(encoded, kTestNopOpcode);
 }
 
 // ── ExtractCPU ───────────────────────────────────────────────────────────────

--- a/amd/comgr/unittests/HotswapTest.cpp
+++ b/amd/comgr/unittests/HotswapTest.cpp
@@ -1,0 +1,209 @@
+//===- HotswapTest.cpp - Unit tests for HotSwap internals -----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+#include "gtest/gtest.h"
+#include <cstring>
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EncodeSBranch
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(EncodeSBranch, ForwardBranchGFX9) {
+  uint8_t out[4] = {};
+  // Branch from offset 0 to offset 8: byte_delta = 8 - 0 - 4 = 4,
+  // dword_offset = 1.
+  ASSERT_TRUE(EncodeSBranch(0, 8, out, /*gfx12=*/false));
+  uint32_t encoded;
+  std::memcpy(&encoded, out, 4);
+  // GFX9 opcode = 0xBF82'0000, offset field = 1 → 0xBF82'0001.
+  EXPECT_EQ(encoded, 0xBF820001u);
+}
+
+TEST(EncodeSBranch, BackwardBranchGFX9) {
+  uint8_t out[4] = {};
+  // Branch from offset 16 to offset 0: byte_delta = 0 - 16 - 4 = -20,
+  // dword_offset = -5.
+  ASSERT_TRUE(EncodeSBranch(16, 0, out, /*gfx12=*/false));
+  uint32_t encoded;
+  std::memcpy(&encoded, out, 4);
+  // -5 as uint16_t = 0xFFFB, combined with GFX9 opcode → 0xBF82'FFFB.
+  EXPECT_EQ(encoded, 0xBF82FFFBu);
+}
+
+TEST(EncodeSBranch, ForwardBranchGFX12) {
+  uint8_t out[4] = {};
+  ASSERT_TRUE(EncodeSBranch(0, 8, out, /*gfx12=*/true));
+  uint32_t encoded;
+  std::memcpy(&encoded, out, 4);
+  // GFX12 opcode = 0xBFA0'0000, offset field = 1 → 0xBFA0'0001.
+  EXPECT_EQ(encoded, 0xBFA00001u);
+}
+
+TEST(EncodeSBranch, UnalignedDeltaFails) {
+  uint8_t out[4] = {};
+  // byte_delta = 7 - 0 - 4 = 3, not divisible by 4.
+  EXPECT_FALSE(EncodeSBranch(0, 7, out));
+}
+
+TEST(EncodeSBranch, OutOfRangeFails) {
+  uint8_t out[4] = {};
+  // dword_offset would be (500000 - 0 - 4) / 4 = 124999, > 32767.
+  EXPECT_FALSE(EncodeSBranch(0, 500000, out));
+}
+
+TEST(EncodeSBranch, ZeroOffsetBranch) {
+  uint8_t out[4] = {};
+  // Branch from offset 0 to offset 4: byte_delta = 0, dword_offset = 0.
+  ASSERT_TRUE(EncodeSBranch(0, 4, out, /*gfx12=*/false));
+  uint32_t encoded;
+  std::memcpy(&encoded, out, 4);
+  EXPECT_EQ(encoded, S_BRANCH_GFX9);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// EncodeSNop
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(EncodeSNop, ProducesCorrectEncoding) {
+  uint8_t out[4] = {};
+  EncodeSNop(out);
+  uint32_t encoded;
+  std::memcpy(&encoded, out, 4);
+  EXPECT_EQ(encoded, S_NOP_OPCODE);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ExtractCPU
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(ExtractCPU, FullISAName) {
+  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250"), "gfx1250");
+}
+
+TEST(ExtractCPU, GFX900) {
+  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx900"), "gfx900");
+}
+
+TEST(ExtractCPU, BareGFX) {
+  EXPECT_EQ(ExtractCPU("gfx942"), "gfx942");
+}
+
+TEST(ExtractCPU, NoGFXPrefix) {
+  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa"), "");
+}
+
+TEST(ExtractCPU, EmptyString) {
+  EXPECT_EQ(ExtractCPU(""), "");
+}
+
+TEST(ExtractCPU, StopsAtNonAlphanumeric) {
+  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250:sramecc+"),
+            "gfx1250");
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// MallocBuffer
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(MallocBuffer, DefaultIsEmpty) {
+  MallocBuffer buf;
+  EXPECT_FALSE(static_cast<bool>(buf));
+  EXPECT_EQ(buf.data, nullptr);
+  EXPECT_EQ(buf.size, 0u);
+}
+
+TEST(MallocBuffer, AllocNonZero) {
+  MallocBuffer buf(64);
+  EXPECT_TRUE(static_cast<bool>(buf));
+  EXPECT_NE(buf.data, nullptr);
+  EXPECT_EQ(buf.size, 64u);
+}
+
+TEST(MallocBuffer, MoveConstructor) {
+  MallocBuffer a(128);
+  uint8_t *orig_data = a.data;
+  MallocBuffer b(std::move(a));
+  EXPECT_EQ(b.data, orig_data);
+  EXPECT_EQ(b.size, 128u);
+  EXPECT_EQ(a.data, nullptr);
+  EXPECT_EQ(a.size, 0u);
+}
+
+TEST(MallocBuffer, MoveAssignment) {
+  MallocBuffer a(64);
+  MallocBuffer b(32);
+  uint8_t *a_data = a.data;
+  b = std::move(a);
+  EXPECT_EQ(b.data, a_data);
+  EXPECT_EQ(b.size, 64u);
+  EXPECT_EQ(a.data, nullptr);
+  EXPECT_EQ(a.size, 0u);
+}
+
+TEST(MallocBuffer, Release) {
+  MallocBuffer buf(64);
+  uint8_t *p = buf.release();
+  EXPECT_NE(p, nullptr);
+  EXPECT_EQ(buf.data, nullptr);
+  EXPECT_EQ(buf.size, 0u);
+  std::free(p);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ParseElfInfo
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(ParseElfInfo, RejectsTruncatedInput) {
+  uint8_t garbage[] = {0x7f, 'E', 'L', 'F', 0, 0, 0, 0};
+  ElfInfo info;
+  EXPECT_FALSE(ParseElfInfo(garbage, sizeof(garbage), info));
+}
+
+TEST(ParseElfInfo, RejectsNonElfInput) {
+  uint8_t not_elf[64] = {};
+  ElfInfo info;
+  EXPECT_FALSE(ParseElfInfo(not_elf, sizeof(not_elf), info));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// BuildNopSledMap (via NopSled struct)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(NopSled, StructDefaults) {
+  NopSled sled{};
+  EXPECT_EQ(sled.start, 0u);
+  EXPECT_EQ(sled.end, 0u);
+  EXPECT_EQ(sled.write_pos, 0u);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RewriteRule (trimmed struct)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(RewriteRule, Defaults) {
+  RewriteRule rule;
+  EXPECT_TRUE(rule.replace_mnemonic.empty());
+  EXPECT_TRUE(rule.preserve_operands);
+  EXPECT_TRUE(rule.replace_bytes.empty());
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ElfInfo / ElfSection / ElfSymbol struct layout
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST(ElfInfo, DefaultsAreEmpty) {
+  ElfInfo info;
+  EXPECT_TRUE(info.sections.empty());
+  EXPECT_TRUE(info.symbols.empty());
+  EXPECT_EQ(info.text_section_idx, -1);
+  EXPECT_EQ(info.text_idx, -1);
+  EXPECT_EQ(info.text_offset, 0u);
+  EXPECT_EQ(info.text_size, 0u);
+  EXPECT_EQ(info.text_addr, 0u);
+}

--- a/amd/comgr/unittests/HotswapTest.cpp
+++ b/amd/comgr/unittests/HotswapTest.cpp
@@ -189,7 +189,6 @@ TEST(NopSled, StructDefaults) {
 TEST(RewriteRule, Defaults) {
   RewriteRule rule;
   EXPECT_TRUE(rule.replace_mnemonic.empty());
-  EXPECT_TRUE(rule.preserve_operands);
   EXPECT_TRUE(rule.replace_bytes.empty());
 }
 

--- a/amd/comgr/unittests/HotswapTest.cpp
+++ b/amd/comgr/unittests/HotswapTest.cpp
@@ -10,9 +10,7 @@
 #include "gtest/gtest.h"
 #include <cstring>
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// EncodeSBranch
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── EncodeSBranch ────────────────────────────────────────────────────────────
 
 TEST(EncodeSBranch, ForwardBranchGFX9) {
   uint8_t out[4] = {};
@@ -56,9 +54,7 @@ TEST(EncodeSBranch, ZeroOffsetBranch) {
   EXPECT_EQ(encoded, S_BRANCH_GFX9);
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// EncodeSNop
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── EncodeSNop ───────────────────────────────────────────────────────────────
 
 TEST(EncodeSNop, ProducesCorrectEncoding) {
   uint8_t out[4] = {};
@@ -68,9 +64,7 @@ TEST(EncodeSNop, ProducesCorrectEncoding) {
   EXPECT_EQ(encoded, S_NOP_OPCODE);
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// ExtractCPU
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── ExtractCPU ───────────────────────────────────────────────────────────────
 
 TEST(ExtractCPU, FullISAName) {
   EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250"), "gfx1250");
@@ -84,19 +78,17 @@ TEST(ExtractCPU, StopsAtNonAlphanumeric) {
   EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250:sramecc+"), "gfx1250");
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// MallocBuffer
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── MallocBuffer ─────────────────────────────────────────────────────────────
 
 TEST(MallocBuffer, AllocAndMove) {
   MallocBuffer a(64);
   ASSERT_TRUE(static_cast<bool>(a));
   EXPECT_EQ(a.size, 64u);
 
-  uint8_t *orig = a.data;
+  uint8_t *orig = a.get();
   MallocBuffer b(std::move(a));
-  EXPECT_EQ(b.data, orig);
-  EXPECT_EQ(a.data, nullptr);
+  EXPECT_EQ(b.get(), orig);
+  EXPECT_EQ(a.get(), nullptr);
   EXPECT_EQ(a.size, 0u);
 }
 
@@ -104,14 +96,12 @@ TEST(MallocBuffer, Release) {
   MallocBuffer buf(64);
   uint8_t *p = buf.release();
   EXPECT_NE(p, nullptr);
-  EXPECT_EQ(buf.data, nullptr);
+  EXPECT_EQ(buf.get(), nullptr);
   EXPECT_EQ(buf.size, 0u);
   std::free(p);
 }
 
-// ═══════════════════════════════════════════════════════════════════════════════
-// ParseElfInfo
-// ═══════════════════════════════════════════════════════════════════════════════
+// ── ParseElfInfo ─────────────────────────────────────────────────────────────
 
 TEST(ParseElfInfo, RejectsTruncatedInput) {
   uint8_t garbage[] = {0x7f, 'E', 'L', 'F', 0, 0, 0, 0};

--- a/amd/comgr/unittests/HotswapTest.cpp
+++ b/amd/comgr/unittests/HotswapTest.cpp
@@ -16,23 +16,17 @@
 
 TEST(EncodeSBranch, ForwardBranchGFX9) {
   uint8_t out[4] = {};
-  // Branch from offset 0 to offset 8: byte_delta = 8 - 0 - 4 = 4,
-  // dword_offset = 1.
   ASSERT_TRUE(EncodeSBranch(0, 8, out, /*gfx12=*/false));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
-  // GFX9 opcode = 0xBF82'0000, offset field = 1 → 0xBF82'0001.
   EXPECT_EQ(encoded, 0xBF820001u);
 }
 
 TEST(EncodeSBranch, BackwardBranchGFX9) {
   uint8_t out[4] = {};
-  // Branch from offset 16 to offset 0: byte_delta = 0 - 16 - 4 = -20,
-  // dword_offset = -5.
   ASSERT_TRUE(EncodeSBranch(16, 0, out, /*gfx12=*/false));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
-  // -5 as uint16_t = 0xFFFB, combined with GFX9 opcode → 0xBF82'FFFB.
   EXPECT_EQ(encoded, 0xBF82FFFBu);
 }
 
@@ -41,25 +35,21 @@ TEST(EncodeSBranch, ForwardBranchGFX12) {
   ASSERT_TRUE(EncodeSBranch(0, 8, out, /*gfx12=*/true));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
-  // GFX12 opcode = 0xBFA0'0000, offset field = 1 → 0xBFA0'0001.
   EXPECT_EQ(encoded, 0xBFA00001u);
 }
 
 TEST(EncodeSBranch, UnalignedDeltaFails) {
   uint8_t out[4] = {};
-  // byte_delta = 7 - 0 - 4 = 3, not divisible by 4.
   EXPECT_FALSE(EncodeSBranch(0, 7, out));
 }
 
 TEST(EncodeSBranch, OutOfRangeFails) {
   uint8_t out[4] = {};
-  // dword_offset would be (500000 - 0 - 4) / 4 = 124999, > 32767.
   EXPECT_FALSE(EncodeSBranch(0, 500000, out));
 }
 
 TEST(EncodeSBranch, ZeroOffsetBranch) {
   uint8_t out[4] = {};
-  // Branch from offset 0 to offset 4: byte_delta = 0, dword_offset = 0.
   ASSERT_TRUE(EncodeSBranch(0, 4, out, /*gfx12=*/false));
   uint32_t encoded;
   std::memcpy(&encoded, out, 4);
@@ -86,62 +76,26 @@ TEST(ExtractCPU, FullISAName) {
   EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250"), "gfx1250");
 }
 
-TEST(ExtractCPU, GFX900) {
-  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx900"), "gfx900");
-}
-
-TEST(ExtractCPU, BareGFX) {
-  EXPECT_EQ(ExtractCPU("gfx942"), "gfx942");
-}
-
 TEST(ExtractCPU, NoGFXPrefix) {
   EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa"), "");
 }
 
-TEST(ExtractCPU, EmptyString) {
-  EXPECT_EQ(ExtractCPU(""), "");
-}
-
 TEST(ExtractCPU, StopsAtNonAlphanumeric) {
-  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250:sramecc+"),
-            "gfx1250");
+  EXPECT_EQ(ExtractCPU("amdgcn-amd-amdhsa--gfx1250:sramecc+"), "gfx1250");
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // MallocBuffer
 // ═══════════════════════════════════════════════════════════════════════════════
 
-TEST(MallocBuffer, DefaultIsEmpty) {
-  MallocBuffer buf;
-  EXPECT_FALSE(static_cast<bool>(buf));
-  EXPECT_EQ(buf.data, nullptr);
-  EXPECT_EQ(buf.size, 0u);
-}
-
-TEST(MallocBuffer, AllocNonZero) {
-  MallocBuffer buf(64);
-  EXPECT_TRUE(static_cast<bool>(buf));
-  EXPECT_NE(buf.data, nullptr);
-  EXPECT_EQ(buf.size, 64u);
-}
-
-TEST(MallocBuffer, MoveConstructor) {
-  MallocBuffer a(128);
-  uint8_t *orig_data = a.data;
-  MallocBuffer b(std::move(a));
-  EXPECT_EQ(b.data, orig_data);
-  EXPECT_EQ(b.size, 128u);
-  EXPECT_EQ(a.data, nullptr);
-  EXPECT_EQ(a.size, 0u);
-}
-
-TEST(MallocBuffer, MoveAssignment) {
+TEST(MallocBuffer, AllocAndMove) {
   MallocBuffer a(64);
-  MallocBuffer b(32);
-  uint8_t *a_data = a.data;
-  b = std::move(a);
-  EXPECT_EQ(b.data, a_data);
-  EXPECT_EQ(b.size, 64u);
+  ASSERT_TRUE(static_cast<bool>(a));
+  EXPECT_EQ(a.size, 64u);
+
+  uint8_t *orig = a.data;
+  MallocBuffer b(std::move(a));
+  EXPECT_EQ(b.data, orig);
   EXPECT_EQ(a.data, nullptr);
   EXPECT_EQ(a.size, 0u);
 }
@@ -169,40 +123,4 @@ TEST(ParseElfInfo, RejectsNonElfInput) {
   uint8_t not_elf[64] = {};
   ElfInfo info;
   EXPECT_FALSE(ParseElfInfo(not_elf, sizeof(not_elf), info));
-}
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// BuildNopSledMap (via NopSled struct)
-// ═══════════════════════════════════════════════════════════════════════════════
-
-TEST(NopSled, StructDefaults) {
-  NopSled sled{};
-  EXPECT_EQ(sled.start, 0u);
-  EXPECT_EQ(sled.end, 0u);
-  EXPECT_EQ(sled.write_pos, 0u);
-}
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// RewriteRule (trimmed struct)
-// ═══════════════════════════════════════════════════════════════════════════════
-
-TEST(RewriteRule, Defaults) {
-  RewriteRule rule;
-  EXPECT_TRUE(rule.replace_mnemonic.empty());
-  EXPECT_TRUE(rule.replace_bytes.empty());
-}
-
-// ═══════════════════════════════════════════════════════════════════════════════
-// ElfInfo / ElfSection / ElfSymbol struct layout
-// ═══════════════════════════════════════════════════════════════════════════════
-
-TEST(ElfInfo, DefaultsAreEmpty) {
-  ElfInfo info;
-  EXPECT_TRUE(info.sections.empty());
-  EXPECT_TRUE(info.symbols.empty());
-  EXPECT_EQ(info.text_section_idx, -1);
-  EXPECT_EQ(info.text_idx, -1);
-  EXPECT_EQ(info.text_offset, 0u);
-  EXPECT_EQ(info.text_size, 0u);
-  EXPECT_EQ(info.text_addr, 0u);
 }

--- a/amd/comgr/unittests/HotswapTest.cpp
+++ b/amd/comgr/unittests/HotswapTest.cpp
@@ -17,54 +17,54 @@ static constexpr uint32_t kTestNopOpcode = 0xBF800000u;
 // ── EncodeSBranch ────────────────────────────────────────────────────────────
 
 TEST(EncodeSBranch, ForwardBranchGFX9) {
-  uint8_t out[4] = {};
+  uint8_t out[kMinInstSize] = {};
   ASSERT_TRUE(EncodeSBranch(0, 8, out, kTestBranchGFX9));
   uint32_t encoded;
-  std::memcpy(&encoded, out, 4);
+  std::memcpy(&encoded, out, sizeof(encoded));
   EXPECT_EQ(encoded, 0xBF820001u);
 }
 
 TEST(EncodeSBranch, BackwardBranchGFX9) {
-  uint8_t out[4] = {};
+  uint8_t out[kMinInstSize] = {};
   ASSERT_TRUE(EncodeSBranch(16, 0, out, kTestBranchGFX9));
   uint32_t encoded;
-  std::memcpy(&encoded, out, 4);
+  std::memcpy(&encoded, out, sizeof(encoded));
   EXPECT_EQ(encoded, 0xBF82FFFBu);
 }
 
 TEST(EncodeSBranch, ForwardBranchGFX12) {
-  uint8_t out[4] = {};
+  uint8_t out[kMinInstSize] = {};
   ASSERT_TRUE(EncodeSBranch(0, 8, out, kTestBranchGFX12));
   uint32_t encoded;
-  std::memcpy(&encoded, out, 4);
+  std::memcpy(&encoded, out, sizeof(encoded));
   EXPECT_EQ(encoded, 0xBFA00001u);
 }
 
 TEST(EncodeSBranch, UnalignedDeltaFails) {
-  uint8_t out[4] = {};
+  uint8_t out[kMinInstSize] = {};
   EXPECT_FALSE(EncodeSBranch(0, 7, out, kTestBranchGFX9));
 }
 
 TEST(EncodeSBranch, OutOfRangeFails) {
-  uint8_t out[4] = {};
+  uint8_t out[kMinInstSize] = {};
   EXPECT_FALSE(EncodeSBranch(0, 500000, out, kTestBranchGFX9));
 }
 
 TEST(EncodeSBranch, ZeroOffsetBranch) {
-  uint8_t out[4] = {};
-  ASSERT_TRUE(EncodeSBranch(0, 4, out, kTestBranchGFX9));
+  uint8_t out[kMinInstSize] = {};
+  ASSERT_TRUE(EncodeSBranch(0, kMinInstSize, out, kTestBranchGFX9));
   uint32_t encoded;
-  std::memcpy(&encoded, out, 4);
+  std::memcpy(&encoded, out, sizeof(encoded));
   EXPECT_EQ(encoded, kTestBranchGFX9);
 }
 
 // ── EncodeSNop ───────────────────────────────────────────────────────────────
 
 TEST(EncodeSNop, ProducesCorrectEncoding) {
-  uint8_t out[4] = {};
+  uint8_t out[kMinInstSize] = {};
   EncodeSNop(out, kTestNopOpcode);
   uint32_t encoded;
-  std::memcpy(&encoded, out, 4);
+  std::memcpy(&encoded, out, sizeof(encoded));
   EXPECT_EQ(encoded, kTestNopOpcode);
 }
 


### PR DESCRIPTION
Add the internal infrastructure for rewriting GFX1250 B0 code objects
to run on A0 silicon. This PR lays the generic engine; per-instruction
patch rules land in subsequent PRs via weak-symbol overrides.

Architecture:
- RewriteConfig parameterizes all ISA-specific behavior (branch opcode,
  NOP opcode, max VGPRs). The infrastructure has zero references to any
  specific GPU generation; only comgr-hotswap-b0a0.cpp and
  comgr-hotswap.cpp know about GFX1250.
- Patch entry points (ApplyInPlacePatches, ApplyTrampolinePatches,
  ApplyWmmaHazardPatch, ApplyWmmaSplitPatches, ApplyScratchPatches)
  are weak symbols returning 0. Each patch group lands as an
  independent PR with a strong override, avoiding merge conflicts.

Module structure:
- comgr-hotswap-internal.h: shared types, RewriteConfig, named
  constants, function declarations
- comgr-hotswap-elf.cpp: ELF parsing (via llvm::object::ELFFile),
  branch/NOP encoding, kernel descriptor read/update, trampoline
  growth with section/program header adjustment, ISA note patching
- comgr-hotswap-llvm.cpp: LLVM MC target init with caching,
  instruction decode/assemble/print, mnemonic swap, trampoline
  builder, VGPR register introspection, WMMA overlap detection
- comgr-hotswap-b0a0.cpp: GFX1250 policy layer — config builder
  (using AMDGPU::IsaInfo::getTotalNumVGPRs), patch dispatcher,
  NOP sled scanning, sled/trampoline code emission, orchestrator
  pipeline (decode → patch → fixup → grow ELF → DWARF → verify)
- comgr-hotswap.cpp: public C API bridge (amd_comgr_hotswap_rewrite)

LLVM integration:
- AMDGPUTargetStreamer::getElfMach() for ELF machine code mapping
- AMDGPU::IsaInfo::getTotalNumVGPRs() for VGPR count from subtarget
- llvm::ELF constants (SHT_SYMTAB, SHT_DYNSYM, SHT_NOTE, STT_FUNC,
  EI_CLASS, ELFCLASS64, ElfMagic) replacing raw numbers
- llvm::alignTo() for note alignment, llvm::isAlnum() for CPU parsing
- llvm::DenseMap, SmallVector, StringMap replacing std containers
- llvm::raw_ostream/errs()/nulls() for logging
- offsetof(Elf64_Ehdr/Shdr/Phdr/Nhdr, ...) for all ELF field access
- sizeof(variable) for all memcpy size arguments

Testing:
- 14 gtest unit tests via comgr_hotswap_obj OBJECT library, gated
  behind TARGET llvm_gtest (no impact on normal builds). Covers
  EncodeSBranch, EncodeSNop, ExtractCPU, MallocBuffer, ParseElfInfo.
- Existing hotswap-rewrite lit test covers the public API.