### PR TITLE
[Comgr][hotswap] Add setpc analysis + sync-translation doc

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(hotswap-transpiler OBJECT
   opcode-map.cpp
   decode.cpp
   wave-projection.cpp
+  setpc-analysis.cpp
 )
 
 if(NOT TARGET hotswap::transpiler)

--- a/amd/comgr/src/hotswap/docs/sync-translation.md
+++ b/amd/comgr/src/hotswap/docs/sync-translation.md
@@ -1,0 +1,555 @@
+# Sync Translation — Barriers, Waitcnt, Fences, Memory Scopes
+
+> **Status:** design proposal. Current raiser implements the 80% path
+> (unified-barrier lowering, waitcnt-as-no-op, SC atomics) which is
+> correct for workgroup-synchronous kernels that match LLVM's default
+> memory model. This doc specifies the remaining semantics and the
+> gates needed to refuse kernels whose synchronisation patterns fall
+> outside that model.
+>
+> **Scope:** gfx1250 → gfx950. The barrier split is gfx12-only in our
+> corpus, but the framework applies to any future ISA pair that
+> diverges on synchronisation primitives.
+
+---
+
+## 1. Problem in one paragraph
+
+The source binary encodes its synchronisation contract in five
+intertwined surfaces: (a) workgroup rendezvous (`s_barrier*`), (b)
+per-wave memory ordering (`s_waitcnt` and its split counterparts),
+(c) memory-scope tags on atomics and fences, (d) cache control
+(`global_inv`, `global_wb`, `buffer_inv`, …), and (e) cluster-level
+synchronisation for multi-XCD dispatches. The target ISA has a
+different primitive for each, and in several cases fewer primitives
+than the source. Translation must preserve the **observable
+happens-before graph** across waves and across memory, even when the
+syntactic primitives disappear. That reduces to: express every
+synchronisation act in LLVM IR at a semantic level the target
+backend will re-materialise correctly on its own ISA, and fail loudly
+when the source expresses something that has no LLVM-level
+equivalent.
+
+## 2. Why LLVM IR can carry most of this for us
+
+Three facts make the translation tractable:
+
+1. **LLVM owns waitcnt.** The backend inserts `s_waitcnt` at code
+   emission based on the IR's memory-model ordering of loads, stores,
+   and atomics. Any source-side `s_waitcnt` is redundant metadata
+   once we have the IR dependences right — the backend rebuilds it
+   for the target generation (unified `s_waitcnt` on gfx9, split
+   counters on gfx12). This is why `handle_sopp.cpp:94` treats
+   waitcnt as a no-op. Current correctness notes do not attribute any
+   tracked Hotswap regression to dropped source waitcnts.
+2. **LLVM owns atomic ordering and scope.** `AtomicOrdering` +
+   `syncscope` are IR-level tags; the backend maps them to target
+   cache-control bits (`glc`, `slc`, `dlc`, `scc` on CDNA;
+   `th`/`scope` on gfx12). As long as the raiser tags atomics with
+   the right (ordering, scope) pair, cross-ISA translation is
+   automatic.
+3. **Workgroup barriers are an intrinsic.** `llvm.amdgcn.s.barrier`
+   is a stable cross-ISA intrinsic that lowers to the right barrier
+   family on every target. That covers the 80% path where every wave
+   in the workgroup reaches every barrier.
+
+The remaining 20% is the set of source patterns that do *not* reduce
+to those IR primitives. Named barriers, fences with non-standard
+scopes, and multi-XCD cluster sync are the cases we must refuse.
+
+## 3. Source model — gfx1250 (gfx12)
+
+### 3.1 Split barriers
+
+gfx12 replaced the monolithic `s_barrier` with two primitives:
+
+- `s_barrier_signal imm16` — signals barrier `imm16`; does not
+  block the wave. Lanes continue executing.
+- `s_barrier_wait imm16` — blocks the wave until barrier `imm16`
+  has been signalled by the required number of waves.
+
+`imm16` is a barrier resource index (0..31 typical; 0 is the default
+workgroup barrier that behaves like the legacy unified `s_barrier`).
+Additional barrier resources (named barriers) can be set up at launch
+time to coordinate subsets of waves — the canonical use case is
+Triton's `warp_specialize` where producer and consumer waves rendezvous
+on different named barriers.
+
+SemOps: `S_BARRIER`, `S_BARRIER_SIGNAL`, `S_BARRIER_WAIT`
+(`semop.hpp:24`).
+
+### 3.2 Split wait counters
+
+gfx12 split the combined `s_waitcnt` into category-specific waits:
+
+- `s_wait_loadcnt N` — VMEM loads outstanding ≤ N
+- `s_wait_storecnt N` — VMEM stores outstanding ≤ N
+- `s_wait_dscnt N` — LDS ops outstanding ≤ N
+- `s_wait_kmcnt N` — SMEM / kernarg loads outstanding ≤ N
+- `s_wait_xcnt N` — export/message count ≤ N
+- `s_wait_loadcnt_dscnt` — fused LOAD + DS wait
+- `s_wait_alu imm16` — VALU dependency wait (gfx12 specific)
+- `s_delay_alu`, `s_clause` — scheduling hints, not memory waits
+
+SemOps: all enumerated at `semop.hpp:18-20`.
+
+### 3.3 Atomic memory scopes
+
+gfx12 atomics carry a two-level scope+scope-of-return encoding in
+`th`/`scope` instruction modifiers. The typical scopes used by Triton
+/ Gluon kernels:
+
+- `agent` (device-scope) — for cross-workgroup atomics
+- `workgroup` — for cross-wave-within-workgroup atomics (rare; LDS
+  atomics cover most of these)
+- `wavefront` — for cross-lane atomics (usually absent; LDS suffices)
+
+The source code's intent is carried by how Triton compiles its
+`atomic_add(..., sem="release", scope="gpu")` etc. down to MC
+instructions. The raiser must recover that intent.
+
+### 3.4 Cache control
+
+Stand-alone cache operations:
+
+- `global_inv scope` — invalidate a cache level
+- `global_wb scope` — write back a cache level
+- `global_wbinv scope` — both
+- `buffer_inv scope` — same for buffer/V# accesses
+
+These exist on gfx12 as first-class SOPP/FLAT instructions. They do
+not have SemOps today. They appear in the kerneldex histograms for
+some GPT-OSS kernels (RCP, softmax normalisation patterns).
+
+### 3.5 Cluster barriers (multi-XCD)
+
+gfx12 with multi-XCD SKUs exposes `cluster.arrive` / `cluster.wait`
+via Gluon; these compile to a coordinated DS-based barrier across
+XCDs. Not present in the captured corpus; listed for gate
+completeness.
+
+## 4. Target model — gfx950 (CDNA4)
+
+### 4.1 What gfx950 has
+
+- `s_barrier` — unified monolithic barrier. All waves in workgroup
+  arrive, all leave. No named barriers.
+- `s_waitcnt vmcnt(N) lgkmcnt(N) expcnt(N)` — combined, three
+  counters. The backend inserts these.
+- `AtomicOrdering` + `syncscope(…)` lower to `glc`, `slc`, `dlc`,
+  `scc` bits on the atomic.
+- `buffer_wbinvl1`, `buffer_wbinvl1_vol`, `buffer_wbl2` — cache
+  control at L1/L2. Each is a SOPP instruction the backend emits.
+- LDS atomics supported natively; cross-wave sync is via
+  `s_barrier` + LDS.
+
+### 4.2 What gfx950 does *not* have
+
+- Named / split barriers. Only one workgroup rendezvous per
+  `s_barrier`.
+- Split wait counters.
+- Cluster sync across XCDs. Multi-XCD coordination on CDNA is done
+  at the CU scheduling level; there is no in-kernel primitive.
+- `s_wait_alu`. The gfx950 backend resolves VALU hazards with
+  register-read stall cycles, not explicit waits.
+
+## 5. Translation design — per primitive
+
+### 5.0 Target-capability dispatch (native vs. collapse)
+
+Every sync primitive in the source has a target-capability branch that
+mirrors the matrix axis (`matrix-translation.md §5.0`): emit the same
+primitive natively when the target supports it, and decompose (or
+collapse, or refuse) when it does not.
+
+The sync axis is distinct in that some primitives are **added** in
+gfx12 (split barriers, split wait counters, `s_wait_alu`), while
+others are **shared** (atomic scopes via LLVM's `syncscope`, workgroup
+barrier). The dispatch table is therefore denser than for matrix.
+
+#### 5.0.1 Capability bits
+
+Extend `ISAProfile` with:
+
+| New bit | Backing feature | Governs |
+|---|---|---|
+| `hasSplitBarriers` | `FeatureGFX12Insts` (split `s_barrier_signal` / `s_barrier_wait`) | §5.1 |
+| `hasSplitWaitCnt` | `FeatureGFX12Insts` (split `s_wait_loadcnt`, `s_wait_dscnt`, …) | §5.2 |
+| `hasSWaitAlu` | `FeatureGFX12Insts` (`s_wait_alu`) | §5.2 |
+| `hasClusterBarriers` | `FeatureClusters` (upstream TableGen name) | §5.5 |
+
+`hasCacheScopedOps` (for `global_inv` / `global_wb` / …) is not a
+separate bit — gfx950 and gfx12 have overlapping but non-identical
+families. §5.4 handles the per-op mapping instead of treating it as
+one capability.
+
+#### 5.0.2 Dispatch table
+
+| Source primitive | Target has capability | Action | Target lacks capability | Action |
+|---|---|---|---|---|
+| `S_BARRIER_SIGNAL/WAIT` (`imm16=0`) | `hasSplitBarriers` | emit split intrinsic pair (§5.1.a) | — | collapse to `llvm.amdgcn.s.barrier` (§5.1.b, existing) |
+| `S_BARRIER_SIGNAL/WAIT` (`imm16≠0`) | `hasSplitBarriers` | emit named-barrier intrinsic (§5.1.a) | — | **refuse** (`namedBarrierUnsupported`; §5.1) |
+| `S_WAIT_{LOAD,STORE,DS,KM,X}CNT` | `hasSplitWaitCnt` | emit matching `llvm.amdgcn.s.waitcnt.*` | — | no-op (backend re-derives on combined counter) (§5.2) |
+| `S_WAIT_ALU` | `hasSWaitAlu` | emit native intrinsic | — | no-op (backend handles VALU hazards) (§5.2) |
+| `S_BARRIER` (monolithic) | always (every AMDGPU target) | emit `llvm.amdgcn.s.barrier` | — | — |
+| Atomics with `(ordering, scope)` | always (LLVM IR is shared) | emit `atomicrmw` with tags (§5.3) | — | — |
+| `GLOBAL_INV/WB/WBINV`, `BUFFER_INV` | per-target table (§5.4) | emit matching intrinsic | — | refuse |
+| Cluster barriers | `hasClusterBarriers` | emit cluster intrinsic pair | — | refuse (§5.5) |
+
+#### 5.0.3 Consequences for same-family retarget
+
+The gfx1251 → gfx1250 path takes the native branch for every sync
+primitive: split barriers stay split, split wait counters stay split,
+`s_wait_alu` stays, and atomics keep their decoded `(ordering, scope)`
+tuple. The "collapse" paths below (§5.1.b's monolithic barrier,
+§5.2's no-op waitcnt) are reached only when targeting pre-gfx12 ISAs
+like gfx942/gfx950. Same as matrix: there is no fast path in the
+byte-patching sense — the capability branch above **is** the fast
+path.
+
+### 5.1 Barriers
+
+#### 5.1.a Native split path — `hasSplitBarriers` targets
+
+When the target ISA also exposes split barriers (gfx12+), emit the
+split intrinsic pair directly:
+
+```cpp
+if (sop == SemOp::S_BARRIER_SIGNAL && ctx.targetIsa.hasSplitBarriers) {
+  auto *fn = Intrinsic::getOrInsertDeclaration(
+      &ctx.M, Intrinsic::amdgcn_s_barrier_signal);
+  ctx.B.CreateCall(fn, {ctx.B.getInt32(di.getImm(0))});
+  hr.handled = true;
+  return hr;
+}
+if (sop == SemOp::S_BARRIER_WAIT && ctx.targetIsa.hasSplitBarriers) {
+  auto *fn = Intrinsic::getOrInsertDeclaration(
+      &ctx.M, Intrinsic::amdgcn_s_barrier_wait);
+  ctx.B.CreateCall(fn, {ctx.B.getInt32(di.getImm(0))});
+  hr.handled = true;
+  return hr;
+}
+```
+
+The `imm16` barrier resource id passes through unchanged — named
+barriers are valid on split-capable targets. G1 (§7) only fires on
+pre-gfx12 targets where the collapse in §5.1.b cannot represent them.
+
+#### 5.1.b Collapse path — pre-gfx12 targets (existing policy)
+
+When the target is pre-gfx12 (`!hasSplitBarriers`), collapse the split
+primitives to the monolithic barrier. Current implementation in
+`handle_sopp.cpp:70-84`:
+
+- `S_BARRIER`, `S_BARRIER_WAIT` → `call void @llvm.amdgcn.s.barrier()`
+- `S_BARRIER_SIGNAL` → no-op (handled = true; emits nothing)
+
+This is correct iff the source uses the **default barrier resource
+(0)** exclusively and *every* wave reaches *every* signal and wait.
+Under that restriction, the wait becomes a full workgroup barrier and
+the signal is redundant with respect to the wait. Since every wave
+signals before it waits, the combined behaviour matches a monolithic
+`s_barrier`.
+
+It is incorrect in three cases:
+
+| Case | Why it breaks |
+|---|---|
+| `imm16 != 0` | Source uses named barriers to rendezvous a **subset** of waves. Monolithic lowering rendezvouses all waves, overclosing the happens-before graph and deadlocking if some waves never reach this wait. |
+| Producer signals `imm16=0` but consumer waits on `imm16=1` (or vice versa) | Different barrier identities — collapsing to one barrier reconverges waves that source kept divergent. |
+| One wave signals twice without a wait in between | The signal count matters for named barriers. The collapse loses that. |
+
+**Refinement:** the named-barrier refusal only applies on the
+collapse path. Per-kernel gate: if `!targetIsa.hasSplitBarriers` and
+any `S_BARRIER_SIGNAL` / `S_BARRIER_WAIT` instruction has `imm16 != 0`,
+refuse with `RaiseFailure::namedBarrierUnsupported`. When the target
+has split barriers, named barriers pass through unchanged via §5.1.a.
+
+At the raiser level that means:
+
+```cpp
+if (sop == SemOp::S_BARRIER_SIGNAL || sop == SemOp::S_BARRIER_WAIT) {
+  int64_t barrierId = di.getImm(0);
+  if (ctx.targetIsa.hasSplitBarriers) {
+    // §5.1.a: native split path, barrierId preserved
+    return emitNativeSplitBarrier(ctx, sop, barrierId);
+  }
+  if (barrierId != 0)
+    return HandlerResult::fail(
+        RaiseFailure::namedBarrierUnsupported(di, barrierId));
+  // else: fall through to existing collapse policy (§5.1.b)
+}
+```
+
+Named barriers are the **load-bearing primitive** of Triton's
+`warp_specialize`. Refusing on the collapse path is the correct
+behaviour for pre-gfx12 targets until we have a real producer/consumer
+model in IR; on gfx12+ targets the primitive exists and we pass it
+through.
+
+### 5.2 Wait counters
+
+#### 5.2.a Native split path — `hasSplitWaitCnt` targets
+
+When the target also has split counters (gfx12+), preserve them
+directly. Each `S_WAIT_*CNT` SemOp maps 1:1 to
+`llvm.amdgcn.s.waitcnt.*`; `S_WAIT_ALU` lowers when `hasSWaitAlu` is
+set. The backend re-emits the same mnemonic on output. No information
+is discarded.
+
+#### 5.2.b No-op collapse path — pre-gfx12 targets (existing policy)
+
+When the target has only the combined counter (`!hasSplitWaitCnt`),
+all waitcnt SemOps fall through as no-ops (`handle_sopp.cpp:94`). The
+backend's memory-model-driven waitcnt insertion on gfx950 replaces
+them.
+
+This is correct on two conditions:
+
+1. The raised IR faithfully represents every memory dependence the
+   source's waitcnt was protecting. That is the default: `load` and
+   `store` SSA values carry dependences, and the backend inserts
+   `s_waitcnt` in the output.
+2. No waitcnt is acting as a **cross-wave** barrier. Waitcnt is a
+   per-wave primitive by definition, so this is tautologically true —
+   but some programming styles use `s_waitcnt` + volatile memory
+   accesses to implement a hand-rolled producer/consumer across
+   waves. That pattern requires a barrier, not a waitcnt, and if a
+   kernel relies on it we would detect it only empirically.
+
+**No rewrite needed.** The sem_op_attrs row for every waitcnt SemOp
+sets `isScheduleHint = true` (a new attr bit) and the raiser's
+per-kernel gate verifies that is the final classification. If a
+future waitcnt variant has real IR-level semantics (e.g., the gfx12
+`s_wait_alu` with VALU dependency tracking that the backend's memory
+model does not capture), add a new attr bit and a handler, don't
+special-case inline.
+
+### 5.3 Atomic memory scopes
+
+Current policy (`handle_flat.cpp:291` etc.): every atomic emits
+`AtomicOrdering::SequentiallyConsistent` (for `atomicrmw`) or
+`Monotonic` (for `cmpxchg`), with the default `syncscope` (system).
+
+This is **conservative-correct for gfx950**: SC + system emits the
+strongest cache-flush pattern, which subsumes every weaker scope the
+source could have wanted. It is also **performance-wrong** for the
+common Triton case where the source intent is `release`
+`agent`-scope. For correctness of the translated kernel, the
+conservative policy ships today; for parity with the source's
+performance, we need to recover the source intent from the gfx12
+th/scope bits.
+
+**Refinement:** extend `DecodedInst` with parsed `(scope, ordering)`
+fields from the gfx12 th/scope modifiers, and use them in
+`handle_flat.cpp` / `handle_mubuf.cpp` when emitting `atomicrmw`.
+The mapping table:
+
+| gfx12 encoding | IR ordering | IR syncscope |
+|---|---|---|
+| `th=0, scope=CU` | `monotonic` | `"workgroup-one-as"` |
+| `th=0, scope=DEV` | `monotonic` | `"agent-one-as"` |
+| `th=0, scope=SYS` | `monotonic` | `""` (system) |
+| `th=RT (release)` | `release` | <scope as above> |
+| `th=NT (nontemporal)` | `monotonic` | scope + nontemporal metadata |
+| `th=HT (high temporal)` | `monotonic` | scope (no extra tag) |
+| `th=BYPASS` | `monotonic` | scope, plus `!nontemporal` |
+
+The `"-one-as"` scope variants are the AMDGPU-specific single-address-
+space scopes; they lower correctly on both gfx12 and gfx9.
+
+**Refusal case:** a scope the target does not support. `wavefront`
+scope is not a standard LLVM AMDGPU scope — reject until the
+AMDGPULowerMemoryModel pass learns it.
+
+### 5.4 Standalone cache operations
+
+These SemOps do not yet exist. Adding them is the first real ISA
+divergence handled at the sync-translation level:
+
+| New SemOp | gfx12 source | gfx950 lowering |
+|---|---|---|
+| `GLOBAL_INV` | `global_inv scope` | `call void @llvm.amdgcn.buffer.wbinvl1()` for CU/DEV; refuse SYS |
+| `GLOBAL_WB` | `global_wb scope` | `call void @llvm.amdgcn.buffer.wbl2()` for DEV |
+| `GLOBAL_WBINV` | `global_wbinv scope` | composition of the two |
+| `BUFFER_INV` | `buffer_inv scope` | same as `GLOBAL_INV` on gfx950 (unified L1) |
+
+If the source's `scope` is not representable with the target's
+intrinsics (e.g., gfx950 has no per-XCD cache op), refuse.
+
+Most Triton/Gluon kernels never emit standalone cache ops — the
+AMDGPULowerMemoryModel pass derives them from atomic ordering+scope.
+We still need the SemOps so we can catch hand-written kernels (like
+some Tensilelite persistent GEMMs) that emit them explicitly.
+
+### 5.5 Cluster barriers
+
+Not yet a SemOp. Cluster sync compiles to `ds_wrap_rtn_b32` +
+`s_waitcnt_vscnt` + a coordinated write-back pattern. Dispatched by
+`ISAProfile::hasClusterBarriers`:
+
+- **Target has cluster barriers** → preserve the primitive (emit the
+  Gluon-level cluster intrinsic pair, `cluster.arrive` /
+  `cluster.wait`).
+- **Target lacks cluster barriers** → refuse. Multi-XCD coordination
+  has no intra-kernel equivalent on pre-cluster ISAs.
+
+Detectable at decode via `hidden_cluster_size` or the Gluon-emitted
+pattern at the disassembly level. Startup-era gate only once a real
+kernel using it lands; placeholder in the refusal taxonomy.
+
+## 6. Decision procedure (per kernel)
+
+Run after ABI gates (`abi-translation.md §7`), before any IR
+emission for sync-related SemOps:
+
+```
+for each decoded instruction:
+  if sop is barrier family:
+    if targetIsa.hasSplitBarriers:
+      emit matching split intrinsic (§5.1.a), imm16 preserved
+    elif imm16 != 0:
+      refuse (namedBarrierUnsupported)
+    else:
+      emit llvm.amdgcn.s.barrier (§5.1.b)
+  if sop is waitcnt family:
+    assert attrs.isScheduleHint == true
+    if targetIsa.hasSplitWaitCnt:
+      emit matching split waitcnt intrinsic (§5.2.a)
+    else:
+      skip (no-op, §5.2.b)
+  if sop is atomic:
+    parse th/scope from decoded modifiers
+    map to (ordering, syncscope)
+    if scope is unrepresentable: refuse
+    emit AtomicRMW with tags
+  if sop is GLOBAL_{INV,WB,WBINV} / BUFFER_INV:
+    map to target intrinsic if supported
+    else: refuse
+  if sop is cluster barrier:
+    if targetIsa.hasClusterBarriers:
+      emit matching intrinsic
+    else:
+      refuse
+```
+
+Every refusal carries the decoded instruction offset and a reason
+string. No silent downgrades.
+
+## 7. Principled fail-loudly gates
+
+### G1 — Named-barrier gate (per-kernel)
+
+Fires on any `S_BARRIER_SIGNAL` / `S_BARRIER_WAIT` with `imm16 != 0`.
+Reason: `namedBarrierUnsupported`.
+
+### G2 — Waitcnt classification (startup)
+
+New `SemOpAttrs::isScheduleHint` bit. Startup verifier:
+`verifyWaitcntAttrCoverage` ensures every SemOp whose MCInstrDesc
+flags it as SOPP *and* whose mnemonic matches `s_wait*|s_clause|s_delay_alu`
+has `isScheduleHint = true`. Catches new LLVM-emitted wait variants
+that we haven't audited.
+
+### G3 — Atomic scope gate (per-kernel)
+
+Wrapped around each atomic emission: if decoded `(th, scope)` does
+not map to a supported IR `(ordering, syncscope)` tuple, refuse with
+`atomicScopeUnsupported`.
+
+### G4 — Cache-op coverage (per-kernel)
+
+For every instruction whose mnemonic matches the cache-op family,
+require a handler that either emits the target equivalent or raises
+`cacheOpUnsupported`. Default (no handler row) is refuse.
+
+### G5 — Cluster sync (per-kernel)
+
+Pattern-match the cluster barrier signature (DS wrap + scoped
+waitcnt) at raise time; refuse on hit.
+
+## 8. Open design questions
+
+1. **Per-wave vs per-workgroup split in the named-barrier refusal.**
+   A kernel that uses named barrier `0` only (which is the default
+   workgroup barrier) is safe. A kernel that uses barriers `0` and
+   `1` with `1` as a partition of waves is not. Does it matter for
+   the refusal granularity? Current answer: no, single refusal is
+   fine. If a realistic kernel shows up with *only* `imm16=0` reads
+   that the disassembler happens to render with an explicit operand,
+   the gate needs a second reading to check the canonical form.
+2. **Waitcnt correctness proof.** "Backend handles it" is correct
+   *assuming* the raised IR encodes all memory dependences. Are
+   there source patterns (e.g., `s_load_*` under divergent EXEC
+   whose result is read conditionally) where the source's explicit
+   waitcnt carries a dependence the IR loses? We have not seen one,
+   but the question is worth auditing once SPE is tightened
+   (`wave-size-translation.md §5.1`).
+3. **Atomic scope default.** When decoded `th/scope` are absent
+   (instruction has no modifiers), we currently default to SC+system.
+   Triton usually emits with explicit modifiers; Tensilelite sometimes
+   does not. Should the default be `monotonic` + `agent`? That
+   would match the usual intent but weakens the conservative-correct
+   posture. Recommendation: keep SC+system default until we have
+   specific kernels failing performance-wise, then revisit with a
+   per-kernel override rather than a global policy change.
+4. **Scope recovery when source uses raw `s_memrealtime` / fence
+   intrinsics.** These appear in a handful of Tensilelite persistent
+   kernels. Not in scope for the GPT-OSS North Star; mentioning so
+   the taxonomy stays complete.
+
+## 9. Engineering tasks
+
+### T1 — Named-barrier gate (G1)
+
+Modify `handle_sopp.cpp:74-84` to read `di.getImm(0)` and refuse on
+non-zero. 15 LoC + one test.
+
+### T2 — Waitcnt classification (G2)
+
+Add `isScheduleHint` to `SemOpAttrs`. Register all `S_WAIT_*`,
+`S_CLAUSE`, `S_DELAY_ALU`, `S_WAITCNT` SemOps in a new
+`getHandlerSOPPScheduleAttrs()` spec list. Add
+`verifyWaitcntAttrCoverage()` called from raiser init. 80 LoC.
+
+### T3 — Atomic scope recovery (G3)
+
+Extend `DecodedInst` with parsed `th`/`scope` fields from gfx12
+modifiers (decode-side change in `decode.cpp`). Rewrite
+`handle_flat.cpp:291-293` / `handle_mubuf.cpp` to use them. Add
+mapping table. ~250 LoC.
+
+### T4 — Cache-op SemOps (G4)
+
+Add `GLOBAL_INV`, `GLOBAL_WB`, `GLOBAL_WBINV`, `BUFFER_INV`,
+`S_MEMREALTIME` (latter for gate only). Handlers emit the right
+intrinsic on gfx950. ~200 LoC.
+
+### T5 — Cluster barrier gate (G5)
+
+Pattern matcher in the post-decode pass; refuse on hit. 80 LoC.
+
+Priority order: **T1 first** (cheap, eliminates a correctness hole
+for any future warp-specialised kernel). T2 before T3 (T2 formalises
+the current behaviour; T3 improves performance but doesn't fix
+correctness). T4 and T5 follow once real kernels hit them.
+
+## 10. Relationship to other axes
+
+- **SPE (`wave-size-translation.md`):** barriers under divergent EXEC are
+  SPE's responsibility — a barrier inside a predicated diamond is
+  wrong for all source ISAs and SPE already refuses that pattern
+  (every wave must reach a barrier). Sync-translation assumes SPE
+  is already enforced.
+- **Matrix (`matrix-translation.md`):** MFMA and WMMA both have
+  implicit waitcnt requirements the backend handles. No
+  sync-specific handling required.
+- **Async / tensor-copy families:** gfx12 async-copy + `async_wait`
+  is a category of wait counter (`s_wait_xcnt`) that we handle as a
+  no-op today when emulation lowers the operation to synchronous
+  buffer loads. Once async-copy is natively lowered, `s_wait_xcnt`
+  has to become a real dependency in the IR.
+- **Cross-cutting capability dispatch:** §5.0 is the sync-axis
+  instance of the project-wide "emit native when the target supports
+  it, decompose only when it does not" principle. See
+  `target-capability-dispatch.md`.

--- a/amd/comgr/src/hotswap/setpc-analysis.cpp
+++ b/amd/comgr/src/hotswap/setpc-analysis.cpp
@@ -1,0 +1,1243 @@
+//===- setpc-analysis.cpp - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Static analysis pass that classifies every `s_set_pc_i64` and
+// `s_swap_pc_i64` site in a decoded kernel into one of three principled
+// shapes:
+//
+//   * DirectA: source SGPR pair is produced by a complete
+//     `s_get_pc_i64 + s_add_co_u32 + s_add_co_ci_u32` chain reachable
+//     in the same basic block. Lowers to `br label %BB_target`.
+//
+//   * IndirectB: subroutine-return shape — the source SGPR pair is the
+//     ret-pair populated by a caller's chain (Pattern B). Lowers to a
+//     `cmp eq + br` cascade (emitted by `emitEnumeratedDispatch` in
+//     handle_sop1.cpp) over the resolved return targets, terminating
+//     in an `unreachable` trap BB. Each call site in the kernel that
+//     wrote that ret-pair contributes one target via the
+//     `chainTerminators` rewrite hook.
+//
+//   * DispatchSet: multi-target dispatch — the source SGPR pair holds
+//     one of N statically-known absolute targets reaching the use site
+//     through distinct CFG paths (e.g. a tensilelite "activation
+//     function dispatcher" — each predecessor block writes a different
+//     chain target into the same pair, then a join block consumes it).
+//     Lowers to the same enumerated-dispatch cascade as IndirectB. For
+//     `s_swap_pc_i64` it ALSO writes the return-PC `blockaddress` into
+//     sdst before the cascade (mirroring the DirectA dst-write).
+//
+// The cascade shape replaces an earlier `indirectbr` lowering; see the
+// rationale block on `emitEnumeratedDispatch` in handle_sop1.cpp for
+// why (FixIrreducible pass compatibility under the irreducible CFGs
+// the call/return pattern produces).
+//
+// See canonical-op.h's `S_SET_PC_I64` and `S_SWAP_PC_I64` doc for the full
+// lowering contracts. The handler in `handle_sop1.cpp` consumes the
+// classification.
+//
+// The pass runs in five phases. The last three together implement the
+// inter-block PC-chain dataflow that distinguishes DispatchSet from
+// "still Unresolvable". Without that dataflow, dispatcher-shaped
+// kernels (the common tensilelite case where the call target is
+// computed in a predecessor of the swap_pc's block) fall into
+// Unresolvable and the handler refuses, blocking large slices of the
+// corpus.
+//
+//   Phase 1 — pre-pass. Walk insts once to enumerate every swap/set_pc
+//             instruction's fallthrough offset and pre-add it to the
+//             working block-leader set. This guarantees the per-block
+//             walk in Phase 2 sees every swap/set_pc as the LAST inst
+//             of its block (so its fallthrough is in a separate block,
+//             and so the block-exit transfer correctly summarises the
+//             pair state up to and including the swap/set_pc).
+//
+//   Phase 2 — per-block intra-block walk. Mirrors the original
+//             single-pass analysis: build per-instruction symbolic-PC
+//             state (chains, scalar imms), classify swap/set_pc sites
+//             that resolve in-block as DirectA (or, if the source pair
+//             was dirtied without a complete chain, as Unresolvable
+//             with the intra-block-specific reason). Sites whose
+//             source pair is pristine through the block are deferred
+//             to Phase 4 with a `PendingDataflow` record. Also collect
+//             every chain terminator (Phase 5 prunes), every PendingB
+//             site (Phase 5 classifies as IndirectB), and per-block
+//             transfer summaries: per-pair {SET(value, terminator),
+//             KILL, PASS}.
+//
+//   Phase 3 — CFG + forward dataflow. Build per-block successor lists
+//             from the last instruction (S_BRANCH / S_CBRANCH_* /
+//             S_SWAP_PC fallthrough / fallthrough-to-leader). Run a
+//             worklist forward dataflow on a finite lattice
+//             (`(SGPR pair) -> (sorted set<uint64_t>, incomplete)`)
+//             where the join is set-union with an incomplete bit OR'd
+//             across paths and a hard cap of `kMaxDispatchTargets`
+//             values per pair (over the cap → mark incomplete and
+//             refuse the use site). Convergence is guaranteed by the
+//             bounded-height lattice.
+//
+//   Phase 4 — re-classify deferred sites. For each PendingDataflow
+//             site, look up the entry facts at its block for the
+//             source pair. Empty / incomplete → Unresolvable with the
+//             dataflow-specific reason. One value → DirectA. Two or
+//             more values (within the cap) → DispatchSet with that
+//             enumerated set as `indirectTargets`. Add every target
+//             to `extraBlockStarts` so the BB-layout phase promotes
+//             it to a leader.
+//
+//   Phase 5 — chain terminator retention. Keep every chain terminator
+//             that feeds either (a) an IndirectB ret-pair (existing
+//             logic, identifies it by `retPairLowReg` membership) OR
+//             (b) a DispatchSet site, where retention is conditional
+//             on BOTH `retPairLowReg == DispatchSet.indirectRetPairLowReg`
+//             AND `resolvedReturnAddr ∈ DispatchSet.indirectTargets`
+//             (so dead chain terminators that don't match a target
+//             are still pruned). Build per-pair return-target lists
+//             for IndirectB. Drop unused terminators so the raiser's
+//             S_ADDC_U32 hook does not gratuitously rewrite chains
+//             that don't feed any classified site.
+//
+// Key invariants this pass enforces:
+//   * Per-block reset: the symbolic-PC table is wiped at every
+//     decoder-known basic-block leader. PC chains do not survive
+//     control flow (within a block). Inter-block survival is encoded
+//     entirely through the dataflow lattice; the per-block intra walk
+//     only sees its own writes.
+//   * Conservative cleanup: any SGPR write the pass cannot model
+//     (e.g. an s_mov, an unrelated s_add) clears the destination's
+//     entry. DirectA is only claimed when the entire chain
+//     (s_get_pc_i64 → s_add_co_u32 → s_add_co_ci_u32) is observable
+//     intra-block; DispatchSet is only claimed when the dataflow
+//     joins exclusively over complete chains (any path that kills the
+//     pair sets `incomplete` and refuses).
+//   * Loud refusal: unresolvable sites are recorded with a
+//     human-readable reason; the handler turns this into an
+//     unsupportedShape failure rather than a silent stub branch.
+//
+// IndirectB call-site handling (Phase 5) is unchanged from the original
+// design: a complete getpc+add chain terminating in s_add_co_ci_u32 to
+// a ret-pair SGPR, immediately followed by an unconditional s_branch
+// into the subroutine region. The post-branch instruction's offset is
+// the return target the call site committed to; we record it as a
+// chain-terminator hook so the raiser rewrites the chain's effect to
+// materialise a `blockaddress(@kernel, %BB_returnAddr)` into the
+// ret-pair (rather than the binary PC the chain would otherwise yield).
+// The same rewrite hook fires for DispatchSet retained terminators —
+// the value materialised is the dispatch target, not a return address,
+// but the mechanism is identical (the field's name remains
+// `resolvedReturnAddr` for backward compatibility with the existing
+// SetPcCallSiteInfo struct).
+
+#include "setpc-analysis.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+#include "SIDefines.h"
+#include "mc-state.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <algorithm>
+#include <deque>
+#include <optional>
+#include <set>
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+namespace {
+
+// Cap on the number of distinct PC-chain values we will enumerate per
+// SGPR pair across CFG edges. Beyond this cap we mark the lattice
+// element `incomplete` and the use site falls into Unresolvable. A
+// practical dispatcher (e.g. an N-way activation-function switch) tops
+// out far below this; any larger fan-out is much more likely to be a
+// runtime-derived chain we cannot enumerate, and refusing loudly is
+// the principled response.
+constexpr size_t kMaxDispatchTargets = 16;
+
+// Classify a register operand as an SGPR and return its hardware
+// index. Returns nullopt for non-SGPR regs (VCC/EXEC/SCC/M0/...).
+// Mirrors the SGPR branch of RaiseContext::parseReg but stays scoped
+// to this analysis (no shared state, so it can run pre-IR).
+std::optional<unsigned> sgprIdx(const MCRegisterInfo &MRI, MCRegister Reg) {
+  if (!Reg)
+    return std::nullopt;
+  MCRegister Lane = MRI.getSubReg(Reg, AMDGPU::sub0);
+  if (!Lane)
+    Lane = Reg;
+  Lane = AMDGPU::mc2PseudoReg(Lane);
+  // Filter the special-purpose registers parseReg handles before
+  // falling through to SGPR_32. None of them participate in PC chains.
+  switch (Lane) {
+  case AMDGPU::VCC_LO:
+  case AMDGPU::VCC_HI:
+  case AMDGPU::EXEC_LO:
+  case AMDGPU::EXEC_HI:
+  case AMDGPU::SCC:
+  case AMDGPU::MODE:
+  case AMDGPU::M0:
+  case AMDGPU::FLAT_SCR_LO:
+  case AMDGPU::FLAT_SCR_HI:
+  case AMDGPU::SGPR_NULL:
+  case AMDGPU::SGPR_NULL_HI:
+  case AMDGPU::XNACK_MASK_LO:
+  case AMDGPU::XNACK_MASK_HI:
+  case AMDGPU::LDS_DIRECT:
+    return std::nullopt;
+  default:
+    break;
+  }
+  unsigned Enc = MRI.getEncodingValue(Reg);
+  if (Enc & (AMDGPU::HWEncoding::IS_VGPR | AMDGPU::HWEncoding::IS_AGPR))
+    return std::nullopt;
+  if (!MRI.getRegClass(AMDGPU::SGPR_32RegClassID).contains(Lane))
+    return std::nullopt;
+  return Enc & AMDGPU::HWEncoding::REG_IDX_MASK;
+}
+
+// Width of the as-decoded register in 32-bit lanes. A pair (s[X:X+1])
+// reports width 2; a scalar reports width 1.
+unsigned regWidth32(const MCRegisterInfo &MRI, MCRegister Reg) {
+  const unsigned MaxSubIdx = MRI.getNumSubRegIndices();
+  unsigned W = 0;
+  for (unsigned SubIdx = AMDGPU::sub0; SubIdx < MaxSubIdx; ++SubIdx) {
+    if (!MRI.getSubReg(Reg, SubIdx))
+      break;
+    ++W;
+  }
+  return W ? W : 1;
+}
+
+// Convenience: extract a 32-bit unsigned immediate from an MCOperand.
+// Returns nullopt if the operand is not an integer immediate.
+std::optional<uint32_t> imm32(const MCInst &Inst, unsigned OpIdx) {
+  if (OpIdx >= Inst.getNumOperands())
+    return std::nullopt;
+  const MCOperand &Op = Inst.getOperand(OpIdx);
+  if (!Op.isImm())
+    return std::nullopt;
+  return static_cast<uint32_t>(Op.getImm() & 0xFFFFFFFFu);
+}
+
+// Per-pair PC-chain state. We track the symbolic absolute kernel
+// offset stored in an SGPR pair sX:X+1, plus the offset of the chain
+// terminator (the s_add_co_ci_u32 high-half add) so the raiser knows
+// which instruction to attach the blockaddress-materialisation hook
+// to. `lowAddDone` records whether the low-half s_add_co_u32 has
+// already fired (a complete chain follows the strict order
+// getpc → low-add → high-add).
+struct PcChain {
+  uint64_t Value = 0;       // symbolic absolute kernel offset
+  uint64_t Terminator = 0;  // offset of the high-half s_add_co_ci_u32
+  bool LowAddDone = false;
+};
+
+// Per-scalar immediate state: tracks SGPR_32 values that are known
+// constants (from `s_add_co_i32 sZ, IMM, IMM`-style folding). Used to
+// resolve the offset operand of the low-half PC add.
+struct ScalarImm {
+  uint32_t Value = 0;
+};
+
+// Intra-block analysis state. Tracks per-pair PC chains and per-half
+// scalar immediates. `intraDirtyHalf_` records every SGPR-half index
+// the block has WRITTEN (chain ops + generic SGPR writes). It is the
+// signal Phase 2 uses to decide whether a swap/set_pc site whose
+// chain didn't resolve intra-block is allowed to fall back on dataflow
+// entry facts (pristine half → defer; dirtied half → refuse loudly).
+class State {
+public:
+  State(const MCRegisterInfo &MRI) : Mri(MRI) {}
+
+  // Wipe everything at a basic-block leader. Chain values do not
+  // survive a control-flow boundary at the intra-block layer; inter-
+  // block survival is encoded entirely through the dataflow lattice.
+  void resetBlock() {
+    PcChains.clear();
+    Scalars.clear();
+    IntraDirtyHalf.clear();
+  }
+
+  // Record a known absolute PC in the SGPR pair starting at `lowIdx`.
+  void recordPc(unsigned LowIdx, uint64_t Value) {
+    PcChain C;
+    C.Value = Value;
+    PcChains[LowIdx] = C;
+    // The pair's high half can no longer be a tracked scalar imm.
+    Scalars.erase(LowIdx);
+    Scalars.erase(LowIdx + 1);
+    IntraDirtyHalf.insert(LowIdx);
+    IntraDirtyHalf.insert(LowIdx + 1);
+  }
+
+  // Look up a tracked PC chain by SGPR low index.
+  PcChain *findPc(unsigned LowIdx) {
+    auto It = PcChains.find(LowIdx);
+    return It == PcChains.end() ? nullptr : &It->second;
+  }
+
+  void recordScalar(unsigned Idx, uint32_t Value) {
+    Scalars[Idx].Value = Value;
+    IntraDirtyHalf.insert(Idx);
+    invalidatePcAt(Idx);
+  }
+
+  std::optional<uint32_t> findScalar(unsigned Idx) const {
+    auto It = Scalars.find(Idx);
+    if (It == Scalars.end())
+      return std::nullopt;
+    return It->second.Value;
+  }
+
+  // Drop any tracked PC pair whose low or high half is `idx`. Marks
+  // `idx` (and the affected pair's other half) as dirty so the
+  // dataflow transfer correctly KILLS pass-through entry facts.
+  void invalidatePcAt(unsigned Idx) {
+    IntraDirtyHalf.insert(Idx);
+    auto It = PcChains.find(Idx);
+    if (It != PcChains.end()) {
+      IntraDirtyHalf.insert(It->first + 1);
+      PcChains.erase(It);
+      return;
+    }
+    if (Idx == 0)
+      return;
+    It = PcChains.find(Idx - 1);
+    if (It != PcChains.end()) {
+      IntraDirtyHalf.insert(It->first);
+      PcChains.erase(It);
+    }
+  }
+
+  void invalidateScalarAt(unsigned Idx) {
+    IntraDirtyHalf.insert(Idx);
+    Scalars.erase(Idx);
+  }
+
+  // Promote an in-progress chain to "low add done": the next
+  // s_add_co_ci_u32 to the matching high-half register completes the
+  // chain.
+  void markLowAddDone(unsigned LowIdx, uint64_t NewValue) {
+    auto It = PcChains.find(LowIdx);
+    if (It == PcChains.end())
+      return;
+    It->second.Value = NewValue;
+    It->second.LowAddDone = true;
+    IntraDirtyHalf.insert(LowIdx);
+  }
+
+  // Finalise the chain at `lowIdx`, returning the resolved value and
+  // the terminator offset. Caller must have already verified the
+  // chain reached lowAddDone.
+  void finishHighAdd(unsigned LowIdx, uint64_t TerminatorOff,
+                     uint64_t AddedHi) {
+    auto It = PcChains.find(LowIdx);
+    if (It == PcChains.end())
+      return;
+    It->second.Value += AddedHi << 32;
+    It->second.Terminator = TerminatorOff;
+    IntraDirtyHalf.insert(LowIdx + 1);
+  }
+
+  // Drop everything that is not a finalised PC pair (i.e. invalidate
+  // any chain whose lowAddDone is false). Called when the analysis
+  // observes any SGPR write that breaks the strict chain order.
+  void dropInProgressChains() {
+    for (auto &Kv : llvm::make_early_inc_range(PcChains)) {
+      if (!Kv.second.LowAddDone) {
+        IntraDirtyHalf.insert(Kv.first);
+        IntraDirtyHalf.insert(Kv.first + 1);
+        PcChains.erase(Kv.first);
+      }
+    }
+  }
+
+  // Whether the block has performed any SGPR write to either half of
+  // pair `lowIdx`. Used by Phase 2 to decide whether a swap/set_pc
+  // site may fall back on dataflow entry facts.
+  bool isPairDirty(unsigned LowIdx) const {
+    return IntraDirtyHalf.count(LowIdx) ||
+           IntraDirtyHalf.count(LowIdx + 1);
+  }
+
+  // Accessors used by Phase 2 to construct the per-block transfer
+  // summary at end-of-block.
+  const llvm::DenseMap<unsigned, PcChain> &pcChains() const {
+    return PcChains;
+  }
+  const llvm::DenseSet<unsigned> &dirtyHalves() const {
+    return IntraDirtyHalf;
+  }
+
+private:
+  const MCRegisterInfo &Mri;
+  llvm::DenseMap<unsigned, PcChain> PcChains;
+  llvm::DenseMap<unsigned, ScalarImm> Scalars;
+  llvm::DenseSet<unsigned> IntraDirtyHalf;
+};
+
+// Mark every SGPR-half written by `di` as dirty in `state` and drop
+// any tracked PC pair whose halves overlap. This is the generic
+// fallthrough for instructions whose semantics we did not model.
+void invalidateGeneralSgprDefs(const DecodedInst &Di,
+                               const MCRegisterInfo &MRI, State &State) {
+  for (unsigned I = 0; I < Di.NumDefs && I < Di.numOps(); ++I) {
+    if (!Di.isReg(I))
+      continue;
+    auto Idx = sgprIdx(MRI, Di.getReg(I));
+    if (!Idx)
+      continue;
+    unsigned W = regWidth32(MRI, Di.getReg(I));
+    for (unsigned K = 0; K < W; ++K) {
+      State.invalidatePcAt(*Idx + K);
+      State.invalidateScalarAt(*Idx + K);
+    }
+  }
+}
+
+// Per-pair transfer summary computed at end of each block in Phase 2,
+// consumed by the Phase 3 dataflow.
+struct PairTransfer {
+  enum class Kind {
+    // Block did not write either half of this pair. Entry facts pass
+    // through unchanged.
+    Pass,
+    // Block ended with this pair holding a complete PC chain whose
+    // value is `value` and whose chain terminator is at offset
+    // `terminator`. Overrides any incoming entry fact.
+    Set,
+    // Block wrote one or both halves of this pair but did not end
+    // with a complete chain (or wrote a non-chain value). Pass-
+    // through entry facts are killed; downstream sees a constraint-
+    // less pair.
+    Kill,
+  };
+  Kind TransferKind = Kind::Pass;
+  uint64_t Value = 0;       // when transferKind == Set
+  uint64_t Terminator = 0;  // when transferKind == Set
+};
+
+// Per-block descriptor used by Phase 2 / 3 / 4. `lastIdx` is inclusive.
+struct BlockData {
+  uint64_t Offset = 0;
+  size_t FirstIdx = 0;
+  size_t LastIdx = 0;
+  llvm::DenseMap<unsigned, PairTransfer> Transfers;
+  SmallVector<uint64_t, 2> Successors;
+};
+
+// A swap/set_pc site whose source pair was pristine through its block
+// and so was deferred to the Phase 4 dataflow re-classification.
+struct PendingDataflowSite {
+  uint64_t BlockOffset = 0;
+  uint64_t SiteOffset = 0;
+  unsigned SrcPair = 0;
+  bool IsSwap = false;
+};
+
+// Pattern B set_pc site whose source ret-pair could not be resolved
+// to a single chain in Phase 2; Phase 5 enumerates matching chain
+// terminators and either classifies as IndirectB or refuses with the
+// pair-no-call-site reason.
+struct PendingB {
+  uint64_t SetpcOffset = 0;
+  unsigned RetPairLowReg = 0;
+};
+
+// Inter-block lattice value for one SGPR pair.
+//   - `values` is the enumerated set of statically-known absolute
+//     kernel offsets the pair can hold at the start of a block, sorted
+//     ascending and capped at kMaxDispatchTargets.
+//   - `incomplete` records that at least one CFG predecessor leaves
+//     the pair in an unmodeled state (overwritten by a non-chain
+//     operation, never constrained at all — pristine kernel entry —
+//     or omitted from a predecessor's exit facts entirely).
+//
+// Use sites consume the lattice: incomplete OR cap-exceeded ⇒ refuse
+// loudly; otherwise the value count picks DirectA (1) or DispatchSet
+// (>1) classification.
+//
+// Lattice element absent from a block's entry-fact map is interpreted
+// by use sites as the unconstrained default (incomplete=true, no
+// values). The JOIN-over-predecessors formulation in Phase 3 only
+// inserts an entry into the map when at least one predecessor's exit
+// facts mention the pair; it then OR's in incomplete from any
+// predecessor that DIDN'T mention the pair.
+struct PcLatticeValue {
+  llvm::SmallVector<uint64_t, 8> Values;  // sorted, deduped
+  bool Incomplete = false;
+};
+
+bool operator==(const PcLatticeValue &A, const PcLatticeValue &B) {
+  return A.Incomplete == B.Incomplete && A.Values == B.Values;
+}
+bool operator!=(const PcLatticeValue &A, const PcLatticeValue &B) {
+  return !(A == B);
+}
+
+// Merge `src` into `dst` (set-union of values, OR of incomplete bits,
+// hard cap at kMaxDispatchTargets values — over-cap promotes to
+// incomplete and stops growing the value list).
+void joinValue(PcLatticeValue &Dst, const PcLatticeValue &Src) {
+  if (Src.Incomplete)
+    Dst.Incomplete = true;
+  for (uint64_t V : Src.Values) {
+    auto It = llvm::lower_bound(Dst.Values, V);
+    if (It != Dst.Values.end() && *It == V)
+      continue;
+    if (Dst.Values.size() >= kMaxDispatchTargets) {
+      Dst.Incomplete = true;
+      break;
+    }
+    Dst.Values.insert(It, V);
+  }
+}
+
+// Compute the set of CFG successor block-offsets for the block whose
+// last instruction is `lastInst`. `nextBlockOffset` is the offset of
+// the next block in linear layout (used for fallthrough); pass
+// `nextBlockExists = false` if `lastInst` is the kernel's final inst.
+//
+// The successor model is intentionally conservative for analysis
+// safety:
+//   * S_BRANCH: 1 successor (decoded target).
+//   * S_CBRANCH_*: 2 successors (target + linear fallthrough).
+//   * S_ENDPGM: 0 successors.
+//   * S_SET_PC_I64: 0 successors. The classification table tells the
+//     raiser where this jumps; for dataflow purposes any survivors
+//     would have to flow through the destination's other predecessors
+//     anyway.
+//   * S_SWAP_PC_I64: 1 successor (linear fallthrough). The swap is a
+//     branch-and-link; control eventually returns into the
+//     fallthrough, which Phase 1 added to extraBlockStarts so it is a
+//     known leader. Source-pair facts survive across the swap (the
+//     swap reads but does not write the source pair); the dst pair
+//     is killed by the swap's transfer.
+//   * Anything else (block ended only because the next inst was an
+//     external BB leader): linear fallthrough.
+SmallVector<uint64_t, 2>
+computeSuccessors(const DecodedInst &LastInst, uint64_t NextBlockOffset,
+                  bool NextBlockExists) {
+  SmallVector<uint64_t, 2> Result;
+  auto BranchTargetFromImm =
+      [&](unsigned OpIdx) -> std::optional<uint64_t> {
+    if (OpIdx >= LastInst.Inst.getNumOperands())
+      return std::nullopt;
+    const MCOperand &Op = LastInst.Inst.getOperand(OpIdx);
+    if (!Op.isImm())
+      return std::nullopt;
+    int64_t Raw = Op.getImm();
+    int64_t BrOff = static_cast<int64_t>(
+        static_cast<int16_t>(static_cast<uint16_t>(Raw & 0xFFFF)));
+    return LastInst.Offset + 4 + BrOff * 4;
+  };
+  switch (LastInst.CanonOp) {
+  case CanonicalOp::S_BRANCH: {
+    auto T = BranchTargetFromImm(0);
+    if (T)
+      Result.push_back(*T);
+    break;
+  }
+  case CanonicalOp::S_CBRANCH_SCC0:
+  case CanonicalOp::S_CBRANCH_SCC1:
+  case CanonicalOp::S_CBRANCH_VCCZ:
+  case CanonicalOp::S_CBRANCH_VCCNZ:
+  case CanonicalOp::S_CBRANCH_EXECZ:
+  case CanonicalOp::S_CBRANCH_EXECNZ: {
+    auto T = BranchTargetFromImm(0);
+    if (T)
+      Result.push_back(*T);
+    if (NextBlockExists)
+      Result.push_back(NextBlockOffset);
+    break;
+  }
+  case CanonicalOp::S_ENDPGM:
+  case CanonicalOp::S_SET_PC_I64:
+    break;
+  case CanonicalOp::S_SWAP_PC_I64:
+  default:
+    if (NextBlockExists)
+      Result.push_back(NextBlockOffset);
+    break;
+  }
+  return Result;
+}
+
+} // namespace
+
+SetPcAnalysis analyseSetPC(ArrayRef<DecodedInst> Insts,
+                           const std::set<uint64_t> &BlockStarts,
+                           const MCState &Mc) {
+  SetPcAnalysis Result;
+  if (Insts.empty())
+    return Result;
+
+  const MCRegisterInfo &MRI = *Mc.RegInfo;
+
+  // ---------------------------------------------------------------
+  // Phase 1 — pre-pass: enumerate every swap/set_pc fallthrough as a
+  // block leader. This guarantees the per-block walk sees each
+  // swap/set_pc as the LAST inst of its block (so its block-exit
+  // transfer correctly summarises the pair state up to the
+  // swap/set_pc, not past it).
+  // ---------------------------------------------------------------
+  llvm::DenseSet<uint64_t> MergedBlockStarts(BlockStarts.begin(),
+                                             BlockStarts.end());
+  for (const DecodedInst &Di : Insts) {
+    if (Di.CanonOp == CanonicalOp::S_SWAP_PC_I64 ||
+        Di.CanonOp == CanonicalOp::S_SET_PC_I64) {
+      uint64_t Fallthrough = Di.Offset + Di.Size;
+      if (MergedBlockStarts.insert(Fallthrough).second)
+        Result.ExtraBlockStarts.insert(Fallthrough);
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Build BlockData skeletons. A "block" is identified by the offset
+  // of an instruction that appears in `insts` AND is in
+  // `mergedBlockStarts`. We skip leader offsets that have no inst
+  // (e.g. fallthroughs past the last decoded inst, or branch targets
+  // outside the decoded range).
+  // ---------------------------------------------------------------
+  llvm::SmallVector<BlockData> Blocks;
+  llvm::DenseMap<uint64_t, size_t> OffsetToBlockIdx;
+  Blocks.reserve(MergedBlockStarts.size());
+  for (size_t I = 0; I < Insts.size(); ++I) {
+    if (MergedBlockStarts.count(Insts[I].Offset)) {
+      BlockData Bd;
+      Bd.Offset = Insts[I].Offset;
+      Bd.FirstIdx = I;
+      Bd.LastIdx = I; // fixed up below
+      OffsetToBlockIdx[Bd.Offset] = Blocks.size();
+      Blocks.push_back(Bd);
+    }
+  }
+  for (size_t Bi = 0; Bi < Blocks.size(); ++Bi) {
+    size_t End = (Bi + 1 < Blocks.size()) ? Blocks[Bi + 1].FirstIdx
+                                          : Insts.size();
+    Blocks[Bi].LastIdx = End - 1;
+  }
+
+  // Always treat the first instruction's block as kernel entry. Phase
+  // 3 seeds that block's entry facts as "unconstrained" (the default
+  // PcLatticeValue), which correctly models pristine register state.
+
+  // ---------------------------------------------------------------
+  // Phase 2 — per-block intra-block walk. For each block, run the
+  // existing chain analysis and collect:
+  //   * setpcSites entries for sites that resolve in-block (DirectA
+  //     direct-branch, or Unresolvable-with-intra-block-reason when
+  //     the source pair was dirtied without a complete chain).
+  //   * pendingDataflow entries for sites whose source pair was
+  //     pristine through the block — Phase 4 reclassifies these.
+  //   * pendingB entries for s_set_pc sites whose source pair could
+  //     not be resolved by a chain (intra OR dataflow) — Phase 5
+  //     classifies these as IndirectB by matching against
+  //     chainTerminators.
+  //   * chainTerminators[high_add_offset] = {chain_value, lowReg} for
+  //     every completed chain. Phase 5 prunes those that don't feed
+  //     any classified site.
+  //   * extraBlockStarts entries for DirectA chain targets and for
+  //     swap_pc fallthroughs (the fallthrough leader was added in
+  //     Phase 1 for analysis correctness; we re-record it here for
+  //     the caller's BB-layout merge).
+  //   * the per-block transfer summary (transfers map).
+  //   * the per-block successor list (computeSuccessors on lastInst).
+  // ---------------------------------------------------------------
+  llvm::SmallVector<PendingDataflowSite> PendingDataflow;
+  llvm::SmallVector<PendingB> PendingBs;
+
+  for (size_t Bi = 0; Bi < Blocks.size(); ++Bi) {
+    BlockData &Bd = Blocks[Bi];
+    State State(MRI);
+    State.resetBlock();
+
+    for (size_t I = Bd.FirstIdx; I <= Bd.LastIdx; ++I) {
+      const DecodedInst &Di = Insts[I];
+
+      switch (Di.CanonOp) {
+      case CanonicalOp::S_GETPC_B64: {
+        if (Di.NumDefs >= 1 && Di.isReg(0)) {
+          auto Idx = sgprIdx(MRI, Di.getReg(0));
+          if (Idx) {
+            State.recordPc(*Idx, Di.Offset + Di.Size);
+            continue;
+          }
+        }
+        break;
+      }
+
+      case CanonicalOp::S_ADD_U32: {
+        if (Di.NumDefs < 1 || !Di.isReg(0))
+          break;
+        auto DstIdx = sgprIdx(MRI, Di.getReg(0));
+        if (!DstIdx)
+          break;
+        unsigned S0 = Di.FirstSrcIdx;
+        unsigned S1 = S0 + 1;
+        auto Src0Imm = imm32(Di.Inst, S0);
+        auto Src1Imm = imm32(Di.Inst, S1);
+        if (Src0Imm && Src1Imm) {
+          State.recordScalar(*DstIdx, *Src0Imm + *Src1Imm);
+          continue;
+        }
+        std::optional<unsigned> Src0Idx;
+        if (Di.isReg(S0))
+          Src0Idx = sgprIdx(MRI, Di.getReg(S0));
+        if (!Src0Idx || *Src0Idx != *DstIdx)
+          break;
+        PcChain *Chain = State.findPc(*DstIdx);
+        if (!Chain || Chain->LowAddDone)
+          break;
+        uint32_t Addend = 0;
+        if (Src1Imm) {
+          Addend = *Src1Imm;
+        } else if (Di.isReg(S1)) {
+          auto Src1Reg = sgprIdx(MRI, Di.getReg(S1));
+          if (!Src1Reg)
+            break;
+          auto Sc = State.findScalar(*Src1Reg);
+          if (!Sc)
+            break;
+          Addend = *Sc;
+        } else {
+          break;
+        }
+        uint64_t NewVal = Chain->Value + static_cast<uint64_t>(Addend);
+        State.markLowAddDone(*DstIdx, NewVal);
+        continue;
+      }
+
+      case CanonicalOp::S_ADDC_U32: {
+        if (Di.NumDefs < 1 || !Di.isReg(0))
+          break;
+        auto DstIdx = sgprIdx(MRI, Di.getReg(0));
+        if (!DstIdx || *DstIdx == 0)
+          break;
+        unsigned LowIdx = *DstIdx - 1;
+        PcChain *Chain = State.findPc(LowIdx);
+        if (!Chain || !Chain->LowAddDone)
+          break;
+        unsigned S0 = Di.FirstSrcIdx;
+        unsigned S1 = S0 + 1;
+        std::optional<unsigned> Src0Idx;
+        if (Di.isReg(S0))
+          Src0Idx = sgprIdx(MRI, Di.getReg(S0));
+        if (!Src0Idx || *Src0Idx != *DstIdx)
+          break;
+        auto Src1Imm = imm32(Di.Inst, S1);
+        if (!Src1Imm)
+          break;
+        State.finishHighAdd(LowIdx, Di.Offset,
+                            static_cast<uint64_t>(*Src1Imm));
+        Result.ChainTerminators[Di.Offset] =
+            SetPcCallSiteInfo{State.findPc(LowIdx)->Value, LowIdx};
+        continue;
+      }
+
+      case CanonicalOp::S_SWAP_PC_I64: {
+        // Phase 1 already added the fallthrough to mergedBlockStarts;
+        // re-record for the caller's BB-layout merge.
+        Result.ExtraBlockStarts.insert(Di.Offset + Di.Size);
+
+        std::optional<unsigned> DstLow;
+        if (Di.NumDefs >= 1 && Di.isReg(0))
+          DstLow = sgprIdx(MRI, Di.getReg(0));
+
+        // Synthetic chain-terminator registration. We always record
+        // it when dstLow is known; Phase 5 drops it if no downstream
+        // s_set_pc_i64 reads `sdst`. The key (di.Offset) is unique
+        // because LLVM never lays two instructions at the same
+        // offset; the value carries (retPair=sdstLow, returnAddr=
+        // swap.end). The raiser's S_ADDC_U32 post-hook does not fire
+        // on S_SWAP_PC_I64 (gated by CanonicalOp), so the equivalent
+        // blockaddress materialisation happens inline in handleSOP1.
+        if (DstLow)
+          Result.ChainTerminators[Di.Offset] =
+              SetPcCallSiteInfo{Di.Offset + Di.Size, *DstLow};
+
+        // Classify the call-target (source pair).
+        unsigned SrcOpIdx = Di.FirstSrcIdx;
+        if (!Di.isReg(SrcOpIdx)) {
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+          Info.RefusalReason =
+              "s_swap_pc_i64 source operand is not a register";
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+          if (DstLow) {
+            State.invalidatePcAt(*DstLow);
+            State.invalidatePcAt(*DstLow + 1);
+          }
+          continue;
+        }
+        auto SrcLow = sgprIdx(MRI, Di.getReg(SrcOpIdx));
+        if (!SrcLow) {
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+          Info.RefusalReason =
+              "s_swap_pc_i64 source register is not an SGPR pair";
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+          if (DstLow) {
+            State.invalidatePcAt(*DstLow);
+            State.invalidatePcAt(*DstLow + 1);
+          }
+          continue;
+        }
+        PcChain *Chain = State.findPc(*SrcLow);
+        if (Chain && Chain->LowAddDone) {
+          // DirectA: chain resolves the absolute callee target intra-block.
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::DirectA;
+          Info.DirectTarget = Chain->Value;
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+          Result.ExtraBlockStarts.insert(Chain->Value);
+          if (Chain->Terminator)
+            Result.ChainTerminators.erase(Chain->Terminator);
+          // The src pair is consumed inline. Mark it dirty so the
+          // block transfer KILLs entry facts (a downstream block on
+          // a back edge would otherwise see the chain value, but the
+          // intra-block consumption invalidates further reasoning).
+          State.invalidatePcAt(*SrcLow);
+        } else if (State.isPairDirty(*SrcLow)) {
+          // The block wrote to srcPair (chain-or-otherwise) but it
+          // didn't end with a complete chain. Dataflow entry facts
+          // are dead. Refuse loudly.
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+          Info.RefusalReason =
+              (llvm::Twine("s_swap_pc_i64 source SGPR pair s[") +
+               llvm::Twine(*SrcLow) + ":" + llvm::Twine(*SrcLow + 1) +
+               "] was modified intra-block without producing a "
+               "statically resolvable getpc+add chain (the block "
+               "either started a chain that did not complete or "
+               "overwrote the pair with a non-chain value); inter-"
+               "block dataflow facts cannot recover this")
+                  .str();
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+        } else {
+          // SrcPair is pristine through the block. Defer to Phase 4
+          // dataflow re-classification.
+          PendingDataflowSite Pds;
+          Pds.BlockOffset = Bd.Offset;
+          Pds.SiteOffset = Di.Offset;
+          Pds.SrcPair = *SrcLow;
+          Pds.IsSwap = true;
+          PendingDataflow.push_back(Pds);
+        }
+        // Dst pair now holds an opaque (return-PC) value; remove from
+        // PC tracking so a downstream s_set_pc_i64 reading dst falls
+        // into Pattern B (enumerated-dispatch cascade) rather than
+        // DirectA.
+        if (DstLow) {
+          State.invalidatePcAt(*DstLow);
+          State.invalidatePcAt(*DstLow + 1);
+        }
+        continue;
+      }
+
+      case CanonicalOp::S_SET_PC_I64: {
+        unsigned SrcOpIdx = Di.FirstSrcIdx;
+        if (!Di.isReg(SrcOpIdx)) {
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+          Info.RefusalReason =
+              "s_set_pc_i64 source operand is not a register";
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+          continue;
+        }
+        auto SrcIdx = sgprIdx(MRI, Di.getReg(SrcOpIdx));
+        if (!SrcIdx) {
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+          Info.RefusalReason =
+              "s_set_pc_i64 source register is not an SGPR pair";
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+          continue;
+        }
+        Result.ExtraBlockStarts.insert(Di.Offset + Di.Size);
+        PcChain *Chain = State.findPc(*SrcIdx);
+        if (Chain && Chain->LowAddDone) {
+          // DirectA intra-block.
+          SetPcSiteInfo Info;
+          Info.SiteKind = SetPcSiteInfo::Kind::DirectA;
+          Info.DirectTarget = Chain->Value;
+          Result.SetpcSites[Di.Offset] = std::move(Info);
+          Result.ExtraBlockStarts.insert(Chain->Value);
+          if (Chain->Terminator)
+            Result.ChainTerminators.erase(Chain->Terminator);
+          State.invalidatePcAt(*SrcIdx);
+          continue;
+        }
+        if (State.isPairDirty(*SrcIdx)) {
+          // Pair was dirtied intra-block without a complete chain;
+          // dataflow facts are dead. Defer to Phase 5 PendingB
+          // classification (matches against chainTerminators) which
+          // correctly handles the subroutine-return shape regardless
+          // of intra-block dirtiness — the IndirectB pattern relies
+          // on the source pair being populated by a CALLER's chain
+          // terminator, not by anything in this block. If no chain
+          // terminator matches this source pair, Phase 5 emits the
+          // pair-no-call-site Unresolvable diagnostic.
+          struct PendingB Pb;
+          Pb.SetpcOffset = Di.Offset;
+          Pb.RetPairLowReg = *SrcIdx;
+          PendingBs.push_back(Pb);
+          continue;
+        }
+        // SrcPair pristine through the block. Defer to Phase 4
+        // dataflow re-classification. If dataflow leaves it
+        // unconstrained, Phase 4 falls through to a PendingB-style
+        // resolution attempt (so subroutine-return shapes still get
+        // classified as IndirectB, not refused).
+        PendingDataflowSite Pds;
+        Pds.BlockOffset = Bd.Offset;
+        Pds.SiteOffset = Di.Offset;
+        Pds.SrcPair = *SrcIdx;
+        Pds.IsSwap = false;
+        PendingDataflow.push_back(Pds);
+        continue;
+      }
+
+      default:
+        break;
+      }
+
+      // Generic fallthrough: invalidate every SGPR (and overlapping
+      // PC pair) the instruction writes to. This prevents stale
+      // chain values from leaking past instructions whose semantics
+      // we did not model. Also drop in-progress chains so a stray
+      // write between getpc and the low add cannot be silently
+      // absorbed into the chain by a later matching add.
+      invalidateGeneralSgprDefs(Di, MRI, State);
+      State.dropInProgressChains();
+    }
+
+    // Compute block-exit transfers from the final state.
+    //   * Every pair in `state.pcChains()` with lowAddDone=true →
+    //     SET(value, terminator). Pass-through is overridden.
+    //   * Every dirty half whose pair is not in pcChains-with-
+    //     lowAddDone → KILL of that pair. Cover BOTH the "low" view
+    //     (half index treated as the pair's low) and the "high" view
+    //     (half index - 1 treated as the pair's low). A dirty half
+    //     can mean two distinct pairs were partially touched; we
+    //     conservatively KILL both. (In the common case the second
+    //     pair is unused and the KILL is harmless.)
+    //   * Pairs with no entry in transfers default to PASS.
+    auto SetKill = [&](unsigned LowIdx) {
+      auto &T = Bd.Transfers[LowIdx];
+      if (T.TransferKind != PairTransfer::Kind::Set)
+        T.TransferKind = PairTransfer::Kind::Kill;
+    };
+    for (const auto &Kv : State.pcChains()) {
+      if (Kv.second.LowAddDone) {
+        PairTransfer &T = Bd.Transfers[Kv.first];
+        T.TransferKind = PairTransfer::Kind::Set;
+        T.Value = Kv.second.Value;
+        T.Terminator = Kv.second.Terminator;
+      } else {
+        SetKill(Kv.first);
+        if (Kv.first > 0)
+          SetKill(Kv.first - 1);
+      }
+    }
+    for (unsigned Half : State.dirtyHalves()) {
+      // Don't downgrade a SET pair to KILL.
+      auto It = Bd.Transfers.find(Half);
+      if (It == Bd.Transfers.end() ||
+          It->second.TransferKind != PairTransfer::Kind::Set)
+        SetKill(Half);
+      if (Half > 0) {
+        auto It2 = Bd.Transfers.find(Half - 1);
+        if (It2 == Bd.Transfers.end() ||
+            It2->second.TransferKind != PairTransfer::Kind::Set)
+          SetKill(Half - 1);
+      }
+    }
+
+    // Compute CFG successors.
+    bool HasNext = (Bi + 1) < Blocks.size();
+    uint64_t NextOff = HasNext ? Blocks[Bi + 1].Offset : 0;
+    Bd.Successors = computeSuccessors(Insts[Bd.LastIdx], NextOff, HasNext);
+  }
+
+  // ---------------------------------------------------------------
+  // Phase 3 — forward dataflow to fixpoint.
+  //
+  //   entryFacts[blockIdx][pairLow] = PcLatticeValue
+  //
+  // Formulation: at each block B,
+  //   entryFacts[B] = JOIN over P ∈ preds(B) of exitFacts(P)
+  //
+  // where exitFacts(P) = transfer(entryFacts[P], P.transfers):
+  //   - SET overrides any incoming entry with {value, !incomplete}
+  //   - KILL overrides with {∅, incomplete}
+  //   - PASS leaves the entry unchanged
+  //
+  // and JOIN is set-union of `values` + OR of `incomplete` bits, with
+  // an additional rule: any pair P that appears in SOME predecessor
+  // P_i's exit but is MISSING from P_j's exit gets incomplete=true
+  // (the missing predecessor leaves P at its kernel-entry-pristine
+  // default = unconstrained).
+  //
+  // Pairs absent from entryFacts[B] are interpreted by use sites as
+  // the unconstrained default, so we only insert entries into the map
+  // when at least one predecessor's exit mentions the pair.
+  //
+  // Convergence is guaranteed by the bounded-height lattice: per
+  // pair, at most kMaxDispatchTargets values + 1 incomplete bit.
+  // The lattice is also monotone (values only grow, incomplete only
+  // 0→1), so JOIN-over-preds-from-scratch with re-entry-on-change is
+  // a sound fixpoint algorithm.
+  // ---------------------------------------------------------------
+
+  // Build predecessor map.
+  llvm::SmallVector<llvm::SmallVector<size_t, 4>> Predecessors(Blocks.size());
+  for (size_t Bi = 0; Bi < Blocks.size(); ++Bi) {
+    for (uint64_t SuccOff : Blocks[Bi].Successors) {
+      auto Sit = OffsetToBlockIdx.find(SuccOff);
+      if (Sit != OffsetToBlockIdx.end())
+        Predecessors[Sit->second].push_back(Bi);
+    }
+  }
+
+  // computeExit applies the per-block transfer to a given entry-fact
+  // map and returns the exit-fact map. PASS pairs flow through; SET
+  // and KILL pairs override.
+  auto ComputeExit =
+      [&](const llvm::DenseMap<unsigned, PcLatticeValue> &Entry,
+          const BlockData &Bd) {
+        llvm::DenseMap<unsigned, PcLatticeValue> Exit = Entry;
+        for (const auto &Kv : Bd.Transfers) {
+          if (Kv.second.TransferKind == PairTransfer::Kind::Set) {
+            PcLatticeValue V;
+            V.Values.push_back(Kv.second.Value);
+            V.Incomplete = false;
+            Exit[Kv.first] = std::move(V);
+          } else if (Kv.second.TransferKind == PairTransfer::Kind::Kill) {
+            PcLatticeValue V;
+            V.Incomplete = true;
+            Exit[Kv.first] = std::move(V);
+          }
+        }
+        return Exit;
+      };
+
+  llvm::SmallVector<llvm::DenseMap<unsigned, PcLatticeValue>> EntryFacts(
+      Blocks.size());
+
+  std::deque<size_t> Worklist;
+  llvm::SmallVector<bool> OnWorklist(Blocks.size(), false);
+  for (size_t Bi = 0; Bi < Blocks.size(); ++Bi) {
+    Worklist.push_back(Bi);
+    OnWorklist[Bi] = true;
+  }
+
+  while (!Worklist.empty()) {
+    size_t Bi = Worklist.front();
+    Worklist.pop_front();
+    OnWorklist[Bi] = false;
+
+    // Recompute entry from JOIN over predecessors.
+    llvm::DenseMap<unsigned, PcLatticeValue> NewEntry;
+    if (!Predecessors[Bi].empty()) {
+      // Collect predecessor exits.
+      llvm::SmallVector<llvm::DenseMap<unsigned, PcLatticeValue>> PredExits;
+      PredExits.reserve(Predecessors[Bi].size());
+      for (size_t Pi : Predecessors[Bi])
+        PredExits.push_back(ComputeExit(EntryFacts[Pi], Blocks[Pi]));
+
+      // Determine the union of pairs mentioned by any predecessor
+      // exit. These are the only pairs whose entry fact differs from
+      // the unconstrained default at this block.
+      llvm::DenseSet<unsigned> Mentioned;
+      for (const auto &Pe : PredExits)
+        for (const auto &Kv : Pe)
+          Mentioned.insert(Kv.first);
+
+      // For each mentioned pair, JOIN every predecessor's
+      // contribution. Predecessors whose exit doesn't mention the
+      // pair contribute incomplete=true (the kernel-entry-pristine
+      // default).
+      for (unsigned Pair : Mentioned) {
+        PcLatticeValue Acc;
+        for (const auto &Pe : PredExits) {
+          auto It = Pe.find(Pair);
+          if (It == Pe.end()) {
+            Acc.Incomplete = true;
+          } else {
+            joinValue(Acc, It->second);
+          }
+        }
+        NewEntry[Pair] = std::move(Acc);
+      }
+    }
+    // Block 0 (kernel entry) has no predecessors → newEntry is empty,
+    // which correctly represents "every pair is unconstrained".
+
+    if (NewEntry != EntryFacts[Bi]) {
+      EntryFacts[Bi] = std::move(NewEntry);
+      for (uint64_t SuccOff : Blocks[Bi].Successors) {
+        auto Sit = OffsetToBlockIdx.find(SuccOff);
+        if (Sit != OffsetToBlockIdx.end() &&
+            !OnWorklist[Sit->second]) {
+          Worklist.push_back(Sit->second);
+          OnWorklist[Sit->second] = true;
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Phase 4 — re-classify deferred sites using dataflow facts.
+  // ---------------------------------------------------------------
+  for (const PendingDataflowSite &Pds : PendingDataflow) {
+    auto Bit = OffsetToBlockIdx.find(Pds.BlockOffset);
+    if (Bit == OffsetToBlockIdx.end())
+      continue;
+    const auto &Facts = EntryFacts[Bit->second];
+    auto It = Facts.find(Pds.SrcPair);
+    bool Resolved =
+        (It != Facts.end()) && !It->second.Incomplete &&
+        !It->second.Values.empty() &&
+        It->second.Values.size() <= kMaxDispatchTargets;
+
+    if (!Resolved) {
+      if (Pds.IsSwap) {
+        SetPcSiteInfo Info;
+        Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+        Info.RefusalReason =
+            (llvm::Twine("s_swap_pc_i64 source SGPR pair s[") +
+             llvm::Twine(Pds.SrcPair) + ":" + llvm::Twine(Pds.SrcPair + 1) +
+             "] does not have a statically resolvable getpc+add "
+             "chain reaching this site (intra-block analysis found "
+             "no chain; inter-block dataflow could not enumerate a "
+             "bounded set of targets -- the value comes from a "
+             "kernarg/runtime source, an unbounded fan-in, or a "
+             "control-flow path that overwrites the pair with an "
+             "unmodelled value)")
+                .str();
+        Result.SetpcSites[Pds.SiteOffset] = std::move(Info);
+      } else {
+        // For s_set_pc_i64, fall through to PendingB — a subroutine-
+        // return shape relies on caller-side chain terminators, not
+        // on the source pair being constrained by intra-kernel
+        // dataflow.
+        struct PendingB Pb;
+        Pb.SetpcOffset = Pds.SiteOffset;
+        Pb.RetPairLowReg = Pds.SrcPair;
+        PendingBs.push_back(Pb);
+      }
+      continue;
+    }
+
+    SmallVector<uint64_t, 4> Targets(It->second.Values.begin(),
+                                     It->second.Values.end());
+    SetPcSiteInfo Info;
+    if (Targets.size() == 1) {
+      Info.SiteKind = SetPcSiteInfo::Kind::DirectA;
+      Info.DirectTarget = Targets[0];
+    } else {
+      Info.SiteKind = SetPcSiteInfo::Kind::DispatchSet;
+      Info.IndirectTargets = Targets;
+      Info.IndirectRetPairLowReg = Pds.SrcPair;
+    }
+    for (uint64_t T : Targets)
+      Result.ExtraBlockStarts.insert(T);
+    Result.SetpcSites[Pds.SiteOffset] = std::move(Info);
+  }
+
+  // ---------------------------------------------------------------
+  // Phase 5 — chain terminator retention + IndirectB classification.
+  //
+  // Retention rule: keep a chain terminator iff it feeds either
+  //   (a) an IndirectB ret-pair (pair-low-index match), OR
+  //   (b) a DispatchSet site (pair-low-index AND value match).
+  // Drop unused terminators so the raiser's S_ADDC_U32 hook does not
+  // gratuitously rewrite chains that don't feed any classified site.
+  // ---------------------------------------------------------------
+
+  // Collect Pattern B consumers.
+  llvm::DenseSet<unsigned> RetPairsConsumedByB;
+  for (const struct PendingB &Pb : PendingBs)
+    RetPairsConsumedByB.insert(Pb.RetPairLowReg);
+
+  // Collect DispatchSet consumers (pair → set of allowed values).
+  llvm::DenseMap<unsigned, llvm::DenseSet<uint64_t>> DispatchSetTargets;
+  for (const auto &Kv : Result.SetpcSites) {
+    if (Kv.second.SiteKind == SetPcSiteInfo::Kind::DispatchSet) {
+      auto &Set = DispatchSetTargets[Kv.second.IndirectRetPairLowReg];
+      for (uint64_t T : Kv.second.IndirectTargets)
+        Set.insert(T);
+    }
+  }
+
+  // Prune chain terminators in place.
+  for (auto &Kv : llvm::make_early_inc_range(Result.ChainTerminators)) {
+    bool KeepForB = RetPairsConsumedByB.contains(Kv.second.RetPairLowReg);
+    bool KeepForDispatch = false;
+    auto Dt = DispatchSetTargets.find(Kv.second.RetPairLowReg);
+    if (Dt != DispatchSetTargets.end() &&
+        Dt->second.count(Kv.second.ResolvedReturnAddr))
+      KeepForDispatch = true;
+    if (!KeepForB && !KeepForDispatch)
+      Result.ChainTerminators.erase(Kv.first);
+  }
+
+  // Build per-pair return-target lists for IndirectB from the
+  // surviving terminators.
+  llvm::DenseMap<unsigned, SmallVector<uint64_t, 4>> TargetsByPair;
+  for (const auto &Kv : Result.ChainTerminators) {
+    if (!RetPairsConsumedByB.count(Kv.second.RetPairLowReg))
+      continue;
+    TargetsByPair[Kv.second.RetPairLowReg].push_back(
+        Kv.second.ResolvedReturnAddr);
+    Result.ExtraBlockStarts.insert(Kv.second.ResolvedReturnAddr);
+  }
+  for (auto &Kv : TargetsByPair) {
+    auto &V = Kv.second;
+    llvm::sort(V);
+    V.erase(std::unique(V.begin(), V.end()), V.end());
+  }
+
+  // Classify PendingB sites.
+  for (const struct PendingB &Pb : PendingBs) {
+    if (Result.SetpcSites.count(Pb.SetpcOffset))
+      continue;  // already classified by Phase 4 (e.g. DispatchSet)
+    auto It = TargetsByPair.find(Pb.RetPairLowReg);
+    if (It == TargetsByPair.end() || It->second.empty()) {
+      SetPcSiteInfo Info;
+      Info.SiteKind = SetPcSiteInfo::Kind::Unresolvable;
+      Info.RefusalReason =
+          (llvm::Twine("s_set_pc_i64 reads SGPR pair s[") +
+           llvm::Twine(Pb.RetPairLowReg) + ":" +
+           llvm::Twine(Pb.RetPairLowReg + 1) +
+           "] but no statically resolvable call-site getpc+add chain "
+           "targets that pair (and inter-block dataflow could not "
+           "enumerate a bounded target set either)")
+              .str();
+      Result.SetpcSites[Pb.SetpcOffset] = std::move(Info);
+      continue;
+    }
+    SetPcSiteInfo Info;
+    Info.SiteKind = SetPcSiteInfo::Kind::IndirectB;
+    Info.IndirectTargets.assign(It->second.begin(), It->second.end());
+    Info.IndirectRetPairLowReg = Pb.RetPairLowReg;
+    Result.SetpcSites[Pb.SetpcOffset] = std::move(Info);
+  }
+
+  return Result;
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/setpc-analysis.h
+++ b/amd/comgr/src/hotswap/setpc-analysis.h
@@ -1,0 +1,153 @@
+//===- setpc-analysis.h - Hotswap transpiler ------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_SETPC_ANALYSIS_H
+#define HOTSWAP_TRANSPILER_SETPC_ANALYSIS_H
+
+#include "decoded-inst.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <cstdint>
+#include <set>
+#include <string>
+
+namespace COMGR::hotswap {
+
+struct MCState;
+
+// Static analysis pass that classifies every `s_set_pc_i64` site in a
+// decoded kernel. See canonical-op.h's S_SET_PC_I64 doc for the three
+// principled lowering shapes (Pattern A direct br, Pattern B / DispatchSet
+// cmp+br cascade via `emitEnumeratedDispatch`, Unresolvable refusal).
+//
+// The analysis is conservative: any SGPR pair whose value path it
+// cannot follow drops out of the symbolic-PC table immediately, so
+// downstream `s_set_pc_i64` sites that read a dropped pair are
+// classified Unresolvable rather than guessed. The handler refuses
+// loudly on Unresolvable — never silently emit a stub branch.
+
+struct SetPcSiteInfo {
+  enum class Kind {
+    // Statically resolvable single-target intra-kernel branch. Source
+    // SGPR pair was produced by a complete `s_get_pc_i64 + s_add_co_u32
+    // + s_add_co_ci_u32` chain in the same basic block as the
+    // s_set_pc_i64 / s_swap_pc_i64. Lowering emits `br label %BB_target`.
+    DirectA,
+    // Subroutine-return shape: the source SGPR pair is the ret-pair
+    // populated by a caller's chainTerminator hook. Lowering emits a
+    // `cmp eq + br` cascade (via `emitEnumeratedDispatch` in
+    // handle_sop1.cpp) over the resolved return targets, terminating
+    // in an `unreachable` trap BB. Pattern B is asymmetric — call-
+    // side and return-side participate through chainTerminators +
+    // pendingB enumeration in Pass 4.
+    IndirectB,
+    // Multi-target dispatch shape: source SGPR pair holds one of N
+    // statically-known absolute targets reaching the use site through
+    // distinct CFG paths (e.g. tensilelite's "activation function
+    // dispatcher" — each predecessor block writes a different chain
+    // target into the same pair, then a join block consumes it). The
+    // inter-block PC-chain dataflow in Pass 3 enumerates the targets;
+    // Pass 5 retains every contributing chain terminator so the raiser
+    // hook writes the per-predecessor i64 marker (the resolved
+    // callee's source-MC byte offset) into the pair at each
+    // predecessor (mirroring the IndirectB return-side mechanism).
+    // The lowering emits the same cmp+br enumerated-dispatch cascade
+    // as IndirectB (comparing the marker against each enumerated
+    // target offset); for s_swap_pc_i64 it ALSO writes the
+    // return-address marker into sdst before the cascade (same as
+    // DirectA). Order is deterministic (ascending) so lit fixtures
+    // can pin shape. See `emitEnumeratedDispatch`'s rationale block
+    // in handle_sop1.cpp for why a cascade (FixIrreducible
+    // compatibility under irreducible CFGs) and why integer markers
+    // rather than `ptrtoint(blockaddress)` (AMDGPU ISel cannot
+    // materialise a `BlockAddress` as an i64).
+    DispatchSet,
+    // Refused. The handler converts this into
+    // `RaiseFailure::unsupportedShape` with `refusalReason`.
+    Unresolvable,
+  };
+  Kind SiteKind = Kind::Unresolvable;
+  // DirectA: the absolute kernel offset to branch to. The lowering
+  // emits `br label %BB_<directTarget>`.
+  uint64_t DirectTarget = 0;
+  // IndirectB: the enumerated set of possible return targets (each is
+  // the absolute kernel offset of a basic block following one of the
+  // identified call sites). Order is deterministic (ascending) so
+  // lit fixtures can pin shape.
+  // DispatchSet: the enumerated set of possible callee/branch targets
+  // (each is the absolute kernel offset of a basic block leader that
+  // is a chain-resolved value of the source pair on some incoming CFG
+  // path). Same ordering contract.
+  llvm::SmallVector<uint64_t, 4> IndirectTargets;
+  // IndirectB: the SGPR low index of the source pair (for diagnostics
+  // and so the handler can read the right pair).
+  // DispatchSet: same — the SGPR low index of the source pair the
+  // handler reads to drive the cmp+br cascade.
+  unsigned IndirectRetPairLowReg = 0;
+  // Unresolvable: human-readable reason for the refusal diagnostic.
+  std::string RefusalReason;
+};
+
+struct SetPcCallSiteInfo {
+  // Absolute kernel offset of the instruction immediately following
+  // the call-site `s_branch` (i.e. the return target the call site
+  // expected). The Pattern B lowering will list this offset's BB as
+  // one of the cascade's enumerated targets.
+  uint64_t ResolvedReturnAddr = 0;
+  // SGPR low index of the ret-pair this call site populates. Pattern
+  // B `s_set_pc_i64 sX:Y` enumerates call sites whose
+  // retPairLowReg == X.
+  unsigned RetPairLowReg = 0;
+};
+
+struct SetPcAnalysis {
+  // Keyed by the s_set_pc_i64 instruction's absolute kernel offset.
+  llvm::DenseMap<uint64_t, SetPcSiteInfo> SetpcSites;
+
+  // Chain-terminator hooks: keyed by the absolute offset of the
+  // s_add_co_ci_u32 (high-half add) that completes a call-site PC
+  // chain. The raiser runs the SOP2 handler normally for that
+  // instruction and then overwrites the ret-pair SGPR with the
+  // plain i64 marker `resolvedReturnAddr` (the source-MC byte
+  // offset of the BB the chain was intended to return to), so the
+  // i64 value carried in the ret-pair across the call is a normal
+  // integer constant on each contributing predecessor path rather
+  // than a binary runtime PC. This makes each downstream
+  // enumerated-dispatch cascade `icmp eq i64 %marker, <offset>`
+  // foldable to `i1 true` under mem2reg + SCCP + InstCombine after
+  // the cross-predecessor phi join, so SimplifyCFG collapses the
+  // cascade to a direct branch on each predecessor-specialised
+  // path. (An earlier revision stored
+  // `ptrtoint(blockaddress(@kernel, %BB_<resolvedReturnAddr>))`
+  // here — that form survived unfolded in irreducible CFGs and
+  // crashed AMDGPU ISel with `Cannot select: BlockAddress`; see
+  // `emitEnumeratedDispatch` in handle_sop1.cpp for the full
+  // rationale.)
+  llvm::DenseMap<uint64_t, SetPcCallSiteInfo> ChainTerminators;
+
+  // Block-start offsets newly discovered by this analysis: Pattern A
+  // direct targets + Pattern B return targets. Caller merges these
+  // into the overall blockStarts BEFORE basic-block layout.
+  llvm::DenseSet<uint64_t> ExtraBlockStarts;
+};
+
+// Run the analysis. `blockStarts` is the set of leaders the decoder
+// already discovered (used to reset the per-block symbolic-PC table
+// at every BB boundary). `mc` provides MCRegisterInfo for SGPR
+// classification.
+SetPcAnalysis analyseSetPC(llvm::ArrayRef<DecodedInst> Insts,
+                           const std::set<uint64_t> &BlockStarts,
+                           const MCState &Mc);
+
+} // namespace COMGR::hotswap
+
+#endif


### PR DESCRIPTION
  * setpc_analysis.{h,cpp} — `runSetPcAnalysis` walks the decoded
    instruction stream and classifies every `s_set_pc_i64` /
    `s_swap_pc_i64` site as DirectA, IndirectB, DispatchSet, or
    Unresolvable. Output is a `SetPcAnalysis{SetpcSites, ChainTerms}`
    bundle handlers consume in Phase 5 to lower indirect branches to
    cmp+br cascades.
  * docs/sync-translation.md — barrier / s_waitcnt / TENSOR_CNT
    translation matrix.

