### PR TITLE
[DebugInfo][test] Add DISubroutineType to DILocalVariable-address-space.ll

### DIFF
--- a/llvm/test/Bitcode/DILocalVariable-address-space.ll
+++ b/llvm/test/Bitcode/DILocalVariable-address-space.ll
@@ -10,10 +10,12 @@
 !llvm.module.flags = !{!6}
 !llvm.dbg.cu = !{!4}
 
-!0 = distinct !DISubprogram(name: "foo", scope: null, isLocal: false, isDefinition: true, isOptimized: false, unit: !4, retainedNodes: !1)
+!0 = distinct !DISubprogram(name: "foo", scope: null, isLocal: false, isDefinition: true, isOptimized: false, unit: !4, retainedNodes: !1, type: !7)
 !1 = !{!2, !3}
 !2 = !DILocalVariable(name: "param", arg: 1, scope: !0, memorySpace: DW_MSPACE_LLVM_group)
 !3 = !DILocalVariable(name: "auto", scope: !0, memorySpace: DW_MSPACE_LLVM_private)
 !4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !5)
 !5 = !DIFile(filename: "source.c", directory: "/dir")
 !6 = !{i32 1, !"Debug Info Version", i32 3}
+!7 = !DISubroutineType(types: !8)
+!8 = !{null}


### PR DESCRIPTION
Upstream commit `81518d06acaa` ("[DebugInfo] Verify DISubprogram has a
type", [llvm/llvm-project#194556](https://github.com/llvm/llvm-project/pull/194556))
added a Verifier rule requiring every `DISubprogram` to carry a non-null
`DISubroutineType`. Upstream updated all its hand-written tests in the
same change, but the AMD-specific `DILocalVariable-address-space.ll`
lives only on the AMD branches and was missed.

Add a minimal `DISubroutineType` referenced from the test's `DISubprogram`,
mirroring upstream's fix to `llvm/test/Assembler/dilocalvariable.ll`.

Lands on `amd-debug` first (where the HeterogeneousDWARF patches live);
will be cherry-picked into the in-flight `amd-staging` upstream merge
(#2405) where the failure currently manifests.