### PR TITLE
Revert "Fix Unknown immediate size X86MCCodeEmitter::encodeInstruction"

### DIFF
--- a/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/X86/MCTargetDesc/CMakeLists.txt
@@ -28,4 +28,3 @@ add_llvm_component_library(LLVMX86Desc
   ADD_TO_COMPONENT
   X86
   )
-set_source_files_properties(X86MCCodeEmitter.cpp PROPERTIES COMPILE_FLAGS "-O2")


### PR DESCRIPTION
This reverts commit 3afeb1805010e0ae546ac02fb40ba47d69ab16aa.

This has been causing build error ever since LLVM moved to PCH by default.
