### PR TITLE
[Comgr] test-unit: support vanilla GTest CMake package

### DIFF
--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -1,32 +1,44 @@
-# GTest discovery: prefer the in-tree llvm_gtest target (LLVM monorepo
-# build); otherwise look for the gtest libraries / headers installed
-# alongside LLVM when LLVM is built with -DLLVM_INSTALL_GTEST=ON. Comgr
-# already depends on a Comgr-compatible LLVM, so we deliberately do not
-# fall back to a separate system GTest install -- the test infrastructure
-# tracks the LLVM we link against. If LLVM was built without
-# LLVM_INSTALL_GTEST, skip the test-unit suite with a warning rather than
-# failing the configure.
+# GTest discovery for Comgr unit tests. Three sources, in priority order:
+#
+# 1. In-tree llvm_gtest target (LLVM monorepo build with utils/unittest/).
+# 2. Vanilla GTest CMake package (find_package(GTest CONFIG)). Used by
+#    superproject builds (e.g. TheRock) that supply googletest via the
+#    standard GTest:: imported targets. This avoids forcing the LLVM
+#    build to enable LLVM_INSTALL_GTEST just to test Comgr.
+# 3. LLVM-installed gtest (-DLLVM_INSTALL_GTEST=ON on the LLVM build).
+#    Legacy fallback for installs that ship llvm_gtest alongside LLVM.
+#
+# If none is available, skip the test-unit suite with a warning rather
+# than failing configure.
 if(TARGET llvm_gtest)
   set(COMGR_GTEST_LIBS llvm_gtest_main llvm_gtest)
   set(COMGR_GTEST_INCLUDE_DIRS "")
 else()
-  find_library(COMGR_LLVM_GTEST_LIB llvm_gtest
-    PATHS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
-  find_library(COMGR_LLVM_GTEST_MAIN_LIB llvm_gtest_main
-    PATHS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
-  find_path(COMGR_LLVM_GTEST_INCLUDE_DIR gtest/gtest.h
-    PATHS ${LLVM_INCLUDE_DIRS} PATH_SUFFIXES llvm-gtest NO_DEFAULT_PATH)
-  if(COMGR_LLVM_GTEST_LIB AND COMGR_LLVM_GTEST_MAIN_LIB
-      AND COMGR_LLVM_GTEST_INCLUDE_DIR)
-    set(COMGR_GTEST_LIBS
-      ${COMGR_LLVM_GTEST_MAIN_LIB} ${COMGR_LLVM_GTEST_LIB})
-    set(COMGR_GTEST_INCLUDE_DIRS ${COMGR_LLVM_GTEST_INCLUDE_DIR})
+  find_package(GTest CONFIG QUIET)
+  if(GTest_FOUND)
+    set(COMGR_GTEST_LIBS GTest::gtest_main GTest::gtest)
+    set(COMGR_GTEST_INCLUDE_DIRS "")
   else()
-    message(WARNING
-      "Comgr test-unit skipped: no llvm_gtest target and no "
-      "LLVM-installed gtest found at ${LLVM_INCLUDE_DIRS}/llvm-gtest. "
-      "Rebuild LLVM with -DLLVM_INSTALL_GTEST=ON to enable.")
-    return()
+    find_library(COMGR_LLVM_GTEST_LIB llvm_gtest
+      PATHS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
+    find_library(COMGR_LLVM_GTEST_MAIN_LIB llvm_gtest_main
+      PATHS ${LLVM_LIBRARY_DIRS} NO_DEFAULT_PATH)
+    find_path(COMGR_LLVM_GTEST_INCLUDE_DIR gtest/gtest.h
+      PATHS ${LLVM_INCLUDE_DIRS} PATH_SUFFIXES llvm-gtest NO_DEFAULT_PATH)
+    if(COMGR_LLVM_GTEST_LIB AND COMGR_LLVM_GTEST_MAIN_LIB
+        AND COMGR_LLVM_GTEST_INCLUDE_DIR)
+      set(COMGR_GTEST_LIBS
+        ${COMGR_LLVM_GTEST_MAIN_LIB} ${COMGR_LLVM_GTEST_LIB})
+      set(COMGR_GTEST_INCLUDE_DIRS ${COMGR_LLVM_GTEST_INCLUDE_DIR})
+    else()
+      message(WARNING
+        "Comgr test-unit skipped: no llvm_gtest target, no GTest "
+        "CMake package, and no LLVM-installed gtest found at "
+        "${LLVM_INCLUDE_DIRS}/llvm-gtest. Provide one of: in-tree LLVM "
+        "with utils/unittest/, find_package(GTest), or "
+        "-DLLVM_INSTALL_GTEST=ON on the LLVM build.")
+      return()
+    endif()
   endif()
 endif()
 


### PR DESCRIPTION
## Motivation

`amd/comgr/test-unit/CMakeLists.txt` discovers gtest from two places,
both coupling Comgr's tests to the LLVM build: the in-tree `llvm_gtest`
target, or an LLVM install built with `-DLLVM_INSTALL_GTEST=ON`.

In TheRock superproject builds, `amd-llvm` is built without
`LLVM_INSTALL_GTEST` (see ROCm/TheRock#4627), but TheRock ships a
first-class `therock-googletest` subproject exposing the standard
`GTest::` imported targets via `find_package(GTest)`. With the current
logic, test-unit silently `return()`s with a warning.

## Technical Details

Insert a middle tier into the discovery ladder:

1. `TARGET llvm_gtest` — unchanged.
2. **`find_package(GTest CONFIG QUIET)`** — new. Picks up vanilla
   googletest from superproject builds.
3. LLVM-installed `llvm_gtest` via `find_library` — unchanged.

`comgr_match_llvm_rtti()` is unchanged; it still gates on
`LLVM_ENABLE_RTTI` regardless of gtest source.

## Test Plan

- LLVM monorepo build: still hits the `llvm_gtest` branch.
- `-DLLVM_INSTALL_GTEST=ON` install: still hits the legacy fallback.
- TheRock with `BUILD_DEPS therock-googletest` on `amd-comgr`: now
  builds via the new `find_package(GTest)` branch.