### PR TITLE
[OMPT][Runtime][OmpTarget] Reuse existing symbols before loading pare…

### DIFF
--- a/offload/plugins-nextgen/common/OMPT/OmptDeviceTracing.h
+++ b/offload/plugins-nextgen/common/OMPT/OmptDeviceTracing.h
@@ -22,6 +22,7 @@
 
 #include <map>
 #include <memory>
+#include <dlfcn.h>
 
 #pragma push_macro("DEBUG_PREFIX")
 #undef DEBUG_PREFIX
@@ -110,6 +111,10 @@ void setParentLibrary(const char *Filename);
 /// for FuncPtr.
 template <typename FT>
 void ensureFuncPtrLoaded(const std::string &FuncName, FT *FuncPtr) {
+  void *SymbolPtr = dlsym(RTLD_DEFAULT, FuncName.c_str());
+  if (SymbolPtr != nullptr)
+    *FuncPtr = reinterpret_cast<FT>(SymbolPtr);
+
   if (*FuncPtr == nullptr) {
     if ((ParentLibrary == nullptr && getParentLibrary() == nullptr) ||
         !ParentLibrary->isValid())


### PR DESCRIPTION
## Summary

This patch improves `ensureFuncPtrLoaded()` by first checking whether the
requested symbol already exists in the current process namespace:

    dlsym(RTLD_DEFAULT, FuncName.c_str())

If found, the function pointer is initialized immediately.

Only when the symbol is unavailable does the code continue to the
existing fallback path using `ParentLibrary->getAddressOfSymbol()`.

## Motivation

Some runtime symbols may already be available in the current execution
context, for example:

- symbols exported by previously loaded shared libraries
- symbols introduced through dependency chains
- symbols already resolved by the runtime loader

In these cases, loading or querying the parent library again is
unnecessary.

This change avoids redundant dynamic loading of `omptarget.so` and
reduces symbol resolution overhead.

## Changes

Before:

- Always depended on `ParentLibrary` lookup path

After:

- First search current process namespace via `RTLD_DEFAULT`
- Fallback to `ParentLibrary` only when needed

## Benefits

- Avoid unnecessary `dlopen` / parent library usage
- Faster symbol resolution path
- Better compatibility with preloaded runtimes
- Keeps existing fallback behavior unchanged

## Testing

- Build completed successfully
- Verified symbols already present in process scope are resolved directly
- Verified fallback path still works when symbols are absent