### PR TITLE
Fix sign of zero where required by the OpenCL spec.

### DIFF
--- a/amd/device-libs/ocml/src/cospiD.cl
+++ b/amd/device-libs/ocml/src/cospiD.cl
@@ -22,6 +22,6 @@ MATH_MANGLE(cospi)(double x)
     long c = AS_LONG((r.i & 1) != 0 ? sc.s : sc.c);
     c ^= r.i > 1 ? SIGNBIT_DP64 : 0;
 
-    return AS_DOUBLE(c);
+    return AS_DOUBLE(c) + 0.0;
 }
 

--- a/amd/device-libs/ocml/src/cospiF.cl
+++ b/amd/device-libs/ocml/src/cospiF.cl
@@ -22,6 +22,6 @@ MATH_MANGLE(cospi)(float x)
     float c = (r.i & 1) != 0 ? sc.s : sc.c;
     c = r.i > 1 ? -c : c;
 
-    return c;
+    return c + 0.0f;
 }
 

--- a/amd/device-libs/ocml/src/cospiH.cl
+++ b/amd/device-libs/ocml/src/cospiH.cl
@@ -24,6 +24,6 @@ MATH_MANGLE(cospi)(half x)
     half c = (r.i & (short)1) == (short)0 ? sc.c : sc.s;
     c = r.i > (short)1 ? -c : c;
 
-    return c;
+    return c + 0.0h;
 }
 

--- a/amd/device-libs/ocml/src/sinpiD.cl
+++ b/amd/device-libs/ocml/src/sinpiD.cl
@@ -23,6 +23,6 @@ MATH_MANGLE(sinpi)(double x)
     s = AS_DOUBLE(AS_LONG(s) ^ (r.i > 1 ? SIGNBIT_DP64 : 0) ^
                   (AS_LONG(x) ^ AS_LONG(ax)));
 
-    return s;
+    return r.hi == 0.0 ? BUILTIN_COPYSIGN_F64(0.0, x) : s;
 }
 

--- a/amd/device-libs/ocml/src/sinpiF.cl
+++ b/amd/device-libs/ocml/src/sinpiF.cl
@@ -21,6 +21,6 @@ MATH_MANGLE(sinpi)(float x)
     float s = (r.i & 1) == 0 ? sc.s : sc.c;
     s = AS_FLOAT(AS_INT(s) ^ (r.i > 1 ? SIGNBIT_SP32 : 0) ^ (AS_INT(x) ^ AS_INT(ax)));
 
-    return s;
+    return r.hi == 0.0f ? BUILTIN_COPYSIGN_F32(0.0f, x) : s;
 }
 

--- a/amd/device-libs/ocml/src/sinpiH.cl
+++ b/amd/device-libs/ocml/src/sinpiH.cl
@@ -24,6 +24,6 @@ MATH_MANGLE(sinpi)(half x)
 
     s = AS_HALF((short)(AS_SHORT(s) ^ (flip ^ (AS_SHORT(x) & (short)SIGNBIT_HP16))));
 
-    return s;
+    return r.hi == 0.0h ? BUILTIN_COPYSIGN_F16(0.0h, x) : s;
 }
 


### PR DESCRIPTION
Fix sign of zero as required by the OpenCL spec.  Detected by the latest updates to the bruteforce test.