### PR TITLE
[WaveTransform] Mark SI_BRCOND* as unanalyzable and define EXEC/VCC

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3228,10 +3228,45 @@ bool SIInstrInfo::analyzeBranchImpl(MachineBasicBlock &MBB,
                                     MachineBasicBlock *&FBB,
                                     SmallVectorImpl<MachineOperand> &Cond,
                                     bool AllowModify) const {
-  if (I->getOpcode() == AMDGPU::S_BRANCH) {
+  unsigned Opc = I->getOpcode();
+  if (Opc == AMDGPU::S_BRANCH) {
     // Unconditional Branch
     TBB = I->getOperand(0).getMBB();
     return false;
+  }
+
+  if (Opc == AMDGPU::SI_BRCOND || Opc == AMDGPU::SI_BRCOND_Z) {
+    // SI_BRCOND/SI_BRCOND_Z are thread-level divergent branch pseudos with
+    // lane-level semantics (per-lane condition register). They cannot be
+    // analyzed as standard wave-level branches because:
+    //
+    // 1. Critical Edge Prevention: Returning true (cannot analyze) prevents
+    //    canSplitCriticalEdge() from splitting edges involving these branches.
+    //    The edge splitting is unwanted as the copies inserted during PHI
+    //    elimination are executed by only active threads at each predecessor
+    //    block guaranteeing no overwrite to the value in question.
+    //
+    // 2. Semantic Mismatch: Standard branch analysis assumes uniform control
+    //    flow (all lanes take same path). SI_BRCOND represents divergent flow
+    //    where different lanes may take different paths. Branch folding,
+    //    if-conversion, and similar optimizations might make wrong judgement
+    //    and make incorrect foldings. Make them unanalyzable would prevent such
+    //    instances.
+    //
+    // 3. Deferred Lowering: These pseudos will be lowered by WaveTransform
+    //    pass into proper EXEC mask manipulation and wave-level branches
+    //    (S_MOV_B64_term exec, S_CBRANCH_EXECZ, etc.). Optimizing before
+    //    lowering would interfere with WaveTransform's reconverging algorithm
+    //    and would lead to suboptimal transforms.
+    //
+    // This is now consistent with legacy pipeline behavior where SI_IF
+    // (structurizer pseudo) is also not analyzed by this function.
+    //
+    // TODO-WAVETRANSFORM: We may need to revisit this fix. Currently, these
+    // instructions are marked with isBranch and forced here to make them
+    // non-analyzable. May be we should reconsider removing the isBranch field
+    // and make it behave similar to SI_IF while making it non-analyzable.
+    return true;
   }
 
   BranchPredicate Pred = getBranchPredicate(I->getOpcode());

--- a/llvm/lib/Target/AMDGPU/SIInstructions.td
+++ b/llvm/lib/Target/AMDGPU/SIInstructions.td
@@ -666,6 +666,7 @@ def SI_BR_UNDEF : SPseudoInstSI <(outs), (ins SOPPBrTarget:$simm16)> {
   let isBranch = 1;
 }
 
+let Uses = [EXEC], Defs = [EXEC,VCC] in {
 // Pseudo thread-level conditional branch used in WaveTransform mode.
 // It takes a virtual lanemask register as the condition. Semantically,
 // a current active lane jumps to the target if its cond-bit is set to 1,
@@ -690,6 +691,8 @@ def SI_BRCOND_Z
   // let usesCustomInserter = 1;
   let isBranch = 1;
 }
+} // End Uses = [EXEC], Defs = [EXEC,VCC]
+
 def SI_PS_LIVE : PseudoInstSI <
   (outs SReg_1:$dst), (ins),
   [(set i1:$dst, (int_amdgcn_ps_live))]> {

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
@@ -35,7 +35,7 @@ define void @divergent_i1_phi_used_outside_loop(float %val, float %pre.cond.val,
   ; CHECK-NEXT:   [[S_CVT_F32_U32_:%[0-9]+]]:sgpr_32 = S_CVT_F32_U32 [[PHI]], implicit $mode
   ; CHECK-NEXT:   [[V_CMP_NGT_F32_e64_:%[0-9]+]]:sreg_32 = nofpexcept V_CMP_NGT_F32_e64 0, killed [[S_CVT_F32_U32_]], 0, [[COPY3]], 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[PHI]], 1, implicit-def dead $scc
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NGT_F32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NGT_F32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.exit:
@@ -87,7 +87,7 @@ define void @divergent_i1_phi_used_outside_loop_larger_loop_body(float %val, ptr
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 0, [[PHI2]], implicit $exec
   ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_CMP_NE_U32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 1, killed [[V_CNDMASK_B32_e64_1]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.3, killed [[V_CMP_NE_U32_e64_1]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.3, killed [[V_CMP_NE_U32_e64_1]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.is.eq.zero:
@@ -168,7 +168,7 @@ define void @divergent_i1_xor_used_outside_loop(float %val, float %pre.cond.val,
   ; CHECK-NEXT:   [[S_CVT_F32_U32_:%[0-9]+]]:sgpr_32 = S_CVT_F32_U32 [[PHI]], implicit $mode
   ; CHECK-NEXT:   [[V_CMP_NGT_F32_e64_:%[0-9]+]]:sreg_32 = nofpexcept V_CMP_NGT_F32_e64 0, killed [[S_CVT_F32_U32_]], 0, [[COPY3]], 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[PHI]], 1, implicit-def dead $scc
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NGT_F32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NGT_F32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.exit:
@@ -217,7 +217,7 @@ define void @divergent_i1_xor_used_outside_loop_larger_loop_body(i32 %num.elts, 
   ; CHECK-NEXT:   [[COPY4:%[0-9]+]]:vgpr_32 = COPY killed $vgpr0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_MOV_B32 0
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 0, [[COPY4]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.4, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.4, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1.loop.start.preheader:
@@ -239,7 +239,7 @@ define void @divergent_i1_xor_used_outside_loop_larger_loop_body(i32 %num.elts, 
   ; CHECK-NEXT:   [[REG_SEQUENCE1:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed %50, %subreg.sub1
   ; CHECK-NEXT:   [[GLOBAL_LOAD_DWORD:%[0-9]+]]:vgpr_32 = GLOBAL_LOAD_DWORD killed [[REG_SEQUENCE1]], 0, 0, implicit $exec :: (load (s32) from %ir.a.plus.i, addrspace 1)
   ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 0, killed [[GLOBAL_LOAD_DWORD]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_EQ_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_EQ_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3.loop.cond:
@@ -247,7 +247,7 @@ define void @divergent_i1_xor_used_outside_loop_larger_loop_body(i32 %num.elts, 
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 [[PHI]], 1, implicit-def dead $scc
   ; CHECK-NEXT:   [[V_CMP_LT_I32_e64_:%[0-9]+]]:sreg_32 = V_CMP_LT_I32_e64 killed [[PHI]], [[COPY4]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_LT_I32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_LT_I32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.block.after.loop:
@@ -265,7 +265,7 @@ define void @divergent_i1_xor_used_outside_loop_larger_loop_body(i32 %num.elts, 
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vgpr_32 = PHI [[V_CNDMASK_B32_e64_]], %bb.2, [[V_CNDMASK_B32_e64_1]], %bb.3
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 0, killed [[PHI1]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.5, killed [[V_CMP_NE_U32_e64_1]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.5, killed [[V_CMP_NE_U32_e64_1]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.4
 entry:
   %start.cond = icmp eq i32 %num.elts, 0
@@ -320,13 +320,14 @@ define void @divergent_i1_icmp_used_outside_loop(i32 %v0, i32 %v1, ptr addrspace
   ; CHECK-NEXT: bb.1.loop.start:
   ; CHECK-NEXT:   successors: %bb.2(0x80000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_]], %bb.0, %2, %bb.6
+  ; CHECK-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_]], %bb.0, %2, %bb.5
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.cond.block.0:
   ; CHECK-NEXT:   successors: %bb.3(0x40000000), %bb.4(0x40000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 [[PHI]], [[COPY5]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 [[PHI]], [[COPY5]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.4, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.4, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.3.if.block.0:
@@ -342,40 +343,35 @@ define void @divergent_i1_icmp_used_outside_loop(i32 %v0, i32 %v1, ptr addrspace
   ; CHECK-NEXT:   GLOBAL_STORE_DWORD killed [[REG_SEQUENCE3]], killed [[COPY6]], 0, 0, implicit $exec :: (store (s32) into %ir.a.plus.i, addrspace 1)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.loop.break.block:
-  ; CHECK-NEXT:   successors: %bb.5(0x04000000), %bb.6(0x7c000000)
+  ; CHECK-NEXT:   successors: %bb.6(0x04000000), %bb.5(0x7c000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 [[PHI]], [[COPY4]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND_Z %bb.6, killed [[V_CMP_EQ_U32_e64_]]
-  ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.5:
-  ; CHECK-NEXT:   successors: %bb.7(0x80000000)
-  ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 [[PHI]], [[COPY4]], implicit $exec
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[PHI]], implicit $exec
-  ; CHECK-NEXT:   S_BRANCH %bb.7
+  ; CHECK-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_EQ_U32_e64_1]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
+  ; CHECK-NEXT:   S_BRANCH %bb.5
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.6.loop.cond:
+  ; CHECK-NEXT: bb.5.loop.cond:
   ; CHECK-NEXT:   successors: %bb.1(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[PHI]], 1, implicit-def dead $scc
   ; CHECK-NEXT:   S_BRANCH %bb.1
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.7.cond.block.1:
-  ; CHECK-NEXT:   successors: %bb.8(0x40000000), %bb.9(0x40000000)
+  ; CHECK-NEXT: bb.6.cond.block.1:
+  ; CHECK-NEXT:   successors: %bb.7(0x40000000), %bb.8(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 killed [[PHI]], killed [[COPY5]], implicit $exec
-  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, -1, killed [[V_CMP_EQ_U32_e64_1]], implicit $exec
+  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, -1, killed [[V_CMP_EQ_U32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 0, killed [[V_CNDMASK_B32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_CMP_NE_U32_e64_1]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 1, killed [[V_CNDMASK_B32_e64_1]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.9, killed [[V_CMP_NE_U32_e64_2]]
-  ; CHECK-NEXT:   S_BRANCH %bb.8
+  ; CHECK-NEXT:   SI_BRCOND %bb.8, killed [[V_CMP_NE_U32_e64_2]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
+  ; CHECK-NEXT:   S_BRANCH %bb.7
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.8.if.block.1:
-  ; CHECK-NEXT:   successors: %bb.9(0x80000000)
+  ; CHECK-NEXT: bb.7.if.block.1:
+  ; CHECK-NEXT:   successors: %bb.8(0x80000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   GLOBAL_STORE_DWORD killed [[REG_SEQUENCE]], killed [[COPY7]], 0, 0, implicit $exec :: (store (s32) into %ir.c, addrspace 1)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT: bb.9.exit:
+  ; CHECK-NEXT: bb.8.exit:
   ; CHECK-NEXT:   SI_RETURN
 entry:
   br label %loop.start
@@ -455,7 +451,7 @@ define amdgpu_ps void @divergent_i1_freeze_used_outside_loop(i32 %n, ptr addrspa
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 0, [[PHI1]], implicit $exec
   ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_CMP_NE_U32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 1, killed [[V_CNDMASK_B32_e64_1]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.3, killed [[V_CMP_NE_U32_e64_1]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.3, killed [[V_CMP_NE_U32_e64_1]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.is.eq.zero:
@@ -477,7 +473,7 @@ define amdgpu_ps void @divergent_i1_freeze_used_outside_loop(i32 %n, ptr addrspa
   ; CHECK-NEXT:   [[PHI2:%[0-9]+]]:vgpr_32 = PHI [[PHI1]], %bb.1, [[V_CNDMASK_B32_e64_2]], %bb.2
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 [[PHI]], 1, implicit-def dead $scc
   ; CHECK-NEXT:   [[V_CMP_GE_I32_e64_:%[0-9]+]]:sreg_32 = V_CMP_GE_I32_e64 killed [[PHI]], [[COPY4]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_GE_I32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_GE_I32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.4
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.4.exit:
@@ -545,7 +541,7 @@ define amdgpu_cs void @loop_with_1break(ptr addrspace(1) %x, ptr addrspace(1) %a
   ; CHECK-NEXT:   [[REG_SEQUENCE4:%[0-9]+]]:vreg_64 = REG_SEQUENCE killed [[V_ADD_CO_U32_e64_]], %subreg.sub0, killed %53, %subreg.sub1
   ; CHECK-NEXT:   [[GLOBAL_LOAD_DWORD:%[0-9]+]]:vgpr_32 = GLOBAL_LOAD_DWORD killed [[REG_SEQUENCE4]], 0, 0, implicit $exec :: (load (s32) from %ir.a.plus.counter, addrspace 1)
   ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 0, killed [[GLOBAL_LOAD_DWORD]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.5, killed [[V_CMP_EQ_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.5, killed [[V_CMP_EQ_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.3
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.break.body:
@@ -577,7 +573,7 @@ define amdgpu_cs void @loop_with_1break(ptr addrspace(1) %x, ptr addrspace(1) %a
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vgpr_32 = PHI [[V_CNDMASK_B32_e64_]], %bb.1, [[V_CNDMASK_B32_e64_1]], %bb.3
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 0, killed [[PHI1]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.2, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.2, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.4
 entry:
   br label %A

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/simplify-uniform-phi.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/simplify-uniform-phi.mir
@@ -16,7 +16,7 @@ body: |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY1]], [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
@@ -35,7 +35,7 @@ body: |
     %1:vgpr_32 = COPY $vgpr0
     %2:sreg_32 = S_MOV_B32 0
     %3:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %1, %2, implicit $exec
-    SI_BRCOND %bb.1, killed %3
+    SI_BRCOND %bb.1, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.1:
@@ -49,9 +49,9 @@ body: |
 ...
 
 ---
-# SGPR PHI with one real value and IMPLICIT_DEF, but neither the 
+# SGPR PHI with one real value and IMPLICIT_DEF, but neither the
 # real value's Block or the other predeccsor block dominates the
-# Phi Block, so no PHI simplification occurs. 
+# Phi Block, so no PHI simplification occurs.
 name: no_simplify_non_dominating_value
 tracksRegLiveness: true
 body: |
@@ -63,7 +63,7 @@ body: |
   ; CHECK-NEXT:   [[COPY:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY]], [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
@@ -88,7 +88,7 @@ body: |
     %0:vgpr_32 = COPY $vgpr0
     %1:sreg_32 = S_MOV_B32 0
     %2:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %0, %1, implicit $exec
-    SI_BRCOND %bb.1, killed %2
+    SI_BRCOND %bb.1, killed %2, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.1:
@@ -106,7 +106,7 @@ body: |
 ...
 
 ---
-# VGPR PHI with one real value and one IMPLICIT_DEF, with the real value's 
+# VGPR PHI with one real value and one IMPLICIT_DEF, with the real value's
 # block dominating PHI block, but since its a VGPR value its not uniform,
 # so PHI simplication is not supposed to occur.
 name: no_simplify_vgpr_phi
@@ -121,7 +121,7 @@ body: |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr1
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY1]], [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
@@ -141,7 +141,7 @@ body: |
     %1:vgpr_32 = COPY $vgpr1
     %2:sreg_32 = S_MOV_B32 0
     %3:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %1, %2, implicit $exec
-    SI_BRCOND %bb.1, killed %3
+    SI_BRCOND %bb.1, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.1:
@@ -170,7 +170,7 @@ body: |
   ; CHECK-NEXT:   [[COPY1:%[0-9]+]]:vgpr_32 = COPY $vgpr0
   ; CHECK-NEXT:   [[S_MOV_B32_:%[0-9]+]]:sreg_32 = S_MOV_B32 0
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 [[COPY1]], [[S_MOV_B32_]], implicit $exec
-  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]]
+  ; CHECK-NEXT:   SI_BRCOND %bb.1, killed [[V_CMP_NE_U32_e64_]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
   ; CHECK-NEXT:   S_BRANCH %bb.2
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.1:
@@ -190,7 +190,7 @@ body: |
     %1:vgpr_32 = COPY $vgpr0
     %2:sreg_32 = S_MOV_B32 0
     %3:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 %1, %2, implicit $exec
-    SI_BRCOND %bb.1, killed %3
+    SI_BRCOND %bb.1, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.1:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-basic.mir
@@ -38,7 +38,7 @@ body:             |
     %8:vgpr_32 = COPY $vgpr0
     %15:sreg_32 = S_MOV_B32 0
     %16:sreg_32 = V_CMP_EQ_U32_e64 %8, killed %15, implicit $exec
-    SI_BRCOND %bb.2, killed %16
+    SI_BRCOND %bb.2, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -85,7 +85,7 @@ body:             |
     %8:vgpr_32 = COPY $vgpr0
     %15:sreg_32 = S_MOV_B32 0
     %16:sreg_32 = V_CMP_EQ_U32_e64 %8, killed %15, implicit $exec
-    SI_BRCOND_Z %bb.2, killed %16
+    SI_BRCOND_Z %bb.2, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -133,7 +133,7 @@ body:             |
     %8:vgpr_32 = COPY $vgpr0
     %15:sreg_32 = S_MOV_B32 0
     %16:sreg_32 = V_CMP_EQ_U32_e64 %8, killed %15, implicit $exec
-    SI_BRCOND %bb.2, killed %16
+    SI_BRCOND %bb.2, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -194,7 +194,7 @@ body:             |
     %8:vgpr_32 = COPY $vgpr0
     %15:sreg_32 = S_MOV_B32 0
     %16:sreg_32 = V_CMP_EQ_U32_e64 %8, killed %15, implicit $exec
-    SI_BRCOND %bb.2, killed %16
+    SI_BRCOND %bb.2, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -387,21 +387,21 @@ body:             |
     %10:vgpr_32 = COPY $vgpr2
     %15:sreg_32 = S_MOV_B32 0
     %16:sreg_32 = V_CMP_EQ_U32_e64 killed %8, %15, implicit $exec
-    SI_BRCOND %bb.2, killed %16
+    SI_BRCOND %bb.2, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
     successors: %bb.3, %bb.4
 
     %17:sreg_32 = V_CMP_EQ_U32_e64 killed %9, %15, implicit $exec
-    SI_BRCOND %bb.3, killed %17
+    SI_BRCOND %bb.3, killed %17, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.2:
     successors: %bb.5, %bb.6
 
     %18:sreg_32 = V_CMP_EQ_U32_e64 killed %10, %15, implicit $exec
-    SI_BRCOND %bb.6, killed %18
+    SI_BRCOND %bb.6, killed %18, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.5
 
   bb.3:
@@ -540,14 +540,14 @@ body:             |
     successors: %bb.3, %bb.4
 
     %17:sreg_32 = V_CMP_EQ_U32_e64 killed %9, %15, implicit $exec
-    SI_BRCOND %bb.3, killed %17
+    SI_BRCOND %bb.3, killed %17, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.2:
     successors: %bb.5, %bb.6
 
     %18:sreg_32 = V_CMP_EQ_U32_e64 killed %10, %15, implicit $exec
-    SI_BRCOND %bb.6, killed %18
+    SI_BRCOND %bb.6, killed %18, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.5
 
   bb.3:
@@ -661,7 +661,7 @@ body:             |
     %10:sgpr_32 = COPY $sgpr2
     %15:sreg_32 = S_MOV_B32 0
     %16:sreg_32 = V_CMP_EQ_U32_e64 killed %8, %15, implicit $exec
-    SI_BRCOND %bb.2, killed %16
+    SI_BRCOND %bb.2, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -766,7 +766,7 @@ body:             |
     %1:sreg_32 = COPY $sgpr0
     %2:sreg_32 = S_MOV_B32 0
     %3:sreg_32 = V_CMP_EQ_U32_e64 %0, %2, implicit $exec
-    SI_BRCOND %bb.2, killed %3
+    SI_BRCOND %bb.2, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -1073,7 +1073,7 @@ body:             |
     %0:vgpr_32 = COPY $vgpr0
     %1:sreg_32 = S_MOV_B32 0
     %2:sreg_32 = V_CMP_EQ_U32_e64 %0, killed %1, implicit $exec
-    SI_BRCOND %bb.2, killed %2
+    SI_BRCOND %bb.2, killed %2, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -1136,7 +1136,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 $vgpr0, implicit $exec
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 [[V_READFIRSTLANE_B32_]], $vgpr0, implicit $exec
-  ; POSTWT-NEXT:   [[S_AND_SAVEEXEC_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 [[V_CMP_EQ_U32_e64_1]], implicit-def $exec, implicit-def dead $scc, implicit $exec
+  ; POSTWT-NEXT:   [[S_AND_SAVEEXEC_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 [[V_CMP_EQ_U32_e64_1]], implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; POSTWT-NEXT:   S_BRANCH %bb.3
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.3:
@@ -1180,7 +1180,7 @@ body:             |
     liveins: $vgpr0, $vgpr4, $vgpr5, $sgpr30_sgpr31
 
     %8:sreg_32 = V_CMP_EQ_U32_e64 0, killed $vgpr5, implicit $exec
-    SI_BRCOND %bb.5, %8
+    SI_BRCOND %bb.5, %8, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -1195,7 +1195,7 @@ body:             |
 
     %26:sreg_32_xm0 = V_READFIRSTLANE_B32 $vgpr0, implicit $exec
     %27:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 %26, $vgpr0, implicit $exec
-    %28:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 %27, implicit-def $exec, implicit-def dead $scc, implicit $exec
+    %28:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 %27, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
 
   bb.3:
     successors: %bb.2(0x40000000), %bb.4(0x40000000)
@@ -1258,7 +1258,7 @@ body:             |
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT:   [[V_READFIRSTLANE_B32_:%[0-9]+]]:sreg_32_xm0 = V_READFIRSTLANE_B32 $vgpr0, implicit $exec
   ; POSTWT-NEXT:   [[V_CMP_EQ_U32_e64_:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 [[V_READFIRSTLANE_B32_]], $vgpr0, implicit $exec
-  ; POSTWT-NEXT:   [[S_AND_SAVEEXEC_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 [[V_CMP_EQ_U32_e64_]], implicit-def $exec, implicit-def dead $scc, implicit $exec
+  ; POSTWT-NEXT:   [[S_AND_SAVEEXEC_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 [[V_CMP_EQ_U32_e64_]], implicit-def dead $exec, implicit-def dead $scc, implicit $exec
   ; POSTWT-NEXT:   S_BRANCH %bb.2
   ; POSTWT-NEXT: {{  $}}
   ; POSTWT-NEXT: bb.2:
@@ -1326,7 +1326,7 @@ body:             |
 
     %27:sreg_32_xm0 = V_READFIRSTLANE_B32 $vgpr0, implicit $exec
     %28:sreg_32_xm0_xexec = V_CMP_EQ_U32_e64 %27, $vgpr0, implicit $exec
-    %29:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 %28, implicit-def $exec, implicit-def dead $scc, implicit $exec
+    %29:sreg_32_xm0_xexec = S_AND_SAVEEXEC_B32 %28, implicit-def dead $exec, implicit-def dead $scc, implicit $exec
 
   bb.2:
     successors: %bb.1(0x40000000), %bb.3(0x40000000)
@@ -1344,7 +1344,7 @@ body:             |
 
     $exec_lo = S_MOV_B32 %26
     %10:sreg_32 = V_CMP_EQ_U32_e64 0, killed $vgpr5, implicit $exec
-    SI_BRCOND %bb.5, %10
+    SI_BRCOND %bb.5, %10, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.4:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-fix-missing-defs.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-fix-missing-defs.mir
@@ -49,7 +49,7 @@ body: |
     %0:vgpr_32 = COPY $vgpr0
     %1:sreg_32 = S_MOV_B32 0
     %2:sreg_32 = V_CMP_EQ_U32_e64 %0, %1, implicit $exec
-    SI_BRCOND %bb.2, %2
+    SI_BRCOND %bb.2, %2, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -128,7 +128,7 @@ body: |
     %0:vgpr_32 = COPY $vgpr0
     %1:sreg_32 = S_MOV_B32 0
     %2:sreg_32 = V_CMP_EQ_U32_e64 %0, %1, implicit $exec
-    SI_BRCOND %bb.2, %2
+    SI_BRCOND %bb.2, %2, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -213,7 +213,7 @@ body: |
     %0:sreg_32 = COPY $sgpr0
     %1:sreg_32 = S_MOV_B32 0
     %2:sreg_32 = V_CMP_EQ_U32_e64 %0, %1, implicit $exec
-    SI_BRCOND %bb.2, %2
+    SI_BRCOND %bb.2, %2, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -297,7 +297,7 @@ body: |
     %0:vgpr_32 = COPY $vgpr0
     %1:sreg_32 = S_MOV_B32 0
     %2:sreg_32 = V_CMP_EQ_U32_e64 %0, %1, implicit $exec
-    SI_BRCOND %bb.2, %2
+    SI_BRCOND %bb.2, %2, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-inlineasm-br.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-inlineasm-br.mir
@@ -132,7 +132,7 @@ body:             |
     %1:sreg_32 = COPY $sgpr0
     %2:sreg_32 = S_MOV_B32 0
     %3:sreg_32 = V_CMP_EQ_U32_e64 %0, %2, implicit $exec
-    SI_BRCOND %bb.2, killed %3
+    SI_BRCOND %bb.2, killed %3, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -146,7 +146,7 @@ body:             |
 
     %4:sreg_32 = S_MOV_B32 1
     %5:sreg_32 = V_CMP_EQ_U32_e64 %0, %4, implicit $exec
-    SI_BRCOND %bb.4, killed %5
+    SI_BRCOND %bb.4, killed %5, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.3 (inlineasm-br-indirect-target):

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-natural-loops.mir
@@ -52,7 +52,7 @@ body:             |
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %12
+    SI_BRCOND %bb.1, killed %12, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.2:
@@ -131,7 +131,7 @@ body:             |
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %12
+    SI_BRCOND %bb.1, killed %12, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.2:
@@ -139,7 +139,7 @@ body:             |
 
     %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %20
+    SI_BRCOND %bb.1, killed %20, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.3:
@@ -213,7 +213,7 @@ body:             |
 
     %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %20
+    SI_BRCOND %bb.1, killed %20, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.3:
@@ -293,7 +293,7 @@ body:             |
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %12
+    SI_BRCOND %bb.1, killed %12, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.2:
@@ -502,7 +502,7 @@ body:             |
     successors: %bb.2, %bb.4
 
     %11:sreg_32 = V_CMP_NE_U32_e64 %10, %0, implicit $exec
-    SI_BRCOND %bb.2, killed %11
+    SI_BRCOND %bb.2, killed %11, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.2:
@@ -510,13 +510,13 @@ body:             |
 
     %20:vgpr_32 = V_ADD_U32_e64 %10, 1, 0, implicit $exec
     %21:sreg_32 = V_CMP_NE_U32_e64 %20, %1, implicit $exec
-    SI_BRCOND %bb.3, killed %21
+    SI_BRCOND %bb.3, killed %21, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:
     %30:sreg_32 = V_CMP_NE_U32_e64 %20, %2, implicit $exec
     %10:vgpr_32 = COPY %20
-    SI_BRCOND %bb.1, killed %30
+    SI_BRCOND %bb.1, killed %30, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.2
 
   bb.4:
@@ -711,14 +711,14 @@ body:             |
     %21:vgpr_32 = V_ADD_U32_e64 %20, 1, 0, implicit $exec
     %22:sreg_32 = V_CMP_NE_U32_e64 %21, %1, implicit $exec
     %20:vgpr_32 = COPY %21
-    SI_BRCOND %bb.2, killed %22
+    SI_BRCOND %bb.2, killed %22, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.3:
     %30:vgpr_32 = V_ADD_U32_e64 %10, 1, 0, implicit $exec
     %31:sreg_32 = V_CMP_NE_U32_e64 %30, %0, implicit $exec
     %10:vgpr_32 = COPY %30
-    SI_BRCOND %bb.1, killed %31
+    SI_BRCOND %bb.1, killed %31, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.4:
@@ -870,7 +870,7 @@ body:             |
 
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
-    SI_BRCOND %bb.2, killed %12
+    SI_BRCOND %bb.2, killed %12, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.2:
@@ -878,7 +878,7 @@ body:             |
 
     %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %20
+    SI_BRCOND %bb.1, killed %20, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:
@@ -886,7 +886,7 @@ body:             |
 
     %30:sreg_32 = V_CMP_NE_U32_e64 %11, %2, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %30
+    SI_BRCOND %bb.1, killed %30, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.5
 
   bb.4:
@@ -1039,7 +1039,7 @@ body:             |
 
     %20:sreg_32 = V_CMP_NE_U32_e64 %11, %1, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %20
+    SI_BRCOND %bb.1, killed %20, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:
@@ -1047,7 +1047,7 @@ body:             |
 
     %30:sreg_32 = V_CMP_NE_U32_e64 %11, %2, implicit $exec
     %10:sreg_32 = COPY %11
-    SI_BRCOND %bb.1, killed %30
+    SI_BRCOND %bb.1, killed %30, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.5
 
   bb.4:
@@ -1211,7 +1211,7 @@ body:             |
 
     %11:sreg_32 = S_ADD_U32 %10, 1, implicit-def $scc
     %12:sreg_32 = V_CMP_NE_U32_e64 %11, %0, implicit $exec
-    SI_BRCOND %bb.2, killed %12
+    SI_BRCOND %bb.2, killed %12, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.2:

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-partial-join.mir
@@ -121,21 +121,21 @@ body:             |
     %3:vgpr_32 = COPY $vgpr2
     %4:sreg_32 = S_MOV_B32 0
     %5:sreg_32 = V_CMP_EQ_U32_e64 killed %1, %4, implicit $exec
-    SI_BRCOND %bb.2, killed %5
+    SI_BRCOND %bb.2, killed %5, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
     successors: %bb.3, %bb.4
 
     %6:sreg_32 = V_CMP_EQ_U32_e64 killed %2, %4, implicit $exec
-    SI_BRCOND %bb.4, killed %6
+    SI_BRCOND %bb.4, killed %6, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.2:
     successors: %bb.4, %bb.5
 
     %7:sreg_32 = V_CMP_EQ_U32_e64 killed %3, %4, implicit $exec
-    SI_BRCOND %bb.5, killed %7
+    SI_BRCOND %bb.5, killed %7, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:
@@ -269,14 +269,14 @@ body:             |
     successors: %bb.3, %bb.4
 
     %6:sreg_32 = V_CMP_EQ_U32_e64 killed %2, %4, implicit $exec
-    SI_BRCOND %bb.4, killed %6
+    SI_BRCOND %bb.4, killed %6, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.2:
     successors: %bb.4, %bb.5
 
     %7:sreg_32 = V_CMP_EQ_U32_e64 killed %3, %4, implicit $exec
-    SI_BRCOND %bb.5, killed %7
+    SI_BRCOND %bb.5, killed %7, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:
@@ -414,7 +414,7 @@ body:             |
     %3:vgpr_32 = COPY $vgpr1
     %4:sreg_32 = S_MOV_B32 0
     %5:sreg_32 = V_CMP_EQ_U32_e64 killed %1, %4, implicit $exec
-    SI_BRCOND %bb.2, killed %5
+    SI_BRCOND %bb.2, killed %5, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -428,7 +428,7 @@ body:             |
     successors: %bb.4, %bb.5
 
     %7:sreg_32 = V_CMP_EQ_U32_e64 killed %3, %4, implicit $exec
-    SI_BRCOND %bb.5, killed %7
+    SI_BRCOND %bb.5, killed %7, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:
@@ -566,14 +566,14 @@ body:             |
     %3:sgpr_32 = COPY $sgpr0
     %4:sreg_32 = S_MOV_B32 0
     %5:sreg_32 = V_CMP_EQ_U32_e64 killed %1, %4, implicit $exec
-    SI_BRCOND %bb.2, killed %5
+    SI_BRCOND %bb.2, killed %5, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
     successors: %bb.3, %bb.4
 
     %6:sreg_32 = V_CMP_EQ_U32_e64 killed %2, %4, implicit $exec
-    SI_BRCOND %bb.4, killed %6
+    SI_BRCOND %bb.4, killed %6, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.2:
@@ -719,7 +719,7 @@ body:             |
     %3:sgpr_32 = COPY $sgpr1
     %4:sreg_32 = S_MOV_B32 0
     %5:sreg_32 = V_CMP_EQ_U32_e64 killed %1, %4, implicit $exec
-    SI_BRCOND %bb.2, killed %5
+    SI_BRCOND %bb.2, killed %5, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.1
 
   bb.1:
@@ -846,7 +846,7 @@ body:             |
     successors: %bb.3, %bb.4
 
     %6:sreg_32 = V_CMP_EQ_U32_e64 killed %2, %4, implicit $exec
-    SI_BRCOND %bb.4, killed %6
+    SI_BRCOND %bb.4, killed %6, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.3
 
   bb.2:
@@ -977,7 +977,7 @@ body:             |
     successors: %bb.4, %bb.5
 
     %7:sreg_32 = V_CMP_EQ_U32_e64 killed %3, %4, implicit $exec
-    SI_BRCOND %bb.5, killed %7
+    SI_BRCOND %bb.5, killed %7, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
     S_BRANCH %bb.4
 
   bb.3:

--- a/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
@@ -2643,9 +2643,8 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB32_2
@@ -2663,15 +2662,15 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB32_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB32_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB32_5
 ; GFX90A-NEXT:  .LBB32_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[4:5], v[0:1]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB32_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -2686,17 +2685,15 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v4
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX90A-NEXT:    v_pk_mov_b32 v[4:5], v[2:3], v[2:3] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB32_4
-; GFX90A-NEXT:  .LBB32_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
-; GFX90A-NEXT:  .LBB32_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB32_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -2712,14 +2709,13 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB32_2
@@ -2735,15 +2731,15 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB32_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB32_6
+; GFX950-NEXT:    s_cbranch_execz .LBB32_5
 ; GFX950-NEXT:  .LBB32_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[4:5], v[0:1]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:  .LBB32_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -2755,20 +2751,17 @@ define void @flat_atomic_xor_expansion_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    buffer_inv sc0 sc1
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v4
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[4:5], v[2:3]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB32_4
-; GFX950-NEXT:  .LBB32_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
-; GFX950-NEXT:  .LBB32_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB32_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -2932,9 +2925,8 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[6:7]
 ; GFX90A-NEXT:    ;;#ASMEND
@@ -2955,15 +2947,15 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB34_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB34_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB34_5
 ; GFX90A-NEXT:  .LBB34_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[4:5], v[0:1]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB34_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -2978,17 +2970,15 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v4
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX90A-NEXT:    v_pk_mov_b32 v[4:5], v[2:3], v[2:3] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB34_4
-; GFX90A-NEXT:  .LBB34_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
-; GFX90A-NEXT:  .LBB34_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB34_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -3001,15 +2991,15 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    s_mov_b64 s[0:1], src_private_base
 ; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, s1, v1
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v[6:7]
 ; GFX950-NEXT:    ;;#ASMEND
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB34_2
@@ -3025,15 +3015,15 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB34_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB34_6
+; GFX950-NEXT:    s_cbranch_execz .LBB34_5
 ; GFX950-NEXT:  .LBB34_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[4:5], v[0:1]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:  .LBB34_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -3045,20 +3035,17 @@ define void @flat_atomic_xor_expansion_i64_ret_v_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    buffer_inv sc0 sc1
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v4
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[4:5], v[2:3]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB34_4
-; GFX950-NEXT:  .LBB34_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
-; GFX950-NEXT:  .LBB34_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB34_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -3356,9 +3343,8 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; def v[6:7]
 ; GFX90A-NEXT:    ;;#ASMEND
@@ -3379,15 +3365,15 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB37_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB37_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB37_5
 ; GFX90A-NEXT:  .LBB37_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[4:5], v[0:1]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB37_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -3402,17 +3388,15 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v4
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX90A-NEXT:    v_pk_mov_b32 v[4:5], v[2:3], v[2:3] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB37_4
-; GFX90A-NEXT:  .LBB37_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
-; GFX90A-NEXT:  .LBB37_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB37_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -3425,15 +3409,15 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    s_mov_b64 s[0:1], src_private_base
 ; GFX950-NEXT:    v_cmp_eq_u32_e32 vcc, s1, v1
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def v[6:7]
 ; GFX950-NEXT:    ;;#ASMEND
+; GFX950-NEXT:    s_nop 0
+; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
+; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB37_2
@@ -3449,15 +3433,15 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB37_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB37_6
+; GFX950-NEXT:    s_cbranch_execz .LBB37_5
 ; GFX950-NEXT:  .LBB37_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[4:5], v[0:1]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:  .LBB37_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -3469,20 +3453,17 @@ define void @flat_atomic_xor_expansion_i64_ret_av_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    buffer_inv sc0 sc1
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[2:3], v[4:5]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v4
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[4:5], v[2:3]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB37_4
-; GFX950-NEXT:  .LBB37_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
-; GFX950-NEXT:  .LBB37_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB37_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -7368,9 +7349,8 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB95_2
@@ -7390,15 +7370,15 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB95_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB95_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB95_5
 ; GFX90A-NEXT:  .LBB95_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB95_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -7411,17 +7391,15 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB95_4
-; GFX90A-NEXT:  .LBB95_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:  .LBB95_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB95_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -7439,14 +7417,13 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB95_2
@@ -7464,15 +7441,15 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB95_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB95_6
+; GFX950-NEXT:    s_cbranch_execz .LBB95_5
 ; GFX950-NEXT:  .LBB95_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:  .LBB95_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -7483,20 +7460,17 @@ define void @flat_atomic_nand_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB95_4
-; GFX950-NEXT:  .LBB95_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:  .LBB95_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB95_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -9177,9 +9151,8 @@ define void @flat_atomic_usub_cond_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v5, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v4, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB111_2
@@ -9200,15 +9173,15 @@ define void @flat_atomic_usub_cond_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v0, v2, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v4, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB111_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB111_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB111_5
 ; GFX90A-NEXT:  .LBB111_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB111_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -9222,17 +9195,15 @@ define void @flat_atomic_usub_cond_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB111_4
-; GFX90A-NEXT:  .LBB111_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:  .LBB111_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB111_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -9250,14 +9221,13 @@ define void @flat_atomic_usub_cond_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB111_2
@@ -9278,15 +9248,15 @@ define void @flat_atomic_usub_cond_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v0, v2, s[0:1]
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB111_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB111_6
+; GFX950-NEXT:    s_cbranch_execz .LBB111_5
 ; GFX950-NEXT:  .LBB111_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:  .LBB111_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -9300,20 +9270,17 @@ define void @flat_atomic_usub_cond_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB111_4
-; GFX950-NEXT:  .LBB111_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:  .LBB111_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB111_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -9492,9 +9459,8 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB113_2
@@ -9516,15 +9482,15 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB113_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB113_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB113_5
 ; GFX90A-NEXT:  .LBB113_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB113_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -9537,17 +9503,15 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB113_4
-; GFX90A-NEXT:  .LBB113_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:  .LBB113_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB113_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -9565,14 +9529,13 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB113_2
@@ -9595,15 +9558,15 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[0:1]
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB113_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB113_6
+; GFX950-NEXT:    s_cbranch_execz .LBB113_5
 ; GFX950-NEXT:  .LBB113_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:  .LBB113_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -9616,20 +9579,17 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB113_4
-; GFX950-NEXT:  .LBB113_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:  .LBB113_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB113_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -11051,9 +11011,8 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB129_2
@@ -11069,15 +11028,15 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v4, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB129_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB129_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB129_5
 ; GFX90A-NEXT:  .LBB129_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB129_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -11087,17 +11046,15 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB129_4
-; GFX90A-NEXT:  .LBB129_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:  .LBB129_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB129_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -11115,14 +11072,13 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB129_2
@@ -11137,15 +11093,15 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB129_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB129_6
+; GFX950-NEXT:    s_cbranch_execz .LBB129_5
 ; GFX950-NEXT:  .LBB129_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:    .p2align 5, , 4
 ; GFX950-NEXT:  .LBB129_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
@@ -11154,20 +11110,17 @@ define void @flat_atomic_fsub_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB129_4
-; GFX950-NEXT:  .LBB129_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:  .LBB129_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB129_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -11746,9 +11699,8 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB135_2
@@ -11768,16 +11720,16 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v4, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB135_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB135_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB135_5
 ; GFX90A-NEXT:  .LBB135_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB135_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -11790,17 +11742,15 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB135_4
-; GFX90A-NEXT:  .LBB135_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:  .LBB135_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB135_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -11818,14 +11768,13 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB135_2
@@ -11844,16 +11793,16 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[0:1]
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB135_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB135_6
+; GFX950-NEXT:    s_cbranch_execz .LBB135_5
 ; GFX950-NEXT:  .LBB135_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
 ; GFX950-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:    .p2align 5, , 4
 ; GFX950-NEXT:  .LBB135_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
@@ -11866,20 +11815,17 @@ define void @flat_atomic_fmaximum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB135_4
-; GFX950-NEXT:  .LBB135_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:  .LBB135_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB135_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -12056,9 +12002,8 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], vcc, exec
 ; GFX90A-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], -1
-; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[4:5]
-; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], -1
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
 ; GFX90A-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB137_2
@@ -12078,16 +12023,16 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v4, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:  .LBB137_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX90A-NEXT:    s_xor_b64 s[4:5], exec, vcc
 ; GFX90A-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB137_6
+; GFX90A-NEXT:    s_cbranch_execz .LBB137_5
 ; GFX90A-NEXT:  .LBB137_3: ; %atomicrmw.global
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
 ; GFX90A-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GFX90A-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GFX90A-NEXT:  .LBB137_4: ; %atomicrmw.start
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
@@ -12100,17 +12045,15 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
-; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB137_4
-; GFX90A-NEXT:  .LBB137_5:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:  .LBB137_6: ; %atomicrmw.phi
+; GFX90A-NEXT:  .LBB137_5: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
@@ -12128,14 +12071,13 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; def a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
-; GFX950-NEXT:    s_mov_b64 s[4:5], -1
+; GFX950-NEXT:    s_mov_b64 s[2:3], -1
 ; GFX950-NEXT:    v_accvgpr_read_b32 v7, a1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v0
 ; GFX950-NEXT:    s_xor_b64 s[0:1], vcc, exec
 ; GFX950-NEXT:    v_accvgpr_read_b32 v6, a0
-; GFX950-NEXT:    s_xor_b64 s[6:7], exec, s[0:1]
-; GFX950-NEXT:    s_mov_b64 s[2:3], 0
+; GFX950-NEXT:    s_xor_b64 s[4:5], exec, s[0:1]
 ; GFX950-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execz .LBB137_2
@@ -12154,16 +12096,16 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[0:1]
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
 ; GFX950-NEXT:  .LBB137_2:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GFX950-NEXT:    s_xor_b64 s[0:1], exec, vcc
 ; GFX950-NEXT:    s_and_b64 s[0:1], s[0:1], exec
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
-; GFX950-NEXT:    s_cbranch_execz .LBB137_6
+; GFX950-NEXT:    s_cbranch_execz .LBB137_5
 ; GFX950-NEXT:  .LBB137_3: ; %atomicrmw.global
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[4:5]
 ; GFX950-NEXT:    v_mov_b32_e32 v8, 0x7ff80000
-; GFX950-NEXT:    s_and_b64 s[4:5], s[4:5], exec
+; GFX950-NEXT:    s_and_b64 s[2:3], s[2:3], exec
 ; GFX950-NEXT:    .p2align 5, , 4
 ; GFX950-NEXT:  .LBB137_4: ; %atomicrmw.start
 ; GFX950-NEXT:    ; =>This Inner Loop Header: Depth=1
@@ -12176,20 +12118,17 @@ define void @flat_atomic_fminimum_f64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[4:5], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
-; GFX950-NEXT:    s_xor_b64 s[4:5], exec, vcc
+; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
 ; GFX950-NEXT:    v_mov_b64_e32 v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB137_4
-; GFX950-NEXT:  .LBB137_5:
-; GFX950-NEXT:    s_or_b64 exec, exec, s[2:3]
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX950-NEXT:  .LBB137_6: ; %atomicrmw.phi
+; GFX950-NEXT:  .LBB137_5: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
@@ -16499,8 +16438,8 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cbranch_vccnz .LBB201_2
 ; GFX90A-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[6:7], 0
-; GFX90A-NEXT:    s_cselect_b32 s4, s6, -1
-; GFX90A-NEXT:    v_mov_b32_e32 v0, s4
+; GFX90A-NEXT:    s_cselect_b32 s6, s6, -1
+; GFX90A-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
@@ -16513,11 +16452,7 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_not_b32_e32 v2, v2
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use a[0:1]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    s_setpc_b64 s[30:31]
+; GFX90A-NEXT:    s_branch .LBB201_4
 ; GFX90A-NEXT:  .LBB201_2: ; %atomicrmw.global
 ; GFX90A-NEXT:    v_pk_mov_b32 v[6:7], s[6:7], s[6:7] op_sel:[0,1]
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -16534,19 +16469,20 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB201_3
-; GFX90A-NEXT:  .LBB201_4:
+; GFX90A-NEXT:  .LBB201_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: flat_atomic_nand_i64_saddr_ret_a_a:
@@ -16568,15 +16504,17 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_cbranch_vccnz .LBB201_2
 ; GFX950-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX950-NEXT:    s_cmp_lg_u64 s[2:3], 0
-; GFX950-NEXT:    s_cselect_b32 s0, s2, -1
-; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s0
+; GFX950-NEXT:    s_cselect_b32 s2, s2, -1
+; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s2
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_and_b32_e32 v2, v1, v5
 ; GFX950-NEXT:    v_and_b32_e32 v4, v0, v4
 ; GFX950-NEXT:    v_not_b32_e32 v3, v2
 ; GFX950-NEXT:    v_not_b32_e32 v2, v4
-; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
-; GFX950-NEXT:    s_branch .LBB201_5
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX950-NEXT:    s_branch .LBB201_4
 ; GFX950-NEXT:  .LBB201_2: ; %atomicrmw.global
 ; GFX950-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -16591,7 +16529,8 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
@@ -16600,11 +16539,8 @@ define void @flat_atomic_nand_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB201_3
-; GFX950-NEXT:  .LBB201_4:
+; GFX950-NEXT:  .LBB201_4: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GFX950-NEXT:  .LBB201_5: ; %atomicrmw.phi
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -18203,8 +18139,8 @@ define void @flat_atomic_usub_cond_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cbranch_vccnz .LBB219_2
 ; GFX90A-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[6:7], 0
-; GFX90A-NEXT:    s_cselect_b32 s4, s6, -1
-; GFX90A-NEXT:    v_mov_b32_e32 v2, s4
+; GFX90A-NEXT:    s_cselect_b32 s6, s6, -1
+; GFX90A-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX90A-NEXT:    buffer_load_dword v0, v2, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
@@ -18218,11 +18154,7 @@ define void @flat_atomic_usub_cond_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    buffer_store_dword v0, v2, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v4, v2, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use a[0:1]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    s_setpc_b64 s[30:31]
+; GFX90A-NEXT:    s_branch .LBB219_4
 ; GFX90A-NEXT:  .LBB219_2: ; %atomicrmw.global
 ; GFX90A-NEXT:    v_pk_mov_b32 v[6:7], s[6:7], s[6:7] op_sel:[0,1]
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -18240,19 +18172,20 @@ define void @flat_atomic_usub_cond_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB219_3
-; GFX90A-NEXT:  .LBB219_4:
+; GFX90A-NEXT:  .LBB219_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: flat_atomic_usub_cond_i64_saddr_ret_a_a:
@@ -18274,18 +18207,20 @@ define void @flat_atomic_usub_cond_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_cbranch_vccnz .LBB219_2
 ; GFX950-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX950-NEXT:    s_cmp_lg_u64 s[2:3], 0
-; GFX950-NEXT:    s_cselect_b32 s0, s2, -1
-; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s0
+; GFX950-NEXT:    s_cselect_b32 s2, s2, -1
+; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s2
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_sub_co_u32_e32 v2, vcc, v0, v4
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    s_nop 0
 ; GFX950-NEXT:    v_subb_co_u32_e32 v3, vcc, v1, v5, vcc
 ; GFX950-NEXT:    v_cmp_ge_u64_e32 vcc, v[0:1], v[4:5]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX950-NEXT:    s_nop 0
 ; GFX950-NEXT:    v_cndmask_b32_e32 v3, v1, v3, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
-; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
-; GFX950-NEXT:    s_branch .LBB219_5
+; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
+; GFX950-NEXT:    s_branch .LBB219_4
 ; GFX950-NEXT:  .LBB219_2: ; %atomicrmw.global
 ; GFX950-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -18303,7 +18238,8 @@ define void @flat_atomic_usub_cond_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
@@ -18312,11 +18248,8 @@ define void @flat_atomic_usub_cond_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB219_3
-; GFX950-NEXT:  .LBB219_4:
+; GFX950-NEXT:  .LBB219_4: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GFX950-NEXT:  .LBB219_5: ; %atomicrmw.phi
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -18481,8 +18414,8 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cbranch_vccnz .LBB221_2
 ; GFX90A-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[6:7], 0
-; GFX90A-NEXT:    s_cselect_b32 s4, s6, -1
-; GFX90A-NEXT:    v_mov_b32_e32 v0, s4
+; GFX90A-NEXT:    s_cselect_b32 s6, s6, -1
+; GFX90A-NEXT:    v_mov_b32_e32 v0, s6
 ; GFX90A-NEXT:    buffer_load_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v2, v0, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(1)
@@ -18497,11 +18430,7 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v2, v0, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    ;;#ASMSTART
-; GFX90A-NEXT:    ; use a[0:1]
-; GFX90A-NEXT:    ;;#ASMEND
-; GFX90A-NEXT:    s_waitcnt vmcnt(0)
-; GFX90A-NEXT:    s_setpc_b64 s[30:31]
+; GFX90A-NEXT:    s_branch .LBB221_4
 ; GFX90A-NEXT:  .LBB221_2: ; %atomicrmw.global
 ; GFX90A-NEXT:    v_pk_mov_b32 v[6:7], s[6:7], s[6:7] op_sel:[0,1]
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -18518,19 +18447,20 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB221_3
-; GFX90A-NEXT:  .LBB221_4:
+; GFX90A-NEXT:  .LBB221_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
+; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: flat_atomic_usub_sat_i64_saddr_ret_a_a:
@@ -18552,20 +18482,22 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_cbranch_vccnz .LBB221_2
 ; GFX950-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX950-NEXT:    s_cmp_lg_u64 s[2:3], 0
-; GFX950-NEXT:    s_cselect_b32 s0, s2, -1
-; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s0
+; GFX950-NEXT:    s_cselect_b32 s2, s2, -1
+; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s2
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_sub_co_u32_e32 v2, vcc, v0, v4
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    s_nop 0
 ; GFX950-NEXT:    v_subb_co_u32_e32 v3, vcc, v1, v5, vcc
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX950-NEXT:    s_nop 0
 ; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
-; GFX950-NEXT:    s_branch .LBB221_5
+; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
+; GFX950-NEXT:    s_branch .LBB221_4
 ; GFX950-NEXT:  .LBB221_2: ; %atomicrmw.global
 ; GFX950-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -18582,7 +18514,8 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
@@ -18591,11 +18524,8 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB221_3
-; GFX950-NEXT:  .LBB221_4:
+; GFX950-NEXT:  .LBB221_4: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GFX950-NEXT:  .LBB221_5: ; %atomicrmw.phi
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -19935,15 +19865,17 @@ define void @flat_atomic_fsub_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cbranch_vccnz .LBB237_2
 ; GFX90A-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[6:7], 0
-; GFX90A-NEXT:    s_cselect_b32 s4, s6, -1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, s4
+; GFX90A-NEXT:    s_cselect_b32 s6, s6, -1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_add_f64 v[2:3], v[0:1], -v[4:5]
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_branch .LBB237_5
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    s_branch .LBB237_4
 ; GFX90A-NEXT:  .LBB237_2: ; %atomicrmw.global
 ; GFX90A-NEXT:    v_pk_mov_b32 v[6:7], s[6:7], s[6:7] op_sel:[0,1]
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -19957,17 +19889,16 @@ define void @flat_atomic_fsub_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB237_3
-; GFX90A-NEXT:  .LBB237_4:
+; GFX90A-NEXT:  .LBB237_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GFX90A-NEXT:  .LBB237_5: ; %atomicrmw.phi
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
@@ -19993,12 +19924,14 @@ define void @flat_atomic_fsub_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_cbranch_vccnz .LBB237_2
 ; GFX950-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX950-NEXT:    s_cmp_lg_u64 s[2:3], 0
-; GFX950-NEXT:    s_cselect_b32 s0, s2, -1
-; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s0
+; GFX950-NEXT:    s_cselect_b32 s2, s2, -1
+; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s2
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_add_f64 v[2:3], v[0:1], -v[4:5]
-; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
-; GFX950-NEXT:    s_branch .LBB237_5
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX950-NEXT:    s_branch .LBB237_4
 ; GFX950-NEXT:  .LBB237_2: ; %atomicrmw.global
 ; GFX950-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -20011,7 +19944,8 @@ define void @flat_atomic_fsub_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
@@ -20020,11 +19954,8 @@ define void @flat_atomic_fsub_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB237_3
-; GFX950-NEXT:  .LBB237_4:
+; GFX950-NEXT:  .LBB237_4: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GFX950-NEXT:  .LBB237_5: ; %atomicrmw.phi
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -20521,8 +20452,8 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cbranch_vccnz .LBB243_2
 ; GFX90A-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[6:7], 0
-; GFX90A-NEXT:    s_cselect_b32 s4, s6, -1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, s4
+; GFX90A-NEXT:    s_cselect_b32 s6, s6, -1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
@@ -20530,10 +20461,12 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_branch .LBB243_5
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    s_branch .LBB243_4
 ; GFX90A-NEXT:  .LBB243_2: ; %atomicrmw.global
 ; GFX90A-NEXT:    v_pk_mov_b32 v[6:7], s[6:7], s[6:7] op_sel:[0,1]
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -20551,17 +20484,16 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB243_3
-; GFX90A-NEXT:  .LBB243_4:
+; GFX90A-NEXT:  .LBB243_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GFX90A-NEXT:  .LBB243_5: ; %atomicrmw.phi
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
@@ -20587,17 +20519,18 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_cbranch_vccnz .LBB243_2
 ; GFX950-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX950-NEXT:    s_cmp_lg_u64 s[2:3], 0
-; GFX950-NEXT:    s_cselect_b32 s0, s2, -1
-; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s0
+; GFX950-NEXT:    s_cselect_b32 s2, s2, -1
+; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s2
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_max_f64 v[2:3], v[0:1], v[4:5]
 ; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
-; GFX950-NEXT:    s_branch .LBB243_5
+; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
+; GFX950-NEXT:    s_branch .LBB243_4
 ; GFX950-NEXT:  .LBB243_2: ; %atomicrmw.global
 ; GFX950-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -20615,7 +20548,8 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
@@ -20624,11 +20558,8 @@ define void @flat_atomic_fmaximum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB243_3
-; GFX950-NEXT:  .LBB243_4:
+; GFX950-NEXT:  .LBB243_4: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GFX950-NEXT:  .LBB243_5: ; %atomicrmw.phi
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -20791,8 +20722,8 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_cbranch_vccnz .LBB245_2
 ; GFX90A-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX90A-NEXT:    s_cmp_lg_u64 s[6:7], 0
-; GFX90A-NEXT:    s_cselect_b32 s4, s6, -1
-; GFX90A-NEXT:    v_mov_b32_e32 v6, s4
+; GFX90A-NEXT:    s_cselect_b32 s6, s6, -1
+; GFX90A-NEXT:    v_mov_b32_e32 v6, s6
 ; GFX90A-NEXT:    buffer_load_dword v0, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_load_dword v1, v6, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    v_mov_b32_e32 v7, 0x7ff80000
@@ -20800,10 +20731,12 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v3, v7, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v6, s[0:3], 0 offen
 ; GFX90A-NEXT:    buffer_store_dword v3, v6, s[0:3], 0 offen offset:4
-; GFX90A-NEXT:    s_branch .LBB245_5
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
+; GFX90A-NEXT:    s_branch .LBB245_4
 ; GFX90A-NEXT:  .LBB245_2: ; %atomicrmw.global
 ; GFX90A-NEXT:    v_pk_mov_b32 v[6:7], s[6:7], s[6:7] op_sel:[0,1]
 ; GFX90A-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -20821,17 +20754,16 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
 ; GFX90A-NEXT:    s_xor_b64 s[6:7], exec, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    v_pk_mov_b32 v[2:3], v[0:1], v[0:1] op_sel:[0,1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    s_mov_b64 exec, vcc
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execnz .LBB245_3
-; GFX90A-NEXT:  .LBB245_4:
+; GFX90A-NEXT:  .LBB245_4: ; %atomicrmw.phi
 ; GFX90A-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GFX90A-NEXT:  .LBB245_5: ; %atomicrmw.phi
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX90A-NEXT:    ;;#ASMSTART
 ; GFX90A-NEXT:    ; use a[0:1]
 ; GFX90A-NEXT:    ;;#ASMEND
@@ -20857,17 +20789,18 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_cbranch_vccnz .LBB245_2
 ; GFX950-NEXT:  ; %bb.1: ; %atomicrmw.private
 ; GFX950-NEXT:    s_cmp_lg_u64 s[2:3], 0
-; GFX950-NEXT:    s_cselect_b32 s0, s2, -1
-; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s0
+; GFX950-NEXT:    s_cselect_b32 s2, s2, -1
+; GFX950-NEXT:    scratch_load_dwordx2 v[0:1], off, s2
 ; GFX950-NEXT:    v_mov_b32_e32 v6, 0x7ff80000
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_min_f64 v[2:3], v[0:1], v[4:5]
 ; GFX950-NEXT:    v_cmp_u_f64_e32 vcc, v[0:1], v[4:5]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e32 v3, v3, v6, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
-; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s0
-; GFX950-NEXT:    s_branch .LBB245_5
+; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
+; GFX950-NEXT:    s_branch .LBB245_4
 ; GFX950-NEXT:  .LBB245_2: ; %atomicrmw.global
 ; GFX950-NEXT:    v_mov_b64_e32 v[6:7], s[2:3]
 ; GFX950-NEXT:    flat_load_dwordx2 v[2:3], v[6:7]
@@ -20885,7 +20818,8 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    flat_atomic_cmpswap_x2 v[0:1], v[6:7], v[0:3] sc0
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) lgkmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, v[0:1], v[2:3]
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, 0, 1, vcc
 ; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v2
 ; GFX950-NEXT:    s_xor_b64 s[2:3], exec, vcc
@@ -20894,11 +20828,8 @@ define void @flat_atomic_fminimum_f64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_mov_b64 exec, vcc
 ; GFX950-NEXT:    ; divergent control-flow edge
 ; GFX950-NEXT:    s_cbranch_execnz .LBB245_3
-; GFX950-NEXT:  .LBB245_4:
+; GFX950-NEXT:  .LBB245_4: ; %atomicrmw.phi
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GFX950-NEXT:  .LBB245_5: ; %atomicrmw.phi
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v0
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND

--- a/llvm/test/CodeGen/AMDGPU/atomics-hw-remarks-gfx90a.ll
+++ b/llvm/test/CodeGen/AMDGPU/atomics-hw-remarks-gfx90a.ll
@@ -20,7 +20,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_agent:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_agent(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -29,7 +29,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_wg:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_wg(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -38,7 +38,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_wavefront:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_wavefront(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -47,7 +47,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_single_thread:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_single_thread(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -56,7 +56,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_aoa:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_aoa(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -65,7 +65,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_wgoa:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_wgoa(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -74,7 +74,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_wfoa:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_wfoa(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:
@@ -83,7 +83,7 @@ main_body:
 }
 
 ; GFX90A-HW-LABEL: atomic_add_unsafe_hw_stoa:
-; GFX90A-HW:    global_atomic_add_f32 v0, v1, s[0:1]
+; GFX90A-HW:    global_atomic_add_f32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 ; GFX90A-HW:    s_endpgm
 define amdgpu_kernel void @atomic_add_unsafe_hw_stoa(ptr addrspace(1) %ptr, float %val) #0 {
 main_body:

--- a/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
+++ b/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
@@ -22,74 +22,73 @@ define amdgpu_ps void @main(i32 %0, float %1) {
 ; ISA-NEXT:    s_mov_b32 m0, s0
 ; ISA-NEXT:    s_mov_b64 s[0:1], -1
 ; ISA-NEXT:    v_interp_p1_f32_e32 v0, v1, attr0.x
-; ISA-NEXT:    v_cmp_nlt_f32_e32 vcc, 0, v0
-; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[0:1]
-; ISA-NEXT:    s_mov_b64 s[0:1], 0
-; ISA-NEXT:    v_cndmask_b32_e64 v3, 0, -1, vcc
 ; ISA-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[0:1]
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:    v_cmp_nlt_f32_e32 vcc, 0, v0
+; ISA-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[0:1]
 ; ISA-NEXT:    s_mov_b64 s[0:1], -1
 ; ISA-NEXT:    s_mov_b32 s10, 0
-; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
+; ISA-NEXT:    s_mov_b64 s[6:7], 0
+; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    s_mov_b64 s[8:9], 0
 ; ISA-NEXT:    s_mov_b64 s[4:5], 0
 ; ISA-NEXT:    s_mov_b64 s[0:1], 0
-; ISA-NEXT:    s_mov_b64 s[6:7], 0
-; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    s_branch .LBB0_2
 ; ISA-NEXT:  .LBB0_1: ; %Flow
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
-; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
-; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
-; ISA-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
-; ISA-NEXT:    s_xor_b64 s[12:13], exec, s[0:1]
+; ISA-NEXT:    s_or_b64 exec, exec, s[8:9]
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
+; ISA-NEXT:    s_xor_b64 s[8:9], vcc, exec
+; ISA-NEXT:    s_xor_b64 s[12:13], exec, s[8:9]
 ; ISA-NEXT:    s_and_b64 s[12:13], s[12:13], exec
-; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], s[12:13]
-; ISA-NEXT:    s_mov_b64 exec, s[0:1]
-; ISA-NEXT:    s_mov_b64 s[0:1], 0
+; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
+; ISA-NEXT:    s_mov_b64 exec, s[8:9]
+; ISA-NEXT:    s_mov_b64 s[8:9], 0
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB0_5
 ; ISA-NEXT:  .LBB0_2: ; %loop
 ; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; ISA-NEXT:    s_cmp_lt_u32 s10, 32
-; ISA-NEXT:    v_mov_b32_e32 v4, v1
-; ISA-NEXT:    v_mov_b32_e32 v3, v1
+; ISA-NEXT:    v_mov_b32_e32 v5, v2
+; ISA-NEXT:    v_mov_b32_e32 v4, v2
 ; ISA-NEXT:    s_cbranch_scc0 .LBB0_1
 ; ISA-NEXT:  ; %bb.3: ; %endif1
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
-; ISA-NEXT:    s_and_b64 s[0:1], exec, vcc
-; ISA-NEXT:    s_or_b64 s[8:9], s[8:9], s[0:1]
-; ISA-NEXT:    s_xor_b64 s[0:1], exec, s[8:9]
-; ISA-NEXT:    v_mov_b32_e32 v4, v1
-; ISA-NEXT:    v_mov_b32_e32 v3, v2
-; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; ISA-NEXT:    s_mov_b64 exec, s[8:9]
-; ISA-NEXT:    s_mov_b64 s[8:9], 0
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
+; ISA-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
+; ISA-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; ISA-NEXT:    v_mov_b32_e32 v5, v2
+; ISA-NEXT:    v_mov_b32_e32 v4, v3
+; ISA-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; ISA-NEXT:    s_mov_b64 exec, s[6:7]
+; ISA-NEXT:    s_mov_b64 s[6:7], 0
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB0_1
 ; ISA-NEXT:  .LBB0_4: ; %endif2
 ; ISA-NEXT:    ; in Loop: Header=BB0_2 Depth=1
 ; ISA-NEXT:    s_add_i32 s10, s10, 1
-; ISA-NEXT:    v_mov_b32_e32 v4, v2
-; ISA-NEXT:    v_mov_b32_e32 v3, v2
+; ISA-NEXT:    v_mov_b32_e32 v5, v3
+; ISA-NEXT:    v_mov_b32_e32 v4, v3
 ; ISA-NEXT:    s_branch .LBB0_1
 ; ISA-NEXT:  .LBB0_5: ; %Flow2
-; ISA-NEXT:    s_or_b64 exec, exec, s[6:7]
-; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; ISA-NEXT:    s_or_b64 exec, exec, s[4:5]
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 1, v1
-; ISA-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; ISA-NEXT:    s_or_b64 s[4:5], s[4:5], s[0:1]
-; ISA-NEXT:    s_xor_b64 s[0:1], exec, s[4:5]
-; ISA-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; ISA-NEXT:    s_xor_b64 s[4:5], vcc, exec
+; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[4:5]
+; ISA-NEXT:    s_xor_b64 s[4:5], exec, s[2:3]
+; ISA-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; ISA-NEXT:    v_mov_b32_e32 v1, 0
-; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
-; ISA-NEXT:    s_mov_b64 exec, s[4:5]
+; ISA-NEXT:    s_or_b64 s[0:1], s[0:1], s[4:5]
+; ISA-NEXT:    s_mov_b64 exec, s[2:3]
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB0_7
 ; ISA-NEXT:  .LBB0_6: ; %if1
 ; ISA-NEXT:    v_sqrt_f32_e32 v1, v0
 ; ISA-NEXT:  .LBB0_7: ; %endloop
-; ISA-NEXT:    s_or_b64 exec, exec, s[2:3]
+; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; ISA-NEXT:    exp mrt0, v1, v1, v1, v1 done vm
 ; ISA-NEXT:    s_endpgm
 start:
@@ -154,37 +153,36 @@ define amdgpu_ps void @i1_copy_assert(i1 %v4) {
 ; ISA-NEXT:    s_mov_b64 s[0:1], -1
 ; ISA-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
 ; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[0:1]
-; ISA-NEXT:    s_mov_b64 s[2:3], -1
-; ISA-NEXT:    s_mov_b32 s6, 0
+; ISA-NEXT:    s_mov_b64 s[0:1], -1
+; ISA-NEXT:    s_mov_b32 s4, 0
 ; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
-; ISA-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v1
-; ISA-NEXT:    s_mov_b64 s[2:3], 0
+; ISA-NEXT:    s_mov_b64 s[0:1], 0
 ; ISA-NEXT:    s_branch .LBB1_2
 ; ISA-NEXT:  .LBB1_1: ; %Flow
 ; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; ISA-NEXT:    s_xor_b64 s[8:9], vcc, exec
-; ISA-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
-; ISA-NEXT:    s_and_b64 s[10:11], s[10:11], exec
-; ISA-NEXT:    s_mov_b32 s6, 1
-; ISA-NEXT:    s_or_b64 s[2:3], s[2:3], s[10:11]
-; ISA-NEXT:    s_mov_b64 exec, s[8:9]
+; ISA-NEXT:    s_xor_b64 s[6:7], vcc, exec
+; ISA-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; ISA-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; ISA-NEXT:    s_mov_b32 s4, 1
+; ISA-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; ISA-NEXT:    s_mov_b64 exec, s[6:7]
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB1_4
 ; ISA-NEXT:  .LBB1_2: ; %loop
 ; ISA-NEXT:    ; =>This Inner Loop Header: Depth=1
-; ISA-NEXT:    s_cmp_lg_u32 s6, 0
+; ISA-NEXT:    s_cmp_lg_u32 s4, 0
+; ISA-NEXT:    v_cmp_ne_u32_e64 s[2:3], 0, v1
 ; ISA-NEXT:    v_mov_b32_e32 v2, v1
-; ISA-NEXT:    s_mov_b64 s[4:5], s[0:1]
 ; ISA-NEXT:    s_cbranch_scc0 .LBB1_1
 ; ISA-NEXT:  ; %bb.3: ; %endif1
 ; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
-; ISA-NEXT:    s_mov_b64 s[4:5], 0
+; ISA-NEXT:    s_mov_b64 s[2:3], 0
 ; ISA-NEXT:    v_mov_b32_e32 v2, v0
 ; ISA-NEXT:    s_branch .LBB1_1
 ; ISA-NEXT:  .LBB1_4: ; %Flow2
-; ISA-NEXT:    s_or_b64 exec, exec, s[2:3]
-; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
+; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
+; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[2:3]
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; ISA-NEXT:    v_mov_b32_e32 v1, 0
 ; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, 1.0, vcc

--- a/llvm/test/CodeGen/AMDGPU/fix-frame-ptr-reg-copy-livein.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-frame-ptr-reg-copy-livein.ll
@@ -10,26 +10,17 @@
 define i32 @fp_save_restore_in_temp_sgpr(ptr addrspace(5) nocapture readonly byval(%struct.Data) align 4 %arg) #0 {
   ; GCN-LABEL: name: fp_save_restore_in_temp_sgpr
   ; GCN: bb.0.begin:
-  ; GCN:   liveins: $sgpr17
-  ; GCN:   $sgpr17 = frame-setup COPY $sgpr33
-  ; GCN:   $sgpr33 = frame-setup COPY $sgpr32
+  ; GCN:   liveins: $sgpr7
+  ; GCN:   $sgpr7 = frame-setup COPY $sgpr33
   ; GCN: bb.1.lp_end:
-  ; GCN:   liveins: $sgpr16, $sgpr17, $vgpr0, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr10_sgpr11, $sgpr12_sgpr13, $sgpr14_sgpr15
-  ; GCN: bb.7:
-  ; GCN:   liveins: $sgpr17, $vgpr0, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9
+  ; GCN:   liveins: $sgpr6, $sgpr7, $vgpr1, $sgpr4_sgpr5
   ; GCN: bb.2:
-  ; GCN:   liveins: $sgpr17, $sgpr4_sgpr5
+  ; GCN:   liveins: $sgpr7, $sgpr4_sgpr5
   ; GCN: bb.3.lp_begin:
-  ; GCN:   liveins: $sgpr16, $sgpr17, $vgpr0, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9, $sgpr10_sgpr11, $sgpr12_sgpr13, $sgpr14_sgpr15
-  ; GCN: bb.8:
-  ; GCN:   liveins: $sgpr17, $vgpr0, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9, $sgpr10_sgpr11, $sgpr12_sgpr13
-  ; GCN: bb.4:
-  ; GCN:   liveins: $sgpr17, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr8_sgpr9
-  ; GCN: bb.5.end:
-  ; GCN:   liveins: $sgpr17, $vgpr0, $sgpr4_sgpr5
-  ; GCN:   $sgpr33 = frame-destroy COPY $sgpr17
-  ; GCN: bb.6:
-  ; GCN:   liveins: $sgpr17, $vgpr0, $sgpr4_sgpr5, $sgpr6_sgpr7, $sgpr10_sgpr11, $sgpr12_sgpr13, $sgpr14_sgpr15
+  ; GCN:   liveins: $sgpr6, $sgpr7, $vgpr1, $sgpr4_sgpr5
+  ; GCN: bb.4.end:
+  ; GCN:   liveins: $sgpr7, $vgpr0, $sgpr4_sgpr5
+  ; GCN:   $sgpr33 = frame-destroy COPY $sgpr7
 begin:
   br label %lp_begin
 

--- a/llvm/test/CodeGen/AMDGPU/global-atomics-fp-wrong-subtarget.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-atomics-fp-wrong-subtarget.ll
@@ -6,29 +6,30 @@
 ; FIXME: This will still fail for gfx6/7 and gfx10 subtargets.
 
 ; DISASSEMBLY-VI: .long 0xdd348000                                           // {{[0-9A-Z]+}}: DD348000
-; DISASSEMBLY-VI-NEXT: v_cndmask_b32_e32 v0, v0, v0, vcc                     // {{[0-9A-Z]+}}: 00000100
+; DISASSEMBLY-VI-NEXT: v_cndmask_b32_e32 v1, v0, v0, vcc                     // {{[0-9A-Z]+}}: 00020100
 
 define amdgpu_kernel void @global_atomic_fadd_noret_f32_wrong_subtarget(ptr addrspace(1) %ptr) #0 {
 ; GCN-LABEL: global_atomic_fadd_noret_f32_wrong_subtarget:
 ; GCN:       ; %bb.0:
-; GCN-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GCN-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GCN-NEXT:    s_mov_b64 s[0:1], exec
+; GCN-NEXT:    v_mbcnt_lo_u32_b32 v0, s0, 0
+; GCN-NEXT:    v_mbcnt_hi_u32_b32 v0, s1, v0
 ; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; GCN-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GCN-NEXT:    s_xor_b64 s[2:3], exec, s[0:1]
-; GCN-NEXT:    s_mov_b64 exec, s[0:1]
+; GCN-NEXT:    s_xor_b64 s[2:3], vcc, exec
+; GCN-NEXT:    s_xor_b64 s[6:7], exec, s[2:3]
+; GCN-NEXT:    s_mov_b64 exec, s[2:3]
 ; GCN-NEXT:    ; divergent control-flow edge
 ; GCN-NEXT:    s_cbranch_execnz .LBB0_2
 ; GCN-NEXT:  .LBB0_1:
 ; GCN-NEXT:    s_endpgm
 ; GCN-NEXT:  .LBB0_2:
-; GCN-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x24
-; GCN-NEXT:    s_bcnt1_i32_b64 s2, exec
-; GCN-NEXT:    v_cvt_f32_ubyte0_e32 v1, s2
+; GCN-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x24
+; GCN-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
+; GCN-NEXT:    v_cvt_f32_ubyte0_e32 v1, s0
 ; GCN-NEXT:    v_mov_b32_e32 v0, 0
 ; GCN-NEXT:    v_mul_f32_e32 v1, 4.0, v1
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    global_atomic_add_f32 v0, v1, s[0:1]
+; GCN-NEXT:    global_atomic_add_f32 v0, v1, s[2:3]
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    buffer_wbinvl1_vol
 ; GCN-NEXT:    s_endpgm

--- a/llvm/test/CodeGen/AMDGPU/hoist-cond.ll
+++ b/llvm/test/CodeGen/AMDGPU/hoist-cond.ll
@@ -6,12 +6,13 @@
 
 ; CHECK: v_cmp_{{..}}_u32_e{{32|64}} [[COND:s\[[0-9]+:[0-9]+\]|vcc]]
 ; CHECK: BB0_1:
-; CHECK-NOT: v_cmp
-; CHECK-NOT: v_cndmask
-; CHECK: s_and_b64 [[TMP:s\[[0-9]+:[0-9]+\]]], exec, [[COND]]
-; CHECK: s_xor_b64 [[TMP]], [[COND]], -1
-; CHECK: s_and_b64 [[TAKEN:s\[[0-9]+:[0-9]+\]]], [[TMP]], exec
-; CHECK: s_mov_b64 exec, [[TAKEN]]
+; CHECK: v_cmp_ne_u32_e32 vcc, 0, v0
+; CHECK: v_cndmask_b32_e64 {{v[0-9]+}}, 0, 1, vcc
+; CHECK: v_cmp_ne_u32_e32 vcc, 1, {{v[0-9]+}}
+; CHECK: s_xor_b64 [[TMP1:s\[[0-9]+:[0-9]+\]]], vcc, exec
+; CHECK: s_xor_b64 [[TMP2:s\[[0-9]+:[0-9]+\]]], exec, [[TMP1]]
+; CHECK: s_and_b64 [[TAKEN:s\[[0-9]+:[0-9]+\]]], [[TMP2]], exec
+; CHECK: s_mov_b64 exec, [[TMP1]]
 ; CHECK: BB0_2:
 
 define amdgpu_kernel void @hoist_cond(ptr addrspace(1) nocapture %arg, ptr addrspace(1) noalias nocapture readonly %arg1, i32 %arg3, i32 %arg4) {

--- a/llvm/test/CodeGen/AMDGPU/infinite-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/infinite-loop.ll
@@ -316,73 +316,54 @@ define amdgpu_kernel void @infinite_loop_nest_ret(ptr addrspace(1) %out) {
 ; SI:       ; %bb.0: ; %entry
 ; SI-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v0
 ; SI-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; SI-NEXT:    s_mov_b64 s[8:9], -1
-; SI-NEXT:    s_mov_b64 s[10:11], 0
-; SI-NEXT:    s_mov_b64 s[14:15], 0
-; SI-NEXT:    s_mov_b64 s[12:13], 0
+; SI-NEXT:    s_mov_b64 s[6:7], -1
+; SI-NEXT:    s_mov_b64 s[8:9], 0
 ; SI-NEXT:    s_xor_b64 s[2:3], exec, s[0:1]
 ; SI-NEXT:    s_mov_b64 exec, s[0:1]
 ; SI-NEXT:    ; divergent control-flow edge
-; SI-NEXT:    s_cbranch_execz .LBB6_9
+; SI-NEXT:    s_cbranch_execz .LBB6_7
 ; SI-NEXT:  .LBB6_1: ; %outer_loop.preheader
-; SI-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x9
+; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
+; SI-NEXT:    s_mov_b32 s3, 0xf000
+; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    v_cmp_eq_u32_e32 vcc, 3, v0
-; SI-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; SI-NEXT:    s_mov_b32 s7, 0xf000
-; SI-NEXT:    s_mov_b32 s6, -1
-; SI-NEXT:    v_mov_b32_e32 v0, 0x3e7
-; SI-NEXT:    s_and_b64 s[0:1], exec, 0
-; SI-NEXT:    v_cmp_ne_u32_e64 s[2:3], 0, v1
-; SI-NEXT:    s_branch .LBB6_3
-; SI-NEXT:  .LBB6_2: ; %loop.exit.guard
-; SI-NEXT:    ; in Loop: Header=BB6_3 Depth=1
-; SI-NEXT:    s_or_b64 exec, exec, s[12:13]
-; SI-NEXT:    s_and_b64 vcc, exec, s[16:17]
-; SI-NEXT:    s_mov_b64 s[12:13], 0
-; SI-NEXT:    s_cbranch_vccnz .LBB6_9
-; SI-NEXT:  .LBB6_3: ; %outer_loop
+; SI-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
+; SI-NEXT:    v_mov_b32_e32 v1, 0x3e7
+; SI-NEXT:    s_branch .LBB6_4
+; SI-NEXT:  .LBB6_2: ; in Loop: Header=BB6_4 Depth=1
+; SI-NEXT:    s_mov_b64 s[4:5], -1
+; SI-NEXT:  .LBB6_3: ; %loop.exit.guard
+; SI-NEXT:    ; in Loop: Header=BB6_4 Depth=1
+; SI-NEXT:    s_or_b64 exec, exec, s[8:9]
+; SI-NEXT:    s_and_b64 vcc, exec, s[4:5]
+; SI-NEXT:    s_mov_b64 s[8:9], 0
+; SI-NEXT:    s_cbranch_vccnz .LBB6_7
+; SI-NEXT:  .LBB6_4: ; %outer_loop
 ; SI-NEXT:    ; =>This Loop Header: Depth=1
-; SI-NEXT:    ; Child Loop BB6_4 Depth 2
-; SI-NEXT:    s_and_b64 s[16:17], s[8:9], exec
-; SI-NEXT:  .LBB6_4: ; %inner_loop
-; SI-NEXT:    ; Parent Loop BB6_3 Depth=1
+; SI-NEXT:    ; Child Loop BB6_5 Depth 2
+; SI-NEXT:    s_and_b64 s[4:5], s[6:7], exec
+; SI-NEXT:  .LBB6_5: ; %inner_loop
+; SI-NEXT:    ; Parent Loop BB6_4 Depth=1
 ; SI-NEXT:    ; => This Inner Loop Header: Depth=2
+; SI-NEXT:    s_and_b64 vcc, exec, 0
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    buffer_store_dword v0, off, s[4:7], 0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], 0
 ; SI-NEXT:    s_waitcnt vmcnt(0)
-; SI-NEXT:    s_mov_b64 vcc, s[0:1]
-; SI-NEXT:    ; implicit-def: $sgpr16_sgpr17
-; SI-NEXT:    s_cbranch_vccnz .LBB6_6
-; SI-NEXT:  ; %bb.5: ; %TransitionBlock
-; SI-NEXT:    ; in Loop: Header=BB6_4 Depth=2
-; SI-NEXT:    s_and_b64 s[18:19], exec, s[2:3]
-; SI-NEXT:    s_and_b64 s[20:21], exec, s[2:3]
-; SI-NEXT:    s_xor_b64 s[20:21], s[2:3], -1
-; SI-NEXT:    s_and_b64 s[20:21], s[20:21], exec
-; SI-NEXT:    s_or_b64 s[10:11], s[10:11], s[20:21]
-; SI-NEXT:    s_xor_b64 s[20:21], exec, s[18:19]
-; SI-NEXT:    s_and_b64 s[20:21], s[20:21], exec
-; SI-NEXT:    s_or_b64 s[14:15], s[14:15], s[20:21]
-; SI-NEXT:    s_mov_b64 exec, s[18:19]
+; SI-NEXT:    ; implicit-def: $sgpr4_sgpr5
+; SI-NEXT:    s_mov_b64 vcc, vcc
+; SI-NEXT:    s_cbranch_vccnz .LBB6_2
+; SI-NEXT:  ; %bb.6: ; %TransitionBlock
+; SI-NEXT:    ; in Loop: Header=BB6_5 Depth=2
+; SI-NEXT:    s_mov_b64 s[4:5], 0
+; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; SI-NEXT:    s_xor_b64 s[10:11], exec, vcc
+; SI-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; SI-NEXT:    s_or_b64 s[8:9], s[8:9], s[10:11]
+; SI-NEXT:    s_mov_b64 exec, vcc
 ; SI-NEXT:    ; divergent control-flow edge
-; SI-NEXT:    s_cbranch_execnz .LBB6_4
-; SI-NEXT:    s_branch .LBB6_7
-; SI-NEXT:  .LBB6_6: ; in Loop: Header=BB6_3 Depth=1
-; SI-NEXT:    s_mov_b64 s[16:17], -1
-; SI-NEXT:  .LBB6_7: ; in Loop: Header=BB6_3 Depth=1
-; SI-NEXT:    s_or_b64 exec, exec, s[14:15]
-; SI-NEXT:    s_xor_b64 s[14:15], exec, s[10:11]
-; SI-NEXT:    s_and_b64 s[14:15], s[14:15], exec
-; SI-NEXT:    s_or_b64 s[12:13], s[12:13], s[14:15]
-; SI-NEXT:    s_mov_b64 exec, s[10:11]
-; SI-NEXT:    s_mov_b64 s[10:11], 0
-; SI-NEXT:    s_mov_b64 s[14:15], 0
-; SI-NEXT:    ; divergent control-flow edge
-; SI-NEXT:    s_cbranch_execz .LBB6_2
-; SI-NEXT:  .LBB6_8: ; in Loop: Header=BB6_3 Depth=1
-; SI-NEXT:    s_mov_b64 s[16:17], 0
-; SI-NEXT:    s_branch .LBB6_2
-; SI-NEXT:  .LBB6_9: ; %UnifiedReturnBlock
+; SI-NEXT:    s_cbranch_execnz .LBB6_5
+; SI-NEXT:    s_branch .LBB6_3
+; SI-NEXT:  .LBB6_7: ; %UnifiedReturnBlock
 ; SI-NEXT:    s_endpgm
 ; IR-LABEL: @infinite_loop_nest_ret(
 ; IR-NEXT:  entry:
@@ -425,32 +406,32 @@ define amdgpu_kernel void @infinite_loop_nest_ret_callbr(ptr addrspace(1) %out) 
 ; SI-NEXT:    v_cndmask_b32_e64 v1, 0, 1, vcc
 ; SI-NEXT:    ;;#ASMSTART
 ; SI-NEXT:    ;;#ASMEND
-; SI-NEXT:    s_mov_b64 s[0:1], -1
-; SI-NEXT:    s_mov_b64 s[2:3], 0
+; SI-NEXT:    s_mov_b64 s[8:9], -1
+; SI-NEXT:    s_mov_b64 s[6:7], 0
 ; SI-NEXT:  ; %bb.1: ; %outer_loop.preheader
-; SI-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0x9
+; SI-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x9
 ; SI-NEXT:    v_cmp_eq_u32_e32 vcc, 3, v0
 ; SI-NEXT:    v_cndmask_b32_e64 v0, 0, 1, vcc
-; SI-NEXT:    s_mov_b32 s7, 0xf000
-; SI-NEXT:    s_mov_b32 s6, -1
+; SI-NEXT:    s_mov_b32 s3, 0xf000
+; SI-NEXT:    s_mov_b32 s2, -1
 ; SI-NEXT:    v_mov_b32_e32 v1, 0x3e7
-; SI-NEXT:    s_mov_b64 s[8:9], -1
-; SI-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[8:9]
-; SI-NEXT:    s_and_b64 vcc, exec, 0
-; SI-NEXT:    s_mov_b64 s[8:9], 0
-; SI-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[8:9]
-; SI-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; SI-NEXT:    s_mov_b64 s[4:5], -1
+; SI-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[4:5]
+; SI-NEXT:    s_mov_b64 s[4:5], 0
+; SI-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[4:5]
+; SI-NEXT:    s_and_b64 s[4:5], s[8:9], exec
 ; SI-NEXT:  .LBB7_2: ; %outer_loop
 ; SI-NEXT:    ; =>This Loop Header: Depth=1
 ; SI-NEXT:    ; Child Loop BB7_3 Depth 2
-; SI-NEXT:    s_mov_b64 s[8:9], 0
+; SI-NEXT:    s_mov_b64 s[4:5], 0
 ; SI-NEXT:    ;;#ASMSTART
 ; SI-NEXT:    ;;#ASMEND
 ; SI-NEXT:  .LBB7_3: ; %inner_loop
 ; SI-NEXT:    ; Parent Loop BB7_2 Depth=1
 ; SI-NEXT:    ; => This Inner Loop Header: Depth=2
+; SI-NEXT:    s_and_b64 vcc, exec, 0
 ; SI-NEXT:    s_waitcnt lgkmcnt(0)
-; SI-NEXT:    buffer_store_dword v1, off, s[4:7], 0
+; SI-NEXT:    buffer_store_dword v1, off, s[0:3], 0
 ; SI-NEXT:    s_waitcnt vmcnt(0)
 ; SI-NEXT:    s_mov_b64 vcc, vcc
 ; SI-NEXT:    s_cbranch_vccnz .LBB7_6
@@ -469,13 +450,13 @@ define amdgpu_kernel void @infinite_loop_nest_ret_callbr(ptr addrspace(1) %out) 
 ; SI-NEXT:    v_mov_b32_e32 v4, v2
 ; SI-NEXT:  .LBB7_7: ; %loop.exit.guard
 ; SI-NEXT:    ; in Loop: Header=BB7_2 Depth=1
-; SI-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v4
-; SI-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
-; SI-NEXT:    s_or_b64 s[8:9], s[8:9], s[0:1]
-; SI-NEXT:    s_xor_b64 s[0:1], exec, s[8:9]
-; SI-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; SI-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
-; SI-NEXT:    s_mov_b64 exec, s[8:9]
+; SI-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-NEXT:    s_xor_b64 s[8:9], vcc, exec
+; SI-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
+; SI-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
+; SI-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; SI-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; SI-NEXT:    s_mov_b64 exec, s[4:5]
 ; SI-NEXT:    ; divergent control-flow edge
 ; SI-NEXT:    s_cbranch_execnz .LBB7_2
 ; SI-NEXT:  .LBB7_8: ; Inline asm indirect target

--- a/llvm/test/CodeGen/AMDGPU/ipra-return-address-save-restore.ll
+++ b/llvm/test/CodeGen/AMDGPU/ipra-return-address-save-restore.ll
@@ -31,7 +31,7 @@ define internal fastcc void @svm_node_closure_bsdf(ptr addrspace(1) %sd, ptr %st
 ; GCN-NOT: v_writelane_b32
 ; GCN: s_waitcnt vmcnt(0)
 ; GCN: s_setpc_b64 s[30:31]
-; GCN: s_movk_i32 s24, 0x60
+; GCN: s_movk_i32 s{{[0-9]+}}, 0x60
 ; GCN-NOT: s31
 ; GCN-NOT: v_readlane_b32
 entry:

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.div.fmas.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.div.fmas.ll
@@ -235,48 +235,40 @@ define amdgpu_kernel void @test_div_fmas_f32_logical_cond_to_vcc(ptr addrspace(1
 define amdgpu_kernel void @test_div_fmas_f32_i1_phi_vcc(ptr addrspace(1) %out, ptr addrspace(1) %in, ptr addrspace(1) %dummy) nounwind {
 ; GCN-LABEL: test_div_fmas_f32_i1_phi_vcc:
 ; GCN:       ; %bb.0: ; %entry
-; GCN-NEXT:    s_load_dwordx4 s[8:11], s[4:5], 0x9
-; GCN-NEXT:    s_load_dwordx2 s[4:5], s[4:5], 0xd
-; GCN-NEXT:    s_mov_b32 s3, 0xf000
-; GCN-NEXT:    s_mov_b32 s2, 0
+; GCN-NEXT:    s_load_dwordx4 s[0:3], s[4:5], 0x9
+; GCN-NEXT:    s_load_dwordx2 s[8:9], s[4:5], 0xd
+; GCN-NEXT:    s_mov_b32 s7, 0xf000
+; GCN-NEXT:    s_mov_b32 s6, 0
 ; GCN-NEXT:    v_lshlrev_b32_e32 v3, 2, v0
 ; GCN-NEXT:    v_mov_b32_e32 v4, 0
 ; GCN-NEXT:    s_waitcnt lgkmcnt(0)
-; GCN-NEXT:    s_mov_b64 s[0:1], s[10:11]
-; GCN-NEXT:    buffer_load_dwordx2 v[1:2], v[3:4], s[0:3], 0 addr64
-; GCN-NEXT:    buffer_load_dword v3, v[3:4], s[0:3], 0 addr64 offset:8
+; GCN-NEXT:    s_mov_b64 s[4:5], s[2:3]
+; GCN-NEXT:    buffer_load_dwordx2 v[1:2], v[3:4], s[4:7], 0 addr64
+; GCN-NEXT:    buffer_load_dword v3, v[3:4], s[4:7], 0 addr64 offset:8
 ; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; GCN-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GCN-NEXT:    s_xor_b64 s[10:11], exec, s[0:1]
-; GCN-NEXT:    s_mov_b64 exec, s[0:1]
+; GCN-NEXT:    s_mov_b64 s[2:3], 0
+; GCN-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[2:3]
+; GCN-NEXT:    s_xor_b64 s[4:5], vcc, exec
+; GCN-NEXT:    s_xor_b64 s[2:3], exec, s[4:5]
+; GCN-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-NEXT:    ; divergent control-flow edge
 ; GCN-NEXT:    s_cbranch_execz .LBB9_2
 ; GCN-NEXT:  .LBB9_1: ; %bb
-; GCN-NEXT:    s_mov_b32 s6, -1
-; GCN-NEXT:    s_mov_b32 s7, s3
-; GCN-NEXT:    buffer_load_dword v0, off, s[4:7], 0
-; GCN-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GCN-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[0:1]
-; GCN-NEXT:  .LBB9_2:
-; GCN-NEXT:    s_or_b64 exec, exec, s[10:11]
-; GCN-NEXT:    s_xor_b64 s[0:1], exec, vcc
-; GCN-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GCN-NEXT:    s_mov_b64 exec, vcc
-; GCN-NEXT:    ; divergent control-flow edge
-; GCN-NEXT:    s_cbranch_execz .LBB9_4
-; GCN-NEXT:  .LBB9_3:
-; GCN-NEXT:    s_mov_b64 s[4:5], 0
-; GCN-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[4:5]
-; GCN-NEXT:  .LBB9_4: ; %exit
-; GCN-NEXT:    s_or_b64 exec, exec, s[0:1]
-; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
 ; GCN-NEXT:    s_mov_b32 s10, -1
+; GCN-NEXT:    s_mov_b32 s11, s7
+; GCN-NEXT:    buffer_load_dword v0, off, s[8:11], 0
+; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GCN-NEXT:    v_cndmask_b32_e64 v0, 0, -1, vcc
+; GCN-NEXT:  .LBB9_2: ; %exit
+; GCN-NEXT:    s_or_b64 exec, exec, s[2:3]
+; GCN-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
+; GCN-NEXT:    s_mov_b32 s2, -1
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
 ; GCN-NEXT:    s_nop 1
 ; GCN-NEXT:    v_div_fmas_f32 v0, v1, v2, v3
-; GCN-NEXT:    s_mov_b32 s11, s3
-; GCN-NEXT:    buffer_store_dword v0, off, s[8:11], 0 offset:8
+; GCN-NEXT:    s_mov_b32 s3, s7
+; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], 0 offset:8
 ; GCN-NEXT:    s_endpgm
 entry:
   %tid = call i32 @llvm.amdgcn.workitem.id.x() nounwind readnone

--- a/llvm/test/CodeGen/AMDGPU/local-atomicrmw-fadd.ll
+++ b/llvm/test/CodeGen/AMDGPU/local-atomicrmw-fadd.ll
@@ -9368,48 +9368,53 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX12-LABEL: local_ds_fadd:
 ; GFX12:       ; %bb.0:
 ; GFX12-NEXT:    s_load_b64 s[2:3], s[4:5], 0x8
-; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
+; GFX12-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX12-NEXT:    s_mov_b32 s1, 0
+; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v0, s6, 0
 ; GFX12-NEXT:    ; implicit-def: $vgpr2
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
 ; GFX12-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    s_add_co_i32 s3, s3, 4
-; GFX12-NEXT:    s_xor_b32 s7, s0, exec_lo
+; GFX12-NEXT:    s_xor_b32 s8, s0, exec_lo
 ; GFX12-NEXT:    s_mov_b32 s0, 0
-; GFX12-NEXT:    s_xor_b32 s6, exec_lo, s7
-; GFX12-NEXT:    s_mov_b32 exec_lo, s7
+; GFX12-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX12-NEXT:    s_mov_b32 exec_lo, s8
 ; GFX12-NEXT:    ; divergent control-flow edge
 ; GFX12-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX12-NEXT:  .LBB28_1:
-; GFX12-NEXT:    s_bcnt1_i32_b32 s7, exec_lo
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX12-NEXT:    v_cvt_f32_ubyte0_e32 v1, s7
-; GFX12-NEXT:    s_lshl_b32 s7, s3, 3
+; GFX12-NEXT:    s_bcnt1_i32_b32 s6, s6
 ; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    v_dual_mov_b32 v2, s7 :: v_dual_mul_f32 v1, 0x42280000, v1
+; GFX12-NEXT:    v_cvt_f32_ubyte0_e32 v1, s6
+; GFX12-NEXT:    s_lshl_b32 s6, s3, 3
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_dual_mov_b32 v2, s6 :: v_dual_mul_f32 v1, 0x42280000, v1
 ; GFX12-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX12-NEXT:    s_wait_dscnt 0x0
 ; GFX12-NEXT:    global_inv scope:SCOPE_SE
 ; GFX12-NEXT:  .LBB28_2:
-; GFX12-NEXT:    s_or_b32 exec_lo, exec_lo, s6
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_or_b32 exec_lo, exec_lo, s7
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    s_mov_b32 s8, exec_lo
 ; GFX12-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc_lo
+; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
 ; GFX12-NEXT:    v_readfirstlane_b32 s6, v2
 ; GFX12-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
-; GFX12-NEXT:    s_xor_b32 s8, vcc_lo, exec_lo
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX12-NEXT:    s_xor_b32 s9, vcc_lo, exec_lo
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_xor_b32 s7, exec_lo, s9
 ; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-NEXT:    s_and_b32 s7, s7, exec_lo
-; GFX12-NEXT:    s_mov_b32 exec_lo, s8
+; GFX12-NEXT:    s_mov_b32 exec_lo, s9
 ; GFX12-NEXT:    ; divergent control-flow edge
 ; GFX12-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX12-NEXT:  .LBB28_3:
-; GFX12-NEXT:    s_bcnt1_i32_b32 s8, exec_lo
+; GFX12-NEXT:    s_bcnt1_i32_b32 s8, s8
 ; GFX12-NEXT:    s_lshl_b32 s3, s3, 4
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12-NEXT:    v_dual_mov_b32 v3, s3 :: v_dual_mul_f32 v2, 0x42280000, v2
@@ -9482,166 +9487,149 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ;
 ; GFX942-LABEL: local_ds_fadd:
 ; GFX942:       ; %bb.0:
-; GFX942-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x8
-; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX942-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
+; GFX942-NEXT:    s_mov_b64 s[8:9], exec
+; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX942-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    s_add_i32 s7, s7, 4
-; GFX942-NEXT:    s_xor_b64 s[16:17], s[0:1], exec
-; GFX942-NEXT:    s_mov_b64 s[12:13], 0
-; GFX942-NEXT:    s_mov_b64 s[8:9], 0
-; GFX942-NEXT:    s_xor_b64 s[14:15], exec, s[16:17]
-; GFX942-NEXT:    s_mov_b64 s[10:11], 0
-; GFX942-NEXT:    s_mov_b64 s[2:3], 0
-; GFX942-NEXT:    s_mov_b64 exec, s[16:17]
+; GFX942-NEXT:    s_add_i32 s3, s3, 4
+; GFX942-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GFX942-NEXT:    s_mov_b64 s[6:7], 0
+; GFX942-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
+; GFX942-NEXT:    s_mov_b64 s[0:1], 0
+; GFX942-NEXT:    ; implicit-def: $vgpr2
+; GFX942-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX942-NEXT:    ; divergent control-flow edge
 ; GFX942-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX942-NEXT:  .LBB28_1:
-; GFX942-NEXT:    s_bcnt1_i32_b64 s17, exec
-; GFX942-NEXT:    s_lshl_b32 s16, s7, 3
-; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v1, s17
+; GFX942-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX942-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX942-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX942-NEXT:    v_mov_b32_e32 v2, s16
+; GFX942-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX942-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX942-NEXT:  .LBB28_2:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX942-NEXT:    s_xor_b64 s[14:15], exec, s[0:1]
-; GFX942-NEXT:    s_and_b64 s[14:15], s[14:15], exec
-; GFX942-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX942-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX942-NEXT:    s_mov_b64 s[8:9], exec
+; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
+; GFX942-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
+; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX942-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX942-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
+; GFX942-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX942-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX942-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX942-NEXT:    ; divergent control-flow edge
 ; GFX942-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX942-NEXT:  .LBB28_3:
-; GFX942-NEXT:    ; implicit-def: $vgpr2
-; GFX942-NEXT:  .LBB28_4:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
-; GFX942-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX942-NEXT:    s_xor_b64 s[16:17], vcc, exec
-; GFX942-NEXT:    s_xor_b64 s[0:1], exec, s[16:17]
-; GFX942-NEXT:    v_readfirstlane_b32 s14, v2
-; GFX942-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX942-NEXT:    s_mov_b64 exec, s[16:17]
-; GFX942-NEXT:    ; divergent control-flow edge
-; GFX942-NEXT:    s_cbranch_execz .LBB28_6
-; GFX942-NEXT:  .LBB28_5:
-; GFX942-NEXT:    s_bcnt1_i32_b64 s15, exec
-; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v2, s15
-; GFX942-NEXT:    s_lshl_b32 s7, s7, 4
+; GFX942-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
+; GFX942-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX942-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, s7
+; GFX942-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX942-NEXT:    ds_add_f32 v3, v2
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:  .LBB28_6:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[0:1]
+; GFX942-NEXT:  .LBB28_4:
+; GFX942-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX942-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX942-NEXT:    v_add_f32_e32 v0, s14, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, s14
+; GFX942-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX942-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GFX942-NEXT:    s_mov_b64 s[0:1], exec
+; GFX942-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX942-NEXT:    v_bfrev_b32_e32 v1, 1
 ; GFX942-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX942-NEXT:    ; implicit-def: $vgpr0
-; GFX942-NEXT:  .LBB28_7: ; %ComputeLoop
+; GFX942-NEXT:  .LBB28_5: ; %ComputeLoop
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX942-NEXT:    s_ff1_i32_b64 s7, s[0:1]
-; GFX942-NEXT:    v_readlane_b32 s14, v2, s7
-; GFX942-NEXT:    v_readfirstlane_b32 s15, v1
-; GFX942-NEXT:    s_mov_b32 m0, s7
-; GFX942-NEXT:    v_add_f32_e32 v1, s14, v1
-; GFX942-NEXT:    v_writelane_b32 v0, s15, m0
-; GFX942-NEXT:    s_lshl_b64 s[14:15], 1, s7
-; GFX942-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[14:15]
-; GFX942-NEXT:    s_cbranch_scc1 .LBB28_7
-; GFX942-NEXT:  ; %bb.8: ; %ComputeEnd
+; GFX942-NEXT:    s_ff1_i32_b64 s3, s[8:9]
+; GFX942-NEXT:    v_readlane_b32 s10, v2, s3
+; GFX942-NEXT:    v_readfirstlane_b32 s11, v1
+; GFX942-NEXT:    s_mov_b32 m0, s3
+; GFX942-NEXT:    v_add_f32_e32 v1, s10, v1
+; GFX942-NEXT:    v_writelane_b32 v0, s11, m0
+; GFX942-NEXT:    s_lshl_b64 s[10:11], 1, s3
+; GFX942-NEXT:    s_andn2_b64 s[8:9], s[8:9], s[10:11]
+; GFX942-NEXT:    s_cbranch_scc1 .LBB28_5
+; GFX942-NEXT:  ; %bb.6: ; %ComputeEnd
 ; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v2, exec_hi, v2
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    s_or_b64 s[12:13], s[12:13], vcc
-; GFX942-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX942-NEXT:    s_or_b64 s[8:9], s[8:9], s[0:1]
-; GFX942-NEXT:    s_xor_b64 s[0:1], exec, s[12:13]
-; GFX942-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX942-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
+; GFX942-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; GFX942-NEXT:    s_and_b64 s[8:9], s[8:9], exec
 ; GFX942-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
-; GFX942-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
-; GFX942-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX942-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX942-NEXT:    ; implicit-def: $vgpr3
+; GFX942-NEXT:    s_mov_b64 exec, s[6:7]
 ; GFX942-NEXT:    ; divergent control-flow edge
-; GFX942-NEXT:    s_cbranch_execz .LBB28_10
-; GFX942-NEXT:  .LBB28_9:
-; GFX942-NEXT:    v_mov_b32_e32 v3, s6
-; GFX942-NEXT:    ds_add_rtn_f32 v1, v3, v1
+; GFX942-NEXT:    s_cbranch_execz .LBB28_8
+; GFX942-NEXT:  .LBB28_7:
+; GFX942-NEXT:    v_mov_b32_e32 v3, s2
+; GFX942-NEXT:    ds_add_rtn_f32 v3, v3, v1
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:  .LBB28_10:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[10:11]
-; GFX942-NEXT:    s_xor_b64 s[0:1], exec, s[8:9]
-; GFX942-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX942-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
-; GFX942-NEXT:    s_mov_b64 exec, s[8:9]
-; GFX942-NEXT:    ; divergent control-flow edge
-; GFX942-NEXT:    s_cbranch_execz .LBB28_12
-; GFX942-NEXT:  .LBB28_11:
-; GFX942-NEXT:    ; implicit-def: $vgpr1
-; GFX942-NEXT:  .LBB28_12:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[2:3]
+; GFX942-NEXT:  .LBB28_8:
+; GFX942-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX942-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x0
-; GFX942-NEXT:    v_readfirstlane_b32 s2, v1
+; GFX942-NEXT:    v_readfirstlane_b32 s2, v3
 ; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX942-NEXT:    v_add_f32_e32 v0, s2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v1, s2
-; GFX942-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
+; GFX942-NEXT:    v_mov_b32_e32 v3, s2
+; GFX942-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    global_store_dword v3, v0, s[0:1]
+; GFX942-NEXT:    global_store_dword v1, v0, s[0:1]
 ; GFX942-NEXT:    s_endpgm
 ;
 ; GFX11-LABEL: local_ds_fadd:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b64 s[2:3], s[4:5], 0x8
-; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
+; GFX11-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX11-NEXT:    s_mov_b32 s1, 0
+; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v0, s6, 0
 ; GFX11-NEXT:    ; implicit-def: $vgpr2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
 ; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_add_i32 s3, s3, 4
-; GFX11-NEXT:    s_xor_b32 s7, s0, exec_lo
+; GFX11-NEXT:    s_xor_b32 s8, s0, exec_lo
 ; GFX11-NEXT:    s_mov_b32 s0, 0
-; GFX11-NEXT:    s_xor_b32 s6, exec_lo, s7
-; GFX11-NEXT:    s_mov_b32 exec_lo, s7
+; GFX11-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX11-NEXT:    s_mov_b32 exec_lo, s8
 ; GFX11-NEXT:    ; divergent control-flow edge
 ; GFX11-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX11-NEXT:  .LBB28_1:
-; GFX11-NEXT:    s_bcnt1_i32_b32 s7, exec_lo
+; GFX11-NEXT:    s_bcnt1_i32_b32 s6, s6
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v1, s7
-; GFX11-NEXT:    s_lshl_b32 s7, s3, 3
+; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v1, s6
+; GFX11-NEXT:    s_lshl_b32 s6, s3, 3
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v2, s7 :: v_dual_mul_f32 v1, 0x42280000, v1
+; GFX11-NEXT:    v_dual_mov_b32 v2, s6 :: v_dual_mul_f32 v1, 0x42280000, v1
 ; GFX11-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    buffer_gl0_inv
 ; GFX11-NEXT:  .LBB28_2:
-; GFX11-NEXT:    s_or_b32 exec_lo, exec_lo, s6
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+; GFX11-NEXT:    s_or_b32 exec_lo, exec_lo, s7
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    s_mov_b32 s8, exec_lo
 ; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc_lo
+; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
 ; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
-; GFX11-NEXT:    s_xor_b32 s8, vcc_lo, exec_lo
+; GFX11-NEXT:    s_xor_b32 s9, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX11-NEXT:    s_xor_b32 s7, exec_lo, s9
 ; GFX11-NEXT:    s_and_b32 s7, s7, exec_lo
-; GFX11-NEXT:    s_mov_b32 exec_lo, s8
+; GFX11-NEXT:    s_mov_b32 exec_lo, s9
 ; GFX11-NEXT:    ; divergent control-flow edge
 ; GFX11-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX11-NEXT:  .LBB28_3:
-; GFX11-NEXT:    s_bcnt1_i32_b32 s8, exec_lo
+; GFX11-NEXT:    s_bcnt1_i32_b32 s8, s8
 ; GFX11-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -9707,43 +9695,45 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX10-LABEL: local_ds_fadd:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
-; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
+; GFX10-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX10-NEXT:    s_mov_b32 s1, 0
+; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v0, s6, 0
 ; GFX10-NEXT:    ; implicit-def: $vgpr2
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
 ; GFX10-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    s_add_i32 s3, s3, 4
-; GFX10-NEXT:    s_xor_b32 s7, s0, exec_lo
+; GFX10-NEXT:    s_xor_b32 s8, s0, exec_lo
 ; GFX10-NEXT:    s_mov_b32 s0, 0
-; GFX10-NEXT:    s_xor_b32 s6, exec_lo, s7
-; GFX10-NEXT:    s_mov_b32 exec_lo, s7
+; GFX10-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX10-NEXT:    s_mov_b32 exec_lo, s8
 ; GFX10-NEXT:    ; divergent control-flow edge
 ; GFX10-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX10-NEXT:  .LBB28_1:
-; GFX10-NEXT:    s_bcnt1_i32_b32 s7, exec_lo
-; GFX10-NEXT:    v_cvt_f32_ubyte0_e32 v1, s7
-; GFX10-NEXT:    s_lshl_b32 s7, s3, 3
-; GFX10-NEXT:    v_mov_b32_e32 v2, s7
+; GFX10-NEXT:    s_bcnt1_i32_b32 s6, s6
+; GFX10-NEXT:    v_cvt_f32_ubyte0_e32 v1, s6
+; GFX10-NEXT:    s_lshl_b32 s6, s3, 3
+; GFX10-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX10-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
 ; GFX10-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    buffer_gl0_inv
 ; GFX10-NEXT:  .LBB28_2:
 ; GFX10-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
-; GFX10-NEXT:    s_or_b32 exec_lo, exec_lo, s6
-; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+; GFX10-NEXT:    s_or_b32 exec_lo, exec_lo, s7
+; GFX10-NEXT:    s_mov_b32 s8, exec_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc_lo
+; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
 ; GFX10-NEXT:    v_readfirstlane_b32 s6, v2
 ; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
-; GFX10-NEXT:    s_xor_b32 s8, vcc_lo, exec_lo
-; GFX10-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX10-NEXT:    s_xor_b32 s9, vcc_lo, exec_lo
+; GFX10-NEXT:    s_xor_b32 s7, exec_lo, s9
 ; GFX10-NEXT:    s_and_b32 s7, s7, exec_lo
-; GFX10-NEXT:    s_mov_b32 exec_lo, s8
+; GFX10-NEXT:    s_mov_b32 exec_lo, s9
 ; GFX10-NEXT:    ; divergent control-flow edge
 ; GFX10-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX10-NEXT:  .LBB28_3:
-; GFX10-NEXT:    s_bcnt1_i32_b32 s8, exec_lo
+; GFX10-NEXT:    s_bcnt1_i32_b32 s8, s8
 ; GFX10-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX10-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX10-NEXT:    v_mov_b32_e32 v3, s3
@@ -9806,175 +9796,158 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ;
 ; GFX90A-LABEL: local_ds_fadd:
 ; GFX90A:       ; %bb.0:
-; GFX90A-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x8
-; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX90A-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
+; GFX90A-NEXT:    s_mov_b64 s[8:9], exec
+; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX90A-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    s_add_i32 s7, s7, 4
-; GFX90A-NEXT:    s_xor_b64 s[16:17], s[0:1], exec
-; GFX90A-NEXT:    s_mov_b64 s[12:13], 0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], 0
-; GFX90A-NEXT:    s_xor_b64 s[14:15], exec, s[16:17]
-; GFX90A-NEXT:    s_mov_b64 s[10:11], 0
-; GFX90A-NEXT:    s_mov_b64 s[2:3], 0
-; GFX90A-NEXT:    s_mov_b64 exec, s[16:17]
+; GFX90A-NEXT:    s_add_i32 s3, s3, 4
+; GFX90A-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
+; GFX90A-NEXT:    s_mov_b64 s[0:1], 0
+; GFX90A-NEXT:    ; implicit-def: $vgpr2
+; GFX90A-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX90A-NEXT:  .LBB28_1:
-; GFX90A-NEXT:    s_bcnt1_i32_b64 s17, exec
-; GFX90A-NEXT:    s_lshl_b32 s16, s7, 3
-; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v1, s17
+; GFX90A-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX90A-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX90A-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v2, s16
+; GFX90A-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX90A-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX90A-NEXT:  .LBB28_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX90A-NEXT:    s_xor_b64 s[14:15], exec, s[0:1]
-; GFX90A-NEXT:    s_and_b64 s[14:15], s[14:15], exec
-; GFX90A-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_mov_b64 s[8:9], exec
+; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
+; GFX90A-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
+; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX90A-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
+; GFX90A-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX90A-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX90A-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX90A-NEXT:  .LBB28_3:
-; GFX90A-NEXT:    ; implicit-def: $vgpr2
-; GFX90A-NEXT:  .LBB28_4:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
-; GFX90A-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX90A-NEXT:    s_xor_b64 s[16:17], vcc, exec
-; GFX90A-NEXT:    s_xor_b64 s[0:1], exec, s[16:17]
-; GFX90A-NEXT:    v_readfirstlane_b32 s14, v2
-; GFX90A-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX90A-NEXT:    s_mov_b64 exec, s[16:17]
-; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB28_6
-; GFX90A-NEXT:  .LBB28_5:
-; GFX90A-NEXT:    s_bcnt1_i32_b64 s15, exec
-; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v2, s15
-; GFX90A-NEXT:    s_lshl_b32 s7, s7, 4
+; GFX90A-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
+; GFX90A-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX90A-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, s7
+; GFX90A-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX90A-NEXT:    ds_add_f32 v3, v2
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:  .LBB28_6:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[0:1]
+; GFX90A-NEXT:  .LBB28_4:
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX90A-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX90A-NEXT:    v_add_f32_e32 v0, s14, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, s14
+; GFX90A-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GFX90A-NEXT:    s_mov_b64 s[0:1], exec
+; GFX90A-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX90A-NEXT:    v_bfrev_b32_e32 v1, 1
 ; GFX90A-NEXT:    ; implicit-def: $vgpr0
-; GFX90A-NEXT:  .LBB28_7: ; %ComputeLoop
+; GFX90A-NEXT:  .LBB28_5: ; %ComputeLoop
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX90A-NEXT:    s_ff1_i32_b64 s7, s[0:1]
-; GFX90A-NEXT:    v_readlane_b32 s14, v2, s7
-; GFX90A-NEXT:    v_readfirstlane_b32 s15, v1
-; GFX90A-NEXT:    s_mov_b32 m0, s7
-; GFX90A-NEXT:    v_writelane_b32 v0, s15, m0
-; GFX90A-NEXT:    v_add_f32_e32 v1, s14, v1
-; GFX90A-NEXT:    s_lshl_b64 s[14:15], 1, s7
-; GFX90A-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[14:15]
-; GFX90A-NEXT:    s_cbranch_scc1 .LBB28_7
-; GFX90A-NEXT:  ; %bb.8: ; %ComputeEnd
+; GFX90A-NEXT:    s_ff1_i32_b64 s3, s[8:9]
+; GFX90A-NEXT:    v_readlane_b32 s10, v2, s3
+; GFX90A-NEXT:    v_readfirstlane_b32 s11, v1
+; GFX90A-NEXT:    s_mov_b32 m0, s3
+; GFX90A-NEXT:    v_writelane_b32 v0, s11, m0
+; GFX90A-NEXT:    v_add_f32_e32 v1, s10, v1
+; GFX90A-NEXT:    s_lshl_b64 s[10:11], 1, s3
+; GFX90A-NEXT:    s_andn2_b64 s[8:9], s[8:9], s[10:11]
+; GFX90A-NEXT:    s_cbranch_scc1 .LBB28_5
+; GFX90A-NEXT:  ; %bb.6: ; %ComputeEnd
 ; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v2, exec_hi, v2
 ; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX90A-NEXT:    s_or_b64 s[12:13], s[12:13], vcc
-; GFX90A-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX90A-NEXT:    s_or_b64 s[8:9], s[8:9], s[0:1]
-; GFX90A-NEXT:    s_xor_b64 s[0:1], exec, s[12:13]
-; GFX90A-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
-; GFX90A-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
-; GFX90A-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX90A-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX90A-NEXT:    ; implicit-def: $vgpr3
+; GFX90A-NEXT:    s_mov_b64 exec, s[6:7]
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB28_10
-; GFX90A-NEXT:  .LBB28_9:
-; GFX90A-NEXT:    v_mov_b32_e32 v3, s6
-; GFX90A-NEXT:    ds_add_rtn_f32 v1, v3, v1
+; GFX90A-NEXT:    s_cbranch_execz .LBB28_8
+; GFX90A-NEXT:  .LBB28_7:
+; GFX90A-NEXT:    v_mov_b32_e32 v3, s2
+; GFX90A-NEXT:    ds_add_rtn_f32 v3, v3, v1
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:  .LBB28_10:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
-; GFX90A-NEXT:    s_xor_b64 s[0:1], exec, s[8:9]
-; GFX90A-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX90A-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
-; GFX90A-NEXT:    s_mov_b64 exec, s[8:9]
-; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB28_12
-; GFX90A-NEXT:  .LBB28_11:
-; GFX90A-NEXT:    ; implicit-def: $vgpr1
-; GFX90A-NEXT:  .LBB28_12:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[2:3]
+; GFX90A-NEXT:  .LBB28_8:
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX90A-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x0
-; GFX90A-NEXT:    v_readfirstlane_b32 s2, v1
+; GFX90A-NEXT:    v_readfirstlane_b32 s2, v3
 ; GFX90A-NEXT:    v_add_f32_e32 v0, s2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, s2
+; GFX90A-NEXT:    v_mov_b32_e32 v3, s2
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
-; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
+; GFX90A-NEXT:    v_mov_b32_e32 v1, 0
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    global_store_dword v3, v0, s[0:1]
+; GFX90A-NEXT:    global_store_dword v1, v0, s[0:1]
 ; GFX90A-NEXT:    s_endpgm
 ;
 ; GFX908-LABEL: local_ds_fadd:
 ; GFX908:       ; %bb.0:
 ; GFX908-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
-; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX908-NEXT:    s_mov_b64 s[8:9], exec
+; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX908-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX908-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX908-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX908-NEXT:    s_add_i32 s3, s3, 4
-; GFX908-NEXT:    s_xor_b64 s[10:11], s[0:1], exec
+; GFX908-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX908-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX908-NEXT:    s_mov_b64 s[6:7], 0
-; GFX908-NEXT:    s_xor_b64 s[8:9], exec, s[10:11]
+; GFX908-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
 ; GFX908-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX908-NEXT:    ; implicit-def: $vgpr2
-; GFX908-NEXT:    s_mov_b64 exec, s[10:11]
+; GFX908-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX908-NEXT:    ; divergent control-flow edge
 ; GFX908-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX908-NEXT:  .LBB28_1:
-; GFX908-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX908-NEXT:    s_lshl_b32 s10, s3, 3
-; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v1, s11
+; GFX908-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX908-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX908-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX908-NEXT:    v_mov_b32_e32 v2, s10
+; GFX908-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX908-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX908-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX908-NEXT:  .LBB28_2:
-; GFX908-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
+; GFX908-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX908-NEXT:    s_mov_b64 s[8:9], exec
+; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
 ; GFX908-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX908-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX908-NEXT:    s_xor_b64 s[12:13], vcc, exec
-; GFX908-NEXT:    s_xor_b64 s[8:9], exec, s[12:13]
-; GFX908-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX908-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX908-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX908-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX908-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
+; GFX908-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX908-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX908-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX908-NEXT:    ; divergent control-flow edge
 ; GFX908-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX908-NEXT:  .LBB28_3:
-; GFX908-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v2, s11
+; GFX908-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX908-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX908-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
 ; GFX908-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX908-NEXT:    ds_add_f32 v3, v2
 ; GFX908-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX908-NEXT:  .LBB28_4:
-; GFX908-NEXT:    s_or_b64 exec, exec, s[8:9]
+; GFX908-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX908-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX908-NEXT:    v_add_f32_e32 v0, s10, v0
-; GFX908-NEXT:    v_mov_b32_e32 v2, s10
+; GFX908-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX908-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX908-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; GFX908-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX908-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
@@ -10024,56 +9997,58 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX8-LABEL: local_ds_fadd:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
-; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX8-NEXT:    s_mov_b64 s[8:9], exec
+; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:    s_add_i32 s3, s3, 4
-; GFX8-NEXT:    s_xor_b64 s[10:11], s[0:1], exec
+; GFX8-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX8-NEXT:    s_mov_b64 s[6:7], 0
-; GFX8-NEXT:    s_xor_b64 s[8:9], exec, s[10:11]
+; GFX8-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
 ; GFX8-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX8-NEXT:    ; implicit-def: $vgpr2
 ; GFX8-NEXT:    s_mov_b32 m0, -1
-; GFX8-NEXT:    s_mov_b64 exec, s[10:11]
+; GFX8-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX8-NEXT:    ; divergent control-flow edge
 ; GFX8-NEXT:    s_cbranch_execz .LBB28_2
 ; GFX8-NEXT:  .LBB28_1:
-; GFX8-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX8-NEXT:    s_lshl_b32 s10, s3, 3
-; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v1, s11
+; GFX8-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX8-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX8-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX8-NEXT:    v_mov_b32_e32 v2, s10
+; GFX8-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX8-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:  .LBB28_2:
-; GFX8-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
+; GFX8-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX8-NEXT:    s_mov_b64 s[8:9], exec
+; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX8-NEXT:    s_xor_b64 s[12:13], vcc, exec
-; GFX8-NEXT:    s_xor_b64 s[8:9], exec, s[12:13]
-; GFX8-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX8-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX8-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX8-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX8-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
+; GFX8-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX8-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX8-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX8-NEXT:    ; divergent control-flow edge
 ; GFX8-NEXT:    s_cbranch_execz .LBB28_4
 ; GFX8-NEXT:  .LBB28_3:
-; GFX8-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v2, s11
+; GFX8-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX8-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX8-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX8-NEXT:    ds_add_f32 v3, v2
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:  .LBB28_4:
-; GFX8-NEXT:    s_or_b64 exec, exec, s[8:9]
+; GFX8-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX8-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX8-NEXT:    v_add_f32_e32 v0, s10, v0
-; GFX8-NEXT:    v_mov_b32_e32 v2, s10
+; GFX8-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX8-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; GFX8-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
@@ -10125,13 +10100,14 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX7-LABEL: local_ds_fadd:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x2
-; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, exec_lo, 0
-; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, exec_hi, v0
+; GFX7-NEXT:    s_mov_b64 s[18:19], exec
+; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, s18, 0
+; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, s19, v0
 ; GFX7-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX7-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX7-NEXT:    s_add_i32 s7, s7, 4
 ; GFX7-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
+; GFX7-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX7-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX7-NEXT:    s_mov_b64 s[8:9], -1
@@ -10149,7 +10125,7 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX7-NEXT:    s_lshl_b32 s0, s7, 3
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX7-NEXT:    ds_read_b32 v2, v1
-; GFX7-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX7-NEXT:    s_bcnt1_i32_b64 s0, s[18:19]
 ; GFX7-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX7-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX7-NEXT:    s_and_b64 s[0:1], s[8:9], exec
@@ -10170,24 +10146,25 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX7-NEXT:    s_cbranch_execnz .LBB28_2
 ; GFX7-NEXT:  .LBB28_3:
 ; GFX7-NEXT:    s_or_b64 exec, exec, s[16:17]
-; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, exec_lo, 0
-; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, exec_hi, v3
+; GFX7-NEXT:    s_mov_b64 s[0:1], exec
+; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, s0, 0
+; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, s1, v3
 ; GFX7-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX7-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX7-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX7-NEXT:    s_or_b64 s[14:15], s[14:15], s[0:1]
-; GFX7-NEXT:    s_xor_b64 s[0:1], exec, s[14:15]
-; GFX7-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX7-NEXT:    s_xor_b64 s[18:19], vcc, exec
+; GFX7-NEXT:    s_or_b64 s[14:15], s[14:15], s[18:19]
+; GFX7-NEXT:    s_xor_b64 s[18:19], exec, s[14:15]
+; GFX7-NEXT:    s_and_b64 s[18:19], s[18:19], exec
 ; GFX7-NEXT:    v_readfirstlane_b32 s16, v2
-; GFX7-NEXT:    s_or_b64 s[12:13], s[12:13], s[0:1]
+; GFX7-NEXT:    s_or_b64 s[12:13], s[12:13], s[18:19]
 ; GFX7-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX7-NEXT:    ; divergent control-flow edge
 ; GFX7-NEXT:    s_cbranch_execz .LBB28_6
 ; GFX7-NEXT:  .LBB28_4:
-; GFX7-NEXT:    s_lshl_b32 s0, s7, 4
-; GFX7-NEXT:    v_mov_b32_e32 v2, s0
+; GFX7-NEXT:    s_lshl_b32 s7, s7, 4
+; GFX7-NEXT:    v_mov_b32_e32 v2, s7
 ; GFX7-NEXT:    ds_read_b32 v4, v2
-; GFX7-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX7-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
 ; GFX7-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX7-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX7-NEXT:    s_and_b64 s[0:1], s[8:9], exec
@@ -10279,14 +10256,15 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ;
 ; GFX6-LABEL: local_ds_fadd:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_load_dword s16, s[4:5], 0x3
-; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, exec_lo, 0
-; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, exec_hi, v0
+; GFX6-NEXT:    s_load_dword s18, s[4:5], 0x3
+; GFX6-NEXT:    s_mov_b64 s[16:17], exec
+; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, s16, 0
+; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, s17, v0
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX6-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    s_add_i32 s16, s16, 4
+; GFX6-NEXT:    s_add_i32 s18, s18, 4
 ; GFX6-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
+; GFX6-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX6-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX6-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX6-NEXT:    s_mov_b64 s[6:7], -1
@@ -10301,10 +10279,10 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX6-NEXT:    ; divergent control-flow edge
 ; GFX6-NEXT:    s_cbranch_execz .LBB28_3
 ; GFX6-NEXT:  .LBB28_1:
-; GFX6-NEXT:    s_lshl_b32 s0, s16, 3
+; GFX6-NEXT:    s_lshl_b32 s0, s18, 3
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX6-NEXT:    ds_read_b32 v2, v1
-; GFX6-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX6-NEXT:    s_bcnt1_i32_b64 s0, s[16:17]
 ; GFX6-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX6-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX6-NEXT:    s_and_b64 s[0:1], s[6:7], exec
@@ -10318,32 +10296,33 @@ define amdgpu_kernel void @local_ds_fadd(ptr addrspace(1) %out, ptr addrspace(3)
 ; GFX6-NEXT:    v_cmp_eq_u32_e64 s[0:1], v2, v4
 ; GFX6-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 s[0:1], 1, v4
-; GFX6-NEXT:    s_xor_b64 s[18:19], exec, s[0:1]
-; GFX6-NEXT:    s_or_b64 s[14:15], s[14:15], s[18:19]
+; GFX6-NEXT:    s_xor_b64 s[16:17], exec, s[0:1]
+; GFX6-NEXT:    s_or_b64 s[14:15], s[14:15], s[16:17]
 ; GFX6-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX6-NEXT:    ; divergent control-flow edge
 ; GFX6-NEXT:    s_cbranch_execnz .LBB28_2
 ; GFX6-NEXT:  .LBB28_3:
 ; GFX6-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, exec_lo, 0
-; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, exec_hi, v3
+; GFX6-NEXT:    s_mov_b64 s[0:1], exec
+; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, s0, 0
+; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, s1, v3
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; GFX6-NEXT:    s_load_dword s14, s[4:5], 0x2
-; GFX6-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX6-NEXT:    s_or_b64 s[12:13], s[12:13], s[0:1]
-; GFX6-NEXT:    s_xor_b64 s[0:1], exec, s[12:13]
-; GFX6-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX6-NEXT:    s_xor_b64 s[16:17], vcc, exec
+; GFX6-NEXT:    s_or_b64 s[12:13], s[12:13], s[16:17]
+; GFX6-NEXT:    s_xor_b64 s[16:17], exec, s[12:13]
+; GFX6-NEXT:    s_and_b64 s[16:17], s[16:17], exec
 ; GFX6-NEXT:    v_readfirstlane_b32 s15, v2
-; GFX6-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
+; GFX6-NEXT:    s_or_b64 s[10:11], s[10:11], s[16:17]
 ; GFX6-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX6-NEXT:    ; divergent control-flow edge
 ; GFX6-NEXT:    s_cbranch_execz .LBB28_6
 ; GFX6-NEXT:  .LBB28_4:
-; GFX6-NEXT:    s_lshl_b32 s0, s16, 4
-; GFX6-NEXT:    v_mov_b32_e32 v2, s0
+; GFX6-NEXT:    s_lshl_b32 s12, s18, 4
+; GFX6-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX6-NEXT:    ds_read_b32 v4, v2
-; GFX6-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX6-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
 ; GFX6-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX6-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX6-NEXT:    s_and_b64 s[0:1], s[6:7], exec
@@ -10450,47 +10429,52 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX12-LABEL: local_ds_fadd_one_as:
 ; GFX12:       ; %bb.0:
 ; GFX12-NEXT:    s_load_b64 s[2:3], s[4:5], 0x8
-; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
+; GFX12-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX12-NEXT:    s_mov_b32 s1, 0
+; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v0, s6, 0
 ; GFX12-NEXT:    ; implicit-def: $vgpr2
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
 ; GFX12-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    s_add_co_i32 s3, s3, 4
-; GFX12-NEXT:    s_xor_b32 s7, s0, exec_lo
+; GFX12-NEXT:    s_xor_b32 s8, s0, exec_lo
 ; GFX12-NEXT:    s_mov_b32 s0, 0
-; GFX12-NEXT:    s_xor_b32 s6, exec_lo, s7
-; GFX12-NEXT:    s_mov_b32 exec_lo, s7
+; GFX12-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX12-NEXT:    s_mov_b32 exec_lo, s8
 ; GFX12-NEXT:    ; divergent control-flow edge
 ; GFX12-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX12-NEXT:  .LBB29_1:
-; GFX12-NEXT:    s_bcnt1_i32_b32 s7, exec_lo
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
-; GFX12-NEXT:    v_cvt_f32_ubyte0_e32 v1, s7
-; GFX12-NEXT:    s_lshl_b32 s7, s3, 3
+; GFX12-NEXT:    s_bcnt1_i32_b32 s6, s6
 ; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
-; GFX12-NEXT:    v_dual_mov_b32 v2, s7 :: v_dual_mul_f32 v1, 0x42280000, v1
+; GFX12-NEXT:    v_cvt_f32_ubyte0_e32 v1, s6
+; GFX12-NEXT:    s_lshl_b32 s6, s3, 3
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
+; GFX12-NEXT:    v_dual_mov_b32 v2, s6 :: v_dual_mul_f32 v1, 0x42280000, v1
 ; GFX12-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX12-NEXT:  .LBB29_2:
-; GFX12-NEXT:    s_or_b32 exec_lo, exec_lo, s6
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_3)
-; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_or_b32 exec_lo, exec_lo, s7
+; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX12-NEXT:    s_mov_b32 s8, exec_lo
 ; GFX12-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc_lo
+; GFX12-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
 ; GFX12-NEXT:    s_wait_dscnt 0x0
 ; GFX12-NEXT:    v_readfirstlane_b32 s6, v2
 ; GFX12-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
-; GFX12-NEXT:    s_xor_b32 s8, vcc_lo, exec_lo
-; GFX12-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX12-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX12-NEXT:    s_xor_b32 s9, vcc_lo, exec_lo
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
+; GFX12-NEXT:    s_xor_b32 s7, exec_lo, s9
 ; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-NEXT:    s_and_b32 s7, s7, exec_lo
-; GFX12-NEXT:    s_mov_b32 exec_lo, s8
+; GFX12-NEXT:    s_mov_b32 exec_lo, s9
 ; GFX12-NEXT:    ; divergent control-flow edge
 ; GFX12-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX12-NEXT:  .LBB29_3:
-; GFX12-NEXT:    s_bcnt1_i32_b32 s8, exec_lo
+; GFX12-NEXT:    s_bcnt1_i32_b32 s8, s8
 ; GFX12-NEXT:    s_lshl_b32 s3, s3, 4
+; GFX12-NEXT:    s_wait_alu depctr_sa_sdst(0)
 ; GFX12-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX12-NEXT:    v_dual_mov_b32 v3, s3 :: v_dual_mul_f32 v2, 0x42280000, v2
@@ -10558,163 +10542,146 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ;
 ; GFX942-LABEL: local_ds_fadd_one_as:
 ; GFX942:       ; %bb.0:
-; GFX942-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x8
-; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX942-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
+; GFX942-NEXT:    s_mov_b64 s[8:9], exec
+; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX942-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    s_add_i32 s7, s7, 4
-; GFX942-NEXT:    s_xor_b64 s[16:17], s[0:1], exec
-; GFX942-NEXT:    s_mov_b64 s[12:13], 0
-; GFX942-NEXT:    s_mov_b64 s[8:9], 0
-; GFX942-NEXT:    s_xor_b64 s[14:15], exec, s[16:17]
-; GFX942-NEXT:    s_mov_b64 s[10:11], 0
-; GFX942-NEXT:    s_mov_b64 s[2:3], 0
-; GFX942-NEXT:    s_mov_b64 exec, s[16:17]
+; GFX942-NEXT:    s_add_i32 s3, s3, 4
+; GFX942-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GFX942-NEXT:    s_mov_b64 s[6:7], 0
+; GFX942-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
+; GFX942-NEXT:    s_mov_b64 s[0:1], 0
+; GFX942-NEXT:    ; implicit-def: $vgpr2
+; GFX942-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX942-NEXT:    ; divergent control-flow edge
 ; GFX942-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX942-NEXT:  .LBB29_1:
-; GFX942-NEXT:    s_bcnt1_i32_b64 s17, exec
-; GFX942-NEXT:    s_lshl_b32 s16, s7, 3
-; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v1, s17
+; GFX942-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX942-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX942-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX942-NEXT:    v_mov_b32_e32 v2, s16
+; GFX942-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX942-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX942-NEXT:  .LBB29_2:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX942-NEXT:    s_xor_b64 s[14:15], exec, s[0:1]
-; GFX942-NEXT:    s_and_b64 s[14:15], s[14:15], exec
-; GFX942-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX942-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX942-NEXT:    s_mov_b64 s[8:9], exec
+; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
+; GFX942-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
+; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX942-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX942-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
+; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX942-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX942-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX942-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX942-NEXT:    ; divergent control-flow edge
 ; GFX942-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX942-NEXT:  .LBB29_3:
-; GFX942-NEXT:    ; implicit-def: $vgpr2
-; GFX942-NEXT:  .LBB29_4:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
-; GFX942-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX942-NEXT:    s_xor_b64 s[16:17], vcc, exec
-; GFX942-NEXT:    s_xor_b64 s[0:1], exec, s[16:17]
-; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    v_readfirstlane_b32 s14, v2
-; GFX942-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX942-NEXT:    s_mov_b64 exec, s[16:17]
-; GFX942-NEXT:    ; divergent control-flow edge
-; GFX942-NEXT:    s_cbranch_execz .LBB29_6
-; GFX942-NEXT:  .LBB29_5:
-; GFX942-NEXT:    s_bcnt1_i32_b64 s15, exec
-; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v2, s15
-; GFX942-NEXT:    s_lshl_b32 s7, s7, 4
+; GFX942-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
+; GFX942-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX942-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, s7
+; GFX942-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX942-NEXT:    ds_add_f32 v3, v2
-; GFX942-NEXT:  .LBB29_6:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[0:1]
+; GFX942-NEXT:  .LBB29_4:
+; GFX942-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX942-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX942-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX942-NEXT:    v_add_f32_e32 v0, s14, v0
-; GFX942-NEXT:    v_mov_b32_e32 v2, s14
+; GFX942-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX942-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GFX942-NEXT:    s_mov_b64 s[0:1], exec
+; GFX942-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX942-NEXT:    v_bfrev_b32_e32 v1, 1
 ; GFX942-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX942-NEXT:    ; implicit-def: $vgpr0
-; GFX942-NEXT:  .LBB29_7: ; %ComputeLoop
+; GFX942-NEXT:  .LBB29_5: ; %ComputeLoop
 ; GFX942-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX942-NEXT:    s_ff1_i32_b64 s7, s[0:1]
-; GFX942-NEXT:    v_readlane_b32 s14, v2, s7
-; GFX942-NEXT:    v_readfirstlane_b32 s15, v1
-; GFX942-NEXT:    s_mov_b32 m0, s7
-; GFX942-NEXT:    v_add_f32_e32 v1, s14, v1
-; GFX942-NEXT:    v_writelane_b32 v0, s15, m0
-; GFX942-NEXT:    s_lshl_b64 s[14:15], 1, s7
-; GFX942-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[14:15]
-; GFX942-NEXT:    s_cbranch_scc1 .LBB29_7
-; GFX942-NEXT:  ; %bb.8: ; %ComputeEnd
+; GFX942-NEXT:    s_ff1_i32_b64 s3, s[8:9]
+; GFX942-NEXT:    v_readlane_b32 s10, v2, s3
+; GFX942-NEXT:    v_readfirstlane_b32 s11, v1
+; GFX942-NEXT:    s_mov_b32 m0, s3
+; GFX942-NEXT:    v_add_f32_e32 v1, s10, v1
+; GFX942-NEXT:    v_writelane_b32 v0, s11, m0
+; GFX942-NEXT:    s_lshl_b64 s[10:11], 1, s3
+; GFX942-NEXT:    s_andn2_b64 s[8:9], s[8:9], s[10:11]
+; GFX942-NEXT:    s_cbranch_scc1 .LBB29_5
+; GFX942-NEXT:  ; %bb.6: ; %ComputeEnd
 ; GFX942-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX942-NEXT:    v_mbcnt_hi_u32_b32 v2, exec_hi, v2
 ; GFX942-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    s_or_b64 s[12:13], s[12:13], vcc
-; GFX942-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX942-NEXT:    s_or_b64 s[8:9], s[8:9], s[0:1]
-; GFX942-NEXT:    s_xor_b64 s[0:1], exec, s[12:13]
-; GFX942-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX942-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
+; GFX942-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; GFX942-NEXT:    s_and_b64 s[8:9], s[8:9], exec
 ; GFX942-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
-; GFX942-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
-; GFX942-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX942-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX942-NEXT:    ; implicit-def: $vgpr3
+; GFX942-NEXT:    s_mov_b64 exec, s[6:7]
 ; GFX942-NEXT:    ; divergent control-flow edge
-; GFX942-NEXT:    s_cbranch_execz .LBB29_10
-; GFX942-NEXT:  .LBB29_9:
-; GFX942-NEXT:    v_mov_b32_e32 v3, s6
-; GFX942-NEXT:    ds_add_rtn_f32 v1, v3, v1
-; GFX942-NEXT:  .LBB29_10:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[10:11]
-; GFX942-NEXT:    s_xor_b64 s[0:1], exec, s[8:9]
-; GFX942-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX942-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
-; GFX942-NEXT:    s_mov_b64 exec, s[8:9]
-; GFX942-NEXT:    ; divergent control-flow edge
-; GFX942-NEXT:    s_cbranch_execz .LBB29_12
-; GFX942-NEXT:  .LBB29_11:
-; GFX942-NEXT:    ; implicit-def: $vgpr1
-; GFX942-NEXT:  .LBB29_12:
-; GFX942-NEXT:    s_or_b64 exec, exec, s[2:3]
+; GFX942-NEXT:    s_cbranch_execz .LBB29_8
+; GFX942-NEXT:  .LBB29_7:
+; GFX942-NEXT:    v_mov_b32_e32 v3, s2
+; GFX942-NEXT:    ds_add_rtn_f32 v3, v3, v1
+; GFX942-NEXT:  .LBB29_8:
+; GFX942-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX942-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x0
 ; GFX942-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX942-NEXT:    v_readfirstlane_b32 s2, v1
+; GFX942-NEXT:    v_readfirstlane_b32 s2, v3
 ; GFX942-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX942-NEXT:    v_mov_b32_e32 v3, 0
+; GFX942-NEXT:    v_mov_b32_e32 v1, 0
 ; GFX942-NEXT:    v_add_f32_e32 v0, s2, v0
-; GFX942-NEXT:    v_mov_b32_e32 v1, s2
-; GFX942-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX942-NEXT:    global_store_dword v3, v0, s[0:1]
+; GFX942-NEXT:    v_mov_b32_e32 v3, s2
+; GFX942-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
+; GFX942-NEXT:    global_store_dword v1, v0, s[0:1]
 ; GFX942-NEXT:    s_endpgm
 ;
 ; GFX11-LABEL: local_ds_fadd_one_as:
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_load_b64 s[2:3], s[4:5], 0x8
-; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
+; GFX11-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX11-NEXT:    s_mov_b32 s1, 0
+; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v0, s6, 0
 ; GFX11-NEXT:    ; implicit-def: $vgpr2
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
 ; GFX11-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
 ; GFX11-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    s_add_i32 s3, s3, 4
-; GFX11-NEXT:    s_xor_b32 s7, s0, exec_lo
+; GFX11-NEXT:    s_xor_b32 s8, s0, exec_lo
 ; GFX11-NEXT:    s_mov_b32 s0, 0
-; GFX11-NEXT:    s_xor_b32 s6, exec_lo, s7
-; GFX11-NEXT:    s_mov_b32 exec_lo, s7
+; GFX11-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX11-NEXT:    s_mov_b32 exec_lo, s8
 ; GFX11-NEXT:    ; divergent control-flow edge
 ; GFX11-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX11-NEXT:  .LBB29_1:
-; GFX11-NEXT:    s_bcnt1_i32_b32 s7, exec_lo
+; GFX11-NEXT:    s_bcnt1_i32_b32 s6, s6
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1)
-; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v1, s7
-; GFX11-NEXT:    s_lshl_b32 s7, s3, 3
+; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v1, s6
+; GFX11-NEXT:    s_lshl_b32 s6, s3, 3
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    v_dual_mov_b32 v2, s7 :: v_dual_mul_f32 v1, 0x42280000, v1
+; GFX11-NEXT:    v_dual_mov_b32 v2, s6 :: v_dual_mul_f32 v1, 0x42280000, v1
 ; GFX11-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX11-NEXT:  .LBB29_2:
-; GFX11-NEXT:    s_or_b32 exec_lo, exec_lo, s6
-; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_3)
-; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+; GFX11-NEXT:    s_or_b32 exec_lo, exec_lo, s7
+; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(VALU_DEP_2)
+; GFX11-NEXT:    s_mov_b32 s8, exec_lo
 ; GFX11-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc_lo
+; GFX11-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
 ; GFX11-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX11-NEXT:    v_readfirstlane_b32 s6, v2
 ; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
-; GFX11-NEXT:    s_xor_b32 s8, vcc_lo, exec_lo
+; GFX11-NEXT:    s_xor_b32 s9, vcc_lo, exec_lo
 ; GFX11-NEXT:    s_delay_alu instid0(SALU_CYCLE_1) | instskip(NEXT) | instid1(SALU_CYCLE_1)
-; GFX11-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX11-NEXT:    s_xor_b32 s7, exec_lo, s9
 ; GFX11-NEXT:    s_and_b32 s7, s7, exec_lo
-; GFX11-NEXT:    s_mov_b32 exec_lo, s8
+; GFX11-NEXT:    s_mov_b32 exec_lo, s9
 ; GFX11-NEXT:    ; divergent control-flow edge
 ; GFX11-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX11-NEXT:  .LBB29_3:
-; GFX11-NEXT:    s_bcnt1_i32_b32 s8, exec_lo
+; GFX11-NEXT:    s_bcnt1_i32_b32 s8, s8
 ; GFX11-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX11-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_1)
@@ -10776,42 +10743,44 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX10-LABEL: local_ds_fadd_one_as:
 ; GFX10:       ; %bb.0:
 ; GFX10-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
-; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
+; GFX10-NEXT:    s_mov_b32 s6, exec_lo
 ; GFX10-NEXT:    s_mov_b32 s1, 0
+; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v0, s6, 0
 ; GFX10-NEXT:    ; implicit-def: $vgpr2
 ; GFX10-NEXT:    v_cmp_ne_u32_e64 s0, 0, v0
 ; GFX10-NEXT:    v_cmp_eq_u32_e32 vcc_lo, 0, v0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    s_add_i32 s3, s3, 4
-; GFX10-NEXT:    s_xor_b32 s7, s0, exec_lo
+; GFX10-NEXT:    s_xor_b32 s8, s0, exec_lo
 ; GFX10-NEXT:    s_mov_b32 s0, 0
-; GFX10-NEXT:    s_xor_b32 s6, exec_lo, s7
-; GFX10-NEXT:    s_mov_b32 exec_lo, s7
+; GFX10-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX10-NEXT:    s_mov_b32 exec_lo, s8
 ; GFX10-NEXT:    ; divergent control-flow edge
 ; GFX10-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX10-NEXT:  .LBB29_1:
-; GFX10-NEXT:    s_bcnt1_i32_b32 s7, exec_lo
-; GFX10-NEXT:    v_cvt_f32_ubyte0_e32 v1, s7
-; GFX10-NEXT:    s_lshl_b32 s7, s3, 3
-; GFX10-NEXT:    v_mov_b32_e32 v2, s7
+; GFX10-NEXT:    s_bcnt1_i32_b32 s6, s6
+; GFX10-NEXT:    v_cvt_f32_ubyte0_e32 v1, s6
+; GFX10-NEXT:    s_lshl_b32 s6, s3, 3
+; GFX10-NEXT:    v_mov_b32_e32 v2, s6
 ; GFX10-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
 ; GFX10-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX10-NEXT:  .LBB29_2:
 ; GFX10-NEXT:    s_waitcnt_depctr depctr_vm_vsrc(0)
-; GFX10-NEXT:    s_or_b32 exec_lo, exec_lo, s6
-; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
+; GFX10-NEXT:    s_or_b32 exec_lo, exec_lo, s7
+; GFX10-NEXT:    s_mov_b32 s8, exec_lo
 ; GFX10-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc_lo
+; GFX10-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
 ; GFX10-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX10-NEXT:    v_readfirstlane_b32 s6, v2
 ; GFX10-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v3
-; GFX10-NEXT:    s_xor_b32 s8, vcc_lo, exec_lo
-; GFX10-NEXT:    s_xor_b32 s7, exec_lo, s8
+; GFX10-NEXT:    s_xor_b32 s9, vcc_lo, exec_lo
+; GFX10-NEXT:    s_xor_b32 s7, exec_lo, s9
 ; GFX10-NEXT:    s_and_b32 s7, s7, exec_lo
-; GFX10-NEXT:    s_mov_b32 exec_lo, s8
+; GFX10-NEXT:    s_mov_b32 exec_lo, s9
 ; GFX10-NEXT:    ; divergent control-flow edge
 ; GFX10-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX10-NEXT:  .LBB29_3:
-; GFX10-NEXT:    s_bcnt1_i32_b32 s8, exec_lo
+; GFX10-NEXT:    s_bcnt1_i32_b32 s8, s8
 ; GFX10-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX10-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX10-NEXT:    v_mov_b32_e32 v3, s3
@@ -10869,172 +10838,155 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ;
 ; GFX90A-LABEL: local_ds_fadd_one_as:
 ; GFX90A:       ; %bb.0:
-; GFX90A-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x8
-; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX90A-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
+; GFX90A-NEXT:    s_mov_b64 s[8:9], exec
+; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX90A-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    s_add_i32 s7, s7, 4
-; GFX90A-NEXT:    s_xor_b64 s[16:17], s[0:1], exec
-; GFX90A-NEXT:    s_mov_b64 s[12:13], 0
-; GFX90A-NEXT:    s_mov_b64 s[8:9], 0
-; GFX90A-NEXT:    s_xor_b64 s[14:15], exec, s[16:17]
-; GFX90A-NEXT:    s_mov_b64 s[10:11], 0
-; GFX90A-NEXT:    s_mov_b64 s[2:3], 0
-; GFX90A-NEXT:    s_mov_b64 exec, s[16:17]
+; GFX90A-NEXT:    s_add_i32 s3, s3, 4
+; GFX90A-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
+; GFX90A-NEXT:    s_mov_b64 s[6:7], 0
+; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
+; GFX90A-NEXT:    s_mov_b64 s[0:1], 0
+; GFX90A-NEXT:    ; implicit-def: $vgpr2
+; GFX90A-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX90A-NEXT:  .LBB29_1:
-; GFX90A-NEXT:    s_bcnt1_i32_b64 s17, exec
-; GFX90A-NEXT:    s_lshl_b32 s16, s7, 3
-; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v1, s17
+; GFX90A-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX90A-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX90A-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX90A-NEXT:    v_mov_b32_e32 v2, s16
+; GFX90A-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX90A-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX90A-NEXT:  .LBB29_2:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX90A-NEXT:    s_xor_b64 s[14:15], exec, s[0:1]
-; GFX90A-NEXT:    s_and_b64 s[14:15], s[14:15], exec
-; GFX90A-NEXT:    s_mov_b64 exec, s[0:1]
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX90A-NEXT:    s_mov_b64 s[8:9], exec
+; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
+; GFX90A-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
+; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX90A-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX90A-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
+; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
+; GFX90A-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX90A-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX90A-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX90A-NEXT:    ; divergent control-flow edge
 ; GFX90A-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX90A-NEXT:  .LBB29_3:
-; GFX90A-NEXT:    ; implicit-def: $vgpr2
-; GFX90A-NEXT:  .LBB29_4:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
-; GFX90A-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
-; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX90A-NEXT:    s_xor_b64 s[16:17], vcc, exec
-; GFX90A-NEXT:    s_xor_b64 s[0:1], exec, s[16:17]
-; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    v_readfirstlane_b32 s14, v2
-; GFX90A-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX90A-NEXT:    s_mov_b64 exec, s[16:17]
-; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB29_6
-; GFX90A-NEXT:  .LBB29_5:
-; GFX90A-NEXT:    s_bcnt1_i32_b64 s15, exec
-; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v2, s15
-; GFX90A-NEXT:    s_lshl_b32 s7, s7, 4
+; GFX90A-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
+; GFX90A-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX90A-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, s7
+; GFX90A-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX90A-NEXT:    ds_add_f32 v3, v2
-; GFX90A-NEXT:  .LBB29_6:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[0:1]
+; GFX90A-NEXT:  .LBB29_4:
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX90A-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX90A-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX90A-NEXT:    v_add_f32_e32 v0, s14, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v2, s14
+; GFX90A-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX90A-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
-; GFX90A-NEXT:    s_mov_b64 s[0:1], exec
+; GFX90A-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
 ; GFX90A-NEXT:    v_bfrev_b32_e32 v1, 1
 ; GFX90A-NEXT:    ; implicit-def: $vgpr0
-; GFX90A-NEXT:  .LBB29_7: ; %ComputeLoop
+; GFX90A-NEXT:  .LBB29_5: ; %ComputeLoop
 ; GFX90A-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GFX90A-NEXT:    s_ff1_i32_b64 s7, s[0:1]
-; GFX90A-NEXT:    v_readlane_b32 s14, v2, s7
-; GFX90A-NEXT:    v_readfirstlane_b32 s15, v1
-; GFX90A-NEXT:    s_mov_b32 m0, s7
-; GFX90A-NEXT:    v_writelane_b32 v0, s15, m0
-; GFX90A-NEXT:    v_add_f32_e32 v1, s14, v1
-; GFX90A-NEXT:    s_lshl_b64 s[14:15], 1, s7
-; GFX90A-NEXT:    s_andn2_b64 s[0:1], s[0:1], s[14:15]
-; GFX90A-NEXT:    s_cbranch_scc1 .LBB29_7
-; GFX90A-NEXT:  ; %bb.8: ; %ComputeEnd
+; GFX90A-NEXT:    s_ff1_i32_b64 s3, s[8:9]
+; GFX90A-NEXT:    v_readlane_b32 s10, v2, s3
+; GFX90A-NEXT:    v_readfirstlane_b32 s11, v1
+; GFX90A-NEXT:    s_mov_b32 m0, s3
+; GFX90A-NEXT:    v_writelane_b32 v0, s11, m0
+; GFX90A-NEXT:    v_add_f32_e32 v1, s10, v1
+; GFX90A-NEXT:    s_lshl_b64 s[10:11], 1, s3
+; GFX90A-NEXT:    s_andn2_b64 s[8:9], s[8:9], s[10:11]
+; GFX90A-NEXT:    s_cbranch_scc1 .LBB29_5
+; GFX90A-NEXT:  ; %bb.6: ; %ComputeEnd
 ; GFX90A-NEXT:    v_mbcnt_lo_u32_b32 v2, exec_lo, 0
 ; GFX90A-NEXT:    v_mbcnt_hi_u32_b32 v2, exec_hi, v2
 ; GFX90A-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v2
-; GFX90A-NEXT:    s_or_b64 s[12:13], s[12:13], vcc
-; GFX90A-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX90A-NEXT:    s_or_b64 s[8:9], s[8:9], s[0:1]
-; GFX90A-NEXT:    s_xor_b64 s[0:1], exec, s[12:13]
-; GFX90A-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX90A-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
+; GFX90A-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; GFX90A-NEXT:    s_and_b64 s[8:9], s[8:9], exec
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, -1, vcc
-; GFX90A-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
-; GFX90A-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX90A-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
+; GFX90A-NEXT:    ; implicit-def: $vgpr3
+; GFX90A-NEXT:    s_mov_b64 exec, s[6:7]
 ; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB29_10
-; GFX90A-NEXT:  .LBB29_9:
-; GFX90A-NEXT:    v_mov_b32_e32 v3, s6
-; GFX90A-NEXT:    ds_add_rtn_f32 v1, v3, v1
-; GFX90A-NEXT:  .LBB29_10:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[10:11]
-; GFX90A-NEXT:    s_xor_b64 s[0:1], exec, s[8:9]
-; GFX90A-NEXT:    s_and_b64 s[0:1], s[0:1], exec
-; GFX90A-NEXT:    s_or_b64 s[2:3], s[2:3], s[0:1]
-; GFX90A-NEXT:    s_mov_b64 exec, s[8:9]
-; GFX90A-NEXT:    ; divergent control-flow edge
-; GFX90A-NEXT:    s_cbranch_execz .LBB29_12
-; GFX90A-NEXT:  .LBB29_11:
-; GFX90A-NEXT:    ; implicit-def: $vgpr1
-; GFX90A-NEXT:  .LBB29_12:
-; GFX90A-NEXT:    s_or_b64 exec, exec, s[2:3]
+; GFX90A-NEXT:    s_cbranch_execz .LBB29_8
+; GFX90A-NEXT:  .LBB29_7:
+; GFX90A-NEXT:    v_mov_b32_e32 v3, s2
+; GFX90A-NEXT:    ds_add_rtn_f32 v3, v3, v1
+; GFX90A-NEXT:  .LBB29_8:
+; GFX90A-NEXT:    s_or_b64 exec, exec, s[0:1]
 ; GFX90A-NEXT:    s_load_dwordx2 s[0:1], s[4:5], 0x0
 ; GFX90A-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX90A-NEXT:    v_readfirstlane_b32 s2, v1
+; GFX90A-NEXT:    v_readfirstlane_b32 s2, v3
 ; GFX90A-NEXT:    v_add_f32_e32 v0, s2, v0
-; GFX90A-NEXT:    v_mov_b32_e32 v1, s2
+; GFX90A-NEXT:    v_mov_b32_e32 v3, s2
 ; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; GFX90A-NEXT:    v_mov_b32_e32 v3, 0
-; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v0, v1, vcc
-; GFX90A-NEXT:    global_store_dword v3, v0, s[0:1]
+; GFX90A-NEXT:    v_mov_b32_e32 v1, 0
+; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v0, v3, vcc
+; GFX90A-NEXT:    global_store_dword v1, v0, s[0:1]
 ; GFX90A-NEXT:    s_endpgm
 ;
 ; GFX908-LABEL: local_ds_fadd_one_as:
 ; GFX908:       ; %bb.0:
 ; GFX908-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
-; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX908-NEXT:    s_mov_b64 s[8:9], exec
+; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX908-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX908-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX908-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX908-NEXT:    s_add_i32 s3, s3, 4
-; GFX908-NEXT:    s_xor_b64 s[10:11], s[0:1], exec
+; GFX908-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX908-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX908-NEXT:    s_mov_b64 s[6:7], 0
-; GFX908-NEXT:    s_xor_b64 s[8:9], exec, s[10:11]
+; GFX908-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
 ; GFX908-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX908-NEXT:    ; implicit-def: $vgpr2
-; GFX908-NEXT:    s_mov_b64 exec, s[10:11]
+; GFX908-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX908-NEXT:    ; divergent control-flow edge
 ; GFX908-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX908-NEXT:  .LBB29_1:
-; GFX908-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX908-NEXT:    s_lshl_b32 s10, s3, 3
-; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v1, s11
+; GFX908-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX908-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX908-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX908-NEXT:    v_mov_b32_e32 v2, s10
+; GFX908-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX908-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX908-NEXT:  .LBB29_2:
-; GFX908-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
+; GFX908-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX908-NEXT:    s_mov_b64 s[8:9], exec
+; GFX908-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX908-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
 ; GFX908-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX908-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX908-NEXT:    s_xor_b64 s[12:13], vcc, exec
-; GFX908-NEXT:    s_xor_b64 s[8:9], exec, s[12:13]
+; GFX908-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX908-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
 ; GFX908-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX908-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX908-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX908-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX908-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX908-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX908-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX908-NEXT:    ; divergent control-flow edge
 ; GFX908-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX908-NEXT:  .LBB29_3:
-; GFX908-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v2, s11
+; GFX908-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX908-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX908-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
 ; GFX908-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX908-NEXT:    ds_add_f32 v3, v2
 ; GFX908-NEXT:  .LBB29_4:
-; GFX908-NEXT:    s_or_b64 exec, exec, s[8:9]
+; GFX908-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX908-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX908-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX908-NEXT:    v_add_f32_e32 v0, s10, v0
-; GFX908-NEXT:    v_mov_b32_e32 v2, s10
+; GFX908-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX908-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX908-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; GFX908-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX908-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
@@ -11083,55 +11035,57 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX8-LABEL: local_ds_fadd_one_as:
 ; GFX8:       ; %bb.0:
 ; GFX8-NEXT:    s_load_dwordx2 s[2:3], s[4:5], 0x8
-; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v0, exec_lo, 0
-; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v0, exec_hi, v0
+; GFX8-NEXT:    s_mov_b64 s[8:9], exec
+; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v0, s8, 0
+; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v0, s9, v0
 ; GFX8-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX8-NEXT:    s_add_i32 s3, s3, 4
-; GFX8-NEXT:    s_xor_b64 s[10:11], s[0:1], exec
+; GFX8-NEXT:    s_xor_b64 s[12:13], s[0:1], exec
+; GFX8-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX8-NEXT:    s_mov_b64 s[6:7], 0
-; GFX8-NEXT:    s_xor_b64 s[8:9], exec, s[10:11]
+; GFX8-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
 ; GFX8-NEXT:    s_mov_b64 s[0:1], 0
 ; GFX8-NEXT:    ; implicit-def: $vgpr2
 ; GFX8-NEXT:    s_mov_b32 m0, -1
-; GFX8-NEXT:    s_mov_b64 exec, s[10:11]
+; GFX8-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX8-NEXT:    ; divergent control-flow edge
 ; GFX8-NEXT:    s_cbranch_execz .LBB29_2
 ; GFX8-NEXT:  .LBB29_1:
-; GFX8-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX8-NEXT:    s_lshl_b32 s10, s3, 3
-; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v1, s11
+; GFX8-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX8-NEXT:    s_lshl_b32 s12, s3, 3
+; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v1, s8
 ; GFX8-NEXT:    v_mul_f32_e32 v1, 0x42280000, v1
-; GFX8-NEXT:    v_mov_b32_e32 v2, s10
+; GFX8-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX8-NEXT:    ds_add_rtn_f32 v2, v2, v1
 ; GFX8-NEXT:  .LBB29_2:
-; GFX8-NEXT:    s_or_b64 exec, exec, s[8:9]
-; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v3, exec_lo, 0
-; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v3, exec_hi, v3
+; GFX8-NEXT:    s_or_b64 exec, exec, s[10:11]
+; GFX8-NEXT:    s_mov_b64 s[8:9], exec
+; GFX8-NEXT:    v_mbcnt_lo_u32_b32 v3, s8, 0
+; GFX8-NEXT:    v_mbcnt_hi_u32_b32 v3, s9, v3
 ; GFX8-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX8-NEXT:    s_xor_b64 s[12:13], vcc, exec
-; GFX8-NEXT:    s_xor_b64 s[8:9], exec, s[12:13]
+; GFX8-NEXT:    s_xor_b64 s[14:15], vcc, exec
+; GFX8-NEXT:    s_xor_b64 s[10:11], exec, s[14:15]
 ; GFX8-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX8-NEXT:    v_readfirstlane_b32 s10, v2
-; GFX8-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GFX8-NEXT:    s_mov_b64 exec, s[12:13]
+; GFX8-NEXT:    v_readfirstlane_b32 s12, v2
+; GFX8-NEXT:    s_and_b64 s[10:11], s[10:11], exec
+; GFX8-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX8-NEXT:    ; divergent control-flow edge
 ; GFX8-NEXT:    s_cbranch_execz .LBB29_4
 ; GFX8-NEXT:  .LBB29_3:
-; GFX8-NEXT:    s_bcnt1_i32_b64 s11, exec
-; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v2, s11
+; GFX8-NEXT:    s_bcnt1_i32_b64 s8, s[8:9]
+; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v2, s8
 ; GFX8-NEXT:    s_lshl_b32 s3, s3, 4
 ; GFX8-NEXT:    v_mul_f32_e32 v2, 0x42280000, v2
 ; GFX8-NEXT:    v_mov_b32_e32 v3, s3
 ; GFX8-NEXT:    ds_add_f32 v3, v2
 ; GFX8-NEXT:  .LBB29_4:
-; GFX8-NEXT:    s_or_b64 exec, exec, s[8:9]
+; GFX8-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GFX8-NEXT:    v_cvt_f32_ubyte0_e32 v0, v0
 ; GFX8-NEXT:    v_mul_f32_e32 v0, 0x42280000, v0
-; GFX8-NEXT:    v_add_f32_e32 v0, s10, v0
-; GFX8-NEXT:    v_mov_b32_e32 v2, s10
+; GFX8-NEXT:    v_add_f32_e32 v0, s12, v0
+; GFX8-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX8-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; GFX8-NEXT:    s_mov_b64 s[8:9], exec
 ; GFX8-NEXT:    v_cndmask_b32_e32 v2, v0, v2, vcc
@@ -11182,13 +11136,14 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX7-LABEL: local_ds_fadd_one_as:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_load_dwordx2 s[6:7], s[4:5], 0x2
-; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, exec_lo, 0
-; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, exec_hi, v0
+; GFX7-NEXT:    s_mov_b64 s[18:19], exec
+; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, s18, 0
+; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, s19, v0
 ; GFX7-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX7-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX7-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX7-NEXT:    s_add_i32 s7, s7, 4
 ; GFX7-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
+; GFX7-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX7-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX7-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX7-NEXT:    s_mov_b64 s[8:9], -1
@@ -11206,7 +11161,7 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX7-NEXT:    s_lshl_b32 s0, s7, 3
 ; GFX7-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX7-NEXT:    ds_read_b32 v2, v1
-; GFX7-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX7-NEXT:    s_bcnt1_i32_b64 s0, s[18:19]
 ; GFX7-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX7-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX7-NEXT:    s_and_b64 s[0:1], s[8:9], exec
@@ -11227,24 +11182,25 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX7-NEXT:    s_cbranch_execnz .LBB29_2
 ; GFX7-NEXT:  .LBB29_3:
 ; GFX7-NEXT:    s_or_b64 exec, exec, s[16:17]
-; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, exec_lo, 0
-; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, exec_hi, v3
+; GFX7-NEXT:    s_mov_b64 s[0:1], exec
+; GFX7-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, s0, 0
+; GFX7-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, s1, v3
 ; GFX7-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX7-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX7-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX7-NEXT:    s_or_b64 s[14:15], s[14:15], s[0:1]
-; GFX7-NEXT:    s_xor_b64 s[0:1], exec, s[14:15]
-; GFX7-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX7-NEXT:    s_xor_b64 s[18:19], vcc, exec
+; GFX7-NEXT:    s_or_b64 s[14:15], s[14:15], s[18:19]
+; GFX7-NEXT:    s_xor_b64 s[18:19], exec, s[14:15]
+; GFX7-NEXT:    s_and_b64 s[18:19], s[18:19], exec
 ; GFX7-NEXT:    v_readfirstlane_b32 s16, v2
-; GFX7-NEXT:    s_or_b64 s[12:13], s[12:13], s[0:1]
+; GFX7-NEXT:    s_or_b64 s[12:13], s[12:13], s[18:19]
 ; GFX7-NEXT:    s_mov_b64 exec, s[14:15]
 ; GFX7-NEXT:    ; divergent control-flow edge
 ; GFX7-NEXT:    s_cbranch_execz .LBB29_6
 ; GFX7-NEXT:  .LBB29_4:
-; GFX7-NEXT:    s_lshl_b32 s0, s7, 4
-; GFX7-NEXT:    v_mov_b32_e32 v2, s0
+; GFX7-NEXT:    s_lshl_b32 s7, s7, 4
+; GFX7-NEXT:    v_mov_b32_e32 v2, s7
 ; GFX7-NEXT:    ds_read_b32 v4, v2
-; GFX7-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX7-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
 ; GFX7-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX7-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX7-NEXT:    s_and_b64 s[0:1], s[8:9], exec
@@ -11336,14 +11292,15 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ;
 ; GFX6-LABEL: local_ds_fadd_one_as:
 ; GFX6:       ; %bb.0:
-; GFX6-NEXT:    s_load_dword s16, s[4:5], 0x3
-; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, exec_lo, 0
-; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, exec_hi, v0
+; GFX6-NEXT:    s_load_dword s18, s[4:5], 0x3
+; GFX6-NEXT:    s_mov_b64 s[16:17], exec
+; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v0, s16, 0
+; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v0, s17, v0
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v0
-; GFX6-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX6-NEXT:    s_waitcnt lgkmcnt(0)
-; GFX6-NEXT:    s_add_i32 s16, s16, 4
+; GFX6-NEXT:    s_add_i32 s18, s18, 4
 ; GFX6-NEXT:    s_xor_b64 s[0:1], s[0:1], exec
+; GFX6-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX6-NEXT:    s_mov_b64 s[2:3], 0
 ; GFX6-NEXT:    v_cmp_eq_u32_e32 vcc, 0, v0
 ; GFX6-NEXT:    s_mov_b64 s[6:7], -1
@@ -11358,10 +11315,10 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX6-NEXT:    ; divergent control-flow edge
 ; GFX6-NEXT:    s_cbranch_execz .LBB29_3
 ; GFX6-NEXT:  .LBB29_1:
-; GFX6-NEXT:    s_lshl_b32 s0, s16, 3
+; GFX6-NEXT:    s_lshl_b32 s0, s18, 3
 ; GFX6-NEXT:    v_mov_b32_e32 v1, s0
 ; GFX6-NEXT:    ds_read_b32 v2, v1
-; GFX6-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX6-NEXT:    s_bcnt1_i32_b64 s0, s[16:17]
 ; GFX6-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX6-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX6-NEXT:    s_and_b64 s[0:1], s[6:7], exec
@@ -11375,32 +11332,33 @@ define amdgpu_kernel void @local_ds_fadd_one_as(ptr addrspace(1) %out, ptr addrs
 ; GFX6-NEXT:    v_cmp_eq_u32_e64 s[0:1], v2, v4
 ; GFX6-NEXT:    v_cndmask_b32_e64 v4, 0, 1, s[0:1]
 ; GFX6-NEXT:    v_cmp_ne_u32_e64 s[0:1], 1, v4
-; GFX6-NEXT:    s_xor_b64 s[18:19], exec, s[0:1]
-; GFX6-NEXT:    s_or_b64 s[14:15], s[14:15], s[18:19]
+; GFX6-NEXT:    s_xor_b64 s[16:17], exec, s[0:1]
+; GFX6-NEXT:    s_or_b64 s[14:15], s[14:15], s[16:17]
 ; GFX6-NEXT:    s_mov_b64 exec, s[0:1]
 ; GFX6-NEXT:    ; divergent control-flow edge
 ; GFX6-NEXT:    s_cbranch_execnz .LBB29_2
 ; GFX6-NEXT:  .LBB29_3:
 ; GFX6-NEXT:    s_or_b64 exec, exec, s[14:15]
-; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, exec_lo, 0
-; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, exec_hi, v3
+; GFX6-NEXT:    s_mov_b64 s[0:1], exec
+; GFX6-NEXT:    v_mbcnt_lo_u32_b32_e64 v3, s0, 0
+; GFX6-NEXT:    v_mbcnt_hi_u32_b32_e32 v3, s1, v3
 ; GFX6-NEXT:    v_cndmask_b32_e64 v1, 0, -1, vcc
 ; GFX6-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; GFX6-NEXT:    s_load_dword s14, s[4:5], 0x2
-; GFX6-NEXT:    s_xor_b64 s[0:1], vcc, exec
-; GFX6-NEXT:    s_or_b64 s[12:13], s[12:13], s[0:1]
-; GFX6-NEXT:    s_xor_b64 s[0:1], exec, s[12:13]
-; GFX6-NEXT:    s_and_b64 s[0:1], s[0:1], exec
+; GFX6-NEXT:    s_xor_b64 s[16:17], vcc, exec
+; GFX6-NEXT:    s_or_b64 s[12:13], s[12:13], s[16:17]
+; GFX6-NEXT:    s_xor_b64 s[16:17], exec, s[12:13]
+; GFX6-NEXT:    s_and_b64 s[16:17], s[16:17], exec
 ; GFX6-NEXT:    v_readfirstlane_b32 s15, v2
-; GFX6-NEXT:    s_or_b64 s[10:11], s[10:11], s[0:1]
+; GFX6-NEXT:    s_or_b64 s[10:11], s[10:11], s[16:17]
 ; GFX6-NEXT:    s_mov_b64 exec, s[12:13]
 ; GFX6-NEXT:    ; divergent control-flow edge
 ; GFX6-NEXT:    s_cbranch_execz .LBB29_6
 ; GFX6-NEXT:  .LBB29_4:
-; GFX6-NEXT:    s_lshl_b32 s0, s16, 4
-; GFX6-NEXT:    v_mov_b32_e32 v2, s0
+; GFX6-NEXT:    s_lshl_b32 s12, s18, 4
+; GFX6-NEXT:    v_mov_b32_e32 v2, s12
 ; GFX6-NEXT:    ds_read_b32 v4, v2
-; GFX6-NEXT:    s_bcnt1_i32_b64 s0, exec
+; GFX6-NEXT:    s_bcnt1_i32_b64 s0, s[0:1]
 ; GFX6-NEXT:    v_cvt_f32_ubyte0_e32 v3, s0
 ; GFX6-NEXT:    v_mul_f32_e32 v3, 0x42280000, v3
 ; GFX6-NEXT:    s_and_b64 s[0:1], s[6:7], exec

--- a/llvm/test/CodeGen/AMDGPU/mul24-pass-ordering.ll
+++ b/llvm/test/CodeGen/AMDGPU/mul24-pass-ordering.ll
@@ -57,64 +57,64 @@ define void @lsr_order_mul24_1(i32 %arg, i32 %arg1, i32 %arg2, ptr addrspace(3) 
 ; GFX9-LABEL: lsr_order_mul24_1:
 ; GFX9:       ; %bb.0: ; %bb
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX9-NEXT:    v_cmp_ge_u32_e32 vcc, v0, v1
-; GFX9-NEXT:    s_xor_b64 s[6:7], vcc, exec
+; GFX9-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v1
+; GFX9-NEXT:    v_and_b32_e32 v5, 1, v18
+; GFX9-NEXT:    s_xor_b64 s[8:9], s[4:5], exec
+; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v5
 ; GFX9-NEXT:    s_mov_b64 s[4:5], -1
-; GFX9-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
-; GFX9-NEXT:    s_mov_b64 exec, s[6:7]
+; GFX9-NEXT:    s_xor_b64 s[6:7], exec, s[8:9]
+; GFX9-NEXT:    s_mov_b64 exec, s[8:9]
 ; GFX9-NEXT:    ; divergent control-flow edge
 ; GFX9-NEXT:    s_cbranch_execz .LBB1_3
 ; GFX9-NEXT:  .LBB1_1: ; %bb19
-; GFX9-NEXT:    v_cvt_f32_u32_e32 v5, v6
-; GFX9-NEXT:    v_and_b32_e32 v7, 1, v18
-; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v7
-; GFX9-NEXT:    v_cndmask_b32_e64 v18, 0, -1, vcc
-; GFX9-NEXT:    v_rcp_iflag_f32_e32 v5, v5
+; GFX9-NEXT:    v_cvt_f32_u32_e32 v7, v6
 ; GFX9-NEXT:    v_add_u32_e32 v4, v4, v0
+; GFX9-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
 ; GFX9-NEXT:    v_and_b32_e32 v6, 0xffffff, v6
-; GFX9-NEXT:    v_lshl_add_u32 v7, v4, 2, v3
-; GFX9-NEXT:    v_lshlrev_b32_e32 v8, 2, v2
-; GFX9-NEXT:    v_add_u32_e32 v9, v17, v12
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v18
+; GFX9-NEXT:    v_rcp_iflag_f32_e32 v7, v7
+; GFX9-NEXT:    v_lshl_add_u32 v8, v4, 2, v3
+; GFX9-NEXT:    v_lshlrev_b32_e32 v9, 2, v2
+; GFX9-NEXT:    v_add_u32_e32 v12, v17, v12
 ; GFX9-NEXT:    v_mov_b32_e32 v4, 0
 ; GFX9-NEXT:    ; implicit-def: $vgpr3
 ; GFX9-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GFX9-NEXT:  .LBB1_2: ; %bb23
 ; GFX9-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v3, v0
-; GFX9-NEXT:    v_add_u32_e32 v12, v17, v0
-; GFX9-NEXT:    v_madak_f32 v3, v3, v5, 0x3727c5ac
+; GFX9-NEXT:    v_madak_f32 v3, v3, v7, 0x3727c5ac
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, v3
 ; GFX9-NEXT:    v_mul_u32_u24_e32 v18, v3, v6
 ; GFX9-NEXT:    v_add_u32_e32 v19, v3, v16
-; GFX9-NEXT:    v_add_u32_e32 v3, v9, v0
+; GFX9-NEXT:    v_add_u32_e32 v3, v17, v0
+; GFX9-NEXT:    v_sub_u32_e32 v20, v3, v18
+; GFX9-NEXT:    v_add_u32_e32 v3, v12, v0
 ; GFX9-NEXT:    v_sub_u32_e32 v3, v3, v18
-; GFX9-NEXT:    v_sub_u32_e32 v12, v12, v18
-; GFX9-NEXT:    v_cmp_lt_u32_e64 s[4:5], v19, v13
-; GFX9-NEXT:    v_mad_u64_u32 v[18:19], s[6:7], v19, v15, v[3:4]
-; GFX9-NEXT:    v_cmp_lt_u32_e64 s[6:7], v12, v14
-; GFX9-NEXT:    s_and_b64 s[4:5], s[4:5], s[6:7]
+; GFX9-NEXT:    v_cmp_lt_u32_e32 vcc, v19, v13
+; GFX9-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v19, v15, v[3:4]
+; GFX9-NEXT:    v_cmp_lt_u32_e64 s[4:5], v20, v14
+; GFX9-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
 ; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[4:5]
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v3
-; GFX9-NEXT:    s_and_b64 s[4:5], s[4:5], vcc
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, v18, s[4:5]
+; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v5
+; GFX9-NEXT:    s_and_b64 vcc, vcc, s[4:5]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, 0, v18, vcc
 ; GFX9-NEXT:    v_lshlrev_b64 v[18:19], 2, v[3:4]
 ; GFX9-NEXT:    v_add_u32_e32 v0, v0, v2
-; GFX9-NEXT:    v_add_co_u32_e64 v18, s[6:7], v10, v18
-; GFX9-NEXT:    v_addc_co_u32_e64 v19, s[6:7], v11, v19, s[6:7]
+; GFX9-NEXT:    v_add_co_u32_e64 v18, s[4:5], v10, v18
+; GFX9-NEXT:    v_addc_co_u32_e64 v19, s[4:5], v11, v19, s[4:5]
 ; GFX9-NEXT:    global_load_dword v3, v[18:19], off
-; GFX9-NEXT:    v_cmp_lt_u32_e64 s[6:7], v0, v1
+; GFX9-NEXT:    v_cmp_lt_u32_e64 s[4:5], v0, v1
+; GFX9-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
+; GFX9-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, v3, s[4:5]
-; GFX9-NEXT:    s_xor_b64 s[4:5], exec, s[6:7]
-; GFX9-NEXT:    ds_write_b32 v7, v3
-; GFX9-NEXT:    v_add_u32_e32 v7, v7, v8
-; GFX9-NEXT:    s_or_b64 s[8:9], s[8:9], s[4:5]
-; GFX9-NEXT:    s_mov_b64 exec, s[6:7]
+; GFX9-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
+; GFX9-NEXT:    ds_write_b32 v8, v3
+; GFX9-NEXT:    v_add_u32_e32 v8, v8, v9
+; GFX9-NEXT:    s_mov_b64 exec, s[4:5]
 ; GFX9-NEXT:    ; divergent control-flow edge
 ; GFX9-NEXT:    s_cbranch_execnz .LBB1_2
 ; GFX9-NEXT:  .LBB1_3: ; %.loopexit
-; GFX9-NEXT:    s_or_b64 exec, exec, s[8:9]
+; GFX9-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 bb:

--- a/llvm/test/CodeGen/AMDGPU/ret_jump.ll
+++ b/llvm/test/CodeGen/AMDGPU/ret_jump.ll
@@ -12,11 +12,7 @@
 
 ; GCN: v_cmp_gt_f32_e32 vcc
 ; GCN: s_xor_b64 [[SAVE1:s\[[0-9]+:[0-9]+\]]], vcc, exec
-; GCN: s_xor_b64 [[SAVE2:s\[[0-9]+:[0-9]+\]]], exec, vcc
-; GCN: s_and_b64 [[SAVE2]], [[SAVE2]], exec
-; GCN: s_mov_b64 exec, vcc
-; GCN: s_or_b64 exec, exec, [[SAVE2]]
-; GCN: s_xor_b64 [[SAVE2]], exec, [[SAVE1]]
+; GCN: s_xor_b64 [[SAVE2:s\[[0-9]+:[0-9]+\]]], exec, [[SAVE1]]
 ; GCN: s_and_b64 [[SAVE2]], [[SAVE2]], exec
 ; GCN: s_mov_b64 exec, [[SAVE1]]
 ; GCN: s_cbranch_execz [[RET_BB]]
@@ -76,8 +72,8 @@ ret.bb:                                          ; preds = %else, %main_body
 ; GCN: {{buffer|flat}}_store_dword
 
 ; GCN: s_or_b64 exec, exec, [[SAVE2]]
-; GCN: s_xor_b64 [[SAVE2]], exec, [[SAVE1]]
-; GCN: s_and_b64 [[SAVE2]], [[SAVE2]], exec
+; GCN: s_xor_b64 [[SAVE3:s\[[0-9]+:[0-9]+\]]], exec, [[SAVE1]]
+; GCN: s_and_b64 [[SAVE3]], [[SAVE3]], exec
 ; GCN: s_mov_b64 exec, [[SAVE1]]
 ; GCN: s_cbranch_execz [[UNIFIED_RET:.LBB[0-9]+_[0-9]+]]
 
@@ -86,7 +82,7 @@ ret.bb:                                          ; preds = %else, %main_body
 ; GCN: ; divergent unreachable
 
 ; GCN: [[UNIFIED_RET]]: ; %UnifiedReturnBlock
-; GCN: s_or_b64 exec, exec, [[SAVE2]]
+; GCN: s_or_b64 exec, exec, [[SAVE3]]
 ; GCN: s_waitcnt
 define amdgpu_ps <{ i32, i32, i32, i32, i32, i32, i32, i32, i32, float, float, float, float, float, float, float, float, float, float, float, float, float, float }> @uniform_br_nontrivial_ret_divergent_br_nontrivial_unreachable(ptr addrspace(4) inreg %arg, ptr addrspace(4) inreg %arg1, ptr addrspace(4) inreg %arg2, ptr addrspace(4) inreg %arg3, float inreg %arg4, i32 inreg %arg5, <2 x i32> %arg6, <2 x i32> %arg7, <2 x i32> %arg8, <3 x i32> %arg9, <2 x i32> %arg10, <2 x i32> %arg11, <2 x i32> %arg12, float %arg13, float %arg14, float %arg15, float %arg16, float %arg17, i32 inreg %arg18, i32 %arg19, float %arg20, i32 %arg21) #0 {
 main_body:

--- a/llvm/test/CodeGen/AMDGPU/salu-to-valu.ll
+++ b/llvm/test/CodeGen/AMDGPU/salu-to-valu.ll
@@ -456,7 +456,7 @@ bb7:                                              ; preds = %bb3
 }
 
 ; GCN-LABEL: {{^}}phi_visit_order:
-; GCN: v_add_i32_e64 v{{[0-9]+}}, s{{\[[0-9]+:[0-9]+\]}}, 1, v{{[0-9]+}}
+; GCN: v_add_i32_e{{32|64}} v{{[0-9]+}}, {{s\[[0-9]+:[0-9]+\]|vcc}}, 1, v{{[0-9]+}}
 define amdgpu_kernel void @phi_visit_order() {
 bb:
   br label %bb1

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -386,68 +386,57 @@ define i64 @v_test_sdiv(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_xor_b32_e32 v0, v0, v10
 ; GCN-IR-NEXT:    v_ashrrev_i32_e32 v11, 31, v3
 ; GCN-IR-NEXT:    v_xor_b32_e32 v1, v1, v10
-; GCN-IR-NEXT:    v_sub_i32_e32 v4, vcc, v0, v10
-; GCN-IR-NEXT:    v_subb_u32_e32 v5, vcc, v1, v10, vcc
+; GCN-IR-NEXT:    v_sub_i32_e32 v6, vcc, v0, v10
+; GCN-IR-NEXT:    v_subb_u32_e32 v7, vcc, v1, v10, vcc
 ; GCN-IR-NEXT:    v_xor_b32_e32 v0, v2, v11
 ; GCN-IR-NEXT:    v_xor_b32_e32 v1, v3, v11
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v11
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v11, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
-; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[4:5]
+; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[6:7]
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v0
 ; GCN-IR-NEXT:    s_or_b64 s[6:7], vcc, s[4:5]
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
 ; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
-; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v4
+; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v6
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
-; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v5
+; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v7
 ; GCN-IR-NEXT:    v_min_u32_e32 v9, v2, v3
 ; GCN-IR-NEXT:    v_sub_i32_e32 v2, vcc, v8, v9
 ; GCN-IR-NEXT:    v_subb_u32_e64 v3, s[4:5], 0, 0, vcc
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 63, v[2:3]
 ; GCN-IR-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[6:7], s[4:5]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v12, v10
 ; GCN-IR-NEXT:    v_mov_b32_e32 v13, v11
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v5, v7, 0, s[6:7]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v6, 0, s[6:7]
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_8
-; GCN-IR-NEXT:  .LBB1_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB1_7
-; GCN-IR-NEXT:  .LBB1_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
+; GCN-IR-NEXT:    s_cbranch_execz .LBB1_5
+; GCN-IR-NEXT:  .LBB1_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v14, vcc, 1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    s_and_b64 s[12:13], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
-; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[4:5], v2
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_9
-; GCN-IR-NEXT:  .LBB1_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
+; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[6:7], v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB1_6
-; GCN-IR-NEXT:  .LBB1_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB1_4
+; GCN-IR-NEXT:  .LBB1_2: ; %udiv-preheader
+; GCN-IR-NEXT:    v_lshr_b64 v[6:7], v[6:7], v14
 ; GCN-IR-NEXT:    v_add_i32_e32 v14, vcc, -1, v0
-; GCN-IR-NEXT:    v_lshr_b64 v[6:7], v[4:5], v6
 ; GCN-IR-NEXT:    v_addc_u32_e32 v15, vcc, -1, v1, vcc
 ; GCN-IR-NEXT:    v_not_b32_e32 v4, v8
 ; GCN-IR-NEXT:    v_add_i32_e32 v16, vcc, v4, v9
@@ -456,7 +445,7 @@ define i64 @v_test_sdiv(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB1_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB1_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v4, 31, v3
@@ -483,29 +472,21 @@ define i64 @v_test_sdiv(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_5
-; GCN-IR-NEXT:  .LBB1_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_3
+; GCN-IR-NEXT:  .LBB1_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GCN-IR-NEXT:    v_lshl_b64 v[1:2], v[2:3], 1
-; GCN-IR-NEXT:    v_or_b32_e32 v0, v5, v2
-; GCN-IR-NEXT:    v_or_b32_e32 v1, v4, v1
-; GCN-IR-NEXT:  .LBB1_7: ; %udiv-end
+; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[2:3], 1
+; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v1
+; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v0
+; GCN-IR-NEXT:  .LBB1_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_xor_b32_e32 v2, v13, v12
-; GCN-IR-NEXT:    v_xor_b32_e32 v3, v11, v10
-; GCN-IR-NEXT:    v_xor_b32_e32 v4, v0, v2
-; GCN-IR-NEXT:    v_xor_b32_e32 v0, v1, v3
-; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v3
-; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v4, v2, vcc
+; GCN-IR-NEXT:    v_xor_b32_e32 v0, v11, v10
+; GCN-IR-NEXT:    v_xor_b32_e32 v1, v13, v12
+; GCN-IR-NEXT:    v_xor_b32_e32 v3, v4, v0
+; GCN-IR-NEXT:    v_xor_b32_e32 v2, v5, v1
+; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v3, v0
+; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v2, v1, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB1_8:
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, v5, 0, s[6:7]
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v1, v4, 0, s[6:7]
-; GCN-IR-NEXT:    s_branch .LBB1_1
-; GCN-IR-NEXT:  .LBB1_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_branch .LBB1_3
   %result = sdiv i64 %x, %y
   ret i64 %result
 }
@@ -1493,61 +1474,49 @@ define i64 @v_test_sdiv_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v0
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
-; GCN-IR-NEXT:    v_min_u32_e32 v4, v2, v3
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffc5, v4
+; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffc5, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], 63, v[2:3]
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[4:5], vcc
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, 24, 0, s[4:5]
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_8
-; GCN-IR-NEXT:  .LBB11_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB11_7
-; GCN-IR-NEXT:  .LBB11_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v5, vcc, 1, v2
+; GCN-IR-NEXT:    s_cbranch_execz .LBB11_5
+; GCN-IR-NEXT:  .LBB11_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    s_and_b64 s[12:13], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], 24, v2
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_9
-; GCN-IR-NEXT:  .LBB11_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB11_6
-; GCN-IR-NEXT:  .LBB11_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB11_4
+; GCN-IR-NEXT:  .LBB11_2: ; %udiv-preheader
 ; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, -1, v0
 ; GCN-IR-NEXT:    v_addc_u32_e32 v13, vcc, -1, v1, vcc
-; GCN-IR-NEXT:    v_lshr_b64 v[6:7], 24, v5
-; GCN-IR-NEXT:    v_sub_i32_e32 v14, vcc, 58, v4
+; GCN-IR-NEXT:    v_lshr_b64 v[6:7], 24, v6
+; GCN-IR-NEXT:    v_sub_i32_e32 v14, vcc, 58, v8
 ; GCN-IR-NEXT:    v_subb_u32_e64 v15, s[10:11], 0, 0, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB11_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB11_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v4, 31, v3
@@ -1574,26 +1543,19 @@ define i64 @v_test_sdiv_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_5
-; GCN-IR-NEXT:  .LBB11_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_3
+; GCN-IR-NEXT:  .LBB11_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[2:3], 1
 ; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v1
-; GCN-IR-NEXT:    v_or_b32_e32 v0, v4, v0
-; GCN-IR-NEXT:  .LBB11_7: ; %udiv-end
+; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v0
+; GCN-IR-NEXT:  .LBB11_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_xor_b32_e32 v0, v0, v10
+; GCN-IR-NEXT:    v_xor_b32_e32 v0, v4, v10
 ; GCN-IR-NEXT:    v_xor_b32_e32 v1, v5, v11
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v10
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v11, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB11_8:
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, 24, 0, s[10:11]
-; GCN-IR-NEXT:    s_branch .LBB11_1
-; GCN-IR-NEXT:  .LBB11_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_branch .LBB11_3
   %result = sdiv i64 24, %x
   ret i64 %result
 }
@@ -1713,62 +1675,51 @@ define i64 @v_test_sdiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v0
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
-; GCN-IR-NEXT:    v_min_u32_e32 v4, v2, v3
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffd0, v4
+; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffd0, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], 63, v[2:3]
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[4:5], vcc
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0x8000
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_8
-; GCN-IR-NEXT:  .LBB12_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB12_7
-; GCN-IR-NEXT:  .LBB12_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v5, vcc, 1, v2
+; GCN-IR-NEXT:    s_cbranch_execz .LBB12_5
+; GCN-IR-NEXT:  .LBB12_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    s_and_b64 s[14:15], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_mov_b64 s[10:11], 0x8000
 ; GCN-IR-NEXT:    s_and_b64 s[12:13], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], s[10:11], v2
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[14:15]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[14:15]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_9
-; GCN-IR-NEXT:  .LBB12_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB12_6
-; GCN-IR-NEXT:  .LBB12_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB12_4
+; GCN-IR-NEXT:  .LBB12_2: ; %udiv-preheader
 ; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, -1, v0
 ; GCN-IR-NEXT:    v_addc_u32_e32 v13, vcc, -1, v1, vcc
-; GCN-IR-NEXT:    v_lshr_b64 v[6:7], s[10:11], v5
-; GCN-IR-NEXT:    v_sub_i32_e32 v14, vcc, 47, v4
+; GCN-IR-NEXT:    v_lshr_b64 v[6:7], s[10:11], v6
+; GCN-IR-NEXT:    v_sub_i32_e32 v14, vcc, 47, v8
 ; GCN-IR-NEXT:    v_subb_u32_e64 v15, s[10:11], 0, 0, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB12_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB12_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v4, 31, v3
@@ -1795,27 +1746,19 @@ define i64 @v_test_sdiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_5
-; GCN-IR-NEXT:  .LBB12_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_3
+; GCN-IR-NEXT:  .LBB12_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[2:3], 1
 ; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v1
-; GCN-IR-NEXT:    v_or_b32_e32 v0, v4, v0
-; GCN-IR-NEXT:  .LBB12_7: ; %udiv-end
+; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v0
+; GCN-IR-NEXT:  .LBB12_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_xor_b32_e32 v0, v0, v10
+; GCN-IR-NEXT:    v_xor_b32_e32 v0, v4, v10
 ; GCN-IR-NEXT:    v_xor_b32_e32 v1, v5, v11
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v10
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v11, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB12_8:
-; GCN-IR-NEXT:    v_mov_b32_e32 v0, 0x8000
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, v0, 0, s[10:11]
-; GCN-IR-NEXT:    s_branch .LBB12_1
-; GCN-IR-NEXT:  .LBB12_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_branch .LBB12_3
   %result = sdiv i64 32768, %x
   ret i64 %result
 }
@@ -1837,64 +1780,53 @@ define i64 @v_test_sdiv_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_ashrrev_i32_e32 v8, 31, v1
 ; GCN-IR-NEXT:    v_xor_b32_e32 v0, v0, v8
 ; GCN-IR-NEXT:    v_xor_b32_e32 v1, v1, v8
-; GCN-IR-NEXT:    v_sub_i32_e32 v2, vcc, v0, v8
-; GCN-IR-NEXT:    v_subb_u32_e32 v3, vcc, v1, v8, vcc
-; GCN-IR-NEXT:    v_ffbh_u32_e32 v0, v2
+; GCN-IR-NEXT:    v_sub_i32_e32 v4, vcc, v0, v8
+; GCN-IR-NEXT:    v_subb_u32_e32 v5, vcc, v1, v8, vcc
+; GCN-IR-NEXT:    v_ffbh_u32_e32 v0, v4
 ; GCN-IR-NEXT:    v_add_i32_e64 v0, s[4:5], 32, v0
-; GCN-IR-NEXT:    v_ffbh_u32_e32 v1, v3
+; GCN-IR-NEXT:    v_ffbh_u32_e32 v1, v5
 ; GCN-IR-NEXT:    v_min_u32_e32 v6, v0, v1
 ; GCN-IR-NEXT:    v_sub_i32_e64 v0, s[4:5], 48, v6
 ; GCN-IR-NEXT:    v_subb_u32_e64 v1, s[4:5], 0, 0, s[4:5]
-; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
+; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[4:5]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], 63, v[0:1]
-; GCN-IR-NEXT:    s_or_b64 s[10:11], vcc, s[4:5]
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[4:5], s[6:7]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v5, 0, s[4:5]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v4, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[6:7], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v8
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_8
-; GCN-IR-NEXT:  .LBB13_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB13_7
-; GCN-IR-NEXT:  .LBB13_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v4, vcc, 1, v0
+; GCN-IR-NEXT:    s_cbranch_execz .LBB13_5
+; GCN-IR-NEXT:  .LBB13_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v7, vcc, 1, v0
 ; GCN-IR-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
-; GCN-IR-NEXT:    s_and_b64 s[12:13], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v0, s[4:5], 63, v0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
-; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[2:3], v0
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_9
-; GCN-IR-NEXT:  .LBB13_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
+; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[4:5], v0
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
+; GCN-IR-NEXT:    v_mov_b32_e32 v2, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v3, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB13_6
-; GCN-IR-NEXT:  .LBB13_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB13_4
+; GCN-IR-NEXT:  .LBB13_2: ; %udiv-preheader
 ; GCN-IR-NEXT:    v_add_i32_e32 v10, vcc, 0xffffffcf, v6
-; GCN-IR-NEXT:    v_lshr_b64 v[4:5], v[2:3], v4
+; GCN-IR-NEXT:    v_lshr_b64 v[4:5], v[4:5], v7
 ; GCN-IR-NEXT:    v_addc_u32_e64 v11, s[10:11], 0, -1, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v6, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v7, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v3, 0
 ; GCN-IR-NEXT:    s_movk_i32 s10, 0x7fff
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB13_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB13_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[4:5], v[4:5], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v2, 31, v1
@@ -1920,27 +1852,19 @@ define i64 @v_test_sdiv_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_5
-; GCN-IR-NEXT:  .LBB13_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_3
+; GCN-IR-NEXT:  .LBB13_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
-; GCN-IR-NEXT:    v_lshl_b64 v[4:5], v[0:1], 1
-; GCN-IR-NEXT:    v_or_b32_e32 v0, v3, v5
-; GCN-IR-NEXT:    v_or_b32_e32 v1, v2, v4
-; GCN-IR-NEXT:  .LBB13_7: ; %udiv-end
+; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[0:1], 1
+; GCN-IR-NEXT:    v_or_b32_e32 v3, v3, v1
+; GCN-IR-NEXT:    v_or_b32_e32 v2, v2, v0
+; GCN-IR-NEXT:  .LBB13_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_xor_b32_e32 v2, v0, v9
-; GCN-IR-NEXT:    v_xor_b32_e32 v0, v1, v8
+; GCN-IR-NEXT:    v_xor_b32_e32 v0, v2, v8
+; GCN-IR-NEXT:    v_xor_b32_e32 v1, v3, v9
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v8
-; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v2, v9, vcc
+; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v9, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB13_8:
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v0, v3, 0, s[10:11]
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v1, v2, 0, s[10:11]
-; GCN-IR-NEXT:    s_branch .LBB13_1
-; GCN-IR-NEXT:  .LBB13_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v2, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v3, 0
-; GCN-IR-NEXT:    s_branch .LBB13_3
   %result = sdiv i64 %x, 32768
   ret i64 %result
 }

--- a/llvm/test/CodeGen/AMDGPU/srem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem64.ll
@@ -379,64 +379,53 @@ define i64 @v_test_srem(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    s_or_b64 s[6:7], vcc, s[4:5]
 ; GCN-IR-NEXT:    v_add_i32_e32 v4, vcc, 32, v4
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v5, v3
-; GCN-IR-NEXT:    v_min_u32_e32 v6, v4, v5
+; GCN-IR-NEXT:    v_min_u32_e32 v10, v4, v5
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v4, v0
 ; GCN-IR-NEXT:    v_add_i32_e32 v4, vcc, 32, v4
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v5, v1
-; GCN-IR-NEXT:    v_min_u32_e32 v7, v4, v5
-; GCN-IR-NEXT:    v_sub_i32_e32 v4, vcc, v6, v7
+; GCN-IR-NEXT:    v_min_u32_e32 v11, v4, v5
+; GCN-IR-NEXT:    v_sub_i32_e32 v4, vcc, v10, v11
 ; GCN-IR-NEXT:    v_subb_u32_e64 v5, s[4:5], 0, 0, vcc
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[4:5]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 63, v[4:5]
 ; GCN-IR-NEXT:    s_or_b64 s[6:7], s[6:7], vcc
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[6:7], s[4:5]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[6:7], s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v13, v12
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v7, v1, 0, s[6:7]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v6, v0, 0, s[6:7]
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_8
-; GCN-IR-NEXT:  .LBB1_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[10:11]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB1_7
-; GCN-IR-NEXT:  .LBB1_2: ; %udiv-bb1
+; GCN-IR-NEXT:    s_cbranch_execz .LBB1_5
+; GCN-IR-NEXT:  .LBB1_1: ; %udiv-bb1
 ; GCN-IR-NEXT:    v_add_i32_e32 v8, vcc, 1, v4
 ; GCN-IR-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
-; GCN-IR-NEXT:    s_and_b64 s[12:13], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v4, s[4:5], 63, v4
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[4:5], v[0:1], v4
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_9
-; GCN-IR-NEXT:  .LBB1_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
+; GCN-IR-NEXT:    v_mov_b32_e32 v6, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v7, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB1_6
-; GCN-IR-NEXT:  .LBB1_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB1_4
+; GCN-IR-NEXT:  .LBB1_2: ; %udiv-preheader
 ; GCN-IR-NEXT:    v_add_i32_e32 v14, vcc, -1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v15, vcc, -1, v3, vcc
-; GCN-IR-NEXT:    v_not_b32_e32 v6, v6
+; GCN-IR-NEXT:    v_not_b32_e32 v6, v10
 ; GCN-IR-NEXT:    v_lshr_b64 v[8:9], v[0:1], v8
-; GCN-IR-NEXT:    v_add_i32_e32 v16, vcc, v6, v7
+; GCN-IR-NEXT:    v_add_i32_e32 v16, vcc, v6, v11
 ; GCN-IR-NEXT:    v_addc_u32_e64 v17, s[10:11], -1, 0, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v10, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v7, 0
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB1_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB1_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[8:9], v[8:9], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v6, 31, v5
@@ -463,20 +452,20 @@ define i64 @v_test_srem(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_5
-; GCN-IR-NEXT:  .LBB1_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB1_3
+; GCN-IR-NEXT:  .LBB1_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[4:5], v[4:5], 1
-; GCN-IR-NEXT:    v_or_b32_e32 v5, v7, v5
-; GCN-IR-NEXT:    v_or_b32_e32 v4, v6, v4
-; GCN-IR-NEXT:  .LBB1_7: ; %udiv-end
+; GCN-IR-NEXT:    v_or_b32_e32 v7, v7, v5
+; GCN-IR-NEXT:    v_or_b32_e32 v6, v6, v4
+; GCN-IR-NEXT:  .LBB1_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_mul_lo_u32 v5, v2, v5
-; GCN-IR-NEXT:    v_mul_hi_u32 v6, v2, v4
-; GCN-IR-NEXT:    v_mul_lo_u32 v3, v3, v4
-; GCN-IR-NEXT:    v_mul_lo_u32 v2, v2, v4
-; GCN-IR-NEXT:    v_add_i32_e32 v5, vcc, v6, v5
-; GCN-IR-NEXT:    v_add_i32_e32 v3, vcc, v5, v3
+; GCN-IR-NEXT:    v_mul_lo_u32 v4, v2, v7
+; GCN-IR-NEXT:    v_mul_hi_u32 v5, v2, v6
+; GCN-IR-NEXT:    v_mul_lo_u32 v3, v3, v6
+; GCN-IR-NEXT:    v_mul_lo_u32 v2, v2, v6
+; GCN-IR-NEXT:    v_add_i32_e32 v4, vcc, v5, v4
+; GCN-IR-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v2
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v3, vcc
 ; GCN-IR-NEXT:    v_xor_b32_e32 v0, v0, v12
@@ -484,14 +473,6 @@ define i64 @v_test_srem(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v12
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v13, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB1_8:
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v5, v1, 0, s[6:7]
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[6:7]
-; GCN-IR-NEXT:    s_branch .LBB1_1
-; GCN-IR-NEXT:  .LBB1_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v6, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v7, 0
-; GCN-IR-NEXT:    s_branch .LBB1_3
   %result = srem i64 %x, %y
   ret i64 %result
 }
@@ -1645,60 +1626,48 @@ define i64 @v_test_srem_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v0
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
-; GCN-IR-NEXT:    v_min_u32_e32 v4, v2, v3
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffc5, v4
+; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffc5, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], 63, v[2:3]
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[4:5], vcc
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, 24, 0, s[4:5]
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_8
-; GCN-IR-NEXT:  .LBB11_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB11_7
-; GCN-IR-NEXT:  .LBB11_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v5, vcc, 1, v2
+; GCN-IR-NEXT:    s_cbranch_execz .LBB11_5
+; GCN-IR-NEXT:  .LBB11_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    s_and_b64 s[12:13], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], 24, v2
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_9
-; GCN-IR-NEXT:  .LBB11_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB11_6
-; GCN-IR-NEXT:  .LBB11_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB11_4
+; GCN-IR-NEXT:  .LBB11_2: ; %udiv-preheader
 ; GCN-IR-NEXT:    v_add_i32_e32 v10, vcc, -1, v0
 ; GCN-IR-NEXT:    v_addc_u32_e32 v11, vcc, -1, v1, vcc
-; GCN-IR-NEXT:    v_lshr_b64 v[6:7], 24, v5
-; GCN-IR-NEXT:    v_sub_i32_e32 v12, vcc, 58, v4
+; GCN-IR-NEXT:    v_lshr_b64 v[6:7], 24, v6
+; GCN-IR-NEXT:    v_sub_i32_e32 v12, vcc, 58, v8
 ; GCN-IR-NEXT:    v_subb_u32_e64 v13, s[10:11], 0, 0, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB11_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB11_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v4, 31, v3
@@ -1725,30 +1694,23 @@ define i64 @v_test_srem_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_5
-; GCN-IR-NEXT:  .LBB11_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB11_3
+; GCN-IR-NEXT:  .LBB11_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
 ; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v3
-; GCN-IR-NEXT:    v_or_b32_e32 v2, v4, v2
-; GCN-IR-NEXT:  .LBB11_7: ; %udiv-end
+; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v2
+; GCN-IR-NEXT:  .LBB11_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_mul_lo_u32 v3, v0, v5
-; GCN-IR-NEXT:    v_mul_hi_u32 v4, v0, v2
-; GCN-IR-NEXT:    v_mul_lo_u32 v1, v1, v2
-; GCN-IR-NEXT:    v_mul_lo_u32 v0, v0, v2
-; GCN-IR-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
-; GCN-IR-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
+; GCN-IR-NEXT:    v_mul_lo_u32 v2, v0, v5
+; GCN-IR-NEXT:    v_mul_hi_u32 v3, v0, v4
+; GCN-IR-NEXT:    v_mul_lo_u32 v1, v1, v4
+; GCN-IR-NEXT:    v_mul_lo_u32 v0, v0, v4
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
+; GCN-IR-NEXT:    v_add_i32_e32 v1, vcc, v2, v1
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, 24, v0
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, 0, v1, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB11_8:
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, 24, 0, s[10:11]
-; GCN-IR-NEXT:    s_branch .LBB11_1
-; GCN-IR-NEXT:  .LBB11_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_branch .LBB11_3
   %result = srem i64 24, %x
   ret i64 %result
 }
@@ -1863,61 +1825,50 @@ define i64 @v_test_srem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v0
 ; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
-; GCN-IR-NEXT:    v_min_u32_e32 v4, v2, v3
-; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffd0, v4
+; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, 0xffffffd0, v8
 ; GCN-IR-NEXT:    v_addc_u32_e64 v3, s[6:7], 0, -1, vcc
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e32 vcc, 63, v[2:3]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], 63, v[2:3]
-; GCN-IR-NEXT:    s_or_b64 s[10:11], s[4:5], vcc
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0x8000
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], vcc
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
+; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_8
-; GCN-IR-NEXT:  .LBB12_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB12_7
-; GCN-IR-NEXT:  .LBB12_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v5, vcc, 1, v2
+; GCN-IR-NEXT:    s_cbranch_execz .LBB12_5
+; GCN-IR-NEXT:  .LBB12_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    s_and_b64 s[14:15], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_mov_b64 s[10:11], 0x8000
 ; GCN-IR-NEXT:    s_and_b64 s[12:13], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], s[10:11], v2
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[14:15]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[14:15]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_9
-; GCN-IR-NEXT:  .LBB12_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB12_6
-; GCN-IR-NEXT:  .LBB12_4: ; %udiv-preheader
+; GCN-IR-NEXT:    s_cbranch_execz .LBB12_4
+; GCN-IR-NEXT:  .LBB12_2: ; %udiv-preheader
 ; GCN-IR-NEXT:    v_add_i32_e32 v10, vcc, -1, v0
 ; GCN-IR-NEXT:    v_addc_u32_e32 v11, vcc, -1, v1, vcc
-; GCN-IR-NEXT:    v_lshr_b64 v[6:7], s[10:11], v5
-; GCN-IR-NEXT:    v_sub_i32_e32 v12, vcc, 47, v4
+; GCN-IR-NEXT:    v_lshr_b64 v[6:7], s[10:11], v6
+; GCN-IR-NEXT:    v_sub_i32_e32 v12, vcc, 47, v8
 ; GCN-IR-NEXT:    v_subb_u32_e64 v13, s[10:11], 0, 0, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB12_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB12_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v4, 31, v3
@@ -1944,31 +1895,23 @@ define i64 @v_test_srem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[10:11]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_5
-; GCN-IR-NEXT:  .LBB12_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB12_3
+; GCN-IR-NEXT:  .LBB12_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
 ; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v3
-; GCN-IR-NEXT:    v_or_b32_e32 v2, v4, v2
-; GCN-IR-NEXT:  .LBB12_7: ; %udiv-end
+; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v2
+; GCN-IR-NEXT:  .LBB12_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_mul_lo_u32 v3, v0, v5
-; GCN-IR-NEXT:    v_mul_hi_u32 v4, v0, v2
-; GCN-IR-NEXT:    v_mul_lo_u32 v1, v1, v2
-; GCN-IR-NEXT:    v_mul_lo_u32 v0, v0, v2
-; GCN-IR-NEXT:    v_add_i32_e32 v3, vcc, v4, v3
-; GCN-IR-NEXT:    v_add_i32_e32 v1, vcc, v3, v1
+; GCN-IR-NEXT:    v_mul_lo_u32 v2, v0, v5
+; GCN-IR-NEXT:    v_mul_hi_u32 v3, v0, v4
+; GCN-IR-NEXT:    v_mul_lo_u32 v1, v1, v4
+; GCN-IR-NEXT:    v_mul_lo_u32 v0, v0, v4
+; GCN-IR-NEXT:    v_add_i32_e32 v2, vcc, v3, v2
+; GCN-IR-NEXT:    v_add_i32_e32 v1, vcc, v2, v1
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, 0x8000, v0
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, 0, v1, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB12_8:
-; GCN-IR-NEXT:    v_mov_b32_e32 v2, 0x8000
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[10:11]
-; GCN-IR-NEXT:    s_branch .LBB12_1
-; GCN-IR-NEXT:  .LBB12_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_branch .LBB12_3
   %result = srem i64 32768, %x
   ret i64 %result
 }
@@ -1997,59 +1940,48 @@ define i64 @v_test_srem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v2, v0
 ; GCN-IR-NEXT:    v_add_i32_e64 v2, s[4:5], 32, v2
 ; GCN-IR-NEXT:    v_ffbh_u32_e32 v3, v1
-; GCN-IR-NEXT:    v_min_u32_e32 v4, v2, v3
-; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 48, v4
+; GCN-IR-NEXT:    v_min_u32_e32 v8, v2, v3
+; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 48, v8
 ; GCN-IR-NEXT:    v_subb_u32_e64 v3, s[4:5], 0, 0, s[4:5]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
 ; GCN-IR-NEXT:    v_cmp_lt_u64_e64 s[4:5], 63, v[2:3]
 ; GCN-IR-NEXT:    v_cmp_eq_u64_e64 s[6:7], 63, v[2:3]
-; GCN-IR-NEXT:    s_or_b64 s[10:11], vcc, s[4:5]
-; GCN-IR-NEXT:    s_or_b64 s[12:13], s[10:11], s[6:7]
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[12:13], exec
+; GCN-IR-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
+; GCN-IR-NEXT:    s_or_b64 s[6:7], s[4:5], s[6:7]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v5, v1, 0, s[4:5]
+; GCN-IR-NEXT:    v_cndmask_b32_e64 v4, v0, 0, s[4:5]
+; GCN-IR-NEXT:    s_xor_b64 s[4:5], s[6:7], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, v10
 ; GCN-IR-NEXT:    s_mov_b64 s[8:9], -1
-; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[12:13]
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_8
-; GCN-IR-NEXT:  .LBB13_1:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
 ; GCN-IR-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
-; GCN-IR-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[4:5]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB13_7
-; GCN-IR-NEXT:  .LBB13_2: ; %udiv-bb1
-; GCN-IR-NEXT:    v_add_i32_e32 v5, vcc, 1, v2
+; GCN-IR-NEXT:    s_cbranch_execz .LBB13_5
+; GCN-IR-NEXT:  .LBB13_1: ; %udiv-bb1
+; GCN-IR-NEXT:    v_add_i32_e32 v6, vcc, 1, v2
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
-; GCN-IR-NEXT:    s_and_b64 s[12:13], exec, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[0:1], v2
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
-; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
-; GCN-IR-NEXT:    s_mov_b64 exec, s[12:13]
-; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_9
-; GCN-IR-NEXT:  .LBB13_3:
-; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
+; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
+; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], s[4:5], exec
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[10:11]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execz .LBB13_6
-; GCN-IR-NEXT:  .LBB13_4: ; %udiv-preheader
-; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, 0xffffffcf, v4
-; GCN-IR-NEXT:    v_lshr_b64 v[6:7], v[0:1], v5
+; GCN-IR-NEXT:    s_cbranch_execz .LBB13_4
+; GCN-IR-NEXT:  .LBB13_2: ; %udiv-preheader
+; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, 0xffffffcf, v8
+; GCN-IR-NEXT:    v_lshr_b64 v[6:7], v[0:1], v6
 ; GCN-IR-NEXT:    v_addc_u32_e64 v13, s[10:11], 0, -1, vcc
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, 0
 ; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
 ; GCN-IR-NEXT:    s_movk_i32 s10, 0x7fff
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
-; GCN-IR-NEXT:  .LBB13_5: ; %udiv-do-while
+; GCN-IR-NEXT:  .LBB13_3: ; %udiv-do-while
 ; GCN-IR-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-IR-NEXT:    v_lshl_b64 v[6:7], v[6:7], 1
 ; GCN-IR-NEXT:    v_lshrrev_b32_e32 v4, 31, v3
@@ -2075,15 +2007,15 @@ define i64 @v_test_srem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    s_or_b64 s[4:5], s[4:5], s[12:13]
 ; GCN-IR-NEXT:    s_mov_b64 exec, s[8:9]
 ; GCN-IR-NEXT:    ; divergent control-flow edge
-; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_5
-; GCN-IR-NEXT:  .LBB13_6: ; %udiv-loop-exit
+; GCN-IR-NEXT:    s_cbranch_execnz .LBB13_3
+; GCN-IR-NEXT:  .LBB13_4: ; %udiv-loop-exit
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[2:3], 1
-; GCN-IR-NEXT:    v_or_b32_e32 v3, v5, v3
-; GCN-IR-NEXT:    v_or_b32_e32 v2, v4, v2
-; GCN-IR-NEXT:  .LBB13_7: ; %udiv-end
+; GCN-IR-NEXT:    v_or_b32_e32 v5, v5, v3
+; GCN-IR-NEXT:    v_or_b32_e32 v4, v4, v2
+; GCN-IR-NEXT:  .LBB13_5: ; %udiv-end
 ; GCN-IR-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[2:3], 15
+; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[4:5], 15
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v2
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v3, vcc
 ; GCN-IR-NEXT:    v_xor_b32_e32 v0, v0, v10
@@ -2091,14 +2023,6 @@ define i64 @v_test_srem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_sub_i32_e32 v0, vcc, v0, v10
 ; GCN-IR-NEXT:    v_subb_u32_e32 v1, vcc, v1, v11, vcc
 ; GCN-IR-NEXT:    s_setpc_b64 s[30:31]
-; GCN-IR-NEXT:  .LBB13_8:
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v3, v1, 0, s[10:11]
-; GCN-IR-NEXT:    v_cndmask_b32_e64 v2, v0, 0, s[10:11]
-; GCN-IR-NEXT:    s_branch .LBB13_1
-; GCN-IR-NEXT:  .LBB13_9:
-; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
-; GCN-IR-NEXT:    v_mov_b32_e32 v5, 0
-; GCN-IR-NEXT:    s_branch .LBB13_3
   %result = srem i64 %x, 32768
   ret i64 %result
 }

--- a/llvm/test/CodeGen/AMDGPU/stack-realign.ll
+++ b/llvm/test/CodeGen/AMDGPU/stack-realign.ll
@@ -339,67 +339,42 @@ define i32 @needs_align1024_stack_args_used_inside_loop(ptr addrspace(5) nocaptu
 ; GCN-LABEL: needs_align1024_stack_args_used_inside_loop:
 ; GCN:       ; %bb.0: ; %begin
 ; GCN-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GCN-NEXT:    s_mov_b32 s17, s33
+; GCN-NEXT:    s_mov_b32 s7, s33
 ; GCN-NEXT:    s_add_i32 s33, s32, 0xffc0
-; GCN-NEXT:    s_mov_b32 s20, s34
+; GCN-NEXT:    s_mov_b32 s10, s34
 ; GCN-NEXT:    s_and_b32 s33, s33, 0xffff0000
 ; GCN-NEXT:    s_mov_b32 s34, s32
-; GCN-NEXT:    v_mov_b32_e32 v0, 0
-; GCN-NEXT:    s_add_i32 s32, s32, 0x30000
 ; GCN-NEXT:    v_lshrrev_b32_e64 v1, 6, s34
+; GCN-NEXT:    v_mov_b32_e32 v0, 0
+; GCN-NEXT:    s_mov_b32 s6, 0
+; GCN-NEXT:    s_mov_b64 s[4:5], 0
+; GCN-NEXT:    s_add_i32 s32, s32, 0x30000
 ; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:1024
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NEXT:    s_mov_b32 s16, 0
-; GCN-NEXT:    s_mov_b64 s[10:11], 0
-; GCN-NEXT:    s_mov_b64 s[14:15], -1
-; GCN-NEXT:    s_mov_b64 s[8:9], 0
-; GCN-NEXT:    s_mov_b64 s[12:13], 0
-; GCN-NEXT:    s_mov_b64 s[6:7], 0
-; GCN-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-NEXT:  .LBB10_1: ; %loop_body
 ; GCN-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GCN-NEXT:    buffer_load_dword v2, v1, s[0:3], 0 offen
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s16, v2
-; GCN-NEXT:    s_xor_b64 s[18:19], vcc, exec
-; GCN-NEXT:    s_or_b64 s[10:11], s[10:11], s[18:19]
-; GCN-NEXT:    s_xor_b64 s[18:19], exec, vcc
-; GCN-NEXT:    s_and_b64 s[18:19], s[18:19], exec
-; GCN-NEXT:    s_or_b64 s[12:13], s[12:13], s[18:19]
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s6, v2
+; GCN-NEXT:    s_xor_b64 s[8:9], exec, vcc
+; GCN-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
 ; GCN-NEXT:    s_mov_b64 exec, vcc
 ; GCN-NEXT:    ; divergent control-flow edge
 ; GCN-NEXT:    s_cbranch_execz .LBB10_4
 ; GCN-NEXT:  .LBB10_2: ; %loop_end
 ; GCN-NEXT:    ; in Loop: Header=BB10_1 Depth=1
-; GCN-NEXT:    s_add_i32 s16, s16, 1
+; GCN-NEXT:    s_add_i32 s6, s6, 1
 ; GCN-NEXT:    v_add_u32_e32 v1, vcc, 4, v1
-; GCN-NEXT:    s_cmp_eq_u32 s16, 9
-; GCN-NEXT:    s_mov_b64 s[8:9], 0
+; GCN-NEXT:    s_cmp_eq_u32 s6, 9
 ; GCN-NEXT:    s_cbranch_scc0 .LBB10_1
 ; GCN-NEXT:  ; %bb.3:
-; GCN-NEXT:    s_and_b64 s[8:9], s[14:15], exec
-; GCN-NEXT:  .LBB10_4:
-; GCN-NEXT:    s_or_b64 exec, exec, s[12:13]
-; GCN-NEXT:    s_xor_b64 s[12:13], exec, s[10:11]
-; GCN-NEXT:    s_and_b64 s[12:13], s[12:13], exec
-; GCN-NEXT:    s_or_b64 s[6:7], s[6:7], s[12:13]
-; GCN-NEXT:    s_mov_b64 exec, s[10:11]
-; GCN-NEXT:    ; divergent control-flow edge
-; GCN-NEXT:  .LBB10_5:
-; GCN-NEXT:    s_or_b64 exec, exec, s[6:7]
-; GCN-NEXT:    s_xor_b64 s[6:7], exec, s[8:9]
-; GCN-NEXT:    s_and_b64 s[6:7], s[6:7], exec
-; GCN-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GCN-NEXT:    s_mov_b64 exec, s[8:9]
-; GCN-NEXT:    ; divergent control-flow edge
-; GCN-NEXT:    s_cbranch_execz .LBB10_7
-; GCN-NEXT:  .LBB10_6:
 ; GCN-NEXT:    v_mov_b32_e32 v0, 1
-; GCN-NEXT:  .LBB10_7: ; %exit
+; GCN-NEXT:  .LBB10_4: ; %exit
 ; GCN-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-NEXT:    s_mov_b32 s32, s34
-; GCN-NEXT:    s_mov_b32 s34, s20
-; GCN-NEXT:    s_mov_b32 s33, s17
+; GCN-NEXT:    s_mov_b32 s34, s10
+; GCN-NEXT:    s_mov_b32 s33, s7
 ; GCN-NEXT:    s_setpc_b64 s[30:31]
 begin:
   %local_var = alloca i32, align 1024, addrspace(5)

--- a/llvm/test/CodeGen/AMDGPU/uniform-phi-with-undef.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-phi-with-undef.ll
@@ -15,40 +15,28 @@ define amdgpu_ps float @uniform_phi_with_undef(float inreg %c, float %v, i32 %x,
 ; GCN-NEXT:    s_mov_b32 s2, -1
 ; GCN-NEXT:    s_xor_b32 s1, s1, s2
 ; GCN-NEXT:    s_and_b32 s2, exec_lo, s1
-; GCN-NEXT:    s_xor_b32 s2, s1, -1
-; GCN-NEXT:    s_and_b32 s3, s2, exec_lo
-; GCN-NEXT:    s_and_b32 s1, exec_lo, s1
-; GCN-NEXT:    s_xor_b32 s2, exec_lo, s3
-; GCN-NEXT:    s_mov_b32 exec_lo, s3
+; GCN-NEXT:    s_xor_b32 s1, s1, -1
+; GCN-NEXT:    s_and_b32 s2, s1, exec_lo
+; GCN-NEXT:    s_xor_b32 s1, exec_lo, s2
+; GCN-NEXT:    s_mov_b32 exec_lo, s2
 ; GCN-NEXT:    ; divergent control-flow edge
-; GCN-NEXT:    s_cbranch_execz .LBB0_1
-; GCN-NEXT:    s_branch .LBB0_3
-; GCN-NEXT:  .LBB0_1:
-; GCN-NEXT:    s_or_b32 exec_lo, exec_lo, s2
-; GCN-NEXT:    s_xor_b32 s2, exec_lo, s1
-; GCN-NEXT:    s_and_b32 s2, s2, exec_lo
-; GCN-NEXT:    s_mov_b32 exec_lo, s1
-; GCN-NEXT:    ; divergent control-flow edge
-; GCN-NEXT:    s_cbranch_execz .LBB0_4
-; GCN-NEXT:  .LBB0_2:
-; GCN-NEXT:    s_branch .LBB0_4
-; GCN-NEXT:  .LBB0_3: ; %if
-; GCN-NEXT:    s_mov_b32 s3, 0x40400000
-; GCN-NEXT:    v_div_scale_f32 v1, s4, s3, s3, v0
+; GCN-NEXT:    s_cbranch_execz .LBB0_2
+; GCN-NEXT:  .LBB0_1: ; %if
+; GCN-NEXT:    s_mov_b32 s2, 0x40400000
+; GCN-NEXT:    v_div_scale_f32 v1, s3, s2, s2, v0
 ; GCN-NEXT:    v_rcp_f32_e64 v2, v1
-; GCN-NEXT:    s_mov_b32 s4, 1.0
-; GCN-NEXT:    v_fma_f32 v3, -v1, v2, s4
+; GCN-NEXT:    s_mov_b32 s3, 1.0
+; GCN-NEXT:    v_fma_f32 v3, -v1, v2, s3
 ; GCN-NEXT:    v_fmac_f32_e64 v2, v3, v2
-; GCN-NEXT:    v_div_scale_f32 v3, vcc_lo, v0, s3, v0
+; GCN-NEXT:    v_div_scale_f32 v3, vcc_lo, v0, s2, v0
 ; GCN-NEXT:    v_mul_f32_e64 v4, v3, v2
 ; GCN-NEXT:    v_fma_f32 v5, -v1, v4, v3
 ; GCN-NEXT:    v_fmac_f32_e64 v4, v5, v2
 ; GCN-NEXT:    v_fma_f32 v1, -v1, v4, v3
 ; GCN-NEXT:    v_div_fmas_f32 v1, v1, v2, v4
-; GCN-NEXT:    v_div_fixup_f32 v0, v1, s3, v0
-; GCN-NEXT:    s_branch .LBB0_1
-; GCN-NEXT:  .LBB0_4: ; %end
-; GCN-NEXT:    s_or_b32 exec_lo, exec_lo, s2
+; GCN-NEXT:    v_div_fixup_f32 v0, v1, s2, v0
+; GCN-NEXT:  .LBB0_2: ; %end
+; GCN-NEXT:    s_or_b32 exec_lo, exec_lo, s1
 ; GCN-NEXT:    v_add_f32_e64 v0, v0, s0
 ; GCN-NEXT:    ; return to shader part epilog
 entry:


### PR DESCRIPTION
This commit makes two related changes to properly handle SI_BRCOND and SI_BRCOND_Z divergent branch pseudos in the late wave transform pipeline.

1. Add implicit Uses/Defs for EXEC and VCC registers:
   - SI_BRCOND/SI_BRCOND_Z now explicitly declare Uses = [EXEC], Defs = [EXEC, VCC]
   - These pseudos will be lowered by WaveTransform into EXEC mask manipulation
   - The lowered sequence modifies both EXEC and VCC registers
   - Making this explicit enables proper liveness tracking.

2. Make SI_BRCOND/SI_BRCOND_Z unanalyzable in analyzeBranchImpl:
   - Add early return true (cannot analyze) for these opcodes
   - Prevents critical edge splitting during PHI elimination
   - Prevents branch folding, if-conversion, and other optimizations that assume uniform (wave-level) control flow
   - SI_BRCOND represents divergent (lane-level) control flow where different lanes may take different paths and due to that the standard branch analysis is inappropriate

These changes look necessary as they represent these pseudo instructions behave the same way SI_IF worked in the legacy pipeline flow.


