### PR TITLE
[Comgr] Use one clang path for resource-dir lookup

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1058,7 +1058,7 @@ AMDGPUCompiler::executeInProcessDriver(ArrayRef<const char *> Args) {
 
   ProcessWarningOptions(Diags, *DiagOpts, *OverlayFS, /*ReportDiags=*/false);
 
-  Driver TheDriver((Twine(env::getLLVMPath()) + "/bin/clang").str(),
+  Driver TheDriver(env::getClangBinaryPath(),
                    llvm::sys::getDefaultTargetTriple(), Diags,
                    "AMDGPU Code Object Manager", OverlayFS);
   TheDriver.setCheckInputsExist(false);
@@ -1598,10 +1598,7 @@ amd_comgr_status_t AMDGPUCompiler::outputResource(llvm::StringRef Path,
 }
 
 amd_comgr_status_t AMDGPUCompiler::addDeviceLibraries() {
-  SmallString<256> ClangBinaryPath(env::getLLVMPath());
-  sys::path::append(ClangBinaryPath, "bin", "clang");
-
-  std::string ClangResourceDir = GetResourcesPath(ClangBinaryPath);
+  std::string ClangResourceDir = GetResourcesPath(env::getClangBinaryPath());
 
   NoGpuLib = false;
 
@@ -2772,9 +2769,7 @@ AMDGPUCompiler::AMDGPUCompiler(DataAction *ActionInfo, DataSet *InSet,
       OverlayFS->pushOverlay(InMemoryFS);
     }
 
-    SmallString<256> ClangBinaryPath(env::getLLVMPath());
-    sys::path::append(ClangBinaryPath, "bin", "clang");
-    std::string ResourceDir = GetResourcesPath(ClangBinaryPath);
+    std::string ResourceDir = GetResourcesPath(env::getClangBinaryPath());
 
     // libc++ headers → <install>/include/c++/v1/<relative-path>
     SmallString<256> LibcxxBase(env::getLLVMPath());

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -170,6 +170,13 @@ static const ClangInstallPaths &getClangInstallPaths() {
       if (probeClangResourceDir(RocmLayout.ClangBinaryPath))
         return RocmLayout;
 
+      SmallString<256> RuntimeWheelPrefix(SoDir);
+      sys::path::append(RuntimeWheelPrefix, "llvm");
+      ClangInstallPaths RuntimeWheelLayout =
+          makeClangInstallPaths(RuntimeWheelPrefix);
+      if (probeClangResourceDir(RuntimeWheelLayout.ClangBinaryPath))
+        return RuntimeWheelLayout;
+
       SmallString<256> StandardPrefix(sys::path::parent_path(SoDir));
       ClangInstallPaths StandardLayout = makeClangInstallPaths(StandardPrefix);
       if (probeClangResourceDir(StandardLayout.ClangBinaryPath))

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -14,10 +14,15 @@
 
 #include "comgr-env.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/VirtualFileSystem.h"
 
 #include <cstdlib>
+
+#ifndef _WIN32
+#include <dlfcn.h>
+#endif
 
 using namespace llvm;
 
@@ -119,9 +124,70 @@ LogLevel resolveLogLevel() {
   return parseLogLevel(Requested, shouldEmitVerboseLogs());
 }
 
-llvm::StringRef getLLVMPath() {
-  static const char *EnvLLVMPath = COMGR_GETENV("LLVM_PATH");
-  return EnvLLVMPath ? EnvLLVMPath : "";
+// Probe whether path P names a clang binary whose derived resource directory
+// exists on disk. The binary itself need not exist; clang's Driver only uses
+// the path to derive the resource dir.
+static bool probeClangResourceDir(StringRef P) {
+  SmallString<256> ResourceDir(
+      sys::path::parent_path(sys::path::parent_path(P)));
+  sys::path::append(ResourceDir, "lib", "clang");
+  return sys::fs::is_directory(ResourceDir);
+}
+
+struct ClangInstallPaths {
+  std::string LLVMPrefix;
+  std::string ClangBinaryPath;
+};
+
+static ClangInstallPaths makeClangInstallPaths(StringRef LLVMPrefix) {
+  SmallString<256> ClangBinaryPath(LLVMPrefix);
+  sys::path::append(ClangBinaryPath, "bin", "clang");
+  return {std::string(LLVMPrefix), std::string(ClangBinaryPath)};
+}
+
+// Keep the LLVM install prefix and clang binary path in one cached decision.
+// The driver resource directory and VFS header locations are derived from
+// these paths; computing them separately can make clang look in a different
+// tree from where Comgr plants embedded headers.
+static const ClangInstallPaths &getClangInstallPaths() {
+  static const ClangInstallPaths Cached = []() -> ClangInstallPaths {
+    const char *EnvLLVMPath = COMGR_GETENV("LLVM_PATH");
+    if (EnvLLVMPath && StringRef(EnvLLVMPath) != "")
+      return makeClangInstallPaths(EnvLLVMPath);
+
+#ifndef _WIN32
+    Dl_info Info;
+    if (dladdr(reinterpret_cast<void *>(&getClangInstallPaths), &Info) &&
+        Info.dli_fname) {
+      StringRef SoDir = sys::path::parent_path(Info.dli_fname);
+
+      // Anchor package-layout probing at the loaded Comgr library. The clang
+      // path may be synthetic; the in-process driver only needs it to derive
+      // the resource directory, so probe the resource tree instead.
+      SmallString<256> RocmPrefix(sys::path::parent_path(SoDir));
+      sys::path::append(RocmPrefix, "llvm");
+      ClangInstallPaths RocmLayout = makeClangInstallPaths(RocmPrefix);
+      if (probeClangResourceDir(RocmLayout.ClangBinaryPath))
+        return RocmLayout;
+
+      SmallString<256> StandardPrefix(sys::path::parent_path(SoDir));
+      ClangInstallPaths StandardLayout = makeClangInstallPaths(StandardPrefix);
+      if (probeClangResourceDir(StandardLayout.ClangBinaryPath))
+        return StandardLayout;
+    }
+#endif
+
+    // Keep fallback paths relative; this avoids assuming a host install layout
+    // while still giving clang and Comgr matching VFS keys.
+    return makeClangInstallPaths("");
+  }();
+  return Cached;
+}
+
+llvm::StringRef getLLVMPath() { return getClangInstallPaths().LLVMPrefix; }
+
+llvm::StringRef getClangBinaryPath() {
+  return getClangInstallPaths().ClangBinaryPath;
 }
 
 StringRef getCachePolicy() {

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -60,6 +60,10 @@ llvm::StringRef getTimeStatisticsGranularity();
 /// otherwise return the default LLVM path.
 llvm::StringRef getLLVMPath();
 
+/// Return the clang binary path used by Comgr's in-process driver and
+/// resource-dir VFS construction.
+llvm::StringRef getClangBinaryPath();
+
 /// If environment variable AMD_COMGR_CACHE_POLICY is set, return the
 /// environment variable, otherwise return empty
 llvm::StringRef getCachePolicy();

--- a/amd/comgr/test-lit/clang-resource-dir.hip
+++ b/amd/comgr/test-lit/clang-resource-dir.hip
@@ -1,0 +1,17 @@
+// REQUIRES: system-linux
+
+// RUN: env -u LLVM_PATH AMD_COMGR_USE_VFS=1 \
+// RUN:   AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_REDIRECT_LOGS=stdout \
+// RUN:   compile-hip-minimal %s %t.bin | %FileCheck %s
+
+// CHECK: Embedded {{[0-9]+}} libc++ headers at: include/c++/v1
+// CHECK: Embedded {{[0-9]+}} clang builtins at: [[RESOURCE:[^" ]*lib/clang/[^" ]+]]/include
+// CHECK: clang "-cc1"
+// CHECK-SAME: "-resource-dir" "[[RESOURCE]]"
+// CHECK: ReturnStatus: AMD_COMGR_STATUS_SUCCESS
+
+#include <stddef.h>
+
+__attribute__((global)) void use_size_t(size_t *out) {
+  *out = sizeof(size_t);
+}


### PR DESCRIPTION
This is split out from #2478.

Comgr used to choose the clang path for the in-process Driver and the
embedded resource-dir VFS path separately. If those paths use different
prefixes, clang can search one resource directory while Comgr populates
another one in the VFS.

This PR makes Comgr build one cached clang install-path decision and use
it for both paths. When `LLVM_PATH` is unset, Comgr anchors probing at
the loaded Comgr library and tries the ROCm and standard sibling install
layouts. If no installed layout is found, it falls back to relative VFS
paths so the fallback clang path and embedded resource-dir keys stay in
the same VFS namespace.

The new lit test unsets `LLVM_PATH`, enables VFS, and checks that the
embedded clang builtin-header path matches clang's `-resource-dir`.

This PR intentionally does not change embedded libc++ header injection
behavior. That header-mixing fix remains in #2445.