### PR TITLE
[CI] Gate amd-staging ci:skip to automated LLVM_MAIN_REVISION bumps

### DIFF
--- a/.github/workflows/PSDB-amd-staging.yml
+++ b/.github/workflows/PSDB-amd-staging.yml
@@ -1,5 +1,8 @@
 name: Compiler CI PSDB trigger on amd-staging branch
 
+# Jenkins PSDB is skipped only for automated LLVM_MAIN_REVISION PRs: `ci:skip`
+# plus matching title/body. Label alone does not suppress PSDB.
+
 # Controls when the workflow will run
 on:
   pull_request:
@@ -11,7 +14,20 @@ on:
 jobs:
   # This workflow contains a single job called "invoke_jenkins_PSDB"
   invoke_jenkins_PSDB:
-    if: github.event.pull_request.draft == false
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request &&
+       github.event.pull_request.draft == false &&
+       !(
+         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+         (
+           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+           (
+             contains(github.event.pull_request.body, 'Automated update of') &&
+             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+           )
+         )
+       ))
     runs-on: 
       group: compiler-generic-runners
     env:

--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -10,6 +10,17 @@ on:
 
 jobs:
   code_formatter:
+    if: >-
+      !(
+        contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+        (
+          contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+          (
+            contains(github.event.pull_request.body, 'Automated update of') &&
+            contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+          )
+        )
+      )
     runs-on: ubuntu-24.04
     container:
       image: 'ghcr.io/llvm/ci-ubuntu-24.04-format'

--- a/.github/workflows/rockci-amd-staging.yml
+++ b/.github/workflows/rockci-amd-staging.yml
@@ -11,6 +11,10 @@
 # For push to main branch, all AMD families will built and tested from `amdgpu_family_matrix.py`.
 #
 # Note: If a test machine is not available for a specific AMD GPU family in `amdgpu_family_matrix.py`, tests will be skipped.
+#
+# Presubmit is skipped only when ALL apply: label `ci:skip` AND the PR matches the
+# automated LLVM_MAIN_REVISION bump (title starts with that phrase OR body contains
+# the automation marker). Arbitrary PRs with only `ci:skip` still run full CI.
 
 name: CI amd-staging
 
@@ -67,6 +71,19 @@ concurrency:
 
 jobs:
   setup:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request &&
+       !(
+         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+         (
+           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+           (
+             contains(github.event.pull_request.body, 'Automated update of') &&
+             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+           )
+         )
+       ))
     uses: ./.github/workflows/setup.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -7,6 +7,9 @@
 # It mirrors ci.yml but uses multi_arch_build_portable_linux.yml instead of
 # ci_linux.yml. Once validated, ci.yml will be updated to use the multi-arch
 # sub-workflows directly.
+#
+# Same `ci:skip` rules as rockci-amd-staging.yml: only automated LLVM_MAIN_REVISION PRs
+# (matching title/body) skip presubmit; label alone is not enough.
 
 name: Multi-Arch CI amd-staging
 
@@ -62,6 +65,19 @@ concurrency:
 
 jobs:
   setup:
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request &&
+       !(
+         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+         (
+           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+           (
+             contains(github.event.pull_request.body, 'Automated update of') &&
+             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+           )
+         )
+       ))
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/spirv-ci.yml
+++ b/.github/workflows/spirv-ci.yml
@@ -1,5 +1,8 @@
 # Top-level dispatcher for the SPIRV-focused CI on amd-staging.
 # Dispatches to per-platform reusable workflows.
+#
+# SPIRV presubmit skips only for automated LLVM_MAIN_REVISION PRs: `ci:skip` plus
+# matching title/body (same rules as rockci-amd-staging.yml).
 
 name: SPIRV Compiler CI - amd-staging
 
@@ -19,10 +22,36 @@ concurrency:
 jobs:
   linux_release:
     name: Linux::release
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request &&
+       !(
+         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+         (
+           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+           (
+             contains(github.event.pull_request.body, 'Automated update of') &&
+             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+           )
+         )
+       ))
     uses: ./.github/workflows/spirv-ci-linux-amd-staging.yml
     secrets: inherit
 
   windows_release:
     name: Windows::release
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request &&
+       !(
+         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+         (
+           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+           (
+             contains(github.event.pull_request.body, 'Automated update of') &&
+             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+           )
+         )
+       ))
     uses: ./.github/workflows/spirv-ci-windows-amd-staging.yml
     secrets: inherit


### PR DESCRIPTION
## Summary
- Limit `ci:skip` on `amd-staging` so presubmit is skipped only for automated `LLVM_MAIN_REVISION` bump PRs (label plus title/body match).
- Apply consistently across RockCI, multi-arch RockCI, SPIRV CI, PR code format, and PSDB so the label alone cannot skip CI on arbitrary PRs.
## Test plan
- [ ] Normal PR with only `ci:skip` still runs CI.
- [ ] Automated LLVM main revision bump PR with `ci:skip` and matching title/body skips as intended.