### PR TITLE
[Comgr] Do not check if `LLVM_LIT_PATH` is defined

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -11,15 +11,13 @@ canonicalize_cmake_boolean(COMGR_SPIRV_TRANSLATOR_AVAILABLE)
 
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 
-if (NOT DEFINED LLVM_LIT_PATH)
-  find_program(LLVM_LIT_PATH
-    NAMES llvm-lit llvm-lit.py llvm-lit.cmd
-    PATHS "${LLVM_TOOLS_BINARY_DIR}/../../bin" "${LLVM_TOOLS_BINARY_DIR}"
-    NO_DEFAULT_PATH
-  )
-  if (NOT LLVM_LIT_PATH)
-    set(LLVM_LIT_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-lit")
-  endif()
+find_program(LLVM_LIT_PATH
+  NAMES llvm-lit llvm-lit.py llvm-lit.cmd
+  PATHS "${LLVM_TOOLS_BINARY_DIR}/../../bin" "${LLVM_TOOLS_BINARY_DIR}"
+  NO_DEFAULT_PATH
+)
+if (NOT LLVM_LIT_PATH)
+  set(LLVM_LIT_PATH "${LLVM_TOOLS_BINARY_DIR}/llvm-lit")
 endif()
 message("-- LLVM_LIT_PATH: ${LLVM_LIT_PATH}")
 


### PR DESCRIPTION
From cmake `find_program` doc:

```
Prior to searching, find_program checks if variable <VAR> is defined. If
the variable is not defined, the search will be performed. If the
variable is defined and its value is NOTFOUND, or ends in -NOTFOUND, the
search will be performed. If the variable contains any other value the
search is not performed.
```

If `LLVM_LIT_PATH` was not found and this `NOTFOUND` was stored in the cache, we would not search for the program.


