### PR TITLE
[Flang][OpenMP][Offload] remove umt speciifc fix from runtime

### DIFF
--- a/offload/libomptarget/omptarget.cpp
+++ b/offload/libomptarget/omptarget.cpp
@@ -1020,7 +1020,7 @@ postProcessingTargetDataEnd(DeviceTy *Device,
         const bool isZeroCopy = PM->getRequirements() & OMPX_REQ_AUTO_ZERO_COPY;
         const bool isUSMMode =
             PM->getRequirements() & OMP_REQ_UNIFIED_SHARED_MEMORY;
-        if (*ShadowPtr.HstPtrAddr == nullptr || isZeroCopy || isUSMMode)
+        if (isZeroCopy || isUSMMode)
           return OFFLOAD_SUCCESS;
         constexpr int64_t VoidPtrSize = sizeof(void *);
         if (ShadowPtr.PtrSize > VoidPtrSize) {
@@ -1468,7 +1468,7 @@ static int targetDataContiguous(ident_t *Loc, DeviceTy &Device, void *ArgsBase,
                   PM->getRequirements() & OMPX_REQ_AUTO_ZERO_COPY;
               const bool isUSMMode =
                   PM->getRequirements() & OMP_REQ_UNIFIED_SHARED_MEMORY;
-              if (*ShadowPtr.HstPtrAddr == nullptr || isZeroCopy || isUSMMode)
+              if (isZeroCopy || isUSMMode)
                 return OFFLOAD_SUCCESS;
               constexpr int64_t VoidPtrSize = sizeof(void *);
               if (ShadowPtr.PtrSize > VoidPtrSize) {


### PR DESCRIPTION
This fix doesn't appear to be required anymore, and it's enabling illegal behaviour at the moment. So, this is an attempt to revert it as UMT no longer seems to depend on the fix (and if it does I'll see about creating a fix for UMTs incorrect behaviour before landing this).


