### PR TITLE
[AMDGPU] comgr: Implement Trampoline Patches for B0-to-A0 Hotswap 2/2 -- Tensor Load Instructions

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -10,6 +10,8 @@
 /// whose fix is larger than the original instruction:
 ///   - ds_*_2addr_stride64_*  : one 8B DS instruction -> two single-address
 ///     DS instructions
+///   - tensor_load_to_lds     : prepend s_pack_hh_b32_b16 to clear multicast
+///     routing bits in the group descriptor's base SGPR
 ///
 //===----------------------------------------------------------------------===//
 
@@ -22,6 +24,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -29,12 +32,13 @@ using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+namespace {
 
 // -- DS stride64 swap table (StringSwitch) ----------------------------------
 //
 // Maps each 2-address DS mnemonic to its single-address replacement.
 
-static StringRef getDs2AddrReplacement(StringRef Mnemonic) {
+StringRef getDs2AddrReplacement(StringRef Mnemonic) {
   return StringSwitch<StringRef>(Mnemonic)
       .Case("ds_load_2addr_stride64_b32", "ds_load_b32")
       .Case("ds_load_2addr_stride64_b64", "ds_load_b64")
@@ -52,7 +56,7 @@ static StringRef getDs2AddrReplacement(StringRef Mnemonic) {
 // building. Sub-register iteration returns ALL fragments (including lo16/hi16);
 // getDirectSubRegs filters to only scalar 32-bit components.
 
-static std::string toAsmRegName(const MCRegisterInfo &MRI, MCRegister Reg) {
+std::string toAsmRegName(const MCRegisterInfo &MRI, MCRegister Reg) {
   const char *N = MRI.getName(Reg);
   if (!N)
     return {};
@@ -64,8 +68,8 @@ static std::string toAsmRegName(const MCRegisterInfo &MRI, MCRegister Reg) {
   return Name.str();
 }
 
-static SmallVector<MCRegister, 4> getDirectSubRegs(MCRegister Reg,
-                                                   const MCRegisterInfo &MRI) {
+SmallVector<MCRegister, 4> getDirectSubRegs(MCRegister Reg,
+                                            const MCRegisterInfo &MRI) {
   SmallVector<MCRegister, 4> Result;
   for (MCPhysReg Sub : MRI.subregs(Reg)) {
     StringRef Name = MRI.getName(Sub);
@@ -77,8 +81,8 @@ static SmallVector<MCRegister, 4> getDirectSubRegs(MCRegister Reg,
 }
 
 // Format a VGPR pair as a range expression: (VGPR0, VGPR1) -> "v[0:1]".
-static std::string fmtRegPair(const MCRegisterInfo &MRI, MCRegister Lo,
-                              MCRegister Hi) {
+std::string fmtRegPair(const MCRegisterInfo &MRI, MCRegister Lo,
+                       MCRegister Hi) {
   std::string LoName = toAsmRegName(MRI, Lo);
   std::string HiName = toAsmRegName(MRI, Hi);
   char Prefix = LoName[0];
@@ -90,7 +94,7 @@ static std::string fmtRegPair(const MCRegisterInfo &MRI, MCRegister Lo,
 // Format a register operand for assembly. Single registers (VGPR0) produce
 // "v0"; register tuples (VGPR0_VGPR1) produce "v[0:1]" by decomposing into
 // their scalar sub-registers.
-static std::string fmtRegOperand(const MCRegisterInfo &MRI, MCRegister Reg) {
+std::string fmtRegOperand(const MCRegisterInfo &MRI, MCRegister Reg) {
   const char *N = MRI.getName(Reg);
   if (!N)
     return {};
@@ -104,7 +108,7 @@ static std::string fmtRegOperand(const MCRegisterInfo &MRI, MCRegister Reg) {
 }
 
 // Format an optional byte offset as " offset:N" (empty string when zero).
-static std::string fmtOffset(uint32_t Offset) {
+std::string fmtOffset(uint32_t Offset) {
   return Offset ? " offset:" + std::to_string(Offset) : "";
 }
 
@@ -129,8 +133,8 @@ struct DsOperands {
 
 // Extract register operands and scaled offsets from a DS 2-address MCInst.
 // Offsets are scaled by 64 * element_size (stride64 encoding).
-static DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
-                                    const LLVMState &LS) {
+DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
+                             const LLVMState &LS) {
   DsOperands Ops;
   Ops.MRI = LS.MRI.get();
 
@@ -138,7 +142,7 @@ static DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
   unsigned ImmsSeen = 0;
   for (unsigned I = 0, E = Inst.getNumOperands(); I < E; ++I) {
     const MCOperand &Op = Inst.getOperand(I);
-    if (Op.isReg() && Op.getReg() != 0)
+    if (Op.isReg() && Op.getReg())
       Ops.Regs.push_back(MCRegister(Op.getReg()));
     else if (Op.isImm()) {
       if (ImmsSeen == 0)
@@ -159,7 +163,7 @@ static DsOperands extractDsOperands(const MCInst &Inst, StringRef FromMnem,
 
 // Split a compound destination register into two formatted destination strings.
 // b32: VReg_64 -> ("v0", "v1"); b64: VReg_128 -> ("v[0:1]", "v[2:3]")
-static std::pair<std::string, std::string>
+std::pair<std::string, std::string>
 splitDstPair(MCRegister CompoundReg, bool IsB64, const MCRegisterInfo &MRI) {
   SmallVector<MCRegister, 4> Subs = getDirectSubRegs(CompoundReg, MRI);
   if (IsB64) {
@@ -174,8 +178,8 @@ splitDstPair(MCRegister CompoundReg, bool IsB64, const MCRegisterInfo &MRI) {
 }
 
 // Expand a DS 2-address load into two single-address loads (dst, addr).
-static std::vector<std::string> expandDs2AddrLoad(const DsOperands &Ops,
-                                                  StringRef ToMnem) {
+std::vector<std::string> expandDs2AddrLoad(const DsOperands &Ops,
+                                           StringRef ToMnem) {
   if (Ops.Regs.size() < 2)
     return {};
   std::pair<std::string, std::string> Dst =
@@ -190,8 +194,8 @@ static std::vector<std::string> expandDs2AddrLoad(const DsOperands &Ops,
 }
 
 // Expand a DS 2-address store into two single-address stores (addr, data).
-static std::vector<std::string> expandDs2AddrStore(const DsOperands &Ops,
-                                                   StringRef ToMnem) {
+std::vector<std::string> expandDs2AddrStore(const DsOperands &Ops,
+                                            StringRef ToMnem) {
   if (Ops.Regs.size() < 3)
     return {};
   const MCRegisterInfo &MRI = *Ops.MRI;
@@ -208,8 +212,8 @@ static std::vector<std::string> expandDs2AddrStore(const DsOperands &Ops,
 
 // Expand a DS 2-address exchange into two single-address exchanges
 // (dst, addr, data).
-static std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
-                                                  StringRef ToMnem) {
+std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
+                                           StringRef ToMnem) {
   if (Ops.Regs.size() < 4)
     return {};
   const MCRegisterInfo &MRI = *Ops.MRI;
@@ -235,10 +239,8 @@ static std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
 // Top-level expansion: extracts operands from the decoded MCInst, computes
 // scaled offsets, then dispatches to the appropriate layout-specific helper.
 
-static std::vector<std::string> expandDs2Addr(const MCInst &Inst,
-                                              StringRef FromMnem,
-                                              StringRef ToMnem,
-                                              const LLVMState &LS) {
+std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
+                                       StringRef ToMnem, const LLVMState &LS) {
   DsOperands Ops = extractDsOperands(Inst, FromMnem, LS);
 
   if (FromMnem.starts_with("ds_load"))
@@ -265,7 +267,7 @@ static std::vector<std::string> expandDs2Addr(const MCInst &Inst,
 // well-formed kernels. If absent (e.g. s_endpgm terminates first), skipping
 // the bump is safe — the hardware wait counter saturates harmlessly.
 
-static bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
+bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
   const MCInstrInfo &MCII = *Ctx.LS.MCII;
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
 
@@ -315,7 +317,7 @@ static bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
 // instructions. The split doubles the outstanding DS operation count, so
 // bumpNextWaitDscnt adjusts the next s_wait_dscnt accordingly.
 
-static bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
+bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
@@ -338,7 +340,7 @@ static bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
     return false;
   }
 
-  std::vector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
+  SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return false;
 
@@ -347,18 +349,217 @@ static bool patchDs2AddrStride64(PatchContext &Ctx, size_t Idx) {
   return true;
 }
 
+// -- getDescriptorBaseSgpr --------------------------------------------------
+//
+// Extract the base SGPR MCRegister from the second operand of a
+// tensor_load_to_lds instruction. The second operand is an 8-SGPR group
+// descriptor (SReg_256); we need its first sub-register for the
+// s_pack_hh_b32_b16 fix.
+
+MCRegister getDescriptorBaseSgpr(const MCInst &Inst,
+                                 const MCRegisterInfo &MRI) {
+  if (Inst.getNumOperands() < 2 || !Inst.getOperand(1).isReg())
+    return MCRegister();
+  MCRegister Tuple = MCRegister(Inst.getOperand(1).getReg());
+  SmallVector<MCRegister, 4> Subs = getDirectSubRegs(Tuple, MRI);
+  return Subs.empty() ? MCRegister() : Subs[0];
+}
+
+// -- isSgprLiveAfter --------------------------------------------------------
+//
+// Conservative forward-scan heuristic. Returns true if the given SGPR
+// (identified by its MCRegister) is used before being redefined in the
+// instruction stream following Idx. Conservatively returns true on
+// control-flow-affecting instructions or end of stream.
+
+bool isSgprLiveAfter(const PatchContext &Ctx, size_t Idx,
+                     MCRegister SgprMCReg) {
+  if (!SgprMCReg.isValid())
+    return true;
+
+  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+  const MCInstrInfo &MCII = *Ctx.LS.MCII;
+
+  for (size_t I = Idx + 1; I < Ctx.Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Ctx.Decoded[I];
+    if (DI.Mnemonic == "<unknown>" || DI.Mnemonic == "<replaced>")
+      continue;
+
+    const MCInst &Inst = DI.Inst;
+    const MCInstrDesc &Desc = MCII.get(Inst.getOpcode());
+
+    if (DI.Mnemonic == "s_endpgm")
+      return false;
+
+    if (Desc.mayAffectControlFlow(Inst, MRI))
+      return true;
+
+    unsigned NumDefs = Desc.getNumDefs();
+    auto RegInRange = [&](ArrayRef<MCOperand> Ops) {
+      for (const MCOperand &Op : Ops) {
+        if (!Op.isReg() || !Op.getReg())
+          continue;
+        if (MRI.regsOverlap(Op.getReg(), SgprMCReg.id()))
+          return true;
+      }
+      return false;
+    };
+    ArrayRef<MCOperand> Operands = Inst.getOperands();
+    ArrayRef<MCOperand> Defs = Operands.slice(0, NumDefs);
+    ArrayRef<MCOperand> Uses = Operands.slice(NumDefs);
+    if (RegInRange(Uses))
+      return true;
+    if (RegInRange(Defs))
+      return false;
+  }
+
+  return true;
+}
+
+// -- allocScratchVgpr -------------------------------------------------------
+std::optional<unsigned> allocScratchVgpr(PatchContext &Ctx, size_t Idx) {
+  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
+  unsigned KdVgprs = 0;
+  if (std::optional<unsigned> Opt =
+          Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize))
+    KdVgprs = *Opt;
+
+  ScratchAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdVgprs,
+                         Ctx.Config.MaxVgprs);
+  std::optional<unsigned> ScratchOpt = Alloc.alloc();
+  if (!ScratchOpt)
+    return std::nullopt;
+
+  if (Alloc.extraVgprsNeeded() > 0 && !KernelName.empty()) {
+    KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+    Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, Alloc.extraVgprsNeeded());
+    Stats.ScratchAboveKd += Alloc.extraVgprsNeeded();
+  }
+
+  return *ScratchOpt;
+}
+
+// -- patchTensorLoadToLds ---------------------------------------------------
+//
+// Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
+// descriptor's base SGPR. If the SGPR is live after the tensor_load, bracket
+// the sequence with v_writelane/v_readlane to save and restore its value
+// through a scratch VGPR lane.
+
+bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
+  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+
+  MCRegister BaseMCReg = getDescriptorBaseSgpr(DI.Inst, MRI);
+  if (!BaseMCReg.isValid()) {
+    log() << "hotswap: error: tensor_load_to_lds: could not extract descriptor "
+             "base register\n";
+    return false;
+  }
+
+  // Idempotency guard: check whether the immediately preceding instruction
+  // matches one of the specific patterns we emit during patching:
+  //   dead-SGPR path: s_pack_hh_b32_b16 sN, 0, sN  (dst == BaseMCReg)
+  //   live-SGPR path: v_writelane_b32 vX, sN, 0     (src == BaseMCReg)
+  if (Idx > 0) {
+    const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+    const MCInst &PI = Prev.Inst;
+    if (Prev.Mnemonic == "s_pack_hh_b32_b16" && PI.getNumOperands() >= 3 &&
+        PI.getOperand(0).isReg() &&
+        MRI.regsOverlap(PI.getOperand(0).getReg(), BaseMCReg.id()) &&
+        PI.getOperand(1).isImm() && PI.getOperand(1).getImm() == 0)
+      return false;
+    if (Prev.Mnemonic == "v_writelane_b32" && PI.getNumOperands() >= 3 &&
+        PI.getOperand(1).isReg() &&
+        MRI.regsOverlap(PI.getOperand(1).getReg(), BaseMCReg.id()) &&
+        PI.getOperand(2).isImm() && PI.getOperand(2).getImm() == 0)
+      return false;
+  }
+
+  std::string BaseSreg = toAsmRegName(MRI, BaseMCReg);
+
+  std::string PackAsm = "s_pack_hh_b32_b16 " + BaseSreg + ", 0, " + BaseSreg;
+  SmallVector<uint8_t> PackBytes = assembleSingleInst(PackAsm, Ctx.LS);
+  if (PackBytes.empty()) {
+    log() << "hotswap: tensor_load_to_lds pack: assembly failed: " << PackAsm
+          << "\n";
+    return false;
+  }
+
+  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
+
+  const uint8_t *OrigInst = Ctx.Text + DI.Offset;
+
+  if (SgprLive) {
+    std::optional<unsigned> ScratchVgpr = allocScratchVgpr(Ctx, Idx);
+    if (!ScratchVgpr) {
+      log() << "hotswap: error: tensor_load_to_lds: no scratch VGPR "
+               "available\n";
+      return false;
+    }
+
+    ScratchPatchInfo SPI;
+    SPI.Offset = DI.Offset;
+    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+    SPI.ScratchRegs.set(*ScratchVgpr);
+    Ctx.OutScratchPatches.push_back(std::move(SPI));
+
+    std::string V = "v" + std::to_string(*ScratchVgpr);
+    std::string SaveAsm = "v_writelane_b32 " + V + ", " + BaseSreg + ", 0";
+    std::string RestoreAsm = "v_readlane_b32 " + BaseSreg + ", " + V + ", 0";
+    SmallVector<uint8_t> Save = assembleSingleInst(SaveAsm, Ctx.LS);
+    SmallVector<uint8_t> Restore = assembleSingleInst(RestoreAsm, Ctx.LS);
+    if (Save.empty() || Restore.empty()) {
+      log() << "hotswap: tensor_load_to_lds: save/restore assembly failed\n";
+      return false;
+    }
+
+    SmallVector<uint8_t> Replacement;
+    Replacement.append(Save.begin(), Save.end());
+    Replacement.append(PackBytes.begin(), PackBytes.end());
+    Replacement.append(OrigInst, OrigInst + DI.Size);
+    Replacement.append(Restore.begin(), Restore.end());
+
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+      return false;
+
+    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
+          << " live, save/restore via " << V << "\n";
+  } else {
+    SmallVector<uint8_t> Replacement;
+    Replacement.append(PackBytes.begin(), PackBytes.end());
+    Replacement.append(OrigInst, OrigInst + DI.Size);
+
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+      return false;
+
+    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
+          << " dead, no save/restore needed\n";
+  }
+
+  DI.Mnemonic = "<replaced>";
+  return true;
+}
+
+} // anonymous namespace
+
 // -- applyTrampolinePatches -------------------------------------------------
 //
 // Strong-symbol override. Handles B0 errata that produce replacement code
 // larger than the original instruction slot:
 //
 //   ds_*_2addr_stride64_*  -> split into two single-address DS ops
+//   tensor_load_to_lds     -> prepend s_pack_hh_b32_b16 (+ save/restore)
 
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
   if (!getDs2AddrReplacement(Mnem).empty())
     return patchDs2AddrStride64(Ctx, Idx) ? 1 : 0;
+
+  if (Mnem == "tensor_load_to_lds")
+    return patchTensorLoadToLds(Ctx, Idx) ? 1 : 0;
 
   return 0;
 }

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -1,0 +1,71 @@
+// COM: Test isSgprLiveAfter edge cases for tensor_load_to_lds patching.
+// COM: A branch instruction between the tensor_load and the next use of
+// COM: the descriptor SGPR forces the heuristic to conservatively assume
+// COM: the SGPR is live, producing save/restore even though the use may
+// COM: not execute on all paths.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load
+// COM: and s_mov (which reads s4). isSgprLiveAfter returns true at the
+// COM: branch, so save/restore is emitted conservatively.
+// DISASM-LABEL: <test_tensor_branch_guard>:
+// DISASM: s_branch
+// DISASM: s_cbranch_scc1
+// DISASM: v_writelane_b32
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: v_readlane_b32
+// DISASM: s_branch
+
+// COM: Idempotency
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_branch_guard
+.p2align 8
+.type test_tensor_branch_guard,@function
+test_tensor_branch_guard:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_cbranch_scc1 .Lskip
+  s_mov_b32 s0, s4
+.Lskip:
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_branch_guard_end:
+.size test_tensor_branch_guard, .Ltest_tensor_branch_guard_end-test_tensor_branch_guard
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_branch_guard
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
@@ -1,0 +1,215 @@
+// COM: Test multi-site tensor_load_to_lds patching: multiple tensor_load
+// COM: instructions in a single kernel. Verifies:
+// COM:   - Each site is independently patched with its own s_pack_hh
+// COM:   - Idempotency guard correctly handles back-to-back patches
+// COM:   - DS + tensor coexistence in the same kernel
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Kernel 1: two tensor_load_to_lds with different descriptors
+// COM: (s[4:11] and s[16:23]). Both should be patched independently.
+// COM: The second tensor_load's predecessor after patching is the first's
+// COM: branch-back, not its own s_pack_hh — idempotency guard must not
+// COM: false-positive on it.
+// DISASM-LABEL: <test_tensor_multi_different>:
+// DISASM: s_branch
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+
+// COM: Kernel 2: two tensor_load_to_lds sharing the same descriptor
+// COM: (s[4:11]). Both should still be patched — the idempotency guard
+// COM: checks the immediately preceding instruction, and after patching
+// COM: the first, the second's predecessor is an s_branch (not s_pack_hh).
+// DISASM-LABEL: <test_tensor_multi_same>:
+// DISASM: s_branch
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+
+// COM: Kernel 3: mixed DS 2-addr + tensor_load in the same kernel.
+// COM: Both patch types should coexist: DS expansion produces two
+// COM: single-address loads + wait bump, tensor produces s_pack_hh.
+// DISASM-LABEL: <test_tensor_mixed_ds>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt
+// DISASM: s_branch
+// DISASM: s_endpgm
+
+// COM: Idempotency
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// ---- Kernel 1: two tensor_loads with different descriptors -----------------
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_multi_different
+.p2align 8
+.type test_tensor_multi_different,@function
+test_tensor_multi_different:
+  tensor_load_to_lds s[0:3], s[4:11]
+  tensor_load_to_lds s[0:3], s[16:23]
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_multi_different_end:
+.size test_tensor_multi_different, .Ltest_tensor_multi_different_end-test_tensor_multi_different
+
+// ---- Kernel 2: two tensor_loads sharing the same descriptor ----------------
+
+.globl test_tensor_multi_same
+.p2align 8
+.type test_tensor_multi_same,@function
+test_tensor_multi_same:
+  tensor_load_to_lds s[0:3], s[4:11]
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_multi_same_end:
+.size test_tensor_multi_same, .Ltest_tensor_multi_same_end-test_tensor_multi_same
+
+// ---- Kernel 3: mixed DS 2-addr + tensor_load in one kernel -----------------
+
+.globl test_tensor_mixed_ds
+.p2align 8
+.type test_tensor_mixed_ds,@function
+test_tensor_mixed_ds:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_mixed_ds_end:
+.size test_tensor_mixed_ds, .Ltest_tensor_mixed_ds_end-test_tensor_mixed_ds
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_multi_different
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 24
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_multi_same
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_mixed_ds
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -1,0 +1,87 @@
+// COM: Test the true trampoline fallback path for tensor_load_to_lds
+// COM: when no NOP sled is available. Two variants:
+// COM:   dead SGPR — s_pack_hh + tensor_load appended via growWithTrampolines
+// COM:   live SGPR — save/pack/tensor/restore (4-instruction sequence)
+// COM:              appended via growWithTrampolines, the largest replacement
+// COM: Both force emitReplacementCode to use emitToTrampoline.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Kernel 1 (dead SGPR, no sled): original tensor_load replaced by
+// COM: s_branch forward. Trampoline body appended in alignment padding.
+// DISASM-LABEL: <test_tensor_trampoline>:
+// DISASM-NOT: tensor_load_to_lds
+// DISASM: s_branch
+// DISASM: s_endpgm
+
+// COM: Dead-SGPR trampoline body: s_pack_hh + tensor_load + branch-back.
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+
+// COM: Live-SGPR trampoline body (for kernel 2): also placed in the
+// COM: padding region. save + pack + tensor + restore + branch-back.
+// DISASM: v_writelane_b32
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: v_readlane_b32
+// DISASM: s_branch
+
+// COM: Kernel 2 (live SGPR, no sled): the original tensor_load is
+// COM: replaced by s_branch backward to the trampoline body above.
+// DISASM-LABEL: <test_tensor_trampoline_live>:
+// DISASM-NOT: tensor_load_to_lds
+// DISASM: s_branch
+// DISASM: s_mov_b32
+// DISASM: s_endpgm
+
+// COM: Idempotency
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_trampoline
+.p2align 8
+.type test_tensor_trampoline,@function
+test_tensor_trampoline:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+.Ltest_tensor_trampoline_end:
+.size test_tensor_trampoline, .Ltest_tensor_trampoline_end-test_tensor_trampoline
+
+// ---- Kernel 2: live SGPR, no NOP sled (trampoline + save/restore) ----------
+
+.globl test_tensor_trampoline_live
+.p2align 8
+.type test_tensor_trampoline_live,@function
+test_tensor_trampoline_live:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+.Ltest_tensor_trampoline_live_end:
+.size test_tensor_trampoline_live, .Ltest_tensor_trampoline_live_end-test_tensor_trampoline_live
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_trampoline
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_trampoline_live
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,0 +1,225 @@
+// COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
+// COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
+// COM: the descriptor's base SGPR. Base operand variants via NOP sled:
+// COM:   dead SGPR  — only s_pack_hh prepended (no save/restore)
+// COM:   live SGPR  — v_writelane save, s_pack_hh, tensor, v_readlane restore
+// COM:   alt descriptor — different SGPR range (s[16:23]) for pack target
+// COM:   SGPR redef — descriptor SGPR overwritten before use (dead path)
+// COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
+// COM: s_branch checks.
+// COM:
+// COM: Companion tests:
+// COM:   hotswap-trampoline-tensor-nosled.s     — trampoline fallback path
+// COM:   hotswap-trampoline-tensor-multi.s      — multi-site stacking
+// COM:   hotswap-trampoline-tensor-liveness.s   — isSgprLiveAfter edge cases
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: --- Per-kernel checks ---
+
+// COM: Kernel 1 (dead SGPR): s_branch forward to sled, s_pack_hh and
+// COM: tensor_load_to_lds appear in sled area, s_branch back to original
+// COM: stream. No v_writelane/v_readlane since descriptor SGPR is dead
+// COM: (s_endpgm follows immediately).
+// DISASM-LABEL: <test_tensor_dead>:
+// DISASM-NOT: v_writelane_b32
+// DISASM-NOT: v_readlane_b32
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+// DISASM-NOT: v_writelane_b32
+// DISASM-NOT: v_readlane_b32
+
+// COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
+// COM: tensor/restore sequence in sled area with branch-back.
+// COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
+// COM: save/restore via scratch VGPR is required.
+// DISASM-LABEL: <test_tensor_live>:
+// DISASM: s_branch
+// DISASM: s_mov_b32
+// DISASM: v_writelane_b32
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: v_readlane_b32
+// DISASM: s_branch
+
+// COM: Kernel 3 (alternate descriptor s[16:23]): verifies
+// COM: getDescriptorBaseSgpr correctly extracts s16 from a different
+// COM: SReg_256 range. s_pack_hh should target s16, not s4.
+// COM: SGPR is dead (s_endpgm follows).
+// DISASM-LABEL: <test_tensor_alt_descriptor>:
+// DISASM-NOT: v_writelane_b32
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_pack_hh_b32_b16 s16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+
+// COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
+// COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
+// COM: isSgprLiveAfter sees a def-before-use and takes the dead path
+// COM: — no save/restore needed.
+// DISASM-LABEL: <test_tensor_sgpr_redef>:
+// DISASM-NOT: v_writelane_b32
+// DISASM-NOT: v_readlane_b32
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: s_branch
+// DISASM-NOT: v_writelane_b32
+// DISASM-NOT: v_readlane_b32
+
+// COM: Idempotency: rewriting the output again should produce identical bytes.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// ---- Kernel 1: tensor_load_to_lds with dead SGPR (s_endpgm follows) --------
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_dead
+.p2align 8
+.type test_tensor_dead,@function
+test_tensor_dead:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_dead_end:
+.size test_tensor_dead, .Ltest_tensor_dead_end-test_tensor_dead
+
+// ---- Kernel 2: tensor_load_to_lds with live SGPR (s4 used after) -----------
+
+.globl test_tensor_live
+.p2align 8
+.type test_tensor_live,@function
+test_tensor_live:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_live_end:
+.size test_tensor_live, .Ltest_tensor_live_end-test_tensor_live
+
+// ---- Kernel 3: tensor_load_to_lds with alternate descriptor s[16:23] -------
+
+.globl test_tensor_alt_descriptor
+.p2align 8
+.type test_tensor_alt_descriptor,@function
+test_tensor_alt_descriptor:
+  tensor_load_to_lds s[0:3], s[16:23]
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_alt_descriptor_end:
+.size test_tensor_alt_descriptor, .Ltest_tensor_alt_descriptor_end-test_tensor_alt_descriptor
+
+// ---- Kernel 4: tensor_load_to_lds with SGPR redefined (dead path) ----------
+
+.globl test_tensor_sgpr_redef
+.p2align 8
+.type test_tensor_sgpr_redef,@function
+test_tensor_sgpr_redef:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s4, 0
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_tensor_sgpr_redef_end:
+.size test_tensor_sgpr_redef, .Ltest_tensor_sgpr_redef_end-test_tensor_sgpr_redef
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_dead
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_live
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_alt_descriptor
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 24
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_sgpr_redef
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel


### PR DESCRIPTION
## Summary

Implements the `tensor_load_to_lds` trampoline patch for the GFX1250 B0-to-A0 HotSwap pipeline. This B0 erratum requires prepending `s_pack_hh_b32_b16` on the group descriptor's base SGPR to clear multicast routing bits before `tensor_load_to_lds` executes — a replacement larger than the original, necessitating trampoline emission.

When the descriptor base SGPR is live after the instruction, the patch brackets the sequence with `v_writelane_b32`/`v_readlane_b32` save/restore through a scratch VGPR allocated via `ScratchAllocator`. The idempotency guard checks both the preceding instruction mnemonic and the same descriptor base register (via `MCRegisterInfo::regsOverlap`) to avoid false skips from unrelated `s_pack_hh` instructions in real code.

All register extraction uses direct `MCInst` operand access with `getDirectSubRegs` to decompose the SReg_256 descriptor tuple. Liveness analysis uses `MCInstrDesc::mayAffectControlFlow` for control-flow detection.

## Changes

- **`comgr-hotswap-patch-trampoline.cpp`** (new) — `applyTrampolinePatches` strong-symbol override with `getDescriptorBaseSgpr`, `isSgprLiveAfter`, `allocScratchVgpr`, `assembleOrFail`, and `patchTensorLoadToLds` helpers. Records `ScratchPatchInfo` after VGPR allocation. Guarded with `#if !defined(_MSC_VER)` for Windows compatibility.
- **`comgr-hotswap-b0a0.cpp`** — Remove `static` from `emitToNopSled`, `emitToTrampoline`, `emitReplacementCode` for cross-TU access. Remove `[[maybe_unused]]` from `emitReplacementCode`.
- **`comgr-hotswap-internal.h`** — Declare emission helpers, `isSgprLiveAfter`, and patch entry points.
- **`CMakeLists.txt`** — Add new source file to library build.
- **`hotswap-rewrite.c`** — Extend the canonical lit test driver with `--dump <file>`, `--check-idempotent` (full `memcmp` byte comparison), and flexible multi-flag argument parsing.
- **`hotswap-trampoline-tensor.s`** (new) — Lit test for tensor_load multicast fix with two test kernels: dead-SGPR variant (no save/restore) and live-SGPR variant (`v_writelane`/`v_readlane` bracket). Both verify idempotency.

## Test plan

- New lit test (`hotswap-trampoline-tensor.s`) covering:
  - Dead-SGPR path: `s_pack_hh_b32_b16` prepended without save/restore
  - Live-SGPR path: `v_writelane_b32` save, `s_pack_hh_b32_b16`, original instruction, `v_readlane_b32` restore
  - Disassembly verification via `llvm-objdump` + `FileCheck`
  - Idempotency verification (second rewrite produces identical output)
- All existing lit tests pass (in-place, e2e, ELF growth, etc.)
- All ctest and unit tests pass