### PR TITLE
[Comgr][hotswap][test] Share an ELF64 header builder across hotswap unit tests

### DIFF
--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
+#include "comgr-test-elf-utils.h"
 #include "gtest/gtest.h"
 #include <cstring>
 
@@ -55,17 +56,9 @@ TEST(ElfView, GetKernelStaticLdsSizeReturnsNulloptWhenKdMissing) {
   const char StrTab[] = "\0.text\0.shstrtab\0";
   std::memcpy(Buf + StrTabOff, StrTab, sizeof(StrTab));
 
-  Elf64_Ehdr Ehdr{};
-  Ehdr.e_ident[0] = 0x7f;
-  Ehdr.e_ident[1] = 'E';
-  Ehdr.e_ident[2] = 'L';
-  Ehdr.e_ident[3] = 'F';
-  Ehdr.e_ident[EI_CLASS] = ELFCLASS64;
-  Ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
-  Ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
   Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
   Ehdr.e_type = ET_REL;
-  Ehdr.e_machine = EM_AMDGPU;
   Ehdr.e_version = EV_CURRENT;
   Ehdr.e_shoff = ShOff;
   Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
@@ -131,17 +124,9 @@ TEST(ElfView, GetKernelStaticLdsSizeReadsLdsSizeFromKernelDescriptor) {
   const char StrTab[] = "\0test_kernel.kd\0";
   std::memcpy(Buf + StrTabOff, StrTab, sizeof(StrTab));
 
-  Elf64_Ehdr Ehdr{};
-  Ehdr.e_ident[0] = 0x7f;
-  Ehdr.e_ident[1] = 'E';
-  Ehdr.e_ident[2] = 'L';
-  Ehdr.e_ident[3] = 'F';
-  Ehdr.e_ident[EI_CLASS] = ELFCLASS64;
-  Ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
-  Ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
   Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
   Ehdr.e_type = ET_REL;
-  Ehdr.e_machine = EM_AMDGPU;
   Ehdr.e_version = EV_CURRENT;
   Ehdr.e_shoff = ShOff;
   Ehdr.e_ehsize = sizeof(Elf64_Ehdr);

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -1,0 +1,38 @@
+//===- comgr-test-elf-utils.h - shared ELF builders for unit tests --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_TEST_UNIT_ELF_UTILS_H
+#define COMGR_TEST_UNIT_ELF_UTILS_H
+
+#include "llvm/BinaryFormat/ELF.h"
+
+#include <cstdint>
+
+namespace comgr_test {
+
+// A zero-initialized 64-bit little-endian ELF header with valid magic and the
+// given machine + e_flags. Callers set any further fields they need.
+inline llvm::ELF::Elf64_Ehdr makeElf64Ehdr(uint16_t Machine,
+                                           uint32_t Flags = 0) {
+  using namespace llvm::ELF;
+  Elf64_Ehdr Ehdr{};
+  Ehdr.e_ident[EI_MAG0] = 0x7f;
+  Ehdr.e_ident[EI_MAG1] = 'E';
+  Ehdr.e_ident[EI_MAG2] = 'L';
+  Ehdr.e_ident[EI_MAG3] = 'F';
+  Ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+  Ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
+  Ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+  Ehdr.e_machine = Machine;
+  Ehdr.e_flags = Flags;
+  return Ehdr;
+}
+
+} // namespace comgr_test
+
+#endif // COMGR_TEST_UNIT_ELF_UTILS_H


### PR DESCRIPTION
## Summary
Extract the duplicated minimal-ELF64-header construction in the comgr hotswap unit tests into a shared helper.

- New `amd/comgr/test-unit/comgr-test-elf-utils.h` with `comgr_test::makeElf64Ehdr(machine, flags)` (valid magic + ELFCLASS64 + LE + version; caller fills the rest).
- `HotswapElfTest.cpp` uses it instead of repeating the `e_ident`/magic boilerplate in each test.

Split out of #2911 at reviewer request, since it's a test-infra cleanup independent of the hotswap tool and can land first.