### PR TITLE
[Comgr] `pruneCache` now returns a proper error

### DIFF
--- a/amd/comgr/src/comgr-cache.cpp
+++ b/amd/comgr/src/comgr-cache.cpp
@@ -166,7 +166,8 @@ CommandCache::getPolicyFromEnv(llvm::raw_ostream &LogS) {
 void CommandCache::prune() {
   Expected<bool> PrunedOrErr = pruneCache(CacheDir, Policy);
   if (!PrunedOrErr) {
-    logAllUnhandledErrors(PrunedOrErr.takeError(), LogS);
+    auto ErrorHandler = getComgrCacheErrorHandler(LogS);
+    ErrorHandler(PrunedOrErr.takeError(), "when pruning the cache");
   }
 }
 

--- a/amd/comgr/src/comgr-cache.cpp
+++ b/amd/comgr/src/comgr-cache.cpp
@@ -164,16 +164,10 @@ CommandCache::getPolicyFromEnv(llvm::raw_ostream &LogS) {
 }
 
 void CommandCache::prune() {
-  // pruneCache calls report_fatal_error when sys::fs::disk_space()
-  // fails and size-based pruning is enabled (MaxSizePercentageOfAvailableSpace
-  // or MaxSizeBytes > 0). Guard against this by probing disk_space before
-  // calling pruneCache; skip pruning entirely if the query fails.
-  if (Policy.MaxSizePercentageOfAvailableSpace > 0 || Policy.MaxSizeBytes > 0) {
-    auto SpaceOrErr = sys::fs::disk_space(CacheDir);
-    if (!SpaceOrErr)
-      return;
+  Expected<bool> PrunedOrErr = pruneCache(CacheDir, Policy);
+  if (!PrunedOrErr) {
+    logAllUnhandledErrors(PrunedOrErr.takeError(), LogS);
   }
-  pruneCache(CacheDir, Policy);
 }
 
 std::unique_ptr<CommandCache> CommandCache::get(raw_ostream &LogS) {
@@ -186,11 +180,13 @@ std::unique_ptr<CommandCache> CommandCache::get(raw_ostream &LogS) {
   if (!Policy)
     return nullptr;
 
-  return std::unique_ptr<CommandCache>(new CommandCache(CacheDir, *Policy));
+  return std::unique_ptr<CommandCache>(
+      new CommandCache(CacheDir, *Policy, LogS));
 }
 
-CommandCache::CommandCache(StringRef CacheDir, const CachePruningPolicy &Policy)
-    : CacheDir(CacheDir.str()), Policy(Policy) {
+CommandCache::CommandCache(StringRef CacheDir, const CachePruningPolicy &Policy,
+                           llvm::raw_ostream &LogS)
+    : CacheDir(CacheDir.str()), Policy(Policy), LogS(LogS) {
   assert(!CacheDir.empty());
 }
 

--- a/amd/comgr/src/comgr-cache.h
+++ b/amd/comgr/src/comgr-cache.h
@@ -27,9 +27,10 @@ namespace COMGR {
 class CommandCache {
   std::string CacheDir;
   llvm::CachePruningPolicy Policy;
+  llvm::raw_ostream &LogS;
 
-  CommandCache(llvm::StringRef CacheDir,
-               const llvm::CachePruningPolicy &Policy);
+  CommandCache(llvm::StringRef CacheDir, const llvm::CachePruningPolicy &Policy,
+               llvm::raw_ostream &LogS);
 
   static std::optional<llvm::CachePruningPolicy>
   getPolicyFromEnv(llvm::raw_ostream &LogS);

--- a/lld/COFF/LTO.cpp
+++ b/lld/COFF/LTO.cpp
@@ -241,7 +241,7 @@ std::vector<InputFile *> BitcodeCompiler::compile() {
   }
 
   if (!ctx.config.ltoCache.empty())
-    pruneCache(ctx.config.ltoCache, ctx.config.ltoCachePolicy, files);
+    check(pruneCache(ctx.config.ltoCache, ctx.config.ltoCachePolicy, files));
 
   std::vector<InputFile *> ret;
   bool emitASM = ctx.config.emit == EmitKind::ASM;

--- a/lld/ELF/LTO.cpp
+++ b/lld/ELF/LTO.cpp
@@ -379,7 +379,8 @@ SmallVector<std::unique_ptr<InputFile>, 0> BitcodeCompiler::compile() {
   }
 
   if (!ctx.arg.thinLTOCacheDir.empty())
-    pruneCache(ctx.arg.thinLTOCacheDir, ctx.arg.thinLTOCachePolicy, files);
+    check(
+        pruneCache(ctx.arg.thinLTOCacheDir, ctx.arg.thinLTOCachePolicy, files));
 
   if (!ctx.arg.ltoObjPath.empty()) {
     saveBuffer(buf[0].second, ctx.arg.ltoObjPath);

--- a/lld/MachO/LTO.cpp
+++ b/lld/MachO/LTO.cpp
@@ -278,7 +278,8 @@ std::vector<ObjFile *> BitcodeCompiler::compile() {
   }
 
   if (!config->thinLTOCacheDir.empty())
-    pruneCache(config->thinLTOCacheDir, config->thinLTOCachePolicy, files);
+    check(
+        pruneCache(config->thinLTOCacheDir, config->thinLTOCachePolicy, files));
 
   std::vector<ObjFile *> ret;
   for (unsigned i = 0; i < maxTasks; ++i) {

--- a/lld/wasm/LTO.cpp
+++ b/lld/wasm/LTO.cpp
@@ -250,7 +250,8 @@ SmallVector<InputFile *, 0> BitcodeCompiler::compile() {
   }
 
   if (!ctx.arg.thinLTOCacheDir.empty())
-    pruneCache(ctx.arg.thinLTOCacheDir, ctx.arg.thinLTOCachePolicy, files);
+    check(
+        pruneCache(ctx.arg.thinLTOCacheDir, ctx.arg.thinLTOCachePolicy, files));
 
   SmallVector<InputFile *, 0> ret;
   for (unsigned i = 0; i != maxTasks; ++i) {

--- a/lldb/source/Core/DataFileCache.cpp
+++ b/lldb/source/Core/DataFileCache.cpp
@@ -46,7 +46,12 @@ llvm::CachePruningPolicy DataFileCache::GetLLDBIndexCachePolicy() {
 
 DataFileCache::DataFileCache(llvm::StringRef path, llvm::CachePruningPolicy policy) {
   m_cache_dir.SetPath(path);
-  pruneCache(path, policy);
+  llvm::Expected<bool> err_or_pruned = pruneCache(path, policy);
+  if (!err_or_pruned) {
+    Log *log = GetLog(LLDBLog::Modules);
+    LLDB_LOG_ERROR(log, err_or_pruned.takeError(),
+                   "failed to prune lldb index cache directory: {0}");
+  }
 
   // This lambda will get called when the data is gotten from the cache and
   // also after the data was set for a given key. We only need to take

--- a/llvm/include/llvm/Support/CachePruning.h
+++ b/llvm/include/llvm/Support/CachePruning.h
@@ -70,8 +70,10 @@ struct CachePruningPolicy {
 LLVM_ABI Expected<CachePruningPolicy>
 parseCachePruningPolicy(StringRef PolicyStr);
 
-/// Peform pruning using the supplied policy, returns true if pruning
+/// Perform pruning using the supplied policy, returns true if pruning
 /// occurred, i.e. if Policy.Interval was expired.
+///
+/// On failure, it returns an Expected with the Error.
 ///
 /// Check whether cache pruning happens using the supplied policy, adds a
 /// ThinLTO warning if cache_size_bytes or cache_size_files is too small for the
@@ -81,7 +83,7 @@ parseCachePruningPolicy(StringRef PolicyStr);
 /// As a safeguard against data loss if the user specifies the wrong directory
 /// as their cache directory, this function will ignore files not matching the
 /// pattern "llvmcache-*".
-LLVM_ABI bool
+LLVM_ABI Expected<bool>
 pruneCache(StringRef Path, CachePruningPolicy Policy,
            const std::vector<std::unique_ptr<MemoryBuffer>> &Files = {});
 } // namespace llvm

--- a/llvm/lib/Debuginfod/Debuginfod.cpp
+++ b/llvm/lib/Debuginfod/Debuginfod.cpp
@@ -274,7 +274,13 @@ Expected<std::string> getCachedOrDownloadArtifact(
         parseCachePruningPolicy(std::getenv("DEBUGINFOD_CACHE_POLICY"));
     if (!PruningPolicyOrErr)
       return PruningPolicyOrErr.takeError();
-    pruneCache(CacheDirectoryPath, *PruningPolicyOrErr);
+
+    Expected<bool> PrunedOrErr =
+        pruneCache(CacheDirectoryPath, *PruningPolicyOrErr);
+    // Log the error but continue execution: failure to prune the cache is not
+    // fatal.
+    if (!PrunedOrErr)
+      logAllUnhandledErrors(PrunedOrErr.takeError(), WithColor::warning());
 
     // Return the path to the artifact on disk.
     return std::string(AbsCachedArtifactPath);

--- a/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
+++ b/llvm/lib/LTO/ThinLTOCodeGenerator.cpp
@@ -1224,7 +1224,12 @@ void ThinLTOCodeGenerator::run() {
     }
   }
 
-  pruneCache(CacheOptions.Path, CacheOptions.Policy, ProducedBinaries);
+  Expected<bool> PrunedOrErr =
+      pruneCache(CacheOptions.Path, CacheOptions.Policy, ProducedBinaries);
+  if (!PrunedOrErr) {
+    errs() << "Error: " << toString(PrunedOrErr.takeError()) << "\n";
+    report_fatal_error("ThinLTO: failure to prune cache");
+  }
 
   // If statistics were requested, print them out now.
   if (llvm::AreStatisticsEnabled())

--- a/llvm/lib/Support/CachePruning.cpp
+++ b/llvm/lib/Support/CachePruning.cpp
@@ -142,8 +142,9 @@ llvm::parseCachePruningPolicy(StringRef PolicyStr) {
 }
 
 /// Prune the cache of files that haven't been accessed in a long time.
-bool llvm::pruneCache(StringRef Path, CachePruningPolicy Policy,
-                      const std::vector<std::unique_ptr<MemoryBuffer>> &Files) {
+Expected<bool>
+llvm::pruneCache(StringRef Path, CachePruningPolicy Policy,
+                 const std::vector<std::unique_ptr<MemoryBuffer>> &Files) {
   using namespace std::chrono;
 
   if (Path.empty())
@@ -278,13 +279,14 @@ bool llvm::pruneCache(StringRef Path, CachePruningPolicy Policy,
 
   // Prune for size now if needed
   if (Policy.MaxSizePercentageOfAvailableSpace > 0 || Policy.MaxSizeBytes > 0) {
-    auto ErrOrSpaceInfo = sys::fs::disk_space(Path);
-    if (!ErrOrSpaceInfo) {
-      auto EC = ErrOrSpaceInfo.getError();
-      report_fatal_error(Twine("Can't get available size for '") + Path.str() +
-                         "': " + EC.message());
+    auto SpaceInfoOrErr = sys::fs::disk_space(Path);
+    if (!SpaceInfoOrErr) {
+      auto EC = SpaceInfoOrErr.getError();
+      return createStringError(EC,
+                               "cannot get available disk space for '%s': '%s'",
+                               Path.str().c_str(), EC.message().c_str());
     }
-    sys::fs::space_info SpaceInfo = ErrOrSpaceInfo.get();
+    sys::fs::space_info SpaceInfo = SpaceInfoOrErr.get();
     auto AvailableSpace = TotalSize + SpaceInfo.free;
 
     if (Policy.MaxSizePercentageOfAvailableSpace == 0)

--- a/llvm/tools/gold/gold-plugin.cpp
+++ b/llvm/tools/gold/gold-plugin.cpp
@@ -1220,7 +1220,7 @@ static ld_plugin_status cleanup_hook(void) {
   // Prune cache
   if (!options::cache_dir.empty()) {
     CachePruningPolicy policy = check(parseCachePruningPolicy(options::cache_policy));
-    pruneCache(options::cache_dir, policy);
+    check(pruneCache(options::cache_dir, policy));
   }
 
   return LDPS_OK;


### PR DESCRIPTION
The upstream PR https://github.com/llvm/llvm-project/pull/191367 makes `pruneCache` return a proper error when `disk_space`
 fails. We can safely ignore the error (but we at least log it).

This PR is to be merged before https://github.com/llvm/llvm-project/pull/191367 lands,
such that our branch is always in a consistent state.

Only the last commit is relevant for amd-staging,.