### PR TITLE
device-libs: Guard trig reduction quadrant index against NaN UB

### DIFF
--- a/amd/device-libs/ocml/src/trigpiredD.cl
+++ b/amd/device-libs/ocml/src/trigpiredD.cl
@@ -17,7 +17,7 @@ MATH_PRIVATE(trigpired)(double x)
 
     struct redret ret;
     ret.hi = MATH_MAD(t, -0.5, x);
-    ret.i = (int)t & 0x3;
+    ret.i = BUILTIN_ISNAN_F64(t) ? 0 : ((int)t & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigpiredF.cl
+++ b/amd/device-libs/ocml/src/trigpiredF.cl
@@ -17,7 +17,7 @@ MATH_PRIVATE(trigpired)(float x)
 
     struct redret ret;
     ret.hi = MATH_MAD(t, -0.5f, x);
-    ret.i = (int)t & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(t) ? 0 : ((int)t & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigpiredH.cl
+++ b/amd/device-libs/ocml/src/trigpiredH.cl
@@ -17,7 +17,7 @@ MATH_PRIVATE(trigpired)(half x)
 
     struct redret ret;
     ret.hi = MATH_MAD(t, -0.5h, x);
-    ret.i = (short)t & (short)0x3;
+    ret.i = BUILTIN_ISNAN_F16(t) ? (short)0 : ((short)t & (short)0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigredH.cl
+++ b/amd/device-libs/ocml/src/trigredH.cl
@@ -21,7 +21,7 @@ MATH_PRIVATE(trigred)(half hx)
 
     struct redret ret;
     ret.hi = (half)BUILTIN_MAD_F32(fn, -pb2_c, BUILTIN_MAD_F32(fn, -pb2_b, BUILTIN_MAD_F32(fn, -pb2_a, x)));
-    ret.i =  (int)fn & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(fn) ? 0 : ((int)fn & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigredsmallD.cl
+++ b/amd/device-libs/ocml/src/trigredsmallD.cl
@@ -30,7 +30,7 @@ MATH_PRIVATE(trigredsmall)(double x)
     struct redret ret;
     ret.hi = rh;
     ret.lo = rt;
-    ret.i = (int)dn & 0x3;
+    ret.i = BUILTIN_ISNAN_F64(dn) ? 0 : ((int)dn & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/ocml/src/trigredsmallF.cl
+++ b/amd/device-libs/ocml/src/trigredsmallF.cl
@@ -53,7 +53,7 @@ mad_reduce(float x)
 
     struct redret ret;
     ret.hi = MATH_MAD(-piby2_l, fn, r);
-    ret.i = (int)fn & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(fn) ? 0 : ((int)fn & 0x3);
     return ret;
 #endif
 }
@@ -87,7 +87,7 @@ fma_reduce(float x)
     ret.hi = r;
 #endif
 
-    ret.i =(int)fn & 0x3;
+    ret.i = BUILTIN_ISNAN_F32(fn) ? 0 : ((int)fn & 0x3);
     return ret;
 }
 

--- a/amd/device-libs/test/compile/CMakeLists.txt
+++ b/amd/device-libs/test/compile/CMakeLists.txt
@@ -107,3 +107,7 @@ foreach(gpu gfx803 gfx900 gfx90a gfx1030 gfx1100 gfx1200)
     FILE_NAME ${CMAKE_CURRENT_SOURCE_DIR}/atomic_work_item_fence.cl
     COMPILE_FLAGS -emit-llvm)
 endforeach()
+
+foreach(gpu gfx90a gfx942 gfx950 gfx1200)
+  add_isa_test(trig_nan_guard ${gpu})
+endforeach()

--- a/amd/device-libs/test/compile/trig_nan_guard.cl
+++ b/amd/device-libs/test/compile/trig_nan_guard.cl
@@ -1,0 +1,41 @@
+// Trig reduction guards the quadrant-index cast against NaN input:
+//   isnan(fn) ? 0 : ((int)fn & 0x3)   (and the (short) variant for half)
+// v_cvt_i*_f* already returns 0 for NaN, so the isnan guard must fold away:
+// the result is the same convert (+ mask) as the unguarded cast, with no
+// compare/select. See llvm/llvm-project#201435.
+// __builtin_isnan is what the device-libs BUILTIN_ISNAN_F* macros expand to.
+
+#pragma OPENCL EXTENSION cl_khr_fp16 : enable
+
+// float -> int: trigredsmallF, trigredH, trigpiredF
+// CHECK-LABEL: {{^}}test_isnan_guard_fptosi_f32:
+// CHECK: v_cvt_i32_f32
+// CHECK-NOT: v_cmp
+// CHECK-NOT: v_cndmask
+int
+test_isnan_guard_fptosi_f32(float x)
+{
+    return __builtin_isnan(x) ? 0 : ((int)x & 0x3);
+}
+
+// double -> int: trigredsmallD, trigpiredD
+// CHECK-LABEL: {{^}}test_isnan_guard_fptosi_f64:
+// CHECK: v_cvt_i32_f64
+// CHECK-NOT: v_cmp
+// CHECK-NOT: v_cndmask
+int
+test_isnan_guard_fptosi_f64(double x)
+{
+    return __builtin_isnan(x) ? 0 : ((int)x & 0x3);
+}
+
+// half -> short: trigpiredH
+// CHECK-LABEL: {{^}}test_isnan_guard_fptosi_f16:
+// CHECK: v_cvt_i16_f16
+// CHECK-NOT: v_cmp
+// CHECK-NOT: v_cndmask
+short
+test_isnan_guard_fptosi_f16(half x)
+{
+    return __builtin_isnan(x) ? (short)0 : ((short)x & (short)0x3);
+}


### PR DESCRIPTION
Guard the `(int)fn & 0x3` quadrant index computation in trig reduction
functions against NaN input. `fptosi NaN` is UB in C and produces
`poison` in LLVM IR, which the compiler exploits during constant-folding
to return garbage from `cos(inf)`, `sin(inf)`, etc.

Fix: `ret.i = BUILTIN_ISNAN(fn) ? 0 : ((int)fn & 0x3);`

Applied to 7 locations across 6 files (trigredsmall F/D, trigred H,
trigpired F/D/H). Upstream PR #201435 pattern matches the isnan
guard replacing it with the saturating intrinsic which removes the UB.

Verified: identical instruction count, all reproducer variants pass.

Fixes: LCOMPILER-2150