### PR TITLE
Reset runtime unloaded flag at hsa_init time.

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -1712,8 +1712,10 @@ hsa_status_t asan_hsa_init() {
   if (status == HSA_STATUS_SUCCESS) {
     // Only clear state when recovering from a prior shutdown (avoids clearing
     // amdgpu_event_registered on every refcount bump and re-registering).
-    if (__sanitizer::AmdgpuMemFuncs::IsAmdgpuRuntimeShutdown())
+    if (__sanitizer::AmdgpuMemFuncs::IsAmdgpuRuntimeShutdown()) {
       __sanitizer::AmdgpuMemFuncs::ClearAmdgpuRuntimeShutdownState();
+      get_allocator().ResetDeviceRuntimeState();
+    }
     __sanitizer::AmdgpuMemFuncs::RegisterSystemEventHandlers();
   }
   return status;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_combined.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_combined.h
@@ -261,6 +261,12 @@ class CombinedAllocator {
 #endif
   }
 
+#if SANITIZER_AMDGPU
+  void ResetDeviceRuntimeState() {
+    device_.ResetRuntimeUnloadedFlag();
+  }
+#endif
+
  private:
   PrimaryAllocator primary_;
   SecondaryAllocator secondary_;

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_device.h
@@ -283,6 +283,10 @@ class DeviceAllocatorT {
     }
   }
 
+  void ResetRuntimeUnloadedFlag() {
+    dev_runtime_unloaded_ = false;
+  }
+
  private:
   bool InitMemFuncs() {
     if (!enabled_ || mem_funcs_inited_ || mem_funcs_init_count_ >= 2) {


### PR DESCRIPTION
runtime unloaded flag needed to be reset after prior shutdown.