### PR TITLE
[WaveTransform] Mark BRCOND* as divergent branches to prevent MIR sinking

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3025,6 +3025,8 @@ bool SIInstrInfo::hasDivergentBranch(const MachineBasicBlock *MBB) const {
   for (const MachineInstr &MI : MBB->terminators()) {
     if (MI.getOpcode() == AMDGPU::SI_IF || MI.getOpcode() == AMDGPU::SI_ELSE ||
         MI.getOpcode() == AMDGPU::SI_LOOP ||
+        MI.getOpcode() == AMDGPU::SI_BRCOND ||
+        MI.getOpcode() == AMDGPU::SI_BRCOND_Z ||
         MI.getOpcode() == AMDGPU::SI_WAVE_CF_EDGE)
       return true;
   }

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
@@ -345,6 +345,7 @@ define void @divergent_i1_icmp_used_outside_loop(i32 %v0, i32 %v1, ptr addrspace
   ; CHECK-NEXT: bb.4.loop.break.block:
   ; CHECK-NEXT:   successors: %bb.6(0x04000000), %bb.5(0x7c000000)
   ; CHECK-NEXT: {{  $}}
+  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, -1, killed [[V_CMP_EQ_U32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_EQ_U32_e64_1:%[0-9]+]]:sreg_32 = V_CMP_EQ_U32_e64 [[PHI]], [[COPY4]], implicit $exec
   ; CHECK-NEXT:   [[COPY7:%[0-9]+]]:vgpr_32 = COPY [[PHI]], implicit $exec
   ; CHECK-NEXT:   SI_BRCOND %bb.6, killed [[V_CMP_EQ_U32_e64_1]], implicit-def dead $exec, implicit-def dead $vcc_lo, implicit $exec
@@ -359,7 +360,6 @@ define void @divergent_i1_icmp_used_outside_loop(i32 %v0, i32 %v1, ptr addrspace
   ; CHECK-NEXT: bb.6.cond.block.1:
   ; CHECK-NEXT:   successors: %bb.7(0x40000000), %bb.8(0x40000000)
   ; CHECK-NEXT: {{  $}}
-  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, -1, killed [[V_CMP_EQ_U32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 0, killed [[V_CNDMASK_B32_e64_]], implicit $exec
   ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1, killed [[V_CMP_NE_U32_e64_1]], implicit $exec
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_2:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 1, killed [[V_CNDMASK_B32_e64_1]], implicit $exec

--- a/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
+++ b/llvm/test/CodeGen/AMDGPU/divergent-branch-uniform-condition.ll
@@ -161,12 +161,13 @@ define amdgpu_ps void @i1_copy_assert(i1 %v4) {
 ; ISA-NEXT:  .LBB1_1: ; %Flow
 ; ISA-NEXT:    ; in Loop: Header=BB1_2 Depth=1
 ; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
-; ISA-NEXT:    s_xor_b64 s[6:7], vcc, exec
-; ISA-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
-; ISA-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; ISA-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[2:3]
+; ISA-NEXT:    s_xor_b64 s[2:3], vcc, exec
+; ISA-NEXT:    s_xor_b64 s[6:7], exec, s[2:3]
+; ISA-NEXT:    s_and_b64 s[6:7], s[6:7], exec
 ; ISA-NEXT:    s_mov_b32 s4, 1
-; ISA-NEXT:    s_or_b64 s[0:1], s[0:1], s[8:9]
-; ISA-NEXT:    s_mov_b64 exec, s[6:7]
+; ISA-NEXT:    s_or_b64 s[0:1], s[0:1], s[6:7]
+; ISA-NEXT:    s_mov_b64 exec, s[2:3]
 ; ISA-NEXT:    ; divergent control-flow edge
 ; ISA-NEXT:    s_cbranch_execz .LBB1_4
 ; ISA-NEXT:  .LBB1_2: ; %loop
@@ -182,10 +183,9 @@ define amdgpu_ps void @i1_copy_assert(i1 %v4) {
 ; ISA-NEXT:    s_branch .LBB1_1
 ; ISA-NEXT:  .LBB1_4: ; %Flow2
 ; ISA-NEXT:    s_or_b64 exec, exec, s[0:1]
-; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, -1, s[2:3]
-; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v0
-; ISA-NEXT:    v_mov_b32_e32 v1, 0
-; ISA-NEXT:    v_cndmask_b32_e64 v0, 0, 1.0, vcc
+; ISA-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; ISA-NEXT:    v_mov_b32_e32 v0, 0
+; ISA-NEXT:    v_cndmask_b32_e64 v1, 0, 1.0, vcc
 ; ISA-NEXT:    exp mrt0, off, off, off, off
 ; ISA-NEXT:    s_endpgm
 start:

--- a/llvm/test/CodeGen/AMDGPU/fix-frame-ptr-reg-copy-livein.ll
+++ b/llvm/test/CodeGen/AMDGPU/fix-frame-ptr-reg-copy-livein.ll
@@ -14,11 +14,9 @@ define i32 @fp_save_restore_in_temp_sgpr(ptr addrspace(5) nocapture readonly byv
   ; GCN:   $sgpr7 = frame-setup COPY $sgpr33
   ; GCN: bb.1.lp_end:
   ; GCN:   liveins: $sgpr6, $sgpr7, $vgpr1, $sgpr4_sgpr5
-  ; GCN: bb.2:
-  ; GCN:   liveins: $sgpr7, $sgpr4_sgpr5
-  ; GCN: bb.3.lp_begin:
+  ; GCN: bb.2.lp_begin:
   ; GCN:   liveins: $sgpr6, $sgpr7, $vgpr1, $sgpr4_sgpr5
-  ; GCN: bb.4.end:
+  ; GCN: bb.3.end:
   ; GCN:   liveins: $sgpr7, $vgpr0, $sgpr4_sgpr5
   ; GCN:   $sgpr33 = frame-destroy COPY $sgpr7
 begin:

--- a/llvm/test/CodeGen/AMDGPU/stack-realign.ll
+++ b/llvm/test/CodeGen/AMDGPU/stack-realign.ll
@@ -344,33 +344,33 @@ define i32 @needs_align1024_stack_args_used_inside_loop(ptr addrspace(5) nocaptu
 ; GCN-NEXT:    s_mov_b32 s10, s34
 ; GCN-NEXT:    s_and_b32 s33, s33, 0xffff0000
 ; GCN-NEXT:    s_mov_b32 s34, s32
-; GCN-NEXT:    v_lshrrev_b32_e64 v1, 6, s34
 ; GCN-NEXT:    v_mov_b32_e32 v0, 0
-; GCN-NEXT:    s_mov_b32 s6, 0
-; GCN-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-NEXT:    s_add_i32 s32, s32, 0x30000
+; GCN-NEXT:    v_lshrrev_b32_e64 v1, 6, s34
 ; GCN-NEXT:    buffer_store_dword v0, off, s[0:3], s33 offset:1024
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
+; GCN-NEXT:    s_mov_b32 s6, 0
+; GCN-NEXT:    s_mov_b64 s[4:5], 0
 ; GCN-NEXT:  .LBB10_1: ; %loop_body
 ; GCN-NEXT:    ; =>This Inner Loop Header: Depth=1
-; GCN-NEXT:    buffer_load_dword v2, v1, s[0:3], 0 offen
+; GCN-NEXT:    buffer_load_dword v0, v1, s[0:3], 0 offen
 ; GCN-NEXT:    s_waitcnt vmcnt(0)
-; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s6, v2
+; GCN-NEXT:    v_cmp_eq_u32_e32 vcc, s6, v0
 ; GCN-NEXT:    s_xor_b64 s[8:9], exec, vcc
 ; GCN-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-NEXT:    v_mov_b32_e32 v0, 0
 ; GCN-NEXT:    s_or_b64 s[4:5], s[4:5], s[8:9]
 ; GCN-NEXT:    s_mov_b64 exec, vcc
 ; GCN-NEXT:    ; divergent control-flow edge
-; GCN-NEXT:    s_cbranch_execz .LBB10_4
+; GCN-NEXT:    s_cbranch_execz .LBB10_3
 ; GCN-NEXT:  .LBB10_2: ; %loop_end
 ; GCN-NEXT:    ; in Loop: Header=BB10_1 Depth=1
 ; GCN-NEXT:    s_add_i32 s6, s6, 1
 ; GCN-NEXT:    v_add_u32_e32 v1, vcc, 4, v1
+; GCN-NEXT:    v_mov_b32_e32 v0, 1
 ; GCN-NEXT:    s_cmp_eq_u32 s6, 9
 ; GCN-NEXT:    s_cbranch_scc0 .LBB10_1
-; GCN-NEXT:  ; %bb.3:
-; GCN-NEXT:    v_mov_b32_e32 v0, 1
-; GCN-NEXT:  .LBB10_4: ; %exit
+; GCN-NEXT:  .LBB10_3: ; %exit
 ; GCN-NEXT:    s_or_b64 exec, exec, s[4:5]
 ; GCN-NEXT:    s_mov_b32 s32, s34
 ; GCN-NEXT:    s_mov_b32 s34, s10


### PR DESCRIPTION
Add SI_BRCOND and SI_BRCOND_Z opcodes to the hasDivergentBranch() check, treating them consistently with other divergent control flow pseudos (SI_IF, SI_ELSE, SI_LOOP) from the structurizer-based flow.

These pseudo branch instructions represent divergent branches where different lanes within a wave take different paths. Marking them via hasDivergentBranch() prevents Machine Instruction Sinking from incorrectly moving instructions across divergent control flow boundaries, which could violate wave semantics.

This PR is a continuation from PR #2632.


