### PR TITLE
[AMDGPU] comgr: Add ElfView::getKernelLdsSize helper

### DIFF
--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -225,13 +225,22 @@ ElfView::getKernelVgprCount(StringRef KernelName,
     return std::nullopt;
   }
   uint32_t Rsrc1;
-  std::memcpy(&Rsrc1, Kd + KdRsrc1Offset, sizeof(Rsrc1));
+  std::memcpy(&Rsrc1,
+              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              sizeof(Rsrc1));
   uint32_t Granulated = AMDHSA_BITS_GET(
       Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
   return (Granulated + 1) * VgprGranuleSize;
 }
 
-std::optional<uint32_t> ElfView::getKernelLdsSize(StringRef KernelName) const {
+// Reads the static (compile-time-fixed) LDS allocation from the kernel
+// descriptor's group_segment_fixed_size field. Dynamic LDS is added by the
+// host at dispatch time and is not visible here -- see the declaration's
+// doc comment for the full lower-bound caveat.
+
+std::optional<uint32_t>
+ElfView::getKernelStaticLdsSize(StringRef KernelName) const {
+  namespace hsa = amdhsa;
   // findKernelDescriptor never writes through the returned pointer in this
   // call path but is shared (non-const) with updateKernelDescriptor. The
   // const_cast on `this` keeps the read-only accessor const-correct without
@@ -239,12 +248,13 @@ std::optional<uint32_t> ElfView::getKernelLdsSize(StringRef KernelName) const {
   const uint8_t *Kd =
       const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
   if (!Kd) {
-    log() << "hotswap: error: getKernelLdsSize: kernel descriptor symbol '"
-          << KernelName << ".kd' not found.\n";
+    log() << "hotswap: error: getKernelStaticLdsSize: kernel descriptor "
+          << "symbol '" << KernelName << ".kd' not found.\n";
     return std::nullopt;
   }
   uint32_t LdsSize;
-  std::memcpy(&LdsSize, Kd + amdhsa::GROUP_SEGMENT_FIXED_SIZE_OFFSET,
+  std::memcpy(&LdsSize,
+              Kd + offsetof(hsa::kernel_descriptor_t, group_segment_fixed_size),
               sizeof(LdsSize));
   return LdsSize;
 }
@@ -266,7 +276,9 @@ void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,
   }
 
   uint32_t Rsrc1;
-  std::memcpy(&Rsrc1, Kd + KdRsrc1Offset, sizeof(Rsrc1));
+  std::memcpy(&Rsrc1,
+              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              sizeof(Rsrc1));
   if (ExtraVgprs != 0 && VgprGranuleSize != 0) {
     uint32_t Current = AMDHSA_BITS_GET(
         Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
@@ -289,7 +301,8 @@ void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,
                     hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
                     std::min<uint32_t>(Current + Extra, MaxGran));
   }
-  std::memcpy(Kd + KdRsrc1Offset, &Rsrc1, sizeof(Rsrc1));
+  std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              &Rsrc1, sizeof(Rsrc1));
 }
 
 // -- Section/program header adjustment for trampoline growth ------------------

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -231,6 +231,24 @@ ElfView::getKernelVgprCount(StringRef KernelName,
   return (Granulated + 1) * VgprGranuleSize;
 }
 
+std::optional<uint32_t> ElfView::getKernelLdsSize(StringRef KernelName) const {
+  // findKernelDescriptor never writes through the returned pointer in this
+  // call path but is shared (non-const) with updateKernelDescriptor. The
+  // const_cast on `this` keeps the read-only accessor const-correct without
+  // duplicating the lookup helper.
+  const uint8_t *Kd =
+      const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
+  if (!Kd) {
+    log() << "hotswap: error: getKernelLdsSize: kernel descriptor symbol '"
+          << KernelName << ".kd' not found.\n";
+    return std::nullopt;
+  }
+  uint32_t LdsSize;
+  std::memcpy(&LdsSize, Kd + amdhsa::GROUP_SEGMENT_FIXED_SIZE_OFFSET,
+              sizeof(LdsSize));
+  return LdsSize;
+}
+
 // -- ElfView::updateKernelDescriptor ------------------------------------------
 
 void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -183,6 +183,11 @@ public:
   std::optional<unsigned> getKernelVgprCount(llvm::StringRef KernelName,
                                              unsigned VgprGranuleSize) const;
 
+  /// Read group_segment_fixed_size (LDS allocation, bytes) from the kernel
+  /// descriptor for \p KernelName. Returns std::nullopt if the descriptor
+  /// symbol is missing.
+  std::optional<uint32_t> getKernelLdsSize(llvm::StringRef KernelName) const;
+
   /// Update the RSRC1 VGPR/SGPR granule counts in the kernel descriptor for
   /// \p KernelName by adding \p ExtraVgprs / \p ExtraSgprs, using
   /// \p VgprGranuleSize / \p SgprGranuleSize so the call is ISA-agnostic.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -96,11 +96,11 @@ struct RewriteRule {
 
 // -- Named constants ----------------------------------------------------------
 
-// Kernel descriptor size and RSRC1 offset from upstream
-// AMDHSAKernelDescriptor.h.
+// Kernel descriptor size from upstream AMDHSAKernelDescriptor.h. Field
+// offsets are resolved via offsetof(amdhsa::kernel_descriptor_t, field)
+// at the access site so the struct definition stays the single source
+// of truth and the *_OFFSET constants do not get spelled out twice.
 static constexpr uint64_t KdSize = sizeof(llvm::amdhsa::kernel_descriptor_t);
-static constexpr uint64_t KdRsrc1Offset =
-    llvm::amdhsa::COMPUTE_PGM_RSRC1_OFFSET;
 
 // Maximum distance (bytes) between an instruction and a NOP sled for the
 // sled to be considered reachable by a single s_branch.
@@ -183,10 +183,23 @@ public:
   std::optional<unsigned> getKernelVgprCount(llvm::StringRef KernelName,
                                              unsigned VgprGranuleSize) const;
 
-  /// Read group_segment_fixed_size (LDS allocation, bytes) from the kernel
-  /// descriptor for \p KernelName. Returns std::nullopt if the descriptor
-  /// symbol is missing.
-  std::optional<uint32_t> getKernelLdsSize(llvm::StringRef KernelName) const;
+  /// Read `group_segment_fixed_size` from the kernel descriptor for
+  /// \p KernelName, i.e. the **static** (compile-time-fixed) LDS allocation
+  /// per work-group in bytes. Returns std::nullopt if the descriptor symbol
+  /// is missing.
+  ///
+  /// This is the only LDS quantity visible in the ELF. Dynamic LDS is
+  /// allocated by the host at dispatch time (carried in the AQL packet's
+  /// `group_segment_size` and propagated to the device via the
+  /// `hidden_dynamic_lds_size` kernarg) and is *not* included here, so the
+  /// returned value is a lower bound on the total LDS the kernel may
+  /// touch. Callers that need to flag potential overflow of A0's 16-bit M0
+  /// limit (DEGFXMI400-12025) can use this as a "definitely exceeds"
+  /// check; "static fits, dynamic pushes over" cannot be detected
+  /// statically. See AMDGPUUsage "Code Object V3 Kernel Descriptor"
+  /// (GROUP_SEGMENT_FIXED_SIZE).
+  std::optional<uint32_t>
+  getKernelStaticLdsSize(llvm::StringRef KernelName) const;
 
   /// Update the RSRC1 VGPR/SGPR granule counts in the kernel descriptor for
   /// \p KernelName by adding \p ExtraVgprs / \p ExtraSgprs, using

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -12,6 +12,22 @@
 
 using namespace COMGR::hotswap;
 
+// File-scope helpers for ELF construction in the tests below.
+
+// Lay out one Elf64_Shdr at \p Sh with the named fields. Fields not
+// relevant to the parse path (sh_addr, sh_info, sh_addralign) stay zero.
+static void writeShdr(uint8_t *Sh, uint32_t Name, uint32_t Type, uint64_t Flags,
+                      uint64_t Off, uint64_t Sz, uint32_t Link,
+                      uint64_t EntSize) {
+  std::memcpy(Sh + 0, &Name, 4);
+  std::memcpy(Sh + 4, &Type, 4);
+  std::memcpy(Sh + 8, &Flags, 8);
+  std::memcpy(Sh + 24, &Off, 8);
+  std::memcpy(Sh + 32, &Sz, 8);
+  std::memcpy(Sh + 40, &Link, 4);
+  std::memcpy(Sh + 56, &EntSize, 8);
+}
+
 // -- ElfView::create ----------------------------------------------------------
 
 TEST(ElfView, RejectsTruncatedInput) {
@@ -26,4 +42,192 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(NotElf, sizeof(NotElf));
   EXPECT_FALSE((bool)ViewOrErr);
   llvm::consumeError(ViewOrErr.takeError());
+}
+
+// -- ElfView::getKernelLdsSize ------------------------------------------------
+//
+// getKernelLdsSize reads group_segment_fixed_size from a kernel descriptor
+// symbol "<KernelName>.kd". Two unit tests cover the helper:
+//   * negative path: no .kd symbol -> std::nullopt
+//   * positive path: hand-crafted ELF with a .kd symbol pointing at an
+//                    embedded kernel descriptor -> the embedded LDS size
+// Real gfx1250 code-object coverage is added by the lit tests in #2302.
+
+TEST(ElfView, GetKernelLdsSizeReturnsNulloptWhenKdMissing) {
+  // Build a minimal valid ELF64: header + .text + .shstrtab. ELFFile::create
+  // succeeds, but no .kd symbol exists, so getKernelLdsSize must take the
+  // missing-KD branch.
+  static constexpr size_t BufSize = 512;
+  alignas(8) uint8_t Buf[BufSize] = {};
+
+  Buf[0] = 0x7f;
+  Buf[1] = 'E';
+  Buf[2] = 'L';
+  Buf[3] = 'F';
+  Buf[4] = llvm::ELF::ELFCLASS64;
+  Buf[5] = llvm::ELF::ELFDATA2LSB;
+  Buf[6] = llvm::ELF::EV_CURRENT;
+  Buf[7] = llvm::ELF::ELFOSABI_AMDGPU_HSA;
+
+  uint16_t EType = llvm::ELF::ET_REL;
+  std::memcpy(Buf + 16, &EType, 2);
+  uint16_t EMachine = llvm::ELF::EM_AMDGPU;
+  std::memcpy(Buf + 18, &EMachine, 2);
+  uint32_t EVersion = llvm::ELF::EV_CURRENT;
+  std::memcpy(Buf + 20, &EVersion, 4);
+
+  uint16_t EhSize = 64;
+  std::memcpy(Buf + 52, &EhSize, 2);
+  uint16_t ShEntSize = 64;
+  std::memcpy(Buf + 58, &ShEntSize, 2);
+  uint16_t ShNum = 3;
+  std::memcpy(Buf + 60, &ShNum, 2);
+  uint16_t ShStrNdx = 2;
+  std::memcpy(Buf + 62, &ShStrNdx, 2);
+
+  static constexpr uint64_t StrTabOff = 256;
+  const char StrTab[] = "\0.text\0.shstrtab\0";
+  std::memcpy(Buf + StrTabOff, StrTab, sizeof(StrTab));
+
+  static constexpr uint64_t TextOff = 320;
+  static constexpr uint64_t TextSize = 16;
+  static constexpr uint64_t ShOff = 64;
+  uint64_t ShOffVal = ShOff;
+  std::memcpy(Buf + 40, &ShOffVal, 8);
+
+  // Shdr[1] = .text
+  uint8_t *Sh1 = Buf + ShOff + 64;
+  uint32_t ShName1 = 1;
+  std::memcpy(Sh1 + 0, &ShName1, 4);
+  uint32_t ShType1 = llvm::ELF::SHT_PROGBITS;
+  std::memcpy(Sh1 + 4, &ShType1, 4);
+  uint64_t ShFlags1 = llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR;
+  std::memcpy(Sh1 + 8, &ShFlags1, 8);
+  uint64_t ShOff1 = TextOff;
+  std::memcpy(Sh1 + 24, &ShOff1, 8);
+  uint64_t ShSize1 = TextSize;
+  std::memcpy(Sh1 + 32, &ShSize1, 8);
+
+  // Shdr[2] = .shstrtab
+  uint8_t *Sh2 = Buf + ShOff + 128;
+  uint32_t ShName2 = 7;
+  std::memcpy(Sh2 + 0, &ShName2, 4);
+  uint32_t ShType2 = llvm::ELF::SHT_STRTAB;
+  std::memcpy(Sh2 + 4, &ShType2, 4);
+  uint64_t ShOff2 = StrTabOff;
+  std::memcpy(Sh2 + 24, &ShOff2, 8);
+  uint64_t ShSize2 = sizeof(StrTab);
+  std::memcpy(Sh2 + 32, &ShSize2, 8);
+
+  llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf, BufSize);
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(ViewOrErr->getKernelLdsSize("nonexistent_kernel"), std::nullopt);
+}
+
+TEST(ElfView, GetKernelLdsSizeReadsLdsSizeFromKernelDescriptor) {
+  // Build a minimal AMDGPU ELF64 with the section topology that
+  // findKernelDescriptor walks: 6 sections (NULL, .text, .rodata, .strtab,
+  // .symtab, .shstrtab). The kernel descriptor is embedded at the start of
+  // .rodata with a known group_segment_fixed_size value, and a symbol named
+  // "test_kernel.kd" in .symtab points at it. getKernelLdsSize must return
+  // the embedded LDS size unchanged.
+  static constexpr size_t BufSize = 1024;
+  alignas(8) uint8_t Buf[BufSize] = {};
+
+  // Section file offsets and sizes. Layout choices keep each section
+  // 8-byte aligned so the ELF parser is happy.
+  static constexpr uint64_t ShOff = 64;
+  static constexpr uint64_t TextOff = 0x1C0;
+  static constexpr uint64_t TextSize = 16;
+  static constexpr uint64_t RodataOff = 0x1D0;
+  static constexpr uint64_t KdSize = 64;
+  static constexpr uint64_t StrTabOff = 0x210;
+  static constexpr uint64_t SymTabOff = 0x220;
+  static constexpr uint64_t SymEntSize = 24;
+  static constexpr uint64_t SymCount = 2;
+  static constexpr uint64_t ShStrTabOff = 0x250;
+  static constexpr uint16_t ShNum = 6;
+  static constexpr uint16_t ShStrNdx = 5;
+  static constexpr uint32_t TestLdsSize = 16384;
+
+  // ELF header.
+  Buf[0] = 0x7f;
+  Buf[1] = 'E';
+  Buf[2] = 'L';
+  Buf[3] = 'F';
+  Buf[4] = llvm::ELF::ELFCLASS64;
+  Buf[5] = llvm::ELF::ELFDATA2LSB;
+  Buf[6] = llvm::ELF::EV_CURRENT;
+  Buf[7] = llvm::ELF::ELFOSABI_AMDGPU_HSA;
+
+  uint16_t EType = llvm::ELF::ET_REL;
+  std::memcpy(Buf + 16, &EType, 2);
+  uint16_t EMachine = llvm::ELF::EM_AMDGPU;
+  std::memcpy(Buf + 18, &EMachine, 2);
+  uint32_t EVersion = llvm::ELF::EV_CURRENT;
+  std::memcpy(Buf + 20, &EVersion, 4);
+  uint64_t ShOffVal = ShOff;
+  std::memcpy(Buf + 40, &ShOffVal, 8);
+  uint16_t EhSize = 64;
+  std::memcpy(Buf + 52, &EhSize, 2);
+  uint16_t ShEntSize = 64;
+  std::memcpy(Buf + 58, &ShEntSize, 2);
+  uint16_t ShNumVal = ShNum;
+  std::memcpy(Buf + 60, &ShNumVal, 2);
+  uint16_t ShStrNdxVal = ShStrNdx;
+  std::memcpy(Buf + 62, &ShStrNdxVal, 2);
+
+  // Section name string table. Entries: "" .text .rodata .strtab .symtab
+  // .shstrtab. Offsets pinned in the shdr writes below.
+  const char ShStrTab[] = "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
+  std::memcpy(Buf + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
+
+  // Symbol name string table. Single named symbol "test_kernel.kd" at
+  // offset 1; offset 0 is the conventional empty name.
+  const char StrTab[] = "\0test_kernel.kd\0";
+  std::memcpy(Buf + StrTabOff, StrTab, sizeof(StrTab));
+
+  // Section header table.
+  uint8_t *Sh = Buf + ShOff;
+  // Shdr[0] = NULL section (already zeroed).
+  // Shdr[1] = .text, name offset 1.
+  writeShdr(Sh + 1 * 64, 1, llvm::ELF::SHT_PROGBITS,
+            llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR, TextOff, TextSize,
+            0, 0);
+  // Shdr[2] = .rodata, name offset 7.
+  writeShdr(Sh + 2 * 64, 7, llvm::ELF::SHT_PROGBITS, llvm::ELF::SHF_ALLOC,
+            RodataOff, KdSize, 0, 0);
+  // Shdr[3] = .strtab, name offset 15.
+  writeShdr(Sh + 3 * 64, 15, llvm::ELF::SHT_STRTAB, 0, StrTabOff,
+            sizeof(StrTab), 0, 0);
+  // Shdr[4] = .symtab, name offset 23; sh_link = 3 (.strtab), sh_entsize = 24
+  // (Elf64_Sym).
+  writeShdr(Sh + 4 * 64, 23, llvm::ELF::SHT_SYMTAB, 0, SymTabOff,
+            SymEntSize * SymCount, 3, SymEntSize);
+  // Shdr[5] = .shstrtab, name offset 31.
+  writeShdr(Sh + 5 * 64, 31, llvm::ELF::SHT_STRTAB, 0, ShStrTabOff,
+            sizeof(ShStrTab), 0, 0);
+
+  // Kernel descriptor body: group_segment_fixed_size at offset 0. The rest
+  // of the 64-byte descriptor stays zero, which is fine for a read-only
+  // helper that only consumes one field.
+  std::memcpy(Buf + RodataOff, &TestLdsSize, sizeof(TestLdsSize));
+
+  // Symbol table. Slot 0 is the conventional null symbol. Slot 1 names
+  // "test_kernel.kd" (st_name=1), binding STB_GLOBAL + type STT_OBJECT in
+  // st_info, shndx=2 (.rodata), st_value=0 (start of .rodata), st_size=64.
+  uint8_t *Sym1 = Buf + SymTabOff + SymEntSize;
+  uint32_t StName = 1;
+  std::memcpy(Sym1 + 0, &StName, 4);
+  Sym1[4] = (llvm::ELF::STB_GLOBAL << 4) | llvm::ELF::STT_OBJECT;
+  uint16_t StShndx = 2;
+  std::memcpy(Sym1 + 6, &StShndx, 2);
+  uint64_t StSize = KdSize;
+  std::memcpy(Sym1 + 16, &StSize, 8);
+
+  llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf, BufSize);
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  std::optional<uint32_t> Lds = ViewOrErr->getKernelLdsSize("test_kernel");
+  ASSERT_TRUE(Lds.has_value());
+  EXPECT_EQ(*Lds, TestLdsSize);
 }

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -12,22 +12,6 @@
 
 using namespace COMGR::hotswap;
 
-// File-scope helpers for ELF construction in the tests below.
-
-// Lay out one Elf64_Shdr at \p Sh with the named fields. Fields not
-// relevant to the parse path (sh_addr, sh_info, sh_addralign) stay zero.
-static void writeShdr(uint8_t *Sh, uint32_t Name, uint32_t Type, uint64_t Flags,
-                      uint64_t Off, uint64_t Sz, uint32_t Link,
-                      uint64_t EntSize) {
-  std::memcpy(Sh + 0, &Name, 4);
-  std::memcpy(Sh + 4, &Type, 4);
-  std::memcpy(Sh + 8, &Flags, 8);
-  std::memcpy(Sh + 24, &Off, 8);
-  std::memcpy(Sh + 32, &Sz, 8);
-  std::memcpy(Sh + 40, &Link, 4);
-  std::memcpy(Sh + 56, &EntSize, 8);
-}
-
 // -- ElfView::create ----------------------------------------------------------
 
 TEST(ElfView, RejectsTruncatedInput) {
@@ -57,67 +41,53 @@ TEST(ElfView, GetKernelLdsSizeReturnsNulloptWhenKdMissing) {
   // Build a minimal valid ELF64: header + .text + .shstrtab. ELFFile::create
   // succeeds, but no .kd symbol exists, so getKernelLdsSize must take the
   // missing-KD branch.
+  using namespace llvm::ELF;
   static constexpr size_t BufSize = 512;
   alignas(8) uint8_t Buf[BufSize] = {};
 
-  Buf[0] = 0x7f;
-  Buf[1] = 'E';
-  Buf[2] = 'L';
-  Buf[3] = 'F';
-  Buf[4] = llvm::ELF::ELFCLASS64;
-  Buf[5] = llvm::ELF::ELFDATA2LSB;
-  Buf[6] = llvm::ELF::EV_CURRENT;
-  Buf[7] = llvm::ELF::ELFOSABI_AMDGPU_HSA;
-
-  uint16_t EType = llvm::ELF::ET_REL;
-  std::memcpy(Buf + 16, &EType, 2);
-  uint16_t EMachine = llvm::ELF::EM_AMDGPU;
-  std::memcpy(Buf + 18, &EMachine, 2);
-  uint32_t EVersion = llvm::ELF::EV_CURRENT;
-  std::memcpy(Buf + 20, &EVersion, 4);
-
-  uint16_t EhSize = 64;
-  std::memcpy(Buf + 52, &EhSize, 2);
-  uint16_t ShEntSize = 64;
-  std::memcpy(Buf + 58, &ShEntSize, 2);
-  uint16_t ShNum = 3;
-  std::memcpy(Buf + 60, &ShNum, 2);
-  uint16_t ShStrNdx = 2;
-  std::memcpy(Buf + 62, &ShStrNdx, 2);
-
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
   static constexpr uint64_t StrTabOff = 256;
+  static constexpr uint64_t TextOff = 320;
+  static constexpr uint64_t TextSize = 16;
+
   const char StrTab[] = "\0.text\0.shstrtab\0";
   std::memcpy(Buf + StrTabOff, StrTab, sizeof(StrTab));
 
-  static constexpr uint64_t TextOff = 320;
-  static constexpr uint64_t TextSize = 16;
-  static constexpr uint64_t ShOff = 64;
-  uint64_t ShOffVal = ShOff;
-  std::memcpy(Buf + 40, &ShOffVal, 8);
+  Elf64_Ehdr Ehdr{};
+  Ehdr.e_ident[0] = 0x7f;
+  Ehdr.e_ident[1] = 'E';
+  Ehdr.e_ident[2] = 'L';
+  Ehdr.e_ident[3] = 'F';
+  Ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  Ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
+  Ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_REL;
+  Ehdr.e_machine = EM_AMDGPU;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = 3;
+  Ehdr.e_shstrndx = 2;
+  std::memcpy(Buf, &Ehdr, sizeof(Ehdr));
 
   // Shdr[1] = .text
-  uint8_t *Sh1 = Buf + ShOff + 64;
-  uint32_t ShName1 = 1;
-  std::memcpy(Sh1 + 0, &ShName1, 4);
-  uint32_t ShType1 = llvm::ELF::SHT_PROGBITS;
-  std::memcpy(Sh1 + 4, &ShType1, 4);
-  uint64_t ShFlags1 = llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR;
-  std::memcpy(Sh1 + 8, &ShFlags1, 8);
-  uint64_t ShOff1 = TextOff;
-  std::memcpy(Sh1 + 24, &ShOff1, 8);
-  uint64_t ShSize1 = TextSize;
-  std::memcpy(Sh1 + 32, &ShSize1, 8);
+  Elf64_Shdr Sh1{};
+  Sh1.sh_name = 1;
+  Sh1.sh_type = SHT_PROGBITS;
+  Sh1.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  Sh1.sh_offset = TextOff;
+  Sh1.sh_size = TextSize;
+  std::memcpy(Buf + ShOff + 1 * sizeof(Elf64_Shdr), &Sh1, sizeof(Sh1));
 
   // Shdr[2] = .shstrtab
-  uint8_t *Sh2 = Buf + ShOff + 128;
-  uint32_t ShName2 = 7;
-  std::memcpy(Sh2 + 0, &ShName2, 4);
-  uint32_t ShType2 = llvm::ELF::SHT_STRTAB;
-  std::memcpy(Sh2 + 4, &ShType2, 4);
-  uint64_t ShOff2 = StrTabOff;
-  std::memcpy(Sh2 + 24, &ShOff2, 8);
-  uint64_t ShSize2 = sizeof(StrTab);
-  std::memcpy(Sh2 + 32, &ShSize2, 8);
+  Elf64_Shdr Sh2{};
+  Sh2.sh_name = 7;
+  Sh2.sh_type = SHT_STRTAB;
+  Sh2.sh_offset = StrTabOff;
+  Sh2.sh_size = sizeof(StrTab);
+  std::memcpy(Buf + ShOff + 2 * sizeof(Elf64_Shdr), &Sh2, sizeof(Sh2));
 
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf, BufSize);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
@@ -131,54 +101,25 @@ TEST(ElfView, GetKernelLdsSizeReadsLdsSizeFromKernelDescriptor) {
   // .rodata with a known group_segment_fixed_size value, and a symbol named
   // "test_kernel.kd" in .symtab points at it. getKernelLdsSize must return
   // the embedded LDS size unchanged.
+  using namespace llvm::ELF;
   static constexpr size_t BufSize = 1024;
   alignas(8) uint8_t Buf[BufSize] = {};
 
   // Section file offsets and sizes. Layout choices keep each section
   // 8-byte aligned so the ELF parser is happy.
-  static constexpr uint64_t ShOff = 64;
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
   static constexpr uint64_t TextOff = 0x1C0;
   static constexpr uint64_t TextSize = 16;
   static constexpr uint64_t RodataOff = 0x1D0;
   static constexpr uint64_t KdSize = 64;
   static constexpr uint64_t StrTabOff = 0x210;
   static constexpr uint64_t SymTabOff = 0x220;
-  static constexpr uint64_t SymEntSize = 24;
-  static constexpr uint64_t SymCount = 2;
   static constexpr uint64_t ShStrTabOff = 0x250;
-  static constexpr uint16_t ShNum = 6;
-  static constexpr uint16_t ShStrNdx = 5;
+  static constexpr uint64_t SymCount = 2;
   static constexpr uint32_t TestLdsSize = 16384;
 
-  // ELF header.
-  Buf[0] = 0x7f;
-  Buf[1] = 'E';
-  Buf[2] = 'L';
-  Buf[3] = 'F';
-  Buf[4] = llvm::ELF::ELFCLASS64;
-  Buf[5] = llvm::ELF::ELFDATA2LSB;
-  Buf[6] = llvm::ELF::EV_CURRENT;
-  Buf[7] = llvm::ELF::ELFOSABI_AMDGPU_HSA;
-
-  uint16_t EType = llvm::ELF::ET_REL;
-  std::memcpy(Buf + 16, &EType, 2);
-  uint16_t EMachine = llvm::ELF::EM_AMDGPU;
-  std::memcpy(Buf + 18, &EMachine, 2);
-  uint32_t EVersion = llvm::ELF::EV_CURRENT;
-  std::memcpy(Buf + 20, &EVersion, 4);
-  uint64_t ShOffVal = ShOff;
-  std::memcpy(Buf + 40, &ShOffVal, 8);
-  uint16_t EhSize = 64;
-  std::memcpy(Buf + 52, &EhSize, 2);
-  uint16_t ShEntSize = 64;
-  std::memcpy(Buf + 58, &ShEntSize, 2);
-  uint16_t ShNumVal = ShNum;
-  std::memcpy(Buf + 60, &ShNumVal, 2);
-  uint16_t ShStrNdxVal = ShStrNdx;
-  std::memcpy(Buf + 62, &ShStrNdxVal, 2);
-
   // Section name string table. Entries: "" .text .rodata .strtab .symtab
-  // .shstrtab. Offsets pinned in the shdr writes below.
+  // .shstrtab. Offsets pinned in the shdr fields below.
   const char ShStrTab[] = "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
   std::memcpy(Buf + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
 
@@ -187,43 +128,88 @@ TEST(ElfView, GetKernelLdsSizeReadsLdsSizeFromKernelDescriptor) {
   const char StrTab[] = "\0test_kernel.kd\0";
   std::memcpy(Buf + StrTabOff, StrTab, sizeof(StrTab));
 
-  // Section header table.
-  uint8_t *Sh = Buf + ShOff;
-  // Shdr[0] = NULL section (already zeroed).
-  // Shdr[1] = .text, name offset 1.
-  writeShdr(Sh + 1 * 64, 1, llvm::ELF::SHT_PROGBITS,
-            llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR, TextOff, TextSize,
-            0, 0);
-  // Shdr[2] = .rodata, name offset 7.
-  writeShdr(Sh + 2 * 64, 7, llvm::ELF::SHT_PROGBITS, llvm::ELF::SHF_ALLOC,
-            RodataOff, KdSize, 0, 0);
-  // Shdr[3] = .strtab, name offset 15.
-  writeShdr(Sh + 3 * 64, 15, llvm::ELF::SHT_STRTAB, 0, StrTabOff,
-            sizeof(StrTab), 0, 0);
-  // Shdr[4] = .symtab, name offset 23; sh_link = 3 (.strtab), sh_entsize = 24
-  // (Elf64_Sym).
-  writeShdr(Sh + 4 * 64, 23, llvm::ELF::SHT_SYMTAB, 0, SymTabOff,
-            SymEntSize * SymCount, 3, SymEntSize);
-  // Shdr[5] = .shstrtab, name offset 31.
-  writeShdr(Sh + 5 * 64, 31, llvm::ELF::SHT_STRTAB, 0, ShStrTabOff,
-            sizeof(ShStrTab), 0, 0);
+  Elf64_Ehdr Ehdr{};
+  Ehdr.e_ident[0] = 0x7f;
+  Ehdr.e_ident[1] = 'E';
+  Ehdr.e_ident[2] = 'L';
+  Ehdr.e_ident[3] = 'F';
+  Ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  Ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
+  Ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_REL;
+  Ehdr.e_machine = EM_AMDGPU;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = 6;
+  Ehdr.e_shstrndx = 5;
+  std::memcpy(Buf, &Ehdr, sizeof(Ehdr));
+
+  // Section header table. Shdr[0] is the conventional NULL section (left
+  // as the buffer's zero-init). Each non-null shdr is zero-initialized by
+  // Elf64_Shdr{} so unspecified fields (sh_addr, sh_info, sh_addralign,
+  // ...) are explicitly zero.
+
+  // Shdr[1] = .text
+  Elf64_Shdr Sh1{};
+  Sh1.sh_name = 1;
+  Sh1.sh_type = SHT_PROGBITS;
+  Sh1.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  Sh1.sh_offset = TextOff;
+  Sh1.sh_size = TextSize;
+  std::memcpy(Buf + ShOff + 1 * sizeof(Elf64_Shdr), &Sh1, sizeof(Sh1));
+
+  // Shdr[2] = .rodata (holds the kernel descriptor)
+  Elf64_Shdr Sh2{};
+  Sh2.sh_name = 7;
+  Sh2.sh_type = SHT_PROGBITS;
+  Sh2.sh_flags = SHF_ALLOC;
+  Sh2.sh_offset = RodataOff;
+  Sh2.sh_size = KdSize;
+  std::memcpy(Buf + ShOff + 2 * sizeof(Elf64_Shdr), &Sh2, sizeof(Sh2));
+
+  // Shdr[3] = .strtab (symbol names)
+  Elf64_Shdr Sh3{};
+  Sh3.sh_name = 15;
+  Sh3.sh_type = SHT_STRTAB;
+  Sh3.sh_offset = StrTabOff;
+  Sh3.sh_size = sizeof(StrTab);
+  std::memcpy(Buf + ShOff + 3 * sizeof(Elf64_Shdr), &Sh3, sizeof(Sh3));
+
+  // Shdr[4] = .symtab; sh_link = 3 (.strtab)
+  Elf64_Shdr Sh4{};
+  Sh4.sh_name = 23;
+  Sh4.sh_type = SHT_SYMTAB;
+  Sh4.sh_offset = SymTabOff;
+  Sh4.sh_size = sizeof(Elf64_Sym) * SymCount;
+  Sh4.sh_link = 3;
+  Sh4.sh_entsize = sizeof(Elf64_Sym);
+  std::memcpy(Buf + ShOff + 4 * sizeof(Elf64_Shdr), &Sh4, sizeof(Sh4));
+
+  // Shdr[5] = .shstrtab (section names)
+  Elf64_Shdr Sh5{};
+  Sh5.sh_name = 31;
+  Sh5.sh_type = SHT_STRTAB;
+  Sh5.sh_offset = ShStrTabOff;
+  Sh5.sh_size = sizeof(ShStrTab);
+  std::memcpy(Buf + ShOff + 5 * sizeof(Elf64_Shdr), &Sh5, sizeof(Sh5));
 
   // Kernel descriptor body: group_segment_fixed_size at offset 0. The rest
   // of the 64-byte descriptor stays zero, which is fine for a read-only
   // helper that only consumes one field.
   std::memcpy(Buf + RodataOff, &TestLdsSize, sizeof(TestLdsSize));
 
-  // Symbol table. Slot 0 is the conventional null symbol. Slot 1 names
-  // "test_kernel.kd" (st_name=1), binding STB_GLOBAL + type STT_OBJECT in
-  // st_info, shndx=2 (.rodata), st_value=0 (start of .rodata), st_size=64.
-  uint8_t *Sym1 = Buf + SymTabOff + SymEntSize;
-  uint32_t StName = 1;
-  std::memcpy(Sym1 + 0, &StName, 4);
-  Sym1[4] = (llvm::ELF::STB_GLOBAL << 4) | llvm::ELF::STT_OBJECT;
-  uint16_t StShndx = 2;
-  std::memcpy(Sym1 + 6, &StShndx, 2);
-  uint64_t StSize = KdSize;
-  std::memcpy(Sym1 + 16, &StSize, 8);
+  // Symbol table. Slot 0 is the conventional null symbol (left as the
+  // buffer's zero-init). Slot 1 names "test_kernel.kd" at .strtab offset 1
+  // and points at the start of .rodata (st_value=0).
+  Elf64_Sym Sym1{};
+  Sym1.st_name = 1;
+  Sym1.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  Sym1.st_shndx = 2;
+  Sym1.st_size = KdSize;
+  std::memcpy(Buf + SymTabOff + 1 * sizeof(Elf64_Sym), &Sym1, sizeof(Sym1));
 
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf, BufSize);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -28,19 +28,21 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
-// -- ElfView::getKernelLdsSize ------------------------------------------------
+// -- ElfView::getKernelStaticLdsSize ------------------------------------------
 //
-// getKernelLdsSize reads group_segment_fixed_size from a kernel descriptor
-// symbol "<KernelName>.kd". Two unit tests cover the helper:
+// getKernelStaticLdsSize reads group_segment_fixed_size (the *static* LDS
+// allocation; dynamic LDS is set by the host at dispatch time and not
+// visible in the ELF) from a kernel descriptor symbol "<KernelName>.kd".
+// Two unit tests cover the helper:
 //   * negative path: no .kd symbol -> std::nullopt
 //   * positive path: hand-crafted ELF with a .kd symbol pointing at an
 //                    embedded kernel descriptor -> the embedded LDS size
 // Real gfx1250 code-object coverage is added by the lit tests in #2302.
 
-TEST(ElfView, GetKernelLdsSizeReturnsNulloptWhenKdMissing) {
+TEST(ElfView, GetKernelStaticLdsSizeReturnsNulloptWhenKdMissing) {
   // Build a minimal valid ELF64: header + .text + .shstrtab. ELFFile::create
-  // succeeds, but no .kd symbol exists, so getKernelLdsSize must take the
-  // missing-KD branch.
+  // succeeds, but no .kd symbol exists, so getKernelStaticLdsSize must take
+  // the missing-KD branch.
   using namespace llvm::ELF;
   static constexpr size_t BufSize = 512;
   alignas(8) uint8_t Buf[BufSize] = {};
@@ -91,16 +93,17 @@ TEST(ElfView, GetKernelLdsSizeReturnsNulloptWhenKdMissing) {
 
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf, BufSize);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  EXPECT_EQ(ViewOrErr->getKernelLdsSize("nonexistent_kernel"), std::nullopt);
+  EXPECT_EQ(ViewOrErr->getKernelStaticLdsSize("nonexistent_kernel"),
+            std::nullopt);
 }
 
-TEST(ElfView, GetKernelLdsSizeReadsLdsSizeFromKernelDescriptor) {
+TEST(ElfView, GetKernelStaticLdsSizeReadsLdsSizeFromKernelDescriptor) {
   // Build a minimal AMDGPU ELF64 with the section topology that
   // findKernelDescriptor walks: 6 sections (NULL, .text, .rodata, .strtab,
   // .symtab, .shstrtab). The kernel descriptor is embedded at the start of
   // .rodata with a known group_segment_fixed_size value, and a symbol named
-  // "test_kernel.kd" in .symtab points at it. getKernelLdsSize must return
-  // the embedded LDS size unchanged.
+  // "test_kernel.kd" in .symtab points at it. getKernelStaticLdsSize must
+  // return the embedded static-LDS size unchanged.
   using namespace llvm::ELF;
   static constexpr size_t BufSize = 1024;
   alignas(8) uint8_t Buf[BufSize] = {};
@@ -213,7 +216,8 @@ TEST(ElfView, GetKernelLdsSizeReadsLdsSizeFromKernelDescriptor) {
 
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf, BufSize);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  std::optional<uint32_t> Lds = ViewOrErr->getKernelLdsSize("test_kernel");
+  std::optional<uint32_t> Lds =
+      ViewOrErr->getKernelStaticLdsSize("test_kernel");
   ASSERT_TRUE(Lds.has_value());
   EXPECT_EQ(*Lds, TestLdsSize);
 }


### PR DESCRIPTION
Adds a small `ElfView` helper that reads `group_segment_fixed_size` from the kernel descriptor symbol `<KernelName>.kd`. Returns` std::nullopt` when the descriptor symbol is missing.

Split out as a precursor to the `ds_*_addtid_b32` trampoline patch (PR #2302). That patch will use the helper to gate a diagnostic for kernels with LDS allocations larger than the A0 16-bit M0 truncation limit.

Unit test `ElfView.GetKernelLdsSizeReturnsNulloptWhenKdMissing` covers the missing-descriptor path with a hand-crafted minimal ELF; the positive path will be exercised through lit once a consumer lands.