### PR TITLE
[flang] Remove `do concurrent` mapping experimental warning

### DIFF
--- a/flang/lib/Frontend/FrontendActions.cpp
+++ b/flang/lib/Frontend/FrontendActions.cpp
@@ -333,13 +333,6 @@ bool CodeGenAction::beginSourceFileAction() {
     opts.doConcurrentMappingKind = DoConcurrentMappingKind::DCMK_None;
   }
 
-  if (opts.doConcurrentMappingKind != DoConcurrentMappingKind::DCMK_None) {
-    unsigned diagID = ci.getDiagnostics().getCustomDiagID(
-        clang::DiagnosticsEngine::Warning,
-        "Mapping `do concurrent` to OpenMP is still experimental.");
-    ci.getDiagnostics().Report(diagID);
-  }
-
   if (isOpenMPEnabled) {
     opts.isTargetDevice = false;
     if (auto offloadMod = llvm::dyn_cast<mlir::omp::OffloadModuleInterface>(


### PR DESCRIPTION
Removes the warning downstream for now since we need this urgently for the SPEC CPU publication. We can do that upstream (with all the expected resistance) later.


