### PR TITLE
[Comgr][hotswap] Add wave projection + ISA profile + abi/wave-mask docs

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(hotswap-transpiler OBJECT
   canonical-op.cpp
   opcode-map.cpp
   decode.cpp
+  wave-projection.cpp
 )
 
 if(NOT TARGET hotswap::transpiler)

--- a/amd/comgr/src/hotswap/docs/abi-translation.md
+++ b/amd/comgr/src/hotswap/docs/abi-translation.md
@@ -1,0 +1,475 @@
+# ABI Translation -- Kernel Descriptor, Kernarg, Buffer Descriptors
+
+> **Status:** design proposal, not yet implemented. Current raiser
+> re-materialises the kernarg layout (`KernargLayout` in
+> `kernarg-layout.hpp`) and emits a fresh kernel descriptor via the
+> target backend (see `raiser.cpp` §Phase 2), which covers the 80%
+> path for simple Triton kernels. This doc specifies the remaining
+> 20% -- the hidden-arg surface, embedded descriptors, and the gates
+> that make ABI mismatches fail loudly instead of silently
+> miscompiling.
+>
+> **Scope:** gfx1250 -> gfx950 (source -> target). The same framework
+> extends to gfx942, gfx90a, gfx1100 with one ISA-feature row per
+> target; nothing in this axis is gfx950-specific at the principle
+> level.
+
+---
+
+## 1. Problem in one paragraph
+
+The translator's output is an LLVM IR module that the stock AMDGPU
+backend compiles and hands to the HSA runtime as a fresh code object.
+That code object has its own kernel descriptor (KD), its own kernarg
+layout, and its own user-SGPR preloaded values -- all re-synthesised by
+the target backend from IR-level attributes. What it must agree with
+is **the host runtime's call site**: the kernarg buffer the dispatch
+packet points at, the grid and workgroup dimensions the user code
+supplied, and the set of implicit arguments the HSA runtime injects.
+The host is still asking for the gfx1250 kernel. The target KD has to
+make the gfx950 binary answer the same question. Any field the source
+kernel *reads* that the target KD cannot *populate identically* is an
+ABI hole, and today we have no gate for it -- the kernel runs and
+silently reads garbage.
+
+## 2. What "translation" actually means on this axis
+
+There are three distinct surfaces, each handled differently:
+
+| Surface | Source state | Target synthesis | Translation mode |
+|---|---|---|---|
+| Kernel descriptor (64-byte AMDHSA KD) | Parsed from `.note` / `.rodata` during load | Re-emitted by target backend from IR attrs | **Attribute-preserving lower-to-IR** |
+| Kernarg segment | Host-side layout, shared by both ISAs | Same -- unchanged | **Layout-preserving** (but hidden-arg slots shift) |
+| Embedded descriptors (V#, T#) | Rare; constructed at runtime from kernargs | Same -- runtime-constructed | **Pass-through** (principle); refuse on embedded constant V# |
+
+The first two are where the real work lives. §4 and §5 cover them.
+The third is included for completeness: it is a gate, not a rewrite.
+
+## 3. Source model -- gfx1250 (gfx12) AMDHSA KD and kernarg
+
+### 3.1 Kernel descriptor fields the raiser cares about
+
+Of the ~20 bitfields in the gfx1250 KD, only these five affect
+correctness of the raised IR (the rest are scheduling/occupancy hints
+the target backend re-derives):
+
+- `enable_wavefront_size32` -- always set on gfx1250. Tells the raiser
+  the source was compiled as wave32.
+- `group_segment_fixed_size` -- LDS bytes. Must be ≤ gfx950 limit
+  (163,840 B) for the kernel to fit at all.
+- `private_segment_fixed_size` -- scratch bytes per lane. Implicitly
+  doubles on wave64 since twice as many lanes are live; the target
+  backend derives this automatically *if* we propagate the original
+  per-lane value as an attribute.
+- `kernarg_size` -- total kernarg bytes. Passed as
+  `meta.kernargSegmentSize` and must be preserved bit-exactly (the
+  host runtime's dispatch packet carries this size).
+- `enable_sgpr_kernarg_segment_ptr` / the user-SGPR preload bits --
+  determine which user SGPRs carry which implicit pointers (kernarg
+  base, dispatch packet, queue ptr, …). gfx12 and gfx9 have different
+  user-SGPR layouts. See §3.3.
+
+Everything else (VGPR/SGPR granulated counts, register usage modes,
+occupancy hints, round-mode bits) is a target-backend output, not a
+translation input.
+
+### 3.2 Kernarg layout
+
+The kernarg segment is a flat byte buffer. The host-side layout is
+the same across ISAs, modulo alignment. The hitch is that the kernel
+reads it via `s_load_*` with small displacements that the raiser has
+to resolve back to IR-level arguments -- `KernargLayout::resolveLoad`
+in `kernarg-layout.hpp:21`. That resolution is already ISA-agnostic.
+
+### 3.3 Hidden arguments
+
+gfx12 Triton kernels commonly consume these hidden args (names from
+the AMDHSA metadata):
+
+- `hidden_block_count_{x,y,z}`
+- `hidden_group_size_{x,y,z}`
+- `hidden_remainder_{x,y,z}`
+- `hidden_grid_dims`
+- `hidden_private_base`, `hidden_shared_base`
+- `hidden_global_offset_{x,y,z}` (legacy, rarely used)
+- `hidden_default_queue`, `hidden_completion_action`,
+  `hidden_multigrid_sync_arg`, `hidden_hostcall_buffer`,
+  `hidden_heap_v1`
+
+The current raiser skips every `hidden_*` arg when building the
+function signature (`raiser.cpp:201-205`). That is correct for
+kernels that never load from them. The moment a kernel reads any
+hidden slot, we silently return zero -- because the allocated kernarg
+bytes are still there, but the IR has no formal parameter covering
+them. This is the first principled gate we need (§7).
+
+### 3.4 User-SGPR preload layout
+
+gfx12 preloads user SGPRs starting at a different base than gfx9 and
+with a different enable-bit encoding. `raiser.cpp:279-292` already
+handles this:
+
+```263:292:amd/comgr/hotswap/raiser.cpp
+  regs.storeSGPR32(B, 2, B.CreateCall(fnWorkgroupIdX, {}, "wg_id_x"));
+  // ...
+  if (AMDGPU::isGFX12Plus(*mc.subtargetInfo)) {
+    B.CreateStore(B.CreateCall(fnWorkgroupIdX, {}, "ttmp9_wg_id"), regs.ttmp[9]);
+    // wave_id = workitem_id_x / wavefront_size (32 for gfx12)
+    Value *tidForTtmp = B.CreateCall(fnWorkitemIdX, {}, "ttmp8_tid");
+    Value *waveId = B.CreateLShr(tidForTtmp, B.getInt32(5), "wave_id_in_wg");
+    Value *ttmp8Val = B.CreateShl(waveId, B.getInt32(25), "ttmp8_val");
+    B.CreateStore(ttmp8Val, regs.ttmp[8]);
+  }
+```
+
+The gfx12-vs-gfx9 user-SGPR divergence is thus already absorbed at the
+*read* side. The *target KD* side (telling gfx950's KD which user SGPR
+carries workgroup_id_x) is the backend's job once the IR calls the
+right intrinsic. This already works.
+
+## 4. Target model -- gfx950 AMDHSA KD re-emission
+
+### 4.0 Target-capability dispatch (KD and kernarg-slot level)
+
+The ABI axis participates in the same project-wide
+"emit native when the target supports it, decompose / synthesise only
+when it does not" principle as matrix (§5.0), async / tensor-copy, and sync
+(§5.0). It is subtler here because "native emit" for ABI means "the
+target backend re-synthesises the KD from IR attributes" rather than
+"the handler emits a specific LLVM intrinsic". What varies by target
+are the user-SGPR layout, the hidden-arg block contents, and the
+`enable_wavefront_size*` bit -- each of which has a capability branch.
+
+#### 4.0.1 Capability bits
+
+Extend `ISAProfile` with:
+
+| New / existing bit | Backing feature | Governs |
+|---|---|---|
+| `waveSize` (existing) | `FeatureWavefrontSize32` | `enable_wavefront_size32` synthesis |
+| `hasGFX12UserSGPRLayout` | `AMDGPU::isGFX12Plus(STI)` (existing helper) | ttmp preload init (`raiser.cpp:284-292`) |
+| `hasFlatScratchArchitected` | `FeatureArchitectedFlatScratch` | interprets `hidden_private_base` |
+| `hasFlatLDSArchitected` | `FeatureArchitectedSGPRs` + flat-LDS bit | interprets `hidden_shared_base` |
+| `maxGroupSegmentSize` (existing profile field) | per-ISA constant | G1 LDS-budget gate |
+
+These are not "emit vs. decompose" in the matrix sense -- they select
+between **attribute values** the backend consumes, not between
+handler paths. Same mechanism, different granularity.
+
+#### 4.0.2 Dispatch pattern
+
+The source-side read of user SGPRs already dispatches on one of these
+bits -- `raiser.cpp:284-292`:
+
+```cpp
+if (AMDGPU::isGFX12Plus(*mc.subtargetInfo)) {
+  // gfx12 ttmp preload layout
+} else {
+  // gfx9/10/11 layout
+}
+```
+
+Promote the feature query to the `ISAProfile` field above so the same
+pattern generalises to every axis without re-reading the subtarget
+info:
+
+```cpp
+if (ctx.sourceIsa.hasGFX12UserSGPRLayout) {
+  initGFX12TtmpPreload(ctx);
+} else {
+  initLegacyTtmpPreload(ctx);
+}
+```
+
+Hidden-arg resolution (§5) then layers on the second branch: for each
+slot, look up the `(sourceIsa, targetIsa)` cell in the compatibility
+table to decide identity/derivable/host-inject/refuse.
+
+#### 4.0.3 Consequences for same-family retarget
+
+gfx1251 -> gfx1250 is an identity on every capability bit in §4.0.1.
+The KD re-emission is bit-identical to the source (modulo backend-
+rederived fields like register counts), every hidden arg maps
+"identity", and no gate fires. This is why the same-family path
+collapses to "raise to IR, lower to target" with no ABI-specific
+work -- the capability branches above all take the identity path.
+
+### 4.1 What the backend gives us for free
+
+Emitting IR with `CallingConv::AMDGPU_KERNEL`, plus:
+
+- Formal parameters typed by the raised kernarg layout
+- Intrinsic calls for `workgroup_id_*`, `workitem_id_*`, dispatch
+  packet pointer, queue pointer, etc.
+- `"amdgpu-flat-work-group-size"` attribute pinned to the source's
+  declared size (`raiser.cpp:231-232`)
+
+…is sufficient for the gfx950 backend to synthesise a valid KD whose
+user-SGPR layout, VGPR/SGPR granulated counts, LDS size, and wave64
+enable bits are all self-consistent.
+
+### 4.2 What the backend cannot infer
+
+Two inputs only the raiser has access to:
+
+1. **Original per-lane scratch size.** The backend allocates scratch
+   from observed spills in the lowered target function. If the source
+   kernel declared scratch the backend doesn't re-derive (e.g.,
+   dynamic stack-like scratch allocated via `hidden_private_base`),
+   we must propagate `meta.privateSegmentFixedSize` as an attribute.
+2. **LDS size commitment.** The source declared a fixed LDS size; the
+   target emission must at least match it (and can be larger). The
+   `"amdgpu-lds-size"` / `addr-space-cast` approach ties this up at
+   IR level -- TODO below.
+
+### 4.2.1 Scratch/private-memory translation
+
+`scratch_*` instructions are not global-memory operations with a special
+base register. They are accesses to the source kernel's per-work-item
+private segment: the hardware swizzles the dword offset by lane and adds
+the wave's launch-time scratch base. The launch-time allocation is requested
+by the KD's `private_segment_fixed_size` plus
+`compute_pgm_rsrc2.ENABLE_PRIVATE_SEGMENT`; on gfx12 the source KD may also
+request `enable_sgpr_flat_scratch_init`, while gfx9/gfx942 target codegen for
+LLVM private memory normally emits scratch opcodes with
+`.amdhsa_enable_private_segment 1` rather than a user-SGPR flat-scratch pair.
+
+Hotswap models this at the ABI layer by creating one addrspace(5) private
+frame for the source private segment, sized from the parsed source KD. A
+translated `scratch_load/store` becomes a load/store through a GEP inside
+that frame. This deliberately lets the target AMDGPU backend lay the source
+private frame out together with any target spills and emit the target KD's
+private-segment fields. Hotswap refuses a `scratch_*` instruction when the
+source KD reports `private_segment_fixed_size == 0`, because inventing
+scratch backing would change the source launch ABI instead of translating it.
+
+### 4.3 What changes at ISA boundary
+
+| Source (gfx1250) | Target (gfx950) | Strategy |
+|---|---|---|
+| `enable_wavefront_size32=1` | Must be wave64 | Clear bit; emit via `CallingConv::AMDGPU_KERNEL` on wave64 subtarget -- backend does the right thing |
+| gfx12 user-SGPR slots for `workgroup_id_x` | gfx9 slots | Abstracted at intrinsic level; see §3.4 |
+| `private_segment_size` at 32-lane wave | At 64-lane wave | Backend re-derives; we propagate via attribute |
+| `group_segment_size` ≤ 327,680 | Limit 163,840 | **Refuse** if source > 163,840 (§7) |
+| `kernarg_size` arbitrary | Same bit-for-bit | Preserve via `KernargLayout` |
+| gfx12 hidden-arg block | gfx9 hidden-arg block | **Per-arg compatibility table** (§5) |
+
+## 5. Hidden argument compatibility table
+
+Each hidden arg is one of:
+
+- **identity** -- present on both ISAs with identical meaning; reads
+  pass through unchanged.
+- **derivable** -- not present in target kernarg, but the value is
+  computable from other available state; raiser synthesises it.
+- **host-inject** -- present on target kernarg, but at a different
+  offset; raiser re-maps the load.
+- **refuse** -- meaningful on source, no equivalent on target; the
+  kernel uses a capability we cannot provide.
+
+| Hidden arg | gfx1250 | gfx950 | Class |
+|---|---|---|---|
+| `hidden_block_count_{x,y,z}` | present | present | identity |
+| `hidden_group_size_{x,y,z}` | present | present | identity |
+| `hidden_remainder_{x,y,z}` | present | present | identity |
+| `hidden_grid_dims` | present | present | identity |
+| `hidden_global_offset_{x,y,z}` | present | present | identity |
+| `hidden_private_base` | present (gfx12 flat-scratch base) | N/A on buffer scratch | derivable -- 0 on gfx950 |
+| `hidden_shared_base` | present (gfx12 flat-LDS base) | N/A | derivable -- 0 on gfx950 |
+| `hidden_default_queue` | present | present | identity |
+| `hidden_completion_action` | present | present | identity |
+| `hidden_multigrid_sync_arg` | present | present | identity |
+| `hidden_hostcall_buffer` | present | present | identity |
+| `hidden_heap_v1` | present | present | identity |
+
+No **refuse** entries in the current table. The two **derivable**
+entries (`hidden_private_base`, `hidden_shared_base`) exist because
+gfx1250 uses architected flat scratch / flat-LDS addressing spaces
+with non-zero base addresses; on gfx950 the per-kernel scratch goes
+through a buffer descriptor (the "flat scratch" path compiles down
+to V# ops) and private_base is effectively zero.
+
+The raiser replaces reads of these slots with a constant `i64 0`. If
+the kernel *writes* to them (it shouldn't -- they're consumed from the
+kernarg-backed hidden block, not written), that is a refusal case.
+
+## 6. Embedded descriptors
+
+### 6.1 Buffer descriptors (V#) in .rodata
+
+V# format changed encoding between gfx11 and gfx12. Triton and
+Tensilelite kernels construct V#s at runtime from kernargs -- the V#
+bits are never stored as a constant in `.rodata`. We have not observed
+any embedded-constant V# in the 170-kernel corpus.
+
+**Gate:** scan `.rodata` for 128-bit-aligned values whose bits 58..63
+match a known DFMT/NFMT pattern; if found, refuse. This is a
+false-positive-prone heuristic, so the gate fires only when we *also*
+observe a `s_load_b128` reading that address in the raised IR.
+
+### 6.2 Runtime-constructed V# -- no translation required
+
+The kernel assembles a V# from base+size+stride+format bits via
+`s_mov_b32` / `s_lshl_b64` / `s_or_b32`. The target backend re-lowers
+`buffer_load_dword` on gfx950's V# format bit layout, using whatever
+the source code computed. The format-code field is the only hazard:
+
+- gfx9 DFMT/NFMT are a (4-bit, 3-bit) split in bits [53..59].
+- gfx12 folded these into a larger `OOB_SELECT` + `FORMAT` at bit [53..62].
+
+If the source code constructs a V# with a format code that is valid
+on gfx12 but meaningless on gfx9 (e.g., `FORMAT = 0x40` indicating
+structured buffer), the `buffer_load` on gfx950 will return garbage.
+
+**Gate at the VALU handler:** when the V#'s format-computing
+instructions fold to a constant, the raiser flags unrecognised codes
+and refuses. When the format is dynamic, emit a runtime assert on
+first use (optional; off by default).
+
+### 6.3 Image descriptors (T#)
+
+Not used by any captured corpus kernel. Treat as refusal until a real
+case appears. The scan in §6.1 extends naturally.
+
+## 7. Principled fail-loudly gates
+
+All gates run at raise time, before any target lowering. Each gate's
+failure yields a `RaiseFailure` with a distinct reason code so the
+loader's rejection report is actionable.
+
+### G1 -- LDS budget (startup on the target subtarget)
+
+```
+if (meta.groupSegmentFixedSize > targetIsa.maxGroupSegmentSize)
+  return RaiseFailure::ldsOverBudget(meta.groupSegmentFixedSize,
+                                     targetIsa.maxGroupSegmentSize);
+```
+
+### G2 -- Hidden-arg coverage (per-kernel at raise)
+
+For every `s_load_*` whose resolved kernarg offset lands in the
+implicit-args block (`offset ≥ kernargs.implicitArgsBase`), identify
+which named hidden arg it reads. If the arg is not in the source's
+declared `meta.args` (Triton sometimes reads past its own declared
+args), refuse. If the arg maps to a **refuse** row in §5, refuse. If
+it maps to a **derivable** row, substitute the IR constant.
+
+### G3 -- User-SGPR compatibility (startup)
+
+For each user-SGPR enable bit the source KD sets, verify the target
+ISA supports the same intrinsic (e.g., `llvm.amdgcn.dispatch.ptr`
+exists across all AMDGPU subtargets, but
+`llvm.amdgcn.implicit.buffer.ptr` is a gfx<11 artefact). Startup
+verification over a fixed mapping table.
+
+### G4 -- Embedded descriptor refusal (per-kernel)
+
+§6.1 scan; refuse on any hit.
+
+### G5 -- Kernarg alignment (per-kernel)
+
+For each argument, verify `byteOffset % byteSize == 0`. The host
+runtime pads to this anyway; a mismatch means the source metadata
+is wrong, and the kernel would have UB already on gfx1250 -- refuse
+rather than inherit the bug.
+
+## 8. Decision procedure (per kernel)
+
+```
+raise(bytes, source_isa, target_isa, meta):
+  run G1, G3 at startup (once per (source_isa, target_isa) pair)
+  for each kernel:
+    run G5 immediately
+    raise to IR, interleaving G2 at each kernarg-load resolution
+    post-raise: run G4
+    if any gate fires: return RaiseFailure
+    else: emit IR; backend synthesises target KD from attrs + IR
+```
+
+No partial accepts. No "best effort" hidden-arg reads. If the kernel
+reaches anything ambiguous, we reject it loudly.
+
+## 9. What this doc does *not* cover
+
+- **Flat-scratch -> buffer-scratch lowering.** That is a memory-ops
+  concern, folded into the existing `handleFLAT` handler (gfx9 buffer
+  scratch is the native flat-addrspace lowering on CDNA). The SemOps
+  for flat/global/scratch loads already exist (`semop.hpp:157-166`);
+  cross-ISA flat-scratch->V# rewrite happens at the handler level, not
+  at ABI level.
+- **VGPR/SGPR count inflation.** The target backend owns this. If IR
+  spills past target register budget, that is a target-backend
+  failure (compile-time error), not an ABI concern.
+- **Occupancy hints.** Intentionally not pinned (`raiser.cpp:234-241`
+  documents why). Performance, not correctness.
+
+## 10. Engineering tasks
+
+In dependency order, cheapest first.
+
+### T1 -- Add `meta.groupSegmentFixedSize` plumbing + G1
+
+One struct field, one check in `raiseToIR` before Phase 2. 30 LoC.
+
+### T2 -- Hidden-arg compatibility table + G2
+
+- `hidden_args_table.hpp` -- static constexpr array keyed on
+  (arg_name, source_isa, target_isa) producing an enum
+  `{Identity, Derivable(constant), HostInject(remap), Refuse}`.
+- Extend `KernargLayout::resolveLoad` to return a hidden-arg handle
+  when the resolved offset is in the implicit block.
+- Raiser consults the table at each resolution; emits constant or
+  `RaiseFailure::hiddenArgUnsupported`.
+
+~150 LoC + table maintenance. The table is data, not code.
+
+### T3 -- Embedded-descriptor scan (G4)
+
+Post-raise pass over the IR walking `.rodata`-backed constants;
+reject on format-code anomalies. ~80 LoC.
+
+### T4 -- Scratch/private-segment propagation
+
+Forward `meta.privateSegmentFixedSize` into `RaiseContext` and model real
+`scratch_*` instructions as addrspace(5) private-frame accesses. The target
+backend then emits the target KD's private segment request; unsupported
+subcases refuse with source KD scratch fields in the structured diagnostic.
+
+### T5 -- User-SGPR compatibility table + G3
+
+Table of (enable-bit, available-intrinsic) × (source_isa, target_isa).
+Startup check against both subtargets. ~60 LoC.
+
+## 11. Open design questions
+
+1. **Where does the source KD live post-load?** Currently the loader
+   parses `meta.*` from the ELF note block. Do we also need the raw
+   64-byte KD bytes as input to the gates, or is the parsed `meta` a
+   sufficient model? Current answer: parsed `meta` is sufficient
+   because every field in §3.1 is already surfaced there. The raw KD
+   is discarded.
+2. **Hostcall and multigrid-sync on cross-ISA translation.** Identity
+   entries in §5 assume the hostcall ABI is ISA-stable. If a future
+   runtime bumps the hostcall format between gfx1250 and gfx950, the
+   table grows a new class: `host-incompatible` (refuse). No action
+   today.
+3. **Embedded V# detection false positives.** §6.1's scan is a
+   heuristic. If it turns out to produce spurious refusals on any
+   real kernel, move the check to first-use of the constant by a V#
+   consumer (so we only flag V#s we can prove are V#s). This is a
+   straightforward refinement; today's corpus has no constants
+   matching the pattern at all, so we ship §6.1 as-is.
+4. **Multi-target from one source.** If the same gfx1250 binary will
+   be retargeted to *both* gfx942 and gfx950 in the same process, do
+   the gates need per-target caching? Today the raiser runs per
+   (source, target) pair, so the gates run fresh each time. No
+   correctness impact; a later optimisation if needed.
+
+## 12. Cross-axis relationship -- capability dispatch
+
+§4.0 is the ABI-axis instance of the project-wide "emit native when
+the target supports it, synthesise only when it does not" principle.
+See `target-capability-dispatch.md` for the shared design and the
+open implementation question (does LLVM already expose per-feature /
+per-intrinsic availability we can reuse for the hidden-arg and
+user-SGPR compatibility tables?).

--- a/amd/comgr/src/hotswap/docs/sgpr-wave-mask-translation.md
+++ b/amd/comgr/src/hotswap/docs/sgpr-wave-mask-translation.md
@@ -1,0 +1,364 @@
+# SGPR Wave-Mask Translation — V_CMP → SGPR → V_CNDMASK under Cross-Widening
+
+> **Status:** design accepted; **intra-BB shadow** implementation landing
+> now (first PR). The **widened-SGPR-storage** alternative is documented
+> in §4 for future reference; it is NOT implemented and not scheduled.
+>
+> **Scope:** wave32 source → wave64 target cross-widening (gfx1250 →
+> gfx942 / gfx950). Same-wave and narrowing directions (wave64 → wave32
+> — currently fatal-errored by `ModuloReplicationProjection::ballotI1ToWidth`)
+> are not affected by this design.
+
+---
+
+## 1. Problem in one paragraph
+
+Source-ISA `v_cmp_*_e64 sDST, a, b` writes a per-lane compare mask into
+a single source-width SGPR. On wave32 source that SGPR is physically 32
+bits. Under cross-widening to wave64 target hardware the ballot runs on
+64 target lanes and produces 64 correct per-lane compare bits — but a
+single SGPR still holds only 32 bits, so the writer truncates to 32
+bits before the store. Target lanes 32..63's compare results are
+destroyed at the write, before any consumer reads. A subsequent
+`v_cndmask_b32_e64 vDST, a, b, sN` (the canonical libdevice-math branch
+shape and the shape every Triton e64-across-BB epilogue lowers to) then
+reads a mask whose upper half is either all-zero (modulo-replication's
+`zext`) or a replication of the lower half (wave-native's `(v << 32) |
+v`), and per-lane selection on those lanes silently misbehaves. On
+`corpus_asin_fp32` the observable cost is ~44% of output elements wrong
+with `|err|` up to ~π/2. No consumer-side cleverness can recover bits
+that were never stored.
+
+## 2. Where the information is lost
+
+In `handle_valu_vcmp.cpp`'s V_CMP → SGPR branch:
+
+```cpp
+Type *sourceWidth = ctx.projection.sourceWaveMaskTy();      // i32 (wave32)
+Value *mask = ctx.projection.ballotI1ToWidth(ctx.B, cmp,
+                                              sourceWidth, "vcmp_ballot");
+ctx.writeRegExecWidth(d, mask);
+```
+
+`ballotI1ToWidth(cmp, i32)` in both `ModuloReplicationProjection` and
+`WaveNativeProjection` collapses to the same narrowing step when the
+source width is smaller than the target hardware wave:
+
+```cpp
+if (wantedBits < waveBits)
+  return B.CreateTrunc(waveMask, resultTy, name + "_trunc");  // <-- lossy
+```
+
+The comment there already acknowledges this as a residual:
+
+> "…a documented residual lossy path that the obstruction classifier
+> (`wave_size_obstruction.cpp`) still has to refuse downstream for
+> kernels that consume the narrowed mask as a per-lane wave mask."
+
+Either the classifier refuses such kernels (declined — loses corpus
+coverage), or the data is preserved somewhere the consumer can still
+reach it.
+
+## 3. Design space
+
+Three strategies were surveyed. The comparison is below; §3.1 picks one
+and §4 documents the alternative that is deliberately NOT scheduled so
+a future reader can pick it up without re-running this analysis.
+
+| strategy | correctness domain | invasiveness | composes with future work |
+|---|---|---|---|
+| **3.1 Side-channel shadow** (chosen) | intra-BB V_CMP → V_CNDMASK without scalar interference — the dominant corpus pattern | localised: ~40 LOC touching 5 files, strictly additive | yes; becomes redundant once §4 or a future reaching-definitions pass lands |
+| **3.2 Obstruction classifier refusal** (declined — conversation history) | all cases where §3.1 or §4 would fix it | ~50 LOC in `wave_size_obstruction.cpp` | parallel second-line defence regardless of which fix lands |
+| **4 Widened SGPR storage** (not scheduled) | all V_CMP → SGPR → wave-mask-consumer patterns, cross-BB, scalar-interleaved, other consumers | systemic: reg-file model change, every SGPR handler audited | supersedes §3.1; orthogonal to §3.2 |
+
+### 3.1 Chosen approach — intra-BB per-lane-i1 shadow
+
+**Insight.** At the moment the V_CMP handler emits the narrow-width
+ballot store, it still has the per-lane `i1` SSA value from its
+`CreateFCmp`. That `i1` carries the full per-lane compare result for
+every target lane. If a matching V_CNDMASK consumer could find it, no
+ballot round-trip is needed.
+
+**Mechanism.** Add one `DenseMap<int, Value*>` to `RaiseContext`:
+
+```cpp
+// For each SGPR baseIdx, the per-lane `i1` produced by the most recent
+// V_CMP_*_e64 writer to that SGPR in the current basic block. Cleared
+// on every BB entry. Invalidated whenever the SGPR is written by any
+// scalar-semantics path (s_mov_b32, s_or_b32, …). A cache, never
+// load-bearing for correctness: absence just routes the consumer
+// through the existing `extractLaneBitFromWaveMask` fallback.
+DenseMap<int, Value*> lastSgprWaveMaskI1;
+```
+
+**Writer side (handle_valu_vcmp.cpp).** After the existing narrow
+ballot / `writeRegExecWidth` sequence for a V_CMP writing an SGPR
+destination, *also* record the per-lane `i1`:
+
+```cpp
+if (sop == SemOp::V_CMP && d.kind == ParsedReg::SGPR)
+  ctx.recordSgprWaveMaskI1(d.baseIdx, cmp);
+```
+
+The narrow store is preserved unchanged — scalar consumers of `sN`
+(e.g. `s_mov_b32 sM, sN`) still see the source-semantic 32-bit value.
+The shadow is strictly additive.
+
+**Consumer side (handle_valu_vop3p.cpp, V_CNDMASK_B32 SGPR arm).**
+Prefer the cached `i1`; fall back to the existing per-lane extract
+otherwise:
+
+```cpp
+if (Value *freshCmp = ctx.lookupSgprWaveMaskI1(condReg.baseIdx)) {
+  cond = freshCmp;
+} else {
+  Value *condVal = ctx.isa.isWave32()
+                       ? ctx.regs.loadSGPR32(ctx.B, condReg.baseIdx)
+                       : ctx.regs.loadSGPR64(ctx.B, condReg.baseIdx);
+  cond = ctx.projection.extractLaneBitFromWaveMask(ctx.B, condVal);
+}
+```
+
+**Invalidation.** Two sources:
+
+1. Scalar write to the SGPR — wire a `onSgprScalarWritten(baseIdx)`
+   callback from `AllocaRegFile::writeReg32 / writeReg64` on the SGPR
+   path, analogous to the existing `onExecWritten` callback. The
+   callback invalidates `map[baseIdx]`. Any new SGPR-writing handler
+   that routes through the public `writeReg32/64` API picks up
+   invalidation automatically.
+2. BB transition — piggyback on the existing BB-boundary hook in
+   `raiser.cpp` next to `ctx.vgprMSBs = 0;`, calling
+   `ctx.clearSgprWaveMaskShadow()`.
+
+Note `writeRegExecWidth` (V_CMP, V_CMPX, `s_*saveexec_*`) does *not*
+invalidate — it is the path that *produces* fresh cache entries (V_CMP)
+or operates on EXEC (V_CMPX / SAVEEXEC) rather than on an SGPR in its
+scalar role.
+
+**Correctness argument.** Three invariants:
+
+- **I1 — Additive, not replacing.** Narrow store and extract reader
+  are both preserved. Absence of the cache routes to the existing
+  (known-semantics, lossy-under-cross-widening, correct-everywhere-else)
+  path. The pre-existing extract path remains available when the shadow is absent.
+- **I2 — Same-BB, SSA-monotonic.** Within a BB, the raiser processes
+  instructions in program order. The SSA value in the cache *is* the
+  last V_CMP's `i1` with no intervening write to the same SGPR.
+- **I3 — Any interference defeats the cache.** Scalar writes invalidate
+  via the reg-file callback; subsequent V_CMP writers overwrite
+  `map[N]` (last-writer wins); BB transition clears everything.
+
+No case where the consumer reads a stale or mismatched `i1`.
+
+**Concrete impact on corpus_asin_fp32.** Each of 8 unroll blocks
+contains two `V_CMP_*_e64 s6, |vN|, 0.5` → `V_CNDMASK_B32_e64 ..., s6`
+pairs with no intervening write to `s6`. All 16 pairs in the kernel
+are intra-BB and cache-covered. Expected post-fix outcome: asin
+bit-exact against the CPU reference (or within fp32 polynomial rounding
+noise, ≪ 1e-5 tolerance).
+
+### 3.2 Rejected at conversation time — classifier refusal
+
+Previously proposed in this project: detect `V_CMP → SGPR → consumed-as-
+per-lane-mask` patterns in `wave_size_obstruction.cpp` and refuse the
+kernel. Declined because it converts a correctness regression into a
+coverage regression, which the Triton / AITER corpora cannot afford.
+Can still land as a second-line defence behind §3.1, covering the
+residual cases (cross-BB, scalar-interleaved, other consumers) that the
+shadow does not reach.
+
+## 4. Not scheduled — widened-SGPR-storage (full-correctness alternative)
+
+Recorded here so a future investigator does not re-run the trade-off
+analysis. This IS the correct answer if §3.1 proves insufficient.
+
+### 4.1 Idea
+
+Back every SGPR whose role includes "wave mask under cross-widening"
+with a target-wave-width alloca (i64 on wave32 → wave64), not the
+source-semantic i32. V_CMP's ballot stores the full 64 bits; V_CNDMASK
+reads the full 64 bits; `extractLaneBitFromWaveMask` indexes into a
+lossless mask.
+
+### 4.2 Variants
+
+**4.2.1 Widen-all.** Every SGPR becomes i64 under cross-widening.
+
+- Simple implementation.
+- Scalar reads of `sN` take the low 32 bits via explicit trunc.
+- Scalar writers (`s_mov_b32 sM, sN`) must decide what to do with the
+  "extra" 32 bits of sM: clear? Preserve from a prior wave-mask write?
+  Source semantics do not define these bits, so any choice is an
+  invention — and the choice is now part of every lift's output.
+- Wastes alloca space (~2×) regardless of how the SGPR is actually used.
+
+**4.2.2 Role-classified widening.** A pre-lift dataflow pass scans the
+instruction stream and marks each SGPR number as SCALAR, WAVE_MASK, or
+BOTH based on its writers and readers. Widen only WAVE_MASK and BOTH.
+
+- Smaller alloca cost.
+- Classification is non-trivial: SGPR reuse across unrelated roles is
+  common (compilers spill scalar constants into the same SGPRs they
+  used for masks a few instructions earlier — the asin kernel reuses
+  `s6` as both a wave mask AND as a polynomial-coefficient scalar).
+- A BOTH classification still has to solve the "what goes in the extra
+  32 bits after a scalar write" problem of 4.2.1.
+
+**4.2.3 Per-write-site role tagging.** Every SGPR write annotates its
+destination with the write's semantic role. The alloca is a sum type:
+it carries *either* a 32-bit scalar OR a 64-bit wave mask, never both;
+a read of the other role triggers a lossy projection.
+
+- Most precise.
+- Requires a runtime/IR-time tag on every SGPR write, and type-dispatch
+  on every read. Effectively reinvents a tiny type system inside the
+  reg file.
+
+### 4.3 Required machinery regardless of variant
+
+- **Reg-file surgery.** `AllocaRegFile::sgpr[]` grows an alloca-width
+  field per SGPR, or switches to a sum type. `storeSGPR32/64`,
+  `loadSGPR32/64`, the pair helpers (`storeSGPR64` splitting across
+  two `sgpr[i]` / `sgpr[i+1]`), and `writeRegExecWidth` / `readOpExec
+  Width` all learn the new model.
+- **SGPR-pair / subregister overlap.** `s[4:5]` currently maps to two
+  i32 allocas; under widening, `s4` alone is i64, and `s[4:5]` is a
+  2-element vector of i64 or an i128 depending on the pairing chosen.
+  Every place that does `baseIdx + 1` on SGPR pairs (`writeReg64`,
+  kernarg unpacking in `handle_smem.cpp`, `s_load_b128` decomposition,
+  …) has to stay consistent with whatever the pair model becomes.
+- **Scalar op semantics on widened SGPRs.** `s_mov_b32`, `s_and_b32`,
+  `s_or_b32`, `s_xor_b32`, the entire SOP family — each must pick a
+  rule for what happens to the high 32 bits of a widened destination.
+  Source semantics are silent on those bits; we invent a rule, and the
+  rule has to be the same across every handler to not miscompile.
+  Candidates: "clear on every scalar write" (forces wave-mask role to
+  go through a dedicated writer), "preserve unchanged" (lets scalar
+  moves propagate wave-mask bits they never read), "broadcast the low
+  32 into the high 32" (matches wave-native's `(v << 32) | v` read-side
+  widening, but pretends the source semantics said so).
+- **Kernarg / memory ABI.** Kernarg SGPRs start life as 32-bit values
+  read out of a kernarg segment; they stay scalars. The widening must
+  not change the on-memory representation or the kernel-descriptor
+  layout; only the in-alloca representation changes.
+- **Obstruction-classifier interaction.** Many of the "Class 4" lane-
+  position-dependent refusals (`CmpxFromLaneId`, `SaveExecFromLaneId`)
+  operate on the same SGPR dataflow. Widened storage potentially lets
+  some of those refusals become emits — the classifier's decision
+  procedure has to be re-audited with the new reg-file model.
+- **Same-wave / narrowing no-ops.** On same-wave lifts (wave32 →
+  wave32, wave64 → wave64) the widening is unnecessary; the design
+  should degenerate to the current narrow storage to keep same-wave
+  codegen quality unchanged. That means the reg-file constructor
+  branches on `(srcIsa, tgtIsa)` and every handler has to handle both
+  branches. (Or we widen unconditionally and rely on the backend to
+  eliminate dead bits — which it mostly does but can miss edge cases.)
+- **Test burden.** Every existing lit fixture that pins a specific IR
+  shape involving an SGPR alloca has to be audited for the width
+  change. Some pin the narrow form on purpose (regression guards for
+  scalar-semantics invariants); those need negative assertions that
+  the widened form is *not* used on same-wave lifts.
+
+### 4.4 When to pull this in
+
+Only when §3.1's limitations hurt a real corpus kernel. Specifically:
+
+- A kernel's V_CMP producer and V_CNDMASK consumer are in different
+  basic blocks, AND the intervening code path cannot be rewritten to
+  keep them in the same BB (e.g. the compiler genuinely needed to
+  spill the mask across a control-flow join).
+- A kernel sandwiches scalar bitwise ops on a wave-mask SGPR between
+  V_CMP and V_CNDMASK (e.g. `v_cmp s6, ...; s_andn2_b32 s6, vcc, s6;
+  v_cndmask ..., s6` — the shadow invalidates at `s_andn2_b32`, and
+  the fallback is the lossy extract). Widened storage does not need
+  the shadow because the SGPR alloca itself carries full fidelity.
+- The wave-mask consumers expand beyond V_CNDMASK_B32 into operations
+  the shadow design cannot easily wire (dozens of new handlers each
+  needing explicit record / lookup / invalidate).
+- Cross-BB coverage becomes a hard requirement for a shipping kernel
+  before a proper reaching-definitions pass on the raised IR is ready.
+
+The V_CMP-to-V_CNDMASK end-to-end recipe is the regression gate for
+whichever design lands: with §3.1 it expands from the narrow block-size
+subset to the full sweep; with §4 it stays at the full sweep and
+additionally pins a cross-BB / scalar-interleaved variant.
+
+## 5. Scope boundaries of the chosen design (§3.1)
+
+### In scope
+
+- V_CMP_*_e64 writers of arbitrary SGPR destinations (single or pair).
+- V_CNDMASK_B32_e64 consumers of SGPR masks.
+- Intra-BB dataflow with no intervening scalar write to the mask SGPR.
+- Invalidation on any scalar SGPR write routed through
+  `AllocaRegFile::writeReg32 / writeReg64`.
+- Invalidation on BB transition.
+
+### Out of scope for this PR
+
+- **Cross-BB V_CMP → V_CNDMASK.** Falls back to the extract. A future
+  reaching-definitions pass on the raised IR (hinted at as the
+  dataflow-upgrade TODO in `wave_size_obstruction.cpp`) is the natural
+  landing site for this.
+- **Scalar-interleaved pattern.** `V_CMP; s_mov_b32 sN, imm;
+  V_CNDMASK` falls back correctly. Fixing this requires §4 or a scalar-
+  write-that-preserves-wave-mask-role annotation scheme.
+- **Other wave-mask consumers.** `S_AND_B32 sexec, sN, sM` and friends
+  that read an SGPR as a wave mask on the EXEC path still go through
+  `readOpExecWidth`, which has its own widening story (`widenToExec`'s
+  `(v << W_src) | v` broadcast). That path is not changed; its
+  correctness is bounded by the same narrow-write limitation at the
+  V_CMP producer. Extending the shadow to drive those consumers is a
+  natural follow-up.
+- **V_CMPX.** V_CMPX writes EXEC, not an SGPR, and its consumer is the
+  EXEC alloca read path (already wave-native-width-correct under
+  `WaveNativeProjection`). Unchanged by this design.
+
+## 6. Test plan
+
+- **Lit fixture — fused path.** `lit_tests/v_cmp_cndmask_sgpr_fused/`.
+  Same HIP kernel shape as the existing `v_cmp_cndmask_sgpr/` (inline-
+  asm-forced `v_cmp_ge_f32_e64 s4, |x|, 0.5` + `v_cndmask_b32_e64
+  r, -1.0, 1.0, s4`). The raised IR CHECK lines pin the direct-i1
+  dataflow: the `fcmp oge` result flows into `select i1` without an
+  intervening `ballot.i64` + `trunc` + `lshr` / `and` / `icmp ne 0`
+  chain between them. A CHECK-NOT on `mask_lane_idx` for that
+  specific pair proves the shadow path was taken.
+- **Lit fixture — fallback companion.** `lit_tests/v_cmp_cndmask_
+  sgpr_scalar_clobber/`. Adds an inline-asm `s_mov_b32 s4, 0x5A5A5A5A`
+  between the V_CMP and the V_CNDMASK. The raised IR CHECK lines pin
+  the extract chain is STILL emitted (`mask_lane_idx` / `lshr` / `and
+  1` / `icmp ne 0`), proving invalidation fired. Negative assertion
+  that no direct `select i1 %vcmpf, …` appears between the compare
+  and the cndmask.
+- **End-to-end recipe gate.** The V_CMP-to-V_CNDMASK recipe should
+  cover the full block-size sweep (`{16, 32, 64, 128, 256}`): the
+  larger blocks now fall into the shadow path and must match
+  bit-exactly.
+- **Corpus asin.** `corpus_asin_fp32` moves from 44 % wrong rows to
+  match (or WRONG with `max|err|` ≪ recipe tolerance, purely from
+  polynomial rounding). `status.py --run` table flips asin from
+  `MISMATCH` to `ALL_MATCH`.
+- **No regressions.** Batch-raise coverage is unchanged because the
+  shadow is an emit-time optimisation, not a lift blocker. The focused
+  unit and lit tests continue to pass.
+
+## 7. Evolution path
+
+- **Step 1 (this PR, §3.1).** Intra-BB V_CMP → V_CNDMASK cache.
+  Closes the corpus_asin_fp32 miscompile.
+- **Step 2 (follow-up, optional).** Obstruction-classifier refusal
+  (§3.2) for the residual cases the cache does not cover. Converts
+  remaining cross-BB / scalar-interleaved miscompiles into loud
+  refusals rather than wrong answers.
+- **Step 3 (conditional).** Reaching-definitions dataflow on the
+  raised IR, leveraging LLVM's `UniformityAnalysis` on the amdgpu_
+  kernel function. Upgrades the shadow from "intra-BB DenseMap" to
+  "full-function per-SGPR last-wave-mask-writer". Wave-mask reads
+  from any dominator anywhere in the function benefit.
+- **Step 4 (conditional).** If any of the "when to pull this in"
+  conditions in §4.4 materialise on a real corpus kernel, implement
+  §4 (widened SGPR storage). The shadow from Steps 1 + 3 becomes
+  redundant (widened storage is lossless; there is nothing for the
+  shadow to repair) and can be deleted.

--- a/amd/comgr/src/hotswap/isa-profile.h
+++ b/amd/comgr/src/hotswap/isa-profile.h
@@ -1,0 +1,123 @@
+//===- isa-profile.h - Hotswap transpiler ---------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_ISA_PROFILE_H
+#define HOTSWAP_TRANSPILER_ISA_PROFILE_H
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h" // AMDGPU::Feature* enum
+#include "Utils/AMDGPUBaseInfo.h"            // AMDGPU::hasMAIInsts
+#include "llvm/MC/MCSubtargetInfo.h"
+
+namespace COMGR::hotswap {
+
+// Snapshot of the capability bits the raiser actually branches on. Every
+// field is derived directly from the MC subtarget feature bits that TableGen
+// emits, so adding a new AMDGPU generation does not require touching this
+// struct; we just read the already-defined FeatureFoo bit.
+//
+// This is a pure value snapshot — the factory copies bits out of the
+// MCSubtargetInfo and does not retain any reference to it. Callers must
+// construct via `fromSubtarget`; there is intentionally no default ctor.
+struct ISAProfile {
+  unsigned WaveSize = 64;
+  bool HasAgpr = false;
+  bool HasMfma = false;
+  bool HasVopd = false;
+  bool HasScalarFp = false;
+  // True iff the subtarget exposes the gfx12-era WMMA instructions
+  // (FeatureWMMA{128,256}bInsts). gfx11 WMMA is encoded via FeatureGFX11Insts
+  // + VOP3P patterns and is not covered here; the only WMMA source we lift
+  // today is gfx1250.
+  bool HasWmmA12 = false;
+  // True iff the subtarget exposes the gfx1250 TENSOR cnt unit
+  // (FeatureGFX1250Insts gates the VIMAGE TENSOR pseudo-instructions
+  // `tensor_load_to_lds_d{2,4}` and `tensor_store_from_lds_d{2,4}` —
+  // see `isGFX125xOnly` in AMDGPU.td and the
+  // `int_amdgcn_tensor_load_to_lds` /
+  // `int_amdgcn_tensor_store_from_lds` intrinsics in
+  // IntrinsicsAMDGPU.td:4213). The flag is consumed by `handleVIMAGE`
+  // to discriminate between the same-target intrinsic-emit path and
+  // the cross-target loud refusal: the gfx942 and earlier ISAs have
+  // no equivalent hardware unit, so cross-target lifts must refuse.
+  bool HasTensorOps = false;
+  // True iff the subtarget exposes gfx950's MAI extensions on top of the
+  // shared gfx9-family `MAIInsts` feature.  Distinct from `HasMfma`, which
+  // is set on every gfx9-family target with MAI (gfx940 / gfx942 / gfx950).
+  // The discriminator is needed for cross-target lowerings whose target
+  // intrinsic exists only on gfx950 -- notably the scaled F8F6F4 MFMA
+  // family (`int_amdgcn_mfma_scale_f32_16x16x128_f8f6f4`,
+  // IntrinsicsAMDGPU.td:3694), which is the gfx950 cross-target for
+  // `v_wmma_scale_f32_16x16x128_f8f6f4`.  gfx942 has `HasMfma == true` but
+  // no scaled F8F6F4 hardware, so the WMMA-scale handler in
+  // `handle_valu_vop3p.cpp` must gate on `HasGfx950Insts` rather than
+  // `HasMfma` to avoid a silent miscompile (the `HasMfma` predicate would
+  // emit `int_amdgcn_mfma_scale_f32_16x16x128_f8f6f4` on gfx942, where the
+  // intrinsic has no codegen pattern and llc would crash at lowering).
+  bool HasGfx950Insts = false;
+  // True iff the target backend can lower the generic FP8 conversion
+  // intrinsics such as `int_amdgcn_cvt_pk_fp8_f32`. gfx942 and gfx950 both
+  // expose this feature, so use it instead of the broader `HasMfma` whenever
+  // a cross-target expansion depends specifically on FP8 conversion support.
+  bool HasFP8ConversionInsts = false;
+  // gfx125 widens compute_pgm_rsrc2.USER_SGPR_COUNT from the older 5-bit
+  // GFX6-GFX120 field to a 6-bit field. Keep this as an ABI property rather
+  // than deriving it from a string at each use site.
+  bool HasGfx125UserSgprCountField = false;
+
+  bool isWave32() const { return WaveSize == 32; }
+
+  static ISAProfile fromSubtarget(const llvm::MCSubtargetInfo &STI) {
+    ISAProfile P;
+    P.WaveSize = STI.hasFeature(llvm::AMDGPU::FeatureWavefrontSize32) ? 32 : 64;
+    // AGPRs/MFMA share the mai-insts feature today; keep them as separate
+    // fields so future divergence stays expressible without touching callers.
+    P.HasMfma = llvm::AMDGPU::hasMAIInsts(STI);
+    P.HasAgpr = P.HasMfma;
+    P.HasVopd = STI.hasFeature(llvm::AMDGPU::FeatureVOPDInsts);
+    P.HasScalarFp = STI.hasFeature(llvm::AMDGPU::FeatureSALUFloatInsts);
+    P.HasWmmA12 = STI.hasFeature(llvm::AMDGPU::FeatureWMMA128bInsts) ||
+                  STI.hasFeature(llvm::AMDGPU::FeatureWMMA256bInsts);
+    P.HasTensorOps = STI.hasFeature(llvm::AMDGPU::FeatureGFX1250Insts);
+    P.HasGfx950Insts = STI.hasFeature(llvm::AMDGPU::FeatureGFX950Insts);
+    P.HasFP8ConversionInsts =
+        STI.hasFeature(llvm::AMDGPU::FeatureFP8ConversionInsts);
+    P.HasGfx125UserSgprCountField = llvm::AMDGPU::isGFX1250Plus(STI);
+    return P;
+  }
+
+  // Test-only factory.  Constructs an `ISAProfile` with only the
+  // `waveSize` dimension set (the other feature flags default to
+  // `false`) so unit tests exercising wave-direction-gated code —
+  // `WaveNativeProjection`'s ctor assertion, `emitLaneActiveBit`'s
+  // source / target wave-width arithmetic, the
+  // `providesFullWaveExecInvariant` contract —
+  // don't have to stand up a full `MCSubtargetInfo` (which would
+  // require pulling in the LLVM AMDGPU target init chain just to
+  // read one bit).  Production code MUST use `fromSubtarget`:
+  // hand-forging loses the cross-checks between feature flags
+  // (e.g. `hasAGPR == hasMFMA`) that `fromSubtarget` derives from
+  // the canonical subtarget feature definitions in LLVM's
+  // AMDGPU.td.  The factory is named and scoped rather than a
+  // public default ctor so `git grep forTesting` is the review
+  // anchor, not `git grep 'ISAProfile()'` (which would also hit
+  // the private default ctor declaration below and mask real
+  // findings).
+  static ISAProfile forTesting(unsigned WaveSize) {
+    ISAProfile P;
+    P.WaveSize = WaveSize;
+    return P;
+  }
+
+ private:
+  ISAProfile() = default; // constructible only via fromSubtarget() /
+                          // forTesting(), per the comments above.
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/wave-projection.cpp
+++ b/amd/comgr/src/hotswap/wave-projection.cpp
@@ -1,0 +1,587 @@
+//===- wave-projection.cpp - Hotswap transpiler ---------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "wave-projection.h"
+
+#include "decoded-inst.h"
+#include "mc-state.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h" // AMDGPU::EXEC, EXEC_LO, EXEC_HI
+#include "Utils/AMDGPUBaseInfo.h"            // AMDGPU::mc2PseudoReg
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegister.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "wave-projection"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+// ----------------------------------------------------------------------------
+// WaveProjection base: lane-id derivation is shared across every projection
+// that keeps each target lane mapped 1:1 to a hardware lane. Subclasses that
+// change that mapping (e.g. a future thread-loop projection) would override.
+// ----------------------------------------------------------------------------
+
+Value *WaveProjection::emitLaneIdx(IRBuilder<> &B) const {
+  Module *M = B.GetInsertBlock()->getModule();
+  Type *I32Ty = B.getInt32Ty();
+  Function *MbcntLo = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_mbcnt_lo);
+  Value *AllOnes = ConstantInt::getSigned(I32Ty, -1);
+  Value *Zero32 = ConstantInt::get(I32Ty, 0);
+  Value *LaneId = B.CreateCall(MbcntLo, {AllOnes, Zero32}, "lane_lo");
+  if (WaveMaskTy != I32Ty) {
+    Function *MbcntHi = Intrinsic::getOrInsertDeclaration(
+        M, Intrinsic::amdgcn_mbcnt_hi);
+    LaneId = B.CreateCall(MbcntHi, {AllOnes, LaneId}, "lane_id");
+  }
+  return LaneId;
+}
+
+Value *WaveProjection::emitWorkitemIdX(IRBuilder<> &B) const {
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Fn = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_workitem_id_x);
+  return B.CreateCall(Fn, {}, "tid");
+}
+
+Value *WaveProjection::emitInitialExec(IRBuilder<> &B) const {
+  // Default: the architectural boot state of a dispatched wave is
+  // "every source lane active", i.e. all-ones in the source-width
+  // EXEC storage. Projections that need to DECOUPLE the modeled
+  // EXEC from the hardware EXEC (e.g. `WaveNativeProjection` below,
+  // which forces hardware EXEC = -1 at entry via
+  // `@llvm.amdgcn.init_whole_wave` and stores the captured original
+  // per-lane active bit into the alloca) override this hook.
+  return ConstantInt::getSigned(execStorageTy(), -1);
+}
+
+Value *WaveProjection::wrapAsWWMValue(IRBuilder<> &B, Value *V,
+                                        const Twine &Name) const {
+  if (providesFullWaveExecInvariant())
+    return V;
+  // `@llvm.amdgcn.strict.wwm`'s overload set in IntrinsicsAMDGPU.td is
+  // `llvm_any_ty`, but in practice the backend lowers only a restricted
+  // set of scalar and vector element types — integers up to i64 and
+  // float/half/bfloat/f32/f64 (plus their fixed-vector shapes).
+  // Calling it with a pointer, aggregate, token, or other
+  // backend-unsupported type would surface as a cryptic signature
+  // error inside `Intrinsic::getOrInsertDeclaration`.  Assert on the
+  // supported subset here so the misuse surfaces at the call site
+  // instead.
+  Type *T = V->getType();
+  Type *ElemTy =
+      T->isVectorTy() ? cast<FixedVectorType>(T)->getElementType() : T;
+  (void)ElemTy;
+  assert((ElemTy->isIntegerTy() || ElemTy->isFloatingPointTy()) &&
+         "wrapAsWWMValue supports only integer / floating-point scalars "
+         "and fixed-length vectors thereof; other types are not in the "
+         "AMDGPU backend's strict.wwm lowering coverage (pointer, token, "
+         "aggregate, etc. would produce a cryptic intrinsic-signature "
+         "error).");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *WwmFn = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_strict_wwm, {T});
+  return B.CreateCall(WwmFn, {V}, Name);
+}
+
+// ----------------------------------------------------------------------------
+// ModuloReplicationProjection.
+// ----------------------------------------------------------------------------
+
+Value *
+ModuloReplicationProjection::emitLaneActiveBit(IRBuilder<> &B,
+                                                Value *ExecVal) const {
+  // Project the target-lane id onto the source EXEC mask under
+  // modulo-replication: target lane L is active iff bit `L mod W_src` of
+  // the source EXEC mask is set. Same-wave and narrowing cases collapse
+  // to the identity because `lane_id < source_wave_bits` already; the
+  // modulo is a no-op and the shift happens at source width.
+  //
+  // Shifting at source width also sidesteps the LLVM-IR poison rule that
+  // `lshr iN, M` is poison for M >= N: the pre-modulo clamps the shift
+  // into [0, execBits).
+  Value *LaneId = emitLaneIdx(B);
+  Type *ExecTy = ExecVal->getType();
+  unsigned ExecBits = ExecTy->getPrimitiveSizeInBits();
+  Value *LaneIdInExec = B.CreateZExtOrTrunc(LaneId, ExecTy, "spe_lane_idx");
+  // execBits is a power of two (32 or 64), so modulo is bitwise AND.
+  Value *LaneMod = B.CreateAnd(
+      LaneIdInExec, ConstantInt::get(ExecTy, ExecBits - 1), "spe_lane_mod");
+  Value *Shifted = B.CreateLShr(ExecVal, LaneMod, "spe_exec_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(ExecTy, 1),
+                            "spe_exec_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(ExecTy, 0), "spe_lane_active");
+}
+
+Value *ModuloReplicationProjection::ballotI1ToWidth(
+    IRBuilder<> &B, Value *Pred, Type *ResultTy, const Twine &Name) const {
+  assert(Pred->getType() == B.getInt1Ty() &&
+         "ballotI1ToWidth requires an i1 predicate");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Ballot = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
+  Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
+  unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
+  unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  if (WantedBits == WaveBits)
+    return WaveMask;
+  if (WantedBits < WaveBits)
+    // MODREP: trunc is the modulo-replication projection of the target
+    // ballot onto the source wave width.
+    return B.CreateTrunc(WaveMask, ResultTy, Name + "_trunc");
+  // `wantedBits > waveBits`: wave64 source on wave32 target. No correct
+  // modulo-replication projection exists (the wider source wave has
+  // lanes that do not exist in the narrower target), so zero-extending
+  // would invent bits. Bail so a future wave64→wave32 lift lands here
+  // rather than silently miscompiles.
+  report_fatal_error(
+      "ballotI1ToWidth: wantedBits > waveBits (wave64 source on wave32 "
+      "target) has no modulo-replication projection; this direction needs "
+      "an explicit policy decision before use");
+}
+
+Value *ModuloReplicationProjection::extractLaneBitFromWaveMask(
+    IRBuilder<> &B, Value *V) const {
+  if (V->getType() == B.getInt1Ty())
+    return V;
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, I64Ty);
+  Type *TargetTy = WaveMaskTy;
+  unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
+  unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
+  if (SrcBits < DstBits) {
+    // Cross-widening case: a narrow source-wave-width mask (e.g. the
+    // 32-bit result of `ballotI1ToWidth(..., i32)` or a saved VCC-lo
+    // read via `loadSGPR32`) has to be widened to the target wave-mask
+    // width before the per-lane shift extracts a single bit.  A plain
+    // `zext` zeros the upper `dstBits - srcBits` positions, which
+    // under wave32 → wave64 makes target lanes 32..63 always read a
+    // zero (their `lane_id` shift lands in the zero-padded upper
+    // half), and downstream every narrow-mask-guarded `v_cndmask_b32`
+    // unconditionally picks its FALSE branch on those lanes.  In the
+    // Triton SwiGLU shape (`corpus_swiglu_fp32`) that FALSE branch is
+    // the 0x80000000 OOB-sentinel offset used to neutralise masked-
+    // out buffer accesses, so all target-wave-upper-half stores land
+    // out-of-bounds and the SRD bounds check silently drops them —
+    // the observed "half of every target wave64's outputs stay at
+    // their zero-initialised value" miscompile.  MODREP's contract
+    // (`wave-size-translation.md` §6 / class-"modulo-replication"
+    // policy) says target lane L reads bit `L mod W_src` of the source
+    // wave's mask, so the right widening *replicates* the narrow mask
+    // into the upper half rather than zero-extending.  That matches
+    // the `WaveNativeProjection::extractLaneBitFromWaveMask`
+    // widen-by-replication path and makes a narrow-mask round-trip on
+    // the consumer side symmetric with what both projections'
+    // narrow-EXEC writers already do on the producer side; the full-
+    // lane-id shift below then correctly selects the replicated bit
+    // for every target lane.
+    Value *Zext = B.CreateZExt(V, TargetTy);
+    Value *Shifted = B.CreateShl(
+        Zext, ConstantInt::get(TargetTy, SrcBits), "mask_widen_shl");
+    V = B.CreateOr(Zext, Shifted, "mask_widen_replicate");
+  } else if (SrcBits > DstBits) {
+    V = B.CreateTrunc(V, TargetTy);
+  } else if (V->getType() != TargetTy) {
+    V = B.CreateBitCast(V, TargetTy);
+  }
+  Value *LaneIdx = emitLaneIdx(B);
+  // Twine names are neutral (`mask_*`) rather than `vcc_*`: the helper
+  // is called from every consumer that reads a wave mask as a per-lane
+  // predicate — the VCC consumer path via `readVCCAsWaveMask` AND the
+  // SGPR-source `V_CNDMASK_B32_e64` consumer path in
+  // `handle_valu_vop3p.cpp`. Keeping the old `vcc_` prefix would make
+  // raised-IR dumps for e.g. the corpus_asin_fp32 kernel print
+  // `%vcc_lane_idx` for reads of `s6`, which misleads.
+  Value *LaneIdxExt = B.CreateZExtOrTrunc(LaneIdx, TargetTy, "mask_lane_idx");
+  Value *Shifted = B.CreateLShr(V, LaneIdxExt, "mask_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(TargetTy, 1),
+                            "mask_lane_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(TargetTy, 0), "mask_lane_i1");
+}
+
+// ----------------------------------------------------------------------------
+// WaveNativeProjection — cross-widening (wave32 → wave64).
+//
+// The base `WaveMaskTy` is already `tgtIsa.isWave32() ? i32 : i64`,
+// which on the only supported direction (wave32 source → wave64
+// target) is `i64`. We reuse it directly for both the EXEC alloca
+// storage and the ballot/lane-active arithmetic so the widths line up
+// without any extra casting.
+// ----------------------------------------------------------------------------
+
+WaveNativeProjection::WaveNativeProjection(const ISAProfile &SrcIsa,
+                                             const ISAProfile &TgtIsa,
+                                             Type *I32Ty, Type *I64Ty)
+    : WaveProjection(SrcIsa, TgtIsa, I32Ty, I64Ty) {
+  // Restrict to the one translation direction where the wave-native
+  // projection's extra invariants are well-defined. Same-wave paths
+  // don't need a widened EXEC (ModRep already collapses to identity
+  // there), and narrowing (wave64 source → wave32 target) loses lanes
+  // regardless of policy — `ModuloReplicationProjection` documents the
+  // narrowing bail via `report_fatal_error` in `ballotI1ToWidth`; the
+  // wave-native projection is not a second answer for that direction.
+  if (!(SrcIsa.isWave32() && !TgtIsa.isWave32()))
+    report_fatal_error(
+        "WaveNativeProjection is defined only for wave32 source → "
+        "wave64 target cross-widening; other directions must use "
+        "ModuloReplicationProjection (same-wave / narrowing) or a "
+        "future ThreadLoopProjection implementation. See hotswap/"
+        "docs/wave-size-translation.md \u00a72.2 for the projection "
+        "ladder.");
+}
+
+Value *WaveNativeProjection::emitInitialExec(IRBuilder<> &B) const {
+  // Wave32 → Wave64 cross-widening decouples the hardware EXEC (what
+  // the target gfx942 wavefront actually applies) from the modeled
+  // source EXEC (what the transpiler's `emitUnderExec` diamonds read
+  // through the alloca). At kernel entry we call
+  // `@llvm.amdgcn.init_whole_wave`, which:
+  //
+  //   (1) sets hardware EXEC = -1 (all 64 Wave64 lanes active), and
+  //   (2) returns a per-lane i1 whose true-bits form the ORIGINAL
+  //       hardware EXEC mask at dispatch time.
+  //
+  // We ballot (1) back into a wave-width i64 and return that as the
+  // value to seed the EXEC alloca with. From this point on the
+  // `emitUnderExec` diamonds guard every VGPR write, memory store,
+  // LDS op, and atomic through an IR-level `br i1 %lane_active`
+  // derived from the alloca — the backend lowers those divergent
+  // branches by setting hardware EXEC to the ballot of the
+  // per-lane predicate inside each `do` block and restoring to
+  // `EXEC = -1` afterwards, so no inactive source lane ever
+  // commits a side effect. Between `emitUnderExec` diamonds the
+  // hardware EXEC is -1, which is exactly what the WMMA → MFMA
+  // cross-lane pipeline in `wmma_lowering.cpp` needs to produce
+  // correct per-lane output on all 64 Wave64 lanes.
+  //
+  // This replaces the prior per-MFMA-output `@llvm.amdgcn.strict.wwm`
+  // strategy. See the long comment block on
+  // `WaveProjection::emitInitialExec` for the register-allocator
+  // pressure argument (`SIPreAllocateWWMRegs` requires dedicated
+  // physregs for every vreg inside a WWM bracket, which a 128×128
+  // matmul tile cannot satisfy).
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *InitWw = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_init_whole_wave);
+  Value *OriginalActive = B.CreateCall(InitWw, {}, "orig_active");
+  // Ballot the per-lane i1 back into a wave-width mask. Reuses the
+  // projection's own ballot emission so the width selection matches
+  // `WaveMaskTy` (i64 on Wave64 target) and the single result-type
+  // overload of `llvm.amdgcn.ballot` selected is the backend-
+  // supported one for this subtarget.
+  return ballotI1ToWidth(B, OriginalActive, WaveMaskTy, "saved_exec");
+}
+
+Value *WaveNativeProjection::emitLaneActiveBit(IRBuilder<> &B,
+                                                 Value *ExecVal) const {
+  // Target lane L is active iff bit L of the widened EXEC is set. The
+  // widened EXEC storage is `WaveMaskTy` (i64 on wave64 target), so
+  // the shift index is the full target lane id (0..63) with no modulo
+  // fold; that is the whole point of the wave-native projection
+  // relative to `ModuloReplicationProjection::emitLaneActiveBit`,
+  // which folds the target lane id into `lane_id mod W_src` and
+  // thereby collapses target lanes 0..31 with 32..63.
+  Value *LaneId = emitLaneIdx(B);
+  Type *ExecTy = ExecVal->getType();
+  assert(ExecTy == WaveMaskTy &&
+         "WaveNativeProjection requires EXEC storage to match the "
+         "target wave mask width; caller must size the alloca via "
+         "execStorageTy()");
+  Value *LaneIdInExec = B.CreateZExtOrTrunc(LaneId, ExecTy, "wn_lane_idx");
+  Value *Shifted = B.CreateLShr(ExecVal, LaneIdInExec, "wn_exec_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(ExecTy, 1),
+                            "wn_exec_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(ExecTy, 0), "wn_lane_active");
+}
+
+Value *WaveNativeProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
+                                              Type *ResultTy,
+                                              const Twine &Name) const {
+  assert(Pred->getType() == B.getInt1Ty() &&
+         "ballotI1ToWidth requires an i1 predicate");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Ballot = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
+  Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
+  unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
+  unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  if (WantedBits == WaveBits)
+    return WaveMask;
+  if (WantedBits < WaveBits)
+    // Narrowing the full target ballot to a source-width scalar loses
+    // the upper half (target lanes 32..63). This is the one residual
+    // truncation the wave-native projection accepts: source-ISA
+    // instructions that name a single 32-bit SGPR destination (e.g.
+    // `v_cmp_lt_u32_e64 s4, ...` on wave32) cannot hold a 64-bit
+    // mask. The `handle_valu_vcmp.cpp` V_CMPX branch asks for
+    // `resultTy = execStorageTy() = WaveMaskTy` and stays at full
+    // width; only the V_CMP→SGPR branch asks for the narrower source
+    // width and takes this trunc. Kernels that consume the truncated
+    // mask as a per-lane wave mask downstream can still miscompile,
+    // and such patterns remain the obstruction classifier's
+    // responsibility to refuse (see `wave_size_obstruction.cpp`).
+    return B.CreateTrunc(WaveMask, ResultTy, Name + "_trunc");
+  // `wantedBits > waveBits`: wave32 target hardware ballot requested
+  // wider than its native mask. This direction only arises on same-
+  // target-wave lifts (not our wave32→wave64 cross-widening), so
+  // reaching it under WaveNativeProjection is a raiser bug.
+  report_fatal_error(
+      "WaveNativeProjection::ballotI1ToWidth: wantedBits > waveBits "
+      "is not defined for wave32 source → wave64 target cross-"
+      "widening; caller must request resultTy ≤ waveMaskTy");
+}
+
+Value *WaveNativeProjection::extractLaneBitFromWaveMask(IRBuilder<> &B,
+                                                         Value *V) const {
+  if (V->getType() == B.getInt1Ty())
+    return V;
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, I64Ty);
+  Type *TargetTy = WaveMaskTy;
+  unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
+  unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
+  if (SrcBits < DstBits) {
+    // Source-width wave mask (e.g. a 32-bit SGPR that caught the
+    // output of `ballotI1ToWidth(..., i32, ...)` above) is widened
+    // back to target width by *replication* so target lane K and
+    // K+W_src read the same bit. Under wave-native this is the
+    // conservative choice — it matches what the V_CMP→SGPR trunc
+    // already implicitly assumed when it picked lanes 0..W_src-1 as
+    // canonical — and it keeps `v_cndmask_b32` / `s_and_b64 exec,
+    // ..., sN` rounds trips behaving like modulo-replication for
+    // the residual save/restore pattern. Replacing replication with
+    // a zero-extend would silently deactivate target lanes 32..63
+    // whenever the kernel restores EXEC through a 32-bit SGPR; the
+    // replication choice is the one that keeps the `v_cmpx →
+    // predicated store → s_mov_b32 exec_lo, -1` shape working.
+    Value *Zext = B.CreateZExt(V, TargetTy);
+    Value *Shifted = B.CreateShl(Zext, SrcBits);
+    V = B.CreateOr(Zext, Shifted, "wn_mask_widen");
+  } else if (SrcBits > DstBits) {
+    V = B.CreateTrunc(V, TargetTy);
+  } else if (V->getType() != TargetTy) {
+    V = B.CreateBitCast(V, TargetTy);
+  }
+  Value *LaneIdx = emitLaneIdx(B);
+  // Neutral `mask_*` naming parity with the ModRep variant above —
+  // same two-caller story (VCC consumer + SGPR-source V_CNDMASK_B32
+  // consumer), same reason to avoid the old `wn_vcc_*` identifiers
+  // surfacing in raised-IR dumps for kernels whose mask source is a
+  // plain SGPR.
+  Value *LaneIdxExt = B.CreateZExtOrTrunc(LaneIdx, TargetTy, "wn_mask_lane_idx");
+  Value *Shifted = B.CreateLShr(V, LaneIdxExt, "wn_mask_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(TargetTy, 1),
+                            "wn_mask_lane_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(TargetTy, 0), "wn_mask_lane_i1");
+}
+
+// ----------------------------------------------------------------------------
+// ThreadLoopProjection — second rung of the coverage ladder described
+// in hotswap/docs/wave-size-translation.md §2.2.
+//
+// This implementation is intentionally conservative at the projection
+// boundary: source-width EXEC storage, source-width lane selection for
+// lane-active/wave-mask extraction, and source-width result typing for
+// ballots. Selection remains opt-in in raiser.cpp.
+// ----------------------------------------------------------------------------
+
+ThreadLoopProjection::ThreadLoopProjection(const ISAProfile &SrcIsa,
+                                            const ISAProfile &TgtIsa,
+                                            Type *I32Ty, Type *I64Ty)
+    : WaveProjection(SrcIsa, TgtIsa, I32Ty, I64Ty) {
+  if (TgtIsa.WaveSize <= SrcIsa.WaveSize)
+    report_fatal_error(
+        "ThreadLoopProjection is defined only for cross-widening "
+        "(target wave > source wave)");
+  if ((TgtIsa.WaveSize % SrcIsa.WaveSize) != 0)
+    report_fatal_error(
+        "ThreadLoopProjection requires target wave size to be an integer "
+        "multiple of source wave size");
+}
+
+Value *ThreadLoopProjection::emitWorkitemIdX(IRBuilder<> &B) const {
+  if (!IterationAlloca)
+    report_fatal_error(
+        "ThreadLoopProjection::emitWorkitemIdX requires an iteration alloca; "
+        "raiser must call setIterationAlloca before emitting source workitem ids");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Fn = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_workitem_id_x);
+  Value *Tid = B.CreateCall(Fn, {}, "tl_hw_tid");
+  Value *LaneId = emitLaneIdx(B);
+  const unsigned SrcBits = Src.WaveSize;
+  const unsigned TgtBits = Tgt.WaveSize;
+  Value *Iter = B.CreateLoad(B.getInt32Ty(), IterationAlloca, "tl_iter");
+  Value *Base = B.CreateAnd(Tid, B.getInt32(~(TgtBits - 1u)), "tl_tid_base");
+  Value *SourceLane = B.CreateAnd(LaneId, B.getInt32(SrcBits - 1u), "tl_source_lane");
+  Value *WaveOffset =
+      B.CreateMul(Iter, B.getInt32(SrcBits), "tl_source_wave_off");
+  return B.CreateAdd(B.CreateAdd(Base, WaveOffset, "tl_tid_wave_base"),
+                     SourceLane, "tl_tid");
+}
+
+Value *ThreadLoopProjection::emitLaneActiveBit(IRBuilder<> &B,
+                                                Value *ExecVal) const {
+  Value *LaneId = emitLaneIdx(B);
+  Type *ExecTy = ExecVal->getType();
+  const unsigned SourceBits = sourceWaveMaskTy()->getPrimitiveSizeInBits();
+  Value *LaneIdInExec = B.CreateZExtOrTrunc(LaneId, ExecTy, "tl_lane_idx");
+  Value *LaneMod = B.CreateAnd(
+      LaneIdInExec, ConstantInt::get(ExecTy, SourceBits - 1), "tl_lane_mod");
+  Value *Shifted = B.CreateLShr(ExecVal, LaneMod, "tl_exec_at_lane");
+  Value *Bit =
+      B.CreateAnd(Shifted, ConstantInt::get(ExecTy, 1), "tl_exec_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(ExecTy, 0), "tl_lane_active");
+}
+
+Value *ThreadLoopProjection::ballotI1ToWidth(IRBuilder<> &B, Value *Pred,
+                                              Type *ResultTy,
+                                              const Twine &Name) const {
+  assert(Pred->getType() == B.getInt1Ty() &&
+         "ballotI1ToWidth requires an i1 predicate");
+  Module *M = B.GetInsertBlock()->getModule();
+  Function *Ballot = Intrinsic::getOrInsertDeclaration(
+      M, Intrinsic::amdgcn_ballot, {waveMaskTy()});
+  Value *WaveMask = B.CreateCall(Ballot, {Pred}, Name);
+  const unsigned WantedBits = ResultTy->getPrimitiveSizeInBits();
+  const unsigned WaveBits = WaveMaskTy->getPrimitiveSizeInBits();
+  if (WantedBits > WaveBits)
+    report_fatal_error(
+        "ThreadLoopProjection::ballotI1ToWidth requires resultTy <= target "
+        "wave mask width");
+  if (WantedBits == WaveBits)
+    return WaveMask;
+  return B.CreateTrunc(WaveMask, ResultTy, Name + "_trunc");
+}
+
+Value *ThreadLoopProjection::extractLaneBitFromWaveMask(
+    IRBuilder<> &B, Value *V) const {
+  if (V->getType() == B.getInt1Ty())
+    return V;
+  Type *TargetTy = V->getType()->getPrimitiveSizeInBits() >
+                           sourceWaveMaskTy()->getPrimitiveSizeInBits()
+                       ? WaveMaskTy
+                       : sourceWaveMaskTy();
+  unsigned SrcBits = V->getType()->getPrimitiveSizeInBits();
+  unsigned DstBits = TargetTy->getPrimitiveSizeInBits();
+  if (SrcBits < DstBits) {
+    V = B.CreateZExt(V, TargetTy);
+  } else if (SrcBits > DstBits) {
+    V = B.CreateTrunc(V, TargetTy);
+  } else if (V->getType() != TargetTy) {
+    V = B.CreateBitCast(V, TargetTy);
+  }
+  Value *LaneIdx = emitLaneIdx(B);
+  Value *LaneIdxExt = B.CreateZExtOrTrunc(LaneIdx, TargetTy, "tl_mask_lane_idx");
+  Value *ShiftIdx = (TargetTy == WaveMaskTy)
+                        ? LaneIdxExt
+                        : B.CreateAnd(LaneIdxExt,
+                                      ConstantInt::get(TargetTy, DstBits - 1),
+                                      "tl_mask_lane_mod");
+  Value *Shifted = B.CreateLShr(V, ShiftIdx, "tl_mask_at_lane");
+  Value *Bit = B.CreateAnd(Shifted, ConstantInt::get(TargetTy, 1),
+                           "tl_mask_lane_bit");
+  return B.CreateICmpNE(Bit, ConstantInt::get(TargetTy, 0), "tl_mask_lane_i1");
+}
+
+unsigned ThreadLoopProjection::numSourceWavesPerTarget() const {
+  return Tgt.WaveSize / Src.WaveSize;
+}
+
+// ----------------------------------------------------------------------------
+// EXEC-writer detection.
+// ----------------------------------------------------------------------------
+
+bool instructionWritesEXEC(const DecodedInst &Di, const MCState &Mc) {
+  if (Di.DefsExec)
+    return true;
+  const MCInstrDesc &Desc = Mc.InstrInfo->get(Di.Inst.getOpcode());
+  for (unsigned I = 0; I < Desc.getNumDefs() && I < Di.Inst.getNumOperands();
+       ++I) {
+    const MCOperand &Mop = Di.Inst.getOperand(I);
+    if (!Mop.isReg() || !Mop.getReg())
+      continue;
+    MCRegister Reg = AMDGPU::mc2PseudoReg(Mop.getReg());
+    if (Reg == AMDGPU::EXEC || Reg == AMDGPU::EXEC_LO ||
+        Reg == AMDGPU::EXEC_HI)
+      return true;
+  }
+  return false;
+}
+
+// ----------------------------------------------------------------------------
+// Phase 1.4 cross-wave warning.
+// ----------------------------------------------------------------------------
+
+bool emitCrossWaveWarning(const WaveProjection &Proj, const MCState &Mc,
+                          ArrayRef<DecodedInst> Insts, StringRef SourceIsa,
+                          StringRef TargetIsa) {
+  if (Proj.sourceIsa().WaveSize == Proj.targetIsa().WaveSize)
+    return false;
+
+  const DecodedInst *FirstExecWriter = nullptr;
+  for (const DecodedInst &Di : Insts) {
+    if (instructionWritesEXEC(Di, Mc)) {
+      FirstExecWriter = &Di;
+      break;
+    }
+  }
+  if (!FirstExecWriter)
+    return false;
+
+  // Route the legacy warn-only diagnostic through LLVM_DEBUG now that
+  // the Phase 1.4.5 classifier (see `wave_size_obstruction.{hpp,cpp}`)
+  // owns the gate decision. The structured decider in raiser.cpp emits
+  // a precise per-obstruction trace via the same DEBUG_TYPE; this
+  // legacy diagnostic remains only as a fallback that surfaces under
+  // `-debug-only=wave-projection` when the classifier's trace is not
+  // enough context. Enable via `raise_cli -debug-only=wave-projection`
+  // or `llvm-opt -debug-only=wave-projection`.
+  LLVM_DEBUG({
+    dbgs() << "transpiler: WARNING: cross-wave translation of an "
+              "EXEC-manipulating kernel relies on modulo-replication, "
+              "which is not provably correct in general.\n"
+           << "  source ISA wave size: " << Proj.sourceIsa().WaveSize << " ("
+           << SourceIsa << ")\n"
+           << "  target ISA wave size: " << Proj.targetIsa().WaveSize << " ("
+           << (TargetIsa.empty() ? SourceIsa : TargetIsa) << ")\n"
+           << "  first EXEC-writer: " << FirstExecWriter->RawMnemonic
+           << " at offset 0x"
+           << format_hex_no_prefix(FirstExecWriter->Offset, 4) << "\n"
+           << "  rationale: the kernel manipulates EXEC; replicating it "
+              "across wave halves will double per-lane side effects in a "
+              "way the source author did not specify. Empirically this is "
+              "correct for kernels whose EXEC writers are lane-position-"
+              "independent (pointwise ops with bounds checks against a "
+              "uniform >= target_wave_bits). The Phase 1.4.5 classifier "
+              "(wave_size_obstruction.cpp) is the principled path for "
+              "deciding between outcome (a)/(b)/(c) per hotswap/docs/"
+              "wave-size-translation.md \u00a77.\n";
+  });
+  return true;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/wave-projection.h
+++ b/amd/comgr/src/hotswap/wave-projection.h
@@ -1,0 +1,528 @@
+//===- wave-projection.h - Hotswap transpiler -----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_WAVE_PROJECTION_H
+#define HOTSWAP_TRANSPILER_WAVE_PROJECTION_H
+
+#include "decoded-inst.h"
+#include "isa-profile.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+
+namespace COMGR::hotswap {
+
+struct MCState;
+
+// ============================================================================
+// WaveProjection — the cross-wave translation policy surface.
+//
+// A *projection* maps a source-ISA wavefront onto a target-ISA wavefront
+// when the two wave widths differ. This is an abstract base; see
+// `ModuloReplicationProjection` below for the sole concrete policy in
+// use today. hotswap/docs/wave-size-translation.md §2.2 catalogues the
+// alternatives (thread-loop, scalarisation, half-wave-masking) that
+// are not yet implemented but whose implementations would each be a
+// new subclass.
+//
+// Every call site on the raiser side names this base class; the choice
+// of projection is made exactly once in `raiseToIR` when we construct
+// the concrete subclass. Adding a new projection is one new subclass +
+// one line in `raiseToIR`.
+//
+// The class is stateless per call (it caches nothing itself); caches
+// that depend on a raise-instance's IR emission position live in
+// `RaiseContext`.
+class WaveProjection {
+public:
+  WaveProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
+                 llvm::Type *I32Ty, llvm::Type *I64Ty)
+      : Src(SrcIsa), Tgt(TgtIsa), I32Ty(I32Ty), I64Ty(I64Ty),
+        WaveMaskTy(TgtIsa.isWave32() ? I32Ty : I64Ty) {}
+
+  virtual ~WaveProjection() = default;
+
+  const ISAProfile &sourceIsa() const { return Src; }
+  const ISAProfile &targetIsa() const { return Tgt; }
+  // Hardware-width wave mask (i32 on wave32 target, i64 on wave64 target).
+  // Distinct from the EXEC alloca storage width returned by
+  // `execStorageTy()`.
+  llvm::Type *waveMaskTy() const { return WaveMaskTy; }
+
+  // Source-width wave mask (i32 on wave32 source, i64 on wave64 source).
+  // This is the width the source ISA observes when reading/writing EXEC
+  // and SGPR wave masks through 32-bit or 64-bit scalar operations.
+  // Modulo-replication keeps `execStorageTy()` equal to this, so EXEC
+  // and the source author's scalar view share a representation; wave-
+  // native cross-widening widens `execStorageTy()` to the target
+  // hardware mask, leaving `sourceWaveMaskTy()` unchanged so source-
+  // width operands (SGPR scalars, imm masks, save/restore SGPRs) keep
+  // their native width at the boundary.
+  llvm::Type *sourceWaveMaskTy() const {
+    return Src.isWave32() ? I32Ty : I64Ty;
+  }
+
+  // EXEC alloca storage width chosen by the projection. Modulo-
+  // replication returns the source wave width (the long-standing
+  // default, see hotswap/docs/wave-size-translation.md §5.1); wave-
+  // native cross-widening returns the target hardware wave mask
+  // width (`WaveMaskTy`) so a target-width ballot from a data-
+  // dependent `v_cmpx` AND's directly into EXEC without losing the
+  // upper half. Callers in `AllocaRegFile::init` use this to size
+  // the alloca; operand read/write helpers in `RaiseContext` use
+  // the same width to decide where a widen-by-replication or a
+  // narrow-by-truncation is required on source-width scalars.
+  virtual llvm::Type *execStorageTy() const { return sourceWaveMaskTy(); }
+
+  // Emit the initial value to store into the EXEC alloca at kernel
+  // entry. Default is all-ones (every source lane active on entry),
+  // which matches the architectural boot state of a dispatched wave.
+  //
+  // Projections that decouple the HARDWARE EXEC (what the target GPU
+  // applies to EXEC-gated writes) from the MODELED source EXEC (what
+  // the transpiler's `emitUnderExec` diamonds read through the alloca)
+  // override this to emit an entry-block side effect that captures the
+  // hardware EXEC into the alloca while forcing hardware EXEC to all-
+  // ones. Wave-native Wave32→Wave64 cross-widening is the canonical
+  // case: the WMMA→MFMA redistribution pipeline in `wmma_lowering.cpp`
+  // must run under hardware EXEC = -1 so lanes 32-63 participate in
+  // the Wave64 MFMA (otherwise they never write their destination
+  // VGPRs on a partial-wave launch and MFMA reads garbage), and
+  // memory stores must STILL honour the original per-lane active mask.
+  // `WaveNativeProjection` threads this by emitting
+  // `@llvm.amdgcn.init_whole_wave` (sets HW EXEC=-1, returns the
+  // original per-lane active bit) followed by a ballot that packs the
+  // per-lane bit into a wave-width mask for the alloca. Downstream,
+  // every VGPR write / memory store / LDS op already routes through
+  // `RaiseContext::emitUnderExec`, which reads the alloca and
+  // conditionally branches, so the hardware-vs-modeled EXEC split is
+  // invisible to handlers.
+  //
+  // This replaces the earlier `@llvm.amdgcn.strict.wwm`-per-MFMA-output
+  // strategy in the WMMA lowering, which crashed
+  // `SIPreAllocateWWMRegs` on large matmul kernels: that pass requires
+  // a DEDICATED physical VGPR per vreg defined inside a WWM bracket,
+  // and the WWM def-chain from an MFMA-output marker walks back
+  // through the entire accumulator initialisation (≈200 IMPLICIT_DEF
+  // / AV_MOV_B32 0 defs in a 128×128 f16 matmul tile's entry region),
+  // which cannot fit in gfx942's 256-VGPR pool once the kernel's
+  // own computation has claimed its share. Moving the EXEC=-1
+  // guarantee to kernel entry sidesteps the allocator pressure
+  // entirely because no intermediate vreg is ever "inside WWM" —
+  // the whole kernel body runs under HW EXEC=-1 and regalloc is
+  // ordinary.
+  virtual llvm::Value *emitInitialExec(llvm::IRBuilder<> &B) const;
+
+  // True iff a 32-bit write to EXEC_LO carries "replicate across the
+  // full widened EXEC" semantics rather than the source-architectural
+  // "replace the low half, keep the high half" semantics. Only wave-
+  // native cross-widening sets this: on wave32 source → wave64 target
+  // the source author's `s_mov_b32 exec_lo, v` means "set the whole
+  // wavefront's EXEC to v", and the wave-native projection models
+  // each target lane as an independent source thread, so a
+  // conceptually-whole-wave write must fan out to both halves of the
+  // widened EXEC. Modulo-replication keeps this false because source
+  // wave width matches EXEC storage width and no widening is needed.
+  virtual bool broadcastNarrowExecLoWrite() const { return false; }
+
+  // Emit the current lane's linear index within the wavefront. Uses
+  // amdgcn.mbcnt.lo (+ mbcnt.hi on wave64) with an all-ones mask: mbcnt
+  // counts set bits strictly below the current lane, which with `-1` as
+  // the mask equals the lane id. Result type is i32. Wave-size choice is
+  // based on the *target* ISA (waveMaskTy) because the lane id is a
+  // runtime property of the hardware the raised IR runs on, independent
+  // of the source ISA.
+  //
+  // Provided as a non-virtual method on the base because every known
+  // projection derives lane id the same way (mbcnt against the target's
+  // hardware wave). Override only if a future projection changes what
+  // "the current lane" means (e.g. a thread-loop projection where a
+  // single target lane iterates over multiple source lanes).
+  virtual llvm::Value *emitLaneIdx(llvm::IRBuilder<> &B) const;
+
+  // Emit the workitem-id-x value that source-ISA code should observe under
+  // this projection.  The default is the target hardware value.  Projections
+  // that split or re-map source waves override this hook so every raiser-created
+  // `workitem.id.x` leaf flows through one policy surface instead of open-coded
+  // `@llvm.amdgcn.workitem.id.x` calls.
+  virtual llvm::Value *emitWorkitemIdX(llvm::IRBuilder<> &B) const;
+
+  // Given the current EXEC alloca value (source-width iN), return an i1
+  // true iff the current lane is active. Concrete projections define
+  // what "active" means — modulo-replication fans each target lane onto
+  // bit `lane_id mod W_src` of the source EXEC mask.
+  virtual llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                          llvm::Value *ExecVal) const = 0;
+
+  // Collect a per-lane i1 predicate into a wave-level bit-mask of width
+  // `resultTy`. Invariant: the ballot MUST match the target wave width
+  // (waveMaskTy) because the AMDGPU backend only has selection patterns
+  // for ballot.i32 on wave32 hardware and ballot.i64 on wave64. Must be
+  // emitted in "outer" / full-EXEC control flow so inactive lanes don't
+  // silently contribute 0.
+  //
+  // Projections differ in how they reconcile a wave-mask of width
+  // `waveMaskTy` with a caller-requested `resultTy` of a different
+  // width. Modulo-replication truncates when narrowing; other
+  // projections might refuse outright or redistribute bits.
+  virtual llvm::Value *ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred,
+                                        llvm::Type *ResultTy,
+                                        const llvm::Twine &Name = "ballot")
+      const = 0;
+
+  // Project a wave-level bit-mask back onto the current lane's bit (i1).
+  // Inverse direction of the ballot. Per-lane i1 inputs short-circuit
+  // to a direct pass-through (some callers already produce the final
+  // per-lane i1 and route through writeReg*(VCC, i1)); those must not
+  // be reinterpreted as a one-bit wave mask.
+  virtual llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                                   llvm::Value *V) const = 0;
+
+  // True iff this projection guarantees hardware EXEC = -1 between
+  // `emitUnderExec` diamonds *kernel-wide*.  When this is true the
+  // WMMA → MFMA redistribute / MFMA / collect pipeline in
+  // `wmma_lowering.cpp` can run without any additional EXEC
+  // scaffolding because every target-wave lane is already HW-active
+  // for the entire kernel body.  When this is false the handler
+  // must route the pipeline through `emitUnderFullWaveExec` below,
+  // which emits per-dword `@llvm.amdgcn.strict.wwm` markers so the
+  // backend inserts a scoped EXEC save/set-minus-one/restore around
+  // the cross-lane collective.
+  //
+  // `ModuloReplicationProjection` returns false because it keeps
+  // hardware EXEC at the source-wave active mask (see
+  // `emitInitialExec`'s comment on why this is correct for the wave-
+  // size-oblivious class of kernels — phantom target lanes stay
+  // HW-inactive kernel-wide, which prevents undef-VGPR contamination
+  // of the source author's own cross-lane ops but means the WMMA
+  // lowering has to locally widen HW EXEC for its own synthesised
+  // cross-lane ops).  `WaveNativeProjection` returns true because its
+  // `emitInitialExec` explicitly calls `@llvm.amdgcn.init_whole_wave`
+  // to set HW EXEC=-1 for the kernel body.
+  virtual bool providesFullWaveExecInvariant() const { return false; }
+
+  // True iff handlers should lower source-ISA lane-indexed primitives
+  // (`readlane`, `writelane`, `readfirstlane`) as source-wave-scoped
+  // operations instead of target-wave-native AMDGPU intrinsics.  The
+  // ThreadLoop route needs this because each target wave contains multiple
+  // source-wave instances; a native target-wave `readlane(31)` or
+  // `readfirstlane` would collapse those instances together.
+  virtual bool sourceWaveScopedLaneOps() const { return false; }
+
+  // Number of source waves whose per-lane fragment data is present in
+  // each target wave under this projection's mapping.  Callers that
+  // synthesise per-source-wave passes (most notably the WMMA → MFMA
+  // redistribute / MFMA / collect pipeline in `wmma_lowering.cpp`)
+  // iterate `groupBase ∈ {0, W_src, ..., (numSourceWavesPerTarget() -
+  // 1) * W_src}` so that each pass covers exactly one source wave's
+  // worth of data.
+  //
+  // `WaveNativeProjection` (wave32 → wave64 cross-widening) maps two
+  // source waves into one target wave (source wave 0 → target lanes
+  // 0..31, source wave 1 → target lanes 32..63) — returns 2.
+  //
+  // `ModuloReplicationProjection` in the cross-widening direction is the
+  // raiser's fallback for the statically-known phantom-lane regime
+  // (`max_flat_workgroup_size < targetWaveSize`, see `raiser.cpp`).  The
+  // single-source-wave subset (`max_flat_workgroup_size <= sourceWaveSize`)
+  // has no active target replica lanes: the second "half" of the target wave
+  // has no source workitem and remains hardware-inactive. Same-wave MODREP
+  // instantiations (source == target wave width) also carry exactly one
+  // source wave per target. Returns 1 in either case. Explicit MODREP opt-out
+  // runs that can activate replica lanes are still guarded by the C5
+  // classifier and other obstruction checks before any code is emitted. A
+  // future projection (`ThreadLoopProjection`) would answer this based on its
+  // wrap count.
+  //
+  // Pure virtual so every new projection must answer the question
+  // explicitly — a silent default would let a new cross-widening
+  // projection pick the wrong pass count in `wmma_lowering.cpp` and
+  // emit a bogus second-source-wave MFMA that read undef from
+  // phantom lanes.
+  virtual unsigned numSourceWavesPerTarget() const = 0;
+
+  // Return `v` wrapped in `@llvm.amdgcn.strict.wwm` iff the current
+  // projection does NOT already guarantee HW EXEC=-1 kernel-wide.
+  // On projections that DO provide the invariant (e.g.
+  // `WaveNativeProjection` via kernel-entry `init_whole_wave`),
+  // this is an identity: returning the input unchanged avoids the
+  // regalloc pressure that `SIPreAllocateWWMRegs` would impose if
+  // we emitted a redundant marker (see `WaveProjection::emitInitial
+  // Exec`'s block comment for the 128×128-matmul accumulator-ring
+  // failure mode).
+  //
+  // The marker tells the AMDGPU backend's `SIWholeQuadMode` pass
+  // that the producing instruction chain must execute under HW
+  // EXEC=-1.  EXEC save/restore materialises as
+  // `s_or_saveexec_b64 sN, -1` / `s_mov_b64 exec, sN` around the
+  // backward-dataflow-minimal region SIWholeQuadMode computes.
+  //
+  // Typing: `strict.wwm`'s overload set is `llvm_any_ty`, so this
+  // helper accepts any SSA type (scalar i32 for per-dword wrapping,
+  // `<4 x float>` for an MFMA accumulator, `<2 x half>` for a
+  // bitcast-ready operand pack, etc.).  WMMA→MFMA lowering uses
+  // i32 for per-dword result wrapping and `<4 x float>` / `<4 x
+  // i32>` for per-MFMA-output wrapping so the MFMA itself is
+  // dragged into the WWM backward slice.
+  //
+  // Why per-MFMA-output wrapping (and not only per-result-dword):
+  // SIWholeQuadMode's backward propagation from a `strict.wwm` on a
+  // `ds_bpermute` result stops at the bpermute boundary because
+  // `ds_bpermute`'s read is EXEC-independent — the backend sees
+  // that the bpermute picks up source lanes 0..W_src-1 by address
+  // and concludes that the MFMA output on lanes W_src..2*W_src-1
+  // is "not consumed".  That's correct under a single-pass MFMA,
+  // but WRONG for our cross-widening lowering: the MFMA OUTPUT
+  // lives in the SAME destination VGPR across all 64 target lanes,
+  // and the subsequent `collectResult` bpermute DOES read those
+  // upper-half lanes (target lanes 16..31 collect from source
+  // lanes 32..63's MFMA output to get rows 8..15 in WMMA layout).
+  // If the MFMA runs under HW EXEC=source-active-mask, target
+  // lanes 32..63 never write their MFMA destination VGPR, so the
+  // collect reads stale data and rows 8..15 of the output are
+  // corrupted.  Wrapping the MFMA output in `strict.wwm` forces
+  // SIWholeQuadMode to mark the MFMA itself as WWM, so it writes
+  // every lane's destination VGPR.
+  llvm::Value *wrapAsWWMValue(llvm::IRBuilder<> &B, llvm::Value *V,
+                               const llvm::Twine &Name = "wwm") const;
+
+protected:
+  ISAProfile Src;
+  ISAProfile Tgt;
+  // Retained on the base so subclass overrides of `sourceWaveMaskTy()`
+  // / `execStorageTy()` can return the canonical i32/i64 IR types
+  // without re-deriving them from the current IRBuilder's context
+  // (subclasses are constructed once per kernel and outlive any
+  // particular builder).
+  llvm::Type *I32Ty;
+  llvm::Type *I64Ty;
+  llvm::Type *WaveMaskTy;
+};
+
+// ============================================================================
+// ModuloReplicationProjection — today's sole concrete projection.
+//
+// Modulo-replication's bet is:
+//
+//   * Target lane L reads bit `L mod W_src` of the source EXEC mask
+//     (`emitLaneActiveBit` / `MODREP`).
+//   * A target ballot.iN truncated to source-width takes the lower
+//     `W_src` lanes as canonical (`ballotI1ToWidth`).
+//   * A wave-level mask projected back onto a per-lane bit indexes by
+//     `lane_id mod W_src` (`extractLaneBitFromWaveMask`).
+//
+// None of that is a hardware fact — it is a *choice*. See hotswap/
+// docs/wave-size-translation.md §6 for the correctness theorem
+// (wave-size-obliviousness) and §2.2 for the alternatives.
+class ModuloReplicationProjection final : public WaveProjection {
+public:
+  using WaveProjection::WaveProjection;
+
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                  llvm::Value *ExecVal) const override;
+  llvm::Value *ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred,
+                                llvm::Type *ResultTy,
+                                const llvm::Twine &Name = "ballot")
+      const override;
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                           llvm::Value *V) const override;
+
+  // MODREP in the cross-widening direction only instantiates when
+  // `raiser.cpp` routes phantom-lane kernels here as the fallback,
+  // and phantom-lane by definition has exactly one source wave per
+  // target wavefront.  Same-wave MODREP instantiations (source ==
+  // target wave width) are also one-source-wave-per-target.
+  unsigned numSourceWavesPerTarget() const override { return 1; }
+};
+
+// ============================================================================
+// WaveNativeProjection — cross-widening (wave32 → wave64) projection
+// that preserves the full target-hardware EXEC mask.
+//
+// Whereas `ModuloReplicationProjection` keeps the EXEC alloca sized to
+// the *source* wave width and truncates a target ballot to that width
+// (losing the upper half on wave32 → wave64 cross-widening), the wave-
+// native projection widens the EXEC alloca to the *target* hardware
+// wave-mask width. Each target lane is treated as an independent
+// source-thread equivalent, so a data-dependent `v_cmpx` that
+// naturally produces a different answer on target lanes 0..31 vs
+// 32..63 keeps both halves distinct through the round trip:
+//
+//     cmp    = icmp ...                           ; per-target-lane i1
+//     ballot = @llvm.amdgcn.ballot.i64(cmp)      ; 64-bit wave mask
+//     curExec= load i64, ptr %exec               ; widened storage
+//     newExec= and i64 curExec, ballot           ; no trunc needed
+//     store  i64 newExec, ptr %exec
+//
+// The price: source-width EXEC writes (`s_mov_b32 exec_lo, v`, `s_*_
+// saveexec_b32 sN, ...`) must be reconciled with the widened storage.
+// This projection picks the symmetry that matches the source author's
+// intent on a wave32 kernel — "the whole wave" — by replicating the
+// 32-bit value into both halves of the widened EXEC. Symmetrically,
+// reads that narrow EXEC to 32 bits (e.g. `s_mov_b32 sN, exec_lo`)
+// take the low half; the save/restore round trip is lossless as long
+// as the kernel author never observes the upper half of EXEC
+// independently of the lower half, which wave32 source ISAs cannot
+// express.
+//
+// Scope. This projection is correct only for wave32 → wave64 cross-
+// widening. Instantiating it for same-wave or narrowing directions
+// would make `broadcastNarrowExecLoWrite()` change EXEC semantics in
+// directions the source author can disambiguate, so the constructor
+// asserts. The ladder in hotswap/docs/wave-size-translation.md §2.2
+// still reserves `ThreadLoopProjection` for higher-obligation
+// rewrites; wave-native sits between the two as the first rung that
+// handles data-dependent EXEC writes correctly without restructuring
+// the raiser's main loop.
+class WaveNativeProjection final : public WaveProjection {
+public:
+  WaveNativeProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
+                        llvm::Type *I32Ty, llvm::Type *I64Ty);
+
+  llvm::Type *execStorageTy() const override { return WaveMaskTy; }
+  bool broadcastNarrowExecLoWrite() const override { return true; }
+  // `init_whole_wave` in `emitInitialExec` forces HW EXEC=-1 for the
+  // kernel body, so this projection does provide the full-wave-EXEC
+  // invariant that WMMA→MFMA lowering (and other
+  // all-lanes-must-participate collectives) require.
+  bool providesFullWaveExecInvariant() const override { return true; }
+  // Wave32 → wave64 cross-widening: two source waves stack into one
+  // target wave (source wave 0 → target lanes 0..31, source wave 1 →
+  // target lanes 32..63).  Callers emitting per-source-wave passes
+  // run two iterations under this projection.
+  unsigned numSourceWavesPerTarget() const override { return 2; }
+
+  llvm::Value *emitInitialExec(llvm::IRBuilder<> &B) const override;
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                  llvm::Value *ExecVal) const override;
+  llvm::Value *ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred,
+                                llvm::Type *ResultTy,
+                                const llvm::Twine &Name = "ballot")
+      const override;
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                           llvm::Value *V) const override;
+};
+
+// ============================================================================
+// ThreadLoopProjection — second rung of the coverage ladder described
+// in hotswap/docs/wave-size-translation.md §2.2.
+//
+// The thread-loop rung is the coverage-ladder home for source-wave-scoped
+// execution. The current implementation is the first useful subset: it banks
+// source-wave predicate masks in target-width storage and emits a virtual
+// workitem id through one projection hook, so C5 equality predicates can keep
+// the two packed source waves distinct. It does NOT yet clone the full CFG into
+// a temporal `for iter in 0..R` loop, and it still does NOT dissolve Class 2
+// cross-lane obstructions (see wave-size-translation.md §7's unrewritable and
+// pending tables).
+//
+// This implementation provides a conservative projection surface:
+//   * target-width EXEC storage so per-source-wave predicate masks can be
+//     carried independently in SGPR-pair shadows;
+//   * source-wave-scoped lane ops;
+//   * target ballots narrowed only when the destination truly is source-width;
+// and reports source-wave-count per target wave as `W_t / W_s`.
+//
+// The projection is intentionally opt-in and currently selected only by
+// an explicit fallback path in `raiser.cpp` after a post-raise SGPR-
+// forced cross-lane rewrite refusal. It does NOT silently replace the
+// default WaveNative/MODREP decisions.
+//
+// MAINTENANCE. When implementing thread-loop (expected trigger: a
+// corpus kernel in outcome (c) under modulo-replication that would be
+// outcome (a) under thread-loop), the steps are:
+//   1. Populate the overridden emitters with thread-loop semantics
+//      (follow the projection sketch in wave-size-translation.md
+//      §2.2's projections table).
+//   2. Add the additional correctness obligations the thread-loop
+//      projection introduces — barrier hoisting, LDS-aliasing — as
+//      extra checks in `buildObstructionReport` gated on the current
+//      projection choice.
+//   3. Extend `decideProjection` to try thread-loop after modulo-
+//      replication refuses, per the ladder in wave-size-
+//      translation.md §2.2.
+class ThreadLoopProjection final : public WaveProjection {
+public:
+  ThreadLoopProjection(const ISAProfile &SrcIsa, const ISAProfile &TgtIsa,
+                       llvm::Type *I32Ty, llvm::Type *I64Ty);
+
+  llvm::Type *execStorageTy() const override { return WaveMaskTy; }
+  bool broadcastNarrowExecLoWrite() const override { return false; }
+  bool providesFullWaveExecInvariant() const override { return false; }
+  bool sourceWaveScopedLaneOps() const override { return true; }
+
+  void setIterationAlloca(llvm::AllocaInst *Iter) { IterationAlloca = Iter; }
+  llvm::Value *emitWorkitemIdX(llvm::IRBuilder<> &B) const override;
+
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &B,
+                                  llvm::Value *ExecVal) const override;
+  llvm::Value *ballotI1ToWidth(llvm::IRBuilder<> &B, llvm::Value *Pred,
+                                llvm::Type *ResultTy,
+                                const llvm::Twine &Name = "ballot")
+      const override;
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &B,
+                                           llvm::Value *V) const override;
+
+  unsigned numSourceWavesPerTarget() const override;
+
+private:
+  llvm::AllocaInst *IterationAlloca = nullptr;
+};
+
+// ============================================================================
+// EXEC-writer detection — architecture-neutral, authoritative.
+//
+// Derivation strategy (no string matching, no per-opcode allow-lists):
+//
+//   (a) Implicit defs — canonical LLVM TableGen-derived source of truth.
+//       `MCInstrDesc::implicit_defs()` is iterated during decoding and
+//       each result is normalised through `AMDGPU::mc2PseudoReg` (strips
+//       subtarget-variant suffixes) before classification. Results are
+//       cached in `DecodedInst::defsEXEC`. Equivalent to
+//       `desc.hasImplicitDefOfPhysReg(EXEC)` extended across the
+//       EXEC/EXEC_LO/EXEC_HI canonical-alias family. Instructions like
+//       `v_cmpx_*` and `s_*_saveexec_*` surface here.
+//
+//   (b) Explicit defs — required because LLVM models some EXEC writers
+//       with EXEC as an *explicit* destination operand (e.g.
+//       `s_mov_b64 exec, sN`, `s_and_b32 exec_lo, exec_lo, s2`).
+//       `hasImplicitDefOfPhysReg` does NOT cover these by design. Walk
+//       the first `desc.getNumDefs()` operands (TableGen convention:
+//       defs always come first in the MCInst operand list) and classify
+//       each through `AMDGPU::mc2PseudoReg`, same as (a).
+//
+// (a) ∪ (b) is exhaustive for AMDGPU: an MCInst either defines a
+// register implicitly (via TableGen `let Defs = [...]`) or explicitly
+// (as an `outs` operand). There is no third path. Both halves ground in
+// MCInstrDesc; no mnemonic parsing and no per-opcode lists.
+bool instructionWritesEXEC(const DecodedInst &Di, const MCState &Mc);
+
+// ============================================================================
+// Cross-wave safety warning (Phase 1.4) — legacy warn-only surface.
+//
+// Kept for the `lit_tests/cross_wave_warn` regression test, which
+// validates the principle that a cross-wave translation with only
+// lane-position-INDEPENDENT EXEC writers continues to raise under the
+// new classifier gate. In production the structured decider
+// `decideProjection` below is the primary surface and this function
+// becomes a diagnostic logger only (routed through LLVM_DEBUG).
+//
+// Returns true iff a diagnostic was emitted.
+bool emitCrossWaveWarning(const WaveProjection &Proj, const MCState &Mc,
+                          llvm::ArrayRef<DecodedInst> Insts,
+                          llvm::StringRef SourceIsa,
+                          llvm::StringRef TargetIsa);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -242,6 +242,26 @@ target_include_directories(OpcodeMapTests PRIVATE
 
 comgr_configure_test_target(OpcodeMapTests)
 
+# -- WaveProjectionTests -----------------------------------------------------------------
+
+add_executable(WaveProjectionTests
+  WaveProjectionTest.cpp)
+
+target_link_libraries(WaveProjectionTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  ${LLVM_PTHREAD_LIB})
+comgr_link_hotswap_transpiler(WaveProjectionTests)
+
+target_include_directories(WaveProjectionTests PRIVATE
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  # WaveProjectionTest pulls in transpiler internals (wave-projection.h ->
+  # amdgpu-formats.h -> SIDefines.h) that need AMDGPU target-private paths.
+  "${LLVM_BUILD_MAIN_SRC_DIR}/lib/Target/AMDGPU"
+  "${LLVM_BUILD_MAIN_SRC_DIR}/lib/Target/AMDGPU/Utils"
+  "${LLVM_BINARY_DIR}/lib/Target/AMDGPU")
+
+comgr_configure_test_target(WaveProjectionTests)
+
 # Register every test binary with the test-unit / check-comgr plumbing.
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
@@ -249,10 +269,12 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:CodeObjectUtilsTests>
   COMMAND $<TARGET_FILE:MCContextInlineSrcmgrTests>
   COMMAND $<TARGET_FILE:OpcodeMapTests>
-  COMMAND $<TARGET_FILE:RaiserScaffoldingTests>)
+  COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
+  COMMAND $<TARGET_FILE:WaveProjectionTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests
   RaiserScaffoldingTests
   CodeObjectUtilsTests
   MCContextInlineSrcmgrTests
-  OpcodeMapTests)
+  OpcodeMapTests
+  WaveProjectionTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/WaveProjectionTest.cpp
+++ b/amd/comgr/test-unit/WaveProjectionTest.cpp
@@ -1,0 +1,408 @@
+//===- wave_projection_test.cpp - wave_projection unit tests --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Unit tests for `WaveProjection::providesFullWaveExecInvariant()` —
+// the virtual method introduced by the WMMA-refusal commit in the
+// matmul_fp16 triage.  The method is the contract that
+// `handle-valu-vop3p.cpp`'s WMMA → MFMA handlers consult before
+// calling `emitWMMAtoMFMA*`; a regression that silently flips the
+// return value for either concrete projection would silently
+// unleash a WMMA miscompile on phantom-lane kernels (see the
+// `wmma_phantom_lane_refuse/` lit fixture for the end-to-end
+// regression fence).
+//
+// These tests cover:
+//
+//   * `ModuloReplicationProjection::providesFullWaveExecInvariant()`
+//     inherits the base default of `false` — MODREP's
+//     `emitInitialExec` returns source-width all-ones and does
+//     NOT call `@llvm.amdgcn.init_whole_wave`, so hardware EXEC
+//     stays at whatever the dispatcher set it to (the source-
+//     wave active mask for a partial-wave launch).  Collective
+//     lowerings that need all target-wave lanes active (WMMA →
+//     MFMA redistribute-collect) must refuse when this is false.
+//
+//   * `WaveNativeProjection::providesFullWaveExecInvariant()`
+//     overrides to `true` because
+//     `WaveNativeProjection::emitInitialExec` explicitly emits
+//     `@llvm.amdgcn.init_whole_wave` which sets HW EXEC = -1 for
+//     the remainder of the kernel body.
+//
+//   * A base-class pointer dispatch works correctly — callers in
+//     `handle-valu-vop3p.cpp` hold a `WaveProjection &` reference
+//     and rely on virtual dispatch to pick the right answer per
+//     kernel.
+//
+//   * `ThreadLoopProjection` is conservative-by-default and does not
+//     provide the full-wave EXEC invariant. It still uses target-width
+//     EXEC storage so source-wave predicate masks can be banked per
+//     packed source wave.
+
+#include "hotswap/wave-projection.h"
+
+#include "hotswap/isa-profile.h"
+
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Type.h"
+
+#include "gtest/gtest.h"
+
+using namespace llvm;
+using COMGR::hotswap::ISAProfile;
+using COMGR::hotswap::ModuloReplicationProjection;
+using COMGR::hotswap::ThreadLoopProjection;
+using COMGR::hotswap::WaveNativeProjection;
+using COMGR::hotswap::WaveProjection;
+
+namespace {
+
+// Canonical source / target ISA profiles for the cross-widening
+// direction the two projections cover.  Matches the source
+// (gfx1250, wave32) / target (gfx942, wave64) cross-widening the
+// matmul_fp16 triage surfaced the bug on.
+//
+// Constructed via `ISAProfile::forTesting(waveSize)` rather than
+// `fromSubtarget` because standing up an `MCSubtargetInfo` would
+// require the full LLVM AMDGPU init chain (multiple
+// `InitializeAllTarget*` calls + target-lookup dance) and buys
+// us nothing for the contract check this file pins — only the
+// `waveSize` dimension is consulted by `WaveNativeProjection`'s
+// direction-gate assertion, and
+// `providesFullWaveExecInvariant()`'s return value is independent
+// of the other feature flags.  See the `forTesting` docstring in
+// `isa-profile.h` for the test-only scope of this factory.
+ISAProfile makeGfx1250Profile() { return ISAProfile::forTesting(32); }
+ISAProfile makeGfx942Profile() { return ISAProfile::forTesting(64); }
+
+} // namespace
+
+// ----------------------------------------------------------------------------
+// MODREP: the base-class default of `false` is inherited; the
+// projection does NOT decouple HW EXEC from the source active
+// mask.  Pins the default so a future refactor that accidentally
+// promotes MODREP to full-wave-EXEC semantics (without actually
+// emitting `init_whole_wave`) would be caught here rather than by
+// the WMMA handler silently accepting MODREP kernels and
+// miscompiling them.
+// ----------------------------------------------------------------------------
+TEST(WaveProjectionContract, ModuloReplicationDoesNotProvideFullWaveExec) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  ModuloReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Proj.providesFullWaveExecInvariant());
+
+  // Cross-check through a base-class reference to confirm the
+  // virtual dispatch resolves to the correct override (or lack
+  // thereof — MODREP inherits the base's `false`).
+  const WaveProjection &Base = Proj;
+  EXPECT_FALSE(Base.providesFullWaveExecInvariant());
+}
+
+// ----------------------------------------------------------------------------
+// WaveNative: overrides to `true` because `emitInitialExec` emits
+// `@llvm.amdgcn.init_whole_wave` which forces HW EXEC = -1 for the
+// kernel body.  Pins the override so a future refactor that
+// removes it (or moves the `init_whole_wave` emission site without
+// updating the contract method) is caught here before it can
+// silently gate off the WMMA handlers' acceptance of
+// WaveNative-raised kernels.
+// ----------------------------------------------------------------------------
+TEST(WaveProjectionContract, WaveNativeProvidesFullWaveExec) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  // WaveNativeProjection's constructor asserts `src.isWave32() &&
+  // !tgt.isWave32()` (per its docstring — this projection is only
+  // defined for wave32 → wave64 cross-widening), so we construct
+  // with the canonical gfx1250 → gfx942 pair.  Any other direction
+  // would fatal-error inside the constructor.
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  WaveNativeProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_TRUE(Proj.providesFullWaveExecInvariant());
+
+  const WaveProjection &Base = Proj;
+  EXPECT_TRUE(Base.providesFullWaveExecInvariant());
+}
+
+// ----------------------------------------------------------------------------
+// The base class's default return value is `false`.  Tested through
+// `ModuloReplicationProjection` above (which inherits the default),
+// but also pinned explicitly here via a minimal subclass that
+// implements only the pure virtuals.  This protects against a
+// future author flipping the default to `true` and thereby silently
+// graduating un-audited projection classes to "allowed to run WMMA"
+// status.
+// ----------------------------------------------------------------------------
+namespace {
+// Minimal concrete `WaveProjection` that only satisfies the pure
+// virtuals required to instantiate — it is not a real projection and
+// is used SOLELY to assert the base class's default return values
+// for the concrete-but-permissive contract methods.
+class DefaultTestProjection final : public WaveProjection {
+public:
+  using WaveProjection::WaveProjection;
+  llvm::Value *emitLaneActiveBit(llvm::IRBuilder<> &,
+                                  llvm::Value *) const override {
+    return nullptr;  // unused by these tests
+  }
+  llvm::Value *ballotI1ToWidth(llvm::IRBuilder<> &, llvm::Value *,
+                                llvm::Type *,
+                                const llvm::Twine &) const override {
+    return nullptr;  // unused by these tests
+  }
+  llvm::Value *extractLaneBitFromWaveMask(llvm::IRBuilder<> &,
+                                           llvm::Value *) const override {
+    return nullptr;  // unused by these tests
+  }
+  // `numSourceWavesPerTarget` is pure virtual on the base — this
+  // subclass exists only to exercise the base-class defaults for the
+  // contract methods we test here.  Answer conservatively with 1 so
+  // the method has *some* well-defined return; the tests below do
+  // not consult this value for `DefaultTestProjection`.
+  unsigned numSourceWavesPerTarget() const override { return 1; }
+};
+} // namespace
+
+TEST(WaveProjectionContract, BaseDefaultIsNotFullWaveExec) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  DefaultTestProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Proj.providesFullWaveExecInvariant());
+}
+
+TEST(WaveProjectionContract, ThreadLoopDoesNotProvideFullWaveExec) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  ThreadLoopProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_FALSE(Proj.providesFullWaveExecInvariant());
+  EXPECT_EQ(Proj.execStorageTy(), I64Ty);
+
+  const WaveProjection &Base = Proj;
+  EXPECT_FALSE(Base.providesFullWaveExecInvariant());
+}
+
+// ----------------------------------------------------------------------------
+// `numSourceWavesPerTarget()` contract.  The WMMA → MFMA lowering in
+// `wmma-lowering.cpp` iterates `groupBase ∈ {0, W_src, ..., (N-1) *
+// W_src}` where N is this value, so a regression that flipped the
+// return for MODREP (from 1 to 2) would synthesise a bogus pass-1
+// MFMA reading undef from phantom lanes.  A regression that flipped
+// WaveNative's return (from 2 to 1) would skip the second source
+// wave's matmul entirely and leave target lanes 32..63 with
+// uncomputed results.
+// ----------------------------------------------------------------------------
+TEST(WaveProjectionContract, ModuloReplicationHasOneSourceWavePerTarget) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  ModuloReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 1u);
+
+  const WaveProjection &Base = Proj;
+  EXPECT_EQ(Base.numSourceWavesPerTarget(), 1u);
+}
+
+TEST(WaveProjectionContract, WaveNativeHasTwoSourceWavesPerTarget) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  WaveNativeProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 2u);
+
+  const WaveProjection &Base = Proj;
+  EXPECT_EQ(Base.numSourceWavesPerTarget(), 2u);
+}
+
+TEST(WaveProjectionContract, ThreadLoopReportsSourceWavesPerTargetRatio) {
+  LLVMContext Ctx;
+  auto *I32Ty = Type::getInt32Ty(Ctx);
+  auto *I64Ty = Type::getInt64Ty(Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+
+  ThreadLoopProjection Proj(Src, Tgt, I32Ty, I64Ty);
+  EXPECT_EQ(Proj.numSourceWavesPerTarget(), 2u);
+
+  const WaveProjection &Base = Proj;
+  EXPECT_EQ(Base.numSourceWavesPerTarget(), 2u);
+}
+
+// ----------------------------------------------------------------------------
+// `wrapAsWWMValue` emission contract.  On projections that DO provide
+// the full-wave-EXEC invariant kernel-wide (WaveNative) the helper is
+// an identity no-op — it MUST NOT emit a `strict.wwm` marker.  On
+// projections that do NOT (ModuloReplication) it emits exactly one
+// `@llvm.amdgcn.strict.wwm` call wrapping its input value.  These
+// tests pin the projection-aware behaviour by synthesising a tiny IR
+// function, invoking the helper, and inspecting the resulting SSA
+// shape directly.  The gate landing in `wmma-lowering.cpp` depends on
+// the no-op behaviour on WaveNative to avoid the regalloc blow-up
+// described in `WaveProjection::emitInitialExec`'s block comment; a
+// regression that silently flips WaveNative to emit a marker (or
+// silently flips MODREP to skip the marker) would silently re-open
+// the 128×128-f16-matmul regalloc failure OR silently drop the
+// MODREP-phantom-lane WMMA correctness scope respectively.
+// ----------------------------------------------------------------------------
+namespace {
+// Minimal IR scaffold: a function `@f(i32 %x)` with a single block.
+// The helper is invoked with the argument; the test inspects the
+// returned value and surrounding instructions.
+struct IRScaffold {
+  LLVMContext Ctx;
+  std::unique_ptr<Module> M;
+  Function *F;
+  BasicBlock *BB;
+  Argument *Arg;
+  IRBuilder<> B;
+
+  IRScaffold() : Ctx(), M(std::make_unique<Module>("t", Ctx)), B(Ctx) {
+    auto *I32Ty = Type::getInt32Ty(Ctx);
+    auto *FnTy = FunctionType::get(Type::getVoidTy(Ctx), {I32Ty}, false);
+    F = Function::Create(FnTy, Function::ExternalLinkage, "f", M.get());
+    BB = BasicBlock::Create(Ctx, "entry", F);
+    Arg = F->getArg(0);
+    B.SetInsertPoint(BB);
+  }
+};
+} // namespace
+
+TEST(WaveProjectionContract, WrapAsWWMValueIsNoOpOnWaveNative) {
+  IRScaffold S;
+  auto *I32Ty = Type::getInt32Ty(S.Ctx);
+  auto *I64Ty = Type::getInt64Ty(S.Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+  WaveNativeProjection Proj(Src, Tgt, I32Ty, I64Ty);
+
+  Value *Result = Proj.wrapAsWWMValue(S.B, S.Arg);
+
+  // Identity — returned value IS the input, no new instruction emitted.
+  EXPECT_EQ(Result, S.Arg);
+  // The entry block has no instructions beyond the (implicit) label.
+  EXPECT_TRUE(S.BB->empty())
+      << "wrapAsWWMValue on WaveNativeProjection must not emit any "
+         "instructions; found " << S.BB->size();
+}
+
+TEST(WaveProjectionContract, WrapAsWWMValueEmitsStrictWWMOnMODREP) {
+  IRScaffold S;
+  auto *I32Ty = Type::getInt32Ty(S.Ctx);
+  auto *I64Ty = Type::getInt64Ty(S.Ctx);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+  ModuloReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+
+  Value *Result = Proj.wrapAsWWMValue(S.B, S.Arg);
+
+  // Result is NOT the input — a strict.wwm call wraps it.
+  EXPECT_NE(Result, S.Arg);
+  auto *Cb = dyn_cast<CallInst>(Result);
+  ASSERT_NE(Cb, nullptr)
+      << "wrapAsWWMValue on MODREP must return a CallInst wrapping "
+         "the input value";
+
+  Function *Callee = Cb->getCalledFunction();
+  ASSERT_NE(Callee, nullptr);
+  EXPECT_EQ(Callee->getIntrinsicID(), Intrinsic::amdgcn_strict_wwm)
+      << "wrapAsWWMValue must emit @llvm.amdgcn.strict.wwm, got "
+      << Callee->getName().str();
+  // One argument — the wrapped input.
+  ASSERT_EQ(Cb->arg_size(), 1u);
+  EXPECT_EQ(Cb->getArgOperand(0), S.Arg);
+  // The overload resolution picked the i32 variant.
+  EXPECT_EQ(Cb->getType(), I32Ty)
+      << "wrapAsWWMValue returned a value of the wrong type for the "
+         "i32 input overload";
+
+  // The emitted instruction should be the only one in the block.
+  EXPECT_EQ(S.BB->size(), 1u)
+      << "wrapAsWWMValue on MODREP should emit exactly one instruction; "
+         "found " << S.BB->size();
+}
+
+// ----------------------------------------------------------------------------
+// Polymorphic-overload coverage for `wrapAsWWMValue`.  `wmma-lowering.cpp`
+// calls the helper with BOTH `i32` (collect output dwords) and
+// `<4 x float>` (MFMA outputs before the unpackDwords -> collect chain).
+// If a future LLVM version drops or narrows the `strict.wwm` overload set
+// for vector fp types, only the scalar-only coverage above would catch
+// the breakage — the MFMA-output path would silently fail to emit the
+// intrinsic, and SIWholeQuadMode would never pull the MFMA into a WWM
+// region, quietly reintroducing the rows-8..15-zero miscompile this
+// helper exists to prevent.  This test exercises the vector overload
+// directly by constructing a `<4 x float>` argument and asserting the
+// intrinsic is invoked with the matching overloaded type.
+// ----------------------------------------------------------------------------
+TEST(WaveProjectionContract, WrapAsWWMValueHandlesVectorFloatOverload) {
+  IRScaffold S;
+  auto *I32Ty = Type::getInt32Ty(S.Ctx);
+  auto *I64Ty = Type::getInt64Ty(S.Ctx);
+  auto *F32Ty = Type::getFloatTy(S.Ctx);
+  auto *V4f32Ty = FixedVectorType::get(F32Ty, 4);
+
+  ISAProfile Src = makeGfx1250Profile();
+  ISAProfile Tgt = makeGfx942Profile();
+  ModuloReplicationProjection Proj(Src, Tgt, I32Ty, I64Ty);
+
+  // Build a <4 x float> value inside the scaffold's entry block so
+  // `wrapAsWWMValue` has a local SSA Value to wrap.  The value itself
+  // doesn't matter — we only inspect the emitted intrinsic call.
+  Value *Vec = PoisonValue::get(V4f32Ty);
+  Value *Result = Proj.wrapAsWWMValue(S.B, Vec);
+
+  auto *Cb = dyn_cast<CallInst>(Result);
+  ASSERT_NE(Cb, nullptr);
+  Function *Callee = Cb->getCalledFunction();
+  ASSERT_NE(Callee, nullptr);
+  EXPECT_EQ(Callee->getIntrinsicID(), Intrinsic::amdgcn_strict_wwm);
+  EXPECT_EQ(Cb->getType(), V4f32Ty)
+      << "wrapAsWWMValue with a <4 x float> input must emit the "
+         "<4 x float>-overloaded strict.wwm variant";
+  ASSERT_EQ(Cb->arg_size(), 1u);
+  EXPECT_EQ(Cb->getArgOperand(0)->getType(), V4f32Ty)
+      << "operand type mismatch — strict.wwm's overload must match "
+         "the input type";
+}


### PR DESCRIPTION
  * wave_projection.{h,cpp} — `WaveProjection` interface + the three
    concrete projections (`ThreadLoopProjection`,
    `WaveNativeProjection`, `ModuloReplicationProjection`) the raiser
    selects between to bridge wave32 -> wave64 cross-widening. Also
    holds the `instructionWritesEXEC` predicate and the per-projection
    `emitLaneActiveBit` helper handlers consume.
  * isa_profile.h — `ISAProfile` snapshots the wave-direction-relevant
    capability bits (wave size, AGPRs/MFMA, VOPD, FP8 conversion,
    gfx950 MAI, gfx1250 TENSOR ops, ...) for a given subtarget.
    `WaveProjection` consumes source/target `ISAProfile`s to pick the
    correct projection policy.
  * docs/abi-translation.md — wave32 <-> wave64 ABI translation
    contract (kernarg layout, user-SGPR seeding, scratch / private
    segment, hidden args).
  * docs/sgpr-wave-mask-translation.md — SGPR-as-wave-mask handling
    rules referenced by handle_valu_vcmp.cpp (lands later).

