### PR TITLE
[AMDGPU] comgr: swap s_barrier_signal_isfirst to s_barrier_signal for A0

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -132,13 +132,23 @@ uint32_t applyInPlacePatches(PatchContext &Ctx, size_t Idx) {
   // original barrier-ID operand. The dummy "-1" is only used to resolve
   // the target opcode via the asm parser.
   //
-  // The _M0 form (s_barrier_signal_isfirst m0) is a separate mnemonic
-  // that does not match this check. The AMDGPU backend never emits
-  // _M0 for compute kernels (no .cpp reference to
-  // S_BARRIER_SIGNAL_ISFIRST_M0 exists outside tablegen/SIInstrInfo.h
-  // predicates), so we intentionally skip it. If a binary ever contains
-  // the _M0 form, the swap will not fire and the log below will report
-  // the miss.
+  // Correctness caveat: the isfirst variant defines SCC; the non-isfirst
+  // variant does not. If downstream code reads SCC expecting the result
+  // of isfirst (e.g. an s_cbranch_scc1 selecting the elected wave), the
+  // swap leaves that read consuming stale SCC. On A0 the isfirst result
+  // is already unreliable due to the underlying race, so the swap removes
+  // a known-broken code path rather than introducing a new one. But it
+  // is not a semantic equivalence. Liveness/CFG-aware detection of SCC
+  // consumers is undecidable in general; the proper fix lives in
+  // A0-targeted Clang codegen and is out of scope for hotswap. This
+  // patch is a runtime mitigation for B0 binaries running on A0.
+  //
+  // The _M0 form has a different tablegen mnemonic string
+  // ("s_barrier_signal_isfirst m0", with the "m0" baked into the
+  // mnemonic itself, not as an operand -- see S_BARRIER_SIGNAL_ISFIRST_M0
+  // in SOPInstructions.td), so it does not match this equality check
+  // and falls through to the dispatcher's "no match" return below.
+  // The AMDGPU backend never emits the _M0 form for compute kernels.
   if (Mnemonic == "s_barrier_signal_isfirst") {
     std::optional<unsigned> NewOpcode =
         resolveOpcode("s_barrier_signal -1", Ctx.LS);
@@ -147,12 +157,6 @@ uint32_t applyInPlacePatches(PatchContext &Ctx, size_t Idx) {
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
       return 1;
     }
-  }
-
-  if (Mnemonic == "s_barrier_signal_isfirst m0") {
-    log() << "hotswap: warning: s_barrier_signal_isfirst m0 at 0x"
-          << utohexstr(DI.Offset)
-          << " not patched (compiler-emitted _M0 form unexpected)\n";
   }
 
   return 0;

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -9,9 +9,13 @@
 /// Strong-symbol override for applyInPlacePatches.  Handles instruction
 /// rewrites that fit in the same code size as the original:
 ///
-///   - cluster_load -> global_load   (opcode swap via MCInst + MCCodeEmitter)
-///   - s_clause     -> s_nop         (byte-level overwrite via
-///   applyByteReplace)
+///   - cluster_load             -> global_load    (opcode swap via MCInst +
+///                                                 MCCodeEmitter)
+///   - s_clause                 -> s_nop          (byte-level overwrite via
+///                                                 applyByteReplace)
+///   - s_barrier_signal_isfirst -> s_barrier_signal
+///                                                (opcode swap; same operand
+///                                                 layout, drops SCC write)
 ///
 /// No trampolines, ELF growth, or extra VGPRs are required.
 ///
@@ -118,6 +122,37 @@ uint32_t applyInPlacePatches(PatchContext &Ctx, size_t Idx) {
             << utohexstr(DI.Offset) << "\n";
       return 1;
     }
+  }
+
+  // s_barrier_signal_isfirst -> s_barrier_signal: on A0, the isfirst
+  // variant may return stale SCC when cluster barriers are in flight.
+  // Both S_BARRIER_SIGNAL_IMM and S_BARRIER_SIGNAL_ISFIRST_IMM share
+  // a single SplitBarrier:$src0 immediate operand (see SOPInstructions.td),
+  // so cloning the decoded MCInst and flipping the opcode preserves the
+  // original barrier-ID operand. The dummy "-1" is only used to resolve
+  // the target opcode via the asm parser.
+  //
+  // The _M0 form (s_barrier_signal_isfirst m0) is a separate mnemonic
+  // that does not match this check. The AMDGPU backend never emits
+  // _M0 for compute kernels (no .cpp reference to
+  // S_BARRIER_SIGNAL_ISFIRST_M0 exists outside tablegen/SIInstrInfo.h
+  // predicates), so we intentionally skip it. If a binary ever contains
+  // the _M0 form, the swap will not fire and the log below will report
+  // the miss.
+  if (Mnemonic == "s_barrier_signal_isfirst") {
+    std::optional<unsigned> NewOpcode =
+        resolveOpcode("s_barrier_signal -1", Ctx.LS);
+    if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
+      log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
+            << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
+      return 1;
+    }
+  }
+
+  if (Mnemonic == "s_barrier_signal_isfirst m0") {
+    log() << "hotswap: warning: s_barrier_signal_isfirst m0 at 0x"
+          << utohexstr(DI.Offset)
+          << " not patched (compiler-emitted _M0 form unexpected)\n";
   }
 
   return 0;

--- a/amd/comgr/test-lit/hotswap-barrier-isfirst.s
+++ b/amd/comgr/test-lit/hotswap-barrier-isfirst.s
@@ -1,0 +1,59 @@
+// COM: Test HotSwap in-place patch s_barrier_signal_isfirst -> s_barrier_signal
+// COM: for GFX1250 A0. A0 may return stale SCC before the barrier completes
+// COM: when the barrier ID names a user cluster barrier; the non-isfirst
+// COM: variant shares encoding size and operand layout but does not write SCC.
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: Verify the patched layout: both isfirst sites are replaced by the
+// COM: non-isfirst variant in place with their operand values preserved
+// COM: (-1 stays -1, -3 stays -3). Surrounding waits and endpgm stay put.
+// COM: DISASM-NOT brackets ensure no s_barrier_signal_isfirst remains
+// COM: anywhere. Wait operands are shown as raw 16-bit hex by llvm-objdump
+// COM: (signed -1 = 0xffff, -3 = 0xfffd).
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: s_barrier_signal_isfirst
+// DISASM: s_barrier_signal -1
+// DISASM-NEXT: s_barrier_wait 0xffff
+// DISASM-NEXT: s_barrier_signal -3
+// DISASM-NEXT: s_barrier_wait 0xfffd
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: s_barrier_signal_isfirst
+
+// COM: Idempotency: rewriting the patched output again must produce
+// COM: identical bytes.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_barrier_isfirst
+.p2align 8
+.type test_barrier_isfirst,@function
+test_barrier_isfirst:
+  // Two isfirst sites with different barrier IDs; both must be swapped
+  // to s_barrier_signal in place with their operand values preserved.
+  s_barrier_signal_isfirst -1
+  s_barrier_wait -1
+  s_barrier_signal_isfirst -3
+  s_barrier_wait -3
+  s_endpgm
+.Ltest_barrier_isfirst_end:
+.size test_barrier_isfirst, .Ltest_barrier_isfirst_end-test_barrier_isfirst
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_barrier_isfirst
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-barrier-mixed.s
+++ b/amd/comgr/test-lit/hotswap-barrier-mixed.s
@@ -1,0 +1,81 @@
+// COM: Selectivity test for the s_barrier_signal_isfirst -> s_barrier_signal
+// COM: in-place patch. A kernel containing isfirst (IMM), non-isfirst, and
+// COM: the _M0 form must have only the IMM isfirst sites rewritten; both
+// COM: non-isfirst and _M0 sites must pass through unchanged. This guards
+// COM: against a regression where the dispatcher accidentally matches the
+// COM: non-isfirst mnemonic (e.g. via prefix or contains() rather than
+// COM: equality) and documents the intentional _M0 passthrough.
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: Verify the patched layout. Kernel order is:
+// COM:   s_barrier_signal_isfirst -1     (IMM, gets swapped)
+// COM:   s_barrier_wait -1               (unchanged)
+// COM:   s_barrier_signal -3             (already non-isfirst, unchanged)
+// COM:   s_barrier_wait -3               (unchanged)
+// COM:   s_barrier_signal_isfirst m0     (_M0 form, intentionally NOT swapped)
+// COM:   s_barrier_wait 0xffff           (unchanged)
+// COM:   s_barrier_signal_isfirst -1     (IMM, gets swapped)
+// COM:   s_barrier_wait -1               (unchanged)
+// COM:   s_endpgm
+// COM: After patching, the two IMM isfirst sites become s_barrier_signal -1.
+// COM: The _M0 site passes through unchanged because the compiler never
+// COM: emits it (separate mnemonic, intentional skip with diagnostic).
+// COM: CHECK-NEXT chain pins the exact interleaving. The leading CHECK-NOT
+// COM: only covers the range before the first match; the _M0 site in the
+// COM: middle is verified structurally by the CHECK-NEXT chain itself.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: s_barrier_signal_isfirst -
+// DISASM: s_barrier_signal -1
+// DISASM-NEXT: s_barrier_wait 0xffff
+// DISASM-NEXT: s_barrier_signal -3
+// DISASM-NEXT: s_barrier_wait 0xfffd
+// DISASM-NEXT: s_barrier_signal_isfirst m0
+// DISASM-NEXT: s_barrier_wait 0xffff
+// DISASM-NEXT: s_barrier_signal -1
+// DISASM-NEXT: s_barrier_wait 0xffff
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: s_barrier_signal_isfirst -
+
+// COM: Idempotency: second rewrite must produce identical bytes (the swapped
+// COM: kernel has no isfirst left, so the second pass is a no-op).
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_barrier_mixed
+.p2align 8
+.type test_barrier_mixed,@function
+test_barrier_mixed:
+  s_barrier_signal_isfirst -1
+  s_barrier_wait -1
+  // Pre-existing non-isfirst site: verifies the dispatcher matches on
+  // equality, not prefix or substring.
+  s_barrier_signal -3
+  s_barrier_wait -3
+  // _M0 form: separate mnemonic, intentionally not patched.
+  s_barrier_signal_isfirst m0
+  s_barrier_wait -1
+  s_barrier_signal_isfirst -1
+  s_barrier_wait -1
+  s_endpgm
+.Ltest_barrier_mixed_end:
+.size test_barrier_mixed, .Ltest_barrier_mixed_end-test_barrier_mixed
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_barrier_mixed
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-barrier-no-isfirst.s
+++ b/amd/comgr/test-lit/hotswap-barrier-no-isfirst.s
@@ -1,0 +1,57 @@
+// COM: Passthrough test for the s_barrier_signal_isfirst -> s_barrier_signal
+// COM: in-place patch. A kernel that already uses the non-isfirst form must
+// COM: be left structurally unchanged: no isfirst should appear anywhere in
+// COM: the patched output, and the original s_barrier_signal sites must
+// COM: remain in place with their original operands.
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: Strict no-op verification: original layout preserved; isfirst variant
+// COM: never appears. CHECK-NOT covers both pre- and post-kernel ranges.
+// COM: Wait operands are shown by llvm-objdump as raw 16-bit hex (signed
+// COM: -1 = 0xffff, -3 = 0xfffd).
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: s_barrier_signal_isfirst
+// DISASM: s_barrier_signal -1
+// DISASM-NEXT: s_barrier_wait 0xffff
+// DISASM-NEXT: s_barrier_signal -3
+// DISASM-NEXT: s_barrier_wait 0xfffd
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: s_barrier_signal_isfirst
+
+// COM: Idempotency: second rewrite must produce identical bytes.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_barrier_no_isfirst
+.p2align 8
+.type test_barrier_no_isfirst,@function
+test_barrier_no_isfirst:
+  // Workgroup barrier (-1) and a user cluster barrier (-3); neither uses
+  // the isfirst form, so the patch must leave both unchanged.
+  s_barrier_signal -1
+  s_barrier_wait -1
+  s_barrier_signal -3
+  s_barrier_wait -3
+  s_endpgm
+.Ltest_barrier_no_isfirst_end:
+.size test_barrier_no_isfirst, .Ltest_barrier_no_isfirst_end-test_barrier_no_isfirst
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_barrier_no_isfirst
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel


### PR DESCRIPTION
## Summary

A0 silicon has a race condition where `s_barrier_signal_isfirst` with a user cluster barrier ID may return garbage in SCC before the barrier completes. The non-isfirst variant (`s_barrier_signal`) has the same encoding size and operand layout but does not write SCC.

This patch adds the `s_barrier_signal_isfirst` -> `s_barrier_signal` in-place opcode swap to the existing `applyInPlacePatches` dispatcher alongside the `cluster_load -> global_load` and `s_clause -> s_nop` rules from #2222. The swap is unconditional for all `s_barrier_signal_isfirst` instructions. Non-isfirst `s_barrier_signal` sites are left unchanged.

## Changes
- **comgr-hotswap-patch-inplace.cpp**: Add `s_barrier_signal_isfirst` -> `s_barrier_signal` swap using the existing `resolveOpcode` / `swapOpcode` helpers. Same pattern as the `cluster_load` swap -- no new infrastructure.
- **hotswap-barrier-isfirst.s**: Positive lit test - kernel with 2x `s_barrier_signal_isfirst -1`. Verifies both are swapped to `s_barrier_signal`, waits are unchanged, no `s_barrier_signal_isfirst` remains anywhere in disassembly. Idempotency check via second rewrite + `cmp`.
- **hotswap-barrier-no-isfirst.s**: Passthrough lit test - kernel with only `s_barrier_signal` (workgroup -1 and user cluster -3). Verifies layout is structurally unchanged and no `s_barrier_signal_isfirst` appears. Idempotency check.
- **hotswap-barrier-mixed.s**: Selectivity lit test - kernel with both `s_barrier_signal_isfirst` and `s_barrier_signal` interleaved. Verifies only the isfirst sites are swapped; the pre-existing non-isfirst site is preserved. Guards against a `starts_with` / `contains` regression in the mnemonic match.

## Tests
- 3 lit tests (positive / passthrough / mixed selectivity) with strict CHECK-NEXT chains and CHECK-NOT brackets
- All existing lit, ctest, and unit tests pass

## Follow up (already tracked)  
Cache all in-place target opcodes in LLVMState at init time (covers cluster_load, s_barrier_signal, and future in-place swaps). Currently each swap calls resolveOpcode per instruction site;
caching at init eliminates redundant assemble+decode on every match.
This is tracked as part of the hotswap code-refactoring effort alongside the others (#2253)