### PR TITLE
[offload] Fix synchronization when record replay is enabled (#193291)

### DIFF
--- a/offload/plugins-nextgen/common/include/PluginInterface.h
+++ b/offload/plugins-nextgen/common/include/PluginInterface.h
@@ -151,6 +151,14 @@ struct AsyncInfoWrapperTy {
     return getQueueAs<Ty>();
   }
 
+  /// Explicitly synchronize with the __tgt_async_info's pending operations
+  /// regardless of which async info this object wraps. The associated
+  /// underlying queue (if any) will not be released. Calling this function does
+  /// not obviate the need to call the finalize function later. This function is
+  /// intended for specific use cases where a synchronous operation needs to
+  /// explicitly wait for the operations already on the queue.
+  Error synchronize();
+
   /// Synchronize with the __tgt_async_info's pending operations if it's the
   /// internal async info. The error associated to the asynchronous operations
   /// issued in this queue must be provided in \p Err. This function will update
@@ -419,8 +427,7 @@ struct GenericKernelTy {
   Error launch(GenericDeviceTy &GenericDevice, void **ArgPtrs,
                ptrdiff_t *ArgOffsets, KernelArgsTy &KernelArgs,
                KernelExtraArgsTy *KernelExtraArgs,
-               AsyncInfoWrapperTy &AsyncInfoWrapper,
-               RecordReplayTy::HandleTy *RRHandle = nullptr) const;
+               AsyncInfoWrapperTy &AsyncInfoWrapper) const;
   virtual Error launchImpl(GenericDeviceTy &GenericDevice,
                            uint32_t NumThreads[3], uint32_t NumBlocks[3],
                            uint32_t DynBlockMemSize, KernelArgsTy &KernelArgs,

--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -54,6 +54,13 @@ AsyncInfoWrapperTy::AsyncInfoWrapperTy(GenericDeviceTy &Device,
   LocalAsyncInfo.ProfilerData = nullptr;
 }
 
+Error AsyncInfoWrapperTy::synchronize() {
+  assert(AsyncInfoPtr && "AsyncInfoWrapperTy already finalized");
+
+  // Synchronize with the async info's operations without releasing the queue.
+  return Device.synchronize(AsyncInfoPtr, /*ReleaseQueue=*/false);
+}
+
 void AsyncInfoWrapperTy::finalize(Error &Err) {
   assert(AsyncInfoPtr && "AsyncInfoWrapperTy already finalized");
 
@@ -320,8 +327,7 @@ GenericKernelTy::prepareBlockMemory(GenericDeviceTy &GenericDevice,
 Error GenericKernelTy::launch(GenericDeviceTy &GenericDevice, void **ArgPtrs,
                               ptrdiff_t *ArgOffsets, KernelArgsTy &KernelArgs,
                               KernelExtraArgsTy *KernelExtraArgs,
-                              AsyncInfoWrapperTy &AsyncInfoWrapper,
-                              RecordReplayTy::HandleTy *RRHandle) const {
+                              AsyncInfoWrapperTy &AsyncInfoWrapper) const {
   llvm::SmallVector<void *, 16> Args;
   llvm::SmallVector<void *, 16> Ptrs;
 
@@ -424,33 +430,47 @@ Error GenericKernelTy::launch(GenericDeviceTy &GenericDevice, void **ArgPtrs,
                                 NumThreads[0], KernelArgs.ThreadLimit[0] > 0);
   }
 
-  // Record the kernel description after we modified the argument count and num
-  // blocks/threads.
+  if (auto Err = printLaunchInfo(GenericDevice, KernelArgs, NumThreads,
+                                 NumBlocks, MultiDeviceLB, MultiDeviceUB))
+    return Err;
+
+  RecordReplayTy::HandleTy RRHandle;
   RecordReplayTy *RecordReplay = GenericDevice.getRecordReplay();
   if (RecordReplay) {
+    // Record replay requires synchronization of any previous operation.
+    if (auto Err = AsyncInfoWrapper.synchronize())
+      return Err;
+
+    // Record the kernel prologue data before kernel launch.
     auto RRHandleOrErr = RecordReplay->recordPrologue(
         *this, KernelArgs, KernelExtraArgs, LaunchParams, NumBlocks, NumThreads,
         DynBlockMemConf.NativeSize);
     if (!RRHandleOrErr)
       return RRHandleOrErr.takeError();
-    if (RRHandle)
-      *RRHandle = *RRHandleOrErr;
+    RRHandle = *RRHandleOrErr;
   }
 
   // Get achieved occupancy for this kernel.
   computeAchievedOccupancy(GenericDevice, NumThreads[0], NumBlocks[0]);
 
-  if (auto Err = printLaunchInfo(GenericDevice, KernelArgs, NumThreads,
-                                 NumBlocks, MultiDeviceLB, MultiDeviceUB))
-    return Err;
-
   if (GenericDevice.Plugin.getProfiler())
     GenericDevice.Plugin.getProfiler()->handlePreKernelLaunch(
         &GenericDevice, NumBlocks, AsyncInfoWrapper);
 
-  return launchImpl(GenericDevice, NumThreads, NumBlocks,
-                    DynBlockMemConf.NativeSize, KernelArgs, LaunchParams,
-                    AsyncInfoWrapper);
+  if (auto Err = launchImpl(GenericDevice, NumThreads, NumBlocks,
+                            DynBlockMemConf.NativeSize, KernelArgs, LaunchParams,
+                            AsyncInfoWrapper))
+    return Err;
+
+  if (RecordReplay) {
+    // Record replay requires synchronization.
+    if (auto Err = AsyncInfoWrapper.synchronize())
+      return Err;
+
+    // Record the epilogue data after kernel synchronization.
+    return RecordReplay->recordEpilogue(*this, RRHandle);
+  }
+  return Plugin::success();
 }
 
 KernelLaunchParamsTy
@@ -1260,8 +1280,7 @@ Error GenericDeviceTy::launchKernel(void *EntryPtr, void **ArgPtrs,
                                     KernelArgsTy &KernelArgs,
                                     KernelExtraArgsTy *KernelExtraArgs,
                                     __tgt_async_info *AsyncInfo) {
-  AsyncInfoWrapperTy AsyncInfoWrapper(*this,
-                                      RecordReplay ? nullptr : AsyncInfo);
+  AsyncInfoWrapperTy AsyncInfoWrapper(*this, AsyncInfo);
 
   GenericKernelTy &GenericKernel =
       *reinterpret_cast<GenericKernelTy *>(EntryPtr);
@@ -1278,16 +1297,10 @@ Error GenericDeviceTy::launchKernel(void *EntryPtr, void **ArgPtrs,
         .emplace(&GenericKernel, std::move(StackTrace), AsyncInfo);
   }
 
-  RecordReplayTy::HandleTy RRHandle;
   auto Err = GenericKernel.launch(*this, ArgPtrs, ArgOffsets, KernelArgs,
-                                  KernelExtraArgs, AsyncInfoWrapper, &RRHandle);
+                                  KernelExtraArgs, AsyncInfoWrapper);
 
-  // 'finalize' here to guarantee next record-replay actions are in-sync
   AsyncInfoWrapper.finalize(Err);
-
-  if (RecordReplay)
-    if (auto Err = RecordReplay->recordEpilogue(GenericKernel, RRHandle))
-      return Err;
 
   return Err;
 }


### PR DESCRIPTION
When kernel record replay was enabled, the operations on the current stream were not synchronized. That's because the current stream was "ignored", and a new stream was used when RR is active. This is invalid when there are pending operations on the original stream and can lead to invalid prologue recording data.

This commit addresses this issue by using the original stream and synchronizing it explicitly before and after kernel launch. This way, we ensure the operations are completed before performing the prologue and epilogue data recording. Additionally, the kernel record replay entry points are moved to the same layer, in `GenericKernelTy::launch()`.


