### PR TITLE
OpenMP divergence: Use BoundArch argument to addClangTargetOptions

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
@@ -365,15 +365,13 @@ void AMDGPUOpenMPToolChain::addClangTargetOptions(
   HostTC.addClangTargetOptions(DriverArgs, CC1Args, BoundArch,
                                DeviceOffloadingKind);
 
-  StringRef GPUArch = DriverArgs.getLastArgValue(options::OPT_march_EQ);
-
   assert(DeviceOffloadingKind == Action::OFK_OpenMP &&
          "Only OpenMP offloading kinds are supported.");
 
   // Extract all the -m options
   std::vector<llvm::StringRef> Features;
   amdgpu::getAMDGPUTargetFeatures(getDriver(), getTriple(), DriverArgs,
-                                  Features, GPUArch);
+                                  Features, BoundArch);
 
   for (auto OneFeature : unifyTargetFeatures(Features)) {
     CC1Args.push_back("-target-feature");
@@ -432,7 +430,7 @@ void AMDGPUOpenMPToolChain::addClangTargetOptions(
     return;
 
   std::string BitcodeSuffix;
-  BitcodeSuffix = llvm::Twine("old-amdgpu-" + GPUArch).str();
+  BitcodeSuffix = llvm::Twine("old-amdgpu-" + BoundArch).str();
 
   addDirectoryList(DriverArgs, LibraryPaths, "", "HIP_DEVICE_LIB_PATH");
 


### PR DESCRIPTION
This function is very divergent from upstream, partially avoid conflict in pending change.


