### PR TITLE
[Comgr][hotswap] Skip cluster_load with SGPR-relative (SADDR) addressing

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -24,9 +24,11 @@
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCFixup.h"
+#include "llvm/MC/MCRegisterInfo.h"
 
 using namespace llvm;
 
@@ -52,6 +54,27 @@ StringRef getClusterLoadReplacementAsm(StringRef Mnemonic) {
       .Case("cluster_load_async_to_lds_b128",
             "global_load_async_to_lds_b128 v0, v[0:1], off")
       .Default("");
+}
+
+/// Detect the SGPR-relative (_SADDR) form of a cluster_load.
+///
+/// The off-form cluster_load carries its global address in a 64-bit VGPR pair
+/// and encodes the saddr field as the "off" sentinel, so all of its register
+/// operands are VGPRs. The _SADDR variant shares the same display mnemonic but
+/// is a distinct MC opcode with an extra scalar saddr operand. The off-form
+/// replacement templates in getClusterLoadReplacementAsm would mis-encode that
+/// scalar operand, so the two forms must be told apart. getNamedOperandIdx() /
+/// OpName are backend-private headers, so -- mirroring the operand-kind
+/// inspection in comgr-hotswap-patch-wmma-split.cpp -- classify by operand
+/// kind: the presence of any SGPR register operand marks the _SADDR form.
+bool usesSgprBaseAddress(const MCInst &Inst, const MCRegisterInfo &MRI) {
+  for (unsigned I = 0, E = Inst.getNumOperands(); I < E; ++I) {
+    const MCOperand &Op = Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() &&
+        StringRef(MRI.getName(Op.getReg())).starts_with("SGPR"))
+      return true;
+  }
+  return false;
 }
 
 /// Resolve the MC opcode index for an assembly mnemonic by parsing a dummy
@@ -98,11 +121,26 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   StringRef ReplacementAsm = getClusterLoadReplacementAsm(Mnemonic);
   if (!ReplacementAsm.empty()) {
-    std::optional<unsigned> NewOpcode = resolveOpcode(ReplacementAsm, Ctx.LS);
-    if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
-      log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
-            << " at 0x" << utohexstr(DI.Offset) << "\n";
-      return 1;
+    // The replacement templates above are all the saddr=off encoding form
+    // (global address in a 64-bit VGPR pair). The SGPR-relative (_SADDR)
+    // cluster_load shares the mnemonic but has a different operand layout, so
+    // reusing the off-form opcode would re-encode its scalar saddr and 32-bit
+    // vaddr as a 64-bit vaddr plus an inline offset -- a corrupt address that
+    // faults the GPU at runtime. Leave the _SADDR form unchanged; cluster_load
+    // with an SGPR base runs natively on A0, so pass-through is correct. A
+    // dedicated _SADDR -> global_load_*_SADDR mapping can be added later if a
+    // B0 erratum ever requires downgrading the SGPR-relative form.
+    if (usesSgprBaseAddress(DI.Inst, *Ctx.LS.MRI)) {
+      log() << "hotswap: inplace: " << Mnemonic
+            << " (SGPR-relative saddr form) left unchanged at 0x"
+            << utohexstr(DI.Offset) << "\n";
+    } else {
+      std::optional<unsigned> NewOpcode = resolveOpcode(ReplacementAsm, Ctx.LS);
+      if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
+        log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
+              << " at 0x" << utohexstr(DI.Offset) << "\n";
+        return 1;
+      }
     }
   }
 

--- a/amd/comgr/test-lit/hotswap-inplace-saddr.s
+++ b/amd/comgr/test-lit/hotswap-inplace-saddr.s
@@ -1,0 +1,60 @@
+// COM: Test HotSwap in-place patch selectivity for cluster_load addressing
+// COM: forms. The B0->A0 replacement templates target the saddr=off (64-bit
+// COM: vaddr) encoding. The SGPR-relative (_SADDR) variant shares the display
+// COM: mnemonic but is a distinct MC opcode with a different operand layout,
+// COM: so reusing the off-form opcode would mis-encode its operands and corrupt
+// COM: the address at runtime. The patcher must skip the _SADDR form and only
+// COM: rewrite the off form.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The two loads appear in program order. The SGPR-relative (_SADDR) site
+// COM: comes first and must be preserved verbatim as a cluster_load with an
+// COM: s[...] base; if the patcher wrongly swapped it, this line would instead
+// COM: disassemble as a global_load and the match would fail.
+// DISASM: cluster_load_b32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
+// COM: Between the preserved _SADDR site and the rewritten off-form site, no
+// COM: off-form cluster_load may survive (the off form must have been swapped).
+// DISASM-NOT: cluster_load_b32 {{.*}}, off
+// COM: The saddr=off site that followed is rewritten to global_load_b32,
+// COM: proving the skip is specific to the _SADDR form, not a blanket opt-out.
+// DISASM: global_load_b32 v{{[0-9]+}}, v[{{[0-9:]+}}], off
+
+// COM: Idempotency: output should be identical on second rewrite.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_saddr_kernel
+.p2align 8
+.type test_saddr_kernel,@function
+test_saddr_kernel:
+  // SGPR-relative (SADDR) form -- must be left unchanged.
+  cluster_load_b32 v4, v1, s[2:3]
+  s_wait_loadcnt 0x0
+  // saddr=off form -- must be swapped to global_load_b32.
+  cluster_load_b32 v5, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_saddr_kernel_end:
+.size test_saddr_kernel, .Ltest_saddr_kernel_end-test_saddr_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_saddr_kernel
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel


### PR DESCRIPTION
The in-place B0->A0 patch matched cluster_load on its display mnemonic and rewrote every site using the saddr=off replacement template. The SGPR-relative (_SADDR) encoding shares the mnemonic but is a distinct MC opcode with a different operand layout (32-bit vaddr plus a scalar saddr vs a 64-bit vaddr). Reusing the off-form opcode re-encoded the operands under the wrong layout, turning e.g. `cluster_load_b32 v4, v1, s[2:3]` into `global_load_b32 v4, v[2:3], off offset:257` and faulting the GPU at runtime.

Detect the _SADDR variant via the MC instruction name and leave it unchanged; cluster_load with an SGPR base runs natively on A0, so pass-through is correct here. The saddr=off form is still rewritten.

Add hotswap-inplace-saddr.s covering selectivity (off-form swapped, _SADDR preserved) and idempotency.


