### PR TITLE
[Comgr] fixes for [MC] Take MCRegisterInfo and MCSubtargetInfo by reference

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -417,7 +417,7 @@ bool executeAssemblerImpl(AssemblerInvocation &Opts, DiagnosticsEngine &Diags,
   std::unique_ptr<MCSubtargetInfo> STI(
       TheTarget->createMCSubtargetInfo(llvm::Triple(Opts.Triple), Opts.CPU, FS));
 
-  MCContext Ctx(Triple(Opts.Triple), *MAI, MRI.get(), STI.get(), &SrcMgr);
+  MCContext Ctx(Triple(Opts.Triple), *MAI, *MRI, *STI, &SrcMgr);
   Ctx.setObjectFileInfo(MOFI.get());
 
   bool PIC = false;

--- a/amd/comgr/src/comgr-disassembly.cpp
+++ b/amd/comgr/src/comgr-disassembly.cpp
@@ -72,7 +72,7 @@ DisassemblyInfo::create(const TargetIdentifier &Ident,
   }
 
   std::unique_ptr<MCContext> Ctx(new (std::nothrow) MCContext(
-      Triple(TT), *MAI, MRI.get(), STI.get()));
+      Triple(TT), *MAI, *MRI, *STI));
   if (!Ctx) {
     return AMD_COMGR_STATUS_ERROR;
   }

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -245,7 +245,7 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
     return S;
   }
 
-  S.Ctx = std::make_unique<MCContext>(TT, *S.MAI, S.MRI.get(), S.STI.get());
+  S.Ctx = std::make_unique<MCContext>(TT, *S.MAI, *S.MRI, *S.STI);
   S.MOFI = std::make_unique<MCObjectFileInfo>();
   S.MOFI->initMCObjectFileInfo(*S.Ctx, false);
   S.Ctx->setObjectFileInfo(S.MOFI.get());


### PR DESCRIPTION
Adapt the three `MCContext` construction sites in Comgr to the new
constructor signature introduced upstream by
[llvm/llvm-project#195032](https://github.com/llvm/llvm-project/pull/195032)
("MCContext/TargetMachine: Take MCRegisterInfo and MCSubtargetInfo by
reference. NFC"), which changes both parameters from
`const MCRegisterInfo *` / `const MCSubtargetInfo *` to references.

Depends on upstream merge #2405 — will not build against current
`amd-staging` until that lands.