### PR TITLE
[Comgr][hotswap] Make tool detection helpers LLVM-free

### DIFF
--- a/amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h
+++ b/amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h
@@ -7,12 +7,10 @@
 //===----------------------------------------------------------------------===//
 //
 // Hotswap detection helpers (no HSA dep), split out so they can be unit-tested.
+// HSA_TOOLS_LIB tool links symbol-hidden static comgr, no StringRef/Elf64_Ehdr
 
 #ifndef COMGR_HOTSWAP_TOOL_DETECT_H
 #define COMGR_HOTSWAP_TOOL_DETECT_H
-
-#include "llvm/ADT/StringRef.h"
-#include "llvm/BinaryFormat/ELF.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -23,12 +21,16 @@ namespace COMGR::hotswap {
 
 // Processor of an ISA name like amdgcn-amd-amdhsa--gfx1250[:feats] (the field
 // after arch-vendor-os-environ; same model as comgr's parseTargetIdentifier).
-inline std::string extractGfxTarget(llvm::StringRef IsaName) {
-  llvm::StringRef Rest = IsaName;
+inline std::string extractGfxTarget(const std::string &IsaName) {
+  std::string Rest = IsaName;
   for (int I = 0; I < 4; ++I) {
-    Rest = Rest.split('-').second;
+    const std::string::size_type Dash = Rest.find('-');
+    if (Dash == std::string::npos) {
+      return std::string();
+    }
+    Rest = Rest.substr(Dash + 1);
   }
-  return Rest.split(':').first.str();
+  return Rest.substr(0, Rest.find(':'));
 }
 
 // Arm only on gfx1250 at ASIC revision A0 (0). Callers must confirm the revision
@@ -37,18 +39,41 @@ inline bool gateAllowsHotswap(const std::string &Gfx, uint32_t Revision) {
   return Gfx == "gfx1250" && Revision == 0;
 }
 
-// True for a 64-bit gfx1250 AMDGPU ELF (aligned-copy header read, e_machine checked).
+// True for a 64-bit gfx1250 AMDGPU ELF (aligned-copy header read, e_machine
+// checked). Raw ELF64 fields, no LLVM dependency (see file header).
 inline bool isGfx1250CodeObject(const void *Data, size_t Size) {
-  if (!Data || Size < sizeof(llvm::ELF::Elf64_Ehdr)) {
+  struct Elf64Header {
+    unsigned char e_ident[16];
+    uint16_t e_type;
+    uint16_t e_machine;
+    uint32_t e_version;
+    uint64_t e_entry;
+    uint64_t e_phoff;
+    uint64_t e_shoff;
+    uint32_t e_flags;
+    uint16_t e_ehsize;
+    uint16_t e_phentsize;
+    uint16_t e_phnum;
+    uint16_t e_shentsize;
+    uint16_t e_shnum;
+    uint16_t e_shstrndx;
+  };
+  static const unsigned char ElfMagic[4] = {0x7f, 'E', 'L', 'F'};
+  constexpr int EiClass = 4;
+  constexpr unsigned char ElfClass64 = 2;
+  constexpr uint16_t EmAmdgpu = 224;
+  constexpr uint32_t EfAmdgpuMach = 0x0ff;
+  constexpr uint32_t EfAmdgpuMachGfx1250 = 0x49;
+
+  if (!Data || Size < sizeof(Elf64Header)) {
     return false;
   }
-  llvm::ELF::Elf64_Ehdr Header;
+  Elf64Header Header;
   std::memcpy(&Header, Data, sizeof(Header));
-  return Header.checkMagic() &&
-         Header.getFileClass() == llvm::ELF::ELFCLASS64 &&
-         Header.e_machine == llvm::ELF::EM_AMDGPU &&
-         (Header.e_flags & llvm::ELF::EF_AMDGPU_MACH) ==
-             llvm::ELF::EF_AMDGPU_MACH_AMDGCN_GFX1250;
+  return std::memcmp(Header.e_ident, ElfMagic, sizeof(ElfMagic)) == 0 &&
+         Header.e_ident[EiClass] == ElfClass64 &&
+         Header.e_machine == EmAmdgpu &&
+         (Header.e_flags & EfAmdgpuMach) == EfAmdgpuMachGfx1250;
 }
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h
+++ b/amd/comgr/src/hotswap/comgr-hotswap-tool-detect.h
@@ -42,6 +42,8 @@ inline bool gateAllowsHotswap(const std::string &Gfx, uint32_t Revision) {
 // True for a 64-bit gfx1250 AMDGPU ELF (aligned-copy header read, e_machine
 // checked). Raw ELF64 fields, no LLVM dependency (see file header).
 inline bool isGfx1250CodeObject(const void *Data, size_t Size) {
+  // Field names follow the ELF spec (cf. llvm::ELF::Elf64_Ehdr).
+  // NOLINTBEGIN(readability-identifier-naming)
   struct Elf64Header {
     unsigned char e_ident[16];
     uint16_t e_type;
@@ -58,6 +60,9 @@ inline bool isGfx1250CodeObject(const void *Data, size_t Size) {
     uint16_t e_shnum;
     uint16_t e_shstrndx;
   };
+  // NOLINTEND(readability-identifier-naming)
+  static_assert(sizeof(Elf64Header) == 64,
+                "Elf64Header must match the 64-byte ELF64 file header layout");
   static const unsigned char ElfMagic[4] = {0x7f, 'E', 'L', 'F'};
   constexpr int EiClass = 4;
   constexpr unsigned char ElfClass64 = 2;


### PR DESCRIPTION
The HSA_TOOLS_LIB tool links only libamd_comgr, which statically embeds LLVM with all LLVM symbols hidden (COMGR_STATIC_LLVM + version script). comgr-hotswap-tool-detect.h used llvm::StringRef and llvm::ELF, so the tool had undefined LLVM symbols (StringRef::find, DisableABIBreakingChecks) that resolved only while comgr still pulled a separate libLLVM.so. Once comgr is a single isolated static LLVM, the tool fails to dlopen ("Tool lib ... failed to load") and no rewrite runs.

Drop the LLVM dependency: extractGfxTarget parses with std::string (find/substr) instead of StringRef::split, and isGfx1250CodeObject reads a minimal local ELF64 header with raw constants instead of llvm::ELF::Elf64_Ehdr. Behavior unchanged; HotswapToolTest still passes.


