### PR TITLE
[Comgr][hotswap] Add raise_failure + RaiseContext + register file

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -51,6 +51,10 @@ add_library(hotswap-transpiler OBJECT
   decode.cpp
   wave-projection.cpp
   setpc-analysis.cpp
+  raise-context.cpp
+  reg-file.cpp
+  kernarg-layout.cpp
+  user-sgpr-layout.cpp
 )
 
 if(NOT TARGET hotswap::transpiler)

--- a/amd/comgr/src/hotswap/handlers.h
+++ b/amd/comgr/src/hotswap/handlers.h
@@ -1,0 +1,55 @@
+//===- handlers.h - Hotswap transpiler ------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_HANDLERS_H
+#define HOTSWAP_TRANSPILER_HANDLERS_H
+
+#include "raise-context.h"
+
+namespace llvm {
+class MCInstrInfo;
+} // namespace llvm
+
+namespace COMGR::hotswap {
+
+class OpcodeMap;
+
+// Asserts every MFMA-format opcode the disassembler can decode has a CanonicalOp
+// handler entry. See `handle_mfma.cpp` for details.
+void verifyMFMACoverage(const llvm::MCInstrInfo &MCII, const OpcodeMap &OpcMap);
+
+HandlerResult handleSOPP(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleSMEM(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleSOPC(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleSOP1(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleSOPK(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleSOP2(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleVALU(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleFLAT(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleDS(RaiseContext &Ctx, const DecodedInst &Di,
+                       OpResolver &Op);
+HandlerResult handleMUBUF(RaiseContext &Ctx, const DecodedInst &Di,
+                          OpResolver &Op);
+HandlerResult handleMFMA(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleVOPD(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op);
+HandlerResult handleVIMAGE(RaiseContext &Ctx, const DecodedInst &Di,
+                           OpResolver &Op);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/hotswap-error.cpp
+++ b/amd/comgr/src/hotswap/hotswap-error.cpp
@@ -1,4 +1,4 @@
-//===- hotswap-error.cpp - Out-of-line HotswapError ID symbol ------------===//
+//===- hotswap-error.cpp - HotswapError IDs + categorised factories ------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
 // amd/comgr/LICENSE.TXT in this repository for license information.
@@ -8,8 +8,138 @@
 
 #include "hotswap-error.h"
 
+#include "decoded-inst.h"
+
 namespace COMGR::hotswap {
 
+// ErrorInfo IDs. One per subclass; the address of each `ID` is what
+// `Err.isA<X>()` discriminates on internally.
 char HotswapError::ID = 0;
+char HotswapBadInputError::ID = 0;
+char HotswapUnsupportedOpcodeError::ID = 0;
+char HotswapUnsupportedShapeError::ID = 0;
+char HotswapSPEUnsafeExecWriterError::ID = 0;
+char HotswapTargetMachineError::ID = 0;
+char HotswapIRVerificationError::ID = 0;
+char HotswapCrossWaveLaneIdLeakError::ID = 0;
+char HotswapCrossWaveUnrewritableShuffleError::ID = 0;
+char HotswapCrossWaveShuffleRewritePendingError::ID = 0;
+char HotswapCrossWaveReplicaRaceError::ID = 0;
+char HotswapCrossWaveLanePredicatedExecError::ID = 0;
+char HotswapCrossWavePredicateChainError::ID = 0;
+char HotswapStrictUnsafeLoweringError::ID = 0;
+char HotswapMissingKernelDescriptorError::ID = 0;
+char HotswapUserSgprLayoutMismatchError::ID = 0;
+
+// Categorised factories. Each constructs the subclass with the
+// stable category string the lit tests grep on as the `Format`
+// field (matches the former `reasonString(RaiseFailureReason)`
+// output character-for-character).
+
+llvm::Error makeHotswapBadInputError(const llvm::Twine &Detail) {
+  return llvm::make_error<HotswapBadInputError>("BadInput", "", 0, Detail);
+}
+
+llvm::Error makeHotswapUnsupportedOpcodeError(const DecodedInst &Di,
+                                              llvm::StringRef FormatName) {
+  return llvm::make_error<HotswapUnsupportedOpcodeError>(
+      FormatName, Di.Mnemonic, Di.Offset, "");
+}
+
+llvm::Error makeHotswapUnsupportedShapeError(const DecodedInst &Di,
+                                             llvm::StringRef FormatName,
+                                             const llvm::Twine &Detail) {
+  return llvm::make_error<HotswapUnsupportedShapeError>(
+      FormatName, Di.Mnemonic, Di.Offset, Detail);
+}
+
+llvm::Error makeHotswapSPEUnsafeExecWriterError(const DecodedInst &Di) {
+  return llvm::make_error<HotswapSPEUnsafeExecWriterError>(
+      "SPE-unmodeled-EXEC-writer", Di.Mnemonic, Di.Offset, "");
+}
+
+llvm::Error makeHotswapTargetMachineError() {
+  return llvm::make_error<HotswapTargetMachineError>(
+      "TargetMachineCreationFailed", "", 0,
+      "createTargetMachine returned null");
+}
+
+llvm::Error makeHotswapIRVerificationError(const llvm::Twine &VerifierMsg) {
+  return llvm::make_error<HotswapIRVerificationError>(
+      "IRVerificationFailed", "", 0, VerifierMsg);
+}
+
+llvm::Error
+makeHotswapCrossWaveLaneIdLeakError(const DecodedInst &Di,
+                                    const llvm::Twine &KindDetail) {
+  return llvm::make_error<HotswapCrossWaveLaneIdLeakError>(
+      "cross-wave-lane-id-leak", Di.Mnemonic, Di.Offset, KindDetail);
+}
+
+llvm::Error makeHotswapCrossWaveUnrewritableShuffleError(
+    const DecodedInst &Di, const llvm::Twine &KindDetail) {
+  return llvm::make_error<HotswapCrossWaveUnrewritableShuffleError>(
+      "cross-wave-unrewritable-shuffle", Di.Mnemonic, Di.Offset, KindDetail);
+}
+
+llvm::Error makeHotswapCrossWaveShuffleRewritePendingError(
+    const DecodedInst &Di, const llvm::Twine &KindDetail) {
+  return llvm::make_error<HotswapCrossWaveShuffleRewritePendingError>(
+      "cross-wave-shuffle-rewrite-pending", Di.Mnemonic, Di.Offset, KindDetail);
+}
+
+llvm::Error
+makeHotswapCrossWaveReplicaRaceError(const DecodedInst &Di,
+                                     const llvm::Twine &KindDetail) {
+  return llvm::make_error<HotswapCrossWaveReplicaRaceError>(
+      "cross-wave-replica-race", Di.Mnemonic, Di.Offset, KindDetail);
+}
+
+llvm::Error makeHotswapCrossWaveLanePredicatedExecError(
+    const DecodedInst &Di, const llvm::Twine &KindDetail) {
+  return llvm::make_error<HotswapCrossWaveLanePredicatedExecError>(
+      "cross-wave-lane-predicated-exec", Di.Mnemonic, Di.Offset, KindDetail);
+}
+
+llvm::Error
+makeHotswapCrossWavePredicateChainError(llvm::StringRef KernelName,
+                                        const llvm::Twine &Detail) {
+  return llvm::make_error<HotswapCrossWavePredicateChainError>(
+      "cross-wave-predicate-chain", "workitem.id.x-predicate-chain-classifier",
+      0, ("kernel '" + KernelName + "': " + Detail).str());
+}
+
+llvm::Error makeHotswapCrossWaveRewriteOracleDisagreementError(
+    llvm::StringRef KernelName, const llvm::Twine &Detail) {
+  // Maps to the LaneIdLeak subclass intentionally: matches the rocm-
+  // side reuse of `CrossWaveLaneIdLeak` for the safety-net so corpus
+  // dashboards see this as a Class 1 refusal alongside the
+  // syntactic-classifier wave-id-leak kinds.
+  return llvm::make_error<HotswapCrossWaveLaneIdLeakError>(
+      "cross-wave-lane-id-leak", "writelane/readlane-post-raise-safety-net", 0,
+      ("kernel '" + KernelName + "': " + Detail).str());
+}
+
+llvm::Error makeHotswapStrictUnsafeLoweringError(const DecodedInst &Di,
+                                                 llvm::StringRef Site,
+                                                 const llvm::Twine &Detail) {
+  return llvm::make_error<HotswapStrictUnsafeLoweringError>(
+      Site, Di.Mnemonic, Di.Offset, Detail);
+}
+
+llvm::Error
+makeHotswapMissingKernelDescriptorError(llvm::StringRef KernelName) {
+  return llvm::make_error<HotswapMissingKernelDescriptorError>(
+      "missing-kernel-descriptor", "<kernel-descriptor>", 0,
+      ("kernel '" + KernelName + "': .kd symbol not parsed").str());
+}
+
+llvm::Error
+makeHotswapUserSgprLayoutMismatchError(llvm::StringRef KernelName,
+                                       const llvm::Twine &Detail) {
+  return llvm::make_error<HotswapUserSgprLayoutMismatchError>(
+      "user-sgpr-layout-mismatch", "<user-sgpr-layout>", 0,
+      ("kernel '" + KernelName + "': " + Detail).str());
+}
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/hotswap-error.h
+++ b/amd/comgr/src/hotswap/hotswap-error.h
@@ -9,38 +9,92 @@
 // `HotswapError` is the dedicated `llvm::ErrorInfo` subclass for failures
 // that the hotswap transpiler detects itself: missing ELF sections,
 // kernels absent from the AMDGPU MsgPack metadata, MC target-stack
-// construction failures, etc. Errors that the transpiler *forwards*
-// from `llvm::object`, `MC`, or `COMGR::lookupSymbolByName` are passed
+// construction failures, unsupported instruction encodings, wave-size
+// obstructions, etc. Errors that the transpiler *forwards* from
+// `llvm::object`, `MC`, or `COMGR::lookupSymbolByName` are passed
 // through as their original ErrorInfo type, so callers can still
 // `handleErrors` on them and tell hotswap-originated failures apart
 // from upstream LLVM ones.
 //
-// The payload is intentionally just a message string -- there's no
-// HotswapErrorCode enum to maintain. Discrimination across the two
-// error origins (hotswap-internal vs. forwarded) happens at the
-// ErrorInfo *type* level via `Err.isA<HotswapError>()` /
-// `handleErrors(... [](const HotswapError &) { ... })`.
+// Two construction shapes:
+//
+//   * Simple-message: `makeHotswapError(detail)` returns a base
+//     `HotswapError` whose only payload is the detail string. Used by
+//     code-object-utils, mc-state, raiser entry-point validation,
+//     etc., where a single message suffices.
+//
+//   * Categorised: per-category `ErrorInfo` subclasses
+//     (`HotswapUnsupportedShapeError`, `HotswapCrossWaveLaneIdLeakError`,
+//     ...) carry structured metadata (`Format`, `Mnemonic`, `Offset`,
+//     `Detail`) so consumers can bucket failures by category via
+//     `Err.isA<X>()` / `handleErrors([] (const X &) { ... })` without
+//     parsing the message string, and so pipeline-level diagnostic
+//     records can populate `Fail{Format,Mnemonic,Offset,Detail}`
+//     fields directly. The `Format` field's value at each factory
+//     matches the stable category strings the lit tests grep on
+//     (`cross-wave-lane-id-leak`, `cross-wave-shuffle-rewrite-pending`,
+//     etc.).
+//
+// Both shapes share the same base `HotswapError` so existing
+// `Err.isA<HotswapError>()` discrimination across hotswap-internal vs.
+// upstream-forwarded errors keeps working uniformly.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef HOTSWAP_TRANSPILER_HOTSWAP_ERROR_H
 #define HOTSWAP_TRANSPILER_HOTSWAP_ERROR_H
 
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
 #include <string>
 #include <system_error>
 
 namespace COMGR::hotswap {
 
+struct DecodedInst;
+
 class HotswapError : public llvm::ErrorInfo<HotswapError> {
 public:
   static char ID;
+
+  // Single-message field used by `makeHotswapError(detail)` callers.
+  // For categorised subclasses this is populated as
+  // "<Format>: <Detail>" so `log()` output is stable regardless of
+  // construction shape.
   std::string Msg;
 
-  explicit HotswapError(const llvm::Twine &Detail) : Msg(Detail.str()) {}
+  // Structured fields populated by categorised subclasses; empty
+  // (default) for simple-message construction. Pipeline-level
+  // diagnostic records read these directly to populate
+  // `PipelineResult::Fail{Format,Mnemonic,Offset,Detail}` without
+  // dyn_casting per category.
+  std::string Format;
+  std::string Mnemonic;
+  uint64_t Offset = 0;
+  std::string Detail;
+
+  // Simple-message constructor. Used by call sites that don't have a
+  // category (e.g. ELF/MC failures).
+  explicit HotswapError(const llvm::Twine &DetailIn) : Msg(DetailIn.str()) {}
+
+  // Categorised constructor. Stores the structured fields and
+  // builds `Msg` as "<Format>: <Detail>" (omitting the colon and
+  // detail if `DetailIn` is empty) so `log()` emits the stable
+  // category string the lit tests grep on.
+  HotswapError(llvm::StringRef FormatIn, llvm::StringRef MnemonicIn,
+               uint64_t OffsetIn, const llvm::Twine &DetailIn)
+      : Format(FormatIn.str()), Mnemonic(MnemonicIn.str()), Offset(OffsetIn),
+        Detail(DetailIn.str()) {
+    if (Detail.empty()) {
+      Msg = Format;
+    } else {
+      Msg = (FormatIn + ": " + DetailIn).str();
+    }
+  }
 
   void log(llvm::raw_ostream &OS) const override { OS << "hotswap: " << Msg; }
 
@@ -49,9 +103,175 @@ public:
   }
 };
 
+// Per-category subclasses. Each inherits HotswapError's constructors
+// via `using ErrorInfo::ErrorInfo;` (LLVM's ErrorInfo template
+// forwards parent-class constructors), so factory functions below
+// can call `llvm::make_error<HotswapXError>(Format, Mnemonic, Offset,
+// Detail)`. `Err.isA<HotswapError>()` returns true for any subclass
+// because the type chain walks up via classID().
+
+class HotswapBadInputError
+    : public llvm::ErrorInfo<HotswapBadInputError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapUnsupportedOpcodeError
+    : public llvm::ErrorInfo<HotswapUnsupportedOpcodeError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapUnsupportedShapeError
+    : public llvm::ErrorInfo<HotswapUnsupportedShapeError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapSPEUnsafeExecWriterError
+    : public llvm::ErrorInfo<HotswapSPEUnsafeExecWriterError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapTargetMachineError
+    : public llvm::ErrorInfo<HotswapTargetMachineError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapIRVerificationError
+    : public llvm::ErrorInfo<HotswapIRVerificationError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapCrossWaveLaneIdLeakError
+    : public llvm::ErrorInfo<HotswapCrossWaveLaneIdLeakError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapCrossWaveUnrewritableShuffleError
+    : public llvm::ErrorInfo<HotswapCrossWaveUnrewritableShuffleError,
+                             HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapCrossWaveShuffleRewritePendingError
+    : public llvm::ErrorInfo<HotswapCrossWaveShuffleRewritePendingError,
+                             HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapCrossWaveReplicaRaceError
+    : public llvm::ErrorInfo<HotswapCrossWaveReplicaRaceError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapCrossWaveLanePredicatedExecError
+    : public llvm::ErrorInfo<HotswapCrossWaveLanePredicatedExecError,
+                             HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapCrossWavePredicateChainError
+    : public llvm::ErrorInfo<HotswapCrossWavePredicateChainError,
+                             HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapStrictUnsafeLoweringError
+    : public llvm::ErrorInfo<HotswapStrictUnsafeLoweringError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapMissingKernelDescriptorError
+    : public llvm::ErrorInfo<HotswapMissingKernelDescriptorError,
+                             HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+class HotswapUserSgprLayoutMismatchError
+    : public llvm::ErrorInfo<HotswapUserSgprLayoutMismatchError, HotswapError> {
+public:
+  static char ID;
+  using ErrorInfo::ErrorInfo;
+};
+
+// ===== Factory functions =====
+//
+// Simple-message factory: existing call sites that just want a
+// HotswapError carrying a single detail string.
+
 inline llvm::Error makeHotswapError(const llvm::Twine &Detail) {
   return llvm::make_error<HotswapError>(Detail);
 }
+
+// Categorised factories. Each mirrors the corresponding former
+// `RaiseFailure::xxx(...)` factory's signature so handler-site
+// rewrites are a 1:1 substitution. The `Format` string at each
+// factory matches the stable category string the lit tests grep on
+// (kept stable across the migration: see the rocm-side
+// `reasonString()` for the canonical list).
+
+llvm::Error makeHotswapBadInputError(const llvm::Twine &Detail);
+llvm::Error makeHotswapUnsupportedOpcodeError(const DecodedInst &Di,
+                                              llvm::StringRef FormatName);
+llvm::Error makeHotswapUnsupportedShapeError(const DecodedInst &Di,
+                                             llvm::StringRef FormatName,
+                                             const llvm::Twine &Detail = {});
+llvm::Error makeHotswapSPEUnsafeExecWriterError(const DecodedInst &Di);
+llvm::Error makeHotswapTargetMachineError();
+llvm::Error makeHotswapIRVerificationError(const llvm::Twine &VerifierMsg);
+llvm::Error makeHotswapCrossWaveLaneIdLeakError(const DecodedInst &Di,
+                                                const llvm::Twine &KindDetail);
+llvm::Error makeHotswapCrossWaveUnrewritableShuffleError(
+    const DecodedInst &Di, const llvm::Twine &KindDetail);
+llvm::Error makeHotswapCrossWaveShuffleRewritePendingError(
+    const DecodedInst &Di, const llvm::Twine &KindDetail);
+llvm::Error
+makeHotswapCrossWaveReplicaRaceError(const DecodedInst &Di,
+                                     const llvm::Twine &KindDetail);
+llvm::Error makeHotswapCrossWaveLanePredicatedExecError(
+    const DecodedInst &Di, const llvm::Twine &KindDetail);
+llvm::Error
+makeHotswapCrossWavePredicateChainError(llvm::StringRef KernelName,
+                                        const llvm::Twine &Detail);
+// Maps to the LaneIdLeak subclass (matches the rocm-side
+// `crossWaveRewriteOracleDisagreement` which reused the LaneIdLeak
+// reason so corpus-level regression dashboards see it as
+// "Class 1 refusal" alongside other wave-id-leak kinds).
+llvm::Error makeHotswapCrossWaveRewriteOracleDisagreementError(
+    llvm::StringRef KernelName, const llvm::Twine &Detail);
+llvm::Error makeHotswapStrictUnsafeLoweringError(const DecodedInst &Di,
+                                                 llvm::StringRef Site,
+                                                 const llvm::Twine &Detail);
+llvm::Error makeHotswapMissingKernelDescriptorError(llvm::StringRef KernelName);
+llvm::Error
+makeHotswapUserSgprLayoutMismatchError(llvm::StringRef KernelName,
+                                       const llvm::Twine &Detail);
 
 } // namespace COMGR::hotswap
 

--- a/amd/comgr/src/hotswap/kernarg-layout.cpp
+++ b/amd/comgr/src/hotswap/kernarg-layout.cpp
@@ -1,0 +1,58 @@
+//===- kernarg-layout.cpp - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "kernarg-layout.h"
+
+#include "llvm/ADT/StringRef.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+SourceHiddenArgByte classifySourceHiddenArgByte(ArrayRef<KernelArgMeta> Args,
+                                                int ByteOffset) {
+  for (const KernelArgMeta &Arg : Args) {
+    if (ByteOffset < Arg.Offset || ByteOffset >= Arg.Offset + Arg.Size)
+      continue;
+
+    StringRef Kind(Arg.ValueKind);
+    if (!Kind.starts_with("hidden_"))
+      return {};
+
+    SourceHiddenArgByte Result;
+    Result.ValueKind = Kind;
+    Result.ArgOffset = Arg.Offset;
+    Result.ByteOffset = ByteOffset;
+    if (Kind == "hidden_block_count_x")
+      Result.Kind = SourceHiddenArgKind::HiddenBlockCountX;
+    else if (Kind == "hidden_block_count_y")
+      Result.Kind = SourceHiddenArgKind::HiddenBlockCountY;
+    else if (Kind == "hidden_block_count_z")
+      Result.Kind = SourceHiddenArgKind::HiddenBlockCountZ;
+    else if (Kind == "hidden_group_size_x")
+      Result.Kind = SourceHiddenArgKind::HiddenGroupSizeX;
+    else if (Kind == "hidden_group_size_y")
+      Result.Kind = SourceHiddenArgKind::HiddenGroupSizeY;
+    else if (Kind == "hidden_group_size_z")
+      Result.Kind = SourceHiddenArgKind::HiddenGroupSizeZ;
+    else if (Kind == "hidden_remainder_x")
+      Result.Kind = SourceHiddenArgKind::HiddenRemainderX;
+    else if (Kind == "hidden_remainder_y")
+      Result.Kind = SourceHiddenArgKind::HiddenRemainderY;
+    else if (Kind == "hidden_remainder_z")
+      Result.Kind = SourceHiddenArgKind::HiddenRemainderZ;
+    else if (Kind == "hidden_grid_dims")
+      Result.Kind = SourceHiddenArgKind::HiddenGridDims;
+    else
+      Result.Kind = SourceHiddenArgKind::UnsupportedHidden;
+    return Result;
+  }
+  return {};
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/kernarg-layout.h
+++ b/amd/comgr/src/hotswap/kernarg-layout.h
@@ -1,0 +1,83 @@
+//===- kernarg-layout.h - Hotswap transpiler ------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_KERNARG_LAYOUT_H
+#define HOTSWAP_TRANSPILER_KERNARG_LAYOUT_H
+
+#include "code-object-utils.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace COMGR::hotswap {
+
+// Source-kernel kernarg-segment metadata shared by the raiser and any
+// helper that needs to reason about the segment without dereferencing
+// it (e.g. the kernel-entry preloaded-SGPR seeding loop).
+//
+// The raiser itself no longer indexes the segment slot-by-slot:
+// kernarg loads lift to GEP+load against `amdgcn_kernarg_segment_ptr`
+// and the AMDGPU backend handles the ABI lowering. This struct keeps
+// only the two pieces of metadata that survive that move.
+struct KernargLayout {
+  // Byte offset (within the source ABI's flat kernarg-segment view)
+  // where the implicit-arg block begins. `handle_smem.cpp` consults
+  // this to reroute SMEM loads at offsets >= implicitArgsBase through
+  // `amdgcn_implicitarg_ptr` instead of the kernarg-segment pointer:
+  // the source kernel's flat view is layout-correct for the source
+  // ABI, but the lifted target kernel reaches implicit args via a
+  // separate runtime pointer, so the offset must be rebased to
+  // `byteOffset - implicitArgsBase`.
+  int ImplicitArgsBase = 0;
+  // Source metadata argument layout, including hidden_* entries. Used to
+  // synthesize source-ABI hidden values without depending on target-runtime
+  // implicit-arg layout.
+  llvm::ArrayRef<KernelArgMeta> Args;
+  // Total kernarg segment size in bytes, copied from the kernel
+  // descriptor's `.kernarg_segment_size`. Informational; the lifted
+  // kernel's `Function` parameter list drives the backend's
+  // `kernarg_segment_size` calculation in the output KD.
+  int KernargSegmentSize = 0;
+};
+
+enum class SourceHiddenArgKind {
+  None,
+  HiddenBlockCountX,
+  HiddenBlockCountY,
+  HiddenBlockCountZ,
+  HiddenGroupSizeX,
+  HiddenGroupSizeY,
+  HiddenGroupSizeZ,
+  HiddenRemainderX,
+  HiddenRemainderY,
+  HiddenRemainderZ,
+  HiddenGridDims,
+  UnsupportedHidden,
+};
+
+struct SourceHiddenArgByte {
+  SourceHiddenArgKind Kind = SourceHiddenArgKind::None;
+  llvm::StringRef ValueKind;
+  int ArgOffset = 0;
+  int ByteOffset = 0;
+
+  bool matched() const { return Kind != SourceHiddenArgKind::None; }
+  unsigned byteIndexInArg() const {
+    return static_cast<unsigned>(ByteOffset - ArgOffset);
+  }
+};
+
+// Resolve a byte offset in the source ABI's flat kernarg/hidden-arg metadata
+// view.  Known source hidden args are later synthesized from dispatch state;
+// unsupported hidden args must refuse instead of falling back to target
+// implicitarg layout.
+SourceHiddenArgByte classifySourceHiddenArgByte(
+    llvm::ArrayRef<KernelArgMeta> Args, int ByteOffset);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/parsed-reg.h
+++ b/amd/comgr/src/hotswap/parsed-reg.h
@@ -20,7 +20,7 @@ struct ParsedReg {
   //   SRC_SCC  : i1 == SCC
   // These cannot be written. We model them as their own kinds so
   // readOp32 / readOp64 can materialise the boolean result on demand
-  // (see raise_context.cpp). Tensile gfx1250 emits them as F16 source
+  // (see raise-context.cpp). Tensile gfx1250 emits them as F16 source
   // operands (e.g. `v_sub_f16 v64, src_vccz, v48`), so the dispatch
   // path must recognise them or the kernel crashes inside parseReg.
   enum Kind { SGPR, VGPR, AGPR, VCC, EXEC, SCC, MODE, M0, FLAT_SCR, TTMP,

--- a/amd/comgr/src/hotswap/raise-context.cpp
+++ b/amd/comgr/src/hotswap/raise-context.cpp
@@ -1,0 +1,737 @@
+//===- raise-context.cpp - Hotswap transpiler -----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "raise-context.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h" // AMDGPU::VCC, AMDGPU::EXEC, ...
+#include "SIDefines.h"                        // AMDGPU::HWEncoding::*
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/Intrinsics.h"
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+BasicBlock *RaiseContext::lookupBB(uint64_t Addr) {
+  auto It = OffsetToBb.find(Addr);
+  if (It != OffsetToBb.end())
+    return It->second;
+  errs() << "transpiler: missing basic block for offset 0x" << utohexstr(Addr)
+         << " -- creating fallback\n";
+  BasicBlock *Bb =
+      BasicBlock::Create(C, "bb_fallback_0x" + utohexstr(Addr), Kernel);
+  OffsetToBb[Addr] = Bb;
+  return Bb;
+}
+
+void RaiseContext::computeVGPRAdjust(const DecodedInst &Di) {
+  std::fill_n(CurrentVgprAdjust, KMaxOps, 0u);
+  if (VgprMsBs == 0)
+    return;
+
+  // vgprMSBs is an 8-bit state shared by single-issue instructions and both
+  // halves of a VOPD pair.  Layout: src0[1:0], src1[3:2], src2[5:4], dst[7:6].
+  unsigned DstMsb = (static_cast<unsigned>(VgprMsBs >> 6) & 0x3u) * 256u;
+  unsigned SrcMsb[3] = {
+      (static_cast<unsigned>(VgprMsBs >> 0) & 0x3u) * 256u,
+      (static_cast<unsigned>(VgprMsBs >> 2) & 0x3u) * 256u,
+      (static_cast<unsigned>(VgprMsBs >> 4) & 0x3u) * 256u,
+  };
+
+  for (unsigned I = 0; I < Di.NumDefs && I < KMaxOps; I++)
+    CurrentVgprAdjust[I] = DstMsb;
+
+  for (unsigned I = 0; I < Di.NumSrcs && I < 3; I++) {
+    unsigned OpIdx = Di.SrcMap[I];
+    if (OpIdx < KMaxOps)
+      CurrentVgprAdjust[OpIdx] = SrcMsb[I];
+  }
+}
+
+// Count how many 32-bit sub-registers make up `reg`. A 32-bit register has
+// no sub0 (getSubReg returns 0) and is reported as width 1. Tuples
+// (SGPR0_SGPR1, VReg_128, ...) walk sub0, sub1, ... until exhausted.
+// The loop is bounded by the target's declared sub-reg index count so it
+// terminates even if a future TableGen change introduced a cycle in the
+// sub-reg graph.
+static int computeRegWidth32(const MCRegisterInfo &MRI, MCRegister Reg) {
+  const unsigned MaxSubIdx = MRI.getNumSubRegIndices();
+  int W = 0;
+  for (unsigned SubIdx = AMDGPU::sub0; SubIdx < MaxSubIdx; ++SubIdx) {
+    if (!MRI.getSubReg(Reg, SubIdx))
+      break;
+    ++W;
+  }
+  return W ? W : 1;
+}
+
+// Locate `reg` inside `RC` and return its 0-based position. Used where the
+// hardware encoding is not what we want (TTMPs live at generation-specific
+// HW slots 108+ or 112+, but downstream we index a logical `ttmp[16]`
+// array). Relies only on TableGen's declared class membership -- no enum
+// arithmetic assumptions.
+static int findIndexInClass(const MCRegisterClass &RC, MCRegister Reg) {
+  for (unsigned I = 0, E = RC.getNumRegs(); I != E; ++I)
+    if (RC.getRegister(I) == Reg)
+      return static_cast<int>(I);
+  return -1;
+}
+
+ParsedReg RaiseContext::parseReg(MCRegister Reg, int MciOpIdx) const {
+  ParsedReg Pr;
+  if (!Reg) {
+    Pr.RegKind = ParsedReg::NOREG;
+    return Pr;
+  }
+
+  const MCRegisterInfo &MRI = *Mc.RegInfo;
+
+  // Width is computed on the as-decoded register: only the subtarget-
+  // specific aliases (TTMPx_gfx9plus, FLAT_SCR_vi, ...) carry the correct
+  // sub0/sub1/... chain from the disassembler.
+  const int Width = computeRegWidth32(MRI, Reg);
+
+  // Reduce everything to a canonical 32-bit pseudo for class/enum lookups:
+  //   * sub0 on the as-decoded register picks the first 32-bit lane out
+  //     of a tuple (sub-reg graph is authoritative on the real MC reg).
+  //   * mc2PseudoReg then strips any subtarget suffix:
+  //       TTMP8_gfx9plus         -> TTMP8
+  //       FLAT_SCR_LO_vi         -> FLAT_SCR_LO
+  //       SGPR_NULL64_gfx11plus  -> SGPR_NULL
+  //       M0_gfx11plus           -> M0
+  MCRegister Lane = MRI.getSubReg(Reg, AMDGPU::sub0);
+  if (!Lane)
+    Lane = Reg;
+  Lane = AMDGPU::mc2PseudoReg(Lane);
+
+  switch (Lane) {
+  // Wave-mask registers. The ``_LO`` / ``_HI`` halves get the same
+  // classification as the full pair; downstream VCC/EXEC handling routes
+  // through loadVCC/storeVCC (which already respects wave size), so the
+  // ``width`` field is informational here rather than load-bearing.
+  case AMDGPU::VCC_LO:
+  case AMDGPU::VCC_HI:
+    Pr.RegKind = ParsedReg::VCC;
+    Pr.Width = Isa.isWave32() ? 1 : 2;
+    return Pr;
+  case AMDGPU::EXEC_LO:
+  case AMDGPU::EXEC_HI:
+    Pr.RegKind = ParsedReg::EXEC;
+    // baseIdx discriminates between the two 32-bit halves of wave64 EXEC
+    // (0 = EXEC_LO, 1 = EXEC_HI). The full 64-bit pair also resolves here
+    // via `sub0(EXEC) = EXEC_LO`, but `width = 2` tags it distinctly so
+    // storeExec partial-write logic can route correctly.
+    Pr.BaseIdx = (Lane == AMDGPU::EXEC_HI) ? 1 : 0;
+    Pr.Width = Width;
+    return Pr;
+  case AMDGPU::SCC:
+    Pr.RegKind = ParsedReg::SCC;
+    Pr.Width = 1;
+    return Pr;
+  case AMDGPU::MODE:
+    Pr.RegKind = ParsedReg::MODE;
+    Pr.Width = 1;
+    return Pr;
+  case AMDGPU::M0:
+    Pr.RegKind = ParsedReg::M0;
+    Pr.Width = 1;
+    return Pr;
+  case AMDGPU::FLAT_SCR_LO:
+  case AMDGPU::FLAT_SCR_HI:
+    Pr.RegKind = ParsedReg::FLAT_SCR;
+    Pr.Width = Width;
+    return Pr;
+  // GFX11+ uses SGPR_NULL / SGPR_NULL_HI (and the 64-bit pair SGPR_NULL64)
+  // as carry-discard sinks, e.g. `v_mad_co_u64_u32 ..., null, ...`. They
+  // have no backing slot -- treat writes to them as no-ops.
+  case AMDGPU::SGPR_NULL:
+  case AMDGPU::SGPR_NULL_HI:
+    Pr.RegKind = ParsedReg::NOREG;
+    return Pr;
+  // XNACK_MASK controls page-fault retry masking per lane. On data-center
+  // GPUs (MI300/MI350) XNACK is typically disabled and the register has no
+  // effect on compute semantics. We treat it as NOREG (reads->zero,
+  // writes->nop). If a kernel compiled with XNACK enabled relies on the
+  // mask for correctness, this approximation is wrong -- but such kernels
+  // are not expected in practice.
+  case AMDGPU::XNACK_MASK_LO:
+  case AMDGPU::XNACK_MASK_HI:
+    Pr.RegKind = ParsedReg::NOREG;
+    return Pr;
+  // LDS_DIRECT (src_lds_direct, enc 254): reads a dword from LDS at the
+  // byte offset held in M0. Used as a VALU source after buffer_load_*_lds.
+  case AMDGPU::LDS_DIRECT:
+    Pr.RegKind = ParsedReg::LDS_DIRECT;
+    Pr.Width = 1;
+    return Pr;
+  // Source-only "compact predicate" registers
+  // (SIRegisterInfo.td:198-200). They have no backing storage; their
+  // value at use-time is a single i1 derived from VCC / EXEC / SCC.
+  // Mark them here so readOp32 / readOp64 can materialise the boolean
+  // (zext to the requested width). Encountered as VOP src operands in
+  // gfx1250 Tensile kernels (e.g. `v_sub_f16 v64, src_vccz, v48`).
+  case AMDGPU::SRC_VCCZ:
+    Pr.RegKind = ParsedReg::SRC_VCCZ;
+    Pr.Width = 1;
+    return Pr;
+  case AMDGPU::SRC_EXECZ:
+    Pr.RegKind = ParsedReg::SRC_EXECZ;
+    Pr.Width = 1;
+    return Pr;
+  case AMDGPU::SRC_SCC:
+    Pr.RegKind = ParsedReg::SRC_SCC;
+    Pr.Width = 1;
+    return Pr;
+  // Aperture / runtime-defined source registers: SRC_SHARED_BASE /
+  // _LIMIT, SRC_PRIVATE_BASE / _LIMIT, SRC_FLAT_SCRATCH_BASE_LO /
+  // _HI, SRC_POPS_EXITING_WAVE_ID. Their values are set per-queue by
+  // the firmware and have no compile-time-knowable IR encoding, so
+  // we cannot lower them principledly. Classify as OTHER so parseReg
+  // does not crash; readOp32 / readOp64 will route OTHER through
+  // `recordReadFailure(unsupportedShape)` and the per-instruction
+  // dispatch loop in raiser.cpp will surface it as a clean
+  // unsupported-shape failure rather than a SIGABRT.
+  case AMDGPU::SRC_SHARED_BASE_LO:
+  case AMDGPU::SRC_SHARED_LIMIT_LO:
+  case AMDGPU::SRC_PRIVATE_BASE_LO:
+  case AMDGPU::SRC_PRIVATE_LIMIT_LO:
+  case AMDGPU::SRC_POPS_EXITING_WAVE_ID:
+  case AMDGPU::SRC_FLAT_SCRATCH_BASE_LO:
+  case AMDGPU::SRC_FLAT_SCRATCH_BASE_HI:
+    Pr.RegKind = ParsedReg::OTHER;
+    Pr.Width = Width;
+    return Pr;
+  default:
+    break;
+  }
+
+  // Family classification via the HW encoding flag bits. getEncodingValue
+  // returns the correct HWEncoding payload for both pseudos and subtarget-
+  // specific aliases. IS_VGPR (bit 10) and IS_AGPR (bit 11) are defined as
+  // disjoint in SIRegisterInfo.td, so checking either first is correct;
+  // AGPR goes first only because it is the more specific case.
+  unsigned Enc = MRI.getEncodingValue(Reg);
+  unsigned HwIdx = Enc & AMDGPU::HWEncoding::REG_IDX_MASK;
+
+  if (Enc & AMDGPU::HWEncoding::IS_AGPR) {
+    Pr.RegKind = ParsedReg::AGPR;
+    Pr.BaseIdx = HwIdx;
+    Pr.Width = Width;
+    if (MciOpIdx >= 0 && static_cast<unsigned>(MciOpIdx) < KMaxOps)
+      Pr.BaseIdx += CurrentVgprAdjust[MciOpIdx];
+    return Pr;
+  }
+  if (Enc & AMDGPU::HWEncoding::IS_VGPR) {
+    Pr.RegKind = ParsedReg::VGPR;
+    Pr.BaseIdx = HwIdx;
+    Pr.Width = Width;
+    if (MciOpIdx >= 0 && static_cast<unsigned>(MciOpIdx) < KMaxOps)
+      Pr.BaseIdx += CurrentVgprAdjust[MciOpIdx];
+    return Pr;
+  }
+
+  // TTMPs live at a generation-specific HW encoding (108+ on gfx9+ vs 112+
+  // on gfx8), so we cannot use the raw encoding as the logical 0..15
+  // index. Locate the lane inside TTMP_32RegClass instead; the class is
+  // defined as `(add (sequence "TTMP%u", 0, 15))` so position == index.
+  const MCRegisterClass &TTMP32 =
+      MRI.getRegClass(AMDGPU::TTMP_32RegClassID);
+  if (int Idx = findIndexInClass(TTMP32, Lane); Idx >= 0) {
+    Pr.RegKind = ParsedReg::TTMP;
+    Pr.BaseIdx = Idx;
+    Pr.Width = Width;
+    return Pr;
+  }
+
+  // SGPR_32 is the narrow class for `SGPR0..SGPR105`; SReg_32 would also
+  // include VCC_LO, EXEC_LO, FLAT_SCR_LO, M0, TTMP_32, SGPR_NULL, and the
+  // SRC_* inline-value registers, which we have already ruled out above.
+  if (MRI.getRegClass(AMDGPU::SGPR_32RegClassID).contains(Lane)) {
+    Pr.RegKind = ParsedReg::SGPR;
+    Pr.BaseIdx = HwIdx;
+    Pr.Width = Width;
+    return Pr;
+  }
+
+  report_fatal_error(Twine("transpiler: parseReg could not classify '") +
+                     MRI.getName(Reg) + "' (enc=0x" +
+                     Twine::utohexstr(Enc) + ")");
+}
+
+Value *RaiseContext::readOp32(const DecodedInst &Di, unsigned OpIdx) {
+  if (Di.isReg(OpIdx)) {
+    ParsedReg Pr = parseReg(Di.getReg(OpIdx), OpIdx);
+    if (Pr.RegKind == ParsedReg::VCC) {
+      if (Projection.sourceWaveScopedLaneOps()) {
+        Value *Mask = Regs.readVCCAsWaveMask(B, Regs.ExecTy);
+        Value *Lo = B.CreateTrunc(Mask, I32Ty, "vcc_src_wave_lo");
+        Value *Hi = B.CreateTrunc(B.CreateLShr(Mask, Isa.WaveSize),
+                                  I32Ty, "vcc_src_wave_hi");
+        Value *Lane = Projection.emitLaneIdx(B);
+        Value *Upper =
+            B.CreateICmpUGE(Lane, ConstantInt::get(I32Ty, Isa.WaveSize),
+                            "vcc_src_wave_upper");
+        return B.CreateSelect(Upper, Hi, Lo, "vcc_src_wave_mask");
+      }
+      // Reading VCC as an i32 (wave32 wave-mask, or low 32 bits on
+      // wave64) is a cross-lane collection: emit amdgcn.ballot so each
+      // lane gets the same bit-mask assembled from all lanes' per-lane
+      // VCC bits. On wave64 this is the low 32 lanes; upper-half reads
+      // are separately materialised via readOp64.
+      return Regs.readVCCAsWaveMask(B, I32Ty);
+    }
+    if (Pr.RegKind == ParsedReg::EXEC) {
+      Value *V = Regs.loadExec(B);
+      if (V->getType() == I32Ty)
+        return V;
+      if (Pr.Width < 2 && Pr.BaseIdx == 1)
+        V = B.CreateLShr(V, 32, "exec_hi_shr");
+      return B.CreateTrunc(V, I32Ty,
+                            (Pr.Width < 2 && Pr.BaseIdx == 1) ? "exec_hi"
+                                                               : "exec_lo");
+    }
+    if (Pr.RegKind == ParsedReg::SCC)
+      return B.CreateZExt(Regs.loadSCC(B), I32Ty);
+    if (Pr.RegKind == ParsedReg::SRC_SCC)
+      return B.CreateZExt(Regs.loadSCC(B), I32Ty);
+    if (Pr.RegKind == ParsedReg::SRC_VCCZ) {
+      Value *Vcc = Regs.readVCCAsWaveMask(B, Regs.ExecTy);
+      Value *Zero = ConstantInt::get(Regs.ExecTy, 0);
+      return B.CreateZExt(B.CreateICmpEQ(Vcc, Zero, "vccz"), I32Ty);
+    }
+    if (Pr.RegKind == ParsedReg::SRC_EXECZ) {
+      Value *Exec = Regs.loadExec(B);
+      Value *Zero = ConstantInt::get(Exec->getType(), 0);
+      return B.CreateZExt(B.CreateICmpEQ(Exec, Zero, "execz"), I32Ty);
+    }
+    if (Pr.RegKind == ParsedReg::NOREG)
+      return ConstantInt::get(I32Ty, 0);
+    if (Pr.RegKind == ParsedReg::MODE)
+      return ConstantInt::get(I32Ty, 0);
+    // OTHER is the parser's "I recognised the register but cannot
+    // model it" channel, used today for runtime-defined aperture
+    // registers (SRC_SHARED_BASE / SRC_FLAT_SCRATCH_BASE_LO etc.,
+    // see parseReg's switch). Surface a clean unsupported-shape
+    // failure on the dispatch loop and return undef so we don't
+    // crash mid-handler -- the next instruction-boundary check in
+    // raiser.cpp will abort the kernel raise.
+    if (Pr.RegKind == ParsedReg::OTHER) {
+      recordReadFailure(makeHotswapUnsupportedShapeError(
+          Di, "operand-read",
+          Twine("readOp32 saw unmodeled register '") +
+              Mc.RegInfo->getName(Di.getReg(OpIdx)) + "' in " + Di.Mnemonic));
+      return UndefValue::get(I32Ty);
+    }
+    Value *V = Regs.readReg32(B, Pr);
+    if (!V) {
+      errs() << "transpiler: unreadable register '"
+             << Mc.RegInfo->getName(Di.getReg(OpIdx)) << "' in " << Di.Mnemonic
+             << "\n";
+      return UndefValue::get(I32Ty);
+    }
+    return V;
+  }
+  if (Di.isImm(OpIdx))
+    return ConstantInt::get(
+        I32Ty, static_cast<uint32_t>(Di.getImm(OpIdx) & 0xFFFFFFFF));
+  if (OpIdx < Di.numOps() && Di.Inst.getOperand(OpIdx).isExpr()) {
+    int64_t Val = 0;
+    if (Di.Inst.getOperand(OpIdx).getExpr()->evaluateAsAbsolute(Val))
+      return ConstantInt::get(I32Ty, static_cast<uint32_t>(Val & 0xFFFFFFFF));
+    return ConstantInt::get(I32Ty, 0);
+  }
+  errs() << "transpiler: readOp32 unresolvable operand " << OpIdx << " in "
+         << Di.Mnemonic << "\n";
+  return UndefValue::get(I32Ty);
+}
+
+Value *RaiseContext::readOp64(const DecodedInst &Di, unsigned OpIdx) {
+  if (Di.isReg(OpIdx)) {
+    ParsedReg Pr = parseReg(Di.getReg(OpIdx), OpIdx);
+    if (Pr.RegKind == ParsedReg::VCC)
+      return Regs.readVCCAsWaveMask(B, I64Ty);
+    if (Pr.RegKind == ParsedReg::EXEC) {
+      Value *V = Regs.loadExec(B);
+      if (V->getType() != I64Ty)
+        V = B.CreateZExt(V, I64Ty, "exec_ext");
+      return V;
+    }
+    // Mirror the readOp32 NOREG / MODE handling: SGPR_NULL64 (carry
+    // sink), XNACK_MASK pairs, and the architectural MODE register
+    // have no backing slot in our reg-file model. The 32-bit path
+    // already returns the zero constant; the 64-bit path crashed
+    // because readReg64 had no branch for these kinds. Returning
+    // i64 0 matches hardware (SGPR_NULL reads as 0; XNACK_MASK and
+    // MODE behave as 0 in compute kernels, see parseReg and the
+    // SHORTCUTS_AND_LIMITATIONS XNACK note for rationale).
+    if (Pr.RegKind == ParsedReg::NOREG || Pr.RegKind == ParsedReg::MODE)
+      return ConstantInt::get(I64Ty, 0);
+    if (Pr.RegKind == ParsedReg::SRC_SCC)
+      return B.CreateZExt(Regs.loadSCC(B), I64Ty);
+    if (Pr.RegKind == ParsedReg::SRC_VCCZ) {
+      Value *Vcc = Regs.readVCCAsWaveMask(B, Regs.ExecTy);
+      Value *Zero = ConstantInt::get(Regs.ExecTy, 0);
+      return B.CreateZExt(B.CreateICmpEQ(Vcc, Zero, "vccz"), I64Ty);
+    }
+    if (Pr.RegKind == ParsedReg::SRC_EXECZ) {
+      Value *Exec = Regs.loadExec(B);
+      Value *Zero = ConstantInt::get(Exec->getType(), 0);
+      return B.CreateZExt(B.CreateICmpEQ(Exec, Zero, "execz"), I64Ty);
+    }
+    if (Pr.RegKind == ParsedReg::OTHER) {
+      recordReadFailure(makeHotswapUnsupportedShapeError(
+          Di, "operand-read",
+          Twine("readOp64 saw unmodeled register '") +
+              Mc.RegInfo->getName(Di.getReg(OpIdx)) + "' in " + Di.Mnemonic));
+      return UndefValue::get(I64Ty);
+    }
+    Value *V = Regs.readReg64(B, Pr);
+    if (!V) {
+      errs() << "transpiler: unreadable register64 '"
+             << Mc.RegInfo->getName(Di.getReg(OpIdx)) << "' in " << Di.Mnemonic
+             << "\n";
+      return UndefValue::get(I64Ty);
+    }
+    return V;
+  }
+  if (Di.isImm(OpIdx))
+    return ConstantInt::getSigned(I64Ty, Di.getImm(OpIdx));
+  if (OpIdx < Di.numOps() && Di.Inst.getOperand(OpIdx).isExpr()) {
+    int64_t Val = 0;
+    Di.Inst.getOperand(OpIdx).getExpr()->evaluateAsAbsolute(Val);
+    return ConstantInt::getSigned(I64Ty, Val);
+  }
+  errs() << "transpiler: readOp64 unresolvable operand " << OpIdx << " in "
+         << Di.Mnemonic << "\n";
+  return UndefValue::get(I64Ty);
+}
+
+Value *RaiseContext::emitUpdateDpp(Value *OldVal, Value *Src, uint16_t Ctrl,
+                                    uint8_t RowMask, uint8_t BankMask,
+                                    bool BoundCtrl) {
+  // P5 lowering -- see the DPP row of hotswap/docs/wave-size-
+  // translation.md §5.3: lift the DPP src-pathway modifier through
+  // `llvm.amdgcn.update.dpp`. The intrinsic is type-overloaded
+  // (`llvm_any_ty`). We route through integer overloads sized to match
+  // the input's bit-width and bitcast through when the input is a
+  // same-width non-integer type (f32 / <2 x i16> / etc.); codegen
+  // picks the same DPP lowering for all same-width overloads.
+  //
+  // Widths supported today: 32-bit and 64-bit, matching the hardware
+  // DPP encoding families (VOP_DPP and VOP_DPP_64). Other widths
+  // `report_fatal_error` -- the tsFlags DPP bit can only be set on
+  // VOP1/VOP2/VOP3 classes whose operands are always 32-bit or 64-bit
+  // in AMDGPU's ISA, so any other width is a decoder/tblgen drift
+  // situation worth surfacing loudly rather than silently downgrading.
+  //
+  // Historical regression gate: a wave32 DPP quad-permute
+  // source kernel using `v_mov_b32_dpp ... quad_perm:[1,0,3,2]`
+  // and runs it on gfx942 wave64, verifying the per-lane XOR-1
+  // quad swap pattern across all 64 lanes. A future change that
+  // breaks the dpp_ctrl/row_mask/bank_mask/bound_ctrl plumbing
+  // through this helper, or the OpResolver `wrapDppIfNeeded` hook
+  // that calls it, would fail this test.
+  assert(OldVal->getType() == Src->getType() &&
+         "emitUpdateDpp: old and src must have matching types");
+  Type *OrigTy = Src->getType();
+  const unsigned Bits = OrigTy->getPrimitiveSizeInBits();
+  Type *IntTy = nullptr;
+  if (Bits == 32)
+    IntTy = I32Ty;
+  else if (Bits == 64)
+    IntTy = I64Ty;
+  else
+    report_fatal_error(
+        "emitUpdateDpp: unsupported DPP operand width (expected 32 or 64 "
+        "bits). Extend the bit-width dispatch below when a new DPP "
+        "operand width lands in AMDGPU's ISA.");
+  auto ToIntTy = [&](Value *V) {
+    return V->getType() == IntTy ? V : B.CreateBitCast(V, IntTy);
+  };
+  Value *OldInt = ToIntTy(OldVal);
+  Value *SrcInt = ToIntTy(Src);
+  Function *Fn = Intrinsic::getOrInsertDeclaration(
+      &M, Intrinsic::amdgcn_update_dpp, {IntTy});
+  Value *Result =
+      B.CreateCall(Fn, {OldInt, SrcInt, B.getInt32(Ctrl),
+                         B.getInt32(RowMask), B.getInt32(BankMask),
+                         B.getInt1(BoundCtrl)},
+                   "dpp");
+  if (Result->getType() != OrigTy)
+    Result = B.CreateBitCast(Result, OrigTy);
+  return Result;
+}
+
+Value *RaiseContext::emitLaneIdx() {
+  // Per-BB memoisation, mirroring `emitLaneActiveBit` below -- the
+  // `mbcnt_lo` (and on wave64, `mbcnt_hi`) pair WaveProjection emits
+  // is invariant within a basic block for a given EXEC value, and
+  // the cached SSA value dominates anything emitted later in the
+  // same BB.
+  //
+  // Invalidation: shared with the lane_active cache via
+  // `resetLaneActiveCache`, which the main raiser loop fires at
+  // every source-instruction boundary. See `emitLaneActiveBit`'s
+  // comment block below for the dominance argument that keeps reuse
+  // safe across `emitUnderExec` diamonds within a single source
+  // instruction's emission.
+  if (CachedLaneIdx && B.GetInsertBlock() == CachedLaneIdxBb)
+    return CachedLaneIdx;
+  CachedLaneIdx = Projection.emitLaneIdx(B);
+  CachedLaneIdxBb = B.GetInsertBlock();
+  return CachedLaneIdx;
+}
+
+Value *RaiseContext::emitLaneActiveBit() {
+  // Memoisation (see RaiseContext::resetLaneActiveCache docs).
+  //
+  // Dominance argument for reusing a cached i1 across blocks within a
+  // single source instruction's emission:
+  //
+  //   Each emitUnderExec diamond is structurally linear:
+  //
+  //     preBB ──┬─▶ doBB ──▶ skipBB
+  //             └────────────▶ skipBB   (the conditional skip edge)
+  //
+  //   Chaining N emitUnderExecs yields
+  //     preBB -> (doBB1 -> skipBB1) -> (doBB2 -> skipBB2) -> … -> skipBBN
+  //
+  //   where every successor BB has preBB on its dominator path. So an
+  //   i1 defined in preBB dominates every subsequent doBB/skipBB emitted
+  //   by the same source-instruction handler.
+  //
+  // The reuse invariant is therefore maintained by the invalidation
+  // contract alone:
+  //   * The raiser main loop calls `resetLaneActiveCache` at every
+  //     source-instruction boundary, covering (a) possible EXEC writes
+  //     by the prior instruction and (b) jumps into offset-keyed
+  //     named BBs where the prior `active` no longer dominates.
+  //   * `ctx.storeExec` resets on EXEC mutation.
+  //   * Any handler that writes EXEC via a lower-level path is
+  //     responsible for calling `resetLaneActiveCache` itself (the
+  //     allow-list audit in raiser.cpp documents that all such sites
+  //     route through `ctx.storeExec` or `writeReg*`->`storeExec`).
+  //
+  // Consequently, a cache *hit* is valid regardless of whether the
+  // current BB equals `cachedLaneActiveBB`.
+  if (CachedLaneActive)
+    return CachedLaneActive;
+
+  // The projection owns the modulo-replication math; this context only
+  // handles the cache + EXEC load.
+  Value *Active = Projection.emitLaneActiveBit(B, Regs.loadExec(B));
+  CachedLaneActive = Active;
+  CachedLaneActiveBb = B.GetInsertBlock();
+  return Active;
+}
+
+void RaiseContext::writeReg32(ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::VGPR || Pr.RegKind == ParsedReg::AGPR) {
+    emitUnderExec([&] { Regs.writeReg32(B, Pr, V); });
+  } else {
+    Regs.writeReg32(B, Pr, V);
+    // regs.writeReg32 dispatches to storeExec when pr.kind == EXEC. The
+    // lane_active memo must be invalidated so subsequent emitUnderExec
+    // calls recompute against the new EXEC value rather than the pre-
+    // write snapshot. See resetLaneActiveCache docs in raise-context.h.
+    if (Pr.RegKind == ParsedReg::EXEC)
+      resetLaneActiveCache();
+  }
+}
+
+void RaiseContext::writeReg64(ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::VGPR || Pr.RegKind == ParsedReg::AGPR) {
+    emitUnderExec([&] { Regs.writeReg64(B, Pr, V); });
+  } else {
+    Regs.writeReg64(B, Pr, V);
+    if (Pr.RegKind == ParsedReg::EXEC)
+      resetLaneActiveCache();
+  }
+}
+
+void RaiseContext::writeRegVec(ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::VGPR || Pr.RegKind == ParsedReg::AGPR) {
+    emitUnderExec([&] { Regs.writeRegVec(B, Pr, V); });
+  } else {
+    // Vector SGPR writes can't target EXEC (EXEC is scalar/pair, never
+    // vector), so no cache invalidation is needed.
+    Regs.writeRegVec(B, Pr, V);
+  }
+}
+
+void RaiseContext::writeRegExecWidth(ParsedReg Pr, Value *V) {
+  // Wave-level commit. SGPR-pair / VCC / EXEC writes carry the wave mask
+  // itself and are computed cross-lane (ballot / sext-i1 today), so they
+  // must not be predicated on the per-lane EXEC bit.
+  Regs.writeRegExecWidth(B, Pr, V);
+  if (Pr.RegKind == ParsedReg::EXEC)
+    resetLaneActiveCache();
+}
+
+void RaiseContext::storeVGPR32(int Idx, Value *V) {
+  emitUnderExec([&] { Regs.storeVGPR32(B, Idx, V); });
+}
+
+void RaiseContext::storeVGPR64(int Idx, Value *V) {
+  emitUnderExec([&] { Regs.storeVGPR64(B, Idx, V); });
+}
+
+void RaiseContext::storeAGPR32(int Idx, Value *V) {
+  emitUnderExec([&] { Regs.storeAGPR32(B, Idx, V); });
+}
+
+void RaiseContext::emitUnderExec(llvm::function_ref<void()> Body) {
+  Value *Active = emitLaneActiveBit();
+  BasicBlock *PreBb = B.GetInsertBlock();
+  Function *F = PreBb->getParent();
+  BasicBlock *DoBb = BasicBlock::Create(C, "spe_do", F);
+  BasicBlock *SkipBb = BasicBlock::Create(C, "spe_skip", F);
+  B.CreateCondBr(Active, DoBb, SkipBb);
+
+  B.SetInsertPoint(DoBb);
+  Body();
+  // `body()` normally falls through without terminating. If a handler ever
+  // ends its emission with an unconditional control-flow op (shouldn't
+  // happen for the side-effectful ops we wrap, but defensively handled),
+  // don't double-terminate doBB.
+  if (!B.GetInsertBlock()->hasTerminator())
+    B.CreateBr(SkipBb);
+
+  B.SetInsertPoint(SkipBb);
+}
+
+
+Value *RaiseContext::readOpExecWidth(const DecodedInst &Di, unsigned OpIdx) {
+  // All callers expect the returned value at `regs.execTy` (the EXEC
+  // alloca storage width). Under modulo-replication `execTy` matches
+  // the source wave-mask width and reads of source-width SGPR / imm
+  // operands are already at the right width. Under wave-native cross-
+  // widening `execTy` is wider than the source-named SGPR (i64 vs
+  // i32 on wave32 source -> wave64 target), so we widen with the same
+  // symmetric replication that `writeReg32(EXEC_LO)` uses on the
+  // write side: `(v << W_src) | v` lifts a wave32 scalar wave mask
+  // to a wave64 scalar wave mask where target lane K and K+W_src
+  // agree. This keeps the save/restore round trip `s_mov_b32 sN,
+  // exec_lo; …; s_mov_b32 exec_lo, sN` behaving as the wave32
+  // author expected, and matches the replication done inside
+  // `WaveNativeProjection::extractLaneBitFromWaveMask` on the VCC
+  // consumer side.
+  auto WidenToExec = [&](Value *Narrow) -> Value * {
+    if (Narrow->getType() == Regs.ExecTy)
+      return Narrow;
+    unsigned Have = Narrow->getType()->getPrimitiveSizeInBits();
+    unsigned Want = Regs.ExecTy->getPrimitiveSizeInBits();
+    if (Have >= Want)
+      return B.CreateZExtOrTrunc(Narrow, Regs.ExecTy);
+    Value *Zext = B.CreateZExt(Narrow, Regs.ExecTy, "wn_src_to_exec_zext");
+    Value *Hi = B.CreateShl(Zext, Have);
+    return B.CreateOr(Zext, Hi, "wn_src_to_exec_mask");
+  };
+
+  if (Di.isReg(OpIdx)) {
+    ParsedReg Pr = parseReg(Di.getReg(OpIdx), OpIdx);
+    if (Pr.RegKind == ParsedReg::VCC)
+      return Regs.readVCCAsWaveMask(B, Regs.ExecTy);
+    if (Pr.RegKind == ParsedReg::EXEC)
+      return Regs.loadExec(B);
+    if (Pr.RegKind == ParsedReg::SGPR) {
+      Value *Narrow =
+          (Projection.sourceWaveScopedLaneOps() && Pr.Width >= 2)
+              ? Regs.loadSGPR64(B, Pr.BaseIdx)
+              : (Isa.isWave32() ? Regs.loadSGPR32(B, Pr.BaseIdx)
+                                : Regs.loadSGPR64(B, Pr.BaseIdx));
+      Value *Fallback = WidenToExec(Narrow);
+      if (Value *ShadowValid = loadSgprWaveMaskValid(Pr.BaseIdx)) {
+        Value *ShadowExec = loadSgprWaveMaskExec(Pr.BaseIdx);
+        if (ShadowExec->getType() != Regs.ExecTy)
+          ShadowExec = B.CreateZExtOrTrunc(ShadowExec, Regs.ExecTy,
+                                           "wm_shadow_exec_cast");
+        return B.CreateSelect(ShadowValid, ShadowExec, Fallback,
+                              "exec_width_sgpr_shadow_sel");
+      }
+      return Fallback;
+    }
+    errs() << "transpiler: readOpExecWidth unresolvable register '"
+           << Mc.RegInfo->getName(Di.getReg(OpIdx)) << "' in " << Di.Mnemonic
+           << "\n";
+    return UndefValue::get(Regs.ExecTy);
+  }
+  // Immediate and relocation-expression operands are always encoded at
+  // the source wave-mask width (32 bits on wave32 source). Materialise
+  // the narrow constant first and then widen through the same
+  // replication path so an author's `s_mov_b32 exec_lo, 0xFFFF0000`
+  // composes the same wave64 EXEC pattern as a save/restore of that
+  // mask through an SGPR would.
+  //
+  // ISA-immediate-as-bit-pattern. `di.getImm` returns an `int64_t`
+  // container that holds the raw literal bits the MC decoder read
+  // out of the instruction's immediate field. Wave-mask idioms
+  // routinely set the high bit of the source-width word --
+  // `0xFFFF0000` (Triton's high-half upper-short mask, flagged in
+  // the example above), `0xFFFFFFFF` (`-1` = all-lanes), `0x80000000`
+  // (lane-31 bit), etc. An earlier `ConstantInt::getSigned(srcTy,
+  // di.getImm(opIdx))` misinterpreted the container as a SIGNED
+  // value and, on a wave32 source whose immediate reads as
+  // `uint32_t ≥ 0x80000000`, tripped APInt's signed-range assertion
+  // (`isIntN(BitWidth, val) && "Value is not an N-bit signed
+  // value"`) -- because `(int64_t)0xFFFF0000 == +4294901760` is
+  // outside `[-2^31, 2^31 - 1]`.
+  //
+  // Principled fix: match `readOp32`'s bit-pattern contract (see
+  // line ~333 above) -- treat the immediate as an unsigned bit
+  // pattern and pack it into the source-width integer via
+  // `ConstantInt::get(..., IsSigned=false)`. Masking to the source
+  // width before the call is a defensive invariant: on wave32
+  // sources, any MC-surfaced 64-bit literal is either the zero-
+  // extended i32 the hardware carries or a bug upstream; masking
+  // lets the invariant hold without relying on `ImplicitTrunc`
+  // (kept off so the call still asserts on a truly malformed
+  // literal rather than silently dropping bits). On wave64
+  // sources the mask is the identity.
+  //
+  // Callers ordered through `readOpExecWidth` today (post-topk
+  // SOP2 immediate-shadow propagation, landed in the
+  // `s_xor_b32 ..., -1` idiom) now reach this immediate path; the
+  // classifier-shielded path that previously never evaluated this
+  // codepath on wave32 sources with high-bit-set literals
+  // (GPT-OSS `_bitmatrix_metadata_compute_stage2`'s `s_and_b32
+  // sN, sM, 0xFFFF0000` sites) no longer traps here.
+  Type *SrcTy = Isa.isWave32() ? I32Ty : I64Ty;
+  uint64_t SrcMask =
+      Isa.isWave32() ? 0xFFFFFFFFull : 0xFFFFFFFFFFFFFFFFull;
+  if (Di.isImm(OpIdx)) {
+    uint64_t Bits = static_cast<uint64_t>(Di.getImm(OpIdx)) & SrcMask;
+    Value *Narrow = ConstantInt::get(SrcTy, Bits, /*IsSigned=*/false);
+    return WidenToExec(Narrow);
+  }
+  if (OpIdx < Di.numOps() && Di.Inst.getOperand(OpIdx).isExpr()) {
+    int64_t Val = 0;
+    Di.Inst.getOperand(OpIdx).getExpr()->evaluateAsAbsolute(Val);
+    uint64_t Bits = static_cast<uint64_t>(Val) & SrcMask;
+    Value *Narrow = ConstantInt::get(SrcTy, Bits, /*IsSigned=*/false);
+    return WidenToExec(Narrow);
+  }
+  errs() << "transpiler: readOpExecWidth unresolvable operand " << OpIdx
+         << " in " << Di.Mnemonic << "\n";
+  return UndefValue::get(Regs.ExecTy);
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/raise-context.h
+++ b/amd/comgr/src/hotswap/raise-context.h
@@ -1,0 +1,629 @@
+//===- raise-context.h - Hotswap transpiler -------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_RAISE_CONTEXT_H
+#define HOTSWAP_TRANSPILER_RAISE_CONTEXT_H
+
+#include "decoded-inst.h"
+#include "isa-profile.h"
+#include "kernarg-layout.h"
+#include "mc-state.h"
+#include "hotswap-error.h"
+#include "parsed-reg.h"
+#include "reg-file.h"
+#include "setpc-analysis.h"
+#include "user-sgpr-layout.h"
+#include "wave-projection.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+#include "llvm/MC/MCRegister.h"
+
+#include <map>
+
+namespace COMGR::hotswap {
+
+// Shared state threaded through every format handler.
+struct RaiseContext {
+  llvm::LLVMContext &C;
+  llvm::Module &M;
+  llvm::IRBuilder<> &B;
+  AllocaRegFile &Regs;
+  const WaveProjection &Projection;
+  const MCState &Mc;
+  const ISAProfile &Isa;       // source ISA (for disassembly / instruction semantics)
+  ISAProfile TargetIsa;        // compilation target ISA (for code generation decisions)
+  KernargLayout &Kernargs;
+  // Source-ISA user-SGPR ABI derived from the kernel descriptor. Owned by
+  // the raiser; threaded into every handler that needs to identify a
+  // specific SGPR by its source-ABI role (e.g. handle_smem.cpp must know
+  // which SGPR holds kernarg_segment_ptr to recognise s_load_b* against
+  // the kernarg segment). Always non-null in production; the raiser
+  // populates it from `UserSgprLayout::fromKernelMeta` before constructing
+  // the context.
+  const UserSgprLayout *Layout = nullptr;
+  llvm::Function *Kernel;
+  llvm::BasicBlock *ThreadLoopLatch = nullptr;
+
+  llvm::Type *I1Ty;
+  llvm::Type *I8Ty;
+  llvm::Type *I32Ty;
+  llvm::Type *I64Ty;
+  llvm::Type *F32Ty;
+  llvm::Type *F16Ty;
+  llvm::Type *F64Ty;
+  llvm::Type *PtrGlobalTy;
+
+  llvm::DenseMap<uint64_t, llvm::BasicBlock *> &OffsetToBb;
+
+  // Source KD private/scratch allocation. `handle_flat.cpp` sets
+  // `usesScratchPrivateSegment` when it lowers a `scratch_*` instruction; the
+  // on-demand private alloca is deliberately managed by LLVM's frame layout so
+  // target spills cannot overlap translated source scratch slots.
+  uint32_t SourcePrivateSegmentFixedSize = 0;
+  uint32_t SourceComputePgmRsrc2 = 0;
+  uint16_t SourceKernelCodeProperties = 0;
+  bool UsesScratchPrivateSegment = false;
+  llvm::AllocaInst *ScratchPrivateSegmentAlloca = nullptr;
+
+  // Result of the static analysis that classifies every s_set_pc_i64
+  // site. Owned by the raiser; the handler reads it to decide
+  // between Pattern A (direct br) and Pattern B / DispatchSet
+  // (cmp+br cascade via `emitEnumeratedDispatch`) lowerings, and
+  // the raiser's main loop reads `chainTerminators` to materialise
+  // call-site blockaddress writes into ret-pair SGPRs. See
+  // setpc-analysis.h for the full contract; see canonical-op.h's
+  // `S_SET_PC_I64` doc for the lowering shapes.
+  const SetPcAnalysis *SetpcAnalysis = nullptr;
+
+  // gfx1250 s_set_vgpr_msb state: only the LOW 8 bits of the instruction's
+  // 16-bit immediate carry runtime meaning.  They encode the MSB bit pair for
+  // every operand slot of the next ALU instruction:
+  //
+  //   [1:0]  src0 MSB        [3:2]  src1 MSB
+  //   [5:4]  src2 MSB        [7:6]  vdst MSB
+  //
+  // Each 2-bit field adds (value * 256) to the corresponding VGPR index.
+  //
+  // The HIGH 8 bits of the `s_set_vgpr_msb` immediate record the PREVIOUS
+  // mode value for compiler bookkeeping (see LLVM's AMDGPULowerVGPREncoding
+  // pass, `setMode()`: "Record previous mode into high 8 bits of the
+  // immediate."). The hardware ignores them, so we mask to 8 bits on store.
+  //
+  // For VOPD dual-issue instructions, the X-op and Y-op share the same MSB
+  // pair per operand slot: LLVM asserts that if X-op and Y-op both reference
+  // the same slot, they must carry identical MSBs ("Invalid VOPD pair was
+  // created" in `computeMode`).  So applying the same 8-bit state to both
+  // halves is correct.
+  uint8_t VgprMsBs = 0;
+
+  // Per-instruction VGPR index adjustment, indexed by MCInst operand index.
+  // Computed from vgprMSBs before each instruction dispatch.
+  static constexpr unsigned KMaxOps = 16;
+  unsigned CurrentVgprAdjust[KMaxOps] = {};
+
+  // Compute currentVGPRAdjust for the given instruction based on vgprMSBs.
+  void computeVGPRAdjust(const DecodedInst &Di);
+
+  llvm::BasicBlock *lookupBB(uint64_t Addr);
+
+  ParsedReg parseReg(llvm::MCRegister Reg, int MciOpIdx = -1) const;
+
+  // Operand reading — mirrors the lambdas in the original raiseToIR.
+  llvm::Value *readOp32(const DecodedInst &Di, unsigned OpIdx);
+  llvm::Value *readOp64(const DecodedInst &Di, unsigned OpIdx);
+  llvm::Value *readOpExecWidth(const DecodedInst &Di, unsigned OpIdx);
+
+  // Emit `llvm.amdgcn.update.dpp.<i32>(old, src, ctrl, row_mask, bank_mask,
+  // bound_ctrl)` — the P5 lowering for src0-path DPP modifiers; see the
+  // DPP row of hotswap/docs/wave-size-translation.md §5.3 for the rewrite
+  // contract. `src` and `old` must be 32-bit (i32 or f32/bitcastable); a
+  // future 64-bit lift would extend the intrinsic overload set and the
+  // bitcast-bridge below. The return type matches `src->getType()` so
+  // callers can feed the result back into the original instruction's
+  // ALU path without reshuffling.
+  //
+  // `OpResolver::src(0)` / `srcF(0)` wrap their return through this helper
+  // when `DecodedInst::hasDpp` is true, so handlers dispatched by CanonicalOp
+  // stay DPP-agnostic. See `decoded-inst.h`'s DPP-state block for how
+  // the modifier operand values reach us.
+  llvm::Value *emitUpdateDpp(llvm::Value *OldVal, llvm::Value *Src,
+                              uint16_t Ctrl, uint8_t RowMask,
+                              uint8_t BankMask, bool BoundCtrl);
+
+  // Materialise the target-hardware lane id (i32) at the current
+  // builder insertion point, with per-BB memoisation. Mirrors the
+  // `cachedLaneActive` pattern: handlers that need the lane id can
+  // call `ctx.emitLaneIdx()` repeatedly within an instruction's
+  // dispatch and reuse the same SSA value, avoiding redundant
+  // `mbcnt_lo` / `mbcnt_hi` chains in the raw IR.
+  //
+  // The cache is invalidated on every source-instruction boundary
+  // by the same `resetLaneActiveCache` call that resets
+  // `cachedLaneActive`, since the dominance lifecycle is identical
+  // (the cached i32 dominates the BB it was emitted in but not
+  // arbitrary later BBs).
+  //
+  // Delegates to `projection.emitLaneIdx(B)` for the actual mbcnt
+  // sequence — `WaveProjection` remains the single source of truth
+  // for *how* lane id is computed; `RaiseContext` only handles
+  // caching.
+  llvm::Value *emitLaneIdx();
+
+  // ==== SIMT Predicated Execution (SPE) helpers
+  // (see hotswap/docs/wave-size-translation.md §5.1). ================
+  //
+  // emitLaneActiveBit() returns an i1 true iff the current lane's bit in the
+  // EXEC-mask alloca is set. Wave-size-aware via targetIsa: the lane id is
+  // built from llvm.amdgcn.mbcnt.lo for wave32 and mbcnt.lo+mbcnt.hi for
+  // wave64. The alloca itself is the current SSA-tracked EXEC value, so
+  // uniform code (EXEC provably -1 by SROA) folds this to `true`.
+  //
+  // Caching: the result is memoised for the duration of a single decoded
+  // instruction's dispatch (`cachedLaneActive` + `cachedLaneActiveBB`).
+  // Handlers that emit multiple `emitUnderExec` diamonds for one source
+  // instruction (e.g. a multi-dword MUBUF store writing four VGPRs) reuse
+  // the same `lane_active` i1 instead of re-emitting the mbcnt / lshr /
+  // and / icmp chain. Invalidated on:
+  //   - Entry to every new source instruction (`resetLaneActiveCache`),
+  //     because intervening instructions may have written EXEC.
+  //   - Insertion-block change within a handler (the cached i1 no longer
+  //     dominates emission points in a new BB).
+  //   - Any explicit EXEC write via `ctx.storeExec`.
+  // LLVM's mem2reg + CSE would clean up the redundancy anyway; the cache
+  // keeps the raw raised IR readable for lit tests that FileCheck the
+  // unoptimised output shape.
+  llvm::Value *emitLaneActiveBit();
+
+  // Invalidate the lane_active and lane_idx memoisations. Called by
+  // the main raiser loop between instructions and by `storeExec`.
+  // Handlers that know they have mutated EXEC through a lower-level
+  // path (e.g. the few places that call `regs.storeExec` directly)
+  // must also invoke this. The lane_idx cache shares the same
+  // invalidation contract: per-BB lifetime, reset at every
+  // instruction boundary so a handler that hops basic blocks (e.g.
+  // SPE diamonds) never reads a cached SSA value out of its
+  // dominance scope.
+  void resetLaneActiveCache() {
+    CachedLaneActive = nullptr;
+    CachedLaneActiveBb = nullptr;
+    CachedLaneIdx = nullptr;
+    CachedLaneIdxBb = nullptr;
+  }
+
+  // Wrap `regs.storeExec` with cache invalidation. Handlers should prefer
+  // this over `regs.storeExec` so the lane_active memo is always
+  // consistent with the live EXEC value.
+  void storeExec(llvm::Value *V) {
+    Regs.storeExec(B, V);
+    resetLaneActiveCache();
+  }
+
+  // Predicated register-commit API. VGPR/AGPR writes are per-lane side
+  // effects and MUST be wrapped in an emitUnderExec diamond so inactive
+  // lanes keep their prior VGPR value; SGPR/VCC/SCC/EXEC/M0/FLAT_SCR/TTMP
+  // writes are wave-level and pass through unchanged. Handlers should
+  // call these instead of reaching into `regs.write*` directly.
+  //
+  // `storeVGPR32` / `storeVGPR64` / `storeAGPR32` are the direct-index
+  // variants used when a handler already knows the register index (e.g.
+  // VOPD's dstX/dstY pair or DS-transpose's contiguous sub-VGPR loop).
+  void writeReg32(ParsedReg Pr, llvm::Value *V);
+  void writeReg64(ParsedReg Pr, llvm::Value *V);
+  void writeRegVec(ParsedReg Pr, llvm::Value *V);
+  void writeRegExecWidth(ParsedReg Pr, llvm::Value *V);
+  void storeVGPR32(int Idx, llvm::Value *V);
+  void storeVGPR64(int Idx, llvm::Value *V);
+  void storeAGPR32(int Idx, llvm::Value *V);
+
+  // emitUnderExec(body) wraps `body()` in an `if (lane_active)` diamond:
+  //
+  //   %active = emitLaneActiveBit()
+  //   br i1 %active, label %exec_do, label %exec_skip
+  //   exec_do:
+  //     body()                 (whatever side-effectful IR the handler emits)
+  //     br label %exec_skip    (only if body() did not itself terminate)
+  //   exec_skip:
+  //     ...                    (insertion point on return)
+  //
+  // Because %active is data-dependent on workitem.id.x, LLVM's divergence
+  // analysis treats the branch as divergent and the AMDGPU backend
+  // rematerialises hardware-level v_cmpx around the do-block. Uniform code
+  // collapses: when %active folds to `true` the diamond vanishes, so this
+  // is a no-op in IR size + codegen terms for non-divergent sites.
+  //
+  // On return, the builder's insertion point is at the start of %exec_skip,
+  // so subsequent handler emission continues in the skip block (which is
+  // topologically the "after" of the wrapped op, exactly like before).
+  void emitUnderExec(llvm::function_ref<void()> Body);
+
+  // Memoised lane_active for this instruction's emission. Kept as public
+  // members (rather than `private:`) so RaiseContext remains an aggregate
+  // and can be brace-initialised from the raiser. Mutate only via
+  // `resetLaneActiveCache` / `emitLaneActiveBit`.
+  llvm::Value *CachedLaneActive = nullptr;
+  llvm::BasicBlock *CachedLaneActiveBb = nullptr;
+
+  // Memoised lane id for this instruction's emission, mirroring the
+  // cachedLaneActive pair above. Used by `emitLaneIdx`. Same public-
+  // field rationale (aggregate brace-init); mutate only via
+  // `resetLaneActiveCache` / `emitLaneIdx`.
+  llvm::Value *CachedLaneIdx = nullptr;
+  llvm::BasicBlock *CachedLaneIdxBb = nullptr;
+
+  // Per-BB cache of the per-lane i1 compare result produced by the
+  // most recent V_CMP_*_e64 writer targeting a given SGPR in this
+  // basic block. Keyed by source-ABI SGPR baseIdx (the low SGPR of
+  // an SGPR pair on wave64 source; the single SGPR on wave32
+  // source). `isPair` distinguishes a wave64-source pair entry
+  // (the value spans [baseIdx, baseIdx+1]) from a wave32-source
+  // single entry (baseIdx only), which matters for the adjacent-
+  // invalidation rule in `invalidateSgprWaveMaskI1`.
+  //
+  // Motivation. The V_CMP -> SGPR store at `handle_valu_vcmp.cpp`
+  // truncates the full target-hardware ballot down to the source
+  // SGPR's physical 32-bit width (`ballotI1ToWidth(cmp, source
+  // WaveMaskTy, ...)` -> `CreateTrunc`), destroying lanes 32..63's
+  // compare results on wave32 source / wave64 target cross-
+  // widening. A V_CNDMASK_B32_e64 consumer in the same BB has no
+  // way to recover those bits from the narrow SGPR — but it does
+  // not need to, because the writer still holds the full per-lane
+  // `i1` SSA value. This cache carries that `i1` across to the
+  // consumer.
+  //
+  // Invariants (maintained in concert by
+  //   * handle_valu_vcmp.cpp V_CMP -> SGPR path writes `cmp` here,
+  //   * handle_valu_vop3p.cpp V_CNDMASK_B32 SGPR-source path reads,
+  //   * AllocaRegFile::onSgprWritten invalidates on any SGPR write
+  //     (with pair-aware adjacent invalidation for the high half
+  //     of a pair rooted at baseIdx-1), and
+  //   * `clearSgprWaveMaskShadow` drops the whole map on BB entry):
+  //
+  //   I1 - Additive. The narrow ballot store and its
+  //        `extractLaneBitFromWaveMask` reader chain are both
+  //        preserved. When the cache is absent, the consumer takes
+  //        the existing (lossy-under-cross-widening) path. No case
+  //        where the fix regresses a previously-correct lowering.
+  //   I2 - SSA-monotonic within a BB. The SSA value returned by
+  //        `lookupSgprWaveMaskI1(N)` is the exact `cmp` produced by
+  //        the last V_CMP writer to sN in the current BB, with no
+  //        intervening write to sN (or to sN+1 if the entry at sN
+  //        is a pair). Linear handler dispatch over the
+  //        instruction stream guarantees this.
+  //   I3 - Any interference defeats the cache. Scalar writes
+  //        invalidate the entry via the reg-file callback, AND
+  //        invalidate a preceding pair entry whose high half this
+  //        write just clobbered (see `invalidateSgprWaveMaskI1`);
+  //        subsequent V_CMP writes overwrite the entry (last-writer
+  //        wins); BB transition clears the whole map.
+  //
+  // Design rationale: see hotswap/docs/sgpr-wave-mask-translation.md
+  // section 3.1 (chosen approach) and section 4 (the
+  // widened-SGPR-storage alternative we deliberately did not
+  // schedule).
+  struct WaveMaskEntry {
+    llvm::Value *I1 = nullptr;
+    // `true` if this entry was recorded for a wave64-source V_CMP
+    // whose destination is an SGPR pair [baseIdx, baseIdx+1]. `false`
+    // for a wave32-source V_CMP whose destination is a single SGPR at
+    // baseIdx. Consulted by `invalidateSgprWaveMaskI1` to decide
+    // whether a write to baseIdx+1 should also invalidate the entry
+    // at baseIdx (pair-aware half-overwrite protection).
+    bool IsPair = false;
+  };
+
+  // Default-construct via an explicit zero-arg temporary to disambiguate
+  // from DenseMap's `explicit` single-unsigned-int constructor under
+  // RaiseContext's aggregate brace-init. (With `= {}` or no initializer
+  // GCC warns: "converting … from initializer list would use explicit
+  // constructor DenseMap(unsigned int)".)
+  llvm::DenseMap<int, WaveMaskEntry> LastSgprWaveMaskI1 =
+      llvm::DenseMap<int, WaveMaskEntry>();
+
+  // Cross-BB, dominance-safe shadow storage for SGPR wave masks.
+  // Each SGPR base index has:
+  //   * sgprWaveMaskExecShadow[idx]  : EXEC-width mask value (i32/i64)
+  //   * sgprWaveMaskValidShadow[idx] : scalar i1 validity bit
+  //
+  // Record/write sites update both allocas; invalidation writes
+  // `valid=false`. Consumers can load-valid+load-mask and pick between
+  // shadow and fallback via `select`, avoiding SSA-dominance hazards.
+  llvm::SmallVector<llvm::AllocaInst *> SgprWaveMaskExecShadow;
+  llvm::SmallVector<llvm::AllocaInst *> SgprWaveMaskValidShadow;
+
+  // Record the per-lane compare i1 produced by a V_CMP_*_e64 write
+  // to SGPR baseIdx in the current BB. Overwrites any prior entry
+  // (last-writer wins — a later V_CMP obviates the earlier value
+  // for any consumer that reads after the write). `isPair` should
+  // be true iff the V_CMP's destination ParsedReg has `width >= 2`
+  // (a wave64-source SGPR pair), so subsequent writes to baseIdx+1
+  // correctly invalidate this entry via
+  // `invalidateSgprWaveMaskI1`'s pair-aware branch.
+  void recordSgprWaveMaskI1(int BaseIdx, llvm::Value *CmpI1, bool IsPair) {
+    LastSgprWaveMaskI1[BaseIdx] = WaveMaskEntry{CmpI1, IsPair};
+    if (BaseIdx >= 0 &&
+        static_cast<size_t>(BaseIdx) < SgprWaveMaskExecShadow.size()) {
+      llvm::Value *ExecMask = Projection.ballotI1ToWidth(
+          B, CmpI1, Regs.ExecTy, "wm_shadow_exec");
+      B.CreateStore(ExecMask, SgprWaveMaskExecShadow[BaseIdx]);
+      B.CreateStore(B.getTrue(), SgprWaveMaskValidShadow[BaseIdx]);
+    }
+  }
+
+  // Look up the cached per-lane i1 for SGPR baseIdx in the current
+  // BB, or null if none (either no V_CMP wrote it, or the entry
+  // was invalidated by a scalar write, or the BB boundary cleared
+  // the map). Callers treat null as "fall back to the standard
+  // extractLaneBitFromWaveMask".
+  llvm::Value *lookupSgprWaveMaskI1(int BaseIdx) const {
+    auto It = LastSgprWaveMaskI1.find(BaseIdx);
+    return It == LastSgprWaveMaskI1.end() ? nullptr : It->second.I1;
+  }
+
+  llvm::Value *loadSgprWaveMaskExec(int BaseIdx) const {
+    if (BaseIdx < 0 || static_cast<size_t>(BaseIdx) >= SgprWaveMaskExecShadow.size())
+      return nullptr;
+    return B.CreateLoad(Regs.ExecTy, SgprWaveMaskExecShadow[BaseIdx],
+                        "sgpr_mask_exec");
+  }
+
+  llvm::Value *loadSgprWaveMaskValid(int BaseIdx) const {
+    if (BaseIdx < 0 || static_cast<size_t>(BaseIdx) >= SgprWaveMaskValidShadow.size())
+      return nullptr;
+    return B.CreateLoad(I1Ty, SgprWaveMaskValidShadow[BaseIdx],
+                        "sgpr_mask_valid");
+  }
+
+  // Invalidate the cached per-lane i1 for SGPR baseIdx. Called by
+  // AllocaRegFile on any SGPR write so the next consumer takes the
+  // narrow-mask fallback rather than a stale i1 whose bits no
+  // longer correspond to the scalar value just stored. Idempotent;
+  // safe to call on an SGPR that had no cached entry.
+  //
+  // Pair-aware adjacent invalidation. On wave64 source, V_CMP_e64
+  // writes an SGPR pair [baseIdx, baseIdx+1] but records a single
+  // entry keyed on baseIdx (via `recordSgprWaveMaskI1(..., /*isPair=*/true)`).
+  // If later code writes to baseIdx+1 alone (e.g.
+  // `s_mov_b32 sHi, imm`), the high half of the pair is clobbered
+  // but the entry at baseIdx would otherwise survive and silently
+  // return a cmp that no longer matches the pair's current value.
+  // So on invalidate(K), if entry at K-1 exists AND is flagged
+  // `isPair`, invalidate K-1 too. The guard on `isPair` avoids
+  // over-invalidation: a single-SGPR wave32 entry at K-1 is
+  // unrelated to a scalar write at K and must NOT be invalidated.
+  void invalidateSgprWaveMaskI1(int BaseIdx) {
+    LastSgprWaveMaskI1.erase(BaseIdx);
+    if (BaseIdx >= 0 &&
+        static_cast<size_t>(BaseIdx) < SgprWaveMaskValidShadow.size())
+      B.CreateStore(B.getFalse(), SgprWaveMaskValidShadow[BaseIdx]);
+    if (BaseIdx > 0) {
+      auto Prev = LastSgprWaveMaskI1.find(BaseIdx - 1);
+      if (Prev != LastSgprWaveMaskI1.end() && Prev->second.IsPair) {
+        LastSgprWaveMaskI1.erase(Prev);
+        if (static_cast<size_t>(BaseIdx - 1) < SgprWaveMaskValidShadow.size())
+          B.CreateStore(B.getFalse(), SgprWaveMaskValidShadow[BaseIdx - 1]);
+      }
+    }
+  }
+
+  // Drop every cached entry. Called at every BB boundary in the
+  // raiser's main loop (alongside `vgprMSBs = 0`) so that cross-BB
+  // V_CMP / V_CNDMASK pairs conservatively fall back to the narrow
+  // extract rather than relying on an i1 that no longer dominates
+  // the consumer. A future reaching-definitions pass on the raised
+  // IR (see sgpr-wave-mask-translation.md section 7 evolution
+  // path) can upgrade this to a proper per-BB merge.
+  void clearSgprWaveMaskShadow() { LastSgprWaveMaskI1.clear(); }
+
+  void collectSgprWaveMaskShadowAllocas(
+      llvm::SmallVectorImpl<llvm::AllocaInst *> &Out) const {
+    Out.append(SgprWaveMaskExecShadow.begin(), SgprWaveMaskExecShadow.end());
+    Out.append(SgprWaveMaskValidShadow.begin(), SgprWaveMaskValidShadow.end());
+  }
+
+  // Pending failure raised during operand-read dispatch (e.g.
+  // `readOp32` / `readOp64` encountering an unmodeled aperture
+  // register such as SRC_SHARED_BASE / SRC_FLAT_SCRATCH_BASE_LO).
+  // Read paths cannot bail mid-handler -- they must return some
+  // Value* -- so they record the failure here and the per-instruction
+  // dispatch loop in `raiser.cpp` consumes `PendingFailure` after each
+  // handler returns and aborts the kernel raise. Set via
+  // `recordReadFailure`; the dispatch loop moves the Error out (via
+  // std::move) and continues with a success state.
+  llvm::Error PendingFailure = llvm::Error::success();
+
+  // Record an operand-read failure. Only the first failure per
+  // instruction is captured; subsequent reads of the same kernel
+  // simply return undef and let the dispatch loop bail on the
+  // first one we observed. Second-and-later errors are consumed
+  // (llvm::Error's checked-flag contract requires explicit
+  // consumption; we drop the redundant errors here rather than
+  // forcing read paths to track first-vs-subsequent themselves).
+  void recordReadFailure(llvm::Error E) {
+    if (PendingFailure) {
+      llvm::consumeError(std::move(E));
+    } else {
+      PendingFailure = std::move(E);
+    }
+  }
+};
+
+// Return value from every format handler.
+//
+// Handlers communicate back in three ways:
+//   * `Handled == true`: the handler fully lowered the instruction.
+//   * `Handled == false`, `Failure` is success: this handler does
+//     not claim the instruction; the main loop falls through to the
+//     generic `UnsupportedOpcode` diagnostic.
+//   * `Handled == false`, `Failure` carries an error: the handler
+//     recognised the instruction but refuses to lower it (e.g.
+//     operand shape unsupported); the main loop moves the Error out
+//     and aborts without consulting other handlers.
+//
+// Use the named constructors `HandlerResult::handled(...)`,
+// `HandlerResult::unclaimed()`, `HandlerResult::refused(Err)` rather
+// than aggregate brace-init so the success/refuse-payload state stays
+// explicit at the call site. Embedding `llvm::Error` as a struct
+// field is supported (the dispatch loop consumes it exactly once via
+// move on the refuse path, and `cantFail` on the success path).
+struct HandlerResult {
+  bool Handled = false;
+  llvm::Value *SccResult = nullptr;
+  bool SccHandled = false;
+  llvm::Error Failure = llvm::Error::success();
+
+  static HandlerResult unclaimed() { return {}; }
+
+  static HandlerResult handled(llvm::Value *Scc = nullptr,
+                               bool SccHandledIn = false) {
+    HandlerResult R;
+    R.Handled = true;
+    R.SccResult = Scc;
+    R.SccHandled = SccHandledIn;
+    return R;
+  }
+
+  static HandlerResult refused(llvm::Error E) {
+    HandlerResult R;
+    R.Handled = false;
+    R.Failure = std::move(E);
+    return R;
+  }
+};
+
+// Reads source operands via srcMap, skipping VOP3 modifiers. If the
+// decoded instruction carries a DPP modifier (`DecodedInst::hasDpp`),
+// `src(0)` / `srcF(0)` / `src64(0)` transparently wrap their result
+// through `RaiseContext::emitUpdateDpp` using the modifier operand
+// values from `di`, so handlers dispatched on the canonicalised
+// CanonicalOp stay DPP-agnostic. See `decoded-inst.h`'s DPP-state block
+// for the data-flow contract.
+struct OpResolver {
+  RaiseContext &Ctx;
+  const DecodedInst &Di;
+
+  unsigned srcIdx(unsigned I) const {
+    assert(I < Di.NumSrcs && "source index out of range");
+    return Di.SrcMap[I];
+  }
+  unsigned nSrcs() const { return Di.NumSrcs; }
+
+  unsigned srcMod(unsigned I) const {
+    unsigned ModIdx = Di.ModMap[I];
+    if (ModIdx == UINT_MAX) return 0;
+    if (!Di.isImm(ModIdx)) return 0;
+    return static_cast<unsigned>(Di.getImm(ModIdx) & 0xF);
+  }
+
+  llvm::Value *applyMods(unsigned I, llvm::Value *V) {
+    unsigned Mods = srcMod(I);
+    if (Mods == 0) return V;
+    bool IsI32 = (V->getType() == Ctx.I32Ty);
+    if (IsI32) V = Ctx.B.CreateBitCast(V, Ctx.F32Ty);
+    if (Mods & 2)
+      V = Ctx.B.CreateUnaryIntrinsic(llvm::Intrinsic::fabs, V, nullptr, "abs");
+    if (Mods & 1)
+      V = Ctx.B.CreateFNeg(V, "neg");
+    if (IsI32) V = Ctx.B.CreateBitCast(V, Ctx.I32Ty);
+    return V;
+  }
+
+  // DPP src-path wrapping. DPP is a src0-only data-pathway modifier: on
+  // hardware, src0 is shuffled across lanes per the DPP control bits
+  // *before* any fmods (neg/abs) and before the ALU op consumes it.
+  // Callers apply ordering: DPP wrap → applyMods → ALU.
+  //
+  // `%old` — the intrinsic's "inactive-lane value" operand — is the
+  // current VGPR value of the instruction's vdst (MCInst operand 0);
+  // we read it lazily and cache within this OpResolver because
+  // handlers that emit multiple side effects for a single source
+  // instruction may call `src(0)` more than once (e.g. VOPD's two
+  // halves). `OpResolver` instances are short-lived so the cache is
+  // strictly scoped.
+  //
+  // Width dispatch: `src(0)` / `srcF(0)` go through the 32-bit read
+  // path and cache `cachedDppOldVdst32`; `src64(0)` goes through the
+  // 64-bit read path and caches `cachedDppOldVdst64`. Handlers that
+  // mix widths on the same instruction (which would be unusual — a
+  // VALU op reads its src0 at a single width) would hit both caches
+  // but each lookup stays coherent. `emitUpdateDpp` supports both
+  // widths; other widths abort loudly.
+  llvm::Value *wrapDppIfNeeded(unsigned LogicalSrc, llvm::Value *Raw) {
+    if (!Di.HasDpp || LogicalSrc != 0) return Raw;
+    if (rejectDpp16FetchInactiveIfNeeded()) return Raw;
+    if (!CachedDppOldVdst32)
+      CachedDppOldVdst32 = Ctx.readOp32(Di, 0);
+    return Ctx.emitUpdateDpp(CachedDppOldVdst32, Raw, Di.DppCtrl, Di.DppRowMask,
+                              Di.DppBankMask, Di.DppBoundCtrl);
+  }
+
+  llvm::Value *src(unsigned I) {
+    return wrapDppIfNeeded(I, Ctx.readOp32(Di, srcIdx(I)));
+  }
+  llvm::Value *srcF(unsigned I) {
+    return applyMods(I, wrapDppIfNeeded(I, Ctx.readOp32(Di, srcIdx(I))));
+  }
+  llvm::Value *src64(unsigned I) {
+    llvm::Value *Raw = Ctx.readOp64(Di, srcIdx(I));
+    if (!Di.HasDpp || I != 0)
+      return Raw;
+    if (rejectDpp16FetchInactiveIfNeeded()) return Raw;
+    if (!CachedDppOldVdst64)
+      CachedDppOldVdst64 = Ctx.readOp64(Di, 0);
+    return Ctx.emitUpdateDpp(CachedDppOldVdst64, Raw, Di.DppCtrl, Di.DppRowMask,
+                              Di.DppBankMask, Di.DppBoundCtrl);
+  }
+  llvm::Value *srcExecWidth(unsigned I) { return Ctx.readOpExecWidth(Di, srcIdx(I)); }
+  int64_t srcImm(unsigned I) { return Di.getImm(srcIdx(I)); }
+
+  ParsedReg dst(unsigned I = 0) { return Ctx.parseReg(Di.getReg(I), I); }
+  bool isSrcReg(unsigned I) { return Di.isReg(srcIdx(I)); }
+
+  ParsedReg srcReg(unsigned I) {
+    unsigned Idx = srcIdx(I);
+    if (!Di.isReg(Idx)) {
+      ParsedReg Pr;
+      Pr.RegKind = ParsedReg::OTHER;
+      return Pr;
+    }
+    return Ctx.parseReg(Di.getReg(Idx), Idx);
+  }
+
+  // Memoised src-0 %old values for DPP wrapping, one per supported
+  // bit-width (32 / 64). Each is populated lazily on the first
+  // `src(0)` / `srcF(0)` / `src64(0)` call for a DPP-flagged
+  // instruction. Kept public so `OpResolver` remains an aggregate and
+  // can be brace-initialised from the raiser
+  // (`OpResolver op{ctx, di};`). Mutate only through the src*
+  // wrappers. Mirrors the `cachedLaneActive` public-field convention
+  // on `RaiseContext` above.
+  llvm::Value *CachedDppOldVdst32 = nullptr;
+  llvm::Value *CachedDppOldVdst64 = nullptr;
+
+private:
+  /// `llvm.amdgcn.update.dpp` has no FI operand. Record refusal when
+  /// Table-57 fetch-inactive is requested; callers must return their
+  /// `Raw` value unchanged when this returns true.
+  bool rejectDpp16FetchInactiveIfNeeded() {
+    if (!Di.DppFi)
+      return false;
+    Ctx.recordReadFailure(makeHotswapUnsupportedShapeError(
+        Di, "DPP",
+        "DPP16 FI fetch-inactive form: llvm.amdgcn.update.dpp has no FI "
+        "operand; extending DPP lifting requires modelling Table 57 "
+        "fetch-inactive semantics rather than silently dropping FI"));
+    return true;
+  }
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/reg-file.cpp
+++ b/amd/comgr/src/hotswap/reg-file.cpp
@@ -1,0 +1,672 @@
+//===- reg-file.cpp - Hotswap transpiler ----------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "reg-file.h"
+
+#include "isa-profile.h"
+#include "wave-projection.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h" // AMDGPU::SGPR_32RegClassID, TTMP_32RegClassID
+
+#include "llvm/ADT/Twine.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cassert>
+#include <string>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Human-readable name for a ParsedReg::Kind. Used only in fatal-error
+// messages, so an accidentally-missed case here surfaces as a slightly
+// uglier diagnostic (`"?<9>"`) rather than a silent bug.
+const char *kindName(ParsedReg::Kind K) {
+  switch (K) {
+  case ParsedReg::SGPR:       return "SGPR";
+  case ParsedReg::VGPR:       return "VGPR";
+  case ParsedReg::AGPR:       return "AGPR";
+  case ParsedReg::VCC:        return "VCC";
+  case ParsedReg::EXEC:       return "EXEC";
+  case ParsedReg::SCC:        return "SCC";
+  case ParsedReg::MODE:       return "MODE";
+  case ParsedReg::M0:         return "M0";
+  case ParsedReg::FLAT_SCR:   return "FLAT_SCR";
+  case ParsedReg::TTMP:       return "TTMP";
+  case ParsedReg::LDS_DIRECT: return "LDS_DIRECT";
+  case ParsedReg::SRC_VCCZ:   return "SRC_VCCZ";
+  case ParsedReg::SRC_EXECZ:  return "SRC_EXECZ";
+  case ParsedReg::SRC_SCC:    return "SRC_SCC";
+  case ParsedReg::NOREG:      return "NOREG";
+  case ParsedReg::OTHER:      return "OTHER";
+  }
+  return "<invalid>";
+}
+
+[[noreturn]] void failUnhandledKind(const char *Fn, ParsedReg Pr) {
+  report_fatal_error(Twine("transpiler: ") + Fn +
+                     ": unhandled ParsedReg Kind " + kindName(Pr.RegKind) +
+                     " (baseIdx=" + Twine(Pr.BaseIdx) +
+                     ", width=" + Twine(Pr.Width) + "). Caller must "
+                     "handle NOREG / OTHER / MODE before dispatching "
+                     "through readReg32/readReg64.");
+}
+
+} // namespace
+
+void AllocaRegFile::init(IRBuilder<> &B, Type *I32Ty, Type *I1Ty,
+                          const ISAProfile &Isa, const MCRegisterInfo &MRI,
+                          const WaveProjection &Proj) {
+  Projection = &Proj;
+  // EXEC storage width is chosen by the projection. Modulo-replication
+  // keeps it at source wave width (the long-standing default); wave-
+  // native cross-widening widens it to the target hardware mask so
+  // data-dependent EXEC writes survive the wave32 → wave64 lift
+  // without truncation. See `WaveProjection::execStorageTy` for the
+  // contract and `wave_projection.cpp:WaveNativeProjection` for the
+  // widened policy. `isa` continues to drive VGPR/AGPR bank sizing
+  // below — it's the *source* profile and thus the right place to
+  // read `hasAGPR` from.
+  ExecTy = Proj.execStorageTy();
+
+  const unsigned NSgpr = MRI.getRegClass(AMDGPU::SGPR_32RegClassID).getNumRegs();
+  Sgpr.assign(NSgpr, nullptr);
+  for (unsigned I = 0; I < NSgpr; ++I)
+    Sgpr[I] = B.CreateAlloca(I32Ty, nullptr, "Sgpr" + std::to_string(I));
+
+  // VGPR storage is explicitly oversized relative to TableGen's VGPR_32
+  // class (see `KVGPRCap` docs in reg-file.h). AGPR storage mirrors
+  // the VGPR size because AGPRs share the same index space under MFMA
+  // encoding conventions.
+  Vgpr.assign(KVGPRCap, nullptr);
+  for (unsigned I = 0; I < KVGPRCap; ++I)
+    Vgpr[I] = B.CreateAlloca(I32Ty, nullptr, "Vgpr" + std::to_string(I));
+
+  if (Isa.HasAgpr) {
+    Agpr.assign(KVGPRCap, nullptr);
+    for (unsigned I = 0; I < KVGPRCap; ++I)
+      Agpr[I] = B.CreateAlloca(I32Ty, nullptr, "Agpr" + std::to_string(I));
+  }
+
+  // Condition-carrying scalar registers are initialised to zero so that a
+  // read-before-write (raiser bug or unhandled instruction) yields a
+  // deterministic "false / inactive" value rather than `undef`/poison.
+  // Poison here would silently destroy SPE predication (the entry block
+  // already reads EXEC, and VCC/SCC feed downstream branches). EXEC is
+  // the only register initialised to all-ones — that is the architectural
+  // boot state of a dispatched wave and is load-bearing for every
+  // subsequent `emitLaneActiveBit` call.
+  Vcc = B.CreateAlloca(I1Ty, nullptr, "Vcc");
+  B.CreateStore(ConstantInt::getFalse(I1Ty), Vcc);
+  Scc = B.CreateAlloca(I1Ty, nullptr, "Scc");
+  B.CreateStore(ConstantInt::getFalse(I1Ty), Scc);
+  Exec = B.CreateAlloca(ExecTy, nullptr, "exec");
+  // The initial EXEC value is projection-dependent. Default (same-wave
+  // / modulo-replication): all-ones. Wave-native Wave32 → Wave64
+  // cross-widening: `@llvm.amdgcn.init_whole_wave` captures the
+  // original per-lane active mask and forces hardware EXEC = -1 so the
+  // WMMA → MFMA cross-lane pipeline can run across all 64 Wave64
+  // lanes even on a partial-wave dispatch. See
+  // `WaveProjection::emitInitialExec` and
+  // `WaveNativeProjection::emitInitialExec` for the correctness
+  // argument and the rationale for superseding the earlier
+  // `@llvm.amdgcn.strict.wwm`-per-MFMA-output strategy.
+  B.CreateStore(Proj.emitInitialExec(B), Exec);
+  M0 = B.CreateAlloca(I32Ty, nullptr, "M0");
+  B.CreateStore(ConstantInt::get(I32Ty, 0), M0);
+  FlatScr[0] = B.CreateAlloca(I32Ty, nullptr, "flat_scr_lo");
+  FlatScr[1] = B.CreateAlloca(I32Ty, nullptr, "flat_scr_hi");
+
+  const unsigned NTtmp = MRI.getRegClass(AMDGPU::TTMP_32RegClassID).getNumRegs();
+  Ttmp.assign(NTtmp, nullptr);
+  for (unsigned I = 0; I < NTtmp; ++I)
+    Ttmp[I] = B.CreateAlloca(I32Ty, nullptr, "ttmp" + std::to_string(I));
+}
+
+void AllocaRegFile::storeSGPR32(IRBuilder<> &B, int Idx, Value *V) {
+  Type *I32Ty = B.getInt32Ty();
+  if (V->getType() != I32Ty)
+    V = B.CreateBitCast(V, I32Ty);
+  B.CreateStore(V, Sgpr[Idx]);
+  // Invalidate any `V_CMP -> per-lane-i1` shadow entry for this SGPR.
+  // Callers that wrote a wave-mask (V_CMP path) re-populate immediately
+  // after; callers that wrote a scalar leave the entry empty so the
+  // next consumer falls back to the narrow-mask extract. See
+  // RaiseContext::lastSgprWaveMaskI1 / onSgprWritten contract.
+  if (OnSgprWritten) OnSgprWritten(Idx);
+}
+
+namespace {
+
+// Shared OOB check for the per-class load/store helpers. Fatal-errors
+// instead of returning undef / crashing inside LLVM — a caller that
+// hands us an out-of-range `idx` has already produced an invalid
+// ParsedReg, which is always a raiser bug rather than a kernel bug.
+[[noreturn]] void failOOB(const char *Fn, int Idx, size_t Cap) {
+  report_fatal_error(Twine("transpiler: ") + Fn + " idx=" + Twine(Idx) +
+                     " out of range [0.." + Twine(Cap) +
+                     ") or null; raiser bug, not a kernel bug — the "
+                     "caller produced an invalid ParsedReg.");
+}
+
+template <typename BankT>
+void assertInBank(const char *Fn, const BankT &Bank, int Idx) {
+  if (Idx < 0 || static_cast<unsigned>(Idx) >= Bank.size() || !Bank[Idx])
+    failOOB(Fn, Idx, Bank.size());
+}
+
+// 64-bit reads touch idx and idx+1; both must be in range.
+template <typename BankT>
+void assertPairInBank(const char *Fn, const BankT &Bank, int Idx) {
+  if (Idx < 0 || static_cast<unsigned>(Idx + 1) >= Bank.size() ||
+      !Bank[Idx] || !Bank[Idx + 1])
+    failOOB(Fn, Idx, Bank.size());
+}
+
+} // namespace
+
+Value *AllocaRegFile::loadSGPR32(IRBuilder<> &B, int Idx) {
+  assertInBank("loadSGPR32", Sgpr, Idx);
+  return B.CreateLoad(B.getInt32Ty(), Sgpr[Idx]);
+}
+
+void AllocaRegFile::storeSGPR64(IRBuilder<> &B, int Idx, Value *V) {
+  assertPairInBank("storeSGPR64", Sgpr, Idx);
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, I64Ty);
+  if (V->getType() != I64Ty)
+    V = B.CreateBitCast(V, I64Ty);
+  Value *Lo = B.CreateTrunc(V, I32Ty);
+  Value *Hi = B.CreateTrunc(B.CreateLShr(V, 32), I32Ty);
+  B.CreateStore(Lo, Sgpr[Idx]);
+  B.CreateStore(Hi, Sgpr[Idx + 1]);
+  // Pair writes invalidate both halves of the shadow. The V_CMP
+  // wave-mask write path keys its `recordSgprWaveMaskI1` on the low
+  // index of the destination pair (on wave64 source this is the
+  // authoritative key; on wave32 source `storeSGPR64` is not reachable
+  // from V_CMP because the source SGPR is physically 32 bits). See
+  // the `onSgprWritten` contract in reg-file.h.
+  if (OnSgprWritten) {
+    OnSgprWritten(Idx);
+    OnSgprWritten(Idx + 1);
+  }
+}
+
+Value *AllocaRegFile::loadSGPR64(IRBuilder<> &B, int Idx) {
+  assertPairInBank("loadSGPR64", Sgpr, Idx);
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+  Value *Lo = B.CreateZExt(B.CreateLoad(I32Ty, Sgpr[Idx]), I64Ty);
+  Value *Hi = B.CreateZExt(B.CreateLoad(I32Ty, Sgpr[Idx + 1]), I64Ty);
+  return B.CreateOr(Lo, B.CreateShl(Hi, 32));
+}
+
+void AllocaRegFile::storeVGPR32(IRBuilder<> &B, int Idx, Value *V) {
+  assertInBank("storeVGPR32", Vgpr, Idx);
+  Type *I32Ty = B.getInt32Ty();
+  if (V->getType() != I32Ty) {
+    if (V->getType()->isPointerTy())
+      V = B.CreatePtrToInt(V, B.getInt64Ty());
+    if (V->getType() == B.getFloatTy())
+      V = B.CreateBitCast(V, I32Ty);
+    else if (V->getType() != I32Ty)
+      V = B.CreateTrunc(V, I32Ty);
+  }
+  B.CreateStore(V, Vgpr[Idx]);
+}
+
+Value *AllocaRegFile::loadVGPR32(IRBuilder<> &B, int Idx) {
+  assertInBank("loadVGPR32", Vgpr, Idx);
+  return B.CreateLoad(B.getInt32Ty(), Vgpr[Idx]);
+}
+
+void AllocaRegFile::storeVGPR64(IRBuilder<> &B, int Idx, Value *V) {
+  assertPairInBank("storeVGPR64", Vgpr, Idx);
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+  if (V->getType()->isPointerTy())
+    V = B.CreatePtrToInt(V, I64Ty);
+  if (V->getType() != I64Ty)
+    V = B.CreateBitCast(V, I64Ty);
+  Value *Lo = B.CreateTrunc(V, I32Ty);
+  Value *Hi = B.CreateTrunc(B.CreateLShr(V, 32), I32Ty);
+  B.CreateStore(Lo, Vgpr[Idx]);
+  B.CreateStore(Hi, Vgpr[Idx + 1]);
+}
+
+Value *AllocaRegFile::loadVGPR64(IRBuilder<> &B, int Idx) {
+  assertPairInBank("loadVGPR64", Vgpr, Idx);
+  Type *I32Ty = B.getInt32Ty();
+  Type *I64Ty = B.getInt64Ty();
+  Value *Lo = B.CreateZExt(B.CreateLoad(I32Ty, Vgpr[Idx]), I64Ty);
+  Value *Hi = B.CreateZExt(B.CreateLoad(I32Ty, Vgpr[Idx + 1]), I64Ty);
+  return B.CreateOr(Lo, B.CreateShl(Hi, 32));
+}
+
+void AllocaRegFile::storeAGPR32(IRBuilder<> &B, int Idx, Value *V) {
+  assertInBank("storeAGPR32", Agpr, Idx);
+  Type *I32Ty = B.getInt32Ty();
+  if (V->getType() != I32Ty)
+    V = B.CreateBitCast(V, I32Ty);
+  B.CreateStore(V, Agpr[Idx]);
+}
+
+Value *AllocaRegFile::loadAGPR32(IRBuilder<> &B, int Idx) {
+  assertInBank("loadAGPR32", Agpr, Idx);
+  return B.CreateLoad(B.getInt32Ty(), Agpr[Idx]);
+}
+
+void AllocaRegFile::storeVCC(IRBuilder<> &B, Value *V) {
+  if (V->getType() != B.getInt1Ty())
+    V = B.CreateICmpNE(V, Constant::getNullValue(V->getType()));
+  B.CreateStore(V, Vcc);
+}
+
+Value *AllocaRegFile::loadVCC(IRBuilder<> &B) {
+  return B.CreateLoad(B.getInt1Ty(), Vcc);
+}
+
+void AllocaRegFile::storeSCC(IRBuilder<> &B, Value *V) {
+  if (V->getType() != B.getInt1Ty())
+    V = B.CreateICmpNE(V, Constant::getNullValue(V->getType()));
+  B.CreateStore(V, Scc);
+}
+
+Value *AllocaRegFile::loadSCC(IRBuilder<> &B) {
+  return B.CreateLoad(B.getInt1Ty(), Scc);
+}
+
+Value *AllocaRegFile::loadExec(IRBuilder<> &B) {
+  return B.CreateLoad(ExecTy, Exec, "exec_val");
+}
+
+void AllocaRegFile::storeExec(IRBuilder<> &B, Value *V) {
+  if (V->getType() != ExecTy)
+    V = B.CreateBitOrPointerCast(V, ExecTy);
+  B.CreateStore(V, Exec);
+  if (OnExecWritten)
+    OnExecWritten();
+}
+
+Value *AllocaRegFile::readVCCAsWaveMask(IRBuilder<> &B, Type *ResultTy) {
+  assert(Projection && "readVCCAsWaveMask requires a WaveProjection — "
+                        "call init() before using this reg-file");
+  return Projection->ballotI1ToWidth(B, loadVCC(B), ResultTy, "vcc_ballot");
+}
+
+Value *AllocaRegFile::readReg32(IRBuilder<> &B, ParsedReg Pr) {
+  if (Pr.RegKind == ParsedReg::SGPR) return loadSGPR32(B, Pr.BaseIdx);
+  if (Pr.RegKind == ParsedReg::VGPR) return loadVGPR32(B, Pr.BaseIdx);
+  if (Pr.RegKind == ParsedReg::AGPR) return loadAGPR32(B, Pr.BaseIdx);
+  // VCC as a 32-bit scalar read: must go through the wave-mask ballot,
+  // NOT a sign-extension of the local i1. Callers that want a per-lane
+  // i1 (e.g. predicating a compute op) should call `loadVCC` directly.
+  // This path is hit by handlers that bypass `RaiseContext::readOp32`
+  // (which performs the same routing); keeping the routing centralised
+  // here prevents silent miscompiles when a new handler adds a direct
+  // `regs.readReg32(VCC)` call. See `readVCCAsWaveMask` for the ballot
+  // invariant (must be emitted at wave-level / full EXEC).
+  if (Pr.RegKind == ParsedReg::VCC)
+    return readVCCAsWaveMask(B, B.getInt32Ty());
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    Value *V = loadExec(B);
+    Type *I32Ty = B.getInt32Ty();
+    if (V->getType() == I32Ty)
+      return V;
+    // wave64 EXEC is i64; pick the correct half when reading a 32-bit
+    // slice. width==2 reads are handled by readReg64 / readExecWidth;
+    // this path is the width==1 case where baseIdx selects LO/HI.
+    if (Pr.Width >= 2)
+      return B.CreateTrunc(V, I32Ty, "exec_lo");
+    if (Pr.BaseIdx == 1)
+      V = B.CreateLShr(V, 32, "exec_hi_shr");
+    return B.CreateTrunc(V, I32Ty, Pr.BaseIdx == 1 ? "exec_hi" : "exec_lo");
+  }
+  if (Pr.RegKind == ParsedReg::SCC)
+    return B.CreateZExt(loadSCC(B), B.getInt32Ty());
+  if (Pr.RegKind == ParsedReg::M0)
+    return B.CreateLoad(B.getInt32Ty(), M0, "m0_val");
+  if (Pr.RegKind == ParsedReg::FLAT_SCR)
+    return B.CreateLoad(B.getInt32Ty(), FlatScr[0], "fscr_val");
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx >= 0 &&
+      static_cast<unsigned>(Pr.BaseIdx) < Ttmp.size())
+    return B.CreateLoad(B.getInt32Ty(), Ttmp[Pr.BaseIdx], "ttmp_val");
+  // GFX9 src_lds_direct (encoding 254): reads one dword from LDS at the
+  // byte address in M0. There is NO auto-increment of M0 on GFX9 — the
+  // kernel manages M0 explicitly between reads. (GFX11+ DSDIR
+  // `lds_direct_load` does auto-increment; if we ever raise GFX11+
+  // kernels that use DSDIR, the increment must be modeled separately.)
+  if (Pr.RegKind == ParsedReg::LDS_DIRECT) {
+    auto *I32Ty = B.getInt32Ty();
+    Value *Addr = B.CreateLoad(I32Ty, M0, "m0_lds_off");
+    auto *LdsPtr = PointerType::get(I32Ty->getContext(), 3);
+    Value *Ptr = B.CreateIntToPtr(Addr, LdsPtr, "lds_direct_ptr");
+    return B.CreateLoad(I32Ty, Ptr, "lds_direct_val");
+  }
+  failUnhandledKind("readReg32", Pr);
+}
+
+Value *AllocaRegFile::readReg64(IRBuilder<> &B, ParsedReg Pr) {
+  if (Pr.RegKind == ParsedReg::SGPR) return loadSGPR64(B, Pr.BaseIdx);
+  if (Pr.RegKind == ParsedReg::VGPR) return loadVGPR64(B, Pr.BaseIdx);
+  // VCC as a 64-bit scalar read: route through the wave-mask ballot.
+  // Previous implementations used `SExt(i1 -> i64)`, which replicates
+  // the CURRENT LANE's VCC bit across all 64 bits — a silent lie when
+  // the consumer expects a wave-level mask (e.g. `s_and_b64 vcc, exec,
+  // vcc`). All direct VCC reads must materialise the full per-lane
+  // collection via `amdgcn.ballot`.
+  if (Pr.RegKind == ParsedReg::VCC)
+    return readVCCAsWaveMask(B, B.getInt64Ty());
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    Value *V = loadExec(B);
+    if (V->getType() != B.getInt64Ty())
+      V = B.CreateZExt(V, B.getInt64Ty(), "exec_ext");
+    return V;
+  }
+  if (Pr.RegKind == ParsedReg::M0)
+    return B.CreateZExt(B.CreateLoad(B.getInt32Ty(), M0, "m0_val"),
+                        B.getInt64Ty());
+  if (Pr.RegKind == ParsedReg::FLAT_SCR) {
+    Type *I32Ty = B.getInt32Ty();
+    Type *I64Ty = B.getInt64Ty();
+    Value *Lo = B.CreateZExt(B.CreateLoad(I32Ty, FlatScr[0]), I64Ty);
+    Value *Hi = B.CreateZExt(B.CreateLoad(I32Ty, FlatScr[1]), I64Ty);
+    return B.CreateOr(Lo, B.CreateShl(Hi, 32), "fscr64");
+  }
+  // TTMP[baseIdx:baseIdx+1] read as i64 — combine the two adjacent
+  // i32 lanes the same way SGPR pairs are combined. The 32-bit
+  // single-lane read above lives in readReg32; this is the
+  // S_LOAD_DWORDX2 / DWORDX4 path where the kernel addresses a TTMP
+  // pair (e.g. `s_load_dwordx2 ..., ttmp[12:13], 0x0`). Without this
+  // case the dispatcher fires `failUnhandledKind`, which the corpus
+  // exercises in 49 gfx1250 kernels.
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx >= 0 &&
+      static_cast<unsigned>(Pr.BaseIdx + 1) < Ttmp.size()) {
+    Type *I32Ty = B.getInt32Ty();
+    Type *I64Ty = B.getInt64Ty();
+    Value *Lo = B.CreateZExt(B.CreateLoad(I32Ty, Ttmp[Pr.BaseIdx]), I64Ty);
+    Value *Hi = B.CreateZExt(B.CreateLoad(I32Ty, Ttmp[Pr.BaseIdx + 1]),
+                              I64Ty);
+    return B.CreateOr(Lo, B.CreateShl(Hi, 32), "ttmp64");
+  }
+  failUnhandledKind("readReg64", Pr);
+}
+
+Value *AllocaRegFile::readExecWidth(IRBuilder<> &B) { return loadExec(B); }
+
+void AllocaRegFile::writeExecWidth(IRBuilder<> &B, Value *V) {
+  storeExec(B, V);
+}
+
+void AllocaRegFile::writeReg32(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::SGPR) { storeSGPR32(B, Pr.BaseIdx, V); return; }
+  if (Pr.RegKind == ParsedReg::VGPR) { storeVGPR32(B, Pr.BaseIdx, V); return; }
+  if (Pr.RegKind == ParsedReg::AGPR) { storeAGPR32(B, Pr.BaseIdx, V); return; }
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    Type *I32Ty = B.getInt32Ty();
+    // Coerce incoming value to i32. storeExec handles width matching to
+    // execTy; for wave64-native EXEC (execTy == i64) a 32-bit write
+    // addresses only a half of the mask and is reconciled below.
+    if (V->getType() != I32Ty) {
+      if (V->getType()->isPointerTy())
+        V = B.CreatePtrToInt(V, B.getInt64Ty());
+      if (V->getType() != I32Ty) {
+        unsigned Bits = V->getType()->getPrimitiveSizeInBits();
+        V = Bits > 32 ? B.CreateTrunc(V, I32Ty)
+                       : B.CreateBitCast(V, I32Ty);
+      }
+    }
+    if (ExecTy == I32Ty || Pr.Width >= 2) {
+      storeExec(B, V);
+      return;
+    }
+    // execTy is i64 and the write is a single-half EXEC_LO or EXEC_HI.
+    // Two reconciliation policies apply depending on the projection:
+    //
+    //   (a) Architectural half-write (default for wave64 source): the
+    //       source author named one 32-bit half, so preserve the other
+    //       half's live value and merge. This is the shape wave64
+    //       source kernels rely on (`s_mov_b32 exec_hi, sN` after an
+    //       `s_mov_b32 exec_lo, sM`).
+    //
+    //   (b) Wave-native cross-widening broadcast (wave32 source →
+    //       wave64 target, per `projection->broadcastNarrowExecLoWrite()`):
+    //       the source author's wave32 view treats `exec_lo` as the
+    //       whole wave mask, so the 32-bit value represents the
+    //       whole-wave intent. The wave-native projection models each
+    //       target lane as an independent source-thread equivalent,
+    //       which means a whole-wave write must fan out to every
+    //       target lane; we replicate the 32-bit value into both
+    //       halves of the widened EXEC. EXEC_HI writes cannot arise
+    //       from a wave32 source (the source ISA has no EXEC_HI), and
+    //       reaching one under wave-native is programmer error or a
+    //       raiser bug, so we fall back to (a) in that case for
+    //       robustness.
+    Value *V64 = B.CreateZExt(V, ExecTy);
+    if (Projection && Projection->broadcastNarrowExecLoWrite() &&
+        Pr.BaseIdx == 0) {
+      // Replicate: EXEC = (v << 32) | v. Equivalent to the
+      // "broadcast wave32 whole-wave mask across both halves of the
+      // widened EXEC" semantics.
+      Value *Hi = B.CreateShl(V64, 32);
+      Value *Merged = B.CreateOr(V64, Hi, "exec_lo_broadcast");
+      storeExec(B, Merged);
+      return;
+    }
+    Value *Cur = loadExec(B);
+    Value *Merged;
+    if (Pr.BaseIdx == 1) {
+      Value *Mask = ConstantInt::get(ExecTy, 0xFFFFFFFFULL);
+      Merged = B.CreateOr(B.CreateAnd(Cur, Mask),
+                           B.CreateShl(V64, 32), "exec_hi_write");
+    } else {
+      Value *Mask = ConstantInt::get(ExecTy, 0xFFFFFFFF00000000ULL);
+      Merged = B.CreateOr(B.CreateAnd(Cur, Mask), V64, "exec_lo_write");
+    }
+    storeExec(B, Merged);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC) {
+    assert(Projection && "writeReg32(VCC) requires a WaveProjection");
+    storeVCC(B, Projection->extractLaneBitFromWaveMask(B, V));
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::M0) {
+    if (V->getType() != B.getInt32Ty()) V = B.CreateBitCast(V, B.getInt32Ty());
+    B.CreateStore(V, M0);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::FLAT_SCR) {
+    if (V->getType() != B.getInt32Ty()) V = B.CreateBitCast(V, B.getInt32Ty());
+    B.CreateStore(V, FlatScr[0]);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx >= 0 &&
+      static_cast<unsigned>(Pr.BaseIdx) < Ttmp.size()) {
+    if (V->getType() != B.getInt32Ty()) V = B.CreateBitCast(V, B.getInt32Ty());
+    B.CreateStore(V, Ttmp[Pr.BaseIdx]);
+    return;
+  }
+}
+
+void AllocaRegFile::writeReg64(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::SGPR) { storeSGPR64(B, Pr.BaseIdx, V); return; }
+  if (Pr.RegKind == ParsedReg::VGPR) { storeVGPR64(B, Pr.BaseIdx, V); return; }
+  if (Pr.RegKind == ParsedReg::VCC) {
+    assert(Projection && "writeReg64(VCC) requires a WaveProjection");
+    storeVCC(B, Projection->extractLaneBitFromWaveMask(B, V));
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    storeExec(B, V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::FLAT_SCR) {
+    Type *I32Ty = B.getInt32Ty();
+    Type *I64Ty = B.getInt64Ty();
+    if (V->getType() != I64Ty) V = B.CreateBitOrPointerCast(V, I64Ty);
+    B.CreateStore(B.CreateTrunc(V, I32Ty), FlatScr[0]);
+    B.CreateStore(B.CreateTrunc(B.CreateLShr(V, 32), I32Ty), FlatScr[1]);
+    return;
+  }
+  // 64-bit TTMP write — split into two i32 stores at baseIdx and
+  // baseIdx+1, matching the readReg64 TTMP shape above. Trap-handler
+  // kernels routinely materialise a 64-bit address into a TTMP pair
+  // before invoking the trap; we route them through the same alloca
+  // bank as the 32-bit case so subsequent reads see the stored value.
+  if (Pr.RegKind == ParsedReg::TTMP && Pr.BaseIdx >= 0 &&
+      static_cast<unsigned>(Pr.BaseIdx + 1) < Ttmp.size()) {
+    Type *I32Ty = B.getInt32Ty();
+    Type *I64Ty = B.getInt64Ty();
+    if (V->getType() != I64Ty) V = B.CreateBitOrPointerCast(V, I64Ty);
+    B.CreateStore(B.CreateTrunc(V, I32Ty), Ttmp[Pr.BaseIdx]);
+    B.CreateStore(B.CreateTrunc(B.CreateLShr(V, 32), I32Ty),
+                   Ttmp[Pr.BaseIdx + 1]);
+    return;
+  }
+}
+
+void AllocaRegFile::writeRegExecWidth(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  if (Pr.RegKind == ParsedReg::SGPR) {
+    // SGPR storage is sized by the *source* architecture: one 32-bit
+    // SGPR on wave32 source (`s_and_saveexec_b32 s0, ...`), a 64-bit
+    // SGPR pair on wave64 source. Under modulo-replication those
+    // widths match `execTy` and no bridging is needed; under wave-
+    // native cross-widening `execTy` is `WaveMaskTy` (i64 target
+    // hardware) while the source-named SGPR is still 32-bit, so the
+    // incoming EXEC-width value must be narrowed to the source width
+    // before the store. See `WaveProjection::sourceWaveMaskTy` for the
+    // width policy. This is the symmetric counterpart of the widen-by-
+    // replication done when the value was first read via
+    // `readOpExecWidth` or computed by the `V_CMP → SGPR` ballot.
+    Type *SourceWidthTy =
+        (Projection && Projection->sourceWaveScopedLaneOps() && Pr.Width >= 2)
+            ? B.getInt64Ty()
+            : (Projection ? Projection->sourceWaveMaskTy() : ExecTy);
+    if (V->getType() != SourceWidthTy) {
+      unsigned Have = V->getType()->getPrimitiveSizeInBits();
+      unsigned Want = SourceWidthTy->getPrimitiveSizeInBits();
+      if (Have > Want)
+        V = B.CreateTrunc(V, SourceWidthTy, "wn_exec_to_src_mask");
+      else if (Have < Want)
+        V = B.CreateZExt(V, SourceWidthTy, "wn_exec_to_src_mask");
+    }
+    if (SourceWidthTy == B.getInt32Ty())
+      storeSGPR32(B, Pr.BaseIdx, V);
+    else
+      storeSGPR64(B, Pr.BaseIdx, V);
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::VCC) {
+    assert(Projection && "writeRegExecWidth(VCC) requires a WaveProjection");
+    storeVCC(B, Projection->extractLaneBitFromWaveMask(B, V));
+    return;
+  }
+  if (Pr.RegKind == ParsedReg::EXEC) {
+    storeExec(B, V);
+    return;
+  }
+}
+
+Value *AllocaRegFile::readRegVec(IRBuilder<> &B, ParsedReg Pr, Type *VecTy) {
+  unsigned N = VecTy->isVectorTy()
+      ? cast<FixedVectorType>(VecTy)->getNumElements()
+      : 1;
+  Type *ElemTy = VecTy->isVectorTy()
+      ? cast<FixedVectorType>(VecTy)->getElementType()
+      : VecTy;
+  unsigned DwordsPerElem = ElemTy->getPrimitiveSizeInBits() / 32;
+  if (DwordsPerElem == 0) DwordsPerElem = 1;
+
+  if (N == 1 && !VecTy->isVectorTy() && VecTy->getPrimitiveSizeInBits() <= 32) {
+    Value *V = readReg32(B, Pr);
+    if (V->getType() != VecTy) V = B.CreateBitCast(V, VecTy);
+    return V;
+  }
+
+  unsigned TotalDwords = 0;
+  if (ElemTy->isFloatTy()) TotalDwords = N;
+  else if (ElemTy->isIntegerTy(32)) TotalDwords = N;
+  else if (ElemTy->isHalfTy()) TotalDwords = (N + 1) / 2;
+  else TotalDwords = (N * ElemTy->getPrimitiveSizeInBits() + 31) / 32;
+
+  SmallVector<Value *> Dwords;
+  for (unsigned I = 0; I < TotalDwords; I++) {
+    ParsedReg Sub = Pr;
+    Sub.BaseIdx = Pr.BaseIdx + I;
+    Sub.Width = 1;
+    Dwords.push_back(readReg32(B, Sub));
+  }
+
+  unsigned TotalBits = TotalDwords * 32;
+  Type *IntTy = Type::getIntNTy(B.getContext(), TotalBits);
+
+  Value *Packed = ConstantInt::get(IntTy, 0);
+  for (unsigned I = 0; I < TotalDwords; I++) {
+    Value *Ext = B.CreateZExt(Dwords[I], IntTy);
+    if (I > 0) Ext = B.CreateShl(Ext, I * 32);
+    Packed = B.CreateOr(Packed, Ext);
+  }
+  return B.CreateBitCast(Packed, VecTy);
+}
+
+void AllocaRegFile::writeRegVec(IRBuilder<> &B, ParsedReg Pr, Value *V) {
+  Type *Ty = V->getType();
+  unsigned TotalBits = Ty->getPrimitiveSizeInBits();
+  unsigned TotalDwords = (TotalBits + 31) / 32;
+
+  Type *IntTy = Type::getIntNTy(B.getContext(), TotalDwords * 32);
+  Type *I32Ty = B.getInt32Ty();
+  Value *Packed = B.CreateBitCast(V, IntTy);
+
+  for (unsigned I = 0; I < TotalDwords; I++) {
+    Value *Dw;
+    if (I == 0)
+      Dw = B.CreateTrunc(Packed, I32Ty);
+    else
+      Dw = B.CreateTrunc(B.CreateLShr(Packed, I * 32), I32Ty);
+    ParsedReg Sub = Pr;
+    Sub.BaseIdx = Pr.BaseIdx + I;
+    Sub.Width = 1;
+    writeReg32(B, Sub, Dw);
+  }
+}
+
+void AllocaRegFile::collectAllocas(SmallVectorImpl<AllocaInst *> &Out) {
+  for (auto *A : Sgpr) if (A) Out.push_back(A);
+  for (auto *A : Vgpr) if (A) Out.push_back(A);
+  for (auto *A : Agpr) if (A) Out.push_back(A);
+  if (Vcc) Out.push_back(Vcc);
+  if (Scc) Out.push_back(Scc);
+  if (Exec) Out.push_back(Exec);
+  if (M0) Out.push_back(M0);
+  for (auto *A : FlatScr) if (A) Out.push_back(A);
+  // ttmps must be promoted too, otherwise they survive into the AMDGPU
+  // backend and trigger AMDGPUPromoteAllocaToLDS, which inserts an
+  // `amdgcn.dispatch.ptr` intrinsic *and* removes the kernel's
+  // `amdgpu-no-dispatch-ptr` attribute (see
+  // AMDGPUPromoteAlloca.cpp::getLocalSizeYZ). Once dispatch_ptr is
+  // re-enabled in the kernel descriptor, the regalloc treats s[0:1] as
+  // a free preloaded SGPR and uses s1 as scratch — corrupting buffer
+  // pointer high words and producing the gfx1250 Triton SIGSEGV (R1).
+  // Lifting these allocas requires a dominating defining store for
+  // every read; raiser.cpp Phase 4 seeds every ttmp with `i32 0` in
+  // the entry block so PromoteMemToReg can lift the rest cleanly.
+  for (auto *A : Ttmp) if (A) Out.push_back(A);
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/reg-file.h
+++ b/amd/comgr/src/hotswap/reg-file.h
@@ -1,0 +1,186 @@
+//===- reg-file.h - Hotswap transpiler ------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_REG_FILE_H
+#define HOTSWAP_TRANSPILER_REG_FILE_H
+
+#include "parsed-reg.h"
+
+#include "llvm/ADT/FunctionExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+
+namespace llvm {
+class MCRegisterInfo;
+} // namespace llvm
+
+namespace COMGR::hotswap {
+
+struct ISAProfile;
+class WaveProjection;
+
+// Per-register alloca-based representation of the AMDGPU register file.
+//
+// Every architectural register gets its own i32 alloca (or i1 for VCC/SCC,
+// i32/i64 for EXEC depending on wave width). `PromoteMemToReg` in
+// `raiser.cpp` Phase 6 lifts these allocas to proper SSA with phis after
+// the handler pass finishes. Keeping per-register state in allocas lets
+// handlers emit straight-line loads/stores during dispatch without
+// worrying about SSA construction.
+//
+// Storage is sized at `init()` time:
+//
+//   * SGPR bank: `MRI.getRegClass(AMDGPU::SGPR_32RegClassID).getNumRegs()`
+//     — the authoritative count from TableGen for the live subtarget (106
+//     on every AMDGPU subtarget today).
+//   * TTMP bank: `MRI.getRegClass(AMDGPU::TTMP_32RegClassID).getNumRegs()`
+//     — 16 on every AMDGPU subtarget.
+//   * VGPR / AGPR bank: `KVGPRCap` (below). NOT sourced from the register
+//     class because gfx1250 `S_SET_VGPR_MSB` extends the runtime-
+//     addressable VGPR index range beyond the TableGen class size (256):
+//     the raiser needs storage for every index a kernel can reach under
+//     MSB replay, not just the indices the assembler names directly.
+//     Keeping the cap explicit documents the extra storage as
+//     intentional.
+//
+//     Sized to match gfx1250's `1024-addressable-vgprs` subtarget
+//     feature (LLVM AMDGPU.td:1120 `def 1024AddressableVGPRs`):
+//     S_SET_VGPR_MSB encodes a 2-bit MSB pair per operand slot, each
+//     contributing `value * 256` to that slot's VGPR index, so the
+//     maximum reachable index is `255 (8-bit base) + 3*256 = 1023`.
+//     A smaller cap (the previous 512) crashed legitimate gfx1250
+//     tensilelite kernels that issue `s_set_vgpr_msb 0x80` followed
+//     by `v_mov_b32 v72 /*v584*/` (vdst MSB=2 → effective index
+//     `72 + 512 = 584`); see `failOOB` in reg-file.cpp.
+struct AllocaRegFile {
+  // See class-level comment for rationale.
+  static constexpr unsigned KVGPRCap = 1024;
+
+  llvm::SmallVector<llvm::AllocaInst *> Sgpr;
+  llvm::SmallVector<llvm::AllocaInst *> Vgpr;
+  llvm::SmallVector<llvm::AllocaInst *> Agpr;
+  llvm::SmallVector<llvm::AllocaInst *> Ttmp;
+  llvm::AllocaInst *Vcc = nullptr;
+  llvm::AllocaInst *Scc = nullptr;
+  llvm::AllocaInst *Exec = nullptr;
+  llvm::AllocaInst *M0 = nullptr;
+  llvm::AllocaInst *FlatScr[2] = {};
+
+  // Width of the EXEC alloca — tracks the *source* ISA wave width
+  // (i32 on wave32 source, i64 on wave64 source). Distinct from the
+  // target-hardware wave mask width owned by `WaveProjection`.
+  llvm::Type *ExecTy = nullptr;
+
+  // Non-owning pointer to the cross-wave projection policy. Used by
+  // VCC read/write paths inside the reg file (ballot for per-lane-i1 →
+  // wave-mask, and the inverse for scalar → per-lane stores). Left null
+  // outside the raiser — the reg file is used in contexts where no
+  // projection exists (e.g. register-file-only unit tests or EXEC
+  // initialisation at function entry) and any code path that would
+  // need the projection (VCC wave-mask round-trip) is then unreachable.
+  const WaveProjection *Projection = nullptr;
+
+  // Invalidation hook fired on every EXEC-mutating store. The owning
+  // RaiseContext installs this so its per-instruction `lane_active`
+  // memo stays in sync regardless of which path hits `storeExec`.
+  //
+  // `unique_function` owns the callable (so the lambda's lifetime can
+  // be decoupled from the stack frame that installs it) while still
+  // being move-only — a correctness nudge toward "installed exactly
+  // once, not copied around."
+  llvm::unique_function<void()> OnExecWritten;
+
+  // Invalidation hook fired on every per-SGPR store, at the low-level
+  // `storeSGPR32` / `storeSGPR64` boundary. The owning RaiseContext
+  // installs this so its `lastSgprWaveMaskI1` shadow map (see raise_
+  // context.h) stays in sync with every path that mutates an SGPR —
+  // including paths that bypass `writeReg32 / writeReg64` to call
+  // `storeSGPR32` directly (several handlers, e.g. handle_smem.cpp's
+  // multi-dword SMEM load splitting, handle_valu.cpp's SCC-flag SGPR
+  // writes).
+  //
+  // `storeSGPR64` fires the hook twice, once per half (idx, idx+1), so
+  // pair writes invalidate both shadow entries. `storeSGPR32` fires it
+  // once.
+  //
+  // The V_CMP wave-mask write path (`writeRegExecWidth` -> `storeSGPR32`/
+  // `storeSGPR64`) ALSO fires this hook, which transiently empties the
+  // shadow entry before the V_CMP handler immediately re-records the
+  // per-lane `i1` via `ctx.recordSgprWaveMaskI1`. That two-step shape
+  // is deliberate: the hook fires on every low-level store, and the
+  // handler layer is where we distinguish "scalar write (leave map
+  // empty)" from "wave-mask write (re-populate map with the i1)".
+  //
+  // See hotswap/docs/sgpr-wave-mask-translation.md section 3.1 for the
+  // full invariants (I1 additive / I2 SSA-monotonic / I3 any
+  // interference defeats the cache).
+  llvm::unique_function<void(int)> OnSgprWritten;
+
+  // Initialise storage.
+  //
+  // `MRI` is queried for the architectural SGPR_32 / TTMP_32 register-
+  // class sizes. `ISAProfile::hasAGPR` selects whether to allocate
+  // AGPR slots. `proj` is stored as a non-owning pointer for use by
+  // VCC read/write paths.
+  void init(llvm::IRBuilder<> &B, llvm::Type *I32Ty, llvm::Type *I1Ty,
+            const ISAProfile &Isa, const llvm::MCRegisterInfo &MRI,
+            const WaveProjection &Proj);
+
+  // Direct per-class store/load helpers. All are predicated on `idx`
+  // being in range for the corresponding class; bounds failures surface
+  // via `errs()` + an undef fallback for reads, and are otherwise
+  // caught at higher levels by the raiser's allocation pass.
+  void storeSGPR32(llvm::IRBuilder<> &B, int Idx, llvm::Value *V);
+  llvm::Value *loadSGPR32(llvm::IRBuilder<> &B, int Idx);
+  void storeSGPR64(llvm::IRBuilder<> &B, int Idx, llvm::Value *V);
+  llvm::Value *loadSGPR64(llvm::IRBuilder<> &B, int Idx);
+  void storeVGPR32(llvm::IRBuilder<> &B, int Idx, llvm::Value *V);
+  llvm::Value *loadVGPR32(llvm::IRBuilder<> &B, int Idx);
+  void storeVGPR64(llvm::IRBuilder<> &B, int Idx, llvm::Value *V);
+  llvm::Value *loadVGPR64(llvm::IRBuilder<> &B, int Idx);
+  void storeAGPR32(llvm::IRBuilder<> &B, int Idx, llvm::Value *V);
+  llvm::Value *loadAGPR32(llvm::IRBuilder<> &B, int Idx);
+
+  void storeVCC(llvm::IRBuilder<> &B, llvm::Value *V);
+  llvm::Value *loadVCC(llvm::IRBuilder<> &B);
+  void storeSCC(llvm::IRBuilder<> &B, llvm::Value *V);
+  llvm::Value *loadSCC(llvm::IRBuilder<> &B);
+  llvm::Value *loadExec(llvm::IRBuilder<> &B);
+  void storeExec(llvm::IRBuilder<> &B, llvm::Value *V);
+
+  // Read VCC as a wave-level bit-mask of width `resultTy`. Routed
+  // through `WaveProjection::ballotI1ToWidth`; see
+  // `wave-projection.h` for the outer-EXEC-only invariant this
+  // relies on.
+  llvm::Value *readVCCAsWaveMask(llvm::IRBuilder<> &B, llvm::Type *ResultTy);
+
+  // Generic read/write by ParsedReg.
+  llvm::Value *readReg32(llvm::IRBuilder<> &B, ParsedReg Pr);
+  llvm::Value *readReg64(llvm::IRBuilder<> &B, ParsedReg Pr);
+  llvm::Value *readExecWidth(llvm::IRBuilder<> &B);
+  void writeExecWidth(llvm::IRBuilder<> &B, llvm::Value *V);
+  void writeReg32(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+  void writeReg64(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+  void writeRegExecWidth(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+
+  // Read/write N dwords as a vector from contiguous VGPRs/AGPRs.
+  llvm::Value *readRegVec(llvm::IRBuilder<> &B, ParsedReg Pr,
+                          llvm::Type *VecTy);
+  void writeRegVec(llvm::IRBuilder<> &B, ParsedReg Pr, llvm::Value *V);
+
+  // Populate `out` with every alloca the raiser emitted, for feeding
+  // into `PromoteMemToReg`.
+  void collectAllocas(llvm::SmallVectorImpl<llvm::AllocaInst *> &Out);
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/user-sgpr-layout.cpp
+++ b/amd/comgr/src/hotswap/user-sgpr-layout.cpp
@@ -1,0 +1,282 @@
+//===- user-sgpr-layout.cpp - Hotswap transpiler --------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "user-sgpr-layout.h"
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/AMDHSAKernelDescriptor.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Append `count` Entry rows to `entries` describing a multi-dword source
+// that occupies `count` consecutive SGPRs. Returns the SGPR index of the
+// first (low) dword, which the factory stores into the convenience
+// `*Sgpr` field for the corresponding source.
+int appendSource(llvm::SmallVectorImpl<UserSgprLayout::Entry> &Entries,
+                 UserSgprLayout::Source Src, unsigned Count) {
+  int FirstIdx = static_cast<int>(Entries.size());
+  for (unsigned I = 0; I < Count; ++I) {
+    UserSgprLayout::Entry E;
+    E.SrcKind = Src;
+    E.SubDword = static_cast<uint8_t>(I);
+    Entries.push_back(E);
+  }
+  return FirstIdx;
+}
+
+const char *sourceName(UserSgprLayout::Source S) {
+  switch (S) {
+  case UserSgprLayout::Source::Unset:                return "Unset";
+  case UserSgprLayout::Source::PrivateSegmentBuffer: return "PrivateSegmentBuffer";
+  case UserSgprLayout::Source::DispatchPtr:          return "DispatchPtr";
+  case UserSgprLayout::Source::QueuePtr:             return "QueuePtr";
+  case UserSgprLayout::Source::KernargSegmentPtr:    return "KernargSegmentPtr";
+  case UserSgprLayout::Source::DispatchId:           return "DispatchId";
+  case UserSgprLayout::Source::FlatScratchInit:      return "FlatScratchInit";
+  case UserSgprLayout::Source::PrivateSegmentSize:   return "PrivateSegmentSize";
+  case UserSgprLayout::Source::PreloadedKernarg:     return "PreloadedKernarg";
+  case UserSgprLayout::Source::WorkgroupIdX:         return "WorkgroupIdX";
+  case UserSgprLayout::Source::WorkgroupIdY:         return "WorkgroupIdY";
+  case UserSgprLayout::Source::WorkgroupIdZ:         return "WorkgroupIdZ";
+  case UserSgprLayout::Source::WorkgroupInfo:        return "WorkgroupInfo";
+  }
+  return "<invalid>";
+}
+
+unsigned userSgprCountFieldWidth(const ISAProfile &SourceProfile) {
+  using namespace llvm::amdhsa;
+  return SourceProfile.HasGfx125UserSgprCountField
+             ? COMPUTE_PGM_RSRC2_GFX125_USER_SGPR_COUNT_WIDTH
+             : COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_WIDTH;
+}
+
+unsigned decodeUserSgprCount(uint32_t ComputePgmRsrc2,
+                             const ISAProfile &SourceProfile) {
+  using namespace llvm::amdhsa;
+  const unsigned Width = userSgprCountFieldWidth(SourceProfile);
+  return (ComputePgmRsrc2 >> COMPUTE_PGM_RSRC2_GFX6_GFX120_USER_SGPR_COUNT_SHIFT) &
+         ((1u << Width) - 1u);
+}
+
+std::string formatMetadataMismatch(const KernelMeta &Meta,
+                                   llvm::StringRef SourceIsa,
+                                   const UserSgprLayout &Layout,
+                                   unsigned DecodedUserSgprCount,
+                                   unsigned UserSgprCountWidth,
+                                   unsigned PreloadLen,
+                                   unsigned PreloadOffsetDwords) {
+  using namespace llvm::amdhsa;
+
+  std::string Detail;
+  llvm::raw_string_ostream Os(Detail);
+  Os << "transpiler: UserSgprLayout::fromKernelMeta: kernel '" << Meta.Name
+     << "' has compute_pgm_rsrc2.USER_SGPR_COUNT="
+     << DecodedUserSgprCount << " (decoded as " << UserSgprCountWidth
+     << "-bit field for source ISA '" << SourceIsa
+     << "') but kernel_code_properties + kernarg_preload imply "
+     << static_cast<unsigned>(Layout.UserSgprCount)
+     << ". KD is inconsistent -- refusing to guess the layout. Raw KD fields:"
+     << " compute_pgm_rsrc1=0x" << llvm::utohexstr(Meta.ComputePgmRsrc1)
+     << " compute_pgm_rsrc2=0x" << llvm::utohexstr(Meta.ComputePgmRsrc2)
+     << " kernel_code_properties=0x"
+     << llvm::utohexstr(static_cast<unsigned>(Meta.KernelCodeProperties))
+     << " kernarg_preload=0x"
+     << llvm::utohexstr(static_cast<unsigned>(Meta.KernargPreload))
+     << " kernarg_preload_length=" << PreloadLen
+     << " kernarg_preload_offset_dwords=" << PreloadOffsetDwords
+     << " kernarg_segment_size=" << Meta.KernargSegmentSize
+     << " enabled_user_sgprs=[";
+
+  bool First = true;
+  auto Append = [&](llvm::StringRef Name, unsigned Count) {
+    if (!First)
+      Os << ",";
+    First = false;
+    Os << Name << ":" << Count;
+  };
+
+  const uint16_t Kcp = Meta.KernelCodeProperties;
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_BUFFER)
+    Append("private_segment_buffer", 4);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_PTR)
+    Append("dispatch_ptr", 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_QUEUE_PTR)
+    Append("queue_ptr", 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR)
+    Append("kernarg_segment_ptr", 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_ID)
+    Append("dispatch_id", 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_FLAT_SCRATCH_INIT)
+    Append("flat_scratch_init", 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_SIZE)
+    Append("private_segment_size", 1);
+  if (PreloadLen > 0)
+    Append("kernarg_preload", PreloadLen);
+
+  Os << "] system_sgprs=[";
+  First = true;
+  auto AppendSystem = [&](llvm::StringRef Name) {
+    if (!First)
+      Os << ",";
+    First = false;
+    Os << Name;
+  };
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X)
+    AppendSystem("workgroup_id_x");
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y)
+    AppendSystem("workgroup_id_y");
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z)
+    AppendSystem("workgroup_id_z");
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_INFO)
+    AppendSystem("workgroup_info");
+  Os << "]";
+  Os.flush();
+  return Detail;
+}
+
+} // namespace
+
+bool UserSgprLayout::tryFromKernelMeta(const KernelMeta &Meta,
+                                       const ISAProfile &SourceProfile,
+                                       llvm::StringRef SourceIsa,
+                                       UserSgprLayout &Layout,
+                                       std::string &FailureDetail) {
+  Layout = UserSgprLayout();
+  FailureDetail.clear();
+
+  if (!Meta.HasKernelDescriptor) {
+    FailureDetail =
+        (llvm::Twine("transpiler: UserSgprLayout::fromKernelMeta: kernel '") +
+         Meta.Name +
+         "' has no parsed kernel descriptor. Cannot derive user-SGPR ABI; "
+         "refuse the lift instead of guessing a hardcoded layout.")
+            .str();
+    return false;
+  }
+
+  using namespace llvm::amdhsa;
+
+  const uint16_t Kcp = Meta.KernelCodeProperties;
+
+  // Walk the canonical KERNEL_CODE_PROPERTY bit order.
+  // Source: LLVM AMDHSAKernelDescriptor.h (bits 0..6 in ascending order).
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_BUFFER)
+    Layout.PrivateSegmentBufferSgpr =
+        appendSource(Layout.Entries, Source::PrivateSegmentBuffer, 4);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_PTR)
+    Layout.DispatchPtrSgpr =
+        appendSource(Layout.Entries, Source::DispatchPtr, 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_QUEUE_PTR)
+    Layout.QueuePtrSgpr = appendSource(Layout.Entries, Source::QueuePtr, 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_KERNARG_SEGMENT_PTR)
+    Layout.KernargSegmentPtrSgpr =
+        appendSource(Layout.Entries, Source::KernargSegmentPtr, 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_DISPATCH_ID)
+    Layout.DispatchIdSgpr = appendSource(Layout.Entries, Source::DispatchId, 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_FLAT_SCRATCH_INIT)
+    Layout.FlatScratchInitSgpr =
+        appendSource(Layout.Entries, Source::FlatScratchInit, 2);
+  if (Kcp & KERNEL_CODE_PROPERTY_ENABLE_SGPR_PRIVATE_SEGMENT_SIZE)
+    Layout.PrivateSegmentSizeSgpr =
+        appendSource(Layout.Entries, Source::PrivateSegmentSize, 1);
+
+  // Kernarg preload (gfx1250+): N dwords from kernarg memory at byte
+  // offset (preloadOffset * 4) get loaded into the user SGPRs immediately
+  // above the enable_sgpr_*-selected ones, before kernel entry. The
+  // sequence is little-endian dword-aligned: dword i goes into
+  // s[user_sgpr_count_so_far + i] and corresponds to kernarg bytes
+  // [(offset+i)*4 .. (offset+i+1)*4 - 1].
+  const uint8_t PreloadLen = static_cast<uint8_t>(
+      (Meta.KernargPreload >> KERNARG_PRELOAD_SPEC_LENGTH_SHIFT) &
+      ((1 << KERNARG_PRELOAD_SPEC_LENGTH_WIDTH) - 1));
+  const uint16_t PreloadOffsetDwords = static_cast<uint16_t>(
+      (Meta.KernargPreload >> KERNARG_PRELOAD_SPEC_OFFSET_SHIFT) &
+      ((1 << KERNARG_PRELOAD_SPEC_OFFSET_WIDTH) - 1));
+  Layout.PreloadedKernargLength = PreloadLen;
+  Layout.PreloadedKernargByteOffset =
+      static_cast<uint16_t>(PreloadOffsetDwords * 4);
+  if (PreloadLen > 0) {
+    Layout.FirstPreloadedKernargSgpr = static_cast<int>(Layout.Entries.size());
+    for (unsigned I = 0; I < PreloadLen; ++I) {
+      Entry E;
+      E.SrcKind = Source::PreloadedKernarg;
+      // Each preloaded dword is its own independent SGPR (no multi-dword
+      // bundling from the KD's perspective -- the byte offset alone identifies
+      // which kernarg slice it carries). subDword stays 0 so Phase 4's
+      // "act on subDword==0 only" loop visits every preload entry.
+      E.SubDword = 0;
+      E.KernargByteOffset =
+          static_cast<uint16_t>((PreloadOffsetDwords + I) * 4);
+      Layout.Entries.push_back(E);
+    }
+  }
+
+  Layout.UserSgprCount = static_cast<uint8_t>(Layout.Entries.size());
+
+  // Sanity-check against compute_pgm_rsrc2.USER_SGPR_COUNT. gfx125 widens
+  // this field to 6 bits; using the older 5-bit decode would read a valid
+  // count of 32 as zero and falsely reject Triton gfx1250 kernels.
+  const unsigned UserSgprCountWidth = userSgprCountFieldWidth(SourceProfile);
+  const unsigned PgmRsrc2UserSgprCount =
+      decodeUserSgprCount(Meta.ComputePgmRsrc2, SourceProfile);
+  if (PgmRsrc2UserSgprCount != Layout.UserSgprCount) {
+    FailureDetail =
+        formatMetadataMismatch(Meta, SourceIsa, Layout, PgmRsrc2UserSgprCount,
+                               UserSgprCountWidth, PreloadLen,
+                               PreloadOffsetDwords);
+    return false;
+  }
+
+  // Workgroup ID SGPRs sit immediately above the user-SGPR region.
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_X)
+    Layout.WorkgroupIdXSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupIdX, 1);
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Y)
+    Layout.WorkgroupIdYSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupIdY, 1);
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_ID_Z)
+    Layout.WorkgroupIdZSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupIdZ, 1);
+  if (Meta.ComputePgmRsrc2 & COMPUTE_PGM_RSRC2_ENABLE_SGPR_WORKGROUP_INFO)
+    Layout.WorkgroupInfoSgpr =
+        appendSource(Layout.Entries, Source::WorkgroupInfo, 1);
+
+  return true;
+}
+
+UserSgprLayout UserSgprLayout::fromKernelMeta(const KernelMeta &Meta,
+                                              const ISAProfile &SourceProfile,
+                                              llvm::StringRef SourceIsa) {
+  UserSgprLayout Layout;
+  std::string FailureDetail;
+  if (!tryFromKernelMeta(Meta, SourceProfile, SourceIsa, Layout, FailureDetail))
+    llvm::report_fatal_error(llvm::StringRef(FailureDetail));
+  return Layout;
+}
+
+std::string UserSgprLayout::toString() const {
+  std::string Result;
+  llvm::raw_string_ostream Os(Result);
+  Os << "user_sgpr_count=" << static_cast<int>(UserSgprCount);
+  for (size_t I = 0; I < Entries.size(); ++I) {
+    const auto &E = Entries[I];
+    Os << " s[" << I << "]=" << sourceName(E.SrcKind);
+    if (E.SrcKind == Source::PreloadedKernarg)
+      Os << "(off=" << E.KernargByteOffset << ")";
+    else if (E.SubDword > 0)
+      Os << "[" << static_cast<int>(E.SubDword) << "]";
+  }
+  return Os.str();
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/user-sgpr-layout.h
+++ b/amd/comgr/src/hotswap/user-sgpr-layout.h
@@ -1,0 +1,131 @@
+//===- user-sgpr-layout.h - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_USER_SGPR_LAYOUT_H
+#define HOTSWAP_TRANSPILER_USER_SGPR_LAYOUT_H
+
+#include "code-object-utils.h"
+#include "isa-profile.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <string>
+
+namespace COMGR::hotswap {
+
+// UserSgprLayout — what each SGPR contains at function entry on the source
+// ISA, derived from the kernel descriptor (KernelMeta::kernelCodeProperties,
+// kernargPreload, computePgmRsrc2).
+//
+// This is the single source of truth for the source-ISA SGPR ABI inside the
+// raiser. The previous implementation hardcoded "kernarg_segment_ptr at
+// s[0:1] / workgroup_id_x at s[2] / workgroup_id_y at s[3]" in raiser.cpp
+// Phase 4 and "isKernarg = (baseIdx == 0)" in handle_smem.cpp; both are
+// wrong as soon as kernarg-preload or a non-default kernel_code_properties
+// value is in play (gfx1250 Triton kernels routinely have both).
+//
+// The factory `fromKernelMeta` walks the bits of `kernel_code_properties`
+// in their canonical order (see LLVM's KERNEL_CODE_PROPERTY_* enum), then
+// appends `kernarg_preload_length` PreloadedKernarg entries (each one
+// dword), then appends the system-SGPR workgroup ids enabled by
+// `compute_pgm_rsrc2`. The resulting `entries` vector is indexed by SGPR
+// index, so `entries[i]` describes the contents of SGPR i at kernel entry.
+//
+// The convenience integer fields (`kernargSegmentPtrSgpr` etc.) are the
+// SGPR indices of the *first* dword of the corresponding source. They are
+// -1 when the source is disabled. Handlers that want to ask "is this SGPR
+// the kernarg pointer?" should compare against these fields rather than
+// re-walking `entries`.
+//
+// We never silently fall back to a hardcoded layout. Callers that can surface a
+// structured lift refusal should use `tryFromKernelMeta`; the legacy
+// `fromKernelMeta` wrapper still aborts loudly for call sites that cannot
+// propagate a failure.
+struct UserSgprLayout {
+  enum class Source : uint8_t {
+    Unset,
+    PrivateSegmentBuffer, // 4 dwords (s[i:i+3]) — Shader Resource Descriptor
+    DispatchPtr,          // 2 dwords — pointer to the AQL dispatch packet
+    QueuePtr,             // 2 dwords — pointer to the HSA queue object
+    KernargSegmentPtr,    // 2 dwords — pointer to the kernarg segment
+    DispatchId,           // 2 dwords — dispatch identifier
+    FlatScratchInit,      // 2 dwords — flat scratch base/size init
+    PrivateSegmentSize,   // 1 dword  — size of private segment per work-item
+    PreloadedKernarg,     // 1 dword  — preloaded kernarg dword (gfx1250 ABI)
+    WorkgroupIdX,         // 1 dword  — system SGPR (compute_pgm_rsrc2 bit 7)
+    WorkgroupIdY,         // 1 dword  — system SGPR (compute_pgm_rsrc2 bit 8)
+    WorkgroupIdZ,         // 1 dword  — system SGPR (compute_pgm_rsrc2 bit 9)
+    WorkgroupInfo,        // 1 dword  — system SGPR (compute_pgm_rsrc2 bit 10)
+  };
+
+  struct Entry {
+    Source SrcKind = Source::Unset;
+    // For multi-dword sources (DispatchPtr, KernargSegmentPtr, ...) this is
+    // the dword index within the source: 0 = lo, 1 = hi for 2-dword
+    // sources, 0..3 for the 4-dword PrivateSegmentBuffer SRD.
+    uint8_t SubDword = 0;
+    // For PreloadedKernarg only: the byte offset within the kernarg segment
+    // that this dword originated from. Computed as
+    // `(kernarg_preload_offset + i) * 4` per the gfx1250 ABI. Used by the
+    // raiser to look up the matching kernarg parameter and extract the
+    // appropriate dword from it.
+    uint16_t KernargByteOffset = 0;
+  };
+
+  llvm::SmallVector<Entry, 16> Entries;
+  uint8_t UserSgprCount = 0; // == entries.size() at end of user-SGPR region
+
+  // Convenience: SGPR index that holds the *low* dword of the corresponding
+  // source. -1 when the source is not enabled in `kernel_code_properties`
+  // / `compute_pgm_rsrc2`. Handlers that need to identify the kernarg
+  // pointer SGPR should compare against `kernargSegmentPtrSgpr` rather than
+  // assuming `0`.
+  int KernargSegmentPtrSgpr = -1;
+  int DispatchPtrSgpr = -1;
+  int QueuePtrSgpr = -1;
+  int DispatchIdSgpr = -1;
+  int FlatScratchInitSgpr = -1;
+  int PrivateSegmentBufferSgpr = -1;
+  int PrivateSegmentSizeSgpr = -1;
+  int WorkgroupIdXSgpr = -1;
+  int WorkgroupIdYSgpr = -1;
+  int WorkgroupIdZSgpr = -1;
+  int WorkgroupInfoSgpr = -1;
+
+  // SGPR index of the *first* preloaded kernarg dword, or -1 when
+  // kernargPreload.length == 0. Useful for debugging / diagnostics.
+  int FirstPreloadedKernargSgpr = -1;
+  uint8_t PreloadedKernargLength = 0;
+  uint16_t PreloadedKernargByteOffset = 0;
+
+  // Build the layout from a parsed kernel descriptor. Returns false and fills
+  // `failureDetail` when the descriptor is missing or internally inconsistent.
+  // `sourceProfile` selects ABI-versioned fields such as gfx125's 6-bit
+  // compute_pgm_rsrc2.USER_SGPR_COUNT. `sourceISA` is used only in diagnostics.
+  static bool tryFromKernelMeta(const KernelMeta &Meta,
+                                const ISAProfile &SourceProfile,
+                                llvm::StringRef SourceIsa,
+                                UserSgprLayout &Layout,
+                                std::string &FailureDetail);
+
+  // Fatal wrapper for callers that cannot return a structured RaiseFailure.
+  static UserSgprLayout fromKernelMeta(const KernelMeta &Meta,
+                                       const ISAProfile &SourceProfile,
+                                       llvm::StringRef SourceIsa);
+
+  // Render a one-line debug summary: useful for HSA_HOTSWAP_DEBUG output
+  // and for failure diagnostics. Format:
+  //   "user_sgpr=N: s[0:1]=KernargSegmentPtr s[2]=PreloadedKernarg(off=0) ..."
+  std::string toString() const;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -63,7 +63,7 @@ function(comgr_link_hotswap_transpiler target)
   target_include_directories(${target} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_BINARY_DIR}/../include
-    # Tests that pull in transpiler internals (wave_projection.h,
+    # Tests that pull in transpiler internals (wave-projection.h,
     # opcode-map.h, ...) need AMDGPU target-private headers too:
     # SIDefines.h, SIInstrInfo.h, AMDGPUBaseInfo.h live in the LLVM
     # source tree, AMDGPUGen*.inc files in the LLVM build tree.
@@ -262,6 +262,21 @@ target_include_directories(WaveProjectionTests PRIVATE
 
 comgr_configure_test_target(WaveProjectionTests)
 
+# -- KernargLayoutTests -----------------------------------------------------------------
+
+add_executable(KernargLayoutTests
+  KernargLayoutTest.cpp)
+
+target_link_libraries(KernargLayoutTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  ${LLVM_PTHREAD_LIB})
+comgr_link_hotswap_transpiler(KernargLayoutTests)
+
+target_include_directories(KernargLayoutTests PRIVATE
+  ${COMGR_GTEST_INCLUDE_DIRS})
+
+comgr_configure_test_target(KernargLayoutTests)
+
 # Register every test binary with the test-unit / check-comgr plumbing.
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
@@ -270,11 +285,13 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:MCContextInlineSrcmgrTests>
   COMMAND $<TARGET_FILE:OpcodeMapTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
-  COMMAND $<TARGET_FILE:WaveProjectionTests>)
+  COMMAND $<TARGET_FILE:WaveProjectionTests>
+  COMMAND $<TARGET_FILE:KernargLayoutTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests
   RaiserScaffoldingTests
   CodeObjectUtilsTests
   MCContextInlineSrcmgrTests
   OpcodeMapTests
-  WaveProjectionTests)
+  WaveProjectionTests
+  KernargLayoutTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/KernargLayoutTest.cpp
+++ b/amd/comgr/test-unit/KernargLayoutTest.cpp
@@ -1,0 +1,83 @@
+//===- kernarg_layout_test.cpp - kernarg_layout unit tests ----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/kernarg-layout.h"
+
+#include "gtest/gtest.h"
+
+#include <vector>
+
+using COMGR::hotswap::KernelArgMeta;
+using COMGR::hotswap::SourceHiddenArgKind;
+using COMGR::hotswap::classifySourceHiddenArgByte;
+
+namespace {
+KernelArgMeta makeArg(const char *Name, int Offset, int Size,
+                      const char *ValueKind) {
+  KernelArgMeta Arg;
+  Arg.Name = Name;
+  Arg.Offset = Offset;
+  Arg.Size = Size;
+  Arg.ValueKind = ValueKind;
+  return Arg;
+}
+} // namespace
+
+TEST(KernargLayout, ClassifiesHiddenBlockCountsByByteContainment) {
+  std::vector<KernelArgMeta> Args = {
+      makeArg("out", 0, 8, "global_buffer"),
+      makeArg("grid_x", 48, 4, "hidden_block_count_x"),
+      makeArg("grid_y", 52, 4, "hidden_block_count_y"),
+      makeArg("grid_z", 56, 4, "hidden_block_count_z"),
+  };
+
+  auto X0 = classifySourceHiddenArgByte(Args, 48);
+  auto X3 = classifySourceHiddenArgByte(Args, 51);
+  auto Y0 = classifySourceHiddenArgByte(Args, 52);
+  auto Z0 = classifySourceHiddenArgByte(Args, 56);
+
+  EXPECT_EQ(X0.Kind, SourceHiddenArgKind::HiddenBlockCountX);
+  EXPECT_EQ(X0.byteIndexInArg(), 0u);
+  EXPECT_EQ(X3.Kind, SourceHiddenArgKind::HiddenBlockCountX);
+  EXPECT_EQ(X3.byteIndexInArg(), 3u);
+  EXPECT_EQ(Y0.Kind, SourceHiddenArgKind::HiddenBlockCountY);
+  EXPECT_EQ(Z0.Kind, SourceHiddenArgKind::HiddenBlockCountZ);
+}
+
+TEST(KernargLayout, ClassifiesGroupSizeRemainderAndGridDims) {
+  std::vector<KernelArgMeta> Args = {
+      makeArg("group_x", 44, 2, "hidden_group_size_x"),
+      makeArg("rem_x", 50, 2, "hidden_remainder_x"),
+      makeArg("grid_dims", 96, 2, "hidden_grid_dims"),
+  };
+
+  EXPECT_EQ(classifySourceHiddenArgByte(Args, 44).Kind,
+            SourceHiddenArgKind::HiddenGroupSizeX);
+  EXPECT_EQ(classifySourceHiddenArgByte(Args, 50).Kind,
+            SourceHiddenArgKind::HiddenRemainderX);
+  EXPECT_EQ(classifySourceHiddenArgByte(Args, 96).Kind,
+            SourceHiddenArgKind::HiddenGridDims);
+}
+
+TEST(KernargLayout, ClassifiesUnsupportedHiddenKinds) {
+  std::vector<KernelArgMeta> Args = {
+      makeArg("hostcall", 64, 8, "hidden_hostcall_buffer"),
+  };
+
+  EXPECT_EQ(classifySourceHiddenArgByte(Args, 64).Kind,
+            SourceHiddenArgKind::UnsupportedHidden);
+}
+
+TEST(KernargLayout, NonHiddenAndMissingOffsetsAreNotHidden) {
+  std::vector<KernelArgMeta> Args = {
+      makeArg("n", 24, 4, "by_value"),
+  };
+
+  EXPECT_FALSE(classifySourceHiddenArgByte(Args, 24).matched());
+  EXPECT_FALSE(classifySourceHiddenArgByte(Args, 28).matched());
+}


### PR DESCRIPTION
Foundation infrastructure consumed by every per-format handler:

  * raise_failure.{h,cpp} — `RaiseFailure` value type with structured
    `Reason`, `Mnemonic`, `Format`, `Detail`, etc. fields plus typed
    factories (`unsupportedOpcode`, `unsupportedShape`, `bailReason`,
    ...). Carries the diagnostic data the kerneldex coverage runner
    bucketizes on.
  * raise_context.{h,cpp} — `RaiseContext` is the per-kernel mutable
    state every handler reads and writes: LLVMContext / Module / IR
    builder, decoded inst stream, register file, kernarg layout,
    user-SGPR layout, ISA profile, wave projection, lane-active mask
    cache, the pending failure for read-path errors, etc.
  * reg_file.{h,cpp} — `AllocaRegFile` models the AMDGPU SGPR/VGPR/AGPR
    register files as an alloca-per-physical-reg promoted to SSA by
    Phase 6 mem2reg. `readReg{32,64,Vec}` / `writeReg{32,64,Vec}`
    handle the bitcasts handlers don't want to repeat.
  * kernarg_layout.{h,cpp} — `KernargLayout` builds the byref placeholder
    type the lifted IR's first parameter takes. Mirrors the source
    kernel's MsgPack-derived offset/size layout.
  * user_sgpr_layout.{h,cpp} — `UserSgprLayout::tryFromKernelMeta`
    derives the source SGPR ABI (workgroup id / private segment buffer
    / kernarg ptr / kernarg-preload SGPRs) from the kernel descriptor.
  * handlers.h — forward declarations for every `handleXXX` entry
    point. Concrete handler files come in subsequent commits.

