### PR TITLE
[AMDGPU] comgr: Add DS_ADDTID trampoline patch for A0 16-bit M0 truncation

### DIFF
--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -118,6 +118,17 @@ static constexpr uint32_t MinInstSize = 4;
 static constexpr int64_t BranchOffsetMin = -32768;
 static constexpr int64_t BranchOffsetMax = 32767;
 
+// MCInst operand layout for ds_load_addtid_b32 / ds_store_addtid_b32. Shared
+// between the trampoline patch (comgr-hotswap-patch-trampoline.cpp) and the
+// unit tests that pin the layout (HotswapMCTest.cpp) so a tablegen change
+// upstream is caught in one place.
+//   operand 0: vdst (load) / data0 (store) -- VGPR register
+//   operand 1: combined offset             -- immediate
+//   operand 2: gds                         -- immediate (0 = LDS, 1 = GDS)
+static constexpr unsigned AddtidOpReg = 0;
+static constexpr unsigned AddtidOpOffset = 1;
+static constexpr unsigned AddtidOpGds = 2;
+
 // -- ElfView ------------------------------------------------------------------
 //
 // Thin wrapper around llvm::object::ELFFile<ELF64LE> that owns the structural

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -707,18 +707,24 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
       std::optional<uint32_t> LdsSize =
           Ctx.Elf.getKernelStaticLdsSize(KernelName);
-      // LdsSize covers only the static (compile-time-fixed) LDS allocation;
-      // dynamic LDS is added by the host at dispatch and not visible in the
-      // ELF, so this check is a "definitely exceeds 64 KiB" lower bound.
-      // Kernels that fit statically but overflow with dynamic LDS will not
-      // trip this warning.
-      if (LdsSize && *LdsSize > AddtidLdsLimitA0)
-        log() << "hotswap: warning: kernel '" << KernelName << "' uses "
-              << DI.Mnemonic << " with static LDS " << *LdsSize << " bytes (> "
-              << AddtidLdsLimitA0
-              << "); A0 16-bit M0 truncation may produce silently wrong "
-                 "results at 0x"
-              << utohexstr(DI.Offset) << "\n";
+      // Trampoline could not be applied: the original ds_*_addtid_b32 stays
+      // in the code object and will silently truncate M0 to 16 bits on A0
+      // (DEGFXMI400-12025) whenever the runtime LDS layout exceeds 64 KiB.
+      // Static LDS is visible in the kernel descriptor; dynamic LDS added
+      // by the host at dispatch (hidden_dynamic_lds_size kernarg or a
+      // dynamic_shared_pointer user arg) is not. The warning therefore
+      // fires unconditionally rather than gating on the visible lower
+      // bound -- a follow-up will use ElfView::kernelUsesDynamicLds to
+      // tighten the condition to (static>64KiB || dynamicUsed).
+      log() << "hotswap: warning: kernel '" << KernelName << "' uses "
+            << DI.Mnemonic
+            << "; trampoline could not be applied, so A0 16-bit M0"
+               " truncation may produce silently wrong results when runtime"
+               " LDS (static + dynamic) exceeds "
+            << AddtidLdsLimitA0 << " bytes";
+      if (LdsSize)
+        log() << " (static LDS = " << *LdsSize << " bytes)";
+      log() << " at 0x" << utohexstr(DI.Offset) << "\n";
       log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
             << utohexstr(DI.Offset) << ": no scratch VGPR available\n";
       return false;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -12,11 +12,16 @@
 ///     DS instructions
 ///   - tensor_load_to_lds     : prepend s_pack_hh_b32_b16 to clear multicast
 ///     routing bits in the group descriptor's base SGPR
+///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
+///     issue a regular ds_*_b32, bypassing the A0 16-bit M0 truncation
+///     (DEGFXMI400-12025). On B0 the DS unit reads 20 bits of M0; on A0 it
+///     reads only 16, silently dropping bits [19:16].
 ///
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCCodeEmitter.h"
@@ -556,6 +561,200 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
   return true;
 }
 
+// -- ADDTID swap table (StringSwitch) ---------------------------------------
+//
+// Maps each ADDTID DS mnemonic to its plain DS replacement. The lane-id
+// expression that ADDTID encodes implicitly is materialised in the ALU by
+// the trampoline body, then a regular DS op consumes the computed address.
+
+StringRef getAddtidReplacement(StringRef Mnemonic) {
+  return StringSwitch<StringRef>(Mnemonic)
+      .Case("ds_load_addtid_b32", "ds_load_b32")
+      .Case("ds_store_addtid_b32", "ds_store_b32")
+      .Default("");
+}
+
+// LDS allocations strictly above this threshold are unreachable through
+// ADDTID once hotswapped to A0, because A0 truncates M0 to 16 bits. The
+// patch itself is still applied (the lane-id math runs through the ALU);
+// this constant only gates a diagnostic so users with oversized LDS
+// allocations are warned that values may still be silently wrong.
+// Derived from the M0 bit-width on A0 so the magic number stays out of
+// the source: 1 << 16 = 65536 bytes addressable per ADDTID encoding.
+constexpr uint32_t AddtidLdsLimitA0 = 1u << 16;
+
+// ADDTID MCInst operand layout (AddtidOpReg / AddtidOpOffset / AddtidOpGds)
+// lives in comgr-hotswap-internal.h so the layout pin is shared with the unit
+// tests in HotswapMCTest.cpp.
+
+// GDS=1 ADDTID is not reachable through the gfx12 assembler -- the asm
+// parser rejects the `gds` modifier on this subtarget, so any MCInst
+// produced by clang/llvm-mc has GDS=0. This predicate stays as
+// defense-in-depth for hand-crafted byte input or future subtargets that
+// re-enable the encoding through the same MCInst slot. Because the path
+// is unreachable on gfx12 it is not exercised by lit; coverage exists via
+// AddTid.{Load,Store}AddTidDecodesWithExpectedLayout pinning the operand
+// shape that this predicate consumes.
+bool isAddtidGds(const MCInst &Inst) {
+  if (Inst.getNumOperands() <= AddtidOpGds)
+    return false;
+  const MCOperand &Op = Inst.getOperand(AddtidOpGds);
+  return Op.isImm() && Op.getImm() != 0;
+}
+
+std::optional<uint32_t> getAddtidOffset(const MCInst &Inst) {
+  if (Inst.getNumOperands() <= AddtidOpOffset)
+    return std::nullopt;
+  const MCOperand &Op = Inst.getOperand(AddtidOpOffset);
+  if (!Op.isImm())
+    return std::nullopt;
+  return static_cast<uint32_t>(Op.getImm());
+}
+
+// Build the trampoline asm for a ds_load_addtid_b32 site. The destination
+// VGPR is reused as the address-compute scratch because the load overwrites
+// it, so no extra VGPR allocation is needed for the load path.
+//
+// The replacement reproduces the ADDTID address computation in the ALU:
+//   lane_id = mbcnt_lo(-1, 0)    ; for waveN, then mbcnt_hi(-1, lane_id)
+//   addr    = m0 + lane_id * 4   ; + offset (folded into the DS encoding)
+std::vector<std::string> buildAddtidLoadAsm(StringRef VName, uint32_t Offset,
+                                            StringRef ToMnem) {
+  std::string V(VName);
+  std::vector<std::string> Lines;
+  Lines.push_back("v_mbcnt_lo_u32_b32 " + V + ", -1, 0");
+  Lines.push_back("v_mbcnt_hi_u32_b32 " + V + ", -1, " + V);
+  Lines.push_back("v_lshlrev_b32 " + V + ", 2, " + V);
+  Lines.push_back("v_add_nc_u32 " + V + ", m0, " + V);
+  Lines.push_back(ToMnem.str() + " " + V + ", " + V + fmtOffset(Offset));
+  return Lines;
+}
+
+// Build the trampoline asm for a ds_store_addtid_b32 site. \p VTmpName is a
+// scratch VGPR holding the computed address; \p VDataName is the original
+// data VGPR. Operand order for ds_store_b32 is (addr, data).
+std::vector<std::string> buildAddtidStoreAsm(StringRef VTmpName,
+                                             StringRef VDataName,
+                                             uint32_t Offset,
+                                             StringRef ToMnem) {
+  std::string VTmp(VTmpName);
+  std::string VData(VDataName);
+  std::vector<std::string> Lines;
+  Lines.push_back("v_mbcnt_lo_u32_b32 " + VTmp + ", -1, 0");
+  Lines.push_back("v_mbcnt_hi_u32_b32 " + VTmp + ", -1, " + VTmp);
+  Lines.push_back("v_lshlrev_b32 " + VTmp + ", 2, " + VTmp);
+  Lines.push_back("v_add_nc_u32 " + VTmp + ", m0, " + VTmp);
+  Lines.push_back(ToMnem.str() + " " + VTmp + ", " + VData + fmtOffset(Offset));
+  return Lines;
+}
+
+// -- patchDsAddtid ----------------------------------------------------------
+//
+// Trampoline expansion for ds_load_addtid_b32 / ds_store_addtid_b32 on
+// A0. The replacement materialises the ADDTID address through the ALU
+// (so the full 32-bit M0 is used) and issues a regular ds_*_b32. GDS=1
+// is rejected: the rewrite stays a no-op so the original (broken on A0)
+// instruction is preserved and the failure is loud in the verbose log.
+
+bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
+  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  StringRef ToMnem = getAddtidReplacement(DI.Mnemonic);
+  if (ToMnem.empty())
+    return false;
+
+  if (isAddtidGds(DI.Inst)) {
+    log() << "hotswap: error: " << DI.Mnemonic << " with GDS=1 at 0x"
+          << utohexstr(DI.Offset)
+          << " is not supported; leaving original instruction in place\n";
+    return false;
+  }
+
+  std::optional<uint32_t> OffsetOpt = getAddtidOffset(DI.Inst);
+  if (!OffsetOpt) {
+    log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
+          << utohexstr(DI.Offset) << ": missing/non-immediate offset\n";
+    return false;
+  }
+  uint32_t Offset = *OffsetOpt;
+
+  if (DI.Inst.getNumOperands() <= AddtidOpReg ||
+      !DI.Inst.getOperand(AddtidOpReg).isReg() ||
+      !DI.Inst.getOperand(AddtidOpReg).getReg()) {
+    log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
+          << utohexstr(DI.Offset) << ": missing register operand\n";
+    return false;
+  }
+
+  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+  MCRegister Reg = MCRegister(DI.Inst.getOperand(AddtidOpReg).getReg());
+  std::string RegName = toAsmRegName(MRI, Reg);
+  if (RegName.empty()) {
+    log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
+          << utohexstr(DI.Offset) << ": cannot resolve register name\n";
+    return false;
+  }
+
+  bool IsLoad = DI.Mnemonic == "ds_load_addtid_b32";
+  std::vector<std::string> AsmLines;
+
+  if (IsLoad) {
+    AsmLines = buildAddtidLoadAsm(RegName, Offset, ToMnem);
+  } else {
+    // Store path needs a scratch VGPR for the address-compute temporary
+    // because the original data VGPR must be preserved as the store source.
+    std::optional<unsigned> TmpVgpr = allocScratchVgpr(Ctx, Idx);
+    if (!TmpVgpr) {
+      std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
+      std::optional<uint32_t> LdsSize =
+          Ctx.Elf.getKernelStaticLdsSize(KernelName);
+      // LdsSize covers only the static (compile-time-fixed) LDS allocation;
+      // dynamic LDS is added by the host at dispatch and not visible in the
+      // ELF, so this check is a "definitely exceeds 64 KiB" lower bound.
+      // Kernels that fit statically but overflow with dynamic LDS will not
+      // trip this warning.
+      if (LdsSize && *LdsSize > AddtidLdsLimitA0)
+        log() << "hotswap: warning: kernel '" << KernelName << "' uses "
+              << DI.Mnemonic << " with static LDS " << *LdsSize << " bytes (> "
+              << AddtidLdsLimitA0
+              << "); A0 16-bit M0 truncation may produce silently wrong "
+                 "results at 0x"
+              << utohexstr(DI.Offset) << "\n";
+      log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
+            << utohexstr(DI.Offset) << ": no scratch VGPR available\n";
+      return false;
+    }
+
+    ScratchPatchInfo SPI;
+    SPI.Offset = DI.Offset;
+    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+    SPI.ScratchRegs.set(*TmpVgpr);
+    Ctx.OutScratchPatches.push_back(std::move(SPI));
+
+    std::string TmpName = ("v" + Twine(*TmpVgpr)).str();
+    AsmLines = buildAddtidStoreAsm(TmpName, RegName, Offset, ToMnem);
+  }
+
+  std::string Combined;
+  for (const std::string &Line : AsmLines)
+    Combined += Line + "\n";
+  SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
+  if (Bytes.empty()) {
+    log() << "hotswap: error: " << DI.Mnemonic
+          << " trampoline assembly failed at 0x" << utohexstr(DI.Offset)
+          << "\n";
+    return false;
+  }
+
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Bytes))
+    return false;
+
+  log() << "hotswap: trampoline: " << DI.Mnemonic << " -> " << ToMnem
+        << " at 0x" << utohexstr(DI.Offset) << " (offset=" << Offset << ", "
+        << RegName << ")\n";
+  DI.Mnemonic = "<replaced>";
+  return true;
+}
+
 } // anonymous namespace
 
 // -- applyTrampolinePatches -------------------------------------------------
@@ -565,6 +764,7 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
 //
 //   ds_*_2addr_stride64_*  -> split into two single-address DS ops
 //   tensor_load_to_lds     -> prepend s_pack_hh_b32_b16 (+ save/restore)
+//   ds_*_addtid_b32        -> materialise lane-id math in ALU, then ds_*_b32
 
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
@@ -574,6 +774,9 @@ static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   if (Mnem == "tensor_load_to_lds")
     return patchTensorLoadToLds(Ctx, Idx) ? 1 : 0;
+
+  if (!getAddtidReplacement(Mnem).empty())
+    return patchDsAddtid(Ctx, Idx) ? 1 : 0;
 
   return 0;
 }

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -602,13 +602,16 @@ bool isAddtidGds(const MCInst &Inst) {
   return Op.isImm() && Op.getImm() != 0;
 }
 
-std::optional<uint32_t> getAddtidOffset(const MCInst &Inst) {
+// The DS offset field is a 16-bit immediate per the gfx12 ISA encoding;
+// returning uint16_t keeps the field width visible at the type level and
+// lets callers widen explicitly when needed.
+std::optional<uint16_t> getAddtidOffset(const MCInst &Inst) {
   if (Inst.getNumOperands() <= AddtidOpOffset)
     return std::nullopt;
   const MCOperand &Op = Inst.getOperand(AddtidOpOffset);
   if (!Op.isImm())
     return std::nullopt;
-  return static_cast<uint32_t>(Op.getImm());
+  return static_cast<uint16_t>(Op.getImm());
 }
 
 // Build the trampoline asm for a ds_load_addtid_b32 site. The destination
@@ -616,16 +619,30 @@ std::optional<uint32_t> getAddtidOffset(const MCInst &Inst) {
 // it, so no extra VGPR allocation is needed for the load path.
 //
 // The replacement reproduces the ADDTID address computation in the ALU:
-//   lane_id = mbcnt_lo(-1, 0)    ; for waveN, then mbcnt_hi(-1, lane_id)
+//   lane_id = mbcnt_lo(-1, 0)    ; lanes 0-31 contribute via exec_lo
+//             mbcnt_hi(-1, V)    ;   lanes 32-63 (wave64) extend through
+//                                ;   exec_hi; in wave32 exec_hi is zero so
+//                                ;   the hi step is a no-op (the sequence
+//                                ;   is identical for both wave sizes)
 //   addr    = m0 + lane_id * 4   ; + offset (folded into the DS encoding)
-std::vector<std::string> buildAddtidLoadAsm(StringRef VName, uint32_t Offset,
-                                            StringRef ToMnem) {
+//
+// Address mask: B0 hardware reads only 20 bits of M0 at the DS unit, so any
+// junk in M0[31:20] (e.g. left over from s_sendmsg or other M0 producers) is
+// ignored. v_add_nc_u32 reads M0 as a full 32-bit scalar source, so we mask
+// the post-add result to the same 20 bits to stay bit-exact with B0 across
+// the entire reachable LDS range (gfx1250 LDS <= 320 KiB and lane_id*4 <=
+// 0xFC, so the sum fits comfortably below 1 MiB and the mask is a no-op for
+// any conforming M0 -- the mask only fires defensively when M0[31:20] is
+// non-zero on entry).
+SmallVector<std::string, 8> buildAddtidLoadAsm(StringRef VName, uint16_t Offset,
+                                               StringRef ToMnem) {
   std::string V(VName);
-  std::vector<std::string> Lines;
+  SmallVector<std::string, 8> Lines;
   Lines.push_back("v_mbcnt_lo_u32_b32 " + V + ", -1, 0");
   Lines.push_back("v_mbcnt_hi_u32_b32 " + V + ", -1, " + V);
   Lines.push_back("v_lshlrev_b32 " + V + ", 2, " + V);
   Lines.push_back("v_add_nc_u32 " + V + ", m0, " + V);
+  Lines.push_back("v_and_b32 " + V + ", 0xfffff, " + V);
   Lines.push_back(ToMnem.str() + " " + V + ", " + V + fmtOffset(Offset));
   return Lines;
 }
@@ -633,17 +650,21 @@ std::vector<std::string> buildAddtidLoadAsm(StringRef VName, uint32_t Offset,
 // Build the trampoline asm for a ds_store_addtid_b32 site. \p VTmpName is a
 // scratch VGPR holding the computed address; \p VDataName is the original
 // data VGPR. Operand order for ds_store_b32 is (addr, data).
-std::vector<std::string> buildAddtidStoreAsm(StringRef VTmpName,
-                                             StringRef VDataName,
-                                             uint32_t Offset,
-                                             StringRef ToMnem) {
+//
+// Same mbcnt_lo/mbcnt_hi pair and 20-bit M0 mask as the load path; see
+// buildAddtidLoadAsm above for the full rationale.
+SmallVector<std::string, 8> buildAddtidStoreAsm(StringRef VTmpName,
+                                                StringRef VDataName,
+                                                uint16_t Offset,
+                                                StringRef ToMnem) {
   std::string VTmp(VTmpName);
   std::string VData(VDataName);
-  std::vector<std::string> Lines;
+  SmallVector<std::string, 8> Lines;
   Lines.push_back("v_mbcnt_lo_u32_b32 " + VTmp + ", -1, 0");
   Lines.push_back("v_mbcnt_hi_u32_b32 " + VTmp + ", -1, " + VTmp);
   Lines.push_back("v_lshlrev_b32 " + VTmp + ", 2, " + VTmp);
   Lines.push_back("v_add_nc_u32 " + VTmp + ", m0, " + VTmp);
+  Lines.push_back("v_and_b32 " + VTmp + ", 0xfffff, " + VTmp);
   Lines.push_back(ToMnem.str() + " " + VTmp + ", " + VData + fmtOffset(Offset));
   return Lines;
 }
@@ -658,9 +679,12 @@ std::vector<std::string> buildAddtidStoreAsm(StringRef VTmpName,
 
 bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  // The dispatcher in applyTrampolinePatchesImpl already gates on
+  // !getAddtidReplacement(Mnem).empty(), so by contract we only see
+  // ds_load_addtid_b32 / ds_store_addtid_b32 here.
   StringRef ToMnem = getAddtidReplacement(DI.Mnemonic);
-  if (ToMnem.empty())
-    return false;
+  assert(!ToMnem.empty() &&
+         "patchDsAddtid called for non-ADDTID mnemonic; caller must filter");
 
   if (isAddtidGds(DI.Inst)) {
     log() << "hotswap: error: " << DI.Mnemonic << " with GDS=1 at 0x"
@@ -669,13 +693,13 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     return false;
   }
 
-  std::optional<uint32_t> OffsetOpt = getAddtidOffset(DI.Inst);
+  std::optional<uint16_t> OffsetOpt = getAddtidOffset(DI.Inst);
   if (!OffsetOpt) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": missing/non-immediate offset\n";
     return false;
   }
-  uint32_t Offset = *OffsetOpt;
+  uint16_t Offset = *OffsetOpt;
 
   if (DI.Inst.getNumOperands() <= AddtidOpReg ||
       !DI.Inst.getOperand(AddtidOpReg).isReg() ||
@@ -695,15 +719,16 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   }
 
   bool IsLoad = DI.Mnemonic == "ds_load_addtid_b32";
-  std::vector<std::string> AsmLines;
+  SmallVector<std::string, 8> AsmLines;
+  std::optional<unsigned> StoreScratchVgpr;
 
   if (IsLoad) {
     AsmLines = buildAddtidLoadAsm(RegName, Offset, ToMnem);
   } else {
     // Store path needs a scratch VGPR for the address-compute temporary
     // because the original data VGPR must be preserved as the store source.
-    std::optional<unsigned> TmpVgpr = allocScratchVgpr(Ctx, Idx);
-    if (!TmpVgpr) {
+    StoreScratchVgpr = allocScratchVgpr(Ctx, Idx);
+    if (!StoreScratchVgpr) {
       std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
       std::optional<uint32_t> LdsSize =
           Ctx.Elf.getKernelStaticLdsSize(KernelName);
@@ -730,13 +755,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       return false;
     }
 
-    ScratchPatchInfo SPI;
-    SPI.Offset = DI.Offset;
-    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
-    SPI.ScratchRegs.set(*TmpVgpr);
-    Ctx.OutScratchPatches.push_back(std::move(SPI));
-
-    std::string TmpName = ("v" + Twine(*TmpVgpr)).str();
+    std::string TmpName = ("v" + Twine(*StoreScratchVgpr)).str();
     AsmLines = buildAddtidStoreAsm(TmpName, RegName, Offset, ToMnem);
   }
 
@@ -753,6 +772,18 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
 
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Bytes))
     return false;
+
+  // Record the scratch-VGPR reservation only after the patch is committed:
+  // any earlier failure (assembly, sled/trampoline emission) leaves no
+  // bytes at DI.Offset to back the reservation, so OutScratchPatches must
+  // not advertise a scratch slot for it.
+  if (StoreScratchVgpr) {
+    ScratchPatchInfo SPI;
+    SPI.Offset = DI.Offset;
+    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+    SPI.ScratchRegs.set(*StoreScratchVgpr);
+    Ctx.OutScratchPatches.push_back(std::move(SPI));
+  }
 
   log() << "hotswap: trampoline: " << DI.Mnemonic << " -> " << ToMnem
         << " at 0x" << utohexstr(DI.Offset) << " (offset=" << Offset << ", "

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -435,8 +435,22 @@ bool isSgprLiveAfter(const PatchContext &Ctx, size_t Idx,
   return true;
 }
 
-// -- allocScratchVgpr -------------------------------------------------------
-std::optional<unsigned> allocScratchVgpr(PatchContext &Ctx, size_t Idx) {
+// -- scratch-VGPR allocation ------------------------------------------------
+//
+// Allocation is split into a pure try-step and a commit-step so callers can
+// decide a scratch VGPR before assembling/emitting the patch and then only
+// charge the kernel descriptor for the extra VGPRs once the patch is known
+// to have landed. Bumping KernelPatchStats inside the try-step would leave
+// orphan VGPR reservations in the kernel descriptor whenever assembly or
+// emission failed downstream.
+
+struct ScratchAlloc {
+  unsigned Vgpr = 0;
+  std::string KernelName;
+  unsigned ExtraVgprsNeeded = 0;
+};
+
+std::optional<ScratchAlloc> tryAllocScratchVgpr(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
   unsigned KdVgprs = 0;
@@ -450,13 +464,21 @@ std::optional<unsigned> allocScratchVgpr(PatchContext &Ctx, size_t Idx) {
   if (!ScratchOpt)
     return std::nullopt;
 
-  if (Alloc.extraVgprsNeeded() > 0 && !KernelName.empty()) {
-    KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-    Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, Alloc.extraVgprsNeeded());
-    Stats.ScratchAboveKd += Alloc.extraVgprsNeeded();
-  }
+  ScratchAlloc Out;
+  Out.Vgpr = *ScratchOpt;
+  Out.KernelName = std::move(KernelName);
+  Out.ExtraVgprsNeeded = Alloc.extraVgprsNeeded();
+  return Out;
+}
 
-  return *ScratchOpt;
+// Apply the kernel-descriptor accounting for a scratch VGPR. Must be called
+// only after the corresponding patch has been emitted successfully.
+void commitScratchVgpr(PatchContext &Ctx, const ScratchAlloc &Alloc) {
+  if (Alloc.ExtraVgprsNeeded == 0 || Alloc.KernelName.empty())
+    return;
+  KernelPatchStats &Stats = Ctx.KernelStats[Alloc.KernelName];
+  Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, Alloc.ExtraVgprsNeeded);
+  Stats.ScratchAboveKd += Alloc.ExtraVgprsNeeded;
 }
 
 // -- patchTensorLoadToLds ---------------------------------------------------
@@ -511,20 +533,14 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
   const uint8_t *OrigInst = Ctx.Text + DI.Offset;
 
   if (SgprLive) {
-    std::optional<unsigned> ScratchVgpr = allocScratchVgpr(Ctx, Idx);
+    std::optional<ScratchAlloc> ScratchVgpr = tryAllocScratchVgpr(Ctx, Idx);
     if (!ScratchVgpr) {
       log() << "hotswap: error: tensor_load_to_lds: no scratch VGPR "
                "available\n";
       return false;
     }
 
-    ScratchPatchInfo SPI;
-    SPI.Offset = DI.Offset;
-    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
-    SPI.ScratchRegs.set(*ScratchVgpr);
-    Ctx.OutScratchPatches.push_back(std::move(SPI));
-
-    std::string V = "v" + std::to_string(*ScratchVgpr);
+    std::string V = "v" + std::to_string(ScratchVgpr->Vgpr);
     std::string SaveAsm = "v_writelane_b32 " + V + ", " + BaseSreg + ", 0";
     std::string RestoreAsm = "v_readlane_b32 " + BaseSreg + ", " + V + ", 0";
     SmallVector<uint8_t> Save = assembleSingleInst(SaveAsm, Ctx.LS);
@@ -542,6 +558,17 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
 
     if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
       return false;
+
+    // Record the scratch reservation only after the patch is committed:
+    // any earlier failure (assembly, emission) leaves nothing at DI.Offset
+    // to back the reservation, and bumping the kernel descriptor would
+    // reserve VGPRs the code object never uses.
+    ScratchPatchInfo SPI;
+    SPI.Offset = DI.Offset;
+    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+    SPI.ScratchRegs.set(ScratchVgpr->Vgpr);
+    Ctx.OutScratchPatches.push_back(std::move(SPI));
+    commitScratchVgpr(Ctx, *ScratchVgpr);
 
     log() << "hotswap: tensor_load_to_lds: " << BaseSreg
           << " live, save/restore via " << V << "\n";
@@ -572,6 +599,13 @@ StringRef getAddtidReplacement(StringRef Mnemonic) {
       .Case("ds_load_addtid_b32", "ds_load_b32")
       .Case("ds_store_addtid_b32", "ds_store_b32")
       .Default("");
+}
+
+// Predicate that pins the load/store dispatch alongside getAddtidReplacement
+// so the two stay in sync if the table grows. Avoids a string compare in
+// patchDsAddtid that would silently diverge from the StringSwitch above.
+bool isAddtidLoad(StringRef Mnemonic) {
+  return Mnemonic == "ds_load_addtid_b32";
 }
 
 // LDS allocations strictly above this threshold are unreachable through
@@ -616,7 +650,10 @@ std::optional<uint16_t> getAddtidOffset(const MCInst &Inst) {
 
 // Build the trampoline asm for a ds_load_addtid_b32 site. The destination
 // VGPR is reused as the address-compute scratch because the load overwrites
-// it, so no extra VGPR allocation is needed for the load path.
+// it, so no extra VGPR allocation is needed for the load path. Reusing the
+// destination as both source operands of ds_load_b32 (`ds_load_b32 vN, vN`)
+// is well-defined on gfx12: the DS unit reads vaddr from the operand file
+// before vdst is written, so the same VGPR can serve both roles.
 //
 // The replacement reproduces the ADDTID address computation in the ALU:
 //   lane_id = mbcnt_lo(-1, 0)    ; lanes 0-31 contribute via exec_lo
@@ -624,7 +661,8 @@ std::optional<uint16_t> getAddtidOffset(const MCInst &Inst) {
 //                                ;   exec_hi; in wave32 exec_hi is zero so
 //                                ;   the hi step is a no-op (the sequence
 //                                ;   is identical for both wave sizes)
-//   addr    = m0 + lane_id * 4   ; + offset (folded into the DS encoding)
+//   addr    = m0 + lane_id * 4   ; + offset (folded into the DS encoding by
+//                                ;   the assembler when ToMnem is emitted)
 //
 // Address mask: B0 hardware reads only 20 bits of M0 at the DS unit, so any
 // junk in M0[31:20] (e.g. left over from s_sendmsg or other M0 producers) is
@@ -634,10 +672,10 @@ std::optional<uint16_t> getAddtidOffset(const MCInst &Inst) {
 // 0xFC, so the sum fits comfortably below 1 MiB and the mask is a no-op for
 // any conforming M0 -- the mask only fires defensively when M0[31:20] is
 // non-zero on entry).
-SmallVector<std::string, 8> buildAddtidLoadAsm(StringRef VName, uint16_t Offset,
-                                               StringRef ToMnem) {
+SmallVector<std::string> buildAddtidLoadAsm(StringRef VName, uint16_t Offset,
+                                            StringRef ToMnem) {
   std::string V(VName);
-  SmallVector<std::string, 8> Lines;
+  SmallVector<std::string> Lines;
   Lines.push_back("v_mbcnt_lo_u32_b32 " + V + ", -1, 0");
   Lines.push_back("v_mbcnt_hi_u32_b32 " + V + ", -1, " + V);
   Lines.push_back("v_lshlrev_b32 " + V + ", 2, " + V);
@@ -653,13 +691,13 @@ SmallVector<std::string, 8> buildAddtidLoadAsm(StringRef VName, uint16_t Offset,
 //
 // Same mbcnt_lo/mbcnt_hi pair and 20-bit M0 mask as the load path; see
 // buildAddtidLoadAsm above for the full rationale.
-SmallVector<std::string, 8> buildAddtidStoreAsm(StringRef VTmpName,
-                                                StringRef VDataName,
-                                                uint16_t Offset,
-                                                StringRef ToMnem) {
+SmallVector<std::string> buildAddtidStoreAsm(StringRef VTmpName,
+                                             StringRef VDataName,
+                                             uint16_t Offset,
+                                             StringRef ToMnem) {
   std::string VTmp(VTmpName);
   std::string VData(VDataName);
-  SmallVector<std::string, 8> Lines;
+  SmallVector<std::string> Lines;
   Lines.push_back("v_mbcnt_lo_u32_b32 " + VTmp + ", -1, 0");
   Lines.push_back("v_mbcnt_hi_u32_b32 " + VTmp + ", -1, " + VTmp);
   Lines.push_back("v_lshlrev_b32 " + VTmp + ", 2, " + VTmp);
@@ -718,18 +756,20 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     return false;
   }
 
-  bool IsLoad = DI.Mnemonic == "ds_load_addtid_b32";
-  SmallVector<std::string, 8> AsmLines;
-  std::optional<unsigned> StoreScratchVgpr;
+  bool IsLoad = isAddtidLoad(DI.Mnemonic);
+  SmallVector<std::string> AsmLines;
+  std::optional<ScratchAlloc> StoreScratch;
 
   if (IsLoad) {
     AsmLines = buildAddtidLoadAsm(RegName, Offset, ToMnem);
   } else {
     // Store path needs a scratch VGPR for the address-compute temporary
     // because the original data VGPR must be preserved as the store source.
-    StoreScratchVgpr = allocScratchVgpr(Ctx, Idx);
-    if (!StoreScratchVgpr) {
+    StoreScratch = tryAllocScratchVgpr(Ctx, Idx);
+    if (!StoreScratch) {
       std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
+      StringRef KernelDisplay =
+          KernelName.empty() ? StringRef("<unknown>") : StringRef(KernelName);
       std::optional<uint32_t> LdsSize =
           Ctx.Elf.getKernelStaticLdsSize(KernelName);
       // Trampoline could not be applied: the original ds_*_addtid_b32 stays
@@ -741,7 +781,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       // fires unconditionally rather than gating on the visible lower
       // bound -- a follow-up will use ElfView::kernelUsesDynamicLds to
       // tighten the condition to (static>64KiB || dynamicUsed).
-      log() << "hotswap: warning: kernel '" << KernelName << "' uses "
+      log() << "hotswap: warning: kernel '" << KernelDisplay << "' uses "
             << DI.Mnemonic
             << "; trampoline could not be applied, so A0 16-bit M0"
                " truncation may produce silently wrong results when runtime"
@@ -755,7 +795,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       return false;
     }
 
-    std::string TmpName = ("v" + Twine(*StoreScratchVgpr)).str();
+    std::string TmpName = ("v" + Twine(StoreScratch->Vgpr)).str();
     AsmLines = buildAddtidStoreAsm(TmpName, RegName, Offset, ToMnem);
   }
 
@@ -773,16 +813,17 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Bytes))
     return false;
 
-  // Record the scratch-VGPR reservation only after the patch is committed:
+  // Commit the scratch-VGPR reservation only after the patch is in place:
   // any earlier failure (assembly, sled/trampoline emission) leaves no
-  // bytes at DI.Offset to back the reservation, so OutScratchPatches must
-  // not advertise a scratch slot for it.
-  if (StoreScratchVgpr) {
+  // bytes at DI.Offset to back the reservation, so neither the descriptor
+  // accounting nor OutScratchPatches must advertise a slot for it.
+  if (StoreScratch) {
     ScratchPatchInfo SPI;
     SPI.Offset = DI.Offset;
     SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
-    SPI.ScratchRegs.set(*StoreScratchVgpr);
+    SPI.ScratchRegs.set(StoreScratch->Vgpr);
     Ctx.OutScratchPatches.push_back(std::move(SPI));
+    commitScratchVgpr(Ctx, *StoreScratch);
   }
 
   log() << "hotswap: trampoline: " << DI.Mnemonic << " -> " << ToMnem

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
@@ -6,6 +6,15 @@
 // COM: .text via growWithTrampolines. Companion to hotswap-trampoline-
 // COM: addtid.s which exercises the in-place NOP-sled path on the same
 // COM: opcode.
+// COM:
+// COM: DISASM convention: the kernel-local sequence (s_branch, s_wait_dscnt,
+// COM: s_endpgm) is checked with a strict DISASM-NEXT chain. The trampoline
+// COM: body lives in a separate region appended by growWithTrampolines, so
+// COM: the second block uses a non-consecutive 'DISASM:' on v_mbcnt_lo to
+// COM: skip over the kernel terminator and any padding the assembler emits
+// COM: between regions, then DISASM-NEXT chains every body instruction so
+// COM: regressions in the math sequence, the 20-bit mask, or the operand
+// COM: order of ds_load_b32 are caught.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
@@ -1,0 +1,64 @@
+// COM: Test the trampoline fallback path for ds_*_addtid_b32 when no NOP
+// COM: sled is available. With zero NOP padding inside the kernel,
+// COM: emitReplacementCode falls back to emitToTrampoline: the original
+// COM: ADDTID is rewritten to s_branch and the 5-instruction expansion
+// COM: (lane-id math + ds_load_b32) is appended after .text via
+// COM: growWithTrampolines. Companion to hotswap-trampoline-addtid.s
+// COM: which exercises the in-place NOP-sled path on the same opcode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The original ADDTID is gone; an s_branch forward replaces it. The
+// COM: surrounding s_wait_dscnt and s_endpgm are untouched.
+// DISASM-LABEL: <test_addtid_nosled>:
+// DISASM-NOT: ds_load_addtid_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: s_endpgm
+
+// COM: Trampoline body appended after .text: lane-id math then ds_load_b32
+// COM: with the original offset folded in, then s_branch back to the
+// COM: instruction following the original ADDTID site.
+// DISASM: v_mbcnt_lo_u32_b32
+// DISASM-NEXT: v_mbcnt_hi_u32_b32
+// DISASM: v_lshlrev_b32
+// DISASM-NEXT: v_add_nc_u32
+// DISASM: ds_load_b32
+// DISASM: s_branch
+
+// COM: Idempotency: rewriting the patched output a second time must
+// COM: produce identical bytes. The trampoline body uses plain ds_load_b32
+// COM: (no ADDTID mnemonic), so the dispatcher leaves it untouched on
+// COM: subsequent runs.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_addtid_nosled
+.p2align 8
+.type test_addtid_nosled,@function
+test_addtid_nosled:
+  ds_load_addtid_b32 v5 offset:128
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_addtid_nosled_end:
+.size test_addtid_nosled, .Ltest_addtid_nosled_end-test_addtid_nosled
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_addtid_nosled
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
@@ -7,8 +7,12 @@
 // COM: addtid.s which exercises the in-place NOP-sled path on the same
 // COM: opcode.
 // COM:
-// COM: DISASM convention: the kernel-local sequence (s_branch, s_wait_dscnt,
-// COM: s_endpgm) is checked with a strict DISASM-NEXT chain. The trampoline
+// COM: DISASM convention: the kernel-local sequence (s_branch, structural
+// COM: s_nop pad, s_wait_dscnt, s_endpgm) is checked with a strict
+// COM: DISASM-NEXT chain. The s_nop is structural: ds_load_addtid_b32 is
+// COM: 8 bytes, s_branch is 4 bytes, so emitToTrampoline always pads the
+// COM: tail half of the original instruction slot with one s_nop -- pinning
+// COM: it here catches any change to that padding scheme. The trampoline
 // COM: body lives in a separate region appended by growWithTrampolines, so
 // COM: the second block uses a non-consecutive 'DISASM:' on v_mbcnt_lo to
 // COM: skip over the kernel terminator and any padding the assembler emits
@@ -35,6 +39,7 @@
 // DISASM-LABEL: <test_addtid_nosled>:
 // DISASM-NOT:   ds_load_addtid_b32
 // DISASM:       s_branch
+// DISASM-NEXT:  s_nop 0
 // DISASM-NEXT:  s_wait_dscnt 0x0
 // DISASM-NEXT:  s_endpgm
 

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
@@ -1,10 +1,11 @@
 // COM: Test the trampoline fallback path for ds_*_addtid_b32 when no NOP
 // COM: sled is available. With zero NOP padding inside the kernel,
 // COM: emitReplacementCode falls back to emitToTrampoline: the original
-// COM: ADDTID is rewritten to s_branch and the 5-instruction expansion
-// COM: (lane-id math + ds_load_b32) is appended after .text via
-// COM: growWithTrampolines. Companion to hotswap-trampoline-addtid.s
-// COM: which exercises the in-place NOP-sled path on the same opcode.
+// COM: ADDTID is rewritten to s_branch and the 6-instruction expansion
+// COM: (lane-id math + 20-bit M0 mask + ds_load_b32) is appended after
+// COM: .text via growWithTrampolines. Companion to hotswap-trampoline-
+// COM: addtid.s which exercises the in-place NOP-sled path on the same
+// COM: opcode.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -16,33 +17,32 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: The original ADDTID is gone; an s_branch forward replaces it. The
-// COM: surrounding s_wait_dscnt and s_endpgm are untouched.
+// ---- Kernel: ds_load_addtid_b32 with no sled --------------------------------
+//
+// COM: Inside the kernel function the original ADDTID is gone; an s_branch
+// COM: forward replaces it. The surrounding s_wait_dscnt and s_endpgm are
+// COM: untouched.
+
 // DISASM-LABEL: <test_addtid_nosled>:
-// DISASM-NOT: ds_load_addtid_b32
-// DISASM: s_branch
-// DISASM: s_wait_dscnt 0x0
-// DISASM: s_endpgm
+// DISASM-NOT:   ds_load_addtid_b32
+// DISASM:       s_branch
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  s_endpgm
 
-// COM: Trampoline body appended after .text: lane-id math then ds_load_b32
-// COM: with the original offset folded in, then s_branch back to the
-// COM: instruction following the original ADDTID site.
-// DISASM: v_mbcnt_lo_u32_b32
-// DISASM-NEXT: v_mbcnt_hi_u32_b32
-// DISASM: v_lshlrev_b32
-// DISASM-NEXT: v_add_nc_u32
-// DISASM: ds_load_b32
-// DISASM: s_branch
+// COM: Trampoline body appended after .text: lane-id math, 20-bit M0 mask
+// COM: (matches B0's DS-unit M0 read width and is a no-op for any
+// COM: conforming M0 value), ds_load_b32 with the original offset:128
+// COM: folded into the DS encoding, then s_branch back to the instruction
+// COM: following the original ADDTID site. All operand-pinned so that an
+// COM: offset/operand/shift/scalar-source regression is caught here.
 
-// COM: Idempotency: rewriting the patched output a second time must
-// COM: produce identical bytes. The trampoline body uses plain ds_load_b32
-// COM: (no ADDTID mnemonic), so the dispatcher leaves it untouched on
-// COM: subsequent runs.
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
+// DISASM:       v_mbcnt_lo_u32_b32 v5, -1, 0
+// DISASM-NEXT:  v_mbcnt_hi_u32_b32 v5, -1, v5
+// DISASM-NEXT:  v_lshlrev_b32_e32 v5, 2, v5
+// DISASM-NEXT:  v_add_nc_u32_e32 v5, m0, v5
+// DISASM-NEXT:  v_and_b32_e32 v5, 0xfffff, v5
+// DISASM-NEXT:  ds_load_b32 v5, v5 offset:128
+// DISASM-NEXT:  s_branch
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -62,3 +62,13 @@ test_addtid_nosled:
   .amdhsa_next_free_vgpr 6
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel
+
+// COM: Idempotency: rewriting the patched output a second time must
+// COM: produce identical bytes. The trampoline body uses plain ds_load_b32
+// COM: (no ADDTID mnemonic), so the dispatcher leaves it untouched on
+// COM: subsequent runs.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -3,8 +3,9 @@
 // COM: On A0 the DS unit truncates M0 to 16 bits, so ADDTID address
 // COM: encodings (M0 + lane_id*4 + offset) silently wrap above 64KB
 // COM: (DEGFXMI400-12025). The trampoline materialises the lane-id math
-// COM: in the ALU using the full 32-bit M0 and issues a regular
-// COM: ds_load_b32 / ds_store_b32, bypassing the buggy address path.
+// COM: in the ALU using M0 masked to 20 bits (matching B0's DS-unit M0
+// COM: read width) and issues a regular ds_load_b32 / ds_store_b32,
+// COM: bypassing the buggy address path.
 // COM:
 // COM: Coverage:
 // COM:   test_addtid_load        : ds_load_addtid_b32 + offset (NOP sled)
@@ -21,49 +22,26 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1: ds_load_addtid_b32 with non-zero offset.
-// COM:   Original site is replaced with s_branch (forward to NOP sled);
-// COM:   the sled body computes lane_id*4 + m0 in vDST, then reads LDS
-// COM:   with the original offset folded into the DS encoding; finally
-// COM:   s_branch returns to the next instruction past the original.
-// DISASM-LABEL: <test_addtid_load>:
-// DISASM-NOT: ds_load_addtid_b32
-// DISASM: s_branch
-// DISASM: v_mbcnt_lo_u32_b32
-// DISASM-NEXT: v_mbcnt_hi_u32_b32
-// DISASM: v_lshlrev_b32
-// DISASM-NEXT: v_add_nc_u32
-// DISASM: ds_load_b32
-// DISASM: s_branch
-
-// COM: Kernel 2: ds_load_addtid_b32 with offset:0 (offset suffix omitted).
-// DISASM-LABEL: <test_addtid_load_zero>:
-// DISASM-NOT: ds_load_addtid_b32
-// DISASM: s_branch
-// DISASM: v_mbcnt_lo_u32_b32
-// DISASM: ds_load_b32
-// DISASM: s_branch
-
-// COM: Kernel 3: ds_store_addtid_b32. Scratch VGPR holds the computed
-// COM: address; original data VGPR is preserved as the store source.
-// DISASM-LABEL: <test_addtid_store>:
-// DISASM-NOT: ds_store_addtid_b32
-// DISASM: s_branch
-// DISASM: v_mbcnt_lo_u32_b32
-// DISASM: v_add_nc_u32
-// DISASM: ds_store_b32
-// DISASM: s_branch
-
-// COM: Idempotency: rewriting the output a second time must produce
-// COM: identical bytes (the patched body has no ADDTID mnemonic so the
-// COM: dispatcher leaves it untouched on subsequent runs).
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
-
 // ---- Kernel 1: ds_load_addtid_b32 with offset --------------------------------
+//
+// COM: Original site is replaced with s_branch (forward to NOP sled). The
+// COM: sled body computes lane_id*4 + m0 in the load's destination VGPR (v5),
+// COM: masks the result to 20 bits to match B0's DS-unit M0 read width, then
+// COM: reads LDS with the original offset folded into the DS encoding, and
+// COM: finally s_branch returns to the instruction following the original.
+// COM: Operand-pinned matches catch any regression that drops the offset,
+// COM: swaps operand order, or changes the shift / add scalar source.
+
+// DISASM-LABEL: <test_addtid_load>:
+// DISASM-NOT:   ds_load_addtid_b32
+// DISASM:       s_branch
+// DISASM:       v_mbcnt_lo_u32_b32 v5, -1, 0
+// DISASM-NEXT:  v_mbcnt_hi_u32_b32 v5, -1, v5
+// DISASM-NEXT:  v_lshlrev_b32_e32 v5, 2, v5
+// DISASM-NEXT:  v_add_nc_u32_e32 v5, m0, v5
+// DISASM-NEXT:  v_and_b32_e32 v5, 0xfffff, v5
+// DISASM-NEXT:  ds_load_b32 v5, v5 offset:128
+// DISASM-NEXT:  s_branch
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -93,8 +71,32 @@ test_addtid_load:
 .Ltest_addtid_load_end:
 .size test_addtid_load, .Ltest_addtid_load_end-test_addtid_load
 
-// ---- Kernel 2: ds_load_addtid_b32 with offset:0 ------------------------------
+.rodata
+.p2align 8
+.amdhsa_kernel test_addtid_load
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
 
+// ---- Kernel 2: ds_load_addtid_b32 with offset:0 ------------------------------
+//
+// COM: Same expansion as kernel 1 but with offset:0. The disassembler omits
+// COM: the offset suffix entirely when the encoded offset is zero, so the
+// COM: ds_load_b32 line drops `offset:N` -- the test pins this so a future
+// COM: change that always emits `offset:0` would surface here.
+
+// DISASM-LABEL: <test_addtid_load_zero>:
+// DISASM-NOT:   ds_load_addtid_b32
+// DISASM:       s_branch
+// DISASM:       v_mbcnt_lo_u32_b32 v6, -1, 0
+// DISASM-NEXT:  v_mbcnt_hi_u32_b32 v6, -1, v6
+// DISASM-NEXT:  v_lshlrev_b32_e32 v6, 2, v6
+// DISASM-NEXT:  v_add_nc_u32_e32 v6, m0, v6
+// DISASM-NEXT:  v_and_b32_e32 v6, 0xfffff, v6
+// DISASM-NEXT:  ds_load_b32 v6, v6
+// DISASM-NEXT:  s_branch
+
+.text
 .globl test_addtid_load_zero
 .p2align 8
 .type test_addtid_load_zero,@function
@@ -121,8 +123,34 @@ test_addtid_load_zero:
 .Ltest_addtid_load_zero_end:
 .size test_addtid_load_zero, .Ltest_addtid_load_zero_end-test_addtid_load_zero
 
-// ---- Kernel 3: ds_store_addtid_b32 ------------------------------------------
+.rodata
+.amdhsa_kernel test_addtid_load_zero
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
 
+// ---- Kernel 3: ds_store_addtid_b32 ------------------------------------------
+//
+// COM: Store path needs a separate scratch VGPR for the address-compute
+// COM: temporary because the original data VGPR (v8) must be preserved as
+// COM: the store source. The scratch register comes from allocScratchVgpr;
+// COM: the exact index varies with liveness, so we capture it through a
+// COM: FileCheck regex variable [[VTMP]] and pin it across the body. Most
+// COM: importantly: the ds_store_b32 operand order must be (addr, data) =
+// COM: ([[VTMP]], v8) -- a swap would silently corrupt the LDS layout.
+
+// DISASM-LABEL: <test_addtid_store>:
+// DISASM-NOT:   ds_store_addtid_b32
+// DISASM:       s_branch
+// DISASM:       v_mbcnt_lo_u32_b32 [[VTMP:v[0-9]+]], -1, 0
+// DISASM-NEXT:  v_mbcnt_hi_u32_b32 [[VTMP]], -1, [[VTMP]]
+// DISASM-NEXT:  v_lshlrev_b32_e32 [[VTMP]], 2, [[VTMP]]
+// DISASM-NEXT:  v_add_nc_u32_e32 [[VTMP]], m0, [[VTMP]]
+// DISASM-NEXT:  v_and_b32_e32 [[VTMP]], 0xfffff, [[VTMP]]
+// DISASM-NEXT:  ds_store_b32 [[VTMP]], v8 offset:64
+// DISASM-NEXT:  s_branch
+
+.text
 .globl test_addtid_store
 .p2align 8
 .type test_addtid_store,@function
@@ -150,18 +178,16 @@ test_addtid_store:
 .size test_addtid_store, .Ltest_addtid_store_end-test_addtid_store
 
 .rodata
-.p2align 8
-.amdhsa_kernel test_addtid_load
-  .amdhsa_next_free_vgpr 6
-  .amdhsa_next_free_sgpr 1
-.end_amdhsa_kernel
-
-.amdhsa_kernel test_addtid_load_zero
-  .amdhsa_next_free_vgpr 7
-  .amdhsa_next_free_sgpr 1
-.end_amdhsa_kernel
-
 .amdhsa_kernel test_addtid_store
   .amdhsa_next_free_vgpr 9
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel
+
+// COM: Idempotency: rewriting the output a second time must produce
+// COM: identical bytes (the patched body has no ADDTID mnemonic so the
+// COM: dispatcher leaves it untouched on subsequent runs).
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -11,6 +11,15 @@
 // COM:   test_addtid_load        : ds_load_addtid_b32 + offset (NOP sled)
 // COM:   test_addtid_load_zero   : ds_load_addtid_b32 + offset:0
 // COM:   test_addtid_store       : ds_store_addtid_b32 needs a scratch VGPR
+// COM:
+// COM: DISASM-NEXT vs DISASM convention used throughout this file: the
+// COM: original ADDTID site is replaced in place by an s_branch, then the
+// COM: NOP-sled padding follows (variable size, depends on how many s_nops
+// COM: were available inside the kernel) and only after the sled does the
+// COM: trampoline body start. The gap is bridged with a non-consecutive
+// COM: 'DISASM:' on v_mbcnt_lo so FileCheck skips over the sled NOPs;
+// COM: every instruction inside the trampoline body is then chained with
+// COM: 'DISASM-NEXT:' so the body itself is verified bit-for-bit.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -133,7 +142,7 @@ test_addtid_load_zero:
 //
 // COM: Store path needs a separate scratch VGPR for the address-compute
 // COM: temporary because the original data VGPR (v8) must be preserved as
-// COM: the store source. The scratch register comes from allocScratchVgpr;
+// COM: the store source. The scratch register comes from tryAllocScratchVgpr;
 // COM: the exact index varies with liveness, so we capture it through a
 // COM: FileCheck regex variable [[VTMP]] and pin it across the body. Most
 // COM: importantly: the ds_store_b32 operand order must be (addr, data) =

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -1,0 +1,167 @@
+// COM: Test HotSwap trampoline patch: ds_*_addtid_b32 expansion.
+// COM:
+// COM: On A0 the DS unit truncates M0 to 16 bits, so ADDTID address
+// COM: encodings (M0 + lane_id*4 + offset) silently wrap above 64KB
+// COM: (DEGFXMI400-12025). The trampoline materialises the lane-id math
+// COM: in the ALU using the full 32-bit M0 and issues a regular
+// COM: ds_load_b32 / ds_store_b32, bypassing the buggy address path.
+// COM:
+// COM: Coverage:
+// COM:   test_addtid_load        : ds_load_addtid_b32 + offset (NOP sled)
+// COM:   test_addtid_load_zero   : ds_load_addtid_b32 + offset:0
+// COM:   test_addtid_store       : ds_store_addtid_b32 needs a scratch VGPR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Kernel 1: ds_load_addtid_b32 with non-zero offset.
+// COM:   Original site is replaced with s_branch (forward to NOP sled);
+// COM:   the sled body computes lane_id*4 + m0 in vDST, then reads LDS
+// COM:   with the original offset folded into the DS encoding; finally
+// COM:   s_branch returns to the next instruction past the original.
+// DISASM-LABEL: <test_addtid_load>:
+// DISASM-NOT: ds_load_addtid_b32
+// DISASM: s_branch
+// DISASM: v_mbcnt_lo_u32_b32
+// DISASM-NEXT: v_mbcnt_hi_u32_b32
+// DISASM: v_lshlrev_b32
+// DISASM-NEXT: v_add_nc_u32
+// DISASM: ds_load_b32
+// DISASM: s_branch
+
+// COM: Kernel 2: ds_load_addtid_b32 with offset:0 (offset suffix omitted).
+// DISASM-LABEL: <test_addtid_load_zero>:
+// DISASM-NOT: ds_load_addtid_b32
+// DISASM: s_branch
+// DISASM: v_mbcnt_lo_u32_b32
+// DISASM: ds_load_b32
+// DISASM: s_branch
+
+// COM: Kernel 3: ds_store_addtid_b32. Scratch VGPR holds the computed
+// COM: address; original data VGPR is preserved as the store source.
+// DISASM-LABEL: <test_addtid_store>:
+// DISASM-NOT: ds_store_addtid_b32
+// DISASM: s_branch
+// DISASM: v_mbcnt_lo_u32_b32
+// DISASM: v_add_nc_u32
+// DISASM: ds_store_b32
+// DISASM: s_branch
+
+// COM: Idempotency: rewriting the output a second time must produce
+// COM: identical bytes (the patched body has no ADDTID mnemonic so the
+// COM: dispatcher leaves it untouched on subsequent runs).
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// ---- Kernel 1: ds_load_addtid_b32 with offset --------------------------------
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_addtid_load
+.p2align 8
+.type test_addtid_load,@function
+test_addtid_load:
+  ds_load_addtid_b32 v5 offset:128
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_addtid_load_end:
+.size test_addtid_load, .Ltest_addtid_load_end-test_addtid_load
+
+// ---- Kernel 2: ds_load_addtid_b32 with offset:0 ------------------------------
+
+.globl test_addtid_load_zero
+.p2align 8
+.type test_addtid_load_zero,@function
+test_addtid_load_zero:
+  ds_load_addtid_b32 v6 offset:0
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_addtid_load_zero_end:
+.size test_addtid_load_zero, .Ltest_addtid_load_zero_end-test_addtid_load_zero
+
+// ---- Kernel 3: ds_store_addtid_b32 ------------------------------------------
+
+.globl test_addtid_store
+.p2align 8
+.type test_addtid_store,@function
+test_addtid_store:
+  ds_store_addtid_b32 v8 offset:64
+  s_wait_dscnt 0x0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_addtid_store_end:
+.size test_addtid_store, .Ltest_addtid_store_end-test_addtid_store
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_addtid_load
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_addtid_load_zero
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_addtid_store
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -580,10 +580,14 @@ TEST(AddTid, LoadTrampolineAsmAssemblesAndDecodes) {
   ASSERT_TRUE(S.Valid);
 
   // Replacement asm for ds_load_addtid_b32 v7 offset:64.
+  // The v_and_b32 with 0xfffff masks M0 to the 20 bits that B0's DS unit
+  // would have read, keeping the rewrite bit-exact with B0 hardware
+  // regardless of stale bits in M0[31:20] on entry.
   std::string Asm = "v_mbcnt_lo_u32_b32 v7, -1, 0\n"
                     "v_mbcnt_hi_u32_b32 v7, -1, v7\n"
                     "v_lshlrev_b32 v7, 2, v7\n"
                     "v_add_nc_u32 v7, m0, v7\n"
+                    "v_and_b32 v7, 0xfffff, v7\n"
                     "ds_load_b32 v7, v7 offset:64\n";
 
   llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
@@ -591,12 +595,13 @@ TEST(AddTid, LoadTrampolineAsmAssemblesAndDecodes) {
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 5u);
+  ASSERT_EQ(Decoded.size(), 6u);
   EXPECT_EQ(Decoded[0].Mnemonic, "v_mbcnt_lo_u32_b32");
   EXPECT_EQ(Decoded[1].Mnemonic, "v_mbcnt_hi_u32_b32");
   EXPECT_EQ(Decoded[2].Mnemonic, "v_lshlrev_b32");
   EXPECT_EQ(Decoded[3].Mnemonic, "v_add_nc_u32");
-  EXPECT_EQ(Decoded[4].Mnemonic, "ds_load_b32");
+  EXPECT_EQ(Decoded[4].Mnemonic, "v_and_b32");
+  EXPECT_EQ(Decoded[5].Mnemonic, "ds_load_b32");
 }
 
 TEST(AddTid, StoreTrampolineAsmAssemblesAndDecodes) {
@@ -604,11 +609,14 @@ TEST(AddTid, StoreTrampolineAsmAssemblesAndDecodes) {
   ASSERT_TRUE(S.Valid);
 
   // Replacement asm for ds_store_addtid_b32 v10 offset:0 with v42 as the
-  // address-compute scratch (the data VGPR v10 is not clobbered).
+  // address-compute scratch (the data VGPR v10 is not clobbered). The
+  // v_and_b32 with 0xfffff masks M0 to the 20-bit DS-unit width; see
+  // LoadTrampolineAsmAssemblesAndDecodes for the rationale.
   std::string Asm = "v_mbcnt_lo_u32_b32 v42, -1, 0\n"
                     "v_mbcnt_hi_u32_b32 v42, -1, v42\n"
                     "v_lshlrev_b32 v42, 2, v42\n"
                     "v_add_nc_u32 v42, m0, v42\n"
+                    "v_and_b32 v42, 0xfffff, v42\n"
                     "ds_store_b32 v42, v10\n";
 
   llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
@@ -616,12 +624,13 @@ TEST(AddTid, StoreTrampolineAsmAssemblesAndDecodes) {
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 5u);
+  ASSERT_EQ(Decoded.size(), 6u);
   EXPECT_EQ(Decoded[0].Mnemonic, "v_mbcnt_lo_u32_b32");
   EXPECT_EQ(Decoded[1].Mnemonic, "v_mbcnt_hi_u32_b32");
   EXPECT_EQ(Decoded[2].Mnemonic, "v_lshlrev_b32");
   EXPECT_EQ(Decoded[3].Mnemonic, "v_add_nc_u32");
-  EXPECT_EQ(Decoded[4].Mnemonic, "ds_store_b32");
+  EXPECT_EQ(Decoded[4].Mnemonic, "v_and_b32");
+  EXPECT_EQ(Decoded[5].Mnemonic, "ds_store_b32");
 }
 
 TEST(AddTid, LoadTrampolineThroughBuildTrampoline) {
@@ -631,7 +640,7 @@ TEST(AddTid, LoadTrampolineThroughBuildTrampoline) {
   std::vector<std::string> AsmLines = {
       "v_mbcnt_lo_u32_b32 v3, -1, 0", "v_mbcnt_hi_u32_b32 v3, -1, v3",
       "v_lshlrev_b32 v3, 2, v3",      "v_add_nc_u32 v3, m0, v3",
-      "ds_load_b32 v3, v3 offset:0",
+      "v_and_b32 v3, 0xfffff, v3",    "ds_load_b32 v3, v3 offset:0",
   };
 
   Trampoline T = buildTrampoline(AsmLines, /*OriginalOffset=*/0x100,
@@ -642,11 +651,11 @@ TEST(AddTid, LoadTrampolineThroughBuildTrampoline) {
   EXPECT_EQ(T.OriginalOffset, 0x100u);
   EXPECT_EQ(T.OriginalSize, 4u);
 
-  // 5 body instructions + 1 branch-back tail.
+  // 6 body instructions + 1 branch-back tail.
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(T.Bytes.data(), T.Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 6u);
-  EXPECT_EQ(Decoded[5].Mnemonic, "s_branch");
+  ASSERT_EQ(Decoded.size(), 7u);
+  EXPECT_EQ(Decoded[6].Mnemonic, "s_branch");
 }
 
 TEST(AddTid, StoreTrampolineThroughBuildTrampoline) {
@@ -661,7 +670,7 @@ TEST(AddTid, StoreTrampolineThroughBuildTrampoline) {
   std::vector<std::string> AsmLines = {
       "v_mbcnt_lo_u32_b32 v42, -1, 0", "v_mbcnt_hi_u32_b32 v42, -1, v42",
       "v_lshlrev_b32 v42, 2, v42",     "v_add_nc_u32 v42, m0, v42",
-      "ds_store_b32 v42, v10",
+      "v_and_b32 v42, 0xfffff, v42",   "ds_store_b32 v42, v10",
   };
 
   Trampoline T = buildTrampoline(AsmLines, /*OriginalOffset=*/0x180,
@@ -672,11 +681,11 @@ TEST(AddTid, StoreTrampolineThroughBuildTrampoline) {
   EXPECT_EQ(T.OriginalOffset, 0x180u);
   EXPECT_EQ(T.OriginalSize, 4u);
 
-  // 5 body instructions + 1 branch-back tail, matching the load variant.
+  // 6 body instructions + 1 branch-back tail, matching the load variant.
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(T.Bytes.data(), T.Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 6u);
+  ASSERT_EQ(Decoded.size(), 7u);
   EXPECT_EQ(Decoded[0].Mnemonic, "v_mbcnt_lo_u32_b32");
-  EXPECT_EQ(Decoded[4].Mnemonic, "ds_store_b32");
-  EXPECT_EQ(Decoded[5].Mnemonic, "s_branch");
+  EXPECT_EQ(Decoded[5].Mnemonic, "ds_store_b32");
+  EXPECT_EQ(Decoded[6].Mnemonic, "s_branch");
 }

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -502,3 +502,181 @@ TEST(HotswapPatchVTable, ProcessSingletonIdentityAndEagerInstall) {
   EXPECT_NE(VT1.applyWmmaSplitPatches, nullptr);
   EXPECT_EQ(VT1.applyScratchPatches, nullptr);
 }
+
+// -- DS ADDTID trampoline support ---------------------------------------------
+//
+// Tests for the ds_load_addtid_b32 / ds_store_addtid_b32 trampoline patch
+// (DEGFXMI400-12025). Coverage is bottom-up: first that the encode/decode
+// of ADDTID instructions exposes the expected MCInst operand layout, then
+// that the trampoline replacement asm round-trips through the MC layer,
+// then that buildTrampoline integrates a full ADDTID body.
+
+namespace {
+
+// AddtidOpReg / AddtidOpOffset / AddtidOpGds operand-layout constants live
+// in comgr-hotswap-internal.h and are imported by the COMGR::hotswap using-
+// declaration at the top of this file.
+
+// Decode a single instruction string and return the resulting MCInst, or
+// llvm::None on failure. Aborts the test if assemble/decode fail so the
+// caller can dereference unconditionally.
+llvm::MCInst decodeOne(llvm::StringRef Asm, const LLVMState &S) {
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+  EXPECT_FALSE(Bytes.empty()) << "failed to assemble: " << Asm.str();
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+      << "failed to decode: " << Asm.str();
+  EXPECT_EQ(Decoded.size(), 1u) << "expected one inst for: " << Asm.str();
+  return Decoded.empty() ? llvm::MCInst() : Decoded[0].Inst;
+}
+
+} // namespace
+
+TEST(AddTid, LoadAddTidDecodesWithExpectedLayout) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::MCInst Inst = decodeOne("ds_load_addtid_b32 v5 offset:128", S);
+  ASSERT_GE(Inst.getNumOperands(), 3u);
+
+  // Direct operand access: register, then offset, then gds bit. No
+  // print-and-parse round-trip -- production code uses the same operand
+  // indices to reach the destination VGPR.
+  EXPECT_TRUE(Inst.getOperand(AddtidOpReg).isReg());
+  EXPECT_NE(Inst.getOperand(AddtidOpReg).getReg(), 0u);
+  EXPECT_TRUE(Inst.getOperand(AddtidOpOffset).isImm());
+  EXPECT_EQ(Inst.getOperand(AddtidOpOffset).getImm(), 128);
+  EXPECT_TRUE(Inst.getOperand(AddtidOpGds).isImm());
+  EXPECT_EQ(Inst.getOperand(AddtidOpGds).getImm(), 0);
+
+  // Production code uses MRI.getName() to resolve the VGPR identifier
+  // ("VGPR5" for v5); pin that so a tablegen rename in upstream catches
+  // here rather than silently breaking the trampoline.
+  const char *N = S.MRI->getName(Inst.getOperand(AddtidOpReg).getReg());
+  ASSERT_NE(N, nullptr);
+  EXPECT_STREQ(N, "VGPR5");
+}
+
+TEST(AddTid, StoreAddTidDecodesWithExpectedLayout) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::MCInst Inst = decodeOne("ds_store_addtid_b32 v10 offset:256", S);
+  ASSERT_GE(Inst.getNumOperands(), 3u);
+  EXPECT_TRUE(Inst.getOperand(AddtidOpReg).isReg());
+  EXPECT_NE(Inst.getOperand(AddtidOpReg).getReg(), 0u);
+  EXPECT_TRUE(Inst.getOperand(AddtidOpOffset).isImm());
+  EXPECT_EQ(Inst.getOperand(AddtidOpOffset).getImm(), 256);
+  EXPECT_TRUE(Inst.getOperand(AddtidOpGds).isImm());
+  EXPECT_EQ(Inst.getOperand(AddtidOpGds).getImm(), 0);
+
+  const char *N = S.MRI->getName(Inst.getOperand(AddtidOpReg).getReg());
+  ASSERT_NE(N, nullptr);
+  EXPECT_STREQ(N, "VGPR10");
+}
+
+TEST(AddTid, LoadTrampolineAsmAssemblesAndDecodes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Replacement asm for ds_load_addtid_b32 v7 offset:64.
+  std::string Asm = "v_mbcnt_lo_u32_b32 v7, -1, 0\n"
+                    "v_mbcnt_hi_u32_b32 v7, -1, v7\n"
+                    "v_lshlrev_b32 v7, 2, v7\n"
+                    "v_add_nc_u32 v7, m0, v7\n"
+                    "ds_load_b32 v7, v7 offset:64\n";
+
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "v_mbcnt_lo_u32_b32");
+  EXPECT_EQ(Decoded[1].Mnemonic, "v_mbcnt_hi_u32_b32");
+  EXPECT_EQ(Decoded[2].Mnemonic, "v_lshlrev_b32");
+  EXPECT_EQ(Decoded[3].Mnemonic, "v_add_nc_u32");
+  EXPECT_EQ(Decoded[4].Mnemonic, "ds_load_b32");
+}
+
+TEST(AddTid, StoreTrampolineAsmAssemblesAndDecodes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Replacement asm for ds_store_addtid_b32 v10 offset:0 with v42 as the
+  // address-compute scratch (the data VGPR v10 is not clobbered).
+  std::string Asm = "v_mbcnt_lo_u32_b32 v42, -1, 0\n"
+                    "v_mbcnt_hi_u32_b32 v42, -1, v42\n"
+                    "v_lshlrev_b32 v42, 2, v42\n"
+                    "v_add_nc_u32 v42, m0, v42\n"
+                    "ds_store_b32 v42, v10\n";
+
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "v_mbcnt_lo_u32_b32");
+  EXPECT_EQ(Decoded[1].Mnemonic, "v_mbcnt_hi_u32_b32");
+  EXPECT_EQ(Decoded[2].Mnemonic, "v_lshlrev_b32");
+  EXPECT_EQ(Decoded[3].Mnemonic, "v_add_nc_u32");
+  EXPECT_EQ(Decoded[4].Mnemonic, "ds_store_b32");
+}
+
+TEST(AddTid, LoadTrampolineThroughBuildTrampoline) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<std::string> AsmLines = {
+      "v_mbcnt_lo_u32_b32 v3, -1, 0", "v_mbcnt_hi_u32_b32 v3, -1, v3",
+      "v_lshlrev_b32 v3, 2, v3",      "v_add_nc_u32 v3, m0, v3",
+      "ds_load_b32 v3, v3 offset:0",
+  };
+
+  Trampoline T = buildTrampoline(AsmLines, /*OriginalOffset=*/0x100,
+                                 /*OriginalSize=*/4,
+                                 /*TrampolineTextOffset=*/0x2000, S);
+
+  ASSERT_FALSE(T.Bytes.empty());
+  EXPECT_EQ(T.OriginalOffset, 0x100u);
+  EXPECT_EQ(T.OriginalSize, 4u);
+
+  // 5 body instructions + 1 branch-back tail.
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(T.Bytes.data(), T.Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  EXPECT_EQ(Decoded[5].Mnemonic, "s_branch");
+}
+
+TEST(AddTid, StoreTrampolineThroughBuildTrampoline) {
+  // Mirror of LoadTrampolineThroughBuildTrampoline for the store path, where
+  // the data VGPR (v10) must be preserved and an allocator-supplied scratch
+  // VGPR (v42) holds the computed address. The two register operands of
+  // ds_store_b32 carry independent VGPR indices, which is what distinguishes
+  // this from the load case (which can fold dst back into address).
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<std::string> AsmLines = {
+      "v_mbcnt_lo_u32_b32 v42, -1, 0", "v_mbcnt_hi_u32_b32 v42, -1, v42",
+      "v_lshlrev_b32 v42, 2, v42",     "v_add_nc_u32 v42, m0, v42",
+      "ds_store_b32 v42, v10",
+  };
+
+  Trampoline T = buildTrampoline(AsmLines, /*OriginalOffset=*/0x180,
+                                 /*OriginalSize=*/4,
+                                 /*TrampolineTextOffset=*/0x2040, S);
+
+  ASSERT_FALSE(T.Bytes.empty());
+  EXPECT_EQ(T.OriginalOffset, 0x180u);
+  EXPECT_EQ(T.OriginalSize, 4u);
+
+  // 5 body instructions + 1 branch-back tail, matching the load variant.
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(T.Bytes.data(), T.Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "v_mbcnt_lo_u32_b32");
+  EXPECT_EQ(Decoded[4].Mnemonic, "ds_store_b32");
+  EXPECT_EQ(Decoded[5].Mnemonic, "s_branch");
+}


### PR DESCRIPTION
Stacked on #2583.

## Problem
`ds_load_addtid_b32` and `ds_store_addtid_b32` compute LDS addresses as `M0 + laneID * 4 + offset`. On B0 the DS unit reads 20 bits of M0 (1 MB); on A0 it reads only 16 (64 KB), silently truncating bits [19:16] (DEGFXMI400-12025). gfx1250 supports up to 320 KB LDS per WGP, so the upper 256 KB is unreachable through ADDTID. When B0-compiled code using ADDTID is hotswapped onto A0, M0 values above 65535 wrap and produce silently wrong LDS accesses.

## Fix
`patchDsAddtid` (in `comgr-hotswap-patch-trampoline.cpp`) rewrites each ADDTID instruction into an ALU sequence (`v_mbcnt_lo_u32_b32` / `v_mbcnt_hi_u32_b32` for laneID, `v_lshlrev_b32` ×4, `v_add_u32` with M0 as a 32-bit operand) followed by a regular `ds_load_b32` / `ds_store_b32`. 
The M0 read is bypassed and the original offset is preserved. 
Emission goes through `emitReplacementCode` (NOP sled preferred, deferred-trampoline fallback). GDS=1 is rejected with a diagnostic.

- **Load** reuses vDST as the laneID temporary (no extra VGPR).
- **Store** pulls a dead VGPR via `allocScratchVgpr`. If none is available the patch bails; when the kernel's LDS exceeds 64 KiB a warning is also logged so the A0 truncation risk surfaces to the user. The LDS size is read through `ElfView::getKernelLdsSize`, added in #2583.

## Testing
- `test-lit/hotswap-trampoline-addtid.s` : sled-based rewrite, operand pinned DISASM across the full 6-instruction body.
- `test-lit/hotswap-trampoline-addtid-nosled.s` : deferred-trampoline fallback.
- `test-unit/HotswapMCTest.cpp` `AddTid` suite: ADDTID assemble/decode round-trips, operand layout, GDS rejection, trampoline asm assembly, `buildTrampoline` integration.