### PR TITLE
[clang] Fix /Fo output path collision for HIP multi-arch compilation

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6699,8 +6699,21 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
         C.getArgs()
             .getLastArg(options::OPT__SLASH_Fo, options::OPT__SLASH_o)
             ->getValue();
-    NamedOutput =
-        MakeCLOutputFilename(C.getArgs(), Val, BaseName, JA.getType());
+    SmallString<128> Filename(
+        MakeCLOutputFilename(C.getArgs(), Val, BaseName, JA.getType()));
+    // When compiling for multiple GPU architectures, each arch produces a
+    // separate object. Append the arch suffix to avoid all arches writing to
+    // the same filename and overwriting each other.
+    // HIP offload uses getOffloadingArch(); CUDA/other uses BoundArch.
+    const char *OffloadArch = JA.getOffloadingArch();
+    StringRef ArchSuffix = OffloadArch ? StringRef(OffloadArch) : BoundArch;
+    if (MultipleArchs && !ArchSuffix.empty()) {
+      llvm::sys::path::replace_extension(Filename, "");
+      Filename += "-";
+      Filename += ArchSuffix;
+      Filename += ".obj";
+    }
+    NamedOutput = C.getArgs().MakeArgString(Filename);
   } else if (JA.getType() == types::TY_Image &&
              C.getArgs().hasArg(options::OPT__SLASH_Fe,
                                 options::OPT__SLASH_o)) {


### PR DESCRIPTION
When using clang-cl with /Fo and multiple --offload-arch flags, all HIP device compilations wrote to the same output filename, leaving only the last arch in the binary.
GetNamedOutputPath() used BoundArch to make filenames unique per arch, but BoundArch is empty for HIP (only CUDA sets it). Fixed by using JA.getOffloadingArch() instead, with BoundArch as fallback for CUDA and other targets.