### PR TITLE
Reland #195550 (alias type check) and silence -Wattribute-alias in device-libs

### DIFF
--- a/amd/device-libs/opencl/src/async/awgcpy.cl
+++ b/amd/device-libs/opencl/src/async/awgcpy.cl
@@ -14,6 +14,9 @@
 #define IATTR
 #define AATTR(A) __attribute__((overloadable, alias(A)))
 
+// Aliases below intentionally sign-pun unsigned OpenCL overloads.
+#pragma clang diagnostic ignored "-Wattribute-alias"
+
 #define BODY(D,S) \
     size_t i; \
     size_t d = mul24(mul24((int)get_local_size(0), (int)get_local_size(1)), (int)get_local_size(2)); \

--- a/amd/device-libs/opencl/src/misc/shuffle.cl
+++ b/amd/device-libs/opencl/src/misc/shuffle.cl
@@ -25,6 +25,9 @@
 #define IATTR __attribute__((const))
 #define AATTR(A) __attribute__((overloadable, const, alias(A)))
 
+// Aliases below intentionally sign-pun unsigned OpenCL overloads.
+#pragma clang diagnostic ignored "-Wattribute-alias"
+
 #define LIST2 t[m.s0], t[m.s1]
 #define LIST4 LIST2, t[m.s2], t[m.s3]
 #define LIST8 LIST4, t[m.s4], t[m.s5], t[m.s6], t[m.s7]

--- a/amd/device-libs/opencl/src/relational/bselect.cl
+++ b/amd/device-libs/opencl/src/relational/bselect.cl
@@ -15,6 +15,9 @@
 #define IATTR __attribute__((const))
 #define AATTR(S) __attribute__((overloadable, const, alias(S)))
 
+// Aliases below intentionally sign-pun unsigned OpenCL overloads.
+#pragma clang diagnostic ignored "-Wattribute-alias"
+
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
 #define char_utype uchar

--- a/amd/device-libs/opencl/src/relational/select.cl
+++ b/amd/device-libs/opencl/src/relational/select.cl
@@ -15,6 +15,9 @@
 #define IATTR __attribute__((const))
 #define AATTR(S) __attribute__((overloadable, const, alias(S)))
 
+// Aliases below intentionally sign-pun unsigned/signed OpenCL overloads.
+#pragma clang diagnostic ignored "-Wattribute-alias"
+
 #pragma OPENCL EXTENSION cl_khr_fp16 : enable
 
 #define char_mask ((char)1 << 7)

--- a/clang/docs/ReleaseNotes.rst
+++ b/clang/docs/ReleaseNotes.rst
@@ -504,6 +504,10 @@ Improvements to Clang's diagnostics
 - Fixed false positive host-device mismatch errors in discarded `if constexpr` branches for CUDA/HIP;
   such calls are now correctly skipped.
 
+- Clang now errors when a function declaration aliases a variable or vice versa. (#GH195550)
+
+- Added ``-Wattribute-alias`` to diagnose type mismatches between an alias and its aliased function. (#GH195550)
+
 Improvements to Clang's time-trace
 ----------------------------------
 

--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -359,6 +359,12 @@ def err_non_default_visibility_dllimport : Error<
   "non-default visibility cannot be applied to 'dllimport' declaration">;
 def err_ifunc_resolver_return : Error<
   "ifunc resolver function must return a pointer">;
+def err_alias_between_function_and_variable : Error<
+  "cannot alias a %select{function|variable}0 with a %select{variable|function}0">;
+def note_aliasee_declaration: Note<"aliasee is declared here">;
+def warn_alias_type_mismatch : Warning<
+  "alias and aliasee have different types %0 and %1">,
+  InGroup<DiagGroup<"attribute-alias">>;
 
 def warn_atomic_op_misaligned : Warning<
   "misaligned atomic operation may incur "

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -834,6 +834,72 @@ void CodeGenModule::checkAliases() {
       continue;
     }
 
+    if (!IsIFunc) {
+      GlobalDecl AliaseeGD;
+      if (!lookupRepresentativeDecl(GV->getName(), AliaseeGD) ||
+          !isa<VarDecl, FunctionDecl>(AliaseeGD.getDecl())) {
+        Diags.Report(Location, diag::err_alias_to_undefined)
+            << IsIFunc << IsIFunc;
+        Error = true;
+        continue;
+      }
+
+      bool AliasIsFuncDecl = isa<FunctionDecl>(D);
+      bool AliaseeIsFunc = isa<llvm::Function, llvm::GlobalIFunc>(GV);
+      // Function declarations can only alias functions (including IFUNCs).
+      // Similarly, variable declarations can only alias variables.
+      if (AliasIsFuncDecl != AliaseeIsFunc) {
+        Diags.Report(Location, diag::err_alias_between_function_and_variable)
+            << AliasIsFuncDecl;
+        Diags.Report(AliaseeGD.getDecl()->getLocation(),
+                     diag::note_aliasee_declaration);
+        Error = true;
+        continue;
+      }
+
+      // Only report functions.
+      // Type mismatches for variables can be intentional.
+      if (AliasIsFuncDecl && AliaseeIsFunc) {
+        QualType AliasTy = D->getType();
+        QualType AliaseeTy = cast<ValueDecl>(AliaseeGD.getDecl())->getType();
+        auto shouldReportTypeMismatch = [&]() {
+          const auto *AliasFTy =
+              AliasTy.getCanonicalType()->getAs<FunctionType>();
+          const auto *AliaseeFTy =
+              AliaseeTy.getCanonicalType()->getAs<FunctionType>();
+          assert(AliasFTy && AliaseeFTy);
+          if (!Context.typesAreCompatible(AliasFTy->getReturnType(),
+                                          AliaseeFTy->getReturnType()))
+            return true;
+          const auto *AliasFPTy = dyn_cast<FunctionProtoType>(AliasFTy);
+          const auto *AliaseeFPTy = dyn_cast<FunctionProtoType>(AliaseeFTy);
+          // Report variadic vs no-prototype.
+          if ((AliasFPTy && AliasFPTy->isVariadic() && !AliaseeFPTy) ||
+              (AliaseeFPTy && AliaseeFPTy->isVariadic() && !AliasFPTy))
+            return true;
+          // Do not report aliases with unspecified parameter lists.
+          if (!AliasFPTy || !AliaseeFPTy)
+            return false;
+          // Report if the parameter lists are different. Any other mismatches,
+          // such as in exception specifications, are ignored.
+          if (AliasFPTy->getNumParams() != AliaseeFPTy->getNumParams() ||
+              AliasFPTy->isVariadic() != AliaseeFPTy->isVariadic())
+            return true;
+          for (unsigned i = 0; i < AliasFPTy->getNumParams(); ++i)
+            if (!Context.typesAreCompatible(AliasFPTy->getParamType(i),
+                                            AliaseeFPTy->getParamType(i)))
+              return true;
+          return false;
+        };
+        if (shouldReportTypeMismatch()) {
+          Diags.Report(Location, diag::warn_alias_type_mismatch)
+              << AliasTy << AliaseeTy;
+          Diags.Report(AliaseeGD.getDecl()->getLocation(),
+                       diag::note_aliasee_declaration);
+        }
+      }
+    }
+
     if (getContext().getTargetInfo().getTriple().isOSAIX())
       if (const llvm::GlobalVariable *GVar =
               dyn_cast<const llvm::GlobalVariable>(GV))

--- a/clang/test/CodeGen/alias.c
+++ b/clang/test/CodeGen/alias.c
@@ -59,7 +59,7 @@ extern void f1(void) __attribute((alias("f0")));
 static inline int foo1() { return 0; }
 // CHECKBASIC-LABEL: define internal i32 @foo1()
 int foo() __attribute__((alias("foo1")));
-int bar() __attribute__((alias("bar1")));
+extern int bar __attribute__((alias("bar1")));
 
 extern int test6();
 void test7() { test6(); }  // test6 is emitted as extern.

--- a/clang/test/Sema/attr-alias-elf.c
+++ b/clang/test/Sema/attr-alias-elf.c
@@ -71,3 +71,58 @@ void test4_foo() __attribute__((alias("test4_bar")));
 
 int test5_bar = 0;
 extern struct incomplete_type test5_foo __attribute__((alias("test5_bar")));
+
+int test6 = 0;
+// expected-note@-1 {{aliasee is declared here}}
+void test6_alias() __attribute__((alias("test6")));
+// expected-error@-1 {{cannot alias a variable with a function}}
+
+extern int test7_alias __attribute__((alias("test7")));
+// expected-error@-1 {{cannot alias a function with a variable}}
+int test7(int x) { return x * 2; }
+// expected-note@-1 {{aliasee is declared here}}
+
+void *test8_ifunc() { return 0; }
+void test8(void) __attribute__((ifunc("test8_ifunc")));
+// expected-note@-1 {{aliasee is declared here}}
+extern int test8_alias __attribute__((alias("test8")));
+// expected-error@-1 {{cannot alias a function with a variable}}
+
+void test9() {}
+// expected-note@-1 {{aliasee is declared here}}
+int test9_alias() __attribute__((alias("test9")));
+// expected-warning@-1 {{alias and aliasee have different types 'int ()' and 'void ()'}}
+
+// No warning for an alias with unspecified parameters if the return types match.
+int test10(int x, int y) { return x + y; }
+int test10_alias() __attribute__((alias("test10")));
+
+// No warning for an alias target with unspecified parameters if the return types match.
+int test11() { return 7; }
+int test11_alias(int x) __attribute__((alias("test11")));
+
+int test12(int x, int y) { return x + y; }
+// expected-note@-1 {{aliasee is declared here}}
+int test12_alias(int x, ...) __attribute__((alias("test12")));
+// expected-warning@-1 {{alias and aliasee have different types 'int (int, ...)' and 'int (int, int)'}}
+
+// No warning when using typedef equivalents.
+typedef int Integer;
+Integer test13(int x) { return x; }
+int test13_alias(Integer) __attribute__((alias("test13")));
+
+// Compiler-generated variables are not valid alias targets.
+char *test14 = "asdf";
+extern char test14_alias[5] __attribute__((alias(".str")));
+// expected-error@-1 {{alias must point to a defined variable or function}}
+
+// Unprototyped functions should not alias variadic function and vice versa.
+int test15() { return 9; }
+// expected-note@-1 {{aliasee is declared here}}
+int test15_alias(int x, ...) __attribute__((alias("test15")));
+// expected-warning@-1 {{alias and aliasee have different types 'int (int, ...)' and 'int ()'}}
+
+void test16(int x, ...) { }
+// expected-note@-1 {{aliasee is declared here}}
+void test16_alias() __attribute__((alias("test16")));
+// expected-warning@-1 {{alias and aliasee have different types 'void ()' and 'void (int, ...)'}}

--- a/clang/test/SemaCXX/attr-alias.cpp
+++ b/clang/test/SemaCXX/attr-alias.cpp
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -triple x86_64-pc-linux -std=c++17 -emit-llvm-only -verify %s
+// expected-no-diagnostics
+
+// Note: this mimics how interceptor functions are defined in the compiler-rt
+// libraries. Despite a declaration in the system header having an exception
+// specification, redeclaring it in the user code does not produce the "missing
+// exception specification" error. Consequently, there should be no warnings
+// about type mismatches for the alias and its aliasee.
+# 1 "attr-alias.h" 1 3
+extern "C" void test1() noexcept(true);
+# 12 "attr-alias.cpp" 2
+extern "C" void test1() __attribute__((alias("test1_aliasee")));
+extern "C" void test1_aliasee() { }

--- a/clang/test/SemaObjC/attr-alias.m
+++ b/clang/test/SemaObjC/attr-alias.m
@@ -1,0 +1,6 @@
+// RUN: %clang_cc1 -triple aarch64-none-linux-gnu -fblocks -verify -emit-llvm-only %s
+
+// Compiler-generated functions are not valid alias targets.
+void foo() { void(^myBlock)(void) = ^{ }; }
+void bar() __attribute__((alias("__foo_block_invoke")));
+// expected-error@-1 {{alias must point to a defined variable or function}}

--- a/compiler-rt/lib/dfsan/dfsan_custom.cpp
+++ b/compiler-rt/lib/dfsan/dfsan_custom.cpp
@@ -55,9 +55,14 @@ using namespace __dfsan;
 #define DECLARE_WEAK_INTERCEPTOR_HOOK(f, ...) \
 SANITIZER_INTERFACE_ATTRIBUTE SANITIZER_WEAK_ATTRIBUTE void f(__VA_ARGS__);
 
+#define PRAGMA(x) _Pragma(#x)
 #define WRAPPER_ALIAS(fun, real)                                          \
+  PRAGMA(clang diagnostic push)                                           \
+  PRAGMA(clang diagnostic ignored "-Wunknown-warning-option")             \
+  PRAGMA(clang diagnostic ignored "-Wattribute-alias")                    \
   SANITIZER_INTERFACE_ATTRIBUTE void __dfsw_##fun() ALIAS(__dfsw_##real); \
-  SANITIZER_INTERFACE_ATTRIBUTE void __dfso_##fun() ALIAS(__dfso_##real);
+  SANITIZER_INTERFACE_ATTRIBUTE void __dfso_##fun() ALIAS(__dfso_##real); \
+  PRAGMA(clang diagnostic pop)
 
 // Async-safe, non-reentrant spin lock.
 namespace {

--- a/revert_patches.txt
+++ b/revert_patches.txt
@@ -17,9 +17,6 @@ breaks build of llvm
 breaks windows build
 [cmake] Refactor DIA SDK detection into FindDIASDK module (#160354)
 ---
-Breaks comgr build
-Reland "[Clang][CodeGen] Report when an alias points to an incompatible target" (#195550)
----
 breaks smoke tests clang-313307_simple_spmd
 [clang] use QualType addrspace when making an alloca (#181390) (
 ---


### PR DESCRIPTION
Reland upstream PR llvm/llvm-project#195550 (\"[Clang][CodeGen] Report when an alias points to an incompatible target\") on amd-staging, and fix the device-libs build break that caused it to be reverted.

The reland was reverted on amd-staging in 80d9f4d07a7b because the new `-Wattribute-alias` warning fires on intentional sign-pun aliases in `amd/device-libs` (which builds with `-Werror`).