### PR TITLE
[Comgr] Honor SPIR-V translator CLI flags in in-process translator path

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -817,13 +817,18 @@ bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
     } else if (Name == "spirv-allow-unknown-intrinsics") {
       // Bare flag → allow all unknown intrinsics. With =prefix1,prefix2 →
       // restrict to listed prefixes. Matches cl::ValueOptional semantics in
-      // llvm-spirv.cpp.
+      // llvm-spirv.cpp. The translator's isUnknownIntrinsicAllowed only
+      // returns true if some prefix matches; an empty prefix matches every
+      // intrinsic name (StringRef::starts_with("") is true), so represent
+      // "allow all" as a single empty prefix rather than an empty list.
       SPIRV::TranslatorOpts::ArgList Prefixes;
       if (HasValue) {
         SmallVector<StringRef, 4> Parts;
         Value.split(Parts, ',', -1, false);
         for (StringRef P : Parts)
           Prefixes.push_back(P);
+      } else {
+        Prefixes.push_back(StringRef());
       }
       AllowUnknownIntrinsics = std::move(Prefixes);
     } else if (Name == "spirv-preserve-auxdata") {

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -754,7 +754,11 @@ bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
       continue;
     StringRef Arg(Args[I]);
 
-    if (Arg == "-o" && I + 1 < N) {
+    if (Arg == "-o") {
+      if (I + 1 >= N) {
+        LogS << "spirv-translator: '-o' requires an argument\n";
+        return false;
+      }
       OutputPath = Args[++I];
       continue;
     }
@@ -845,7 +849,7 @@ bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
 
 } // namespace
 
-// Execute amd-llvm-spirv in-process using writeSpirv
+// Execute amd-llvm-spirv in-process using writeSpirv.
 // Args format: [options...] <input.bc> -o <output.spv>
 amd_comgr_status_t executeSPIRVTranslator(ArrayRef<const char *> Args,
                                           raw_ostream &LogS) {
@@ -990,7 +994,7 @@ executeCommand(const Command &Job, raw_ostream &LogS,
 #ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
     if (ExeName.contains("llvm-spirv")) {
       if (env::shouldEmitVerboseLogs()) {
-        logArgv(LogS, "llvm-spirv", Argv);
+        logArgv(LogS, "amd-llvm-spirv", Argv);
       }
       return executeSPIRVTranslator(Arguments, LogS);
     }

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -690,21 +690,176 @@ amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
 }
 
 #ifdef COMGR_SPIRV_TRANSLATOR_AVAILABLE
+namespace {
+
+// Map "SPV_…" extension name → SPIRV::ExtensionID using the x-macro shipped
+// with the translator. Mirrors the table that amd-llvm-spirv builds in
+// parseSPVExtOption (llvm-spirv.cpp).
+const llvm::DenseMap<StringRef, SPIRV::ExtensionID> &spirvExtensionNameMap() {
+  static const auto Map = []() {
+    llvm::DenseMap<StringRef, SPIRV::ExtensionID> M;
+#define EXT(X) M[#X] = SPIRV::ExtensionID::X;
+#include "LLVMSPIRVExtensions.inc"
+#undef EXT
+    return M;
+  }();
+  return Map;
+}
+
+bool parseSpirvVersionStr(StringRef V, SPIRV::VersionNumber &Out,
+                         raw_ostream &LogS) {
+  if (V == "1.0") Out = SPIRV::VersionNumber::SPIRV_1_0;
+  else if (V == "1.1") Out = SPIRV::VersionNumber::SPIRV_1_1;
+  else if (V == "1.2") Out = SPIRV::VersionNumber::SPIRV_1_2;
+  else if (V == "1.3") Out = SPIRV::VersionNumber::SPIRV_1_3;
+  else if (V == "1.4") Out = SPIRV::VersionNumber::SPIRV_1_4;
+  else if (V == "1.5") Out = SPIRV::VersionNumber::SPIRV_1_5;
+  else if (V == "1.6") Out = SPIRV::VersionNumber::SPIRV_1_6;
+  else {
+    LogS << "spirv-translator: unknown --spirv-max-version '" << V << "'\n";
+    return false;
+  }
+  return true;
+}
+
+bool parseDebugInfoEISStr(StringRef V, SPIRV::DebugInfoEIS &Out,
+                          raw_ostream &LogS) {
+  if (V == "legacy") Out = SPIRV::DebugInfoEIS::SPIRV_Debug;
+  else if (V == "ocl-100") Out = SPIRV::DebugInfoEIS::OpenCL_DebugInfo_100;
+  else if (V == "nonsemantic-shader-100")
+    Out = SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_100;
+  else if (V == "nonsemantic-shader-200")
+    Out = SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_200;
+  else {
+    LogS << "spirv-translator: unknown --spirv-debug-info-version '" << V
+         << "'\n";
+    return false;
+  }
+  return true;
+}
+
+bool parseSpirvExtList(StringRef Spec,
+                      SPIRV::TranslatorOpts::ExtensionsStatusMap &Status,
+                      raw_ostream &LogS) {
+  const auto &Names = spirvExtensionNameMap();
+  SmallVector<StringRef, 16> Items;
+  Spec.split(Items, ',', -1, false);
+  for (StringRef Item : Items) {
+    if (Item.empty() || (Item.front() != '+' && Item.front() != '-')) {
+      LogS << "spirv-translator: invalid --spirv-ext value '" << Item
+           << "' (expected +EXT or -EXT)\n";
+      return false;
+    }
+    bool Allow = Item.front() == '+';
+    StringRef Name = Item.drop_front();
+    if (Name == "all") {
+      for (const auto &E : Names)
+        Status[E.second] = Allow;
+      continue;
+    }
+    auto It = Names.find(Name);
+    if (It == Names.end()) {
+      LogS << "spirv-translator: unknown extension '" << Name
+           << "' in --spirv-ext\n";
+      return false;
+    }
+    Status[It->second] = Allow;
+  }
+  return true;
+}
+
+// Parse the --spirv-* subset of the amd-llvm-spirv CLI that the HIPAMD clang
+// driver emits (see clang/lib/Driver/ToolChains/HIPAMD.cpp), populating Opts
+// to match. Also extracts InputPath (.bc) and OutputPath (-o argument).
+// Unrecognized --spirv-* flags are logged and ignored.
+bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
+                              SPIRV::TranslatorOpts &Opts,
+                              StringRef &InputPath, StringRef &OutputPath,
+                              raw_ostream &LogS) {
+  SPIRV::VersionNumber MaxVer = SPIRV::VersionNumber::MaximumVersion;
+  SPIRV::TranslatorOpts::ExtensionsStatusMap ExtStatus;
+  std::optional<SPIRV::DebugInfoEIS> DebugEIS;
+  std::optional<SPIRV::TranslatorOpts::ArgList> AllowUnknownIntrinsics;
+  bool PreserveAux = false;
+
+  for (size_t I = 0, N = Args.size(); I < N; ++I) {
+    if (!Args[I])
+      continue;
+    StringRef Arg(Args[I]);
+
+    if (Arg == "-o" && I + 1 < N) {
+      OutputPath = Args[++I];
+      continue;
+    }
+    if (Arg.ends_with(".bc")) {
+      InputPath = Arg;
+      continue;
+    }
+
+    // Normalize: strip leading "--" or "-" so we can compare against bare names.
+    StringRef Body = Arg;
+    if (!Body.consume_front("--") && !Body.consume_front("-"))
+      continue;
+
+    auto EqPos = Body.find('=');
+    StringRef Name = Body.substr(0, EqPos);
+    bool HasValue = EqPos != StringRef::npos;
+    StringRef Value = HasValue ? Body.substr(EqPos + 1) : StringRef();
+
+    if (Name == "spirv-max-version" && HasValue) {
+      if (!parseSpirvVersionStr(Value, MaxVer, LogS))
+        return false;
+    } else if (Name == "spirv-ext" && HasValue) {
+      if (!parseSpirvExtList(Value, ExtStatus, LogS))
+        return false;
+    } else if (Name == "spirv-debug-info-version" && HasValue) {
+      SPIRV::DebugInfoEIS EIS;
+      if (!parseDebugInfoEISStr(Value, EIS, LogS))
+        return false;
+      DebugEIS = EIS;
+    } else if (Name == "spirv-allow-unknown-intrinsics") {
+      // Bare flag → allow all unknown intrinsics. With =prefix1,prefix2 →
+      // restrict to listed prefixes. Matches cl::ValueOptional semantics in
+      // llvm-spirv.cpp.
+      SPIRV::TranslatorOpts::ArgList Prefixes;
+      if (HasValue) {
+        SmallVector<StringRef, 4> Parts;
+        Value.split(Parts, ',', -1, false);
+        for (StringRef P : Parts)
+          Prefixes.push_back(P);
+      }
+      AllowUnknownIntrinsics = std::move(Prefixes);
+    } else if (Name == "spirv-preserve-auxdata") {
+      PreserveAux = true;
+    } else if (Name == "spirv-lower-const-expr") {
+      // No-op: this is a global cl::opt with cl::init(true) in
+      // SPIRVLowerConstExpr.cpp; the default already matches. Recognized so we
+      // don't warn.
+    } else if (Name.starts_with("spirv-")) {
+      LogS << "spirv-translator: ignoring unrecognized flag '" << Arg << "'\n";
+    }
+  }
+
+  Opts = SPIRV::TranslatorOpts(MaxVer, ExtStatus);
+  if (PreserveAux)
+    Opts.setPreserveAuxData(true);
+  if (DebugEIS)
+    Opts.setDebugInfoEIS(*DebugEIS);
+  if (AllowUnknownIntrinsics)
+    Opts.setSPIRVAllowUnknownIntrinsics(*AllowUnknownIntrinsics);
+  return true;
+}
+
+} // namespace
+
 // Execute amd-llvm-spirv in-process using writeSpirv
 // Args format: [options...] <input.bc> -o <output.spv>
 amd_comgr_status_t executeSPIRVTranslator(ArrayRef<const char *> Args,
                                           raw_ostream &LogS) {
-  // Parse args: find input .bc and -o <output>
   StringRef InputPath, OutputPath;
-
-  for (size_t I = 0; I < Args.size(); ++I) {
-    StringRef Arg(Args[I]);
-    if (Arg == "-o" && I + 1 < Args.size()) {
-      OutputPath = Args[++I];
-    } else if (Arg.ends_with(".bc")) {
-      InputPath = Arg;
-    }
-  }
+  SPIRV::TranslatorOpts Opts;
+  if (!parseSPIRVTranslatorArgs(Args, Opts, InputPath, OutputPath, LogS))
+    return AMD_COMGR_STATUS_ERROR;
 
   if (InputPath.empty() || OutputPath.empty()) {
     LogS << "spirv-translator: missing input or output files\n";
@@ -725,12 +880,6 @@ amd_comgr_status_t executeSPIRVTranslator(ArrayRef<const char *> Args,
     Err.print("spirv-translator", LogS);
     return AMD_COMGR_STATUS_ERROR;
   }
-
-  // Configure SPIRV translator options (match amd-llvm-spirv defaults)
-  SPIRV::TranslatorOpts Opts;
-  Opts.enableAllExtensions();
-  Opts.setPreserveAuxData(true);
-  Opts.setSPIRVAllowUnknownIntrinsics({"llvm.amdgcn"});
 
   // Translate to SPIRV
   std::string ErrMsg;

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -706,41 +706,9 @@ const llvm::DenseMap<StringRef, SPIRV::ExtensionID> &spirvExtensionNameMap() {
   return Map;
 }
 
-bool parseSpirvVersionStr(StringRef V, SPIRV::VersionNumber &Out,
-                         raw_ostream &LogS) {
-  if (V == "1.0") Out = SPIRV::VersionNumber::SPIRV_1_0;
-  else if (V == "1.1") Out = SPIRV::VersionNumber::SPIRV_1_1;
-  else if (V == "1.2") Out = SPIRV::VersionNumber::SPIRV_1_2;
-  else if (V == "1.3") Out = SPIRV::VersionNumber::SPIRV_1_3;
-  else if (V == "1.4") Out = SPIRV::VersionNumber::SPIRV_1_4;
-  else if (V == "1.5") Out = SPIRV::VersionNumber::SPIRV_1_5;
-  else if (V == "1.6") Out = SPIRV::VersionNumber::SPIRV_1_6;
-  else {
-    LogS << "spirv-translator: unknown --spirv-max-version '" << V << "'\n";
-    return false;
-  }
-  return true;
-}
-
-bool parseDebugInfoEISStr(StringRef V, SPIRV::DebugInfoEIS &Out,
-                          raw_ostream &LogS) {
-  if (V == "legacy") Out = SPIRV::DebugInfoEIS::SPIRV_Debug;
-  else if (V == "ocl-100") Out = SPIRV::DebugInfoEIS::OpenCL_DebugInfo_100;
-  else if (V == "nonsemantic-shader-100")
-    Out = SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_100;
-  else if (V == "nonsemantic-shader-200")
-    Out = SPIRV::DebugInfoEIS::NonSemantic_Shader_DebugInfo_200;
-  else {
-    LogS << "spirv-translator: unknown --spirv-debug-info-version '" << V
-         << "'\n";
-    return false;
-  }
-  return true;
-}
-
 bool parseSpirvExtList(StringRef Spec,
-                      SPIRV::TranslatorOpts::ExtensionsStatusMap &Status,
-                      raw_ostream &LogS) {
+                       SPIRV::TranslatorOpts::ExtensionsStatusMap &Status,
+                       raw_ostream &LogS) {
   const auto &Names = spirvExtensionNameMap();
   SmallVector<StringRef, 16> Items;
   Spec.split(Items, ',', -1, false);
@@ -773,9 +741,8 @@ bool parseSpirvExtList(StringRef Spec,
 // to match. Also extracts InputPath (.bc) and OutputPath (-o argument).
 // Unrecognized --spirv-* flags are logged and ignored.
 bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
-                              SPIRV::TranslatorOpts &Opts,
-                              StringRef &InputPath, StringRef &OutputPath,
-                              raw_ostream &LogS) {
+                              SPIRV::TranslatorOpts &Opts, StringRef &InputPath,
+                              StringRef &OutputPath, raw_ostream &LogS) {
   SPIRV::VersionNumber MaxVer = SPIRV::VersionNumber::MaximumVersion;
   SPIRV::TranslatorOpts::ExtensionsStatusMap ExtStatus;
   std::optional<SPIRV::DebugInfoEIS> DebugEIS;
@@ -796,7 +763,8 @@ bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
       continue;
     }
 
-    // Normalize: strip leading "--" or "-" so we can compare against bare names.
+    // Normalize: strip leading "--" or "-" so we can compare against bare
+    // names.
     StringRef Body = Arg;
     if (!Body.consume_front("--") && !Body.consume_front("-"))
       continue;
@@ -807,16 +775,41 @@ bool parseSPIRVTranslatorArgs(ArrayRef<const char *> Args,
     StringRef Value = HasValue ? Body.substr(EqPos + 1) : StringRef();
 
     if (Name == "spirv-max-version" && HasValue) {
-      if (!parseSpirvVersionStr(Value, MaxVer, LogS))
+      using V_ = SPIRV::VersionNumber;
+      auto Parsed = llvm::StringSwitch<std::optional<V_>>(Value)
+                        .Case("1.0", V_::SPIRV_1_0)
+                        .Case("1.1", V_::SPIRV_1_1)
+                        .Case("1.2", V_::SPIRV_1_2)
+                        .Case("1.3", V_::SPIRV_1_3)
+                        .Case("1.4", V_::SPIRV_1_4)
+                        .Case("1.5", V_::SPIRV_1_5)
+                        .Case("1.6", V_::SPIRV_1_6)
+                        .Default(std::nullopt);
+      if (!Parsed) {
+        LogS << "spirv-translator: unknown --spirv-max-version '" << Value
+             << "'\n";
         return false;
+      }
+      MaxVer = *Parsed;
     } else if (Name == "spirv-ext" && HasValue) {
       if (!parseSpirvExtList(Value, ExtStatus, LogS))
         return false;
     } else if (Name == "spirv-debug-info-version" && HasValue) {
-      SPIRV::DebugInfoEIS EIS;
-      if (!parseDebugInfoEISStr(Value, EIS, LogS))
+      using EIS_ = SPIRV::DebugInfoEIS;
+      auto Parsed = llvm::StringSwitch<std::optional<EIS_>>(Value)
+                        .Case("legacy", EIS_::SPIRV_Debug)
+                        .Case("ocl-100", EIS_::OpenCL_DebugInfo_100)
+                        .Case("nonsemantic-shader-100",
+                              EIS_::NonSemantic_Shader_DebugInfo_100)
+                        .Case("nonsemantic-shader-200",
+                              EIS_::NonSemantic_Shader_DebugInfo_200)
+                        .Default(std::nullopt);
+      if (!Parsed) {
+        LogS << "spirv-translator: unknown --spirv-debug-info-version '"
+             << Value << "'\n";
         return false;
-      DebugEIS = EIS;
+      }
+      DebugEIS = *Parsed;
     } else if (Name == "spirv-allow-unknown-intrinsics") {
       // Bare flag → allow all unknown intrinsics. With =prefix1,prefix2 →
       // restrict to listed prefixes. Matches cl::ValueOptional semantics in

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -2440,7 +2440,8 @@ AMDGPUCompiler::translateSpirvToBitcodeImpl(DataSet *SpirvInSet,
 
     if (env::shouldEmitVerboseLogs()) {
       LogS << "SPIR-V Translation: amd-llvm-spirv -r --spirv-target-env=CL2.0 "
-           << getFilePath(Input, InputDir) << " "
+              "--spirv-preserve-auxdata "
+           << getFilePath(Input, InputDir) << " -o "
            << getFilePath(Output, OutputDir) << " (command line equivalent)\n";
     }
 

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator-honors-driver-flags.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator-honors-driver-flags.hip
@@ -1,9 +1,12 @@
 // REQUIRES: comgr-has-spirv-translator
 
-// COM: Verify COMGR honors the --spirv-* flags HIPAMD emits today.
-// COM: Each RUN pins one observable side-effect of a specific driver flag.
+// COM: Verify COMGR honors the --spirv-* flags HIPAMD emits today (see
+// COM: clang/lib/Driver/ToolChains/HIPAMD.cpp). Each RUN pins one observable
+// COM: side-effect of a specific driver flag. The kernel calls an amdgcn
+// COM: intrinsic to exercise --spirv-allow-unknown-intrinsics, and -g is
+// COM: passed to exercise --spirv-debug-info-version.
 
-// RUN: source-to-spirv -nogpuinc %s %t.spv
+// RUN: source-to-spirv -nogpuinc -g %s %t.spv
 // RUN: test -s %t.spv
 
 // COM: --spirv-ext=+all,-SPV_KHR_untyped_pointers (disabled).
@@ -12,14 +15,25 @@
 // COM: --spirv-ext=+all (must allow extensions outside the default set).
 // RUN: grep -a "SPV_INTEL_kernel_attributes" %t.spv
 
-// COM: --spirv-preserve-auxdata.
+// COM: --spirv-allow-unknown-intrinsics (bare flag → allow all).
+// RUN: grep -a "llvm.amdgcn.workitem.id.x" %t.spv
+
+// COM: --spirv-preserve-auxdata (always-on extended instruction set import).
 // RUN: grep -a "NonSemantic.AuxData" %t.spv
 
+// COM: --spirv-debug-info-version=nonsemantic-shader-200.
+// RUN: grep -a "NonSemantic.Shader.DebugInfo.200" %t.spv
+
+// COM: Two of HIPAMD's driver flags have no test here:
+// COM:  --spirv-max-version=1.6: TranslatorOpts::MaxVersion already defaults
+// COM:    to MaximumVersion (1.6), so dropping the flag does not change the
+// COM:    emitted version for any kernel that fits in <=1.6.
+// COM:  --spirv-lower-const-expr: the global cl::opt in SPIRVLowerConstExpr.cpp
+// COM:    is cl::init(true), so the flag matches the default and has no
+// COM:    observable side-effect to assert on.
+
 __attribute__((device))
-void clean_value(float* ptr) { *ptr = 0; }
+unsigned get_id() { return __builtin_amdgcn_workitem_id_x(); }
 
 __attribute__((global))
-void add_value(float* a, float* b, float* res) {
-    *res = *a + *b;
-    clean_value(a);
-}
+void k(unsigned* p) { *p = get_id(); }

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator-honors-driver-flags.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator-honors-driver-flags.hip
@@ -1,0 +1,28 @@
+// REQUIRES: comgr-has-spirv-translator
+
+// COM: Regression test: COMGR's in-process SPIR-V translator must honor the
+// COM: --spirv-* flags that the HIPAMD clang driver emits. In particular,
+// COM: HIPAMD passes --spirv-ext=+all,-SPV_KHR_untyped_pointers; if COMGR
+// COM: ignores the flag and re-enables all extensions, the resulting SPIR-V
+// COM: contains untyped pointers and downstream BC linking fails.
+
+// COM: Run COMGR's HIP-source-to-SPIR-V pipeline (this exercises the same
+// COM: clang driver path as hipRTC, which inserts the --spirv-ext flag).
+// RUN: source-to-spirv -nogpuinc %s %t.spv
+
+// COM: SPIR-V file should exist and be non-empty.
+// RUN: test -s %t.spv
+
+// COM: OpExtension declarations are length-prefixed ASCII strings in the
+// COM: binary, so grep can verify presence/absence directly without needing
+// COM: SPIRV-Tools or --to-text support in the build.
+// RUN: not grep -a "SPV_KHR_untyped_pointers" %t.spv
+
+__attribute__((device))
+void clean_value(float* ptr) { *ptr = 0; }
+
+__attribute__((global))
+void add_value(float* a, float* b, float* res) {
+    *res = *a + *b;
+    clean_value(a);
+}

--- a/amd/comgr/test-lit/spirv-tests/spirv-translator-honors-driver-flags.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-translator-honors-driver-flags.hip
@@ -1,22 +1,19 @@
 // REQUIRES: comgr-has-spirv-translator
 
-// COM: Regression test: COMGR's in-process SPIR-V translator must honor the
-// COM: --spirv-* flags that the HIPAMD clang driver emits. In particular,
-// COM: HIPAMD passes --spirv-ext=+all,-SPV_KHR_untyped_pointers; if COMGR
-// COM: ignores the flag and re-enables all extensions, the resulting SPIR-V
-// COM: contains untyped pointers and downstream BC linking fails.
+// COM: Verify COMGR honors the --spirv-* flags HIPAMD emits today.
+// COM: Each RUN pins one observable side-effect of a specific driver flag.
 
-// COM: Run COMGR's HIP-source-to-SPIR-V pipeline (this exercises the same
-// COM: clang driver path as hipRTC, which inserts the --spirv-ext flag).
 // RUN: source-to-spirv -nogpuinc %s %t.spv
-
-// COM: SPIR-V file should exist and be non-empty.
 // RUN: test -s %t.spv
 
-// COM: OpExtension declarations are length-prefixed ASCII strings in the
-// COM: binary, so grep can verify presence/absence directly without needing
-// COM: SPIRV-Tools or --to-text support in the build.
+// COM: --spirv-ext=+all,-SPV_KHR_untyped_pointers (disabled).
 // RUN: not grep -a "SPV_KHR_untyped_pointers" %t.spv
+
+// COM: --spirv-ext=+all (must allow extensions outside the default set).
+// RUN: grep -a "SPV_INTEL_kernel_attributes" %t.spv
+
+// COM: --spirv-preserve-auxdata.
+// RUN: grep -a "NonSemantic.AuxData" %t.spv
 
 __attribute__((device))
 void clean_value(float* ptr) { *ptr = 0; }


### PR DESCRIPTION
## Summary

When HIP code is compiled to SPIR-V through COMGR (e.g. via hipRTC), the HIPAMD
clang driver invokes `llvm-spirv` with flags like
`--spirv-ext=+all,-SPV_KHR_untyped_pointers`. COMGR intercepts the command and
runs it in-process via `writeSpirv`, but `executeSPIRVTranslator` only scanned
`Args` for the input/output filenames and built `SPIRV::TranslatorOpts` from
scratch with `enableAllExtensions()` — re-enabling `SPV_KHR_untyped_pointers`
after the driver explicitly disabled it, producing SPIR-V with untyped pointers
and breaking downstream BC link.

This PR parses the `--spirv-*` subset emitted by HIPAMD (max-version, ext map
with `+all`/`-EXT` semantics, debug-info-version, allow-unknown-intrinsics,
preserve-auxdata) and configures `TranslatorOpts` to match, so the in-process
path behaves like the standalone `amd-llvm-spirv` tool.