### PR TITLE
[AMDGPU] comgr: read SGPR count from msgpack metadata instead of reserved KD field

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -52,10 +52,7 @@ static constexpr unsigned Gfx1250MaxVgprs = 256;
 // interpret COMPUTE_PGM_RSRC1.GRANULATED_WORKITEM_VGPR_COUNT.
 // GFX12 wave32: 106 user-addressable SGPRs (s0-s105); s106-s107 are VCC.
 static constexpr unsigned Gfx1250MaxSgprs = 106;
-// SGPR encoding granularity is 8 across all AMDGPU generations
-// (getSGPREncodingGranule in AMDGPUBaseInfo.cpp).
 static constexpr unsigned Gfx1250VgprGranuleSize = 16;
-static constexpr unsigned Gfx1250SgprGranuleSize = 8;
 
 /// Build the default RewriteConfig used for the GFX1250 B0-to-A0 rewrite:
 /// fills in the identity source / target ISA (both gfx1250) and the
@@ -74,7 +71,6 @@ static RewriteConfig makeGfx1250B0A0Config() {
   Config.MaxVgprs = Gfx1250MaxVgprs;
   Config.MaxSgprs = Gfx1250MaxSgprs;
   Config.VgprGranuleSize = Gfx1250VgprGranuleSize;
-  Config.SgprGranuleSize = Gfx1250SgprGranuleSize;
   return Config;
 }
 
@@ -416,10 +412,9 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
       continue;
     std::optional<unsigned> VgprsBefore =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
-    if (Stats.ExtraVgprs > 0 || Stats.ExtraSgprs > 0)
-      Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs, Stats.ExtraSgprs,
-                                 Config.VgprGranuleSize,
-                                 Config.SgprGranuleSize);
+    if (Stats.ExtraVgprs > 0)
+      Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs,
+                                 Config.VgprGranuleSize);
     std::optional<unsigned> VgprsAfter =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
     log() << "hotswap: liveness: kernel " << KName

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -44,7 +44,7 @@ namespace hotswap {
 // layer only carries ISA identifiers and register granularity -- no
 // target-specific opcode bits should land here.
 
-static constexpr unsigned Gfx1250MaxVgprs = 256;
+static constexpr unsigned Gfx1250MaxVgprs = 1024;
 // GFX1250 wave32 VGPR ENCODING granularity is 16 (per
 // AMDGPUBaseInfo::getVGPREncodingGranule with Feature1024AddressableVGPRs),
 // not the 8 used by earlier GFX10/11 wave32. Used by ElfView's KD

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -16,6 +16,7 @@
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
 
 using namespace llvm;
 
@@ -260,73 +261,112 @@ ElfView::getKernelStaticLdsSize(StringRef KernelName) const {
 }
 
 // -- ElfView::getKernelSgprCount ----------------------------------------------
+//
+// Reads .sgpr_count from the amdhsa.kernels msgpack metadata note.
+// On GFX10+ GRANULATED_WAVEFRONT_SGPR_COUNT in the kernel descriptor is
+// architecturally reserved (must be zero), so the metadata note is the
+// preferred source. Falls back to the KD field when no metadata note is
+// present (e.g. minimal test ELFs assembled with -nostdlib).
+
+static constexpr unsigned SgprEncodingGranule = 8;
 
 std::optional<unsigned>
-ElfView::getKernelSgprCount(StringRef KernelName,
-                            unsigned SgprGranuleSize) const {
-  if (SgprGranuleSize == 0) {
-    log() << "hotswap: error: getKernelSgprCount: SgprGranuleSize is 0 for "
-          << "kernel '" << KernelName << "'.\n";
-    return std::nullopt;
+ElfView::getKernelSgprCount(StringRef KernelName) const {
+  // --- Try msgpack metadata note first. ---
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (PhdrsOrErr) {
+    for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+      if (Phdr.p_type != ELF::PT_NOTE)
+        continue;
+      Error Err = Error::success();
+      for (const auto &Note : File.notes(Phdr, Err)) {
+        if (Note.getName() != "AMDGPU" ||
+            Note.getType() != ELF::NT_AMDGPU_METADATA)
+          continue;
+
+        StringRef Blob = Note.getDescAsStringRef(4);
+        msgpack::Document Doc;
+        if (!Doc.readFromBlob(Blob, false))
+          continue;
+
+        msgpack::DocNode Root = Doc.getRoot();
+        if (!Root.isMap())
+          continue;
+        auto KernelsIt = Root.getMap().find("amdhsa.kernels");
+        if (KernelsIt == Root.getMap().end() || !KernelsIt->second.isArray())
+          continue;
+
+        for (auto &KNode : KernelsIt->second.getArray()) {
+          if (!KNode.isMap())
+            continue;
+          auto &KMap = KNode.getMap();
+          auto NameIt = KMap.find(".name");
+          if (NameIt == KMap.end() || !NameIt->second.isString() ||
+              NameIt->second.getString() != KernelName)
+            continue;
+
+          auto SgprIt = KMap.find(".sgpr_count");
+          if (SgprIt == KMap.end())
+            break;
+          if (SgprIt->second.getKind() == msgpack::Type::UInt)
+            return static_cast<unsigned>(SgprIt->second.getUInt());
+          if (SgprIt->second.getKind() == msgpack::Type::Int)
+            return static_cast<unsigned>(SgprIt->second.getInt());
+          break;
+        }
+      }
+      if (errorToBool(std::move(Err)))
+        break;
+    }
+  } else {
+    consumeError(PhdrsOrErr.takeError());
   }
+
+  // --- Fallback: read the KD field. ---
+  // The LLVM assembler populates GRANULATED_WAVEFRONT_SGPR_COUNT even on
+  // GFX10+ where the hardware ignores it, so this is still usable for
+  // ROCm-compiled code objects that lack a metadata note.
   namespace hsa = amdhsa;
   uint8_t *Kd = const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
-  if (!Kd) {
-    log() << "hotswap: error: getKernelSgprCount: kernel descriptor symbol '"
-          << KernelName << ".kd' not found.\n";
+  if (!Kd)
     return std::nullopt;
-  }
   uint32_t Rsrc1;
   std::memcpy(&Rsrc1,
               Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               sizeof(Rsrc1));
   uint32_t Granulated = AMDHSA_BITS_GET(
       Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
-  return (Granulated + 1) * SgprGranuleSize;
+  return (Granulated + 1) * SgprEncodingGranule;
 }
 
 // -- ElfView::updateKernelDescriptor ------------------------------------------
 
 void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,
-                                     unsigned ExtraSgprs,
-                                     unsigned VgprGranuleSize,
-                                     unsigned SgprGranuleSize) {
+                                     unsigned VgprGranuleSize) {
   namespace hsa = amdhsa;
   uint8_t *Kd = findKernelDescriptor(KernelName);
   if (!Kd) {
     log() << "hotswap: error: updateKernelDescriptor: kernel descriptor "
-          << "symbol '" << KernelName << ".kd' not found; requested " << "+"
-          << ExtraVgprs << " VGPRs / +" << ExtraSgprs
-          << " SGPRs silently dropped.\n";
+          << "symbol '" << KernelName << ".kd' not found; requested +"
+          << ExtraVgprs << " VGPRs silently dropped.\n";
     return;
   }
+
+  if (ExtraVgprs == 0 || VgprGranuleSize == 0)
+    return;
 
   uint32_t Rsrc1;
   std::memcpy(&Rsrc1,
               Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               sizeof(Rsrc1));
-  if (ExtraVgprs != 0 && VgprGranuleSize != 0) {
-    uint32_t Current = AMDHSA_BITS_GET(
-        Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
-    uint32_t MaxGran = static_cast<uint32_t>(
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT >>
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT_SHIFT);
-    unsigned Extra = (ExtraVgprs + VgprGranuleSize - 1) / VgprGranuleSize;
-    AMDHSA_BITS_SET(Rsrc1,
-                    hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
-                    std::min<uint32_t>(Current + Extra, MaxGran));
-  }
-  if (ExtraSgprs != 0 && SgprGranuleSize != 0) {
-    uint32_t Current = AMDHSA_BITS_GET(
-        Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
-    uint32_t MaxGran = static_cast<uint32_t>(
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT >>
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT_SHIFT);
-    unsigned Extra = (ExtraSgprs + SgprGranuleSize - 1) / SgprGranuleSize;
-    AMDHSA_BITS_SET(Rsrc1,
-                    hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT,
-                    std::min<uint32_t>(Current + Extra, MaxGran));
-  }
+  uint32_t Current = AMDHSA_BITS_GET(
+      Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+  uint32_t MaxGran = static_cast<uint32_t>(
+      hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT >>
+      hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT_SHIFT);
+  unsigned Extra = (ExtraVgprs + VgprGranuleSize - 1) / VgprGranuleSize;
+  AMDHSA_BITS_SET(Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
+                  std::min<uint32_t>(Current + Extra, MaxGran));
   std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               &Rsrc1, sizeof(Rsrc1));
 }

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -212,17 +212,19 @@ public:
   std::optional<uint32_t>
   getKernelStaticLdsSize(llvm::StringRef KernelName) const;
 
-  /// Read the SGPR count from the kernel descriptor for \p KernelName.
-  /// Returns std::nullopt if the descriptor is not found.
-  std::optional<unsigned> getKernelSgprCount(llvm::StringRef KernelName,
-                                             unsigned SgprGranuleSize) const;
+  /// Read the SGPR count for \p KernelName from the \c amdhsa.kernels
+  /// msgpack metadata note (\c .sgpr_count key). On GFX10+ the kernel
+  /// descriptor's \c GRANULATED_WAVEFRONT_SGPR_COUNT is architecturally
+  /// reserved, so this is the only reliable source.
+  /// Returns std::nullopt if the metadata note is missing or the kernel
+  /// is not found.
+  std::optional<unsigned> getKernelSgprCount(llvm::StringRef KernelName) const;
 
-  /// Update the RSRC1 VGPR/SGPR granule counts in the kernel descriptor for
-  /// \p KernelName by adding \p ExtraVgprs / \p ExtraSgprs, using
-  /// \p VgprGranuleSize / \p SgprGranuleSize so the call is ISA-agnostic.
+  /// Update the RSRC1 VGPR granule count in the kernel descriptor for
+  /// \p KernelName by adding \p ExtraVgprs. The SGPR granule field is
+  /// not updated because it is reserved on GFX10+.
   void updateKernelDescriptor(llvm::StringRef KernelName, unsigned ExtraVgprs,
-                              unsigned ExtraSgprs, unsigned VgprGranuleSize,
-                              unsigned SgprGranuleSize);
+                              unsigned VgprGranuleSize);
 
   /// Grow the ELF by inserting trampoline bytes after `.text` and adjusting
   /// all section and program headers. Returns a null unique_ptr on failure.
@@ -284,7 +286,6 @@ struct RewriteConfig {
   unsigned MaxVgprs = 0;
   unsigned MaxSgprs = 0;
   unsigned VgprGranuleSize = 0;
-  unsigned SgprGranuleSize = 0;
 };
 
 // -- LLVM MC context ----------------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -150,8 +150,7 @@ ScratchAllocation allocateScratch(PatchContext &Ctx, size_t Idx) {
   VgprAllocator VgprAlloc(Ctx.Liveness.LiveBefore[Idx], VgprKdCount,
                           Ctx.Config.MaxVgprs);
 
-  std::optional<unsigned> KdSgprs =
-      Ctx.Elf.getKernelSgprCount(KernelName, Ctx.Config.SgprGranuleSize);
+  std::optional<unsigned> KdSgprs = Ctx.Elf.getKernelSgprCount(KernelName);
   unsigned SgprKdCount = KdSgprs.value_or(Ctx.Config.MaxSgprs);
   SgprAllocator SgprAlloc(SgprKdCount, Ctx.Config.MaxSgprs);
 


### PR DESCRIPTION
## Summary

On GFX10+, `GRANULATED_WAVEFRONT_SGPR_COUNT` in the kernel descriptor is architecturally reserved and must be zero — the hardware ignores it. The scratch SGPR allocator introduced in #2328 was reading this field to determine where to start allocating scratch SGPRs, which is unreliable: a code object that correctly zeroes the field would cause the allocator to start at s8, potentially clobbering live registers.

This PR replaces the KD-field approach with a metadata-first strategy: read `.sgpr_count` from the `amdhsa.kernels` msgpack metadata note (`NT_AMDGPU_METADATA`), falling back to the KD field for minimal ELFs that lack a metadata note (e.g. lit test objects assembled with `-nostdlib`).

Also fixes `Gfx1250MaxVgprs` from 256 to 1024 — GFX1250 has `Feature1024AddressableVGPRs` and with wave32, `getAddressableNumVGPRs` returns 1024.

Follow-up to #2328 (specifically @jmmartinez's [review comment](https://github.com/ROCm/llvm-project/pull/2328#discussion_r3346859386) noting the SGPR field is reserved on GFX10+, and [comment](https://github.com/ROCm/llvm-project/pull/2328#discussion_r3386641668) noting gfx1250 has 1024 VGPRs).

## Implementation Details

**`comgr-hotswap-elf.cpp` — `getKernelSgprCount()` rewritten:**
- Primary path: iterate `PT_NOTE` program headers → find `NT_AMDGPU_METADATA` note → parse msgpack blob via `llvm::msgpack::Document::readFromBlob()` → walk `amdhsa.kernels` array → match `.name` to the kernel → return `.sgpr_count`.
- Fallback path: if no metadata note is present, read `GRANULATED_WAVEFRONT_SGPR_COUNT` from the kernel descriptor with the correct encoding granule (8), matching `getSGPREncodingGranule()` in `AMDGPUBaseInfo.cpp`.
- Returns `std::nullopt` on failure; the caller falls back to `MaxSgprs` (106), which is conservative (no headroom → patch refused rather than silent clobber).

**`comgr-hotswap-elf.cpp` — `updateKernelDescriptor()` simplified:**
- Removed `ExtraSgprs` and `SgprGranuleSize` parameters.
- Deleted the SGPR write block — bumping a reserved field has no effect on hardware.
- VGPR update path unchanged (that field is not reserved).

**`comgr-hotswap-internal.h`:**
- `getKernelSgprCount()` signature: removed `SgprGranuleSize` parameter (metadata provides the raw count directly).
- `updateKernelDescriptor()` signature: removed `ExtraSgprs` and `SgprGranuleSize`.
- `RewriteConfig`: removed `SgprGranuleSize` field.

**`comgr-hotswap-patch-f32-to-e5m3.cpp`:**
- `allocateScratch()`: updated call to `getKernelSgprCount()` (no granule argument).

**`comgr-hotswap-b0a0.cpp`:**
- Removed `Gfx1250SgprGranuleSize` constant.
- Fixed `Gfx1250MaxVgprs` from 256 to 1024 (`Feature1024AddressableVGPRs` + wave32).
- Updated `updateKernelDescriptor()` call site to match new signature.

No build system changes — `LLVMBinaryFormat` (which includes msgpack) is already linked by COMGR.

## Test Coverage

- **49/49 hotswap lit tests pass**, including all 7 FP8 E5M3 tests and the new WMMA split test. The CHECK patterns use `s_mov_b32` without specifying SGPR numbers, so they are agnostic to which specific SGPRs the allocator selects.
- **4/4 HotswapElfTests** and **44/44 HotswapMCTests** pass.
- The KD fallback path is exercised by every existing lit test (assembled with `-nostdlib`, which produces ELFs without metadata notes). The metadata path will be exercised by production code objects compiled with `hipcc`/`clang` which always include `NT_AMDGPU_METADATA`.