### PR TITLE
[AMDGPU] comgr: Fix ELF trampoline growth for clang/lld-produced HSACOs

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -518,7 +518,7 @@ amd_comgr_status_t retargetCodeObjectB0A0(const void *ElfData, size_t ElfSize,
     if (!fixupTrampolineBranches(Deferred, Text, Elf.textSize(), LS))
       log() << "hotswap: error: some trampolines could not be fixed up\n";
 
-    Result = Elf.growWithTrampolines(Deferred);
+    Result = Elf.growWithTrampolines(Deferred, LS.SNopBytes);
     if (!Result) {
       log() << "hotswap: error: retargetCodeObjectB0A0: "
             << "ElfView::growWithTrampolines returned null with "

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -314,6 +314,14 @@ static void adjustSectionHeaders(uint8_t *Elf, size_t ElfSize,
       uint64_t NewOffset = ShOffset + TrampTotal;
       std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
                   sizeof(NewOffset));
+      uint64_t ShFlags;
+      std::memcpy(&ShFlags, Sh + offsetof(Shdr, sh_flags), sizeof(ShFlags));
+      if (ShFlags & ELF::SHF_ALLOC) {
+        uint64_t ShAddr;
+        std::memcpy(&ShAddr, Sh + offsetof(Shdr, sh_addr), sizeof(ShAddr));
+        ShAddr += TrampTotal;
+        std::memcpy(Sh + offsetof(Shdr, sh_addr), &ShAddr, sizeof(ShAddr));
+      }
     }
   }
 }
@@ -354,6 +362,14 @@ static void adjustProgramHeaders(uint8_t *Elf, size_t ElfSize,
     } else if (POffset > TextOffset) {
       POffset += TrampTotal;
       std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
+      uint64_t PVaddr;
+      std::memcpy(&PVaddr, Ph + offsetof(Phdr, p_vaddr), sizeof(PVaddr));
+      PVaddr += TrampTotal;
+      std::memcpy(Ph + offsetof(Phdr, p_vaddr), &PVaddr, sizeof(PVaddr));
+      uint64_t PPaddr;
+      std::memcpy(&PPaddr, Ph + offsetof(Phdr, p_paddr), sizeof(PPaddr));
+      PPaddr += TrampTotal;
+      std::memcpy(Ph + offsetof(Phdr, p_paddr), &PPaddr, sizeof(PPaddr));
     }
   }
 }
@@ -380,25 +396,7 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines) const {
     return nullptr;
   }
 
-  // Enforce the invariant: no SHF_ALLOC section may start past `.text`. We
-  // only shift file offsets, not virtual addresses, so any loaded section
-  // appearing after `.text` would end up with stale sh_addr / p_vaddr.
   uint64_t TextEnd = textOffset() + textSize();
-  for (const ELFT::Shdr &Shdr : Sections) {
-    if (!(Shdr.sh_flags & ELF::SHF_ALLOC))
-      continue;
-    if (Shdr.sh_offset < TextEnd)
-      continue;
-    Expected<StringRef> NameOrErr = File.getSectionName(Shdr);
-    StringRef Name = NameOrErr ? *NameOrErr : StringRef("<unknown>");
-    if (!NameOrErr)
-      consumeError(NameOrErr.takeError());
-    log() << "hotswap: error: growWithTrampolines refuses to run: "
-          << "SHF_ALLOC section '" << Name << "' starts at file offset "
-          << Shdr.sh_offset << " which is past .text end " << TextEnd
-          << "; virtual address shifting is not implemented.\n";
-    return nullptr;
-  }
 
   const size_t NewSize = InputSize + TrampTotal;
   std::unique_ptr<WritableMemoryBuffer> Buf =

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -377,7 +377,8 @@ static void adjustProgramHeaders(uint8_t *Elf, size_t ElfSize,
 // -- ElfView::growWithTrampolines ---------------------------------------------
 
 std::unique_ptr<WritableMemoryBuffer>
-ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines) const {
+ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
+                             ArrayRef<uint8_t> SNopBytes) const {
   const size_t InputSize = size();
   const uint8_t *Input = data();
 
@@ -398,7 +399,21 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines) const {
 
   uint64_t TextEnd = textOffset() + textSize();
 
-  const size_t NewSize = InputSize + TrampTotal;
+  // Pad TrampTotal to the maximum alignment of post-.text SHF_ALLOC sections
+  // so that shifting their virtual addresses preserves sh_addralign invariants.
+  uint64_t MaxPostTextAlign = 1;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC))
+      continue;
+    if (Shdr.sh_offset <= textOffset())
+      continue;
+    if (Shdr.sh_addralign > MaxPostTextAlign)
+      MaxPostTextAlign = Shdr.sh_addralign;
+  }
+  size_t PaddedTrampTotal = llvm::alignTo(TrampTotal, MaxPostTextAlign);
+  size_t PadBytes = PaddedTrampTotal - TrampTotal;
+
+  const size_t NewSize = InputSize + PaddedTrampTotal;
   std::unique_ptr<WritableMemoryBuffer> Buf =
       WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
   if (!Buf) {
@@ -415,15 +430,25 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines) const {
     std::memcpy(Out + Pos, T.Bytes.data(), T.Bytes.size());
     Pos += T.Bytes.size();
   }
+  if (PadBytes > 0 && SNopBytes.size() == MinInstSize) {
+    for (size_t I = 0; I < PadBytes; I += MinInstSize)
+      std::memcpy(Out + Pos + I, SNopBytes.data(), MinInstSize);
+    Pos += PadBytes;
+  } else if (PadBytes > 0) {
+    std::memset(Out + Pos, 0, PadBytes);
+    Pos += PadBytes;
+  }
   if (TextEnd < InputSize)
     std::memcpy(Out + Pos, Input + TextEnd, InputSize - TextEnd);
 
-  adjustSectionHeaders(Out, NewSize, textOffset(), textSize(), TrampTotal);
-  adjustProgramHeaders(Out, NewSize, textOffset(), textSize(), TrampTotal);
+  adjustSectionHeaders(Out, NewSize, textOffset(), textSize(),
+                       PaddedTrampTotal);
+  adjustProgramHeaders(Out, NewSize, textOffset(), textSize(),
+                       PaddedTrampTotal);
   log() << "hotswap: growWithTrampolines: grew ELF from " << InputSize << " to "
         << NewSize << " bytes (" << Trampolines.size() << " trampoline"
         << (Trampolines.size() == 1 ? "" : "s") << ", " << TrampTotal
-        << " bytes appended).\n";
+        << " trampoline bytes + " << PadBytes << " alignment padding).\n";
   return Buf;
 }
 

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -399,18 +399,23 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
 
   uint64_t TextEnd = textOffset() + textSize();
 
-  // Pad TrampTotal to the maximum alignment of post-.text SHF_ALLOC sections
-  // so that shifting their virtual addresses preserves sh_addralign invariants.
+  // Pad TrampTotal to the maximum alignment of all post-.text sections so
+  // that shifting file offsets preserves sh_addralign invariants. The
+  // sh_addr update in adjustSectionHeaders is still gated on SHF_ALLOC.
   uint64_t MaxPostTextAlign = 1;
   for (const ELFT::Shdr &Shdr : Sections) {
-    if (!(Shdr.sh_flags & ELF::SHF_ALLOC))
-      continue;
     if (Shdr.sh_offset <= textOffset())
       continue;
     if (Shdr.sh_addralign > MaxPostTextAlign)
       MaxPostTextAlign = Shdr.sh_addralign;
   }
   size_t PaddedTrampTotal = llvm::alignTo(TrampTotal, MaxPostTextAlign);
+  if (PaddedTrampTotal > SIZE_MAX - InputSize) {
+    log() << "hotswap: error: growWithTrampolines: padded trampoline bytes ("
+          << PaddedTrampTotal << ") + ELF size (" << InputSize
+          << ") overflow size_t.\n";
+    return nullptr;
+  }
   size_t PadBytes = PaddedTrampTotal - TrampTotal;
 
   const size_t NewSize = InputSize + PaddedTrampTotal;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -193,12 +193,13 @@ public:
   /// Grow the ELF by inserting trampoline bytes after `.text` and adjusting
   /// all section and program headers. Returns a null unique_ptr on failure.
   ///
-  /// Invariant: `.text` must be the last SHF_ALLOC section in its load
-  /// segment. Any loaded section appearing past `.text` in the file causes
-  /// the function to refuse (with a diagnostic through log()) rather than
-  /// silently emit stale virtual addresses.
+  /// SHF_ALLOC sections after `.text` (e.g. `.dynamic` in clang/lld-produced
+  /// HSACOs) are handled: their file offsets, virtual addresses (sh_addr,
+  /// p_vaddr, p_paddr), and segment sizes are shifted by the total
+  /// trampoline size to keep the ELF layout consistent.
   std::unique_ptr<llvm::WritableMemoryBuffer>
-  growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines) const;
+  growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines,
+                      llvm::ArrayRef<uint8_t> SNopBytes) const;
 
 private:
   ElfView(ELFFileT File, ELFT::ShdrRange Sections,

--- a/amd/comgr/test-lit/hotswap-elf-growth.s
+++ b/amd/comgr/test-lit/hotswap-elf-growth.s
@@ -1,0 +1,42 @@
+// COM: Verify that hotswap-rewrite succeeds on a clang-assembled ELF where
+// COM: .dynamic follows .text (the layout that previously caused
+// COM: growWithTrampolines to refuse). No patches are applied here (the
+// COM: kernel contains no patchable instructions), but the rewrite pipeline
+// COM: must accept the ELF rather than returning an error.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// COM: Confirm .dynamic exists after .text in the input ELF.
+// RUN: %llvm-readelf --section-headers %t.elf | %FileCheck --check-prefix=LAYOUT %s
+// LAYOUT: .text
+// LAYOUT: .dynamic
+
+// COM: hotswap-rewrite must succeed (not reject the ELF).
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: Output ELF is valid and disassemblable.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM: file format elf64-amdgpu
+// DISASM: s_endpgm
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_elf_growth
+.p2align 8
+.type test_elf_growth,@function
+test_elf_growth:
+  v_mov_b32_e32 v0, 0
+  s_endpgm
+.Ltest_elf_growth_end:
+.size test_elf_growth, .Ltest_elf_growth_end-test_elf_growth
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_elf_growth
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel


### PR DESCRIPTION
## Summary
`growWithTrampolines` previously refused to operate on ELFs where any `SHF_ALLOC` section (e.g. `.dynamic`) appeared after `.text` in the file layout. clang/lld-produced HSACOs always place `.dynamic` after `.text`, so trampoline-based hotswap patch will fail on code objects assembled via `%clang` in lit tests.

## Changes
- Removed the conservative refuse check that blocked growth when post-`.text` alloc sections exist.
- `adjustSectionHeaders`: shift `sh_addr` for `SHF_ALLOC` sections after `.text`, keeping virtual addresses consistent with the shifted file offsets.
- `adjustProgramHeaders`: shift `p_vaddr` and `p_paddr` for segments after `.text`, keeping the ELF loader mapping consistent.
- `growWithTrampolines` signature updated to accept `SNopBytes` for alignment padding. Trampoline insertion is padded to the maximum `sh_addralign` of post-`.text` alloc sections (using `llvm::alignTo`) to preserve section alignment invariants. Padding is filled with s_nop bytes.
- Updated the header comment in `comgr-hotswap-internal.h` to reflect the new behavior (replaces the old "must be the last SHF_ALLOC section" invariant).
- Updated the call site in `comgr-hotswap-b0a0.cpp` to pass `LS.SNopBytes`.


The data copy and file-offset shifting (`sh_offset`, `p_offset`, `e_shoff`) were already implemented correctly. Only the virtual address updates were missing.

## Need
This unblocks `.s` lit tests for all trampoline-based hotswap patches:
- DS2 split (#2281)
- WMMA hazard (#2265)
- Barrier isfirst (#2287)
- DS ADDTID (#2302)

Without this fix, these patches can only be tested via comgr-action C drivers that produce a different ELF layout.

## Test plan
It is an infra only change.  
- **hotswap-elf-growth.s** (new): assembles a gfx1250 kernel via `%clang -nostdlib`, confirms `.dynamic` exists after `.text` in the input ELF, runs `hotswap-rewrite --output`, and verifies the output is a valid disassemblable elf64-amdgpu.
- Existing `hotswap-rewrite.c` and `hotswap-rewrite-e2e.hip` tests still pass (no regression).