### PR TITLE
[AMDGPU] comgr: Preserve drain s_wait_dscnt in bumpNextWaitDscnt

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -258,14 +258,17 @@ std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
 //
 // After splitting one DS 2-addr instruction into two, the next s_wait_dscnt
 // in the same straight-line block must be incremented by 1 to account for the
-// extra outstanding DS operation.
+// extra outstanding DS operation -- except when the wait is a drain
+// (s_wait_dscnt 0), which must stay a drain after any number of splits
+// (relaxing it would let split halves escape; see #2585 for the deferred
+// general non-drain refinement).
 //
 // Returns true if a wait was found and bumped, false otherwise.
 //
 // If the wait is past a branch or join point, we conservatively do nothing:
 // the compiler guarantees a straight-line s_wait_dscnt follows each DS op in
 // well-formed kernels. If absent (e.g. s_endpgm terminates first), skipping
-// the bump is safe — the hardware wait counter saturates harmlessly.
+// the bump is safe -- the hardware wait counter saturates harmlessly.
 
 bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
   const MCInstrInfo &MCII = *Ctx.LS.MCII;
@@ -288,13 +291,19 @@ bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
       continue;
 
     // s_wait_dscnt has a single immediate operand (the wait count) at
-    // index 0. Increment it directly.
+    // index 0; increment it directly. The drain case is handled below.
     if (DI.Inst.getNumOperands() == 0)
       return false;
     MCInst NewInst = DI.Inst;
     MCOperand &Op = NewInst.getOperand(0);
     if (!Op.isImm())
       return false;
+    if (Op.getImm() == 0)
+      return false;
+    // TODO(#2585): the +1 is conservative for K > 0 -- it over-bumps splits
+    // of "must-complete" ops at the wait. That's suboptimal stall behavior,
+    // never a hazard. The drain (K == 0) over-bump WOULD be a hazard and is
+    // handled above; the general fix needs outstanding-DS analysis.
     Op.setImm(Op.getImm() + 1);
 
     SmallVector<char, 8> Bytes;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -259,9 +259,12 @@ std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
 // After splitting one DS 2-addr instruction into two, the next s_wait_dscnt
 // in the same straight-line block must be incremented by 1 to account for the
 // extra outstanding DS operation -- except when the wait is a drain
-// (s_wait_dscnt 0), which must stay a drain after any number of splits
-// (relaxing it would let split halves escape; see #2585 for the deferred
-// general non-drain refinement).
+// (s_wait_dscnt 0), which must stay a drain after any number of splits.
+// Relaxing a drain would let the split halves escape into a downstream data
+// hazard, so drains are preserved verbatim and only non-drain (K > 0) waits
+// are bumped here. A general dataflow-based bump (computed from the live
+// outstanding-DS count at the wait site) would subsume both cases; that
+// refinement is deferred and tracked outside the source tree.
 //
 // Returns true if a wait was found and bumped, false otherwise.
 //
@@ -300,10 +303,12 @@ bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
       return false;
     if (Op.getImm() == 0)
       return false;
-    // TODO(#2585): the +1 is conservative for K > 0 -- it over-bumps splits
-    // of "must-complete" ops at the wait. That's suboptimal stall behavior,
-    // never a hazard. The drain (K == 0) over-bump WOULD be a hazard and is
-    // handled above; the general fix needs outstanding-DS analysis.
+    // The +1 here is conservative for K > 0: it over-bumps splits of
+    // "must-complete" operations at the wait site. That is a suboptimal
+    // stall, never a correctness hazard. The drain (K == 0) over-bump
+    // WOULD be a hazard and is handled by the early return above. A
+    // precise replacement needs outstanding-DS dataflow at the wait
+    // site, which subsumes the drain special-case naturally.
     Op.setImm(Op.getImm() + 1);
 
     SmallVector<char, 8> Bytes;

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
@@ -1,6 +1,7 @@
-// COM: Test multi-DS stacking: two ds_load_2addr_stride64_b32 sites
-// COM: before a single s_wait_dscnt. Each expansion bumps the wait by 1,
-// COM: so the final counter should be 0x2 (not 0x1).
+// COM: Test multi-DS stacking against a drain s_wait_dscnt: two
+// COM: ds_load_2addr_stride64_b32 sites share a single s_wait_dscnt 0x0,
+// COM: which must stay at 0x0 across both splits. The non-drain bump path
+// COM: is covered by hotswap-trampoline-ds-pipelined.s.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -13,12 +14,12 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
 // COM: Both DS2 instructions are replaced by s_branch to their respective
-// COM: expansion sleds. The single s_wait_dscnt is bumped twice (0x0 -> 0x2).
+// COM: expansion sleds; the shared drain wait stays at 0x0.
 // DISASM-LABEL: <test_multi_ds>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x2
+// DISASM: s_wait_dscnt 0x0
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -14,12 +14,12 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: The original DS2 is gone; s_branch forward replaces it. The bumped
-// COM: s_wait_dscnt stays at the original position.
+// COM: The original DS2 is gone; s_branch forward replaces it. The drain
+// COM: s_wait_dscnt stays at the original position with imm unchanged (0x0).
 // DISASM-LABEL: <test_ds_trampoline>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x1
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_endpgm
 
 // COM: Trampoline body appended after .text: expanded DS loads + branch-back.

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
@@ -1,0 +1,119 @@
+// COM: Test HotSwap trampoline patch: non-drain s_wait_dscnt bump path.
+// COM: Inputs use s_wait_dscnt 0x1 (pipelined wait permitting one in-flight
+// COM: DS op), so each DS 2-addr split must increment the imm by 1. Inverse
+// COM: of hotswap-trampoline-ds.s, which exercises drain preservation.
+// COM:
+// COM:   Kernel 1: one DS2 split  + s_wait_dscnt 0x1 -> bumped to 0x2.
+// COM:   Kernel 2: two DS2 splits + s_wait_dscnt 0x1 -> bumped to 0x3.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Kernel 1 (single split, +1 bump): one DS2 -> s_branch and the wait
+// COM: incremented from 0x1 to 0x2.
+// DISASM-LABEL: <test_ds_pipelined_single>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x2
+// DISASM: ds_load_b32 v0
+// DISASM: ds_load_b32 v1
+// DISASM: s_branch
+
+// COM: Kernel 2 (two splits, +2 bump): two DS2 sites share one wait, which
+// COM: is bumped twice from 0x1 to 0x3.
+// DISASM-LABEL: <test_ds_pipelined_multi>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_branch
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x3
+
+// COM: Idempotency: a second rewrite must not bump 0x2 / 0x3 further.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// ---- Kernel 1: single split, +1 bump (0x1 -> 0x2) ---------------------------
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_pipelined_single
+.p2align 8
+.type test_ds_pipelined_single,@function
+test_ds_pipelined_single:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x1
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_pipelined_single_end:
+.size test_ds_pipelined_single, .Ltest_ds_pipelined_single_end-test_ds_pipelined_single
+
+// ---- Kernel 2: two splits, +2 bump (0x1 -> 0x3) -----------------------------
+
+.globl test_ds_pipelined_multi
+.p2align 8
+.type test_ds_pipelined_multi,@function
+test_ds_pipelined_multi:
+  ds_load_2addr_stride64_b32 v[0:1], v4 offset0:0 offset1:1
+  ds_load_2addr_stride64_b32 v[2:3], v4 offset0:2 offset1:3
+  s_wait_dscnt 0x1
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Ltest_ds_pipelined_multi_end:
+.size test_ds_pipelined_multi, .Ltest_ds_pipelined_multi_end-test_ds_pipelined_multi
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_pipelined_single
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds_pipelined_multi
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds.s
@@ -1,13 +1,17 @@
-// COM: Test HotSwap trampoline patch: ds_*_2addr_stride64_* expansion
-// COM: into two single-address DS instructions with s_wait_dscnt bump.
+// COM: Test HotSwap trampoline patch: ds_*_2addr_stride64_* expansion into
+// COM: two single-address DS instructions. Each kernel here uses a drain
+// COM: s_wait_dscnt 0x0, which must stay at 0x0 after splitting (see the
+// COM: bumpNextWaitDscnt header for the rationale).
+// COM:
 // COM: Covers b32 load, b64 load, b32 store, and b32 exchange operand
 // COM: variants via the NOP sled emission mechanism. Verifies explicit
 // COM: s_branch generation for the forward/back jumps.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-trampoline-ds-multi.s   — multi-DS stacking (bump accumulation)
-// COM:   hotswap-trampoline-ds-nosled.s  — true trampoline fallback (no NOP sled)
-// COM:   hotswap-trampoline-ds-nowait.s  — control-flow guard (no s_wait_dscnt)
+// COM:   hotswap-trampoline-ds-multi.s     -- drain preservation under stacking
+// COM:   hotswap-trampoline-ds-pipelined.s -- non-drain bump path (0x1 -> 0x2/0x3)
+// COM:   hotswap-trampoline-ds-nosled.s    -- true trampoline fallback (no NOP sled)
+// COM:   hotswap-trampoline-ds-nowait.s    -- control-flow guard (no s_wait_dscnt)
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -21,40 +25,40 @@
 
 // COM: --- Per-kernel checks ---
 
-// COM: Kernel 1 (b32 load): s_branch forward to sled, bumped wait stays
-// COM: at original position, expanded loads appear in sled area with
-// COM: s_branch back to the wait instruction.
+// COM: Kernel 1 (b32 load): s_branch forward to sled, the wait stays at the
+// COM: original position with imm unchanged (0x0), expanded loads appear in
+// COM: the sled area with s_branch back to the wait instruction.
 // DISASM-LABEL: <test_ds_load_b32>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x1
+// DISASM: s_wait_dscnt 0x0
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
 // DISASM: s_branch
 
-// COM: Kernel 2 (b64 load): b64 register pairs formatted as v[X:Y]
+// COM: Kernel 2 (b64 load): b64 register pairs formatted as v[X:Y].
 // DISASM-LABEL: <test_ds_load_b64>:
 // DISASM-NOT: ds_load_2addr_stride64_b64
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x1
+// DISASM: s_wait_dscnt 0x0
 // DISASM: ds_load_b64 v[0:1]
 // DISASM: ds_load_b64 v[2:3]
 // DISASM: s_branch
 
-// COM: Kernel 3 (b32 store): store operand layout (addr, data0, data1)
+// COM: Kernel 3 (b32 store): store operand layout (addr, data0, data1).
 // DISASM-LABEL: <test_ds_store_b32>:
 // DISASM-NOT: ds_store_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x1
+// DISASM: s_wait_dscnt 0x0
 // DISASM: ds_store_b32 v2, v0
 // DISASM: ds_store_b32 v2, v1
 // DISASM: s_branch
 
-// COM: Kernel 4 (b32 exchange): exchange operand layout (dst, addr, data)
+// COM: Kernel 4 (b32 exchange): exchange operand layout (dst, addr, data).
 // DISASM-LABEL: <test_ds_xchg_b32>:
 // DISASM-NOT: ds_storexchg_2addr_stride64_rtn_b32
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x1
+// DISASM: s_wait_dscnt 0x0
 // DISASM: ds_storexchg_rtn_b32 v0
 // DISASM: ds_storexchg_rtn_b32 v1
 // DISASM: s_branch

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -12,8 +12,6 @@
 
 using namespace COMGR::hotswap;
 
-// -- ElfView::create ----------------------------------------------------------
-
 TEST(ElfView, RejectsTruncatedInput) {
   uint8_t Garbage[] = {0x7f, 'E', 'L', 'F', 0, 0, 0, 0};
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(Garbage, sizeof(Garbage));

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -12,6 +12,8 @@
 
 using namespace COMGR::hotswap;
 
+// -- ElfView::create ----------------------------------------------------------
+
 TEST(ElfView, RejectsTruncatedInput) {
   uint8_t Garbage[] = {0x7f, 'E', 'L', 'F', 0, 0, 0, 0};
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(Garbage, sizeof(Garbage));


### PR DESCRIPTION
Follow-up to #2369. The split-aware wait bump was incrementing drains (s_wait_dscnt 0) along with bounded waits, relaxing them and letting split halves escape into a downstream data hazard. 
Skip the bump when imm == 0; non-drain waits still bump by +1.

This will unlock PR #2281.

(follow-up #2585): a small dataflow pass at the wait site computing the bump from `(outstanding-count-at-wait, K)`. It would subsume the drain special-case naturally and remove the `// TODO:` marker left in `bumpNextWaitDscnt`.