### PR TITLE
Rework constructRoccmPath so ROCM_PATH env var is lower priority.

### DIFF
--- a/amd/hipcc/src/hipBin_base.h
+++ b/amd/hipcc/src/hipBin_base.h
@@ -358,16 +358,33 @@ void HipBinBase::constructHipPath() {
 
 // constructs the ROCM path
 void HipBinBase::constructRoccmPath() {
-  // we need to use --rocm-path option
+  // The --rocm-path argument option takes precedence over all other settings.
   string rocm_path_name = getrocm_pathOption();
-
-  // chose the --rocm-path option first, if specified.
-  if (!rocm_path_name.empty())
+  if (!rocm_path_name.empty()) {
     variables_.roccmPathEnv_ = rocm_path_name;
-  else if (envVariables_.roccmPathEnv_.empty()) {
-    variables_.roccmPathEnv_ = getHipPath();
-  } else {
-    variables_.roccmPathEnv_ = envVariables_.roccmPathEnv_;}
+    return;
+  }
+
+  fs::path full_path(hipcc::utils::getSelfPath());
+  fs::path parent_path = full_path.parent_path();
+
+  // Next, check for `../lib/llvm/bin/`, the standard ROCm install structure.
+  fs::path llvm_path = parent_path / "lib" / "llvm" / "bin";
+  if (fs::exists(llvm_path)) {
+    variables_.roccmPathEnv_ = parent_path.string();
+    return;
+  }
+
+  // Otherwise, check the ROCM_PATH environment variable from the HIP SDK.
+  // Self-contained builds/installs should not read stale global state when
+  // the install layout is detectable (same rationale as constructHipPath).
+  if (!envVariables_.roccmPathEnv_.empty()) {
+    variables_.roccmPathEnv_ = envVariables_.roccmPathEnv_;
+    return;
+  }
+
+  // Finally, fallback to the HIP path.
+  variables_.roccmPathEnv_ = getHipPath();
 }
 
 // reads the Hip Version


### PR DESCRIPTION
Progress on [ROCm/TheRock#5716](https://github.com/ROCm/TheRock/pull/5716). Mirrors [ROCm/llvm-project#289](https://github.com/ROCm/llvm-project/pull/289) for `constructRoccmPath() / ROCM_PATH`.

The HIP SDK sets `ROCM_PATH`, which hipcc can pick up instead of the self-contained install layout next to the binary. That causes `hipcc --help` and rocm-sdk test failures when a stale system-wide ROCM install is on the runner.

Validated downstream in TheRock CI: failing run [26882526084](https://github.com/ROCm/TheRock/actions/runs/26882526084/job/79297304052#step:11:41), passing with this change [27130253660](https://github.com/ROCm/TheRock/actions/runs/27130253660/job/80306302745#step:10:33).

Longer term, path info should be stamped into packaged tools rather than relying on global env vars and filesystem heuristics. For now, this extends the same install-layout check already used in `constructHipPath()`.