### PR TITLE
[Comgr] Add end-to-end LIT coverage for amd_comgr_hotswap_rewrite

### DIFF
--- a/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
@@ -22,12 +22,30 @@ int main(int argc, char *argv[]) {
   }
 
   if (argc < 4)
-    fail("usage: hotswap-rewrite <elf_file> <source_isa> <target_isa> [--zero-size]");
+    fail("usage: hotswap-rewrite <elf_file> <source_isa> <target_isa> "
+         "[--zero-size | --output <path>]");
 
   const char *ElfFile = argv[1];
   const char *SourceISA = argv[2];
   const char *TargetISA = argv[3];
-  int ZeroSize = (argc > 4 && strcmp(argv[4], "--zero-size") == 0);
+
+  // Optional trailing flags. They are mutually exclusive; --zero-size is
+  // used by the negative tests that exercise INVALID_ARGUMENT paths;
+  // --output <path> is used by the e2e test to save the rewrite output
+  // for inspection by llvm-readelf / llvm-objdump.
+  int ZeroSize = 0;
+  const char *OutputPath = NULL;
+  if (argc > 4) {
+    if (strcmp(argv[4], "--zero-size") == 0) {
+      ZeroSize = 1;
+    } else if (strcmp(argv[4], "--output") == 0) {
+      if (argc < 6)
+        fail("--output requires a path argument");
+      OutputPath = argv[5];
+    } else {
+      fail("unknown flag '%s'", argv[4]);
+    }
+  }
 
   char *ElfBuf;
   size_t ElfSize = (size_t)setBuf(ElfFile, &ElfBuf);
@@ -65,6 +83,9 @@ int main(int argc, char *argv[]) {
 
   if (memcmp(OutBuf, ElfBuf, ElfSize) != 0)
     fail("output content differs from input");
+
+  if (OutputPath)
+    dumpData(OutputData, OutputPath);
 
   free(OutBuf);
   amd_comgr_(release_data(OutputData));

--- a/amd/comgr/test-lit/hotswap-rewrite-e2e.hip
+++ b/amd/comgr/test-lit/hotswap-rewrite-e2e.hip
@@ -1,0 +1,60 @@
+// COM: End-to-end coverage of the HotSwap rewrite pipeline on a real
+// COM: clang-produced gfx1250 code object. Drives the full
+// COM: compile -> hotswap-rewrite -> verify chain using the in-tree
+// COM: clang + llvm-readelf + llvm-objdump substitutions.
+// COM:
+// COM: Patches in amd/comgr/src/comgr-hotswap-b0a0.cpp are weak stubs
+// COM: returning 0 until the concrete patch .cpp files land, so the
+// COM: dispatcher currently emits an output that is bytewise-identical
+// COM: to the input. Even with no patches applied we can assert that
+// COM: (1) the rewrite returns SUCCESS, (2) the output is a valid
+// COM: gfx1250 ELF that preserves the ISA identification, and (3) .text
+// COM: is still present and disassemblable as AMDGPU code. The
+// COM: per-patch PRs will layer in their own `llvm-objdump | FileCheck`
+// COM: stanzas on top of this harness to assert their specific opcode
+// COM: changes / trampolines.
+
+// COM: Compile a tiny kernel targeting gfx1250 to a raw code object.
+// RUN: %clang --offload-arch=gfx1250 --offload-device-only \
+// RUN:     --no-gpu-bundle-output -nogpulib -nogpuinc \
+// RUN:     %s -o %t.input.elf
+
+// COM: Sanity: input is a gfx1250 ELF (attested in both the e_flags
+// COM: field of the ELF header and the AMDHSA metadata note).
+// RUN: %llvm-readelf -h %t.input.elf | %FileCheck --check-prefix=INPUT-FLAGS %s
+// INPUT-FLAGS: Flags:{{.*}}gfx1250
+// RUN: %llvm-readelf --notes %t.input.elf | %FileCheck --check-prefix=INPUT-META %s
+// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+
+// COM: Run hotswap-rewrite; save the output so we can inspect it.
+// RUN: hotswap-rewrite %t.input.elf \
+// RUN:     amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:     --output %t.output.elf \
+// RUN:   | %FileCheck --check-prefix=STATUS %s
+// STATUS: RESULT: SUCCESS
+
+// COM: Output ELF is valid and still identifies as gfx1250 (patches are
+// COM: weak stubs, so the identity should be preserved untouched; future
+// COM: patch PRs that intentionally change the target ISA note will
+// COM: update this stanza).
+// RUN: %llvm-readelf -h %t.output.elf | %FileCheck --check-prefix=OUTPUT-FLAGS %s
+// OUTPUT-FLAGS: Flags:{{.*}}gfx1250
+// RUN: %llvm-readelf --notes %t.output.elf | %FileCheck --check-prefix=OUTPUT-META %s
+// OUTPUT-META: amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+
+// COM: .text section is still present and marked executable.
+// RUN: %llvm-readelf --section-headers %t.output.elf \
+// RUN:   | %FileCheck --check-prefix=SECTIONS %s
+// SECTIONS: .text{{.*}}PROGBITS
+
+// COM: Disassembly is legible as AMDGPU code. The function symbol name
+// COM: depends on C++ mangling; we do not hard-code it here.
+// RUN: %llvm-objdump -d %t.output.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM: file format elf64-amdgpu
+// DISASM: Disassembly of section .text:
+// DISASM: s_endpgm
+
+__attribute__((global))
+void add(float *A, float *B, float *C) {
+  *C = *A + *B;
+}

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -34,5 +34,6 @@ def _fwd(*parts):
 config.substitutions.append(('%clang', _fwd(config.llvm_tools_dir, 'clang')))
 config.substitutions.append(('%llvm-dis', _fwd(config.llvm_tools_dir, 'llvm-dis')))
 config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-objdump')))
+config.substitutions.append(('%llvm-readelf', _fwd(config.llvm_tools_dir, 'llvm-readelf')))
 config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
 config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))


### PR DESCRIPTION
## Summary

End-to-end LIT coverage for `amd_comgr_hotswap_rewrite`. Drives the full compile -> hotswap-rewrite -> verify chain on a real clang-produced gfx1250 code object, using the in-tree `%clang` / `%llvm-readelf` / `%llvm-objdump` / `%FileCheck` substitutions -- no external toolchain required.

Follow-up to #2203. Implements part (A) of the testing-infrastructure plan [laid out in that PR's comment thread](https://github.com/ROCm/llvm-project/pull/2203#issuecomment-4294614480): the dedicated infra-PR that goes in before any real-patch PR lands.

## Changes

- `test-lit/hotswap-rewrite-e2e.hip` (new): compiles a tiny kernel with `%clang --offload-arch=gfx1250 --offload-device-only`, pipes the resulting code object through `hotswap-rewrite`, and verifies the output with `%llvm-readelf -h` / `%llvm-readelf --notes` / `%llvm-readelf --section-headers` / `%llvm-objdump -d`.
- `test-lit/lit.cfg.py`: add `%llvm-readelf` substitution (only `%llvm-objdump` was wired up previously).
- `test-lit/comgr-sources/hotswap-rewrite.c`: optional `--output <path>` flag to write the rewrite output to a file so LIT tests can inspect it. Existing `--zero-size` negative-path coverage and the NULL-args / unsupported-ISA / malformed-ELF stanzas are unchanged.

## What this covers today

Patches in `comgr-hotswap-b0a0.cpp` are weak stubs returning 0 in #2203, so the dispatcher currently emits an output that is bytewise-identical to the input. Even with no patches applied we assert:

- Input is a gfx1250 ELF (`e_flags` contains `gfx1250`, AMDHSA metadata note records `amdhsa.target: amdgcn-amd-amdhsa--gfx1250`).
- `amd_comgr_hotswap_rewrite` returns `AMD_COMGR_STATUS_SUCCESS`.
- Output ELF preserves the gfx1250 identity on both channels (`e_flags` + AMDHSA note).
- `.text` section is still present and `PROGBITS`.
- `llvm-objdump` recognizes the output as `elf64-amdgpu` and disassembles through `s_endpgm`.

## Future per-patch PRs

Each subsequent real-patch PR (in-place / trampoline / WMMA / scratch) will layer its own `llvm-objdump | FileCheck` stanza on top of this harness to assert the specific opcode changes / trampolines its policy introduces. No further infra PRs needed -- part (B) of the plan in #2203 is a per-PR convention rather than a dedicated PR.

## Test plan

- [x] \`llvm-lit tools/comgr/test-lit/hotswap-rewrite-e2e.hip\` passes locally
- [x] Existing \`tools/comgr/test-lit/hotswap-rewrite.c\` still passes (driver changes are backward-compatible)
- [ ] \`check-comgr\` green in CI (PSDB / compiler-ci-amd-staging)

cc @lamb-j @chinmaydd

Made with [Cursor](https://cursor.com)