### PR TITLE
Merge Reference PR for: [OpenMP][MLIR] Modify lowering OpenMP Dialect lowering to support attach mapping

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -5310,9 +5310,6 @@ static bool checkHasClauseMapFlag(omp::ClauseMapFlags flag,
 // Certain flags are discarded here such as RefPtee and co.
 static llvm::omp::OpenMPOffloadMappingFlags
 convertClauseMapFlags(omp::ClauseMapFlags mlirFlags) {
-  auto mapTypeToBool = [&mlirFlags](omp::ClauseMapFlags flag) {
-    return (mlirFlags & flag) == flag;
-  };
   const bool hasExplicitMap =
       (mlirFlags & ~omp::ClauseMapFlags::is_device_ptr) !=
       omp::ClauseMapFlags::none;
@@ -5320,46 +5317,46 @@ convertClauseMapFlags(omp::ClauseMapFlags mlirFlags) {
   llvm::omp::OpenMPOffloadMappingFlags mapType =
       llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_NONE;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::to))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::to))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_TO;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::from))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::from))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_FROM;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::always))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::always))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ALWAYS;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::del))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::del))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_DELETE;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::return_param))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::return_param))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_RETURN_PARAM;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::priv))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::priv))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_PRIVATE;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::literal))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::literal))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_LITERAL;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::implicit))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::implicit))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_IMPLICIT;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::close))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::close))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_CLOSE;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::present))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::present))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_PRESENT;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::ompx_hold))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::ompx_hold))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_OMPX_HOLD;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::attach))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::attach))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH;
 
-  if (checkHasClauseMapFlag(mlirFlags, omp::ClauseMapFlags::descriptor))
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::descriptor))
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_DESCRIPTOR;
 
-  if (mapTypeToBool(omp::ClauseMapFlags::is_device_ptr)) {
+  if (bitEnumContainsAll(mlirFlags, omp::ClauseMapFlags::is_device_ptr)) {
     mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_TARGET_PARAM;
     if (!hasExplicitMap)
       mapType |= llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_LITERAL;
@@ -5377,11 +5374,10 @@ static void collectMapDataFromMapOperands(
 
   auto checkRefPtrOrPteeMapWithAttach = [](omp::ClauseMapFlags mapType) {
     bool hasRefType =
-        checkHasClauseMapFlag(mapType, omp::ClauseMapFlags::ref_ptr) ||
-        checkHasClauseMapFlag(mapType, omp::ClauseMapFlags::ref_ptee) ||
-        checkHasClauseMapFlag(mapType, omp::ClauseMapFlags::ref_ptr_ptee);
+        bitEnumContainsAll(mapType, omp::ClauseMapFlags::ref_ptr) ||
+        bitEnumContainsAll(mapType, omp::ClauseMapFlags::ref_ptee);
     return hasRefType &&
-           checkHasClauseMapFlag(mapType, omp::ClauseMapFlags::attach);
+           bitEnumContainsAll(mapType, omp::ClauseMapFlags::attach);
   };
 
   auto checkIsAMember = [](const auto &mapVars, auto mapOp) {
@@ -5470,10 +5466,10 @@ static void collectMapDataFromMapOperands(
     bool found = false;
     for (llvm::Value *basePtr : mapData.OriginalValue) {
       auto mapOp = cast<omp::MapInfoOp>(mapData.MapClause[index]);
-      // TODO/FIXME: Currently we define an equivelant mapping as
-      // the same base pointer and an equivelant member count, but
-      // that is a loose definition, we may have to extend to check
-      // for other fields (varPtrPtr/invidiual members being mapped)
+      // TODO: Currently we define an equivalent mapping as
+      // the same base pointer and an equivalent member count, but
+      // that is a loose definition. We may have to extend to check
+      // for other fields (varPtrPtr/individual members being mapped).
       // Note: Attach maps are not the same as a normal data transfer
       // they specify to the runtime to perform an attach map and they
       // (at least at the moment) are never something we would aim to
@@ -5592,14 +5588,10 @@ static int getMapDataMemberIdx(MapInfoData &mapData, omp::MapInfoOp memberOp) {
   return std::distance(mapData.MapClause.begin(), res);
 }
 
-static void sortMapIndices(llvm::SmallVector<size_t> &indices,
-                           mlir::omp::MapInfoOp mapInfo,
-                           bool ascending = true) {
-  mlir::ArrayAttr indexAttr = mapInfo.getMembersIndexAttr();
-  if (indexAttr.empty() || indexAttr.size() == 1 || indices.empty() ||
-      indices.size() == 1)
-    return;
-
+static void sortMapIndices(llvm::SmallVectorImpl<size_t> &indices,
+                           omp::MapInfoOp mapInfo, bool first = true) {
+  ArrayAttr indexAttr = mapInfo.getMembersIndexAttr();
+  llvm::SmallVector<size_t> occludedChildren;
   llvm::sort(
       indices.begin(), indices.end(), [&](const size_t a, const size_t b) {
         // Bail early if we are asked to look at the same index. If we do not
@@ -5627,10 +5619,10 @@ static void sortMapIndices(llvm::SmallVector<size_t> &indices,
             continue;
 
           if (aIndex < bIndex)
-            return ascending;
+            return first;
 
           if (aIndex > bIndex)
-            return !ascending;
+            return !first;
         }
 
         // Iterated up until the end of the smallest member and
@@ -5638,6 +5630,10 @@ static void sortMapIndices(llvm::SmallVector<size_t> &indices,
         // the member with the lowest index count, so the "parent"
         return memberIndicesA.size() < memberIndicesB.size();
       });
+
+  for (auto v : occludedChildren)
+    indices.erase(std::remove(indices.begin(), indices.end(), v),
+                  indices.end());
 }
 
 static omp::MapInfoOp getFirstOrLastMappedMemberPtr(omp::MapInfoOp mapInfo,
@@ -5652,30 +5648,7 @@ static omp::MapInfoOp getFirstOrLastMappedMemberPtr(omp::MapInfoOp mapInfo,
   llvm::SmallVector<size_t> indices;
   indices.resize(indexAttr.size());
   std::iota(indices.begin(), indices.end(), 0);
-
-  llvm::sort(indices, [&](const size_t a, const size_t b) {
-    auto memberIndicesA = cast<ArrayAttr>(indexAttr[a]);
-    auto memberIndicesB = cast<ArrayAttr>(indexAttr[b]);
-    for (const auto it : llvm::zip(memberIndicesA, memberIndicesB)) {
-      int64_t aIndex = cast<IntegerAttr>(std::get<0>(it)).getInt();
-      int64_t bIndex = cast<IntegerAttr>(std::get<1>(it)).getInt();
-
-      if (aIndex == bIndex)
-        continue;
-
-      if (aIndex < bIndex)
-        return first;
-
-      if (aIndex > bIndex)
-        return !first;
-    }
-
-    // Iterated the up until the end of the smallest member and
-    // they were found to be equal up to that point, so select
-    // the member with the lowest index count, so the "parent"
-    return memberIndicesA.size() < memberIndicesB.size();
-  });
-
+  sortMapIndices(indices, mapInfo, first);
   return llvm::cast<omp::MapInfoOp>(
       mapInfo.getMembers()[indices.front()].getDefiningOp());
 }
@@ -5756,19 +5729,15 @@ calculateBoundsOffset(LLVM::ModuleTranslation &moduleTranslation,
   return idx;
 }
 
-static llvm::SmallVector<int64_t> getAsIntegers(mlir::ArrayAttr values) {
-  llvm::SmallVector<int64_t> ints;
-  ints.reserve(values.size());
-  llvm::transform(values, std::back_inserter(ints), [](mlir::Attribute value) {
-    return mlir::cast<mlir::IntegerAttr>(value).getInt();
+static void getAsIntegers(ArrayAttr values, llvm::SmallVector<int64_t> &ints) {
+  llvm::transform(values, std::back_inserter(ints), [](Attribute value) {
+    return cast<IntegerAttr>(value).getInt();
   });
-  return ints;
 }
 
 // Gathers members that are overlapping in the parent, excluding members that
 // themselves overlap, keeping the top-most (closest to parents level) map.
 static void getOverlappedMembers(llvm::SmallVector<size_t> &overlapMapDataIdxs,
-                                 MapInfoData &mapData,
                                  omp::MapInfoOp parentOp) {
   // No members mapped, no overlaps.
   if (parentOp.getMembers().empty())
@@ -5780,43 +5749,38 @@ static void getOverlappedMembers(llvm::SmallVector<size_t> &overlapMapDataIdxs,
     return;
   }
 
-  // 1) collect list of top-level overlapping members from MemberOp
-  llvm::SmallVector<std::pair<int, mlir::ArrayAttr>> memberByIndex;
-  mlir::ArrayAttr indexAttr = parentOp.getMembersIndexAttr();
-  for (auto [memIndex, indicesAttr] : llvm::enumerate(indexAttr))
-    memberByIndex.push_back(
-        std::make_pair(memIndex, mlir::cast<mlir::ArrayAttr>(indicesAttr)));
+  ArrayAttr indexAttr = parentOp.getMembersIndexAttr();
+  size_t numMembers = indexAttr.size();
 
-  // Sort the smallest first (higher up the parent -> member chain), so that
-  // when we remove members, we remove as much as we can in the initial
-  // iterations, shortening the number of passes required.
-  llvm::sort(memberByIndex.begin(), memberByIndex.end(),
-             [&](auto a, auto b) { return a.second.size() < b.second.size(); });
+  // Pre-convert all member indices to integer arrays for efficient comparison.
+  llvm::SmallVector<llvm::SmallVector<int64_t>> memberIndices(numMembers);
+  for (auto [i, indicesAttr] : llvm::enumerate(indexAttr))
+    getAsIntegers(cast<ArrayAttr>(indicesAttr), memberIndices[i]);
 
-  // Remove elements from the vector if there is a parent element that
-  // supersedes it. i.e. if member [0] is mapped, we can remove members [0,1],
-  // [0,2].. etc.
-  for (auto v : make_early_inc_range(memberByIndex)) {
-    auto vArr = getAsIntegers(v.second);
-    memberByIndex.erase(
-        std::remove_if(memberByIndex.begin(), memberByIndex.end(),
-                       [&](auto x) {
-                         if (v == x)
-                           return false;
-
-                         auto xArr = getAsIntegers(x.second);
-                         return std::equal(vArr.begin(), vArr.end(),
-                                           xArr.begin()) &&
-                                xArr.size() >= vArr.size();
-                       }),
-        memberByIndex.end());
+  // For each member, check if it's superseded by another (shorter prefix)
+  // member. If member j's indices are a prefix of member i's indices, then
+  // i is a child of j and should be skipped. e.g. if member [0] is mapped,
+  // we skip members [0,1], [0,2], etc.
+  llvm::SmallDenseSet<size_t> skipIndices;
+  for (size_t i = 0; i < numMembers; ++i) {
+    const auto &iIndices = memberIndices[i];
+    for (size_t j = 0; j < numMembers; ++j) {
+      if (i == j)
+        continue;
+      const auto &jIndices = memberIndices[j];
+      // If j's indices are a strict prefix of i's indices, skip i
+      if (jIndices.size() < iIndices.size() &&
+          std::equal(jIndices.begin(), jIndices.end(), iIndices.begin())) {
+        skipIndices.insert(i);
+        break; // No need to check other potential parents
+      }
+    }
   }
 
-  // Collect the indices from mapData that we need, as we technically need the
-  // base pointer etc. info, which is stored in there and primarily accessible
-  // via index at the moment.
-  for (auto v : memberByIndex)
-    overlapMapDataIdxs.push_back(v.first);
+  // Collect indices of members that are not superseded by a parent.
+  for (size_t i = 0; i < numMembers; ++i)
+    if (!skipIndices.contains(i))
+      overlapMapDataIdxs.push_back(i);
 }
 
 // The intent is to verify if the mapped data being passed is a
@@ -5853,6 +5817,16 @@ static bool isUseDevicePtrItem(omp::MapInfoOp mapInfoOp) {
   }
   return false;
 }
+
+/// This function handles the insertion of a single item of map data from
+/// MapInfoData into the OMPIRBuilder's MapInfo list. Utilising this function
+/// means the map being inserted can be treated as a non-parent map entity,
+/// if the memberOfFlag is set then the map being inserted is treated as
+/// a member map of a larger entity. The insertion into the MapInfo list of
+/// the OMPIRBuilder can vary based on a number of factors, such as if it's
+/// a ref_ptr or ref_ptee map, if it's a member of a record, what construct
+/// the map belongs to and the various map type bit flags that are set for
+/// the map.
 static void
 processIndividualMap(llvm::IRBuilderBase &builder,
                      llvm::OpenMPIRBuilder &ompBuilder, MapInfoData &mapData,
@@ -5861,9 +5835,6 @@ processIndividualMap(llvm::IRBuilderBase &builder,
                      llvm::omp::OpenMPOffloadMappingFlags memberOfFlag =
                          llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_NONE,
                      bool isTargetParam = true, int mapDataParentIdx = -1) {
-  // Declare Target Mappings are excluded from being marked as
-  // OMP_MAP_TARGET_PARAM as they are not passed as parameters, they're
-  // marked with OMP_MAP_PTR_AND_OBJ instead.
   auto mapFlag = mapData.Types[mapDataIdx];
   auto mapInfoOp = llvm::cast<omp::MapInfoOp>(mapData.MapClause[mapDataIdx]);
 
@@ -5872,6 +5843,10 @@ processIndividualMap(llvm::IRBuilderBase &builder,
                        llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH) ==
                       llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH);
 
+  // Declare target variables are not passed to the kernel, and for the moment
+  // attach maps are not passed to the kernel. However, it is possible to create
+  // attach maps that transfer data and thus can be kernel arguments, but our
+  // existing frontend does not do this.
   if (isTargetParam &&
       (targetDirective == TargetDirectiveEnumTy::Target &&
        !mapData.IsDeclareTarget[mapDataIdx]) &&
@@ -5903,8 +5878,8 @@ processIndividualMap(llvm::IRBuilderBase &builder,
   // We apply MAP_PTR_AND_OBJ when within a declare mapper object as it enforces
   // MEMBER_OF mappings on maps that are passed the initial nesting depth, which
   // includes pointed to data and attach members, both of which are technically
-  // not part of the main object. This has the side-affect of causing early
-  // map-backs in certain cases where an implicit declare mapepr has been
+  // not part of the main object. This has the side effect of causing early
+  // map-backs in certain cases where an implicit declare mapper has been
   // emitted for a target region. Applying MAP_PTR_AND_OBJ in these situations
   // circumvents this.
   if (isPtrTy && !isAttachMap && mapData.IsDeclareTarget[mapDataIdx])
@@ -5913,16 +5888,19 @@ processIndividualMap(llvm::IRBuilderBase &builder,
   // if we're provided a mapDataParentIdx, then the data being mapped is
   // part of a larger object (in a parent <-> member mapping) and in this
   // case our BasePointer should be the parent. Except in the edge case
-  // where we are mapping pointee data, in this case we try stay close to
+  // where we are mapping pointee data, where we try staying close to
   // what Clang currently does and utilise the regular base pointer of the
   // data.
+  bool isRefPtee =
+      !bitEnumContainsAll(mapInfoOp.getMapType(),
+                          omp::ClauseMapFlags::ref_ptr) &&
+      bitEnumContainsAll(mapInfoOp.getMapType(), omp::ClauseMapFlags::ref_ptee);
+  bool isRefPtrPtee = bitEnumContainsAll(mapInfoOp.getMapType(),
+                                         omp::ClauseMapFlags::ref_ptr |
+                                             omp::ClauseMapFlags::ref_ptee);
+
   if (!mapInfoOp->getParentOfType<omp::DeclareMapperOp>() &&
-      mapDataParentIdx >= 0 &&
-      !(checkHasClauseMapFlag(mapInfoOp.getMapType(),
-                              omp::ClauseMapFlags::ref_ptee) ||
-        (checkHasClauseMapFlag(mapInfoOp.getMapType(),
-                               omp::ClauseMapFlags::ref_ptr_ptee) &&
-         isPtrTy))) {
+      mapDataParentIdx >= 0 && !(isRefPtee || (isRefPtrPtee && isPtrTy))) {
     combinedInfo.BasePointers.emplace_back(
         mapData.BasePointers[mapDataParentIdx]);
   } else {
@@ -5942,80 +5920,6 @@ processIndividualMap(llvm::IRBuilderBase &builder,
                     builder.CreateIsNull(mapData.Pointers[mapDataIdx]),
                     builder.getInt64(0), mapData.Sizes[mapDataIdx])
               : mapData.Sizes[mapDataIdx]);
-}
-
-// This functions similarly to the check in the OpenMP offload runtime,
-// if we have an attach map type and the size is larger than the 8-bytes
-// for a regular pointer, then it's a descriptor. No other types should
-// be flagged with the attach map type.
-bool isDescriptorMap(LLVM::ModuleTranslation &moduleTranslation,
-                     llvm::Type *type,
-                     llvm::omp::OpenMPOffloadMappingFlags mapType) {
-  if ((mapType & llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH) !=
-      llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH)
-    return false;
-  auto dataLayout = moduleTranslation.getLLVMModule()->getDataLayout();
-  if ((dataLayout.getTypeSizeInBits(type) / 8) <= 8)
-    return false;
-  return true;
-}
-
-static void
-gatherImmediateMembers(llvm::SmallVector<size_t> &immediateMapDataIdxs,
-                       MapInfoData &mapData, omp::MapInfoOp parent, Value map) {
-  mlir::ArrayAttr indexAttr = parent.getMembersIndexAttr();
-  llvm::SmallVector<std::pair<int, mlir::ArrayAttr>> memberByIndex;
-  for (auto [memIndex, indicesAttr] : llvm::enumerate(indexAttr))
-    memberByIndex.push_back(
-        std::make_pair(memIndex, mlir::cast<mlir::ArrayAttr>(indicesAttr)));
-
-  mlir::ArrayAttr searchIdx;
-  if (map.getDefiningOp() != parent) {
-    auto res = llvm::find(parent.getMembers(), map);
-    assert(res != parent.getMembers().end() &&
-           "MapInfoOp for Member not found in parent members");
-    auto mapIdx = std::distance(parent.getMembers().begin(), res);
-    searchIdx = mlir::cast<mlir::ArrayAttr>(indexAttr[mapIdx]);
-    memberByIndex.erase(std::next(memberByIndex.begin(), mapIdx));
-  }
-
-  // Remove anything that has no chance of being an immediate child of the map
-  // we're trying to find immediate children of, due to the depth being greater
-  // than a difference of 1 or equal to the current depth.
-  unsigned int depthMax =
-      (searchIdx == mlir::ArrayAttr()) ? 1 : searchIdx.size() + 1;
-  unsigned int depthCurrent =
-      (searchIdx == mlir::ArrayAttr()) ? 0 : searchIdx.size();
-  memberByIndex.erase(std::remove_if(memberByIndex.begin(), memberByIndex.end(),
-                                     [&](auto a) {
-                                       return a.second.size() > depthMax ||
-                                              a.second.size() == depthCurrent;
-                                     }),
-                      memberByIndex.end());
-  // Remove anything that doesn't have the same set of initial indices as
-  // the member we're trying to finds immediate children, and what we are
-  // left with should be the immediate children. If we're the top level
-  // parent and by extension have no searchIdx, we can skip this step as
-  // everything leftover from the previous step should be an immediate
-  // child.
-  if (searchIdx != mlir::ArrayAttr()) {
-    auto immediateParentIdx = getAsIntegers(searchIdx);
-    memberByIndex.erase(
-        std::remove_if(memberByIndex.begin(), memberByIndex.end(),
-                       [&](auto a) {
-                         auto childIdx = getAsIntegers(a.second);
-                         return !std::equal(immediateParentIdx.begin(),
-                                            immediateParentIdx.end(),
-                                            childIdx.begin());
-                       }),
-        memberByIndex.end());
-  }
-
-  for (auto v : memberByIndex) {
-    immediateMapDataIdxs.push_back(getMapDataMemberIdx(
-        mapData, llvm::cast<omp::MapInfoOp>(
-                     parent.getMembers()[v.first].getDefiningOp())));
-  }
 }
 
 // This creates two insertions into the MapInfosTy data structure for the
@@ -6039,37 +5943,37 @@ static void mapParentWithMembers(
     MapInfoData &mapData, uint64_t mapDataIndex,
     llvm::omp::OpenMPOffloadMappingFlags memberOfFlag,
     TargetDirectiveEnumTy targetDirective) {
-  using mapFlags = llvm::omp::OpenMPOffloadMappingFlags;
+  using MapFlags = llvm::omp::OpenMPOffloadMappingFlags;
   assert(!ompBuilder.Config.isTargetDevice() &&
          "function only supported for host device codegen");
+  auto parentClause =
+      llvm::cast<omp::MapInfoOp>(mapData.MapClause[mapDataIndex]);
+  auto *parentMapper = mapData.Mappers[mapDataIndex];
+
   // Map the first segment of the parent. If a user-defined mapper is attached,
   // include the parent's to/from-style bits (and common modifiers) in this
   // base entry so the mapper receives correct copy semantics via its 'type'
   // parameter. Also keep TARGET_PARAM when required for kernel arguments.
-  llvm::omp::OpenMPOffloadMappingFlags baseFlag =
-      (targetDirective == TargetDirectiveEnumTy::Target &&
-       !mapData.IsDeclareTarget[mapDataIndex])
-          ? llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_TARGET_PARAM
-          : llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_NONE;
-  auto parentClause =
-      llvm::cast<omp::MapInfoOp>(mapData.MapClause[mapDataIndex]);
+  MapFlags baseFlag = (targetDirective == TargetDirectiveEnumTy::Target &&
+                       !mapData.IsDeclareTarget[mapDataIndex])
+                          ? MapFlags::OMP_MAP_TARGET_PARAM
+                          : MapFlags::OMP_MAP_NONE;
 
-  auto *parentMapper = mapData.Mappers[mapDataIndex];
   if (parentMapper) {
     // Preserve relevant map-type bits from the parent clause. These include
     // the copy direction (TO/FROM), as well as commonly used modifiers that
     // should be visible to the mapper for correct behaviour.
-    mapFlags parentFlags = mapData.Types[mapDataIndex];
-    mapFlags preserve = mapFlags::OMP_MAP_TO | mapFlags::OMP_MAP_FROM |
-                        mapFlags::OMP_MAP_ALWAYS | mapFlags::OMP_MAP_CLOSE |
-                        mapFlags::OMP_MAP_PRESENT |
-                        mapFlags::OMP_MAP_OMPX_HOLD |
-                        mapFlags::OMP_MAP_IMPLICIT;
+    MapFlags parentFlags = mapData.Types[mapDataIndex];
+    MapFlags preserve = MapFlags::OMP_MAP_TO | MapFlags::OMP_MAP_FROM |
+                        MapFlags::OMP_MAP_ALWAYS | MapFlags::OMP_MAP_CLOSE |
+                        MapFlags::OMP_MAP_PRESENT |
+                        MapFlags::OMP_MAP_OMPX_HOLD |
+                        MapFlags::OMP_MAP_IMPLICIT;
     baseFlag |= (parentFlags & preserve);
   } else {
-    mapFlags parentFlags = mapData.Types[mapDataIndex];
-    mapFlags preserve =
-        mapFlags::OMP_MAP_PRESENT | mapFlags::OMP_MAP_RETURN_PARAM;
+    MapFlags parentFlags = mapData.Types[mapDataIndex];
+    MapFlags preserve =
+        MapFlags::OMP_MAP_PRESENT | MapFlags::OMP_MAP_RETURN_PARAM;
     baseFlag |= (parentFlags & preserve);
   }
 
@@ -6121,8 +6025,10 @@ static void mapParentWithMembers(
     // TODO: May be good to extend MapInfoData to support tracking of both
     // VarPtr/VarPtrPtr BaseType's to better distinguish what's being used more
     // consistently.
-    bool isRefPteeMap = checkHasClauseMapFlag(lastMemberMapInfo.getMapType(),
-                                              omp::ClauseMapFlags::ref_ptee);
+    bool isRefPteeMap = bitEnumContainsAll(lastMemberMapInfo.getMapType(),
+                                           omp::ClauseMapFlags::ref_ptee) &&
+                        !bitEnumContainsAll(lastMemberMapInfo.getMapType(),
+                                            omp::ClauseMapFlags::ref_ptr);
     llvm::Type *castType = mapData.BaseType[lastMemberIdx];
     if (isRefPteeMap)
       castType =
@@ -6140,22 +6046,26 @@ static void mapParentWithMembers(
       /*isSigned=*/false);
   combinedInfo.Sizes.push_back(size);
 
+  // This creates the initial MEMBER_OF mapping that consists of
+  // the parent/top level container (same as above effectively, except
+  // with a fixed initial compile time size and separate maptype which
+  // indicates the true mape type (tofrom etc.). This parent mapping is
+  // only relevant if the structure in its totality is being mapped,
+  // otherwise the above suffices.
   if (!parentClause.getPartialMap()) {
     // TODO: This will need to be expanded to include the whole host of logic
     // for the map flags that Clang currently supports (e.g. it should do some
     // further case specific flag modifications). For the moment, it handles
     // what we support as expected.
-    llvm::omp::OpenMPOffloadMappingFlags mapFlag = mapData.Types[mapDataIndex];
-
-    bool hasMapClose = (llvm::omp::OpenMPOffloadMappingFlags(mapFlag) &
-                        llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_CLOSE) ==
-                       llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_CLOSE;
+    MapFlags mapFlag = mapData.Types[mapDataIndex];
+    bool hasMapClose = (MapFlags(mapFlag) & MapFlags::OMP_MAP_CLOSE) ==
+                       MapFlags::OMP_MAP_CLOSE;
     ompBuilder.setCorrectMemberOfFlag(mapFlag, memberOfFlag);
 
     llvm::SmallVector<size_t> overlapIdxs;
     // Find all of the members that "overlap", i.e. occlude other members that
     // were mapped alongside the parent, e.g. member [0], occludes
-    getOverlappedMembers(overlapIdxs, mapData, parentClause);
+    getOverlappedMembers(overlapIdxs, parentClause);
 
     // When we only have one overlap we skip the case that tries to segment the
     // mapping as best it can without creating holes, as the calculation is more
@@ -6196,8 +6106,8 @@ static void mapParentWithMembers(
       // members of derived types.
       mapFlag &= ~llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_RETURN_PARAM;
 
-      // TODO: We may want to skip arrays/array sections in this as Clang does
-      // so it appears to be an optimisation rather than a neccessity though,
+      // TODO: We may want to skip arrays/array sections in this as Clang does.
+      // It appears to be an optimisation rather than a necessity though,
       // but this requires further investigation. However, we would have to make
       // sure to not exclude maps with bounds that ARE pointers, as these are
       // processed as seperate components, i.e. pointer + data.
@@ -6216,8 +6126,7 @@ static void mapParentWithMembers(
         combinedInfo.BasePointers.emplace_back(
             mapData.BasePointers[mapDataIndex]);
         combinedInfo.Pointers.emplace_back(lowAddr);
-
-        llvm::Value *sizeCalc = builder.CreateIntCast(
+        auto sizeCalc = builder.CreateIntCast(
             builder.CreatePtrDiff(builder.getInt8Ty(),
                                   mapData.OriginalValue[mapDataOverlapIdx],
                                   lowAddr),
@@ -6226,7 +6135,7 @@ static void mapParentWithMembers(
         // (e.g. if lowAddr happens to be the first member), which isn't
         // correct, even if the runtimes is sometimes fine with it so, in these
         // scenarios we select the types size instead.
-        llvm::Value *sizeSel = builder.CreateSelect(
+        auto sizeSel = builder.CreateSelect(
             builder.CreateICmpNE(builder.getInt64(0), sizeCalc), sizeCalc,
             isPtrMap ? llvm::ConstantExpr::getSizeOf(builder.getPtrTy())
                      : mapData.Sizes[mapDataOverlapIdx]);
@@ -6281,10 +6190,11 @@ static void processMapWithMembersOf(LLVM::ModuleTranslation &moduleTranslation,
     // Clang maps array without bounds as pointers (which we do not
     // currently do), whereas we treat them as arrays in all cases
     // currently.
-    processIndividualMap(builder, ompBuilder, mapData, memberDataIdx,
-                         combinedInfo, targetDirective,
-                         llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_NONE,
-                         true, mapDataIndex);
+    processIndividualMap(
+        builder, ompBuilder, mapData, memberDataIdx, combinedInfo,
+        targetDirective,
+        /*MemberOfFlag=*/llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_NONE,
+        /*isTargetParam=*/true, mapDataIndex);
     return;
   }
 
@@ -6312,8 +6222,8 @@ static void processMapWithMembersOf(LLVM::ModuleTranslation &moduleTranslation,
                            targetDirective);
     } else {
       processIndividualMap(builder, ompBuilder, mapData, mapInfoIdx[i],
-                           combinedInfo, targetDirective, memberOfFlag, false,
-                           mapDataIndex);
+                           combinedInfo, targetDirective, memberOfFlag,
+                           /*isTargetParam=*/false, mapDataIndex);
     }
   }
 }
@@ -6335,7 +6245,7 @@ createAlteredByCaptureMap(MapInfoData &mapData,
           llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH) ==
          llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_ATTACH);
 
-    // if it's declare target, skip it, it's handled separately. However, if
+    // If it's declare target, skip it, it's handled separately. However, if
     // it's declare target, and an attach map, we want to calculate the exact
     // address offset so that we attach correctly.
     if (!mapData.IsDeclareTarget[i] ||
@@ -7025,10 +6935,10 @@ handleDeclareTargetMapVar(MapInfoData &mapData,
         continue;
       auto mapOp = cast<omp::MapInfoOp>(mapData.MapClause[i]);
       llvm::Value *substitute = mapData.BasePointers[i];
-      if (isDeclareTargetLink(mapOp.getVarPtrPtr() ? mapOp.getVarPtrPtr()
-                                                   : mapOp.getVarPtr()) ||
-          (isDeclareTargetTo(mapOp.getVarPtrPtr() ? mapOp.getVarPtrPtr()
-                                                  : mapOp.getVarPtr()) &&
+      auto declTarPtr =
+          mapOp.getVarPtrPtr() ? mapOp.getVarPtrPtr() : mapOp.getVarPtr();
+      if (isDeclareTargetLink(declTarPtr) ||
+          (isDeclareTargetTo(declTarPtr) &&
            moduleTranslation.getOpenMPBuilder()
                ->Config.hasRequiresUnifiedSharedMemory())) {
         builder.SetCurrentDebugLocation(insn->getDebugLoc());
@@ -7847,9 +7757,9 @@ convertOmpTarget(Operation &opInst, llvm::IRBuilderBase &builder,
   }
 
   for (size_t i = 0, e = mapData.OriginalValue.size(); i != e; ++i) {
-    // 1) Declare target arguments are not passed to kernels as arguments
-    // 2) Attach maps are not passed in as arguments to kernels
-    // 3) Children of record objects are not passed in as arguments
+    // 1) Declare target arguments are not passed to kernels as arguments.
+    // 2) Attach maps are not passed in as arguments to kernels.
+    // 3) Children of record objects are not passed in as arguments.
     // TODO: We currently do not handle cases where a member is explicitly
     // passed in as an argument, this will likley need to be handled in
     // the near future, rather than using IsAMember, it may be better to

--- a/mlir/test/Target/LLVMIR/omptarget-host-ref-semantics.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-host-ref-semantics.mlir
@@ -1,0 +1,273 @@
+// RUN: mlir-translate -mlir-to-llvmir %s | FileCheck %s
+
+// Tests that we correctly lower the different variations of reference pointer
+// and attach semantics.
+
+module attributes {omp.is_gpu = false, omp.is_target_device = false, omp.requires = #omp<clause_requires none>, omp.target_triples = ["amdgcn-amd-amdhsa"], omp.version = #omp.version<version = 61>} {
+  llvm.func @attach_always_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(tofrom) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(always, to) capture(ByRef) members(%map1 : [0] : !llvm.ptr) -> !llvm.ptr {name = "x"}
+    %map3 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(always, attach, ref_ptr, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map3 -> %arg3, %map1 -> %arg4 : !llvm.ptr, !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @attach_never_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(tofrom) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(always, to) capture(ByRef) members(%map1 : [0] : !llvm.ptr) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map1 -> %arg3 : !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @attach_auto_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(tofrom) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(always, to) capture(ByRef) members(%map1 : [0] : !llvm.ptr) -> !llvm.ptr {name = "x"}
+    %map3 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(attach, ref_ptr, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map3 -> %arg3, %map1 -> %arg4 : !llvm.ptr, !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @ref_ptr_ptee_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(to, ref_ptr, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(to, ref_ptr, ref_ptee) capture(ByRef) members(%map1 : [0] : !llvm.ptr) -> !llvm.ptr {name = "x"}
+    %map3 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(attach, ref_ptr, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map3 -> %arg3, %map1 -> %arg4 : !llvm.ptr, !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @ref_ptr_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(to, ref_ptr) capture(ByRef) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(attach, ref_ptr) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map1 -> %arg3 : !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @ref_ptee_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(to, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(attach, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map1 -> %arg3 : !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+
+  llvm.func @ref_ptr_ptee_attach_never_(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+    %map1 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(to, ref_ptr, ref_ptee) capture(ByRef) var_ptr_ptr(%arg1 : !llvm.ptr, i32) -> !llvm.ptr {name = ""}
+    %map2 = omp.map.info var_ptr(%arg0 : !llvm.ptr, !llvm.struct<(ptr, i64, i32, i8, i8, i8, i8)>) map_clauses(to, ref_ptr, ref_ptee) capture(ByRef) members(%map1 : [0] : !llvm.ptr) -> !llvm.ptr {name = "x"}
+    omp.target map_entries(%map2 -> %arg2, %map1 -> %arg3 : !llvm.ptr, !llvm.ptr) {
+      omp.terminator
+    }
+    llvm.return
+  }
+}
+
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [5 x i64] [i64 32, i64 281474976710661, i64 3, i64 32772, i64 288]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [4 x i64] [i64 32, i64 281474976710661, i64 3, i64 288]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [5 x i64] [i64 32, i64 281474976710661, i64 3, i64 32768, i64 288]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [5 x i64] [i64 32, i64 281474976710657, i64 1, i64 32768, i64 288]
+// CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [3 x i64] [i64 0, i64 24, i64 0]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [3 x i64] [i64 32768, i64 33, i64 288]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [3 x i64] [i64 32768, i64 33, i64 288]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [4 x i64] [i64 32, i64 281474976710657, i64 1, i64 288]
+
+// CHECK: define void @attach_always_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK:  %[[VAL_0:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_1:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8 }, ptr %[[ARG0]], i32 1
+// CHECK:  %[[VAL_3:.*]] = ptrtoaddr ptr %[[VAL_2]] to i64
+// CHECK:  %[[VAL_4:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+// CHECK:  %[[VAL_5:.*]] = sub i64 %[[VAL_3]], %[[VAL_4]]
+// CHECK:  %[[VAL_1_CMP:.*]] = icmp eq ptr %[[VAL_1]], null
+// CHECK:  %[[VAL_1_SEL:.*]] = select i1 %[[VAL_1_CMP]], i64 0, i64 4
+// CHECK:  %[[VAL_2_CMP:.*]] = icmp eq ptr %[[VAL_0]], null
+// CHECK:  %[[VAL_2_SEL:.*]] = select i1 %[[VAL_2_CMP]], i64 0, i64 24
+
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_5]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 2
+// CHECK:  store ptr %[[VAL_1]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 2
+// CHECK:  store i64 %[[VAL_1_SEL]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 3
+// CHECK:  store ptr %[[VAL_0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 3
+// CHECK:  store i64 %[[VAL_2_SEL]], ptr %[[SIZES]], align 8
+
+
+
+// CHECK: define void @attach_never_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK:  %[[VAL_1:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8 }, ptr %[[ARG0]], i32 1
+// CHECK:  %[[VAL_3:.*]] = ptrtoaddr ptr %[[VAL_2]] to i64
+// CHECK:  %[[VAL_4:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+// CHECK:  %[[VAL_5:.*]] = sub i64 %[[VAL_3]], %[[VAL_4]]
+// CHECK:  %[[VAL_7:.*]] = icmp eq ptr %[[VAL_1]], null
+// CHECK:  %[[VAL_8:.*]] = select i1 %[[VAL_7]], i64 0, i64 4
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [4 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_5]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 2
+// CHECK:  store ptr %[[VAL_1]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [4 x i64], ptr %.offload_sizes, i32 0, i32 2
+// CHECK:  store i64 %[[VAL_8]], ptr %[[SIZES]], align 8
+
+
+// CHECK: define void @attach_auto_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK:  %[[VAL_0:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_1:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8 }, ptr %[[ARG0]], i32 1
+// CHECK:  %[[VAL_3:.*]] = ptrtoaddr ptr %[[VAL_2]] to i64
+// CHECK:  %[[VAL_4:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+// CHECK:  %[[VAL_5:.*]] = sub i64 %[[VAL_3]], %[[VAL_4]]
+// CHECK:  %[[VAL_1_CMP:.*]] = icmp eq ptr %[[VAL_1]], null
+// CHECK:  %[[VAL_1_SEL:.*]] = select i1 %[[VAL_1_CMP]], i64 0, i64 4
+// CHECK:  %[[VAL_2_CMP:.*]] = icmp eq ptr %[[VAL_0]], null
+// CHECK:  %[[VAL_2_SEL:.*]] = select i1 %[[VAL_2_CMP]], i64 0, i64 24
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_5]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 2
+// CHECK:  store ptr %[[VAL_1]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 2
+// CHECK:  store i64 %[[VAL_1_SEL]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 3
+// CHECK:  store ptr %[[VAL_0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 3
+// CHECK:  store i64 %[[VAL_2_SEL]], ptr %[[SIZES]], align 8
+
+
+// CHECK: define void @ref_ptr_ptee_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK:  %[[VAL_0:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_1:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8 }, ptr %[[ARG0]], i32 1
+// CHECK:  %[[VAL_3:.*]] = ptrtoaddr ptr %[[VAL_2]] to i64
+// CHECK:  %[[VAL_4:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+// CHECK:  %[[VAL_5:.*]] = sub i64 %[[VAL_3]], %[[VAL_4]]
+// CHECK:  %[[VAL_1_CMP:.*]] = icmp eq ptr %[[VAL_1]], null
+// CHECK:  %[[VAL_1_SEL:.*]] = select i1 %[[VAL_1_CMP]], i64 0, i64 4
+// CHECK:  %[[VAL_2_CMP:.*]] = icmp eq ptr %[[VAL_0]], null
+// CHECK:  %[[VAL_2_SEL:.*]] = select i1 %[[VAL_2_CMP]], i64 0, i64 24
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_5]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  store ptr %[[ARG1]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 2
+// CHECK:  store ptr %[[VAL_1]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 2
+// CHECK:  store i64 %[[VAL_1_SEL]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 3
+// CHECK:  store ptr %[[VAL_0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 3
+// CHECK:  store i64 %[[VAL_2_SEL]], ptr %[[SIZES]], align 8
+
+// CHECK: define void @ref_ptr_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK:  %[[VAL_0:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_1:.*]] = icmp eq ptr %[[VAL_0]], null
+// CHECK:  %[[VAL_2:.*]] = select i1 %[[VAL_1]], i64 0, i64 24
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[VAL_0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [3 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_2]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+
+// CHECK: define void @ref_ptee_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK: %[[VAL_0:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK: %[[VAL_1:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK: %[[VAL_2:.*]] = icmp eq ptr %[[VAL_0]], null
+// CHECK: %[[VAL_3:.*]] = select i1 %[[VAL_2]], i64 0, i64 24
+// CHECK: %[[VAL_4:.*]] = icmp eq ptr %[[VAL_1]], null
+// CHECK: %[[VAL_5:.*]] = select i1 %[[VAL_4]], i64 0, i64 4
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[VAL_0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [3 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_3]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG1]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [3 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[VAL_1]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [3 x i64], ptr %.offload_sizes, i32 0, i32 1
+// CHECK:  store i64 %[[VAL_5]], ptr %[[SIZES]], align 8
+
+// CHECK: define void @ref_ptr_ptee_attach_never_(ptr %[[ARG0:.*]], ptr %[[ARG1:.*]])
+// CHECK:  %[[VAL_1:.*]] = load ptr, ptr %[[ARG1]], align 8
+// CHECK:  %[[VAL_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8 }, ptr %[[ARG0]], i32 1
+// CHECK:  %[[VAL_3:.*]] = ptrtoaddr ptr %[[VAL_2]] to i64
+// CHECK:  %[[VAL_4:.*]] = ptrtoaddr ptr %[[ARG0]] to i64
+// CHECK:  %[[VAL_5:.*]] = sub i64 %[[VAL_3]], %[[VAL_4]]
+// CHECK:  %[[VAL_7:.*]] = icmp eq ptr %[[VAL_1]], null
+// CHECK:  %[[VAL_8:.*]] = select i1 %[[VAL_7]], i64 0, i64 4
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [4 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[VAL_5]], ptr %[[SIZES]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[ARG0]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[BASEPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  store ptr %[[ARG1]], ptr %[[BASEPTRS]], align 8
+// CHECK:  %[[OFFPTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 2
+// CHECK:  store ptr %[[VAL_1]], ptr %[[OFFPTRS]], align 8
+// CHECK:  %[[SIZES:.*]] = getelementptr inbounds [4 x i64], ptr %.offload_sizes, i32 0, i32 2
+// CHECK:  store i64 %[[VAL_8]], ptr %[[SIZES]], align 8

--- a/mlir/test/Target/LLVMIR/omptarget-mapper-combined-entry.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-mapper-combined-entry.mlir
@@ -40,3 +40,5 @@ module attributes {omp.target_triples = ["amdgcn-amd-amdhsa"]} {
 // CHECK: store ptr null, ptr %[[MAPPER1]]
 // CHECK: %[[MAPPER2:.*]] = getelementptr inbounds [4 x ptr], ptr %[[MAPPERS]], i64 0, i64 2
 // CHECK: store ptr null, ptr %[[MAPPER2]]
+// CHECK: %[[MAPPER3:.*]] = getelementptr inbounds [4 x ptr], ptr %[[MAPPERS]], i64 0, i64 3
+// CHECK: store ptr null, ptr %[[MAPPER3]]

--- a/mlir/test/Target/LLVMIR/omptarget-nested-ptr-record-type-mapping-host.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-nested-ptr-record-type-mapping-host.mlir
@@ -45,6 +45,8 @@ module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-a
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
 // CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 0
 // CHECK:  store ptr %[[NESTED_STRUCT_PTR_MEMBER_GEP]], ptr %[[OFFLOAD_PTRS]], align 8
+// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [4 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  store i64 %[[DTYPE_SIZE_SEGMENT_CALC_4]], ptr %[[OFFLOAD_SIZES]], align 8
 
 // CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8

--- a/mlir/test/Target/LLVMIR/omptarget-nested-record-type-mapping-host.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-nested-record-type-mapping-host.mlir
@@ -42,14 +42,14 @@ llvm.func @_QQmain() {
 // CHECK: %[[FIRST_MEMBER:.*]] = getelementptr i32, ptr %[[MEMBER_ACCESS_1]], i64 1
 // CHECK: %[[FIRST_MEMBER_OFF:.*]] = ptrtoaddr ptr %[[FIRST_MEMBER]] to i64
 // CHECK: %[[SECOND_MEMBER_OFF:.*]] = ptrtoaddr ptr %[[MEMBER_ACCESS_3]] to i64
-// CHECK: %[[OFFLOAD_SIZE:.*]] = sub i64 %[[FIRST_MEMBER_OFF]], %[[SECOND_MEMBER_OFF]]
+// CHECK: %[[MEMBER_DIFF:.*]] = sub i64 %[[FIRST_MEMBER_OFF]], %[[SECOND_MEMBER_OFF]]
 
 // CHECK: %[[BASE_PTR_ARR:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // CHECK: store ptr %[[ALLOCA]], ptr %[[BASE_PTR_ARR]], align 8
 // CHECK: %[[PTR_ARR:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_ptrs, i32 0, i32 0
 // CHECK: store ptr %[[MEMBER_ACCESS_3]], ptr %[[PTR_ARR]], align 8
 // CHECK: %[[SIZE_ARR:.*]] = getelementptr inbounds [5 x i64], ptr %.offload_sizes, i32 0, i32 0
-// CHECK: store i64 %[[OFFLOAD_SIZE]], ptr %[[SIZE_ARR]], align 8
+// CHECK: store i64 %[[MEMBER_DIFF]], ptr %[[SIZE_ARR]], align 8
 
 // CHECK: %[[BASE_PTR_ARR_2:.*]] = getelementptr inbounds [5 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
 // CHECK: store ptr %[[ALLOCA]], ptr %[[BASE_PTR_ARR_2]], align 8

--- a/mlir/test/Target/LLVMIR/omptarget-nowait.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-nowait.mlir
@@ -34,7 +34,6 @@ module attributes {omp.target_triples = ["amdgcn-amd-amdhsa"]} {
 // CHECK: %[[MAPPERS:.*]] = alloca [5 x ptr], align 8
 // CHECK: %[[SIZES:.*]] = alloca [5 x i64], align 4
 
-
 // CHECK: %[[VAL_20:.*]] = getelementptr inbounds [5 x ptr], ptr %[[BASEPTRS]], i32 0, i32 0
 // CHECK: %[[BASEPTRS_GEP:.*]] = getelementptr inbounds [5 x ptr], ptr %[[BASEPTRS]], i32 0, i32 0
 // CHECK: %[[PTRS_GEP:.*]] = getelementptr inbounds [5 x ptr], ptr %[[PTRS]], i32 0, i32 0

--- a/mlir/test/Target/LLVMIR/omptarget-record-type-mapping-host.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-record-type-mapping-host.mlir
@@ -40,14 +40,14 @@ llvm.func @_QQmain() {
 // CHECK: %[[FIRST_MEMBER:.*]] = getelementptr i32, ptr %[[MEMBER_ACCESS_1]], i64 1
 // CHECK: %[[FIRST_MEMBER_OFF:.*]] = ptrtoaddr ptr %[[FIRST_MEMBER]] to i64
 // CHECK: %[[SECOND_MEMBER_OFF:.*]] = ptrtoaddr ptr %[[MEMBER_ACCESS_2]] to i64
-// CHECK: %[[OFFLOAD_SIZE:.*]] = sub i64 %[[FIRST_MEMBER_OFF]], %[[SECOND_MEMBER_OFF]]
+// CHECK: %[[MEMBER_DIFF:.*]] = sub i64 %[[FIRST_MEMBER_OFF]], %[[SECOND_MEMBER_OFF]]
 
 // CHECK: %[[BASE_PTR_ARR:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // CHECK: store ptr %[[ALLOCA]], ptr %[[BASE_PTR_ARR]], align 8
 // CHECK: %[[PTR_ARR:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 0
 // CHECK: store ptr %[[MEMBER_ACCESS_2]], ptr %[[PTR_ARR]], align 8
 // CHECK: %[[SIZE_ARR:.*]] = getelementptr inbounds [4 x i64], ptr %.offload_sizes, i32 0, i32 0
-// CHECK: store i64 %[[OFFLOAD_SIZE]], ptr %[[SIZE_ARR]], align 8
+// CHECK: store i64 %[[MEMBER_DIFF]], ptr %[[SIZE_ARR]], align 8
 
 // CHECK: %[[BASE_PTR_ARR_2:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
 // CHECK: store ptr %[[ALLOCA]], ptr %[[BASE_PTR_ARR_2]], align 8

--- a/offload/test/offloading/fortran/descriptor-stack-jam-regression.f90
+++ b/offload/test/offloading/fortran/descriptor-stack-jam-regression.f90
@@ -5,7 +5,8 @@
 ! device.
 ! REQUIRES: flang, amdgpu
 
-! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: env LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
 module test
 contains
     subroutine kernel_1d(array)

--- a/offload/test/offloading/fortran/map_attach_always.f90
+++ b/offload/test/offloading/fortran/map_attach_always.f90
@@ -1,0 +1,70 @@
+
+! This checks that attach always forces attachment.
+! NOTE: We have to make sure the old default auto attach behaviour is off to
+! yield the correct results for this test. Otherwise the second target will
+! be treated as if we'd had the attach always specified!
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: env LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=0 %libomptarget-run-generic 2>&1 | %fcheck-generic
+program main
+    implicit none
+    integer,  pointer :: map_ptr(:)
+    integer, target :: a(10)
+    integer, target :: b(10)
+    integer :: index, n
+    logical :: correct
+
+    n = 10
+    correct = .true.
+
+    do index = 1, n
+        a(index) = 10
+        b(index) = 20
+    end do
+
+    map_ptr => a
+
+   ! This should map a,b and map_ptr to device, and attach map_ptr
+   ! to a (as it is assigned to it above), and as b is already on
+   ! device running through target.
+   !$omp target enter data map(ref_ptr_ptee, to: map_ptr)
+   !$omp target enter data map(to: b, a)
+
+    !$omp target map(to: index) map(tofrom: correct)
+        do index = 1, n
+            if (map_ptr(index) /= 10) then
+                correct = .false.
+            endif
+        end do
+    !$omp end target
+
+    map_ptr => b
+
+    ! No attach always to force re-attachment, so we should still
+    ! be attached to "a"
+    !$omp target map(to: index) map(tofrom: correct)
+        do index = 1, n
+            if (map_ptr(index) /= 10) then
+                correct = .false.
+            endif
+        end do
+    !$omp end target
+
+    !$omp target map(to: index) map(attach(always): map_ptr) map(tofrom: correct)
+        do index = 1, n
+            if (map_ptr(index) /= 20) then
+                correct = .false.
+            endif
+        end do
+    !$omp end target
+
+    if (correct .NEQV. .true.) then
+        print*, "Failed!"
+        stop 1
+    endif
+
+    print*, "Passed!"
+end program
+
+!CHECK: Passed!

--- a/offload/test/offloading/fortran/map_attach_never.f90
+++ b/offload/test/offloading/fortran/map_attach_never.f90
@@ -1,0 +1,55 @@
+! This checks that attach never prevents pointer attachment when specified.
+! NOTE: We have to make sure the old default auto attach behaviour is off to
+! yield the correct results for this test. Otherwise the second target will
+! be treated as if we'd had the attach always specified!
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: env LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=0 %libomptarget-run-generic 2>&1 | %fcheck-generic
+program main
+    implicit none
+    integer,  pointer :: map_ptr(:)
+    integer, target :: a(10)
+    integer, target :: b(10)
+    integer :: index, n
+    logical :: correct
+
+    correct = .true.
+    n = 10
+
+    do index = 1, n
+        a(index) = 10
+        b(index) = 20
+    end do
+
+    map_ptr => a
+
+    ! This should map a and map_ptr to device, and attach map_ptr
+    ! to a (as it is assigned to it above).
+    !$omp target enter data map(ref_ptr_ptee, to: map_ptr)
+
+    map_ptr => b
+
+    ! As "b" hasn't been mapped to device yet, the first time it's mapped will
+    ! be when map_ptr is re-mapped (implicitly or explicitly), the default behavior
+    ! when LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS is switched off would force attachment
+    ! of map_ptr to b as we've assigned it above. To prevent this and test the never
+    ! attachment, we can apply attach(never), which prevents this reattachment from
+    ! occurring
+    !$omp target map(to: index) map(tofrom: correct) map(attach(never): map_ptr)
+        do index = 1, n
+            if (map_ptr(index) /= 10) then
+                correct = .false.
+            endif
+        end do
+    !$omp end target
+
+    if (correct .NEQV. .true.) then
+        print*, "Failed!"
+        stop 1
+    endif
+
+    print*, "Passed!"
+end program
+
+!CHECK: Passed!

--- a/offload/test/offloading/fortran/map_ref_ptr_ptee_test_1.f90
+++ b/offload/test/offloading/fortran/map_ref_ptr_ptee_test_1.f90
@@ -1,0 +1,47 @@
+! This checks that we can specify ref_ptee and ref_ptr, not encounter
+! an error and correctly map data to and from device.
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic -fopenmp-version=61
+! RUN: env LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=0  %libomptarget-run-generic 2>&1 | %fcheck-generic
+program main
+    implicit none
+    integer,  pointer :: map_ptr(:)
+    integer, target :: b(10)
+    integer :: index
+
+    map_ptr => b
+
+    ! Should have auto attach applied and automatically
+    ! attach to ref_ptee. So internally we implicitly apply
+    ! the attach map type.
+    !$omp target enter data map(ref_ptee, to: map_ptr)
+    !$omp target enter data map(ref_ptr, to: map_ptr)
+
+    ! should in theory memory access fault if we haven't attached
+    ! correctly above. But if all went well should go fine.
+    !$omp target map(to: index)
+        do index = 1, 10
+            map_ptr(index) = index
+        end do
+    !$omp end target
+
+    ! Don't care about the descriptor, but we do want to
+    ! deallocate it and only it and then map the data
+    ! back. Doing it in a weird-ish order to test we can
+    ! delete the descriptor separately and still pull the
+    ! data back.
+    !$omp target exit data map(ref_ptee, from: map_ptr)
+    !$omp target exit data map(ref_ptr, delete: map_ptr)
+
+    do index = 1, 10
+        if (map_ptr(index) /= index) then
+            print*, "Failed!"
+            stop 1
+        endif
+    end do
+
+    print*, "Passed!"
+end program
+
+! CHECK: Passed!

--- a/offload/test/offloading/fortran/map_ref_ptr_ptee_test_2.f90
+++ b/offload/test/offloading/fortran/map_ref_ptr_ptee_test_2.f90
@@ -1,0 +1,47 @@
+! This checks that we can specify ref_ptee and ref_ptr, not encounter
+! an error and correctly map data to and from device. This does so
+! in a different order from map_ref_ptr_ptee_test_1.f90 to verify we
+! do not hit any odd runtime errors from mapping in a different order.
+! REQUIRES: flang, amdgpu
+
+! RUN: %libomptarget-compile-fortran-generic -fopenmp-version=61
+! RUN: env LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=0  %libomptarget-run-generic 2>&1 | %fcheck-generic
+
+program main
+    implicit none
+    integer,  pointer :: map_ptr(:)
+    integer, target :: b(10)
+    integer :: index
+
+    map_ptr => b
+
+    !$omp target enter data map(ref_ptr, to: map_ptr)
+    !$omp target enter data map(ref_ptee, to: map_ptr)
+
+    ! should in theory memory access fault if we haven't attached
+    ! correctly above. But if all went well should go fine.
+    !$omp target map(to: index)
+        do index = 1, 10
+            map_ptr(index) = index
+        end do
+    !$omp end target
+
+    ! Don't care about the descriptor, but we do want to
+    ! deallocate it and only it and then map the data
+    ! back. Doing it in a weird-ish order to test we can
+    ! delete the descriptor separately and still pull the
+    ! data back.
+    !$omp target exit data map(ref_ptr, delete: map_ptr)
+    !$omp target exit data map(ref_ptee, from: map_ptr)
+
+    do index = 1, 10
+        if (map_ptr(index) /= index) then
+            print*, "Failed!"
+            stop 1
+        endif
+    end do
+
+    print*, "Passed!"
+end program
+
+! CHECK: Passed

--- a/offload/test/offloading/fortran/target-map-pointer-to-dtype-allocatable-member.f90
+++ b/offload/test/offloading/fortran/target-map-pointer-to-dtype-allocatable-member.f90
@@ -4,7 +4,8 @@
 ! directives
 ! REQUIRES: flang, amdgpu
 
-! RUN: %libomptarget-compile-fortran-run-and-check-generic
+! RUN: %libomptarget-compile-fortran-generic
+! RUN: env LIBOMPTARGET_TREAT_ATTACH_AUTO_AS_ALWAYS=1 %libomptarget-run-generic 2>&1 | %fcheck-generic
 module dtype
     type :: my_dtype
             integer :: s, e


### PR DESCRIPTION
This PR adjusts the LLVM-IR lowering to support the new attach map type that the runtime uses to link data and pointer together, this swaps the mapping from the older OMP_MAP_PTR_AND_OBJ map type in most cases and allows slightly more complicated ref_ptr/ptee and attach semantics.


