### PR TITLE
[OpenMP][MLIR] Fix GPU memory fault for private VLA arrays in DistributeForStaticLoop

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -3880,6 +3880,150 @@ convertOmpWsloop(Operation &opInst, llvm::IRBuilderBase &builder,
     }
   }
 
+  // For GPU SPMD DistributeForStaticLoop constructs with a separate alloca
+  // address space (e.g., addrspace(5) on AMD GPU):
+  //
+  // Step 1 — VLA scratch overflow fix:
+  //   Private VLA arrays (e.g., Fortran assumed-shape auto-arrays declared with
+  //   `real, dimension(size(b,1)) :: tmp`) cause the omp.private init region to
+  //   emit `alloca float, i64 N, addrspace(5)` inside the outlined parallel
+  //   function.  The kernel descriptor's private_segment_fixed_size is set
+  //   statically at compile time and is too small for variable N, so the
+  //   runtime data pointer lands in unmapped scratch VRAM → GPU page fault.
+  //   Fix: replace every dynamic (variable-size) alloca in allocaAddrSpace with
+  //   a device malloc call so the data pointer lives in device global memory.
+  //   TODO: insert a matching free() after the loop body callback returns;
+  //   that insertion point is not available here (deferred as a follow-up).
+  //
+  // Step 2 — box descriptor capture fix:
+  //   Fixed-size box struct allocas in allocaAddrSpace are allocated in the
+  //   parallel function and their flat pointers get captured by
+  //   applyWorkshareLoop into struct_arg, where they are shared across all
+  //   worker threads.  Fix: insert a per-invocation copy of the box at the
+  //   top of the loop body so each callback invocation has its own descriptor.
+  //   NOTE: replaceUsesWithIf must run before CreateMemCpy; creating the memcpy
+  //   first causes replaceUsesWithIf to replace its own source → self-copy.
+  if (workshareLoopType ==
+          llvm::omp::WorksharingLoopType::DistributeForStaticLoop &&
+      loopInfo) {
+    llvm::Module *M = moduleTranslation.getLLVMModule();
+    unsigned allocAS = M->getDataLayout().getAllocaAddrSpace();
+    unsigned defaultAS = M->getDataLayout().getProgramAddressSpace();
+
+    if (allocAS != defaultAS) {
+      // Step 1: replace VLA (variable-size) allocas in scratch with malloc.
+      llvm::Function *F = loopInfo->getBody()->getParent();
+      llvm::SmallVector<llvm::AllocaInst *, 4> dynaAllocas;
+      for (auto &BB : *F)
+        for (auto &I : BB)
+          if (auto *AI = llvm::dyn_cast<llvm::AllocaInst>(&I))
+            if (AI->getAddressSpace() == allocAS &&
+                !llvm::isa<llvm::ConstantInt>(AI->getArraySize()))
+              dynaAllocas.push_back(AI);
+
+      for (llvm::AllocaInst *AI : dynaAllocas) {
+        llvm::IRBuilderBase::InsertPointGuard ipg(builder);
+        builder.SetInsertPoint(AI);
+        llvm::Type *elemTy = AI->getAllocatedType();
+        uint64_t elemSize = M->getDataLayout().getTypeAllocSize(elemTy);
+        llvm::Value *count = AI->getArraySize();
+        llvm::Value *countI64 =
+            builder.CreateZExtOrTrunc(count, builder.getInt64Ty());
+        llvm::Value *byteCount =
+            (elemSize == 1)
+                ? countI64
+                : builder.CreateMul(countI64, builder.getInt64(elemSize),
+                                    "omp.vla.bytes");
+        llvm::FunctionCallee mallocFn = M->getOrInsertFunction(
+            "malloc",
+            llvm::FunctionType::get(builder.getPtrTy(defaultAS),
+                                    {builder.getInt64Ty()}, false));
+        llvm::Value *mallocPtr =
+            builder.CreateCall(mallocFn, {byteCount}, "omp.vla.malloc");
+        // NOTE: The corresponding free() must be inserted after the loop body
+        // callback completes (in the parallel function, after the distribute
+        // call).  That insertion point is not easily recoverable from here
+        // because applyWorkshareLoop outlines the callback after this block.
+        // Tracked as a follow-up; kernel-lifetime leaks are benign for now.
+        // Replace addrspacecast(AI → defaultAS) uses with the malloc result.
+        llvm::SmallVector<llvm::User *> users(AI->users());
+        for (llvm::User *U : users)
+          if (auto *ASC = llvm::dyn_cast<llvm::AddrSpaceCastInst>(U))
+            if (ASC->getDestAddressSpace() == defaultAS) {
+              ASC->replaceAllUsesWith(mallocPtr);
+              ASC->eraseFromParent();
+            }
+        if (AI->use_empty())
+          AI->eraseFromParent();
+      }
+
+      // Step 2: relocate box struct allocas into the loop body.
+      // Walk omp.wsloop → omp.distribute → omp.parallel to find private vars.
+      mlir::Operation *distOp = wsloopOp->getParentOp();
+      mlir::Operation *parOp = distOp ? distOp->getParentOp() : nullptr;
+      auto parallelOp = mlir::dyn_cast_if_present<omp::ParallelOp>(parOp);
+      if (parallelOp) {
+        PrivateVarsInfo parentPrivInfo(parallelOp);
+        if (!parentPrivInfo.blockArgs.empty()) {
+          // Collect all basic blocks that belong to the (not-yet-outlined)
+          // loop body, stopping at the latch and not re-entering the header.
+          llvm::SmallPtrSet<llvm::BasicBlock *, 32> loopBodyBlocks;
+          llvm::SmallVector<llvm::BasicBlock *> worklist = {
+              loopInfo->getBody()};
+          while (!worklist.empty()) {
+            llvm::BasicBlock *bb = worklist.pop_back_val();
+            if (bb == loopInfo->getLatch())
+              continue;
+            if (!loopBodyBlocks.insert(bb).second)
+              continue;
+            for (llvm::BasicBlock *succ : llvm::successors(bb))
+              if (succ != loopInfo->getHeader())
+                worklist.push_back(succ);
+          }
+          llvm::IRBuilderBase::InsertPointGuard ipg(builder);
+          builder.SetInsertPoint(loopInfo->getBody(),
+                                 loopInfo->getBody()->begin());
+          for (size_t i = 0; i < parentPrivInfo.blockArgs.size(); ++i) {
+            omp::PrivateClauseOp &privDecl = parentPrivInfo.privatizers[i];
+            mlir::BlockArgument blockArg = parentPrivInfo.blockArgs[i];
+            llvm::Value *oldLLVMVar =
+                moduleTranslation.lookupValue(blockArg);
+            if (!oldLLVMVar)
+              continue;
+            llvm::Value *base = oldLLVMVar;
+            if (auto *cast = llvm::dyn_cast<llvm::AddrSpaceCastInst>(base))
+              base = cast->getPointerOperand();
+            auto *oldAlloca = llvm::dyn_cast<llvm::AllocaInst>(base);
+            if (!oldAlloca || oldAlloca->getAddressSpace() != allocAS)
+              continue;
+            // Skip allocatables: their init region handles allocation
+            // explicitly, so the box struct is not a plain stack copy.
+            if (!privDecl.getDeallocRegion().empty())
+              continue;
+            llvm::Type *allocTy = oldAlloca->getAllocatedType();
+            auto *newAlloca =
+                builder.CreateAlloca(allocTy, nullptr, "omp.private.alloc");
+            llvm::Value *newLLVMVar = builder.CreateAddrSpaceCast(
+                newAlloca, builder.getPtrTy(defaultAS),
+                "omp.private.alloc.ascast");
+            // replaceUsesWithIf BEFORE CreateMemCpy: this preserves oldLLVMVar
+            // as the memcpy source, so applyWorkshareLoop sees it used in the
+            // loop body and captures it in struct_arg for the work callback.
+            oldLLVMVar->replaceUsesWithIf(newLLVMVar, [&](llvm::Use &U) {
+              auto *inst = llvm::dyn_cast<llvm::Instruction>(U.getUser());
+              return inst && loopBodyBlocks.count(inst->getParent());
+            });
+            llvm::Value *boxSizeVal = llvm::ConstantInt::get(
+                builder.getInt64Ty(),
+                M->getDataLayout().getTypeAllocSize(allocTy));
+            builder.CreateMemCpy(newLLVMVar, llvm::MaybeAlign(), oldLLVMVar,
+                                 llvm::MaybeAlign(), boxSizeVal);
+          }
+        }
+      }
+    }
+  }
+
   llvm::OpenMPIRBuilder::InsertPointOrErrorTy wsloopIP =
       ompBuilder->applyWorkshareLoop(
           ompLoc.DL, loopInfo, allocaIP, loopNeedsBarrier,

--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -4001,6 +4001,13 @@ convertOmpWsloop(Operation &opInst, llvm::IRBuilderBase &builder,
             if (!privDecl.getDeallocRegion().empty())
               continue;
             llvm::Type *allocTy = oldAlloca->getAllocatedType();
+            // Only replicate struct (box descriptor) allocas. Scalar private
+            // variables are per-thread in the parallel function's stack frame
+            // and do not need a per-iteration copy; applying the replication
+            // to scalars adds unnecessary overhead and alters codegen that
+            // existing tests rely on.
+            if (!allocTy->isStructTy())
+              continue;
             auto *newAlloca =
                 builder.CreateAlloca(allocTy, nullptr, "omp.private.alloc");
             llvm::Value *newLLVMVar = builder.CreateAddrSpaceCast(

--- a/mlir/test/Target/LLVMIR/omptarget-box-private-wsloop.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-box-private-wsloop.mlir
@@ -1,0 +1,64 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// Regression test: the alloca for a private array descriptor (box struct) must
+// be replicated per-invocation of the loop body callback rather than shared
+// across all worker threads via struct_arg.
+//
+// When lowering omp.parallel { omp.distribute { omp.wsloop } } on GPU,
+// applyWorkshareLoop outlines the loop body into a callback and captures the
+// flat pointer of any alloca in allocaAddrSpace through struct_arg.  All
+// threads then share the same box, which can lead to races when the box is
+// modified inside the loop body.
+//
+// The fix inserts a per-invocation alloca + memcpy at the top of the loop body
+// callback, so each invocation gets its own local copy of the box.
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memory_space", 5 : ui32>>, llvm.data_layout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9", llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_gpu = true, omp.is_target_device = true} {
+
+  // Privatizer for a fixed-size array descriptor {data_ptr, extent}.
+  // The init region copies the source descriptor into the private slot.
+  omp.private {type = private} @box.privatizer : !llvm.struct<(ptr, i64)> init {
+  ^bb0(%arg0: !llvm.ptr, %arg1: !llvm.ptr):
+    %c16 = llvm.mlir.constant(16 : i32) : i32
+    "llvm.intr.memcpy"(%arg1, %arg0, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    omp.yield(%arg1 : !llvm.ptr)
+  }
+
+  llvm.func @box_private_distribute_wsloop(%box_in : !llvm.ptr) attributes {
+    omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>,
+    target_cpu = "gfx90a",
+    target_features = #llvm.target_features<["+gfx9-insts", "+wavefrontsize64"]>
+  } {
+    %c1_i32 = llvm.mlir.constant(1 : i32) : i32
+    %c1_i64 = llvm.mlir.constant(1 : i64) : i64
+    %box = llvm.alloca %c1_i64 x !llvm.struct<(ptr, i64)> : (i64) -> !llvm.ptr<5>
+    %box_flat = llvm.addrspacecast %box : !llvm.ptr<5> to !llvm.ptr
+    %c16 = llvm.mlir.constant(16 : i32) : i32
+    "llvm.intr.memcpy"(%box_flat, %box_in, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    omp.parallel private(@box.privatizer %box_flat -> %priv : !llvm.ptr) {
+      omp.distribute {
+        omp.wsloop {
+          omp.loop_nest (%i) : i32 = (%c1_i32) to (%c1_i32) inclusive step (%c1_i32) {
+            %ptr_gep = llvm.getelementptr %priv[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, i64)>
+            %ptr = llvm.load %ptr_gep : !llvm.ptr -> !llvm.ptr
+            %val = llvm.mlir.constant(1.0 : f32) : f32
+            llvm.store %val, %ptr : f32, !llvm.ptr
+            omp.yield
+          }
+        } {omp.composite}
+      } {omp.composite}
+      omp.terminator
+    } {omp.composite}
+    llvm.return
+  }
+}
+
+// The loop body callback (takes i32 iteration index as first arg) must contain
+// a per-invocation alloca and memcpy for the private box descriptor, so each
+// callback invocation operates on its own local copy rather than the shared one
+// captured in struct_arg.
+
+// CHECK-LABEL: define internal void @{{.*}}omp_par(i32
+// CHECK: omp.private.alloc
+// CHECK: omp.private.alloc.ascast
+// CHECK: call void @llvm.memcpy.p0.p0.i64

--- a/mlir/test/Target/LLVMIR/omptarget-vla-private.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-vla-private.mlir
@@ -1,0 +1,66 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s --check-prefix=NEG
+
+// Regression test: a variable-length alloca inside an omp.private init region
+// must NOT be lowered to an addrspace(5) (scratch segment) alloca on GPU
+// targets.  The scratch segment has a fixed, limited size per workitem
+// (private_segment_fixed_size), and a VLA there overflows it at runtime.
+// The fix replaces the VLA with a device @malloc call.
+//
+// Tested construct: omp.parallel { omp.distribute { omp.wsloop } }
+// with a private VLA whose size is read from a runtime array descriptor.
+
+module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memory_space", 5 : ui32>>, llvm.data_layout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-p7:160:256:256:32-p8:128:128:128:48-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7:8:9", llvm.target_triple = "amdgcn-amd-amdhsa", omp.is_gpu = true, omp.is_target_device = true} {
+
+  // Privatizer for a simple array descriptor {data_ptr, extent}.
+  // The init region allocates private storage sized at runtime, producing a
+  // VLA alloca.  Without the fix the alloca lands in addrspace(5); with the
+  // fix it is replaced by a @malloc call.
+  omp.private {type = private} @vla_arr.privatizer : !llvm.struct<(ptr, i64)> init {
+  ^bb0(%arg0: !llvm.ptr, %arg1: !llvm.ptr):
+    %gep = llvm.getelementptr %arg0[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, i64)>
+    %n = llvm.load %gep : !llvm.ptr -> i64
+    %arr = llvm.alloca %n x f32 {bindc_name = "arr"} : (i64) -> !llvm.ptr<5>
+    %arr_flat = llvm.addrspacecast %arr : !llvm.ptr<5> to !llvm.ptr
+    %undef = llvm.mlir.undef : !llvm.struct<(ptr, i64)>
+    %d0 = llvm.insertvalue %arr_flat, %undef[0] : !llvm.struct<(ptr, i64)>
+    %d1 = llvm.insertvalue %n, %d0[1] : !llvm.struct<(ptr, i64)>
+    llvm.store %d1, %arg1 : !llvm.struct<(ptr, i64)>, !llvm.ptr
+    omp.yield(%arg1 : !llvm.ptr)
+  }
+
+  llvm.func @vla_private_distribute_wsloop(%box_in : !llvm.ptr) attributes {
+    omp.declare_target = #omp.declaretarget<device_type = (any), capture_clause = (to)>,
+    target_cpu = "gfx90a",
+    target_features = #llvm.target_features<["+gfx9-insts", "+wavefrontsize64"]>
+  } {
+    %c1_i32 = llvm.mlir.constant(1 : i32) : i32
+    %c1_i64 = llvm.mlir.constant(1 : i64) : i64
+    %box = llvm.alloca %c1_i64 x !llvm.struct<(ptr, i64)> : (i64) -> !llvm.ptr<5>
+    %box_flat = llvm.addrspacecast %box : !llvm.ptr<5> to !llvm.ptr
+    %c16 = llvm.mlir.constant(16 : i32) : i32
+    "llvm.intr.memcpy"(%box_flat, %box_in, %c16) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    omp.parallel private(@vla_arr.privatizer %box_flat -> %priv : !llvm.ptr) {
+      omp.distribute {
+        omp.wsloop {
+          omp.loop_nest (%i) : i32 = (%c1_i32) to (%c1_i32) inclusive step (%c1_i32) {
+            %ptr_gep = llvm.getelementptr %priv[0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(ptr, i64)>
+            %ptr = llvm.load %ptr_gep : !llvm.ptr -> !llvm.ptr
+            %val = llvm.mlir.constant(1.0 : f32) : f32
+            llvm.store %val, %ptr : f32, !llvm.ptr
+            omp.yield
+          }
+        } {omp.composite}
+      } {omp.composite}
+      omp.terminator
+    } {omp.composite}
+    llvm.return
+  }
+}
+
+// VLA private storage must be allocated via device malloc, not a
+// variable-length alloca in the scratch segment.
+// CHECK: call ptr @malloc(i64
+
+// No VLA alloca must appear in addrspace(5) (GPU scratch segment).
+// NEG-NOT: alloca float, i64 {{.*}}, addrspace(5)


### PR DESCRIPTION
Fixes #2419.

Private VLA arrays (`real, dimension(size(b,1)) :: tmp`) with `private(tmp)` in `target teams distribute parallel do collapse(2)` cause a GPU memory fault on AMD GPU.

Two bugs fixed in `convertOmpWsloop` (`OpenMPToLLVMIRTranslation.cpp`), both triggered before `applyWorkshareLoop` for `DistributeForStaticLoop` on targets where `allocaAddrSpace != programAddressSpace` (e.g., AMD GPU addrspace(5)):

Bug 1 - VLA scratch overflow (root cause of the fault)

The `omp.private` init region emits `alloca float, i64 N, addrspace(5)` inside the outlined parallel function, where N is a runtime value (the extent of an assumed-shape dummy argument). The kernel descriptor's `private_segment_fixed_size` is set statically and is too small for variable N, so the array data pointer lands in unmapped scratch VRAM -> GPU page fault for N >= ~10.

Fix: scan the parent parallel function for dynamic (variable-size) allocas in `allocaAddrSpace` and replace each with a `malloc` call so the data pointer lives in device global memory.

The matching `free` is not yet inserted; the correct insertion point (the parallel function, after the distribute callback returns) is not available at the point where the malloc is emitted because `applyWorkshareLoop` has not yet outlined the loop body. Tracked in #2423.

Bug 2 - box descriptor shared across threads

Fixed-size Fortran array descriptor (box, 48 bytes) allocas in `allocaAddrSpace` are placed in the parallel function. `applyWorkshareLoop` captures their flat pointers into `struct_arg`, sharing one master-thread descriptor across all worker threads.

Fix: insert a per-invocation alloca + `memcpy` at the top of the loop body so each callback invocation has its own local copy of the descriptor. Restricted to struct types only; scalar private variables are already per-thread in the parallel function's stack frame and do not need replication.

Ordering required: `replaceUsesWithIf` must run before `CreateMemCpy`. Inserting the memcpy first causes the subsequent `replaceUsesWithIf` to replace the memcpy's own source operand with the new alloca -> self-copy -> uninitialized descriptor in the work callback.

Tests

- `omptarget-vla-private.mlir`: verifies the VLA is replaced by `call ptr @malloc(i64` and no `alloca float, i64 ..., addrspace(5)` is emitted
- `omptarget-box-private-wsloop.mlir`: verifies the loop body callback gets a per-invocation alloca and `memcpy` for the private box descriptor
- Minimal Fortran reproducer from issue #2419 (`n=64`): outputs correct value (`1.`), no GPU fault, exit 0
- Tested on therock-afar-23.2.1 (LLVM 23, `amdgcn-amd-amdhsa`, gfx90a / MI250) via an LD_PRELOAD shim built from the patched translation file

Prior variants (ROCm 7.2, amdflang 23 at -O0/-O2, debug) faulted at runtime before this fix

Local regression testing

All 231 tests in `mlir/test/Target/LLVMIR/` were run against the patched and unpatched translation library. Only the two new tests produce different output; all 229 existing tests are byte-for-byte identical between patched and unpatched, including the split-input-file GPU tests and all non-GPU tests.

During this testing a regression was caught and fixed: the Bug 2 replication was initially applied to all private allocas including scalars, which would have broken `omptarget-memcpy-align-metadata.mlir`. Restricting replication to struct types resolved the regression.

The Fortran end-to-end test was recompiled from source with the final patch and produces `L1 Error: 0. / PASS`, exit 0.