### PR TITLE
[Comgr][hotswap] Add comgr hotswap runtime tool (loaded via HSA_TOOLS_LIB env var)

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -52,3 +52,35 @@ target_link_libraries(hotswap-transpiler
     LLVMSupport
     LLVMTargetParser
 )
+
+# HSA_TOOLS_LIB hotswap tool (libamd_comgr_hotswap_tool.so): ROCR loads it via
+# HSA_TOOLS_LIB and it rewrites code objects through the comgr hotswap API.
+# Off by default - it is an opt-in artifact most comgr consumers do not need.
+# When enabled it requires the HSA headers (inc/hsa.h, from
+# HOTSWAP_TOOL_HSA_INCLUDE_ROOT); configuration errors if they are not found.
+option(HOTSWAP_BUILD_TOOL "Build the HSA_TOOLS_LIB hotswap tool" OFF)
+if(HOTSWAP_BUILD_TOOL)
+  if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(FATAL_ERROR
+      "HOTSWAP_BUILD_TOOL is only supported on Linux (it requires the HSA "
+      "runtime); set HOTSWAP_BUILD_TOOL=OFF on this platform.")
+  endif()
+  find_path(HOTSWAP_TOOL_HSA_INC inc/hsa.h HINTS "${HOTSWAP_TOOL_HSA_INCLUDE_ROOT}")
+  if(NOT HOTSWAP_TOOL_HSA_INC)
+    message(FATAL_ERROR
+      "HOTSWAP_BUILD_TOOL is ON but inc/hsa.h was not found. Set "
+      "HOTSWAP_TOOL_HSA_INCLUDE_ROOT to the rocr-runtime hsa-runtime directory, "
+      "or set HOTSWAP_BUILD_TOOL=OFF.")
+  endif()
+  # amd/comgr/src/hotswap binary dir -> amd/comgr binary dir (generated amd_comgr.h).
+  get_filename_component(_comgr_bin "${CMAKE_CURRENT_BINARY_DIR}/../.." ABSOLUTE)
+  add_library(amd_comgr_hotswap_tool SHARED comgr-hotswap-tool.cpp)
+  set_target_properties(amd_comgr_hotswap_tool PROPERTIES
+    CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON POSITION_INDEPENDENT_CODE ON)
+  target_include_directories(amd_comgr_hotswap_tool PRIVATE
+    "${HOTSWAP_TOOL_HSA_INC}"
+    "${_comgr_bin}/include")  # generated amd_comgr.h
+  target_link_libraries(amd_comgr_hotswap_tool PRIVATE amd_comgr)
+  install(TARGETS amd_comgr_hotswap_tool
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}" COMPONENT amd-comgr)
+endif()

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -1,17 +1,89 @@
-# Hotswap Transpiler
+# HotSwap
 
-The hotswap transpiler raises AMDGPU code objects into LLVM IR, re-lowers
-them through the stock AMDGPU backend for a different target ISA, and
-relinks the result into a single merged HSACO. It is a sibling to the
-byte-level `amd_comgr_hotswap_rewrite` API: where rewrite applies a small
-set of stepping-specific patches in place, transpilation hands the entire
-code object to the IR pipeline.
+HotSwap rewrites AMDGPU code objects at load time so that a binary built for one
+gfx1250 stepping runs correctly on another. The `amd_comgr_hotswap_rewrite` API
+applies a small set of stepping-specific patches in place, without recompiling
+the code object.
 
-## Build
+This directory ships two things:
 
-The library can be configured standalone for development:
+- The comgr hotswap tool (`libamd_comgr_hotswap_tool.so`), loaded via the
+  `HSA_TOOLS_LIB` env var, which applies the rewrite automatically at runtime.
+- The transpiler, a raiser-based path for the heavier cross-ISA case. It is
+  documented at the bottom of this file.
 
+The tool is Linux only: it requires the HSA runtime, so the build errors on
+other platforms.
+
+## Running with the tool
+
+Point `HSA_TOOLS_LIB` at the tool and run any HIP or HSA application unchanged:
+
+```bash
+HSA_TOOLS_LIB=/opt/rocm/lib/libamd_comgr_hotswap_tool.so ./my_app
 ```
+
+`HSA_TOOLS_LIB` tells the `libhsa-runtime` what tool to hand each code object it encounters to before dispatch. When the tool detects a gfx1250 A0 board, it rewrites every gfx1250 code object in place via `amd_comgr_hotswap_rewrite`. Everything else passes through untouched.
+
+If a rewrite fails, the tool logs the failure and forwards the original code
+object. The application still runs, just without the rewrite applied.
+
+## Supported architectures
+
+| Architecture        | Status      |
+| ------------------- | ----------- |
+| gfx1250, ASIC rev A0 | Rewrite armed |
+| gfx950              | Coming soon |
+| gfx942              | Coming soon |
+
+HotSwap currently requires a homogeneous GPU setup. Running it across multiple
+GPUs is not supported.
+
+The tool detects the device on its own. It reads the agent ISA name and
+`HSA_AMD_AGENT_INFO_ASIC_REVISION`, then arms the rewrite only when the target
+is gfx1250, the revision is 0 (A0), and the revision query succeeded. A failed
+query is never treated as A0. On any other device or revision, code objects pass
+through unchanged. No environment variable is needed to turn this on.
+
+To confirm the rewrite is active, set `HSA_HOTSWAP_TOOL_VERBOSE=1` and look for
+this line in the logs:
+
+```bash
+hotswap_tool: device=gfx1250 asic_revision=0 -> A0 (rewrite armed)
+```
+
+## Environment variables
+
+| Variable                   | Effect                                                        |
+| -------------------------- | ------------------------------------------------------------- |
+| `HSA_TOOLS_LIB`            | Standard HSA hook. Set it to this `.so` to load the tool.     |
+| `HSA_HOTSWAP_TOOL_VERBOSE` | Set to `1` for diagnostic logging to stderr, covering device detection and per-code-object rewrite results. Logging only; does not change behavior. Off by default. |
+
+## Building the tool
+
+The tool is off by default, since most comgr consumers do not need it. Enable it
+and point the build at the HSA headers:
+
+```bash
+cmake -S amd/comgr -B build \
+  -DHOTSWAP_BUILD_TOOL=ON \
+  -DHOTSWAP_TOOL_HSA_INCLUDE_ROOT=/path/to/rocr-runtime/runtime/hsa-runtime
+ninja -C build amd_comgr_hotswap_tool
+```
+
+If `HOTSWAP_BUILD_TOOL` is on but `inc/hsa.h` cannot be found under
+`HOTSWAP_TOOL_HSA_INCLUDE_ROOT`, the build fails.
+
+## Transpiler (cross-gen)
+
+The transpiler is the heavier sibling to the byte-level rewrite. It raises
+AMDGPU code objects into LLVM IR, re-lowers them through the stock AMDGPU backend
+for a different target ISA, and relinks the result into a single merged HSACO.
+The rewrite path applies in-place stepping patches; the transpiler instead hands
+the whole code object to the IR pipeline. It can be built standalone for
+development:
+
+```bash
 cmake -S amd/comgr/hotswap -B build-hotswap \
   -DLLVM_DIR=$PWD/build/lib/cmake/llvm
 ninja -C build-hotswap

--- a/amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h
+++ b/amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h
@@ -1,0 +1,56 @@
+//===- comgr-hotswap-tool-detect.h - gfx target + A0 gate helpers ---------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Hotswap detection helpers (no HSA dep), split out so they can be unit-tested.
+
+#ifndef COMGR_HOTSWAP_TOOL_DETECT_H
+#define COMGR_HOTSWAP_TOOL_DETECT_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/BinaryFormat/ELF.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+namespace COMGR::hotswap {
+
+// Processor of an ISA name like amdgcn-amd-amdhsa--gfx1250[:feats] (the field
+// after arch-vendor-os-environ; same model as comgr's parseTargetIdentifier).
+inline std::string extractGfxTarget(llvm::StringRef IsaName) {
+  llvm::StringRef Rest = IsaName;
+  for (int I = 0; I < 4; ++I) {
+    Rest = Rest.split('-').second;
+  }
+  return Rest.split(':').first.str();
+}
+
+// Arm only on gfx1250 at ASIC revision A0 (0). Callers must confirm the revision
+// query succeeded before calling; a failed query is handled at the call site.
+inline bool gateAllowsHotswap(const std::string &Gfx, uint32_t Revision) {
+  return Gfx == "gfx1250" && Revision == 0;
+}
+
+// True for a 64-bit gfx1250 AMDGPU ELF (aligned-copy header read, e_machine checked).
+inline bool isGfx1250CodeObject(const void *Data, size_t Size) {
+  if (!Data || Size < sizeof(llvm::ELF::Elf64_Ehdr)) {
+    return false;
+  }
+  llvm::ELF::Elf64_Ehdr Header;
+  std::memcpy(&Header, Data, sizeof(Header));
+  return Header.checkMagic() &&
+         Header.getFileClass() == llvm::ELF::ELFCLASS64 &&
+         Header.e_machine == llvm::ELF::EM_AMDGPU &&
+         (Header.e_flags & llvm::ELF::EF_AMDGPU_MACH) ==
+             llvm::ELF::EF_AMDGPU_MACH_AMDGCN_GFX1250;
+}
+
+} // namespace COMGR::hotswap
+
+#endif // COMGR_HOTSWAP_TOOL_DETECT_H

--- a/amd/comgr/src/hotswap/comgr-hotswap-tool.cpp
+++ b/amd/comgr/src/hotswap/comgr-hotswap-tool.cpp
@@ -1,0 +1,248 @@
+//===- comgr-hotswap-tool.cpp - HSA_TOOLS_LIB B0->A0 rewrite tool ---------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// comgr hotswap tool (libamd_comgr_hotswap_tool.so), loaded via HSA_TOOLS_LIB.
+// B0->A0 rewrite for gfx1250. Load with
+// HSA_TOOLS_LIB=/path/libamd_comgr_hotswap_tool.so. Each gfx1250 A0 code object
+// is rewritten via amd_comgr_hotswap_rewrite before reader creation; everything
+// else passes through. HSA_HOTSWAP_TOOL_VERBOSE=1 for logging.
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "inc/hsa.h"
+#include "inc/hsa_api_trace.h"
+#include "inc/hsa_ext_amd.h"
+#include <amd_comgr.h>
+
+#include "comgr-hotswap-tool-detect.h"
+
+namespace COMGR::hotswap {
+
+constexpr const char *Gfx1250Isa = "amdgcn-amd-amdhsa--gfx1250";
+
+// Bare HSA_TOOLS_LIB callbacks carry no user-data, so all state lives here.
+namespace {
+struct HotswapTool {
+  decltype(hsa_code_object_reader_create_from_memory) *RealReaderCreate =
+      nullptr;
+  decltype(hsa_iterate_agents) *IterateAgents = nullptr;
+  decltype(hsa_agent_get_info) *AgentGetInfo = nullptr;
+  decltype(hsa_isa_get_info_alt) *IsaGetInfoAlt = nullptr;
+  CoreApiTable *Core = nullptr; // table we patch; restored in OnUnload
+
+  bool Verbose = false;
+  std::once_flag DetectOnce;
+  bool DeviceIsA0 = false;
+
+  // HSA references retained bytes for the module lifetime
+  std::mutex RetainMutex;
+  // Deque keeps element addresses stable
+  std::deque<std::vector<uint8_t>> Retained;
+
+  void detectDevice();
+  void ensureDetected() {
+    std::call_once(DetectOnce, [this] { detectDevice(); });
+  }
+};
+} // namespace
+
+// Function-local static singleton: one instance, thread-safe init, no globals.
+// Detection is deferred (ensureDetected) because the HSA table is wired by
+// OnLoad after construction and agents are only enumerable once HSA is up.
+static HotswapTool &getTool() {
+  static HotswapTool Tool;
+  return Tool;
+}
+
+#define LOG(...)                                                               \
+  do {                                                                         \
+    if (getTool().Verbose) {                                                   \
+      std::fprintf(stderr, "hotswap_tool: " __VA_ARGS__);                      \
+      std::fprintf(stderr, "\n");                                              \
+    }                                                                          \
+  } while (0)
+
+// First GPU agent: assume homogenous setup for Hotswap
+static hsa_status_t findGpuAgent(hsa_agent_t Agent, void *Data) {
+  hsa_device_type_t Type;
+  if (getTool().AgentGetInfo(Agent, HSA_AGENT_INFO_DEVICE, &Type) ==
+          HSA_STATUS_SUCCESS &&
+      Type == HSA_DEVICE_TYPE_GPU) {
+    *static_cast<hsa_agent_t *>(Data) = Agent;
+    return HSA_STATUS_INFO_BREAK;
+  }
+  return HSA_STATUS_SUCCESS;
+}
+
+void HotswapTool::detectDevice() {
+  if (!IterateAgents || !AgentGetInfo || !IsaGetInfoAlt) {
+    LOG("detectDevice: HSA function pointers unavailable; rewrite disarmed");
+    return;
+  }
+  hsa_agent_t Gpu = {0};
+  IterateAgents(&findGpuAgent, &Gpu);
+  if (Gpu.handle == 0) {
+    LOG("detectDevice: no GPU agent found; rewrite disarmed");
+    return;
+  }
+
+  // Size the ISA-name buffer from the queried length
+  hsa_isa_t Isa = {0};
+  std::string Gfx;
+  if (AgentGetInfo(Gpu, HSA_AGENT_INFO_ISA, &Isa) == HSA_STATUS_SUCCESS) {
+    uint32_t NameLen = 0;
+    if (IsaGetInfoAlt(Isa, HSA_ISA_INFO_NAME_LENGTH, &NameLen) ==
+            HSA_STATUS_SUCCESS &&
+        NameLen > 0) {
+      std::vector<char> Name(NameLen + 1, '\0');
+      if (IsaGetInfoAlt(Isa, HSA_ISA_INFO_NAME, Name.data()) ==
+          HSA_STATUS_SUCCESS) {
+        Gfx = extractGfxTarget(Name.data());
+      }
+    }
+  }
+
+  // A failed revision query must not be mistaken for A0 (0); bail out disarmed.
+  uint32_t Revision = 0;
+  if (AgentGetInfo(
+          Gpu, static_cast<hsa_agent_info_t>(HSA_AMD_AGENT_INFO_ASIC_REVISION),
+          &Revision) != HSA_STATUS_SUCCESS) {
+    LOG("detectDevice: ASIC revision query failed; rewrite disarmed");
+    return;
+  }
+
+  DeviceIsA0 = gateAllowsHotswap(Gfx, Revision);
+  LOG("device=%s asic_revision=%u -> %s", Gfx.empty() ? "?" : Gfx.c_str(),
+      Revision, DeviceIsA0 ? "A0 (rewrite armed)" : "B0/native");
+}
+
+// Rewrite a gfx1250 object for A0; identity ISA, the A0 fix is in the rewrite.
+static bool rewriteCodeObject(const void *Src, size_t Size,
+                              std::vector<uint8_t> &Out) {
+  amd_comgr_data_t Input = {0};
+  if (amd_comgr_create_data(AMD_COMGR_DATA_KIND_EXECUTABLE, &Input) !=
+      AMD_COMGR_STATUS_SUCCESS) {
+    LOG("comgr create_data FAILED");
+    return false;
+  }
+  amd_comgr_data_t Output = {0};
+  amd_comgr_status_t Status =
+      amd_comgr_set_data(Input, Size, static_cast<const char *>(Src));
+  if (Status == AMD_COMGR_STATUS_SUCCESS) {
+    Status = amd_comgr_hotswap_rewrite(Input, Gfx1250Isa, Gfx1250Isa, &Output);
+  } else {
+    LOG("comgr set_data FAILED (status=%d)", static_cast<int>(Status));
+  }
+  amd_comgr_release_data(Input);
+  if (Status != AMD_COMGR_STATUS_SUCCESS) {
+    LOG("comgr rewrite FAILED (status=%d)", static_cast<int>(Status));
+    if (Output.handle) {
+      amd_comgr_release_data(Output);
+    }
+    return false;
+  }
+  size_t OutSize = 0;
+  Status = amd_comgr_get_data(Output, &OutSize, nullptr);
+  if (Status == AMD_COMGR_STATUS_SUCCESS && OutSize > 0) {
+    Out.resize(OutSize);
+    Status = amd_comgr_get_data(Output, &OutSize,
+                                reinterpret_cast<char *>(Out.data()));
+  } else {
+    LOG("comgr get_data returned no output (status=%d, size=%zu)",
+        static_cast<int>(Status), OutSize);
+    Status = AMD_COMGR_STATUS_ERROR;
+  }
+  amd_comgr_release_data(Output);
+  if (Status != AMD_COMGR_STATUS_SUCCESS) {
+    LOG("comgr get_data FAILED (status=%d)", static_cast<int>(Status));
+    return false;
+  }
+  LOG("comgr rewrite ok (%zu->%zu)", Size, OutSize);
+  return true;
+}
+
+// Replaces hsa_code_object_reader_create_from_memory in the API table.
+static hsa_status_t readerCreateWrapper(const void *CodeObject, size_t Size,
+                                        hsa_code_object_reader_t *Reader) {
+  HotswapTool &Tool = getTool();
+  Tool.ensureDetected();
+
+  // Forward invalid args and non-target objects to the real entry untouched.
+  if (!CodeObject || !Size || !Reader || !Tool.DeviceIsA0 ||
+      !isGfx1250CodeObject(CodeObject, Size)) {
+    return Tool.RealReaderCreate(CodeObject, Size, Reader);
+  }
+
+  std::vector<uint8_t> Rewritten;
+  if (!rewriteCodeObject(CodeObject, Size, Rewritten)) {
+    // Warn unconditionally (not LOG): a failed rewrite forwards the original.
+    std::fprintf(stderr, "hotswap_tool: rewrite failed; forwarding original\n");
+    return Tool.RealReaderCreate(CodeObject, Size, Reader);
+  }
+
+  const uint8_t *Persisted;
+  size_t PersistedSize;
+  {
+    const std::lock_guard<std::mutex> Lock(Tool.RetainMutex);
+    Tool.Retained.emplace_back(std::move(Rewritten));
+    Persisted = Tool.Retained.back().data();
+    PersistedSize = Tool.Retained.back().size();
+  }
+  return Tool.RealReaderCreate(Persisted, PersistedSize, Reader);
+}
+
+} // namespace COMGR::hotswap
+
+// OnLoad/OnUnload names and signatures are fixed by the HSA tool ABI.
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" bool OnLoad(void *Table, uint64_t, uint64_t, const char *const *) {
+  using namespace COMGR::hotswap;
+  const HsaApiTable *Api = static_cast<const HsaApiTable *>(Table);
+  if (!Api || !Api->core_) {
+    return false;
+  }
+  CoreApiTable *Core = Api->core_;
+  if (!Core->hsa_iterate_agents_fn || !Core->hsa_agent_get_info_fn ||
+      !Core->hsa_isa_get_info_alt_fn ||
+      !Core->hsa_code_object_reader_create_from_memory_fn) {
+    return false;
+  }
+  if (Core->hsa_code_object_reader_create_from_memory_fn ==
+      &readerCreateWrapper) {
+    return true;
+  }
+
+  HotswapTool &Tool = getTool();
+  if (const char *Verb = std::getenv("HSA_HOTSWAP_TOOL_VERBOSE")) {
+    Tool.Verbose = Verb[0] && Verb[0] != '0';
+  }
+  Tool.IterateAgents = Core->hsa_iterate_agents_fn;
+  Tool.AgentGetInfo = Core->hsa_agent_get_info_fn;
+  Tool.IsaGetInfoAlt = Core->hsa_isa_get_info_alt_fn;
+  Tool.RealReaderCreate = Core->hsa_code_object_reader_create_from_memory_fn;
+  Tool.Core = Core;
+  Core->hsa_code_object_reader_create_from_memory_fn = &readerCreateWrapper;
+  return true;
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" void OnUnload() {
+  using namespace COMGR::hotswap;
+  HotswapTool &Tool = getTool();
+  // Restore the original entry so the table doesn't dangle after unload.
+  if (Tool.Core && Tool.RealReaderCreate) {
+    Tool.Core->hsa_code_object_reader_create_from_memory_fn =
+        Tool.RealReaderCreate;
+  }
+}

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -163,6 +163,65 @@ target_include_directories(RaiserScaffoldingTests PRIVATE
 
 comgr_configure_test_target(RaiserScaffoldingTests)
 
+# -- HotswapToolTests ---------------------------------------------------------
+#
+# Pure device-detection helpers for the HSA_TOOLS_LIB tool
+# (hotswap/comgr-hotswap-tool-detect.h): gfx-target extraction and the A0
+# rewrite gate. Header-only, so no comgr/LLVM sources are compiled in.
+
+add_executable(HotswapToolTests
+  HotswapToolTest.cpp)
+
+llvm_map_components_to_libnames(COMGR_TEST_UNIT_TOOL_LIBS BinaryFormat Support)
+
+target_link_libraries(HotswapToolTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  ${COMGR_TEST_UNIT_TOOL_LIBS}
+  ${LLVM_PTHREAD_LIB})
+
+# Disable gtest's LLVM-type printers; the tool helpers need no LLVM type support.
+target_compile_definitions(HotswapToolTests PRIVATE GTEST_NO_LLVM_SUPPORT=true)
+
+target_include_directories(HotswapToolTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+comgr_configure_test_target(HotswapToolTests)
+
+# -- HotswapToolLoaderTests ---------------------------------------------------
+#
+# Drives the tool's HSA_TOOLS_LIB entry points (OnLoad/OnUnload) against a stub
+# HSA API table. Compiles the tool TU directly, so it needs the HSA headers and
+# amd_comgr; gated on HOTSWAP_BUILD_TOOL like the tool itself.
+if(HOTSWAP_BUILD_TOOL AND HOTSWAP_TOOL_HSA_INC)
+  add_executable(HotswapToolLoaderTests
+    HotswapToolLoaderTest.cpp
+    ../src/hotswap/comgr-hotswap-tool.cpp)
+
+  llvm_map_components_to_libnames(COMGR_TEST_UNIT_LOADER_LIBS
+    BinaryFormat Support)
+
+  target_link_libraries(HotswapToolLoaderTests PRIVATE
+    ${COMGR_GTEST_LIBS}
+    amd_comgr
+    ${COMGR_TEST_UNIT_LOADER_LIBS}
+    ${LLVM_PTHREAD_LIB})
+
+  target_compile_definitions(HotswapToolLoaderTests PRIVATE
+    GTEST_NO_LLVM_SUPPORT=true)
+
+  target_include_directories(HotswapToolLoaderTests PRIVATE
+    ${LLVM_INCLUDE_DIRS}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../src
+    "${HOTSWAP_TOOL_HSA_INC}"
+    ${COMGR_GTEST_INCLUDE_DIRS}
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+  comgr_configure_test_target(HotswapToolLoaderTests)
+endif()
+
 # -- DemangleSymbolNameTest ---------------------------------------------------
 
 add_executable(DemangleSymbolNameTest
@@ -199,8 +258,14 @@ endif()
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
   COMMAND $<TARGET_FILE:HotswapMCTests>
+  COMMAND $<TARGET_FILE:HotswapToolTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>)
-add_dependencies(test-unit HotswapElfTests HotswapMCTests
+add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapToolTests
   RaiserScaffoldingTests DemangleSymbolNameTest)
+if(TARGET HotswapToolLoaderTests)
+  add_dependencies(test-unit HotswapToolLoaderTests)
+  add_custom_command(TARGET test-unit POST_BUILD
+    COMMAND $<TARGET_FILE:HotswapToolLoaderTests>)
+endif()
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/HotswapToolLoaderTest.cpp
+++ b/amd/comgr/test-unit/HotswapToolLoaderTest.cpp
@@ -1,0 +1,93 @@
+//===- HotswapToolLoaderTest.cpp - Unit tests for the HSA tool ABI --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Drives the tool's HSA_TOOLS_LIB entry points against a stub HSA API table:
+// OnLoad validates the table and installs the reader-create wrapper, OnUnload
+// restores it. No GPU is involved; the rewrite path is covered on real silicon.
+
+#include "inc/hsa.h"
+#include "inc/hsa_api_trace.h"
+#include "gtest/gtest.h"
+
+#include <cstddef>
+#include <cstdint>
+
+// Entry points exported by the tool; names are fixed by the HSA tool ABI.
+// NOLINTBEGIN(readability-identifier-naming)
+extern "C" bool OnLoad(void *Table, uint64_t RuntimeVersion,
+                       uint64_t FailedToolCount,
+                       const char *const *FailedToolNames);
+extern "C" void OnUnload();
+// NOLINTEND(readability-identifier-naming)
+
+using ReaderCreateFn = decltype(hsa_code_object_reader_create_from_memory) *;
+
+static hsa_status_t stubReaderCreate(const void *, size_t,
+                                     hsa_code_object_reader_t *) {
+  return HSA_STATUS_SUCCESS;
+}
+static hsa_status_t stubIterateAgents(hsa_status_t (*)(hsa_agent_t, void *),
+                                      void *) {
+  return HSA_STATUS_SUCCESS;
+}
+static hsa_status_t stubAgentGetInfo(hsa_agent_t, hsa_agent_info_t, void *) {
+  return HSA_STATUS_SUCCESS;
+}
+static hsa_status_t stubIsaGetInfoAlt(hsa_isa_t, hsa_isa_info_t, void *) {
+  return HSA_STATUS_SUCCESS;
+}
+
+// A CoreApiTable wired with the function pointers OnLoad requires.
+static CoreApiTable makeStubCore() {
+  CoreApiTable Core{};
+  Core.hsa_iterate_agents_fn = stubIterateAgents;
+  Core.hsa_agent_get_info_fn = stubAgentGetInfo;
+  Core.hsa_isa_get_info_alt_fn = stubIsaGetInfoAlt;
+  Core.hsa_code_object_reader_create_from_memory_fn = stubReaderCreate;
+  return Core;
+}
+
+TEST(HotswapToolLoader, OnLoadRejectsInvalidTables) {
+  EXPECT_FALSE(OnLoad(nullptr, 0, 0, nullptr));
+
+  HsaApiTable NoCore{};
+  NoCore.core_ = nullptr;
+  EXPECT_FALSE(OnLoad(&NoCore, 0, 0, nullptr));
+
+  CoreApiTable Core = makeStubCore();
+  Core.hsa_code_object_reader_create_from_memory_fn = nullptr;
+  HsaApiTable Table{};
+  Table.core_ = &Core;
+  EXPECT_FALSE(OnLoad(&Table, 0, 0, nullptr));
+}
+
+TEST(HotswapToolLoader, OnLoadInstallsWrapperAndIsIdempotent) {
+  CoreApiTable Core = makeStubCore();
+  HsaApiTable Table{};
+  Table.core_ = &Core;
+  ReaderCreateFn &Entry = Core.hsa_code_object_reader_create_from_memory_fn;
+
+  ASSERT_TRUE(OnLoad(&Table, 0, 0, nullptr));
+  ReaderCreateFn Installed = Entry;
+  EXPECT_NE(Installed, stubReaderCreate);
+
+  ASSERT_TRUE(OnLoad(&Table, 0, 0, nullptr)); // already installed -> no-op
+  EXPECT_EQ(Entry, Installed);
+}
+
+TEST(HotswapToolLoader, OnUnloadRestoresOriginalEntry) {
+  CoreApiTable Core = makeStubCore();
+  HsaApiTable Table{};
+  Table.core_ = &Core;
+  ReaderCreateFn &Entry = Core.hsa_code_object_reader_create_from_memory_fn;
+
+  ASSERT_TRUE(OnLoad(&Table, 0, 0, nullptr));
+  ASSERT_NE(Entry, stubReaderCreate);
+  OnUnload();
+  EXPECT_EQ(Entry, stubReaderCreate);
+}

--- a/amd/comgr/test-unit/HotswapToolTest.cpp
+++ b/amd/comgr/test-unit/HotswapToolTest.cpp
@@ -1,0 +1,77 @@
+//===- HotswapToolTest.cpp - Unit tests for the HSA_TOOLS_LIB tool --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Covers the pure device-detection helpers the hotswap tool uses to decide
+// whether a board is gfx1250 A0 (rewrite armed) or not. The rest of the tool
+// is glue over the HSA loader API and is exercised on real silicon.
+
+#include "comgr-test-elf-utils.h"
+#include "hotswap/comgr-hotswap-tool-detect.h"
+#include "gtest/gtest.h"
+
+using namespace COMGR::hotswap;
+
+TEST(ExtractGfxTarget, BareProcessorWithoutTripleYieldsEmpty) {
+  // An ISA name is a full target ID; a bare processor is not one.
+  EXPECT_TRUE(extractGfxTarget("gfx1250").empty());
+}
+
+TEST(ExtractGfxTarget, FullIsaNameYieldsBareTarget) {
+  EXPECT_EQ(extractGfxTarget("amdgcn-amd-amdhsa--gfx1250"), "gfx1250");
+}
+
+TEST(ExtractGfxTarget, FeatureSuffixIsDropped) {
+  EXPECT_EQ(extractGfxTarget("amdgcn-amd-amdhsa--gfx1250:sramecc+:xnack-"),
+            "gfx1250");
+}
+
+TEST(ExtractGfxTarget, MissingTargetYieldsEmpty) {
+  EXPECT_TRUE(extractGfxTarget("amdgcn-amd-amdhsa--").empty());
+  EXPECT_TRUE(extractGfxTarget("").empty());
+}
+
+TEST(GateAllowsHotswap, ArmsOnGfx1250RevisionZero) {
+  EXPECT_TRUE(gateAllowsHotswap("gfx1250", /*Revision=*/0));
+}
+
+TEST(GateAllowsHotswap, DoesNotArmOnNonZeroRevision) {
+  EXPECT_FALSE(gateAllowsHotswap("gfx1250", /*Revision=*/1));
+}
+
+TEST(GateAllowsHotswap, DoesNotArmOnOtherTargets) {
+  EXPECT_FALSE(gateAllowsHotswap("gfx950", /*Revision=*/0));
+}
+
+TEST(IsGfx1250CodeObject, NullDataIsRejected) {
+  EXPECT_FALSE(isGfx1250CodeObject(nullptr, 4096));
+}
+
+TEST(IsGfx1250CodeObject, TruncatedInputIsRejected) {
+  llvm::ELF::Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(
+      llvm::ELF::EM_AMDGPU, llvm::ELF::EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  EXPECT_FALSE(isGfx1250CodeObject(&Ehdr, sizeof(Ehdr) - 1));
+}
+
+TEST(IsGfx1250CodeObject, NonAmdgpuElfIsRejected) {
+  // Same mach bits, wrong e_machine: must not be misidentified as gfx1250.
+  llvm::ELF::Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(
+      llvm::ELF::EM_X86_64, llvm::ELF::EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  EXPECT_FALSE(isGfx1250CodeObject(&Ehdr, sizeof(Ehdr)));
+}
+
+TEST(IsGfx1250CodeObject, WrongMachIsRejected) {
+  llvm::ELF::Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(
+      llvm::ELF::EM_AMDGPU, llvm::ELF::EF_AMDGPU_MACH_AMDGCN_GFX1100);
+  EXPECT_FALSE(isGfx1250CodeObject(&Ehdr, sizeof(Ehdr)));
+}
+
+TEST(IsGfx1250CodeObject, Gfx1250IsAccepted) {
+  llvm::ELF::Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(
+      llvm::ELF::EM_AMDGPU, llvm::ELF::EF_AMDGPU_MACH_AMDGCN_GFX1250);
+  EXPECT_TRUE(isGfx1250CodeObject(&Ehdr, sizeof(Ehdr)));
+}


### PR DESCRIPTION
_Supersedes #2911_ — same branch, rebased + squashed onto current `amd-staging` (which now includes #2929). Re-created because the GitHub UI was stuck rendering the rebased #2911.

## Summary
Optional comgr hotswap tool (`libamd_comgr_hotswap_tool.so`), loaded via the `HSA_TOOLS_LIB` env var, that runs the comgr hotswap rewrite at runtime. Inert unless pointed at:

```
HSA_TOOLS_LIB=/path/libamd_comgr_hotswap_tool.so ./my_app
```

`libhsa-runtime` then hands each code object to the tool before dispatch; on a gfx1250 board detected as A0 it rewrites each gfx1250 code object via `amd_comgr_hotswap_rewrite`, else passes through. No ROCR/CLR fork, no `LD_PRELOAD`. Linux only (it requires the HSA runtime).

## Rewrite-target selection
The tool auto-detects the device: it reads the agent ISA name and `HSA_AMD_AGENT_INFO_ASIC_REVISION`, and arms the rewrite only when the target is `gfx1250`, the revision is `0` (A0), and the revision query actually succeeded (a failed query is never treated as A0). No environment variable is required to enable it. `HSA_HOTSWAP_TOOL_VERBOSE=1` adds diagnostic logging and is logging-only.

The decision is cached once for the process, so the tool targets single-GPU / homogeneous-gfx1250 setups; per-agent gating would require intercepting executable load (where the agent is known) and is left as follow-up.

## Files
- **`amd/comgr/src/hotswap/comgr-hotswap-tool.cpp`** (new): the tool. `OnLoad` validates the API table and the function pointers it needs, wraps `hsa_code_object_reader_create_from_memory`, resolves device ISA + `ASIC_REVISION` once, rewrites gfx1250 code objects on an A0 board (forwarding invalid args and the original buffer on failure), retains rewritten buffers for the reader's lifetime, and `OnUnload` restores the original loader entry.
- **`amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h`** (new): header-only detection helpers (gfx-target extraction, the A0 gate, the gfx1250 ELF test), split out so they can be unit-tested without HSA.
- **`amd/comgr/test-unit/HotswapToolTest.cpp`** (+ `test-unit/CMakeLists.txt`): unit tests for the detection helpers.
- **`amd/comgr/src/hotswap/CMakeLists.txt`**: builds the tool, gated by `HOTSWAP_BUILD_TOOL` (OFF by default; an opt-in artifact most comgr consumers do not need). Configuration errors if `HOTSWAP_BUILD_TOOL=ON` but the HSA headers are not found, or on a non-Linux platform.
- **`amd/comgr/src/hotswap/README.md`**: tool usage, the environment variables and their observable effect, and supported architectures.

## Related PRs
- **#2929** - shared ELF64 test header (`comgr-test-elf-utils.h`) used by `HotswapToolTest`. **Merged**; this PR is rebased on top (it does not re-add or modify that file).
- **#2926** - honor `COMGR_STATIC_LLVM` against a dylib-enabled LLVM. The tool's in-process rewrite needs a statically-linked comgr (a dynamically-linked comgr has an uninitialized LLVM target registry, which breaks the in-process blit/HIPRTC compile on device). Pending.
