### PR TITLE
[comgr] Adding comgr's multi-threaded test back in

### DIFF
--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -239,7 +239,7 @@ add_comgr_test(file_map c)
 add_comgr_test(symbolize_test c)
 add_comgr_test(mangled_names_test c)
 # Disabled due to AddressSanitizer limitation with multithreaded programs
-# add_comgr_test(multithread_test cpp)
+add_comgr_test(multithread_test cpp)
 add_comgr_test(nested_kernel_test c)
 add_comgr_test(map_elf_virtual_address_test c)
 add_comgr_test(compile_source_to_executable c)


### PR DESCRIPTION
# Re-enable comgr's multithreaded test

A one-line change to re-enable the multithreaded test in comgr which had been commented out because it would break with ASAN builds. The break was a bug in ASAN which has now been [patched upstream](https://github.com/llvm/llvm-project/pull/179000).

## Testing

Build ASAN in LLVM (`-DCOMPILER_RT_BUILD_SANITIZERS=ON`). Build comgr with and without ASAN (`-DADDRESS_SANITIZER=On`). The tests pass in both builds.

