### PR TITLE
[CI] Repurposing upstream auto-labeler job for ROCm labels

### DIFF
--- a/.github/rocm-prs-labeler.yml
+++ b/.github/rocm-prs-labeler.yml
@@ -1,0 +1,25 @@
+comgr:
+  - changed-files:
+    - any-glob-to-any-file:
+      - amd/comgr/**
+
+device-libs:
+  - changed-files:
+    - any-glob-to-any-file:
+      - amd/device-libs/**
+
+hipcc:
+  - changed-files:
+    - any-glob-to-any-file:
+      - amd/hipcc/**
+
+flang:
+  - changed-files:
+    - any-glob-to-any-file:
+      - flang/**
+      - flang-rt/**
+
+openmp:
+  - changed-files:
+    - any-glob-to-any-file:
+      - openmp/**

--- a/.github/rocm-prs-labeler.yml
+++ b/.github/rocm-prs-labeler.yml
@@ -3,6 +3,13 @@ comgr:
     - any-glob-to-any-file:
       - amd/comgr/**
 
+hotswap:
+  - changed-files:
+    - any-glob-to-any-file:
+      - amd/comgr/src/hotswap/**
+      - amd/comgr/test-lit/hotswap/**
+      - amd/comgr/src/comgr-hotswap*
+
 device-libs:
   - changed-files:
     - any-glob-to-any-file:

--- a/.github/workflows/rocm-new-prs.yml
+++ b/.github/workflows/rocm-new-prs.yml
@@ -1,0 +1,35 @@
+name: "Labelling new pull requests"
+
+permissions:
+  contents: read
+
+on:
+  # It's safe to use pull_request_target here, because we aren't checking out
+  # code from the pull request branch.
+  # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+  automate-prs-labels:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-24.04
+    # Ignore PRs with more than 10 commits.  Pull requests with a lot of
+    # commits tend to be accidents usually when someone made a mistake while trying
+    # to rebase.  We want to ignore these pull requests to avoid excessive
+    # notifications.
+    if: >
+      github.repository == 'ROCm/llvm-project' &&
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.commits < 10
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          configuration-path: .github/rocm-prs-labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Removes the greeter from the original upstream job and modifies the labels in new-prs-labeler.yml to the ones used in this fork.