### PR TITLE
Improve Debug instruction support in SIFrameLowering

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFrameLowering.cpp
@@ -1737,13 +1737,14 @@ void SIFrameLowering::processFunctionBeforeFrameFinalized(
     BitVector SpillFIs(MFI.getObjectIndexEnd(), false);
     BitVector NonVGPRSpillFIs(MFI.getObjectIndexEnd(), false);
 
-    bool SeenDbgInstr = false;
+    // To gather DBG_VALUE and DBG_VALUE_LIST instructions.
+    MIVector DbgValInsts;
 
     for (MachineBasicBlock &MBB : MF) {
       for (MachineInstr &MI : llvm::make_early_inc_range(MBB)) {
         int FrameIndex;
         if (MI.isDebugInstr())
-          SeenDbgInstr = true;
+          DbgValInsts.push_back(&MI);
 
         if (TII->isVGPRSpill(MI)) {
           // Try to eliminate stack used by VGPR spills before frame
@@ -1784,8 +1785,8 @@ void SIFrameLowering::processFunctionBeforeFrameFinalized(
 
       MBB.sortUniqueLiveIns();
 
-      if (!SpillFIs.empty() && SeenDbgInstr)
-        clearDebugInfoForSpillFIs(MFI, MBB, SpillFIs);
+      if (!SpillFIs.empty() && !DbgValInsts.empty())
+        updateDbgValueInstsForSpillFIs(DbgValInsts, SpillFIs);
     }
   }
 

--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
@@ -34,7 +34,6 @@ using namespace llvm;
 #define DEBUG_TYPE "si-lower-sgpr-spills"
 
 using MBBVector = SmallVector<MachineBasicBlock *, 4>;
-using MIVector  = SmallVector<MachineInstr*>;
 
 namespace {
 
@@ -83,8 +82,6 @@ public:
       int FI, MachineBasicBlock *MBB, MachineBasicBlock::iterator InsertPt,
       DenseMap<Register, LaneVGPRInsertPt> &LaneVGPRDomInstr);
   void determineRegsForWWMAllocation(MachineFunction &MF, BitVector &RegMask);
-  void updateDbgValueInst(MachineInstr &MI, const BitVector &SpillFIs);
-  void updateDbgValueInsts(MIVector &Insts, const BitVector &SpillFIs);
 };
 
 class SILowerSGPRSpillsLegacy : public MachineFunctionPass {
@@ -427,102 +424,6 @@ bool SILowerSGPRSpillsLegacy::runOnMachineFunction(MachineFunction &MF) {
   return SILowerSGPRSpills(LIS, Indexes, MDT, MCI).run(MF);
 }
 
-// Replace frame index in a DBG_VALUE or DBG_VALUE_LIST instruction with VGPR lane.
-void SILowerSGPRSpills::updateDbgValueInst(MachineInstr &MI,
-                                           const BitVector &SpillFIs) {
-  assert(MI.isDebugValue());
-  const MachineFunction *MF = MI.getParent()->getParent();
-  auto *FuncInfo = MF->getInfo<SIMachineFunctionInfo>();
-  const auto &FrInfo = MF->getFrameInfo();
-
-  auto WasOpndSpilled = [&](const MachineOperand &Opnd) {
-    return (Opnd.isFI() && !FrInfo.isFixedObjectIndex(Opnd.getIndex()) &&
-            SpillFIs[Opnd.getIndex()]);
-  };
-
-  if (MI.getDebugExpression()->holdsOldElements()) {
-    // For old-style DIExpressions, just do nothing and we will drop all
-    // spilled FIs below.
-    // FIXME: We should instead, update it with the
-    // correct register value. It should be worked out later.
-  } else {
-    DIExprBuilder Builder(*MI.getDebugExpression());
-    IntegerType *TypeInt8 = IntegerType::get(Builder.getContext(), 8);
-    IntegerType *TypeInt32 = IntegerType::get(Builder.getContext(), 32);
-    for (auto &&I = Builder.begin(); I != Builder.end();) {
-      if (auto *Arg = std::get_if<DIOp::Arg>(&*I++)) {
-        MachineOperand &MO = MI.getDebugOperand(Arg->getIndex());
-        if (!WasOpndSpilled(MO))
-          continue;
-        ArrayRef<SIRegisterInfo::SpilledReg> VGPRSpills =
-            FuncInfo->getSGPRSpillToVirtualVGPRLanes(MO.getIndex());
-        // FIXME: This is a very narrow pattern to match, we could handle much
-        // more, both intervening ops and multi-lane spills
-        if (I != Builder.end() && std::get_if<DIOp::Deref>(&*I) &&
-            VGPRSpills.size() == 1) {
-          const SIRegisterInfo::SpilledReg &VGPRSpill = VGPRSpills.front();
-          // Change the type of DIOpArg and replace the following DIOpDeref
-          // with DIOpConstant + DIOpByteOfset.
-          Arg->setResultType(TypeInt32);
-          ConstantData *C =
-              ConstantInt::get(TypeInt8, VGPRSpill.Lane * 8, true);
-          const std::initializer_list<DIOp::Variant> Ops = {
-              DIOp::Constant(C), DIOp::ByteOffset(TypeInt32)};
-          I = Builder.insert(Builder.erase(I), Ops) + Ops.size();
-          // Replace stack (frame index) argument of MI with VGPR
-          MO.ChangeToRegister(VGPRSpill.VGPR, false);
-        } else {
-          MO.ChangeToRegister(Register(), /*isDef=*/false);
-        }
-      }
-    }
-    MI.getDebugExpressionOp().setMetadata(Builder.intoExpression());
-  }
-  // Any spilled FIs we haven't handled by this point should just be dropped.
-  for (MachineOperand &Op : MI.debug_operands()) {
-    if (WasOpndSpilled(Op))
-      Op.ChangeToRegister(Register(), /*isDef=*/false);
-  }
-}
-
-// Update DBG_VALUE and DBG_VALUE_LIST instructions so that they correctly
-// reflect performed stack to VGPR spills.
-// Examples:
-//  DBG_VALUE  %stack.8, 0, !"next", !DIExpression(DIOpArg(0, ptr addrspace(5)),
-//                                                 DIOpDeref(i32))
-//    --->
-//  DBG_VALUE  %249 : vgpr_32, 0, !"next", !DIExpression(DIOpArg(0, i32),
-//                                                       DIOpConstant(i8 40),
-//                                                       DIOpByteOffset(i32))
-//
-//
-//  DBG_VALUE_LIST !"next", !DIExpression(DIOpArg(0, ptr addrspace(5)),
-//                                        DIOpDeref(i32),
-//                                        DIOpArg(1, ptr addrspace(5)),
-//                                        DIOpDeref(i32),
-//                                        DIOpAdd()),
-//                 %stack.9, %stack.5
-//    --->
-//  DBG_VALUE_LIST !"next", !DIExpression(DIOpArg(0, i32),
-//                                        DIOpConstant(i8 40),
-//                                        DIOpByteOffset(i32),
-//                                        DIOpArg(1, ptr addrspace(5)),
-//                                        DIOpDeref(i32),
-//                                        DIOpAdd()),
-//                 %14 : vgpr_32, %stack.5
-//
-void SILowerSGPRSpills::updateDbgValueInsts(MIVector &Insts,
-                                            const BitVector &SpillFIs) {
-  for (MachineInstr *MI : Insts) {
-    if (MI->isDebugValue() &&
-        std::any_of(MI->operands_begin(), MI->operands_end(),
-                    [](auto &Opnd) { return Opnd.isFI(); })) {
-      updateDbgValueInst(*MI, SpillFIs);
-    }
-  }
-  Insts.clear();
-}
-
 bool SILowerSGPRSpills::run(MachineFunction &MF) {
   const GCNSubtarget &ST = MF.getSubtarget<GCNSubtarget>();
   TII = ST.getInstrInfo();
@@ -661,7 +562,7 @@ bool SILowerSGPRSpills::run(MachineFunction &MF) {
       FuncInfo->updateNonWWMRegMask(NonWwmRegMask);
     }
 
-    updateDbgValueInsts(DbgValInsts, SpillFIs);
+    updateDbgValueInstsForSpillFIs(DbgValInsts, SpillFIs);
 
     // All those frame indices which are dead by now should be removed from the
     // function frame. Otherwise, there is a side effect such as re-mapping of

--- a/llvm/lib/Target/AMDGPU/SISpillUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/SISpillUtils.cpp
@@ -34,7 +34,7 @@ static void updateDbgValueInstForSpillFIs(MachineInstr &MI,
     // correct register value. It should be worked out later.
   } else {
     DIExprBuilder Builder(*MI.getDebugExpression());
-    IntegerType *TypeInt8 = IntegerType::get(Builder.getContext(), 8);
+    IntegerType *TypeInt16 = IntegerType::get(Builder.getContext(), 16);
     IntegerType *TypeInt32 = IntegerType::get(Builder.getContext(), 32);
     for (auto &&I = Builder.begin(); I != Builder.end();) {
       if (auto *Arg = std::get_if<DIOp::Arg>(&*I++)) {
@@ -52,7 +52,7 @@ static void updateDbgValueInstForSpillFIs(MachineInstr &MI,
           // with DIOpConstant + DIOpByteOfset.
           Arg->setResultType(TypeInt32);
           ConstantData *C =
-              ConstantInt::get(TypeInt8, VGPRSpill.Lane * 8, true);
+              ConstantInt::get(TypeInt16, VGPRSpill.Lane * 8, true);
           const std::initializer_list<DIOp::Variant> Ops = {
               DIOp::Constant(C), DIOp::ByteOffset(TypeInt32)};
           I = Builder.insert(Builder.erase(I), Ops) + Ops.size();

--- a/llvm/lib/Target/AMDGPU/SISpillUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/SISpillUtils.cpp
@@ -8,7 +8,6 @@
 
 #include "SISpillUtils.h"
 #include "SIMachineFunctionInfo.h"
-#include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 

--- a/llvm/lib/Target/AMDGPU/SISpillUtils.cpp
+++ b/llvm/lib/Target/AMDGPU/SISpillUtils.cpp
@@ -7,28 +7,80 @@
 //===----------------------------------------------------------------------===//
 
 #include "SISpillUtils.h"
+#include "SIMachineFunctionInfo.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/CodeGen/MachineFrameInfo.h"
 #include "llvm/CodeGen/MachineFunction.h"
 
 using namespace llvm;
 
-void llvm::clearDebugInfoForSpillFIs(MachineFrameInfo &MFI,
-                                     MachineBasicBlock &MBB,
-                                     const BitVector &SpillFIs) {
-  // FIXME: The dead frame indices are replaced with a null register from the
-  // debug value instructions. We should instead update it with the correct
-  // register value. But not sure the register value alone is adequate to lower
-  // the DIExpression. It should be worked out later.
-  for (MachineInstr &MI : MBB) {
-    if (!MI.isDebugValue())
-      continue;
+// Replace frame index in a DBG_VALUE or DBG_VALUE_LIST instruction with VGPR
+// lane.
+static void updateDbgValueInstForSpillFIs(MachineInstr &MI,
+                                          const BitVector &SpillFIs) {
+  assert(MI.isDebugValue());
+  const MachineFunction *MF = MI.getParent()->getParent();
+  auto *FuncInfo = MF->getInfo<SIMachineFunctionInfo>();
+  const auto &FrInfo = MF->getFrameInfo();
 
-    for (MachineOperand &Op : MI.debug_operands()) {
-      if (Op.isFI() && !MFI.isFixedObjectIndex(Op.getIndex()) &&
-          SpillFIs[Op.getIndex()]) {
-        Op.ChangeToRegister(Register(), /*isDef=*/false);
+  auto WasOpndSpilled = [&](const MachineOperand &Opnd) {
+    return (Opnd.isFI() && !FrInfo.isFixedObjectIndex(Opnd.getIndex()) &&
+            SpillFIs[Opnd.getIndex()]);
+  };
+
+  if (MI.getDebugExpression()->holdsOldElements()) {
+    // For old-style DIExpressions, just do nothing and we will drop all
+    // spilled FIs below.
+    // FIXME: We should instead, update it with the
+    // correct register value. It should be worked out later.
+  } else {
+    DIExprBuilder Builder(*MI.getDebugExpression());
+    IntegerType *TypeInt8 = IntegerType::get(Builder.getContext(), 8);
+    IntegerType *TypeInt32 = IntegerType::get(Builder.getContext(), 32);
+    for (auto &&I = Builder.begin(); I != Builder.end();) {
+      if (auto *Arg = std::get_if<DIOp::Arg>(&*I++)) {
+        MachineOperand &MO = MI.getDebugOperand(Arg->getIndex());
+        if (!WasOpndSpilled(MO))
+          continue;
+        ArrayRef<SIRegisterInfo::SpilledReg> VGPRSpills =
+            FuncInfo->getSGPRSpillToVirtualVGPRLanes(MO.getIndex());
+        // FIXME: This is a very narrow pattern to match, we could handle much
+        // more, both intervening ops and multi-lane spills
+        if (I != Builder.end() && std::get_if<DIOp::Deref>(&*I) &&
+            VGPRSpills.size() == 1) {
+          const SIRegisterInfo::SpilledReg &VGPRSpill = VGPRSpills.front();
+          // Change the type of DIOpArg and replace the following DIOpDeref
+          // with DIOpConstant + DIOpByteOfset.
+          Arg->setResultType(TypeInt32);
+          ConstantData *C =
+              ConstantInt::get(TypeInt8, VGPRSpill.Lane * 8, true);
+          const std::initializer_list<DIOp::Variant> Ops = {
+              DIOp::Constant(C), DIOp::ByteOffset(TypeInt32)};
+          I = Builder.insert(Builder.erase(I), Ops) + Ops.size();
+          // Replace stack (frame index) argument of MI with VGPR
+          MO.ChangeToRegister(VGPRSpill.VGPR, false);
+        } else {
+          MO.ChangeToRegister(Register(), /*isDef=*/false);
+        }
       }
     }
+    MI.getDebugExpressionOp().setMetadata(Builder.intoExpression());
   }
+  // Any spilled FIs we haven't handled by this point should just be dropped.
+  for (MachineOperand &Op : MI.debug_operands()) {
+    if (WasOpndSpilled(Op))
+      Op.ChangeToRegister(Register(), /*isDef=*/false);
+  }
+}
+
+void llvm::updateDbgValueInstsForSpillFIs(MIVector &Insts,
+                                          const BitVector &SpillFIs) {
+  for (MachineInstr *MI : Insts) {
+    if (MI->isDebugValue() &&
+        std::any_of(MI->operands_begin(), MI->operands_end(),
+                    [](auto &Opnd) { return Opnd.isFI(); })) {
+      updateDbgValueInstForSpillFIs(*MI, SpillFIs);
+    }
+  }
+  Insts.clear();
 }

--- a/llvm/lib/Target/AMDGPU/SISpillUtils.h
+++ b/llvm/lib/Target/AMDGPU/SISpillUtils.h
@@ -12,13 +12,36 @@
 namespace llvm {
 
 class BitVector;
-class MachineBasicBlock;
-class MachineFrameInfo;
 
-/// Replace frame index operands with null registers in debug value instructions
-/// for the specified spill frame indices.
-void clearDebugInfoForSpillFIs(MachineFrameInfo &MFI, MachineBasicBlock &MBB,
-                               const BitVector &SpillFIs);
+using MIVector = SmallVector<MachineInstr *>;
+
+// Update DBG_VALUE and DBG_VALUE_LIST instructions so that they correctly
+// reflect performed stack to VGPR spills.
+// Examples:
+//  DBG_VALUE  %stack.8, 0, !"next", !DIExpression(DIOpArg(0, ptr addrspace(5)),
+//                                                 DIOpDeref(i32))
+//    --->
+//  DBG_VALUE  %249 : vgpr_32, 0, !"next", !DIExpression(DIOpArg(0, i32),
+//                                                       DIOpConstant(i8 40),
+//                                                       DIOpByteOffset(i32))
+//
+//
+//  DBG_VALUE_LIST !"next", !DIExpression(DIOpArg(0, ptr addrspace(5)),
+//                                        DIOpDeref(i32),
+//                                        DIOpArg(1, ptr addrspace(5)),
+//                                        DIOpDeref(i32),
+//                                        DIOpAdd()),
+//                 %stack.9, %stack.5
+//    --->
+//  DBG_VALUE_LIST !"next", !DIExpression(DIOpArg(0, i32),
+//                                        DIOpConstant(i8 40),
+//                                        DIOpByteOffset(i32),
+//                                        DIOpArg(1, ptr addrspace(5)),
+//                                        DIOpDeref(i32),
+//                                        DIOpAdd()),
+//                 %14 : vgpr_32, %stack.5
+//
+void updateDbgValueInstsForSpillFIs(MIVector &Insts, const BitVector &SpillFIs);
 
 } // end namespace llvm
 

--- a/llvm/lib/Target/AMDGPU/SISpillUtils.h
+++ b/llvm/lib/Target/AMDGPU/SISpillUtils.h
@@ -9,6 +9,10 @@
 #ifndef LLVM_LIB_TARGET_AMDGPU_SISPILLUTILS_H
 #define LLVM_LIB_TARGET_AMDGPU_SISPILLUTILS_H
 
+#include "llvm/ADT/BitVector.h"
+#include "llvm/CodeGen/MachineInstr.h"
+#include "llvm/IR/DebugInfoMetadata.h"
+
 namespace llvm {
 
 class BitVector;

--- a/llvm/test/CodeGen/AMDGPU/dead-frame-index-dbg-value.ll
+++ b/llvm/test/CodeGen/AMDGPU/dead-frame-index-dbg-value.ll
@@ -1,23 +1,73 @@
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx1100 < %s | FileCheck %s
-; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx900 < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 < %s | FileCheck %s
+; RUN: llc -O0 -mtriple=amdgcn-amd-amdhsa -mcpu=gfx90a < %s | FileCheck %s
 
-; Check that debug values referencing eliminated frame indices don't crash.
-; The AMDGPU backend can eliminate spill slots during frame finalization
-; (e.g., SGPR spills to VGPR lanes). Debug values referencing these eliminated
-; frame indices need to be cleaned up to avoid assertions in PrologEpilogInserter.
+; Check that debug values referencing eliminated frame indices don't crash when
+; VGPR spills are folded to AGPRs in SIFrameLowering::processFunctionBeforeFrameFinalized
+; (requires hasMAIInsts(), hasSpilledVGPRs(), and amdgpu-spill-vgpr-to-agpr).
+; Consumer gfx9 (e.g. gfx900) and RDNA3 gfx11 lack FeatureMAIInsts, so they never
+; take that path; use CDNA-class targets and forced VGPR spills.
+;
+; At -O0 AMDGPU uses RegAllocFast for VGPRs (not LiveDebugVariables::emitDebugValues).
+; Fast RA rewrites #dbg_value to a physical register when the vreg is already
+; assigned; updateDbgValueInstForSpillFIs only sees DBG_VALUE operands with FI if
+; the watched value is actually spilled (buildDbgValueForSpill in spill()). %v5 is
+; kept in a VGPR for the 10-operand inline asm, so dbg on %v5 never gets an FI.
+; Use %v2, which is spilled under register pressure (spill-vgpr-to-agpr.ll pattern).
+; amdgpu-num-vgpr must be 11, not 10, or inline asm fails before RA finishes.
 
 %struct.Buffer = type { [8 x i64] }
 
 ; CHECK-LABEL: test_dbg_value_dead_frame_idx:
-; CHECK: ;DEBUG_VALUE: test_dbg_value_dead_frame_idx:slot <- [DW_OP_LLVM_arg 0, DW_OP_LLVM_arg 1, DW_OP_constu 64, DW_OP_mul, DW_OP_plus, DW_OP_stack_value] {{.*}}
+; Exercise VGPR-spill -> AGPR migration (not scratch) on CDNA.
+; CHECK-DAG: v_accvgpr_write_b32
+; DIArgList on kernel args (typically stays in registers).
+; CHECK-DAG: ;DEBUG_VALUE: test_dbg_value_dead_frame_idx:slot <- [DW_OP_LLVM_arg 0, DW_OP_LLVM_arg 1, DW_OP_constu 64, DW_OP_mul, DW_OP_plus, DW_OP_stack_value] {{.*}}
+; Spilled VGPR tracked for debug (may use stack location then FI cleanup).
+; CHECK-DAG: ;DEBUG_VALUE: test_dbg_value_dead_frame_idx:spill_witness {{.*}}
 ; CHECK: s_endpgm
-define amdgpu_kernel void @test_dbg_value_dead_frame_idx(ptr addrspace(1) %out, i64 %idx) !dbg !10 {
+define amdgpu_kernel void @test_dbg_value_dead_frame_idx(ptr addrspace(1) %out, i64 %idx) #0 !dbg !10 {
 entry:
   #dbg_value(!DIArgList(ptr addrspace(1) %out, i64 %idx), !15, !DIExpression(DW_OP_LLVM_arg, 0, DW_OP_LLVM_arg, 1, DW_OP_constu, 64, DW_OP_mul, DW_OP_plus, DW_OP_stack_value), !17)
+  %tid = load volatile i32, ptr addrspace(1) poison
+  call void asm sideeffect "", "a,a,a,a,a,a,a,a,a"(i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7, i32 8, i32 9)
+  %p1 = getelementptr inbounds i32, ptr addrspace(1) %out, i32 %tid
+  %p2 = getelementptr inbounds i32, ptr addrspace(1) %p1, i32 4
+  %p3 = getelementptr inbounds i32, ptr addrspace(1) %p2, i32 8
+  %p4 = getelementptr inbounds i32, ptr addrspace(1) %p3, i32 12
+  %p5 = getelementptr inbounds i32, ptr addrspace(1) %p4, i32 16
+  %p6 = getelementptr inbounds i32, ptr addrspace(1) %p5, i32 20
+  %p7 = getelementptr inbounds i32, ptr addrspace(1) %p6, i32 24
+  %p8 = getelementptr inbounds i32, ptr addrspace(1) %p7, i32 28
+  %p9 = getelementptr inbounds i32, ptr addrspace(1) %p8, i32 32
+  %p10 = getelementptr inbounds i32, ptr addrspace(1) %p9, i32 36
+  %v1 = load volatile i32, ptr addrspace(1) %p1
+  %v2 = load volatile i32, ptr addrspace(1) %p2
+  #dbg_value(i32 %v2, !19, !DIExpression(), !20)
+  %v3 = load volatile i32, ptr addrspace(1) %p3
+  %v4 = load volatile i32, ptr addrspace(1) %p4
+  %v5 = load volatile i32, ptr addrspace(1) %p5
+  %v6 = load volatile i32, ptr addrspace(1) %p6
+  %v7 = load volatile i32, ptr addrspace(1) %p7
+  %v8 = load volatile i32, ptr addrspace(1) %p8
+  %v9 = load volatile i32, ptr addrspace(1) %p9
+  %v10 = load volatile i32, ptr addrspace(1) %p10
+  call void asm sideeffect "", "v,v,v,v,v,v,v,v,v,v"(i32 %v1, i32 %v2, i32 %v3, i32 %v4, i32 %v5, i32 %v6, i32 %v7, i32 %v8, i32 %v9, i32 %v10)
+  store volatile i32 %v1, ptr addrspace(1) poison
+  store volatile i32 %v2, ptr addrspace(1) poison
+  store volatile i32 %v3, ptr addrspace(1) poison
+  store volatile i32 %v4, ptr addrspace(1) poison
+  store volatile i32 %v5, ptr addrspace(1) poison
+  store volatile i32 %v6, ptr addrspace(1) poison
+  store volatile i32 %v7, ptr addrspace(1) poison
+  store volatile i32 %v8, ptr addrspace(1) poison
+  store volatile i32 %v9, ptr addrspace(1) poison
+  store volatile i32 %v10, ptr addrspace(1) poison
   %ptr = getelementptr %struct.Buffer, ptr addrspace(1) %out, i64 %idx
   store i64 0, ptr addrspace(1) %ptr, align 8
   ret void
 }
+
+attributes #0 = { nounwind "amdgpu-num-vgpr"="11" }
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}
@@ -31,6 +81,10 @@ entry:
 !7 = distinct !DICompositeType(tag: DW_TAG_structure_type, name: "Buffer", file: !1, line: 1, size: 512, flags: DIFlagTypePassByValue, elements: !2)
 !10 = distinct !DISubprogram(name: "test_dbg_value_dead_frame_idx", scope: !1, file: !1, line: 10, type: !11, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition | DISPFlagOptimized, unit: !0)
 !11 = !DISubroutineType(types: !12)
-!12 = !{null, !6}
+!12 = !{null, !6, !18}
+!18 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
 !15 = !DILocalVariable(name: "slot", scope: !10, file: !1, line: 11, type: !6)
 !17 = !DILocation(line: 11, column: 1, scope: !10)
+!19 = !DILocalVariable(name: "spill_witness", scope: !10, file: !1, line: 12, type: !21)
+!20 = !DILocation(line: 12, column: 1, scope: !10)
+!21 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-list.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-list.mir
@@ -47,7 +47,7 @@ body:             |
     renamable $sgpr10 = IMPLICIT_DEF
     SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
     ; Test the path we expect to work (Arg followed immediately by Deref)
-    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, i32), DIOpConstant(i8 0), DIOpByteOffset(i32)), [[DEF]], 0, {{.*}}
+    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, i32), DIOpConstant(i16 0), DIOpByteOffset(i32)), [[DEF]], 0, {{.*}}
     DBG_VALUE_LIST !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(i32)), %stack.0, 0, debug-location !9
     S_NOP 0
     ; Test that we replace unhandled stack indexes with $noreg

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value.mir
@@ -42,7 +42,7 @@ body:             |
   ; SGPR_SPILL-LABEL: name: test
   ; SGPR_SPILL: bb.0:
   ; SGPR_SPILL:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr10, 0, [[DEF]]
-  ; SGPR_SPILL-NEXT:   DBG_VALUE [[DEF]], 0, {{.+}}, !DIExpression(DIOpArg(0, i32), DIOpConstant(i8 0), DIOpByteOffset(i32)), {{.+}}
+  ; SGPR_SPILL-NEXT:   DBG_VALUE [[DEF]], 0, {{.+}}, !DIExpression(DIOpArg(0, i32), DIOpConstant(i16 0), DIOpByteOffset(i32)), {{.+}}
   bb.0:
     renamable $sgpr10 = IMPLICIT_DEF
     SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32


### PR DESCRIPTION
## Summary
This PR improves debug information (DI) handling in SIFrameLowering to ensure proper metadata preservation during register spilling operations.

## Changes
- Enhanced debug info tracking for spill operations
- Common code moved from SILowerSGPRSpills.cpp to SISpillUtils.cpp and SISpillUtils.h
- Existing test case improved




