### PR TITLE
[SDAG] Avoid simplifySelect freeze cycle on undef arms

### DIFF
--- a/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
+++ b/llvm/lib/CodeGen/SelectionDAG/SelectionDAG.cpp
@@ -11536,10 +11536,22 @@ SDValue SelectionDAG::simplifySelect(SDValue Cond, SDValue T, SDValue F) {
   // select, ?, T, undef --> T
   if (Cond.isUndef())
     return isConstantValueOfAnyType(T) ? T : F;
-  if (T.isUndef())
-    return isGuaranteedNotToBePoison(F) ? F : getFreeze(F);
-  if (F.isUndef())
-    return isGuaranteedNotToBePoison(T) ? T : getFreeze(T);
+  // Only freeze when arm has poison flags; always-freezing cycles with
+  // visitFREEZE on large IR (ROCm/llvm-project#2616).
+  if (T.isUndef()) {
+    if (isGuaranteedNotToBePoison(F))
+      return F;
+    if (F->hasPoisonGeneratingFlags())
+      return getFreeze(F);
+    return SDValue();
+  }
+  if (F.isUndef()) {
+    if (isGuaranteedNotToBePoison(T))
+      return T;
+    if (T->hasPoisonGeneratingFlags())
+      return getFreeze(T);
+    return SDValue();
+  }
 
   // select true, T, F --> T
   // select false, T, F --> F

--- a/llvm/test/CodeGen/AMDGPU/fract-match.ll
+++ b/llvm/test/CodeGen/AMDGPU/fract-match.ll
@@ -166,21 +166,23 @@ define <3 x float> @safe_math_fract_v3f32(<3 x float> %x, ptr addrspace(1) write
 ; GFX7-LABEL: safe_math_fract_v3f32:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_mov_b32_e32 v10, 0x204
+; GFX7-NEXT:    v_mov_b32_e32 v11, 0x204
 ; GFX7-NEXT:    v_fract_f32_e32 v8, v0
-; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v0, v10
-; GFX7-NEXT:    s_mov_b32 s6, 0
+; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v0, v11
 ; GFX7-NEXT:    v_floor_f32_e32 v5, v0
-; GFX7-NEXT:    v_fract_f32_e32 v9, v2
+; GFX7-NEXT:    v_fract_f32_e32 v9, v1
 ; GFX7-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v2, v10
+; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v1, v11
+; GFX7-NEXT:    s_mov_b32 s6, 0
+; GFX7-NEXT:    v_floor_f32_e32 v6, v1
+; GFX7-NEXT:    v_fract_f32_e32 v10, v2
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v9, v0, vcc
+; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v2, v11
 ; GFX7-NEXT:    s_mov_b32 s7, 0xf000
 ; GFX7-NEXT:    s_mov_b32 s4, s6
 ; GFX7-NEXT:    s_mov_b32 s5, s6
 ; GFX7-NEXT:    v_floor_f32_e32 v7, v2
-; GFX7-NEXT:    v_floor_f32_e32 v6, v1
-; GFX7-NEXT:    v_fract_f32_e32 v1, v1
-; GFX7-NEXT:    v_cndmask_b32_e64 v2, v9, 0, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, v10, 0, vcc
 ; GFX7-NEXT:    buffer_store_dwordx3 v[5:7], v[3:4], s[4:7], 0 addr64
 ; GFX7-NEXT:    s_waitcnt vmcnt(0)
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
@@ -188,17 +190,19 @@ define <3 x float> @safe_math_fract_v3f32(<3 x float> %x, ptr addrspace(1) write
 ; GFX8-LABEL: safe_math_fract_v3f32:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v10, 0x204
+; GFX8-NEXT:    v_mov_b32_e32 v11, 0x204
 ; GFX8-NEXT:    v_fract_f32_e32 v8, v0
-; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v0, v10
+; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v0, v11
 ; GFX8-NEXT:    v_floor_f32_e32 v5, v0
-; GFX8-NEXT:    v_fract_f32_e32 v9, v2
+; GFX8-NEXT:    v_fract_f32_e32 v9, v1
 ; GFX8-NEXT:    v_cndmask_b32_e64 v0, v8, 0, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v2, v10
-; GFX8-NEXT:    v_floor_f32_e32 v7, v2
+; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v1, v11
 ; GFX8-NEXT:    v_floor_f32_e32 v6, v1
-; GFX8-NEXT:    v_fract_f32_e32 v1, v1
-; GFX8-NEXT:    v_cndmask_b32_e64 v2, v9, 0, vcc
+; GFX8-NEXT:    v_fract_f32_e32 v10, v2
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v9, v0, vcc
+; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v2, v11
+; GFX8-NEXT:    v_floor_f32_e32 v7, v2
+; GFX8-NEXT:    v_cndmask_b32_e64 v2, v10, 0, vcc
 ; GFX8-NEXT:    global_store_dwordx3 v[3:4], v[5:7], off
 ; GFX8-NEXT:    s_waitcnt vmcnt(0)
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
@@ -209,14 +213,17 @@ define <3 x float> @safe_math_fract_v3f32(<3 x float> %x, ptr addrspace(1) write
 ; GFX11-NEXT:    v_fract_f32_e32 v8, v0
 ; GFX11-NEXT:    v_cmp_class_f32_e64 s0, v0, 0x204
 ; GFX11-NEXT:    v_floor_f32_e32 v5, v0
-; GFX11-NEXT:    v_fract_f32_e32 v9, v2
-; GFX11-NEXT:    v_floor_f32_e32 v7, v2
+; GFX11-NEXT:    v_fract_f32_e32 v9, v1
 ; GFX11-NEXT:    v_floor_f32_e32 v6, v1
+; GFX11-NEXT:    v_fract_f32_e32 v10, v2
 ; GFX11-NEXT:    v_cndmask_b32_e64 v0, v8, 0, s0
+; GFX11-NEXT:    v_cmp_class_f32_e64 s0, v1, 0x204
+; GFX11-NEXT:    v_floor_f32_e32 v7, v2
+; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX11-NEXT:    v_cndmask_b32_e64 v1, v9, s0, s0
 ; GFX11-NEXT:    v_cmp_class_f32_e64 s0, v2, 0x204
-; GFX11-NEXT:    v_fract_f32_e32 v1, v1
 ; GFX11-NEXT:    global_store_b96 v[3:4], v[5:7], off
-; GFX11-NEXT:    v_cndmask_b32_e64 v2, v9, 0, s0
+; GFX11-NEXT:    v_cndmask_b32_e64 v2, v10, 0, s0
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: safe_math_fract_v3f32:
@@ -229,16 +236,20 @@ define <3 x float> @safe_math_fract_v3f32(<3 x float> %x, ptr addrspace(1) write
 ; GFX12-NEXT:    v_fract_f32_e32 v8, v0
 ; GFX12-NEXT:    v_cmp_class_f32_e64 s0, v0, 0x204
 ; GFX12-NEXT:    v_floor_f32_e32 v5, v0
-; GFX12-NEXT:    v_fract_f32_e32 v9, v2
-; GFX12-NEXT:    v_floor_f32_e32 v7, v2
+; GFX12-NEXT:    v_fract_f32_e32 v9, v1
 ; GFX12-NEXT:    v_floor_f32_e32 v6, v1
+; GFX12-NEXT:    v_fract_f32_e32 v10, v2
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
 ; GFX12-NEXT:    v_cndmask_b32_e64 v0, v8, 0, s0
+; GFX12-NEXT:    v_cmp_class_f32_e64 s0, v1, 0x204
+; GFX12-NEXT:    v_floor_f32_e32 v7, v2
+; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_2)
+; GFX12-NEXT:    v_cndmask_b32_e64 v1, v9, s0, s0
 ; GFX12-NEXT:    v_cmp_class_f32_e64 s0, v2, 0x204
-; GFX12-NEXT:    v_fract_f32_e32 v1, v1
 ; GFX12-NEXT:    global_store_b96 v[3:4], v[5:7], off
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v2, v9, 0, s0
+; GFX12-NEXT:    v_cndmask_b32_e64 v2, v10, 0, s0
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
 ; GFX6-IR-LABEL: define <3 x float> @safe_math_fract_v3f32(
 ; GFX6-IR-SAME: <3 x float> [[X:%.*]], ptr addrspace(1) writeonly captures(none) [[IP:%.*]]) #[[ATTR0]] {
@@ -5487,27 +5498,31 @@ define <3 x float> @safe_math_fract_f32_swapped_edge_case_vector(<3 x float> %x)
 ; GFX7-LABEL: safe_math_fract_f32_swapped_edge_case_vector:
 ; GFX7:       ; %bb.0: ; %entry
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_mov_b32_e32 v5, 0x1fb
+; GFX7-NEXT:    v_mov_b32_e32 v6, 0x1fb
 ; GFX7-NEXT:    v_fract_f32_e32 v3, v0
-; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v0, v5
-; GFX7-NEXT:    v_fract_f32_e32 v4, v2
+; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v0, v6
+; GFX7-NEXT:    v_fract_f32_e32 v4, v1
 ; GFX7-NEXT:    v_cndmask_b32_e32 v0, 0, v3, vcc
-; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v2, v5
-; GFX7-NEXT:    v_fract_f32_e32 v1, v1
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
+; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v1, v6
+; GFX7-NEXT:    v_fract_f32_e32 v5, v2
+; GFX7-NEXT:    v_cndmask_b32_e32 v1, v0, v4, vcc
+; GFX7-NEXT:    v_cmp_class_f32_e32 vcc, v2, v6
+; GFX7-NEXT:    v_cndmask_b32_e32 v2, 0, v5, vcc
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-LABEL: safe_math_fract_f32_swapped_edge_case_vector:
 ; GFX8:       ; %bb.0: ; %entry
 ; GFX8-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX8-NEXT:    v_mov_b32_e32 v5, 0x1fb
+; GFX8-NEXT:    v_mov_b32_e32 v6, 0x1fb
 ; GFX8-NEXT:    v_fract_f32_e32 v3, v0
-; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v0, v5
-; GFX8-NEXT:    v_fract_f32_e32 v4, v2
+; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v0, v6
+; GFX8-NEXT:    v_fract_f32_e32 v4, v1
 ; GFX8-NEXT:    v_cndmask_b32_e32 v0, 0, v3, vcc
-; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v2, v5
-; GFX8-NEXT:    v_fract_f32_e32 v1, v1
-; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc
+; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v1, v6
+; GFX8-NEXT:    v_fract_f32_e32 v5, v2
+; GFX8-NEXT:    v_cndmask_b32_e32 v1, v0, v4, vcc
+; GFX8-NEXT:    v_cmp_class_f32_e32 vcc, v2, v6
+; GFX8-NEXT:    v_cndmask_b32_e32 v2, 0, v5, vcc
 ; GFX8-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX11-LABEL: safe_math_fract_f32_swapped_edge_case_vector:
@@ -5515,12 +5530,14 @@ define <3 x float> @safe_math_fract_f32_swapped_edge_case_vector(<3 x float> %x)
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_fract_f32_e32 v3, v0
 ; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 0x1fb
-; GFX11-NEXT:    v_fract_f32_e32 v4, v2
-; GFX11-NEXT:    v_fract_f32_e32 v1, v1
+; GFX11-NEXT:    v_fract_f32_e32 v4, v1
+; GFX11-NEXT:    v_fract_f32_e32 v5, v2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_1) | instid1(VALU_DEP_4)
 ; GFX11-NEXT:    v_cndmask_b32_e32 v0, 0, v3, vcc_lo
+; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 0x1fb
+; GFX11-NEXT:    v_cndmask_b32_e32 v1, s0, v4, vcc_lo
 ; GFX11-NEXT:    v_cmp_class_f32_e64 vcc_lo, v2, 0x1fb
-; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc_lo
+; GFX11-NEXT:    v_cndmask_b32_e32 v2, 0, v5, vcc_lo
 ; GFX11-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX12-LABEL: safe_math_fract_f32_swapped_edge_case_vector:
@@ -5532,13 +5549,16 @@ define <3 x float> @safe_math_fract_f32_swapped_edge_case_vector(<3 x float> %x)
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    v_fract_f32_e32 v3, v0
 ; GFX12-NEXT:    v_cmp_class_f32_e64 vcc_lo, v0, 0x1fb
-; GFX12-NEXT:    v_fract_f32_e32 v4, v2
-; GFX12-NEXT:    v_fract_f32_e32 v1, v1
+; GFX12-NEXT:    v_fract_f32_e32 v4, v1
+; GFX12-NEXT:    v_fract_f32_e32 v5, v2
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-NEXT:    v_cndmask_b32_e32 v0, 0, v3, vcc_lo
+; GFX12-NEXT:    v_cmp_class_f32_e64 vcc_lo, v1, 0x1fb
+; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
+; GFX12-NEXT:    v_cndmask_b32_e32 v1, s0, v4, vcc_lo
 ; GFX12-NEXT:    v_cmp_class_f32_e64 vcc_lo, v2, 0x1fb
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-NEXT:    v_cndmask_b32_e32 v2, 0, v4, vcc_lo
+; GFX12-NEXT:    v_cndmask_b32_e32 v2, 0, v5, vcc_lo
 ; GFX12-NEXT:    s_setpc_b64 s[30:31]
 ; GFX6-IR-LABEL: define <3 x float> @safe_math_fract_f32_swapped_edge_case_vector(
 ; GFX6-IR-SAME: <3 x float> [[X:%.*]]) #[[ATTR1]] {

--- a/llvm/test/CodeGen/X86/avx512-fma-intrinsics.ll
+++ b/llvm/test/CodeGen/X86/avx512-fma-intrinsics.ll
@@ -1155,6 +1155,9 @@ define <4 x float> @foo() {
 ; CHECK-NEXT:    vmovss {{.*#+}} xmm0 = mem[0],zero,zero,zero
 ; CHECK-NEXT:    # EVEX TO VEX Compression encoding: [0xc5,0xfa,0x10,0x00]
 ; CHECK-NEXT:    vfmsub213ss {rd-sae}, %xmm0, %xmm0, %xmm0 # encoding: [0x62,0xf2,0x7d,0x38,0xab,0xc0]
+; CHECK-NEXT:    movb $1, %al # encoding: [0xb0,0x01]
+; CHECK-NEXT:    kmovw %eax, %k1 # encoding: [0xc5,0xf8,0x92,0xc8]
+; CHECK-NEXT:    vmovss %xmm0, %xmm0, %xmm0 {%k1} # encoding: [0x62,0xf1,0x7e,0x09,0x10,0xc0]
 ; CHECK-NEXT:    ret{{[l|q]}} # encoding: [0xc3]
 entry:
   %0 = load <4 x float>, ptr undef, align 16

--- a/llvm/test/CodeGen/X86/fshl.ll
+++ b/llvm/test/CodeGen/X86/fshl.ll
@@ -561,9 +561,15 @@ define i32 @const_shift_i32(i32 %x, i32 %y) nounwind {
 define i64 @const_shift_i64(i64 %x, i64 %y) nounwind {
 ; X86-FAST-LABEL: const_shift_i64:
 ; X86-FAST:       # %bb.0:
-; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-FAST-NEXT:    xorl %eax, %eax
+; X86-FAST-NEXT:    testb %al, %al
+; X86-FAST-NEXT:    # implicit-def: $eax
+; X86-FAST-NEXT:    jne .LBB10_2
+; X86-FAST-NEXT:  # %bb.1:
+; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-FAST-NEXT:  .LBB10_2:
 ; X86-FAST-NEXT:    shrdl $25, %ecx, %eax
 ; X86-FAST-NEXT:    shldl $7, %ecx, %edx
 ; X86-FAST-NEXT:    retl
@@ -571,16 +577,22 @@ define i64 @const_shift_i64(i64 %x, i64 %y) nounwind {
 ; X86-SLOW-LABEL: const_shift_i64:
 ; X86-SLOW:       # %bb.0:
 ; X86-SLOW-NEXT:    pushl %esi
-; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %edx
-; X86-SLOW-NEXT:    movl %ecx, %esi
+; X86-SLOW-NEXT:    xorl %eax, %eax
+; X86-SLOW-NEXT:    testb %al, %al
+; X86-SLOW-NEXT:    # implicit-def: $esi
+; X86-SLOW-NEXT:    jne .LBB10_2
+; X86-SLOW-NEXT:  # %bb.1:
+; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SLOW-NEXT:  .LBB10_2:
 ; X86-SLOW-NEXT:    shrl $25, %esi
+; X86-SLOW-NEXT:    movl %ecx, %eax
+; X86-SLOW-NEXT:    shll $7, %eax
+; X86-SLOW-NEXT:    orl %esi, %eax
+; X86-SLOW-NEXT:    shrl $25, %ecx
 ; X86-SLOW-NEXT:    shll $7, %edx
-; X86-SLOW-NEXT:    orl %esi, %edx
-; X86-SLOW-NEXT:    shll $7, %ecx
-; X86-SLOW-NEXT:    shrl $25, %eax
-; X86-SLOW-NEXT:    orl %ecx, %eax
+; X86-SLOW-NEXT:    orl %ecx, %edx
 ; X86-SLOW-NEXT:    popl %esi
 ; X86-SLOW-NEXT:    retl
 ;

--- a/llvm/test/CodeGen/X86/fshr.ll
+++ b/llvm/test/CodeGen/X86/fshr.ll
@@ -541,9 +541,17 @@ define i32 @const_shift_i32(i32 %x, i32 %y) nounwind {
 define i64 @const_shift_i64(i64 %x, i64 %y) nounwind {
 ; X86-FAST-LABEL: const_shift_i64:
 ; X86-FAST:       # %bb.0:
-; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-FAST-NEXT:    movb $1, %dl
+; X86-FAST-NEXT:    testb %dl, %dl
+; X86-FAST-NEXT:    jne .LBB10_1
+; X86-FAST-NEXT:  # %bb.2:
+; X86-FAST-NEXT:    # implicit-def: $edx
+; X86-FAST-NEXT:    jmp .LBB10_3
+; X86-FAST-NEXT:  .LBB10_1:
+; X86-FAST-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-FAST-NEXT:  .LBB10_3:
 ; X86-FAST-NEXT:    shldl $25, %ecx, %edx
 ; X86-FAST-NEXT:    shrdl $7, %ecx, %eax
 ; X86-FAST-NEXT:    retl
@@ -551,16 +559,24 @@ define i64 @const_shift_i64(i64 %x, i64 %y) nounwind {
 ; X86-SLOW-LABEL: const_shift_i64:
 ; X86-SLOW:       # %bb.0:
 ; X86-SLOW-NEXT:    pushl %esi
-; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-SLOW-NEXT:    movb $1, %dl
+; X86-SLOW-NEXT:    testb %dl, %dl
+; X86-SLOW-NEXT:    jne .LBB10_1
+; X86-SLOW-NEXT:  # %bb.2:
+; X86-SLOW-NEXT:    # implicit-def: $esi
+; X86-SLOW-NEXT:    jmp .LBB10_3
+; X86-SLOW-NEXT:  .LBB10_1:
 ; X86-SLOW-NEXT:    movl {{[0-9]+}}(%esp), %esi
+; X86-SLOW-NEXT:  .LBB10_3:
+; X86-SLOW-NEXT:    shll $25, %esi
+; X86-SLOW-NEXT:    movl %eax, %edx
+; X86-SLOW-NEXT:    shrl $7, %edx
+; X86-SLOW-NEXT:    orl %esi, %edx
 ; X86-SLOW-NEXT:    shrl $7, %ecx
-; X86-SLOW-NEXT:    movl %esi, %eax
 ; X86-SLOW-NEXT:    shll $25, %eax
 ; X86-SLOW-NEXT:    orl %ecx, %eax
-; X86-SLOW-NEXT:    shrl $7, %esi
-; X86-SLOW-NEXT:    shll $25, %edx
-; X86-SLOW-NEXT:    orl %esi, %edx
 ; X86-SLOW-NEXT:    popl %esi
 ; X86-SLOW-NEXT:    retl
 ;

--- a/llvm/test/CodeGen/X86/funnel-shift.ll
+++ b/llvm/test/CodeGen/X86/funnel-shift.ll
@@ -276,9 +276,15 @@ define i32 @fshl_i32_const_overshift(i32 %x, i32 %y) nounwind {
 define i64 @fshl_i64_const_overshift(i64 %x, i64 %y) nounwind {
 ; X86-SSE2-LABEL: fshl_i64_const_overshift:
 ; X86-SSE2:       # %bb.0:
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
+; X86-SSE2-NEXT:    movb $1, %dl
+; X86-SSE2-NEXT:    testb %dl, %dl
+; X86-SSE2-NEXT:    # implicit-def: $edx
+; X86-SSE2-NEXT:    je .LBB7_2
+; X86-SSE2-NEXT:  # %bb.1:
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-SSE2-NEXT:  .LBB7_2:
 ; X86-SSE2-NEXT:    shldl $9, %ecx, %edx
 ; X86-SSE2-NEXT:    shrdl $23, %ecx, %eax
 ; X86-SSE2-NEXT:    retl
@@ -1031,9 +1037,15 @@ define i32 @fshr_i32_const_overshift(i32 %x, i32 %y) nounwind {
 define i64 @fshr_i64_const_overshift(i64 %x, i64 %y) nounwind {
 ; X86-SSE2-LABEL: fshr_i64_const_overshift:
 ; X86-SSE2:       # %bb.0:
-; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %ecx
 ; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %edx
+; X86-SSE2-NEXT:    xorl %eax, %eax
+; X86-SSE2-NEXT:    testb %al, %al
+; X86-SSE2-NEXT:    # implicit-def: $eax
+; X86-SSE2-NEXT:    jne .LBB44_2
+; X86-SSE2-NEXT:  # %bb.1:
+; X86-SSE2-NEXT:    movl {{[0-9]+}}(%esp), %eax
+; X86-SSE2-NEXT:  .LBB44_2:
 ; X86-SSE2-NEXT:    shrdl $9, %ecx, %eax
 ; X86-SSE2-NEXT:    shldl $23, %ecx, %edx
 ; X86-SSE2-NEXT:    retl

--- a/llvm/test/CodeGen/X86/known-bits.ll
+++ b/llvm/test/CodeGen/X86/known-bits.ll
@@ -7,7 +7,11 @@ define void @knownbits_zext_in_reg(ptr) nounwind {
 ; X86:       # %bb.0: # %BB
 ; X86-NEXT:    pushl %ebx
 ; X86-NEXT:    movl {{[0-9]+}}(%esp), %eax
-; X86-NEXT:    movzbl (%eax), %ecx
+; X86-NEXT:    movzbl (%eax), %eax
+; X86-NEXT:    movb $1, %cl
+; X86-NEXT:    testb %cl, %cl
+; X86-NEXT:    cmovnel %eax, %eax
+; X86-NEXT:    movzbl %al, %ecx
 ; X86-NEXT:    imull $101, %ecx, %eax
 ; X86-NEXT:    shrl $14, %eax
 ; X86-NEXT:    imull $177, %ecx, %edx
@@ -31,6 +35,10 @@ define void @knownbits_zext_in_reg(ptr) nounwind {
 ; X64-LABEL: knownbits_zext_in_reg:
 ; X64:       # %bb.0: # %BB
 ; X64-NEXT:    movzbl (%rdi), %eax
+; X64-NEXT:    movb $1, %cl
+; X64-NEXT:    testb %cl, %cl
+; X64-NEXT:    cmovnel %eax, %eax
+; X64-NEXT:    movzbl %al, %eax
 ; X64-NEXT:    imull $101, %eax, %ecx
 ; X64-NEXT:    shrl $14, %ecx
 ; X64-NEXT:    imull $177, %eax, %edx

--- a/llvm/test/CodeGen/X86/pr90847.ll
+++ b/llvm/test/CodeGen/X86/pr90847.ll
@@ -16,7 +16,8 @@ define i32 @PR90847(<8 x float> %x) nounwind {
 ; AVX1-NEXT:    vcmpeqps %ymm0, %ymm1, %ymm0
 ; AVX1-NEXT:    vmovmskps %ymm0, %ecx
 ; AVX1-NEXT:    movl $32, %eax
-; AVX1-NEXT:    rep bsfl %ecx, %eax
+; AVX1-NEXT:    bsfl %ecx, %eax
+; AVX1-NEXT:    cmovel %eax, %eax
 ; AVX1-NEXT:    vzeroupper
 ; AVX1-NEXT:    retq
 ;
@@ -31,7 +32,8 @@ define i32 @PR90847(<8 x float> %x) nounwind {
 ; AVX2-NEXT:    vcmpeqps %ymm0, %ymm1, %ymm0
 ; AVX2-NEXT:    vmovmskps %ymm0, %ecx
 ; AVX2-NEXT:    movl $32, %eax
-; AVX2-NEXT:    rep bsfl %ecx, %eax
+; AVX2-NEXT:    bsfl %ecx, %eax
+; AVX2-NEXT:    cmovel %eax, %eax
 ; AVX2-NEXT:    vzeroupper
 ; AVX2-NEXT:    retq
 entry:


### PR DESCRIPTION
Draft for review. The actual fix should land upstream on `llvm/llvm-project` (where the buggy commit lives) and propagate via the amd-staging merge — this PR is for triage feedback.

## Problem

`llc -O2 -mcpu=gfx950` hangs on rocPRIM's `adjacent_difference_impl` benchmark kernel. DAG combiner spins ~93k combines/sec on freeze nodes — the freeze inserted by `simplifySelect` (per upstream PR #175199) cycles with `DAGCombiner::visitFREEZE` across the many select-with-undef sites in rocPRIM's primbench templates.

Full trace + reduced repro: ROCm/llvm-project#2616.

## Fix

Only insert the freeze when the surviving arm carries poison-generating flags (the motivating `trunc nuw` case from #175018). Otherwise skip the simplification rather than insert a freeze that may cycle. Correctness preserved — still does not propagate poison.

## Validation

| Test | Before | After |
|---|---|---|
| `llc -O2 -mcpu=gfx950 reduced.ll` | hang | 53 ms |
| Full TU (42 k lines) | hang | 2.7 s |
| X86 + AMDGPU CodeGen lit suites | baseline | 0 net new failures |

7 test snapshots auto-updated via `update_llc_test_checks.py` (codegen-shape only — register allocation, extra explicit-zero materialization; no correctness changes).
