### PR TITLE
[Flang][OpenMP][MLIR] LC-1761 Performance Regression Fix 2

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/OpenMP/OpenMPToLLVMIRTranslation.cpp
@@ -5950,6 +5950,42 @@ static void mapParentWithMembers(
       llvm::cast<omp::MapInfoOp>(mapData.MapClause[mapDataIndex]);
   auto *parentMapper = mapData.Mappers[mapDataIndex];
 
+  auto getLowAndHighAddr = [&builder, &mapData,
+                            &moduleTranslation](omp::MapInfoOp mapOp) {
+    llvm::Value *lowAddr, *highAddr;
+    int firstMemberIdx = getMapDataMemberIdx(
+        mapData, getFirstOrLastMappedMemberPtr(mapOp, true));
+    lowAddr = builder.CreatePointerCast(mapData.BasePointers[firstMemberIdx],
+                                        builder.getPtrTy());
+
+    int lastMemberIdx = getMapDataMemberIdx(
+        mapData, getFirstOrLastMappedMemberPtr(mapOp, false));
+    auto lastMemberMapInfo =
+        cast<omp::MapInfoOp>(mapData.MapClause[lastMemberIdx]);
+
+    // NOTE: Currently, for RefPtee the BaseType is set to the varPtrPtr field,
+    // which is the pointer datas type and not the member within the structure
+    // that it's part of, so we have to make sure we use the member type in this
+    // case when calculating the parents size offsets.
+    // TODO: May be good to extend MapInfoData to support tracking of both
+    // VarPtr/VarPtrPtr BaseType's to better distinguish what's being used more
+    // consistently.
+    bool isRefPteeMap = bitEnumContainsAll(lastMemberMapInfo.getMapType(),
+                                           omp::ClauseMapFlags::ref_ptee) &&
+                        !bitEnumContainsAll(lastMemberMapInfo.getMapType(),
+                                            omp::ClauseMapFlags::ref_ptr);
+    llvm::Type *castType = mapData.BaseType[lastMemberIdx];
+    if (isRefPteeMap)
+      castType =
+          moduleTranslation.convertType(lastMemberMapInfo.getVarPtrType());
+    highAddr = builder.CreatePointerCast(
+        builder.CreateGEP(castType, mapData.BasePointers[lastMemberIdx],
+                          builder.getInt64(1)),
+        builder.getPtrTy());
+    return std::make_pair(std::make_pair(lowAddr, firstMemberIdx),
+                          std::make_pair(highAddr, lastMemberIdx));
+  };
+
   // Map the first segment of the parent. If a user-defined mapper is attached,
   // include the parent's to/from-style bits (and common modifiers) in this
   // base entry so the mapper receives correct copy semantics via its 'type'
@@ -5996,7 +6032,6 @@ static void mapParentWithMembers(
   // Fortran pointers and allocatables, the mapping of the pointed to
   // data by the descriptor (which itself, is a structure containing
   // runtime information on the dynamically allocated data).
-
   llvm::Value *lowAddr, *highAddr;
   if (!parentClause.getPartialMap()) {
     lowAddr = builder.CreatePointerCast(mapData.Pointers[mapDataIndex],
@@ -6007,37 +6042,11 @@ static void mapParentWithMembers(
         builder.getPtrTy());
     combinedInfo.Pointers.emplace_back(mapData.Pointers[mapDataIndex]);
   } else {
-    auto mapOp = dyn_cast<omp::MapInfoOp>(mapData.MapClause[mapDataIndex]);
-    int firstMemberIdx = getMapDataMemberIdx(
-        mapData, getFirstOrLastMappedMemberPtr(mapOp, true));
-    lowAddr = builder.CreatePointerCast(mapData.BasePointers[firstMemberIdx],
-                                        builder.getPtrTy());
-
-    int lastMemberIdx = getMapDataMemberIdx(
-        mapData, getFirstOrLastMappedMemberPtr(mapOp, false));
-    auto lastMemberMapInfo =
-        cast<omp::MapInfoOp>(mapData.MapClause[lastMemberIdx]);
-
-    // NOTE: Currently, for RefPtee the BaseType is set to the varPtrPtr field,
-    // which is the pointer datas type and not the member within the structure
-    // that it's part of, so we have to make sure we use the member type in this
-    // case when calculating the parents size offsets.
-    // TODO: May be good to extend MapInfoData to support tracking of both
-    // VarPtr/VarPtrPtr BaseType's to better distinguish what's being used more
-    // consistently.
-    bool isRefPteeMap = bitEnumContainsAll(lastMemberMapInfo.getMapType(),
-                                           omp::ClauseMapFlags::ref_ptee) &&
-                        !bitEnumContainsAll(lastMemberMapInfo.getMapType(),
-                                            omp::ClauseMapFlags::ref_ptr);
-    llvm::Type *castType = mapData.BaseType[lastMemberIdx];
-    if (isRefPteeMap)
-      castType =
-          moduleTranslation.convertType(lastMemberMapInfo.getVarPtrType());
-    highAddr = builder.CreatePointerCast(
-        builder.CreateGEP(castType, mapData.BasePointers[lastMemberIdx],
-                          builder.getInt64(1)),
-        builder.getPtrTy());
-    combinedInfo.Pointers.emplace_back(mapData.BasePointers[firstMemberIdx]);
+    auto lowAndHigh = getLowAndHighAddr(parentClause);
+    highAddr = std::get<0>(std::get<1>(lowAndHigh));
+    lowAddr = std::get<0>(std::get<0>(lowAndHigh));
+    combinedInfo.Pointers.emplace_back(
+        mapData.BasePointers[std::get<1>(std::get<0>(lowAndHigh))]);
   }
 
   llvm::Value *size = builder.CreateIntCast(
@@ -6062,16 +6071,18 @@ static void mapParentWithMembers(
                        MapFlags::OMP_MAP_CLOSE;
     ompBuilder.setCorrectMemberOfFlag(mapFlag, memberOfFlag);
 
-    llvm::SmallVector<size_t> overlapIdxs;
     // Find all of the members that "overlap", i.e. occlude other members that
     // were mapped alongside the parent, e.g. member [0], occludes
+    llvm::SmallVector<size_t> overlapIdxs;
     getOverlappedMembers(overlapIdxs, parentClause);
 
     // When we only have one overlap we skip the case that tries to segment the
-    // mapping as best it can without creating holes, as the calculation is more
-    // likely to have more overhead than anything we gain from mapping a smaller
-    // chunk of data. This can be seen in cases where we are mapping Fortran
-    // descriptors which are a special case of record type mapping.
+    // mapping as best it can without creating holes. This is because in these
+    // scenarios we have a singular map, so can reduce the complexity of the
+    // map or we have a pointer/descriptor map, in which case segmenting the
+    // map based on pointee record members doesn't make sense and will cause
+    // runtime issues. TODO: For the latter case we need a clearer method of
+    // checking this, the method is a tad overkill and non-obvious.
     //
     // The cases for close and update are unique edge cases where the segmenting
     // does not play well with the runtime currently.
@@ -6088,17 +6099,6 @@ static void mapParentWithMembers(
       combinedInfo.Pointers.emplace_back(mapData.Pointers[mapDataIndex]);
       combinedInfo.Sizes.emplace_back(mapData.Sizes[mapDataIndex]);
     } else {
-      // We need to make sure the overlapped members are sorted in order of
-      // lowest address to highest address
-      sortMapIndices(overlapIdxs, parentClause);
-
-      lowAddr = builder.CreatePointerCast(mapData.Pointers[mapDataIndex],
-                                          builder.getPtrTy());
-      highAddr = builder.CreatePointerCast(
-          builder.CreateConstGEP1_32(mapData.BaseType[mapDataIndex],
-                                     mapData.Pointers[mapDataIndex], 1),
-          builder.getPtrTy());
-
       // Currently, the return parameter should be the over-riding parent in
       // cases where we have a return parameter that is echoed to all members,
       // the main case of this currently is with fortran descriptors. It may
@@ -6106,44 +6106,9 @@ static void mapParentWithMembers(
       // members of derived types.
       mapFlag &= ~llvm::omp::OpenMPOffloadMappingFlags::OMP_MAP_RETURN_PARAM;
 
-      // TODO: We may want to skip arrays/array sections in this as Clang does.
-      // It appears to be an optimisation rather than a necessity though,
-      // but this requires further investigation. However, we would have to make
-      // sure to not exclude maps with bounds that ARE pointers, as these are
-      // processed as seperate components, i.e. pointer + data.
-      for (auto v : overlapIdxs) {
-        auto mapDataOverlapIdx = getMapDataMemberIdx(
-            mapData,
-            cast<omp::MapInfoOp>(parentClause.getMembers()[v].getDefiningOp()));
-        auto isPtrMap = checkIfPointerMap(
-            llvm::cast<omp::MapInfoOp>(mapData.MapClause[mapDataOverlapIdx]));
-        combinedInfo.Types.emplace_back(mapFlag);
-        combinedInfo.DevicePointers.emplace_back(
-            llvm::OpenMPIRBuilder::DeviceInfoTy::None);
-        combinedInfo.Mappers.emplace_back(nullptr);
-        combinedInfo.Names.emplace_back(LLVM::createMappingInformation(
-            mapData.MapClause[mapDataIndex]->getLoc(), ompBuilder));
-        combinedInfo.BasePointers.emplace_back(
-            mapData.BasePointers[mapDataIndex]);
-        combinedInfo.Pointers.emplace_back(lowAddr);
-        auto sizeCalc = builder.CreateIntCast(
-            builder.CreatePtrDiff(builder.getInt8Ty(),
-                                  mapData.OriginalValue[mapDataOverlapIdx],
-                                  lowAddr),
-            builder.getInt64Ty(), /*isSigned=*/true);
-        // In certain cases, we'll generate a size of 0 if we're not careful
-        // (e.g. if lowAddr happens to be the first member), which isn't
-        // correct, even if the runtimes is sometimes fine with it so, in these
-        // scenarios we select the types size instead.
-        auto sizeSel = builder.CreateSelect(
-            builder.CreateICmpNE(builder.getInt64(0), sizeCalc), sizeCalc,
-            isPtrMap ? llvm::ConstantExpr::getSizeOf(builder.getPtrTy())
-                     : mapData.Sizes[mapDataOverlapIdx]);
-        combinedInfo.Sizes.emplace_back(sizeSel);
-        lowAddr = builder.CreateConstGEP1_32(
-            isPtrMap ? builder.getPtrTy() : mapData.BaseType[mapDataOverlapIdx],
-            mapData.BasePointers[mapDataOverlapIdx], 1);
-      }
+      auto lowAndHigh = getLowAndHighAddr(parentClause);
+      highAddr = std::get<0>(std::get<1>(lowAndHigh));
+      lowAddr = std::get<0>(std::get<0>(lowAndHigh));
 
       combinedInfo.Types.emplace_back(mapFlag);
       combinedInfo.DevicePointers.emplace_back(

--- a/mlir/test/Target/LLVMIR/omptarget-fortran-allocatable-record-type-mapping-host.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-fortran-allocatable-record-type-mapping-host.mlir
@@ -114,10 +114,10 @@ module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-a
 
 // CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [4 x i64] [i64 0, i64 48, i64 0, i64 0]
 // CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [4 x i64] [i64 32, i64 281474976710659, i64 3, i64 288]
-// CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [11 x i64] [i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 48, i64 0, i64 4, i64 0]
-// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [11 x i64] [i64 32, i64 281474976710659, i64 281474976710659, i64 281474976710659, i64 281474976710659, i64 281474976710659, i64 3, i64 281474976710659, i64 3, i64 281474976710659, i64 288]
-// CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [11 x i64] [i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 0, i64 48, i64 0, i64 4, i64 0]
-// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [11 x i64] [i64 32, i64 281474976710659, i64 281474976710659, i64 281474976710659, i64 281474976710659, i64 281474976710659, i64 3, i64 281474976710659, i64 3, i64 281474976710659, i64 288]
+// CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [7 x i64] [i64 0, i64 0, i64 0, i64 48, i64 0, i64 4, i64 0]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [7 x i64] [i64 32, i64 281474976710659, i64 3, i64 281474976710659, i64 3, i64 281474976710659, i64 288]
+// CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [7 x i64] [i64 0, i64 0, i64 0, i64 48, i64 0, i64 4, i64 0]
+// CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [7 x i64] [i64 32, i64 281474976710659, i64 3, i64 281474976710659, i64 3, i64 281474976710659, i64 288]
 // CHECK: @.offload_sizes{{.*}} = private unnamed_addr constant [4 x i64] [i64 0, i64 48, i64 0, i64 0]
 // CHECK: @.offload_maptypes{{.*}} = private unnamed_addr constant [4 x i64] [i64 32, i64 281474976710659, i64 3, i64 288]
 
@@ -148,7 +148,6 @@ module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-a
 // CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_ptrs, i32 0, i32 2
 // CHECK:  store ptr %[[ARR_OFFSET]], ptr %[[OFFLOAD_PTRS]], align 8
 
-
 // CHECK: define void @omp_allocatable_derived_type_member_map(ptr %[[ARG:.*]]) {
 
 // CHECK: %[[LOCAL_ALLOCATABLE_DTYPE_ALLOCA_2:.*]] = alloca { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, align 8
@@ -172,78 +171,31 @@ module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-a
 // CHECK: %[[DTYPE_SIZE_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_SIZE_SEGMENT_CALC_1]] to i64
 // CHECK: %[[DTYPE_SIZE_SEGMENT_CALC_3:.*]] = ptrtoaddr ptr %[[ARG]] to i64
 // CHECK: %[[DTYPE_SIZE_SEGMENT_CALC_4:.*]] = sub i64 %[[DTYPE_SIZE_SEGMENT_CALC_2]], %[[DTYPE_SIZE_SEGMENT_CALC_3]]
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %[[ARG]], i32 1
-// CHECK: %[[DTYPE_OFFLOAD_PTR_1:.*]] = getelementptr ptr, ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_2]], i32 1
-// CHECK: %[[DTYPE_SIZE2_SEGMENT_CALC:.*]] = ptrtoaddr ptr %[[DTYPE_ALLOCATABLE_MEMBER_ACCESS]] to i64
-// CHECK: %[[DTYPE_SIZE2_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_OFFLOAD_PTR_1]] to i64
-// CHECK: %[[DTYPE_SIZE2_SEGMENT_CALC_3:.*]] = sub i64 %[[DTYPE_SIZE2_SEGMENT_CALC]], %[[DTYPE_SIZE2_SEGMENT_CALC_2]]
-// CHECK: %[[DTYPE_NON_ZERO_SZ:.*]] = icmp ne i64 0, %[[DTYPE_SIZE2_SEGMENT_CALC_3]]
-// CHECK: %[[SEL_SZ:.*]] = select i1 %[[DTYPE_NON_ZERO_SZ]], i64 %[[DTYPE_SIZE2_SEGMENT_CALC_3]], i64 48
-// CHECK: %[[DTYPE_OFFLOAD_PTR_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, ptr %[[DTYPE_ALLOCATABLE_MEMBER_ACCESS]], i32 1
-// CHECK: %[[DTYPE_SIZE3_SEGMENT_CALC:.*]] = ptrtoaddr ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR]] to i64
-// CHECK: %[[DTYPE_SIZE3_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_OFFLOAD_PTR_2]] to i64
-// CHECK: %[[DTYPE_SIZE3_SEGMENT_CALC_3:.*]] = sub i64 %[[DTYPE_SIZE3_SEGMENT_CALC]], %[[DTYPE_SIZE3_SEGMENT_CALC_2]]
-// CHECK: %[[DTYPE_NON_ZERO_SZ2:.*]] = icmp ne i64 0, %[[DTYPE_SIZE3_SEGMENT_CALC_3]]
-// CHECK: %[[SEL_SZ2:.*]] = select i1 %[[DTYPE_NON_ZERO_SZ2]], i64 %[[DTYPE_SIZE3_SEGMENT_CALC_3]], i64 ptrtoint (ptr getelementptr (ptr, ptr null, i32 1) to i64)
-// CHECK: %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_GEP:.*]] = getelementptr ptr, ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR]], i32 1
-// CHECK: %[[DTYPE_SIZE4_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_REGULAR_MEMBER_ACCESS]] to i64
-// CHECK: %[[DTYPE_SIZE4_SEGMENT_CALC_3:.*]] = ptrtoaddr ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_GEP]] to i64
-// CHECK: %[[DTYPE_SIZE4_SEGMENT_CALC_4:.*]] = sub i64 %[[DTYPE_SIZE4_SEGMENT_CALC_2]], %[[DTYPE_SIZE4_SEGMENT_CALC_3]]
-// CHECK: %[[DTYPE_NON_ZERO_SZ3:.*]] = icmp ne i64 0, %[[DTYPE_SIZE4_SEGMENT_CALC_4]]
-// CHECK: %[[SEL_SZ3:.*]] = select i1 %[[DTYPE_NON_ZERO_SZ3]], i64 %[[DTYPE_SIZE4_SEGMENT_CALC_4]], i64 4
-// CHECK: %[[DTYPE_OFFLOAD_PTR_3:.*]] = getelementptr i32, ptr %[[DTYPE_REGULAR_MEMBER_ACCESS]], i32 1
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_SIZE5_SEGMENT_CALC]] to i64
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_3:.*]] = ptrtoaddr ptr %[[DTYPE_OFFLOAD_PTR_3]] to i64
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_4:.*]] = sub i64 %[[DTYPE_SIZE5_SEGMENT_CALC_2]], %[[DTYPE_SIZE5_SEGMENT_CALC_3]]
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 0
 // CHECK:  store ptr %[[ARG]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [7 x i64], ptr %.offload_sizes, i32 0, i32 0
 // CHECK:  store i64 %[[DTYPE_SIZE_SEGMENT_CALC_4]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 1
-// CHECK:  store ptr %[[ARG]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_2]], ptr %[[OFFLOAD_PTRS]], align 8
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 2
-// CHECK:  store ptr %[[DTYPE_OFFLOAD_PTR_1]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 2
-// CHECK:  store i64 %[[SEL_SZ]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 3
-// CHECK:  store ptr %[[DTYPE_OFFLOAD_PTR_2]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 3
-// CHECK:  store i64 %[[SEL_SZ2]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 4
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 4
-// CHECK:  store ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_GEP]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 4
-// CHECK:  store i64 %[[SEL_SZ3]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 5
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 5
-// CHECK:  store ptr %[[DTYPE_OFFLOAD_PTR_3]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 5
-// CHECK:  store i64 %[[DTYPE_SIZE5_SEGMENT_CALC_4]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 6
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 6
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 2
 // CHECK:  store ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_2_LOAD]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 7
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 7
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 3
 // CHECK:  store ptr %[[DTYPE_ALLOCATABLE_MEMBER_ACCESS]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 8
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 4
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 8
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 4
 // CHECK:  store ptr %[[ARR_OFFSET]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 9
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 5
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 9
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 5
 // CHECK:  store ptr %[[DTYPE_REGULAR_MEMBER_ACCESS]], ptr %[[OFFLOAD_PTRS]], align 8
 
 // CHECK: define void @omp_alloca_nested_derived_type_map(ptr %[[ARG:.*]]) {
@@ -271,78 +223,31 @@ module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-a
 // CHECK: %[[DTYPE_SIZE_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_SIZE_SEGMENT_CALC_1]] to i64
 // CHECK: %[[DTYPE_SIZE_SEGMENT_CALC_3:.*]] = ptrtoaddr ptr %[[ARG]] to i64
 // CHECK: %[[DTYPE_SIZE_SEGMENT_CALC_4:.*]] = sub i64 %[[DTYPE_SIZE_SEGMENT_CALC_2]], %[[DTYPE_SIZE_SEGMENT_CALC_3]]
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_1:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8, ptr, [1 x i64] }, ptr %[[ARG]], i32 1
-// CHECK: %[[DTYPE_OFFLOAD_PTR_1:.*]] = getelementptr ptr, ptr %[[DTYPE_ALLOCATABLE_BADDR_GEP]], i32 1
-// CHECK: %[[DTYPE_SIZE2_SEGMENT_CALC:.*]] = ptrtoaddr ptr %[[DTYPE_NESTED_ALLOCATABLE_MEMBER_GEP]] to i64
-// CHECK: %[[DTYPE_SIZE2_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_OFFLOAD_PTR_1]] to i64
-// CHECK: %[[DTYPE_SIZE2_SEGMENT_CALC_3:.*]] = sub i64 %[[DTYPE_SIZE2_SEGMENT_CALC]], %[[DTYPE_SIZE2_SEGMENT_CALC_2]]
-// CHECK: %[[SZ_CMP:.*]] = icmp ne i64 0, %[[DTYPE_SIZE2_SEGMENT_CALC_3]]
-// CHECK: %[[SZ_SEL:.*]] = select i1 %[[SZ_CMP]], i64 %[[DTYPE_SIZE2_SEGMENT_CALC_3]], i64 48
-// CHECK: %[[DTYPE_OFFLOAD_PTR_2:.*]] = getelementptr { ptr, i64, i32, i8, i8, i8, i8, [1 x [3 x i64]] }, ptr %[[DTYPE_NESTED_ALLOCATABLE_MEMBER_GEP]], i32 1
-// CHECK: %[[DTYPE_SIZE3_SEGMENT_CALC:.*]] = ptrtoaddr ptr %[[DTYPE_NESTED_ALLOCATABLE_MEMBER_BADDR_GEP]] to i64
-// CHECK: %[[DTYPE_SIZE3_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_OFFLOAD_PTR_2]] to i64
-// CHECK: %[[DTYPE_SIZE3_SEGMENT_CALC_3:.*]] = sub i64 %[[DTYPE_SIZE3_SEGMENT_CALC]], %[[DTYPE_SIZE3_SEGMENT_CALC_2]]
-// CHECK: %[[SZ_CMP:.*]] = icmp ne i64 0, %[[DTYPE_SIZE3_SEGMENT_CALC_3]]
-// CHECK: %[[SZ_SEL2:.*]] = select i1 %[[SZ_CMP]], i64 %[[DTYPE_SIZE3_SEGMENT_CALC_3]], i64 ptrtoint (ptr getelementptr (ptr, ptr null, i32 1) to i64)
-// CHECK: %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_GEP:.*]] = getelementptr ptr, ptr %[[DTYPE_NESTED_ALLOCATABLE_MEMBER_BADDR_GEP]], i32 1
-// CHECK: %[[DTYPE_SIZE4_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_NESTED_REGULAR_MEMBER_GEP]] to i64
-// CHECK: %[[DTYPE_SIZE4_SEGMENT_CALC_3:.*]] = ptrtoaddr ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_GEP]] to i64
-// CHECK: %[[DTYPE_SIZE4_SEGMENT_CALC_4:.*]] = sub i64 %[[DTYPE_SIZE4_SEGMENT_CALC_2]], %[[DTYPE_SIZE4_SEGMENT_CALC_3]]
-// CHECK: %[[SZ_CMP:.*]] = icmp ne i64 0, %[[DTYPE_SIZE4_SEGMENT_CALC_4]]
-// CHECK: %[[SZ_SEL3:.*]] = select i1 %[[SZ_CMP]], i64 %[[DTYPE_SIZE4_SEGMENT_CALC_4]], i64 4
-// CHECK: %[[DTYPE_OFFLOAD_PTR_3:.*]] = getelementptr i32, ptr %[[DTYPE_NESTED_REGULAR_MEMBER_GEP]], i32 1
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_2:.*]] = ptrtoaddr ptr %[[DTYPE_SIZE5_SEGMENT_CALC_1]] to i64
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_3:.*]] = ptrtoaddr ptr %[[DTYPE_OFFLOAD_PTR_3]] to i64
-// CHECK: %[[DTYPE_SIZE5_SEGMENT_CALC_4:.*]] = sub i64 %[[DTYPE_SIZE5_SEGMENT_CALC_2]], %[[DTYPE_SIZE5_SEGMENT_CALC_3]]
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 0
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 0
 // CHECK:  store ptr %[[ARG]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 0
+// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [7 x i64], ptr %.offload_sizes, i32 0, i32 0
 // CHECK:  store i64 %[[DTYPE_SIZE_SEGMENT_CALC_4]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 1
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 1
-// CHECK:  store ptr %[[ARG]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 1
+// CHECK:  store ptr %[[DTYPE_ALLOCATABLE_BADDR_GEP]], ptr %[[OFFLOAD_PTRS]], align 8
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 2
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 2
-// CHECK:  store ptr %[[DTYPE_OFFLOAD_PTR_1]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 2
-// CHECK:  store i64 %[[SZ_SEL]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 3
-// CHECK:  store ptr %[[DTYPE_OFFLOAD_PTR_2]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 3
-// CHECK:  store i64 %[[SZ_SEL2]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 4
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 4
-// CHECK:  store ptr %[[DTYPE_ALLOCATABLE_MEMBER_BADDR_GEP]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 4
-// CHECK:  store i64 %[[SZ_SEL3]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 5
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 5
-// CHECK:  store ptr %[[DTYPE_OFFLOAD_PTR_3]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_SIZES:.*]] = getelementptr inbounds [11 x i64], ptr %.offload_sizes, i32 0, i32 5
-// CHECK:  store i64 %[[DTYPE_SIZE5_SEGMENT_CALC_4]], ptr %[[OFFLOAD_SIZES]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 6
-// CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 6
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 2
 // CHECK:  store ptr %[[DTYPE_ALLOCATABLE_BADDR_LOAD]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 7
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 3
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 7
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 3
 // CHECK:  store ptr %[[DTYPE_NESTED_ALLOCATABLE_MEMBER_GEP]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 8
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 4
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 8
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 4
 // CHECK:  store ptr %[[ARR_OFFSET]], ptr %[[OFFLOAD_PTRS]], align 8
-// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_baseptrs, i32 0, i32 9
+// CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_baseptrs, i32 0, i32 5
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8
-// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [11 x ptr], ptr %.offload_ptrs, i32 0, i32 9
+// CHECK:  %[[OFFLOAD_PTRS:.*]] = getelementptr inbounds [7 x ptr], ptr %.offload_ptrs, i32 0, i32 5
 // CHECK:  store ptr %[[DTYPE_NESTED_REGULAR_MEMBER_GEP]], ptr %[[OFFLOAD_PTRS]], align 8
 
 // CHECK: define void @omp_nested_derived_type_alloca_map(ptr %[[ARG:.*]]) {
@@ -355,8 +260,6 @@ module attributes {omp.is_target_device = false, omp.target_triples = ["amdgcn-a
 // CHECK:  %[[CALC_2:.*]] = ptrtoaddr ptr %[[CALC_1]] to i64
 // CHECK:  %[[CALC_3:.*]] = ptrtoaddr ptr %[[NESTED_ALLOCATABLE_MEMBER_GEP]] to i64
 // CHECK:  %[[CALC_4:.*]] = sub i64 %[[CALC_2]], %[[CALC_3]]
-// CHECK:  %[[CMP:.*]] = icmp eq ptr %[[ARR_OFFSET]], null
-// CHECK:  %[[SEL:.*]] = select i1 %[[CMP]], i64 0, i64 20
 
 // CHECK:  %[[BASE_PTRS:.*]] = getelementptr inbounds [4 x ptr], ptr %.offload_baseptrs, i32 0, i32 0
 // CHECK:  store ptr %[[ARG]], ptr %[[BASE_PTRS]], align 8


### PR DESCRIPTION
This attempts to fix the second part of the performance regression in LC-1761 by simplifying the segmentation mapping into a simple minimum slice of the mapped area as opposed to a more complex but situationally more optimal mapping (likely a lot more situational than I originally thought).


