### PR TITLE
[Comgr] Fix detection of .incbin assembler directive on Windows

### DIFF
--- a/amd/comgr/cmake/CheckEmbed.cmake
+++ b/amd/comgr/cmake/CheckEmbed.cmake
@@ -27,13 +27,17 @@ incbin_test:
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_incbin.s ${TEST_ASM_SOURCE})
 
+set(HAVE_INCBIN_SUPPORT OFF)
+set(TEST_ASM_OBJECT ${CMAKE_CURRENT_BINARY_DIR}/test_incbin.o)
+file(REMOVE ${TEST_ASM_OBJECT})
+
 if(CMAKE_ASM_COMPILER)
   execute_process(
     COMMAND ${CMAKE_ASM_COMPILER} -c ${CMAKE_CURRENT_BINARY_DIR}/test_incbin.s
-                                  -o ${CMAKE_CURRENT_BINARY_DIR}/test_incbin.o
+                                  -o ${TEST_ASM_OBJECT}
     RESULT_VARIABLE asm_result)
 
-  if(asm_result EQUAL 0)
+  if(asm_result EQUAL 0 AND EXISTS ${TEST_ASM_OBJECT})
     set(HAVE_INCBIN_SUPPORT ON)
   endif()
 endif()


### PR DESCRIPTION
The `.incbin` configure check is too weak for MSVC/Windows. 
cl.exe returns success while ignoring the .s file and producing no object. 
This incorrectly sets COMGR_USE_INCBIN.


