### PR TITLE
[Offload][OMPT] Adapt device tracing for `omp_initial_device` on host

### DIFF
--- a/offload/libomptarget/OpenMP/OMPT/OmptTracing.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/OmptTracing.cpp
@@ -392,10 +392,9 @@ ompt_record_ompt_t *Interface::stopTargetDataAllocTrace(int64_t DeviceId,
     return nullptr;
 
   setTraceRecordCommon(DataPtr, ompt_callback_target_data_op);
-  setTraceRecordTargetDataOp(&DataPtr->record.target_data_op,
-                             ompt_target_data_alloc, HstPtrBegin,
-                             /*SrcDeviceNum=*/omp_get_initial_device(),
-                             *TgtPtrBegin, DeviceId, Size, Code);
+  setTraceRecordTargetDataOp(
+      &DataPtr->record.target_data_op, ompt_target_data_alloc, HstPtrBegin,
+      /*SrcDeviceNum=*/omp_initial_device, *TgtPtrBegin, DeviceId, Size, Code);
 
   // The trace record has been created, mark it ready for delivery to the tool
   TRM->setTRStatus(DataPtr, OmptTracingBufferMgr::TR_ready);
@@ -426,7 +425,8 @@ ompt_record_ompt_t *Interface::stopTargetDataDeleteTrace(int64_t DeviceId,
   setTraceRecordTargetDataOp(&DataPtr->record.target_data_op,
                              ompt_target_data_delete, TgtPtrBegin, DeviceId,
                              /*DstAddr=*/nullptr,
-                             /*DstDeviceNum=*/-1, /*Bytes=*/0, Code);
+                             /*DstDeviceNum=*/omp_initial_device, /*Bytes=*/0,
+                             Code);
 
   // The trace record has been created, mark it ready for delivery to the tool
   TRM->setTRStatus(DataPtr, OmptTracingBufferMgr::TR_ready);

--- a/offload/libomptarget/device.cpp
+++ b/offload/libomptarget/device.cpp
@@ -313,7 +313,7 @@ int32_t DeviceTy::submitData(void *TgtPtrBegin, void *HstPtrBegin, int64_t Size,
           RegionInterface
               .getTraceGenerators<ompt_target_data_transfer_to_device>(),
           AsyncInfo, RTL->getProfiler(), /*TracedDeviceId=*/DeviceID,
-          /*EventType=*/ompt_callback_target_data_op, omp_get_initial_device(),
+          /*EventType=*/ompt_callback_target_data_op, omp_initial_device,
           HstPtrBegin, DeviceID, TgtPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
 
@@ -344,7 +344,7 @@ int32_t DeviceTy::retrieveData(void *HstPtrBegin, void *TgtPtrBegin,
               .getTraceGenerators<ompt_target_data_transfer_from_device>(),
           AsyncInfo, RTL->getProfiler(), /*TracedDeviceId=*/DeviceID,
           /*EventType=*/ompt_callback_target_data_op, DeviceID, TgtPtrBegin,
-          omp_get_initial_device(), HstPtrBegin, Size,
+          omp_initial_device, HstPtrBegin, Size,
           /*CodePtr=*/OMPT_GET_RETURN_ADDRESS);)
 
   setAsyncInfoSynchronous(AsyncInfo, ForceSynchronousTargetRegions);


### PR DESCRIPTION
In [llvm-project#192924](https://github.com/llvm/llvm-project/pull/192924), all host side callbacks were changed to pass `omp_initial_device` instead of `omp_get_initial_device()` to an attached tool. This change allowed to set `initial_device_num` in `ompt_start_tool` to a fixed value, hence enabling tools to rely on a passed identifier to differentiate the host device from any other device.

However, this change needs to be adapted in the device tracing records as well, as tools might rely on both host-side callbacks and device tracing records having consistent identifiers. A tool might e.g. discard invalid records due to not recognizing the passed `omp_get_initial_device()`. This is amplified by `ompt_get_num_devices()` not yielding the actual number of devices.

Thus, update the device tracing interface to also consistently use `omp_initial_device` for the host device.


