### PR TITLE
[Comgr] Fix hotswap transpiler link order breaking in-process LLD

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -211,11 +211,11 @@ target_include_directories(amd_comgr
 
 # The hotswap subdirectory is added unconditionally below (around the
 # add_subdirectory(src/hotswap) line) so the OBJECT library is available
-# to the test-unit suite; here we opt amd_comgr into linking the
-# transpiler in (its TUs land in amd_comgr.so) and exposing the
-# `amd_comgr_hotswap_transpile` entry point.
+# to the test-unit suite; here we opt amd_comgr into exposing the
+# `amd_comgr_hotswap_transpile` entry point. The transpiler link edge is
+# added after the curated LLVM/LLD link block below (see "hotswap transpiler
+# link edge"), not here.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
-  target_link_libraries(amd_comgr PRIVATE hotswap::transpiler)
   target_compile_definitions(amd_comgr PRIVATE COMGR_ENABLE_HOTSWAP_TRANSPILE=1)
 endif()
 
@@ -601,6 +601,13 @@ target_link_libraries(amd_comgr
     ${LLD_LIBS}
     ${LLVM_LIBS}
     ${CLANG_LIBS})
+
+# hotswap transpiler link edge — must come after the curated LLVM set above so
+# static-archive resolution pulls in the full set (incl. LLVMCodeGen's -mcpu
+# registration) before the transpiler's partial LLVM deps.
+if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
+  target_link_libraries(amd_comgr PRIVATE hotswap::transpiler)
+endif()
 
 if(TARGET embedded-resource-dir)
   target_link_libraries(amd_comgr PRIVATE embedded-resource-dir)


### PR DESCRIPTION
## Motivation

With `COMGR_ENABLE_HOTSWAP_TRANSPILE=ON`, comgr's in-process LLD rejects the forwarded `-plugin-opt=mcpu=<gpu>` with:

```
ld.lld: error: -plugin-opt=mcpu=: Unknown command line argument '-mcpu=gfx1250'.
ld.lld: Did you mean '--stats=gfx1250'?
```

This breaks build-time AOT compilation in downstream consumers that drive comgr's LLD-as-a-library codegen path — e.g. rocFFT's `rocfft_aot_helper` on gfx1250.

## Root cause

The `hotswap::transpiler` link edge was added to `amd_comgr` **before** the curated `${LLD_LIBS} ${LLVM_LIBS} ${CLANG_LIBS}` block. The hotswap OBJECT library carries a *partial* LLVM set (`LLVMCore`, `LLVMSupport`, `LLVMTargetParser`) as PUBLIC deps (needed for its standalone test consumer, `RaiserScaffoldingTests`).

With static-archive linking (e.g. `COMGR_STATIC_LLVM=ON`, as TheRock uses), symbol resolution is single-pass and order-sensitive. The partial set satisfied the CommandLine symbols first, so `LLVMCodeGen`'s `CommandFlags.cpp` — which registers the `-mcpu` `cl::opt` — was never pulled in. The "Did you mean `--stats`?" suggestion is the tell: LLD's CommandLine registry has LLD's own options but is missing the codegen `mcpu` option.

## Fix

Move the `hotswap::transpiler` link edge to **after** the curated LLVM/LLD link block so the full LLVM set (incl. `LLVMCodeGen`) resolves first. The `COMGR_ENABLE_HOTSWAP_TRANSPILE` compile definition is order-independent and stays at its original site.

No behavior change when `COMGR_ENABLE_HOTSWAP_TRANSPILE=OFF` (the default).
