### PR TITLE
[Infra] Fix to get the submodule name instead of path for teams notification

### DIFF
--- a/.github/workflows/build_metadata_extractor.py
+++ b/.github/workflows/build_metadata_extractor.py
@@ -77,10 +77,11 @@ class BuildMetadataExtractor:
         #the_rock_commit = manifest_data.get('the_rock_commit', '')
         #commit_url = f"{self.base_url}/commit/{the_rock_commit}"
         table = '| Submodule | URL |\n|-----------|-----|\n'
+        commit_base_url = f"https://github.com/{self.org_name}"
         for submodule_name,pin_sha in manifest_data.items():
             if submodule_name == 'rccl':  # Filter out specific submodules
                continue
-            submodule_url = f"{self.base_url}/{submodule_name}"
+            submodule_url = f"{commit_base_url}/{submodule_name}"
             commit_url = f"{submodule_url}/commit/{pin_sha}"
             table += f'| {submodule_name} | ({commit_url}) |\n'
 

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -223,13 +223,17 @@ jobs:
         timeout-minutes: 30
         run: |
              commit_log=$(./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1)
-             echo "$commit_log" | grep "checked out" | \
-             sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/" | \
              while read path commit; do
-                url=$(git config -f .gitmodules --get "submodule.${path}.url")
-                repo=$(basename "$url" .git)
-                echo "$repo $commit"
-             done > submodule-commit-${{ inputs.stage_name }}.txt
+               url=$(git config -f .gitmodules --get "submodule.${path}.url" 2>/dev/null)
+               if [ -n "$url" ]; then
+                  repo=$(basename "$url" .git)
+               else
+                  repo="${path##*/}"
+               fi
+               echo "$repo $commit"
+             done < <(echo "$commit_log" | grep "checked out" | \
+              sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/") \
+               > submodule-commit-${STAGE_NAME}.txt
 
       - name: Upload submodule commit file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -221,21 +221,12 @@ jobs:
 
       - name: Fetch sources
         timeout-minutes: 30
-        shell: bash
         run: |
              commit_log=$(./build_tools/fetch_sources.py --stage "${STAGE_NAME}" --jobs 12 --depth 1)
-             while read -r path commit; do
-               url=$(git config -f .gitmodules --get "submodule.${path}.url" 2>/dev/null)
-               if [ -n "$url" ]; then
-                 repo=$(basename "$url" .git)
-               else
-                 repo="${path##*/}"
-               fi
-               echo "$repo $commit"
-             done < <(
-               echo "$commit_log" | grep "checked out" | \
-               sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/"
-             ) > "submodule-commit-${STAGE_NAME}.txt"
+             echo "$commit_log" | awk -F"'" '/Submodule path/ {
+               n = split($2, a, "/")
+               print a[n], $4
+             }' > submodule-commit-${STAGE_NAME}.txt
 
       - name: Upload submodule commit file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -223,9 +223,13 @@ jobs:
         timeout-minutes: 30
         run: |
              commit_log=$(./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1)
-             echo "$commit_log" | grep "^Submodule path" | \
-             grep "checked out" | sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/" \
-             > submodule-commit-${{ inputs.stage_name }}.txt
+             echo "$commit_log" | grep "checked out" | \
+             sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/" | \
+             while read path commit; do
+                url=$(git config -f .gitmodules --get "submodule.${path}.url")
+                repo=$(basename "$url" .git)
+                echo "$repo $commit"
+             done > submodule-commit-${{ inputs.stage_name }}.txt
 
       - name: Upload submodule commit file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -222,18 +222,19 @@ jobs:
       - name: Fetch sources
         timeout-minutes: 30
         run: |
-             commit_log=$(./build_tools/fetch_sources.py --stage ${STAGE_NAME} --jobs 12 --depth 1)
-             while read path commit; do
+             commit_log=$(./build_tools/fetch_sources.py --stage "${STAGE_NAME}" --jobs 12 --depth 1)
+             while read -r path commit; do
                url=$(git config -f .gitmodules --get "submodule.${path}.url" 2>/dev/null)
                if [ -n "$url" ]; then
-                  repo=$(basename "$url" .git)
+                 repo=$(basename "$url" .git)
                else
-                  repo="${path##*/}"
+                 repo="${path##*/}"
                fi
                echo "$repo $commit"
-             done < <(echo "$commit_log" | grep "checked out" | \
-              sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/") \
-               > submodule-commit-${STAGE_NAME}.txt
+             done < <(
+               echo "$commit_log" | grep "checked out" | \
+               sed "s/Submodule path '\([^']*\)': checked out '\([^']*\)'/\1 \2/"
+             ) > "submodule-commit-${STAGE_NAME}.txt"
 
       - name: Upload submodule commit file
         uses: actions/upload-artifact@v4

--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -221,6 +221,7 @@ jobs:
 
       - name: Fetch sources
         timeout-minutes: 30
+        shell: bash
         run: |
              commit_log=$(./build_tools/fetch_sources.py --stage "${STAGE_NAME}" --jobs 12 --depth 1)
              while read -r path commit; do


### PR DESCRIPTION
1. Now this patch, helps to get the repo name instead of the path where clone happens
2. And the submodule block in notifier is changed to use the proper base url instead of api