### PR TITLE
device-libs: Guard trig reduction quadrant index against NaN UB

### DIFF
--- a/amd/device-libs/ocml/src/trigpiredD.cl
+++ b/amd/device-libs/ocml/src/trigpiredD.cl
@@ -17,7 +17,7 @@ MATH_PRIVATE(trigpired)(double x)
 
     struct redret ret;
     ret.hi = MATH_MAD(t, -0.5, x);
-    ret.i = (int)t & 0x3;
+    ret.i = BUILTIN_ISNAN_F64(t) ? 0 : ((int)t & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigpiredF.cl
+++ b/amd/device-libs/ocml/src/trigpiredF.cl
@@ -17,7 +17,7 @@ MATH_PRIVATE(trigpired)(float x)
 
     struct redret ret;
     ret.hi = MATH_MAD(t, -0.5f, x);
-    ret.i = (int)t & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(t) ? 0 : ((int)t & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigpiredH.cl
+++ b/amd/device-libs/ocml/src/trigpiredH.cl
@@ -17,7 +17,7 @@ MATH_PRIVATE(trigpired)(half x)
 
     struct redret ret;
     ret.hi = MATH_MAD(t, -0.5h, x);
-    ret.i = (short)t & (short)0x3;
+    ret.i = BUILTIN_ISNAN_F16(t) ? (short)0 : ((short)t & (short)0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigredH.cl
+++ b/amd/device-libs/ocml/src/trigredH.cl
@@ -21,7 +21,7 @@ MATH_PRIVATE(trigred)(half hx)
 
     struct redret ret;
     ret.hi = (half)BUILTIN_MAD_F32(fn, -pb2_c, BUILTIN_MAD_F32(fn, -pb2_b, BUILTIN_MAD_F32(fn, -pb2_a, x)));
-    ret.i =  (int)fn & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(fn) ? 0 : ((int)fn & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigredsmallD.cl
+++ b/amd/device-libs/ocml/src/trigredsmallD.cl
@@ -30,7 +30,7 @@ MATH_PRIVATE(trigredsmall)(double x)
     struct redret ret;
     ret.hi = rh;
     ret.lo = rt;
-    ret.i = (int)dn & 0x3;
+    ret.i = BUILTIN_ISNAN_F64(dn) ? 0 : ((int)dn & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigredsmallF.cl
+++ b/amd/device-libs/ocml/src/trigredsmallF.cl
@@ -53,7 +53,7 @@ mad_reduce(float x)
 
     struct redret ret;
     ret.hi = MATH_MAD(-piby2_l, fn, r);
-    ret.i = (int)fn & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(fn) ? 0 : ((int)fn & 0x3);
     return ret;
 #endif
 }
@@ -87,7 +87,7 @@ fma_reduce(float x)
     ret.hi = r;
 #endif
 
-    ret.i =(int)fn & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(fn) ? 0 : ((int)fn & 0x3);
     return ret;
 }
 


### PR DESCRIPTION
Guard the `(int)fn & 0x3` quadrant index computation in trig reduction
functions against NaN input. `fptosi NaN` is UB in C and produces
`poison` in LLVM IR, which the compiler exploits during constant-folding
to return garbage from `cos(inf)`, `sin(inf)`, etc.

Fix: `ret.i = BUILTIN_ISNAN(fn) ? 0 : ((int)fn & 0x3);`

Applied to 7 locations across 6 files (trigredsmall F/D, trigred H,
trigpired F/D/H). Verified on gfx90a.

Fixes: LCOMPILER-2150