### PR TITLE
[Comgr] Reject colon character in data object names

### DIFF
--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -646,6 +646,11 @@ amd_comgr_status_t AMD_COMGR_API
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
 
+  // Drive letters like "C:\" break getFilePath()'s temp-dir join.
+  if (Name && StringRef(Name).contains(':')) {
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
   return DataP->setName(Name);
 }
 

--- a/amd/comgr/test-lit/comgr-sources/data-action.c
+++ b/amd/comgr/test-lit/comgr-sources/data-action.c
@@ -124,6 +124,17 @@ int main(int argc, char *argv[]) {
   amd_comgr_(action_info_set_vfs(DataAction, true));
   amd_comgr_(action_info_set_vfs(DataAction, false));
 
+  // ---- create_data, set_data_name
+  // Relative-path names are allowed; ':' (drive letters like "C:\") is not.
+  amd_comgr_data_t Data;
+  amd_comgr_(create_data(AMD_COMGR_DATA_KIND_SOURCE, &Data));
+  amd_comgr_(set_data_name(Data, "source.hip"));
+  amd_comgr_(set_data_name(Data, "sub/source.hip"));
+  amd_comgr_(set_data_name(Data, NULL));
+  fail_amd_comgr_(set_data_name(Data, "C:/path/source.hip"));
+  fail_amd_comgr_(set_data_name(Data, "source.hip:stream"));
+  amd_comgr_(release_data(Data));
+
   amd_comgr_(destroy_action_info(DataAction));
   return 0;
 }

--- a/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
+++ b/amd/comgr/test-lit/comgr-sources/source-to-spirv.c
@@ -38,7 +38,7 @@ int main(int argc, const char *argv[]) {
 
   amd_comgr_(create_data(AMD_COMGR_DATA_KIND_SOURCE, &DataSource));
   amd_comgr_(set_data(DataSource, SizeSource, BufSource));
-  amd_comgr_(set_data_name(DataSource, InputPath));
+  amd_comgr_(set_data_name(DataSource, "source.hip"));
 
   amd_comgr_(create_data_set(&DataSetSource));
   amd_comgr_(data_set_add(DataSetSource, DataSource));


### PR DESCRIPTION
On Windows, passing a path with a drive letter to
amd_comgr_set_data_name causes Comgr to append the name onto its temp directory without inserting a separator, producing a malformed path of the form
"<tempdir>C:\path\file". The resulting directory creation fails, and every spirv-tests case fails on that platform with no useful diagnostic.

Reject ':' in data object names. Relative-path names (e.g. "sub/foo.h" used for include data objects) remain valid; only drive-letter components are rejected.

Also update source-to-spirv.c to pass a basename instead of a full path.


