### PR TITLE
[Comgr][hotswap] Add raise_cli + lit harness for hotswap-raise fixtures

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -8,6 +8,7 @@ endfunction()
 
 canonicalize_cmake_boolean(COMGR_SPIRV_BACKEND_AVAILABLE)
 canonicalize_cmake_boolean(COMGR_SPIRV_TRANSLATOR_AVAILABLE)
+canonicalize_cmake_boolean(COMGR_ENABLE_HOTSWAP_TRANSPILE)
 
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 
@@ -54,5 +55,47 @@ add_comgr_lit_binary(status-string c)
 add_comgr_lit_binary(data-action c)
 add_comgr_lit_binary(lookup-code-object c)
 add_comgr_lit_binary(hotswap-rewrite c)
+if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
+
+  # raise_cli is the per-kernel transpile-to-IR driver used by the
+  # hotswap-transpile/ lit fixtures. It links the in-tree hotswap
+  # transpiler OBJECT library directly (the public amd_comgr API only
+  # exposes the rewriting flow, not raw IR emission), so it doesn't fit
+  # the add_comgr_lit_binary macro that links amd_comgr. Also compiles
+  # in comgr-metadata.cpp because hotswap calls into
+  # `metadata::walkElfMetadataIntoDoc` / `getElfIsaNameFromBuffer`;
+  # `--gc-sections` drops the unreferenced bits.
+  add_executable(raise_cli
+    comgr-sources/raise_cli.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/comgr-metadata.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/comgr-symbol.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../test-shared/standalone-init.cpp)
+  llvm_update_compile_flags(raise_cli)
+  # Mirror amd_comgr's RTTI/EH posture: every typeinfo we touch comes
+  # from LLVM libs that were built with -fno-rtti, so any TU here that
+  # emits typeinfo (Error/ErrorInfo, format_adapter, etc.) will fail
+  # to link if compiled with RTTI on.
+  if(NOT LLVM_ENABLE_RTTI)
+    if(MSVC)
+      target_compile_options(raise_cli PRIVATE /GR-)
+    else()
+      target_compile_options(raise_cli PRIVATE -fno-rtti)
+    endif()
+  endif()
+  target_include_directories(raise_cli PRIVATE
+    ${LLVM_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    ${CMAKE_CURRENT_BINARY_DIR}/../include)
+  # `amd_comgr` provides the public C entry points
+  # (`amd_comgr_create_data` / `set_data` / `release_data`) that
+  # `code-object-utils.cpp` calls into to wrap raw ELF bytes for the
+  # `metadata::getMetadataRoot` / `metadata::getElfIsaName` paths.
+  target_link_libraries(raise_cli PRIVATE hotswap::transpiler amd_comgr)
+  if(NOT MSVC)
+    target_compile_options(raise_cli PRIVATE -ffunction-sections -fdata-sections)
+    target_link_options(raise_cli PRIVATE -Wl,--gc-sections)
+  endif()
+  add_dependencies(check-comgr raise_cli)
+endif()
 
 add_dependencies(check-comgr test-lit)

--- a/amd/comgr/test-lit/comgr-sources/raise_cli.cpp
+++ b/amd/comgr/test-lit/comgr-sources/raise_cli.cpp
@@ -1,0 +1,207 @@
+//===- raise_cli.cpp - Hotswap transpiler --------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Per-file raiser CLI used by the hotswap-raise/ lit fixtures.
+//
+// Usage:
+//   raise_cli <code-object.co|.hsaco> --emit-ir[=<kernel>]
+//             [--isa=<arch>] [--target-isa=<arch>]
+//
+// --emit-ir mode runs `raiseToIR` in-process, dumps the raised LLVM IR
+// for a single kernel on stdout, and leaves stderr alone so FileCheck
+// can match warnings / abort-gate diagnostics. Selects the only kernel
+// when the code object has one, or requires the `=<kernel>` form when
+// there are multiple. Exits 0 iff the kernel raised successfully;
+// non-zero otherwise.
+//
+// Subsequent commits add the default fork-mode (per-kernel crash
+// isolation for the kerneldex runner) and `--write-hsaco` mode (full
+// raise + llc + lld pipeline) once `hotswap/pipeline.h` lands.
+
+#include "comgr-metadata.h"
+#include "hotswap/code-object-utils.h"
+#include "hotswap/raiser.h"
+
+#include "llvm/IR/Module.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::string autoDetectIsa(llvm::StringRef Path) {
+  for (size_t I = 0; I + 3 < Path.size(); ++I) {
+    if (Path[I] == 'g' && Path[I + 1] == 'f' && Path[I + 2] == 'x') {
+      size_t J = I + 3;
+      while (J < Path.size() &&
+             std::isdigit(static_cast<unsigned char>(Path[J])))
+        ++J;
+      if (J > I + 3) {
+        if (J < Path.size() && Path[J] >= 'a' && Path[J] <= 'z')
+          ++J;
+        return Path.substr(I, J - I).str();
+      }
+    }
+  }
+  return {};
+}
+
+int usage() {
+  llvm::errs()
+      << "usage:\n"
+         "  raise_cli <code-object.co|.hsaco> --emit-ir[=<kernel>] "
+         "[--isa=<arch>] [--target-isa=<arch>]\n"
+         "\n"
+         "--emit-ir mode dumps raised LLVM IR for a single kernel on stdout.\n"
+         "  No fork; stderr left alone for FileCheck.\n"
+         "ISA is inferred from the filename when --isa is not given.\n";
+  return 2;
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  std::string CoPath;
+  std::string Isa;
+  std::string TargetIsa;
+  bool EmitIr = false;
+  std::string EmitIrKernel;
+  for (int I = 1; I < argc; ++I) {
+    std::string A = argv[I];
+    if (A.rfind("--isa=", 0) == 0) {
+      Isa = A.substr(6);
+    } else if (A == "--isa") {
+      if (I + 1 >= argc)
+        return usage();
+      Isa = argv[++I];
+    } else if (A.rfind("--target-isa=", 0) == 0) {
+      TargetIsa = A.substr(13);
+    } else if (A == "--target-isa") {
+      if (I + 1 >= argc)
+        return usage();
+      TargetIsa = argv[++I];
+    } else if (A == "--emit-ir") {
+      EmitIr = true;
+    } else if (A.rfind("--emit-ir=", 0) == 0) {
+      EmitIr = true;
+      EmitIrKernel = A.substr(10);
+    } else if (!A.empty() && A[0] == '-') {
+      llvm::errs() << "raise_cli: unknown flag: " << A << "\n";
+      return usage();
+    } else if (CoPath.empty()) {
+      CoPath = A;
+    } else {
+      llvm::errs() << "raise_cli: unexpected positional arg: " << A << "\n";
+      return usage();
+    }
+  }
+  if (CoPath.empty())
+    return usage();
+  if (!EmitIr) {
+    llvm::errs() << "raise_cli: this build only supports --emit-ir mode\n";
+    return usage();
+  }
+
+  std::vector<uint8_t> CoData = COMGR::hotswap::readFile(CoPath);
+  if (CoData.empty()) {
+    llvm::errs() << "raise_cli: cannot read " << CoPath << "\n";
+    return 2;
+  }
+  llvm::MemoryBufferRef CoBuf(
+      llvm::StringRef(reinterpret_cast<const char *>(CoData.data()),
+                      CoData.size()),
+      "");
+
+  if (Isa.empty()) {
+    Isa = autoDetectIsa(CoPath);
+    if (Isa.empty()) {
+      std::string ElfIsa;
+      if (COMGR::metadata::getElfIsaName(CoBuf, ElfIsa) ==
+          AMD_COMGR_STATUS_SUCCESS)
+        Isa = std::move(ElfIsa);
+    }
+    if (Isa.empty()) {
+      llvm::errs() << "raise_cli: could not infer ISA from " << CoPath
+                   << "; pass --isa=<arch>\n";
+      return 2;
+    }
+  }
+
+  auto KernelNamesOrErr = COMGR::hotswap::listKernelNames(CoBuf);
+  if (!KernelNamesOrErr) {
+    llvm::errs() << "raise_cli: no kernels in " << CoPath << ": "
+                 << llvm::toString(KernelNamesOrErr.takeError()) << "\n";
+    return 2;
+  }
+  llvm::SmallVector<std::string> KernelNames = std::move(*KernelNamesOrErr);
+  if (KernelNames.empty()) {
+    llvm::errs() << "raise_cli: no kernels in " << CoPath << "\n";
+    return 2;
+  }
+
+  auto TextOrErr = COMGR::hotswap::extractTextSection(CoBuf);
+  if (!TextOrErr) {
+    llvm::errs() << "raise_cli: could not extract .text from " << CoPath
+                 << ": " << llvm::toString(TextOrErr.takeError()) << "\n";
+    return 2;
+  }
+  // Note: text bytes are unused at P6's smaller raise_cli (raiseToIR takes
+  // only ISA / kernel name / metadata at this point); later commits wire
+  // the extracted bytes through.
+  (void)*TextOrErr;
+
+  std::string Target;
+  if (EmitIrKernel.empty()) {
+    if (KernelNames.size() != 1) {
+      llvm::errs() << "raise_cli: --emit-ir requires =<kernel> when the "
+                      "code object has "
+                   << KernelNames.size() << " kernels\n";
+      return 2;
+    }
+    Target = KernelNames.front();
+  } else {
+    bool Found = false;
+    for (const auto &Kn : KernelNames)
+      if (Kn == EmitIrKernel) {
+        Target = Kn;
+        Found = true;
+        break;
+      }
+    if (!Found) {
+      llvm::errs() << "raise_cli: kernel '" << EmitIrKernel
+                   << "' not found in " << CoPath << "\n";
+      return 2;
+    }
+  }
+
+  auto MetaOrErr = COMGR::hotswap::extractKernelMeta(CoBuf, Target);
+  if (!MetaOrErr) {
+    llvm::errs() << "raise_cli: kernel '" << Target << "' metadata: "
+                 << llvm::toString(MetaOrErr.takeError()) << "\n";
+    return 1;
+  }
+  COMGR::hotswap::KernelMeta Meta = std::move(*MetaOrErr);
+  auto Raised = COMGR::hotswap::raiseToIR(Isa, Target, Meta);
+  if (!Raised.Success) {
+    llvm::errs() << "raise_cli: kernel '" << Target << "' failed to raise: "
+                 << (Raised.Failure.Detail.empty()
+                         ? "unknown"
+                         : Raised.Failure.Detail.c_str())
+                 << "\n";
+    return 1;
+  }
+  llvm::raw_fd_ostream Os(/*fd=*/1, /*shouldClose=*/false);
+  Raised.Module->print(Os, /*AAW=*/nullptr);
+  return 0;
+}

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -17,6 +17,9 @@ if config.comgr_spirv_backend_available:
 if config.comgr_spirv_translator_available:
     config.available_features.add("comgr-has-spirv-translator")
 
+if config.comgr_enable_hotswap_transpile:
+    config.available_features.add("comgr-hotswap-transpile")
+
 if platform.system() == "Windows":
     config.available_features.add("system-windows")
 elif platform.system() == "Linux":
@@ -39,3 +42,17 @@ config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-
 config.substitutions.append(('%llvm-readelf', _fwd(config.llvm_tools_dir, 'llvm-readelf')))
 config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
 config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))
+config.substitutions.append(('%not', _fwd(config.llvm_tools_dir, 'not')))
+# %llvm_mc bakes in the AMDGPU triple + object filetype so each hotswap-
+# transpile/ RUN line only has to vary -mcpu=<isa>; %ld_lld is the raw
+# linker invoked with -shared to produce an amdhsa code object the
+# raise_cli driver consumes.
+config.substitutions.append(
+    ('%llvm_mc',
+     _fwd(config.llvm_tools_dir, 'llvm-mc') +
+         ' -triple=amdgcn-amd-amdhsa -filetype=obj'))
+config.substitutions.append(('%ld_lld', _fwd(config.llvm_tools_dir, 'ld.lld')))
+# %raise_cli resolves to the raise_cli driver built alongside test-lit.
+# Fixtures may also invoke it as a bare `raise_cli` (resolved via PATH
+# from `comgr_obj_dir` in lit.site.cfg.py); both spellings are supported.
+config.substitutions.append(('%raise_cli', _fwd(config.comgr_obj_dir, 'raise_cli')))

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -9,6 +9,7 @@ config.my_obj_root = _fwd(r'@CMAKE_CURRENT_BINARY_DIR@')
 
 config.comgr_spirv_backend_available = @COMGR_SPIRV_BACKEND_AVAILABLE@
 config.comgr_spirv_translator_available = @COMGR_SPIRV_TRANSLATOR_AVAILABLE@
+config.comgr_enable_hotswap_transpile = @COMGR_ENABLE_HOTSWAP_TRANSPILE@
 
 config.llvm_tools_dir = _fwd(r'@LLVM_TOOLS_BINARY_DIR@')
 config.comgr_obj_dir = config.my_obj_root

--- a/amd/comgr/test-shared/standalone-init.cpp
+++ b/amd/comgr/test-shared/standalone-init.cpp
@@ -1,0 +1,98 @@
+//===- standalone-init.cpp - LLVM init for standalone hotswap binaries ----===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Test/CLI-only translation unit. Provides definitions of
+// `COMGR::ensureLLVMInitialized` and `COMGR::parseTargetIdentifier` for
+// standalone binaries that link the hotswap-transpiler OBJECT library
+// (`raise_cli` and the gtest unit tests) WITHOUT linking `amd_comgr.so`.
+//
+// `amd_comgr.so` statically bakes its own copy of LLVM (Support, Target,
+// AMDGPU*) and hides every internal symbol via the export map. A test
+// binary that linked the .so for these helpers would register AMDGPU into
+// the .so's `TargetRegistry` singleton, while the binary's own statically
+// linked LLVM would still see an empty registry — same code, two LLVM
+// instances, zero shared globals. Compiling this TU directly into the
+// standalone binary's link line keeps the init landing on the binary's
+// own LLVM globals.
+//
+// Body intentionally identical to `comgr.cpp`'s definitions; we are not
+// extracting the production code into a shared TU because that adds a
+// new file to `amd_comgr.so`'s source list (review-fragile) for a
+// concern that only matters to test/CLI binaries. The duplication is
+// localized to test infrastructure under `test-shared/`.
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr.h"
+#include "comgr-metadata.h"
+
+#include "llvm/Support/TargetSelect.h"
+
+#include <mutex>
+
+using namespace llvm;
+
+amd_comgr_status_t COMGR::parseTargetIdentifier(StringRef IdentStr,
+                                                TargetIdentifier &Ident) {
+  SmallVector<StringRef, 5> IsaNameComponents;
+  IdentStr.split(IsaNameComponents, '-', 4);
+  if (IsaNameComponents.size() != 5) {
+    return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+  }
+
+  Ident.Arch = IsaNameComponents[0];
+  Ident.Vendor = IsaNameComponents[1];
+  Ident.OS = IsaNameComponents[2];
+  Ident.Environ = IsaNameComponents[3];
+
+  Ident.Features.clear();
+  IsaNameComponents[4].split(Ident.Features, ':');
+
+  Ident.Processor = Ident.Features[0];
+  Ident.Features.erase(Ident.Features.begin());
+
+  // TODO: Add a LIT test for this
+  if (IdentStr == "spirv64-amd-amdhsa--amdgcnspirv" ||
+      IdentStr == "spirv64-amd-amdhsa-unknown-amdgcnspirv") {
+    if (!Ident.Features.empty())
+      return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
+
+  size_t IsaIndex;
+  amd_comgr_status_t Status = metadata::getIsaIndex(IdentStr, IsaIndex);
+  if (Status != AMD_COMGR_STATUS_SUCCESS) {
+    return Status;
+  }
+
+  for (auto Feature : Ident.Features) {
+    if (!metadata::isSupportedFeature(IsaIndex, Feature)) {
+      return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
+    }
+  }
+
+  return AMD_COMGR_STATUS_SUCCESS;
+}
+
+void COMGR::ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, []() {
+    LLVMInitializeAMDGPUTarget();
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+#ifdef COMGR_SPIRV_BACKEND_AVAILABLE
+    LLVMInitializeSPIRVTarget();
+    LLVMInitializeSPIRVTargetInfo();
+    LLVMInitializeSPIRVTargetMC();
+    LLVMInitializeSPIRVAsmPrinter();
+#endif
+  });
+}

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -59,7 +59,8 @@ function(comgr_link_hotswap_transpiler target)
   target_link_libraries(${target} PRIVATE hotswap::transpiler amd_comgr)
   target_sources(${target} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src/comgr-metadata.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/../src/comgr-symbol.cpp)
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src/comgr-symbol.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../test-shared/standalone-init.cpp)
   target_include_directories(${target} PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../src
     ${CMAKE_CURRENT_BINARY_DIR}/../include


### PR DESCRIPTION
Wires up the per-kernel raiser CLI and the lit-harness scaffolding the subsequent handler commits' fixtures consume:

  * test-lit/comgr-sources/raise_cli.cpp — minimal --emit-ir driver that calls `raiseToIR` directly and dumps the resulting Module to stdout via `Module::print`. Subsequent commits add the default fork mode (kerneldex coverage) and `--write-hsaco` mode (full pipeline) once `hotswap/pipeline.h` lands.
  * test-lit/CMakeLists.txt — gates a new `raise_cli` target on COMGR_ENABLE_HOTSWAP_TRANSPILE; links `hotswap::transpiler` plus `comgr-metadata.cpp` and the just-extracted `comgr-target-init.cpp` directly so the binary doesn't pull in the rest of the amd_comgr public surface.
  * test-lit/lit.site.cfg.py.in — exposes the COMGR_ENABLE_HOTSWAP_TRANSPILE configure-time value.
  * test-lit/lit.cfg.py — adds `comgr-hotswap-transpile` REQUIRES feature plus the `%llvm_mc`, `%ld_lld`, `%not`, and `%raise_cli` substitutions every hotswap-raise/ RUN line uses.
  * test-unit/CMakeLists.txt — `comgr_link_hotswap_transpiler` helper grows to compile `comgr-target-init.cpp` into every unit-test binary so `ensureLLVMInitialized` resolves at link time.
  * src/hotswap/code_object_utils.{h,cpp} — adds the `readFile` helper raise_cli and (later) the pipeline driver consume to slurp HSACO / IR / asm artefacts off disk; matches the convention of centralising file I/O in the metadata layer.

The raiser stays at its decode-and-bail / IR-scaffold form from the preceding commits. With these in place the lit harness is reachable but every hotswap-raise/ fixture FAILs honestly until the dispatch loop lands at the `Wire raiser dispatcher` commit.


