### PR TITLE
[AMDGPU] comgr: add HotSwap B0-to-A0 policy and public API (3/3)

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -77,6 +77,7 @@ set(SOURCES
   src/comgr-disassembly.cpp
   src/comgr-env.cpp
   src/comgr-hotswap.cpp
+  src/comgr-hotswap-b0a0.cpp
   src/comgr-hotswap-elf.cpp
   src/comgr-hotswap-llvm.cpp
   src/comgr-libcxx-headers.cpp

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1,0 +1,553 @@
+//===- comgr-hotswap-b0a0.cpp - GFX1250 B0-to-A0 patch dispatcher --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Dispatcher for B0-to-A0 silicon stepping patches and the
+/// retargetCodeObjectB0A0 orchestrator that drives the full pipeline:
+/// decode -> patch -> trampoline growth -> DWARF update.
+///
+/// Patch entry points are declared as weak symbols returning 0. Each
+/// comgr-hotswap-patch-*.cpp file provides a strong override, allowing
+/// patches to land as independent PRs with no merge conflicts.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/StringExtras.h"
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+// -- GFX1250 B0-to-A0 constants -----------------------------------------------
+//
+// All instruction encoding lives in LLVMState (s_branch opcode + pre-encoded
+// s_nop bytes, populated at initLLVM time via the MC asm parser). This policy
+// layer only carries ISA identifiers and register granularity -- no
+// target-specific opcode bits should land here.
+
+static constexpr unsigned Gfx1250MaxVgprs = 256;
+// GFX12 wave32 VGPR granularity; SGPR granularity is a fixed 16 across all
+// AMDGPU generations Comgr's hotswap currently supports.
+static constexpr unsigned Gfx1250VgprGranuleSize = 8;
+static constexpr unsigned Gfx1250SgprGranuleSize = 16;
+
+/// Build the default RewriteConfig used for the GFX1250 B0-to-A0 rewrite:
+/// fills in the identity source / target ISA (both gfx1250) and the
+/// AMDGPU register granularity constants consumed by
+/// ElfView::updateKernelDescriptor. Instruction-encoding state is not
+/// carried in RewriteConfig; see LLVMState for the s_branch opcode and
+/// pre-encoded s_nop bytes.
+static RewriteConfig makeGfx1250B0A0Config() {
+  // `Config` / `Cfg` are reserved below: `Config` always names a
+  // RewriteConfig; `Cfg` is only used for the CFG (control-flow graph)
+  // local in applyGfx1250B0toA0Rules.
+  RewriteConfig Config;
+  Config.SourceIsa = "amdgcn-amd-amdhsa--gfx1250";
+  Config.TargetIsa = "amdgcn-amd-amdhsa--gfx1250";
+  Config.TargetCpu = "gfx1250";
+  Config.MaxVgprs = Gfx1250MaxVgprs;
+  Config.VgprGranuleSize = Gfx1250VgprGranuleSize;
+  Config.SgprGranuleSize = Gfx1250SgprGranuleSize;
+  return Config;
+}
+
+// -- Forward declarations for patch/liveness/DWARF stubs ----------------------
+//
+// These have weak default definitions below; patch .cpp files may provide
+// strong overrides at link time so patches can land as independent PRs.
+
+uint32_t applyInPlacePatches(PatchContext &, size_t);
+uint32_t applyTrampolinePatches(PatchContext &, size_t);
+uint32_t applyWmmaHazardPatch(PatchContext &);
+uint32_t applyWmmaSplitPatches(PatchContext &, size_t);
+uint32_t applyScratchPatches(PatchContext &, size_t);
+CFG buildCfg(ArrayRef<InternalDecodedInst> Decoded, const MCInstrInfo &);
+LivenessInfo computeLiveness(ArrayRef<InternalDecodedInst> Decoded, const CFG &,
+                             const MCInstrInfo &, const MCRegisterInfo &,
+                             unsigned MaxVgprs);
+RegDefUse getInstRegDefUse(const MCInst &, const MCInstrInfo &,
+                           const MCRegisterInfo &);
+int64_t getBranchImm(const MCInst &);
+bool verifyPatchCorrectness(const uint8_t *, uint64_t, const LLVMState &,
+                            ArrayRef<ScratchPatchInfo>, unsigned);
+bool addTrampolineSymbols(WritableMemoryBuffer &ElfBuf,
+                          ArrayRef<Trampoline> Trampolines,
+                          uint64_t TextSizeBefore, unsigned TextSectionIdx);
+bool patchDebugLine(WritableMemoryBuffer &ElfBuf,
+                    ArrayRef<Trampoline> Trampolines, uint64_t TextSizeBefore,
+                    uint64_t TextAddr);
+void patchDebugRanges(uint8_t *Elf, size_t ElfSize, uint64_t TextAddr,
+                      uint64_t TextSizeBefore, uint64_t TrampTotal);
+void patchDebugInfo(uint8_t *Elf, size_t ElfSize, uint64_t TextAddr,
+                    uint64_t TextSizeBefore, uint64_t TrampTotal);
+void patchDebugFrame(uint8_t *Elf, size_t ElfSize, uint64_t TextAddr,
+                     uint64_t TextSizeBefore, uint64_t TrampTotal);
+
+// -- Weak-symbol patch stubs --------------------------------------------------
+
+__attribute__((weak)) uint32_t applyInPlacePatches(PatchContext &, size_t) {
+  return 0;
+}
+__attribute__((weak)) uint32_t applyTrampolinePatches(PatchContext &, size_t) {
+  return 0;
+}
+__attribute__((weak)) uint32_t applyWmmaHazardPatch(PatchContext &) {
+  return 0;
+}
+__attribute__((weak)) uint32_t applyWmmaSplitPatches(PatchContext &, size_t) {
+  return 0;
+}
+__attribute__((weak)) uint32_t applyScratchPatches(PatchContext &, size_t) {
+  return 0;
+}
+
+// -- Weak-symbol liveness stubs -----------------------------------------------
+//
+// Conservative defaults: all VGPRs reported live. ScratchAllocator will
+// allocate above KD count (correct but suboptimal until the real liveness
+// layer lands).
+
+__attribute__((weak)) CFG buildCfg(ArrayRef<InternalDecodedInst> Decoded,
+                                   const MCInstrInfo &) {
+  (void)Decoded;
+  return CFG();
+}
+
+__attribute__((weak)) LivenessInfo computeLiveness(
+    ArrayRef<InternalDecodedInst> Decoded, const CFG &, const MCInstrInfo &,
+    const MCRegisterInfo &, unsigned MaxVgprs) {
+  LivenessInfo Info;
+  BitVector AllLive(MaxVgprs);
+  AllLive.set(0, MaxVgprs);
+  Info.LiveBefore.resize(Decoded.size(), AllLive);
+  Info.LiveAfter.resize(Decoded.size(), AllLive);
+  Info.Converged = true;
+  return Info;
+}
+
+__attribute__((weak)) RegDefUse getInstRegDefUse(const MCInst &,
+                                                 const MCInstrInfo &,
+                                                 const MCRegisterInfo &) {
+  return {};
+}
+
+__attribute__((weak)) int64_t getBranchImm(const MCInst &) { return 0; }
+
+__attribute__((weak)) bool verifyPatchCorrectness(const uint8_t *, uint64_t,
+                                                  const LLVMState &,
+                                                  ArrayRef<ScratchPatchInfo>,
+                                                  unsigned) {
+  return true;
+}
+
+// -- Weak-symbol DWARF stubs --------------------------------------------------
+
+__attribute__((weak)) bool addTrampolineSymbols(WritableMemoryBuffer &,
+                                                ArrayRef<Trampoline>, uint64_t,
+                                                unsigned) {
+  return true;
+}
+__attribute__((weak)) bool patchDebugLine(WritableMemoryBuffer &,
+                                          ArrayRef<Trampoline>, uint64_t,
+                                          uint64_t) {
+  return true;
+}
+__attribute__((weak)) void patchDebugRanges(uint8_t *, size_t, uint64_t,
+                                            uint64_t, uint64_t) {}
+__attribute__((weak)) void patchDebugInfo(uint8_t *, size_t, uint64_t, uint64_t,
+                                          uint64_t) {}
+__attribute__((weak)) void patchDebugFrame(uint8_t *, size_t, uint64_t,
+                                           uint64_t, uint64_t) {}
+
+// -- NOP sled scanning --------------------------------------------------------
+
+/// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
+/// MinNopSledSize bytes long and return the resulting NopSled list (each
+/// sled records Start / End byte offsets in .text and the initial WritePos
+/// at Start). These sleds are the landing zones emitToNopSled targets for
+/// in-place rewrites. NOPs are identified by MC opcode (cached on \p LS at
+/// initLLVM() time) rather than mnemonic string, so the scanner is robust
+/// against printer aliasing / mnemonic formatting variations.
+static std::vector<NopSled>
+buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS) {
+  std::vector<NopSled> Sleds;
+  const size_t N = Decoded.size();
+  size_t I = 0;
+  while (I < N) {
+    if (Decoded[I].Inst.getOpcode() == LS.SNopOpcode) {
+      uint64_t Start = Decoded[I].Offset;
+      uint64_t End = Start;
+      while (I < N && Decoded[I].Inst.getOpcode() == LS.SNopOpcode) {
+        End = Decoded[I].Offset + Decoded[I].Size;
+        ++I;
+      }
+      if (End - Start >= MinNopSledSize)
+        Sleds.push_back({Start, End, Start});
+    } else {
+      ++I;
+    }
+  }
+  return Sleds;
+}
+
+// -- Sled-or-trampoline code emission -----------------------------------------
+
+/// Emit the replacement code for the instruction at [\p InstOffset,
+/// \p InstOffset + \p InstSize) into a nearby NOP sled: writes \p Replacement
+/// into the sled, appends a branch-back to the next instruction after the
+/// original site, overwrites the original site with a branch-forward to the
+/// sled, and pads the leftover bytes of the original slot with cached s_nop
+/// bytes. Advances \c Sled.WritePos by the amount consumed. Returns false if
+/// either branch encoding fails, leaving \c Ctx.Text partially written.
+[[nodiscard]] static bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
+                                        uint64_t InstOffset, uint32_t InstSize,
+                                        ArrayRef<uint8_t> Replacement) {
+  const LLVMState &LS = Ctx.LS;
+  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Replacement.size());
+
+  uint8_t BrBack[MinInstSize];
+  if (!LS.encodeSBranch(Sled.WritePos + Replacement.size(),
+                        InstOffset + InstSize, BrBack)) {
+    log() << "hotswap: error: emitToNopSled: encodeSBranch for branch-back "
+          << "at sled offset 0x"
+          << utohexstr(Sled.WritePos + Replacement.size()) << " -> 0x"
+          << utohexstr(InstOffset + InstSize) << " failed.\n";
+    return false;
+  }
+  std::memcpy(Ctx.Text + Sled.WritePos + Replacement.size(), BrBack,
+              sizeof(BrBack));
+
+  uint8_t BrFwd[MinInstSize];
+  if (!LS.encodeSBranch(InstOffset, Sled.WritePos, BrFwd)) {
+    log() << "hotswap: error: emitToNopSled: encodeSBranch for branch-fwd "
+          << "at original offset 0x" << utohexstr(InstOffset) << " -> sled 0x"
+          << utohexstr(Sled.WritePos) << " failed.\n";
+    return false;
+  }
+  std::memcpy(Ctx.Text + InstOffset, BrFwd, sizeof(BrFwd));
+
+  // Pad the tail of the replaced instruction slot with cached s_nop bytes
+  // (pre-encoded in LLVMState at initLLVM() time).
+  for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
+    std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
+
+  Sled.WritePos += Replacement.size() + MinInstSize;
+  return true;
+}
+
+/// Queue a deferred trampoline for the instruction at [\p InstOffset,
+/// \p InstOffset + \p InstSize) with \p Replacement as its body. The final
+/// branch encoding (branch-back at the trampoline tail and branch-forward
+/// overwrite at the original site) is filled in by fixupTrampolineBranches
+/// once the post-.text trampoline layout is known -- we reserve
+/// MinInstSize zero bytes at the end of the trampoline body as a
+/// placeholder rather than encoding twice. Used when there is no reachable
+/// NOP sled for an in-place sled patch.
+[[nodiscard]] static bool emitToTrampoline(PatchContext &Ctx,
+                                           uint64_t InstOffset,
+                                           uint32_t InstSize,
+                                           ArrayRef<uint8_t> Replacement) {
+  Trampoline T;
+  T.OriginalOffset = InstOffset;
+  T.OriginalSize = InstSize;
+  T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
+  // Reserve the branch-back slot; fixupTrampolineBranches fills it in.
+  T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
+  Ctx.OutTrampolines.emplace_back(std::move(T));
+  return true;
+}
+
+/// Emit \p Replacement for the instruction at [\p InstOffset,
+/// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
+/// reachable sled with sufficient headroom exists; otherwise falls back to a
+/// deferred trampoline. Marked [[maybe_unused]] because the weak-stub patch
+/// passes in this file do not yet call it -- the concrete patch .cpp files
+/// that land alongside will.
+[[maybe_unused, nodiscard]] static bool
+emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                    ArrayRef<uint8_t> Replacement) {
+  // findNearestSled already enforces that the returned sled has at least
+  // `Needed` bytes of headroom, so a non-null result is sufficient to take
+  // the in-place path.
+  uint64_t Needed = Replacement.size() + MinInstSize;
+  if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed))
+    return emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement);
+  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+}
+
+// -- applyGfx1250B0toA0Rules --------------------------------------------------
+
+/// Main per-instruction dispatcher for the GFX1250 B0-to-A0 rewrite.
+/// Builds the NOP sled map, CFG, and VGPR liveness for the decoded stream,
+/// then walks each decoded instruction and runs the patch passes in order
+/// (in-place -> trampoline -> WMMA split -> scratch). Each pass gets a
+/// chance to claim the instruction; first non-zero return wins. Also runs
+/// the whole-function WMMA-hazard pass after the per-instruction loop and
+/// records per-kernel stats via ElfView::updateKernelDescriptor.
+/// Returns the total number of applied patches across all passes.
+static uint32_t
+applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
+                        uint8_t *Text, uint64_t TextSize, const LLVMState &LS,
+                        std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
+                        std::vector<ScratchPatchInfo> &OutScratchPatches,
+                        const RewriteConfig &Config) {
+  uint32_t Patched = 0;
+  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS);
+
+  CFG Cfg = buildCfg(Decoded, *LS.MCII);
+  LivenessInfo Liveness =
+      computeLiveness(Decoded, Cfg, *LS.MCII, *LS.MRI, Config.MaxVgprs);
+
+  if (!Liveness.Converged) {
+    log() << "hotswap: error: liveness analysis did not converge, using "
+          << "conservative all-VGPRs-live fallback\n";
+    BitVector AllVgprs(Config.MaxVgprs);
+    AllVgprs.set(0, Config.MaxVgprs);
+    for (size_t I = 0, LE = Liveness.LiveBefore.size(); I < LE; ++I) {
+      Liveness.LiveBefore[I] = AllVgprs;
+      Liveness.LiveAfter[I] = AllVgprs;
+    }
+  }
+
+  StringMap<KernelPatchStats> KernelStats;
+  PatchContext Ctx{Config,           Decoded, Text, TextSize, LS,
+                   OutTrampolines,   Sleds,   Elf,  Liveness, KernelStats,
+                   OutScratchPatches};
+
+  for (size_t Idx = 0, E = Decoded.size(); Idx < E; ++Idx) {
+    const InternalDecodedInst &DI = Decoded[Idx];
+    if (DI.Mnemonic == "<unknown>")
+      continue;
+
+    uint32_t P = 0;
+    P += applyInPlacePatches(Ctx, Idx);
+    if (P) {
+      Patched += P;
+      continue;
+    }
+    P += applyTrampolinePatches(Ctx, Idx);
+    if (P) {
+      Patched += P;
+      continue;
+    }
+    P += applyWmmaSplitPatches(Ctx, Idx);
+    if (P) {
+      Patched += P;
+      continue;
+    }
+    P += applyScratchPatches(Ctx, Idx);
+    if (P) {
+      Patched += P;
+      continue;
+    }
+  }
+
+  Patched += applyWmmaHazardPatch(Ctx);
+
+  for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
+    StringRef KName = KV.first();
+    const KernelPatchStats &Stats = KV.second;
+    if (KName.empty())
+      continue;
+    std::optional<unsigned> VgprsBefore =
+        Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
+    if (Stats.ExtraVgprs > 0)
+      Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs, 0,
+                                 Config.VgprGranuleSize,
+                                 Config.SgprGranuleSize);
+    std::optional<unsigned> VgprsAfter =
+        Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
+    log() << "hotswap: liveness: kernel " << KName
+          << ": vgprs_before=" << VgprsBefore.value_or(0)
+          << ", vgprs_after=" << VgprsAfter.value_or(0)
+          << ", scratch_reused=" << Stats.ScratchReused
+          << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";
+  }
+  return Patched;
+}
+
+// -- retargetCodeObjectB0A0 helpers -------------------------------------------
+
+/// Finalize the deferred trampolines produced by emitToTrampoline: resolves
+/// the branch-back at the tail of each trampoline to land on the next
+/// instruction after the original site, writes the branch-forward + s_nop
+/// padding at the original .text slot, and reports per-trampoline encoding
+/// failures through log(). Runs after all patch passes finish so the
+/// post-.text layout of trampolines is known. Returns false if any
+/// trampoline could not be fixed up, but still patches the ones that can.
+[[nodiscard]] static bool
+fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
+                        uint64_t TextSize, const LLVMState &LS) {
+  // Fail-fast on the first encoding error: the position of later
+  // trampolines depends on earlier ones, so a single bad branch would
+  // cascade into incorrect layout. A single failure invalidates the whole
+  // rewrite, so there is nothing useful to recover beyond it.
+  uint64_t TrampOffset = TextSize;
+  for (Trampoline &T : Trampolines) {
+    uint64_t TP = TrampOffset;
+    TrampOffset += T.Bytes.size();
+
+    uint8_t BrBack[MinInstSize];
+    if (!LS.encodeSBranch(TP + T.Bytes.size() - MinInstSize,
+                          T.OriginalOffset + T.OriginalSize, BrBack)) {
+      log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    std::memcpy(T.Bytes.data() + T.Bytes.size() - MinInstSize, BrBack,
+                sizeof(BrBack));
+
+    uint8_t BrFwd[MinInstSize];
+    if (!LS.encodeSBranch(T.OriginalOffset, TP, BrFwd)) {
+      log() << "hotswap: error: trampoline branch-fwd encoding failed at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    std::memcpy(Text + T.OriginalOffset, BrFwd, sizeof(BrFwd));
+    // Pad the tail of the replaced slot with cached s_nop bytes.
+    for (uint32_t I = MinInstSize; I < T.OriginalSize; I += MinInstSize)
+      std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
+                  MinInstSize);
+  }
+  return true;
+}
+
+/// Fix up DWARF sections of the grown ELF after trampolines have been
+/// appended: adds trampoline symbols to the symbol table, shifts
+/// .debug_line / .debug_ranges / .debug_info / .debug_frame addresses by
+/// the total trampoline footprint, and reports per-section failures via
+/// log(). Individual patchDebug* helpers are weak stubs here; concrete
+/// implementations land in separate PRs.
+static void patchDebugSections(WritableMemoryBuffer &ElfBuf,
+                               ArrayRef<Trampoline> Trampolines,
+                               const ElfView &Elf, size_t TrampTotal) {
+  uint8_t *Data = reinterpret_cast<uint8_t *>(ElfBuf.getBufferStart());
+  size_t Size = ElfBuf.getBufferSize();
+  if (!addTrampolineSymbols(ElfBuf, Trampolines, Elf.textSize(),
+                            Elf.textSectionIndex()))
+    log() << "hotswap: error: addTrampolineSymbols failed\n";
+  patchDebugRanges(Data, Size, Elf.textAddr(), Elf.textSize(), TrampTotal);
+  patchDebugInfo(Data, Size, Elf.textAddr(), Elf.textSize(), TrampTotal);
+  patchDebugFrame(Data, Size, Elf.textAddr(), Elf.textSize(), TrampTotal);
+  if (!patchDebugLine(ElfBuf, Trampolines, Elf.textSize(), Elf.textAddr()))
+    log() << "hotswap: error: patchDebugLine failed\n";
+}
+
+/// Re-open the grown ELF and cross-check that no scratch-patched site
+/// reads a VGPR still live at the patch point: builds a fresh ElfView over
+/// the output buffer, hands the new .text to verifyPatchCorrectness, and
+/// logs a diagnostic if the verifier detects a potential conflict. Runs
+/// only when the scratch patch pass produced at least one ScratchPatchInfo
+/// record.
+static void runScratchVerification(WritableMemoryBuffer &OutBuf,
+                                   const LLVMState &LS,
+                                   ArrayRef<ScratchPatchInfo> ScratchPatches,
+                                   unsigned MaxVgprs) {
+  // Build a fresh ElfView over the grown buffer to find the new .text.
+  // WritableMemoryBuffer::getBufferStart() returns char *, so no const_cast
+  // is needed on the way to ElfView::create's uint8_t * contract.
+  uint8_t *Data = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
+  Expected<ElfView> ViewOrErr = ElfView::create(Data, OutBuf.getBufferSize());
+  if (!ViewOrErr) {
+    consumeError(ViewOrErr.takeError());
+    return;
+  }
+  if (ViewOrErr->textSize() == 0)
+    return;
+  if (!verifyPatchCorrectness(ViewOrErr->textData(), ViewOrErr->textSize(), LS,
+                              ScratchPatches, MaxVgprs))
+    log() << "hotswap: error: post-patch verification detected possible "
+          << "scratch conflicts\n";
+}
+
+// -- retargetCodeObjectB0A0 ---------------------------------------------------
+
+amd_comgr_status_t retargetCodeObjectB0A0(const void *ElfData, size_t ElfSize,
+                                          const TargetIdentifier &TargetIdent,
+                                          std::unique_ptr<MemoryBuffer> &Out) {
+  // Take a working copy so the input is preserved and we have a mutable
+  // buffer to parse / patch.
+  std::vector<uint8_t> Buf(static_cast<const uint8_t *>(ElfData),
+                           static_cast<const uint8_t *>(ElfData) + ElfSize);
+
+  Expected<ElfView> ViewOrErr = ElfView::create(Buf.data(), Buf.size());
+  if (!ViewOrErr) {
+    log() << "hotswap: error: retargetCodeObjectB0A0: input is not a "
+          << "parseable ELF64 (" << toString(ViewOrErr.takeError()) << ").\n";
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  if (ViewOrErr->textSize() == 0) {
+    log() << "hotswap: error: retargetCodeObjectB0A0: input ELF has empty "
+          << ".text section; nothing to rewrite.\n";
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+  ElfView &Elf = *ViewOrErr;
+
+  LLVMState LS = initLLVM(TargetIdent);
+  if (!LS.Valid) {
+    log() << "hotswap: error: retargetCodeObjectB0A0: initLLVM failed "
+          << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  RewriteConfig Config = makeGfx1250B0A0Config();
+
+  uint8_t *Text = Elf.textData();
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Text, Elf.textSize(), LS, Decoded)) {
+    log() << "hotswap: error: retargetCodeObjectB0A0: decodeTextSection "
+          << "failed on .text (" << Elf.textSize() << " bytes).\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+
+  std::vector<Trampoline> Deferred;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  uint32_t Count = applyGfx1250B0toA0Rules(
+      Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches, Config);
+
+  log() << "hotswap: applied " << Count << " patches\n";
+
+  std::unique_ptr<WritableMemoryBuffer> Result;
+  if (!Deferred.empty()) {
+    if (!fixupTrampolineBranches(Deferred, Text, Elf.textSize(), LS))
+      log() << "hotswap: error: some trampolines could not be fixed up\n";
+
+    Result = Elf.growWithTrampolines(Deferred);
+    if (!Result) {
+      log() << "hotswap: error: retargetCodeObjectB0A0: "
+            << "ElfView::growWithTrampolines returned null with "
+            << Deferred.size() << " trampolines queued.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+
+    size_t TrampTotal = 0;
+    for (const Trampoline &T : Deferred)
+      TrampTotal += T.Bytes.size();
+    patchDebugSections(*Result, Deferred, Elf, TrampTotal);
+  } else {
+    Result = WritableMemoryBuffer::getNewUninitMemBuffer(ElfSize);
+    if (!Result) {
+      log() << "hotswap: error: retargetCodeObjectB0A0: "
+            << "getNewUninitMemBuffer(" << ElfSize
+            << ") failed (out of memory) for the patched output copy.\n";
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    }
+    std::memcpy(Result->getBufferStart(), Buf.data(), ElfSize);
+  }
+
+  if (!ScratchPatches.empty())
+    runScratchVerification(*Result, LS, ScratchPatches, Config.MaxVgprs);
+
+  Out = std::move(Result);
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -12,6 +12,7 @@
 /// Module structure:
 ///   comgr-hotswap-elf.cpp       ELF parsing, binary helpers, trampoline growth
 ///   comgr-hotswap-llvm.cpp      LLVM MC infrastructure (disasm/asm/encode)
+///   comgr-hotswap-b0a0.cpp      GFX1250 B0-to-A0 policy + public API
 ///
 //===----------------------------------------------------------------------===//
 
@@ -30,7 +31,10 @@
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/BinaryFormat/ELF.h"
 #include "llvm/MC/MCAsmInfo.h"
@@ -38,6 +42,7 @@
 #include "llvm/MC/MCContext.h"
 #include "llvm/MC/MCDisassembler/MCDisassembler.h"
 #include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrDesc.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCObjectFileInfo.h"
@@ -266,12 +271,23 @@ struct LLVMState {
   std::unique_ptr<llvm::MCDisassembler> MCD;
   std::unique_ptr<llvm::MCInstPrinter> MCIP;
   std::unique_ptr<llvm::MCCodeEmitter> MCE;
+  /// Target-provided branch / call / relocation analysis. May be null on
+  /// targets that do not implement MCInstrAnalysis; callers must check
+  /// before dispatching. Cached here so downstream patch passes can ask
+  /// `MIA->isBranch(Inst)` / `isCall(Inst)` / `evaluateBranch(...)` instead
+  /// of matching mnemonic strings.
+  std::unique_ptr<llvm::MCInstrAnalysis> MIA;
   std::string Cpu;
 
-  /// MC opcode index for `s_branch`, resolved once at initLLVM() via
-  /// MCInstrInfo::getName. Used by encodeSBranch() below to construct a
-  /// fresh MCInst per call.
+  /// MC opcode index for `s_branch`, resolved once at initLLVM() via the
+  /// asm parser. Used by encodeSBranch() below to construct a fresh MCInst
+  /// per call.
   unsigned SBranchOpcode = 0;
+
+  /// MC opcode index for `s_nop`. Resolved via the asm parser at initLLVM()
+  /// time so decoded-stream consumers (e.g. buildNopSledMap) can match NOPs
+  /// by opcode rather than mnemonic string.
+  unsigned SNopOpcode = 0;
 
   /// Pre-encoded bytes for `s_nop 0` (MinInstSize bytes). Populated at
   /// initLLVM() time via MCCodeEmitter and used by applyByteReplace() and
@@ -335,6 +351,137 @@ Trampoline buildTrampoline(llvm::ArrayRef<std::string> AsmLines,
 bool checkVgprOverlap(const llvm::MCInst &WmmaInst,
                       const llvm::MCInst &ValuInst,
                       const llvm::MCRegisterInfo &MRI);
+
+// -- VGPR liveness types ------------------------------------------------------
+
+/// Per-instruction def/use bitvectors over the VGPR index space. Populated by
+/// getInstRegDefUse() during liveness analysis; each bit position corresponds
+/// to one VGPR (index matches AMDGPU VGPR numbering, e.g. bit 5 = V5).
+struct RegDefUse {
+  llvm::BitVector Defs;
+  llvm::BitVector Uses;
+};
+
+/// A basic block in the decoded-instruction CFG. Offsets are byte offsets
+/// into .text; \c InstIndices stores positions in the flat Decoded vector;
+/// \c Successors / \c Predecessors are indices into CFG::Blocks.
+struct BasicBlock {
+  uint64_t StartOffset = 0;
+  uint64_t EndOffset = 0;
+  llvm::SmallVector<size_t> InstIndices;
+  llvm::SmallVector<unsigned> Successors;
+  llvm::SmallVector<unsigned> Predecessors;
+};
+
+/// Control-flow graph over the decoded instruction stream. \c OffsetToBlock
+/// is the inverted index mapping a .text byte offset to its owning block
+/// index in \c Blocks, used to resolve branch-target / fall-through edges
+/// during CFG construction.
+struct CFG {
+  std::vector<BasicBlock> Blocks;
+  llvm::DenseMap<uint64_t, unsigned> OffsetToBlock;
+};
+
+/// Dataflow-liveness result for a kernel's VGPR set. \c LiveBefore[i] and
+/// \c LiveAfter[i] are the live-in / live-out bitvectors for Decoded[i].
+/// \c Converged is false when the iterative solver hit its iteration cap;
+/// callers fall back to a conservative all-VGPRs-live analysis in that case.
+struct LivenessInfo {
+  std::vector<llvm::BitVector> LiveBefore;
+  std::vector<llvm::BitVector> LiveAfter;
+  bool Converged = false;
+};
+
+/// Allocates scratch VGPRs for a patch point, preferring to reuse dead slots
+/// from the kernel's existing allocation before extending the allocation past
+/// the kernel descriptor's reported VGPR count. Constructed per patch site
+/// with the live-set at that site and the kernel's current / maximum VGPR
+/// counts.
+struct ScratchAllocator {
+  llvm::BitVector LiveAtPoint;
+  unsigned KdAllocatedVgprs = 0;
+  unsigned NextAboveKd = 0;
+  unsigned MaxVgprs = 0;
+  unsigned ExtraAllocated = 0;
+
+  ScratchAllocator(const llvm::BitVector &Live, unsigned KdVgprs, unsigned Max)
+      : LiveAtPoint(Live), KdAllocatedVgprs(KdVgprs), NextAboveKd(KdVgprs),
+        MaxVgprs(Max) {}
+
+  /// Allocate one VGPR not currently marked live. Returns std::nullopt if
+  /// the kernel's existing VGPR pool is saturated and there is no headroom
+  /// below MaxVgprs for an additional allocation.
+  std::optional<unsigned> alloc() {
+    for (unsigned V = KdAllocatedVgprs; V-- > 0;) {
+      if (!LiveAtPoint.test(V)) {
+        LiveAtPoint.set(V);
+        return V;
+      }
+    }
+    if (NextAboveKd >= MaxVgprs)
+      return std::nullopt;
+    unsigned V = NextAboveKd++;
+    ExtraAllocated++;
+    LiveAtPoint.set(V);
+    return V;
+  }
+
+  unsigned extraVgprsNeeded() const { return ExtraAllocated; }
+};
+
+/// Bookkeeping for a single patch site's scratch allocation. \c Offset is
+/// the .text byte offset of the patch; \c ScratchRegs is the bitvector of
+/// VGPRs the patch claimed at that site. Consumed by the post-patch
+/// verifier (verifyPatchCorrectness) to check the patches are mutually
+/// consistent across the kernel.
+struct ScratchPatchInfo {
+  uint64_t Offset = 0;
+  llvm::BitVector ScratchRegs;
+};
+
+// -- Patch types --------------------------------------------------------------
+
+/// Per-kernel counters accumulated by the patch passes. Reported via log()
+/// at the end of the rewrite and exposed through the public
+/// amd_comgr_hotswap_result_t once that result struct is wired up.
+struct KernelPatchStats {
+  unsigned ExtraVgprs = 0;
+  unsigned ScratchReused = 0;
+  unsigned ScratchAboveKd = 0;
+};
+
+/// Mutable per-run context threaded through all patch passes. Bundles the
+/// input config, decoded instruction stream, raw .text bytes, MC state,
+/// output streams (trampolines / scratch info), and the shared ELF view +
+/// liveness result so patch passes have a single parameter to pass around.
+struct PatchContext {
+  const RewriteConfig &Config;
+  std::vector<InternalDecodedInst> &Decoded;
+  uint8_t *Text = nullptr;
+  uint64_t TextSize = 0;
+  const LLVMState &LS;
+  std::vector<Trampoline> &OutTrampolines;
+  std::vector<NopSled> &NopSleds;
+  ElfView &Elf;
+  const LivenessInfo &Liveness;
+  llvm::StringMap<KernelPatchStats> &KernelStats;
+  std::vector<ScratchPatchInfo> &OutScratchPatches;
+};
+
+// -- Function declarations (B0-to-A0 policy layer) ----------------------------
+
+/// Run the full GFX1250 B0-to-A0 rewrite pipeline on \p ElfData / \p ElfSize.
+/// \p TargetIdent is the parsed target ISA (produced upstream by Comgr's
+/// parseTargetIdentifier()); it is threaded into the MC init so the subtarget
+/// triple and feature flags are preserved rather than being reconstructed
+/// from just the processor name. On success \p Out is populated with an owned
+/// buffer containing the rewritten code object. The caller can transfer the
+/// buffer directly to a comgr DataObject via
+/// DataObject::setData(std::unique_ptr<MemoryBuffer>).
+amd_comgr_status_t
+retargetCodeObjectB0A0(const void *ElfData, size_t ElfSize,
+                       const TargetIdentifier &TargetIdent,
+                       std::unique_ptr<llvm::MemoryBuffer> &Out);
 
 } // namespace hotswap
 } // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -266,11 +266,16 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
     return S;
   }
 
+  // MCInstrAnalysis is optional -- AMDGPU may not implement one -- so we
+  // don't fail initLLVM if it comes back null. Consumers must null-check.
+  S.MIA.reset(S.Target->createMCInstrAnalysis(S.MCII.get()));
+
   // Resolve AMDGPU instruction primitives through the asm parser so we pick
   // up the subtarget-appropriate opcode variant (e.g. S_BRANCH_gfx12 vs
-  // S_BRANCH_gfx10) without hardcoding names or bits. s_branch is cached as
-  // an MC opcode index; s_nop is pre-encoded to 4 bytes since its
-  // representation is a constant.
+  // S_BRANCH_gfx10) without hardcoding names or bits. s_branch / s_nop are
+  // cached as MC opcode indices; s_nop is additionally pre-encoded to 4
+  // bytes since its representation is a constant and pad loops memcpy it
+  // directly.
   S.SBranchOpcode = resolveOpcodeViaParse("s_branch 0", S);
   if (S.SBranchOpcode >= S.MCII->getNumOpcodes()) {
     log() << "hotswap: error: initLLVM: failed to resolve 's_branch' opcode "
@@ -278,9 +283,16 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
     return S;
   }
 
-  SmallVector<uint8_t> NopBytes = assembleSingleInst("s_nop 0", S);
+  SmallVector<MCInst, 2> NopInsts = parseAsmToMCInsts("s_nop 0", S);
+  if (NopInsts.size() != 1) {
+    log() << "hotswap: error: initLLVM: failed to parse 's_nop 0' for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+  S.SNopOpcode = NopInsts[0].getOpcode();
+  SmallVector<uint8_t> NopBytes = encodeMCInst(NopInsts[0], S);
   if (NopBytes.size() != MinInstSize) {
-    log() << "hotswap: error: initLLVM: 's_nop 0' assembled to "
+    log() << "hotswap: error: initLLVM: 's_nop 0' encoded to "
           << NopBytes.size() << " bytes; expected " << MinInstSize
           << " for CPU '" << S.Cpu << "'.\n";
     return S;

--- a/amd/comgr/src/comgr-hotswap.cpp
+++ b/amd/comgr/src/comgr-hotswap.cpp
@@ -1,4 +1,4 @@
-//===- comgr-hotswap.cpp - HotSwap ISA stepping rewrite (stub) -----------===//
+//===- comgr-hotswap.cpp - HotSwap ISA rewriting: public API bridge -------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -6,40 +6,43 @@
 //===----------------------------------------------------------------------===//
 
 #include "amd_comgr.h"
+#include "comgr-hotswap-internal.h"
 #include "comgr.h"
 
 using namespace COMGR;
 
 amd_comgr_status_t AMD_COMGR_API amd_comgr_hotswap_rewrite(
-    amd_comgr_data_t input,
-    const char *source_isa_name, const char *target_isa_name,
-    amd_comgr_data_t *output) {
+    amd_comgr_data_t input, const char *source_isa_name,
+    const char *target_isa_name, amd_comgr_data_t *output) {
   DataObject *InputP = DataObject::convert(input);
   if (!InputP || !InputP->Data ||
-      InputP->DataKind != AMD_COMGR_DATA_KIND_EXECUTABLE ||
-      !source_isa_name || !target_isa_name || !output)
+      InputP->DataKind != AMD_COMGR_DATA_KIND_EXECUTABLE || !source_isa_name ||
+      !target_isa_name || !output)
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Validate and parse both ISA names.
   TargetIdentifier SourceIdent, TargetIdent;
   if (parseTargetIdentifier(source_isa_name, SourceIdent) ||
       parseTargetIdentifier(target_isa_name, TargetIdent))
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Currently only GFX1250 B0-to-A0 is supported.
   if (SourceIdent.Processor != "gfx1250" || TargetIdent.Processor != "gfx1250")
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  // Stub: return a copy of the input unchanged.
-  // Full B0-to-A0 patching implementation follows in subsequent commits.
+  std::unique_ptr<llvm::MemoryBuffer> OutBuffer;
+  amd_comgr_status_t Status = hotswap::retargetCodeObjectB0A0(
+      InputP->Data, InputP->Size, TargetIdent, OutBuffer);
+  if (Status != AMD_COMGR_STATUS_SUCCESS)
+    return Status;
+  if (!OutBuffer)
+    return AMD_COMGR_STATUS_ERROR;
+
   DataObject *OutputP = DataObject::allocate(AMD_COMGR_DATA_KIND_EXECUTABLE);
   if (!OutputP)
     return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
 
-  if (auto Status =
-          OutputP->setData(llvm::StringRef(InputP->Data, InputP->Size))) {
+  if (amd_comgr_status_t SetStatus = OutputP->setData(std::move(OutBuffer))) {
     OutputP->release();
-    return Status;
+    return SetStatus;
   }
 
   *output = DataObject::convert(OutputP);

--- a/amd/comgr/test-lit/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/hotswap-rewrite.c
@@ -1,6 +1,6 @@
 // COM: Test HotSwap rewrite API
 
-// COM: Create a minimal test ELF file
+// COM: Create a minimal test ELF file (ELF64 header only, no sections).
 // RUN: printf '\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00' > %t.elf
 
 // COM: NULL-argument validation (no args)
@@ -22,7 +22,15 @@
 // RUN:   | %FileCheck --check-prefix=ZEROSIZE %s
 // ZEROSIZE: RESULT: INVALID_ARGUMENT
 
-// COM: Supported GFX1250 pair (stub returns input unchanged)
+// COM: Supported GFX1250 pair on a malformed ELF (no .text section).
+// COM: retargetCodeObjectB0A0 rejects inputs that fail ELF64 parsing or have
+// COM: an empty .text section with INVALID_ARGUMENT -- returning SUCCESS with
+// COM: an unchanged copy there would silently hide caller-side bugs.
 // RUN: hotswap-rewrite %t.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   | %FileCheck --check-prefix=SUPPORTED %s
-// SUPPORTED: RESULT: SUCCESS
+// RUN:   | %FileCheck --check-prefix=MALFORMED %s
+// MALFORMED: RESULT: INVALID_ARGUMENT
+
+// COM: End-to-end coverage on a real gfx1250 code object (compiled via clang
+// COM: --offload-arch=gfx1250, verified with llvm-readelf + llvm-objdump) is
+// COM: tracked as a follow-up once the gfx1250 kernel-compile driver is wired
+// COM: into the test-lit infrastructure.


### PR DESCRIPTION
[AMDGPU] comgr: add GFX1250 B0-to-A0 rewrite policy and public API

Add the GFX1250-specific policy layer and orchestrator that drives
the HotSwap rewriting pipeline, building on the ELF and MC
infrastructure from the previous two PRs.

Policy (comgr-hotswap-b0a0.cpp):
- MakeGfx1250B0A0Config: builds RewriteConfig with GFX12 branch
  opcode, NOP opcode, and 256 addressable VGPRs
- Weak-symbol patch stubs (ApplyInPlacePatches,
  ApplyTrampolinePatches, ApplyWmmaHazardPatch, ApplyWmmaSplitPatches,
  ApplyScratchPatches) returning 0 — strong overrides land as
  independent PRs with no merge conflicts
- Weak-symbol liveness/DWARF stubs with conservative defaults
- EmitToNopSled/EmitToTrampoline: code emission strategies with
  automatic fallback from sled to deferred trampoline
- RetargetCodeObjectB0A0: orchestrator pipeline — parse ELF → init
  LLVM → decode → apply rules → fixup trampolines → grow ELF →
  patch debug sections → verify scratch correctness

Public API (comgr-hotswap.cpp):
- amd_comgr_hotswap_rewrite: C API bridge from DataObject to the
  raw-buffer pipeline, currently gated to GFX1250 source/target

All GFX1250 knowledge is confined to these two files. The
infrastructure layers (ELF, MC) remain fully ISA-agnostic.