### PR TITLE
[Workflows] Enable pr-code-format on amd-staging PRs

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -6,8 +6,7 @@ permissions:
 on:
   pull_request:
     branches:
-      - main
-      - 'users/**'
+      - amd-staging
 
 jobs:
   code_formatter:
@@ -18,7 +17,6 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
-    if: github.repository == 'llvm/llvm-project'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -6,8 +6,7 @@ permissions:
 on:
   pull_request:
     branches:
-      - main
-      - 'users/**'
+      - amd-staging
     paths:
       - 'clang-tools-extra/clang-tidy/**'
       - 'clang-tools-extra/docs/clang-tidy/**'
@@ -15,7 +14,6 @@ on:
 
 jobs:
   code_linter:
-    if: github.repository_owner == 'llvm'
     runs-on: ubuntu-24.04
     defaults:
       run:


### PR DESCRIPTION
## Summary

The upstream `pr-code-format.yml` workflow only runs on PRs targeting `main` or `users/**`, and is gated by `if: github.repository == 'llvm/llvm-project'`. As a result, it never runs on PRs against `amd-staging` in this fork.

This change:
- Replaces the branch filter with `amd-staging`.
- Removes the `github.repository` guard.

The existing `issue-write.yml` already listens for "Check code formatting" via `workflow_run`, so format-check comments will be posted on PRs once the job runs — no additional wiring needed.