### PR TITLE
[ASan][AMDGPU] Fix ROCr agent_memory_lock_ self-deadlock under quarantine

### DIFF
--- a/compiler-rt/lib/asan/asan_allocator.cpp
+++ b/compiler-rt/lib/asan/asan_allocator.cpp
@@ -331,9 +331,18 @@ QuarantineCache* GetQuarantineCache(AsanThreadLocalMallocStorage* ms) {
   return reinterpret_cast<QuarantineCache*>(ms->quarantine_cache);
 }
 
+QuarantineCache* GetQuarantineCacheDevice(AsanThreadLocalMallocStorage* ms) {
+  CHECK(ms);
+  CHECK_LE(sizeof(QuarantineCache), sizeof(ms->quarantine_cache_device));
+  return reinterpret_cast<QuarantineCache*>(ms->quarantine_cache_device);
+}
+
 void AllocatorOptions::SetFrom(const Flags* f, const CommonFlags* cf) {
   quarantine_size_mb = f->quarantine_size_mb;
   thread_local_quarantine_size_kb = f->thread_local_quarantine_size_kb;
+  device_quarantine_size_mb = f->device_quarantine_size_mb;
+  device_thread_local_quarantine_size_kb =
+      f->device_thread_local_quarantine_size_kb;
   min_redzone = f->redzone;
   max_redzone = f->max_redzone;
   may_return_null = cf->allocator_may_return_null;
@@ -344,6 +353,9 @@ void AllocatorOptions::SetFrom(const Flags* f, const CommonFlags* cf) {
 void AllocatorOptions::CopyTo(Flags* f, CommonFlags* cf) {
   f->quarantine_size_mb = quarantine_size_mb;
   f->thread_local_quarantine_size_kb = thread_local_quarantine_size_kb;
+  f->device_quarantine_size_mb = device_quarantine_size_mb;
+  f->device_thread_local_quarantine_size_kb =
+      device_thread_local_quarantine_size_kb;
   f->redzone = min_redzone;
   f->max_redzone = max_redzone;
   cf->allocator_may_return_null = may_return_null;
@@ -357,9 +369,12 @@ struct Allocator {
 
   AsanAllocator allocator;
   AsanQuarantine quarantine;
+  // Dedicated quarantine for device (HSA) allocations; see QuarantineChunk.
+  AsanQuarantine quarantine_device;
   StaticSpinMutex fallback_mutex;
   AllocatorCache fallback_allocator_cache;
   QuarantineCache fallback_quarantine_cache;
+  QuarantineCache fallback_quarantine_cache_device;
 
   uptr max_user_defined_malloc_size;
 
@@ -371,7 +386,9 @@ struct Allocator {
   // ------------------- Initialization ------------------------
   explicit Allocator(LinkerInitialized)
       : quarantine(LINKER_INITIALIZED),
-        fallback_quarantine_cache(LINKER_INITIALIZED) {}
+        quarantine_device(LINKER_INITIALIZED),
+        fallback_quarantine_cache(LINKER_INITIALIZED),
+        fallback_quarantine_cache_device(LINKER_INITIALIZED) {}
 
   void CheckOptions(const AllocatorOptions& options) const {
     CHECK_GE(options.min_redzone, 16);
@@ -385,6 +402,9 @@ struct Allocator {
     CheckOptions(options);
     quarantine.Init((uptr)options.quarantine_size_mb << 20,
                     (uptr)options.thread_local_quarantine_size_kb << 10);
+    quarantine_device.Init(
+        (uptr)options.device_quarantine_size_mb << 20,
+        (uptr)options.device_thread_local_quarantine_size_kb << 10);
     atomic_store(&alloc_dealloc_mismatch, options.alloc_dealloc_mismatch,
                  memory_order_release);
     atomic_store(&min_redzone, options.min_redzone, memory_order_release);
@@ -716,28 +736,37 @@ struct Allocator {
 
   // Expects the chunk to already be marked as quarantined by using
   // AtomicallySetQuarantineFlagIfAllocated.
-  void QuarantineChunk(AsanChunk* m, void* ptr, BufferedStackTrace* stack) {
+  void QuarantineChunk(AsanChunk* m, void* ptr, BufferedStackTrace* stack,
+                       bool is_device) {
     CHECK_EQ(atomic_load(&m->chunk_state, memory_order_relaxed),
              CHUNK_QUARANTINE);
     AsanThread* t = GetCurrentThread();
     m->SetFreeContext(t ? t->tid() : 0, StackDepotPut(*stack));
 
+    // Route host and device frees to separate quarantines so that a host free
+    // can never evict a device chunk (whose recycle issues a real hsa free
+    // under ROCr's agent_memory_lock_) and vice versa.
+    AsanQuarantine& q = is_device ? quarantine_device : quarantine;
+
     // Push into quarantine.
     if (t) {
       AsanThreadLocalMallocStorage* ms = &t->malloc_storage();
       AllocatorCache* ac = GetAllocatorCache(ms);
-      quarantine.Put(GetQuarantineCache(ms), QuarantineCallback(ac, stack), m,
-                     m->UsedSize());
+      QuarantineCache* qc =
+          is_device ? GetQuarantineCacheDevice(ms) : GetQuarantineCache(ms);
+      q.Put(qc, QuarantineCallback(ac, stack), m, m->UsedSize());
     } else {
       SpinMutexLock l(&fallback_mutex);
       AllocatorCache* ac = &fallback_allocator_cache;
-      quarantine.Put(&fallback_quarantine_cache, QuarantineCallback(ac, stack),
-                     m, m->UsedSize());
+      QuarantineCache* qc = is_device ? &fallback_quarantine_cache_device
+                                      : &fallback_quarantine_cache;
+      q.Put(qc, QuarantineCallback(ac, stack), m, m->UsedSize());
     }
   }
 
   void Deallocate(void* ptr, uptr delete_size, uptr delete_alignment,
-                  BufferedStackTrace* stack, AllocType alloc_type) {
+                  BufferedStackTrace* stack, AllocType alloc_type,
+                  bool is_device = false) {
     uptr p = reinterpret_cast<uptr>(ptr);
     if (p == 0)
       return;
@@ -802,7 +831,7 @@ struct Allocator {
     thread_stats.frees++;
     thread_stats.freed += m->UsedSize();
 
-    QuarantineChunk(m, ptr, stack);
+    QuarantineChunk(m, ptr, stack, is_device);
   }
 
   void* Reallocate(void* old_ptr, uptr new_size, BufferedStackTrace* stack) {
@@ -857,6 +886,8 @@ struct Allocator {
   void CommitBack(AsanThreadLocalMallocStorage* ms, BufferedStackTrace* stack) {
     AllocatorCache* ac = GetAllocatorCache(ms);
     quarantine.Drain(GetQuarantineCache(ms), QuarantineCallback(ac, stack));
+    quarantine_device.Drain(GetQuarantineCacheDevice(ms),
+                            QuarantineCallback(ac, stack));
     allocator.SwallowCache(ac);
   }
 
@@ -954,11 +985,17 @@ struct Allocator {
       quarantine.DrainAndRecycle(
           GetQuarantineCache(ms),
           QuarantineCallback(GetAllocatorCache(ms), stack));
+      quarantine_device.DrainAndRecycle(
+          GetQuarantineCacheDevice(ms),
+          QuarantineCallback(GetAllocatorCache(ms), stack));
     }
     {
       SpinMutexLock l(&fallback_mutex);
       quarantine.DrainAndRecycle(
           &fallback_quarantine_cache,
+          QuarantineCallback(&fallback_allocator_cache, stack));
+      quarantine_device.DrainAndRecycle(
+          &fallback_quarantine_cache_device,
           QuarantineCallback(&fallback_allocator_cache, stack));
     }
 
@@ -1490,6 +1527,7 @@ DECLARE_REAL(hsa_status_t, hsa_amd_memory_pool_allocate,
   hsa_amd_memory_pool_t memory_pool, size_t size, uint32_t flags,
   void **ptr)
 DECLARE_REAL(hsa_status_t, hsa_amd_memory_pool_free, void *ptr)
+DECLARE_REAL(hsa_status_t, hsa_memory_free, void* ptr)
 DECLARE_REAL(hsa_status_t, hsa_amd_ipc_memory_create, void *ptr, size_t len,
   hsa_amd_ipc_memory_t *handle)
 DECLARE_REAL(hsa_status_t, hsa_amd_ipc_memory_attach,
@@ -1529,7 +1567,7 @@ hsa_status_t asan_hsa_amd_memory_pool_free(
   BufferedStackTrace *stack) {
   void *p = get_allocator().GetBlockBegin(ptr);
   if (p) {
-    instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC);
+    instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC, /*is_device=*/true);
     return HSA_STATUS_SUCCESS;
   }
   return REAL(hsa_amd_memory_pool_free)(ptr);
@@ -1671,7 +1709,7 @@ hsa_status_t asan_hsa_amd_vmem_address_free(void* ptr, size_t size,
 
   void* p = get_allocator().GetBlockBegin(ptr);
   if (p) {
-    instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC);
+    instance.Deallocate(ptr, 0, 0, stack, FROM_MALLOC, /*is_device=*/true);
     return HSA_STATUS_SUCCESS;
   }
   return REAL(hsa_amd_vmem_address_free)(ptr, size);

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -34,6 +34,8 @@ class AsanChunk;
 struct AllocatorOptions {
   u32 quarantine_size_mb;
   u32 thread_local_quarantine_size_kb;
+  u32 device_quarantine_size_mb;
+  u32 device_thread_local_quarantine_size_kb;
   u16 min_redzone;
   u16 max_redzone;
   u8 may_return_null;
@@ -275,6 +277,10 @@ using AllocatorCache = AsanAllocator::AllocatorCache;
 
 struct AsanThreadLocalMallocStorage {
   uptr quarantine_cache[16];
+  // Separate thread-local quarantine cache for device (HSA) allocations so
+  // that a host free can never evict a device chunk (and vice versa). See
+  // the agent_memory_lock_ re-entrancy notes in asan_allocator.cpp.
+  uptr quarantine_cache_device[16];
   AllocatorCache allocator_cache;
   void CommitBack();
 
@@ -343,6 +349,7 @@ hsa_status_t asan_hsa_amd_memory_pool_allocate(
 hsa_status_t asan_hsa_amd_memory_pool_free(
   void *ptr,
   BufferedStackTrace *stack);
+hsa_status_t asan_hsa_memory_free(void* ptr, BufferedStackTrace* stack);
 hsa_status_t asan_hsa_amd_agents_allow_access(
   uint32_t num_agents, const hsa_agent_t *agents, const uint32_t *flags,
   const void *ptr,

--- a/compiler-rt/lib/asan/asan_flags.cpp
+++ b/compiler-rt/lib/asan/asan_flags.cpp
@@ -204,6 +204,21 @@ static void ProcessFlags() {
            "quarantine_size_mb is set to 0\n", SanitizerToolName);
     Die();
   }
+  // Device quarantine sizes default to the host quarantine sizes so that
+  // device allocations keep the same use-after-free detection window.
+  if (f->device_quarantine_size_mb < 0)
+    f->device_quarantine_size_mb = f->quarantine_size_mb;
+  if (f->device_thread_local_quarantine_size_kb < 0)
+    f->device_thread_local_quarantine_size_kb =
+        f->thread_local_quarantine_size_kb;
+  if (f->device_thread_local_quarantine_size_kb == 0 &&
+      f->device_quarantine_size_mb > 0) {
+    Report(
+        "%s: device_thread_local_quarantine_size_kb can be set to 0 only "
+        "when device_quarantine_size_mb is set to 0\n",
+        SanitizerToolName);
+    Die();
+  }
   if (!f->replace_str && common_flags()->intercept_strlen) {
     Report("WARNING: strlen interceptor is enabled even though replace_str=0. "
            "Use intercept_strlen=0 to disable it.");

--- a/compiler-rt/lib/asan/asan_flags.inc
+++ b/compiler-rt/lib/asan/asan_flags.inc
@@ -28,6 +28,15 @@ ASAN_FLAG(int, thread_local_quarantine_size_kb, -1,
           "increase the chance of false negatives. It is not advised to go "
           "lower than 64Kb, otherwise frequent transfers to global quarantine "
           "might affect performance.")
+ASAN_FLAG(int, device_quarantine_size_mb, -1,
+          "Size (in Mb) of the separate quarantine used for device (HSA) "
+          "allocations. Defaults to quarantine_size_mb when negative. A "
+          "dedicated device quarantine prevents host frees from evicting "
+          "device chunks, avoiding a real hsa free under ROCr locks.")
+ASAN_FLAG(int, device_thread_local_quarantine_size_kb, -1,
+          "Size (in Kb) of the thread local quarantine for device (HSA) "
+          "allocations. Defaults to thread_local_quarantine_size_kb when "
+          "negative.")
 ASAN_FLAG(int, redzone, 16,
           "Minimal size (in bytes) of redzones around heap objects. "
           "Requirement: redzone >= 16, is a power of two.")

--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -915,6 +915,13 @@ INTERCEPTOR(hsa_status_t, hsa_amd_memory_pool_free, void *ptr) {
   return asan_hsa_amd_memory_pool_free(ptr, &stack);
 }
 
+INTERCEPTOR(hsa_status_t, hsa_memory_free, void* ptr) {
+  AsanInitFromRtl();
+  ENSURE_HSA_INITED();
+  GET_STACK_TRACE_FREE;
+  return asan_hsa_amd_memory_pool_free(ptr, &stack);
+}
+
 INTERCEPTOR(hsa_status_t, hsa_amd_agents_allow_access, uint32_t num_agents,
   const hsa_agent_t *agents, const uint32_t *flags, const void *ptr) {
   AsanInitFromRtl();
@@ -1035,6 +1042,7 @@ void InitializeAmdgpuInterceptors() {
   ASAN_INTERCEPT_FUNC(hsa_memory_copy);
   ASAN_INTERCEPT_FUNC(hsa_amd_memory_pool_allocate);
   ASAN_INTERCEPT_FUNC(hsa_amd_memory_pool_free);
+  ASAN_INTERCEPT_FUNC(hsa_memory_free);
   ASAN_INTERCEPT_FUNC(hsa_amd_agents_allow_access);
   ASAN_INTERCEPT_FUNC(hsa_amd_memory_async_copy);
 #if HSA_AMD_INTERFACE_VERSION_MINOR>=1

--- a/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_allocator_amdgpu.cpp
@@ -43,6 +43,68 @@ static const size_t kPageSize_ = 4096;
 static atomic_uint8_t amdgpu_runtime_shutdown{0};
 static atomic_uint8_t amdgpu_event_registered{0};
 
+// ---------------------------------------------------------------------------
+// Re-entrancy guard against ROCr agent_memory_lock_ self-deadlock.
+//
+// ROCr's MemoryRegion::Allocate()/Free() both take the same non-recursive
+// agent_memory_lock_. With ASan's quarantine, a libc free() performed by ROCr
+// *while it holds that lock* (e.g. bind_mem_to_numa() inside an allocation)
+// can be intercepted, trigger a quarantine eviction, and recycle an older
+// device chunk -- issuing a REAL hsa_amd_memory_pool_free() that re-enters
+// MemoryRegion::Free() on the same thread and dead-locks on the same mutex.
+//
+// To break the cycle we never issue a REAL device free while this thread is
+// already executing inside a REAL device allocate/free. Instead the pointer is
+// parked on a thread-local list and flushed once the outermost real-HSA call
+// has fully unwound (and ROCr has released agent_memory_lock_).
+// ---------------------------------------------------------------------------
+
+// Nesting depth of REAL hsa allocate/free calls on the current thread.
+__attribute__((
+    tls_model("initial-exec"))) static THREADLOCAL uptr real_hsa_depth = 0;
+
+// Thread-local stack of device pointers whose REAL free was deferred because
+// it was requested from within a REAL hsa call. Bounded, intrusive storage to
+// avoid any allocation on this path.
+static const uptr kMaxDeferredFrees = 64;
+__attribute__((tls_model("initial-exec"))) static THREADLOCAL void*
+    deferred_free_ptrs[kMaxDeferredFrees];
+__attribute__((
+    tls_model("initial-exec"))) static THREADLOCAL uptr deferred_free_count = 0;
+
+namespace {
+// RAII marker for "this thread is inside a REAL hsa allocate/free".
+struct RealHsaScope {
+  RealHsaScope() { ++real_hsa_depth; }
+  ~RealHsaScope() { --real_hsa_depth; }
+};
+}  // namespace
+
+// Issue the REAL device free for a single pointer. Must only be called when it
+// is safe to take ROCr's agent_memory_lock_ (i.e. not nested inside a REAL hsa
+// call on this thread).
+static void RealDeviceFree(void* p) {
+  DevicePointerInfo DevPtrInfo;
+  if (AmdgpuMemFuncs::GetPointerInfo(reinterpret_cast<uptr>(p), &DevPtrInfo)) {
+    if (DevPtrInfo.type == HSA_EXT_POINTER_TYPE_HSA) {
+      UNUSED hsa_status_t status = hsa_amd.memory_pool_free(p);
+    } else if (DevPtrInfo.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR) {
+      UNUSED hsa_status_t status =
+          hsa_amd.vmem_address_free(p, DevPtrInfo.map_size);
+    }
+  }
+}
+
+// Drain any device frees that were deferred while nested inside a REAL hsa
+// call. Called once the outermost real-HSA scope has unwound.
+static void FlushDeferredDeviceFrees() {
+  // Snapshot-and-clear style: each RealDeviceFree() runs outside the guard.
+  while (deferred_free_count > 0) {
+    void* p = deferred_free_ptrs[--deferred_free_count];
+    RealDeviceFree(p);
+  }
+}
+
 #  define LOAD_HSA_FUNC_WITH_ERROR_CHECK(func, name, success)         \
     func = (decltype(func))dlsym(RTLD_NEXT, name);                    \
     if (!func) {                                                      \
@@ -109,14 +171,25 @@ void *AmdgpuMemFuncs::Allocate(uptr size, uptr alignment,
 
   AmdgpuAllocationInfo *aa_info =
       reinterpret_cast<AmdgpuAllocationInfo *>(da_info);
-  if (!aa_info->memory_pool.handle) {
-    aa_info->status = hsa_amd.vmem_address_reserve_align(
-        &aa_info->ptr, size, aa_info->address, aa_info->alignment,
-        aa_info->flags64);
-  } else {
-    aa_info->status = hsa_amd.memory_pool_allocate(
-        aa_info->memory_pool, size, aa_info->flags, &aa_info->ptr);
+  {
+    // Mark this thread as being inside a REAL hsa call. ROCr takes
+    // agent_memory_lock_ for the duration; any quarantine-driven device free
+    // that fires underneath must be deferred, not issued, to avoid re-locking
+    // the same non-recursive mutex on this thread.
+    RealHsaScope real_hsa_scope;
+    if (!aa_info->memory_pool.handle) {
+      aa_info->status = hsa_amd.vmem_address_reserve_align(
+          &aa_info->ptr, size, aa_info->address, aa_info->alignment,
+          aa_info->flags64);
+    } else {
+      aa_info->status = hsa_amd.memory_pool_allocate(
+          aa_info->memory_pool, size, aa_info->flags, &aa_info->ptr);
+    }
   }
+  // Outermost real-HSA scope has unwound here; ROCr has released its lock so
+  // it is now safe to issue any device frees that were deferred underneath.
+  if (real_hsa_depth == 0 && deferred_free_count > 0)
+    FlushDeferredDeviceFrees();
   if (aa_info->status != HSA_STATUS_SUCCESS)
     return nullptr;
 
@@ -133,15 +206,21 @@ void AmdgpuMemFuncs::Deallocate(void *p) {
     return;
   }
 
-  DevicePointerInfo DevPtrInfo;
-  if (AmdgpuMemFuncs::GetPointerInfo(reinterpret_cast<uptr>(p), &DevPtrInfo)) {
-    if (DevPtrInfo.type == HSA_EXT_POINTER_TYPE_HSA) {
-      UNUSED hsa_status_t status = hsa_amd.memory_pool_free(p);
-    } else if (DevPtrInfo.type == HSA_EXT_POINTER_TYPE_RESERVED_ADDR) {
-      UNUSED hsa_status_t status =
-          hsa_amd.vmem_address_free(p, DevPtrInfo.map_size);
+  // If we are nested inside a REAL hsa allocate/free on this thread, ROCr is
+  // currently holding agent_memory_lock_. Issuing the REAL free now would
+  // re-enter MemoryRegion::Free() and dead-lock on that same non-recursive
+  // mutex. Defer the free until the outermost real-HSA call unwinds.
+  if (real_hsa_depth > 0) {
+    if (LIKELY(deferred_free_count < kMaxDeferredFrees)) {
+      deferred_free_ptrs[deferred_free_count++] = p;
+      return;
     }
+    // Deferral list is full (pathologically deep nesting). Fall through and
+    // free directly; this is exceedingly unlikely and preserves correctness
+    // over the (already remote) risk of re-entrancy at this depth.
   }
+
+  RealDeviceFree(p);
 }
 
 bool AmdgpuMemFuncs::GetPointerInfo(uptr ptr, DevicePointerInfo* ptr_info) {


### PR DESCRIPTION
With ASan, ROCr's MemoryRegion::Allocate() and Free() take the same non-recursive agent_memory_lock_. While that lock is held during an allocation, ROCr may perform a libc free() (e.g. the libnuma bitmask in bind_mem_to_numa()). ASan intercepts that free; if the quarantine is full it recycles an older device chunk and issues a REAL hsa_amd_memory_pool_free() on the same thread, which re-enters MemoryRegion::Free() and dead-locks on the same mutex. The hang is timing-dependent (e.g. reproducible with quarantine_size_mb=600).


