### PR TITLE
[Comgr] Fix test-unit CMake to use the project's LLVM and C++17

### DIFF
--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -78,9 +78,16 @@ target_link_libraries(HotswapElfTests PRIVATE
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(HotswapElfTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/../src
   ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+set_target_properties(HotswapElfTests PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED Yes
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 comgr_match_llvm_rtti(HotswapElfTests)
 
@@ -118,9 +125,16 @@ target_link_libraries(HotswapMCTests PRIVATE
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(HotswapMCTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/../src
   ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+set_target_properties(HotswapMCTests PROPERTIES
+  CXX_STANDARD 17
+  CXX_STANDARD_REQUIRED Yes
+  CXX_EXTENSIONS No
+  POSITION_INDEPENDENT_CODE ON)
 
 comgr_match_llvm_rtti(HotswapMCTests)
 

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -42,11 +42,13 @@ else()
   endif()
 endif()
 
-# LLVM is built with -fno-rtti by default; matching that here avoids
-# undefined references to LLVM type_info symbols when linking against
-# libLLVM*.a / .so. gtest itself does not require user-side RTTI
-# (-DGTEST_HAS_RTTI=0 is set when gtest is built).
-function(comgr_match_llvm_rtti target)
+# Pin C++17 and mirror LLVM's RTTI setting (avoids type_info link errors
+# against libLLVM*).
+function(comgr_configure_test_target target)
+  set_target_properties(${target} PROPERTIES
+    CXX_STANDARD 17
+    CXX_STANDARD_REQUIRED Yes
+    CXX_EXTENSIONS No)
   if(NOT LLVM_ENABLE_RTTI)
     if(MSVC)
       target_compile_options(${target} PRIVATE /GR-)
@@ -83,13 +85,7 @@ target_include_directories(HotswapElfTests PRIVATE
   ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
 
-set_target_properties(HotswapElfTests PROPERTIES
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED Yes
-  CXX_EXTENSIONS No
-  POSITION_INDEPENDENT_CODE ON)
-
-comgr_match_llvm_rtti(HotswapElfTests)
+comgr_configure_test_target(HotswapElfTests)
 
 # -- HotswapMCTests -----------------------------------------------------------
 #
@@ -130,13 +126,7 @@ target_include_directories(HotswapMCTests PRIVATE
   ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
 
-set_target_properties(HotswapMCTests PROPERTIES
-  CXX_STANDARD 17
-  CXX_STANDARD_REQUIRED Yes
-  CXX_EXTENSIONS No
-  POSITION_INDEPENDENT_CODE ON)
-
-comgr_match_llvm_rtti(HotswapMCTests)
+comgr_configure_test_target(HotswapMCTests)
 
 # Register both test binaries with the test-unit / check-comgr plumbing.
 add_custom_target(test-unit


### PR DESCRIPTION
The `HotswapElfTests` and `HotswapMCTests` targets in `amd/comgr/test-unit/CMakeLists.txt` were configured without `${LLVM_INCLUDE_DIRS}` and without setting `CXX_STANDARD 17`. `llvm_map_components_to_libnames` returns plain library names (not modern imported targets), so `target_link_libraries` did not propagate include dirs or language standard. The test compiles silently picked up a stale system LLVM (e.g. `libllvm-14-dev`) and GCC's default C++14, producing a cascade of unrelated-looking errors: missing `std::optional`, `StringRef::starts_with`, `MCContext` ctor mismatch, `MCStreamer` `override` mismatches, etc.

Fix: add `${LLVM_INCLUDE_DIRS}` to both `target_include_directories(...)` blocks and a `set_target_properties(... CXX_STANDARD 17 CXX_STANDARD_REQUIRED Yes CXX_EXTENSIONS No POSITION_INDEPENDENT_CODE ON)` on each target — matching how `amd_comgr` itself is configured (`amd/comgr/CMakeLists.txt:337-345`).

Reproduced on PSDB build #325 against `amd-feature/wave-transform`.

Co-Authored-By: Claude <noreply@anthropic.com>