### PR TITLE
[ASan] Exclude .hipFatBinSegment and .nvFatBinSegment from instrument…

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2193,6 +2193,16 @@ bool ModuleAddressSanitizer::shouldInstrumentGlobal(GlobalVariable *G) const {
       return false;
     }
 
+    // Do not instrument HIP/CUDA fat binary wrapper sections. These sections
+    // contain tightly-packed arrays of __CudaFatBinaryWrapper structs (24
+    // bytes each). The HIP runtime and tools like rocm-kpack walk these
+    // sections assuming a contiguous 24-byte stride. Adding redzones would
+    // break this layout assumption.
+    // See https://github.com/ROCm/TheRock/issues/4680
+    if (Section == ".hipFatBinSegment" || Section == ".nvFatBinSegment") {
+      return false;
+    }
+
     // Do not instrument user-defined sections (with names resembling
     // valid C identifiers)
     if (TargetTriple.isOSBinFormatELF()) {


### PR DESCRIPTION
These sections contain tightly-packed arrays of __CudaFatBinaryWrapper structs (24 bytes each). The HIP/CUDA runtime and tools like rocm-kpack walk these sections assuming a contiguous 24-byte stride.

When ASan instruments globals in these sections, it adds redzones and alignment padding, breaking the layout assumption. This causes failures like:
  - ".hipFatBinSegment size 128 is not a multiple of wrapper size (24)"
  - "Unexpected magic 0x00000000 at wrapper 1"

Add these sections to the exemption list in shouldInstrumentGlobal(), similar to .preinit_array, .init_array, and .fini_array.

Fixes: https://github.com/ROCm/TheRock/issues/4680

Noticed issue in https://github.com/ROCm/TheRock/actions/runs/24646315874/job/72061754947 and now fixed and tested here: https://github.com/ROCm/TheRock/actions/runs/25816355734/job/75859833854


