### PR TITLE
Reapply "clang: Refactor handling of offload sanitizer arguments (#196737)"

### DIFF
--- a/amd/comgr/test-lit/comgr-sources/compile-hip-asan.c
+++ b/amd/comgr/test-lit/comgr-sources/compile-hip-asan.c
@@ -37,7 +37,7 @@ int main(int argc, char *argv[]) {
 
   amd_comgr_(create_action_info(&DataAction));
   amd_comgr_(action_info_set_language(DataAction, AMD_COMGR_LANGUAGE_HIP));
-  amd_comgr_(action_info_set_isa_name(DataAction, "amdgcn-amd-amdhsa--gfx900"));
+  amd_comgr_(action_info_set_isa_name(DataAction, "amdgcn-amd-amdhsa--gfx900:xnack+"));
   amd_comgr_(action_info_set_option_list(DataAction, CompileOptions,
                                          CompileOptionsCount));
   amd_comgr_(action_info_set_device_lib_linking(DataAction, true));

--- a/clang/include/clang/Driver/RocmInstallationDetector.h
+++ b/clang/include/clang/Driver/RocmInstallationDetector.h
@@ -141,9 +141,6 @@ private:
   // Asan runtime library
   SmallString<0> AsanRTL;
 
-  // OpenMP ASan runtime library
-  SmallString<0> OpenMPASanRTLPath;
-
   // Libraries swapped based on compile flags.
   ConditionalLibrary WavefrontSize64;
   ConditionalLibrary FiniteOnly;
@@ -177,8 +174,7 @@ private:
 public:
   RocmInstallationDetector(const Driver &D, const llvm::Triple &HostTriple,
                            const llvm::opt::ArgList &Args,
-                           bool DetectHIPRuntime = true,
-                           bool DetectOpenMPRuntime = true);
+                           bool DetectHIPRuntime = true);
 
   /// Get file paths of default bitcode libraries common to AMDGPU based
   /// toolchains.
@@ -240,9 +236,6 @@ public:
   /// Returns empty string of Asan runtime library is not available.
   StringRef getAsanRTLPath() const { return AsanRTL; }
 
-  /// Returns empty string of OpenMP Asan runtime library is not available.
-  StringRef getOpenMPASanRTLPath() const { return OpenMPASanRTLPath; }
-
   StringRef getWavefrontSize64Path(bool Enabled) const {
     return WavefrontSize64.get(Enabled);
   }
@@ -275,7 +268,6 @@ public:
 
   void detectDeviceLibrary();
   void detectHIPRuntime();
-  void detectOpenMPRuntime();
 
   /// Get the values for --rocm-device-lib-path arguments
   ArrayRef<std::string> getRocmDeviceLibPathArg() const {

--- a/clang/include/clang/Driver/SanitizerArgs.h
+++ b/clang/include/clang/Driver/SanitizerArgs.h
@@ -9,6 +9,7 @@
 #define LLVM_CLANG_DRIVER_SANITIZERARGS_H
 
 #include "clang/Basic/Sanitizers.h"
+#include "clang/Driver/Action.h"
 #include "clang/Driver/Types.h"
 #include "llvm/Option/Arg.h"
 #include "llvm/Option/ArgList.h"
@@ -85,7 +86,9 @@ class SanitizerArgs {
 public:
   /// Parses the sanitizer arguments from an argument list.
   SanitizerArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
-                bool DiagnoseErrors = true);
+                bool DiagnoseErrors = true, bool DiagnoseBoundArchErrors = true,
+                StringRef BoundArch = "",
+                Action::OffloadKind DeviceOffloadKind = Action::OFK_None);
 
   bool needsSharedRt() const { return SharedRuntime; }
   bool needsStableAbi() const { return StableABI; }

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -19,6 +19,7 @@
 #include "llvm/ADT/APFloat.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FloatingPointMode.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Frontend/Debug/Options.h"
@@ -188,7 +189,12 @@ private:
   Tool *getOffloadPackager() const;
   Tool *getLinkerWrapper() const;
 
+  /// Track if diagnostics have been emitted for sanitizer arguments already to
+  /// avoid duplicate diagnostics.
   mutable bool SanitizerArgsChecked = false;
+
+  /// Set of BoundArch values which have already had diagnostics emitted.
+  mutable llvm::SmallSet<StringRef, 4> BoundArchSanitizerArgsChecked;
 
   /// The effective clang triple for the current Job.
   mutable llvm::Triple EffectiveTriple;
@@ -345,7 +351,18 @@ public:
   /// -print-multi-flags-experimental argument.
   Multilib::flags_list getMultilibFlags(const llvm::opt::ArgList &) const;
 
-  SanitizerArgs getSanitizerArgs(const llvm::opt::ArgList &JobArgs) const;
+  SanitizerArgs getSanitizerArgs(
+      const llvm::opt::ArgList &JobArgs, StringRef BoundArch = "",
+      Action::OffloadKind DeviceOffloadKind = Action::OFK_None) const;
+
+  /// Returns the feature requirement for a sanitizer on a specific arch for
+  /// diagnostic purposes. Returns the required feature name (e.g., "xnack+") if
+  /// the sanitizer is generally supported but requires a specific feature for
+  /// the given BoundArch, or an empty StringRef otherwise.
+  virtual StringRef getSanitizerRequirement(SanitizerMask Kinds,
+                                            StringRef BoundArch) const {
+    return {};
+  }
 
   const XRayArgs getXRayArgs(const llvm::opt::ArgList &) const;
 

--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -398,7 +398,9 @@ bool SanitizerArgs::needsLTO() const {
 
 SanitizerArgs::SanitizerArgs(const ToolChain &TC,
                              const llvm::opt::ArgList &Args,
-                             bool DiagnoseErrors) {
+                             bool DiagnoseErrors, bool DiagnoseBoundArchErrors,
+                             StringRef BoundArch,
+                             Action::OffloadKind DeviceOffloadKind) {
   SanitizerMask AllRemove;      // During the loop below, the accumulated set of
                                 // sanitizers disabled by the current sanitizer
                                 // argument or any argument after it.
@@ -412,8 +414,16 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
   SanitizerMask IgnoreForUbsanFeature; // Accumulated set of values passed to
                                        // `-fsanitize-ignore-for-ubsan-feature`.
   SanitizerMask Kinds;
-  const SanitizerMask Supported =
-      setGroupBits(TC.getSupportedSanitizers("", Action::OFK_None));
+
+  // Figure out the base toolchain's sanitizer support so we can diagnose the
+  // diff for a specific BoundArch.
+  const SanitizerMask ToolChainSupported =
+      setGroupBits(TC.getSupportedSanitizers("", DeviceOffloadKind));
+
+  const SanitizerMask BoundArchSupported =
+      BoundArch.empty() ? ToolChainSupported
+                        : setGroupBits(TC.getSupportedSanitizers(
+                              BoundArch, DeviceOffloadKind));
 
   CfiCrossDso = Args.hasFlag(options::OPT_fsanitize_cfi_cross_dso,
                              options::OPT_fno_sanitize_cfi_cross_dso, false);
@@ -540,15 +550,79 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
         DiagnosedKinds |= SanitizerKind::CFIMFCall;
       }
 
-      if (SanitizerMask KindsToDiagnose = Add & ~Supported & ~DiagnosedKinds) {
-        if (DiagnoseErrors) {
-          std::string Desc = describeSanitizeArg(Arg, KindsToDiagnose);
-          D.Diag(diag::err_drv_unsupported_opt_for_target)
-              << Desc << TC.getTriple().str();
+      // Check for sanitizers that are supported by the toolchain but not for
+      // this specific arch (e.g., AMDGPU requires specific subtarget features
+      // for address sanitizer.)
+      if (SanitizerMask ArchSpecificUnsupported =
+              Add & ToolChainSupported & ~BoundArchSupported & ~DiagnosedKinds;
+          ArchSpecificUnsupported && DiagnoseBoundArchErrors) {
+        // Upgrade the warning to an error if the unsupported sanitizer was
+        // explicitly specified for the bound arch.
+
+        // FIXME: There are additional options which explicitly bind to this
+        // device.
+        bool IsExplicitDevice =
+            Arg->getBaseArg().getOption().matches(options::OPT_Xarch_device);
+
+        // Check if the toolchain provides a feature requirement hint for
+        // any of the unsupported sanitizers
+        StringRef Requirement =
+            TC.getSanitizerRequirement(ArchSpecificUnsupported, BoundArch);
+        if (!Requirement.empty()) {
+          // Emit diagnostic with feature requirement
+          //
+          // TODO: Use variant of unsupported_option_part_for_target that
+          // includes offload_arch_req_feature
+          D.Diag(
+              IsExplicitDevice
+                  ? diag::
+                        err_drv_unsupported_option_for_offload_arch_req_feature
+                  : diag::
+                        warn_drv_unsupported_option_for_offload_arch_req_feature)
+              << Arg->getAsString(Args) << BoundArch << Requirement;
+        } else {
+          // Fall back to generic diagnostic if no requirement was provided
+          SanitizerSet UnsupportedSet;
+          UnsupportedSet.Mask = ArchSpecificUnsupported;
+          D.Diag(diag::warn_drv_unsupported_option_part_for_target)
+              << toString(UnsupportedSet) << Arg->getAsString(Args)
+              << Triple.str();
         }
+
+        DiagnosedKinds |= ArchSpecificUnsupported;
+      }
+
+      // Check for sanitizers that are not supported at all by the toolchain
+      if (SanitizerMask KindsToDiagnose =
+              Add & ~ToolChainSupported & ~DiagnosedKinds;
+          DiagnoseErrors && KindsToDiagnose) {
+        bool IsExplicitDevice =
+            Arg->getBaseArg().getOption().matches(options::OPT_Xarch_device);
+        // For device offload compilation, emit a warning since the sanitizer
+        // may still work on the host. For non-offload compilation or explicit
+        // device specification, emit an error.
+        if (DeviceOffloadKind != Action::OFK_None &&
+            DeviceOffloadKind != Action::OFK_Host) {
+          // For warnings, extract just the sanitizer names (e.g., "fuzzer")
+          // instead of the full argument (e.g., "-fsanitize=fuzzer")
+          SanitizerSet KindSet;
+          KindSet.Mask = KindsToDiagnose;
+          D.Diag(IsExplicitDevice
+                     ? diag::err_drv_unsupported_option_part_for_target
+                     : diag::warn_drv_unsupported_option_part_for_target)
+              << toString(KindSet) << Arg->getAsString(Args)
+              << TC.getTriple().str();
+        } else {
+          // For non-offload targets, use the shorter diagnostic format
+          D.Diag(diag::err_drv_unsupported_opt_for_target)
+              << describeSanitizeArg(Arg, KindsToDiagnose)
+              << TC.getTriple().str();
+        }
+
         DiagnosedKinds |= KindsToDiagnose;
       }
-      Add &= Supported;
+
+      Add &= BoundArchSupported;
 
       // Test for -fno-rtti + explicit -fsanitizer=vptr before expanding groups
       // so we don't error out if -fno-rtti and -fsanitize=undefined were
@@ -599,7 +673,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
                                 options::OPT_fno_wrapv_pointer, S))
           Add &= ~SanitizerKind::PointerOverflow;
       }
-      Add &= Supported;
+      Add &= BoundArchSupported;
 
       if (Add & SanitizerKind::Fuzzer)
         Add |= SanitizerKind::FuzzerNoLink;
@@ -714,7 +788,7 @@ SanitizerArgs::SanitizerArgs(const ToolChain &TC,
   // c++abi-specific  parts of UBSan runtime, and they are not provided by the
   // toolchain. We don't have a good way to check the latter, so we just
   // check if the toolchan supports vptr.
-  if (~Supported & SanitizerKind::Vptr) {
+  if (~BoundArchSupported & SanitizerKind::Vptr) {
     SanitizerMask KindsToDiagnose = Kinds & ~TrappingKinds & NeedsUbsanCxxRt;
     // The runtime library supports the Microsoft C++ ABI, but only well enough
     // for CFI. FIXME: Remove this once we support vptr on Windows.

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -516,8 +516,15 @@ ToolChain::getMultilibFlags(const llvm::opt::ArgList &Args) const {
 }
 
 SanitizerArgs
-ToolChain::getSanitizerArgs(const llvm::opt::ArgList &JobArgs) const {
-  SanitizerArgs SanArgs(*this, JobArgs, !SanitizerArgsChecked);
+ToolChain::getSanitizerArgs(const llvm::opt::ArgList &JobArgs,
+                            StringRef BoundArch,
+                            Action::OffloadKind DeviceOffloadKind) const {
+  SanitizerArgs SanArgs(*this, JobArgs,
+                        /*DiagnoseErrors=*/!SanitizerArgsChecked,
+                        /*DiagnoseBoundArchErrors=*/
+                        BoundArchSanitizerArgsChecked.insert(BoundArch).second,
+                        BoundArch, DeviceOffloadKind);
+
   SanitizerArgsChecked = true;
   return SanArgs;
 }

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -1868,8 +1868,6 @@ ToolChain::getSupportedSanitizers(StringRef BoundArch,
     Res |= SanitizerKind::MemTag;
   if (getTriple().isBPF())
     Res |= SanitizerKind::KernelAddress;
-  if (getTriple().isAMDGPU())
-    Res |= SanitizerKind::Address;
   return Res;
 }
 

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -987,6 +987,9 @@ AMDGPUToolChain::ParsedTargetIDType
 AMDGPUToolChain::getParsedTargetID(const llvm::opt::ArgList &DriverArgs) const {
   StringRef TargetID = DriverArgs.getLastArgValue(options::OPT_mcpu_EQ);
   if (TargetID.empty())
+    TargetID = DriverArgs.getLastArgValue(options::OPT_march_EQ);
+
+  if (TargetID.empty())
     return {std::nullopt, std::nullopt, std::nullopt};
 
   llvm::StringMap<bool> FeatureMap;
@@ -1058,15 +1061,14 @@ void ROCMToolChain::addClangTargetOptions(
   if (TT.getEnvironment() == llvm::Triple::LLVM)
     return;
 
-  // Get the device name and canonicalize it
-  const StringRef GpuArch = getGPUArch(DriverArgs);
-  auto Kind = llvm::AMDGPU::parseArchAMDGCN(GpuArch);
-  const StringRef CanonArch = llvm::AMDGPU::getArchNameAMDGCN(Kind);
-  StringRef LibDeviceFile = RocmInstallation->getLibDeviceFile(CanonArch);
+  AMDGPUToolChain::ParsedTargetIDType TargetID = getParsedTargetID(DriverArgs);
+  StringRef GpuArch =
+      TargetID.OptionalGPUArch ? *TargetID.OptionalGPUArch : StringRef();
+
+  StringRef LibDeviceFile = RocmInstallation->getLibDeviceFile(GpuArch);
   auto ABIVer = DeviceLibABIVersion::fromCodeObjectVersion(
       getAMDGPUCodeObjectVersion(getDriver(), DriverArgs));
-  if (!RocmInstallation->checkCommonBitcodeLibs(CanonArch, LibDeviceFile,
-                                                ABIVer))
+  if (!RocmInstallation->checkCommonBitcodeLibs(GpuArch, LibDeviceFile, ABIVer))
     return;
 
   // Add the OpenCL specific bitcode library.
@@ -1076,7 +1078,9 @@ void ROCMToolChain::addClangTargetOptions(
   // Add the generic set of libraries.
   BCLibs.append(RocmInstallation->getCommonBitcodeLibs(
       DriverArgs, LibDeviceFile, GpuArch, DeviceOffloadingKind,
-      getSanitizerArgs(DriverArgs).needsAsanRt()));
+      getSanitizerArgs(DriverArgs, TargetID.OptionalTargetID.value_or(""),
+                       DeviceOffloadingKind)
+          .needsAsanRt()));
 
   for (auto [BCFile, Internalize] : BCLibs) {
     if (Internalize)
@@ -1160,8 +1164,8 @@ bool AMDGPUToolChain::shouldSkipArgument(const llvm::opt::Arg *A) const {
 
 llvm::SmallVector<ToolChain::BitCodeLibraryInfo, 12>
 ROCMToolChain::getCommonDeviceLibNames(
-    const llvm::opt::ArgList &DriverArgs, llvm::StringRef GPUArch,
-    Action::OffloadKind DeviceOffloadingKind) const {
+    const llvm::opt::ArgList &DriverArgs, llvm::StringRef TargetID,
+    llvm::StringRef GPUArch, Action::OffloadKind DeviceOffloadingKind) const {
   auto Kind = llvm::AMDGPU::parseArchAMDGCN(GPUArch);
   const StringRef CanonArch = llvm::AMDGPU::getArchNameAMDGCN(Kind);
 
@@ -1174,46 +1178,51 @@ ROCMToolChain::getCommonDeviceLibNames(
 
   return RocmInstallation->getCommonBitcodeLibs(
       DriverArgs, LibDeviceFile, GPUArch, DeviceOffloadingKind,
-      getSanitizerArgs(DriverArgs).needsAsanRt());
+      getSanitizerArgs(DriverArgs, TargetID, DeviceOffloadingKind)
+          .needsAsanRt());
 }
 
-bool AMDGPUToolChain::shouldSkipSanitizeOption(
-    const ToolChain &TC, const llvm::opt::ArgList &DriverArgs,
-    StringRef TargetID, const llvm::opt::Arg *A) const {
-  auto &Diags = TC.getDriver().getDiags();
-  bool IsExplicitDevice =
-      A->getBaseArg().getOption().matches(options::OPT_Xarch_device);
+static bool isXnackAvailable(const llvm::Triple &TT, llvm::StringRef TargetID) {
+  // Arch-specific check - only report as supported if arch has xnack+
+  llvm::StringRef Processor = getProcessorFromTargetID(TT, TargetID);
+  auto ProcKind = TT.isAMDGCN() ? llvm::AMDGPU::parseArchAMDGCN(Processor)
+                                : llvm::AMDGPU::parseArchR600(Processor);
+  auto Features = TT.isAMDGCN() ? llvm::AMDGPU::getArchAttrAMDGCN(ProcKind)
+                                : llvm::AMDGPU::getArchAttrR600(ProcKind);
 
-  // Check 'xnack+' availability by default
-  llvm::StringRef Processor =
-      getProcessorFromTargetID(TC.getTriple(), TargetID);
-  auto ProcKind = TC.getTriple().isAMDGCN()
-                      ? llvm::AMDGPU::parseArchAMDGCN(Processor)
-                      : llvm::AMDGPU::parseArchR600(Processor);
-  auto Features = TC.getTriple().isAMDGCN()
-                      ? llvm::AMDGPU::getArchAttrAMDGCN(ProcKind)
-                      : llvm::AMDGPU::getArchAttrR600(ProcKind);
-  if (Features & llvm::AMDGPU::FEATURE_XNACK_ALWAYS)
-    return false;
-
-  // Look for the xnack feature in TargetID
-  llvm::StringMap<bool> FeatureMap;
-  auto OptionalGpuArch = parseTargetID(TC.getTriple(), TargetID, &FeatureMap);
-  assert(OptionalGpuArch && "Invalid Target ID");
-  (void)OptionalGpuArch;
-  auto Loc = FeatureMap.find("xnack");
-  if (Loc == FeatureMap.end() || !Loc->second) {
-    if (IsExplicitDevice) {
-      Diags.Report(
-          clang::diag::err_drv_unsupported_option_for_offload_arch_req_feature)
-          << A->getAsString(DriverArgs) << TargetID << "xnack+";
-    } else {
-      Diags.Report(
-          clang::diag::warn_drv_unsupported_option_for_offload_arch_req_feature)
-          << A->getAsString(DriverArgs) << TargetID << "xnack+";
-    }
+  // If processor has xnack always on, Address sanitizer is supported
+  bool XnackAvailable = (Features & llvm::AMDGPU::FEATURE_XNACK_ALWAYS);
+  if (XnackAvailable)
     return true;
-  }
 
-  return false;
+  // Otherwise, check if xnack+ is explicitly enabled in the target ID
+  llvm::StringMap<bool> FeatureMap;
+  auto OptionalGpuArch = parseTargetID(TT, TargetID, &FeatureMap);
+  if (!OptionalGpuArch)
+    return false;
+  auto Loc = FeatureMap.find("xnack");
+  return (Loc != FeatureMap.end() && Loc->second);
+}
+
+SanitizerMask AMDGPUToolChain::getSupportedSanitizers(
+    StringRef BoundArch, Action::OffloadKind DeviceOffloadKind) const {
+  SanitizerMask SupportedMask =
+      ToolChain::getSupportedSanitizers(BoundArch, DeviceOffloadKind);
+
+  // Address sanitizer is potentially supported, but depends on the exact target
+  // arch xnack support.
+  if (BoundArch.empty() || isXnackAvailable(getTriple(), BoundArch))
+    SupportedMask |= SanitizerKind::Address;
+
+  return SupportedMask;
+}
+
+StringRef AMDGPUToolChain::getSanitizerRequirement(SanitizerMask Kinds,
+                                                   StringRef BoundArch) const {
+  // Address sanitizer requires xnack+ feature
+  if ((Kinds & SanitizerKind::Address) && !BoundArch.empty() &&
+      !isXnackAvailable(getTriple(), BoundArch)) {
+    return "xnack+";
+  }
+  return "";
 }

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -313,8 +313,7 @@ RocmInstallationDetector::getInstallationPathCandidates() {
 
 RocmInstallationDetector::RocmInstallationDetector(
     const Driver &D, const llvm::Triple &HostTriple,
-    const llvm::opt::ArgList &Args, bool DetectHIPRuntime,
-    bool DetectOpenMPRuntime)
+    const llvm::opt::ArgList &Args, bool DetectHIPRuntime)
     : D(D) {
   Verbose = Args.hasArg(options::OPT_v);
   RocmPathArg = Args.getLastArgValue(options::OPT_rocm_path_EQ);
@@ -368,25 +367,6 @@ RocmInstallationDetector::RocmInstallationDetector(
 
   if (DetectHIPRuntime)
     detectHIPRuntime();
-  if (DetectOpenMPRuntime)
-    detectOpenMPRuntime();
-}
-
-void RocmInstallationDetector::detectOpenMPRuntime() {
-  assert(OpenMPASanRTLPath.empty());
-  // Set OpenMP ASan library directory path for pre-instrumented device
-  // libraries (e.g., libompdevice.a). This path is used when linking with
-  // -fsanitize=address for OpenMP offloading.
-  OpenMPASanRTLPath = llvm::sys::path::parent_path(D.Dir);
-  llvm::sys::path::append(OpenMPASanRTLPath, "lib", "asan");
-  if (D.getVFS().exists(OpenMPASanRTLPath))
-    return;
-  // Fallback: Search ASan libs in the ROCm tree (e.g. /opt/rocm/llvm/lib/asan).
-  const auto &Candidates = getInstallationPathCandidates();
-  if (Candidates.empty())
-    return;
-  OpenMPASanRTLPath = Candidates.front().Path;
-  llvm::sys::path::append(OpenMPASanRTLPath, "lib", "llvm", "lib", "asan");
 }
 
 void RocmInstallationDetector::detectDeviceLibrary() {
@@ -770,24 +750,10 @@ AMDGPUToolChain::AMDGPUToolChain(const Driver &D, const llvm::Triple &Triple,
   // It is done here to avoid repeated warning or error messages for
   // each tool invocation.
   checkAMDGPUCodeObjectVersion(D, Args);
-  // When ASan is enabled, setup ASan library path configuration early so that
-  // the linker finds ASan-instrumented libraries.
-  checkAndAddAMDGPUSanLibPaths(Args);
 }
 
 Tool *AMDGPUToolChain::buildLinker() const {
   return new tools::amdgpu::Linker(*this);
-}
-
-// Common function to check and add ASan library paths.
-void AMDGPUToolChain::checkAndAddAMDGPUSanLibPaths(const ArgList &Args) {
-  // For OpenMP: when ASan is enabled, prepend the OpenMP ASan library path so
-  // the linker finds ASan-instrumented libraries.
-  if (getSanitizerArgs(Args).needsAsanRt()) {
-    StringRef OmpASanPath = RocmInstallation->getOpenMPASanRTLPath();
-    if (!OmpASanPath.empty() && getVFS().exists(OmpASanPath))
-      getFilePaths().insert(getFilePaths().begin(), OmpASanPath.str());
-  }
 }
 
 DerivedArgList *
@@ -1132,17 +1098,16 @@ RocmInstallationDetector::getCommonBitcodeLibs(
       BCLibs.emplace_back(BCLib);
     }
   };
+  auto AddSanBCLibs = [&]() {
+    if (Pref.GPUSan)
+      AddBCLib(getAsanRTLPath(), false);
+  };
 
-  // For OpenMP, openmp-devicertl(libompdevice.a) already contains ASan GPU
-  // runtime and Ockl functions (via POST_BUILD). Don't add it again at driver
-  // level to avoid duplicates as most of the symbols have USED attribute and
-  // duplicates entries in llvm.compiler.used & llvm.used makes their
-  // duplicate definitions persist even with internalization enabled
-  if (Pref.GPUSan && !Pref.IsOpenMP)
-    // Add Gpu Sanitizer RTL bitcode lib required for AMDGPU Sanitizer
-    AddBCLib(getAsanRTLPath(),false);
+  AddSanBCLibs();
   AddBCLib(getOCMLPath());
   if (!Pref.IsOpenMP)
+    AddBCLib(getOCKLPath());
+  else if (Pref.GPUSan && Pref.IsOpenMP)
     AddBCLib(getOCKLPath());
   AddBCLib(getUnsafeMathPath(Pref.UnsafeMathOpt || Pref.FastRelaxedMath));
   AddBCLib(getFiniteOnlyPath(Pref.FiniteOnly || Pref.FastRelaxedMath));

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -157,8 +157,6 @@ public:
   virtual Expected<SmallVector<std::string>>
   getSystemGPUArchs(const llvm::opt::ArgList &Args) const override;
 
-  void checkAndAddAMDGPUSanLibPaths(const llvm::opt::ArgList &Args);
-
 protected:
   /// Check and diagnose invalid target ID specified by -mcpu.
   virtual void checkTargetID(const llvm::opt::ArgList &DriverArgs) const;

--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -144,11 +144,8 @@ public:
   /// Needed for translating LTO options.
   const char *getDefaultLinker() const override { return "ld.lld"; }
 
-  /// Should skip sanitize option.
-  bool shouldSkipSanitizeOption(const ToolChain &TC,
-                                const llvm::opt::ArgList &DriverArgs,
-                                StringRef TargetID,
-                                const llvm::opt::Arg *A) const;
+  StringRef getSanitizerRequirement(SanitizerMask Kinds,
+                                    StringRef BoundArch) const override;
 
   /// Should skip argument.
   bool shouldSkipArgument(const llvm::opt::Arg *Arg) const;
@@ -184,6 +181,10 @@ protected:
   /// Common warning options shared by AMDGPU HIP, OpenCL and OpenMP toolchains.
   /// Language specific warning options should go to derived classes.
   void addClangWarningOptions(llvm::opt::ArgStringList &CC1Args) const override;
+
+  SanitizerMask
+  getSupportedSanitizers(StringRef BoundArch,
+                         Action::OffloadKind DeviceOffloadKind) const override;
 };
 
 class LLVM_LIBRARY_VISIBILITY ROCMToolChain : public AMDGPUToolChain {
@@ -198,22 +199,8 @@ public:
   // Returns a list of device library names shared by different languages
   llvm::SmallVector<BitCodeLibraryInfo, 12>
   getCommonDeviceLibNames(const llvm::opt::ArgList &DriverArgs,
-                          llvm::StringRef GPUArch,
+                          llvm::StringRef TargetID, llvm::StringRef GPUArch,
                           Action::OffloadKind DeviceOffloadingKind) const;
-
-  // FIXME: Remove this and make use of OffloadKind argument to
-  // getSupportedSanitizers
-  static constexpr SanitizerMask getOffloadSupportedSanitizers() {
-    return SanitizerKind::Address | SanitizerKind::Undefined |
-           SanitizerKind::UndefinedGroup;
-  }
-
-  SanitizerMask
-  getSupportedSanitizers(StringRef BoundArch,
-                         Action::OffloadKind DeviceOffloadKind) const override {
-    assert(DeviceOffloadKind == Action::OFK_None);
-    return getOffloadSupportedSanitizers();
-  }
 
   bool diagnoseUnsupportedOption(const llvm::opt::Arg *A,
                                  const llvm::opt::DerivedArgList &DAL,
@@ -237,61 +224,6 @@ public:
               : clang::diag::warn_drv_unsupported_option_for_target;
       Diags.Report(DiagID) << A->getAsString(DAL) << getTriple().str();
     }
-    return true;
-  }
-
-  bool handleSanitizeOption(const ToolChain &TC, llvm::opt::DerivedArgList &DAL,
-                            const llvm::opt::ArgList &DriverArgs,
-                            StringRef TargetID, const llvm::opt::Arg *A) const {
-    if (TargetID.empty())
-      return false;
-    // If we shouldn't do sanitizing, skip it.
-    if (!DriverArgs.hasFlag(options::OPT_fgpu_sanitize,
-                            options::OPT_fno_gpu_sanitize, true))
-      return true;
-    const llvm::opt::Option &Opt = A->getOption();
-    // Sanitizer coverage is currently not supported for AMDGPU, so warn/error
-    // on every related option.
-    if (Opt.matches(options::OPT_fsan_cov_Group)) {
-      diagnoseUnsupportedOption(A, DAL, DriverArgs);
-    }
-    // If this isn't a sanitizer option, don't handle it.
-    if (!Opt.matches(options::OPT_fsanitize_EQ))
-      return false;
-
-    SmallVector<const char *, 4> SupportedSanitizers;
-    SmallVector<const char *, 4> UnSupportedSanitizers;
-
-    SanitizerMask Supported = ROCMToolChain::getOffloadSupportedSanitizers();
-    SanitizerMask SupportedMask;
-    for (const char *Value : A->getValues()) {
-      SanitizerMask K = parseSanitizerValue(Value, /*Allow Groups*/ true);
-      if (K & Supported) {
-        SupportedSanitizers.push_back(Value);
-        SupportedMask |= K;
-      } else {
-        UnSupportedSanitizers.push_back(Value);
-      }
-    }
-
-    // If there are no supported sanitizers, drop the whole argument.
-    if (SupportedSanitizers.empty()) {
-      diagnoseUnsupportedOption(A, DAL, DriverArgs);
-      return true;
-    }
-    // If only some sanitizers are unsupported, report each one individually.
-    if (!UnSupportedSanitizers.empty()) {
-      for (const char *Value : UnSupportedSanitizers) {
-        diagnoseUnsupportedOption(A, DAL, DriverArgs, Value);
-      }
-    }
-    // The xnack+ feature is only required for ASan on AMDGPU.
-    if ((SupportedMask & SanitizerKind::Address) &&
-        shouldSkipSanitizeOption(TC, DriverArgs, TargetID, A))
-      return true;
-
-    // Add a new argument with only the supported sanitizers.
-    DAL.AddJoinedArg(A, A->getOption(), llvm::join(SupportedSanitizers, ","));
     return true;
   }
 };

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
@@ -454,9 +454,18 @@ llvm::opt::DerivedArgList *AMDGPUOpenMPToolChain::TranslateArgs(
   const OptTable &Opts = getDriver().getOpts();
 
   for (Arg *A : Args) {
-    // Filter unsupported sanitizers passed from the HostTC.
-    if (!handleSanitizeOption(*this, *DAL, Args, BoundArch, A))
-      DAL->append(A);
+    // Sanitizer coverage is currently not supported for AMDGPU.
+    if (A->getOption().matches(options::OPT_fsan_cov_Group)) {
+      diagnoseUnsupportedOption(A, *DAL, Args);
+      continue;
+    }
+
+    if (A->getOption().matches(options::OPT_fsanitize_EQ) &&
+        !Args.hasFlag(options::OPT_fgpu_sanitize, options::OPT_fno_gpu_sanitize,
+                      true))
+      continue;
+
+    DAL->append(A);
   }
 
   if (!BoundArch.empty()) {
@@ -545,21 +554,6 @@ void AMDGPUOpenMPToolChain::AddIAMCUIncludeArgs(const ArgList &Args,
   HostTC.AddIAMCUIncludeArgs(Args, CC1Args);
 }
 
-SanitizerMask AMDGPUOpenMPToolChain::getSupportedSanitizers(
-    StringRef BoundArch, Action::OffloadKind DeviceOffloadKind) const {
-  // The AMDGPUOpenMPToolChain only supports sanitizers in the sense that it
-  // allows sanitizer arguments on the command line if they are supported by the
-  // host toolchain. The AMDGPUOpenMPToolChain will later filter unsupported
-  // sanitizers from the command line arguments.
-  //
-  // This behavior is necessary because the host and device toolchains
-  // invocations often share the command line, so the device toolchain must
-  // tolerate flags meant only for the host toolchain.
-
-  // FIXME: Be accurate and use DeviceOffloadKind.
-  return HostTC.getSupportedSanitizers(BoundArch, DeviceOffloadKind);
-}
-
 VersionTuple
 AMDGPUOpenMPToolChain::computeMSVCVersion(const Driver *D,
                                           const ArgList &Args) const {
@@ -573,12 +567,14 @@ AMDGPUOpenMPToolChain::getDeviceLibs(
   if (!Args.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib, true))
     return {};
 
-  StringRef GpuArch = getProcessorFromTargetID(
-      getTriple(), Args.getLastArgValue(options::OPT_mcpu_EQ));
+  AMDGPUToolChain::ParsedTargetIDType TargetID = getParsedTargetID(Args);
+  if (!TargetID.OptionalTargetID)
+    return {};
 
   SmallVector<BitCodeLibraryInfo, 12> BCLibs;
   for (auto BCLib :
-       getCommonDeviceLibNames(Args, GpuArch.str(), DeviceOffloadingKind))
+       getCommonDeviceLibNames(Args, *TargetID.OptionalTargetID,
+                               *TargetID.OptionalGPUArch, DeviceOffloadingKind))
     BCLibs.emplace_back(BCLib);
 
   return BCLibs;

--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -79,6 +79,7 @@ public:
   llvm::opt::DerivedArgList *
   TranslateArgs(const llvm::opt::DerivedArgList &Args, StringRef BoundArch,
                 Action::OffloadKind DeviceOffloadKind) const override;
+
   void
   addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
                         llvm::opt::ArgStringList &CC1Args,
@@ -106,9 +107,6 @@ public:
   AddFlangSystemIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                             llvm::opt::ArgStringList &FlangArgs) const override;
 
-  SanitizerMask
-  getSupportedSanitizers(StringRef BoundArch,
-                         Action::OffloadKind DeviceOffloadKind) const override;
 
   StringRef getAsanRTLPath() const {
     return RocmInstallation->getAsanRTLPath();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -6259,7 +6259,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddLastArg(CmdArgs, options::OPT_fno_knr_functions);
 
-  auto SanitizeArgs = TC.getSanitizerArgs(Args);
+  const char *OffloadArch = JA.getOffloadingArch();
+  auto SanitizeArgs = TC.getSanitizerArgs(Args, OffloadArch ? OffloadArch : "",
+                                          JA.getOffloadingDeviceKind());
   Args.AddLastArg(CmdArgs,
                   options::OPT_fallow_runtime_check_skip_hot_cutoff_EQ);
 

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9738,7 +9738,8 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   // compilation job.
   const llvm::DenseSet<unsigned> CompilerOptions{
       OPT_v,
-      OPT_fsanitize_EQ,
+      OPT_cuda_path_EQ,
+      OPT_rocm_path_EQ,
       OPT_hip_path_EQ,
       OPT_O_Group,
       OPT_g_Group,

--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -315,9 +315,18 @@ HIPAMDToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
   const OptTable &Opts = getDriver().getOpts();
 
   for (Arg *A : Args) {
-    // Filter unsupported sanitizers passed from the HostTC.
-    if (!handleSanitizeOption(*this, *DAL, Args, BoundArch, A))
-      DAL->append(A);
+    // Sanitizer coverage is currently not supported for AMDGPU.
+    if (A->getOption().matches(options::OPT_fsan_cov_Group)) {
+      diagnoseUnsupportedOption(A, *DAL, Args);
+      continue;
+    }
+
+    if (A->getOption().matches(options::OPT_fsanitize_EQ) &&
+        !Args.hasFlag(options::OPT_fgpu_sanitize, options::OPT_fno_gpu_sanitize,
+                      true))
+      continue;
+
+    DAL->append(A);
   }
 
   if (!BoundArch.empty()) {
@@ -369,21 +378,6 @@ void HIPAMDToolChain::AddHIPIncludeArgs(const ArgList &DriverArgs,
   RocmInstallation->AddHIPIncludeArgs(DriverArgs, CC1Args);
 }
 
-SanitizerMask HIPAMDToolChain::getSupportedSanitizers(
-    StringRef BoundArch, Action::OffloadKind DeviceOffloadKind) const {
-  // The HIPAMDToolChain only supports sanitizers in the sense that it allows
-  // sanitizer arguments on the command line if they are supported by the host
-  // toolchain. The HIPAMDToolChain will later filter unsupported sanitizers
-  // from the command line arguments.
-  //
-  // This behavior is necessary because the host and device toolchains
-  // invocations often share the command line, so the device toolchain must
-  // tolerate flags meant only for the host toolchain.
-  //
-  // FIXME: Be accurate and use DeviceOffloadKind.
-  return HostTC.getSupportedSanitizers(BoundArch, DeviceOffloadKind);
-}
-
 VersionTuple HIPAMDToolChain::computeMSVCVersion(const Driver *D,
                                                  const ArgList &Args) const {
   return HostTC.computeMSVCVersion(D, Args);
@@ -397,9 +391,13 @@ HIPAMDToolChain::getDeviceLibs(const llvm::opt::ArgList &DriverArgs,
 
   if (!DriverArgs.hasFlag(options::OPT_offloadlib, options::OPT_no_offloadlib,
                           true) ||
-      TT.getEnvironment() == llvm::Triple::LLVM ||
-      getGPUArch(DriverArgs) == "amdgcnspirv")
+      TT.getEnvironment() == llvm::Triple::LLVM)
     return {};
+
+  AMDGPUToolChain::ParsedTargetIDType TargetID = getParsedTargetID(DriverArgs);
+  if (!TargetID.OptionalTargetID || TargetID.OptionalTargetID == "amdgcnspirv")
+    return {};
+
   ArgStringList LibraryPaths;
 
   // Find in --hip-device-lib-path and HIP_LIBRARY_PATH.
@@ -432,12 +430,11 @@ HIPAMDToolChain::getDeviceLibs(const llvm::opt::ArgList &DriverArgs,
       getDriver().Diag(diag::err_drv_no_rocm_device_lib) << 0;
       return {};
     }
-    StringRef GpuArch = getGPUArch(DriverArgs);
-    assert(!GpuArch.empty() && "Must have an explicit GPU arch.");
 
     // Add common device libraries like ocml etc.
-    for (auto N :
-         getCommonDeviceLibNames(DriverArgs, GpuArch, DeviceOffloadingKind))
+    for (auto N : getCommonDeviceLibNames(
+             DriverArgs, *TargetID.OptionalTargetID, *TargetID.OptionalGPUArch,
+             DeviceOffloadingKind))
       BCLibs.emplace_back(N);
 
     // Add instrument lib.

--- a/clang/lib/Driver/ToolChains/HIPAMD.h
+++ b/clang/lib/Driver/ToolChains/HIPAMD.h
@@ -69,6 +69,7 @@ public:
                                         const JobAction &JA,
                                         Compilation &C,
                                         const InputInfoList &Inputs) const override;
+
   void
   addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,
                         llvm::opt::ArgStringList &CC1Args,
@@ -88,10 +89,6 @@ public:
   llvm::SmallVector<BitCodeLibraryInfo, 12>
   getDeviceLibs(const llvm::opt::ArgList &Args,
                 Action::OffloadKind DeviceOffloadKind) const override;
-
-  SanitizerMask
-  getSupportedSanitizers(StringRef BoundArch,
-                         Action::OffloadKind DeviceOffloadKind) const override;
 
   VersionTuple
   computeMSVCVersion(const Driver *D,

--- a/clang/test/Driver/amdgpu-openmp-sanitize-options.c
+++ b/clang/test/Driver/amdgpu-openmp-sanitize-options.c
@@ -91,11 +91,11 @@
 // RUN:   | FileCheck -check-prefixes=ERRSANCOV %s
 
 
+// NOTSUPPORTED-DAG: warning: ignoring 'leak' in '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa'
 // INVALIDCOMBINATION1: warning: ignoring 'fuzzer' in '-fsanitize=address,fuzzer' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
 // INVALIDCOMBINATION2: warning: ignoring 'fuzzer' in '-fsanitize=fuzzer,address' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
 
 // FAIL-DAG: error: cannot find ROCm device library for ABI version 5; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library
-// NOTSUPPORTED-DAG: warning: ignoring '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa'
 
 // NOXNACK: warning: ignoring '-fsanitize=address' option for offload arch 'gfx908' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead
 // XNACKNEG: warning: ignoring '-fsanitize=address' option for offload arch 'gfx908:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead
@@ -111,7 +111,7 @@
 // SAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "ir".*}}
 // SAN: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=amdgcn-amd-amdhsa=-fsanitize=address".* "--host-triple=x86_64-unknown-linux-gnu".* "--linker-path=[^"]*".* "--whole-archive" "[^"]*(libclang_rt.asan_static.a|libclang_rt.asan_static-x86_64.a)".* "--whole-archive" "[^"]*(libclang_rt.asan.a|libclang_rt.asan-x86_64.a)".*}}
 
-// UNSUPPORTEDERROR: error: '-fsanitize=leak' option is not currently supported for target 'amdgcn-amd-amdhsa'
+// UNSUPPORTEDERROR: error: 'leak' in '-fsanitize=leak' option is not currently supported for target 'amdgcn-amd-amdhsa'
 // XNACKERROR: error: '-fsanitize=address' option for offload arch 'gfx908:xnack-' is not currently supported there. Use it with an offload arch containing 'xnack+' instead
 // INVALIDCOMBINATIONERROR: error: 'fuzzer' in '-fsanitize=fuzzer,address' option is not currently supported for target 'amdgcn-amd-amdhsa'
 

--- a/clang/test/Driver/amdgpu-openmp-sanitize-options.c
+++ b/clang/test/Driver/amdgpu-openmp-sanitize-options.c
@@ -9,7 +9,7 @@
 // RUN:   | FileCheck --check-prefixes=NOTSUPPORTED,FAIL %s
 
 // Memory, Leak, UndefinedBehaviour and Thread Sanitizer are not supported on AMDGPU.
-// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address -fsanitize=leak -fgpu-sanitize --rocm-path=%S/Inputs/rocm -nogpuinc  %s 2>&1 \
+// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address -fsanitize=leak -fgpu-sanitize --rocm-path=%S/Inputs/rocm -nogpuinc  %s 2>&1 \
 // RUN:   | FileCheck --check-prefix=NOTSUPPORTED %s
 
 // GPU ASan Enabled Test Cases
@@ -58,18 +58,18 @@
 // implicitly turns on LLVMs SanitizerCoverage, which the driver then forwards
 // to the device cc1. SanitizerCoverage is not supported on amdgcn.)
 
-// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=fuzzer,address --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ -fsanitize=fuzzer,address --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION2 %s
 
 // Do the same for multiple -fsanitize arguments and multi-arch scenarios.
 
-// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ --offload-arch=gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+ --offload-arch=gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN: not  %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN: not %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=fuzzer,address -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
+// RUN:   %clang -no-canonical-prefixes -### --target=x86_64-unknown-linux-gnu -fopenmp=libomp --offload-arch=gfx908:xnack+,gfx900:xnack- -fsanitize=fuzzer,address -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=HOSTSANCOMBINATION2,NOTSUPPORTED-DAG,INVALIDCOMBINATION2 %s
 
 // Check for -fsanitize-coverage options
@@ -104,12 +104,12 @@
 // HOSTSANCOMBINATION: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address,fuzzer,fuzzer-no-link".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "c".*}}
 // HOSTSANCOMBINATION2: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address,fuzzer,fuzzer-no-link,leak".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "c".*}}
 
-// GPUSAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu".* "-emit-llvm-bc".* "-target-cpu" "(gfx908|gfx900|gfx1250|gfx1251)".* "-fopenmp".* "-fsanitize=address".* "-x" "c".*}}
+// GPUSAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu".* "-emit-llvm-bc".* "-mlink-bitcode-file" "[^"]*asanrtl.bc".* "-mlink-builtin-bitcode" "[^"]*ockl.bc".* "-target-cpu" "(gfx908|gfx900|gfx1250|gfx1251)".* "-fopenmp".* "-fsanitize=address".* "-x" "c".*}}
 // NOGPUSAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "amdgcn-amd-amdhsa" "-aux-triple" "x86_64-unknown-linux-gnu".* "-emit-llvm-bc".* "-target-cpu" "(gfx908|gfx900)".* "-fopenmp".* "-x" "c".*}}
 
 // SAN: {{"[^"]*llvm-offload-binary[^"]*" "-o".* "--image=file=.*.bc,triple=amdgcn-amd-amdhsa,arch=(gfx908|gfx1250|gfx1251)(:xnack\-|:xnack\+)?,kind=openmp(,feature=(\-xnack|\+xnack))?"}}
 // SAN: {{"[^"]*clang[^"]*" "-cc1" "-triple" "x86_64-unknown-linux-gnu".* "-fopenmp".* "-fsanitize=address".* "--offload-targets=amdgcn-amd-amdhsa".* "-x" "ir".*}}
-// SAN: {{"[^"]*clang-linker-wrapper[^"]*".* "--device-compiler=amdgcn-amd-amdhsa=-fsanitize=address".* "--host-triple=x86_64-unknown-linux-gnu".* "--linker-path=[^"]*".* "--whole-archive" "[^"]*(libclang_rt.asan_static.a|libclang_rt.asan_static-x86_64.a)".* "--whole-archive" "[^"]*(libclang_rt.asan.a|libclang_rt.asan-x86_64.a)".*}}
+// SAN: {{"[^"]*clang-linker-wrapper[^"]*".* "--host-triple=x86_64-unknown-linux-gnu".* "--linker-path=[^"]*".* "--whole-archive" "[^"]*(libclang_rt.asan_static.a|libclang_rt.asan_static-x86_64.a)".* "--whole-archive" "[^"]*(libclang_rt.asan.a|libclang_rt.asan-x86_64.a)".*}}
 
 // UNSUPPORTEDERROR: error: 'leak' in '-fsanitize=leak' option is not currently supported for target 'amdgcn-amd-amdhsa'
 // XNACKERROR: error: '-fsanitize=address' option for offload arch 'gfx908:xnack-' is not currently supported there. Use it with an offload arch containing 'xnack+' instead

--- a/clang/test/Driver/amdgpu-validate-sanitize.cl
+++ b/clang/test/Driver/amdgpu-validate-sanitize.cl
@@ -32,9 +32,10 @@
 // CHECK-SAME: "-mlink-bitcode-file" "{{.*}}asanrtl.bc"
 // CHECK-SAME: "-fsanitize=address"
 
-// GENERIC: "-fsanitize=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound" "-fsanitize-recover=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,vla-bound" "-fsanitize-merge=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound" "-fno-sanitize-memory-param-retval" "-fno-sanitize-address-use-odr-indicator"
+
+// GENERIC: "-fsanitize=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,null,nullability-arg,nullability-assign,nullability-return,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound,unsigned-integer-overflow,unsigned-shift-base,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation,implicit-integer-sign-change,implicit-bitfield-conversion,local-bounds,alloc-token" "-fsanitize-recover=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,float-divide-by-zero,function,integer-divide-by-zero,nonnull-attribute,null,nullability-arg,nullability-assign,nullability-return,pointer-overflow,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,vla-bound,unsigned-integer-overflow,unsigned-shift-base,implicit-unsigned-integer-truncation,implicit-signed-integer-truncation,implicit-integer-sign-change,implicit-bitfield-conversion" "-fsanitize-trap=local-bounds" "-fsanitize-merge=alignment,array-bounds,bool,builtin,enum,float-cast-overflow,function,integer-divide-by-zero,nonnull-attribute,null,pointer-overflow,return,returns-nonnull-attribute,shift-base,shift-exponent,signed-integer-overflow,unreachable,vla-bound"
 
 
 // FIXME: Should not be forwarding argument
-// ExRR-NOT: asanrtl.bc
+// ERR-NOT: asanrtl.bc
 // ERR: "-fsanitize=address"

--- a/clang/test/Driver/hip-sanitize-options.hip
+++ b/clang/test/Driver/hip-sanitize-options.hip
@@ -110,9 +110,9 @@
 
 // FAIL: error: cannot find ROCm device library for ABI version 5; provide its path via '--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build without ROCm device library
 
-// XNACK-DAG: warning: ignoring '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa'
-// XNACK-DAG: warning: ignoring '-fsanitize=address' option for offload arch 'gfx900:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead
-// XNACK-DAG: warning: ignoring '-fsanitize=address' option for offload arch 'gfx906' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead
+// XNACK: warning: ignoring 'leak' in '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa'
+// XNACK: warning: ignoring '-fsanitize=address' option for offload arch 'gfx900:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead
+// XNACK: warning: ignoring '-fsanitize=address' option for offload arch 'gfx906' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead
 // XNACK-DAG: {{"[^"]*clang[^"]*".* "-mlink-bitcode-file" ".*asanrtl.bc".* "-target-cpu" "gfx900".* "-target-feature" "\+xnack".* "-fsanitize=address"}}
 // XNACK-DAG: {{"[^"]*clang[^"]*".* "-target-cpu" "gfx900".* "-target-feature" "-xnack"}}
 // XNACK-DAG: {{"[^"]*clang[^"]*".* "-target-cpu" "gfx906"}}
@@ -150,23 +150,23 @@
 // INVALIDCOMBINATION-DAG: {{"[^"]*clang[^"]*".* "-mlink-bitcode-file" ".*asanrtl.bc".* "-target-cpu" "gfx900".* "-target-feature" "\+xnack".* "-fsanitize=address"}}
 // INVALIDCOMBINATION-DAG: {{"[^"]*clang[^"]*".* "-triple" "x86_64-unknown-linux-gnu".* "-fsanitize=address,fuzzer,fuzzer-no-link"}}
 
-// MULT1-DAG: warning: ignoring 'fuzzer' in '-fsanitize=address,fuzzer' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
-// MULT1-DAG: warning: ignoring '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
-// MULT1-DAG: warning: ignoring 'fuzzer' in '-fsanitize=address,fuzzer' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
-// MULT1-DAG: warning: ignoring '-fsanitize=address,fuzzer' option for offload arch 'gfx908:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead [-Woption-ignored]
-// MULT1-DAG: warning: ignoring '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
+// MULT1: warning: ignoring 'leak' in '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
+// MULT1: warning: ignoring 'fuzzer' in '-fsanitize=address,fuzzer' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
 
-// MULT2-DAG: warning: ignoring 'fuzzer' in '-fsanitize=fuzzer,address' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
-// MULT2-DAG: warning: ignoring '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
-// MULT2-DAG: warning: ignoring 'fuzzer' in '-fsanitize=fuzzer,address' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
-// MULT2-DAG: warning: ignoring '-fsanitize=fuzzer,address' option for offload arch 'gfx908:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead [-Woption-ignored]
-// MULT2-DAG: warning: ignoring '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
+// FIXME: This should produce a separate warning for address and fuzzer. The xnack+ hint only applies to the address part
+// MULT1: warning: ignoring '-fsanitize=address,fuzzer' option for offload arch 'gfx908:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead [-Woption-ignored]
+
+// MULT2: warning: ignoring 'leak' in '-fsanitize=leak' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
+// MULT2: warning: ignoring 'fuzzer' in '-fsanitize=fuzzer,address' option as it is not currently supported for target 'amdgcn-amd-amdhsa' [-Woption-ignored]
+
+// FIXME: This should produce a separate warning for address and fuzzer. The xnack+ hint only applies to the address part
+// MULT2: warning: ignoring '-fsanitize=fuzzer,address' option for offload arch 'gfx908:xnack-' as it is not currently supported there. Use it with an offload arch containing 'xnack+' instead [-Woption-ignored]
 
 // XNACK2-DAG: {{"[^"]*clang[^"]*".* "-mlink-bitcode-file" ".*asanrtl.bc".* "-target-cpu" "gfx900".* "-target-feature" "\+xnack".* "-fsanitize=address"}}
 // XNACK2-DAG: {{"[^"]*clang[^"]*".* "-target-cpu" "gfx908"}}
 // XNACK2-DAG: {{"[^"]*clang[^"]*".* "-triple" "x86_64-unknown-linux-gnu".* "-fsanitize=address,fuzzer,fuzzer-no-link,leak"}}
 
-// UNSUPPORTEDERROR: error: '-fsanitize=leak' option is not currently supported for target 'amdgcn-amd-amdhsa'
+// UNSUPPORTEDERROR: error: 'leak' in '-fsanitize=leak' option is not currently supported for target 'amdgcn-amd-amdhsa'
 // XNACKERROR: error: '-fsanitize=address' option for offload arch 'gfx900:xnack-' is not currently supported there. Use it with an offload arch containing 'xnack+' instead
 // INVALIDCOMBINATIONERROR: error: 'fuzzer' in '-fsanitize=fuzzer,address' option is not currently supported for target 'amdgcn-amd-amdhsa'
 

--- a/clang/test/Driver/hip-sanitize-options.hip
+++ b/clang/test/Driver/hip-sanitize-options.hip
@@ -58,19 +58,19 @@
 // implicitly turns on LLVMs SanitizerCoverage, which the driver then forwards
 // to the device cc1. SanitizerCoverage is not supported on amdgcn.)
 
-// RUN: not %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
 // RUN:   -fsanitize=address,fuzzer --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=INVALIDCOMBINATION,INVALIDCOMBINATION1 %s
-// RUN: not %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ \
 // RUN:   -fsanitize=fuzzer,address --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=INVALIDCOMBINATION,INVALIDCOMBINATION2 %s
 
 // Do the same for multiple -fsanitize arguments and multi-arch scenarios.
 
-// RUN: not %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ --offload-arch=gfx908:xnack- \
+// RUN:   %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+ --offload-arch=gfx908:xnack- \
 // RUN:   -fsanitize=address,fuzzer -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=MULT1,XNACK2 %s
-// RUN: not  %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+,gfx908:xnack- \
+// RUN:   %clang -### --target=x86_64-unknown-linux-gnu --offload-arch=gfx900:xnack+,gfx908:xnack- \
 // RUN:   -fsanitize=fuzzer,address -fsanitize=leak --rocm-path=%S/Inputs/rocm %s 2>&1 \
 // RUN:   | FileCheck -check-prefixes=MULT2,XNACK2 %s
 

--- a/openmp/device/CMakeLists.txt
+++ b/openmp/device/CMakeLists.txt
@@ -52,7 +52,6 @@ if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn" OR
   )
   get_target_property(_ocml_bc ocml IMPORTED_LOCATION)
   get_target_property(_ockl_bc ockl IMPORTED_LOCATION)
-  get_target_property(_asanrtl_bc asanrtl IMPORTED_LOCATION)
 
   if(NOT _ockl_bc)
     message(FATAL_ERROR "Could not find ockl.bc")
@@ -60,18 +59,7 @@ if("${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn" OR
   if(NOT _ocml_bc)
     message(FATAL_ERROR "Could not find ocml.bc")
   endif()
-  if(NOT _asanrtl_bc)
-    message(FATAL_ERROR "Could not find asanrtl.bc")
-  endif()
-  if(SANITIZER_AMDGPU)
-    list(APPEND compile_flags "SHELL: -DSANITIZER_AMDGPU=1")
-    # For ASan: Don't link asanrtl.bc and ockl.bc at compile time of libompdevice.a
-    # They will be linked once in POST_BUILD step to avoid duplicates symbols
-    # Note: Oclc control constants are provided using Platform.h
-    #
-  else()
-    list(APPEND compile_flags "SHELL: -Xclang -mlink-builtin-bitcode -Xclang ${_ockl_bc}")
-  endif()
+  list(APPEND compile_flags "SHELL: -Xclang -mlink-builtin-bitcode -Xclang ${_ockl_bc}")
   list(APPEND compile_flags "SHELL: -Xclang -mlink-builtin-bitcode -Xclang ${_ocml_bc}")
 endif()
 
@@ -141,30 +129,6 @@ endif()
 if(LLVM_DEFAULT_TARGET_TRIPLE)
   target_link_options(libompdevice PRIVATE "--target=${LLVM_DEFAULT_TARGET_TRIPLE}")
 endif()
-
-# For SANITIZER_AMDGPU: Use llvm-link POST_BUILD to merge ASAN runtime and OCKL
-# into the device library bitcode to resolve all and __asan_* __ockl_* symbols
-if(SANITIZER_AMDGPU)
-  find_program(LLVM_LINK_EXECUTABLE NAMES llvm-link HINTS ${LLVM_TOOLS_BINARY_DIR})
-  if(NOT LLVM_LINK_EXECUTABLE)
-    message(FATAL_ERROR "llvm-link not found")
-  endif()
-  add_custom_command(TARGET libompdevice POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy 
-      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc
-      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc.tmp
-    COMMAND ${LLVM_LINK_EXECUTABLE}
-      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc.tmp
-      ${_asanrtl_bc}
-      ${_ockl_bc}
-      --only-needed
-      -o ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc
-    COMMAND ${CMAKE_COMMAND} -E remove
-      ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-${target_name}.bc.tmp
-    COMMENT "Merging asanrtl.bc and ockl.bc into libomptarget-${target_name}.bc"
-  )
-endif()
-
 install(TARGETS libompdevice
         PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ
         DESTINATION ${OPENMP_INSTALL_LIBDIR}

--- a/openmp/device/include/Platform.h
+++ b/openmp/device/include/Platform.h
@@ -21,126 +21,124 @@ namespace platform {
 // define them here.
 extern "C" {
 
-#define USED __attribute__((used))
-
 // Disable unsafe math optimizations in the implementation.
-USED extern const inline bool __oclc_unsafe_math_opt = 0;
+extern const inline bool __oclc_unsafe_math_opt = 0;
 
 // Disable denormalization at zero optimizations in the implementation.
-USED extern const inline bool __oclc_daz_opt = 0;
+extern const inline bool __oclc_daz_opt = 0;
 
 // Disable rounding optimizations for 32-bit square roots.
-USED extern const inline bool __oclc_correctly_rounded_sqrt32 = 1;
+extern const inline bool __oclc_correctly_rounded_sqrt32 = 1;
 
 // Disable finite math optimizations.
-USED extern const inline bool __oclc_finite_only_opt = 0;
+extern const inline bool __oclc_finite_only_opt = 0;
 
 // Spoof this to wave64 since we only compile for a single architecture.
-USED extern const inline bool __oclc_wavefrontsize64 = 1;
+extern const inline bool __oclc_wavefrontsize64 = 1;
 
 // This is only relevant for statically resolving `malloc`, set to COV6.
-USED extern const inline bool __oclc_ABI_version = 600;
+extern const inline bool __oclc_ABI_version = 600;
 
 #if defined(__gfx700__)
-USED extern const inline unsigned __oclc_ISA_version = 7000;
+extern const inline unsigned __oclc_ISA_version = 7000;
 #elif defined(__gfx701__)
-USED extern const inline unsigned __oclc_ISA_version = 7001;
+extern const inline unsigned __oclc_ISA_version = 7001;
 #elif defined(__gfx702__)
-USED extern const inline unsigned __oclc_ISA_version = 7002;
+extern const inline unsigned __oclc_ISA_version = 7002;
 #elif defined(__gfx703__)
-USED extern const inline unsigned __oclc_ISA_version = 7003;
+extern const inline unsigned __oclc_ISA_version = 7003;
 #elif defined(__gfx704__)
-USED extern const inline unsigned __oclc_ISA_version = 7004;
+extern const inline unsigned __oclc_ISA_version = 7004;
 #elif defined(__gfx705__)
-USED extern const inline unsigned __oclc_ISA_version = 7005;
+extern const inline unsigned __oclc_ISA_version = 7005;
 #elif defined(__gfx801__)
-USED extern const inline unsigned __oclc_ISA_version = 8001;
+extern const inline unsigned __oclc_ISA_version = 8001;
 #elif defined(__gfx802__)
-USED extern const inline unsigned __oclc_ISA_version = 8002;
+extern const inline unsigned __oclc_ISA_version = 8002;
 #elif defined(__gfx803__)
-USED extern const inline unsigned __oclc_ISA_version = 8003;
+extern const inline unsigned __oclc_ISA_version = 8003;
 #elif defined(__gfx805__)
-USED extern const inline unsigned __oclc_ISA_version = 8005;
+extern const inline unsigned __oclc_ISA_version = 8005;
 #elif defined(__gfx810__)
-USED extern const inline unsigned __oclc_ISA_version = 8100;
+extern const inline unsigned __oclc_ISA_version = 8100;
 #elif defined(__gfx900__)
-USED extern const inline unsigned __oclc_ISA_version = 9000;
+extern const inline unsigned __oclc_ISA_version = 9000;
 #elif defined(__gfx902__)
-USED extern const inline unsigned __oclc_ISA_version = 9002;
+extern const inline unsigned __oclc_ISA_version = 9002;
 #elif defined(__gfx904__)
-USED extern const inline unsigned __oclc_ISA_version = 9004;
+extern const inline unsigned __oclc_ISA_version = 9004;
 #elif defined(__gfx906__)
-USED extern const inline unsigned __oclc_ISA_version = 9006;
+extern const inline unsigned __oclc_ISA_version = 9006;
 #elif defined(__gfx908__)
-USED extern const inline unsigned __oclc_ISA_version = 9008;
+extern const inline unsigned __oclc_ISA_version = 9008;
 #elif defined(__gfx909__)
-USED extern const inline unsigned __oclc_ISA_version = 9009;
+extern const inline unsigned __oclc_ISA_version = 9009;
 #elif defined(__gfx90a__)
-USED extern const inline unsigned __oclc_ISA_version = 9010;
+extern const inline unsigned __oclc_ISA_version = 9010;
 #elif defined(__gfx90c__)
-USED extern const inline unsigned __oclc_ISA_version = 9012;
+extern const inline unsigned __oclc_ISA_version = 9012;
 #elif defined(__gfx942__)
-USED extern const inline unsigned __oclc_ISA_version = 9402;
+extern const inline unsigned __oclc_ISA_version = 9402;
 #elif defined(__gfx950__)
-USED extern const inline unsigned __oclc_ISA_version = 9500;
+extern const inline unsigned __oclc_ISA_version = 9500;
 #elif defined(__gfx1010__)
-USED extern const inline unsigned __oclc_ISA_version = 10100;
+extern const inline unsigned __oclc_ISA_version = 10100;
 #elif defined(__gfx1011__)
-USED extern const inline unsigned __oclc_ISA_version = 10101;
+extern const inline unsigned __oclc_ISA_version = 10101;
 #elif defined(__gfx1012__)
-USED extern const inline unsigned __oclc_ISA_version = 10102;
+extern const inline unsigned __oclc_ISA_version = 10102;
 #elif defined(__gfx1013__)
-USED extern const inline unsigned __oclc_ISA_version = 10103;
+extern const inline unsigned __oclc_ISA_version = 10103;
 #elif defined(__gfx1030__)
-USED extern const inline unsigned __oclc_ISA_version = 10300;
+extern const inline unsigned __oclc_ISA_version = 10300;
 #elif defined(__gfx1031__)
-USED extern const inline unsigned __oclc_ISA_version = 10301;
+extern const inline unsigned __oclc_ISA_version = 10301;
 #elif defined(__gfx1032__)
-USED extern const inline unsigned __oclc_ISA_version = 10302;
+extern const inline unsigned __oclc_ISA_version = 10302;
 #elif defined(__gfx1033__)
-USED extern const inline unsigned __oclc_ISA_version = 10303;
+extern const inline unsigned __oclc_ISA_version = 10303;
 #elif defined(__gfx1034__)
-USED extern const inline unsigned __oclc_ISA_version = 10304;
+extern const inline unsigned __oclc_ISA_version = 10304;
 #elif defined(__gfx1035__)
-USED extern const inline unsigned __oclc_ISA_version = 10305;
+extern const inline unsigned __oclc_ISA_version = 10305;
 #elif defined(__gfx1036__)
-USED extern const inline unsigned __oclc_ISA_version = 10306;
+extern const inline unsigned __oclc_ISA_version = 10306;
 #elif defined(__gfx1100__)
-USED extern const inline unsigned __oclc_ISA_version = 11000;
+extern const inline unsigned __oclc_ISA_version = 11000;
 #elif defined(__gfx1101__)
-USED extern const inline unsigned __oclc_ISA_version = 11001;
+extern const inline unsigned __oclc_ISA_version = 11001;
 #elif defined(__gfx1102__)
-USED extern const inline unsigned __oclc_ISA_version = 11002;
+extern const inline unsigned __oclc_ISA_version = 11002;
 #elif defined(__gfx1103__)
-USED extern const inline unsigned __oclc_ISA_version = 11003;
+extern const inline unsigned __oclc_ISA_version = 11003;
 #elif defined(__gfx1150__)
-USED extern const inline unsigned __oclc_ISA_version = 11500;
+extern const inline unsigned __oclc_ISA_version = 11500;
 #elif defined(__gfx1151__)
-USED extern const inline unsigned __oclc_ISA_version = 11501;
+extern const inline unsigned __oclc_ISA_version = 11501;
 #elif defined(__gfx1152__)
-USED extern const inline unsigned __oclc_ISA_version = 11502;
+extern const inline unsigned __oclc_ISA_version = 11502;
 #elif defined(__gfx1153__)
-USED extern const inline unsigned __oclc_ISA_version = 11503;
+extern const inline unsigned __oclc_ISA_version = 11503;
 #elif defined(__gfx1200__)
-USED extern const inline unsigned __oclc_ISA_version = 12000;
+extern const inline unsigned __oclc_ISA_version = 12000;
 #elif defined(__gfx1201__)
-USED extern const inline unsigned __oclc_ISA_version = 12001;
+extern const inline unsigned __oclc_ISA_version = 12001;
 #elif defined(__gfx9_generic__)
-USED extern const inline unsigned __oclc_ISA_version = 9000;
+extern const inline unsigned __oclc_ISA_version = 9000;
 #elif defined(__gfx9_4_generic__)
-USED extern const inline unsigned __oclc_ISA_version = 9402;
+extern const inline unsigned __oclc_ISA_version = 9402;
 #elif defined(__gfx10_1_generic__)
-USED extern const inline unsigned __oclc_ISA_version = 10100;
+extern const inline unsigned __oclc_ISA_version = 10100;
 #elif defined(__gfx10_3_generic__)
-USED extern const inline unsigned __oclc_ISA_version = 10300;
+extern const inline unsigned __oclc_ISA_version = 10300;
 #elif defined(__gfx11_generic__)
-USED extern const inline unsigned __oclc_ISA_version = 11003;
+extern const inline unsigned __oclc_ISA_version = 11003;
 #elif defined(__gfx12_generic__)
-USED extern const inline unsigned __oclc_ISA_version = 12000;
+extern const inline unsigned __oclc_ISA_version = 12000;
 #else
 // The only thing this controls that we care about is fast FMA.
 // FIXME: We need to stop relying on the DeviceRTL math libs this way.
-USED extern const inline unsigned __oclc_ISA_version = 7001;
+extern const inline unsigned __oclc_ISA_version = 7001;
 #endif
 }
 

--- a/revert_patches.txt
+++ b/revert_patches.txt
@@ -11,14 +11,11 @@ breaks rocgdb UT
 breaks windows build
 [cmake] Refactor DIA SDK detection into FindDIASDK module (#160354)
 ---
-breaks comgr test
-clang: Refactor handling of offload sanitizer arguments (#196737)
----
 breaks hipcub build
 [InstCombine] Fold zext into de-interleaving (factor=2) instructions (#195330)
 ---
 needs merge work: Kruse
-aa8e38f4f871 [OpenMP] FIx omp_lib.mod compilation for the GPU 
+aa8e38f4f871 [OpenMP] FIx omp_lib.mod compilation for the GPU
 9e01e0970c4c [Flang-RT] Disable tests by default without mod
 911eddeed7ba [Flang] Fix omp_lib.h location and search path
 bafde6fbb [Flang] Move builtin .mod generation into runtimes


### PR DESCRIPTION
Reapply upstream #196737 (originally reverted in 73d4899e85ff for breaking the Comgr asan test), fix the Comgr test, and revert PR #1334.

Since the original revert of #196737, upstream #199642 ("clang/AMDGPU: Report all runtimeless sanitizers as available") landed and modified the same `getSupportedSanitizers` function. The revert had clobbered it, so this reapply also restores #199642's delegation to `ToolChain::getSupportedSanitizers` and its updated test expectations, keeping the result consistent with upstream.

PR #1334 ("[ASan][OpenMP] Fix OpenMP ASan driver and device-rtl build") added an `AMDGPUToolChain` ctor-time `getSanitizerArgs(Args)` call with no `BoundArch`/`OffloadKind`. After the reapply, that call hits the new `OFK_None` hard-error path and silences the later correct call from `Clang.cpp` — turning `warning: ignoring 'leak' in '-fsanitize=leak'` into `error: unsupported option '-fsanitize=leak'`. Matt Arsenault flagged this exact regression on the #1334 review and asked it not be carried out-of-tree; the upstream replacement (llvm/llvm-project#179636) is still open pending Multilib infrastructure.

Locally verified all three previously-failing tests pass with this stack: `Clang :: Driver/amdgpu-openmp-sanitize-options.c`, `Clang :: Driver/hip-sanitize-options.hip`, `Comgr :: compile-hip-asan.c`.
