### PR TITLE
[Comgr] Fix SPIR-V triple typo in setIsaName

### DIFF
--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -940,8 +940,8 @@ amd_comgr_status_t AMD_COMGR_API
     return AMD_COMGR_STATUS_SUCCESS;
   }
 
-  if (StringRef(IsaName) == "spir64-amd-amdhsa--amdgcnspirv" ||
-      StringRef(IsaName )== "spir64-amd-amdhsa-unknown-amdgcnspirv") {
+  if (StringRef(IsaName) == "spirv64-amd-amdhsa--amdgcnspirv" ||
+      StringRef(IsaName) == "spirv64-amd-amdhsa-unknown-amdgcnspirv") {
     return ActionP->setIsaName(IsaName);
   }
 


### PR DESCRIPTION
The short-circuit in `amd_comgr_action_info_set_isa_name` checked for `spir64-...` but the canonical HIP SPIR-V triple is `spirv64-...` (LLVM `Triple::spirv64`) — matching `parseTargetIdentifier` (SWDEV-533122) and the strings CLR passes in. Introduced as a typo in 967115f.

Dead code on real inputs: nothing in CLR or the LLVM amd subtree passes `spir64-amd-amdhsa-...amdgcnspirv`. Fix aligns the two Comgr call sites with clang and CLR.

Discovered while reviewing #2710.