### PR TITLE
[NFC][Comgr] Remove DemangleTest dependency with LLVM Support

### DIFF
--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -161,30 +161,30 @@ target_include_directories(RaiserScaffoldingTests PRIVATE
 
 comgr_configure_test_target(RaiserScaffoldingTests)
 
-# -- DemangleTests ---------------------------------------------------
+# -- DemangleSymbolNameTest ---------------------------------------------------
 
-add_executable(DemangleTests
-  DemangleTest.cpp)
+add_executable(DemangleSymbolNameTest
+  DemangleSymbolNameTest.cpp)
 
-target_link_libraries(DemangleTests PRIVATE
+target_link_libraries(DemangleSymbolNameTest PRIVATE
   ${COMGR_GTEST_LIBS}
   amd_comgr
   ${LLVM_PTHREAD_LIB})
 
-target_include_directories(DemangleTests PRIVATE
+target_include_directories(DemangleSymbolNameTest PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/../src
   ${COMGR_GTEST_INCLUDE_DIRS}
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
 
-comgr_configure_test_target(DemangleTests)
+comgr_configure_test_target(DemangleSymbolNameTest)
 
 # amd_comgr is a shared lib; the test-unit target runs the exe directly
 # without the PATH setup the lit suite uses, so place the DLL next to it.
 if(WIN32 AND COMGR_BUILD_SHARED_LIBS)
-  add_custom_command(TARGET DemangleTests POST_BUILD
+  add_custom_command(TARGET DemangleSymbolNameTest POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-      $<TARGET_FILE:amd_comgr> $<TARGET_FILE_DIR:DemangleTests>)
+      $<TARGET_FILE:amd_comgr> $<TARGET_FILE_DIR:DemangleSymbolNameTest>)
 endif()
 
 # Register every test binary with the test-unit / check-comgr plumbing.
@@ -192,7 +192,7 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
   COMMAND $<TARGET_FILE:HotswapMCTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
-  COMMAND $<TARGET_FILE:DemangleTests>)
+  COMMAND $<TARGET_FILE:DemangleSymbolNameTest>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests
-  RaiserScaffoldingTests DemangleTests)
+  RaiserScaffoldingTests DemangleSymbolNameTest)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -171,6 +171,12 @@ target_link_libraries(DemangleSymbolNameTest PRIVATE
   amd_comgr
   ${LLVM_PTHREAD_LIB})
 
+# Gtest's LLVM support brings in some printers for LLVM types (StringRef, etc.).
+# When building in-tree, the included headers bring in some code that depend on LLVM's abi-breaking checks.
+# This adds a dependency with LLVM's Support library.
+# We could link against Support, but since we're not using these printers we can just disable them.
+target_compile_definitions(DemangleSymbolNameTest PRIVATE GTEST_NO_LLVM_SUPPORT=true)
+
 target_include_directories(DemangleSymbolNameTest PRIVATE
   ${LLVM_INCLUDE_DIRS}
   ${CMAKE_CURRENT_SOURCE_DIR}/../src

--- a/amd/comgr/test-unit/DemangleSymbolNameTest.cpp
+++ b/amd/comgr/test-unit/DemangleSymbolNameTest.cpp
@@ -1,4 +1,4 @@
-//===- DemangleTest.cpp - Unit tests for COMGR Demangle ----------------===//
+//===- DemangleSymbolNameTest.cpp - Unit tests for COMGR Demangle ---------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
 // amd/comgr/LICENSE.TXT in this repository for license information.
@@ -9,10 +9,10 @@
 #include "common.h"
 #include "gtest/gtest.h"
 
-class DemangleTest
+class DemangleSymbolNameTest
     : public ::testing::TestWithParam<std::tuple<const char *, const char *>> {};
 
-TEST_P(DemangleTest, DemangleMatch) {
+TEST_P(DemangleSymbolNameTest, DemangleMatch) {
   auto [MangledName, ExpectedString] = GetParam();
   amd_comgr_data_t MangledData, DemangledData;
 
@@ -36,7 +36,7 @@ TEST_P(DemangleTest, DemangleMatch) {
   ASSERT_COMGR(release_data(DemangledData));
 }
 
-INSTANTIATE_TEST_SUITE_P(DemangleTable, DemangleTest,
+INSTANTIATE_TEST_SUITE_P(DemangleTable, DemangleSymbolNameTest,
   ::testing::Values(
   // Tests from llvm/unittests/Demangle/DemangleTest.cpp
   std::make_tuple("_", "_"),


### PR DESCRIPTION
Due to a header in gtest bringing in some llvm symbols, `DemangleTest`
depended on the abi-breaking checks; even though it used none.

Compilation failed with:
```
/usr/bin/ld:
tools/comgr/test-unit/CMakeFiles/DemangleSymbolNameTest.dir/DemangleSymbolNameTest.cpp.o:
undefined reference to symbol '_ZN4llvm23EnableABIBreakingChecksE'
/usr/bin/ld: _build/lib/libLLVMSupport.so.23.0git: error adding symbols: DSO missing from command line
```

This patch breaks the dependency by disabling gtest's LLVM extensions
for this test, since they're unused.

(reopen of https://github.com/ROCm/llvm-project/pull/2851 that I wrongly merged over the wrong user branch).

Depends on https://github.com/ROCm/llvm-project/pull/2850