### PR TITLE
EXPERIMENTAL: partial revert of #197745: keep addrspacecast for HIP kernel prolog temps

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -3376,7 +3376,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
         // may be aliased, copy it to ensure that the parameter variable is
         // mutable and has a unique adress, as C requires.
         if (ArgI.getIndirectRealign() || ArgI.isIndirectAliased()) {
-          RawAddress AlignedTemp = CreateMemTempWithoutCast(Ty, "coerce");
+          RawAddress AlignedTemp = CreateMemTemp(Ty, "coerce");
 
           // Copy from the incoming argument pointer to the temporary with the
           // appropriate alignment.
@@ -3506,7 +3506,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
             ParameterABI::SwiftErrorResult) {
           QualType pointeeTy = Ty->getPointeeType();
           assert(pointeeTy->isPointerType());
-          RawAddress temp = CreateMemTempWithoutCast(
+          RawAddress temp = CreateMemTemp(
               pointeeTy, getPointerAlign(), "swifterror.temp");
           Address arg = makeNaturalAddressForPointer(
               V, pointeeTy, getContext().getTypeAlignInChars(pointeeTy));
@@ -3561,7 +3561,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
           dyn_cast<llvm::StructType>(ArgI.getCoerceToType());
 
       RawAddress DebugAddr = Address::invalid();
-      Address Alloca = CreateMemTempWithoutCast(
+      Address Alloca = CreateMemTemp(
           Ty, getContext().getDeclAlign(Arg), Arg->getName());
 
       // Pointer to store into.
@@ -3653,7 +3653,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
       // Reconstruct into a temporary.
       RawAddress DebugAddr = Address::invalid();
       Address alloca =
-          CreateMemTempWithoutCast(Ty, getContext().getDeclAlign(Arg));
+          CreateMemTemp(Ty, getContext().getDeclAlign(Arg));
       ArgVals.push_back(ParamValue::forIndirect(alloca));
 
       auto coercionType = ArgI.getCoerceAndExpandType();
@@ -3696,7 +3696,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
       // arguments.
       RawAddress DebugAddr = Address::invalid();
       Address Alloca =
-          CreateMemTempWithoutCast(Ty, getContext().getDeclAlign(Arg));
+          CreateMemTemp(Ty, getContext().getDeclAlign(Arg));
       LValue LV = MakeAddrLValue(Alloca, Ty);
       ArgVals.push_back(ParamValue::forIndirect(Alloca, DebugAddr));
 
@@ -3713,7 +3713,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
     case ABIArgInfo::TargetSpecific: {
       auto *AI = Fn->getArg(FirstIRArg);
       AI->setName(Arg->getName() + ".target_coerce");
-      Address Alloca = CreateMemTempWithoutCast(
+      Address Alloca = CreateMemTemp(
           Ty, getContext().getDeclAlign(Arg), Arg->getName());
       Address Ptr = emitAddressAtOffset(*this, Alloca, ArgI);
       CGM.getABIInfo().createCoercedStore(AI, Ptr, ArgI, false, *this);
@@ -3736,7 +3736,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
         RawAddress DebugAddr = Address::invalid();
         RawAddress Alloca = CreateMemTemp(Ty, "tmp", &DebugAddr);
         ArgVals.push_back(
-            ParamValue::forIndirect(CreateMemTempWithoutCast(Ty)));
+            ParamValue::forIndirect(CreateMemTemp(Ty)));
       } else {
         llvm::Value *U = llvm::UndefValue::get(ConvertType(Arg->getType()));
         ArgVals.push_back(ParamValue::forDirect(U));
@@ -5043,7 +5043,7 @@ struct DestroyUnpassedArg final : EHScopeStack::Cleanup {
 RValue CallArg::getRValue(CodeGenFunction &CGF) const {
   if (!HasLV)
     return RV;
-  LValue Copy = CGF.MakeAddrLValue(CGF.CreateMemTempWithoutCast(Ty), Ty);
+  LValue Copy = CGF.MakeAddrLValue(CGF.CreateMemTemp(Ty), Ty);
   CGF.EmitAggregateCopy(Copy, LV, Ty, AggValueSlot::DoesNotOverlap,
                         LV.isVolatile());
   IsUsed = true;
@@ -5623,7 +5623,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
           // placeholder with a regular aggregate temporary alloca. Store the
           // address of this alloca into the struct.
           Addr =
-              CreateMemTempWithoutCast(info_it->type, "inalloca.indirect.tmp");
+              CreateMemTemp(info_it->type, "inalloca.indirect.tmp");
           Address ArgSlot = Builder.CreateStructGEP(
               ArgMemory, ArgInfo.getInAllocaFieldIndex());
           Builder.CreateStore(Addr.getPointer(), ArgSlot);
@@ -5768,7 +5768,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
           swiftErrorArg = makeNaturalAddressForPointer(
               V, pointeeTy, getContext().getTypeAlignInChars(pointeeTy));
 
-          swiftErrorTemp = CreateMemTempWithoutCast(
+          swiftErrorTemp = CreateMemTemp(
               pointeeTy, getPointerAlign(), "swifterror.temp");
           V = swiftErrorTemp.getPointer();
           cast<llvm::AllocaInst>(V)->setSwiftError(true);
@@ -5804,7 +5804,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
       // FIXME: Avoid the conversion through memory if possible.
       Address Src = Address::invalid();
       if (!I->isAggregate()) {
-        Src = CreateMemTempWithoutCast(I->Ty, "coerce");
+        Src = CreateMemTemp(I->Ty, "coerce");
         I->copyInto(*this, Src);
       } else {
         Src = I->hasLValue() ? I->getKnownLValue().getAddress()
@@ -5961,7 +5961,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
     case ABIArgInfo::TargetSpecific: {
       Address Src = Address::invalid();
       if (!I->isAggregate()) {
-        Src = CreateMemTempWithoutCast(I->Ty, "target_coerce");
+        Src = CreateMemTemp(I->Ty, "target_coerce");
         I->copyInto(*this, Src);
       } else {
         Src = I->hasLValue() ? I->getKnownLValue().getAddress()
@@ -6497,7 +6497,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
             getContext().getTypeInfoDataSizeInChars(RetTy).Width.getQuantity();
 
         if (!DestPtr.isValid()) {
-          DestPtr = CreateMemTempWithoutCast(RetTy, "coerce");
+          DestPtr = CreateMemTemp(RetTy, "coerce");
           DestIsVolatile = false;
           DestSize = getContext().getTypeSizeInChars(RetTy).getQuantity();
         }
@@ -6522,7 +6522,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         Address StorePtr = emitAddressAtOffset(*this, DestPtr, RetAI);
         bool DestIsVolatile = ReturnValue.isVolatile();
         if (!DestPtr.isValid()) {
-          DestPtr = CreateMemTempWithoutCast(RetTy, "target_coerce");
+          DestPtr = CreateMemTemp(RetTy, "target_coerce");
           DestIsVolatile = false;
         }
         CGM.getABIInfo().createCoercedStore(CI, StorePtr, RetAI, DestIsVolatile,

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2962,13 +2962,10 @@ public:
   /// aggregate type.
   AggValueSlot CreateAggTemp(QualType T, const Twine &Name = "tmp",
                              RawAddress *Alloca = nullptr) {
-    RawAddress Addr = CreateMemTempWithoutCast(T, Name);
-    if (Alloca)
-      *Alloca = Addr;
     return AggValueSlot::forAddr(
-        Addr, T.getQualifiers(), AggValueSlot::IsNotDestructed,
-        AggValueSlot::DoesNotNeedGCBarriers, AggValueSlot::IsNotAliased,
-        AggValueSlot::DoesNotOverlap);
+        CreateMemTemp(T.getUnqualifiedType(), Name, Alloca), T.getQualifiers(),
+        AggValueSlot::IsNotDestructed, AggValueSlot::DoesNotNeedGCBarriers,
+        AggValueSlot::IsNotAliased, AggValueSlot::DoesNotOverlap);
   }
 
   /// EvaluateExprAsBool - Perform the usual unary conversions on the specified


### PR DESCRIPTION
Narrow revert of the CreateMemTemp -> CreateMemTempWithoutCast swaps in clang/lib/CodeGen/CGCall.cpp and CodeGenFunction.h::CreateAggTemp from upstream 2825dfa027e6 (#197745).  Without this the rocprim device_batch_memcpy test on gfx942 hits HSA_STATUS_ERROR_MEMORY_APERTURE_VIOLATION because kernel-prolog allocas mix raw addrspace(5) uses with deferred flat-cast uses, defeating AMDGPUPromoteAlloca and leaving the per-thread temps in scratch with a flat pointer that fails the runtime aperture check.
Bisection evidence (rocprim test_device_batch_memcpy TU, 390 amdgpu_kernel definitions): with this revert all 390 kernel bodies are byte-identical to the pre-PR (2825dfa027e6^) baseline; without it none are. This branch is intentionally based on 7481d98b62fb^ (the parent of the blanket revert) so the partial revert is the only delta against the post-PR state, isolating the gfx942 fix at the call-site granularity.


