### PR TITLE
[Clang][HIP] Make __hip_atomic_* builtins a hard error

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -273,7 +273,6 @@ def UnguardedAvailability : DiagGroup<"unguarded-availability",
 def : DiagGroup<"partial-availability", [UnguardedAvailability]>;
 def DeprecatedDynamicExceptionSpec
     : DiagGroup<"deprecated-dynamic-exception-spec">;
-def HipDeprecatedBuiltins : DiagGroup<"hip-deprecated-builtins">;
 def DeprecatedBuiltins : DiagGroup<"deprecated-builtins">;
 def DeprecatedImplementations :DiagGroup<"deprecated-implementations">;
 def DeprecatedIncrementBool : DiagGroup<"deprecated-increment-bool">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6356,9 +6356,8 @@ def warn_unavailable_def : Warning<
 def warn_deprecated_builtin : Warning<
   "builtin %0 is deprecated; use %1 instead">,
   InGroup<DeprecatedBuiltins>;
-def warn_hip_deprecated_builtin : Warning<
-  "builtin %0 is deprecated; use %1 instead">,
-  InGroup<HipDeprecatedBuiltins>, DefaultIgnore;
+def err_hip_deprecated_builtin : Error<
+  "builtin %0 is deprecated; use %1 instead">;
 def warn_deprecated_builtin_no_suggestion : Warning<"builtin %0 is deprecated">,
   InGroup<DeprecatedBuiltins>;
 def err_unavailable : Error<"%0 is unavailable">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -6344,9 +6344,8 @@ def warn_unavailable_def : Warning<
 def warn_deprecated_builtin : Warning<
   "builtin %0 is deprecated; use %1 instead">,
   InGroup<DeprecatedBuiltins>;
-def warn_hip_deprecated_builtin : Warning<
-  "builtin %0 is deprecated; use %1 instead">,
-  InGroup<HipDeprecatedBuiltins>, DefaultIgnore;
+def err_hip_deprecated_builtin : Error<
+  "builtin %0 is deprecated; use %1 instead">;
 def warn_deprecated_builtin_no_suggestion : Warning<"builtin %0 is deprecated">,
   InGroup<DeprecatedBuiltins>;
 def err_unavailable : Error<"%0 is unavailable">;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4841,7 +4841,7 @@ static void DiagnoseDeprecatedHIPAtomic(Sema &S, SourceRange ExprRange,
     llvm_unreachable("unhandled HIP atomic op");
   }
 
-  auto DB = S.Diag(ExprRange.getBegin(), diag::warn_hip_deprecated_builtin)
+  auto DB = S.Diag(ExprRange.getBegin(), diag::err_hip_deprecated_builtin)
             << OldName << NewName;
   if (!CanFixIt)
     return;

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -4704,7 +4704,7 @@ static void DiagnoseDeprecatedHIPAtomic(Sema &S, SourceRange ExprRange,
     llvm_unreachable("unhandled HIP atomic op");
   }
 
-  auto DB = S.Diag(ExprRange.getBegin(), diag::warn_hip_deprecated_builtin)
+  auto DB = S.Diag(ExprRange.getBegin(), diag::err_hip_deprecated_builtin)
             << OldName << NewName;
   if (!CanFixIt)
     return;

--- a/clang/test/SemaHIP/atomic-deprecated.hip
+++ b/clang/test/SemaHIP/atomic-deprecated.hip
@@ -1,13 +1,13 @@
-// RUN: %clang_cc1 -x hip -triple amdgcn -fcuda-is-device -verify -fsyntax-only -Whip-deprecated-builtins %s
-// RUN: %clang_cc1 -x hip -triple amdgcn -fcuda-is-device -fdiagnostics-parseable-fixits -Whip-deprecated-builtins %s 2>&1 | FileCheck %s
+// RUN: %clang_cc1 -x hip -triple amdgcn -fcuda-is-device -verify -fsyntax-only %s
+// RUN: not %clang_cc1 -x hip -triple amdgcn -fcuda-is-device -fdiagnostics-parseable-fixits %s 2>&1 | FileCheck %s
 
 #define __device__ __attribute__((device))
 
 __device__ void test(int *p, int v, int s) {
-  __hip_atomic_load(p, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);     // expected-warning {{builtin __hip_atomic_load is deprecated; use __scoped_atomic_load_n instead}}
-  __hip_atomic_store(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM); // expected-warning {{builtin __hip_atomic_store is deprecated; use __scoped_atomic_store_n instead}}
-  __hip_atomic_load(p, __ATOMIC_RELAXED, s);                             // expected-warning {{builtin __hip_atomic_load is deprecated; use __scoped_atomic_load_n instead}}
-  __hip_atomic_store(p, v, __ATOMIC_RELAXED, s);                         // expected-warning {{builtin __hip_atomic_store is deprecated; use __scoped_atomic_store_n instead}}
+  __hip_atomic_load(p, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);     // expected-error {{builtin __hip_atomic_load is deprecated; use __scoped_atomic_load_n instead}}
+  __hip_atomic_store(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM); // expected-error {{builtin __hip_atomic_store is deprecated; use __scoped_atomic_store_n instead}}
+  __hip_atomic_load(p, __ATOMIC_RELAXED, s);                             // expected-error {{builtin __hip_atomic_load is deprecated; use __scoped_atomic_load_n instead}}
+  __hip_atomic_store(p, v, __ATOMIC_RELAXED, s);                         // expected-error {{builtin __hip_atomic_store is deprecated; use __scoped_atomic_store_n instead}}
 }
 
 // Statically known scope: both the builtin name and the scope argument get fix-its.
@@ -22,13 +22,13 @@ __device__ void test(int *p, int v, int s) {
 // Fetch ops: argument layout matches __scoped_atomic_fetch_*.  Scope varies
 // across all six __HIP_MEMORY_SCOPE_* values.
 __device__ void test_fetch(int *p, int v) {
-  __hip_atomic_fetch_add(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SINGLETHREAD); // expected-warning {{builtin __hip_atomic_fetch_add is deprecated; use __scoped_atomic_fetch_add instead}}
-  __hip_atomic_fetch_sub(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WAVEFRONT);    // expected-warning {{builtin __hip_atomic_fetch_sub is deprecated; use __scoped_atomic_fetch_sub instead}}
-  __hip_atomic_fetch_and(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);    // expected-warning {{builtin __hip_atomic_fetch_and is deprecated; use __scoped_atomic_fetch_and instead}}
-  __hip_atomic_fetch_or(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);         // expected-warning {{builtin __hip_atomic_fetch_or is deprecated; use __scoped_atomic_fetch_or instead}}
-  __hip_atomic_fetch_xor(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);       // expected-warning {{builtin __hip_atomic_fetch_xor is deprecated; use __scoped_atomic_fetch_xor instead}}
-  __hip_atomic_fetch_min(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_CLUSTER);      // expected-warning {{builtin __hip_atomic_fetch_min is deprecated; use __scoped_atomic_fetch_min instead}}
-  __hip_atomic_fetch_max(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SINGLETHREAD); // expected-warning {{builtin __hip_atomic_fetch_max is deprecated; use __scoped_atomic_fetch_max instead}}
+  __hip_atomic_fetch_add(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SINGLETHREAD); // expected-error {{builtin __hip_atomic_fetch_add is deprecated; use __scoped_atomic_fetch_add instead}}
+  __hip_atomic_fetch_sub(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WAVEFRONT);    // expected-error {{builtin __hip_atomic_fetch_sub is deprecated; use __scoped_atomic_fetch_sub instead}}
+  __hip_atomic_fetch_and(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);    // expected-error {{builtin __hip_atomic_fetch_and is deprecated; use __scoped_atomic_fetch_and instead}}
+  __hip_atomic_fetch_or(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);         // expected-error {{builtin __hip_atomic_fetch_or is deprecated; use __scoped_atomic_fetch_or instead}}
+  __hip_atomic_fetch_xor(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SYSTEM);       // expected-error {{builtin __hip_atomic_fetch_xor is deprecated; use __scoped_atomic_fetch_xor instead}}
+  __hip_atomic_fetch_min(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_CLUSTER);      // expected-error {{builtin __hip_atomic_fetch_min is deprecated; use __scoped_atomic_fetch_min instead}}
+  __hip_atomic_fetch_max(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_SINGLETHREAD); // expected-error {{builtin __hip_atomic_fetch_max is deprecated; use __scoped_atomic_fetch_max instead}}
 }
 // CHECK: fix-it:{{.*}}:{[[@LINE-8]]:3-[[@LINE-8]]:25}:"__scoped_atomic_fetch_add"
 // CHECK: fix-it:{{.*}}:{[[@LINE-9]]:50-[[@LINE-9]]:81}:"__MEMORY_SCOPE_SINGLE"
@@ -50,9 +50,9 @@ __device__ void test_fetch(int *p, int v) {
 // argument layout (scoped form takes an additional 'weak' boolean and passes
 // 'desired' by pointer), so only a deprecation warning is emitted.
 __device__ void test_exchange(int *p, int *ep, int v) {
-  __hip_atomic_exchange(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WAVEFRONT);                               // expected-warning {{builtin __hip_atomic_exchange is deprecated; use __scoped_atomic_exchange_n instead}}
-  __hip_atomic_compare_exchange_weak(p, ep, v, __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);   // expected-warning {{builtin __hip_atomic_compare_exchange_weak is deprecated; use __scoped_atomic_compare_exchange instead}}
-  __hip_atomic_compare_exchange_strong(p, ep, v, __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);     // expected-warning {{builtin __hip_atomic_compare_exchange_strong is deprecated; use __scoped_atomic_compare_exchange instead}}
+  __hip_atomic_exchange(p, v, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WAVEFRONT);                               // expected-error {{builtin __hip_atomic_exchange is deprecated; use __scoped_atomic_exchange_n instead}}
+  __hip_atomic_compare_exchange_weak(p, ep, v, __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_WORKGROUP);   // expected-error {{builtin __hip_atomic_compare_exchange_weak is deprecated; use __scoped_atomic_compare_exchange instead}}
+  __hip_atomic_compare_exchange_strong(p, ep, v, __ATOMIC_RELAXED, __ATOMIC_RELAXED, __HIP_MEMORY_SCOPE_AGENT);     // expected-error {{builtin __hip_atomic_compare_exchange_strong is deprecated; use __scoped_atomic_compare_exchange instead}}
 }
 // CHECK: fix-it:{{.*}}:{[[@LINE-4]]:3-[[@LINE-4]]:24}:"__scoped_atomic_exchange_n"
 // CHECK: fix-it:{{.*}}:{[[@LINE-5]]:49-[[@LINE-5]]:77}:"__MEMORY_SCOPE_WVFRNT"


### PR DESCRIPTION
This generates an error instead of the silent warning introduced in #189897

NOT TO BE SUBMITTED. This is a pre-commit EPSDB check before upstream review.

Assisted-By: Claude Sonnet 4.6


