### PR TITLE
[Flang][OpenMP] Track device ID at allocation time for correct deallocation

### DIFF
--- a/flang-rt/lib/amd/CMakeLists.txt
+++ b/flang-rt/lib/amd/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_flangrt_library(flang_rt.amd STATIC SHARED
   amd_alloc.cpp
+  amd_util.cpp
   INSTALL_WITH_TOOLCHAIN
 )
 

--- a/flang-rt/lib/amd/amd_alloc.cpp
+++ b/flang-rt/lib/amd/amd_alloc.cpp
@@ -16,7 +16,7 @@
 #include "flang/Runtime/AMD/amd_alloc.h"
 #include "flang-rt/runtime/allocator-registry.h"
 #include "flang-rt/runtime/descriptor.h"
-#include "flang-rt/runtime/lock.h"
+#include "flang/Runtime/AMD/amd_util.h"
 #include "flang/Support/Fortran.h"
 #include <algorithm>
 #include <cstdio>
@@ -24,7 +24,6 @@
 #include <cstring>
 #include <limits>
 #include <string_view>
-#include <unordered_map>
 
 namespace Fortran::runtime::amd {
 
@@ -43,25 +42,7 @@ extern "C" void omp_target_free(void *, int);
 // OpenMPFree can pass the correct device ID to omp_target_free,
 // even if omp_set_default_device() was called between ALLOCATE
 // and DEALLOCATE.
-static Lock allocDeviceMapLock;
-static std::unordered_map<void *, int> allocDeviceMap;
-
-static void trackAllocation(void *pointer, int device) {
-  CriticalSection guard(allocDeviceMapLock);
-  allocDeviceMap[pointer] = device;
-}
-
-static int retrieveAndRemoveDevice(void *pointer) {
-  CriticalSection guard(allocDeviceMapLock);
-  auto it = allocDeviceMap.find(pointer);
-  if (it != allocDeviceMap.end()) {
-    int device = it->second;
-    allocDeviceMap.erase(it);
-    return device;
-  }
-  // Fallback if the pointer is not tracked.
-  return omp_get_default_device();
-}
+static PointerDeviceMap allocDeviceMap;
 
 static void *OpenMPAlloc(std::size_t AllocationSize, std::int64_t *) {
 #if ALLOC_DEBUG
@@ -73,7 +54,7 @@ static void *OpenMPAlloc(std::size_t AllocationSize, std::int64_t *) {
   int device{omp_get_default_device()};
   void *pointer{omp_target_alloc(AllocationSize, device)};
   if (pointer) {
-    trackAllocation(pointer, device);
+    allocDeviceMap.insert(pointer, device);
   }
 #if ALLOC_DEBUG
   if (debugEnabled) {
@@ -87,7 +68,7 @@ static void *OpenMPAlloc(std::size_t AllocationSize, std::int64_t *) {
 }
 
 static void OpenMPFree(void *pointer) {
-  int device{retrieveAndRemoveDevice(pointer)};
+  int device{allocDeviceMap.removeAndGet(pointer)};
 #if ALLOC_DEBUG
   if (debugEnabled) {
     std::fprintf(stderr, "[AMD_ALLOC] %s(%p) device %d (%s:%d)\n",

--- a/flang-rt/lib/amd/amd_alloc.cpp
+++ b/flang-rt/lib/amd/amd_alloc.cpp
@@ -16,6 +16,7 @@
 #include "flang/Runtime/AMD/amd_alloc.h"
 #include "flang-rt/runtime/allocator-registry.h"
 #include "flang-rt/runtime/descriptor.h"
+#include "flang-rt/runtime/lock.h"
 #include "flang/Support/Fortran.h"
 #include <algorithm>
 #include <cstdio>
@@ -23,6 +24,7 @@
 #include <cstring>
 #include <limits>
 #include <string_view>
+#include <unordered_map>
 
 namespace Fortran::runtime::amd {
 
@@ -37,6 +39,30 @@ extern "C" int omp_get_default_device(void);
 extern "C" void *omp_target_alloc(std::size_t, int);
 extern "C" void omp_target_free(void *, int);
 
+// Track which device each pointer was allocated on so that
+// OpenMPFree can pass the correct device ID to omp_target_free,
+// even if omp_set_default_device() was called between ALLOCATE
+// and DEALLOCATE.
+static Lock allocDeviceMapLock;
+static std::unordered_map<void *, int> allocDeviceMap;
+
+static void trackAllocation(void *pointer, int device) {
+  CriticalSection guard(allocDeviceMapLock);
+  allocDeviceMap[pointer] = device;
+}
+
+static int retrieveAndRemoveDevice(void *pointer) {
+  CriticalSection guard(allocDeviceMapLock);
+  auto it = allocDeviceMap.find(pointer);
+  if (it != allocDeviceMap.end()) {
+    int device = it->second;
+    allocDeviceMap.erase(it);
+    return device;
+  }
+  // Fallback if the pointer is not tracked.
+  return omp_get_default_device();
+}
+
 static void *OpenMPAlloc(std::size_t AllocationSize, std::int64_t *) {
 #if ALLOC_DEBUG
   if (debugEnabled) {
@@ -46,6 +72,9 @@ static void *OpenMPAlloc(std::size_t AllocationSize, std::int64_t *) {
 #endif
   int device{omp_get_default_device()};
   void *pointer{omp_target_alloc(AllocationSize, device)};
+  if (pointer) {
+    trackAllocation(pointer, device);
+  }
 #if ALLOC_DEBUG
   if (debugEnabled) {
     std::fprintf(stderr,
@@ -57,14 +86,15 @@ static void *OpenMPAlloc(std::size_t AllocationSize, std::int64_t *) {
   return pointer;
 }
 
-void OpenMPFree(void *pointer) {
+static void OpenMPFree(void *pointer) {
+  int device{retrieveAndRemoveDevice(pointer)};
 #if ALLOC_DEBUG
   if (debugEnabled) {
-    std::fprintf(stderr, "[AMD_ALLOC] %s(%p) (%s:%d)\n", __PRETTY_FUNCTION__,
-        pointer, __FILE__, __LINE__);
+    std::fprintf(stderr, "[AMD_ALLOC] %s(%p) device %d (%s:%d)\n",
+        __PRETTY_FUNCTION__, pointer, device, __FILE__, __LINE__);
   }
 #endif
-  omp_target_free(pointer, omp_get_default_device());
+  omp_target_free(pointer, device);
 }
 
 static void registerOpenMPAllocator() {

--- a/flang-rt/lib/amd/amd_util.cpp
+++ b/flang-rt/lib/amd/amd_util.cpp
@@ -1,0 +1,62 @@
+//===-- lib/amd/amd_util.cpp ------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "flang/Runtime/AMD/amd_util.h"
+#include "flang-rt/runtime/lock.h"
+#include <cstdlib>
+#include <cstring>
+
+namespace Fortran::runtime::amd {
+
+static constexpr std::size_t initialCapacity{256};
+
+static Lock pointerDeviceMapLock;
+
+void PointerDeviceMap::grow() {
+  std::size_t newCapacity = capacity_ ? capacity_ * 2 : initialCapacity;
+  Entry *newEntries =
+      static_cast<Entry *>(std::realloc(entries_, newCapacity * sizeof(Entry)));
+  if (!newEntries) {
+    return; // allocation failed; caller will cope
+  }
+  entries_ = newEntries;
+  capacity_ = newCapacity;
+}
+
+void PointerDeviceMap::insert(void *pointer, int device) {
+  CriticalSection guard(pointerDeviceMapLock);
+  if (count_ == capacity_) {
+    grow();
+    if (count_ == capacity_) {
+      return; // grow failed
+    }
+  }
+  entries_[count_++] = {pointer, device};
+}
+
+int PointerDeviceMap::removeAndGet(void *pointer) {
+  CriticalSection guard(pointerDeviceMapLock);
+  for (std::size_t i = 0; i < count_; ++i) {
+    if (entries_[i].pointer == pointer) {
+      int device = entries_[i].device;
+      // Swap with last entry and shrink.
+      entries_[i] = entries_[--count_];
+      return device;
+    }
+  }
+  return -1;
+}
+
+void PointerDeviceMap::dump() const {
+  CriticalSection guard(pointerDeviceMapLock);
+  for (std::size_t i = 0; i < count_; ++i) {
+    std::fprintf(stderr, "%p -> %d\n", entries_[i].pointer, entries_[i].device);
+  }
+}
+
+} // namespace Fortran::runtime::amd

--- a/flang/include/flang/Runtime/AMD/amd_util.h
+++ b/flang/include/flang/Runtime/AMD/amd_util.h
@@ -1,0 +1,46 @@
+//===-- include/flang/Runtime/AMD/amd_util.h --------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef FORTRAN_RUNTIME_AMD_UTIL_H_
+#define FORTRAN_RUNTIME_AMD_UTIL_H_
+
+#include <cstddef>
+
+namespace Fortran::runtime::amd {
+
+// A simple thread-safe map from pointer to integer value (e.g. device ID).
+// Implemented as a dynamically-grown array with linear search to avoid
+// pulling in C++ runtime dependencies via std::unordered_map.
+class PointerDeviceMap {
+public:
+  // Record that |pointer| is associated with |device|.
+  void insert(void *pointer, int device);
+
+  // Look up and remove the entry for |pointer|.  Returns the associated
+  // device ID, or |fallback| if the pointer was not found.
+  int removeAndGet(void *pointer);
+
+  // Dump the pointer-device table
+  void dump() const;
+
+private:
+  struct Entry {
+    void *pointer;
+    int device;
+  };
+
+  void grow();
+
+  Entry *entries_{nullptr};
+  std::size_t count_{0};
+  std::size_t capacity_{0};
+};
+
+} // namespace Fortran::runtime::amd
+
+#endif // FORTRAN_RUNTIME_AMD_UTIL_H_


### PR DESCRIPTION
If omp_set_default_device() is called between ALLOCATE and DEALLOCATE, OpenMPFree would pass the wrong device ID to omp_target_free. Fix this by maintaining a pointer-to-device map so that deallocation always uses the device the memory was originally allocated on.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
