### PR TITLE
[Offload][AMDGPU] Add guard for prefaulting

### DIFF
--- a/offload/libomptarget/PluginManager.cpp
+++ b/offload/libomptarget/PluginManager.cpp
@@ -343,7 +343,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
 
   PM->RTLsMtx.unlock();
 
-  bool IsAPU = Plugins.size() > 0;
+  bool IsAPU = false;
 
   bool UseAutoZeroCopy = false;
   auto ExclusiveDevicesAccessor = getExclusiveDevicesAccessor();
@@ -352,6 +352,7 @@ void PluginManager::registerLib(__tgt_bin_desc *Desc) {
   if (ExclusiveDevicesAccessor->size() > 0) {
     auto &Device = *(*ExclusiveDevicesAccessor)[0];
     UseAutoZeroCopy = Device.useAutoZeroCopy();
+    IsAPU = Device.checkIfAPU();
   }
 
   if (UseAutoZeroCopy)


### PR DESCRIPTION
By design, eager map should only available for APUs, the existing logic didn't prevent dGPU from enabling it by `OMPX_EAGER_ZERO_COPY_MAPS=1`. This PR restricts eager map with an APU check. 

It will not affect other behaviors. Passed smoke tests.