### PR TITLE
[Comgr] Fix race-condition on compilation/execution of Comgr's lit tests

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -25,7 +25,6 @@ message("-- LLVM_LIT_PATH: ${LLVM_LIT_PATH}")
 
 add_custom_target(test-lit COMMAND "${LLVM_LIT_PATH}"
                   "${CMAKE_CURRENT_BINARY_DIR}" -v)
-add_dependencies(test-lit amd_comgr)
 
 macro(add_comgr_lit_binary name lang)
   add_executable("${name}" "comgr-sources/${name}.${lang}")
@@ -36,7 +35,7 @@ macro(add_comgr_lit_binary name lang)
       C_EXTENSIONS No)
   endif()
   target_link_libraries("${name}" amd_comgr)
-  add_dependencies(check-comgr "${name}")
+  add_dependencies(test-lit "${name}")
 endmacro()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
When running Comgr's tests through `ninja check-comgr` I was getting several weird fails:

```text
time-statistics.cl.script: line 1: /home/juamarti/llvm/_build/tools/comgr/test-lit/compile-opencl-minimal: Permission denied
```

These fails were absent when running the exact same tests directly through lit.

The underlying problem was _running_ the lit tests did not depend on the _compilation_ of those binaries. So they could happen in parallel, leading to weird error messages and flaky tests.

This patch sets the following dependency between targets: check-comgr <- test-lit <- comgr-lit-binary <- amd_comgr