### PR TITLE
[Comgr] Guard operand access in bumpNextWaitDscnt

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -295,6 +295,8 @@ static bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
     // s_wait_dscnt has a single immediate operand (the wait count) at
     // index 0. Increment it directly.
     MCInst NewInst = DI.Inst;
+    if (NewInst.getNumOperands() == 0)
+      return false;
     MCOperand &Op = NewInst.getOperand(0);
     if (!Op.isImm())
       return false;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -294,9 +294,9 @@ static bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
 
     // s_wait_dscnt has a single immediate operand (the wait count) at
     // index 0. Increment it directly.
-    MCInst NewInst = DI.Inst;
-    if (NewInst.getNumOperands() == 0)
+    if (DI.Inst.getNumOperands() == 0)
       return false;
+    MCInst NewInst = DI.Inst;
     MCOperand &Op = NewInst.getOperand(0);
     if (!Op.isImm())
       return false;


### PR DESCRIPTION
`bumpNextWaitDscnt` unconditionally reads operand 0 of an `s_wait_dscnt` `MCInst`. If the decoded instruction has zero operands the read returns uninitialized `SmallVector` inline storage, which gcc `-O` flags as `-Wmaybe-uninitialized`. Add an explicit `getNumOperands() == 0` early return before the access.