### PR TITLE
[Comgr] Fix Windows build: use LLVM_ATTRIBUTE_WEAK for hotswap stubs

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -19,6 +19,7 @@
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/Compiler.h"
 
 using namespace llvm;
 
@@ -92,19 +93,17 @@ void patchDebugFrame(uint8_t *Elf, size_t ElfSize, uint64_t TextAddr,
 
 // -- Weak-symbol patch stubs --------------------------------------------------
 
-__attribute__((weak)) uint32_t applyInPlacePatches(PatchContext &, size_t) {
+LLVM_ATTRIBUTE_WEAK uint32_t applyInPlacePatches(PatchContext &, size_t) {
   return 0;
 }
-__attribute__((weak)) uint32_t applyTrampolinePatches(PatchContext &, size_t) {
+LLVM_ATTRIBUTE_WEAK uint32_t applyTrampolinePatches(PatchContext &, size_t) {
   return 0;
 }
-__attribute__((weak)) uint32_t applyWmmaHazardPatch(PatchContext &) {
+LLVM_ATTRIBUTE_WEAK uint32_t applyWmmaHazardPatch(PatchContext &) { return 0; }
+LLVM_ATTRIBUTE_WEAK uint32_t applyWmmaSplitPatches(PatchContext &, size_t) {
   return 0;
 }
-__attribute__((weak)) uint32_t applyWmmaSplitPatches(PatchContext &, size_t) {
-  return 0;
-}
-__attribute__((weak)) uint32_t applyScratchPatches(PatchContext &, size_t) {
+LLVM_ATTRIBUTE_WEAK uint32_t applyScratchPatches(PatchContext &, size_t) {
   return 0;
 }
 
@@ -114,13 +113,13 @@ __attribute__((weak)) uint32_t applyScratchPatches(PatchContext &, size_t) {
 // allocate above KD count (correct but suboptimal until the real liveness
 // layer lands).
 
-__attribute__((weak)) CFG buildCfg(ArrayRef<InternalDecodedInst> Decoded,
-                                   const MCInstrInfo &) {
+LLVM_ATTRIBUTE_WEAK CFG buildCfg(ArrayRef<InternalDecodedInst> Decoded,
+                                 const MCInstrInfo &) {
   (void)Decoded;
   return CFG();
 }
 
-__attribute__((weak)) LivenessInfo computeLiveness(
+LLVM_ATTRIBUTE_WEAK LivenessInfo computeLiveness(
     ArrayRef<InternalDecodedInst> Decoded, const CFG &, const MCInstrInfo &,
     const MCRegisterInfo &, unsigned MaxVgprs) {
   LivenessInfo Info;
@@ -132,39 +131,39 @@ __attribute__((weak)) LivenessInfo computeLiveness(
   return Info;
 }
 
-__attribute__((weak)) RegDefUse getInstRegDefUse(const MCInst &,
-                                                 const MCInstrInfo &,
-                                                 const MCRegisterInfo &) {
+LLVM_ATTRIBUTE_WEAK RegDefUse getInstRegDefUse(const MCInst &,
+                                               const MCInstrInfo &,
+                                               const MCRegisterInfo &) {
   return {};
 }
 
-__attribute__((weak)) int64_t getBranchImm(const MCInst &) { return 0; }
+LLVM_ATTRIBUTE_WEAK int64_t getBranchImm(const MCInst &) { return 0; }
 
-__attribute__((weak)) bool verifyPatchCorrectness(const uint8_t *, uint64_t,
-                                                  const LLVMState &,
-                                                  ArrayRef<ScratchPatchInfo>,
-                                                  unsigned) {
+LLVM_ATTRIBUTE_WEAK bool verifyPatchCorrectness(const uint8_t *, uint64_t,
+                                                const LLVMState &,
+                                                ArrayRef<ScratchPatchInfo>,
+                                                unsigned) {
   return true;
 }
 
 // -- Weak-symbol DWARF stubs --------------------------------------------------
 
-__attribute__((weak)) bool addTrampolineSymbols(WritableMemoryBuffer &,
-                                                ArrayRef<Trampoline>, uint64_t,
-                                                unsigned) {
+LLVM_ATTRIBUTE_WEAK bool addTrampolineSymbols(WritableMemoryBuffer &,
+                                              ArrayRef<Trampoline>, uint64_t,
+                                              unsigned) {
   return true;
 }
-__attribute__((weak)) bool patchDebugLine(WritableMemoryBuffer &,
-                                          ArrayRef<Trampoline>, uint64_t,
-                                          uint64_t) {
+LLVM_ATTRIBUTE_WEAK bool patchDebugLine(WritableMemoryBuffer &,
+                                        ArrayRef<Trampoline>, uint64_t,
+                                        uint64_t) {
   return true;
 }
-__attribute__((weak)) void patchDebugRanges(uint8_t *, size_t, uint64_t,
-                                            uint64_t, uint64_t) {}
-__attribute__((weak)) void patchDebugInfo(uint8_t *, size_t, uint64_t, uint64_t,
+LLVM_ATTRIBUTE_WEAK void patchDebugRanges(uint8_t *, size_t, uint64_t, uint64_t,
                                           uint64_t) {}
-__attribute__((weak)) void patchDebugFrame(uint8_t *, size_t, uint64_t,
-                                           uint64_t, uint64_t) {}
+LLVM_ATTRIBUTE_WEAK void patchDebugInfo(uint8_t *, size_t, uint64_t, uint64_t,
+                                        uint64_t) {}
+LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
+                                         uint64_t) {}
 
 // -- NOP sled scanning --------------------------------------------------------
 


### PR DESCRIPTION
## Summary

PR #2203 introduced 15 weak-symbol patch / liveness / DWARF stubs in `comgr-hotswap-b0a0.cpp` using GCC/Clang attribute syntax:

```cpp
__attribute__((weak)) uint32_t applyInPlacePatches(PatchContext &, size_t) {
  return 0;
}
```

MSVC does not understand this. It tokenizes `__attribute__` as an identifier and `weak` as undeclared, then errors on every weak stub:

```
comgr-hotswap-b0a0.cpp(95): error C2065: 'weak': undeclared identifier
comgr-hotswap-b0a0.cpp(95): error C2374: '__attribute__': redefinition
[...repeats for every weak stub at lines 95, 98, 101, 104, 107, 117,
 123, 135, 141, 143, 152, 157, 162, 164, 166...]
```

This PR replaces the raw GCC attribute with LLVM's portable `LLVM_ATTRIBUTE_WEAK` macro from `llvm/Support/Compiler.h`. On Linux/macOS it expands to `__attribute__((__weak__))` (current behaviour preserved); on Windows it expands to nothing — the symbols become regular strong symbols, which compiles fine because `comgr-hotswap-b0a0.cpp` is currently the only TU defining these names.

Failing Windows job from PR #2203: https://github.com/ROCm/llvm-project/actions/runs/24758866527/job/72438109210

## Scope

Immediate Windows unblock only. The weak-symbol pattern was chosen so follow-up patch PRs (#2222 in-place patches, future trampoline / WMMA / scratch) can each provide strong-symbol overrides without merge conflicts. On Windows, that overriding mechanism does not work — when a follow-up PR adds a strong override of one of these stubs, both TUs will emit a strong symbol and the linker will fail with a duplicate-symbol error.

A follow-up is needed to address the override pattern on Windows, options including:
- Function-pointer registration where each patch module registers its override in a static initializer
- `__declspec(selectany)` (with care — semantics differ from Unix weak)
- `#ifdef`-out the patch overrides on MSVC (degraded but compiles)

Out of scope for this PR.