### PR TITLE
[Comgr] Fix hotswap asm parser SourceMgr crash on bad input

### DIFF
--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -145,17 +145,25 @@ static SmallVector<MCInst, 2> parseAsmToMCInsts(StringRef AsmStr,
                                                 const LLVMState &S) {
   S.Ctx->reset();
 
+  // Register the buffer with the context's inline SourceMgr so that
+  // MCContext::diagnose() can resolve source locations on the error path.
+  // A bare local SourceMgr would be invisible to MCContext, and the asm
+  // parser hits MCContext::diagnose() (via SourceMgr::PrintMessage) when
+  // it encounters bad input -- without a registered SourceMgr that path
+  // aborts at `Either SourceMgr should be available` in MCContext.cpp.
+  S.Ctx->initInlineSourceManager();
+  SourceMgr *SrcMgr = S.Ctx->getInlineSourceManager();
+
   std::string FullAsm = (".text\n" + AsmStr).str();
   std::unique_ptr<MemoryBuffer> Buf =
       MemoryBuffer::getMemBuffer(FullAsm, "", false);
-  SourceMgr SrcMgr;
-  SrcMgr.AddNewSourceBuffer(std::move(Buf), SMLoc());
+  SrcMgr->AddNewSourceBuffer(std::move(Buf), SMLoc());
 
   InstCapturingStreamer Streamer(*S.Ctx);
 
   MCTargetOptions McOpts;
   std::unique_ptr<MCAsmParser> Parser(
-      createMCAsmParser(SrcMgr, *S.Ctx, Streamer, *S.MAI));
+      createMCAsmParser(*SrcMgr, *S.Ctx, Streamer, *S.MAI));
   std::unique_ptr<MCTargetAsmParser> TAP(
       S.Target->createMCAsmParser(*S.STI, *Parser, *S.MCII, McOpts));
   if (!TAP) {


### PR DESCRIPTION
## Summary

`parseAsmToMCInsts` in `comgr-hotswap-llvm.cpp` creates a local `SourceMgr` and passes it to `createMCAsmParser`, but never registers it with the surrounding `MCContext`. Positive parses (e.g. `s_nop 0`) never call `MCContext::diagnose()` so the gap is invisible. The negative path — bad assembly input — triggers `diagnose()`, which walks `SrcMgr` (null), then `InlineSrcMgr` (also null), and aborts:

```
Either SourceMgr should be available
UNREACHABLE executed at .../llvm/lib/MC/MCContext.cpp:1093!
```

This crashes `HotswapMCTests.AssembleDecode.RejectsGarbageAsm` and fails `make check-comgr` on Linux.

## Fix

`MCContext` has no public `setSourceManager` setter — `SrcMgr` is constructor-only. Use `MCContext::initInlineSourceManager()` + `getInlineSourceManager()` to obtain a context-owned `SourceMgr` that `MCContext::diagnose()` finds via the `InlineSrcMgr` fallback. The buffer is registered with the inline manager and the parser is handed the same manager — positive parses behave identically; negative parses now report a real diagnostic instead of aborting.

Single change in `parseAsmToMCInsts`. `assembleSingleInst` and `resolveOpcodeViaParse` both go through this helper, so they benefit too.