### PR TITLE
[Comgr] Add GRANULARITY to Comgr Profiler

### DIFF
--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -127,14 +127,14 @@ HTML for investigation:
     $ make -j
     $ make test test-lit
     $ cd profiles
-    # Manually aggregate the data and create text report.
+#Manually aggregate the data and create text report.
     $ $LLVM_PROJECT/bin/llvm-profdata merge -sparse *.profraw -o \
         comgr_test.profdata # merge and index data
     $ $LLVM_PROJECT/bin/llvm-cov report ../libamd_comgr.so \
         -instr-profile=comgr_test.profdata \
         -ignore-filename-regex="[cl].*/include/*" # show test report without \
         includes
-    # Or use python script to aggregate the data and create html report.
+#Or use python script to aggregate the data and create html report.
     $ $LLVM_PROJECT/../llvm/utils/prepare-code-coverage-artifact.py \
         --preserve-profiles $LLVM_PROJECT/bin/llvm-profdata \
         $LLVM_PROJECT/bin/llvm-cov . html ../libamd_comgr.so \
@@ -220,6 +220,9 @@ include:
   include additional Comgr-specific informational messages.
 * `AMD_COMGR_TIME_STATISTICS`: If this is set, and is not "0", logs will
   include additional Comgr-specific timing information for compilation actions.
+* `AMD_COMGR_TIME_STATISTICS_GRANULARITY`: If this is set to "us" or "ns",
+  Comgr-specific timing information in logs will be in units of "us" or "ns"
+  respectively. Defaults to "ms" otherwise.
 * `AMD_COMGR_DRIVER_OPTIONS_APPEND`: If set, the space-separated options are
   appended to all clang driver invocations. This can be used to inject
   additional compiler flags for debugging or experimentation without modifying

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -127,14 +127,14 @@ HTML for investigation:
     $ make -j
     $ make test test-lit
     $ cd profiles
-    #Manually aggregate the data and create text report.
+    # Manually aggregate the data and create text report.
     $ $LLVM_PROJECT/bin/llvm-profdata merge -sparse *.profraw -o \
         comgr_test.profdata # merge and index data
     $ $LLVM_PROJECT/bin/llvm-cov report ../libamd_comgr.so \
         -instr-profile=comgr_test.profdata \
         -ignore-filename-regex="[cl].*/include/*" # show test report without \
         includes
-    #Or use python script to aggregate the data and create html report.
+    # Or use python script to aggregate the data and create html report.
     $ $LLVM_PROJECT/../llvm/utils/prepare-code-coverage-artifact.py \
         --preserve-profiles $LLVM_PROJECT/bin/llvm-profdata \
         $LLVM_PROJECT/bin/llvm-cov . html ../libamd_comgr.so \

--- a/amd/comgr/README.md
+++ b/amd/comgr/README.md
@@ -127,14 +127,14 @@ HTML for investigation:
     $ make -j
     $ make test test-lit
     $ cd profiles
-#Manually aggregate the data and create text report.
+    #Manually aggregate the data and create text report.
     $ $LLVM_PROJECT/bin/llvm-profdata merge -sparse *.profraw -o \
         comgr_test.profdata # merge and index data
     $ $LLVM_PROJECT/bin/llvm-cov report ../libamd_comgr.so \
         -instr-profile=comgr_test.profdata \
         -ignore-filename-regex="[cl].*/include/*" # show test report without \
         includes
-#Or use python script to aggregate the data and create html report.
+    #Or use python script to aggregate the data and create html report.
     $ $LLVM_PROJECT/../llvm/utils/prepare-code-coverage-artifact.py \
         --preserve-profiles $LLVM_PROJECT/bin/llvm-profdata \
         $LLVM_PROJECT/bin/llvm-cov . html ../libamd_comgr.so \

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -59,14 +59,28 @@ bool needTimeStatistics() {
   return TimeStatistics && StringRef(TimeStatistics) != "0";
 }
 
+uint32_t getGranularityUnitsPerSecond() {
+  static const char *TimeStatisticsGranularity =
+      getenv("AMD_COMGR_TIME_STATISTICS_GRANULARITY");
+  if (!TimeStatisticsGranularity)
+    return 1e3;
+  StringRef G(TimeStatisticsGranularity);
+  if (G == "us")
+    return 1e6;
+  else if (G == "ns")
+    return 1e9;
+  else
+    return 1e3;
+}
+
 llvm::StringRef getTimeStatisticsGranularity() {
-  static const char *TimeStatisticsGranularity = getenv("AMD_COMGR_TIME_STATISTICS_GRANULARITY");
-  bool ValidGranularity = StringRef(TimeStatisticsGranularity) == "ms"
-                       || StringRef(TimeStatisticsGranularity) == "us"
-                       || StringRef(TimeStatisticsGranularity) == "ns";
-  if (ValidGranularity) {
-    return TimeStatisticsGranularity;
-  }
+  static const char *TimeStatisticsGranularity =
+      getenv("AMD_COMGR_TIME_STATISTICS_GRANULARITY");
+  if (!TimeStatisticsGranularity)
+    return "ms";
+  StringRef G(TimeStatisticsGranularity);
+  if (G == "ms" || G == "us" || G == "ns")
+    return G;
   return "ms";
 }
 

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -60,17 +60,12 @@ bool needTimeStatistics() {
 }
 
 uint32_t getGranularityUnitsPerSecond() {
-  static const char *TimeStatisticsGranularity =
-      getenv("AMD_COMGR_TIME_STATISTICS_GRANULARITY");
-  if (!TimeStatisticsGranularity)
-    return 1e3;
-  StringRef G(TimeStatisticsGranularity);
+  StringRef G = getTimeStatisticsGranularity();
   if (G == "us")
     return 1e6;
   else if (G == "ns")
     return 1e9;
-  else
-    return 1e3;
+  return 1e3;
 }
 
 llvm::StringRef getTimeStatisticsGranularity() {

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -59,6 +59,17 @@ bool needTimeStatistics() {
   return TimeStatistics && StringRef(TimeStatistics) != "0";
 }
 
+llvm::StringRef getTimeStatisticsGranularity() {
+  static const char *TimeStatisticsGranularity = getenv("AMD_COMGR_TIME_STATISTICS_GRANULARITY");
+  bool ValidGranularity = StringRef(TimeStatisticsGranularity) == "ms"
+                       || StringRef(TimeStatisticsGranularity) == "us"
+                       || StringRef(TimeStatisticsGranularity) == "ns";
+  if (ValidGranularity) {
+    return TimeStatisticsGranularity;
+  }
+  return "ms";
+}
+
 bool shouldEmitVerboseLogs() {
   static char *VerboseLogs = getenv("AMD_COMGR_EMIT_VERBOSE_LOGS");
   return VerboseLogs && StringRef(VerboseLogs) != "0";

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -29,10 +29,10 @@ bool shouldEmitVerboseLogs();
 /// Return whether the environment requests time statistics collection.
 bool needTimeStatistics();
 
-// Return granularity (ms, us, ns) units per second
+/// Return granularity (ms, us, ns) units per second
 uint32_t getGranularityUnitsPerSecond();
 
-// Return granularity of time statistics (ms, us, ns)
+/// Return granularity of time statistics (ms, us, ns)
 llvm::StringRef getTimeStatisticsGranularity();
 
 /// If environment variable LLVM_PATH is set, return the environment variable,

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -29,6 +29,9 @@ bool shouldEmitVerboseLogs();
 /// Return whether the environment requests time statistics collection.
 bool needTimeStatistics();
 
+// Return granularity of time statistics (ms, us, ns)
+llvm::StringRef getTimeStatisticsGranularity();
+
 /// If environment variable LLVM_PATH is set, return the environment variable,
 /// otherwise return the default LLVM path.
 llvm::StringRef getLLVMPath();

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -29,6 +29,9 @@ bool shouldEmitVerboseLogs();
 /// Return whether the environment requests time statistics collection.
 bool needTimeStatistics();
 
+// Return granularity (ms, us, ns) units per second
+uint32_t getGranularityUnitsPerSecond();
+
 // Return granularity of time statistics (ms, us, ns)
 llvm::StringRef getTimeStatisticsGranularity();
 

--- a/amd/comgr/src/time-stat/perf-timer.h
+++ b/amd/comgr/src/time-stat/perf-timer.h
@@ -17,6 +17,7 @@ class PerfTimerImpl {
 protected:
   long long CounterStart;
   double PCFreq;
+  uint32_t GranularityPerSecond;
 
 public:
   PerfTimerImpl() : CounterStart(0), PCFreq(0.0) {};

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -104,7 +104,7 @@ ProfilePoint::~ProfilePoint() {
 class PerfTimerWindows : public PerfTimerImpl {
 
 public:
-  PerfTimerWindows(){};
+  PerfTimerWindows() {};
   virtual bool Init() override {
     LARGE_INTEGER li;
     if (QueryPerformanceCounter(&li))
@@ -120,7 +120,7 @@ public:
     }
     // QueryPerformanceFrequency returns counts per second
     // If we need milliseconds we divide by 10^3
-    uint32_t GranularityPerSecond = env::getGranularityUnitsPerSecond();
+    GranularityPerSecond = env::getGranularityUnitsPerSecond();
     PCFreq = li.QuadPart / GranularityPerSecond;
     return true;
   }
@@ -155,7 +155,7 @@ public:
     }
     // clock_getres returns counts per nanosecond
     // If we need milliseconds we multiply by 10^6
-    uint32_t GranularityPerSecond = env::getGranularityUnitsPerSecond();
+    GranularityPerSecond = env::getGranularityUnitsPerSecond();
     PCFreq = (Res.tv_sec * 1e9 + Res.tv_nsec) * (1e9 / GranularityPerSecond);
     return true;
   }

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -104,7 +104,7 @@ ProfilePoint::~ProfilePoint() {
 class PerfTimerWindows : public PerfTimerImpl {
 
 public:
-  PerfTimerWindows() {};
+  PerfTimerWindows(){};
   virtual bool Init() override {
     LARGE_INTEGER li;
     if (QueryPerformanceCounter(&li))
@@ -120,14 +120,8 @@ public:
     }
     // QueryPerformanceFrequency returns counts per second
     // If we need milliseconds we divide by 10^3
-    // TODO: granularity as env var
-    StringRef TimeStatisticsGranularity = env::getTimeStatisticsGranularity();
-    int Divisor = 1e3;
-    if (TimeStatisticsGranularity == "us")
-      Divisor = 1
-    else if (TimeStatisticsGranularity == "ns")
-      Divisor = 1e-3;
-    PCFreq = li.QuadPart / Divisor;
+    uint32_t GranularityPerSecond = env::getGranularityUnitsPerSecond();
+    PCFreq = li.QuadPart / GranularityPerSecond;
     return true;
   }
 
@@ -161,14 +155,8 @@ public:
     }
     // clock_getres returns counts per nanosecond
     // If we need milliseconds we multiply by 10^6
-    // TODO: granularity as env var
-    StringRef TimeStatisticsGranularity = env::getTimeStatisticsGranularity();
-    int Multiplicand = 1e6;
-    if (TimeStatisticsGranularity == "us")
-      Multiplicand = 1e3;
-    else if (TimeStatisticsGranularity == "ns")
-      Multiplicand = 1;
-    PCFreq = (Res.tv_sec * 1e9 + Res.tv_nsec) * Multiplicand;
+    uint32_t GranularityPerSecond = env::getGranularityUnitsPerSecond();
+    PCFreq = (Res.tv_sec * 1e9 + Res.tv_nsec) * (1e9 / GranularityPerSecond);
     return true;
   }
 

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -8,7 +8,7 @@
 ///
 /// \file
 /// This file implements Comgr's built-in profiler, which can be enabled with
-/// the AMD_COMGR_TIME_STATISTICS enviornment variable.
+/// the AMD_COMGR_TIME_STATISTICS environment variable.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -121,7 +121,13 @@ public:
     // QueryPerformanceFrequency returns counts per second
     // If we need milliseconds we divide by 10^3
     // TODO: granularity as env var
-    PCFreq = li.QuadPart / 1e3;
+    StringRef TimeStatisticsGranularity = env::getTimeStatisticsGranularity();
+    int Divisor = 1e3;
+    if (TimeStatisticsGranularity == "us")
+      Divisor = 1
+    else if (TimeStatisticsGranularity == "ns")
+      Divisor = 1e-3;
+    PCFreq = li.QuadPart / Divisor;
     return true;
   }
 
@@ -156,7 +162,13 @@ public:
     // clock_getres returns counts per nanosecond
     // If we need milliseconds we multiply by 10^6
     // TODO: granularity as env var
-    PCFreq = (Res.tv_sec * 1e9 + Res.tv_nsec) * 1e6;
+    StringRef TimeStatisticsGranularity = env::getTimeStatisticsGranularity();
+    int Multiplicand = 1e6;
+    if (TimeStatisticsGranularity == "us")
+      Multiplicand = 1e3;
+    else if (TimeStatisticsGranularity == "ns")
+      Multiplicand = 1;
+    PCFreq = (Res.tv_sec * 1e9 + Res.tv_nsec) * Multiplicand;
     return true;
   }
 

--- a/amd/comgr/src/time-stat/time-stat.h
+++ b/amd/comgr/src/time-stat/time-stat.h
@@ -64,7 +64,8 @@ public:
     for (const auto &Item : ProfileDataMap) {
       *pLog << llvm::format("%-50s", Item.getKey().str().c_str())
             << llvm::format("%6d", Item.getValue().Counter) << " calls "
-            << llvm::format("%10.4f", Item.getValue().TimeTaken) << " " << env::getTimeStatisticsGranularity() << "\n";
+            << llvm::format("%10.4f", Item.getValue().TimeTaken) << " "
+            << env::getTimeStatisticsGranularity() << "\n";
     }
   }
 };

--- a/amd/comgr/src/time-stat/time-stat.h
+++ b/amd/comgr/src/time-stat/time-stat.h
@@ -63,8 +63,8 @@ public:
   void dumpPerfStats() {
     for (const auto &Item : ProfileDataMap) {
       *pLog << llvm::format("%-50s", Item.getKey().str().c_str())
-            << llvm::format("%6d", Item.getValue().Counter) << " calls"
-            << llvm::format("%10.4f", Item.getValue().TimeTaken) << " ms\n";
+            << llvm::format("%6d", Item.getValue().Counter) << " calls "
+            << llvm::format("%10.4f", Item.getValue().TimeTaken) << " " << env::getTimeStatisticsGranularity() << "\n";
     }
   }
 };

--- a/amd/comgr/test-lit/time-statistics.cl
+++ b/amd/comgr/test-lit/time-statistics.cl
@@ -1,12 +1,14 @@
 // COM: Check for any runtime errors with the Comgr Profilier
 // RUN: AMD_COMGR_TIME_STATISTICS=1 compile-opencl-minimal %s %t.dflt.bin 1.2
-// RUN: grep 'ms' PerfStatsLog.txt
+// RUN: grep 'ms$' PerfStatsLog.txt
 // RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=ms compile-opencl-minimal %s %t.ms.bin 1.2
-// RUN: grep 'ms' PerfStatsLog.txt
+// RUN: grep 'ms$' PerfStatsLog.txt
 // RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=us compile-opencl-minimal %s %t.us.bin 1.2
-// RUN: grep 'us' PerfStatsLog.txt
+// RUN: grep 'us$' PerfStatsLog.txt
 // RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=ns compile-opencl-minimal %s %t.ns.bin 1.2
-// RUN: grep 'ns' PerfStatsLog.txt
+// RUN: grep 'ns$' PerfStatsLog.txt
+// RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=foo compile-opencl-minimal %s %t.ns.bin 1.2
+// RUN: grep 'ms$' PerfStatsLog.txt
 
 void kernel add(__global float *A, __global float *B, __global float *C) {
     *C = *A + *B;

--- a/amd/comgr/test-lit/time-statistics.cl
+++ b/amd/comgr/test-lit/time-statistics.cl
@@ -1,6 +1,12 @@
 // COM: Check for any runtime errors with the Comgr Profilier
-// RUN: AMD_COMGR_TIME_STATISTICS=1 compile-opencl-minimal %s %t.bin 1.2
-// RUN: test -f PerfStatsLog.txt
+// RUN: AMD_COMGR_TIME_STATISTICS=1 compile-opencl-minimal %s %t.dflt.bin 1.2
+// RUN: grep 'ms' PerfStatsLog.txt
+// RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=ms compile-opencl-minimal %s %t.ms.bin 1.2
+// RUN: grep 'ms' PerfStatsLog.txt
+// RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=us compile-opencl-minimal %s %t.us.bin 1.2
+// RUN: grep 'us' PerfStatsLog.txt
+// RUN: AMD_COMGR_TIME_STATISTICS=1 AMD_COMGR_TIME_STATISTICS_GRANULARITY=ns compile-opencl-minimal %s %t.ns.bin 1.2
+// RUN: grep 'ns' PerfStatsLog.txt
 
 void kernel add(__global float *A, __global float *B, __global float *C) {
     *C = *A + *B;


### PR DESCRIPTION
Added environment variable AMD_COMGR_TIME_STATISTICS_GRANULARITY that can be set to ms, us, or ns. When running time statistics with this environment variable set, the PerfStatsLog.txt file created will adjust the units of the outputs respectively.

Fixes #2637 issue.