### PR TITLE
[Comgr] Detect llvm-link inputs positionally, not by .bc extension

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -633,11 +633,15 @@ amd_comgr_status_t linkWithLLD(llvm::ArrayRef<const char *> Args,
 }
 
 // Execute llvm-link in-process using llvm::Linker
-// Args format: -o <output.bc> <input1.bc> <input2.bc> ...
+// Args format: -o <output> <input1> <input2> ...
+// Inputs are LLVM bitcode regardless of file extension. The driver may name
+// intermediate device bitcode with a .o suffix (e.g. for amdgcnspirv
+// device-only compiles), so inputs are detected positionally rather than by
+// extension.
 // TODO: refactor this implementation to use a shared infra with linkBitcodeToBitcode()
 amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
                                    raw_ostream &LogS) {
-  // Parse args: find -o <output> and collect input .bc files
+  // Parse args: find -o <output> and collect non-flag inputs.
   StringRef OutputPath;
   SmallVector<StringRef, 4> InputPaths;
 
@@ -645,7 +649,7 @@ amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
     StringRef Arg(Args[I]);
     if (Arg == "-o" && I + 1 < Args.size()) {
       OutputPath = Args[++I];
-    } else if (Arg.ends_with(".bc")) {
+    } else if (!Arg.starts_with("-")) {
       InputPaths.push_back(Arg);
     }
   }

--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -633,11 +633,6 @@ amd_comgr_status_t linkWithLLD(llvm::ArrayRef<const char *> Args,
 }
 
 // Execute llvm-link in-process using llvm::Linker
-// Args format: -o <output> <input1> <input2> ...
-// Inputs are LLVM bitcode regardless of file extension. The driver may name
-// intermediate device bitcode with a .o suffix (e.g. for amdgcnspirv
-// device-only compiles), so inputs are detected positionally rather than by
-// extension.
 // TODO: refactor this implementation to use a shared infra with linkBitcodeToBitcode()
 amd_comgr_status_t executeLLVMLink(ArrayRef<const char *> Args,
                                    raw_ostream &LogS) {


### PR DESCRIPTION
`executeLLVMLink` collected inputs by `.bc` suffix. The clang driver may name intermediate device bitcode with a `.o` suffix (e.g. `amdgcnspirv` device-only, where the backend phase emits LTO bitcode into a `.o`), so those inputs were silently dropped and the `SOURCE_TO_SPIRV` translator path failed with "missing input or output files".

Detect inputs positionally: any arg that isn't a flag and isn't the `-o` value is an input. Inputs are LLVM bitcode regardless of extension.

No behavior change on current `amd-staging` (the driver still emits SPIR-V directly there, so `llvm-link` never receives a `.o` input). The fix matters once the upstream LTO-by-default driver change lands.