### PR TITLE
[CI] Add Comgr Compiler CI workflow

### DIFF
--- a/.github/workflows/comgr-ci-linux.yml
+++ b/.github/workflows/comgr-ci-linux.yml
@@ -1,6 +1,9 @@
-# Linux variant of the Comgr CI: builds LLVM/Clang/translator/Comgr in one
-# job and runs the Comgr lit + ctest + gtest suites in a single test job
-# that consumes a GHA artifact uploaded by the build job.
+# Linux variant of the Comgr CI: builds LLVM/Clang/translator/device-libs
+# (with compiler-rt sanitizers) in one job, then a single ASAN test job
+# rebuilds Comgr with -fsanitize=address and runs the Comgr lit + ctest +
+# gtest suites via check-comgr. Non-ASAN Comgr coverage already runs in
+# TheRock's Multi-Arch CI compiler-runtime stage, so this workflow focuses
+# on ASAN.
 
 name: Comgr Compiler CI - Linux
 
@@ -9,7 +12,9 @@ on:
 
 jobs:
   # =====================================================================
-  # Build LLVM + Clang + amd-llvm-spirv + device-libs + Comgr.
+  # Build LLVM + Clang + amd-llvm-spirv + compiler-rt + device-libs.
+  # Comgr is not built here; the ASAN test job rebuilds it from scratch
+  # with -DADDRESS_SANITIZER=ON against this LLVM.
   # Strip binaries and upload the build trees as a single artifact for
   # the test job to consume.
   # =====================================================================
@@ -78,31 +83,16 @@ jobs:
       - name: Build device-libs
         run: ninja -C build-device-libs
 
-      - name: Configure Comgr
-        # LLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR points Comgr at
-        # the in-tree translator headers so COMGR_SPIRV_TRANSLATOR_AVAILABLE
-        # turns ON (otherwise translator-dependent lit tests are UNSUPPORTED).
-        run: |
-          cmake -G Ninja -S amd/comgr -B build-comgr \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/build-device-libs" \
-            -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
-            -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD/llvm/projects/SPIRV-LLVM-Translator \
-            -DBUILD_TESTING=ON
-
-      - name: Build Comgr
-        run: ninja -C build-comgr amd_comgr
-
       - name: Strip binaries
         run: |
-          find build build-comgr build-device-libs \
+          find build build-device-libs \
             -type f \( -executable -o -name '*.so*' -o -name '*.a' \) \
             -exec strip --strip-unneeded {} + 2>/dev/null || true
 
       # Tar before upload: actions/upload-artifact@v4 strips +x bits and
       # excludes hidden files (loses FetchContent .git dirs).
       - name: Tar build trees
-        run: tar -cf linux-build-tree.tar build build-comgr build-device-libs
+        run: tar -cf linux-build-tree.tar build build-device-libs
 
       - name: Upload build tree artifact
         uses: actions/upload-artifact@v4
@@ -114,67 +104,11 @@ jobs:
           if-no-files-found: error
 
   # =====================================================================
-  # Test - Comgr (lit + gtest + ctest)
-  # =====================================================================
-  test_comgr:
-    name: Test Comgr
-    needs: build
-    runs-on: azure-linux-scale-rocm
-    timeout-minutes: 30
-    container:
-      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
-
-    steps:
-      - name: Checkout llvm-project (PR head)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Checkout SPIRV-LLVM-Translator (amd-staging)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: ROCm/SPIRV-LLVM-Translator
-          ref: amd-staging
-          path: llvm/projects/SPIRV-LLVM-Translator
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Download build tree artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: comgr-linux-build-tree
-
-      # touch build.ninja so it's newer than CMakeCache.txt — without it
-      # tar -m's per-file mtimes can trigger a cmake regen + cascade rebuild.
-      - name: Untar build trees
-        run: |
-          tar -xmf linux-build-tree.tar
-          touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja
-
-      - name: Test - Comgr (check-comgr)
-        # check-comgr depends on test-lit (runs lit suite) and test-unit
-        # (runs gtest binaries via its COMMAND block), then runs ctest for
-        # the legacy C tests. Single target = all three test layers.
-        id: check_comgr
-        run: ninja -C build-comgr check-comgr
-
-      - name: Show failed Comgr ctest output
-        # check-comgr invokes ctest without --output-on-failure, so failures
-        # show "***Failed" with no stderr. Re-run any failed cases verbosely
-        # and redirect comgr's internal log buffer to stderr so clang errors
-        # from inside amd_comgr_do_action() surface (otherwise comgr just
-        # returns AMD_COMGR_STATUS_ERROR with no detail).
-        if: failure() && steps.check_comgr.conclusion == 'failure'
-        env:
-          AMD_COMGR_REDIRECT_LOGS: stderr
-        run: ctest --test-dir build-comgr --output-on-failure --rerun-failed
-
-  # =====================================================================
-  # Test - Comgr (ASAN): rebuild only Comgr with -fsanitize=address against
-  # the non-ASAN LLVM from the build artifact. ASAN interceptors hook the
-  # process-global malloc, so allocations from non-ASAN LLVM code linked
-  # into amd_comgr.so still route through ASAN's allocator and get tracked.
+  # Test - Comgr (ASAN): build Comgr with -fsanitize=address against the
+  # non-ASAN LLVM from the build artifact, then run check-comgr (lit +
+  # ctest + gtest). ASAN interceptors hook the process-global malloc, so
+  # allocations from non-ASAN LLVM code linked into amd_comgr.so still
+  # route through ASAN's allocator and get tracked.
   # detect_leaks=0 because LLVM has known long-lived allocations that look
   # like leaks at process exit.
   # =====================================================================
@@ -208,11 +142,11 @@ jobs:
           name: comgr-linux-build-tree
 
       - name: Untar build trees
+        # touch build.ninja so it's newer than CMakeCache.txt — without it
+        # tar -m's per-file mtimes can trigger a cmake regen + cascade rebuild.
         run: |
           tar -xmf linux-build-tree.tar
           touch build/build.ninja build-device-libs/build.ninja
-          # Drop the non-ASAN Comgr build; we'll rebuild into build-comgr-asan/.
-          rm -rf build-comgr
 
       - name: Configure Comgr (ASAN)
         # Use the just-built clang as compiler so -fsanitize=address links

--- a/.github/workflows/comgr-ci-linux.yml
+++ b/.github/workflows/comgr-ci-linux.yml
@@ -1,0 +1,234 @@
+# Linux variant of the Comgr CI: builds LLVM/Clang/translator/Comgr in one
+# job and runs the Comgr lit + ctest + gtest suites in a single test job
+# that consumes a GHA artifact uploaded by the build job.
+
+name: Comgr Compiler CI - Linux
+
+on:
+  workflow_call:
+
+jobs:
+  # =====================================================================
+  # Build LLVM + Clang + amd-llvm-spirv + device-libs + Comgr.
+  # Strip binaries and upload the build trees as a single artifact for
+  # the test job to consume.
+  # =====================================================================
+  build:
+    name: Build
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 120
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
+
+    steps:
+      # llvm-project at PR head (default checkout). The SPIRV translator
+      # is dropped in at amd-staging tip under llvm/projects/ — Comgr's
+      # SOURCE_TO_SPIRV action invokes the llvm-spirv binary at runtime.
+      - name: Checkout llvm-project (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout SPIRV-LLVM-Translator (amd-staging)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/SPIRV-LLVM-Translator
+          ref: amd-staging
+          path: llvm/projects/SPIRV-LLVM-Translator
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Configure LLVM
+        run: |
+          cmake -G Ninja -S llvm -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_ENABLE_PROJECTS="clang;lld" \
+            -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
+            -DLLVM_INCLUDE_TESTS=ON \
+            -DLLVM_INSTALL_GTEST=ON \
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar"
+
+      - name: Build LLVM + Clang + amd-llvm-spirv + test deps
+        # *-test-depends pulls in FileCheck, llvm-dis, etc. used by Comgr's
+        # lit suite (test-lit's only declared dep is amd_comgr; tool deps
+        # are implicit at lit-cfg substitution time).
+        run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv
+
+      - name: Configure device-libs
+        run: |
+          cmake -G Ninja -S amd/device-libs -B build-device-libs \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH=$PWD/build \
+            -DLLVM_DIR=$PWD/build/lib/cmake/llvm
+
+      - name: Build device-libs
+        run: ninja -C build-device-libs
+
+      - name: Configure Comgr
+        # LLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR points Comgr at
+        # the in-tree translator headers so COMGR_SPIRV_TRANSLATOR_AVAILABLE
+        # turns ON (otherwise translator-dependent lit tests are UNSUPPORTED).
+        run: |
+          cmake -G Ninja -S amd/comgr -B build-comgr \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/build-device-libs" \
+            -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
+            -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD/llvm/projects/SPIRV-LLVM-Translator \
+            -DBUILD_TESTING=ON
+
+      - name: Build Comgr
+        run: ninja -C build-comgr amd_comgr
+
+      - name: Strip binaries
+        run: |
+          find build build-comgr build-device-libs \
+            -type f \( -executable -o -name '*.so*' -o -name '*.a' \) \
+            -exec strip --strip-unneeded {} + 2>/dev/null || true
+
+      # Tar before upload: actions/upload-artifact@v4 strips +x bits and
+      # excludes hidden files (loses FetchContent .git dirs).
+      - name: Tar build trees
+        run: tar -cf linux-build-tree.tar build build-comgr build-device-libs
+
+      - name: Upload build tree artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: comgr-linux-build-tree
+          path: linux-build-tree.tar
+          retention-days: 1
+          compression-level: 6
+          if-no-files-found: error
+
+  # =====================================================================
+  # Test - Comgr (lit + gtest + ctest)
+  # =====================================================================
+  test_comgr:
+    name: Test Comgr
+    needs: build
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 30
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
+
+    steps:
+      - name: Checkout llvm-project (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout SPIRV-LLVM-Translator (amd-staging)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/SPIRV-LLVM-Translator
+          ref: amd-staging
+          path: llvm/projects/SPIRV-LLVM-Translator
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download build tree artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: comgr-linux-build-tree
+
+      # touch build.ninja so it's newer than CMakeCache.txt — without it
+      # tar -m's per-file mtimes can trigger a cmake regen + cascade rebuild.
+      - name: Untar build trees
+        run: |
+          tar -xmf linux-build-tree.tar
+          touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja
+
+      - name: Test - Comgr (check-comgr)
+        # check-comgr depends on test-lit (runs lit suite) and test-unit
+        # (runs gtest binaries via its COMMAND block), then runs ctest for
+        # the legacy C tests. Single target = all three test layers.
+        id: check_comgr
+        run: ninja -C build-comgr check-comgr
+
+      - name: Show failed Comgr ctest output
+        # check-comgr invokes ctest without --output-on-failure, so failures
+        # show "***Failed" with no stderr. Re-run any failed cases verbosely
+        # and redirect comgr's internal log buffer to stderr so clang errors
+        # from inside amd_comgr_do_action() surface (otherwise comgr just
+        # returns AMD_COMGR_STATUS_ERROR with no detail).
+        if: failure() && steps.check_comgr.conclusion == 'failure'
+        env:
+          AMD_COMGR_REDIRECT_LOGS: stderr
+        run: ctest --test-dir build-comgr --output-on-failure --rerun-failed
+
+  # =====================================================================
+  # Test - Comgr (ASAN): rebuild only Comgr with -fsanitize=address against
+  # the non-ASAN LLVM from the build artifact. ASAN interceptors hook the
+  # process-global malloc, so allocations from non-ASAN LLVM code linked
+  # into amd_comgr.so still route through ASAN's allocator and get tracked.
+  # detect_leaks=0 because LLVM has known long-lived allocations that look
+  # like leaks at process exit.
+  # =====================================================================
+  test_comgr_asan:
+    name: Test Comgr (ASAN)
+    needs: build
+    runs-on: azure-linux-scale-rocm
+    timeout-minutes: 45
+    container:
+      image: ghcr.io/rocm/therock_build_manylinux_x86_64@sha256:702a5133851e6d1daf1207d2c9fbb01c2667914a5b6dc5a01faeb3ce66ea6421
+
+    steps:
+      - name: Checkout llvm-project (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout SPIRV-LLVM-Translator (amd-staging)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/SPIRV-LLVM-Translator
+          ref: amd-staging
+          path: llvm/projects/SPIRV-LLVM-Translator
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download build tree artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: comgr-linux-build-tree
+
+      - name: Untar build trees
+        run: |
+          tar -xmf linux-build-tree.tar
+          touch build/build.ninja build-device-libs/build.ninja
+          # Drop the non-ASAN Comgr build; we'll rebuild into build-comgr-asan/.
+          rm -rf build-comgr
+
+      - name: Configure Comgr (ASAN)
+        # ADDRESS_SANITIZER=ON is Comgr's first-class ASAN option (see
+        # amd/comgr/CMakeLists.txt). It sets -fsanitize=address +
+        # -fno-omit-frame-pointer on C/CXX, links libsan, and handles
+        # the shared-library-with-asan special case Comgr's build needs.
+        run: |
+          cmake -G Ninja -S amd/comgr -B build-comgr-asan \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/build-device-libs" \
+            -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
+            -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD/llvm/projects/SPIRV-LLVM-Translator \
+            -DBUILD_TESTING=ON \
+            -DADDRESS_SANITIZER=ON
+
+      - name: Build Comgr (ASAN)
+        run: ninja -C build-comgr-asan amd_comgr
+
+      - name: Test - Comgr ASAN (check-comgr)
+        id: check_comgr_asan
+        env:
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:print_stacktrace=1
+          AMD_COMGR_REDIRECT_LOGS: stderr
+        run: ninja -C build-comgr-asan check-comgr
+
+      - name: Show failed Comgr ASAN ctest output
+        if: failure() && steps.check_comgr_asan.conclusion == 'failure'
+        env:
+          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:print_stacktrace=1
+          AMD_COMGR_REDIRECT_LOGS: stderr
+        run: ctest --test-dir build-comgr-asan --output-on-failure --rerun-failed

--- a/.github/workflows/comgr-ci-linux.yml
+++ b/.github/workflows/comgr-ci-linux.yml
@@ -39,22 +39,34 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      # compiler-rt is enabled via LLVM_ENABLE_RUNTIMES so the just-built
+      # clang has its own libclang_rt.asan available. The Test Comgr (ASAN)
+      # job uses clang (not gcc) to compile Comgr so -fsanitize=address
+      # resolves to LLVM's runtime, not the distro's libasan. BUILTINS off
+      # to keep build time down — sanitizers don't need them on x86_64.
       - name: Configure LLVM
         run: |
           cmake -G Ninja -S llvm -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
+            -DLLVM_ENABLE_RUNTIMES="compiler-rt" \
+            -DCOMPILER_RT_BUILD_BUILTINS=OFF \
+            -DCOMPILER_RT_BUILD_LIBFUZZER=OFF \
+            -DCOMPILER_RT_BUILD_PROFILE=OFF \
+            -DCOMPILER_RT_BUILD_MEMPROF=OFF \
+            -DCOMPILER_RT_BUILD_XRAY=OFF \
+            -DCOMPILER_RT_BUILD_ORC=OFF \
             -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_INSTALL_GTEST=ON \
             -DLLVM_LIT_ARGS="-sv --no-progress-bar"
 
-      - name: Build LLVM + Clang + amd-llvm-spirv + test deps
+      - name: Build LLVM + Clang + amd-llvm-spirv + compiler-rt + test deps
         # *-test-depends pulls in FileCheck, llvm-dis, etc. used by Comgr's
-        # lit suite (test-lit's only declared dep is amd_comgr; tool deps
-        # are implicit at lit-cfg substitution time).
-        run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv
+        # lit suite. `runtimes` builds compiler-rt's sanitizer libs (used
+        # by the Test Comgr (ASAN) job).
+        run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv runtimes
 
       - name: Configure device-libs
         run: |
@@ -203,13 +215,17 @@ jobs:
           rm -rf build-comgr
 
       - name: Configure Comgr (ASAN)
-        # ADDRESS_SANITIZER=ON is Comgr's first-class ASAN option (see
-        # amd/comgr/CMakeLists.txt). It sets -fsanitize=address +
-        # -fno-omit-frame-pointer on C/CXX, links libsan, and handles
-        # the shared-library-with-asan special case Comgr's build needs.
+        # Use the just-built clang as compiler so -fsanitize=address links
+        # LLVM-shipped libclang_rt.asan (built via LLVM_ENABLE_RUNTIMES in
+        # the Build job) instead of the distro's libasan. ADDRESS_SANITIZER=ON
+        # is Comgr's first-class ASAN option (see amd/comgr/CMakeLists.txt):
+        # sets -fsanitize=address + -fno-omit-frame-pointer on C/CXX, links
+        # libsan, and handles the shared-library-with-asan special case.
         run: |
           cmake -G Ninja -S amd/comgr -B build-comgr-asan \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=$PWD/build/bin/clang \
+            -DCMAKE_CXX_COMPILER=$PWD/build/bin/clang++ \
             -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/build-device-libs" \
             -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
             -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD/llvm/projects/SPIRV-LLVM-Translator \

--- a/.github/workflows/comgr-ci-linux.yml
+++ b/.github/workflows/comgr-ci-linux.yml
@@ -221,11 +221,20 @@ jobs:
         # is Comgr's first-class ASAN option (see amd/comgr/CMakeLists.txt):
         # sets -fsanitize=address + -fno-omit-frame-pointer on C/CXX, links
         # libsan, and handles the shared-library-with-asan special case.
+        #
+        # CMAKE_BUILD_RPATH bakes the compiler-rt runtime dir into every
+        # built binary so libclang_rt.asan-x86_64.so resolves at process
+        # start. Comgr is a shared library, so Comgr's CMakeLists picks
+        # -shared-libsan (avoids ODR violation when multiple consumers load
+        # amd_comgr.so) — but that means the .so is needed at runtime.
         run: |
+          ASAN_RPATH=$($PWD/build/bin/clang -print-runtime-dir)
+          echo "ASAN runtime dir: $ASAN_RPATH"
           cmake -G Ninja -S amd/comgr -B build-comgr-asan \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=$PWD/build/bin/clang \
             -DCMAKE_CXX_COMPILER=$PWD/build/bin/clang++ \
+            -DCMAKE_BUILD_RPATH="$ASAN_RPATH" \
             -DCMAKE_PREFIX_PATH="$PWD/build;$PWD/build-device-libs" \
             -DLLVM_DIR=$PWD/build/lib/cmake/llvm \
             -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD/llvm/projects/SPIRV-LLVM-Translator \

--- a/.github/workflows/comgr-ci-windows.yml
+++ b/.github/workflows/comgr-ci-windows.yml
@@ -1,0 +1,201 @@
+# Windows variant of the Comgr CI: builds LLVM/Clang/translator/Comgr in
+# one job and runs the Comgr lit + ctest + gtest suites in a single test
+# job that consumes a GHA artifact uploaded by the build job. Mirrors
+# comgr-ci-linux.yml in shape; differs in runner, MSVC env setup, no
+# container, no strip.
+
+name: Comgr Compiler CI - Windows
+
+on:
+  workflow_call:
+
+jobs:
+  # =====================================================================
+  # Build LLVM + Clang + amd-llvm-spirv + device-libs + Comgr.
+  # =====================================================================
+  build:
+    name: Build
+    runs-on: azure-windows-scale-rocm
+    timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      # Long path support for the deep llvm-project tree under runner workspace.
+      - name: Enable git long paths
+        run: git config --global core.longpaths true
+
+      # Pinned ninja 1.12.1 — TheRock pins this version because 1.13.0 has a bug.
+      - name: Install ninja
+        run: choco install -y ninja --version 1.12.1
+
+      # MSVC environment so cmake -GNinja can find cl.exe + link.exe.
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      # zstd dev libs for clang-offload-bundler compression support. Two
+      # vcpkg installs exist on this runner: C:\vcpkg (classic mode, what
+      # `vcpkg` in PATH resolves to) and the MSVC-bundled one at $VCPKG_ROOT
+      # (manifest-mode only — no `vcpkg install <pkg>` support). We use
+      # C:\vcpkg for both install and toolchain lookup so they match.
+      - name: Install zstd via vcpkg
+        run: vcpkg install zstd:x64-windows
+
+      - name: Checkout llvm-project (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout SPIRV-LLVM-Translator (amd-staging)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/SPIRV-LLVM-Translator
+          ref: amd-staging
+          path: llvm/projects/SPIRV-LLVM-Translator
+          fetch-depth: 1
+          persist-credentials: false
+
+      # CMAKE_TOOLCHAIN_FILE points cmake at the C:\vcpkg find_package
+      # shims so LLVM_ENABLE_ZSTD=FORCE_ON locates the vcpkg-installed
+      # zstd. FORCE_ON makes the configure fail loudly if zstd is missing
+      # rather than silently building clang-offload-bundler without
+      # compression.
+      - name: Configure LLVM
+        run: |
+          cmake -G Ninja -S llvm -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DLLVM_ENABLE_ASSERTIONS=ON \
+            -DLLVM_ENABLE_PROJECTS="clang;lld" \
+            -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
+            -DLLVM_ENABLE_ZSTD=FORCE_ON \
+            -DLLVM_INCLUDE_TESTS=ON \
+            -DLLVM_INSTALL_GTEST=ON \
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar"
+
+      - name: Build LLVM + Clang + amd-llvm-spirv + test deps
+        # *-test-depends pulls in FileCheck, llvm-dis, etc. used by Comgr's
+        # lit suite (test-lit's only declared dep is amd_comgr; tool deps
+        # are implicit at lit-cfg substitution time).
+        run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv
+
+      # Use $(pwd -W) for cmake -D paths: in MSYS bash $PWD is Unix-style
+      # (/c/...) which cmake's find_package can't traverse on Windows.
+      # pwd -W returns Windows-style with forward slashes (C:/...).
+      # Pass CMAKE_TOOLCHAIN_FILE here too: LLVM exports LLVMSupport
+      # linking against zstd::libzstd_shared, and consumers like
+      # find_package(LLVM) in device-libs/Comgr need the vcpkg toolchain
+      # loaded so that imported zstd target is defined.
+      - name: Configure device-libs
+        run: |
+          PWD_WIN=$(pwd -W)
+          cmake -G Ninja -S amd/device-libs -B build-device-libs \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DCMAKE_PREFIX_PATH=$PWD_WIN/build \
+            -DLLVM_DIR=$PWD_WIN/build/lib/cmake/llvm
+
+      - name: Build device-libs
+        run: ninja -C build-device-libs
+
+      - name: Configure Comgr
+        run: |
+          PWD_WIN=$(pwd -W)
+          cmake -G Ninja -S amd/comgr -B build-comgr \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DCMAKE_PREFIX_PATH="$PWD_WIN/build;$PWD_WIN/build-device-libs" \
+            -DLLVM_DIR=$PWD_WIN/build/lib/cmake/llvm \
+            -DAMDDeviceLibs_DIR=$PWD_WIN/build-device-libs/lib/cmake/AMDDeviceLibs \
+            -DLLVM_EXTERNAL_SPIRV_LLVM_TRANSLATOR_SOURCE_DIR=$PWD_WIN/llvm/projects/SPIRV-LLVM-Translator \
+            -DBUILD_TESTING=ON
+
+      - name: Build Comgr
+        run: ninja -C build-comgr amd_comgr
+
+      # No strip on Windows: PE/COFF debug info lives in separate .pdb files
+      # rather than embedded in the .exe/.dll, so the binaries themselves are
+      # already stripped. Tar directly.
+      - name: Tar build trees
+        run: tar -cf windows-build-tree.tar build build-comgr build-device-libs
+
+      - name: Upload build tree artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: comgr-windows-build-tree
+          path: windows-build-tree.tar
+          retention-days: 1
+          compression-level: 6
+          if-no-files-found: error
+
+  # =====================================================================
+  # Test - Comgr (lit + gtest + ctest)
+  # =====================================================================
+  test_comgr:
+    name: Test Comgr
+    needs: build
+    runs-on: azure-windows-scale-rocm
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Enable git long paths
+        run: git config --global core.longpaths true
+
+      - name: Install ninja
+        run: choco install -y ninja --version 1.12.1
+
+      - name: Configure MSVC
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+      # zstd must be present at the same C:\vcpkg path the build job used,
+      # because build.ninja embeds C:/vcpkg/installed/.../zstd.lib as a
+      # build-edge input that ninja validates at planning time.
+      - name: Install zstd via vcpkg
+        run: vcpkg install zstd:x64-windows
+
+      - name: Checkout llvm-project (PR head)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout SPIRV-LLVM-Translator (amd-staging)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ROCm/SPIRV-LLVM-Translator
+          ref: amd-staging
+          path: llvm/projects/SPIRV-LLVM-Translator
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Download build tree artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: comgr-windows-build-tree
+
+      - name: Untar build trees
+        run: |
+          tar -xmf windows-build-tree.tar
+          touch build/build.ninja build-comgr/build.ninja build-device-libs/build.ninja
+
+      - name: Test - Comgr (check-comgr)
+        id: check_comgr
+        env:
+          AMD_COMGR_REDIRECT_LOGS: stderr
+        run: ninja -C build-comgr check-comgr
+
+      - name: Show failed Comgr ctest output
+        # check-comgr invokes ctest without --output-on-failure, so failures
+        # show "***Failed" with no stderr. Re-run any failed cases verbosely
+        # and redirect comgr's internal log buffer to stderr so clang errors
+        # from inside amd_comgr_do_action() surface (otherwise comgr just
+        # returns AMD_COMGR_STATUS_ERROR with no detail).
+        if: failure() && steps.check_comgr.conclusion == 'failure'
+        env:
+          AMD_COMGR_REDIRECT_LOGS: stderr
+        run: ctest --test-dir build-comgr --output-on-failure --rerun-failed

--- a/.github/workflows/comgr-ci.yml
+++ b/.github/workflows/comgr-ci.yml
@@ -1,0 +1,28 @@
+# Top-level dispatcher for the Comgr-focused CI on amd-staging.
+# Dispatches to per-platform reusable workflows.
+
+name: Comgr Compiler CI
+
+on:
+  pull_request:
+    branches: [amd-staging]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  linux_release:
+    name: Linux::release
+    uses: ./.github/workflows/comgr-ci-linux.yml
+    secrets: inherit
+
+  windows_release:
+    name: Windows::release
+    uses: ./.github/workflows/comgr-ci-windows.yml
+    secrets: inherit


### PR DESCRIPTION
Adds a Comgr-focused PR CI for `amd-staging`, mirroring the SPIRV CI shape (workflow_call dispatcher + per-platform variants) but trimmed to just the Comgr scope.

## Files

- `.github/workflows/comgr-ci.yml` — top-level dispatcher
- `.github/workflows/comgr-ci-linux.yml` — Linux variant + ASAN job
- `.github/workflows/comgr-ci-windows.yml` — Windows variant

## Jobs (all gating, not added to required-check rules)

- `Linux::release / Build` — LLVM/Clang/translator/device-libs/Comgr
- `Linux::release / Test Comgr` — `ninja check-comgr` (lit + ctest + gtest)
- `Linux::release / Test Comgr (ASAN)` — rebuilds Comgr with `-DADDRESS_SANITIZER=ON` against the non-ASAN LLVM from the artifact, then runs the full Comgr test set under ASAN
- `Windows::release / Build` + `Test Comgr`

## Known caveats

- **Windows lane will be red until #2491 lands** (HotswapMCTests link failure on Windows, #2479).
- **3 `spirv-tests/` failures on Windows** (#2487, Comgr SOURCE_TO_SPIRV opaque error) will keep Windows red beyond #2491. Accepted for now.