### PR TITLE
Fix missing LLVM include paths in RaiserScaffoldingTests introduced by commit 7587b27c7078

### DIFF
--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -150,7 +150,10 @@ target_link_libraries(RaiserScaffoldingTests PRIVATE
   ${LLVM_PTHREAD_LIB})
 
 target_include_directories(RaiserScaffoldingTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
   ${COMGR_GTEST_INCLUDE_DIRS})
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
 
 comgr_configure_test_target(RaiserScaffoldingTests)
 

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -152,7 +152,7 @@ target_link_libraries(RaiserScaffoldingTests PRIVATE
 target_include_directories(RaiserScaffoldingTests PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/../src
-  ${COMGR_GTEST_INCLUDE_DIRS})
+  ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
 
 comgr_configure_test_target(RaiserScaffoldingTests)


### PR DESCRIPTION
Fix missing LLVM include paths in RaiserScaffoldingTests introduced by https://github.com/ROCm/llvm-project/commit/7587b27c707859987aa65d4b5e668f42a0f69e70 