### PR TITLE
[Comgr] Honor COMGR_STATIC_LLVM against a dylib-enabled LLVM

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -538,6 +538,12 @@ install(FILES
   COMPONENT amd-comgr
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/${AMD_COMGR_PACKAGE_PREFIX}")
 
+# TODO: GH issue #2927 - re-assert static linkage find_package re-enables later.
+if(COMGR_STATIC_LLVM)
+  set(LLVM_LINK_LLVM_DYLIB OFF)
+  set(CLANG_LINK_CLANG_DYLIB OFF)
+endif()
+
 if(NOT CLANG_LINK_CLANG_DYLIB)
   set(CLANG_LIBS
     clangBasic


### PR DESCRIPTION
## Summary
Re-assert the static-link vars right before comgr's link logic so `COMGR_STATIC_LLVM=ON` is actually honored when building against a dylib-enabled LLVM.

With `COMGR_STATIC_LLVM=ON`, comgr sets `LLVM_LINK_LLVM_DYLIB`/`CLANG_LINK_CLANG_DYLIB` OFF near the top of the file, **before** `find_package`. A later `include(opencl_header)` re-runs `find_package(Clang)`, which re-reads the Clang/LLVM package config and flips both vars back **ON** — so by the time the link libraries are resolved, comgr links the dynamic `libLLVM.so`/`libclang-cpp.so` even though a static build was requested. This re-asserts the vars OFF after all `find_package` calls, right before the link logic.

It is a **no-op unless `COMGR_STATIC_LLVM=ON`**, and only matters when building comgr static against a dylib-enabled LLVM (e.g. TheRock).

## Note
Split out of #2911 at reviewer request so it can land independently/first; #2911 then no longer carries this CMake change.