### PR TITLE
[Comgr] Add AMD_COMGR_DATA_KIND_BUNDLE for heterogeneous offload bundles

### DIFF
--- a/amd/comgr/include/amd_comgr.h.in
+++ b/amd/comgr/include/amd_comgr.h.in
@@ -391,24 +391,49 @@ typedef enum amd_comgr_data_kind_s {
   AMD_COMGR_DATA_KIND_AR = 0x11,
   /**
    * The data is a bitcode bundle.
+   *
+   * Deprecated: use AMD_COMGR_DATA_KIND_BUNDLE. The unbundle action now
+   * detects each entry's payload kind from its bytes, so a typed bundle
+   * kind is no longer required.
    */
-  AMD_COMGR_DATA_KIND_BC_BUNDLE = 0x12,
+  AMD_COMGR_DATA_KIND_BC_BUNDLE
+      AMD_COMGR_DEPRECATED("Use AMD_COMGR_DATA_KIND_BUNDLE.") = 0x12,
   /**
    * The data is an archive bundle.
+   *
+   * Deprecated: use AMD_COMGR_DATA_KIND_BUNDLE. The unbundle action now
+   * inspects the input bytes and routes archive-of-bundle inputs through
+   * the archive bundler path automatically.
    */
-  AMD_COMGR_DATA_KIND_AR_BUNDLE = 0x13,
+  AMD_COMGR_DATA_KIND_AR_BUNDLE
+      AMD_COMGR_DEPRECATED("Use AMD_COMGR_DATA_KIND_BUNDLE.") = 0x13,
   /**
    * The data is an object file bundle.
+   *
+   * Deprecated: use AMD_COMGR_DATA_KIND_BUNDLE. The unbundle action now
+   * detects each entry's payload kind from its bytes, so a typed bundle
+   * kind is no longer required.
    */
-  AMD_COMGR_DATA_KIND_OBJ_BUNDLE = 0x14,
+  AMD_COMGR_DATA_KIND_OBJ_BUNDLE
+      AMD_COMGR_DEPRECATED("Use AMD_COMGR_DATA_KIND_BUNDLE.") = 0x14,
   /**
    * The data is SPIR-V IR
    */
   AMD_COMGR_DATA_KIND_SPIRV = 0x15,
   /**
+   * The data is an offload bundle (clang-offload-bundler output) or an
+   * archive of offload bundles. The bundle may be heterogeneous,
+   * carrying entries of different payload kinds (for example ELF
+   * objects for one offload arch and SPIR-V for another). When
+   * unbundled, the input bytes are inspected to route archive inputs
+   * through the archive bundler path, and each output data object's
+   * kind is determined by inspecting the extracted bytes.
+   */
+  AMD_COMGR_DATA_KIND_BUNDLE = 0x16,
+  /**
    * Marker for last valid data kind.
    */
-  AMD_COMGR_DATA_KIND_LAST = AMD_COMGR_DATA_KIND_SPIRV
+  AMD_COMGR_DATA_KIND_LAST = AMD_COMGR_DATA_KIND_BUNDLE
 } amd_comgr_data_kind_t;
 
 /**

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -36,6 +36,7 @@
 #include "clang/FrontendTool/Utils.h"
 #include "clang/Options/Options.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/BinaryFormat/Magic.h"
 #include "llvm/Bitcode/BitcodeWriter.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/LLVMContext.h"
@@ -1512,6 +1513,29 @@ amd_comgr_status_t AMDGPUCompiler::compileToRelocatable() {
   return processFiles(AMD_COMGR_DATA_KIND_RELOCATABLE, ".o");
 }
 
+// Detect the payload kind of a single extracted bundle entry by inspecting
+// the leading bytes. Used by the AMD_COMGR_DATA_KIND_BUNDLE unbundle path
+// (and the deprecated typed bundle kinds), which may carry heterogeneous
+// payloads (e.g. ELF for one offload arch and SPIR-V for another).
+static amd_comgr_data_kind_t detectPayloadKind(StringRef Bytes) {
+  switch (llvm::identify_magic(Bytes)) {
+  case llvm::file_magic::bitcode:
+    return AMD_COMGR_DATA_KIND_BC;
+  case llvm::file_magic::elf:
+  case llvm::file_magic::elf_relocatable:
+  case llvm::file_magic::elf_executable:
+  case llvm::file_magic::elf_shared_object:
+  case llvm::file_magic::elf_core:
+    return AMD_COMGR_DATA_KIND_EXECUTABLE;
+  case llvm::file_magic::spirv_object:
+    return AMD_COMGR_DATA_KIND_SPIRV;
+  case llvm::file_magic::archive:
+    return AMD_COMGR_DATA_KIND_AR;
+  default:
+    return AMD_COMGR_DATA_KIND_BYTES;
+  }
+}
+
 amd_comgr_status_t AMDGPUCompiler::unbundle() {
   if (auto Status = createTmpDirs()) {
     return Status;
@@ -1521,29 +1545,49 @@ amd_comgr_status_t AMDGPUCompiler::unbundle() {
   auto Cache = CommandCache::get(LogS);
   for (auto *Input : InSet->DataObjects) {
 
-    const char *FileExtension;
-    amd_comgr_data_kind_t UnbundledDataKind;
-    switch (Input->DataKind) {
-    case AMD_COMGR_DATA_KIND_BC_BUNDLE:
-      FileExtension = "bc";
-      UnbundledDataKind = AMD_COMGR_DATA_KIND_BC;
-      break;
-    case AMD_COMGR_DATA_KIND_AR_BUNDLE:
-      FileExtension = "a";
-      UnbundledDataKind = AMD_COMGR_DATA_KIND_AR;
-      break;
-    case AMD_COMGR_DATA_KIND_OBJ_BUNDLE:
-      FileExtension = "o";
-      UnbundledDataKind = AMD_COMGR_DATA_KIND_EXECUTABLE;
-      break;
-    default:
+    // The deprecated typed bundle kinds (BC_BUNDLE, OBJ_BUNDLE,
+    // AR_BUNDLE) are accepted as aliases for BUNDLE; routing is driven
+    // entirely by inspecting the input bytes.
+    if (Input->DataKind != AMD_COMGR_DATA_KIND_BUNDLE &&
+        Input->DataKind != AMD_COMGR_DATA_KIND_BC_BUNDLE &&
+        Input->DataKind != AMD_COMGR_DATA_KIND_OBJ_BUNDLE &&
+        Input->DataKind != AMD_COMGR_DATA_KIND_AR_BUNDLE) {
       return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
     }
+
+    UnbundleOp Op;
+    // BundlerFilesType is the clang-offload-bundler -type= hint and
+    // must be one of its recognized values (bc/o/s/a/ast/gch). It does
+    // not affect the extracted bytes.
+    const char *BundlerFilesType;
+    amd_comgr_data_kind_t UnbundledDataKind;
+    bool DetectPerEntryKind;
+    if (llvm::identify_magic(StringRef(Input->Data, Input->Size)) ==
+        llvm::file_magic::archive) {
+      // Archive of bundles -> UnbundleArchive. Each output is a
+      // per-target archive; the data kind is fixed.
+      Op = UnbundleOp::Archive;
+      BundlerFilesType = "a";
+      UnbundledDataKind = AMD_COMGR_DATA_KIND_AR;
+      DetectPerEntryKind = false;
+    } else {
+      // Plain offload bundle (compressed or not). The bundler treats
+      // payloads opaquely; each entry's data kind is determined after
+      // extraction by inspecting the bytes.
+      Op = UnbundleOp::Files;
+      BundlerFilesType = "o";
+      UnbundledDataKind = AMD_COMGR_DATA_KIND_BYTES;
+      DetectPerEntryKind = true;
+    }
+    // Internally name input/output temp files with a generic ".bundle"
+    // suffix; the resolved data kind comes from detection (or is fixed
+    // for archives), independent of the bundler's -type= hint.
+    static constexpr const char *TempExt = "bundle";
 
     // Configure Offload Bundler
     OffloadBundlerConfig BundlerConfig;
     BundlerConfig.AllowMissingBundles = true;
-    BundlerConfig.FilesType = FileExtension;
+    BundlerConfig.FilesType = BundlerFilesType;
     BundlerConfig.HipOpenmpCompatible = 1;
     BundlerConfig.AllowNoHost = 1;
 
@@ -1552,7 +1596,7 @@ amd_comgr_status_t AMDGPUCompiler::unbundle() {
       const size_t BufSize = sizeof(char) * 30;
       char *Buf = (char *)malloc(BufSize);
       snprintf(Buf, BufSize, "comgr-bundle-%d.%s", std::rand() % 10000,
-               FileExtension);
+               TempExt);
       Input->Name = Buf;
     }
 
@@ -1575,14 +1619,14 @@ amd_comgr_status_t AMDGPUCompiler::unbundle() {
     if (env::shouldEmitVerboseLogs()) {
       LogS << "   Extracting Bundle:\n"
            << "   Input Filename: " << BundlerConfig.InputFileNames[0] << "\n"
-           << "   Unbundled Files Extension: ." << FileExtension << "\n";
+           << "   Bundler Files Type: ." << BundlerFilesType << "\n";
     }
 
     for (StringRef Entry : ActionInfo->BundleEntryIDs) {
       // Add an output file for each target
       SmallString<128> OutputFilePath = OutputDir;
       sys::path::append(OutputFilePath,
-                        OutputPrefix + "-" + Entry + "." + FileExtension);
+                        OutputPrefix + "-" + Entry + "." + TempExt);
 
       BundlerConfig.TargetNames.emplace_back(Entry);
       BundlerConfig.OutputFileNames.emplace_back(OutputFilePath);
@@ -1594,7 +1638,7 @@ amd_comgr_status_t AMDGPUCompiler::unbundle() {
       }
     }
 
-    UnbundleCommand Unbundle(Input->DataKind, BundlerConfig);
+    UnbundleCommand Unbundle(Op, BundlerConfig);
     if (Cache) {
       if (auto Status = Cache->execute(Unbundle, LogS)) {
         return Status;
@@ -1619,6 +1663,16 @@ amd_comgr_status_t AMDGPUCompiler::unbundle() {
       DataObject *Result = DataObject::convert(ResultT);
       if (auto Status = inputFromFile(Result, OutputFilePath))
         return Status;
+
+      if (DetectPerEntryKind) {
+        Result->DataKind =
+            detectPayloadKind(StringRef(Result->Data, Result->Size));
+        if (env::shouldEmitVerboseLogs()) {
+          LogS << "\tDetected payload kind for " << OutputFilePath
+               << ": 0x" << llvm::Twine::utohexstr(Result->DataKind).str()
+               << "\n";
+        }
+      }
 
       StringRef OutputFileName = sys::path::filename(OutputFilePath);
       Result->setName(OutputFileName);

--- a/amd/comgr/src/comgr-unbundle-command.cpp
+++ b/amd/comgr/src/comgr-unbundle-command.cpp
@@ -25,7 +25,7 @@ using SizeFieldType = uint32_t;
 
 bool UnbundleCommand::canCache() const {
   // The header format for AR files is not the same as object files
-  if (Kind == AMD_COMGR_DATA_KIND_AR_BUNDLE)
+  if (Op == UnbundleOp::Archive)
     return false;
 
   StringRef InputFilename = Config.InputFileNames.front();
@@ -94,26 +94,21 @@ amd_comgr_status_t UnbundleCommand::execute(raw_ostream &LogS) {
 
   OffloadBundler Bundler(Config);
 
-  switch (Kind) {
-  case AMD_COMGR_DATA_KIND_BC_BUNDLE:
-  case AMD_COMGR_DATA_KIND_OBJ_BUNDLE: {
+  switch (Op) {
+  case UnbundleOp::Files: {
     if (Error Err = Bundler.UnbundleFiles()) {
       logAllUnhandledErrors(std::move(Err), LogS, "Unbundle Error: ");
       return AMD_COMGR_STATUS_ERROR;
     }
     break;
   }
-  case AMD_COMGR_DATA_KIND_AR_BUNDLE: {
+  case UnbundleOp::Archive: {
     if (Error Err = Bundler.UnbundleArchive()) {
       logAllUnhandledErrors(std::move(Err), LogS, "Unbundle Archives Error: ");
       return AMD_COMGR_STATUS_ERROR;
     }
     break;
   }
-  default:
-    assert(false && "invalid bundle type");
-    LogS << "Unbundle Error: invalid bundle type\n";
-    return AMD_COMGR_STATUS_ERROR;
   }
 
   return AMD_COMGR_STATUS_SUCCESS;

--- a/amd/comgr/src/comgr-unbundle-command.h
+++ b/amd/comgr/src/comgr-unbundle-command.h
@@ -16,9 +16,12 @@ class OffloadBundlerConfig;
 } // namespace clang
 
 namespace COMGR {
+// Selects which OffloadBundler operation the unbundle action drives.
+enum class UnbundleOp { Files, Archive };
+
 class UnbundleCommand final : public CachedCommandAdaptor {
 private:
-  amd_comgr_data_kind_t Kind;
+  UnbundleOp Op;
   const clang::OffloadBundlerConfig &Config;
 
   // To avoid copies, store the output of execute, such that readExecuteOutput
@@ -26,9 +29,8 @@ private:
   llvm::SmallString<64> OutputBuffer;
 
 public:
-  UnbundleCommand(amd_comgr_data_kind_t Kind,
-                  const clang::OffloadBundlerConfig &Config)
-      : Kind(Kind), Config(Config) {}
+  UnbundleCommand(UnbundleOp Op, const clang::OffloadBundlerConfig &Config)
+      : Op(Op), Config(Config) {}
 
   bool canCache() const override;
   llvm::Error writeExecuteOutput(llvm::StringRef CachedBuffer) override;

--- a/amd/comgr/test-lit/cache-tests/unbundle-cached.hip
+++ b/amd/comgr/test-lit/cache-tests/unbundle-cached.hip
@@ -12,23 +12,26 @@
 // With the cache enabled, test that we write one file to the cache
 // RUN: export AMD_COMGR_CACHE=1
 // RUN: export AMD_COMGR_CACHE_DIR=%t.cache
-// RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx900 \
-// RUN:    %t.cache_1.bc
-// RUN: %llvm-dis %t.cache_1.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: unbundle %t.compressed-bundle.bc %t.cache_1 \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx900
+// RUN: %llvm-dis %t.cache_1-hip-amdgcn-amd-amdhsa-unknown-gfx900.bc -o - \
+// RUN:    | %FileCheck --check-prefixes=BOTH,GFX9 %s
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 2 -eq $COUNT ]
 //
 // If there is a re-run, the cache contents remain the same
-// RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx900 \
-// RUN:    %t.cache_2.bc
-// RUN: %llvm-dis %t.cache_2.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: unbundle %t.compressed-bundle.bc %t.cache_2 \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx900
+// RUN: %llvm-dis %t.cache_2-hip-amdgcn-amd-amdhsa-unknown-gfx900.bc -o - \
+// RUN:    | %FileCheck --check-prefixes=BOTH,GFX9 %s
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 2 -eq $COUNT ]
 //
 // A run with different input options results in new contents in the cache
-// RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1030 \
-// RUN:    %t.cache_3.bc
-// RUN: %llvm-dis %t.cache_3.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
+// RUN: unbundle %t.compressed-bundle.bc %t.cache_3 \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx1030
+// RUN: %llvm-dis %t.cache_3-hip-amdgcn-amd-amdhsa-unknown-gfx1030.bc -o - \
+// RUN:    | %FileCheck --check-prefixes=BOTH,GFX10 %s
 // RUN: COUNT=$(ls "%t.cache" | wc -l)
 // RUN: [ 3 -eq $COUNT ]
 

--- a/amd/comgr/test-lit/comgr-sources/unbundle.c
+++ b/amd/comgr/test-lit/comgr-sources/unbundle.c
@@ -8,72 +8,124 @@
 
 #include "amd_comgr.h"
 #include "common.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *extensionForKind(amd_comgr_data_kind_t Kind) {
+  switch (Kind) {
+  case AMD_COMGR_DATA_KIND_BC:
+    return "bc";
+  case AMD_COMGR_DATA_KIND_SPIRV:
+    return "spv";
+  case AMD_COMGR_DATA_KIND_EXECUTABLE:
+    return "o";
+  case AMD_COMGR_DATA_KIND_AR:
+    return "a";
+  default:
+    return "bin";
+  }
+}
 
 int main(int argc, char *argv[]) {
-  char *BundleData;
-  size_t BundleSize;
-
   if (argc < 4) {
-    printf("Usage: %s <bc bundle> <arch> <bc output>\n", argv[0]);
+    printf("Usage: %s <bundle> <output-prefix> <entry-id> [<entry-id>...]\n",
+           argv[0]);
     return -1;
   }
 
   const char *BundlePath = argv[1];
-  const char *Arch = argv[2];
-  const char *BitcodePath = argv[3];
+  const char *OutputPrefix = argv[2];
+  const char **EntryIDs = (const char **)&argv[3];
+  size_t EntryCount = (size_t)(argc - 3);
 
-  amd_comgr_data_t OneBundle;
+  char *BundleData;
+  size_t BundleSize = setBuf(BundlePath, &BundleData);
+
+  amd_comgr_data_t Bundle;
   amd_comgr_data_set_t InputBundles;
-
-  BundleSize = setBuf(BundlePath, &BundleData);
-
   amd_comgr_(create_data_set(&InputBundles));
-  amd_comgr_(create_data(AMD_COMGR_DATA_KIND_BC_BUNDLE, &OneBundle));
-  amd_comgr_(set_data(OneBundle, BundleSize, BundleData));
-  amd_comgr_(set_data_name(OneBundle, "bundle.bc"));
-  amd_comgr_(data_set_add(InputBundles, OneBundle));
+  amd_comgr_(create_data(AMD_COMGR_DATA_KIND_BUNDLE, &Bundle));
+  amd_comgr_(set_data(Bundle, BundleSize, BundleData));
+  amd_comgr_(set_data_name(Bundle, "bundle"));
+  amd_comgr_(data_set_add(InputBundles, Bundle));
 
-  amd_comgr_data_set_t OutputBitcode;
-  amd_comgr_(create_data_set(&OutputBitcode));
+  amd_comgr_data_set_t Outputs;
+  amd_comgr_(create_data_set(&Outputs));
 
   amd_comgr_action_info_t DataAction;
   amd_comgr_(create_action_info(&DataAction));
+  amd_comgr_(action_info_set_bundle_entry_ids(DataAction, EntryIDs, EntryCount));
 
-  const char *AllArch[] = {Arch};
-  amd_comgr_(action_info_set_bundle_entry_ids(DataAction, AllArch, 1));
   amd_comgr_(do_action(AMD_COMGR_ACTION_UNBUNDLE, DataAction, InputBundles,
-                       OutputBitcode));
+                       Outputs));
 
-  size_t Count;
-  amd_comgr_(action_data_count(OutputBitcode, AMD_COMGR_DATA_KIND_BC, &Count));
+  // Walk every kind that the unbundle action may produce and write each
+  // output to <prefix>-<entry-id>.<ext>. The entry ID is recovered from the
+  // data object's name, which the unbundle action sets to
+  // "<input-name>-<entry-id>.<ext>".
+  static const amd_comgr_data_kind_t Kinds[] = {
+      AMD_COMGR_DATA_KIND_BC,
+      AMD_COMGR_DATA_KIND_SPIRV,
+      AMD_COMGR_DATA_KIND_EXECUTABLE,
+      AMD_COMGR_DATA_KIND_AR,
+      AMD_COMGR_DATA_KIND_BYTES,
+  };
+  size_t KindsCount = sizeof(Kinds) / sizeof(Kinds[0]);
 
-  if (Count != 1) {
-    printf("AMD_COMGR_ACTION_COMPILE_SOURCE_TO_BC Failed: "
-           "produced %zu BC objects (expected 1)\n",
-           Count);
-    exit(1);
+  for (size_t K = 0; K < KindsCount; ++K) {
+    size_t Count = 0;
+    amd_comgr_(action_data_count(Outputs, Kinds[K], &Count));
+
+    for (size_t I = 0; I < Count; ++I) {
+      amd_comgr_data_t Out;
+      amd_comgr_(action_data_get_data(Outputs, Kinds[K], I, &Out));
+
+      // Recover entry ID from data name: "bundle-<entry-id>.<ext>".
+      size_t NameSize = 0;
+      amd_comgr_(get_data_name(Out, &NameSize, NULL));
+      char *Name = (char *)malloc(NameSize);
+      amd_comgr_(get_data_name(Out, &NameSize, Name));
+
+      const char *EntryStart = strchr(Name, '-');
+      if (!EntryStart) {
+        printf("Unexpected output name: %s\n", Name);
+        exit(1);
+      }
+      EntryStart += 1; // skip the '-'
+      const char *EntryEnd = strrchr(EntryStart, '.');
+      if (!EntryEnd) {
+        printf("Unexpected output name: %s\n", Name);
+        exit(1);
+      }
+      size_t EntryLen = (size_t)(EntryEnd - EntryStart);
+
+      const char *Ext = extensionForKind(Kinds[K]);
+      size_t PathLen = strlen(OutputPrefix) + 1 + EntryLen + 1 + strlen(Ext) + 1;
+      char *OutPath = (char *)malloc(PathLen);
+      snprintf(OutPath, PathLen, "%s-%.*s.%s", OutputPrefix, (int)EntryLen,
+               EntryStart, Ext);
+
+      size_t BufferSize = 0;
+      amd_comgr_(get_data(Out, &BufferSize, NULL));
+      char *Buffer = (char *)malloc(BufferSize);
+      amd_comgr_(get_data(Out, &BufferSize, Buffer));
+
+      FILE *F = fopen(OutPath, "wb");
+      fwrite(Buffer, 1, BufferSize, F);
+      fclose(F);
+
+      free(Buffer);
+      free(OutPath);
+      free(Name);
+      amd_comgr_(release_data(Out));
+    }
   }
 
-  amd_comgr_data_t OneBitcode;
-  amd_comgr_(action_data_get_data(OutputBitcode, AMD_COMGR_DATA_KIND_BC, 0,
-                                  &OneBitcode));
-
-  size_t BufferSize;
-  amd_comgr_(get_data(OneBitcode, &BufferSize, 0x0));
-  char *Buffer = (char *)malloc(BufferSize);
-  amd_comgr_(get_data(OneBitcode, &BufferSize, Buffer));
-
-  FILE *BitcodeFile = fopen(BitcodePath, "wb");
-  fwrite(Buffer, 1, BufferSize, BitcodeFile);
-  fclose(BitcodeFile);
-
-  free(Buffer);
-  amd_comgr_(release_data(OneBitcode));
-  amd_comgr_(release_data(OneBundle));
+  amd_comgr_(release_data(Bundle));
   amd_comgr_(destroy_action_info(DataAction));
-  amd_comgr_(destroy_data_set(OutputBitcode));
+  amd_comgr_(destroy_data_set(Outputs));
   amd_comgr_(destroy_data_set(InputBundles));
   free(BundleData);
-
   return 0;
 }

--- a/amd/comgr/test-lit/spirv-tests/unbundle-mixed.hip
+++ b/amd/comgr/test-lit/spirv-tests/unbundle-mixed.hip
@@ -1,0 +1,55 @@
+// REQUIRES: comgr-has-spirv
+
+// COM: Create a heterogeneous offload bundle with one ELF entry (gfx906)
+// COM: and one SPIRV entry (amdgcnspirv), then again with --offload-compress.
+// RUN: %clang -c -x hip \
+// RUN:    --offload-arch=gfx906 --offload-arch=amdgcnspirv \
+// RUN:    -nogpulib -nogpuinc \
+// RUN:    --gpu-bundle-output --offload-device-only \
+// RUN:    %s -o %t.mixed.bundle
+//
+// RUN: %clang -c -x hip \
+// RUN:    --offload-arch=gfx906 --offload-arch=amdgcnspirv \
+// RUN:    -nogpulib -nogpuinc \
+// RUN:    --gpu-bundle-output --offload-device-only \
+// RUN:    --offload-compress \
+// RUN:    %s -o %t.mixed.compressed.bundle
+
+// COM: Extract both entries through Comgr's generic BUNDLE unbundle.
+// COM: Detection picks the data kind per entry: ELF -> .o, SPIRV -> .spv.
+// RUN: unbundle %t.mixed.bundle %t \
+// RUN:    hipv4-amdgcn-amd-amdhsa--gfx906 \
+// RUN:    hipv4-spirv64-amd-amdhsa--amdgcnspirv
+
+// COM: ELF entry should be a valid AMDGPU object for gfx906.
+// RUN: llvm-readobj --file-headers %t-hipv4-amdgcn-amd-amdhsa--gfx906.o \
+// RUN:    | %FileCheck --check-prefix=ELF %s
+// ELF: Format: elf64-amdgpu
+// ELF: Machine: EM_AMDGPU
+// ELF: Flags [
+// ELF: EF_AMDGPU_MACH_AMDGCN_GFX906
+
+// COM: SPIRV entry should round-trip through the SPIRV translator.
+// RUN: spirv-translator %t-hipv4-spirv64-amd-amdhsa--amdgcnspirv.spv -o %t.spv.bc
+// RUN: %llvm-dis %t.spv.bc -o - | %FileCheck --check-prefix=SPV %s
+// SPV: target triple = "amdgcn-amd-amdhsa"
+// SPV: define amdgpu_kernel void @_Z9add_valuePfS_S_
+
+// COM: Same checks for the compressed bundle.
+// RUN: unbundle %t.mixed.compressed.bundle %t.compressed \
+// RUN:    hipv4-amdgcn-amd-amdhsa--gfx906 \
+// RUN:    hipv4-spirv64-amd-amdhsa--amdgcnspirv
+// RUN: llvm-readobj --file-headers %t.compressed-hipv4-amdgcn-amd-amdhsa--gfx906.o \
+// RUN:    | %FileCheck --check-prefix=ELF %s
+// RUN: spirv-translator %t.compressed-hipv4-spirv64-amd-amdhsa--amdgcnspirv.spv -o %t.compressed.spv.bc
+// RUN: %llvm-dis %t.compressed.spv.bc -o - | %FileCheck --check-prefix=SPV %s
+
+__attribute__((device))
+void clean_value(float* ptr) { *ptr = 0; }
+
+__attribute__((global))
+void add_value(float* a, float* b, float* res) {
+    *res = *a + *b;
+
+    clean_value(a);
+}

--- a/amd/comgr/test-lit/spirv-tests/unbundle-spirv.hip
+++ b/amd/comgr/test-lit/spirv-tests/unbundle-spirv.hip
@@ -1,0 +1,40 @@
+// REQUIRES: comgr-has-spirv
+
+// COM: Create a SPIRV bundle for amdgcnspirv
+// RUN: %clang -c -x hip --offload-arch=amdgcnspirv \
+// RUN:    -nogpulib -nogpuinc \
+// RUN:    --gpu-bundle-output --offload-device-only \
+// RUN:    %s -o %t.bundle.spv
+//
+// COM: Create a compressed SPIRV bundle (add --offload-compress)
+// RUN: %clang -c -x hip --offload-arch=amdgcnspirv \
+// RUN:    -nogpulib -nogpuinc \
+// RUN:    --gpu-bundle-output --offload-device-only \
+// RUN:    --offload-compress \
+// RUN:    %s -o %t.compressed-bundle.spv
+
+// COM: Extract via Comgr's generic BUNDLE unbundle. Detection picks
+// COM: AMD_COMGR_DATA_KIND_SPIRV from the bytes, so the driver writes
+// COM: the entry to a .spv file. If detection misclassified the payload
+// COM: the spirv-translator step would fail to find its input.
+// RUN: unbundle %t.bundle.spv %t hip-spirv64-amd-amdhsa--amdgcnspirv
+// RUN: spirv-translator %t-hip-spirv64-amd-amdhsa--amdgcnspirv.spv -o %t.bc
+// RUN: %llvm-dis %t.bc -o - | %FileCheck %s
+
+// RUN: unbundle %t.compressed-bundle.spv %t.compressed hip-spirv64-amd-amdhsa--amdgcnspirv
+// RUN: spirv-translator %t.compressed-hip-spirv64-amd-amdhsa--amdgcnspirv.spv -o %t.compressed.bc
+// RUN: %llvm-dis %t.compressed.bc -o - | %FileCheck %s
+
+// CHECK: target triple = "amdgcn-amd-amdhsa"
+// CHECK: define void @_Z11clean_valuePf
+// CHECK: define amdgpu_kernel void @_Z9add_valuePfS_S_
+
+__attribute__((device))
+void clean_value(float* ptr) { *ptr = 0; }
+
+__attribute__((global))
+void add_value(float* a, float* b, float* res) {
+    *res = *a + *b;
+
+    clean_value(a);
+}

--- a/amd/comgr/test-lit/unbundle.hip
+++ b/amd/comgr/test-lit/unbundle.hip
@@ -11,12 +11,18 @@
 // RUN:    --offload-compress \
 // RUN:    %s -o %t.compressed-bundle.bc
 //
-// Extract using Comgr
-// RUN: unbundle %t.bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx900 %t.gfx900.bc
-// RUN: %llvm-dis %t.gfx900.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
+// Extract using Comgr's generic BUNDLE unbundle (kind detected from bytes)
+// RUN: unbundle %t.bundle.bc %t \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx900 \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx1030
+// RUN: %llvm-dis %t-hip-amdgcn-amd-amdhsa-unknown-gfx900.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: %llvm-dis %t-hip-amdgcn-amd-amdhsa-unknown-gfx1030.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
 //
-// RUN: unbundle %t.compressed-bundle.bc hip-amdgcn-amd-amdhsa-unknown-gfx1030 %t.compressed.gfx1030.bc
-// RUN: %llvm-dis %t.compressed.gfx1030.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
+// RUN: unbundle %t.compressed-bundle.bc %t.compressed \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx900 \
+// RUN:    hip-amdgcn-amd-amdhsa-unknown-gfx1030
+// RUN: %llvm-dis %t.compressed-hip-amdgcn-amd-amdhsa-unknown-gfx900.bc -o - | %FileCheck --check-prefixes=BOTH,GFX9 %s
+// RUN: %llvm-dis %t.compressed-hip-amdgcn-amd-amdhsa-unknown-gfx1030.bc -o - | %FileCheck --check-prefixes=BOTH,GFX10 %s
 //
 // BOTH: target triple = "amdgcn-amd-amdhsa"
 // GFX9: "target-cpu"="gfx900"

--- a/amd/comgr/test/unbundle_hip_test.c
+++ b/amd/comgr/test/unbundle_hip_test.c
@@ -63,7 +63,7 @@ int main(int Argc, char *Argv[]) {
   checkError(Status, "amd_comgr_create_data_set");
 
   // Bitcode
-  Status = amd_comgr_create_data(AMD_COMGR_DATA_KIND_BC_BUNDLE, &DataBitcode);
+  Status = amd_comgr_create_data(AMD_COMGR_DATA_KIND_BUNDLE, &DataBitcode);
   checkError(Status, "amd_comgr_create_data");
   Status = amd_comgr_set_data(DataBitcode, SizeBitcode, BufBitcode);
   checkError(Status, "amd_comgr_set_data");
@@ -73,8 +73,7 @@ int main(int Argc, char *Argv[]) {
   checkError(Status, "amd_comgr_data_set_add");
 
   // ObjectFile
-  Status =
-      amd_comgr_create_data(AMD_COMGR_DATA_KIND_OBJ_BUNDLE, &DataObjectFile);
+  Status = amd_comgr_create_data(AMD_COMGR_DATA_KIND_BUNDLE, &DataObjectFile);
   checkError(Status, "amd_comgr_create_data");
   Status = amd_comgr_set_data(DataObjectFile, SizeObjectFile, BufObjectFile);
   checkError(Status, "amd_comgr_set_data");


### PR DESCRIPTION
## Summary

A single clang-offload-bundler bundle can carry entries of different payload kinds — for example `--offload-arch=gfx906,amdgcnspirv` produces one bundle that mixes ELF and SPIR-V. The existing typed bundle kinds (`BC_BUNDLE`, `OBJ_BUNDLE`, `AR_BUNDLE`) tag every extracted entry with a single output data kind, so heterogeneous payloads round-trip through `AMD_COMGR_ACTION_UNBUNDLE` with the wrong `DataKind` set on the resulting data set.

This change introduces `AMD_COMGR_DATA_KIND_BUNDLE`, a single generic bundle kind whose unbundle path:

1. Inspects the input bytes via `llvm::identify_magic` and routes archive-of-bundle inputs through the `UnbundleArchive` path automatically.
2. Inspects each extracted entry's bytes (also via `llvm::identify_magic`) and assigns the appropriate per-entry data kind:

| Detected payload | Output data kind |
|------------------|------------------|
| LLVM bitcode     | `BC`             |
| ELF              | `EXECUTABLE`     |
| SPIR-V           | `SPIRV`          |
| `ar` archive     | `AR`             |
| anything else    | `BYTES`          |

The legacy `BC_BUNDLE`, `OBJ_BUNDLE`, and `AR_BUNDLE` kinds are accepted as aliases for `BUNDLE` and marked deprecated via `AMD_COMGR_DEPRECATED`. Internally, `UnbundleCommand` now takes an `UnbundleOp { Files | Archive }` instead of an `amd_comgr_data_kind_t`, so the bundler dispatch is decoupled from the deprecated public enum.

## Behavior notes

- Internal temp files written during unbundling now use a uniform `.bundle` extension (visible only with `AMD_COMGR_SAVE_TEMPS=1`). The clang-offload-bundler `-type=` hint still uses a recognized value (`o` or `a`) selected by the input-bytes sniff.
- Output `DataKind` for legacy `BC_BUNDLE` / `OBJ_BUNDLE` callers is unchanged in practice (detection picks the same kind their typed switch arm used to produce).

## Changes

- `include/amd_comgr.h.in`: add `AMD_COMGR_DATA_KIND_BUNDLE = 0x16`, advance `_LAST`, deprecate `BC_BUNDLE`, `OBJ_BUNDLE`, `AR_BUNDLE`.
- `src/comgr-compiler.cpp`: add `detectPayloadKind` using `llvm::identify_magic`; collapse the per-typed-kind arms in `AMDGPUCompiler::unbundle()` into a single magic-byte sniff that drives both the bundler op and the per-entry detection.
- `src/comgr-unbundle-command.{h,cpp}`: introduce `enum class UnbundleOp { Files, Archive }`; `UnbundleCommand` takes `UnbundleOp`, `canCache()` and `execute()` switch on it.
- `test-lit/comgr-sources/unbundle.c`: rewrite the LIT test driver to use `BUNDLE` and emit `<prefix>-<entry-id>.<ext>` outputs based on the detected per-entry kind.
- `test-lit/unbundle.hip`, `test-lit/cache-tests/unbundle-cached.hip`: switch to the new driver interface.
- `test-lit/spirv-tests/unbundle-spirv.hip` (new): SPIR-V-only bundle, compressed and uncompressed.
- `test-lit/spirv-tests/unbundle-mixed.hip` (new): heterogeneous `gfx906`+`amdgcnspirv` bundle, compressed and uncompressed; verifies the ELF entry via `llvm-readobj` and the SPIR-V entry via `spirv-translator`.
- `test/unbundle_hip_test.c`: switch `BC_BUNDLE` / `OBJ_BUNDLE` references to `BUNDLE`.