### PR TITLE
[Comgr] Link with TransformUtils that defines llvm::CloneFunction

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -562,6 +562,7 @@ else()
     Support
     Symbolize
     TargetParser
+    TransformUtils
     ${SPIRV_STATIC_LIB}
     )
 endif()


### PR DESCRIPTION
With `BUILD_SHARED_LIBS`, compilation would fail with:

```
/usr/bin/ld:
tools/comgr/CMakeFiles/amd_comgr.dir/src/comgr-compiler.cpp.o: in function
`COMGR::AMDGPUCompiler::cloneKernelsInBitcode(COMGR::DataSet*)': /home/juamarti/llvm/_llvm/amd/comgr/src/comgr-compiler.cpp:2588: undefined reference to `llvm::CloneFunction(llvm::Function*, llvm::ValueMap<llvm::Value const*, llvm::WeakTrackingVH, llvm::ValueMapConfig<llvm::Value const*, llvm::sys::SmartMutex<false> >
>&, llvm::ClonedCodeInfo*)'
```

