### PR TITLE
[AMDGPU] comgr: add HotSwap ELF infrastructure (1/3)

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SOURCES
   src/comgr-disassembly.cpp
   src/comgr-env.cpp
   src/comgr-hotswap.cpp
+  src/comgr-hotswap-elf.cpp
   src/comgr-libcxx-headers.cpp
   src/comgr-metadata.cpp
   src/comgr-signal.cpp
@@ -558,6 +559,10 @@ if(BUILD_TESTING)
   endif()
   add_subdirectory(test)
   add_subdirectory(test-lit)
+
+  if(TARGET llvm_gtest)
+    add_subdirectory(unittests)
+  endif()
 endif()
 
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -1,0 +1,451 @@
+//===- comgr-hotswap-elf.cpp - ELF helpers and trampoline growth ----------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of hotswap::ElfView and the free-function ELF helpers.
+/// Parses are delegated to llvm::object::ELFFile; there is no hand-rolled
+/// section/symbol cache.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/StringExtras.h"
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+using Ehdr = ELF::Elf64_Ehdr;
+using Shdr = ELF::Elf64_Shdr;
+using Phdr = ELF::Elf64_Phdr;
+using ELFT = ElfView::ELFT;
+using ELFFileT = ElfView::ELFFileT;
+
+// -- s_branch encoding --------------------------------------------------------
+
+bool encodeSBranch(uint64_t FromOffset, uint64_t ToOffset,
+                   uint8_t OutBytes[MinInstSize], uint32_t SBranchOpcode) {
+  int64_t ByteDelta = static_cast<int64_t>(ToOffset) -
+                      static_cast<int64_t>(FromOffset) - MinInstSize;
+  if (ByteDelta % MinInstSize != 0)
+    return false;
+  int64_t DwordOffset = ByteDelta / MinInstSize;
+  if (DwordOffset < BranchOffsetMin || DwordOffset > BranchOffsetMax)
+    return false;
+  uint32_t Encoded =
+      SBranchOpcode | (static_cast<uint16_t>(DwordOffset) & BranchOffsetMask);
+  std::memcpy(OutBytes, &Encoded, sizeof(Encoded));
+  return true;
+}
+
+// -- applyByteReplace ---------------------------------------------------------
+
+bool applyByteReplace(const RewriteRule &Rule, uint64_t InstOffset,
+                      uint32_t InstSize, uint8_t *Text, uint64_t TextSize,
+                      uint32_t SNopOpcode) {
+  if (InstOffset + InstSize > TextSize)
+    return false;
+  const size_t ReplaceSize = Rule.ReplaceBytes.size();
+  if (ReplaceSize > InstSize)
+    return false;
+  std::memcpy(Text + InstOffset, Rule.ReplaceBytes.data(), ReplaceSize);
+  uint64_t PadOffset = InstOffset + ReplaceSize;
+  uint64_t Remaining = InstSize - ReplaceSize;
+  while (Remaining >= MinInstSize) {
+    std::memcpy(Text + PadOffset, &SNopOpcode, sizeof(SNopOpcode));
+    PadOffset += MinInstSize;
+    Remaining -= MinInstSize;
+  }
+  return true;
+}
+
+// -- findNearestSled ----------------------------------------------------------
+
+NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
+                         uint64_t Needed) {
+  NopSled *Best = nullptr;
+  int64_t BestDist = INT64_MAX;
+  for (NopSled &Sled : Sleds) {
+    if (Sled.WritePos + Needed > Sled.End)
+      continue;
+    int64_t Dist = std::abs(static_cast<int64_t>(Sled.WritePos) -
+                            static_cast<int64_t>(Offset));
+    if (Dist < MaxSledDistance && Dist < BestDist) {
+      Best = &Sled;
+      BestDist = Dist;
+    }
+  }
+  return Best;
+}
+
+// -- ElfView::create ----------------------------------------------------------
+
+Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
+  // Data/Size are kept as factory parameters to document that the caller
+  // must hand in a mutable buffer (hotswap mutates bytes through the
+  // resulting ElfView). Once ELFFile is constructed, it owns the structural
+  // view over these same bytes and we do not need to store Data/Size
+  // separately -- ELFFile::base() / ELFFile::getBufSize() alias them.
+  Expected<ELFFileT> FileOrErr = ELFFileT::create(
+      StringRef(reinterpret_cast<const char *>(Data), Size));
+  if (!FileOrErr)
+    return FileOrErr.takeError();
+
+  const ELFFileT &File = *FileOrErr;
+  Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
+  if (!SectionsOrErr)
+    return SectionsOrErr.takeError();
+  ELFT::ShdrRange Sections = *SectionsOrErr;
+
+  const ELFT::Shdr *Text = nullptr;
+  unsigned TextIdx = 0;
+  unsigned Idx = 0;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    Expected<StringRef> NameOrErr = File.getSectionName(Shdr);
+    if (!NameOrErr) {
+      consumeError(NameOrErr.takeError());
+      ++Idx;
+      continue;
+    }
+    if (*NameOrErr == ".text" && Shdr.sh_offset + Shdr.sh_size <= Size) {
+      Text = &Shdr;
+      TextIdx = Idx;
+      break;
+    }
+    ++Idx;
+  }
+  if (!Text)
+    return createStringError(object::object_error::parse_failed,
+                             "no .text section found");
+  return ElfView(std::move(*FileOrErr), Sections, Text, TextIdx);
+}
+
+// -- ElfView::findKernelAtOffset ----------------------------------------------
+
+std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      consumeError(SymsOrErr.takeError());
+      continue;
+    }
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(SymShdr, Sections);
+    if (!StrTabOrErr) {
+      consumeError(StrTabOrErr.takeError());
+      continue;
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.getType() != ELF::STT_FUNC &&
+          Sym.getType() != ELF::STT_GNU_IFUNC)
+        continue;
+      if (Sym.st_shndx != TextSectionIndex)
+        continue;
+      if (TextOffset < Sym.st_value ||
+          TextOffset >= Sym.st_value + Sym.st_size)
+        continue;
+      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+      if (!NameOrErr) {
+        log() << "hotswap: error: findKernelAtOffset: function symbol "
+              << "covering offset 0x" << utohexstr(TextOffset)
+              << " has unreadable name: "
+              << toString(NameOrErr.takeError()) << "\n";
+        return "";
+      }
+      return NameOrErr->str();
+    }
+  }
+  log() << "hotswap: findKernelAtOffset: no function symbol covers offset 0x"
+        << utohexstr(TextOffset) << " in .text.\n";
+  return "";
+}
+
+// -- ElfView::findKernelDescriptor --------------------------------------------
+
+uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
+  std::string KdName = (KernelName + ".kd").str();
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      consumeError(SymsOrErr.takeError());
+      continue;
+    }
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(SymShdr, Sections);
+    if (!StrTabOrErr) {
+      consumeError(StrTabOrErr.takeError());
+      continue;
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+      if (!NameOrErr) {
+        consumeError(NameOrErr.takeError());
+        continue;
+      }
+      if (*NameOrErr != KdName)
+        continue;
+      unsigned Shndx = Sym.st_shndx;
+      Expected<const ELFT::Shdr *> HostShdrOrErr = File.getSection(Shndx);
+      if (!HostShdrOrErr) {
+        consumeError(HostShdrOrErr.takeError());
+        continue;
+      }
+      const ELFT::Shdr &HostShdr = **HostShdrOrErr;
+      if (Sym.st_value < HostShdr.sh_addr)
+        continue;
+      uint64_t FileOffset =
+          HostShdr.sh_offset + (Sym.st_value - HostShdr.sh_addr);
+      if (FileOffset + KdSize > size())
+        continue;
+      return data() + FileOffset;
+    }
+  }
+  return nullptr;
+}
+
+// -- ElfView::getKernelVgprCount ----------------------------------------------
+
+std::optional<unsigned>
+ElfView::getKernelVgprCount(StringRef KernelName,
+                            unsigned VgprGranuleSize) const {
+  if (VgprGranuleSize == 0) {
+    log() << "hotswap: error: getKernelVgprCount: VgprGranuleSize is 0 for "
+          << "kernel '" << KernelName << "'.\n";
+    return std::nullopt;
+  }
+  namespace hsa = amdhsa;
+  // findKernelDescriptor never writes through the returned pointer in this
+  // call path but is shared (non-const) with updateKernelDescriptor. The
+  // const_cast on `this` keeps the read-only accessor const-correct without
+  // duplicating the lookup helper.
+  uint8_t *Kd =
+      const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
+  if (!Kd) {
+    log() << "hotswap: error: getKernelVgprCount: kernel descriptor symbol '"
+          << KernelName << ".kd' not found.\n";
+    return std::nullopt;
+  }
+  uint32_t Rsrc1;
+  std::memcpy(&Rsrc1, Kd + KdRsrc1Offset, sizeof(Rsrc1));
+  uint32_t Granulated = AMDHSA_BITS_GET(
+      Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+  return (Granulated + 1) * VgprGranuleSize;
+}
+
+// -- ElfView::updateKernelDescriptor ------------------------------------------
+
+void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,
+                                     unsigned ExtraSgprs,
+                                     unsigned VgprGranuleSize,
+                                     unsigned SgprGranuleSize) {
+  namespace hsa = amdhsa;
+  uint8_t *Kd = findKernelDescriptor(KernelName);
+  if (!Kd) {
+    log() << "hotswap: error: updateKernelDescriptor: kernel descriptor "
+          << "symbol '" << KernelName << ".kd' not found; requested "
+          << "+" << ExtraVgprs << " VGPRs / +" << ExtraSgprs
+          << " SGPRs silently dropped.\n";
+    return;
+  }
+
+  uint32_t Rsrc1;
+  std::memcpy(&Rsrc1, Kd + KdRsrc1Offset, sizeof(Rsrc1));
+  if (ExtraVgprs != 0 && VgprGranuleSize != 0) {
+    uint32_t Current = AMDHSA_BITS_GET(
+        Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+    uint32_t MaxGran = static_cast<uint32_t>(
+        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT >>
+        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT_SHIFT);
+    unsigned Extra = (ExtraVgprs + VgprGranuleSize - 1) / VgprGranuleSize;
+    AMDHSA_BITS_SET(Rsrc1,
+                    hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                    std::min<uint32_t>(Current + Extra, MaxGran));
+  }
+  if (ExtraSgprs != 0 && SgprGranuleSize != 0) {
+    uint32_t Current = AMDHSA_BITS_GET(
+        Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
+    uint32_t MaxGran = static_cast<uint32_t>(
+        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT >>
+        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT_SHIFT);
+    unsigned Extra = (ExtraSgprs + SgprGranuleSize - 1) / SgprGranuleSize;
+    AMDHSA_BITS_SET(Rsrc1,
+                    hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
+                    std::min<uint32_t>(Current + Extra, MaxGran));
+  }
+  std::memcpy(Kd + KdRsrc1Offset, &Rsrc1, sizeof(Rsrc1));
+}
+
+// -- Section/program header adjustment for trampoline growth ------------------
+
+static void adjustSectionHeaders(uint8_t *Elf, size_t ElfSize,
+                                 uint64_t TextOffset, uint64_t TextSize,
+                                 size_t TrampTotal) {
+  if (ElfSize < sizeof(Ehdr))
+    return;
+
+  uint64_t TextEnd = TextOffset + TextSize;
+  uint64_t Shoff;
+  uint16_t Shentsize;
+  uint16_t Shnum;
+  std::memcpy(&Shoff, Elf + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, Elf + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
+  std::memcpy(&Shnum, Elf + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+  if (Shentsize < sizeof(Shdr))
+    return;
+
+  if (Shoff >= TextEnd) {
+    uint64_t NewShoff = Shoff + TrampTotal;
+    std::memcpy(Elf + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+    Shoff = NewShoff;
+  }
+
+  for (uint16_t I = 0; I < Shnum; ++I) {
+    uint64_t ShPos = Shoff + static_cast<uint64_t>(I) * Shentsize;
+    if (ShPos + sizeof(Shdr) > ElfSize)
+      break;
+    uint8_t *Sh = Elf + ShPos;
+    uint64_t ShOffset;
+    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
+
+    if (ShOffset == TextOffset) {
+      uint64_t NewTextSize = TextSize + TrampTotal;
+      std::memcpy(Sh + offsetof(Shdr, sh_size), &NewTextSize,
+                  sizeof(NewTextSize));
+    } else if (ShOffset > TextOffset) {
+      uint64_t NewOffset = ShOffset + TrampTotal;
+      std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
+                  sizeof(NewOffset));
+    }
+  }
+}
+
+static void adjustProgramHeaders(uint8_t *Elf, size_t ElfSize,
+                                 uint64_t TextOffset, uint64_t TextSize,
+                                 size_t TrampTotal) {
+  if (ElfSize < sizeof(Ehdr))
+    return;
+
+  uint64_t TextEnd = TextOffset + TextSize;
+  uint64_t Phoff;
+  uint16_t Phentsize;
+  uint16_t Phnum;
+  std::memcpy(&Phoff, Elf + offsetof(Ehdr, e_phoff), sizeof(Phoff));
+  std::memcpy(&Phentsize, Elf + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
+  std::memcpy(&Phnum, Elf + offsetof(Ehdr, e_phnum), sizeof(Phnum));
+  if (Phentsize < sizeof(Phdr))
+    return;
+
+  for (uint16_t I = 0; I < Phnum; ++I) {
+    uint64_t PhPos = Phoff + static_cast<uint64_t>(I) * Phentsize;
+    if (PhPos + sizeof(Phdr) > ElfSize)
+      break;
+    uint8_t *Ph = Elf + PhPos;
+    uint64_t POffset;
+    uint64_t PFilesz;
+    uint64_t PMemsz;
+    std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
+    std::memcpy(&PFilesz, Ph + offsetof(Phdr, p_filesz), sizeof(PFilesz));
+    std::memcpy(&PMemsz, Ph + offsetof(Phdr, p_memsz), sizeof(PMemsz));
+
+    if (POffset <= TextOffset && POffset + PFilesz >= TextEnd) {
+      PFilesz += TrampTotal;
+      PMemsz += TrampTotal;
+      std::memcpy(Ph + offsetof(Phdr, p_filesz), &PFilesz, sizeof(PFilesz));
+      std::memcpy(Ph + offsetof(Phdr, p_memsz), &PMemsz, sizeof(PMemsz));
+    } else if (POffset > TextOffset) {
+      POffset += TrampTotal;
+      std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
+    }
+  }
+}
+
+// -- ElfView::growWithTrampolines ---------------------------------------------
+
+std::unique_ptr<WritableMemoryBuffer>
+ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines) const {
+  const size_t InputSize = size();
+  const uint8_t *Input = data();
+
+  size_t TrampTotal = 0;
+  for (const Trampoline &T : Trampolines)
+    TrampTotal += T.Bytes.size();
+  if (TrampTotal == 0) {
+    log() << "hotswap: growWithTrampolines: no trampolines to insert; "
+          << "returning empty result.\n";
+    return nullptr;
+  }
+  if (TrampTotal > SIZE_MAX - InputSize) {
+    log() << "hotswap: error: growWithTrampolines: trampoline bytes ("
+          << TrampTotal << ") + existing ELF size (" << InputSize
+          << ") overflow size_t.\n";
+    return nullptr;
+  }
+
+  // Enforce the invariant: no SHF_ALLOC section may start past `.text`. We
+  // only shift file offsets, not virtual addresses, so any loaded section
+  // appearing after `.text` would end up with stale sh_addr / p_vaddr.
+  uint64_t TextEnd = textOffset() + textSize();
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC))
+      continue;
+    if (Shdr.sh_offset < TextEnd)
+      continue;
+    Expected<StringRef> NameOrErr = File.getSectionName(Shdr);
+    StringRef Name = NameOrErr ? *NameOrErr : StringRef("<unknown>");
+    if (!NameOrErr)
+      consumeError(NameOrErr.takeError());
+    log() << "hotswap: error: growWithTrampolines refuses to run: "
+          << "SHF_ALLOC section '" << Name << "' starts at file offset "
+          << Shdr.sh_offset << " which is past .text end " << TextEnd
+          << "; virtual address shifting is not implemented.\n";
+    return nullptr;
+  }
+
+  const size_t NewSize = InputSize + TrampTotal;
+  std::unique_ptr<WritableMemoryBuffer> Buf =
+      WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
+  if (!Buf) {
+    log() << "hotswap: error: growWithTrampolines: "
+          << "WritableMemoryBuffer::getNewUninitMemBuffer(" << NewSize
+          << ") failed (out of memory).\n";
+    return nullptr;
+  }
+
+  uint8_t *Out = reinterpret_cast<uint8_t *>(Buf->getBufferStart());
+  std::memcpy(Out, Input, TextEnd);
+  uint64_t Pos = TextEnd;
+  for (const Trampoline &T : Trampolines) {
+    std::memcpy(Out + Pos, T.Bytes.data(), T.Bytes.size());
+    Pos += T.Bytes.size();
+  }
+  if (TextEnd < InputSize)
+    std::memcpy(Out + Pos, Input + TextEnd, InputSize - TextEnd);
+
+  adjustSectionHeaders(Out, NewSize, textOffset(), textSize(), TrampTotal);
+  adjustProgramHeaders(Out, NewSize, textOffset(), textSize(), TrampTotal);
+  log() << "hotswap: growWithTrampolines: grew ELF from " << InputSize
+        << " to " << NewSize << " bytes (" << Trampolines.size()
+        << " trampoline" << (Trampolines.size() == 1 ? "" : "s") << ", "
+        << TrampTotal << " bytes appended).\n";
+  return Buf;
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1,0 +1,225 @@
+//===- comgr-hotswap-internal.h - HotSwap internal types and declarations -===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Internal header for the HotSwap ISA rewriting subsystem. Shared by all
+/// comgr-hotswap-*.cpp compilation units. Not part of the public COMGR API.
+///
+/// Module structure:
+///   comgr-hotswap-elf.cpp       ELF parsing, binary helpers, trampoline growth
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_HOTSWAP_INTERNAL_H
+#define COMGR_HOTSWAP_INTERNAL_H
+
+#include "amd_comgr.h"
+#include "comgr-env.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/ELF.h"
+#include "llvm/Object/ELF.h"
+#include "llvm/Object/ELFTypes.h"
+#include "llvm/Support/AMDHSAKernelDescriptor.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace COMGR {
+namespace hotswap {
+
+// -- Logging ------------------------------------------------------------------
+//
+// Single output stream for all hotswap diagnostics (errors, warnings, and
+// verbose traces). Returns llvm::errs() if AMD_COMGR_EMIT_VERBOSE_LOGS is set
+// (via COMGR::env::shouldEmitVerboseLogs()) and llvm::nulls() otherwise, so
+// hotswap output stays quiet in normal use but callers can opt in to the full
+// diagnostic trail without relinking. Every function that returns a null /
+// empty / failure result should emit here with a `"hotswap: error: ..."` or
+// `"hotswap: ..."` prefix so the failure path is traceable.
+
+inline llvm::raw_ostream &log() {
+  return COMGR::env::shouldEmitVerboseLogs() ? llvm::errs() : llvm::nulls();
+}
+
+// -- Trampoline and NOP sled --------------------------------------------------
+
+struct Trampoline {
+  uint64_t OriginalOffset = 0;
+  uint32_t OriginalSize = 0;
+  llvm::SmallVector<uint8_t> Bytes;
+};
+
+struct NopSled {
+  uint64_t Start = 0;
+  uint64_t End = 0;
+  uint64_t WritePos = 0;
+};
+
+// -- Rewrite rule -------------------------------------------------------------
+
+struct RewriteRule {
+  std::string ReplaceMnemonic;
+  llvm::SmallVector<uint8_t> ReplaceBytes;
+};
+
+// -- Named constants ----------------------------------------------------------
+
+// Minimum valid ELF64 size.
+static constexpr uint64_t MinElfSize = sizeof(llvm::ELF::Elf64_Ehdr);
+
+// Kernel descriptor size and RSRC1 offset from upstream
+// AMDHSAKernelDescriptor.h.
+static constexpr uint64_t KdSize = sizeof(llvm::amdhsa::kernel_descriptor_t);
+static constexpr uint64_t KdRsrc1Offset = llvm::amdhsa::COMPUTE_PGM_RSRC1_OFFSET;
+
+// Maximum distance (bytes) between an instruction and a NOP sled for the
+// sled to be considered reachable by a single s_branch.
+static constexpr int64_t MaxSledDistance = 131072;
+
+// Minimum size (bytes) of a consecutive NOP run to be usable as a sled.
+static constexpr uint64_t MinNopSledSize = 8;
+
+// Minimum AMDGPU instruction size (one dword).
+static constexpr uint32_t MinInstSize = 4;
+
+// s_branch encoding: 16-bit signed dword offset field.
+static constexpr int64_t BranchOffsetMin = -32768;
+static constexpr int64_t BranchOffsetMax = 32767;
+static constexpr uint32_t BranchOffsetMask = 0xFFFF;
+
+// -- ElfView ------------------------------------------------------------------
+//
+// Thin wrapper around llvm::object::ELFFile<ELF64LE> that owns the structural
+// view of a mutable code-object buffer. The caller retains ownership of the
+// bytes; ElfView exposes LLVM's ELF iterators through member methods and
+// caches the .text section lookup.
+
+class ElfView {
+public:
+  using ELFT = llvm::object::ELF64LE;
+  using ELFFileT = llvm::object::ELFFile<ELFT>;
+
+  /// Parse \p Data / \p Size into an ElfView. Fails if the bytes are not a
+  /// valid ELF64 or if no `.text` section is found.
+  static llvm::Expected<ElfView> create(uint8_t *Data, size_t Size);
+
+  ElfView(ElfView &&) = default;
+  ElfView &operator=(ElfView &&) = default;
+  ElfView(const ElfView &) = delete;
+  ElfView &operator=(const ElfView &) = delete;
+
+  const ELFFileT &file() const { return File; }
+  size_t size() const { return File.getBufSize(); }
+
+  /// Writable view of the underlying bytes. The caller that constructed this
+  /// ElfView via `create(uint8_t *, size_t)` retains ownership of the buffer;
+  /// ElfView just exposes a typed, mutable alias onto `ELFFile::base()`. Safe
+  /// because the factory was handed a `uint8_t *` and the buffer outlives
+  /// this ElfView.
+  uint8_t *data() {
+    return const_cast<uint8_t *>(File.base());
+  }
+  const uint8_t *data() const { return File.base(); }
+
+  /// Section header range, cached at construction time. The underlying
+  /// storage is the file buffer, which lives at least as long as this
+  /// ElfView, so the range is always valid to iterate.
+  ELFT::ShdrRange sections() const { return Sections; }
+
+  /// Return the cached `.text` section header. Never null for a successfully
+  /// constructed ElfView.
+  const ELFT::Shdr *textSection() const { return TextSection; }
+
+  uint64_t textOffset() const { return TextSection->sh_offset; }
+  uint64_t textSize() const { return TextSection->sh_size; }
+  uint64_t textAddr() const { return TextSection->sh_addr; }
+
+  /// Index of the `.text` section in the section header table.
+  unsigned textSectionIndex() const { return TextSectionIndex; }
+
+  /// Pointer into the buffer for the first byte of `.text`.
+  uint8_t *textData() { return data() + textOffset(); }
+  const uint8_t *textData() const { return data() + textOffset(); }
+
+  /// Find the kernel function symbol whose range includes \p TextOffset.
+  /// Returns "" if no matching function symbol exists.
+  std::string findKernelAtOffset(uint64_t TextOffset) const;
+
+  /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
+  /// or nullptr if not found.
+  uint8_t *findKernelDescriptor(llvm::StringRef KernelName);
+
+  /// Read the VGPR count from the kernel descriptor for \p KernelName.
+  /// Returns std::nullopt if the descriptor is not found.
+  std::optional<unsigned> getKernelVgprCount(llvm::StringRef KernelName,
+                                             unsigned VgprGranuleSize) const;
+
+  /// Update the RSRC1 VGPR/SGPR granule counts in the kernel descriptor for
+  /// \p KernelName by adding \p ExtraVgprs / \p ExtraSgprs, using
+  /// \p VgprGranuleSize / \p SgprGranuleSize so the call is ISA-agnostic.
+  void updateKernelDescriptor(llvm::StringRef KernelName, unsigned ExtraVgprs,
+                              unsigned ExtraSgprs, unsigned VgprGranuleSize,
+                              unsigned SgprGranuleSize);
+
+  /// Grow the ELF by inserting trampoline bytes after `.text` and adjusting
+  /// all section and program headers. Returns a null unique_ptr on failure.
+  ///
+  /// Invariant: `.text` must be the last SHF_ALLOC section in its load
+  /// segment. Any loaded section appearing past `.text` in the file causes
+  /// the function to refuse (with a diagnostic on llvm::errs()) rather than
+  /// silently emit stale virtual addresses.
+  std::unique_ptr<llvm::WritableMemoryBuffer>
+  growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines) const;
+
+private:
+  ElfView(ELFFileT File, ELFT::ShdrRange Sections,
+          const ELFT::Shdr *TextSection, unsigned TextSectionIndex)
+      : File(std::move(File)), Sections(Sections), TextSection(TextSection),
+        TextSectionIndex(TextSectionIndex) {}
+
+  ELFFileT File;
+  ELFT::ShdrRange Sections;
+  const ELFT::Shdr *TextSection;
+  unsigned TextSectionIndex;
+};
+
+// -- Free-function ELF helpers (no ELF state required) ------------------------
+
+/// Encode an s_branch from \p FromOffset to \p ToOffset using \p SBranchOpcode.
+/// Writes MinInstSize bytes to \p OutBytes. Returns false if the delta is
+/// unaligned or out of the 16-bit signed dword range.
+[[nodiscard]] bool encodeSBranch(uint64_t FromOffset, uint64_t ToOffset,
+                                 uint8_t OutBytes[MinInstSize],
+                                 uint32_t SBranchOpcode);
+
+/// Overwrite instruction bytes at \p InstOffset with \p Rule.ReplaceBytes,
+/// padding remaining bytes with s_nop instructions. Returns false on bounds
+/// violation.
+[[nodiscard]] bool applyByteReplace(const RewriteRule &Rule,
+                                    uint64_t InstOffset, uint32_t InstSize,
+                                    uint8_t *Text, uint64_t TextSize,
+                                    uint32_t SNopOpcode);
+
+/// Find the nearest NOP sled to \p Offset with at least \p Needed bytes of
+/// free space. Returns nullptr if none found within MaxSledDistance.
+NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
+                         uint64_t Needed);
+
+} // namespace hotswap
+} // namespace COMGR
+
+#endif // COMGR_HOTSWAP_INTERNAL_H

--- a/amd/comgr/unittests/CMakeLists.txt
+++ b/amd/comgr/unittests/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(LLVM_LINK_COMPONENTS
+  Object
+  Support
+  TargetParser
+  )
+
+add_unittest(check-comgr HotswapElfTests
+  HotswapElfTest.cpp
+  ../src/comgr-hotswap-elf.cpp
+  # COMGR::env::shouldEmitVerboseLogs() is referenced by the inline
+  # COMGR::hotswap::log() helper in comgr-hotswap-internal.h; link its
+  # definition so non-inlined builds (e.g. -O0 / ASan) resolve.
+  ../src/comgr-env.cpp)
+
+target_include_directories(HotswapElfTests PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)

--- a/amd/comgr/unittests/HotswapElfTest.cpp
+++ b/amd/comgr/unittests/HotswapElfTest.cpp
@@ -1,0 +1,77 @@
+//===- HotswapElfTest.cpp - Unit tests for HotSwap ELF layer --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+#include "gtest/gtest.h"
+#include <cstring>
+
+using namespace COMGR::hotswap;
+
+static constexpr uint32_t TestBranchGfx9 = 0xBF820000u;
+static constexpr uint32_t TestBranchGfx12 = 0xBFA00000u;
+
+// -- encodeSBranch ------------------------------------------------------------
+
+TEST(EncodeSBranch, ForwardBranchGfx9) {
+  uint8_t Out[MinInstSize] = {};
+  ASSERT_TRUE(encodeSBranch(0, 8, Out, TestBranchGfx9));
+  uint32_t Encoded;
+  std::memcpy(&Encoded, Out, sizeof(Encoded));
+  EXPECT_EQ(Encoded, 0xBF820001u);
+}
+
+TEST(EncodeSBranch, BackwardBranchGfx9) {
+  uint8_t Out[MinInstSize] = {};
+  ASSERT_TRUE(encodeSBranch(16, 0, Out, TestBranchGfx9));
+  uint32_t Encoded;
+  std::memcpy(&Encoded, Out, sizeof(Encoded));
+  EXPECT_EQ(Encoded, 0xBF82FFFBu);
+}
+
+TEST(EncodeSBranch, ForwardBranchGfx12) {
+  uint8_t Out[MinInstSize] = {};
+  ASSERT_TRUE(encodeSBranch(0, 8, Out, TestBranchGfx12));
+  uint32_t Encoded;
+  std::memcpy(&Encoded, Out, sizeof(Encoded));
+  EXPECT_EQ(Encoded, 0xBFA00001u);
+}
+
+TEST(EncodeSBranch, UnalignedDeltaFails) {
+  uint8_t Out[MinInstSize] = {};
+  EXPECT_FALSE(encodeSBranch(0, 7, Out, TestBranchGfx9));
+}
+
+TEST(EncodeSBranch, OutOfRangeFails) {
+  uint8_t Out[MinInstSize] = {};
+  EXPECT_FALSE(encodeSBranch(0, 500000, Out, TestBranchGfx9));
+}
+
+TEST(EncodeSBranch, ZeroOffsetBranch) {
+  uint8_t Out[MinInstSize] = {};
+  ASSERT_TRUE(encodeSBranch(0, MinInstSize, Out, TestBranchGfx9));
+  uint32_t Encoded;
+  std::memcpy(&Encoded, Out, sizeof(Encoded));
+  EXPECT_EQ(Encoded, TestBranchGfx9);
+}
+
+// -- ElfView::create ----------------------------------------------------------
+
+TEST(ElfView, RejectsTruncatedInput) {
+  uint8_t Garbage[] = {0x7f, 'E', 'L', 'F', 0, 0, 0, 0};
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Garbage, sizeof(Garbage));
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
+TEST(ElfView, RejectsNonElfInput) {
+  uint8_t NotElf[64] = {};
+  llvm::Expected<ElfView> ViewOrErr = ElfView::create(NotElf, sizeof(NotElf));
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}


### PR DESCRIPTION
[AMDGPU] comgr: add HotSwap ELF parsing and binary mutation layer

Add reusable ELF infrastructure for the HotSwap ISA rewriting
subsystem. This layer is pure binary manipulation with no LLVM MC
dependency beyond llvm::object::ELFFile for parsing.

Functions:
- EncodeSBranch/EncodeSNop: parameterized branch/NOP encoding
- ParseElfInfo: ELF64 section, symbol, and .text extraction via
  llvm::object::ELFFile
- GrowElfWithTrampolines: insert bytes after .text and adjust all
  section/program headers (AdjustSectionHeaders, AdjustProgramHeaders)
- UpdateKernelDescriptor/GetKernelVgprCount: kernel descriptor RSRC1
  field read/update via shared FindKernelDescriptor helper
- PatchElfIsa: rewrite ELF e_flags and AMDGPU ISA note using
  AMDGPU_MACH_LIST from llvm/BinaryFormat/ELF.h
- FindNearestSled/ApplyByteReplace: NOP sled management and byte
  replacement with NOP padding
- ExtractCPU: ISA string → GPU name extraction

All ISA-specific behavior is parameterized through RewriteConfig so
the infrastructure has zero GPU-generation assumptions. Uses
llvm::ELF named constants, offsetof(), sizeof(var), llvm::alignTo(),
llvm::isAlnum(), and llvm::SmallVector throughout.

Includes 14 gtest unit tests for internal functions not reachable
through the public C API: branch encoding (forward, backward, GFX9
vs GFX12, alignment rejection, range rejection), NOP encoding, CPU
extraction edge cases, MallocBuffer RAII semantics, and ELF
rejection for truncated/invalid input.