### PR TITLE
[AMDGPU] comgr: split non-stride64 DS 2-address ops for A0

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -146,12 +146,21 @@ std::string fmtOffset(uint32_t Offset) {
 // For b32 operations, destinations are split into individual VGPRs.
 // For b64 operations, destinations are split into VGPR pairs (v[X:Y]).
 
+// Maximum byte offset encodable in a single-address DS instruction's
+// 16-bit immediate offset field on gfx12. The replacement we emit uses
+// this field directly, so any scaled byte offset that exceeds it cannot
+// be represented and the patch must be skipped.
+constexpr uint32_t Ds1AddrOffsetMax = 0xFFFF;
+
 struct DsOperands {
   SmallVector<MCRegister, 4> Regs;
-  uint32_t Off0;
-  uint32_t Off1;
-  bool IsB64;
-  const MCRegisterInfo *MRI;
+  uint32_t Off0 = 0;
+  uint32_t Off1 = 0;
+  bool IsB64 = false;
+  // Cleared if extractDsOperands cannot produce an offset that fits the
+  // single-address DS encoding; callers must check before consuming Off*.
+  bool Valid = true;
+  const MCRegisterInfo *MRI = nullptr;
 };
 
 // Extract register operands and scaled offsets from a DS 2-address MCInst.
@@ -161,6 +170,13 @@ struct DsOperands {
 // (index * 64 * ElemBytes) byte offsets. The replacement single-address
 // instructions take byte offsets directly, so we materialise the scaled
 // value here once and let the layout-specific helpers consume it.
+//
+// Range check: the stride64 b64 encoding can scale a raw 8-bit index up to
+// 255 * 64 * 8 = 130560 bytes, which overflows the single-address 16-bit
+// offset field (max 0xFFFF = 65535). When that happens the patch is not
+// representable in this expansion shape and we mark the operand bag
+// invalid so the caller leaves the original (broken-on-A0) instruction
+// in place rather than emitting a silently-truncated replacement.
 DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
                              const LLVMState &LS) {
   DsOperands Ops;
@@ -183,8 +199,23 @@ DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
 
   uint32_t ElemBytes = FromMnem.contains("_b64") ? 8 : 4;
   uint32_t Scale = FromMnem.contains("_stride64_") ? 64 * ElemBytes : ElemBytes;
-  Ops.Off0 = static_cast<uint32_t>(RawOff0) * Scale;
-  Ops.Off1 = static_cast<uint32_t>(RawOff1) * Scale;
+  // Compute scaled offsets in 64-bit so an oversize stride64_b64 index
+  // does not silently wrap when assigned to Off*.
+  uint64_t Scaled0 = static_cast<uint64_t>(RawOff0) * Scale;
+  uint64_t Scaled1 = static_cast<uint64_t>(RawOff1) * Scale;
+  if (Scaled0 > Ds1AddrOffsetMax || Scaled1 > Ds1AddrOffsetMax) {
+    log() << "hotswap: error: " << FromMnem
+          << " scaled offsets exceed the single-address DS 16-bit field "
+             "(off0=raw "
+          << RawOff0 << " * scale " << Scale << " = " << Scaled0
+          << ", off1=raw " << RawOff1 << " * scale " << Scale << " = "
+          << Scaled1 << ", max " << Ds1AddrOffsetMax
+          << "); leaving original instruction in place\n";
+    Ops.Valid = false;
+    return Ops;
+  }
+  Ops.Off0 = static_cast<uint32_t>(Scaled0);
+  Ops.Off1 = static_cast<uint32_t>(Scaled1);
   Ops.IsB64 = (ElemBytes == 8);
   return Ops;
 }
@@ -270,15 +301,17 @@ std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
 std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
                                        StringRef ToMnem, const LLVMState &LS) {
   DsOperands Ops = extractDsOperands(Inst, FromMnem, LS);
+  if (!Ops.Valid)
+    return {};
 
-  if (FromMnem.starts_with("ds_load"))
+  // Use the trailing underscore so the three prefixes are disjoint
+  // ("ds_load_", "ds_store_", "ds_storexchg_"); without it "ds_store" is a
+  // prefix of "ds_storexchg" and the dispatch order would matter.
+  if (FromMnem.starts_with("ds_load_"))
     return expandDs2AddrLoad(Ops, ToMnem);
-  // Order matters: "ds_storexchg" must be checked before "ds_store" since
-  // the latter is a prefix of the former and would otherwise greedily match
-  // the xchg mnemonics.
-  if (FromMnem.starts_with("ds_storexchg"))
+  if (FromMnem.starts_with("ds_storexchg_"))
     return expandDs2AddrXchg(Ops, ToMnem);
-  if (FromMnem.starts_with("ds_store"))
+  if (FromMnem.starts_with("ds_store_"))
     return expandDs2AddrStore(Ops, ToMnem);
 
   log() << "hotswap: error: unrecognized DS mnemonic: " << FromMnem << "\n";

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -147,7 +147,7 @@ std::string fmtOffset(uint32_t Offset) {
 // For b64 operations, destinations are split into VGPR pairs (v[X:Y]).
 
 // Maximum byte offset encodable in a single-address DS instruction's
-// 16-bit immediate offset field on gfx12. The replacement we emit uses
+// 16-bit immediate offset field on gfx1250. The replacement we emit uses
 // this field directly, so any scaled byte offset that exceeds it cannot
 // be represented and the patch must be skipped.
 constexpr uint32_t Ds1AddrOffsetMax = 0xFFFF;
@@ -157,9 +157,6 @@ struct DsOperands {
   uint32_t Off0 = 0;
   uint32_t Off1 = 0;
   bool IsB64 = false;
-  // Cleared if extractDsOperands cannot produce an offset that fits the
-  // single-address DS encoding; callers must check before consuming Off*.
-  bool Valid = true;
   const MCRegisterInfo *MRI = nullptr;
 };
 
@@ -174,11 +171,11 @@ struct DsOperands {
 // Range check: the stride64 b64 encoding can scale a raw 8-bit index up to
 // 255 * 64 * 8 = 130560 bytes, which overflows the single-address 16-bit
 // offset field (max 0xFFFF = 65535). When that happens the patch is not
-// representable in this expansion shape and we mark the operand bag
-// invalid so the caller leaves the original (broken-on-A0) instruction
-// in place rather than emitting a silently-truncated replacement.
-DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
-                             const LLVMState &LS) {
+// representable in this expansion shape; std::nullopt signals the failure
+// to the caller, which leaves the original (broken-on-A0) instruction in
+// place rather than emitting a silently-truncated replacement.
+std::optional<DsOperands>
+extractDsOperands(const MCInst &Inst, StringRef FromMnem, const LLVMState &LS) {
   DsOperands Ops;
   Ops.MRI = LS.MRI.get();
 
@@ -211,8 +208,7 @@ DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
           << ", off1=raw " << RawOff1 << " * scale " << Scale << " = "
           << Scaled1 << ", max " << Ds1AddrOffsetMax
           << "); leaving original instruction in place\n";
-    Ops.Valid = false;
-    return Ops;
+    return std::nullopt;
   }
   Ops.Off0 = static_cast<uint32_t>(Scaled0);
   Ops.Off1 = static_cast<uint32_t>(Scaled1);
@@ -300,19 +296,19 @@ std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
 
 std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
                                        StringRef ToMnem, const LLVMState &LS) {
-  DsOperands Ops = extractDsOperands(Inst, FromMnem, LS);
-  if (!Ops.Valid)
+  std::optional<DsOperands> Ops = extractDsOperands(Inst, FromMnem, LS);
+  if (!Ops)
     return {};
 
   // Use the trailing underscore so the three prefixes are disjoint
   // ("ds_load_", "ds_store_", "ds_storexchg_"); without it "ds_store" is a
   // prefix of "ds_storexchg" and the dispatch order would matter.
   if (FromMnem.starts_with("ds_load_"))
-    return expandDs2AddrLoad(Ops, ToMnem);
+    return expandDs2AddrLoad(*Ops, ToMnem);
   if (FromMnem.starts_with("ds_storexchg_"))
-    return expandDs2AddrXchg(Ops, ToMnem);
+    return expandDs2AddrXchg(*Ops, ToMnem);
   if (FromMnem.starts_with("ds_store_"))
-    return expandDs2AddrStore(Ops, ToMnem);
+    return expandDs2AddrStore(*Ops, ToMnem);
 
   log() << "hotswap: error: unrecognized DS mnemonic: " << FromMnem << "\n";
   return {};

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -8,8 +8,13 @@
 /// \file
 /// Strong-symbol override for applyTrampolinePatches. Handles B0 errata
 /// whose fix is larger than the original instruction:
-///   - ds_*_2addr_stride64_*  : one 8B DS instruction -> two single-address
-///     DS instructions
+///   - ds_*_2addr_*           : one 8B DS instruction -> two single-address
+///     DS instructions. Covers both the stride64 and non-stride64 encodings:
+///     A0 requires DS2 addresses to be aligned to the payload size, while
+///     B0 dropped that restriction, so a B0-compiled binary may emit a
+///     2-address DS instruction with unaligned offsets that silently
+///     corrupts LDS on A0. The expansion uses two single-address ops with
+///     byte offsets scaled appropriately for each encoding.
 ///   - tensor_load_to_lds     : prepend s_pack_hh_b32_b16 to clear multicast
 ///     routing bits in the group descriptor's base SGPR
 ///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
@@ -39,16 +44,27 @@ namespace COMGR {
 namespace hotswap {
 namespace {
 
-// -- DS stride64 swap table (StringSwitch) ----------------------------------
+// -- DS 2-address swap table (StringSwitch) ---------------------------------
 //
-// Maps each 2-address DS mnemonic to its single-address replacement.
+// Maps each 2-address DS mnemonic to its single-address replacement. Covers
+// both encodings -- the stride64 variants pack the index*64*ElemBytes
+// stride into each per-operand offset field, while the non-stride64
+// variants encode raw index*ElemBytes byte offsets. The single-address
+// replacement is the same regardless of encoding; only the offset scale
+// differs (see extractDsOperands).
 
 StringRef getDs2AddrReplacement(StringRef Mnemonic) {
   return StringSwitch<StringRef>(Mnemonic)
+      .Case("ds_load_2addr_b32", "ds_load_b32")
+      .Case("ds_load_2addr_b64", "ds_load_b64")
       .Case("ds_load_2addr_stride64_b32", "ds_load_b32")
       .Case("ds_load_2addr_stride64_b64", "ds_load_b64")
+      .Case("ds_store_2addr_b32", "ds_store_b32")
+      .Case("ds_store_2addr_b64", "ds_store_b64")
       .Case("ds_store_2addr_stride64_b32", "ds_store_b32")
       .Case("ds_store_2addr_stride64_b64", "ds_store_b64")
+      .Case("ds_storexchg_2addr_rtn_b32", "ds_storexchg_rtn_b32")
+      .Case("ds_storexchg_2addr_rtn_b64", "ds_storexchg_rtn_b64")
       .Case("ds_storexchg_2addr_stride64_rtn_b32", "ds_storexchg_rtn_b32")
       .Case("ds_storexchg_2addr_stride64_rtn_b64", "ds_storexchg_rtn_b64")
       .Default("");
@@ -120,10 +136,12 @@ std::string fmtOffset(uint32_t Offset) {
 // -- DS expansion -----------------------------------------------------------
 //
 // Expands one DS 2-address instruction into two single-address assembly
-// strings. The three operation types have different operand layouts:
-//   Load:  ds_load_2addr_stride64  vdst_pair, addr, off0, off1
-//   Store: ds_store_2addr_stride64 addr, data0, data1, off0, off1
-//   Xchg:  ds_storexchg_2addr_stride64_rtn vdst_pair, addr, data0, data1, ...
+// strings. The three operation types have different operand layouts (the
+// stride64 and non-stride64 encodings share identical operand layouts;
+// only the offset scale differs):
+//   Load:  ds_load_2addr[_stride64]  vdst_pair, addr, off0, off1
+//   Store: ds_store_2addr[_stride64] addr, data0, data1, off0, off1
+//   Xchg:  ds_storexchg_2addr[_stride64]_rtn vdst_pair, addr, data0, data1, ...
 //
 // For b32 operations, destinations are split into individual VGPRs.
 // For b64 operations, destinations are split into VGPR pairs (v[X:Y]).
@@ -137,7 +155,12 @@ struct DsOperands {
 };
 
 // Extract register operands and scaled offsets from a DS 2-address MCInst.
-// Offsets are scaled by 64 * element_size (stride64 encoding).
+// The per-operand immediate fields hold dword indices that the hardware
+// scales differently for the two encodings: the non-stride64 forms encode
+// (index * ElemBytes) byte offsets, while the stride64 forms encode
+// (index * 64 * ElemBytes) byte offsets. The replacement single-address
+// instructions take byte offsets directly, so we materialise the scaled
+// value here once and let the layout-specific helpers consume it.
 DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
                              const LLVMState &LS) {
   DsOperands Ops;
@@ -159,7 +182,7 @@ DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
   }
 
   uint32_t ElemBytes = FromMnem.contains("_b64") ? 8 : 4;
-  uint32_t Scale = 64 * ElemBytes;
+  uint32_t Scale = FromMnem.contains("_stride64_") ? 64 * ElemBytes : ElemBytes;
   Ops.Off0 = static_cast<uint32_t>(RawOff0) * Scale;
   Ops.Off1 = static_cast<uint32_t>(RawOff1) * Scale;
   Ops.IsB64 = (ElemBytes == 8);
@@ -250,6 +273,9 @@ std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
 
   if (FromMnem.starts_with("ds_load"))
     return expandDs2AddrLoad(Ops, ToMnem);
+  // Order matters: "ds_storexchg" must be checked before "ds_store" since
+  // the latter is a prefix of the former and would otherwise greedily match
+  // the xchg mnemonics.
   if (FromMnem.starts_with("ds_storexchg"))
     return expandDs2AddrXchg(Ops, ToMnem);
   if (FromMnem.starts_with("ds_store"))
@@ -330,13 +356,17 @@ bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
   return false;
 }
 
-// -- patchDs2AddrStride64 ---------------------------------------------------
+// -- patchDs2Addr -----------------------------------------------------------
 //
-// Expand one ds_*_2addr_stride64_* instruction into two single-address DS
-// instructions. The split doubles the outstanding DS operation count, so
-// bumpNextWaitDscnt adjusts the next s_wait_dscnt accordingly.
+// Expand one ds_*_2addr_* instruction (stride64 or non-stride64) into two
+// single-address DS instructions. Each split adds one outstanding DS op, so
+// bumpNextWaitDscnt increments the next non-drain s_wait_dscnt by +1 per
+// split and preserves drains verbatim. Because that helper writes the bumped
+// immediate back into Ctx.Decoded[I].Inst, adjacent DS2 sites that target
+// the same non-drain wait accumulate (the second call observes the first
+// call's update, so N splits before one wait produce a K -> K+N update).
 
-bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
+bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
@@ -344,8 +374,8 @@ bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
   std::vector<std::string> Expanded =
       expandDs2Addr(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
   if (Expanded.empty()) {
-    log() << "hotswap: error: ds_2addr_stride64 expansion failed for: "
-          << DI.Mnemonic << "\n";
+    log() << "hotswap: error: ds_2addr expansion failed for: " << DI.Mnemonic
+          << "\n";
     return false;
   }
 
@@ -354,8 +384,7 @@ bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
     Combined += Line + "\n";
   SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
   if (Bytes.empty()) {
-    log() << "hotswap: error: ds_2addr_stride64: assembly failed: " << Combined
-          << "\n";
+    log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
     return false;
   }
 
@@ -363,7 +392,10 @@ bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return false;
 
-  bumpNextWaitDscnt(Ctx, Idx);
+  // Return value intentionally discarded: false is a normal outcome when the
+  // wait is a drain (preserved), absent before s_endpgm/branch, or carries a
+  // non-immediate operand -- none of which are errors at this site.
+  (void)bumpNextWaitDscnt(Ctx, Idx);
   DI.Mnemonic = "<replaced>";
   return true;
 }
@@ -840,7 +872,8 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
 // Strong-symbol override. Handles B0 errata that produce replacement code
 // larger than the original instruction slot:
 //
-//   ds_*_2addr_stride64_*  -> split into two single-address DS ops
+//   ds_*_2addr_*           -> split into two single-address DS ops
+//     (covers both the stride64 and non-stride64 encodings)
 //   tensor_load_to_lds     -> prepend s_pack_hh_b32_b16 (+ save/restore)
 //   ds_*_addtid_b32        -> materialise lane-id math in ALU, then ds_*_b32
 
@@ -848,7 +881,7 @@ static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
   if (!getDs2AddrReplacement(Mnem).empty())
-    return patchDs2AddrStride64(Ctx, Idx) ? 1 : 0;
+    return patchDs2Addr(Ctx, Idx) ? 1 : 0;
 
   if (Mnem == "tensor_load_to_lds")
     return patchTensorLoadToLds(Ctx, Idx) ? 1 : 0;

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -12,7 +12,9 @@
 // COM:
 // COM: Companion test:
 // COM:   hotswap-trampoline-ds-nostride64.s -- non-stride64 base case
-// COM:     (load b32, load b64, store b32, exchange b32) drain forms.
+// COM:     (load b32, load b64, store b32, exchange b32, store b64,
+// COM:     exchange b64, and a load+store+xchg combination kernel) drain
+// COM:     forms.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -24,30 +26,34 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// ---- Kernel: 2x ds_load_2addr_b32 + drain s_wait_dscnt 0x0 ----------------
 // COM: Both DS2 instructions are replaced by s_branch to their respective
 // COM: expansion sleds. The single shared s_wait_dscnt stays at 0x0
 // COM: (drain preservation under stacking in the non-stride64 path).
+// COM: The two sleds together expand to 4 single-address ds_load_b32
+// COM: instructions; offsets (raw 1/2 and 3/4) scale by ElemBytes=4 to
+// COM: byte offsets 4/8 and 12/16 across the two sites.
 // DISASM-LABEL: <test_multi_ds_nostride64>:
 // DISASM-NOT: ds_load_2addr_b32
 // DISASM: s_branch
 // DISASM: s_branch
 // DISASM: s_wait_dscnt 0x0
+// COM: Sled 1 (first DS2 site, vdst pair v[0:1]).
+// DISASM: ds_load_b32 v0, v4 offset:4
+// DISASM-NEXT: ds_load_b32 v1, v4 offset:8
+// COM: Sled 2 (second DS2 site, vdst pair v[2:3]).
+// DISASM: ds_load_b32 v2, v4 offset:12
+// DISASM-NEXT: ds_load_b32 v3, v4 offset:16
 
-// COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
-
-.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
-.text
 .globl test_multi_ds_nostride64
 .p2align 8
 .type test_multi_ds_nostride64,@function
 test_multi_ds_nostride64:
-  ds_load_2addr_b32 v[0:1], v4 offset0:0 offset1:1
-  ds_load_2addr_b32 v[2:3], v4 offset0:2 offset1:3
+  ds_load_2addr_b32 v[0:1], v4 offset0:1 offset1:2
+  ds_load_2addr_b32 v[2:3], v4 offset0:3 offset1:4
   s_wait_dscnt 0x0
   s_endpgm
   s_nop 0
@@ -74,6 +80,13 @@ test_multi_ds_nostride64:
   s_nop 0
 .Ltest_multi_ds_nostride64_end:
 .size test_multi_ds_nostride64, .Ltest_multi_ds_nostride64_end-test_multi_ds_nostride64
+
+// COM: Idempotency: rewriting the output again should produce identical bytes.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -1,0 +1,83 @@
+// COM: Test multi-DS stacking for the non-stride64 DS 2-address family:
+// COM: two ds_load_2addr_b32 sites before a single s_wait_dscnt 0x0
+// COM: (drain). Both splits target the same wait, but because it is a
+// COM: drain it must stay at 0x0 after the patch -- bumping it (to 0x1
+// COM: or 0x2) would relax the wait and let split halves escape past it.
+// COM:
+// COM: The Ctx.Decoded writeback path itself (the ROCm/llvm-project#2281
+// COM: review concern raised by @yxsamliu, that adjacent splits before the
+// COM: same wait must accumulate bumps via in-place imm update) is
+// COM: exercised by the non-drain bump test hotswap-trampoline-ds-pipelined.s,
+// COM: whose multi-split kernel walks the wait from 0x1 to 0x3.
+// COM:
+// COM: Companion test:
+// COM:   hotswap-trampoline-ds-nostride64.s -- non-stride64 base case
+// COM:     (load b32, load b64, store b32, exchange b32) drain forms.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Both DS2 instructions are replaced by s_branch to their respective
+// COM: expansion sleds. The single shared s_wait_dscnt stays at 0x0
+// COM: (drain preservation under stacking in the non-stride64 path).
+// DISASM-LABEL: <test_multi_ds_nostride64>:
+// DISASM-NOT: ds_load_2addr_b32
+// DISASM: s_branch
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+
+// COM: Idempotency
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_multi_ds_nostride64
+.p2align 8
+.type test_multi_ds_nostride64,@function
+test_multi_ds_nostride64:
+  ds_load_2addr_b32 v[0:1], v4 offset0:0 offset1:1
+  ds_load_2addr_b32 v[2:3], v4 offset0:2 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_multi_ds_nostride64_end:
+.size test_multi_ds_nostride64, .Ltest_multi_ds_nostride64_end-test_multi_ds_nostride64
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_multi_ds_nostride64
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -1,0 +1,265 @@
+// COM: Test HotSwap trampoline patch for the non-stride64 DS 2-address
+// COM: family: ds_*_2addr_b{32,64} and ds_storexchg_2addr_rtn_b{32,64}.
+// COM: Covers b32 load, b64 load, b32 store, b64 store, and b32 exchange.
+// COM: These differ from the stride64 forms only in the byte-offset scale
+// COM: applied to each per-operand index (ElemBytes vs 64 * ElemBytes), so
+// COM: the trampoline shape (s_branch forward + sled + s_branch back) and
+// COM: the s_wait_dscnt handling are shared with the stride64 path. Each
+// COM: kernel here uses s_wait_dscnt 0x0 (drain) as input and exercises
+// COM: the drain-preservation rule: the imm must stay at 0x0 after the
+// COM: split (bumping a drain to K would let K split halves escape past
+// COM: the wait).
+// COM:
+// COM: Companion tests:
+// COM:   hotswap-trampoline-ds-nostride64-multi.s -- drain preservation
+// COM:     under multi-DS stacking in the non-stride64 path.
+// COM:   hotswap-trampoline-ds-pipelined.s -- non-drain bump path (covers
+// COM:     the Ctx.Decoded writeback for the 0x1 -> 0x2 / 0x3 case
+// COM:     originally raised in the ROCm/llvm-project#2281 review).
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: --- Per-kernel checks ---
+
+// COM: Kernel 1 (b32 load, non-stride64): offsets index*4. Source
+// COM: offset0:4 offset1:8 -> byte offsets 16 and 32. The input wait is
+// COM: s_wait_dscnt 0x0 (drain) and stays at 0x0 after the split.
+// DISASM-LABEL: <test_ds_load_b32_nostride64>:
+// DISASM-NOT: ds_load_2addr_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_load_b32 v0, v2 offset:16
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:32
+// DISASM: s_branch
+
+// COM: Kernel 2 (b64 load, non-stride64): offsets index*8. Source
+// COM: offset0:1 offset1:2 -> byte offsets 8 and 16. b64 destinations
+// COM: format as v[X:Y] register pairs; drain wait stays at 0x0.
+// DISASM-LABEL: <test_ds_load_b64_nostride64>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_load_b64 v[0:1], v4 offset:8
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
+// DISASM: s_branch
+
+// COM: Kernel 3 (b32 store, non-stride64): store operand layout
+// COM: (addr, data0, data1). Source offset0:1 offset1:2 -> byte
+// COM: offsets 4 and 8; drain wait stays at 0x0.
+// DISASM-LABEL: <test_ds_store_b32_nostride64>:
+// DISASM-NOT: ds_store_2addr_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_store_b32 v2, v0 offset:4
+// DISASM-NEXT: ds_store_b32 v2, v1 offset:8
+// DISASM: s_branch
+
+// COM: Kernel 4 (b32 exchange, non-stride64): exchange operand layout
+// COM: (dst, addr, data0, data1). Source offset0:1 offset1:3 -> byte
+// COM: offsets 4 and 12; drain wait stays at 0x0.
+// DISASM-LABEL: <test_ds_xchg_b32_nostride64>:
+// DISASM-NOT: ds_storexchg_2addr_rtn_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_storexchg_rtn_b32 v0, v2, v3 offset:4
+// DISASM-NEXT: ds_storexchg_rtn_b32 v1, v2, v4 offset:12
+// DISASM: s_branch
+
+// COM: Kernel 5 (b64 store, non-stride64): store operand layout (addr,
+// COM: data0_pair, data1_pair). Source offset0:1 offset1:2 -> byte
+// COM: offsets 8 and 16. b64 data operands format as v[X:Y] register
+// COM: pairs (exercises fmtRegOperand on the data side, complementing
+// COM: kernel 2 which exercises it on the destination side); drain
+// COM: wait stays at 0x0.
+// DISASM-LABEL: <test_ds_store_b64_nostride64>:
+// DISASM-NOT: ds_store_2addr_b64
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_store_b64 v4, v[0:1] offset:8
+// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:16
+// DISASM: s_branch
+
+// COM: Idempotency: rewriting the output again should produce identical
+// COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// ---- Kernel 1: ds_load_2addr_b32 (non-stride64, byte offset = idx*4) -------
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_load_b32_nostride64
+.p2align 8
+.type test_ds_load_b32_nostride64,@function
+test_ds_load_b32_nostride64:
+  ds_load_2addr_b32 v[0:1], v2 offset0:4 offset1:8
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_load_b32_nostride64_end:
+.size test_ds_load_b32_nostride64, .Ltest_ds_load_b32_nostride64_end-test_ds_load_b32_nostride64
+
+// ---- Kernel 2: ds_load_2addr_b64 (non-stride64, byte offset = idx*8) -------
+
+.globl test_ds_load_b64_nostride64
+.p2align 8
+.type test_ds_load_b64_nostride64,@function
+test_ds_load_b64_nostride64:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_load_b64_nostride64_end:
+.size test_ds_load_b64_nostride64, .Ltest_ds_load_b64_nostride64_end-test_ds_load_b64_nostride64
+
+// ---- Kernel 3: ds_store_2addr_b32 (non-stride64 store operand layout) ------
+
+.globl test_ds_store_b32_nostride64
+.p2align 8
+.type test_ds_store_b32_nostride64,@function
+test_ds_store_b32_nostride64:
+  ds_store_2addr_b32 v2, v0, v1 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_store_b32_nostride64_end:
+.size test_ds_store_b32_nostride64, .Ltest_ds_store_b32_nostride64_end-test_ds_store_b32_nostride64
+
+// ---- Kernel 4: ds_storexchg_2addr_rtn_b32 (non-stride64 exchange layout) ---
+
+.globl test_ds_xchg_b32_nostride64
+.p2align 8
+.type test_ds_xchg_b32_nostride64,@function
+test_ds_xchg_b32_nostride64:
+  ds_storexchg_2addr_rtn_b32 v[0:1], v2, v3, v4 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_xchg_b32_nostride64_end:
+.size test_ds_xchg_b32_nostride64, .Ltest_ds_xchg_b32_nostride64_end-test_ds_xchg_b32_nostride64
+
+// ---- Kernel 5: ds_store_2addr_b64 (non-stride64 store, b64 data pairs) -----
+
+.globl test_ds_store_b64_nostride64
+.p2align 8
+.type test_ds_store_b64_nostride64,@function
+test_ds_store_b64_nostride64:
+  ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_store_b64_nostride64_end:
+.size test_ds_store_b64_nostride64, .Ltest_ds_store_b64_nostride64_end-test_ds_store_b64_nostride64
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_load_b32_nostride64
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_load_b64_nostride64
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_store_b32_nostride64
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_xchg_b32_nostride64
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_store_b64_nostride64
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -1,6 +1,11 @@
 // COM: Test HotSwap trampoline patch for the non-stride64 DS 2-address
 // COM: family: ds_*_2addr_b{32,64} and ds_storexchg_2addr_rtn_b{32,64}.
-// COM: Covers b32 load, b64 load, b32 store, b64 store, and b32 exchange.
+// COM: Covers (1) b32 load, (2) b64 load, (3) b32 store, (4) b32 exchange,
+// COM: (5) b64 store, (6) b64 exchange, and (7) a load+store+xchg
+// COM: combination kernel that exercises the per-instruction dispatcher
+// COM: in applyTrampolinePatchesImpl across multiple variant types in a
+// COM: single trampoline pass.
+// COM:
 // COM: These differ from the stride64 forms only in the byte-offset scale
 // COM: applied to each per-operand index (ElemBytes vs 64 * ElemBytes), so
 // COM: the trampoline shape (s_branch forward + sled + s_branch back) and
@@ -27,8 +32,10 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: --- Per-kernel checks ---
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
 
+// ---- Kernel 1: ds_load_2addr_b32 (non-stride64, byte offset = idx*4) -------
 // COM: Kernel 1 (b32 load, non-stride64): offsets index*4. Source
 // COM: offset0:4 offset1:8 -> byte offsets 16 and 32. The input wait is
 // COM: s_wait_dscnt 0x0 (drain) and stays at 0x0 after the split.
@@ -40,65 +47,6 @@
 // DISASM-NEXT: ds_load_b32 v1, v2 offset:32
 // DISASM: s_branch
 
-// COM: Kernel 2 (b64 load, non-stride64): offsets index*8. Source
-// COM: offset0:1 offset1:2 -> byte offsets 8 and 16. b64 destinations
-// COM: format as v[X:Y] register pairs; drain wait stays at 0x0.
-// DISASM-LABEL: <test_ds_load_b64_nostride64>:
-// DISASM-NOT: ds_load_2addr_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_load_b64 v[0:1], v4 offset:8
-// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
-// DISASM: s_branch
-
-// COM: Kernel 3 (b32 store, non-stride64): store operand layout
-// COM: (addr, data0, data1). Source offset0:1 offset1:2 -> byte
-// COM: offsets 4 and 8; drain wait stays at 0x0.
-// DISASM-LABEL: <test_ds_store_b32_nostride64>:
-// DISASM-NOT: ds_store_2addr_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_store_b32 v2, v0 offset:4
-// DISASM-NEXT: ds_store_b32 v2, v1 offset:8
-// DISASM: s_branch
-
-// COM: Kernel 4 (b32 exchange, non-stride64): exchange operand layout
-// COM: (dst, addr, data0, data1). Source offset0:1 offset1:3 -> byte
-// COM: offsets 4 and 12; drain wait stays at 0x0.
-// DISASM-LABEL: <test_ds_xchg_b32_nostride64>:
-// DISASM-NOT: ds_storexchg_2addr_rtn_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_storexchg_rtn_b32 v0, v2, v3 offset:4
-// DISASM-NEXT: ds_storexchg_rtn_b32 v1, v2, v4 offset:12
-// DISASM: s_branch
-
-// COM: Kernel 5 (b64 store, non-stride64): store operand layout (addr,
-// COM: data0_pair, data1_pair). Source offset0:1 offset1:2 -> byte
-// COM: offsets 8 and 16. b64 data operands format as v[X:Y] register
-// COM: pairs (exercises fmtRegOperand on the data side, complementing
-// COM: kernel 2 which exercises it on the destination side); drain
-// COM: wait stays at 0x0.
-// DISASM-LABEL: <test_ds_store_b64_nostride64>:
-// DISASM-NOT: ds_store_2addr_b64
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: ds_store_b64 v4, v[0:1] offset:8
-// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:16
-// DISASM: s_branch
-
-// COM: Idempotency: rewriting the output again should produce identical
-// COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
-
-// ---- Kernel 1: ds_load_2addr_b32 (non-stride64, byte offset = idx*4) -------
-
-.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
-.text
 .globl test_ds_load_b32_nostride64
 .p2align 8
 .type test_ds_load_b32_nostride64,@function
@@ -126,6 +74,16 @@ test_ds_load_b32_nostride64:
 .size test_ds_load_b32_nostride64, .Ltest_ds_load_b32_nostride64_end-test_ds_load_b32_nostride64
 
 // ---- Kernel 2: ds_load_2addr_b64 (non-stride64, byte offset = idx*8) -------
+// COM: Kernel 2 (b64 load, non-stride64): offsets index*8. Source
+// COM: offset0:1 offset1:2 -> byte offsets 8 and 16. b64 destinations
+// COM: format as v[X:Y] register pairs; drain wait stays at 0x0.
+// DISASM-LABEL: <test_ds_load_b64_nostride64>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_load_b64 v[0:1], v4 offset:8
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
+// DISASM: s_branch
 
 .globl test_ds_load_b64_nostride64
 .p2align 8
@@ -154,6 +112,16 @@ test_ds_load_b64_nostride64:
 .size test_ds_load_b64_nostride64, .Ltest_ds_load_b64_nostride64_end-test_ds_load_b64_nostride64
 
 // ---- Kernel 3: ds_store_2addr_b32 (non-stride64 store operand layout) ------
+// COM: Kernel 3 (b32 store, non-stride64): store operand layout
+// COM: (addr, data0, data1). Source offset0:1 offset1:2 -> byte
+// COM: offsets 4 and 8; drain wait stays at 0x0.
+// DISASM-LABEL: <test_ds_store_b32_nostride64>:
+// DISASM-NOT: ds_store_2addr_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_store_b32 v2, v0 offset:4
+// DISASM-NEXT: ds_store_b32 v2, v1 offset:8
+// DISASM: s_branch
 
 .globl test_ds_store_b32_nostride64
 .p2align 8
@@ -182,6 +150,16 @@ test_ds_store_b32_nostride64:
 .size test_ds_store_b32_nostride64, .Ltest_ds_store_b32_nostride64_end-test_ds_store_b32_nostride64
 
 // ---- Kernel 4: ds_storexchg_2addr_rtn_b32 (non-stride64 exchange layout) ---
+// COM: Kernel 4 (b32 exchange, non-stride64): exchange operand layout
+// COM: (dst, addr, data0, data1). Source offset0:1 offset1:3 -> byte
+// COM: offsets 4 and 12; drain wait stays at 0x0.
+// DISASM-LABEL: <test_ds_xchg_b32_nostride64>:
+// DISASM-NOT: ds_storexchg_2addr_rtn_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_storexchg_rtn_b32 v0, v2, v3 offset:4
+// DISASM-NEXT: ds_storexchg_rtn_b32 v1, v2, v4 offset:12
+// DISASM: s_branch
 
 .globl test_ds_xchg_b32_nostride64
 .p2align 8
@@ -210,6 +188,19 @@ test_ds_xchg_b32_nostride64:
 .size test_ds_xchg_b32_nostride64, .Ltest_ds_xchg_b32_nostride64_end-test_ds_xchg_b32_nostride64
 
 // ---- Kernel 5: ds_store_2addr_b64 (non-stride64 store, b64 data pairs) -----
+// COM: Kernel 5 (b64 store, non-stride64): store operand layout (addr,
+// COM: data0_pair, data1_pair). Source offset0:1 offset1:2 -> byte
+// COM: offsets 8 and 16. b64 data operands format as v[X:Y] register
+// COM: pairs (exercises fmtRegOperand on the data side, complementing
+// COM: kernel 2 which exercises it on the destination side); drain
+// COM: wait stays at 0x0.
+// DISASM-LABEL: <test_ds_store_b64_nostride64>:
+// DISASM-NOT: ds_store_2addr_b64
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_store_b64 v4, v[0:1] offset:8
+// DISASM-NEXT: ds_store_b64 v4, v[2:3] offset:16
+// DISASM: s_branch
 
 .globl test_ds_store_b64_nostride64
 .p2align 8
@@ -237,6 +228,130 @@ test_ds_store_b64_nostride64:
 .Ltest_ds_store_b64_nostride64_end:
 .size test_ds_store_b64_nostride64, .Ltest_ds_store_b64_nostride64_end-test_ds_store_b64_nostride64
 
+// ---- Kernel 6: ds_storexchg_2addr_rtn_b64 (non-stride64 b64 exchange) ------
+// COM: Kernel 6 (b64 exchange, non-stride64): exchange operand layout
+// COM: (dst_pair, addr, data0_pair, data1_pair). Source offset0:1
+// COM: offset1:2 -> byte offsets 8 and 16. Both vdst halves AND the data
+// COM: operands format as v[X:Y] register pairs (exercises splitDstPair
+// COM: AND fmtRegOperand on b64 within the xchg dispatch path, complementing
+// COM: kernel 4 which exercises the b32 xchg layout); drain wait stays
+// COM: at 0x0.
+// DISASM-LABEL: <test_ds_xchg_b64_nostride64>:
+// DISASM-NOT: ds_storexchg_2addr_rtn_b64
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_storexchg_rtn_b64 v[0:1], v8, v[4:5] offset:8
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[2:3], v8, v[6:7] offset:16
+// DISASM: s_branch
+
+.globl test_ds_xchg_b64_nostride64
+.p2align 8
+.type test_ds_xchg_b64_nostride64,@function
+test_ds_xchg_b64_nostride64:
+  ds_storexchg_2addr_rtn_b64 v[0:3], v8, v[4:5], v[6:7] offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_xchg_b64_nostride64_end:
+.size test_ds_xchg_b64_nostride64, .Ltest_ds_xchg_b64_nostride64_end-test_ds_xchg_b64_nostride64
+
+// ---- Kernel 7: combination (load + store + xchg in one kernel) -------------
+// COM: Kernel 7 (combination, non-stride64): a single function body mixes
+// COM: ds_load_2addr_b32, ds_store_2addr_b32, and ds_storexchg_2addr_rtn_b32
+// COM: before a single drain s_wait_dscnt 0x0. Verifies that the per-
+// COM: instruction dispatcher in applyTrampolinePatchesImpl correctly
+// COM: routes each variant to its own expansion type without state leakage
+// COM: across types in a single trampoline pass; drain wait stays at 0x0
+// COM: across all three split sites. Sleds appear in source order: load,
+// COM: store, xchg. All offsets scale by ElemBytes=4.
+// COM:   ds_load_2addr_b32  offset0:1 offset1:2 -> byte 4, 8
+// COM:   ds_store_2addr_b32 offset0:3 offset1:4 -> byte 12, 16
+// COM:   ds_storexchg_*_b32 offset0:5 offset1:6 -> byte 20, 24
+// DISASM-LABEL: <test_ds_combo_nostride64>:
+// DISASM-NOT: ds_load_2addr_b32
+// DISASM-NOT: ds_store_2addr_b32
+// DISASM-NOT: ds_storexchg_2addr_rtn_b32
+// DISASM: s_branch
+// DISASM: s_branch
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// COM: Sled 1: load expansion.
+// DISASM: ds_load_b32 v0, v8 offset:4
+// DISASM-NEXT: ds_load_b32 v1, v8 offset:8
+// COM: Sled 2: store expansion.
+// DISASM: ds_store_b32 v8, v2 offset:12
+// DISASM-NEXT: ds_store_b32 v8, v3 offset:16
+// COM: Sled 3: xchg expansion.
+// DISASM: ds_storexchg_rtn_b32 v4, v8, v6 offset:20
+// DISASM-NEXT: ds_storexchg_rtn_b32 v5, v8, v7 offset:24
+
+.globl test_ds_combo_nostride64
+.p2align 8
+.type test_ds_combo_nostride64,@function
+test_ds_combo_nostride64:
+  ds_load_2addr_b32 v[0:1], v8 offset0:1 offset1:2
+  ds_store_2addr_b32 v8, v2, v3 offset0:3 offset1:4
+  ds_storexchg_2addr_rtn_b32 v[4:5], v8, v6, v7 offset0:5 offset1:6
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_combo_nostride64_end:
+.size test_ds_combo_nostride64, .Ltest_ds_combo_nostride64_end-test_ds_combo_nostride64
+
+// COM: Idempotency: rewriting the output again should produce identical
+// COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
 .rodata
 .p2align 8
 .amdhsa_kernel test_ds_load_b32_nostride64
@@ -261,5 +376,15 @@ test_ds_store_b64_nostride64:
 
 .amdhsa_kernel test_ds_store_b64_nostride64
   .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_xchg_b64_nostride64
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_combo_nostride64
+  .amdhsa_next_free_vgpr 9
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
@@ -1,0 +1,154 @@
+// COM: Test the offset-overflow guard in extractDsOperands. The single-
+// COM: address DS instructions that the trampoline emits use a 16-bit
+// COM: immediate offset field (max 0xFFFF = 65535 bytes). The stride64
+// COM: forms scale a raw 8-bit per-operand index by (64 * ElemBytes), so
+// COM: ds_*_2addr_stride64_b64 (Scale = 512) overflows for any raw index
+// COM: >= 128:
+// COM:
+// COM:   raw 128 * 512 = 65536  -- one past the limit
+// COM:   raw 255 * 512 = 130560 -- worst case
+// COM:
+// COM: When that happens the patch is not representable, so the trampoline
+// COM: must leave the original (broken-on-A0) instruction in place rather
+// COM: than emit a silently-truncated single-address replacement.
+// COM:
+// COM: Coverage:
+// COM:   test_ds_load_b64_overflow : raw 128/255 -> scaled 65536/130560
+// COM:                               (both off0 and off1 overflow)
+// COM:   test_ds_load_b64_inrange  : raw 1/2 -> scaled 512/1024
+// COM:                               (control: in-range stride64_b64 IS rewritten)
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// COM: Capture the verbose log on stderr to confirm the overflow message
+// COM: fires for the out-of-range kernel. AMD_COMGR_EMIT_VERBOSE_LOGS=1
+// COM: routes log() to llvm::errs(); we merge it into stdout for FileCheck.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LOG %s
+// COM: Pin the message shape (mnemonic, both raw + scaled values, the
+// COM: 16-bit limit, and the "leaving original instruction in place"
+// COM: closer) so a regression in the message format or the limit
+// COM: constant fails here, not in some downstream-symptoms test. The
+// COM: generic "ds_2addr expansion failed" line is the patchDs2Addr-level
+// COM: error that follows naturally from the overflow guard returning
+// COM: an empty expansion; pin it too so a refactor that reroutes the
+// COM: error path is caught. RESULT: SUCCESS comes last because the
+// COM: rewrite as a whole succeeds (the in-range kernel is patched).
+// LOG:      hotswap: error: ds_load_2addr_stride64_b64 scaled offsets exceed
+// LOG-SAME: the single-address DS 16-bit field
+// LOG-SAME: off0=raw 128 * scale 512 = 65536
+// LOG-SAME: off1=raw 255 * scale 512 = 130560
+// LOG-SAME: max 65535
+// LOG-SAME: leaving original instruction in place
+// LOG:      hotswap: error: ds_2addr expansion failed for: ds_load_2addr_stride64_b64
+// LOG:      RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// ---- Kernel 1: out-of-range -- patch must NOT fire --------------------------
+// COM: Both per-operand indices scale past 0xFFFF (off0:128 -> 65536,
+// COM: off1:255 -> 130560). The trampoline must reject the patch and
+// COM: leave ds_load_2addr_stride64_b64 in the kernel verbatim. No
+// COM: s_branch is inserted, no replacement ds_load_b64 appears, the
+// COM: NOP sled is unused. The DISASM-NOT lines pin all three negatives.
+// DISASM-LABEL: <test_ds_load_b64_overflow>:
+// DISASM:       ds_load_2addr_stride64_b64 v[0:3], v4 offset0:128 offset1:255
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  s_endpgm
+// DISASM-NOT:   s_branch
+// DISASM-NOT:   ds_load_b64
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_load_b64_overflow
+.p2align 8
+.type test_ds_load_b64_overflow,@function
+test_ds_load_b64_overflow:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:128 offset1:255
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_load_b64_overflow_end:
+.size test_ds_load_b64_overflow, .Ltest_ds_load_b64_overflow_end-test_ds_load_b64_overflow
+
+// ---- Kernel 2: in-range -- patch MUST fire (negative control) --------------
+// COM: Same opcode as kernel 1 but raw indices 1 and 2 (scaled 512 and
+// COM: 1024, well below 0xFFFF). The patch must fire here -- otherwise
+// COM: kernel 1 above would pass for the wrong reason (patch broken
+// COM: across the board, not specifically gated by the overflow check).
+// DISASM-LABEL: <test_ds_load_b64_inrange>:
+// DISASM-NOT:   ds_load_2addr_stride64_b64
+// DISASM:       s_branch
+// DISASM:       s_wait_dscnt 0x0
+// DISASM:       ds_load_b64 v[0:1], v4 offset:512
+// DISASM-NEXT:  ds_load_b64 v[2:3], v4 offset:1024
+// DISASM:       s_branch
+
+.globl test_ds_load_b64_inrange
+.p2align 8
+.type test_ds_load_b64_inrange,@function
+test_ds_load_b64_inrange:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_load_b64_inrange_end:
+.size test_ds_load_b64_inrange, .Ltest_ds_load_b64_inrange_end-test_ds_load_b64_inrange
+
+// COM: Idempotency. For the overflow kernel the original instruction is
+// COM: still a ds_*_2addr_*, so the second pass would attempt to patch
+// COM: it again, hit the same overflow, and again leave it alone. For
+// COM: the in-range kernel the body now uses plain ds_load_b64, which
+// COM: the dispatcher does not recognise, so it is also untouched. Net:
+// COM: byte-identical output between passes.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_load_b64_overflow
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_load_b64_inrange
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel


### PR DESCRIPTION
Depends on #2584.

## Summary
A0 silicon requires DS 2-address instructions to have offsets aligned to the payload size. 
B0 dropped that restriction, so a B0-compiled binary may emit a 2-address DS instruction with unaligned offsets that silently corrupts LDS on A0.

The trampoline PR (introduced in #2369, with the drain-preserving wait fix in #2584) already covers the stride64 variants. This PR extends `getDs2AddrReplacement` and `extractDsOperands` in `comgr-hotswap-patch-trampoline.cpp` to the non-stride64 encodings of the same families, including the `storexchg` form:

| Mnemonic | Replacement | Byte-offset scale |
|---|---|---|
| `ds_load_2addr_b32`           | 2× `ds_load_b32`           | `index * 4` |
| `ds_load_2addr_b64`           | 2× `ds_load_b64`           | `index * 8` |
| `ds_store_2addr_b32`          | 2× `ds_store_b32`          | `index * 4` |
| `ds_store_2addr_b64`          | 2× `ds_store_b64`          | `index * 8` |
| `ds_storexchg_2addr_rtn_b32`  | 2× `ds_storexchg_rtn_b32`  | `index * 4` |
| `ds_storexchg_2addr_rtn_b64`  | 2× `ds_storexchg_rtn_b64`  | `index * 8` |

The stride64 forms encode `index * 64 * ElemBytes` byte offsets; the non-stride64 forms encode `index * ElemBytes`. Replacement single-address instructions take byte offsets directly, so a single ternary in `extractDsOperands` materialises the right scale for each encoding and the layout-specific expansion helpers are unchanged.

## Follow-up
- Cache resolved opcodes in `LLVMState` at init time (same follow-up as [#2257).](https://github.com/ROCm/llvm-project/issues/2253#issuecomment-4346485087)