### PR TITLE
Reapply "[HIP][SPIR-V] Enable SPIR-V backend by default (#198338)"

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPAMD.cpp
+++ b/clang/lib/Driver/ToolChains/HIPAMD.cpp
@@ -172,9 +172,9 @@ void AMDGCN::Linker::constructLinkAndEmitSpirvCommand(
   const char *LinkedBCFilePath = HIP::getTempFile(C, LinkedBCFilePrefix, "bc");
   InputInfo LinkedBCFile(&JA, LinkedBCFilePath, Output.getBaseInput());
 
-  bool UseSPIRVBackend =
-      Args.hasFlag(options::OPT_use_spirv_backend,
-                   options::OPT_no_use_spirv_backend, /*Default=*/false);
+  bool UseSPIRVBackend = Args.hasFlag(options::OPT_use_spirv_backend,
+                                      options::OPT_no_use_spirv_backend,
+                                      /*Default=*/true);
 
   constructLLVMLinkCommand(C, JA, Inputs, LinkedBCFile, Args);
 

--- a/clang/test/Driver/hip-phases.hip
+++ b/clang/test/Driver/hip-phases.hip
@@ -688,7 +688,8 @@
 // Test the new driver bundling SPIR-V targets.
 //
 // RUN: %clang -### --target=x86_64-linux-gnu --offload-new-driver -ccc-print-phases \
-// RUN:        --offload-device-only --offload-arch=amdgcnspirv,gfx1030 %s 2>&1 \
+// RUN:        --offload-device-only -no-use-spirv-backend \
+// RUN:        --offload-arch=amdgcnspirv,gfx1030 %s 2>&1 \
 // RUN: | FileCheck -check-prefix=SPIRV-ONLY %s
 //      SPIRV-ONLY: 0: input, "[[INPUT:.+]]", hip, (device-hip, gfx1030)
 // SPIRV-ONLY-NEXT: 1: preprocessor, {0}, hip-cpp-output, (device-hip, gfx1030)

--- a/clang/test/Driver/hip-toolchain-no-rdc.hip
+++ b/clang/test/Driver/hip-toolchain-no-rdc.hip
@@ -37,12 +37,12 @@
 // RUN: 2>&1 | FileCheck -check-prefixes=LKONLY %s
 
 // RUN: %clang -### --target=x86_64-linux-gnu --no-offload-new-driver \
-// RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 \
+// RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 -no-use-spirv-backend \
 // RUN:   %s -nogpuinc -nogpulib \
 // RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV %s
 
 // RUN: %clang -### --target=x86_64-linux-gnu --offload-new-driver \
-// RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 \
+// RUN:   --offload-arch=amdgcnspirv --offload-arch=gfx900 -no-use-spirv-backend \
 // RUN:   %s -nogpuinc -nogpulib \
 // RUN: 2>&1 | FileCheck -check-prefixes=AMDGCNSPIRV-NEW %s
 

--- a/clang/test/Driver/spirv-amd-toolchain.c
+++ b/clang/test/Driver/spirv-amd-toolchain.c
@@ -17,12 +17,14 @@
 // RUN: %clang -### -ccc-print-bindings -use-spirv-backend --target=spirv64-amd-amdhsa %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=BINDINGS
 
-// RUN: %clang -### --target=spirv64-amd-amdhsa %s 2>&1 \
+// RUN: %clang -### -no-use-spirv-backend --target=spirv64-amd-amdhsa %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=INVOCATION
 // INVOCATION: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-disable-llvm-optzns" {{.*}} "-o" "[[OUTPUT:.+]]" "-x" "c"
 // INVOCATION: "{{.*}}llvm-link" "-o" "[[LINKED_OUTPUT:.+]]" "[[OUTPUT]]"
 // INVOCATION: "{{.*}}llvm-spirv" "--spirv-max-version=1.6" "--spirv-ext=+all" "--spirv-allow-unknown-intrinsics" "--spirv-lower-const-expr" "--spirv-preserve-auxdata" "--spirv-debug-info-version=nonsemantic-shader-200" "[[LINKED_OUTPUT]]" "-o" "a.out"
 
+// RUN: %clang -### --target=spirv64-amd-amdhsa %s 2>&1 \
+// RUN:   | FileCheck %s --check-prefix=INVOCATION-SPIRV-BACKEND
 // RUN: %clang -### -use-spirv-backend --target=spirv64-amd-amdhsa %s 2>&1 \
 // RUN:   | FileCheck %s --check-prefix=INVOCATION-SPIRV-BACKEND
 // INVOCATION-SPIRV-BACKEND: "-cc1" "-triple" "spirv64-amd-amdhsa" {{.*}}"-disable-llvm-optzns" {{.*}} "-o" "[[OUTPUT:.+]]" "-x" "c"


### PR DESCRIPTION
## Summary

Reapplies upstream LLVM #198338, re-enabling the SPIR-V backend by default for HIP SPIR-V targets to match upstream. This reverts `229722cfc1e0`.

`-no-use-spirv-backend` still selects the `llvm-spirv` translator path.

## Background

The original change was reverted because TheRock's compiler did not build the in-tree LLVM SPIRV backend, so `amdgcnspirv` compiles failed (`No available targets are compatible with triple "spirv64-amd-amdhsa"`) and COMGR lit tests broke in the Compiler CI.

TheRock now builds the SPIRV target (ROCm/TheRock#4690 on `compiler/amd-staging` adds `SPIRV` to `LLVM_TARGETS_TO_BUILD`), so the backend is available and the default can be restored.

## Changes

- `clang/lib/Driver/ToolChains/HIPAMD.cpp` — `UseSPIRVBackend` default `false` → `true`
- `clang/test/Driver/{hip-phases,hip-toolchain-no-rdc}.hip`, `clang/test/Driver/spirv-amd-toolchain.c` — updated to exercise both default-backend and `-no-use-spirv-backend` paths