### PR TITLE
[Offload][OpenMP] Fix assertion failure !isBareMode.

### DIFF
--- a/offload/plugins-nextgen/common/src/PluginInterface.cpp
+++ b/offload/plugins-nextgen/common/src/PluginInterface.cpp
@@ -436,7 +436,7 @@ Error GenericKernelTy::launch(GenericDeviceTy &GenericDevice, void **ArgPtrs,
         KernelRecord->getLaunchParamsForKernel(*this, GenericDevice);
     EffectiveNumBlocks[0] = Teams;
     EffectiveNumThreads[0] = Threads;
-  } else if (!KernelArgs.Flags.StrictBlocksAndThreads) {
+  } else if (!KernelArgs.Flags.StrictBlocksAndThreads && !isBareMode()) {
     EffectiveNumThreads[0] =
         getEffectiveNumThreads(GenericDevice, EffectiveNumThreads[0]);
 


### PR DESCRIPTION
This problem occurs while offloading to x86_64. There are scenarios where the execution mode may not be found during runtime, which then uses the default BARE mode. So, in addition to checking for strict mode, the runtime needs to check for bare mode as well before calling the utilities for thread and block computation.


