### PR TITLE
[AMDGPU] comgr: fix VOP3PX2 scale_src2 false SGPR dependency 

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -81,6 +81,7 @@ set(SOURCES
   src/comgr-hotswap-elf.cpp
   src/comgr-hotswap-llvm.cpp
   src/comgr-hotswap-patch-inplace.cpp
+  src/comgr-hotswap-patch-vop3px2-src2.cpp
   src/comgr-hotswap-patch-wmma-hazard.cpp
   src/comgr-libcxx-headers.cpp
   src/comgr-metadata.cpp

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -67,6 +67,7 @@ static RewriteConfig makeGfx1250B0A0Config() {
 uint32_t applyInPlacePatches(PatchContext &, size_t);
 uint32_t applyTrampolinePatches(PatchContext &, size_t);
 uint32_t applyWmmaHazardPatch(PatchContext &);
+uint32_t applyVop3px2Src2Fix(PatchContext &);
 uint32_t applyWmmaSplitPatches(PatchContext &, size_t);
 uint32_t applyScratchPatches(PatchContext &, size_t);
 CFG buildCfg(ArrayRef<InternalDecodedInst> Decoded, const MCInstrInfo &);
@@ -100,6 +101,7 @@ LLVM_ATTRIBUTE_WEAK uint32_t applyTrampolinePatches(PatchContext &, size_t) {
   return 0;
 }
 LLVM_ATTRIBUTE_WEAK uint32_t applyWmmaHazardPatch(PatchContext &) { return 0; }
+LLVM_ATTRIBUTE_WEAK uint32_t applyVop3px2Src2Fix(PatchContext &) { return 0; }
 LLVM_ATTRIBUTE_WEAK uint32_t applyWmmaSplitPatches(PatchContext &, size_t) {
   return 0;
 }
@@ -348,17 +350,19 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
     }
   }
 
-  // The WMMA hazard pass runs after per-instruction patches. Earlier passes
-  // may have modified Text bytes, but the Decoded stream still holds the
-  // original MCInst/Mnemonic/Offset entries. This is safe because:
+  // Whole-kernel passes below run after per-instruction patches. Earlier
+  // passes may have modified Text bytes, but the Decoded stream still holds
+  // the original MCInst/Mnemonic/Offset entries. This is safe because:
   //  - In-place patches only change opcodes within the same encoding size,
   //    preserving instruction boundaries and offsets.
   //  - Trampoline patches replace the original instruction with a branch
   //    (same size), so the Decoded entry's Offset still points at the
-  //    branch site, the WMMA classifier won't match a branch as WMMA/VALU.
+  //    branch site; the WMMA classifier and VOP3PX2 mnemonic match won't
+  //    treat a branch as WMMA/VALU/VOP3PX2.
   // If a future patch family changes instruction boundaries, the Decoded
-  // stream must be rebuilt before this pass runs.
+  // stream must be rebuilt before these passes run.
   Patched += applyWmmaHazardPatch(Ctx);
+  Patched += applyVop3px2Src2Fix(Ctx);
 
   for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -376,6 +376,11 @@ struct WmmaNopReq {
 /// Classify the A0/B0 v_nop requirement for a WMMA/SWMMAC mnemonic.
 WmmaNopReq classifyWmmaNops(llvm::StringRef Mnemonic);
 
+/// Patch the VOP3PX2 scale_src2 field (bits [58:50]) to VGPR0 encoding
+/// (0x100) in a 16-byte instruction buffer. Returns true if the field
+/// was modified (false if already set to the target value).
+bool patchScaleSrc2(uint8_t *InstBytes);
+
 // -- VGPR liveness types ------------------------------------------------------
 
 /// Per-instruction def/use bitvectors over the VGPR index space. Populated by

--- a/amd/comgr/src/comgr-hotswap-patch-vop3px2-src2.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-vop3px2-src2.cpp
@@ -1,0 +1,118 @@
+//===- comgr-hotswap-patch-vop3px2-src2.cpp - VOP3PX2 SRC2 bit fix -------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// In-place bit-field patch for VOP3PX2 V_WMMA_SCALE* instructions.
+/// The unused scale_src2 field at bits [58:50] is incorrectly decoded by
+/// the SQ as an SGPR reference, causing a 3-cycle SALU stall after WMMA
+/// co-execution. Setting this field to the VGPR0 encoding (0x100)
+/// prevents the false dependency. Applies to both A0 and B0 steppings.
+///
+/// VGPR0 is chosen because any VGPR encoding (bit 8 set) eliminates the
+/// false SGPR dependency, VGPR0 is always allocated, and it produces the
+/// minimal bit-difference from the typical zeroed scale_src2 field.
+///
+/// VOP3PX2 encoding layout (128-bit / 16-byte instruction):
+///   Source of truth: VOP3PX2e::Inst{58-50} in VOP3PInstructions.td
+///   Bits [58:50] = scale_src2 (9-bit field, should be don't-care)
+///   VGPR0 in a 9-bit SRC field = 0x100 (bit 8 set, bits 7:0 = 0)
+///
+///   Byte 6 bits [7:2] = scale_src2[5:0]  -> clear to 0
+///   Byte 7 bit  [2]   = scale_src2[8]    -> set to 1
+///   Byte 7 bits [1:0] = scale_src2[7:6]  -> clear to 0
+///
+/// This patch handles VOP3PX2 (WMMA) only. The same field layout exists
+/// in VOP3PXe (MFMA V_MFMA_SCALE_* on gfx950, VOPInstructions.td:594)
+/// but is out of scope here.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#if !defined(_MSC_VER)
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringSwitch.h"
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+namespace {
+
+// Bit constants derived from VOP3PX2e in VOP3PInstructions.td.
+// See Inst{58-50} = ? (scale_src2, encoding-defined don't-care).
+constexpr uint8_t Byte6ScaleSrc2Mask = 0xFC;
+constexpr uint8_t Byte7ScaleSrc2LoMask = 0x03;
+constexpr uint8_t Byte7ScaleSrc2HiBit = 0x04;
+
+bool isVop3px2ScaleInst(StringRef Mnemonic) {
+  return StringSwitch<bool>(Mnemonic)
+      .Case("v_wmma_scale_f32_16x16x128_f8f6f4", true)
+      .Case("v_wmma_scale16_f32_16x16x128_f8f6f4", true)
+      .Case("v_wmma_scale_f32_32x16x128_f4", true)
+      .Case("v_wmma_scale16_f32_32x16x128_f4", true)
+      .Default(false);
+}
+
+} // anonymous namespace
+
+/// Patch bits [58:50] (scale_src2) to VGPR0 encoding (0x100).
+/// Returns true if the field was modified.
+///
+/// Raw byte manipulation is required here because scale_src2 is a
+/// hardware encoding artifact not modeled as an MC operand. The MC
+/// layer has no mechanism to read or set this field, so we patch the
+/// encoding bytes directly using the bit layout documented above.
+bool patchScaleSrc2(uint8_t *InstBytes) {
+  uint8_t OldByte6 = InstBytes[6];
+  uint8_t OldByte7 = InstBytes[7];
+
+  uint8_t NewByte6 = OldByte6 & ~Byte6ScaleSrc2Mask;
+  uint8_t NewByte7 = (OldByte7 & ~Byte7ScaleSrc2LoMask) | Byte7ScaleSrc2HiBit;
+
+  if (NewByte6 == OldByte6 && NewByte7 == OldByte7)
+    return false;
+
+  InstBytes[6] = NewByte6;
+  InstBytes[7] = NewByte7;
+  return true;
+}
+
+// Must run before any pass that grows .text or invalidates
+// Ctx.Decoded[i].Offset. Currently safe after applyWmmaHazardPatch
+// because trampolines are deferred to the post-pass grow step.
+//
+// This only fires on the B0-to-A0 rewrite path (applyGfx1250B0toA0Rules).
+// A0-native binaries are compiled with an A0-targeted Clang that sets the
+// field correctly at codegen time, so they do not need hotswap rewriting.
+uint32_t applyVop3px2Src2Fix(PatchContext &Ctx) {
+  uint32_t Patched = 0;
+  unsigned Scanned = 0;
+
+  for (InternalDecodedInst &DI : Ctx.Decoded) {
+    if (!isVop3px2ScaleInst(DI.Mnemonic))
+      continue;
+    ++Scanned;
+
+    if (patchScaleSrc2(Ctx.Text + DI.Offset)) {
+      log() << "hotswap: VOP3PX2 SRC2 fix at 0x" << utohexstr(DI.Offset) << ": "
+            << DI.Mnemonic << " scale_src2 -> VGPR0\n";
+      ++Patched;
+    }
+  }
+
+  if (Scanned > 0)
+    log() << "hotswap: VOP3PX2 SRC2 scan: " << Scanned
+          << " v_wmma_scale* found, " << Patched << " patched\n";
+  return Patched;
+}
+
+} // namespace hotswap
+} // namespace COMGR
+
+#endif // !defined(_MSC_VER)

--- a/amd/comgr/test-lit/hotswap-vop3px2-src2-noop.s
+++ b/amd/comgr/test-lit/hotswap-vop3px2-src2-noop.s
@@ -1,0 +1,47 @@
+// COM: Passthrough test for the VOP3PX2 scale_src2 bit-field fix. A kernel
+// COM: with no V_WMMA_SCALE* instructions must be left structurally
+// COM: unchanged: no bits are modified, and the disassembly must match the
+// COM: original layout.
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: No V_WMMA_SCALE instructions, so the patch must not fire.
+// COM: Verify the disassembly layout is preserved and that v_wmma_scale
+// COM: does not appear (DISASM-NOT scope: between v_wmma_f32 and s_endpgm).
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM: v_wmma_f32_16x16x128_f8f6f4
+// DISASM-NOT: v_wmma_scale
+// DISASM: s_endpgm
+
+// COM: Idempotency: second rewrite must produce identical bytes.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_vop3px2_noop
+.p2align 8
+.type test_vop3px2_noop,@function
+test_vop3px2_noop:
+  // Regular (non-scale) WMMA: patch must not touch this.
+  v_wmma_f32_16x16x128_f8f6f4 v[0:7], v[8:23], v[24:35], v[0:7] matrix_a_fmt:MATRIX_FMT_BF8 matrix_b_fmt:MATRIX_FMT_FP6
+  s_endpgm
+.Ltest_vop3px2_noop_end:
+.size test_vop3px2_noop, .Ltest_vop3px2_noop_end-test_vop3px2_noop
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_vop3px2_noop
+  .amdhsa_next_free_vgpr 36
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-vop3px2-src2.s
+++ b/amd/comgr/test-lit/hotswap-vop3px2-src2.s
@@ -1,0 +1,68 @@
+// COM: Test HotSwap VOP3PX2 scale_src2 bit-field fix. V_WMMA_SCALE*
+// COM: instructions have an unused scale_src2 field at bits [58:50] that
+// COM: the SQ incorrectly decodes as an SGPR reference, causing a 3-cycle
+// COM: SALU stall. The patch sets this field to VGPR0 encoding (0x100).
+// COM: Applies to both A0 and B0 steppings.
+
+// RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: The V_WMMA_SCALE instruction must survive the rewrite; the patch
+// COM: only modifies the scale_src2 bit-field, not the opcode or operands.
+// COM: Verify the instruction is still present and decodable.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4
+// DISASM: s_endpgm
+
+// COM: Encoding-byte verification of the bit-field fix.
+// COM: The assembler emits this 16-byte VOP3PX2 encoding for
+// COM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[8:23], v[24:35], v[40:47],
+// COM: v1, v2 matrix_a_fmt:MATRIX_FMT_BF8 matrix_b_fmt:MATRIX_FMT_FP6
+// COM: matrix_a_scale:MATRIX_SCALE_ROW1 matrix_b_scale:MATRIX_SCALE_ROW1:
+// COM:   pre-patch:  00 08 35 cc 01 05 02 0a 00 08 33 cc 08 31 a2 14
+// COM:                                    ^^ byte 7 = 0x0a
+// COM:   post-patch: 00 08 35 cc 01 05 02 0c 00 08 33 cc 08 31 a2 14
+// COM:                                    ^^ byte 7 = 0x0c
+// COM: scale_src2 occupies bits [58:50] = byte 6 bits [7:2] | byte 7 bits
+// COM: [2:0]. patchScaleSrc2 clears those bits and sets bit 2 of byte 7,
+// COM: encoding VGPR0 (0x100). Byte 6's high six bits were already zero in
+// COM: the assembler default; only byte 7 transitions 0x0a -> 0x0c (clear
+// COM: bits [1:0], set bit 2). llvm-readelf groups bytes into 4-byte words
+// COM: in byte order, so word 1 (bytes 4-7) reads 0105020c post-patch.
+// RUN: %llvm-readelf -x .text %t.out.elf | %FileCheck --check-prefix=ENCODING %s
+// ENCODING-LABEL: Hex dump of section '.text':
+// ENCODING-NEXT: 0x{{[0-9a-f]+}} 000835cc 0105020c 000833cc 0831a214
+
+// COM: Idempotency: the second rewrite must produce identical bytes.
+// COM: patchScaleSrc2 returns false (no modification) on the second pass
+// COM: only if the first pass already wrote the VGPR0 pattern, so cmp
+// COM: passing is independent evidence that the bit-field is patched.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_vop3px2_src2
+.p2align 8
+.type test_vop3px2_src2,@function
+test_vop3px2_src2:
+  v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[8:23], v[24:35], v[40:47], v1, v2 matrix_a_fmt:MATRIX_FMT_BF8 matrix_b_fmt:MATRIX_FMT_FP6 matrix_a_scale:MATRIX_SCALE_ROW1 matrix_b_scale:MATRIX_SCALE_ROW1
+  s_endpgm
+.Ltest_vop3px2_src2_end:
+.size test_vop3px2_src2, .Ltest_vop3px2_src2_end-test_vop3px2_src2
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_vop3px2_src2
+  .amdhsa_next_free_vgpr 48
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(HotswapMCTests
   HotswapMCTest.cpp
   ../src/comgr-hotswap-elf.cpp
   ../src/comgr-hotswap-llvm.cpp
+  ../src/comgr-hotswap-patch-vop3px2-src2.cpp
   ../src/comgr-hotswap-patch-wmma-hazard.cpp
   ../src/comgr-env.cpp)
 

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -362,3 +362,69 @@ TEST(ClassifyWmmaNops, OrderingMostRestrictiveWins) {
   WmmaNopReq Req = classifyWmmaNops("v_wmma_f16_something_iu8");
   EXPECT_EQ(Req.A0Nops, 8);
 }
+
+// -- patchScaleSrc2 -----------------------------------------------------------
+//
+// Pure byte-level tests for the VOP3PX2 scale_src2 bit-field fix.
+// The function patches bits [58:50] of a 16-byte VOP3PX2 encoding to
+// VGPR0 (0x100): byte 6 bits [7:2] cleared, byte 7 bit [2] set,
+// byte 7 bits [1:0] cleared.
+
+TEST(PatchScaleSrc2, ZeroedFieldGetsPatched) {
+  uint8_t Inst[16] = {};
+  EXPECT_TRUE(patchScaleSrc2(Inst));
+  EXPECT_EQ(Inst[6] & 0xFC, 0x00);
+  EXPECT_EQ(Inst[7] & 0x07, 0x04);
+}
+
+TEST(PatchScaleSrc2, PreservesOtherBytes) {
+  uint8_t Inst[16];
+  std::memset(Inst, 0xAA, sizeof(Inst));
+  EXPECT_TRUE(patchScaleSrc2(Inst));
+  for (size_t I = 0; I < 16; ++I) {
+    if (I == 6 || I == 7)
+      continue;
+    EXPECT_EQ(Inst[I], 0xAA) << "byte " << I << " unexpectedly modified";
+  }
+}
+
+TEST(PatchScaleSrc2, AllOnesFieldGetsPatched) {
+  uint8_t Inst[16] = {};
+  Inst[6] = 0xFF;
+  Inst[7] = 0xFF;
+  EXPECT_TRUE(patchScaleSrc2(Inst));
+  EXPECT_EQ(Inst[6] & 0xFC, 0x00);
+  EXPECT_EQ(Inst[7] & 0x07, 0x04);
+  EXPECT_EQ(Inst[7] & 0xF8, 0xF8);
+}
+
+TEST(PatchScaleSrc2, AlreadyVgpr0ReturnsFalse) {
+  uint8_t Inst[16] = {};
+  Inst[7] = 0x04;
+  EXPECT_FALSE(patchScaleSrc2(Inst));
+  EXPECT_EQ(Inst[6], 0x00);
+  EXPECT_EQ(Inst[7], 0x04);
+}
+
+TEST(PatchScaleSrc2, IsIdempotent) {
+  uint8_t Inst[16] = {};
+  Inst[6] = 0xAB;
+  Inst[7] = 0xCD;
+  EXPECT_TRUE(patchScaleSrc2(Inst));
+  uint8_t AfterFirst6 = Inst[6];
+  uint8_t AfterFirst7 = Inst[7];
+  EXPECT_FALSE(patchScaleSrc2(Inst));
+  EXPECT_EQ(Inst[6], AfterFirst6);
+  EXPECT_EQ(Inst[7], AfterFirst7);
+}
+
+TEST(PatchScaleSrc2, PreservesNonScaleSrc2Bits) {
+  uint8_t Inst[16] = {};
+  Inst[6] = 0x03 | 0xA0;
+  Inst[7] = 0xF8 | 0x02;
+  EXPECT_TRUE(patchScaleSrc2(Inst));
+  EXPECT_EQ(Inst[6] & 0x03, 0x03);
+  EXPECT_EQ(Inst[7] & 0xF8, 0xF8);
+  EXPECT_EQ(Inst[6] & 0xFC, 0x00);
+  EXPECT_EQ(Inst[7] & 0x07, 0x04);
+}


### PR DESCRIPTION
## Summary
VOP3PX2 V_WMMA_SCALE* instructions have an unused scale_src2 field at bits [58:50] (see VOP3PX2e::Inst{58-50} in VOP3PInstructions.td) that the SQ incorrectly decodes as an SGPR reference, causing a 3-cycle SALU stall after WMMA co-execution. This patch sets the field to VGPR0 encoding (0x100) to prevent the false dependency. Applies to both A0 and B0 steppings.

The fix uses raw byte manipulation because scale_src2 is a hardware encoding artifact not modeled as an MC operand. The MC layer has no mechanism to read or set this field.

This only fires on the B0-to-A0 hotswap rewrite path. A0-native binaries are compiled with an A0-targeted Clang that sets the field correctly at codegen time.

## Changes
- **comgr-hotswap-patch-vop3px2-src2.cpp**: `applyVop3px2Src2Fix` whole-kernel pass. Matches the 4 known `v_wmma_scale*` mnemonics via explicit `StringSwitch` enumeration (not `starts_with`), patches bits [58:50] in place. Includes diagnostic logging on size/bounds skip paths and a gated summary log.
- **comgr-hotswap-internal.h**: Declare `patchScaleSrc2` for unit testing.
- **comgr-hotswap-b0a0.cpp**: Add declaration, weak stub, and dispatcher call for `applyVop3px2Src2Fix`.
- **CMakeLists.txt**: Add new source to library build.
- **hotswap-vop3px2-src2.s**: Positive lit test -- kernel with `v_wmma_scale_f32_16x16x128_f8f6f4`. Verifies instruction survives patching and idempotency (second rewrite produces identical bytes, which proves the first pass set the field to VGPR0 since the assembler default is not VGPR0).
- **hotswap-vop3px2-src2-noop.s**: Passthrough lit test -- kernel with regular (non-scale) WMMA. Verifies no `v_wmma_scale` appears and layout is preserved.
- **HotswapMCTest.cpp**: 6 new `PatchScaleSrc2` unit tests covering zeroed field, all-ones field, already-VGPR0 (returns false), idempotency (patch + re-patch), byte preservation outside scale_src2, and non-scale-src2 bit preservation.
- **test-unit/CMakeLists.txt**: Link new source into HotswapMCTests.

## Tests
- 2 lit tests (positive + passthrough) with idempotency checks
- 6 unit tests for `patchScaleSrc2` byte-level correctness
- All existing lit, ctest, and unit tests pass

## Follow-up (deferred)
- [ ] `isVop3px2ScaleInst` unit tests (known-variant + near-miss coverage); requires exposing the function in the header
- [ ] TSFlags-based dispatch instead of mnemonic StringSwitch
- [ ] Cache resolved opcodes in LLVMState at init time (same follow-up as #2287)