### PR TITLE
[Comgr] Add AMD_COMGR_CLANG_EXECUTABLE env var, deprecate LLVM_PATH

### DIFF
--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -173,11 +173,13 @@ required. If the value is used, it is read once at the time it is needed, and
 then cached. The exact behavior when changing these values during the execution
 of a process after Comgr APIs have been invoked is undefined.
 
-Comgr supports an environment variable to help locate LLVM:
+Comgr supports an environment variable to override the clang executable used
+as argv[0] for the in-process driver (and the basis for clang resource directory
+lookup):
 
-* `LLVM_PATH`: If set, it is used as an absolute path to the root of the LLVM
-  installation, which is currently used to locate the clang resource directory
-  and clang binary path, allowing for additional optimizations.
+* `AMD_COMGR_CLANG_EXECUTABLE`: If set, the absolute path to a clang executable.
+* `LLVM_PATH` (deprecated): If set and `AMD_COMGR_CLANG_EXECUTABLE` is not,
+  `<LLVM_PATH>/bin/clang` is used.
 
 ### Caching
 Comgr utilizes a cache to preserve the results of compilations between executions.

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1050,7 +1050,12 @@ AMDGPUCompiler::executeInProcessDriver(ArrayRef<const char *> Args) {
 
   ProcessWarningOptions(Diags, *DiagOpts, *OverlayFS, /*ReportDiags=*/false);
 
-  Driver TheDriver((Twine(env::getLLVMPath()) + "/bin/clang").str(),
+  StringRef ClangExecutable = env::getClangExecutable();
+  if (env::shouldEmitVerboseLogs()) {
+    LogS << "    Clang Executable: " << ClangExecutable << "\n";
+  }
+
+  Driver TheDriver(ClangExecutable.str(),
                    llvm::sys::getDefaultTargetTriple(), Diags,
                    "AMDGPU Code Object Manager", OverlayFS);
   TheDriver.setCheckInputsExist(false);
@@ -1217,7 +1222,7 @@ amd_comgr_status_t AMDGPUCompiler::processFile(DataObject *Input,
   // This ensures backward compatibility while providing headers on systems
   // without C++ development headers (e.g., driver-only installs).
   if (HasEmbeddedHeaders && getLanguage() == AMD_COMGR_LANGUAGE_HIP) {
-    SmallString<256> LibcxxPath(env::getLLVMPath());
+    SmallString<256> LibcxxPath(env::getLLVMInstallDir());
     sys::path::append(LibcxxPath, "include", "c++", "v1");
     Argv.push_back("-idirafter");
     Argv.push_back(Saver.save(StringRef(LibcxxPath)).data());
@@ -1474,10 +1479,7 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
 }
 
 amd_comgr_status_t AMDGPUCompiler::addDeviceLibraries() {
-  SmallString<256> ClangBinaryPath(env::getLLVMPath());
-  sys::path::append(ClangBinaryPath, "bin", "clang");
-
-  std::string ClangResourceDir = GetResourcesPath(ClangBinaryPath);
+  std::string ClangResourceDir = GetResourcesPath(env::getClangExecutable());
 
   NoGpuLib = false;
 
@@ -2748,12 +2750,10 @@ AMDGPUCompiler::AMDGPUCompiler(DataAction *ActionInfo, DataSet *InSet,
       OverlayFS->pushOverlay(InMemoryFS);
     }
 
-    SmallString<256> ClangBinaryPath(env::getLLVMPath());
-    sys::path::append(ClangBinaryPath, "bin", "clang");
-    std::string ResourceDir = GetResourcesPath(ClangBinaryPath);
+    std::string ResourceDir = GetResourcesPath(env::getClangExecutable());
 
     // libc++ headers → <install>/include/c++/v1/<relative-path>
-    SmallString<256> LibcxxBase(env::getLLVMPath());
+    SmallString<256> LibcxxBase(env::getLLVMInstallDir());
     sys::path::append(LibcxxBase, "include", "c++", "v1");
 
     for (const auto &Entry : getLibcxxHeaderFiles()) {

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1050,7 +1050,7 @@ AMDGPUCompiler::executeInProcessDriver(ArrayRef<const char *> Args) {
 
   ProcessWarningOptions(Diags, *DiagOpts, *OverlayFS, /*ReportDiags=*/false);
 
-  StringRef ClangExecutable = env::getClangExecutable();
+  StringRef ClangExecutable = env::getClangExecutablePath();
   if (env::shouldEmitVerboseLogs()) {
     LogS << "    Clang Executable: " << ClangExecutable << "\n";
   }
@@ -1479,7 +1479,7 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
 }
 
 amd_comgr_status_t AMDGPUCompiler::addDeviceLibraries() {
-  std::string ClangResourceDir = GetResourcesPath(env::getClangExecutable());
+  std::string ClangResourceDir = GetResourcesPath(env::getClangExecutablePath());
 
   NoGpuLib = false;
 
@@ -2750,7 +2750,7 @@ AMDGPUCompiler::AMDGPUCompiler(DataAction *ActionInfo, DataSet *InSet,
       OverlayFS->pushOverlay(InMemoryFS);
     }
 
-    std::string ResourceDir = GetResourcesPath(env::getClangExecutable());
+    std::string ResourceDir = GetResourcesPath(env::getClangExecutablePath());
 
     // libc++ headers → <install>/include/c++/v1/<relative-path>
     SmallString<256> LibcxxBase(env::getLLVMInstallDir());

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -14,7 +14,6 @@
 
 #include "comgr-env.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
@@ -66,7 +65,7 @@ bool shouldEmitVerboseLogs() {
   return VerboseLogs && StringRef(VerboseLogs) != "0";
 }
 
-llvm::StringRef getClangExecutable() {
+llvm::StringRef getClangExecutablePath() {
   static const std::string Path = [] {
     if (const char *E = std::getenv("AMD_COMGR_CLANG_EXECUTABLE"))
       if (E[0] != '\0')
@@ -84,7 +83,7 @@ llvm::StringRef getClangExecutable() {
 
 llvm::StringRef getLLVMInstallDir() {
   static const std::string Dir =
-      sys::path::parent_path(sys::path::parent_path(getClangExecutable())).str();
+      sys::path::parent_path(sys::path::parent_path(getClangExecutablePath())).str();
   return Dir;
 }
 

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -13,7 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "comgr-env.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
 using namespace llvm;
@@ -64,9 +66,26 @@ bool shouldEmitVerboseLogs() {
   return VerboseLogs && StringRef(VerboseLogs) != "0";
 }
 
-llvm::StringRef getLLVMPath() {
-  static const char *EnvLLVMPath = std::getenv("LLVM_PATH");
-  return EnvLLVMPath;
+llvm::StringRef getClangExecutable() {
+  static const std::string Path = [] {
+    if (const char *E = std::getenv("AMD_COMGR_CLANG_EXECUTABLE"))
+      if (E[0] != '\0')
+        return std::string(E);
+    if (const char *E = std::getenv("LLVM_PATH"))
+      if (E[0] != '\0') {
+        SmallString<256> P(E);
+        sys::path::append(P, "bin", "clang");
+        return std::string(P);
+      }
+    return std::string();
+  }();
+  return Path;
+}
+
+llvm::StringRef getLLVMInstallDir() {
+  static const std::string Dir =
+      sys::path::parent_path(sys::path::parent_path(getClangExecutable())).str();
+  return Dir;
 }
 
 StringRef getCachePolicy() {

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -31,9 +31,9 @@ bool needTimeStatistics();
 
 /// Path to the clang executable. AMD_COMGR_CLANG_EXECUTABLE, else
 /// <LLVM_PATH>/bin/clang for back-compat, else empty.
-llvm::StringRef getClangExecutable();
+llvm::StringRef getClangExecutablePath();
 
-/// LLVM install root, derived from getClangExecutable().
+/// LLVM install root, derived from getClangExecutablePath().
 llvm::StringRef getLLVMInstallDir();
 
 /// If environment variable AMD_COMGR_CACHE_POLICY is set, return the

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -29,9 +29,12 @@ bool shouldEmitVerboseLogs();
 /// Return whether the environment requests time statistics collection.
 bool needTimeStatistics();
 
-/// If environment variable LLVM_PATH is set, return the environment variable,
-/// otherwise return the default LLVM path.
-llvm::StringRef getLLVMPath();
+/// Path to the clang executable. AMD_COMGR_CLANG_EXECUTABLE, else
+/// <LLVM_PATH>/bin/clang for back-compat, else empty.
+llvm::StringRef getClangExecutable();
+
+/// LLVM install root, derived from getClangExecutable().
+llvm::StringRef getLLVMInstallDir();
 
 /// If environment variable AMD_COMGR_CACHE_POLICY is set, return the
 /// environment variable, otherwise return empty

--- a/amd/comgr/test-lit/clang-executable-env-var.cl
+++ b/amd/comgr/test-lit/clang-executable-env-var.cl
@@ -3,8 +3,17 @@
 // RUN: AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_REDIRECT_LOGS=stdout \
 // RUN:    compile-opencl-minimal %s %t.bin 1.2 | %FileCheck %s
 
-// CHECK: Clang Executable: {{.*}}clang{{.*}}
+// Verify LLVM_PATH back-compat: <LLVM_PATH>/bin/clang is used when
+// AMD_COMGR_CLANG_EXECUTABLE is not set.
+// RUN: LLVM_PATH=%S/.. \
+// RUN: AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_REDIRECT_LOGS=stdout \
+// RUN:    compile-opencl-minimal %s %t.bin 1.2 | %FileCheck --check-prefix=LEGACY %s
+
+// CHECK: Clang Executable: {{.*[/\\]}}clang
 // CHECK: ReturnStatus: AMD_COMGR_STATUS_SUCCESS
+
+// LEGACY: Clang Executable: {{.*[/\\]}}bin{{[/\\]}}clang
+// LEGACY: ReturnStatus: AMD_COMGR_STATUS_SUCCESS
 
 __kernel void test(__global int* out) {
   *out = 42;

--- a/amd/comgr/test-lit/clang-executable-env-var.cl
+++ b/amd/comgr/test-lit/clang-executable-env-var.cl
@@ -1,0 +1,11 @@
+// Verify AMD_COMGR_CLANG_EXECUTABLE is honored and appears in the verbose log.
+// RUN: AMD_COMGR_CLANG_EXECUTABLE=%clang \
+// RUN: AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_REDIRECT_LOGS=stdout \
+// RUN:    compile-opencl-minimal %s %t.bin 1.2 | %FileCheck %s
+
+// CHECK: Clang Executable: {{.*}}clang{{.*}}
+// CHECK: ReturnStatus: AMD_COMGR_STATUS_SUCCESS
+
+__kernel void test(__global int* out) {
+  *out = 42;
+}


### PR DESCRIPTION
Introduces `AMD_COMGR_CLANG_EXECUTABLE` as the preferred override for the clang executable used as argv[0] in Comgr's in-process driver. `LLVM_PATH` is kept as a deprecated alias (`<LLVM_PATH>/bin/clang`).

Consolidates the five ad-hoc `getLLVMPath() + "/bin/clang"` sites into two helpers (`getClangExecutable()`, `getLLVMInstallDir()`), adds a verbose log line for the resolved path, and adds a lit test.

Default behavior is unchanged when no env var is set. Replaces #1536 — see that PR's closing comment for the directional discussion.