### PR TITLE
[WaveTransform] Fix inverted lane mask to use exec-masked condition

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2206,26 +2206,18 @@ void ControlFlowRewriter::rewrite() {
         // Skip XOR inversion if the condition register use was undef.
         // Inverting undef (undef ^ -1) is still undef.
         if (LaneOrigin.InvertCondition) {
-          // CondReg = EXEC ^ origCond;
-          //
-          // Ideally we would XOR with EXEC instead of -1 to avoid redundant
-          // AND with EXEC later, but LICM can move the condition in ways which
-          // violate such an optimisation.  Discard and demote operations
-          // can also modify the value of EXEC requiring an AND.
-          // TODO: We rely on later passes to clean up,
-          // e.g. folding the XOR into the original V_CMP.
           Register Prev = CondReg;
           if (!LaneOrigin.CondIsUndef) {
             CondReg = LMU.createLaneMaskReg();
-            auto FlipCondReg =
-                BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm,
-                        {}, TII.get(LMC.XorOpc), CondReg)
-                    .addReg(Prev);
-            if (LMA.isSubsetOfExec(Prev, *LaneOrigin.Node->Block,
-                                   MBBILaneOriginNodeFirstTerm))
-              FlipCondReg.addReg(LMC.ExecReg);
-            else
-              FlipCondReg.addImm(-1);
+            // Prev is guaranteed to be a subset of EXEC here: either the
+            // original CondReg was already a subset, or we masked it with
+            // AND(EXEC, CondReg) above. XOR with EXEC flips only within
+            // active lanes, so the result is also a subset of EXEC and
+            // no further AND with EXEC is needed downstream.
+            BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm,
+                    {}, TII.get(LMC.XorOpc), CondReg)
+                .addReg(Prev)
+                .addReg(LMC.ExecReg);
           }
 
           RegMap[std::make_pair(LaneOrigin.Node->Block, LaneOrigin.CondReg)]

--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2220,8 +2220,8 @@ void ControlFlowRewriter::rewrite() {
             auto FlipCondReg =
                 BuildMI(*LaneOrigin.Node->Block, MBBILaneOriginNodeFirstTerm,
                         {}, TII.get(LMC.XorOpc), CondReg)
-                    .addReg(LaneOrigin.CondReg);
-            if (LMA.isSubsetOfExec(LaneOrigin.CondReg, *LaneOrigin.Node->Block,
+                    .addReg(Prev);
+            if (LMA.isSubsetOfExec(Prev, *LaneOrigin.Node->Block,
                                    MBBILaneOriginNodeFirstTerm))
               FlipCondReg.addReg(LMC.ExecReg);
             else

--- a/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.inverse.ballot.i32.ll
+++ b/llvm/test/CodeGen/AMDGPU/llvm.amdgcn.inverse.ballot.i32.ll
@@ -146,10 +146,9 @@ define amdgpu_cs void @inverse_ballot_branch(i32 inreg %s0_1, i32 inreg %s2, ptr
 ;
 ; SDAG-LABEL: inverse_ballot_branch:
 ; SDAG:       ; %bb.0: ; %entry
-; SDAG-NEXT:    s_and_b32 s2, exec_lo, s1
-; SDAG-NEXT:    s_xor_b32 s1, s1, -1
+; SDAG-NEXT:    s_and_b32 s1, exec_lo, s1
 ; SDAG-NEXT:    v_mov_b32_e32 v2, s0
-; SDAG-NEXT:    s_and_b32 s2, s1, exec_lo
+; SDAG-NEXT:    s_xor_b32 s2, s1, exec_lo
 ; SDAG-NEXT:    s_xor_b32 s1, exec_lo, s2
 ; SDAG-NEXT:    s_mov_b32 exec_lo, s2
 ; SDAG-NEXT:    ; divergent control-flow edge

--- a/llvm/test/CodeGen/AMDGPU/sdiv64.ll
+++ b/llvm/test/CodeGen/AMDGPU/sdiv64.ll
@@ -424,8 +424,7 @@ define i64 @v_test_sdiv(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[6:7], v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
@@ -464,8 +463,7 @@ define i64 @v_test_sdiv(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v16, vcc, 1, v16
 ; GCN-IR-NEXT:    v_addc_u32_e32 v17, vcc, 0, v17, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v5
 ; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, v4
@@ -1496,8 +1494,7 @@ define i64 @v_test_sdiv_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], 24, v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
@@ -1535,8 +1532,7 @@ define i64 @v_test_sdiv_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v14, vcc, 1, v14
 ; GCN-IR-NEXT:    v_addc_u32_e32 v15, vcc, 0, v15, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v5
 ; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, v4
@@ -1698,9 +1694,8 @@ define i64 @v_test_sdiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_mov_b64 s[10:11], 0x8000
-; GCN-IR-NEXT:    s_and_b64 s[12:13], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[12:13], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], s[10:11], v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
@@ -1738,8 +1733,7 @@ define i64 @v_test_sdiv_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v14, vcc, 1, v14
 ; GCN-IR-NEXT:    v_addc_u32_e32 v15, vcc, 0, v15, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v5
 ; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, v4
@@ -1807,8 +1801,7 @@ define i64 @v_test_sdiv_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v1, vcc, 0, v1, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v0, s[4:5], 63, v0
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[0:1], v[4:5], v0
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v2, 0
@@ -1843,8 +1836,7 @@ define i64 @v_test_sdiv_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v10, vcc, 1, v10
 ; GCN-IR-NEXT:    v_addc_u32_e32 v11, vcc, 0, v11, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_or_b32_e32 v1, v7, v1
 ; GCN-IR-NEXT:    v_mov_b32_e32 v7, v3
 ; GCN-IR-NEXT:    s_xor_b64 s[12:13], exec, s[8:9]

--- a/llvm/test/CodeGen/AMDGPU/srem64.ll
+++ b/llvm/test/CodeGen/AMDGPU/srem64.ll
@@ -404,8 +404,7 @@ define i64 @v_test_srem(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v5, vcc, 0, v5, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v4, s[4:5], 63, v4
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[4:5], v[0:1], v4
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v6, 0
@@ -444,8 +443,7 @@ define i64 @v_test_srem(i64 %x, i64 %y) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v16, vcc, 1, v16
 ; GCN-IR-NEXT:    v_addc_u32_e32 v17, vcc, 0, v17, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v11, v7
 ; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v10, v6
@@ -1647,8 +1645,7 @@ define i64 @v_test_srem_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], 24, v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
@@ -1686,8 +1683,7 @@ define i64 @v_test_srem_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, 1, v12
 ; GCN-IR-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v5
 ; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, v4
@@ -1847,9 +1843,8 @@ define i64 @v_test_srem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
 ; GCN-IR-NEXT:    s_mov_b64 s[10:11], 0x8000
-; GCN-IR-NEXT:    s_and_b64 s[12:13], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[12:13], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], s[10:11], v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[12:13]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
@@ -1887,8 +1882,7 @@ define i64 @v_test_srem_pow2_k_num_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, 1, v12
 ; GCN-IR-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v5
 ; GCN-IR-NEXT:    s_xor_b64 s[10:11], exec, s[8:9]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v8, v4
@@ -1962,8 +1956,7 @@ define i64 @v_test_srem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_addc_u32_e32 v3, vcc, 0, v3, vcc
 ; GCN-IR-NEXT:    v_sub_i32_e64 v2, s[4:5], 63, v2
 ; GCN-IR-NEXT:    s_and_b64 s[4:5], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[4:5], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[10:11], s[4:5], exec
+; GCN-IR-NEXT:    s_xor_b64 s[10:11], s[4:5], exec
 ; GCN-IR-NEXT:    v_lshl_b64 v[2:3], v[0:1], v2
 ; GCN-IR-NEXT:    s_xor_b64 s[4:5], exec, s[10:11]
 ; GCN-IR-NEXT:    v_mov_b32_e32 v4, 0
@@ -1998,8 +1991,7 @@ define i64 @v_test_srem_pow2_k_den_i64(i64 %x) {
 ; GCN-IR-NEXT:    v_add_i32_e32 v12, vcc, 1, v12
 ; GCN-IR-NEXT:    v_addc_u32_e32 v13, vcc, 0, v13, vcc
 ; GCN-IR-NEXT:    s_and_b64 s[8:9], exec, vcc
-; GCN-IR-NEXT:    s_xor_b64 s[8:9], vcc, -1
-; GCN-IR-NEXT:    s_and_b64 s[8:9], s[8:9], exec
+; GCN-IR-NEXT:    s_xor_b64 s[8:9], s[8:9], exec
 ; GCN-IR-NEXT:    v_or_b32_e32 v3, v9, v3
 ; GCN-IR-NEXT:    v_mov_b32_e32 v9, v5
 ; GCN-IR-NEXT:    s_xor_b64 s[12:13], exec, s[8:9]

--- a/llvm/test/CodeGen/AMDGPU/uniform-phi-with-undef.ll
+++ b/llvm/test/CodeGen/AMDGPU/uniform-phi-with-undef.ll
@@ -14,9 +14,8 @@ define amdgpu_ps float @uniform_phi_with_undef(float inreg %c, float %v, i32 %x,
 ; GCN-NEXT:    v_cmp_lt_i32_e64 s1, v2, v1
 ; GCN-NEXT:    s_mov_b32 s2, -1
 ; GCN-NEXT:    s_xor_b32 s1, s1, s2
-; GCN-NEXT:    s_and_b32 s2, exec_lo, s1
-; GCN-NEXT:    s_xor_b32 s1, s1, -1
-; GCN-NEXT:    s_and_b32 s2, s1, exec_lo
+; GCN-NEXT:    s_and_b32 s1, exec_lo, s1
+; GCN-NEXT:    s_xor_b32 s2, s1, exec_lo
 ; GCN-NEXT:    s_xor_b32 s1, exec_lo, s2
 ; GCN-NEXT:    s_mov_b32 exec_lo, s2
 ; GCN-NEXT:    ; divergent control-flow edge


### PR DESCRIPTION
When the branch condition register is not a subset of EXEC, the lane mask emission first masks it with EXEC via AND(exec, cond). However, the subsequent XOR inversion was using the original unmasked condition register instead of the AND result. This caused two issues:

1. The AND result was dead - computed but never consumed.
2. The XOR with -1 produced bits outside EXEC, forcing buildMergeLaneMasks to emit a redundant AND with EXEC downstream.

Fix both by passing the current live lane mask value (Prev) to the XOR and to the isSubsetOfExec check. Since AND(exec, cond) is recognized as a subset of EXEC, the XOR now uses EXEC instead of -1, producing a result that is itself a subset of EXEC. This eliminates the redundant second AND in buildMergeLaneMasks.

Net effect: saves one instruction per inverted non-subset branch condition (AND + XOR(-1) + AND(exec) → AND + XOR(exec)).


