### PR TITLE
[Comgr] Log message on temp file creation failure suggesting bad TMPDIR

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1101,7 +1101,14 @@ amd_comgr_status_t AMDGPUCompiler::createTmpDirs() {
                            std::to_string(Id++));
 
   ProfilePoint Point("CreateDir");
-  if (fs::createUniqueDirectory(TmpDirPrefix, TmpDir)) {
+  // TMPDIR being non-existent causes errors here, indicate in log
+  if (std::error_code EC = fs::createUniqueDirectory(TmpDirPrefix, TmpDir)) {
+    LogS << "comgr-compiler: failed to create temporary directory '"
+         << TmpDirPrefix << "': " << EC.message() << "\n";
+    const char *TmpDirEnv = std::getenv("TMPDIR");
+    if (TmpDirEnv)
+      LogS << "comgr-compiler: TMPDIR='" << TmpDirEnv
+           << "' may not exist or be writable\n";
     return AMD_COMGR_STATUS_ERROR;
   }
 

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1101,14 +1101,15 @@ amd_comgr_status_t AMDGPUCompiler::createTmpDirs() {
                            std::to_string(Id++));
 
   ProfilePoint Point("CreateDir");
-  // TMPDIR being non-existent causes errors here, indicate in log
   if (std::error_code EC = fs::createUniqueDirectory(TmpDirPrefix, TmpDir)) {
-    LogS << "comgr-compiler: failed to create temporary directory '"
-         << TmpDirPrefix << "': " << EC.message() << "\n";
-    const char *TmpDirEnv = std::getenv("TMPDIR");
-    if (TmpDirEnv)
-      LogS << "comgr-compiler: TMPDIR='" << TmpDirEnv
-           << "' may not exist or be writable\n";
+    if (env::shouldEmitVerboseLogs()) {
+      LogS << "comgr-compiler: failed to create temporary directory '"
+           << TmpDirPrefix << "': " << EC.message() << "\n";
+      const char *TmpDirEnv = std::getenv("TMPDIR");
+      if (TmpDirEnv)
+        LogS << "comgr-compiler: TMPDIR='" << TmpDirEnv
+             << "' may not exist or be writable\n";
+    }
     return AMD_COMGR_STATUS_ERROR;
   }
 


### PR DESCRIPTION
Addresses https://github.com/ROCm/TheRock/issues/3103. Currently when TMPDIR is set to a path that does not exist or is otherwise inaccessible, comgr will fail to create temporary files and throw an error, but the root cause is not suggested or captured anywhere.

The added logging indicates to users that they should check their TMPDIR and will show up in the comgr logs and console output with AMD_LOG_LEVEL=1 and above when AMD_COMGR_EMIT_VERBOSE_LOGS=1.