### PR TITLE
[Flang][Clang][omptarget] Skip update maps of size 0, similar to PTR_AND_OBJ path

### DIFF
--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -1401,6 +1401,12 @@ static int targetDataContiguous(ident_t *Loc, DeviceTy &Device, void *ArgsBase,
     return OFFLOAD_SUCCESS;
   }
 
+  if (ArgSize == 0) {
+    ODBG(ODT_Mapping) << "hst data:" << HstPtrBegin
+                      << " zero size, becomes a noop";
+    return OFFLOAD_SUCCESS;
+  }
+
   if (ArgType & OMP_TGT_MAPTYPE_TO) {
     ODBG(ODT_Mapping) << "Moving " << ArgSize << " bytes (hst:" << HstPtrBegin
                       << ") -> (tgt:" << TgtPtrBegin << ")";


### PR DESCRIPTION
Now that OpenMP has the attach map style, it's possible for pointer maps to bypass the size 0 check that PTR_AND_OBJ does before sending out data submits. This PR tries to add a size 0 barrier from submitting data to device for target update cases, the enter/exit map scenarios and regular target take different paths that already avoid this scenario.

The size 0 submission is bad for multi-SDMA engine devices as we disallow these types of mappings and return an error in these cases. So, we need to avoid the submission to the plugin in the first place without impacting any ref counting or other runtime book keeping.


