### PR TITLE
Fix race condition with __amd_streamOpsDecrement (LCOMPILER-2128)

### DIFF
--- a/amd/device-libs/opencl/src/misc/amdblit.cl
+++ b/amd/device-libs/opencl/src/misc/amdblit.cl
@@ -789,7 +789,7 @@ __amd_streamOpsDecrement(
     __global atomic_ulong* ptrUlong,
     ulong value) {
 
-    [[clang::atomic(remote_memory, fine_grained_memory)]]
+    __attribute__((atomic(remote_memory, fine_grained_memory)))
     {
       if (ptrUint) {
         __scoped_atomic_fetch_sub((volatile uint*)ptrUint, (uint)value, memory_order_relaxed, __MEMORY_SCOPE_SYSTEM);

--- a/amd/device-libs/opencl/src/misc/amdblit.cl
+++ b/amd/device-libs/opencl/src/misc/amdblit.cl
@@ -789,16 +789,16 @@ __amd_streamOpsDecrement(
     __global atomic_ulong* ptrUlong,
     ulong value) {
 
-    // Use __opencl_atomic_fetch_sub with specific attributes instead of
+    // Use __scoped_atomic_fetch_sub with specific attributes instead of
     // atomic_fetch_*_explicit which makes different assumptions and attaches
     // attributes that are not appropriate in this case. This is a consequence
     // of known hardware limitations affecting `atomicrwm sub` over PCIe.
     [[clang::atomic(remote_memory, fine_grained_memory)]]
     {
       if (ptrUint) {
-        __opencl_atomic_fetch_sub(ptrUint, (uint)value, memory_order_relaxed, memory_scope_all_svm_devices);
+        __scoped_atomic_fetch_sub((volatile uint*)ptrUint, (uint)value, memory_order_relaxed, __MEMORY_SCOPE_SYSTEM);
       } else {
-        __opencl_atomic_fetch_sub(ptrUlong, value, memory_order_relaxed, memory_scope_all_svm_devices);
+        __scoped_atomic_fetch_sub((volatile ulong*)ptrUlong, value, memory_order_relaxed, __MEMORY_SCOPE_SYSTEM);
       }
     }
 }

--- a/amd/device-libs/opencl/src/misc/amdblit.cl
+++ b/amd/device-libs/opencl/src/misc/amdblit.cl
@@ -789,10 +789,6 @@ __amd_streamOpsDecrement(
     __global atomic_ulong* ptrUlong,
     ulong value) {
 
-    // Use __scoped_atomic_fetch_sub with specific attributes instead of
-    // atomic_fetch_*_explicit which makes different assumptions and attaches
-    // attributes that are not appropriate in this case. This is a consequence
-    // of known hardware limitations affecting `atomicrwm sub` over PCIe.
     [[clang::atomic(remote_memory, fine_grained_memory)]]
     {
       if (ptrUint) {

--- a/amd/device-libs/opencl/src/misc/amdblit.cl
+++ b/amd/device-libs/opencl/src/misc/amdblit.cl
@@ -789,12 +789,17 @@ __amd_streamOpsDecrement(
     __global atomic_ulong* ptrUlong,
     ulong value) {
 
-    // Use atomic_fetch_add_explicit as a workaround for known hardware limitations affecting
-    // atomic_fetch_sub_explicit over PCIe.
-    if (ptrUint) {
-      atomic_fetch_add_explicit (ptrUint, -value,  memory_order_relaxed, memory_scope_all_svm_devices);
-    } else {
-      atomic_fetch_add_explicit  (ptrUlong, -value,  memory_order_relaxed, memory_scope_all_svm_devices);
+    // Use __opencl_atomic_fetch_sub with specific attributes instead of
+    // atomic_fetch_*_explicit which makes different assumptions and attaches
+    // attributes that are not appropriate in this case. This is a consequence
+    // of known hardware limitations affecting `atomicrwm sub` over PCIe.
+    [[clang::atomic(remote_memory, fine_grained_memory)]]
+    {
+      if (ptrUint) {
+        __opencl_atomic_fetch_sub(ptrUint, (uint)value, memory_order_relaxed, memory_scope_all_svm_devices);
+      } else {
+        __opencl_atomic_fetch_sub(ptrUlong, value, memory_order_relaxed, memory_scope_all_svm_devices);
+      }
     }
 }
 


### PR DESCRIPTION
Use of `atomic_fetch_add_explicit` results in an `atomic rmw` with `!amdgpu.no.fine.grained.memory` and `!amdgpu.no.remote.memory`. This worked as long as the instruction remained an `add`. However a recent InstCombine change resulted in the `add` (of a negated value) being transformed into a `sub`.

This change is based on the recommendation from Sam [here](https://amd-hub.atlassian.net/browse/LCOMPILER-2128?focusedCommentId=433141).