### PR TITLE
[HIP] Enable implicit host device templates by default

### DIFF
--- a/clang/include/clang/AST/ASTContext.h
+++ b/clang/include/clang/AST/ASTContext.h
@@ -1395,6 +1395,11 @@ public:
   /// in device compilation.
   llvm::DenseSet<const FunctionDecl *> CUDAImplicitHostDeviceFunUsedByDevice;
 
+  /// Keep track of CUDA/HIP wrong-side overload candidates seen in overload
+  /// resolution. Their usage is owned by the opposite compilation side, so the
+  /// current side should not warn that they are unused.
+  llvm::DenseSet<const FunctionDecl *> CUDAWrongSideOverloadCandidates;
+
   /// Map of SYCL kernels indexed by the unique type used to name the kernel.
   /// Entries are not serialized but are recreated on deserialization of a
   /// sycl_kernel_entry_point attributed function declaration.

--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -1239,11 +1239,11 @@ defm gpu_rdc : BoolFOption<"gpu-rdc",
 
 defm offload_implicit_host_device_templates :
   BoolFOption<"offload-implicit-host-device-templates",
-  LangOpts<"OffloadImplicitHostDeviceTemplates">, DefaultFalse,
+  LangOpts<"OffloadImplicitHostDeviceTemplates">, Default<"LangOpts->HIP">,
   PosFlag<SetTrue, [], [ClangOption, CC1Option],
           "Template functions or specializations without host, device and "
           "global attributes have implicit host device attributes (CUDA/HIP only)">,
-  NegFlag<SetFalse>>;
+  NegFlag<SetFalse, [], [ClangOption, CC1Option]>>;
 
 def fgpu_default_stream_EQ : Joined<["-"], "fgpu-default-stream=">,
   HelpText<"Specify default stream. The default value is 'legacy'. (CUDA/HIP only)">,

--- a/clang/include/clang/Sema/SemaCUDA.h
+++ b/clang/include/clang/Sema/SemaCUDA.h
@@ -176,8 +176,9 @@ public:
   /// \param Callee target function
   ///
   /// \returns preference value for particular Caller/Callee combination.
-  CUDAFunctionPreference IdentifyPreference(const FunctionDecl *Caller,
-                                            const FunctionDecl *Callee);
+  CUDAFunctionPreference
+  IdentifyPreference(const FunctionDecl *Caller, const FunctionDecl *Callee,
+                     bool IgnoreImplicitHDAttr = false);
 
   /// Determines whether Caller may invoke Callee, based on their CUDA
   /// host/device attributes.  Returns false if the call is not allowed.

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1943,7 +1943,6 @@ public:
 
   // Emission state of the root node of the current use graph.
   bool ShouldEmitRootNode;
-  bool ShouldEmitRootDiags;
 
   // Current OpenMP device context level. It is initialized to 0 and each
   // entering of device context increases it by 1 and each exit decreases
@@ -1951,8 +1950,7 @@ public:
   unsigned InOMPDeviceContext;
 
   DeferredDiagnosticsEmitter(Sema &S)
-      : Inherited(S), ShouldEmitRootNode(false), ShouldEmitRootDiags(false),
-        InOMPDeviceContext(0) {}
+      : Inherited(S), ShouldEmitRootNode(false), InOMPDeviceContext(0) {}
 
   bool shouldVisitDiscardedStmt() const { return false; }
 
@@ -2045,7 +2043,7 @@ public:
           }))
         Callers.push_back({Caller, Loc});
     }
-    if (ShouldEmitRootDiags || InOMPDeviceContext)
+    if (ShouldEmitRootNode || InOMPDeviceContext)
       FnsToEmit.insert(FD);
     // Do not revisit a function if the function body has been completely
     // visited before.
@@ -2064,15 +2062,8 @@ public:
 
   void checkRecordedDecl(Decl *D) {
     if (auto *FD = dyn_cast<FunctionDecl>(D)) {
-      Sema::FunctionEmissionStatus ES =
-          S.getEmissionStatus(FD, /*Final=*/true);
-      ShouldEmitRootDiags = ES == Sema::FunctionEmissionStatus::Emitted;
-      ShouldEmitRootNode = ShouldEmitRootDiags;
-      if (!ShouldEmitRootNode && S.getLangOpts().CUDAIsDevice &&
-          S.getLangOpts().OffloadImplicitHostDeviceTemplates &&
-          SemaCUDA::isImplicitHostDeviceFunction(FD) &&
-          !S.Context.CUDAImplicitHostDeviceFunUsedByDevice.count(FD))
-        ShouldEmitRootNode = true;
+      ShouldEmitRootNode = S.getEmissionStatus(FD, /*Final=*/true) ==
+                           Sema::FunctionEmissionStatus::Emitted;
       checkFunc(SourceLocation(), FD);
     } else
       checkVar(cast<VarDecl>(D));

--- a/clang/lib/Sema/Sema.cpp
+++ b/clang/lib/Sema/Sema.cpp
@@ -1943,6 +1943,7 @@ public:
 
   // Emission state of the root node of the current use graph.
   bool ShouldEmitRootNode;
+  bool ShouldEmitRootDiags;
 
   // Current OpenMP device context level. It is initialized to 0 and each
   // entering of device context increases it by 1 and each exit decreases
@@ -1950,7 +1951,8 @@ public:
   unsigned InOMPDeviceContext;
 
   DeferredDiagnosticsEmitter(Sema &S)
-      : Inherited(S), ShouldEmitRootNode(false), InOMPDeviceContext(0) {}
+      : Inherited(S), ShouldEmitRootNode(false), ShouldEmitRootDiags(false),
+        InOMPDeviceContext(0) {}
 
   bool shouldVisitDiscardedStmt() const { return false; }
 
@@ -2043,7 +2045,7 @@ public:
           }))
         Callers.push_back({Caller, Loc});
     }
-    if (ShouldEmitRootNode || InOMPDeviceContext)
+    if (ShouldEmitRootDiags || InOMPDeviceContext)
       FnsToEmit.insert(FD);
     // Do not revisit a function if the function body has been completely
     // visited before.
@@ -2062,8 +2064,15 @@ public:
 
   void checkRecordedDecl(Decl *D) {
     if (auto *FD = dyn_cast<FunctionDecl>(D)) {
-      ShouldEmitRootNode = S.getEmissionStatus(FD, /*Final=*/true) ==
-                           Sema::FunctionEmissionStatus::Emitted;
+      Sema::FunctionEmissionStatus ES =
+          S.getEmissionStatus(FD, /*Final=*/true);
+      ShouldEmitRootDiags = ES == Sema::FunctionEmissionStatus::Emitted;
+      ShouldEmitRootNode = ShouldEmitRootDiags;
+      if (!ShouldEmitRootNode && S.getLangOpts().CUDAIsDevice &&
+          S.getLangOpts().OffloadImplicitHostDeviceTemplates &&
+          SemaCUDA::isImplicitHostDeviceFunction(FD) &&
+          !S.Context.CUDAImplicitHostDeviceFunUsedByDevice.count(FD))
+        ShouldEmitRootNode = true;
       checkFunc(SourceLocation(), FD);
     } else
       checkVar(cast<VarDecl>(D));

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -337,7 +337,13 @@ SemaCUDA::IdentifyPreference(const FunctionDecl *Caller,
        CallerTarget == CUDAFunctionTarget::Device))
     return CFP_Native;
 
-  // (b) Calling HostDevice is OK for everyone.
+  // (b) Calling HostDevice is OK for everyone. An implicit host/device
+  // function still belongs to the active compilation side for overload
+  // preference purposes; otherwise making a host-only template implicitly
+  // device-capable can change host overload resolution.
+  if (CalleeTarget == CUDAFunctionTarget::HostDevice &&
+      isImplicitHostDeviceFunction(Callee))
+    return CFP_Native;
   if (CalleeTarget == CUDAFunctionTarget::HostDevice)
     return CFP_HostDevice;
 

--- a/clang/lib/Sema/SemaCUDA.cpp
+++ b/clang/lib/Sema/SemaCUDA.cpp
@@ -310,7 +310,8 @@ SemaCUDA::CUDAVariableTarget SemaCUDA::IdentifyTarget(const VarDecl *Var) {
 
 SemaCUDA::CUDAFunctionPreference
 SemaCUDA::IdentifyPreference(const FunctionDecl *Caller,
-                             const FunctionDecl *Callee) {
+                             const FunctionDecl *Callee,
+                             bool IgnoreImplicitHDAttr) {
   assert(Callee && "Callee must be valid.");
 
   // Treat ctor/dtor as host device function in device var initializer to allow
@@ -322,7 +323,7 @@ SemaCUDA::IdentifyPreference(const FunctionDecl *Caller,
     return CFP_HostDevice;
 
   CUDAFunctionTarget CallerTarget = IdentifyTarget(Caller);
-  CUDAFunctionTarget CalleeTarget = IdentifyTarget(Callee);
+  CUDAFunctionTarget CalleeTarget = IdentifyTarget(Callee, IgnoreImplicitHDAttr);
 
   // If one of the targets is invalid, the check always fails, no matter what
   // the other target is.
@@ -337,13 +338,7 @@ SemaCUDA::IdentifyPreference(const FunctionDecl *Caller,
        CallerTarget == CUDAFunctionTarget::Device))
     return CFP_Native;
 
-  // (b) Calling HostDevice is OK for everyone. An implicit host/device
-  // function still belongs to the active compilation side for overload
-  // preference purposes; otherwise making a host-only template implicitly
-  // device-capable can change host overload resolution.
-  if (CalleeTarget == CUDAFunctionTarget::HostDevice &&
-      isImplicitHostDeviceFunction(Callee))
-    return CFP_Native;
+  // (b) Calling HostDevice is OK for everyone.
   if (CalleeTarget == CUDAFunctionTarget::HostDevice)
     return CFP_HostDevice;
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -21280,15 +21280,16 @@ Sema::FunctionEmissionStatus Sema::getEmissionStatus(const FunctionDecl *FD,
         (T == CUDAFunctionTarget::Device || T == CUDAFunctionTarget::Global))
       return FunctionEmissionStatus::CUDADiscarded;
 
-    // Implicit host/device templates are only potential device functions. A
-    // host-side instantiation still participates in normal semantic analysis,
-    // but it should not be treated as a root for device deferred diagnostics
-    // unless it is actually reached from device code.
-    if (LangOpts.CUDAIsDevice && LangOpts.OffloadImplicitHostDeviceTemplates &&
-        SemaCUDA::isImplicitHostDeviceFunction(FD) && !FD->isConstexpr() &&
-        !isLambdaCallOperator(FD) &&
+    // An explicit instantiation of an implicit host/device function template is
+    // only a potential device function. Do not treat the host-side explicit
+    // instantiation as device-emitted unless device code actually reaches it.
+    TemplateSpecializationKind TSK = FD->getTemplateSpecializationKind();
+    if (LangOpts.CUDAIsDevice &&
+        (TSK == TSK_ExplicitInstantiationDeclaration ||
+         TSK == TSK_ExplicitInstantiationDefinition) &&
+        SemaCUDA::isImplicitHostDeviceFunction(FD) &&
         !Context.CUDAImplicitHostDeviceFunUsedByDevice.count(FD))
-      return FunctionEmissionStatus::Unknown;
+      return FunctionEmissionStatus::CUDADiscarded;
 
     if (IsEmittedForExternalSymbol())
       return FunctionEmissionStatus::Emitted;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -1927,6 +1927,16 @@ bool Sema::ShouldWarnIfUnusedFileScopedDecl(const DeclaratorDecl *D) const {
     return false;
 
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
+    if (LangOpts.CUDA && Context.CUDAWrongSideOverloadCandidates.contains(FD)) {
+      bool IsHost = FD->hasAttr<CUDAHostAttr>() || !FD->hasAttr<CUDADeviceAttr>();
+      bool IsDeviceOnly =
+          !FD->hasAttr<CUDAHostAttr>() && FD->hasAttr<CUDADeviceAttr>();
+      bool IsGlobal = FD->hasAttr<CUDAGlobalAttr>();
+      if ((LangOpts.CUDAIsDevice && IsHost) ||
+          (!LangOpts.CUDAIsDevice && (IsDeviceOnly || IsGlobal)))
+        return false;
+    }
+
     if (FD->getTemplateSpecializationKind() == TSK_ImplicitInstantiation)
       return false;
     // A non-out-of-line declaration of a member specialization was implicitly
@@ -21270,14 +21280,15 @@ Sema::FunctionEmissionStatus Sema::getEmissionStatus(const FunctionDecl *FD,
         (T == CUDAFunctionTarget::Device || T == CUDAFunctionTarget::Global))
       return FunctionEmissionStatus::CUDADiscarded;
 
-    // Implicit host/device templates are only potential device functions.
-    // Do not treat host-side explicit instantiations as device-emitted unless
-    // they are actually reached from device code.
+    // Implicit host/device templates are only potential device functions. A
+    // host-side instantiation still participates in normal semantic analysis,
+    // but it should not be treated as a root for device deferred diagnostics
+    // unless it is actually reached from device code.
     if (LangOpts.CUDAIsDevice && LangOpts.OffloadImplicitHostDeviceTemplates &&
         SemaCUDA::isImplicitHostDeviceFunction(FD) && !FD->isConstexpr() &&
         !isLambdaCallOperator(FD) &&
         !Context.CUDAImplicitHostDeviceFunUsedByDevice.count(FD))
-      return FunctionEmissionStatus::CUDADiscarded;
+      return FunctionEmissionStatus::Unknown;
 
     if (IsEmittedForExternalSymbol())
       return FunctionEmissionStatus::Emitted;

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -21280,14 +21280,13 @@ Sema::FunctionEmissionStatus Sema::getEmissionStatus(const FunctionDecl *FD,
         (T == CUDAFunctionTarget::Device || T == CUDAFunctionTarget::Global))
       return FunctionEmissionStatus::CUDADiscarded;
 
-    // An explicit instantiation of an implicit host/device function template is
-    // only a potential device function. Do not treat the host-side explicit
-    // instantiation as device-emitted unless device code actually reaches it.
-    TemplateSpecializationKind TSK = FD->getTemplateSpecializationKind();
+    // An implicit host/device function template is only a potential device
+    // function. Do not treat a host-side instantiation as device-emitted unless
+    // device code actually reaches it.
     if (LangOpts.CUDAIsDevice &&
-        (TSK == TSK_ExplicitInstantiationDeclaration ||
-         TSK == TSK_ExplicitInstantiationDefinition) &&
-        SemaCUDA::isImplicitHostDeviceFunction(FD) &&
+        (FD->getDescribedFunctionTemplate() ||
+         FD->isFunctionTemplateSpecialization()) &&
+        SemaCUDA::isImplicitHostDeviceFunction(FD) && !FD->isConstexpr() &&
         !Context.CUDAImplicitHostDeviceFunUsedByDevice.count(FD))
       return FunctionEmissionStatus::CUDADiscarded;
 

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -9085,7 +9085,9 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
     }
   }
 
-  // zero sized static arrays are not allowed in HIP device functions
+  // Zero-sized static arrays are not allowed in HIP device functions. For
+  // host/device functions this is only a device-side issue if the function is
+  // actually emitted for the device, so defer the diagnostic until then.
   if (getLangOpts().HIP && LangOpts.CUDAIsDevice) {
     if (FunctionDecl *FD = getCurFunctionDecl();
         FD &&
@@ -9093,7 +9095,9 @@ void Sema::CheckVariableDeclarationType(VarDecl *NewVD) {
       if (const ConstantArrayType *ArrayT =
               getASTContext().getAsConstantArrayType(T);
           ArrayT && ArrayT->isZeroSize()) {
-        Diag(NewVD->getLocation(), diag::err_typecheck_zero_array_size) << 2;
+        CUDA().DiagIfDeviceCode(NewVD->getLocation(),
+                                diag::err_typecheck_zero_array_size)
+            << 2;
       }
     }
   }

--- a/clang/lib/Sema/SemaDecl.cpp
+++ b/clang/lib/Sema/SemaDecl.cpp
@@ -21266,6 +21266,15 @@ Sema::FunctionEmissionStatus Sema::getEmissionStatus(const FunctionDecl *FD,
         (T == CUDAFunctionTarget::Device || T == CUDAFunctionTarget::Global))
       return FunctionEmissionStatus::CUDADiscarded;
 
+    // Implicit host/device templates are only potential device functions.
+    // Do not treat host-side explicit instantiations as device-emitted unless
+    // they are actually reached from device code.
+    if (LangOpts.CUDAIsDevice && LangOpts.OffloadImplicitHostDeviceTemplates &&
+        SemaCUDA::isImplicitHostDeviceFunction(FD) && !FD->isConstexpr() &&
+        !isLambdaCallOperator(FD) &&
+        !Context.CUDAImplicitHostDeviceFunUsedByDevice.count(FD))
+      return FunctionEmissionStatus::CUDADiscarded;
+
     if (IsEmittedForExternalSymbol())
       return FunctionEmissionStatus::Emitted;
 

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -7452,6 +7452,10 @@ void Sema::AddOverloadCandidate(
   // (CUDA B.1): Check for invalid calls between targets.
   if (getLangOpts().CUDA) {
     const FunctionDecl *Caller = getCurFunctionDecl(/*AllowLambda=*/true);
+    if (Caller && Function &&
+        CUDA().IdentifyPreference(Caller, Function) ==
+            SemaCUDA::CFP_WrongSide)
+      getASTContext().CUDAWrongSideOverloadCandidates.insert(Function);
     // Skip the check for callers that are implicit members, because in this
     // case we may not yet know what the member's target is; the target is
     // inferred for the member automatically, based on the bases and fields of
@@ -8022,13 +8026,17 @@ void Sema::AddMethodCandidate(
   }
 
   // (CUDA B.1): Check for invalid calls between targets.
-  if (getLangOpts().CUDA)
-    if (!CUDA().IsAllowedCall(getCurFunctionDecl(/*AllowLambda=*/true),
-                              Method)) {
+  if (getLangOpts().CUDA) {
+    const FunctionDecl *Caller = getCurFunctionDecl(/*AllowLambda=*/true);
+    if (Caller && Method &&
+        CUDA().IdentifyPreference(Caller, Method) == SemaCUDA::CFP_WrongSide)
+      getASTContext().CUDAWrongSideOverloadCandidates.insert(Method);
+    if (!CUDA().IsAllowedCall(Caller, Method)) {
       Candidate.Viable = false;
       Candidate.FailureKind = ovl_fail_bad_target;
       return;
     }
+  }
 
   if (Method->getTrailingRequiresClause()) {
     ConstraintSatisfaction Satisfaction;

--- a/clang/lib/Sema/SemaOverload.cpp
+++ b/clang/lib/Sema/SemaOverload.cpp
@@ -11289,8 +11289,36 @@ bool clang::isBetterOverloadCandidate(
   // to determine which is better.
   if (S.getLangOpts().CUDA && Cand1.Function && Cand2.Function) {
     FunctionDecl *Caller = S.getCurFunctionDecl(/*AllowLambda=*/true);
-    return S.CUDA().IdentifyPreference(Caller, Cand1.Function) >
-           S.CUDA().IdentifyPreference(Caller, Cand2.Function);
+    auto P1 = S.CUDA().IdentifyPreference(Caller, Cand1.Function);
+    auto P2 = S.CUDA().IdentifyPreference(Caller, Cand2.Function);
+    if (P1 != P2)
+      return P1 > P2;
+
+    // If two host/device candidates are otherwise tied, break ties for an
+    // implicit host/device function as if the implicit device attribute had not
+    // been added. This preserves overload resolution for pure C++ templates in
+    // host compilation while still preferring explicit device overloads in
+    // device compilation.
+    if (P1 == SemaCUDA::CFP_HostDevice) {
+      bool IsCand1ImplicitHD =
+          SemaCUDA::isImplicitHostDeviceFunction(Cand1.Function);
+      bool IsCand2ImplicitHD =
+          SemaCUDA::isImplicitHostDeviceFunction(Cand2.Function);
+      if (IsCand1ImplicitHD != IsCand2ImplicitHD) {
+        auto OriginalP1 = IsCand1ImplicitHD
+                              ? S.CUDA().IdentifyPreference(
+                                    Caller, Cand1.Function,
+                                    /*IgnoreImplicitHDAttr=*/true)
+                              : P1;
+        auto OriginalP2 = IsCand2ImplicitHD
+                              ? S.CUDA().IdentifyPreference(
+                                    Caller, Cand2.Function,
+                                    /*IgnoreImplicitHDAttr=*/true)
+                              : P2;
+        if (OriginalP1 != OriginalP2)
+          return OriginalP1 > OriginalP2;
+      }
+    }
   }
 
   // General member function overloading is handled above, so this only handles

--- a/clang/test/Lexer/has_extension.cu
+++ b/clang/test/Lexer/has_extension.cu
@@ -3,6 +3,11 @@
 // RUN: %clang_cc1 -E -triple x86_64-linux-gnu %s -o - \
 // RUN:   -foffload-implicit-host-device-templates \
 // RUN:   | FileCheck -check-prefix=HDT %s
+// RUN: %clang_cc1 -E -triple x86_64-linux-gnu -x hip %s -o - \
+// RUN:   | FileCheck -check-prefix=HDT %s
+// RUN: %clang_cc1 -E -triple x86_64-linux-gnu -x hip %s -o - \
+// RUN:   -fno-offload-implicit-host-device-templates \
+// RUN:   | FileCheck -check-prefix=NOHDT %s
 
 // NOHDT: no_implicit_host_device_templates
 // HDT: has_implicit_host_device_templates

--- a/clang/test/SemaHIP/implicit-host-device-overload-preference.hip
+++ b/clang/test/SemaHIP/implicit-host-device-overload-preference.hip
@@ -1,0 +1,42 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s
+// RUN: %clang_cc1 -std=c++20 -fcuda-is-device -fsyntax-only %s
+
+#define __device__ __attribute__((device))
+#define __global__ __attribute__((global))
+#define __host__ __attribute__((host))
+
+struct HostOnlyArg {};
+struct DeviceArg {};
+
+template <class T> struct Wrapper {};
+
+// This models a host-only library/template operator that becomes implicit H+D
+// when the option is on by default.
+template <class T> int select(Wrapper<T>, T) { return 1; }
+
+// This models an explicit H+D generic overload. It remains available, but it
+// should not steal overload resolution from the native-side implicit H+D
+// overload above.
+template <class T>
+__host__ __device__ long select(T, HostOnlyArg) {
+  return 2;
+}
+
+void hostUse() {
+  static_assert(sizeof(select(Wrapper<HostOnlyArg>{}, HostOnlyArg{})) ==
+                sizeof(int));
+}
+
+// Same rule on the device side: a formerly device-only template that is
+// implicit H+D should keep native preference over an explicit H+D overload.
+template <class T> __device__ int deviceSelect(Wrapper<T>, T) { return 1; }
+
+template <class T>
+__host__ __device__ long deviceSelect(T, DeviceArg) {
+  return 2;
+}
+
+__global__ void deviceUse() {
+  static_assert(sizeof(deviceSelect(Wrapper<DeviceArg>{}, DeviceArg{})) ==
+                sizeof(int));
+}

--- a/clang/test/SemaHIP/implicit-host-device-template-instantiation.hip
+++ b/clang/test/SemaHIP/implicit-host-device-template-instantiation.hip
@@ -1,0 +1,39 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -fcuda-is-device %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -fcuda-is-device -verify -DDEVICE_USE %s
+
+#define __global__ __attribute__((global))
+
+static int directHostOnly() { return 42; } // expected-note {{'directHostOnly' declared here}}
+
+template <class T> T directHostReference() {
+  return static_cast<T>(directHostOnly()); // expected-error {{reference to __host__ function 'directHostOnly' in __host__ __device__ function}}
+}
+
+// A host-side explicit instantiation should not force a device instantiation
+// for an implicit host/device template.
+template int directHostReference<int>();
+
+static int transitiveHostOnly() { return 42; } // expected-note {{'transitiveHostOnly' declared here}}
+
+template <class T> T transitiveLeaf() {
+  return static_cast<T>(transitiveHostOnly()); // expected-error {{reference to __host__ function 'transitiveHostOnly' in __host__ __device__ function}}
+}
+
+template <class T> T transitiveRoot() {
+  return transitiveLeaf<T>(); // expected-note {{called by 'transitiveRoot<int>'}}
+}
+
+// Host-side explicit instantiations in a chain should not force device
+// instantiations either.
+template int transitiveLeaf<int>();
+template int transitiveRoot<int>();
+
+#ifdef DEVICE_USE
+__global__ void directKernel(int *out) {
+  *out = directHostReference<int>(); // expected-note {{called by 'directKernel'}}
+}
+
+__global__ void transitiveKernel(int *out) {
+  *out = transitiveRoot<int>(); // expected-note {{called by 'transitiveKernel'}}
+}
+#endif

--- a/clang/test/SemaHIP/implicit-host-device-template-instantiation.hip
+++ b/clang/test/SemaHIP/implicit-host-device-template-instantiation.hip
@@ -28,6 +28,30 @@ template <class T> T transitiveRoot() {
 template int transitiveLeaf<int>();
 template int transitiveRoot<int>();
 
+template <class T> void zeroLengthArrayHostReference() {
+  T *extra[0] = {}; // expected-error {{zero-length arrays are not permitted in HIP device code}}
+  (void)extra;
+}
+
+// A host-side explicit instantiation with a device-invalid body should also
+// stay host-only unless device code needs it.
+template void zeroLengthArrayHostReference<void>();
+
+constexpr int zeroLengthArrayConstexprHostReference() {
+  int extra[0] = {}; // expected-error {{zero-length arrays are not permitted in HIP device code}}
+  return sizeof(extra);
+}
+
+static_assert(zeroLengthArrayConstexprHostReference() == 0);
+
+void zeroLengthArrayLambdaHostReference() {
+  auto lambda = [] {
+    int extra[0] = {};
+    return sizeof(extra);
+  };
+  (void)lambda();
+}
+
 #ifdef DEVICE_USE
 __global__ void directKernel(int *out) {
   *out = directHostReference<int>(); // expected-note {{called by 'directKernel'}}
@@ -35,5 +59,21 @@ __global__ void directKernel(int *out) {
 
 __global__ void transitiveKernel(int *out) {
   *out = transitiveRoot<int>(); // expected-note {{called by 'transitiveKernel'}}
+}
+
+__global__ void zeroLengthArrayKernel() {
+  zeroLengthArrayHostReference<void>(); // expected-note {{called by 'zeroLengthArrayKernel'}}
+}
+
+__global__ void zeroLengthArrayConstexprKernel(int *out) {
+  *out = zeroLengthArrayConstexprHostReference(); // expected-note {{called by 'zeroLengthArrayConstexprKernel'}}
+}
+
+__global__ void zeroLengthArrayLambdaKernel(int *out) {
+  auto lambda = [] {
+    int extra[0] = {}; // expected-error {{zero-length arrays are not permitted in HIP device code}}
+    return sizeof(extra);
+  };
+  *out = lambda(); // expected-note {{called by 'zeroLengthArrayLambdaKernel'}}
 }
 #endif

--- a/clang/test/SemaHIP/implicit-host-device-template-nextafter-ambiguity.hip
+++ b/clang/test/SemaHIP/implicit-host-device-template-nextafter-ambiguity.hip
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s
+// RUN: %clang_cc1 -std=c++20 -fcuda-is-device -fsyntax-only %s
+
+#define __host__ __attribute__((host))
+#define __device__ __attribute__((device))
+
+template <class T1, class T2> int host_like(T1, T2);
+template <class T1, class T2> __host__ __device__ long host_like(T1, T2);
+
+void host_use(double *Val, int I) {
+  static_assert(sizeof(host_like(Val[I], 1)) == sizeof(int));
+}
+
+template <class T1, class T2> double nextafter(T1, T2);
+
+template <class T1, class T2> __device__ double nextafter(T1, T2);
+
+__device__ void device_use(double *Val, int I) {
+  (void)nextafter(Val[I], 1);
+}

--- a/clang/test/SemaHIP/implicit-host-device-templates-default.hip
+++ b/clang/test/SemaHIP/implicit-host-device-templates-default.hip
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only %s
+// RUN: %clang_cc1 -std=c++20 -fsyntax-only -verify -fno-offload-implicit-host-device-templates -DNO_IMPLICIT_HDT %s
+
+#define __global__ __attribute__((global))
+
+template <class T> T &&declval();
+
+template <class T>
+concept HasMember = requires {
+  declval<T>().member; // expected-note {{because 'declval<T>().member' would be invalid: no matching function for call to 'declval'}}
+};
+
+struct S {
+  int member;
+};
+
+template <class T>
+  requires HasMember<T> // expected-note {{because 'S' does not satisfy 'HasMember'}}
+__global__ void kernel() {} // expected-note {{candidate template ignored: constraints not satisfied [with T = S]}}
+
+#ifdef NO_IMPLICIT_HDT
+// The expected diagnostics for the opt-out run are attached to the template
+// declaration and explicit instantiation.
+#endif
+template __global__ void kernel<S>(); // expected-error {{explicit instantiation of 'kernel' does not refer to a function template, variable template, member function, member class, or static data member}}

--- a/clang/test/SemaHIP/implicit-host-device-unused-wrong-side-candidate.hip
+++ b/clang/test/SemaHIP/implicit-host-device-unused-wrong-side-candidate.hip
@@ -1,0 +1,20 @@
+// RUN: %clang_cc1 -std=c++20 -fcuda-is-device -Wall -Werror -fsyntax-only -DDEVICE_USE %s
+// RUN: %clang_cc1 -std=c++20 -fcuda-is-device -Wall -Werror -fsyntax-only -fno-offload-implicit-host-device-templates %s
+
+struct HostOnlyTy {};
+struct DeviceTy {};
+
+static bool operator==(HostOnlyTy, HostOnlyTy) { return true; }
+__attribute__((device)) bool operator==(DeviceTy, DeviceTy) { return true; }
+
+template <class T> bool compare(T lhs, T rhs) { return lhs == rhs; }
+
+void hostUse() {
+  (void)compare(HostOnlyTy{}, HostOnlyTy{});
+}
+
+#ifdef DEVICE_USE
+__attribute__((device)) bool deviceUse() {
+  return compare(DeviceTy{}, DeviceTy{});
+}
+#endif


### PR DESCRIPTION
Turn on implicit host device templates for HIP so standard C++ helper templates remain usable from device contexts by default. Only treat implicit host-device template specializations as device-emitted when they are actually reached from device code, so host-side explicit instantiations keep compiling.