### PR TITLE
[comgr] gfx1250/1251 xnack ISA Metadata Correction

### DIFF
--- a/amd/comgr/src/comgr-isa-metadata.def
+++ b/amd/comgr/src/comgr-isa-metadata.def
@@ -75,8 +75,8 @@ HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1171",          false, false, EF_AMDGPU_MAC
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1172",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1172,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   16, 1024, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1200",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1200,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1201",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1201,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1250",          true,  true,  EF_AMDGPU_MACH_AMDGCN_GFX1250,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1251",          true,  true,  EF_AMDGPU_MACH_AMDGCN_GFX1251,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1250",          true,  false, EF_AMDGPU_MACH_AMDGCN_GFX1250,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1251",          true,  false, EF_AMDGPU_MACH_AMDGCN_GFX1251,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
 
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx9-generic",     false,  true, EF_AMDGPU_MACH_AMDGCN_GFX9_GENERIC,    true,  true, 65536,  32,  4,   40, 1024,   16, 800, 102,    4, 256, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx9-4-generic",   true,   true, EF_AMDGPU_MACH_AMDGCN_GFX9_4_GENERIC,  true, false, 65536,  32,  4,   40, 1024,   16, 800, 102,    8, 512, 512)


### PR DESCRIPTION
gfx1250/1251 have a FEATURE_XNACK_ALWAYS flag in llvm-project/llvm/include/llvm/TargetParser/AMDGPUTargetParser.def. xnack is always on, so it is not a configurable parameter and as a result, running clang with -mcpu=gfx1250:xnack+ will trigger an error. The xnack flag isn't supported for gfx1250/1251, so xnack should be false for these two in comgr-isa-metadata.def. This PR makes that change.