### PR TITLE
[NFC][Comgr] Remove `DemangleTest` dependency with LLVMSupport

### DIFF
--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -171,6 +171,12 @@ target_link_libraries(DemangleSymbolNameTest PRIVATE
   amd_comgr
   ${LLVM_PTHREAD_LIB})
 
+# Gtest's LLVM support brings in some printers for LLVM types (StringRef, etc.).
+# When building in-tree, the included headers bring in some code that depend on LLVM's abi-breaking checks.
+# This adds a dependency with LLVM's Support library.
+# We could link against Support, but since we're not using these printers we can just disable them.
+target_compile_definitions(DemangleSymbolNameTest PRIVATE GTEST_NO_LLVM_SUPPORT=true)
+
 target_include_directories(DemangleSymbolNameTest PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/../src


### PR DESCRIPTION
Due to a header in gtest bringin in some llvm symbols, `DemangleTest` depended on the abi-breaking checks; even though it used none.

Compilation failed with:
```
/usr/bin/ld:
tools/comgr/test-unit/CMakeFiles/DemangleSymbolNameTest.dir/DemangleSymbolNameTest.cpp.o:
undefined reference to symbol '_ZN4llvm23EnableABIBreakingChecksE'
/usr/bin/ld: _build/lib/libLLVMSupport.so.23.0git: error adding symbols: DSO missing from command line
```

This patch breaks the dependency by disabling gtest's LLVM extensions for this test, since they're unused.

Depends on https://github.com/ROCm/llvm-project/pull/2851

