### PR TITLE
[WaveTransform] Handle Vreg1 widening with uses within same MBB.

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -35,7 +35,7 @@ private:
   // defining MBB is semantically a lane mask throughout its live range.
   // Widening it to VGPR_32 (V_CNDMASK/V_CMP round-trip) is unnecessary;
   // simply reclassify it to the lane-mask register class.
-  bool isAllUsesOfVreg1SameMBB(const MachineInstr &MI) const {
+  bool canTreatAsLocalLaneMask(const MachineInstr &MI) const {
     if (MI.getOpcode() != AMDGPU::COPY)
       return false;
 
@@ -284,7 +284,7 @@ bool Vreg1WideningHelper::widenVreg1s() {
 
       assert(!MI.getOperand(0).getSubReg());
 
-      if (isAllUsesOfVreg1SameMBB(MI)) {
+      if (canTreatAsLocalLaneMask(MI)) {
         markAsLaneMask(DstReg);
         continue;
       }

--- a/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUFinalizeISelWaveTransform.cpp
@@ -30,45 +30,25 @@ public:
 
 private:
   DenseSet<Register> ConstrainRegs;
-  // This function matches the narrow SCC-lowering pattern that must stay in
-  // lane-mask form instead of widening to VGPR_32.
-  //
-  // Example:
-  //   %0:vreg_1 = COPY <lane-mask>
-  //   $scc = COPY %0
-  // `SIFixSGPRCopies` immediately lowers that to:
-  //   %0:vreg_1 = COPY <lane-mask>
-  //   S_AND_* %0, $exec
-  // so `%0` is still semantically a lane mask.
-  bool isLaneMaskToImmediateSAndUse(
-      const MachineInstr &MI, const AMDGPU::LaneMaskConstants &LMC) const {
+
+  // A vreg_1 defined by a COPY from a lane-mask that never leaves its
+  // defining MBB is semantically a lane mask throughout its live range.
+  // Widening it to VGPR_32 (V_CNDMASK/V_CMP round-trip) is unnecessary;
+  // simply reclassify it to the lane-mask register class.
+  bool isAllUsesOfVreg1SameMBB(const MachineInstr &MI) const {
     if (MI.getOpcode() != AMDGPU::COPY)
       return false;
 
     if (!isLaneMaskReg(MI.getOperand(1).getReg()))
       return false;
 
-    Register CurReg = MI.getOperand(0).getReg();
+    Register DstReg = MI.getOperand(0).getReg();
+    const MachineBasicBlock *DefMBB = MI.getParent();
+    for (const MachineInstr &UseMI : MRI->use_nodbg_instructions(DstReg))
+      if (UseMI.getParent() != DefMBB)
+        return false;
 
-    if (!CurReg.isVirtual() || !MRI->hasOneUse(CurReg))
-      return false;
-
-    auto NextIt = std::next(MachineBasicBlock::const_iterator(MI));
-    if (NextIt == MI.getParent()->end())
-      return false;
-
-    const MachineInstr &UseMI = *MRI->use_instr_begin(CurReg);
-    if (&UseMI != &*NextIt)
-      return false;
-
-    if (UseMI.getOpcode() == LMC.AndOpc) {
-      Register Src0 = UseMI.getOperand(1).getReg();
-      Register Src1 = UseMI.getOperand(2).getReg();
-      return (Src0 == CurReg && Src1 == LMC.ExecReg) ||
-              (Src1 == CurReg && Src0 == LMC.ExecReg);
-    }
-
-    return false;
+    return true;
   }
 
 public:
@@ -304,7 +284,7 @@ bool Vreg1WideningHelper::widenVreg1s() {
 
       assert(!MI.getOperand(0).getSubReg());
 
-      if (isLaneMaskToImmediateSAndUse(MI, *LMC)) {
+      if (isAllUsesOfVreg1SameMBB(MI)) {
         markAsLaneMask(DstReg);
         continue;
       }

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/divergence-divergent-i1-used-outside-loop.ll
@@ -28,10 +28,9 @@ define void @divergent_i1_phi_used_outside_loop(float %val, float %pre.cond.val,
   ; CHECK-NEXT:   successors: %bb.2(0x04000000), %bb.1(0x7c000000)
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT:   [[PHI:%[0-9]+]]:sreg_32 = PHI [[S_MOV_B32_]], %bb.0, %4, %bb.1
-  ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vgpr_32 = PHI [[V_CNDMASK_B32_e64_]], %bb.0, %39, %bb.1
+  ; CHECK-NEXT:   [[PHI1:%[0-9]+]]:vgpr_32 = PHI [[V_CNDMASK_B32_e64_]], %bb.0, %24, %bb.1
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_:%[0-9]+]]:sreg_32 = V_CMP_NE_U32_e64 0, [[PHI1]], implicit $exec
-  ; CHECK-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32_xm0_xexec = S_XOR_B32 killed [[V_CMP_NE_U32_e64_]], -1, implicit-def dead $scc
-  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, -1, killed [[S_XOR_B32_]], implicit $exec
+  ; CHECK-NEXT:   [[S_XOR_B32_:%[0-9]+]]:sreg_32 = S_XOR_B32 killed [[V_CMP_NE_U32_e64_]], -1, implicit-def dead $scc
   ; CHECK-NEXT:   [[S_CVT_F32_U32_:%[0-9]+]]:sgpr_32 = S_CVT_F32_U32 [[PHI]], implicit $mode
   ; CHECK-NEXT:   [[V_CMP_NGT_F32_e64_:%[0-9]+]]:sreg_32 = nofpexcept V_CMP_NGT_F32_e64 0, killed [[S_CVT_F32_U32_]], 0, [[COPY3]], 0, implicit $mode, implicit $exec
   ; CHECK-NEXT:   [[S_ADD_I32_:%[0-9]+]]:sreg_32 = S_ADD_I32 killed [[PHI]], 1, implicit-def dead $scc
@@ -40,8 +39,8 @@ define void @divergent_i1_phi_used_outside_loop(float %val, float %pre.cond.val,
   ; CHECK-NEXT: {{  $}}
   ; CHECK-NEXT: bb.2.exit:
   ; CHECK-NEXT:   [[V_CMP_NE_U32_e64_1:%[0-9]+]]:sreg_32_xm0_xexec = V_CMP_NE_U32_e64 0, killed [[PHI1]], implicit $exec
-  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_2:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1065353216, killed [[V_CMP_NE_U32_e64_1]], implicit $exec
-  ; CHECK-NEXT:   FLAT_STORE_DWORD killed [[REG_SEQUENCE]], killed [[V_CNDMASK_B32_e64_2]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s32) into %ir.addr)
+  ; CHECK-NEXT:   [[V_CNDMASK_B32_e64_1:%[0-9]+]]:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, 1065353216, killed [[V_CMP_NE_U32_e64_1]], implicit $exec
+  ; CHECK-NEXT:   FLAT_STORE_DWORD killed [[REG_SEQUENCE]], killed [[V_CNDMASK_B32_e64_1]], 0, 0, implicit $exec, implicit $flat_scr :: (store (s32) into %ir.addr)
   ; CHECK-NEXT:   SI_RETURN
 entry:
   %pre.cond = fcmp ogt float %pre.cond.val, 1.0

--- a/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
+++ b/llvm/test/CodeGen/AMDGPU/a-v-flat-atomicrmw.ll
@@ -8933,8 +8933,6 @@ define void @flat_atomic_udec_wrap_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_gt_u64_e64 s[6:7], v[2:3], v[0:1]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[4:5]
-; GFX90A-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v2
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v6, v1, s[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v0, v5, v0, s[4:5]
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v3
@@ -8988,14 +8986,12 @@ define void @flat_atomic_udec_wrap_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e64 s[0:1], 0, v[2:3]
 ; GFX950-NEXT:    v_cmp_gt_u64_e64 s[2:3], v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX950-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[0:1]
 ; GFX950-NEXT:    v_lshl_add_u64 v[4:5], v[2:3], 0, -1
-; GFX950-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v7
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX950-NEXT:    v_cndmask_b32_e64 v1, v5, v1, s[0:1]
 ; GFX950-NEXT:    v_cndmask_b32_e64 v0, v4, v0, s[0:1]
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX950-NEXT:    scratch_store_dwordx2 v6, v[0:1], off
 ; GFX950-NEXT:  .LBB109_2:
 ; GFX950-NEXT:    s_or_b64 exec, exec, s[4:5]
@@ -9053,8 +9049,6 @@ define void @flat_atomic_udec_wrap_i64_ret_av_av(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_cmp_eq_u64_e64 s[4:5], 0, v[0:1]
 ; GFX90A-NEXT:    v_cmp_gt_u64_e64 s[6:7], v[0:1], v[2:3]
 ; GFX90A-NEXT:    s_or_b64 s[4:5], s[4:5], s[6:7]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[4:5]
-; GFX90A-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v7
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v3, v6, v3, s[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v5, v2, s[4:5]
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
@@ -9103,11 +9097,8 @@ define void @flat_atomic_udec_wrap_i64_ret_av_av(ptr %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e64 s[0:1], 0, v[0:1]
 ; GFX950-NEXT:    v_cmp_gt_u64_e64 s[2:3], v[0:1], v[2:3]
-; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
-; GFX950-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[0:1]
 ; GFX950-NEXT:    v_lshl_add_u64 v[4:5], v[0:1], 0, -1
-; GFX950-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v7
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    s_or_b64 s[0:1], s[0:1], s[2:3]
 ; GFX950-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[0:1]
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v4, v2, s[0:1]
 ; GFX950-NEXT:    scratch_store_dwordx2 v6, v[2:3], off
@@ -9475,8 +9466,6 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
 ; GFX90A-NEXT:    v_subb_co_u32_e64 v2, s[4:5], v2, v7, s[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[4:5]
-; GFX90A-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v3
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v1, 0, s[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[4:5]
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
@@ -9551,9 +9540,6 @@ define void @flat_atomic_usub_sat_i64_ret_a_a(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_subb_co_u32_e64 v3, s[0:1], v1, v7, s[0:1]
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[0:1]
-; GFX950-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v5
-; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s[0:1]
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[0:1]
 ; GFX950-NEXT:    scratch_store_dwordx2 v4, v[2:3], off
@@ -9631,8 +9617,6 @@ define void @flat_atomic_usub_sat_i64_ret_av_av(ptr %ptr) #0 {
 ; GFX90A-NEXT:    v_sub_co_u32_e64 v3, s[4:5], v0, v6
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_subb_co_u32_e64 v4, s[4:5], v1, v7, s[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[4:5]
-; GFX90A-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v5
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v4, v4, 0, s[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s[4:5]
 ; GFX90A-NEXT:    buffer_store_dword v3, v2, s[0:3], 0 offen
@@ -9701,9 +9685,6 @@ define void @flat_atomic_usub_sat_i64_ret_av_av(ptr %ptr) #0 {
 ; GFX950-NEXT:    v_sub_co_u32_e64 v2, s[0:1], v0, v6
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_subb_co_u32_e64 v3, s[0:1], v1, v7, s[0:1]
-; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v5, 0, -1, s[0:1]
-; GFX950-NEXT:    v_cmp_ne_u32_e64 s[0:1], 0, v5
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, s[0:1]
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, s[0:1]
@@ -17947,11 +17928,9 @@ define void @flat_atomic_udec_wrap_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_addc_co_u32_e32 v6, vcc, -1, v3, vcc
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
 ; GFX90A-NEXT:    v_cmp_gt_u64_e64 s[4:5], v[2:3], v[0:1]
-; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX90A-NEXT:    v_cndmask_b32_e64 v2, 0, -1, s[4:5]
-; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v2
+; GFX90A-NEXT:    s_or_b64 vcc, vcc, s[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v1, v6, v1, vcc
+; GFX90A-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v0, v5, v0, vcc
 ; GFX90A-NEXT:    buffer_store_dword v1, v4, s[0:3], 0 offen offset:4
 ; GFX90A-NEXT:    buffer_store_dword v0, v4, s[0:3], 0 offen
@@ -17994,15 +17973,13 @@ define void @flat_atomic_udec_wrap_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    s_waitcnt vmcnt(0)
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[2:3]
 ; GFX950-NEXT:    v_cmp_gt_u64_e64 s[0:1], v[2:3], v[0:1]
-; GFX950-NEXT:    s_or_b64 s[0:1], vcc, s[0:1]
 ; GFX950-NEXT:    v_lshl_add_u64 v[4:5], v[2:3], 0, -1
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[0:1]
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
-; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
+; GFX950-NEXT:    s_or_b64 vcc, vcc, s[0:1]
 ; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
+; GFX950-NEXT:    v_accvgpr_write_b32 a0, v2
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[0:1], s2
+; GFX950-NEXT:    v_accvgpr_write_b32 a1, v3
 ; GFX950-NEXT:    ;;#ASMSTART
 ; GFX950-NEXT:    ; use a[0:1]
 ; GFX950-NEXT:    ;;#ASMEND
@@ -18053,9 +18030,7 @@ define void @flat_atomic_udec_wrap_i64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_addc_co_u32_e32 v6, vcc, -1, v1, vcc
 ; GFX90A-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
 ; GFX90A-NEXT:    v_cmp_gt_u64_e64 s[4:5], v[0:1], v[2:3]
-; GFX90A-NEXT:    s_or_b64 s[4:5], vcc, s[4:5]
-; GFX90A-NEXT:    v_cndmask_b32_e64 v7, 0, -1, s[4:5]
-; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v7
+; GFX90A-NEXT:    s_or_b64 vcc, vcc, s[4:5]
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v2, v5, v2, vcc
 ; GFX90A-NEXT:    v_cndmask_b32_e32 v3, v6, v3, vcc
 ; GFX90A-NEXT:    buffer_store_dword v2, v4, s[0:3], 0 offen
@@ -18094,11 +18069,8 @@ define void @flat_atomic_udec_wrap_i64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    ;;#ASMEND
 ; GFX950-NEXT:    v_cmp_eq_u64_e32 vcc, 0, v[0:1]
 ; GFX950-NEXT:    v_cmp_gt_u64_e64 s[0:1], v[0:1], v[2:3]
-; GFX950-NEXT:    s_or_b64 s[0:1], vcc, s[0:1]
 ; GFX950-NEXT:    v_lshl_add_u64 v[4:5], v[0:1], 0, -1
-; GFX950-NEXT:    v_cndmask_b32_e64 v6, 0, -1, s[0:1]
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
-; GFX950-NEXT:    s_nop 1
+; GFX950-NEXT:    s_or_b64 vcc, vcc, s[0:1]
 ; GFX950-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
@@ -18424,8 +18396,6 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_accvgpr_write_b32 a1, v2
 ; GFX90A-NEXT:    v_subb_co_u32_e32 v2, vcc, v2, v5, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v3, 0, -1, vcc
-; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v1, v1, 0, vcc
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX90A-NEXT:    buffer_store_dword v1, v0, s[0:3], 0 offen
@@ -18491,9 +18461,6 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_a_a(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    v_subb_co_u32_e32 v3, vcc, v1, v5, vcc
 ; GFX950-NEXT:    v_accvgpr_write_b32 a1, v1
 ; GFX950-NEXT:    s_nop 0
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
-; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc
 ; GFX950-NEXT:    scratch_store_dwordx2 off, v[2:3], s2
@@ -18564,8 +18531,6 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX90A-NEXT:    v_sub_co_u32_e32 v3, vcc, v0, v4
 ; GFX90A-NEXT:    s_waitcnt vmcnt(0)
 ; GFX90A-NEXT:    v_subb_co_u32_e32 v4, vcc, v1, v5, vcc
-; GFX90A-NEXT:    v_cndmask_b32_e64 v5, 0, -1, vcc
-; GFX90A-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v5
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
 ; GFX90A-NEXT:    v_cndmask_b32_e64 v4, v4, 0, vcc
 ; GFX90A-NEXT:    buffer_store_dword v3, v2, s[0:3], 0 offen
@@ -18624,9 +18589,6 @@ define void @flat_atomic_usub_sat_i64_saddr_ret_av_av(ptr inreg %ptr) #0 {
 ; GFX950-NEXT:    v_sub_co_u32_e32 v2, vcc, v0, v4
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_subb_co_u32_e32 v3, vcc, v1, v5, vcc
-; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e64 v3, v3, 0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e64 v2, v2, 0, vcc

--- a/llvm/test/CodeGen/AMDGPU/fsqrt.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/fsqrt.f64.ll
@@ -26,12 +26,10 @@ define double @v_sqrt_f64(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -56,12 +54,10 @@ define double @v_sqrt_f64(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -146,12 +142,10 @@ define double @v_sqrt_f64_fneg(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -176,12 +170,10 @@ define double @v_sqrt_f64_fneg(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -267,12 +259,10 @@ define double @v_sqrt_f64_fabs(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -297,12 +287,10 @@ define double @v_sqrt_f64_fabs(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -388,12 +376,10 @@ define double @v_sqrt_f64_fneg_fabs(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -418,12 +404,10 @@ define double @v_sqrt_f64_fneg_fabs(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -734,12 +718,10 @@ define double @v_sqrt_f64_nnan(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -764,12 +746,10 @@ define double @v_sqrt_f64_nnan(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1282,12 +1262,10 @@ define double @v_sqrt_f64_nsz(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1312,12 +1290,10 @@ define double @v_sqrt_f64_nsz(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1610,6 +1586,8 @@ define double @v_sqrt_f64_afn(double %x) {
 ; GFX6-SDAG:       ; %bb.0:
 ; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -1617,10 +1595,6 @@ define double @v_sqrt_f64_afn(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1629,6 +1603,8 @@ define double @v_sqrt_f64_afn(double %x) {
 ; GFX8-SDAG:       ; %bb.0:
 ; GFX8-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -1636,10 +1612,6 @@ define double @v_sqrt_f64_afn(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1686,6 +1658,8 @@ define double @v_sqrt_f64_afn_nsz(double %x) {
 ; GFX6-SDAG:       ; %bb.0:
 ; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -1693,10 +1667,6 @@ define double @v_sqrt_f64_afn_nsz(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1705,6 +1675,8 @@ define double @v_sqrt_f64_afn_nsz(double %x) {
 ; GFX8-SDAG:       ; %bb.0:
 ; GFX8-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -1712,10 +1684,6 @@ define double @v_sqrt_f64_afn_nsz(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1763,6 +1731,9 @@ define <2 x double> @v_sqrt_v2f64_afn(<2 x double> %x) {
 ; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[2:3]
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v16, 0x260
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v16
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v16
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[8:9], v[0:1], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[10:11], v[2:3], v[6:7]
@@ -1776,18 +1747,11 @@ define <2 x double> @v_sqrt_v2f64_afn(<2 x double> %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[2:3]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v8
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-SDAG-LABEL: v_sqrt_v2f64_afn:
@@ -1795,6 +1759,9 @@ define <2 x double> @v_sqrt_v2f64_afn(<2 x double> %x) {
 ; GFX8-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[2:3]
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v16, 0x260
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v16
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v16
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[8:9], v[0:1], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[10:11], v[2:3], v[6:7]
@@ -1808,18 +1775,11 @@ define <2 x double> @v_sqrt_v2f64_afn(<2 x double> %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[2:3]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v8
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX6-GISEL-LABEL: v_sqrt_v2f64_afn:
@@ -1886,6 +1846,8 @@ define double @v_sqrt_f64_afn_nnan(double %x) {
 ; GFX6-SDAG:       ; %bb.0:
 ; GFX6-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; GFX6-SDAG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -1893,10 +1855,6 @@ define double @v_sqrt_f64_afn_nnan(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -1905,6 +1863,8 @@ define double @v_sqrt_f64_afn_nnan(double %x) {
 ; GFX8-SDAG:       ; %bb.0:
 ; GFX8-SDAG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v8, 0x260
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; GFX8-SDAG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -1912,10 +1872,6 @@ define double @v_sqrt_f64_afn_nnan(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -2367,12 +2323,10 @@ define double @v_sqrt_f64__enough_unsafe_attrs(double %x) #3 {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -2397,12 +2351,10 @@ define double @v_sqrt_f64__enough_unsafe_attrs(double %x) #3 {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -2487,12 +2439,10 @@ define double @v_sqrt_f64__unsafe_attr(double %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -2517,12 +2467,10 @@ define double @v_sqrt_f64__unsafe_attr(double %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
@@ -2596,8 +2544,8 @@ define <2 x double> @v_sqrt_v2f64(<2 x double> %x) {
 ; GFX6-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[2:3]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v4, 0x100
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v5, 0, v4, vcc
-; GFX6-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
+; GFX6-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v5
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[0:1]
 ; GFX6-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[2:3]
@@ -2619,22 +2567,18 @@ define <2 x double> @v_sqrt_v2f64(<2 x double> %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[2:3]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
 ; GFX6-SDAG-NEXT:    v_mov_b32_e32 v8, 0xffffff80
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v8, vcc
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v9
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
 ; GFX6-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v9
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-SDAG-LABEL: v_sqrt_v2f64:
@@ -2646,8 +2590,8 @@ define <2 x double> @v_sqrt_v2f64(<2 x double> %x) {
 ; GFX8-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[2:3]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v4, 0x100
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v5, 0, v4, vcc
-; GFX8-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
+; GFX8-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v5
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[0:1]
 ; GFX8-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[2:3]
@@ -2669,22 +2613,18 @@ define <2 x double> @v_sqrt_v2f64(<2 x double> %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[2:3]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
 ; GFX8-SDAG-NEXT:    v_mov_b32_e32 v8, 0xffffff80
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v8, vcc
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v9
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
 ; GFX8-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v9
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX6-GISEL-LABEL: v_sqrt_v2f64:
@@ -2829,30 +2769,24 @@ define <3 x double> @v_sqrt_v3f64(<3 x double> %x) {
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[10:11], -v[14:15], v[14:15], v[2:3]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[18:19], -v[16:17], v[16:17], v[4:5]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[8:9], v[10:11], v[8:9], v[14:15]
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v10, 0xffffff80
-; GFX6-SDAG-NEXT:    v_mov_b32_e32 v14, 0x260
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v15, 0, v10, vcc
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v14
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v20, 0, v10, s[4:5]
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v21, 0, v10, s[6:7]
 ; GFX6-SDAG-NEXT:    v_fma_f64 v[10:11], v[18:19], v[12:13], v[16:17]
-; GFX6-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v15
-; GFX6-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v20
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v12, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v14
-; GFX6-SDAG-NEXT:    v_ldexp_f64 v[10:11], v[10:11], v21
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[4:5], v14
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v14, 0xffffff80
+; GFX6-SDAG-NEXT:    v_mov_b32_e32 v15, 0x260
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v12, 0, v14, vcc
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v14, s[4:5]
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[6:7]
+; GFX6-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v12
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v15
+; GFX6-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v13
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v15
+; GFX6-SDAG-NEXT:    v_ldexp_f64 v[10:11], v[10:11], v14
+; GFX6-SDAG-NEXT:    v_cmp_class_f64_e64 s[6:7], v[4:5], v15
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
 ; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v2, v8, v2, vcc
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc
-; GFX6-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v4, v10, v4, vcc
-; GFX6-SDAG-NEXT:    v_cndmask_b32_e32 v5, v11, v5, vcc
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v2, v8, v2, s[4:5]
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v3, v9, v3, s[4:5]
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v4, v10, v4, s[6:7]
+; GFX6-SDAG-NEXT:    v_cndmask_b32_e64 v5, v11, v5, s[6:7]
 ; GFX6-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX8-SDAG-LABEL: v_sqrt_v3f64:
@@ -2899,30 +2833,24 @@ define <3 x double> @v_sqrt_v3f64(<3 x double> %x) {
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[10:11], -v[14:15], v[14:15], v[2:3]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[18:19], -v[16:17], v[16:17], v[4:5]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[8:9], v[10:11], v[8:9], v[14:15]
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v10, 0xffffff80
-; GFX8-SDAG-NEXT:    v_mov_b32_e32 v14, 0x260
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v15, 0, v10, vcc
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v14
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v20, 0, v10, s[4:5]
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v21, 0, v10, s[6:7]
 ; GFX8-SDAG-NEXT:    v_fma_f64 v[10:11], v[18:19], v[12:13], v[16:17]
-; GFX8-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v15
-; GFX8-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v20
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v12, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v14
-; GFX8-SDAG-NEXT:    v_ldexp_f64 v[10:11], v[10:11], v21
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[4:5], v14
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v14, 0, -1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v14, 0xffffff80
+; GFX8-SDAG-NEXT:    v_mov_b32_e32 v15, 0x260
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v12, 0, v14, vcc
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v13, 0, v14, s[4:5]
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v14, 0, v14, s[6:7]
+; GFX8-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v12
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v15
+; GFX8-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v13
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v15
+; GFX8-SDAG-NEXT:    v_ldexp_f64 v[10:11], v[10:11], v14
+; GFX8-SDAG-NEXT:    v_cmp_class_f64_e64 s[6:7], v[4:5], v15
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
 ; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v13
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v2, v8, v2, vcc
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v3, v9, v3, vcc
-; GFX8-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v14
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v4, v10, v4, vcc
-; GFX8-SDAG-NEXT:    v_cndmask_b32_e32 v5, v11, v5, vcc
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v2, v8, v2, s[4:5]
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v3, v9, v3, s[4:5]
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v4, v10, v4, s[6:7]
+; GFX8-SDAG-NEXT:    v_cndmask_b32_e64 v5, v11, v5, s[6:7]
 ; GFX8-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX6-GISEL-LABEL: v_sqrt_v3f64:

--- a/llvm/test/CodeGen/AMDGPU/mul24-pass-ordering.ll
+++ b/llvm/test/CodeGen/AMDGPU/mul24-pass-ordering.ll
@@ -59,11 +59,11 @@ define void @lsr_order_mul24_1(i32 %arg, i32 %arg1, i32 %arg2, ptr addrspace(3) 
 ; GFX9-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX9-NEXT:    v_cmp_ge_u32_e64 s[4:5], v0, v1
 ; GFX9-NEXT:    v_and_b32_e32 v5, 1, v18
-; GFX9-NEXT:    s_xor_b64 s[8:9], s[4:5], exec
+; GFX9-NEXT:    s_xor_b64 s[6:7], s[4:5], exec
 ; GFX9-NEXT:    v_cmp_eq_u32_e32 vcc, 1, v5
 ; GFX9-NEXT:    s_mov_b64 s[4:5], -1
-; GFX9-NEXT:    s_xor_b64 s[6:7], exec, s[8:9]
-; GFX9-NEXT:    s_mov_b64 exec, s[8:9]
+; GFX9-NEXT:    s_xor_b64 s[8:9], exec, s[6:7]
+; GFX9-NEXT:    s_mov_b64 exec, s[6:7]
 ; GFX9-NEXT:    ; divergent control-flow edge
 ; GFX9-NEXT:    s_cbranch_execz .LBB1_3
 ; GFX9-NEXT:  .LBB1_1: ; %bb19
@@ -81,6 +81,7 @@ define void @lsr_order_mul24_1(i32 %arg, i32 %arg1, i32 %arg2, ptr addrspace(3) 
 ; GFX9-NEXT:  .LBB1_2: ; %bb23
 ; GFX9-NEXT:    ; =>This Inner Loop Header: Depth=1
 ; GFX9-NEXT:    v_cvt_f32_u32_e32 v3, v0
+; GFX9-NEXT:    v_cmp_ne_u32_e64 s[6:7], 0, v5
 ; GFX9-NEXT:    v_madak_f32 v3, v3, v7, 0x3727c5ac
 ; GFX9-NEXT:    v_cvt_u32_f32_e32 v3, v3
 ; GFX9-NEXT:    v_mul_u32_u24_e32 v18, v3, v6
@@ -93,10 +94,7 @@ define void @lsr_order_mul24_1(i32 %arg, i32 %arg1, i32 %arg2, ptr addrspace(3) 
 ; GFX9-NEXT:    v_mad_u64_u32 v[18:19], s[4:5], v19, v15, v[3:4]
 ; GFX9-NEXT:    v_cmp_lt_u32_e64 s[4:5], v20, v14
 ; GFX9-NEXT:    s_and_b64 s[4:5], vcc, s[4:5]
-; GFX9-NEXT:    v_cndmask_b32_e64 v3, 0, -1, s[4:5]
-; GFX9-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v3
-; GFX9-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v5
-; GFX9-NEXT:    s_and_b64 vcc, vcc, s[4:5]
+; GFX9-NEXT:    s_and_b64 vcc, s[4:5], s[6:7]
 ; GFX9-NEXT:    v_cndmask_b32_e32 v3, 0, v18, vcc
 ; GFX9-NEXT:    v_lshlrev_b64 v[18:19], 2, v[3:4]
 ; GFX9-NEXT:    v_add_u32_e32 v0, v0, v2
@@ -104,8 +102,8 @@ define void @lsr_order_mul24_1(i32 %arg, i32 %arg1, i32 %arg2, ptr addrspace(3) 
 ; GFX9-NEXT:    v_addc_co_u32_e64 v19, s[4:5], v11, v19, s[4:5]
 ; GFX9-NEXT:    global_load_dword v3, v[18:19], off
 ; GFX9-NEXT:    v_cmp_lt_u32_e64 s[4:5], v0, v1
-; GFX9-NEXT:    s_xor_b64 s[8:9], exec, s[4:5]
-; GFX9-NEXT:    s_or_b64 s[6:7], s[6:7], s[8:9]
+; GFX9-NEXT:    s_xor_b64 s[6:7], exec, s[4:5]
+; GFX9-NEXT:    s_or_b64 s[8:9], s[8:9], s[6:7]
 ; GFX9-NEXT:    s_waitcnt vmcnt(0)
 ; GFX9-NEXT:    v_cndmask_b32_e32 v3, 0, v3, vcc
 ; GFX9-NEXT:    ds_write_b32 v8, v3
@@ -114,7 +112,7 @@ define void @lsr_order_mul24_1(i32 %arg, i32 %arg1, i32 %arg2, ptr addrspace(3) 
 ; GFX9-NEXT:    ; divergent control-flow edge
 ; GFX9-NEXT:    s_cbranch_execnz .LBB1_2
 ; GFX9-NEXT:  .LBB1_3: ; %.loopexit
-; GFX9-NEXT:    s_or_b64 exec, exec, s[6:7]
+; GFX9-NEXT:    s_or_b64 exec, exec, s[8:9]
 ; GFX9-NEXT:    s_waitcnt lgkmcnt(0)
 ; GFX9-NEXT:    s_setpc_b64 s[30:31]
 bb:

--- a/llvm/test/CodeGen/AMDGPU/rsq.f64.ll
+++ b/llvm/test/CodeGen/AMDGPU/rsq.f64.ll
@@ -1069,12 +1069,10 @@ define double @v_rsq_f64(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -1110,8 +1108,6 @@ define double @v_rsq_f64(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -1161,10 +1157,8 @@ define double @v_rsq_f64(double %x) {
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1246,12 +1240,10 @@ define double @v_rsq_f64(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1314,12 +1306,10 @@ define double @v_rsq_f64_fabs(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64_fabs:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v5, 0x240
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e64 v[2:3], |v[0:1]|
-; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e64 s[4:5], |v[0:1]|, v5
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v5, 0x240
+; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e64 vcc, |v[0:1]|, v5
 ; SI-SDAG-IR-NEXT:    v_and_b32_e32 v4, 0x7fffffff, v1
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v4, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -1354,10 +1344,8 @@ define double @v_rsq_f64_fabs(double %x) {
 ; VI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-IR-NEXT:    v_rsq_f64_e64 v[2:3], |v[0:1]|
 ; VI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x240
-; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e64 s[4:5], |v[0:1]|, v4
+; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e64 vcc, |v[0:1]|, v4
 ; VI-SDAG-IR-NEXT:    v_and_b32_e32 v5, 0x7fffffff, v1
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v1, 0, -1, s[4:5]
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v1
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v5, v3, vcc
@@ -1399,11 +1387,9 @@ define double @v_rsq_f64_fabs(double %x) {
 ; SI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0xffffff80
 ; SI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_mov_b32_e32 v9, 0x260
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v8, 0, v8, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
+; SI-SDAG-CG-NEXT:    s_mov_b32 s6, 0x3ff00000
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
-; SI-SDAG-CG-NEXT:    s_mov_b32 s6, 0x3ff00000
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[6:7], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
@@ -1411,9 +1397,9 @@ define double @v_rsq_f64_fabs(double %x) {
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v8
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
+; SI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
+; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1495,12 +1481,10 @@ define double @v_rsq_f64_fabs(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1584,10 +1568,8 @@ define double @v_rsq_f64_missing_contract0(double %x) {
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1669,12 +1651,10 @@ define double @v_rsq_f64_missing_contract0(double %x) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1757,10 +1737,8 @@ define double @v_rsq_f64_missing_contract1(double %x) {
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1842,12 +1820,10 @@ define double @v_rsq_f64_missing_contract1(double %x) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -1910,12 +1886,10 @@ define double @v_neg_rsq_f64(double %x) {
 ; SI-SDAG-IR-LABEL: v_neg_rsq_f64:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -1951,8 +1925,6 @@ define double @v_neg_rsq_f64(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -2002,10 +1974,8 @@ define double @v_neg_rsq_f64(double %x) {
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], -1.0
@@ -2087,12 +2057,10 @@ define double @v_neg_rsq_f64(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], -1.0
@@ -2159,76 +2127,72 @@ define <2 x double> @v_rsq_v2f64(<2 x double> %x) {
 ; SI-SDAG-NEXT:    s_brev_b32 s5, 8
 ; SI-SDAG-NEXT:    v_cmp_gt_f64_e32 vcc, s[4:5], v[2:3]
 ; SI-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[0:1]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v8, 0x100
-; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
+; SI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x100
+; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
+; SI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v6
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v8
+; SI-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[0:1]
 ; SI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
-; SI-SDAG-NEXT:    v_rsq_f64_e32 v[8:9], v[0:1]
 ; SI-SDAG-NEXT:    s_mov_b32 s6, 0x3ff00000
-; SI-SDAG-NEXT:    v_mul_f64 v[6:7], v[2:3], v[4:5]
+; SI-SDAG-NEXT:    v_mul_f64 v[10:11], v[0:1], v[6:7]
+; SI-SDAG-NEXT:    v_mul_f64 v[6:7], v[6:7], 0.5
+; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
+; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[10:11], 0.5
 ; SI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
-; SI-SDAG-NEXT:    v_mul_f64 v[12:13], v[0:1], v[8:9]
-; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[8:9], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[4:5], v[6:7], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[12:13], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[10:11], v[6:7]
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[10:11], v[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[12:13], v[16:17], v[12:13]
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[16:17], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[10:11], v[14:15], v[10:11]
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[10:11], v[10:11], v[0:1]
+; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[18:19], v[6:7], v[10:11]
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
 ; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[10:11], v[0:1]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v16, 0xffffff80
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[12:13], v[8:9], v[10:11]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v17, 0x260
-; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[10:11], v[0:1]
-; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[6:7], v[2:3]
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[8:9], v[10:11]
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v16, s[4:5]
-; SI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], v17
-; SI-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, -1, s[4:5]
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v9, v1, s[4:5]
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v8, v0, s[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[4:5], v[6:7]
-; SI-SDAG-NEXT:    v_div_scale_f64 v[8:9], s[4:5], v[0:1], v[0:1], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[6:7], v[2:3]
-; SI-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v16, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[14:15], v[4:5], v[6:7]
-; SI-SDAG-NEXT:    v_rcp_f64_e32 v[6:7], v[8:9]
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v17
-; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v12, 0, -1, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; SI-SDAG-NEXT:    v_mov_b32_e32 v14, 0xffffff80
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[12:13], v[6:7], v[10:11]
+; SI-SDAG-NEXT:    v_mov_b32_e32 v15, 0x260
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v14, s[4:5]
+; SI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v10
+; SI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], v15
+; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[8:9], v[2:3]
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
+; SI-SDAG-NEXT:    v_div_scale_f64 v[6:7], s[4:5], v[0:1], v[0:1], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[16:17], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[8:9], v[2:3]
+; SI-SDAG-NEXT:    v_rcp_f64_e32 v[12:13], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[10:11], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_cndmask_b32_e32 v8, 0, v14, vcc
+; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v8
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v15
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[6:7], v[12:13], 1.0
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[5:6], v[6:7], v[10:11], v[6:7]
-; SI-SDAG-NEXT:    v_div_scale_f64 v[12:13], s[4:5], v[2:3], v[2:3], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[5:6], 1.0
-; SI-SDAG-NEXT:    v_div_scale_f64 v[14:15], s[4:5], 1.0, v[0:1], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[5:6], v[10:11], v[5:6]
-; SI-SDAG-NEXT:    v_rcp_f64_e32 v[6:7], v[12:13]
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v9
-; SI-SDAG-NEXT:    v_mul_f64 v[10:11], v[14:15], v[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[12:13], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[10:11], v[14:15]
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[18:19], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[8:9], v[12:13]
+; SI-SDAG-NEXT:    v_div_scale_f64 v[10:11], s[4:5], v[2:3], v[2:3], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], -v[6:7], v[8:9], 1.0
+; SI-SDAG-NEXT:    v_div_scale_f64 v[12:13], s[4:5], 1.0, v[0:1], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[8:9], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_rcp_f64_e32 v[8:9], v[10:11]
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v7
+; SI-SDAG-NEXT:    v_mul_f64 v[14:15], v[12:13], v[4:5]
+; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[10:11], v[8:9], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[6:7], v[14:15], v[12:13]
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[8:9], v[18:19], v[8:9]
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[18:19], s[4:5], 1.0, v[2:3], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[12:13], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v15
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[10:11], v[6:7], 1.0
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v13
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[8:9], v[6:7]
 ; SI-SDAG-NEXT:    s_xor_b64 vcc, s[4:5], vcc
 ; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[18:19], v[6:7]
-; SI-SDAG-NEXT:    v_div_fmas_f64 v[4:5], v[16:17], v[4:5], v[10:11]
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[12:13], v[8:9], v[18:19]
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v13
+; SI-SDAG-NEXT:    v_div_fmas_f64 v[4:5], v[16:17], v[4:5], v[14:15]
+; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[8:9], v[18:19]
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v11
 ; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v19
 ; SI-SDAG-NEXT:    s_xor_b64 vcc, s[4:5], vcc
 ; SI-SDAG-NEXT:    v_div_fixup_f64 v[0:1], v[4:5], v[0:1], 1.0
 ; SI-SDAG-NEXT:    s_nop 0
-; SI-SDAG-NEXT:    v_div_fmas_f64 v[6:7], v[10:11], v[6:7], v[8:9]
+; SI-SDAG-NEXT:    v_div_fmas_f64 v[6:7], v[12:13], v[6:7], v[8:9]
 ; SI-SDAG-NEXT:    v_div_fixup_f64 v[2:3], v[6:7], v[2:3], 1.0
 ; SI-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2317,46 +2281,42 @@ define <2 x double> @v_rsq_v2f64(<2 x double> %x) {
 ; VI-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x100
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v5, 0, v4, vcc
-; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v5
 ; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v4
-; VI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
+; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v5
 ; VI-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[0:1]
-; VI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
-; VI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
+; VI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
 ; VI-SDAG-NEXT:    v_mul_f64 v[10:11], v[0:1], v[6:7]
 ; VI-SDAG-NEXT:    v_mul_f64 v[6:7], v[6:7], 0.5
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
+; VI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
+; VI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[10:11], 0.5
-; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
-; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
 ; VI-SDAG-NEXT:    v_fma_f64 v[10:11], v[10:11], v[14:15], v[10:11]
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[6:7]
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
+; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[0:1]
-; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[4:5], v[8:9]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
 ; VI-SDAG-NEXT:    v_fma_f64 v[10:11], v[14:15], v[6:7], v[10:11]
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[4:5], v[8:9]
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[0:1]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
 ; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v8, 0xffffff80
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
-; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v8, vcc
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v9
 ; VI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
-; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
-; VI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v9
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; VI-SDAG-NEXT:    v_div_scale_f64 v[5:6], s[4:5], v[0:1], v[0:1], 1.0
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; VI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
+; VI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v9
+; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
+; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; VI-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; VI-SDAG-NEXT:    v_div_scale_f64 v[5:6], s[6:7], v[0:1], v[0:1], 1.0
+; VI-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, v2, s[4:5]
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[7:8], s[4:5], v[2:3], v[2:3], 1.0
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[17:18], s[4:5], 1.0, v[2:3], 1.0
 ; VI-SDAG-NEXT:    v_rcp_f64_e32 v[9:10], v[5:6]
@@ -2463,76 +2423,72 @@ define <2 x double> @v_neg_rsq_v2f64(<2 x double> %x) {
 ; SI-SDAG-NEXT:    s_brev_b32 s5, 8
 ; SI-SDAG-NEXT:    v_cmp_gt_f64_e32 vcc, s[4:5], v[2:3]
 ; SI-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[0:1]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v8, 0x100
-; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
+; SI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x100
+; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
+; SI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v6
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v8
+; SI-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[0:1]
 ; SI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
-; SI-SDAG-NEXT:    v_rsq_f64_e32 v[8:9], v[0:1]
 ; SI-SDAG-NEXT:    s_mov_b32 s6, 0xbff00000
-; SI-SDAG-NEXT:    v_mul_f64 v[6:7], v[2:3], v[4:5]
+; SI-SDAG-NEXT:    v_mul_f64 v[10:11], v[0:1], v[6:7]
+; SI-SDAG-NEXT:    v_mul_f64 v[6:7], v[6:7], 0.5
+; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
+; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[10:11], 0.5
 ; SI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
-; SI-SDAG-NEXT:    v_mul_f64 v[12:13], v[0:1], v[8:9]
-; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[8:9], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[4:5], v[6:7], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[12:13], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[10:11], v[6:7]
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[10:11], v[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[12:13], v[16:17], v[12:13]
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[16:17], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[10:11], v[14:15], v[10:11]
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[10:11], v[10:11], v[0:1]
+; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[18:19], v[6:7], v[10:11]
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
 ; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[10:11], v[0:1]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v16, 0xffffff80
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[12:13], v[8:9], v[10:11]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v17, 0x260
-; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[10:11], v[0:1]
-; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[6:7], v[2:3]
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[8:9], v[10:11]
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v16, s[4:5]
-; SI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], v17
-; SI-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, -1, s[4:5]
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v9, v1, s[4:5]
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v8, v0, s[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[4:5], v[6:7]
-; SI-SDAG-NEXT:    v_div_scale_f64 v[8:9], s[4:5], v[0:1], v[0:1], -1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[6:7], v[2:3]
-; SI-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v16, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[14:15], v[4:5], v[6:7]
-; SI-SDAG-NEXT:    v_rcp_f64_e32 v[6:7], v[8:9]
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v17
-; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v12, 0, -1, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; SI-SDAG-NEXT:    v_mov_b32_e32 v14, 0xffffff80
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[12:13], v[6:7], v[10:11]
+; SI-SDAG-NEXT:    v_mov_b32_e32 v15, 0x260
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v14, s[4:5]
+; SI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v10
+; SI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], v15
+; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[8:9], v[2:3]
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
+; SI-SDAG-NEXT:    v_div_scale_f64 v[6:7], s[4:5], v[0:1], v[0:1], -1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[16:17], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[8:9], v[2:3]
+; SI-SDAG-NEXT:    v_rcp_f64_e32 v[12:13], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[10:11], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_cndmask_b32_e32 v8, 0, v14, vcc
+; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v8
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v15
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[6:7], v[12:13], 1.0
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[5:6], v[6:7], v[10:11], v[6:7]
-; SI-SDAG-NEXT:    v_div_scale_f64 v[12:13], s[4:5], v[2:3], v[2:3], -1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[5:6], 1.0
-; SI-SDAG-NEXT:    v_div_scale_f64 v[14:15], s[4:5], -1.0, v[0:1], -1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[5:6], v[10:11], v[5:6]
-; SI-SDAG-NEXT:    v_rcp_f64_e32 v[6:7], v[12:13]
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v9
-; SI-SDAG-NEXT:    v_mul_f64 v[10:11], v[14:15], v[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[12:13], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[10:11], v[14:15]
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[18:19], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[8:9], v[12:13]
+; SI-SDAG-NEXT:    v_div_scale_f64 v[10:11], s[4:5], v[2:3], v[2:3], -1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], -v[6:7], v[8:9], 1.0
+; SI-SDAG-NEXT:    v_div_scale_f64 v[12:13], s[4:5], -1.0, v[0:1], -1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[8:9], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_rcp_f64_e32 v[8:9], v[10:11]
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v7
+; SI-SDAG-NEXT:    v_mul_f64 v[14:15], v[12:13], v[4:5]
+; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[10:11], v[8:9], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[6:7], v[14:15], v[12:13]
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[8:9], v[18:19], v[8:9]
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[18:19], s[4:5], -1.0, v[2:3], -1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[12:13], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v15
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[10:11], v[6:7], 1.0
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v13
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[8:9], v[6:7]
 ; SI-SDAG-NEXT:    s_xor_b64 vcc, s[4:5], vcc
 ; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[18:19], v[6:7]
-; SI-SDAG-NEXT:    v_div_fmas_f64 v[4:5], v[16:17], v[4:5], v[10:11]
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[12:13], v[8:9], v[18:19]
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v13
+; SI-SDAG-NEXT:    v_div_fmas_f64 v[4:5], v[16:17], v[4:5], v[14:15]
+; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[8:9], v[18:19]
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v11
 ; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v19
 ; SI-SDAG-NEXT:    s_xor_b64 vcc, s[4:5], vcc
 ; SI-SDAG-NEXT:    v_div_fixup_f64 v[0:1], v[4:5], v[0:1], -1.0
 ; SI-SDAG-NEXT:    s_nop 0
-; SI-SDAG-NEXT:    v_div_fmas_f64 v[6:7], v[10:11], v[6:7], v[8:9]
+; SI-SDAG-NEXT:    v_div_fmas_f64 v[6:7], v[12:13], v[6:7], v[8:9]
 ; SI-SDAG-NEXT:    v_div_fixup_f64 v[2:3], v[6:7], v[2:3], -1.0
 ; SI-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -2621,46 +2577,42 @@ define <2 x double> @v_neg_rsq_v2f64(<2 x double> %x) {
 ; VI-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x100
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v5, 0, v4, vcc
-; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v5
 ; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v4
-; VI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
+; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v5
 ; VI-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[0:1]
-; VI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
-; VI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
+; VI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
 ; VI-SDAG-NEXT:    v_mul_f64 v[10:11], v[0:1], v[6:7]
 ; VI-SDAG-NEXT:    v_mul_f64 v[6:7], v[6:7], 0.5
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
+; VI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
+; VI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[10:11], 0.5
-; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
-; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
 ; VI-SDAG-NEXT:    v_fma_f64 v[10:11], v[10:11], v[14:15], v[10:11]
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[6:7]
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
+; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[0:1]
-; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[4:5], v[8:9]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
 ; VI-SDAG-NEXT:    v_fma_f64 v[10:11], v[14:15], v[6:7], v[10:11]
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[4:5], v[8:9]
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[0:1]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
 ; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v8, 0xffffff80
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
-; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v8, vcc
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v9
 ; VI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
-; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
-; VI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v9
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; VI-SDAG-NEXT:    v_div_scale_f64 v[5:6], s[4:5], v[0:1], v[0:1], -1.0
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; VI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
+; VI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v9
+; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
+; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; VI-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; VI-SDAG-NEXT:    v_div_scale_f64 v[5:6], s[6:7], v[0:1], v[0:1], -1.0
+; VI-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, v2, s[4:5]
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[7:8], s[4:5], v[2:3], v[2:3], -1.0
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[17:18], s[4:5], -1.0, v[2:3], -1.0
 ; VI-SDAG-NEXT:    v_rcp_f64_e32 v[9:10], v[5:6]
@@ -2783,10 +2735,8 @@ define <2 x double> @v_neg_rsq_v2f64_poisonelt(<2 x double> %x) {
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], -1.0
@@ -2904,12 +2854,10 @@ define <2 x double> @v_neg_rsq_v2f64_poisonelt(<2 x double> %x) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], -1.0
@@ -3009,77 +2957,73 @@ define <2 x double> @v_neg_pos_rsq_v2f64(<2 x double> %x) {
 ; SI-SDAG-NEXT:    s_brev_b32 s5, 8
 ; SI-SDAG-NEXT:    v_cmp_gt_f64_e32 vcc, s[4:5], v[2:3]
 ; SI-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[0:1]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v8, 0x100
-; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
+; SI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x100
+; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v6, vcc
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, v6, s[4:5]
+; SI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v6
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v8
+; SI-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[0:1]
 ; SI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
-; SI-SDAG-NEXT:    v_rsq_f64_e32 v[8:9], v[0:1]
 ; SI-SDAG-NEXT:    s_mov_b32 s6, 0xbff00000
-; SI-SDAG-NEXT:    v_mul_f64 v[6:7], v[2:3], v[4:5]
+; SI-SDAG-NEXT:    v_mul_f64 v[10:11], v[0:1], v[6:7]
+; SI-SDAG-NEXT:    v_mul_f64 v[6:7], v[6:7], 0.5
+; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
+; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[10:11], 0.5
 ; SI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
-; SI-SDAG-NEXT:    v_mul_f64 v[12:13], v[0:1], v[8:9]
-; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[8:9], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[4:5], v[6:7], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[12:13], 0.5
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[10:11], v[6:7]
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[10:11], v[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[12:13], v[16:17], v[12:13]
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[16:17], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[10:11], v[14:15], v[10:11]
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[10:11], v[10:11], v[0:1]
+; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[18:19], v[6:7], v[10:11]
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
 ; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[10:11], v[0:1]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v16, 0xffffff80
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], v[12:13], v[8:9], v[10:11]
-; SI-SDAG-NEXT:    v_mov_b32_e32 v17, 0x260
-; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[10:11], v[0:1]
-; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[6:7], v[2:3]
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[8:9], v[10:11]
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v16, s[4:5]
-; SI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], v17
-; SI-SDAG-NEXT:    v_ldexp_f64 v[8:9], v[8:9], v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, -1, s[4:5]
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v9, v1, s[4:5]
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v8, v0, s[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[4:5], v[6:7]
-; SI-SDAG-NEXT:    v_div_scale_f64 v[8:9], s[4:5], v[0:1], v[0:1], -1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[6:7], v[2:3]
-; SI-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v16, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[14:15], v[4:5], v[6:7]
-; SI-SDAG-NEXT:    v_rcp_f64_e32 v[6:7], v[8:9]
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v17
-; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v12, 0, -1, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v12
+; SI-SDAG-NEXT:    v_mov_b32_e32 v14, 0xffffff80
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[12:13], v[6:7], v[10:11]
+; SI-SDAG-NEXT:    v_mov_b32_e32 v15, 0x260
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v10, 0, v14, s[4:5]
+; SI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v10
+; SI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[0:1], v15
+; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[8:9], v[2:3]
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
+; SI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
+; SI-SDAG-NEXT:    v_div_scale_f64 v[6:7], s[4:5], v[0:1], v[0:1], -1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[16:17], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[8:9], v[2:3]
+; SI-SDAG-NEXT:    v_rcp_f64_e32 v[12:13], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[10:11], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_cndmask_b32_e32 v8, 0, v14, vcc
+; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v8
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v15
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[6:7], v[12:13], 1.0
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
-; SI-SDAG-NEXT:    v_fma_f64 v[5:6], v[6:7], v[10:11], v[6:7]
-; SI-SDAG-NEXT:    v_div_scale_f64 v[12:13], s[4:5], v[2:3], v[2:3], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[8:9], v[5:6], 1.0
-; SI-SDAG-NEXT:    v_div_scale_f64 v[14:15], s[4:5], -1.0, v[0:1], -1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[5:6], v[10:11], v[5:6]
-; SI-SDAG-NEXT:    v_rcp_f64_e32 v[6:7], v[12:13]
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v9
-; SI-SDAG-NEXT:    v_mul_f64 v[10:11], v[14:15], v[4:5]
-; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[12:13], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[8:9], v[10:11], v[14:15]
-; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[18:19], v[6:7]
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[8:9], v[12:13]
+; SI-SDAG-NEXT:    v_div_scale_f64 v[10:11], s[4:5], v[2:3], v[2:3], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], -v[6:7], v[8:9], 1.0
+; SI-SDAG-NEXT:    v_div_scale_f64 v[12:13], s[4:5], -1.0, v[0:1], -1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[4:5], v[8:9], v[4:5], v[8:9]
+; SI-SDAG-NEXT:    v_rcp_f64_e32 v[8:9], v[10:11]
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v1, v7
+; SI-SDAG-NEXT:    v_mul_f64 v[14:15], v[12:13], v[4:5]
+; SI-SDAG-NEXT:    v_fma_f64 v[18:19], -v[10:11], v[8:9], 1.0
+; SI-SDAG-NEXT:    v_fma_f64 v[16:17], -v[6:7], v[14:15], v[12:13]
+; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[8:9], v[18:19], v[8:9]
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[18:19], s[4:5], 1.0, v[2:3], 1.0
-; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[12:13], v[6:7], 1.0
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v15
+; SI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[10:11], v[6:7], 1.0
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s6, v13
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[8:9], v[6:7]
 ; SI-SDAG-NEXT:    s_xor_b64 vcc, s[4:5], vcc
 ; SI-SDAG-NEXT:    v_mul_f64 v[8:9], v[18:19], v[6:7]
 ; SI-SDAG-NEXT:    s_mov_b32 s4, 0x3ff00000
-; SI-SDAG-NEXT:    v_div_fmas_f64 v[4:5], v[16:17], v[4:5], v[10:11]
-; SI-SDAG-NEXT:    v_fma_f64 v[10:11], -v[12:13], v[8:9], v[18:19]
-; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v13
+; SI-SDAG-NEXT:    v_div_fmas_f64 v[4:5], v[16:17], v[4:5], v[14:15]
+; SI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[10:11], v[8:9], v[18:19]
+; SI-SDAG-NEXT:    v_cmp_eq_u32_e32 vcc, v3, v11
 ; SI-SDAG-NEXT:    v_cmp_eq_u32_e64 s[4:5], s4, v19
 ; SI-SDAG-NEXT:    s_xor_b64 vcc, s[4:5], vcc
 ; SI-SDAG-NEXT:    v_div_fixup_f64 v[0:1], v[4:5], v[0:1], -1.0
 ; SI-SDAG-NEXT:    s_nop 0
-; SI-SDAG-NEXT:    v_div_fmas_f64 v[6:7], v[10:11], v[6:7], v[8:9]
+; SI-SDAG-NEXT:    v_div_fmas_f64 v[6:7], v[12:13], v[6:7], v[8:9]
 ; SI-SDAG-NEXT:    v_div_fixup_f64 v[2:3], v[6:7], v[2:3], 1.0
 ; SI-SDAG-NEXT:    s_setpc_b64 s[30:31]
 ;
@@ -3170,46 +3114,42 @@ define <2 x double> @v_neg_pos_rsq_v2f64(<2 x double> %x) {
 ; VI-SDAG-NEXT:    v_cmp_gt_f64_e64 s[4:5], s[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x100
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v5, 0, v4, vcc
-; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v5
 ; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, v4, s[4:5]
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[0:1], v[0:1], v4
-; VI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
+; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v5
 ; VI-SDAG-NEXT:    v_rsq_f64_e32 v[6:7], v[0:1]
-; VI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
-; VI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
+; VI-SDAG-NEXT:    v_rsq_f64_e32 v[4:5], v[2:3]
 ; VI-SDAG-NEXT:    v_mul_f64 v[10:11], v[0:1], v[6:7]
 ; VI-SDAG-NEXT:    v_mul_f64 v[6:7], v[6:7], 0.5
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
+; VI-SDAG-NEXT:    v_mul_f64 v[8:9], v[2:3], v[4:5]
+; VI-SDAG-NEXT:    v_mul_f64 v[4:5], v[4:5], 0.5
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[6:7], v[10:11], 0.5
-; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
-; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[4:5], v[8:9], 0.5
 ; VI-SDAG-NEXT:    v_fma_f64 v[10:11], v[10:11], v[14:15], v[10:11]
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[6:7], v[14:15], v[6:7]
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[8:9], v[12:13], v[8:9]
+; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[12:13], v[4:5]
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[0:1]
-; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[4:5], v[8:9]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
 ; VI-SDAG-NEXT:    v_fma_f64 v[10:11], v[14:15], v[6:7], v[10:11]
-; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[8:9], v[12:13], v[4:5], v[8:9]
 ; VI-SDAG-NEXT:    v_fma_f64 v[14:15], -v[10:11], v[10:11], v[0:1]
+; VI-SDAG-NEXT:    v_fma_f64 v[12:13], -v[8:9], v[8:9], v[2:3]
+; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
 ; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[12:13], v[4:5], v[8:9]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v8, 0xffffff80
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v9, 0x260
-; VI-SDAG-NEXT:    v_fma_f64 v[6:7], v[14:15], v[6:7], v[10:11]
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v10, 0, v8, vcc
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v9
 ; VI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, v8, s[4:5]
-; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
-; VI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e64 s[4:5], 0, v9
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v1, v7, v1, s[4:5]
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v0, v6, v0, s[4:5]
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
-; VI-SDAG-NEXT:    v_div_scale_f64 v[5:6], s[4:5], v[0:1], v[0:1], -1.0
-; VI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
+; VI-SDAG-NEXT:    v_ldexp_f64 v[6:7], v[6:7], v8
+; VI-SDAG-NEXT:    v_cmp_class_f64_e64 s[4:5], v[2:3], v9
+; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v10
+; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v7, v1, vcc
+; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v6, v0, vcc
+; VI-SDAG-NEXT:    v_cndmask_b32_e64 v3, v5, v3, s[4:5]
+; VI-SDAG-NEXT:    v_div_scale_f64 v[5:6], s[6:7], v[0:1], v[0:1], -1.0
+; VI-SDAG-NEXT:    v_cndmask_b32_e64 v2, v4, v2, s[4:5]
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[7:8], s[4:5], v[2:3], v[2:3], 1.0
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[17:18], s[4:5], 1.0, v[2:3], 1.0
 ; VI-SDAG-NEXT:    v_rcp_f64_e32 v[9:10], v[5:6]
@@ -3404,10 +3344,8 @@ define double @v_rsq_f64_fneg_fabs(double %x) {
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -3489,12 +3427,10 @@ define double @v_rsq_f64_fneg_fabs(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -3559,12 +3495,10 @@ define double @v_rsq_f64__afn_sqrt(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64__afn_sqrt:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -3600,8 +3534,6 @@ define double @v_rsq_f64__afn_sqrt(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -3637,9 +3569,7 @@ define double @v_rsq_f64__afn_sqrt(double %x) {
 ; SI-SDAG-CG-NEXT:    s_mov_b32 s6, 0x3ff00000
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[6:7], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
@@ -3698,6 +3628,8 @@ define double @v_rsq_f64__afn_sqrt(double %x) {
 ; VI-SDAG-CG:       ; %bb.0:
 ; VI-SDAG-CG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -3705,10 +3637,6 @@ define double @v_rsq_f64__afn_sqrt(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], 1.0
@@ -3760,12 +3688,10 @@ define double @v_rsq_f64__afn_fdiv(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64__afn_fdiv:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -3801,8 +3727,6 @@ define double @v_rsq_f64__afn_fdiv(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -3851,10 +3775,8 @@ define double @v_rsq_f64__afn_fdiv(double %x) {
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-CG-NEXT:    v_rcp_f64_e32 v[2:3], v[0:1]
@@ -3917,12 +3839,10 @@ define double @v_rsq_f64__afn_fdiv(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-CG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_rcp_f64_e32 v[2:3], v[0:1]
@@ -3973,12 +3893,10 @@ define double @v_rsq_f64__afn(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64__afn:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -4014,8 +3932,6 @@ define double @v_rsq_f64__afn(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -4048,10 +3964,8 @@ define double @v_rsq_f64__afn(double %x) {
 ; SI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
 ; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[6:7], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
@@ -4092,6 +4006,8 @@ define double @v_rsq_f64__afn(double %x) {
 ; VI-SDAG-CG:       ; %bb.0:
 ; VI-SDAG-CG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -4099,10 +4015,6 @@ define double @v_rsq_f64__afn(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_rcp_f64_e32 v[2:3], v[0:1]
@@ -4142,12 +4054,10 @@ define double @v_neg_rsq_f64__afn(double %x) {
 ; SI-SDAG-IR-LABEL: v_neg_rsq_f64__afn:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -4183,8 +4093,6 @@ define double @v_neg_rsq_f64__afn(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -4217,10 +4125,8 @@ define double @v_neg_rsq_f64__afn(double %x) {
 ; SI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
 ; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[6:7], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
@@ -4261,6 +4167,8 @@ define double @v_neg_rsq_f64__afn(double %x) {
 ; VI-SDAG-CG:       ; %bb.0:
 ; VI-SDAG-CG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -4268,10 +4176,6 @@ define double @v_neg_rsq_f64__afn(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_rcp_f64_e32 v[2:3], v[0:1]
@@ -4452,12 +4356,10 @@ define double @v_rsq_f64__afn_nnan(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64__afn_nnan:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -4493,8 +4395,6 @@ define double @v_rsq_f64__afn_nnan(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -4527,10 +4427,8 @@ define double @v_rsq_f64__afn_nnan(double %x) {
 ; SI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
 ; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[6:7], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
@@ -4571,6 +4469,8 @@ define double @v_rsq_f64__afn_nnan(double %x) {
 ; VI-SDAG-CG:       ; %bb.0:
 ; VI-SDAG-CG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -4578,10 +4478,6 @@ define double @v_rsq_f64__afn_nnan(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_rcp_f64_e32 v[2:3], v[0:1]
@@ -5549,12 +5445,10 @@ define double @v_rsq_f64_unsafe(double %x) {
 ; SI-SDAG-IR-LABEL: v_rsq_f64_unsafe:
 ; SI-SDAG-IR:       ; %bb.0:
 ; SI-SDAG-IR-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; SI-SDAG-IR-NEXT:    v_mov_b32_e32 v4, 0x260
 ; SI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; SI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
-; SI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; SI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; SI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -5590,8 +5484,6 @@ define double @v_rsq_f64_unsafe(double %x) {
 ; VI-SDAG-IR-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s4, 0
 ; VI-SDAG-IR-NEXT:    s_mov_b32 s5, 0x3fd80000
-; VI-SDAG-IR-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-IR-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v1, v1, v3, vcc
 ; VI-SDAG-IR-NEXT:    v_cndmask_b32_e32 v0, v0, v2, vcc
 ; VI-SDAG-IR-NEXT:    v_mul_f64 v[0:1], v[0:1], -v[2:3]
@@ -5624,10 +5516,8 @@ define double @v_rsq_f64_unsafe(double %x) {
 ; SI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
 ; SI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
 ; SI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
-; SI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; SI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
-; SI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[4:5], v[4:5], v[6:7], v[4:5]
 ; SI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
@@ -5668,6 +5558,8 @@ define double @v_rsq_f64_unsafe(double %x) {
 ; VI-SDAG-CG:       ; %bb.0:
 ; VI-SDAG-CG-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; VI-SDAG-CG-NEXT:    v_rsq_f64_e32 v[2:3], v[0:1]
+; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v8, 0x260
+; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v8
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[4:5], v[0:1], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_mul_f64 v[2:3], v[2:3], 0.5
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[2:3], v[4:5], 0.5
@@ -5675,10 +5567,6 @@ define double @v_rsq_f64_unsafe(double %x) {
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[2:3], v[6:7], v[2:3]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-CG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
-; VI-SDAG-CG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-CG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-CG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-CG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-CG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-CG-NEXT:    v_rcp_f64_e32 v[2:3], v[0:1]
@@ -5941,8 +5829,6 @@ define double @v_div_contract_sqrt_f64(double %x, double %y) {
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v6
 ; SI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x260
 ; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v6
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[4:5], s[4:5], v[2:3], v[2:3], v[0:1]
@@ -6023,12 +5909,10 @@ define double @v_div_contract_sqrt_f64(double %x, double %y) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[6:7], v[6:7], v[2:3]
 ; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[8:9], v[4:5], v[6:7]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v6, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v7, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v7
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v6
-; VI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v6
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[4:5], s[4:5], v[2:3], v[2:3], v[0:1]
@@ -6112,8 +5996,6 @@ define double @v_div_arcp_sqrt_f64(double %x, double %y) {
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v6
 ; SI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x260
 ; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v6
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[4:5], s[4:5], v[2:3], v[2:3], v[0:1]
@@ -6194,12 +6076,10 @@ define double @v_div_arcp_sqrt_f64(double %x, double %y) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[6:7], v[6:7], v[2:3]
 ; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[8:9], v[4:5], v[6:7]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v6, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v7, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v7
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v6
-; VI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v6
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[4:5], s[4:5], v[2:3], v[2:3], v[0:1]
@@ -6283,8 +6163,6 @@ define double @v_div_contract_arcp_sqrt_f64(double %x, double %y) {
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v6
 ; SI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x260
 ; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v6
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[4:5], s[4:5], v[2:3], v[2:3], v[0:1]
@@ -6365,12 +6243,10 @@ define double @v_div_contract_arcp_sqrt_f64(double %x, double %y) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[8:9], -v[6:7], v[6:7], v[2:3]
 ; VI-SDAG-NEXT:    v_fma_f64 v[4:5], v[8:9], v[4:5], v[6:7]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v6, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v7, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v6, 0, v6, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v7
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[4:5], v[4:5], v6
-; VI-SDAG-NEXT:    v_mov_b32_e32 v6, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[2:3], v6
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v6, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v6
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v3, v5, v3, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v2, v4, v2, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[4:5], s[4:5], v[2:3], v[2:3], v[0:1]
@@ -6455,10 +6331,8 @@ define double @v_div_const_contract_sqrt_f64(double %x) {
 ; SI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; SI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v8, vcc
-; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; SI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; SI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
+; SI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v9
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; SI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; SI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[4:5], v[0:1], v[0:1], s[6:7]
@@ -6544,12 +6418,10 @@ define double @v_div_const_contract_sqrt_f64(double %x) {
 ; VI-SDAG-NEXT:    v_fma_f64 v[6:7], -v[4:5], v[4:5], v[0:1]
 ; VI-SDAG-NEXT:    v_fma_f64 v[2:3], v[6:7], v[2:3], v[4:5]
 ; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0xffffff80
+; VI-SDAG-NEXT:    v_mov_b32_e32 v5, 0x260
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v4, 0, v4, vcc
+; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v5
 ; VI-SDAG-NEXT:    v_ldexp_f64 v[2:3], v[2:3], v4
-; VI-SDAG-NEXT:    v_mov_b32_e32 v4, 0x260
-; VI-SDAG-NEXT:    v_cmp_class_f64_e32 vcc, v[0:1], v4
-; VI-SDAG-NEXT:    v_cndmask_b32_e64 v4, 0, -1, vcc
-; VI-SDAG-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v4
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v1, v3, v1, vcc
 ; VI-SDAG-NEXT:    v_cndmask_b32_e32 v0, v2, v0, vcc
 ; VI-SDAG-NEXT:    v_div_scale_f64 v[2:3], s[6:7], v[0:1], v[0:1], s[4:5]

--- a/llvm/test/CodeGen/AMDGPU/select-nsz-known-values-to-fmin-fmax.ll
+++ b/llvm/test/CodeGen/AMDGPU/select-nsz-known-values-to-fmin-fmax.ll
@@ -821,47 +821,33 @@ define <2 x double> @v_max_pat_v2f64_oge(<2 x double> nofpclass(nan) %a, <2 x do
 ; GFX7-LABEL: v_max_pat_v2f64_oge:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_cmp_ge_f64_e32 vcc, v[2:3], v[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX7-NEXT:    v_cmp_ge_f64_e32 vcc, v[0:1], v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX7-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GFX7-NEXT:    v_cmp_ge_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_max_pat_v2f64_oge:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-NEXT:    v_cmp_ge_f64_e32 vcc, v[2:3], v[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX900-NEXT:    v_cmp_ge_f64_e32 vcc, v[0:1], v[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX900-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GFX900-NEXT:    v_cmp_ge_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX900-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX900-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX900-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_max_pat_v2f64_oge:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_ge_f64_e32 vcc, v[2:3], v[6:7]
-; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX950-NEXT:    v_cmp_ge_f64_e32 vcc, v[0:1], v[4:5]
-; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; GFX950-NEXT:    v_cmp_ge_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
@@ -871,12 +857,7 @@ define <2 x double> @v_max_pat_v2f64_oge(<2 x double> nofpclass(nan) %a, <2 x do
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_cmp_ge_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc_lo
-; GFX11-NEXT:    v_cmp_ge_f64_e32 vcc_lo, v[2:3], v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_cmp_ne_u32_e64 s0, 0, v9
+; GFX11-NEXT:    v_cmp_ge_f64_e64 s0, v[2:3], v[6:7]
 ; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s0
@@ -891,14 +872,7 @@ define <2 x double> @v_max_pat_v2f64_oge(<2 x double> nofpclass(nan) %a, <2 x do
 ; GFX12-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    v_cmp_ge_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc_lo
-; GFX12-NEXT:    v_cmp_ge_f64_e32 vcc_lo, v[2:3], v[6:7]
-; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc_lo
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX12-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX12-NEXT:    v_cmp_ne_u32_e64 s0, 0, v9
+; GFX12-NEXT:    v_cmp_ge_f64_e64 s0, v[2:3], v[6:7]
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)
@@ -915,47 +889,33 @@ define <2 x double> @v_min_pat_v2f64_olt(<2 x double> nofpclass(nan) %a, <2 x do
 ; GFX7-LABEL: v_min_pat_v2f64_olt:
 ; GFX7:       ; %bb.0:
 ; GFX7-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX7-NEXT:    v_cmp_lt_f64_e32 vcc, v[2:3], v[6:7]
-; GFX7-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX7-NEXT:    v_cmp_lt_f64_e32 vcc, v[0:1], v[4:5]
-; GFX7-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX7-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GFX7-NEXT:    v_cmp_lt_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX7-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX7-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX7-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX7-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX7-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX7-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX7-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX7-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX900-LABEL: v_min_pat_v2f64_olt:
 ; GFX900:       ; %bb.0:
 ; GFX900-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX900-NEXT:    v_cmp_lt_f64_e32 vcc, v[2:3], v[6:7]
-; GFX900-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX900-NEXT:    v_cmp_lt_f64_e32 vcc, v[0:1], v[4:5]
-; GFX900-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX900-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
+; GFX900-NEXT:    v_cmp_lt_f64_e64 s[4:5], v[2:3], v[6:7]
 ; GFX900-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX900-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX900-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
-; GFX900-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
-; GFX900-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
+; GFX900-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s[4:5]
+; GFX900-NEXT:    v_cndmask_b32_e64 v3, v7, v3, s[4:5]
 ; GFX900-NEXT:    s_setpc_b64 s[30:31]
 ;
 ; GFX950-LABEL: v_min_pat_v2f64_olt:
 ; GFX950:       ; %bb.0:
 ; GFX950-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
-; GFX950-NEXT:    v_cmp_lt_f64_e32 vcc, v[2:3], v[6:7]
-; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc
 ; GFX950-NEXT:    v_cmp_lt_f64_e32 vcc, v[0:1], v[4:5]
-; GFX950-NEXT:    s_nop 1
-; GFX950-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v9
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e32 v0, v4, v0, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v1, v5, v1, vcc
-; GFX950-NEXT:    v_cmp_ne_u32_e32 vcc, 0, v8
+; GFX950-NEXT:    v_cmp_lt_f64_e32 vcc, v[2:3], v[6:7]
 ; GFX950-NEXT:    s_nop 1
 ; GFX950-NEXT:    v_cndmask_b32_e32 v2, v6, v2, vcc
 ; GFX950-NEXT:    v_cndmask_b32_e32 v3, v7, v3, vcc
@@ -965,12 +925,7 @@ define <2 x double> @v_min_pat_v2f64_olt(<2 x double> nofpclass(nan) %a, <2 x do
 ; GFX11:       ; %bb.0:
 ; GFX11-NEXT:    s_waitcnt vmcnt(0) expcnt(0) lgkmcnt(0)
 ; GFX11-NEXT:    v_cmp_lt_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX11-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc_lo
-; GFX11-NEXT:    v_cmp_lt_f64_e32 vcc_lo, v[2:3], v[6:7]
-; GFX11-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc_lo
-; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX11-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX11-NEXT:    v_cmp_ne_u32_e64 s0, 0, v9
+; GFX11-NEXT:    v_cmp_lt_f64_e64 s0, v[2:3], v[6:7]
 ; GFX11-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
 ; GFX11-NEXT:    s_delay_alu instid0(VALU_DEP_2)
 ; GFX11-NEXT:    v_cndmask_b32_e64 v2, v6, v2, s0
@@ -985,14 +940,7 @@ define <2 x double> @v_min_pat_v2f64_olt(<2 x double> nofpclass(nan) %a, <2 x do
 ; GFX12-NEXT:    s_wait_bvhcnt 0x0
 ; GFX12-NEXT:    s_wait_kmcnt 0x0
 ; GFX12-NEXT:    v_cmp_lt_f64_e32 vcc_lo, v[0:1], v[4:5]
-; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v8, 0, -1, vcc_lo
-; GFX12-NEXT:    v_cmp_lt_f64_e32 vcc_lo, v[2:3], v[6:7]
-; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
-; GFX12-NEXT:    v_cndmask_b32_e64 v9, 0, -1, vcc_lo
-; GFX12-NEXT:    s_delay_alu instid0(VALU_DEP_3) | instskip(NEXT) | instid1(VALU_DEP_2)
-; GFX12-NEXT:    v_cmp_ne_u32_e32 vcc_lo, 0, v8
-; GFX12-NEXT:    v_cmp_ne_u32_e64 s0, 0, v9
+; GFX12-NEXT:    v_cmp_lt_f64_e64 s0, v[2:3], v[6:7]
 ; GFX12-NEXT:    s_wait_alu depctr_va_vcc(0)
 ; GFX12-NEXT:    v_dual_cndmask_b32 v0, v4, v0 :: v_dual_cndmask_b32 v1, v5, v1
 ; GFX12-NEXT:    s_wait_alu depctr_va_sdst(0)


### PR DESCRIPTION
A vreg_1 defined and used within the same MBB via lanemask register require no i1 widening and can be used directly maintaining the semantic equivalnce.


