### PR TITLE
OpenMP divergence: Remove openmp toolchain overrides of isPICDefault

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -82,9 +82,6 @@ public:
                         llvm::StringRef BoundArch,
                         Action::OffloadKind DeviceOffloadKind) const override;
 
-  bool isPICDefault() const override { return false; }
-  bool isPICDefaultForced() const override { return false; }
-
   CXXStdlibType GetCXXStdlibType(const llvm::opt::ArgList &Args) const override;
   void AddClangCXXStdlibIncludeArgs(
       const llvm::opt::ArgList &Args,


### PR DESCRIPTION
These are not upstream, not tested, and should not be different from HIP.


