### PR TITLE
[psdb][linux] pass platform to aomp smoke test

### DIFF
--- a/.github/workflows/test_artifacts.yml
+++ b/.github/workflows/test_artifacts.yml
@@ -127,7 +127,7 @@ jobs:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
       test_runs_on: ${{ inputs.test_runs_on }}
-      platform: ${{ needs.configure_test_matrix.outputs.platform }}
+      platform: 'linux'
 
   test_components:
     name: 'Test ${{ matrix.components.job_name }}'


### PR DESCRIPTION
   - aomp smoke test seems to have been running directly on baremetal
   - this patch forces the platform to linux
   - once we migrate to multi arch, we will revisit this patch as the platform
      should be auto fetched instead of this hardcoding


