### PR TITLE
[Comgr][Cmake] Fix incbin detection

### DIFF
--- a/amd/comgr/cmake/CheckEmbed.cmake
+++ b/amd/comgr/cmake/CheckEmbed.cmake
@@ -34,7 +34,7 @@ if(CMAKE_ASM_COMPILER)
     RESULT_VARIABLE asm_result)
 
   if(asm_result EQUAL 0)
-    set(HAVE_INCBIN_SUPPORT 1 PARENT_SCOPE)
+    set(HAVE_INCBIN_SUPPORT ON)
   endif()
 endif()
 


### PR DESCRIPTION
The check is included through `include(CheckEmbed.cmake)`.

Before this patch, we were setting the output variable in the `PARENT_SCOPE`. So the current scope did not have access to the variable. Since we included the check through a simple `include` it's executed in the current scope as if it was a macro, and not a function call.

Even if the `execute_process` was successful, we would report incbin as not being available; and set the wrong default behaviour.

This patch sets the output variable in the current scope.

For clarity, I also changed `1` to `ON`.


