### PR TITLE
[Comgr][hotswap] Add SOPP + SOPC handlers

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -55,6 +55,8 @@ add_library(hotswap-transpiler OBJECT
   reg-file.cpp
   kernarg-layout.cpp
   user-sgpr-layout.cpp
+  handle-sopp.cpp
+  handle-sopc.cpp
 )
 
 if(NOT TARGET hotswap::transpiler)

--- a/amd/comgr/src/hotswap/docs/sync-translation.md
+++ b/amd/comgr/src/hotswap/docs/sync-translation.md
@@ -39,7 +39,7 @@ Three facts make the translation tractable:
    and atomics. Any source-side `s_waitcnt` is redundant metadata
    once we have the IR dependences right — the backend rebuilds it
    for the target generation (unified `s_waitcnt` on gfx9, split
-   counters on gfx12). This is why `handle_sopp.cpp:94` treats
+   counters on gfx12). This is why `handle-sopp.cpp:94` treats
    waitcnt as a no-op. Current correctness notes do not attribute any
    tracked Hotswap regression to dropped source waitcnts.
 2. **LLVM owns atomic ordering and scope.** `AtomicOrdering` +
@@ -239,7 +239,7 @@ pre-gfx12 targets where the collapse in §5.1.b cannot represent them.
 
 When the target is pre-gfx12 (`!hasSplitBarriers`), collapse the split
 primitives to the monolithic barrier. Current implementation in
-`handle_sopp.cpp:70-84`:
+`handle-sopp.cpp:70-84`:
 
 - `S_BARRIER`, `S_BARRIER_WAIT` → `call void @llvm.amdgcn.s.barrier()`
 - `S_BARRIER_SIGNAL` → no-op (handled = true; emits nothing)
@@ -300,7 +300,7 @@ is discarded.
 #### 5.2.b No-op collapse path — pre-gfx12 targets (existing policy)
 
 When the target has only the combined counter (`!hasSplitWaitCnt`),
-all waitcnt SemOps fall through as no-ops (`handle_sopp.cpp:94`). The
+all waitcnt SemOps fall through as no-ops (`handle-sopp.cpp:94`). The
 backend's memory-model-driven waitcnt insertion on gfx950 replaces
 them.
 
@@ -502,7 +502,7 @@ waitcnt) at raise time; refuse on hit.
 
 ### T1 — Named-barrier gate (G1)
 
-Modify `handle_sopp.cpp:74-84` to read `di.getImm(0)` and refuse on
+Modify `handle-sopp.cpp:74-84` to read `di.getImm(0)` and refuse on
 non-zero. 15 LoC + one test.
 
 ### T2 — Waitcnt classification (G2)

--- a/amd/comgr/src/hotswap/handle-sopc.cpp
+++ b/amd/comgr/src/hotswap/handle-sopc.cpp
@@ -1,0 +1,220 @@
+//===- handle-sopc.cpp - Hotswap transpiler -------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "handlers.h"
+
+#include "llvm/IR/DerivedTypes.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+HandlerResult handleSOPC(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op) {
+  HandlerResult Hr;
+  CanonicalOp Sop = Di.CanonOp;
+
+  // s_set_gpr_idx_on enables GPR dynamic indexing via M0.
+  // In scalar model, we store the index value to M0 and treat this as a
+  // control-flow nop. The actual VGPR indexing effect is not modeled.
+  if (Sop == CanonicalOp::S_SET_GPR_IDX_ON) {
+    ParsedReg M0reg;
+    M0reg.RegKind = ParsedReg::M0;
+    M0reg.BaseIdx = 0;
+    Ctx.Regs.writeReg32(Ctx.B, M0reg, Op.src(0));
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_SET_GPR_IDX_OFF) {
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_SETVSKIP) {
+    Hr.Handled = true;
+    return Hr;
+  }
+  // 64-bit unsigned SOPC compares (gfx8+ S_CMP_EQ_U64 / S_CMP_LG_U64).
+  // Both operands are full 64-bit SGPR pairs per SOPInstructions.td's
+  // `SOPC_CMP_64` record (the only SOPC compare shape that takes
+  // 64-bit operands -- there are no signed or ordered 64-bit SOPC
+  // compares on any AMDGPU generation). Read both with `op.src64`
+  // and emit a single `icmp eq/ne i64` into SCC.
+  //
+  // Test back-reference: lit_tests/s_cmp_eq_u64/ pins the `icmp eq
+  // i64` shape this lift produces. A regression that narrowed the
+  // operands to i32 (a common shortcut against 64-bit SGPR pairs)
+  // would break the corpus's per-thread-mask compares used in
+  // tensilelite gemm dispatch.
+  if (Sop == CanonicalOp::S_CMP_EQ_U64) {
+    Value *Cmp64 =
+        Ctx.B.CreateICmpEQ(Op.src64(0), Op.src64(1), "scmp64");
+    Ctx.Regs.storeSCC(Ctx.B, Cmp64);
+    Hr.SccHandled = true;
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_CMP_LG_U64) {
+    Value *Cmp64 =
+        Ctx.B.CreateICmpNE(Op.src64(0), Op.src64(1), "scmp64");
+    Ctx.Regs.storeSCC(Ctx.B, Cmp64);
+    Hr.SccHandled = true;
+    Hr.Handled = true;
+    return Hr;
+  }
+
+  // SOPC bit-test family (SOPInstructions.td:1411-1414; gfx6+).
+  // Shape per the GCN3/RDNA/CDNA ISA references
+  // (e.g. RDNA3 ISA ref §4.3.2 "Scalar ALU Operations"):
+  //
+  //   S_BITCMP0_B32  SCC = (src0 & (1u  << (src1 & 0x1F))) == 0
+  //   S_BITCMP1_B32  SCC = (src0 & (1u  << (src1 & 0x1F))) != 0
+  //   S_BITCMP0_B64  SCC = (src0 & (1ul << (src1 & 0x3F))) == 0
+  //   S_BITCMP1_B64  SCC = (src0 & (1ul << (src1 & 0x3F))) != 0
+  //
+  // We mask src1 explicitly (rather than relying on shift-wraparound
+  // behaviour) so that the IR matches the hardware invariant
+  // bit-exactly on every generation -- `shl i32 _, N` for N>=32 and
+  // `shl i64 _, N` for N>=64 are UB in LLVM IR, and a corpus kernel
+  // that feeds an SGPR with garbage in the high bits would otherwise
+  // lift to poison under LLVM's IR rules while the hardware produces
+  // a well-defined SCC.
+  //
+  // Both _0 and _1 variants share the shift-and-mask chain; only the
+  // final icmp predicate differs.  A single classifier keeps the
+  // parity with the SOPC compare family above (`S_CMP_*`) and makes
+  // the four opcodes share exactly one code path.
+  {
+    bool Is64 = (Sop == CanonicalOp::S_BITCMP0_B64 || Sop == CanonicalOp::S_BITCMP1_B64);
+    bool IsB32 = (Sop == CanonicalOp::S_BITCMP0_B32 || Sop == CanonicalOp::S_BITCMP1_B32);
+    if (Is64 || IsB32) {
+      Value *Src0 = Is64 ? Op.src64(0) : Op.src(0);
+      Type *IntTy = Is64 ? Ctx.I64Ty : Ctx.I32Ty;
+      uint64_t Mask = Is64 ? 0x3F : 0x1F;
+
+      // Shift amount: src1 is always an SReg_32; mask to 5/6 bits and
+      // widen to the src0 width before shifting to keep `shl` in
+      // range.
+      Value *Shamt = Op.src(1);
+      if (Shamt->getType() != Ctx.I32Ty)
+        Shamt = Ctx.B.CreateBitOrPointerCast(Shamt, Ctx.I32Ty);
+      Shamt = Ctx.B.CreateAnd(Shamt, ConstantInt::get(Ctx.I32Ty, Mask),
+                              "bitcmp_shamt");
+      if (Is64) Shamt = Ctx.B.CreateZExt(Shamt, Ctx.I64Ty, "bitcmp_shamt64");
+
+      Value *Bit = Ctx.B.CreateShl(ConstantInt::get(IntTy, 1), Shamt,
+                                    "bitcmp_bit");
+      Value *Masked = Ctx.B.CreateAnd(Src0, Bit, "bitcmp_mask");
+      Value *Zero = ConstantInt::get(IntTy, 0);
+      bool IsZeroPred =
+          (Sop == CanonicalOp::S_BITCMP0_B32 || Sop == CanonicalOp::S_BITCMP0_B64);
+      Value *Scc = IsZeroPred
+                       ? Ctx.B.CreateICmpEQ(Masked, Zero, "bitcmp0")
+                       : Ctx.B.CreateICmpNE(Masked, Zero, "bitcmp1");
+      Ctx.Regs.storeSCC(Ctx.B, Scc);
+      Hr.SccHandled = true;
+      Hr.Handled = true;
+      return Hr;
+    }
+  }
+
+  Value *Src0 = Op.src(0);
+  Value *Src1 = Op.src(1);
+  Value *Cmp = nullptr;
+  if (Sop == CanonicalOp::S_CMP_GT_I32)
+    Cmp = Ctx.B.CreateICmpSGT(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_LT_I32)
+    Cmp = Ctx.B.CreateICmpSLT(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_GE_I32)
+    Cmp = Ctx.B.CreateICmpSGE(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_LE_I32)
+    Cmp = Ctx.B.CreateICmpSLE(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_EQ_U32)
+    Cmp = Ctx.B.CreateICmpEQ(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_LG_U32)
+    Cmp = Ctx.B.CreateICmpNE(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_GE_U32)
+    Cmp = Ctx.B.CreateICmpUGE(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_GT_U32)
+    Cmp = Ctx.B.CreateICmpUGT(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_LT_U32)
+    Cmp = Ctx.B.CreateICmpULT(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_LE_U32)
+    Cmp = Ctx.B.CreateICmpULE(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_EQ_I32)
+    Cmp = Ctx.B.CreateICmpEQ(Src0, Src1, "scmp");
+  else if (Sop == CanonicalOp::S_CMP_LG_I32)
+    Cmp = Ctx.B.CreateICmpNE(Src0, Src1, "scmp");
+  // GFX12 scalar FP compares (ordered and unordered variants)
+  else if (Sop >= CanonicalOp::S_CMP_EQ_F32 && Sop <= CanonicalOp::S_CMP_NLG_F32) {
+    Value *F0 = Ctx.B.CreateBitCast(Src0, Ctx.F32Ty);
+    Value *F1 = Ctx.B.CreateBitCast(Src1, Ctx.F32Ty);
+    if (Sop == CanonicalOp::S_CMP_EQ_F32)
+      Cmp = Ctx.B.CreateFCmpOEQ(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_LG_F32)
+      Cmp = Ctx.B.CreateFCmpONE(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_GT_F32)
+      Cmp = Ctx.B.CreateFCmpOGT(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_GE_F32)
+      Cmp = Ctx.B.CreateFCmpOGE(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_LT_F32)
+      Cmp = Ctx.B.CreateFCmpOLT(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_LE_F32)
+      Cmp = Ctx.B.CreateFCmpOLE(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_NEQ_F32)
+      Cmp = Ctx.B.CreateFCmpUNE(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_NLT_F32)
+      Cmp = Ctx.B.CreateFCmpUGE(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_NLE_F32)
+      Cmp = Ctx.B.CreateFCmpUGT(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_NGT_F32)
+      Cmp = Ctx.B.CreateFCmpULE(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_NGE_F32)
+      Cmp = Ctx.B.CreateFCmpULT(F0, F1, "scmpf");
+    else if (Sop == CanonicalOp::S_CMP_NLG_F32)
+      Cmp = Ctx.B.CreateFCmpUEQ(F0, F1, "scmpf");
+  } else if (Sop >= CanonicalOp::S_CMP_EQ_F16 && Sop <= CanonicalOp::S_CMP_NLG_F16) {
+    Type *F16Ty = Type::getHalfTy(Ctx.C);
+    Value *F0 = Ctx.B.CreateBitCast(
+        Ctx.B.CreateTrunc(Src0, Type::getInt16Ty(Ctx.C)), F16Ty);
+    Value *F1 = Ctx.B.CreateBitCast(
+        Ctx.B.CreateTrunc(Src1, Type::getInt16Ty(Ctx.C)), F16Ty);
+    if (Sop == CanonicalOp::S_CMP_EQ_F16)
+      Cmp = Ctx.B.CreateFCmpOEQ(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_LG_F16)
+      Cmp = Ctx.B.CreateFCmpONE(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_GT_F16)
+      Cmp = Ctx.B.CreateFCmpOGT(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_GE_F16)
+      Cmp = Ctx.B.CreateFCmpOGE(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_LT_F16)
+      Cmp = Ctx.B.CreateFCmpOLT(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_LE_F16)
+      Cmp = Ctx.B.CreateFCmpOLE(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_NEQ_F16)
+      Cmp = Ctx.B.CreateFCmpUNE(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_NLT_F16)
+      Cmp = Ctx.B.CreateFCmpUGE(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_NLE_F16)
+      Cmp = Ctx.B.CreateFCmpUGT(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_NGT_F16)
+      Cmp = Ctx.B.CreateFCmpULE(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_NGE_F16)
+      Cmp = Ctx.B.CreateFCmpULT(F0, F1, "scmpf16");
+    else if (Sop == CanonicalOp::S_CMP_NLG_F16)
+      Cmp = Ctx.B.CreateFCmpUEQ(F0, F1, "scmpf16");
+  }
+  if (Cmp) {
+    Ctx.Regs.storeSCC(Ctx.B, Cmp);
+    Hr.SccHandled = true;
+    Hr.Handled = true;
+    return Hr;
+  }
+  return Hr;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/handle-sopp.cpp
+++ b/amd/comgr/src/hotswap/handle-sopp.cpp
@@ -1,0 +1,162 @@
+//===- handle-sopp.cpp - Hotswap transpiler -------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "handlers.h"
+
+#include "llvm/IR/IntrinsicsAMDGPU.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+HandlerResult handleSOPP(RaiseContext &Ctx, const DecodedInst &Di,
+                         OpResolver &Op) {
+  (void)Op;
+  HandlerResult Hr;
+  CanonicalOp Sop = Di.CanonOp;
+
+  if (Sop == CanonicalOp::S_ENDPGM) {
+    if (Ctx.ThreadLoopLatch)
+      Ctx.B.CreateBr(Ctx.ThreadLoopLatch);
+    else
+      Ctx.B.CreateRetVoid();
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_BRANCH) {
+    int64_t Raw = Di.getImm(0);
+    int64_t BrOff = static_cast<int64_t>(
+        static_cast<int16_t>(static_cast<uint16_t>(Raw & 0xFFFF)));
+    Ctx.B.CreateBr(Ctx.lookupBB(Di.Offset + 4 + BrOff * 4));
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_CBRANCH_EXECZ || Sop == CanonicalOp::S_CBRANCH_EXECNZ) {
+    int64_t Raw = Di.getImm(0);
+    int64_t BrOff = static_cast<int64_t>(
+        static_cast<int16_t>(static_cast<uint16_t>(Raw & 0xFFFF)));
+    uint64_t Target = Di.Offset + 4 + BrOff * 4;
+    BasicBlock *TargetBb = Ctx.lookupBB(Target);
+    BasicBlock *FallthroughBb = Ctx.lookupBB(Di.Offset + Di.Size);
+    Value *ExecVal = Ctx.Regs.loadExec(Ctx.B);
+    Value *IsZero = Ctx.B.CreateICmpEQ(
+        ExecVal, Constant::getNullValue(Ctx.Regs.ExecTy), "exec_is_zero");
+    if (Sop == CanonicalOp::S_CBRANCH_EXECZ)
+      Ctx.B.CreateCondBr(IsZero, TargetBb, FallthroughBb);
+    else
+      Ctx.B.CreateCondBr(Ctx.B.CreateNot(IsZero, "exec_nz"), TargetBb,
+                         FallthroughBb);
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_CBRANCH_SCC0 || Sop == CanonicalOp::S_CBRANCH_SCC1) {
+    int64_t Raw = Di.getImm(0);
+    int64_t BrOff = static_cast<int64_t>(
+        static_cast<int16_t>(static_cast<uint16_t>(Raw & 0xFFFF)));
+    uint64_t Target = Di.Offset + 4 + BrOff * 4;
+    BasicBlock *TargetBb = Ctx.lookupBB(Target);
+    BasicBlock *FallthroughBb = Ctx.lookupBB(Di.Offset + Di.Size);
+    Value *SccV = Ctx.Regs.loadSCC(Ctx.B);
+    if (Sop == CanonicalOp::S_CBRANCH_SCC0)
+      SccV = Ctx.B.CreateNot(SccV, "not_scc");
+    Ctx.B.CreateCondBr(SccV, TargetBb, FallthroughBb);
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_CBRANCH_VCCNZ || Sop == CanonicalOp::S_CBRANCH_VCCZ) {
+    int64_t Raw = Di.getImm(0);
+    int64_t BrOff = static_cast<int64_t>(
+        static_cast<int16_t>(static_cast<uint16_t>(Raw & 0xFFFF)));
+    uint64_t Target = Di.Offset + 4 + BrOff * 4;
+    BasicBlock *TargetBb = Ctx.lookupBB(Target);
+    BasicBlock *FallthroughBb = Ctx.lookupBB(Di.Offset + Di.Size);
+    Value *VccV = Ctx.Regs.loadVCC(Ctx.B);
+    if (Sop == CanonicalOp::S_CBRANCH_VCCZ)
+      VccV = Ctx.B.CreateNot(VccV, "not_vcc");
+    Ctx.B.CreateCondBr(VccV, TargetBb, FallthroughBb);
+    Hr.Handled = true;
+    return Hr;
+  }
+  // Barriers. GFX<12 uses a single `s_barrier`; GFX12+ splits it into a
+  // separate signal and wait (both SOPP in this format). We model signal as
+  // a no-op (the cross-wave rendezvous happens at the wait) and wait (or the
+  // legacy unified barrier) as a full LLVM `amdgcn.s.barrier` call.
+  if (Sop == CanonicalOp::S_BARRIER || Sop == CanonicalOp::S_BARRIER_WAIT) {
+    Function *BarrierFn =
+        Intrinsic::getOrInsertDeclaration(&Ctx.M, Intrinsic::amdgcn_s_barrier);
+    Ctx.B.CreateCall(BarrierFn, {});
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_BARRIER_SIGNAL) {
+    Hr.Handled = true;
+    return Hr;
+  }
+  if (Sop == CanonicalOp::S_SET_VGPR_MSB) {
+    // Only the low 8 bits of the immediate carry runtime meaning; the high
+    // 8 bits record the previous mode for compiler bookkeeping (see
+    // AMDGPULowerVGPREncoding::setMode in LLVM).  The hardware ignores them.
+    int64_t Imm = Di.getImm(0);
+    Ctx.VgprMsBs = static_cast<uint8_t>(Imm & 0xFF);
+    Hr.Handled = true;
+    return Hr;
+  }
+
+  // Source wait counters are ordering operations, not decorative no-ops.  The
+  // TensorDescriptor MXFP upcast emits `s_wait_dscnt 0` between LDS stores /
+  // loads and split barriers; dropping it lets gfx942 reach `s_barrier` before
+  // the prior DS operation is complete, producing sparse nondeterministic sign
+  // flips after the LDS reshape.  Cross-target counter names do not map 1:1, so
+  // use the conservative gfx942-compatible wait-all form.
+  if (Sop == CanonicalOp::S_WAITCNT || Sop == CanonicalOp::S_WAIT_LOADCNT ||
+      Sop == CanonicalOp::S_WAIT_KMCNT || Sop == CanonicalOp::S_WAIT_DSCNT ||
+      Sop == CanonicalOp::S_WAIT_XCNT || Sop == CanonicalOp::S_WAIT_LOADCNT_DSCNT) {
+    Function *WaitFn =
+        Intrinsic::getOrInsertDeclaration(&Ctx.M, Intrinsic::amdgcn_s_waitcnt);
+    Ctx.B.CreateCall(WaitFn, {Ctx.B.getInt32(0)});
+    Hr.Handled = true;
+    return Hr;
+  }
+
+  // gfx1250 async-memory wait counters. Explicit arm (rather than
+  // falling through to the generic SOPP no-op catch-all below) so
+  // this handler's surface documents the async/tensor cross-target
+  // correctness argument alongside the other SOPP branches.
+  //
+  // Both counters track work in dedicated gfx1250 hardware units
+  // (`ASYNCcnt`, `TENSORcnt`; programming_manual.pdf §4.9.9 and
+  // §6 respectively) that do not exist on gfx942.  The source DMAs
+  // they gate are emulated as synchronous `load`+`store` chains on
+  // the cross-target arm (see `handle_flat.cpp`'s
+  // `GLOBAL_LOAD_ASYNC_TO_LDS_B*` handler and `handle_vimage.cpp`'s
+  // refusal → future emulation for TENSOR ops), so by the time the
+  // wait site is reached the underlying memory transfer has
+  // already completed at the IR level.  IR dataflow from the
+  // emulated `store` through subsequent LDS reads carries the
+  // happens-before the native counter was enforcing; the backend
+  // re-inserts the target-appropriate `s_waitcnt lgkmcnt(0)` on
+  // gfx942 from that ordering constraint.
+  //
+  // On the same-target arm (gfx1250 → gfx1250) this branch remains
+  // emission-light for now: the async intrinsic's
+  // `IntrInaccessibleMemOrArgMemOnly` annotation prevents reorder across the
+  // wait site, while the asynchronous operation itself is what carries the
+  // relevant memory dependency.  Do not merge this arm with the ordinary
+  // wait-counter branch above unless the async/tensor counter semantics have a
+  // target-independent wait-all lowering too.
+  if (Sop == CanonicalOp::S_WAIT_ASYNCCNT || Sop == CanonicalOp::S_WAIT_TENSORCNT) {
+    Hr.Handled = true;
+    return Hr;
+  }
+
+  // All other SOPP instructions (nop, scheduling hints, etc.) are no-ops.
+  Hr.Handled = true;
+  return Hr;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/opcode-map.cpp
+++ b/amd/comgr/src/hotswap/opcode-map.cpp
@@ -105,7 +105,7 @@ static const Entry kCanonTable[] = {
     //   * the raiser's generic `Unsupported instruction` diagnostic
     //     doesn't fire on these wait sites when the companion
     //     async DMA / TENSOR op has been emulated or lifted; and
-    //   * `handle_sopp.cpp`'s generic SOPP no-op arm explicitly
+    //   * `handle-sopp.cpp`'s generic SOPP no-op arm explicitly
     //     covers them.
     // See the `S_WAIT_ASYNCCNT` / `S_WAIT_TENSORCNT` CanonicalOp doc
     // block in `canonical-op.h` for the cross-target correctness
@@ -256,7 +256,7 @@ static const Entry kCanonTable[] = {
     // single entry per variant covers every AMDGPU generation back to
     // gfx6.  Writes SCC only — no scalar destination register — which
     // matches the SOPC compare shape already implemented alongside in
-    // handle_sopc.cpp.
+    // handle-sopc.cpp.
     E(S_BITCMP0_B32, S_BITCMP0_B32),
     E(S_BITCMP1_B32, S_BITCMP1_B32),
     E(S_BITCMP0_B64, S_BITCMP0_B64),

--- a/amd/comgr/test-lit/hotswap-raise/abort_gate.s
+++ b/amd/comgr/test-lit/hotswap-raise/abort_gate.s
@@ -1,0 +1,88 @@
+; RUN: %llvm_mc -mcpu=gfx942 %s -o %t.o && %ld_lld -shared %t.o -o %t.hsaco \
+; RUN:   && %not raise_cli %t.hsaco --emit-ir=unknown_exec_writer_kernel 2>&1 | %FileCheck %s --check-prefix=STDERR
+;
+; The raiser must refuse to lower a kernel that contains an
+; EXEC-writing instruction whose SemOp is not declared SPE-safe
+; (`routesExecThroughStoreExec` in `sem_op_attrs.cpp`). This prevents
+; us from silently emitting IR for an opcode whose handler has not
+; been audited against the per-lane predication assumption.
+;
+; The fixture pins `s_flbit_i32_b32` as the offending instruction:
+; its `S_FLBIT_I32_B32` SemOp is deliberately absent from the
+; attribute table because no handler has been written for that shape
+; of EXEC write. Routing the dst to `exec_lo` makes the EXEC-writer
+; detector flag it.
+;
+; We assert two things:
+;
+;   1. The raiser exits non-zero (`%not` inverts the exit code — the
+;      test passes only when raise_cli actually failed).
+;   2. The stderr diagnostic names the instruction and explains why,
+;      matching on stable substrings. We do not pin to the full
+;      sentence to keep the test resilient to future rewordings.
+;
+; History: the diagnostic previously mentioned "SPE-modelled
+; allow-list"; that wording was replaced by the attribute-based check
+; ("routesExecThroughStoreExec") when P1.3 moved the allow-list into
+; `sem_op_attrs.cpp`. The attribute name is the new stable substring.
+
+; STDERR: transpiler: pre-translation abort:
+; STDERR-SAME: 's_flbit_i32_b32'
+; STDERR-SAME: writes EXEC
+; STDERR-SAME: routesExecThroughStoreExec
+
+; The raise_cli wrapper reports the failure once more so the kerneldex
+; coverage format is preserved; the mnemonic must match.
+; STDERR: raise_cli: kernel 'unknown_exec_writer_kernel' failed to raise:
+; STDERR-SAME: s_flbit_i32_b32
+; STDERR-SAME: SPE-unmodeled-EXEC-writer
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 6
+	.text
+	.globl	unknown_exec_writer_kernel
+	.p2align	8
+	.type	unknown_exec_writer_kernel,@function
+unknown_exec_writer_kernel:
+	s_load_dwordx2 s[0:1], s[0:1], 0x0
+	;;#ASMSTART
+	s_flbit_i32_b32 exec_lo, 0x12345678
+	s_mov_b64 exec, -1
+	
+	;;#ASMEND
+	s_nop 0
+	v_lshlrev_b32_e32 v1, 2, v0
+	s_waitcnt lgkmcnt(0)
+	global_store_dword v1, v0, s[0:1]
+	s_endpgm
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel unknown_exec_writer_kernel
+		.amdhsa_kernarg_size 8
+		.amdhsa_user_sgpr_count 2
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_next_free_vgpr 2
+		.amdhsa_next_free_sgpr 2
+		.amdhsa_accum_offset 4
+		.amdhsa_float_denorm_mode_32 3
+	.end_amdhsa_kernel
+	.text
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - { .address_space:  global, .offset:         0, .size:           8, .value_kind:     global_buffer }
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 8
+    .max_flat_workgroup_size: 1024
+    .name:           unknown_exec_writer_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     8
+    .symbol:         unknown_exec_writer_kernel.kd
+    .vgpr_count:     2
+    .wavefront_size: 64
+amdhsa.version: [1, 2]
+...
+
+	.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-raise/group_segment_fixed_size_attr.s
+++ b/amd/comgr/test-lit/hotswap-raise/group_segment_fixed_size_attr.s
@@ -1,0 +1,92 @@
+; RUN: %llvm_mc -mcpu=gfx1250 %s -o %t.o && %ld_lld -shared %t.o -o %t.hsaco \
+; RUN:   && raise_cli %t.hsaco --target-isa=gfx942 \
+; RUN:     --emit-ir=group_segment_fixed_size_attr_kernel 2>/dev/null \
+; RUN:   | %FileCheck %s --check-prefix=IR
+;
+; Regression fence for the static-LDS-size propagation in `raiser.cpp`.
+; Without this attribute, every lifted kernel with static LDS would
+; get `.group_segment_fixed_size: 0` in its HSACO KD, causing every
+; LDS access to return zero (the segment is unallocated from the
+; hardware's perspective).
+;
+; The fixture's source `__shared__ int lds[1024]` yields a source
+; `.group_segment_fixed_size: 4096` in the gfx1250 HSACO's KD.  The
+; raiser must propagate that into an `amdgpu-lds-size` function
+; attribute on the lifted kernel so `AMDGPUMachineFunctionInfo`
+; picks it up in the cross-targeted gfx942 codegen.
+;
+; We assert:
+;   1) The lifted kernel function carries `"amdgpu-lds-size"="4096,4096"`
+;      (min=max=4096 since the source's static size is known exactly).
+;   2) The source's `__shared__ int lds[1024]` lowered to at least one
+;      addrspace(3) ds_write / ds_load pair in the IR (i.e. the LDS is
+;      actually used — otherwise the attribute would be a no-op and
+;      the fixture would pass vacuously).
+
+; IR-LABEL: define amdgpu_kernel void @group_segment_fixed_size_attr_kernel(
+; IR-DAG: store {{.*}}, ptr addrspace(3)
+; IR-DAG: load {{.*}}, ptr addrspace(3)
+; IR: attributes #{{[0-9]+}} = { {{.*}}"amdgpu-lds-size"="4096,4096"{{.*}} }
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+	.amdhsa_code_object_version 6
+	.text
+	.globl	group_segment_fixed_size_attr_kernel
+	.p2align	8
+	.type	group_segment_fixed_size_attr_kernel,@function
+group_segment_fixed_size_attr_kernel:   ; @group_segment_fixed_size_attr_kernel
+; %bb.0:
+	v_dual_add_nc_u32 v1, 1, v0 :: v_dual_lshlrev_b32 v2, 2, v0
+	s_load_b64 s[0:1], s[0:1], 0x0
+	s_delay_alu instid0(VALU_DEP_1)
+	v_and_b32_e32 v1, 31, v1
+	ds_store_b32 v2, v0
+	s_wait_dscnt 0x0
+	; wave barrier
+	v_lshlrev_b32_e32 v1, 2, v1
+	ds_load_b32 v1, v1
+	s_wait_dscnt 0x0
+	s_wait_kmcnt 0x0
+	global_store_b32 v0, v1, s[0:1] scale_offset
+	s_endpgm
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel group_segment_fixed_size_attr_kernel
+		.amdhsa_group_segment_fixed_size 4096
+		.amdhsa_kernarg_size 8
+		.amdhsa_user_sgpr_count 2
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_wavefront_size32 1
+		.amdhsa_system_sgpr_workgroup_id_x 1
+		.amdhsa_next_free_vgpr 3
+		.amdhsa_next_free_sgpr 2
+		.amdhsa_float_denorm_mode_32 3
+		.amdhsa_inst_pref_size 1
+	.end_amdhsa_kernel
+	.text
+	.p2alignl 7, 3214868480
+	.fill 96, 4, 3214868480
+	.text
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - .address_space:  global
+        .offset:         0
+        .size:           8
+        .value_kind:     global_buffer
+    .group_segment_fixed_size: 4096
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 8
+    .max_flat_workgroup_size: 32
+    .name:           group_segment_fixed_size_attr_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     2
+    .symbol:         group_segment_fixed_size_attr_kernel.kd
+    .vgpr_count:     3
+    .wavefront_size: 32
+amdhsa.target:   amdgcn-amd-amdhsa--gfx1250
+amdhsa.version: [1, 2]
+...
+
+	.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-raise/saveexec.s
+++ b/amd/comgr/test-lit/hotswap-raise/saveexec.s
@@ -1,0 +1,97 @@
+; RUN: %llvm_mc -mcpu=gfx942 %s -o %t.o && %ld_lld -shared %t.o -o %t.hsaco \
+; RUN:   && raise_cli %t.hsaco --emit-ir=saveexec_kernel 2>/dev/null | %FileCheck %s
+;
+; Audit: `s_and_saveexec_b64` routes its EXEC write through
+; `storeExec` (handle_sop1.cpp). This SemOp family is the one
+; EXEC-writer that is simultaneously an SGPR-pair producer — the
+; handler has to (a) save the OLD EXEC into the destination SGPR
+; pair, and (b) write `old_exec AND src` to EXEC. Post-mem2reg we
+; cannot see the SGPR-pair save directly (the saved value may fold
+; away if the kernel never reads it), but we can see the new EXEC
+; SSA value (`%new_exec`) being consumed by the SPE active-bit
+; computation that wraps the subsequent side-effectful store.
+;
+; If the S_AND_SAVEEXEC_B64 handler regressed and no longer routed
+; through storeExec, the `lshr i64 <exec>, %spe_lane_mod` before the
+; store would still read `-1` (the initial EXEC) instead of
+; `%new_exec`, and the single-lane-gated store would silently
+; execute on every lane.
+
+; CHECK-LABEL: define amdgpu_kernel void @saveexec_kernel(
+
+; v_cmp_lt_u32_e64 produces the narrow mask in s[4:5]. Pre-mem2reg
+; that's a store to the relevant sgpr alloca; post-mem2reg it's the
+; SSA name for the comparison's sign-extended i64 representation.
+; CHECK:       %vcmp = icmp ult i32 %tid, 16
+
+; s_and_saveexec_b64 writes `old_exec AND src` to EXEC. The handler
+; names the new EXEC SSA value `%new_exec` — this is the audit
+; signal.
+; CHECK:       %new_exec = and i64 -1, %{{[^ ]+}}
+
+; The SPE lane-active computation that follows (wrapping the
+; global_store_dword) keys off %new_exec, NOT -1. This proves the
+; SSA graph of EXEC reflects the saveexec write.
+; CHECK:       %[[AT_LANE:[^ ]+]] = lshr i64 %new_exec, %{{[^ ]+}}
+; CHECK-NEXT:  %[[BIT:[^ ]+]] = and i64 %[[AT_LANE]], 1
+; CHECK-NEXT:  %[[ACTIVE:[^ ]+]] = icmp ne i64 %[[BIT]], 0
+; CHECK-NEXT:  br i1 %[[ACTIVE]], label %[[DO:[^ ,]+]], label %{{[^ ,]+}}
+
+; The store under the narrowed EXEC is the observable side-effect
+; that motivates the whole audit.
+; CHECK:       [[DO]]:
+; CHECK-NEXT:    store i32 {{.*}}, ptr addrspace(1) %{{[^ ]+}}, align 4
+
+	.amdgcn_target "amdgcn-amd-amdhsa--gfx942"
+	.amdhsa_code_object_version 6
+	.text
+	.globl	saveexec_kernel
+	.p2align	8
+	.type	saveexec_kernel,@function
+saveexec_kernel:
+	s_load_dwordx2 s[0:1], s[0:1], 0x0
+	v_mov_b32_e32 v3, 0
+	v_lshlrev_b32_e32 v2, 2, v0
+	v_mov_b32_e32 v1, 0xcc
+	s_waitcnt lgkmcnt(0)
+	v_lshl_add_u64 v[2:3], s[0:1], 0, v[2:3]
+	;;#ASMSTART
+	v_cmp_lt_u32_e64 s[4:5], v0, 16
+	s_and_saveexec_b64 s[6:7], s[4:5]
+	global_store_dword v[2:3], v1, off
+	s_waitcnt vmcnt(0)
+	s_mov_b64 exec, s[6:7]
+	
+	;;#ASMEND
+	s_endpgm
+	.section	.rodata,"a",@progbits
+	.p2align	6, 0x0
+	.amdhsa_kernel saveexec_kernel
+		.amdhsa_kernarg_size 8
+		.amdhsa_user_sgpr_count 2
+		.amdhsa_user_sgpr_kernarg_segment_ptr 1
+		.amdhsa_next_free_vgpr 4
+		.amdhsa_next_free_sgpr 8
+		.amdhsa_accum_offset 4
+		.amdhsa_float_denorm_mode_32 3
+	.end_amdhsa_kernel
+	.text
+	.amdgpu_metadata
+---
+amdhsa.kernels:
+  - .args:
+      - { .address_space:  global, .offset:         0, .size:           8, .value_kind:     global_buffer }
+    .group_segment_fixed_size: 0
+    .kernarg_segment_align: 8
+    .kernarg_segment_size: 8
+    .max_flat_workgroup_size: 1024
+    .name:           saveexec_kernel
+    .private_segment_fixed_size: 0
+    .sgpr_count:     14
+    .symbol:         saveexec_kernel.kd
+    .vgpr_count:     4
+    .wavefront_size: 64
+amdhsa.version: [1, 2]
+...
+
+	.end_amdgpu_metadata


### PR DESCRIPTION
  * handle_sopp.cpp — SOP_NoOperand / SOP_Subroutine entries: s_endpgm, s_barrier, s_branch, s_cbranch_*, s_setprio, s_sleep, s_waitcnt family, s_waitcnt_depctr/lgkmcnt/expcnt/vmcnt, plus the gfx1250 s_wait_tensorcnt the VIMAGE handler later defers to.
  * handle_sopc.cpp — scalar comparisons (s_cmp_eq_i32 / s_cmp_lt_u64 / s_bitcmp1_b32 / ...) writing to SCC. Mirrors LLVM's AMDGPUInstructions.td:1107 categorisation.

Both handlers are reachable through the in-progress dispatch loop (landing later in `Wire raiser dispatcher`); the current decode-and-bail raiser does not call them yet, but their TUs land in the OBJECT lib so the dispatcher hook-up in the later commit becomes a no-build-rebuild change.

Lit fixtures for SOPP/SOPC follow with the dispatcher commit since they FileCheck the lifted IR shape, which depends on the dispatcher actually calling these handlers.


