### PR TITLE
[AMDGPU] comgr: Added CLOCK_MONOTONIC_RAW define to allow successful compilation and usage on FreeBSD

### DIFF
--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -34,7 +34,7 @@
 
 #if defined(__FreeBSD__) && !defined(CLOCK_MONOTONIC_RAW)
 #define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
-#endif 
+#endif
 
 using namespace llvm;
 using namespace COMGR;

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -32,6 +32,10 @@
 #include <time.h>
 #endif
 
+#if defined(__FreeBSD__) && !defined(CLOCK_MONOTONIC_RAW)
+#define CLOCK_MONOTONIC_RAW CLOCK_MONOTONIC
+#endif 
+
 using namespace llvm;
 using namespace COMGR;
 


### PR DESCRIPTION
Motivation:
I'm working to get ROCm supported on FreeBSD, and so far have the `rocm-core`, `rocr-runtime`, and `rocminfo` compiling and `rocminfo` currently shows `ROCk module is NOT loaded, possibly no GPU devices`. To get `rocr-runtime`, and `rocminfo` compiled, I need to use this fork of llvm, and make this one change to get this fork to compile & run on FreeBSD. 


Without this change, when building on FreeBSD we get the error;

```
root@freebsd-angel-halo:~/dev/llvm-project/amd/comgr/build # ninja
[0/2] Re-checking globbed directories...
[4/214] Generating source/reloc-asm.o
clang-23: warning: argument unused during compilation: '-nogpulib' [-Wunused-command-line-argument]
clang-23: warning: argument unused during compilation: '-nogpuinc' [-Wunused-command-line-argument]
[56/214] Embedding clang resource directory
[89/214] Tracing libc++ header dependencies for HIPRTC
Header trace: 179 libc++ files, 10 Clang builtin files
Generated manifest /root/dev/llvm-project/amd/comgr/build/lib/libcxx/libcxx_manifest.tsv with 181 libc++ + 10 clang headers
[89/214] Embedding libc++ headers for HIPRTC
[140/214] Building CXX object CMakeFiles/amd_comgr.dir/src/time-stat/time-stat.cpp.o                                                                       
FAILED: [code=1] CMakeFiles/amd_comgr.dir/src/time-stat/time-stat.cpp.o 
/usr/bin/c++ -DAMD_COMGR_BUILD -DAMD_COMGR_EXPORT -DAMD_COMGR_GIT_BRANCH=amd-staging -DAMD_COMGR_GIT_COMMIT=469ab5fc69c1 -DCOMGR_HAS_LIBCXX_HEADERS=1 -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -D__STDC_LIMIT_MACROS -Damd_comgr_EXPORTS -I/usr/local/rocm-llvm/include -I/root/dev/llvm-project/amd/comgr/src -I/root/dev/llvm-project/amd/comgr/build/include -isystem /usr/local/include -O3 -DNDEBUG -std=c++17 -fPIC -fno-rtti -Wall -Wno-attributes -fms-extensions -fvisibility=hidden -fno-strict-aliasing -MD -MT CMakeFiles/amd_comgr.dir/src/time-stat/time-stat.cpp.o -MF CMakeFiles/amd_comgr.dir/src/time-stat/time-stat.cpp.o.d -o CMakeFiles/amd_comgr.dir/src/time-stat/time-stat.cpp.o -c /root/dev/llvm-project/amd/comgr/src/time-stat/time-stat.cpp
/root/dev/llvm-project/amd/comgr/src/time-stat/time-stat.cpp:148:24: error: use of undeclared identifier 'CLOCK_MONOTONIC_RAW'
  148 |     if (!clock_gettime(CLOCK_MONOTONIC_RAW, &StartTime)) {
      |                        ^~~~~~~~~~~~~~~~~~~
/root/dev/llvm-project/amd/comgr/src/time-stat/time-stat.cpp:156:22: error: use of undeclared identifier 'CLOCK_MONOTONIC_RAW'
  156 |     if (clock_getres(CLOCK_MONOTONIC_RAW, &Res)) {
      |                      ^~~~~~~~~~~~~~~~~~~
/root/dev/llvm-project/amd/comgr/src/time-stat/time-stat.cpp:169:24: error: use of undeclared identifier 'CLOCK_MONOTONIC_RAW'
  169 |     if (!clock_gettime(CLOCK_MONOTONIC_RAW, &EndTime)) {
      |                        ^~~~~~~~~~~~~~~~~~~
3 errors generated.
[166/214] Building CXX object CMakeFiles/amd_comgr.dir/src/comgr-compiler.cpp.o
ninja: build stopped: subcommand failed.

```
With this change it builds normally. 

Here are my hardware specs:
### Hardware & OS Specs
* **OS:** 16.0-CURRENT (amd64) (commit hash; `fb4e7898a359a5044e6794c7fe8a698d29af1fd3`)
* **CPU:** AMD RYZEN AI MAX+ 395 w/ Radeon 8060S          
* **RAM:** 63 GB
* **GPU:** Advanced Micro Devices, Inc. [AMD/ATI] Strix Halo [Radeon Graphics / Radeon 8050S Graphics / Radeon 8060S Graphics]


