### PR TITLE
[LLVM][Transforms][Attributor] - Add batch reachability optimization to forallInterferingAccesses

### DIFF
--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -86,6 +86,7 @@ static cl::opt<bool> ManifestInternal(
     cl::desc("Manifest Attributor internal string attributes."),
     cl::init(false));
 
+
 static cl::opt<int> MaxHeapToStackSize("max-heap-to-stack-size", cl::init(128),
                                        cl::Hidden);
 
@@ -1092,7 +1093,14 @@ struct AAPointerInfoImpl
     HasBeenWrittenTo = false;
 
     SmallPtrSet<const Access *, 8> DominatingWrites;
-    SmallVector<std::pair<const Access *, bool>, 8> InterferingAccesses;
+
+    // All Accesses are not equal. AccessCB partitions them into two groups.
+    // IntraFnAccesses: When RemoteI is in the same function as I (Scope).
+    // See CanSkipAccessBatch below (Batch Reachability Optimization)
+    // InterFnAccesses: When RemoteI is in a different function as I. Processed
+    // by CanSkipAccess.
+    SmallVector<std::pair<const Access *, bool>, 8> IntraFnAccesses;
+    SmallVector<std::pair<const Access *, bool>, 8> InterFnAccesses;
 
     Function &Scope = *I.getFunction();
     bool IsKnownNoSync;
@@ -1252,9 +1260,21 @@ struct AAPointerInfoImpl
 
       // Track if all interesting accesses are in the same `nosync` function as
       // the given instruction.
-      AllInSameNoSyncFn &= Acc.getRemoteInst()->getFunction() == &Scope;
+      AllInSameNoSyncFn &= AccInSameScope;
 
-      InterferingAccesses.push_back({&Acc, Exact});
+      // Only truly local accesses (LocalI == RemoteI) use the batch BFS path.
+      // Imported accesses (from translateAndAddStateFromCallee) have
+      // LocalI != RemoteI: LocalI is the call site, RemoteI is the actual
+      // instruction in the callee. For recursive calls, RemoteI is in the
+      // same function but at a different invocation context. The batch BFS
+      // would incorrectly check block-level reachability between I and
+      // RemoteI, missing the call-site indirection. These must go through
+      // CanSkipAccess with isPotentiallyReachable, which correctly handles
+      // cross-invocation reachability via the call graph.
+      if (AccInSameScope && Acc.getLocalInst() == Acc.getRemoteInst())
+        IntraFnAccesses.push_back({&Acc, Exact});
+      else
+        InterFnAccesses.push_back({&Acc, Exact});
       return true;
     };
     if (!State::forallInterferingAccesses(I, AccessCB, Range))
@@ -1277,8 +1297,9 @@ struct AAPointerInfoImpl
     auto CanSkipAccess = [&](const Access &Acc, bool Exact) {
       if (SkipCB && SkipCB(Acc))
         return true;
-      if (!CanIgnoreThreading(Acc))
+      if (!CanIgnoreThreading(Acc)) {
         return false;
+      }
 
       // Check read (RAW) dependences and write (WAR) dependences as necessary.
       // If we successfully excluded all effects we are interested in, the
@@ -1343,14 +1364,297 @@ struct AAPointerInfoImpl
       return LeastDominatingWriteInst != Acc.getRemoteInst();
     };
 
-    // Run the user callback on all accesses we cannot skip and return if
-    // that succeeded for all or not.
-    for (auto &It : InterferingAccesses) {
-      if ((!AllInSameNoSyncFn && !IsThreadLocalObj && !ExecDomainAA) ||
-          !CanSkipAccess(*It.first, It.second)) {
-        if (!UserCB(*It.first, It.second))
+    {
+      // Batch reachability optimization for CanSkipAccess.
+      //
+      // Without this optimization, each interfering access would trigger two
+      // independent AA::isPotentiallyReachable calls. Each call traverses the
+      // CFG from scratch. With N interfering accesses, this is 2 * N
+      // independent BFS traversals over the same function's CFG — redundant
+      // work.
+      //
+      // This optimization pre-computes two block-level reachability sets:
+      //   ReachableFromI: all basic blocks reachable forward from I's block
+      //   ReachableToI:   all basic blocks that can reach I's block (backward)
+      //
+      // These are computed lazily (on first use) via a single BFS each,
+      // respecting the ExclusionSet (must-write barriers) and liveness
+      // (dead edges from AAIsDead). Then for each intra-function access,
+      // a cheap set lookup replaces the full isPotentiallyReachable call:
+      //   - ReadChecked:  if Acc's block is NOT in ReachableFromI, I can't
+      //                   reach Acc, so Acc's read can't observe I's write.
+      //   - WriteChecked: if Acc's block is NOT in ReachableToI, Acc can't
+      //                   reach I, so Acc's write can't affect I's read.
+      //
+      // If the block-level check is inconclusive, we fall back to
+      // isPotentiallyReachable.
+      //
+      //
+
+      DenseSet<const BasicBlock *> ReachableFromI;
+      bool ReachableFromIComputed = false;
+
+      DenseSet<const BasicBlock *> ReachableToI;
+      bool ReachableToIComputed = false;
+
+      // Map each basic block to the ExclusionSet instructions it contains.
+      // Built once and shared across the BFS helpers and same-block checks
+      // in CanSkipAccessBatch, replacing per-use iteration over ExclusionSet.
+      DenseMap<const BasicBlock *, SmallVector<const Instruction *, 2>>
+          ExcludedBlockInsts;
+      for (const Instruction *ExclI : ExclusionSet)
+        ExcludedBlockInsts[ExclI->getParent()].push_back(ExclI);
+
+      // Lazily compute forward reachability from I's block.
+      // BFS over successor edges within Scope, skipping dead edges (AAIsDead)
+      // and not traversing past ExclusionSet blocks (must-write barriers).
+      // I's block is always traversed (its successors are always explored).
+      // Other blocks containing ExclusionSet instructions are added to the
+      // reachable set but their successors are NOT explored.
+      //
+      // Note: we do NOT block I's block even if it contains an ExclusionSet
+      // instruction after I. This matches isPotentiallyReachable / isReachableImpl
+      // semantics, which check SuccBB == ToBB before ExclusionBlocks and thus
+      // always consider direct successors as reachable.
+      auto EnsureReachableFromI = [&]() {
+        if (ReachableFromIComputed)
+          return;
+
+        const BasicBlock *FromBB = I.getParent();
+        SmallVector<const BasicBlock *, 16> Worklist;
+        Worklist.push_back(FromBB);
+        ReachableFromI.insert(FromBB);
+
+        const auto *LivenessAA = A.getAAFor<AAIsDead>(
+            QueryingAA, IRPosition::function(Scope), DepClassTy::OPTIONAL);
+
+        while (!Worklist.empty()) {
+          const BasicBlock *BB = Worklist.pop_back_val();
+
+          // Don't traverse past ExclusionSet blocks (must-write barriers),
+          // but always traverse I's own block.
+          if (BB != FromBB && ExcludedBlockInsts.count(BB))
+            continue;
+
+          for (const BasicBlock *SuccBB : successors(BB)) {
+            if (LivenessAA && LivenessAA->isEdgeDead(BB, SuccBB))
+              continue;
+
+            if (ReachableFromI.insert(SuccBB).second)
+              Worklist.push_back(SuccBB);
+          }
+        }
+        ReachableFromIComputed = true;
+      };
+
+      // Lazily compute backward reachability to I's block.
+      // BFS over predecessor edges within Scope, skipping dead edges and
+      // not traversing past ExclusionSet blocks. This is the mirror of
+      // EnsureReachableFromI: it answers "can Acc reach I?" rather than
+      // "can I reach Acc?".
+      //
+      // Lazily compute backward reachability to I's block.
+      // BFS over predecessor edges within Scope, skipping dead edges and
+      // not traversing past ExclusionSet blocks. This is the mirror of
+      // EnsureReachableFromI: it answers "can Acc reach I?" rather than
+      // "can I reach Acc?".
+      //
+      // As with EnsureReachableFromI, I's block is always traversed
+      // (its predecessors are always explored) to match isPotentiallyReachable
+      // semantics.
+      auto EnsureReachableToI = [&]() {
+        if (ReachableToIComputed)
+          return;
+
+        const BasicBlock *ToBB = I.getParent();
+        SmallVector<const BasicBlock *, 16> Worklist;
+        Worklist.push_back(ToBB);
+        ReachableToI.insert(ToBB);
+
+        const auto *LivenessAA = A.getAAFor<AAIsDead>(
+            QueryingAA, IRPosition::function(Scope), DepClassTy::OPTIONAL);
+
+        while (!Worklist.empty()) {
+          const BasicBlock *BB = Worklist.pop_back_val();
+
+          for (const BasicBlock *PredBB : predecessors(BB)) {
+            if (LivenessAA && LivenessAA->isEdgeDead(PredBB, BB))
+              continue;
+
+            if (!ReachableToI.insert(PredBB).second)
+              continue;
+
+            // Don't traverse past ExclusionSet blocks, but always
+            // traverse I's own block (ToBB).
+            bool Blocked = (PredBB != ToBB && ExcludedBlockInsts.count(PredBB));
+
+            if (!Blocked)
+              Worklist.push_back(PredBB);
+          }
+        }
+        ReachableToIComputed = true;
+      };
+
+      // Batch variant of CanSkipAccess for intra-function accesses.
+      //
+      // The batch BFS can safely be used as a negative filter (skip iPR when
+      // BFS says "not reachable") only when iPR agrees for all paths the BFS
+      // can't model. This requires:
+      //   (a) norecurse: instructionCanReach can't find paths back to Scope
+      //   (b) GoBackwardsCB returns false for Scope: iPR won't step back to
+      //   callers
+      // Both hold for allocas in norecurse functions where
+      // GoBackwardsCB(*Scope) = IsLiveInCalleeCB(*Scope) = (AIFn != Scope) =
+      // false.
+      //
+      // When BFSSafe is true (alloca in norecurse fn), the BFS is used as a
+      // negative filter: if Acc's block is NOT in the reachable set,
+      // isPotentiallyReachable would also return false, so we can directly
+      // set Checked = true without calling isPotentiallyReachable.
+      //
+      // When BFSSafe is false, the BFS cannot be a negative filter because
+      // isPotentiallyreachable considers inter-procedural and cross-invocation
+      // paths that the BFS can't model. In that case, we skip the BFS entirely
+      // and only use the same-block optimization (which doesn't depend on the
+      // BFS).
+      bool BFSSafe = false;
+      if (isa<AllocaInst>(&getAssociatedValue()) && IsLiveInCalleeCB)
+        BFSSafe = true;
+
+      auto CanSkipAccessBatch = [&](const Access &Acc, bool Exact) {
+        if (SkipCB && SkipCB(Acc))
+          return true;
+        if (!CanIgnoreThreading(Acc)) {
           return false;
+        }
+
+        bool ReadChecked = !FindInterferingReads;
+        bool WriteChecked = !FindInterferingWrites;
+
+        // Forward reachability: can I reach Acc?
+        if (!ReadChecked) {
+          if (BFSSafe) {
+            EnsureReachableFromI();
+            bool BlockReachable =
+                ReachableFromI.count(Acc.getRemoteInst()->getParent());
+
+            if (!BlockReachable) {
+              // BFS-safe negative filter: the BFS is a complete model of
+              // reachability for allocas in norecurse functions.
+              ReadChecked = true;
+            } else if (I.getParent() == Acc.getRemoteInst()->getParent() &&
+                       I.comesBefore(Acc.getRemoteInst())) {
+              // Same-block optimization.
+              auto It = ExcludedBlockInsts.find(I.getParent());
+              if (It != ExcludedBlockInsts.end()) {
+                for (const Instruction *ExclI : It->second) {
+                  if (I.comesBefore(ExclI) &&
+                      ExclI->comesBefore(Acc.getRemoteInst())) {
+                    ReadChecked = true;
+                    break;
+                  }
+                }
+              }
+            }
+          } else {
+            // Not BFS-safe: only apply same-block optimization.
+            if (I.getParent() == Acc.getRemoteInst()->getParent() &&
+                I.comesBefore(Acc.getRemoteInst())) {
+              auto It = ExcludedBlockInsts.find(I.getParent());
+              if (It != ExcludedBlockInsts.end()) {
+                for (const Instruction *ExclI : It->second) {
+                  if (I.comesBefore(ExclI) &&
+                      ExclI->comesBefore(Acc.getRemoteInst())) {
+                    ReadChecked = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+
+          if (!ReadChecked) {
+            if (!AA::isPotentiallyReachable(A, I, *Acc.getRemoteInst(),
+                                            QueryingAA, &ExclusionSet,
+                                            IsLiveInCalleeCB)) {
+              ReadChecked = true;
+            }
+          }
+        }
+
+        // Backward reachability: can Acc reach I?
+        if (!WriteChecked) {
+          if (BFSSafe) {
+            EnsureReachableToI();
+            bool BlockReachable =
+                ReachableToI.count(Acc.getRemoteInst()->getParent());
+
+            if (!BlockReachable) {
+              WriteChecked = true;
+            } else if (I.getParent() == Acc.getRemoteInst()->getParent() &&
+                       Acc.getRemoteInst()->comesBefore(&I)) {
+              auto It = ExcludedBlockInsts.find(I.getParent());
+              if (It != ExcludedBlockInsts.end()) {
+                for (const Instruction *ExclI : It->second) {
+                  if (Acc.getRemoteInst()->comesBefore(ExclI) &&
+                      ExclI->comesBefore(&I)) {
+                    WriteChecked = true;
+                    break;
+                  }
+                }
+              }
+            }
+          } else {
+            if (I.getParent() == Acc.getRemoteInst()->getParent() &&
+                Acc.getRemoteInst()->comesBefore(&I)) {
+              auto It = ExcludedBlockInsts.find(I.getParent());
+              if (It != ExcludedBlockInsts.end()) {
+                for (const Instruction *ExclI : It->second) {
+                  if (Acc.getRemoteInst()->comesBefore(ExclI) &&
+                      ExclI->comesBefore(&I)) {
+                    WriteChecked = true;
+                    break;
+                  }
+                }
+              }
+            }
+          }
+
+          if (!WriteChecked) {
+            if (!AA::isPotentiallyReachable(A, *Acc.getRemoteInst(), I,
+                                            QueryingAA, &ExclusionSet,
+                                            IsLiveInCalleeCB)) {
+              WriteChecked = true;
+            }
+          }
+        }
+        if (ReadChecked && WriteChecked)
+          return true;
+
+        if (!DT || !UseDominanceReasoning)
+          return false;
+        if (!DominatingWrites.count(&Acc))
+          return false;
+        return LeastDominatingWriteInst != Acc.getRemoteInst();
+      };
+
+      // Process intra-function accesses.
+      for (auto &It : IntraFnAccesses) {
+        if ((!AllInSameNoSyncFn && !IsThreadLocalObj && !ExecDomainAA) ||
+            !CanSkipAccessBatch(*It.first, It.second)) {
+          if (!UserCB(*It.first, It.second))
+            return false;
+        }
       }
+
+      // Process cross-function accesses.
+        for (auto &It : InterFnAccesses) {
+          if ((!AllInSameNoSyncFn && !IsThreadLocalObj && !ExecDomainAA) ||
+              !CanSkipAccess(*It.first, It.second)) {
+            if (!UserCB(*It.first, It.second))
+              return false;
+          }
+        }
     }
     return true;
   }

--- a/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
+++ b/llvm/lib/Transforms/IPO/AttributorAttributes.cpp
@@ -86,7 +86,6 @@ static cl::opt<bool> ManifestInternal(
     cl::desc("Manifest Attributor internal string attributes."),
     cl::init(false));
 
-
 static cl::opt<int> MaxHeapToStackSize("max-heap-to-stack-size", cl::init(128),
                                        cl::Hidden);
 
@@ -1413,9 +1412,10 @@ struct AAPointerInfoImpl
       // reachable set but their successors are NOT explored.
       //
       // Note: we do NOT block I's block even if it contains an ExclusionSet
-      // instruction after I. This matches isPotentiallyReachable / isReachableImpl
-      // semantics, which check SuccBB == ToBB before ExclusionBlocks and thus
-      // always consider direct successors as reachable.
+      // instruction after I. This matches isPotentiallyReachable /
+      // isReachableImpl semantics, which check SuccBB == ToBB before
+      // ExclusionBlocks and thus always consider direct successors as
+      // reachable.
       auto EnsureReachableFromI = [&]() {
         if (ReachableFromIComputed)
           return;
@@ -1648,13 +1648,13 @@ struct AAPointerInfoImpl
       }
 
       // Process cross-function accesses.
-        for (auto &It : InterFnAccesses) {
-          if ((!AllInSameNoSyncFn && !IsThreadLocalObj && !ExecDomainAA) ||
-              !CanSkipAccess(*It.first, It.second)) {
-            if (!UserCB(*It.first, It.second))
-              return false;
-          }
+      for (auto &It : InterFnAccesses) {
+        if ((!AllInSameNoSyncFn && !IsThreadLocalObj && !ExecDomainAA) ||
+            !CanSkipAccess(*It.first, It.second)) {
+          if (!UserCB(*It.first, It.second))
+            return false;
         }
+      }
     }
     return true;
   }


### PR DESCRIPTION
In `AAPointerInfoImpl::forallInterferingAccesses`, each interfering access
triggers an independent `AA::isPotentiallyReachable` call. Each such call
may perform a BFS traversal of the function's CFG, query
`AAIntraFnReachability` (with its own BFS/cache lookup), query
`AAInterFnReachability` (recursive call-graph traversal), and potentially
step backward through call sites. With N interfering accesses for a
given instruction I, this amounts to up to 2N independent
`isPotentiallyReachable` calls (forward and reverse), each redundantly
traversing the same CFG.

For large LTO modules with many kernel entry points and shared runtime
globals, N can grow into the thousands per `forallInterferingAccesses`
invocation due to cross-function access imports
(`translateAndAddStateFromCallee`). The repeated CFG traversals become a
dominant cost in the Attributor's fixpoint iteration.

This patch introduces three optimizations that work together:

1. Batch BFS reachability sets

Pre-compute two block-level reachability sets lazily (on first use):

`ReachableFromI`: forward BFS from I's block (can I reach Acc?)
`ReachableToI`: backward BFS to I's block (can Acc reach I?)
Both BFS traversals respect the `ExclusionSet` (must-write barriers)
and liveness (dead edges from `AAIsDead`). A pre-computed
`ExcludedBlockInsts` map (BasicBlock -> ExclusionSet instructions in
that block) provides O(1) blocking checks during BFS.

For allocas in norecurse functions, the BFS is a sound negative
filter: if Acc's block is not in the reachable set, we skip the
`isPotentiallyReachable` call entirely. This is safe because (a)
norecurse prevents `instructionCanReach` from finding paths back into
the function, and (b) the `GoBackwardsCB` returns false for the
alloca's function, preventing caller stepping — so `isPotentiallyReachable` has no
inter-procedural paths that the intra-function BFS would miss.

For other pointer types (globals, non-norecurse allocas), the BFS
is not used as a negative filter because iPR considers
cross-invocation and inter-procedural paths that the BFS cannot
model. In these cases the BFS is skipped entirely to avoid wasted
computation.

2. Same-block optimization

When I and Acc are in the same basic block, resolve reachability
with a direct instruction ordering check (`comesBefore`) instead of
calling `isPotentiallyReachable`. If `I` comes before `Acc` (forward) or
`Acc` comes before `I` (backward), check whether any `ExclusionSet`
instruction lies between them using the `ExcludedBlockInsts` map. A
barrier means the path is blocked; no barrier means reachability
holds. This avoids the expensive `isPotentiallReachable` call regardless of `BFSSafe`
status.

3. Access partitioning by scope

Partition interfering accesses in `AccessCB` into two groups:

`IntraFnAccesses`: RemoteI is in the same function as I, and
`LocalI == RemoteI` (truly local, not imported). Processed by
`CanSkipAccessBatch`, which applies both the batch BFS and same-
block optimizations.
`InterFnAccesses`: all other accesses (cross-function or imported
from callees via `translateAndAddStateFromCallee` where
`LocalI != RemoteI`). Processed by the original `CanSkipAccess` path
with `isPotentiallyReachable`.
This partitioning is necessary because the batch BFS and same-block
optimizations are purely intra-procedural — they reason about CFG
paths within a single function. Cross-function accesses require
inter-procedural reasoning (call-graph traversal, backward stepping
through callers) that only `isPotentiallyReachable` provides. Without
the partitioning, the batch BFS would be triggered for cross-
function accesses where it provides no benefit, while also paying the
cost of building the reachability sets unnecessarily.

The `LocalI == RemoteI` guard is critical for correctness: imported
accesses from recursive calls have `RemoteI` in the same function but
at a different invocation context. The batch BFS would incorrectly
check block-level reachability between I and RemoteI, missing the
call-site indirection that `isPotentiallyReachable` correctly handles
via the call graph.

Together these optimizations reduce link time by ~30% on a large
Fortran/OpenMP application with ~160 GPU kernel entry points, by
amortizing and avoiding redundant `isPotentiallyReachable` calls
during the Attributor's fixpoint iteration.

Assisted by: Opus 4.6

(Cherry-picked from https://github.com/llvm/llvm-project/pull/190078)
Blocked upstream waiting on reviews from Johannes.