### PR TITLE
[Comgr][hotswap] Drain after ds_*_2addr split instead of relaxing the next wait

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -29,8 +29,6 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
-#include "llvm/MC/MCCodeEmitter.h"
-#include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -314,86 +312,14 @@ std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
   return {};
 }
 
-// -- bumpNextWaitDscnt ------------------------------------------------------
-//
-// After splitting one DS 2-addr instruction into two, the next s_wait_dscnt
-// in the same straight-line block must be incremented by 1 to account for the
-// extra outstanding DS operation -- except when the wait is a drain
-// (s_wait_dscnt 0), which must stay a drain after any number of splits.
-// Relaxing a drain would let the split halves escape into a downstream data
-// hazard, so drains are preserved verbatim and only non-drain (K > 0) waits
-// are bumped here. A general dataflow-based bump (computed from the live
-// outstanding-DS count at the wait site) would subsume both cases; that
-// refinement is deferred and tracked outside the source tree.
-//
-// Returns true if a wait was found and bumped, false otherwise.
-//
-// If the wait is past a branch or join point, we conservatively do nothing:
-// the compiler guarantees a straight-line s_wait_dscnt follows each DS op in
-// well-formed kernels. If absent (e.g. s_endpgm terminates first), skipping
-// the bump is safe -- the hardware wait counter saturates harmlessly.
-
-bool bumpNextWaitDscnt(PatchContext &Ctx, size_t Idx) {
-  const MCInstrInfo &MCII = *Ctx.LS.MCII;
-  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-
-  for (size_t I = Idx + 1; I < Ctx.Decoded.size(); ++I) {
-    const InternalDecodedInst &DI = Ctx.Decoded[I];
-    if (DI.Mnemonic == "<unknown>" || DI.Mnemonic == "<replaced>")
-      continue;
-    if (DI.Mnemonic == "s_endpgm")
-      return false;
-
-    // Stop at any control-flow instruction (branches, jumps, calls) to
-    // avoid bumping a wait that belongs to a different execution path.
-    const MCInstrDesc &Desc = MCII.get(DI.Inst.getOpcode());
-    if (Desc.mayAffectControlFlow(DI.Inst, MRI))
-      return false;
-
-    if (DI.Mnemonic != "s_wait_dscnt")
-      continue;
-
-    // s_wait_dscnt has a single immediate operand (the wait count) at
-    // index 0; increment it directly. The drain case is handled below.
-    if (DI.Inst.getNumOperands() == 0)
-      return false;
-    MCInst NewInst = DI.Inst;
-    MCOperand &Op = NewInst.getOperand(0);
-    if (!Op.isImm())
-      return false;
-    if (Op.getImm() == 0)
-      return false;
-    // The +1 here is conservative for K > 0: it over-bumps splits of
-    // "must-complete" operations at the wait site. That is a suboptimal
-    // stall, never a correctness hazard. The drain (K == 0) over-bump
-    // WOULD be a hazard and is handled by the early return above. A
-    // precise replacement needs outstanding-DS dataflow at the wait
-    // site, which subsumes the drain special-case naturally.
-    Op.setImm(Op.getImm() + 1);
-
-    SmallVector<char, 8> Bytes;
-    SmallVector<MCFixup, 2> Fixups;
-    Ctx.LS.MCE->encodeInstruction(NewInst, Bytes, Fixups, *Ctx.LS.STI);
-
-    uint64_t Off = Ctx.Decoded[I].Offset;
-    std::memcpy(Ctx.Text + Off, Bytes.data(), Bytes.size());
-
-    Ctx.Decoded[I].Inst = NewInst;
-    return true;
-  }
-
-  return false;
-}
-
 // -- patchDs2Addr -----------------------------------------------------------
 //
 // Expand one ds_*_2addr_* instruction (stride64 or non-stride64) into two
-// single-address DS instructions. Each split adds one outstanding DS op, so
-// bumpNextWaitDscnt increments the next non-drain s_wait_dscnt by +1 per
-// split and preserves drains verbatim. Because that helper writes the bumped
-// immediate back into Ctx.Decoded[I].Inst, adjacent DS2 sites that target
-// the same non-drain wait accumulate (the second call observes the first
-// call's update, so N splits before one wait produce a K -> K+N update).
+// single-address DS instructions, followed by an s_wait_dscnt 0 drain so both
+// halves are guaranteed complete before any downstream DS consumer. Splitting
+// one DS instruction into two perturbs the outstanding-DS instruction count
+// that later s_wait_dscnt immediates encode; the local drain sidesteps that
+// entirely (see the rationale in the body below).
 
 bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -411,6 +337,18 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   std::string Combined;
   for (const std::string &Line : Expanded)
     Combined += Line + "\n";
+  // Drain the DS counter right after the split pair so both halves are
+  // guaranteed complete before any downstream consumer. The original code
+  // tracked completion of the single 2-addr instruction via a later
+  // s_wait_dscnt whose immediate counts outstanding DS *instructions*;
+  // splitting one instruction into two perturbs that count. Adjusting the
+  // downstream wait by +1 (the previous bumpNextWaitDscnt approach) relaxes
+  // the wait (s_wait_dscnt K stalls until outstanding <= K, so a larger K
+  // waits for FEWER ops), which lets a consumer read the second half's LDS
+  // slot before it lands -- observed as NaN in MIOpen layernormbfp16. A
+  // local drain is unconditionally correct; a precise per-wait dataflow
+  // recomputation is the eventual optimization (tracked separately).
+  Combined += "s_wait_dscnt 0\n";
   SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
@@ -421,10 +359,6 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return false;
 
-  // Return value intentionally discarded: false is a normal outcome when the
-  // wait is a drain (preserved), absent before s_endpgm/branch, or carries a
-  // non-immediate operand -- none of which are errors at this site.
-  (void)bumpNextWaitDscnt(Ctx, Idx);
   DI.Mnemonic = "<replaced>";
   return true;
 }

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
@@ -1,7 +1,8 @@
 // COM: Test multi-DS stacking against a drain s_wait_dscnt: two
 // COM: ds_load_2addr_stride64_b32 sites share a single s_wait_dscnt 0x0,
-// COM: which must stay at 0x0 across both splits. The non-drain bump path
-// COM: is covered by hotswap-trampoline-ds-pipelined.s.
+// COM: which is left in place across both splits (each split also emits its
+// COM: own s_wait_dscnt 0x0 drain). Non-drain wait preservation is covered by
+// COM: hotswap-trampoline-ds-pipelined.s.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -1,14 +1,9 @@
 // COM: Test multi-DS stacking for the non-stride64 DS 2-address family:
 // COM: two ds_load_2addr_b32 sites before a single s_wait_dscnt 0x0
-// COM: (drain). Both splits target the same wait, but because it is a
-// COM: drain it must stay at 0x0 after the patch -- bumping it (to 0x1
-// COM: or 0x2) would relax the wait and let split halves escape past it.
-// COM:
-// COM: The Ctx.Decoded writeback path itself (the ROCm/llvm-project#2281
-// COM: review concern raised by @yxsamliu, that adjacent splits before the
-// COM: same wait must accumulate bumps via in-place imm update) is
-// COM: exercised by the non-drain bump test hotswap-trampoline-ds-pipelined.s,
-// COM: whose multi-split kernel walks the wait from 0x1 to 0x3.
+// COM: (drain). Each split is expanded into two single-address loads
+// COM: followed by its own s_wait_dscnt 0x0 drain, and the pre-existing
+// COM: downstream drain is left in place -- so both split halves always
+// COM: complete before any consumer.
 // COM:
 // COM: Companion test:
 // COM:   hotswap-trampoline-ds-nostride64.s -- non-stride64 base case

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -10,17 +10,14 @@
 // COM: applied to each per-operand index (ElemBytes vs 64 * ElemBytes), so
 // COM: the trampoline shape (s_branch forward + sled + s_branch back) and
 // COM: the s_wait_dscnt handling are shared with the stride64 path. Each
-// COM: kernel here uses s_wait_dscnt 0x0 (drain) as input and exercises
-// COM: the drain-preservation rule: the imm must stay at 0x0 after the
-// COM: split (bumping a drain to K would let K split halves escape past
-// COM: the wait).
+// COM: split emits its own s_wait_dscnt 0x0 drain after the two
+// COM: single-address ops; a pre-existing downstream drain is left in place.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-trampoline-ds-nostride64-multi.s -- drain preservation
+// COM:   hotswap-trampoline-ds-nostride64-multi.s -- drain insertion
 // COM:     under multi-DS stacking in the non-stride64 path.
-// COM:   hotswap-trampoline-ds-pipelined.s -- non-drain bump path (covers
-// COM:     the Ctx.Decoded writeback for the 0x1 -> 0x2 / 0x3 case
-// COM:     originally raised in the ROCm/llvm-project#2281 review).
+// COM:   hotswap-trampoline-ds-pipelined.s -- non-drain downstream wait
+// COM:     preserved while each split adds its own drain.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
@@ -1,7 +1,8 @@
-// COM: Test bumpNextWaitDscnt control-flow guard: a DS2 instruction
-// COM: followed directly by s_endpgm with no s_wait_dscnt in the same
-// COM: basic block. The guard must stop at s_endpgm without inserting
-// COM: or corrupting any wait instruction.
+// COM: Test the DS2 split drain when there is no downstream wait: a DS2
+// COM: instruction followed directly by s_endpgm with no s_wait_dscnt in the
+// COM: same basic block. The split still emits its own s_wait_dscnt 0x0 drain
+// COM: after the two single-address ops, so both halves complete even though
+// COM: the original kernel had no wait before s_endpgm.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -13,13 +14,17 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: The DS2 is still expanded (replaced by s_branch to sled), but no
-// COM: s_wait_dscnt appears anywhere — the guard hit s_endpgm and returned.
+// COM: The DS2 is expanded (replaced by s_branch to sled); the sled holds the
+// COM: two single-address loads followed by the split's own s_wait_dscnt 0x0
+// COM: drain. No downstream wait existed, so the only wait is the split drain.
 // DISASM-LABEL: <test_ds_nowait>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
 // DISASM: s_endpgm
-// DISASM-NOT: s_wait_dscnt
+// DISASM: ds_load_b32 v0
+// DISASM: ds_load_b32 v1
+// DISASM: s_wait_dscnt 0x0
+// DISASM: s_branch
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
@@ -1,10 +1,9 @@
-// COM: Test HotSwap trampoline patch: non-drain s_wait_dscnt bump path.
-// COM: Inputs use s_wait_dscnt 0x1 (pipelined wait permitting one in-flight
-// COM: DS op), so each DS 2-addr split must increment the imm by 1. Inverse
-// COM: of hotswap-trampoline-ds.s, which exercises drain preservation.
-// COM:
-// COM:   Kernel 1: one DS2 split  + s_wait_dscnt 0x1 -> bumped to 0x2.
-// COM:   Kernel 2: two DS2 splits + s_wait_dscnt 0x1 -> bumped to 0x3.
+// COM: Test HotSwap trampoline patch: each ds_*_2addr_* split is followed by
+// COM: a local s_wait_dscnt 0x0 drain so both split halves complete before any
+// COM: downstream consumer. An existing non-drain wait (s_wait_dscnt 0x1) is
+// COM: left untouched -- the split's own drain provides the ordering, so the
+// COM: downstream wait must NOT be relaxed (relaxing it would let a consumer
+// COM: read a not-yet-landed half; see the patchDs2Addr rationale).
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -16,32 +15,41 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (single split, +1 bump): one DS2 -> s_branch and the wait
-// COM: incremented from 0x1 to 0x2.
+// COM: Kernel 1 (single split): one DS2 -> two single-address loads followed
+// COM: by an s_wait_dscnt 0x0 drain; the downstream s_wait_dscnt 0x1 is left
+// COM: unchanged.
 // DISASM-LABEL: <test_ds_pipelined_single>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x2
+// DISASM: s_wait_dscnt 0x1
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_branch
 
-// COM: Kernel 2 (two splits, +2 bump): two DS2 sites share one wait, which
-// COM: is bumped twice from 0x1 to 0x3.
+// COM: Kernel 2 (two splits): each split lands its own s_wait_dscnt 0x0 drain;
+// COM: the shared downstream s_wait_dscnt 0x1 is left unchanged.
 // DISASM-LABEL: <test_ds_pipelined_multi>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
 // DISASM: s_branch
-// DISASM: s_wait_dscnt 0x3
+// DISASM: s_wait_dscnt 0x1
+// DISASM: ds_load_b32 v0
+// DISASM: ds_load_b32 v1
+// DISASM: s_wait_dscnt 0x0
+// DISASM: ds_load_b32 v2
+// DISASM: ds_load_b32 v3
+// DISASM: s_wait_dscnt 0x0
 
-// COM: Idempotency: a second rewrite must not bump 0x2 / 0x3 further.
+// COM: Idempotency: a second rewrite produces identical bytes (the 2-addr
+// COM: forms are gone, so there is nothing left to split).
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// ---- Kernel 1: single split, +1 bump (0x1 -> 0x2) ---------------------------
+// ---- Kernel 1: single split + drain; downstream 0x1 wait preserved ----------
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -71,7 +79,7 @@ test_ds_pipelined_single:
 .Ltest_ds_pipelined_single_end:
 .size test_ds_pipelined_single, .Ltest_ds_pipelined_single_end-test_ds_pipelined_single
 
-// ---- Kernel 2: two splits, +2 bump (0x1 -> 0x3) -----------------------------
+// ---- Kernel 2: two splits, each + drain; downstream 0x1 wait preserved ------
 
 .globl test_ds_pipelined_multi
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-ds.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds.s
@@ -1,17 +1,17 @@
 // COM: Test HotSwap trampoline patch: ds_*_2addr_stride64_* expansion into
-// COM: two single-address DS instructions. Each kernel here uses a drain
-// COM: s_wait_dscnt 0x0, which must stay at 0x0 after splitting (see the
-// COM: bumpNextWaitDscnt header for the rationale).
+// COM: two single-address DS instructions, each split followed by its own
+// COM: s_wait_dscnt 0x0 drain. A pre-existing drain after the 2-addr op is
+// COM: left in place (see the patchDs2Addr rationale).
 // COM:
 // COM: Covers b32 load, b64 load, b32 store, and b32 exchange operand
 // COM: variants via the NOP sled emission mechanism. Verifies explicit
 // COM: s_branch generation for the forward/back jumps.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-trampoline-ds-multi.s     -- drain preservation under stacking
-// COM:   hotswap-trampoline-ds-pipelined.s -- non-drain bump path (0x1 -> 0x2/0x3)
+// COM:   hotswap-trampoline-ds-multi.s     -- drain insertion under stacking
+// COM:   hotswap-trampoline-ds-pipelined.s -- non-drain wait preserved + drain
 // COM:   hotswap-trampoline-ds-nosled.s    -- true trampoline fallback (no NOP sled)
-// COM:   hotswap-trampoline-ds-nowait.s    -- control-flow guard (no s_wait_dscnt)
+// COM:   hotswap-trampoline-ds-nowait.s    -- split drain when no downstream wait
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 


### PR DESCRIPTION
The B0->A0 trampoline patch splits one ds_*_2addr_* instruction into two single-address DS ops. To account for the extra outstanding DS op it then bumped the next s_wait_dscnt immediate by +1 per split. That is the wrong direction: s_wait_dscnt K stalls until the outstanding-DS count is <= K, so a larger K waits for *fewer* ops to retire. When the split instruction is the last DS op before that wait, the downstream consumer reads the second half's LDS slot before it has landed, corrupting the result.

This was observed as NaN/incorrect output in MIOpen layernormbfp16 (and other LDS-reduction kernels) on a gfx1250 A0 board: the kernel verifies correctly without hotswap but fails once the rewrite is applied.

Fix: after emitting the two single-address ops, append a local s_wait_dscnt 0 drain so both halves are guaranteed complete before any downstream consumer, and drop bumpNextWaitDscnt entirely. The drain is unconditionally correct regardless of how splitting perturbs the outstanding-DS instruction count; a pre-existing downstream wait is left untouched. A precise per-wait dataflow recomputation (waiting only as much as needed) remains a future optimization.

Validated on a gfx1250 A0 GPU: MIOpen layernorm/groupnorm/t5layernorm (fp32/fp16/bf16) verify ok with hotswap enabled, and the full comgr hotswap lit suite passes.


