### PR TITLE
[Comgr][hotswap] Add bare-bones hotswap transpiler scaffolding

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -118,6 +118,16 @@ set(SOURCES
   src/comgr-unbundle-command.cpp
   src/time-stat/time-stat.cpp)
 
+# Hotswap binary transpiler, opt-in. The hotswap project lives under
+# amd/comgr/src/hotswap as a private COMGR subproject. When enabled, we
+# link the hotswap OBJECT library into amd_comgr (its TUs land directly
+# in amd_comgr.so so hotswap files can call comgr-metadata helpers
+# without a layering inversion) and compile the
+# comgr-hotswap-transpile.cpp entry point. When disabled, the
+# amd_comgr_hotswap_transpile API is simply not provided.
+option(COMGR_ENABLE_HOTSWAP_TRANSPILE
+  "Build the hotswap-transpiler-backed amd_comgr_hotswap_transpile entry point" OFF)
+
 # Add Windows resource file for version info
 if(WIN32)
   # Allow users to override the DLL name via -DCOMGR_DLL_NAME
@@ -195,6 +205,16 @@ endif()
 target_include_directories(amd_comgr
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/src)
+
+# The hotswap subdirectory is added unconditionally below (around the
+# add_subdirectory(src/hotswap) line) so the OBJECT library is available
+# to the test-unit suite; here we opt amd_comgr into linking the
+# transpiler in (its TUs land in amd_comgr.so) and exposing the
+# `amd_comgr_hotswap_transpile` entry point.
+if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
+  target_link_libraries(amd_comgr PRIVATE hotswap::transpiler)
+  target_compile_definitions(amd_comgr PRIVATE COMGR_ENABLE_HOTSWAP_TRANSPILE=1)
+endif()
 
 message("")
 message("------------LLVM_DIR: ${LLVM_DIR}")
@@ -602,6 +622,12 @@ if (NOT WIN32)
       c
       ${CMAKE_DL_LIBS})
 endif()
+
+# Hotswap subproject — IR-level transpiler library + supporting tools.
+# Always added so the static library is available to the test-unit suite;
+# linking into amd_comgr happens in a later patch via the
+# COMGR_ENABLE_HOTSWAP_TRANSPILE option.
+add_subdirectory(src/hotswap)
 
 include(CTest)
 if(BUILD_TESTING)

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 3.20)
+project(hotswap-transpiler LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# --- LLVM ---------------------------------------------------------------------
+if(NOT TARGET LLVMSupport)
+  find_package(LLVM REQUIRED CONFIG)
+endif()
+if(NOT COMMAND llvm_update_compile_flags)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+endif()
+
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+# --- Library ------------------------------------------------------------------
+# OBJECT library so its translation units land directly in amd_comgr.so when
+# `target_link_libraries(amd_comgr PRIVATE hotswap::transpiler)` runs (gated
+# on COMGR_ENABLE_HOTSWAP_TRANSPILE in the parent CMakeLists.txt). This puts
+# the hotswap raiser and the rest of comgr in the same TU set so hotswap
+# files can call comgr-metadata helpers directly without a layering inversion
+# or a separate static archive.
+add_library(hotswap-transpiler OBJECT
+  raiser.cpp
+)
+
+if(NOT TARGET hotswap::transpiler)
+  add_library(hotswap::transpiler ALIAS hotswap-transpiler)
+endif()
+
+# Match LLVM's compile flags (no-rtti, no-exceptions) — every LLVM type we
+# consume relies on LLVM's hand-rolled RTTI rather than C++ typeid; mixing
+# RTTI-on TUs with RTTI-off LLVM libs produces undefined-reference errors
+# for `typeinfo` symbols on any class with a virtual method.
+llvm_update_compile_flags(hotswap-transpiler)
+
+set_target_properties(hotswap-transpiler PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Public include root so consumers can `#include "hotswap/raiser.hpp"`.
+target_include_directories(hotswap-transpiler PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
+)
+
+target_link_libraries(hotswap-transpiler
+  PUBLIC
+    LLVMCore
+    LLVMSupport
+    LLVMTargetParser
+)

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -1,0 +1,19 @@
+# Hotswap Transpiler
+
+The hotswap transpiler raises AMDGPU code objects into LLVM IR, re-lowers
+them through the stock AMDGPU backend for a different target ISA, and
+relinks the result into a single merged HSACO. It is a sibling to the
+byte-level `amd_comgr_hotswap_rewrite` API: where rewrite applies a small
+set of stepping-specific patches in place, transpilation hands the entire
+code object to the IR pipeline.
+
+## Build
+
+The library can be configured standalone for development:
+
+```
+cmake -S amd/comgr/hotswap -B build-hotswap \
+  -DLLVM_DIR=$PWD/build/lib/cmake/llvm
+ninja -C build-hotswap
+ctest --test-dir build-hotswap -L transpiler
+```

--- a/amd/comgr/src/hotswap/code_object_utils.h
+++ b/amd/comgr/src/hotswap/code_object_utils.h
@@ -1,0 +1,65 @@
+//===- code_object_utils.h - AMDGPU code-object metadata ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_H
+#define HOTSWAP_TRANSPILER_CODE_OBJECT_UTILS_H
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/MathExtras.h"
+
+#include <cstdint>
+#include <string>
+
+namespace COMGR::hotswap {
+
+struct KernelArgMeta {
+  std::string Name;
+  uint32_t Offset = 0;
+  uint32_t Size = 0;
+  std::string ValueKind;
+  int AddressSpace = -1;
+};
+
+// Per-kernel metadata extracted from the AMDGPU code object's MsgPack notes
+// + kernel descriptor (`<name>.kd`).
+struct KernelMeta {
+  std::string Name;
+  uint32_t KernargSegmentSize = 0;
+  uint32_t GroupSegmentFixedSize = 0;
+  uint32_t PrivateSegmentFixedSize = 0;
+  uint32_t MaxFlatWorkgroupSize = 256;
+  llvm::SmallVector<KernelArgMeta, 8> Args;
+
+  bool HasKernelDescriptor = false;
+  uint32_t ComputePgmRsrc1 = 0;
+  uint32_t ComputePgmRsrc2 = 0;
+  uint16_t KernelCodeProperties = 0;
+  uint16_t KernargPreload = 0;
+
+  // Byte offset (8-byte aligned) of the first hidden argument in the
+  // kernarg segment. Hidden arguments (`hidden_*` value kinds) are
+  // appended after every explicit argument.
+  uint64_t implicitArgsBase() const {
+    uint64_t MaxEnd = 0;
+    for (const KernelArgMeta &Arg : Args) {
+      if (llvm::StringRef(Arg.ValueKind).starts_with("hidden_")) {
+        continue;
+      }
+      uint64_t End = static_cast<uint64_t>(Arg.Offset) + Arg.Size;
+      if (End > MaxEnd) {
+        MaxEnd = End;
+      }
+    }
+    return llvm::alignTo(MaxEnd, 8);
+  }
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/raise_failure.h
+++ b/amd/comgr/src/hotswap/raise_failure.h
@@ -1,0 +1,36 @@
+//===- raise_failure.h - Structured raise-failure values ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_RAISE_FAILURE_H
+#define HOTSWAP_TRANSPILER_RAISE_FAILURE_H
+
+#include <cstdint>
+#include <string>
+
+namespace COMGR::hotswap {
+
+// Lives in its own header so the handler layer can depend on failure
+// values without pulling in the rest of the top-level `raiser.h`
+// interface.
+enum class RaiseFailureReason : uint16_t {
+  None = 0,
+  BadInput,
+};
+
+
+struct RaiseFailure {
+  RaiseFailureReason Reason = RaiseFailureReason::None;
+  // Optional human-readable context.
+  std::string Detail;
+
+  bool hasFailed() const { return Reason != RaiseFailureReason::None; }
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/raiser.cpp
+++ b/amd/comgr/src/hotswap/raiser.cpp
@@ -1,0 +1,102 @@
+//===- raiser.cpp - Hotswap MC -> LLVM IR raiser scaffolding --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "raiser.h"
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/TargetParser/TargetParser.h"
+#include "llvm/TargetParser/Triple.h"
+
+namespace COMGR::hotswap {
+
+namespace {
+
+constexpr llvm::StringLiteral AMDGPUTriple = "amdgcn-amd-amdhsa";
+
+// Reject obviously-bad inputs before constructing IR. Mirrors the
+// preconditions the full pipeline enforces in subsequent commits.
+//
+// Ideally we would reuse `COMGR::parseTargetIdentifier`, but that helper
+// currently lives behind the comgr-metadata layer in `src/comgr.cpp` and
+// is not reachable from the hotswap subproject. As a stop-gap, validate
+// the AMDGPU processor name through `llvm::AMDGPU::parseArchAMDGCN`.
+RaiseFailure validateInputs(llvm::StringRef SourceISA,
+                            llvm::StringRef KernelName,
+                            const KernelMeta &Meta) {
+  RaiseFailure F;
+  if (SourceISA.empty()) {
+    F.Reason = RaiseFailureReason::BadInput;
+    F.Detail = "source ISA string is empty";
+    return F;
+  }
+  // The disassembler-facing identifier is `<arch>-<vendor>-<os>-<env>-<gfx>`;
+  // `parseArchAMDGCN` inspects the trailing component.
+  llvm::StringRef GfxName = SourceISA.rsplit('-').second;
+  if (GfxName.empty()) {
+    GfxName = SourceISA;
+  }
+  if (llvm::AMDGPU::parseArchAMDGCN(GfxName) == llvm::AMDGPU::GK_NONE) {
+    F.Reason = RaiseFailureReason::BadInput;
+    F.Detail =
+        ("source ISA '" + SourceISA + "' does not name an AMDGPU GPU").str();
+    return F;
+  }
+  if (KernelName.empty()) {
+    F.Reason = RaiseFailureReason::BadInput;
+    F.Detail = "kernel name is empty";
+    return F;
+  }
+  if (!Meta.HasKernelDescriptor) {
+    F.Reason = RaiseFailureReason::BadInput;
+    F.Detail = ("kernel '" + KernelName + "' has no parsed kernel descriptor")
+                   .str();
+    return F;
+  }
+  return F;
+}
+
+} // namespace
+
+RaiseResult raiseToIR(llvm::StringRef SourceISA,
+                      llvm::StringRef KernelName,
+                      const KernelMeta &Meta) {
+  using namespace llvm;
+
+  RaiseResult Result;
+  Result.Failure = validateInputs(SourceISA, KernelName, Meta);
+  if (Result.Failure.hasFailed()) {
+    return Result;
+  }
+
+  Result.Ctx = std::make_unique<LLVMContext>();
+  LLVMContext &C = *Result.Ctx;
+  Result.Module = std::make_unique<Module>("transpiler_module", C);
+  Module &M = *Result.Module;
+  M.setTargetTriple(Triple(AMDGPUTriple));
+
+  FunctionType *FuncTy =
+      FunctionType::get(Type::getVoidTy(C), /*isVarArg=*/false);
+  Function *F =
+      Function::Create(FuncTy, GlobalValue::ExternalLinkage, KernelName, &M);
+  F->setCallingConv(CallingConv::AMDGPU_KERNEL);
+
+  BasicBlock *Entry = BasicBlock::Create(C, "entry", F);
+  IRBuilder<> B(Entry);
+  B.CreateRetVoid();
+
+  Result.Success = true;
+  return Result;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raiser.h
+++ b/amd/comgr/src/hotswap/raiser.h
@@ -1,0 +1,48 @@
+//===- raiser.h - Hotswap MC -> LLVM IR raiser entry point --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_RAISER_H
+#define HOTSWAP_TRANSPILER_RAISER_H
+
+#include "code_object_utils.h"
+#include "raise_failure.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <memory>
+
+namespace llvm {
+class LLVMContext;
+class Module;
+} // namespace llvm
+
+namespace COMGR::hotswap {
+
+struct RaiseResult {
+  std::unique_ptr<llvm::LLVMContext> Ctx;
+  std::unique_ptr<llvm::Module> Module;
+  // Structured failure description. `failure.reason == None` iff `success`.
+  RaiseFailure Failure;
+  bool Success = false;
+};
+
+// Raise a kernel named `KernelName` whose source ISA is `SourceISA`. `Meta`
+// carries the MsgPack-derived per-kernel metadata. The scaffolding
+// implementation emits a `ret void` placeholder and refuses inputs the full
+// pipeline would also refuse: missing kernel descriptor, empty kernel name,
+// and `SourceISA` strings that don't parse via
+// `llvm::AMDGPU::parseArchAMDGCN`. The kernel-text bytes, kernel offset, and
+// compilation-target ISA become real parameters once the decoder is wired
+// in (subsequent commit).
+RaiseResult raiseToIR(llvm::StringRef SourceISA,
+                      llvm::StringRef KernelName,
+                      const KernelMeta &Meta);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -43,7 +43,9 @@ else()
 endif()
 
 # Pin C++17 and mirror LLVM's RTTI setting (avoids type_info link errors
-# against libLLVM*).
+# against LLVM libs built with RTTI off, including hotswap::transpiler
+# which carries its own non-RTTI / non-exceptions compile flags via
+# llvm_update_compile_flags()).
 function(comgr_configure_test_target target)
   set_target_properties(${target} PROPERTIES
     CXX_STANDARD 17
@@ -128,9 +130,31 @@ target_include_directories(HotswapMCTests PRIVATE
 
 comgr_configure_test_target(HotswapMCTests)
 
-# Register both test binaries with the test-unit / check-comgr plumbing.
+# -- RaiserScaffoldingTests ---------------------------------------------------
+#
+# Pins the bare-bones raiser scaffolding contract (`hotswap/raiser.hpp`):
+# empty input produces a verifyModule-clean `llvm::Module` with a single
+# `AMDGPU_KERNEL` `ret void` function, plus the failure paths for missing
+# kernel descriptor / malformed ISA.
+
+add_executable(RaiserScaffoldingTests
+  RaiserScaffoldingTest.cpp)
+
+target_link_libraries(RaiserScaffoldingTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::transpiler
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(RaiserScaffoldingTests PRIVATE
+  ${COMGR_GTEST_INCLUDE_DIRS})
+
+comgr_configure_test_target(RaiserScaffoldingTests)
+
+# Register every test binary with the test-unit / check-comgr plumbing.
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
-  COMMAND $<TARGET_FILE:HotswapMCTests>)
-add_dependencies(test-unit HotswapElfTests HotswapMCTests)
+  COMMAND $<TARGET_FILE:HotswapMCTests>
+  COMMAND $<TARGET_FILE:RaiserScaffoldingTests>)
+add_dependencies(test-unit HotswapElfTests HotswapMCTests
+  RaiserScaffoldingTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/RaiserScaffoldingTest.cpp
+++ b/amd/comgr/test-unit/RaiserScaffoldingTest.cpp
@@ -1,0 +1,106 @@
+//===- RaiserScaffoldingTest.cpp - Hotswap transpiler scaffolding test ----===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Pins the scaffolding contract `raiseToIR` advertises: an empty input
+// produces a well-formed `llvm::Module` containing one `AMDGPU_KERNEL`
+// function whose body is exactly `ret void`, with the AMDGPU triple set.
+// Empty inputs succeed; missing kernel descriptor / malformed ISA inputs
+// are rejected with a structured failure.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/raiser.h"
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "gtest/gtest.h"
+
+namespace {
+
+COMGR::hotswap::KernelMeta makeKernelMeta(llvm::StringRef Name) {
+  COMGR::hotswap::KernelMeta Meta;
+  Meta.Name = Name.str();
+  Meta.HasKernelDescriptor = true;
+  return Meta;
+}
+
+} // namespace
+
+TEST(RaiserScaffolding, EmptyInputProducesValidModule) {
+  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
+  COMGR::hotswap::RaiseResult Result =
+      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+
+  ASSERT_TRUE(Result.Success);
+  ASSERT_NE(Result.Ctx, nullptr);
+  ASSERT_NE(Result.Module, nullptr);
+
+  std::string Err;
+  llvm::raw_string_ostream ErrStream(Err);
+  EXPECT_FALSE(llvm::verifyModule(*Result.Module, &ErrStream)) << Err;
+}
+
+TEST(RaiserScaffolding, ModuleAdvertisesAMDGPUTriple) {
+  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
+  COMGR::hotswap::RaiseResult Result =
+      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+
+  ASSERT_TRUE(Result.Success);
+  ASSERT_NE(Result.Module, nullptr);
+  EXPECT_EQ(Result.Module->getTargetTriple().str(), "amdgcn-amd-amdhsa");
+}
+
+TEST(RaiserScaffolding, KernelFunctionIsAMDGPUKernelWithRetVoid) {
+  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
+  COMGR::hotswap::RaiseResult Result =
+      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+
+  ASSERT_TRUE(Result.Success);
+  llvm::Function *Fn = Result.Module->getFunction("kernel");
+  ASSERT_NE(Fn, nullptr);
+  EXPECT_EQ(Fn->getCallingConv(), llvm::CallingConv::AMDGPU_KERNEL);
+  ASSERT_EQ(Fn->size(), 1u);
+  llvm::BasicBlock &Entry = Fn->getEntryBlock();
+  ASSERT_FALSE(Entry.empty());
+  EXPECT_TRUE(llvm::isa<llvm::ReturnInst>(Entry.getTerminator()));
+}
+
+TEST(RaiserScaffolding, MissingKernelDescriptorIsRejected) {
+  COMGR::hotswap::KernelMeta Meta;
+  Meta.Name = "kernel";
+  Meta.HasKernelDescriptor = false;
+  COMGR::hotswap::RaiseResult Result =
+      COMGR::hotswap::raiseToIR("gfx942", "kernel", Meta);
+
+  EXPECT_FALSE(Result.Success);
+  EXPECT_TRUE(Result.Failure.hasFailed());
+}
+
+TEST(RaiserScaffolding, EmptyTargetIsaIsRejected) {
+  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
+  COMGR::hotswap::RaiseResult Result =
+      COMGR::hotswap::raiseToIR("", "kernel", Meta);
+
+  EXPECT_FALSE(Result.Success);
+  EXPECT_TRUE(Result.Failure.hasFailed());
+}
+
+TEST(RaiserScaffolding, MalformedTargetIsaIsRejected) {
+  COMGR::hotswap::KernelMeta Meta = makeKernelMeta("kernel");
+  COMGR::hotswap::RaiseResult Result =
+      COMGR::hotswap::raiseToIR("not-a-real-isa", "kernel", Meta);
+
+  EXPECT_FALSE(Result.Success);
+  EXPECT_TRUE(Result.Failure.hasFailed());
+}


### PR DESCRIPTION
Lands the minimal scaffolding
needed to build a `hotswap-transpiler` static library:

  * `raiser.{hpp,cpp}` — `raiseToIR()` entry point. The implementation creates an `llvm::Module` with a single `ret void` AMDGPU kernel function for any input. ELF ingestion, MC disassembly and the per-format raise handlers land in subsequent patches.
  * `raise_failure.{hpp,cpp}` — structured failure values consumed by `RaiseResult::failure`.
  * `code_object_utils.hpp` — `KernelMeta` struct used in the `raiseToIR` signature.
  * Minimal `CMakeLists.txt` linking only `LLVMCore`, `LLVMSupport`, `LLVMTargetParser`. The full library/include surface grows incrementally as later patches need it.
  * `tests/raiser_empty_module_test.cpp` (gtest) verifies the scaffolding contract: an empty input produces a well-formed module with one `AMDGPU_KERNEL` function whose body is `ret void`.


