### PR TITLE
[WaveTransform] Preserve kill terminators during CFG rewrite

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -1958,11 +1958,13 @@ void ControlFlowRewriter::rewrite() {
 
     if (!Info.OrigExit) {
       // Remove original terminators, preserving artificial terminators
-      // (EXEC management ops) and hardware-managed branches (e.g.
-      // S_SUBVECTOR_LOOP) that pass through to assembly unchanged.
+      // (EXEC management ops), hardware-managed branches (e.g.
+      // S_SUBVECTOR_LOOP) that pass through to assembly unchanged, and
+      // kill terminators that will be lowered later by si-wqm.
       while (!Node->Block->empty() && Node->Block->back().isTerminator() &&
              !isArtificialTerminator(Node->Block->back()) &&
-             !isHardwareManagedBranch(Node->Block->back()))
+             !isHardwareManagedBranch(Node->Block->back()) &&
+             !TII.isKillTerminator(Node->Block->back().getOpcode()))
         Node->Block->back().eraseFromParent();
     }
 


### PR DESCRIPTION
WaveTransform's terminator removal loop was erasing SI_KILL_I1_TERMINATOR and SI_KILL_F32_COND_IMM_TERMINATOR instructions because they were not recognized as artificial terminators or hardware-managed branches. This caused si-wqm, which runs after WaveTransform in the LWT pipeline, to find an empty KillInstrs list and skip all kill lowering — resulting in missing exec mask modifications, missing dead blocks, and missing null exports for fully-killed waves. This patch preserves the kill terminators during wave transform like other custom preserved terminators.


