### PR TITLE
[AMDGPU][COMGR] Use text displacement for hotswap kernel entry workarounds

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -104,6 +104,7 @@ set(SOURCES
   src/comgr-hotswap.cpp
   src/comgr-hotswap-b0a0.cpp
   src/comgr-hotswap-profile.cpp
+  src/comgr-hotswap-displacement.cpp
   src/comgr-hotswap-entry-trampoline.cpp
   src/comgr-hotswap-entry-trampoline-fast.cpp
   src/comgr-hotswap-occupancy.cpp

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2655,10 +2655,10 @@ copyOutputBuffer(const void *Data, size_t Size, StringRef CopyKind) {
 
 // -- retargetCodeObject -------------------------------------------------------
 
-amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
-                                      const TargetIdentifier &TargetIdent,
-                                      const Gfx1250RewriteOptions &Options,
-                                      std::unique_ptr<MemoryBuffer> &Out) {
+static amd_comgr_status_t retargetCodeObjectImpl(
+    const void *ElfData, size_t ElfSize, const TargetIdentifier &TargetIdent,
+    const Gfx1250RewriteOptions &Options, std::unique_ptr<MemoryBuffer> &Out,
+    bool AllowTextDisplacement, HotswapProfile &Profile) {
   // The dispatcher fetches the patch vtable lazily via
   // getHotswapPatchVTable() inside applyGfx1250B0toA0Rules; the singleton's
   // initializer binds every register*Patch slot on first access, so no
@@ -2667,22 +2667,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   const bool RunInstructionPatches =
       Options.RunB0A0Patches ||
       Options.MaskPolicy != MaskWorkaroundPolicy::None;
-  if (!RunInstructionPatches && !Options.RunEntryTrampolines) {
-    std::unique_ptr<WritableMemoryBuffer> Result =
-        copyOutputBuffer(ElfData, ElfSize, "no-op");
-    if (!Result)
-      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
-    Out = std::move(Result);
-    return AMD_COMGR_STATUS_SUCCESS;
-  }
-
-  // One profiling session per code object, merged into TimeStatistics when it
-  // goes out of scope. Prof gates the manual per-phase clock reads.
-  HotswapProfile Profile(hotswapProfilingEnabled());
   const bool Prof = Profile.enabled();
-  // RAII guard: records phase:rewrite_total on every return path.
-  [[maybe_unused]] HotswapProfile::Scope TotalScope =
-      Profile.time(HotswapMetric::RewriteTotal);
 
   // Take a working copy so the input is preserved and we have a mutable
   // buffer to parse / patch.
@@ -2742,6 +2727,44 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       log() << "hotswap: error: retargetCodeObject: initLLVM failed "
             << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
       return AMD_COMGR_STATUS_ERROR;
+    }
+  }
+
+  // Direct displacement is an entry-workaround optimization only. Apply the
+  // entry prefixes before ordinary instruction rewriting so the existing
+  // NOP-sled/trampoline planner sees the final instruction offsets. If the ELF
+  // cannot be displaced safely, continue from the pristine working copy and
+  // append the established entry stubs below.
+  if (Options.RunEntryTrampolines && AllowTextDisplacement && !UseFastAppend) {
+    std::vector<DisplacementEdit> EntryDisplacements;
+    std::optional<uint32_t> EntryCount =
+        collectKernelEntryDisplacements(Elf, LS, EntryDisplacements);
+    if (!EntryCount)
+      return AMD_COMGR_STATUS_ERROR;
+
+    if (!EntryDisplacements.empty()) {
+      Expected<std::unique_ptr<WritableMemoryBuffer>> DisplacedOrErr =
+          tryApplyTextDisplacementToNewBuffer(Elf, LS, EntryDisplacements);
+      if (DisplacedOrErr) {
+        std::unique_ptr<WritableMemoryBuffer> Displaced =
+            std::move(*DisplacedOrErr);
+        if (!RunInstructionPatches) {
+          Out = std::move(Displaced);
+          return AMD_COMGR_STATUS_SUCCESS;
+        }
+
+        Gfx1250RewriteOptions RemainingOptions = Options;
+        RemainingOptions.RunEntryTrampolines = false;
+        RemainingOptions.UseB0B0EntryFastPath = false;
+        return retargetCodeObjectImpl(Displaced->getBufferStart(),
+                                      Displaced->getBufferSize(), TargetIdent,
+                                      RemainingOptions, Out,
+                                      /*AllowTextDisplacement=*/false, Profile);
+      }
+
+      log() << "hotswap: entry displacement unavailable: "
+            << toString(DisplacedOrErr.takeError())
+            << "; using appended entry stubs\n";
     }
   }
 
@@ -2947,6 +2970,33 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   Out = std::move(Result);
   return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
+                                      const TargetIdentifier &TargetIdent,
+                                      const Gfx1250RewriteOptions &Options,
+                                      std::unique_ptr<MemoryBuffer> &Out) {
+  const bool RunInstructionPatches =
+      Options.RunB0A0Patches ||
+      Options.MaskPolicy != MaskWorkaroundPolicy::None;
+  if (!RunInstructionPatches && !Options.RunEntryTrampolines) {
+    std::unique_ptr<WritableMemoryBuffer> Result =
+        copyOutputBuffer(ElfData, ElfSize, "no-op");
+    if (!Result)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    Out = std::move(Result);
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
+
+  // One profiling session per code object, merged into TimeStatistics when it
+  // goes out of scope. Prof gates the manual per-phase clock reads.
+  HotswapProfile Profile(hotswapProfilingEnabled());
+  // RAII guard: records phase:rewrite_total on every return path.
+  [[maybe_unused]] HotswapProfile::Scope TotalScope =
+      Profile.time(HotswapMetric::RewriteTotal);
+
+  return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
+                                /*AllowTextDisplacement=*/true, Profile);
 }
 
 } // namespace hotswap

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -1,0 +1,936 @@
+//===- comgr-hotswap-displacement.cpp - HotSwap text displacement --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Direct `.text` displacement for HotSwap rewrites. This layer inserts
+/// larger replacement sequences into `.text`, shifts the displaced code
+/// forward, repairs direct PC-relative scalar branches when it can prove the
+/// new encoding, and updates ELF metadata. Appended trampolines remain the
+/// fallback when any check fails.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/MC/MCFixup.h"
+#include "llvm/Support/Alignment.h"
+
+#include <algorithm>
+#include <limits>
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+using Ehdr = ELF::Elf64_Ehdr;
+using Shdr = ELF::Elf64_Shdr;
+using Phdr = ELF::Elf64_Phdr;
+using ELFT = ElfView::ELFT;
+using ELFFileT = ElfView::ELFFileT;
+
+namespace {
+
+Error makeDisplacementError(const Twine &Msg) {
+  std::string Message = Msg.str();
+  log() << "hotswap: displacement unavailable: " << Message << "\n";
+  return createStringError(object::object_error::parse_failed, Message);
+}
+
+Expected<uint64_t> requiredGrowthAlignment(const ElfView &Elf) {
+  uint64_t MaxAlign = 1;
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (Shdr.sh_offset <= Elf.textOffset())
+      continue;
+    MaxAlign = std::max<uint64_t>(MaxAlign, Shdr.sh_addralign);
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr) {
+    return makeDisplacementError(
+        "failed to read program headers while computing displacement "
+        "alignment: " +
+        Twine(toString(PhdrsOrErr.takeError())));
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_offset <= Elf.textOffset())
+      continue;
+    MaxAlign = std::max<uint64_t>(MaxAlign, Phdr.p_align);
+  }
+  return std::max<uint64_t>(MaxAlign, 1);
+}
+
+Error validateDebugSections(const ElfView &Elf) {
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr) {
+      return makeDisplacementError(
+          "failed to read section name while checking debug info: " +
+          Twine(toString(NameOrErr.takeError())));
+    }
+    StringRef Name = *NameOrErr;
+    if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
+        Name == ".eh_frame" || Name == ".eh_frame_hdr") {
+      return makeDisplacementError("debug/unwind section '" + Twine(Name) +
+                                   "' requires address remapping");
+    }
+  }
+  return Error::success();
+}
+
+bool isPcSensitiveForDisplacement(const InternalDecodedInst &DI,
+                                  const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  if (Opcode == LS.SAddPcI64Opcode || Opcode == LS.SGetPcI64Opcode ||
+      Opcode == LS.SSetPcI64Opcode || Opcode == LS.SSwapPcI64Opcode ||
+      Opcode == LS.SPrefetchInstPcRelOpcode ||
+      Opcode == LS.SPrefetchDataPcRelOpcode)
+    return true;
+
+  const MCInstrDesc &Desc = LS.MCII->get(Opcode);
+  for (const MCOperandInfo &Operand : Desc.operands())
+    if (Operand.OperandType == MCOI::OPERAND_PCREL)
+      return !LS.MIA->isBranch(DI.Inst);
+  return false;
+}
+
+Error validateVirtualGrowth(const ElfView &Elf, uint64_t PaddedGrowth) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr() ||
+      PaddedGrowth > std::numeric_limits<uint64_t>::max() - Elf.textAddr() -
+                         Elf.textSize())
+    return makeDisplacementError("displaced .text virtual end overflows");
+  const uint64_t OldTextEnd = Elf.textAddr() + Elf.textSize();
+  const uint64_t NewTextEnd = OldTextEnd + PaddedGrowth;
+
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) || &Shdr == Elf.textSection() ||
+        Shdr.sh_size == 0)
+      continue;
+    if (Shdr.sh_addr >= OldTextEnd && Shdr.sh_addr < NewTextEnd) {
+      return makeDisplacementError(
+          "displaced .text would overlap a later allocatable section");
+    }
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr) {
+    return makeDisplacementError(
+        "failed to read program headers while validating displacement: " +
+        Twine(toString(PhdrsOrErr.takeError())));
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_filesz > std::numeric_limits<uint64_t>::max() - Phdr.p_offset)
+      return makeDisplacementError("program-header file range overflows");
+    const uint64_t SegmentFileEnd = Phdr.p_offset + Phdr.p_filesz;
+    if (Phdr.p_type == ELF::PT_LOAD && Phdr.p_offset <= Elf.textOffset() &&
+        SegmentFileEnd >= Elf.textOffset() + Elf.textSize() &&
+        SegmentFileEnd != Elf.textOffset() + Elf.textSize()) {
+      return makeDisplacementError(
+          ".text is not the last file-backed content in its PT_LOAD segment");
+    }
+
+    if (Phdr.p_type != ELF::PT_LOAD || Phdr.p_memsz == 0)
+      continue;
+    if (Phdr.p_vaddr >= OldTextEnd && Phdr.p_vaddr < NewTextEnd) {
+      return makeDisplacementError(
+          "displaced .text would overlap a later PT_LOAD segment");
+    }
+  }
+  return Error::success();
+}
+
+Error validateTextRelocations(const ElfView &Elf) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
+    return makeDisplacementError(
+        ".text virtual range overflows while checking relocations");
+  }
+  const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
+
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (Shdr.sh_type != ELF::SHT_REL && Shdr.sh_type != ELF::SHT_RELA)
+      continue;
+
+    if (Shdr.sh_info == Elf.textSectionIndex()) {
+      Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+      if (!NameOrErr) {
+        return makeDisplacementError(
+            "failed to read relocation section name: " +
+            Twine(toString(NameOrErr.takeError())));
+      }
+      return makeDisplacementError("relocation section '" + Twine(*NameOrErr) +
+                                   "' references .text");
+    }
+
+    // Dynamic relocation sections use sh_info == 0. r_offset identifies the
+    // location to update, but the relocation's symbol or addend can separately
+    // resolve to displaced code. Reject either direction until displacement
+    // can rewrite relocation expressions as well as their destinations.
+    if (Shdr.sh_info == 0) {
+      if (Shdr.sh_type == ELF::SHT_RELA) {
+        Expected<ELFT::RelaRange> RelasOrErr = Elf.file().relas(Shdr);
+        if (!RelasOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation section: " +
+              Twine(toString(RelasOrErr.takeError())));
+        }
+        Expected<const ELFT::Shdr *> SymtabOrErr =
+            Elf.file().getSection(Shdr.sh_link);
+        if (!SymtabOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation symbol table: " +
+              Twine(toString(SymtabOrErr.takeError())));
+        }
+
+        for (const ELFT::Rela &Rela : *RelasOrErr) {
+          if (Rela.r_offset >= Elf.textAddr() && Rela.r_offset < TextEnd) {
+            return makeDisplacementError(
+                "dynamic relocation section targets a displaced .text "
+                "address");
+          }
+
+          if (Rela.r_addend >= 0) {
+            const uint64_t Addend = static_cast<uint64_t>(Rela.r_addend);
+            if (Addend >= Elf.textAddr() && Addend < TextEnd) {
+              return makeDisplacementError(
+                  "dynamic relocation addend references a displaced .text "
+                  "address");
+            }
+          }
+
+          Expected<const ELFT::Sym *> SymOrErr =
+              Elf.file().getRelocationSymbol(Rela, *SymtabOrErr);
+          if (!SymOrErr) {
+            return makeDisplacementError(
+                "failed to read dynamic relocation symbol: " +
+                Twine(toString(SymOrErr.takeError())));
+          }
+          const ELFT::Sym *Sym = *SymOrErr;
+          if (Sym &&
+              (Sym->st_shndx == Elf.textSectionIndex() ||
+               (Sym->st_value >= Elf.textAddr() && Sym->st_value < TextEnd))) {
+            return makeDisplacementError(
+                "dynamic relocation symbol references displaced .text");
+          }
+        }
+      } else {
+        Expected<ELFT::RelRange> RelsOrErr = Elf.file().rels(Shdr);
+        if (!RelsOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation section: " +
+              Twine(toString(RelsOrErr.takeError())));
+        }
+        Expected<const ELFT::Shdr *> SymtabOrErr =
+            Elf.file().getSection(Shdr.sh_link);
+        if (!SymtabOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation symbol table: " +
+              Twine(toString(SymtabOrErr.takeError())));
+        }
+
+        for (const ELFT::Rel &Rel : *RelsOrErr) {
+          if (Rel.r_offset >= Elf.textAddr() && Rel.r_offset < TextEnd) {
+            return makeDisplacementError(
+                "dynamic relocation section targets a displaced .text "
+                "address");
+          }
+
+          Expected<const ELFT::Sym *> SymOrErr =
+              Elf.file().getRelocationSymbol(Rel, *SymtabOrErr);
+          if (!SymOrErr) {
+            return makeDisplacementError(
+                "failed to read dynamic relocation symbol: " +
+                Twine(toString(SymOrErr.takeError())));
+          }
+          const ELFT::Sym *Sym = *SymOrErr;
+          if (Sym &&
+              (Sym->st_shndx == Elf.textSectionIndex() ||
+               (Sym->st_value >= Elf.textAddr() && Sym->st_value < TextEnd))) {
+            return makeDisplacementError(
+                "dynamic relocation symbol references displaced .text");
+          }
+
+          // SHT_REL stores its addend at r_offset. Without interpreting each
+          // AMDGPU relocation width and target section, a symbol-free record
+          // cannot prove that its implicit addend is independent of .text.
+          if (!Sym && Rel.getType(false) != ELF::R_AMDGPU_NONE) {
+            return makeDisplacementError(
+                "symbol-free dynamic REL relocation has an implicit addend");
+          }
+        }
+      }
+    }
+  }
+  return Error::success();
+}
+
+Error validateKernelEntryMappings(const ElfView &Elf,
+                                  const DisplacementPlan &Plan) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
+    return makeDisplacementError(
+        ".text virtual range overflows while checking kernel entries");
+  }
+  const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
+
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> OldEntry = entryVAddr(KD);
+    if (!OldEntry) {
+      return makeDisplacementError("failed to resolve kernel entry for '" +
+                                   Twine(KD.KernelName) + "'");
+    }
+    if (*OldEntry < Elf.textAddr() || *OldEntry >= TextEnd) {
+      return makeDisplacementError(
+          "kernel entry for '" + Twine(KD.KernelName) +
+          "' is outside .text and may contain an unrepairable entry stub");
+    }
+
+    uint64_t NewEntryOffset = 0;
+    if (!Plan.mapOffset(*OldEntry - Elf.textAddr(),
+                        DisplacementMapBias::BeforeInsertedBytes,
+                        NewEntryOffset)) {
+      return makeDisplacementError("kernel entry for '" + Twine(KD.KernelName) +
+                                   "' maps inside a replaced range");
+    }
+    if (NewEntryOffset >
+        std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
+      return makeDisplacementError("displaced kernel entry for '" +
+                                   Twine(KD.KernelName) + "' overflows");
+    }
+    const uint64_t NewEntry = Elf.textAddr() + NewEntryOffset;
+    if (NewEntry % KernelEntryStubStride != 0) {
+      return makeDisplacementError("displaced kernel entry for '" +
+                                   Twine(KD.KernelName) +
+                                   "' is not 256-byte aligned");
+    }
+  }
+  return Error::success();
+}
+
+Expected<SmallVector<uint8_t>>
+reencodePcrelBranch(const InternalDecodedInst &DI, uint64_t NewFrom,
+                    uint64_t NewTarget, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SBranchOpcode) {
+    SmallVector<uint8_t> Encoded = LS.encodeSBranch(NewFrom, NewTarget);
+    if (Encoded.empty()) {
+      return makeDisplacementError("s_branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " is out of range after displacement");
+    }
+    return Encoded;
+  }
+
+  if (DI.Inst.getNumOperands() == 0 || !DI.Inst.getOperand(0).isImm()) {
+    return makeDisplacementError(
+        "branch at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+        " does not expose an immediate target operand");
+  }
+
+  int64_t ByteDelta = static_cast<int64_t>(NewTarget) -
+                      static_cast<int64_t>(NewFrom) -
+                      static_cast<int64_t>(DI.Size);
+  if (ByteDelta % MinInstSize != 0) {
+    return makeDisplacementError("branch at old .text offset 0x" +
+                                 Twine::utohexstr(DI.Offset) +
+                                 " has unaligned displacement after rewrite");
+  }
+
+  int64_t DwordOffset = ByteDelta / MinInstSize;
+  if (DwordOffset < BranchOffsetMin || DwordOffset > BranchOffsetMax) {
+    return makeDisplacementError("branch at old .text offset 0x" +
+                                 Twine::utohexstr(DI.Offset) +
+                                 " is out of simm16 range after displacement");
+  }
+
+  MCInst NewInst = DI.Inst;
+  NewInst.getOperand(0).setImm(DwordOffset);
+  SmallVector<char, 16> Code;
+  SmallVector<MCFixup, 4> Fixups;
+  LS.MCE->encodeInstruction(NewInst, Code, Fixups, *LS.STI);
+  SmallVector<uint8_t> Encoded(Code.begin(), Code.end());
+  if (Encoded.size() != DI.Size) {
+    return makeDisplacementError("branch at old .text offset 0x" +
+                                 Twine::utohexstr(DI.Offset) +
+                                 " changed encoded size during re-encode");
+  }
+  return Encoded;
+}
+
+Error repairBranches(const ElfView &Elf, const LLVMState &LS,
+                     const DisplacementPlan &Plan,
+                     SmallVectorImpl<uint8_t> &NewText) {
+  if (!LS.MIA) {
+    return makeDisplacementError(
+        "branch analysis through LLVM MC is unavailable");
+  }
+
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Elf.textData(), Elf.textSize(), LS, Decoded)) {
+    return makeDisplacementError(
+        "failed to decode .text while validating branches");
+  }
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (Plan.rangeOverlapsReplacement(DI.Offset, DI.Size))
+      continue;
+
+    const MCInst &Inst = DI.Inst;
+    if (isPcSensitiveForDisplacement(DI, LS)) {
+      return makeDisplacementError(
+          "pc-sensitive instruction '" + Twine(DI.Mnemonic) +
+          "' at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+          " requires linked-address repair");
+    }
+    if (LS.MIA->isCall(Inst)) {
+      return makeDisplacementError("call at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " is not supported by displacement");
+    }
+    if (LS.MIA->isIndirectBranch(Inst)) {
+      return makeDisplacementError("indirect branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " is not supported by displacement");
+    }
+    if (!LS.MIA->isBranch(Inst))
+      continue;
+
+    uint64_t OldTarget = 0;
+    if (!LS.MIA->evaluateBranch(Inst, DI.Offset, DI.Size, OldTarget)) {
+      return makeDisplacementError("branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " target could not be evaluated");
+    }
+    if (OldTarget >= Elf.textSize()) {
+      return makeDisplacementError("branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " targets outside .text");
+    }
+
+    uint64_t NewFrom = 0;
+    uint64_t NewTarget = 0;
+    if (!Plan.mapOffset(DI.Offset, DisplacementMapBias::AfterInsertedBytes,
+                        NewFrom)) {
+      return makeDisplacementError("branch source at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " maps inside a replaced range");
+    }
+    if (!Plan.mapOffset(OldTarget, DisplacementMapBias::BeforeInsertedBytes,
+                        NewTarget)) {
+      return makeDisplacementError("branch target at old .text offset 0x" +
+                                   Twine::utohexstr(OldTarget) +
+                                   " maps inside a replaced range");
+    }
+
+    Expected<SmallVector<uint8_t>> EncodedOrErr =
+        reencodePcrelBranch(DI, NewFrom, NewTarget, LS);
+    if (!EncodedOrErr)
+      return EncodedOrErr.takeError();
+    SmallVector<uint8_t> &Encoded = *EncodedOrErr;
+
+    if (NewFrom + Encoded.size() > NewText.size()) {
+      return makeDisplacementError("re-encoded branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " writes past rebuilt .text");
+    }
+    std::memcpy(NewText.data() + NewFrom, Encoded.data(), Encoded.size());
+  }
+  return Error::success();
+}
+
+Error adjustSectionHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
+                                        const ElfView &OldElf, size_t Growth) {
+  if (ElfSize < sizeof(Ehdr)) {
+    return makeDisplacementError(
+        "displaced ELF is smaller than its ELF64 header");
+  }
+
+  const uint64_t TextOffset = OldElf.textOffset();
+  const uint64_t TextSize = OldElf.textSize();
+  const uint64_t TextEnd = TextOffset + TextSize;
+
+  uint64_t Shoff = 0;
+  uint16_t Shentsize = 0;
+  uint16_t Shnum = 0;
+  std::memcpy(&Shoff, Elf + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, Elf + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
+  std::memcpy(&Shnum, Elf + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+  if (Shentsize < sizeof(Shdr)) {
+    return makeDisplacementError(
+        "displaced ELF section-header entry is too small");
+  }
+
+  if (Shoff >= TextEnd) {
+    uint64_t NewShoff = Shoff + Growth;
+    std::memcpy(Elf + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+    Shoff = NewShoff;
+  }
+
+  for (uint16_t I = 0; I < Shnum; ++I) {
+    uint64_t ShPos = Shoff + static_cast<uint64_t>(I) * Shentsize;
+    if (ShPos > ElfSize || sizeof(Shdr) > ElfSize - ShPos) {
+      return makeDisplacementError(
+          "displaced ELF section-header table is out of bounds");
+    }
+    uint8_t *Sh = Elf + ShPos;
+    uint64_t ShOffset = 0;
+    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
+
+    if (I == OldElf.textSectionIndex()) {
+      uint64_t NewTextSize = TextSize + Growth;
+      std::memcpy(Sh + offsetof(Shdr, sh_size), &NewTextSize,
+                  sizeof(NewTextSize));
+    } else if (ShOffset >= TextEnd) {
+      uint64_t NewOffset = ShOffset + Growth;
+      std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
+                  sizeof(NewOffset));
+    }
+  }
+  return Error::success();
+}
+
+Error adjustProgramHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
+                                        const ElfView &OldElf, size_t Growth) {
+  if (ElfSize < sizeof(Ehdr)) {
+    return makeDisplacementError(
+        "displaced ELF is smaller than its ELF64 header");
+  }
+
+  const uint64_t TextOffset = OldElf.textOffset();
+  const uint64_t TextEnd = TextOffset + OldElf.textSize();
+
+  uint64_t Phoff = 0;
+  uint16_t Phentsize = 0;
+  uint16_t Phnum = 0;
+  std::memcpy(&Phoff, Elf + offsetof(Ehdr, e_phoff), sizeof(Phoff));
+  std::memcpy(&Phentsize, Elf + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
+  std::memcpy(&Phnum, Elf + offsetof(Ehdr, e_phnum), sizeof(Phnum));
+  if (Phentsize < sizeof(Phdr)) {
+    return makeDisplacementError(
+        "displaced ELF program-header entry is too small");
+  }
+
+  if (Phoff >= TextEnd) {
+    uint64_t NewPhoff = Phoff + Growth;
+    std::memcpy(Elf + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
+    Phoff = NewPhoff;
+  }
+
+  for (uint16_t I = 0; I < Phnum; ++I) {
+    uint64_t PhPos = Phoff + static_cast<uint64_t>(I) * Phentsize;
+    if (PhPos > ElfSize || sizeof(Phdr) > ElfSize - PhPos) {
+      return makeDisplacementError(
+          "displaced ELF program-header table is out of bounds");
+    }
+    uint8_t *Ph = Elf + PhPos;
+    uint64_t POffset = 0;
+    uint64_t PFilesz = 0;
+    uint64_t PMemsz = 0;
+    std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
+    std::memcpy(&PFilesz, Ph + offsetof(Phdr, p_filesz), sizeof(PFilesz));
+    std::memcpy(&PMemsz, Ph + offsetof(Phdr, p_memsz), sizeof(PMemsz));
+
+    if (POffset <= TextOffset && POffset + PFilesz >= TextEnd) {
+      PFilesz += Growth;
+      PMemsz = std::max(PMemsz, PFilesz);
+      std::memcpy(Ph + offsetof(Phdr, p_filesz), &PFilesz, sizeof(PFilesz));
+      std::memcpy(Ph + offsetof(Phdr, p_memsz), &PMemsz, sizeof(PMemsz));
+    } else if (POffset >= TextEnd) {
+      POffset += Growth;
+      std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
+    }
+  }
+  return Error::success();
+}
+
+Error adjustSymbolValuesForDisplacement(uint8_t *Elf, size_t ElfSize,
+                                        const ElfView &OldElf,
+                                        const DisplacementPlan &Plan) {
+  Expected<ELFFileT> FileOrErr =
+      ELFFileT::create(StringRef(reinterpret_cast<const char *>(Elf), ElfSize));
+  if (!FileOrErr) {
+    return makeDisplacementError(
+        "failed to parse displaced ELF for symbol repair: " +
+        Twine(toString(FileOrErr.takeError())));
+  }
+  ELFFileT File = std::move(*FileOrErr);
+
+  Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
+  if (!SectionsOrErr) {
+    return makeDisplacementError(
+        "failed to read displaced ELF sections for symbol repair: " +
+        Twine(toString(SectionsOrErr.takeError())));
+  }
+  ELFT::ShdrRange Sections = *SectionsOrErr;
+
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      return makeDisplacementError(
+          "failed to read symbol table during displacement: " +
+          Twine(toString(SymsOrErr.takeError())));
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.st_shndx == ELF::SHN_UNDEF || Sym.st_shndx >= ELF::SHN_LORESERVE)
+        continue;
+
+      Expected<const ELFT::Shdr *> DefShdrOrErr = File.getSection(Sym.st_shndx);
+      if (!DefShdrOrErr) {
+        return makeDisplacementError(
+            "failed to read a symbol's defining section during displacement: " +
+            Twine(toString(DefShdrOrErr.takeError())));
+      }
+      const ELFT::Shdr &DefShdr = **DefShdrOrErr;
+
+      const uint8_t *SymBytes = reinterpret_cast<const uint8_t *>(&Sym);
+      if (SymBytes < File.base() || SymBytes > File.end() ||
+          static_cast<size_t>(File.end() - SymBytes) < sizeof(ELFT::Sym)) {
+        return makeDisplacementError(
+            "symbol table entry is outside displaced ELF buffer");
+      }
+      uint64_t SymOffset = SymBytes - File.base();
+
+      if (Sym.st_shndx == OldElf.textSectionIndex()) {
+        const bool LooksLikeVAddr =
+            Sym.st_value >= DefShdr.sh_addr &&
+            Sym.st_value - DefShdr.sh_addr <= Plan.oldTextSize();
+        const uint64_t OldOffset =
+            LooksLikeVAddr ? Sym.st_value - DefShdr.sh_addr : Sym.st_value;
+        if (OldOffset > Plan.oldTextSize()) {
+          return makeDisplacementError(
+              "text symbol value is outside the original .text section");
+        }
+
+        uint64_t NewOffset = 0;
+        if (!Plan.mapOffset(OldOffset, DisplacementMapBias::BeforeInsertedBytes,
+                            NewOffset)) {
+          return makeDisplacementError(
+              "text symbol value maps inside a replaced range");
+        }
+        const uint64_t NewValue =
+            LooksLikeVAddr ? DefShdr.sh_addr + NewOffset : NewOffset;
+        std::memcpy(Elf + SymOffset + offsetof(ELFT::Sym, st_value), &NewValue,
+                    sizeof(NewValue));
+
+        if (Sym.st_size != 0) {
+          if (OldOffset > Plan.oldTextSize() ||
+              Sym.st_size > Plan.oldTextSize() - OldOffset) {
+            return makeDisplacementError(
+                "text symbol extends outside the original .text section");
+          }
+          uint64_t OldEnd = OldOffset + Sym.st_size;
+          uint64_t NewStart = 0;
+          uint64_t NewEnd = 0;
+          // An insertion at the symbol start belongs to this symbol, while
+          // one exactly at the half-open end belongs to the next symbol.
+          if (!Plan.mapOffset(OldOffset,
+                              DisplacementMapBias::BeforeInsertedBytes,
+                              NewStart) ||
+              !Plan.mapOffset(OldEnd, DisplacementMapBias::BeforeInsertedBytes,
+                              NewEnd) ||
+              NewEnd < NewStart) {
+            return makeDisplacementError(
+                "text symbol boundaries cannot be remapped");
+          }
+          uint64_t NewSize = NewEnd - NewStart;
+          std::memcpy(Elf + SymOffset + offsetof(ELFT::Sym, st_size), &NewSize,
+                      sizeof(NewSize));
+        }
+        continue;
+      }
+
+      // Existing non-text virtual addresses are immutable. Fully linked AMDGPU
+      // code objects contain baked address materializations with no
+      // relocations; moving the target symbol would silently retarget those
+      // instructions.
+      // ElfView.GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol
+      // demonstrates the linked-address dependency.
+    }
+  }
+  return Error::success();
+}
+
+Error rewriteKernelDescriptorEntriesForDisplacement(
+    WritableMemoryBuffer &OutBuf, const ElfView &OldElf,
+    const DisplacementPlan &Plan) {
+  uint8_t *Data = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
+  Expected<ElfView> OutViewOrErr =
+      ElfView::create(Data, OutBuf.getBufferSize());
+  if (!OutViewOrErr) {
+    return makeDisplacementError(
+        "failed to reparse displaced ELF for descriptor repair: " +
+        Twine(toString(OutViewOrErr.takeError())));
+  }
+
+  ElfView &OutElf = *OutViewOrErr;
+  for (const KernelDescriptorInfo &KD : OldElf.kernelDescriptors()) {
+    std::optional<uint64_t> OldEntryVAddr = entryVAddr(KD);
+    if (!OldEntryVAddr) {
+      return makeDisplacementError("failed to resolve kernel entry for '" +
+                                   Twine(KD.KernelName) + "'");
+    }
+    if (*OldEntryVAddr < OldElf.textAddr() ||
+        *OldEntryVAddr >= OldElf.textAddr() + OldElf.textSize())
+      continue;
+
+    uint64_t OldEntryOffset = *OldEntryVAddr - OldElf.textAddr();
+    uint64_t NewEntryOffset = 0;
+    if (!Plan.mapOffset(OldEntryOffset,
+                        DisplacementMapBias::BeforeInsertedBytes,
+                        NewEntryOffset)) {
+      return makeDisplacementError("kernel descriptor entry for '" +
+                                   Twine(KD.KernelName) +
+                                   "' maps inside a replaced range");
+    }
+
+    std::optional<uint64_t> NewKdVAddr =
+        OutElf.getKernelDescriptorVAddr(KD.KernelName);
+    if (!NewKdVAddr) {
+      return makeDisplacementError("missing kernel descriptor for '" +
+                                   Twine(KD.KernelName) +
+                                   "' after displacement");
+    }
+
+    const uint64_t NewEntryVAddr = OutElf.textAddr() + NewEntryOffset;
+    std::optional<int64_t> NewKdEntryOffset = checkedSignedDifference(
+        NewEntryVAddr, *NewKdVAddr,
+        (Twine("displaced kernel entry offset for '") + KD.KernelName + "'")
+            .str());
+    if (!NewKdEntryOffset) {
+      return makeDisplacementError(
+          "displaced kernel entry offset is not representable for '" +
+          Twine(KD.KernelName) + "'");
+    }
+    if (!OutElf.updateKernelDescriptorEntryOffset(KD.KernelName,
+                                                  *NewKdEntryOffset)) {
+      return makeDisplacementError(
+          "failed to update kernel descriptor entry for '" +
+          Twine(KD.KernelName) + "'");
+    }
+  }
+  return Error::success();
+}
+
+Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
+                            const DisplacementPlan &Plan,
+                            WritableMemoryBuffer &OutBuf) {
+  const size_t InputSize = Elf.size();
+  const size_t NewSize = Plan.newElfSize(InputSize);
+  if (OutBuf.getBufferSize() != NewSize) {
+    return makeDisplacementError(
+        "output buffer has incorrect size for displacement");
+  }
+
+  SmallVector<uint8_t> NewText = Plan.buildText(
+      ArrayRef<uint8_t>(Elf.textData(), Elf.textSize()), LS.SNopBytes);
+  if (NewText.size() != Plan.paddedTextSize()) {
+    return makeDisplacementError(
+        "rebuilt .text size does not match displacement plan");
+  }
+  if (Error Err = repairBranches(Elf, LS, Plan, NewText))
+    return Err;
+
+  uint8_t *Out = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
+  const uint8_t *Input = Elf.data();
+  const uint64_t TextOffset = Elf.textOffset();
+  const uint64_t TextEnd = TextOffset + Elf.textSize();
+
+  std::memcpy(Out, Input, TextOffset);
+  std::memcpy(Out + TextOffset, NewText.data(), NewText.size());
+  if (TextEnd < InputSize) {
+    std::memcpy(Out + TextOffset + NewText.size(), Input + TextEnd,
+                InputSize - TextEnd);
+  }
+
+  if (Error Err = adjustSectionHeadersForTextGrowth(Out, NewSize, Elf,
+                                                    Plan.paddedGrowth()))
+    return Err;
+  if (Error Err = adjustProgramHeadersForTextGrowth(Out, NewSize, Elf,
+                                                    Plan.paddedGrowth()))
+    return Err;
+  if (Error Err = adjustSymbolValuesForDisplacement(Out, NewSize, Elf, Plan))
+    return Err;
+
+  if (Error Err =
+          rewriteKernelDescriptorEntriesForDisplacement(OutBuf, Elf, Plan))
+    return Err;
+
+  log() << "hotswap: displacement: grew ELF from " << InputSize << " to "
+        << NewSize << " bytes (" << Plan.edits().size() << " edit"
+        << (Plan.edits().size() == 1 ? "" : "s") << ", raw growth "
+        << Plan.rawGrowth() << " bytes, padded growth " << Plan.paddedGrowth()
+        << " bytes).\n";
+  return Error::success();
+}
+
+} // namespace
+
+Expected<DisplacementPlan>
+DisplacementPlan::create(const ElfView &Elf,
+                         ArrayRef<DisplacementEdit> InputEdits) {
+  if (InputEdits.empty())
+    return makeDisplacementError("no displacement edits requested");
+
+  std::vector<DisplacementEdit> Sorted;
+  Sorted.reserve(InputEdits.size());
+  for (const DisplacementEdit &Edit : InputEdits)
+    Sorted.push_back(Edit);
+
+  std::stable_sort(Sorted.begin(), Sorted.end(),
+                   [](const DisplacementEdit &A, const DisplacementEdit &B) {
+                     return A.Offset < B.Offset;
+                   });
+
+  uint64_t RawGrowth = 0;
+  std::optional<uint64_t> PrevOffset;
+  uint64_t PrevEnd = 0;
+  for (const DisplacementEdit &Edit : Sorted) {
+    if (Edit.ReplacementBytes.empty())
+      return makeDisplacementError("displacement edit has empty replacement");
+    if (Edit.Offset > Elf.textSize() ||
+        Edit.OriginalSize > Elf.textSize() - Edit.Offset) {
+      return makeDisplacementError("displacement edit is out of .text bounds");
+    }
+    if (Edit.ReplacementBytes.size() < Edit.OriginalSize)
+      return makeDisplacementError("displacement edit shrinks code");
+    if (Edit.ReplacementBytes.size() == Edit.OriginalSize)
+      return makeDisplacementError("displacement edit has no size delta");
+    if (PrevOffset && Edit.Offset < PrevEnd)
+      return makeDisplacementError("displacement edits overlap");
+    if (PrevOffset && Edit.Offset == *PrevOffset) {
+      return makeDisplacementError(
+          "multiple displacement edits share an offset");
+    }
+
+    uint64_t EditGrowth = Edit.ReplacementBytes.size() - Edit.OriginalSize;
+    if (EditGrowth > std::numeric_limits<uint64_t>::max() - RawGrowth)
+      return makeDisplacementError("displacement growth overflows uint64_t");
+    RawGrowth += EditGrowth;
+    PrevOffset = Edit.Offset;
+    PrevEnd = Edit.Offset + Edit.OriginalSize;
+  }
+
+  Expected<uint64_t> AlignmentOrErr = requiredGrowthAlignment(Elf);
+  if (!AlignmentOrErr)
+    return AlignmentOrErr.takeError();
+  uint64_t Alignment = *AlignmentOrErr;
+  if (!isPowerOf2_64(Alignment))
+    return makeDisplacementError("post-.text alignment is not a power of two");
+  uint64_t Remainder = RawGrowth % Alignment;
+  uint64_t Padding = Remainder == 0 ? 0 : Alignment - Remainder;
+  if (Padding > std::numeric_limits<uint64_t>::max() - RawGrowth)
+    return makeDisplacementError("aligned displacement growth overflows");
+  uint64_t PaddedGrowth = RawGrowth + Padding;
+  if (Error Err = validateVirtualGrowth(Elf, PaddedGrowth))
+    return std::move(Err);
+  if (PaddedGrowth > std::numeric_limits<size_t>::max() - Elf.size())
+    return makeDisplacementError("displaced ELF size overflows size_t");
+  return DisplacementPlan(Elf.textSize(), RawGrowth, PaddedGrowth,
+                          std::move(Sorted));
+}
+
+bool DisplacementPlan::mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
+                                 uint64_t &NewOffset) const {
+  if (OldOffset > OldTextSize)
+    return false;
+
+  uint64_t Delta = 0;
+  for (const DisplacementEdit &Edit : Edits) {
+    const uint64_t EditEnd = Edit.Offset + Edit.OriginalSize;
+    const uint64_t EditDelta = Edit.ReplacementBytes.size() - Edit.OriginalSize;
+
+    if (OldOffset < Edit.Offset)
+      break;
+
+    if (OldOffset == Edit.Offset) {
+      if (Edit.OriginalSize == 0 &&
+          Bias == DisplacementMapBias::AfterInsertedBytes) {
+        Delta += EditDelta;
+        continue;
+      }
+      break;
+    }
+
+    if (OldOffset < EditEnd)
+      return false;
+
+    Delta += EditDelta;
+  }
+
+  NewOffset = OldOffset + Delta;
+  return true;
+}
+
+bool DisplacementPlan::rangeOverlapsReplacement(uint64_t OldOffset,
+                                                uint64_t Size) const {
+  if (Size == 0)
+    return false;
+  const uint64_t OldEnd = OldOffset + Size;
+  for (const DisplacementEdit &Edit : Edits) {
+    if (Edit.OriginalSize == 0)
+      continue;
+    const uint64_t EditEnd = Edit.Offset + Edit.OriginalSize;
+    if (OldOffset < EditEnd && OldEnd > Edit.Offset)
+      return true;
+  }
+  return false;
+}
+
+SmallVector<uint8_t>
+DisplacementPlan::buildText(ArrayRef<uint8_t> OldText,
+                            ArrayRef<uint8_t> SNopBytes) const {
+  SmallVector<uint8_t> Out;
+  Out.reserve(paddedTextSize());
+
+  uint64_t Pos = 0;
+  for (const DisplacementEdit &Edit : Edits) {
+    Out.append(OldText.begin() + Pos, OldText.begin() + Edit.Offset);
+    Out.append(Edit.ReplacementBytes.begin(), Edit.ReplacementBytes.end());
+    Pos = Edit.Offset + Edit.OriginalSize;
+  }
+  Out.append(OldText.begin() + Pos, OldText.end());
+
+  uint64_t PadBytes = paddedTextSize() - Out.size();
+  while (PadBytes >= MinInstSize && SNopBytes.size() == MinInstSize) {
+    Out.append(SNopBytes.begin(), SNopBytes.end());
+    PadBytes -= MinInstSize;
+  }
+  Out.append(PadBytes, uint8_t{0});
+  return Out;
+}
+
+Expected<std::unique_ptr<WritableMemoryBuffer>>
+tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
+                                    ArrayRef<DisplacementEdit> Edits) {
+  if (Error Err = validateDebugSections(Elf))
+    return std::move(Err);
+  if (Error Err = validateTextRelocations(Elf))
+    return std::move(Err);
+
+  Expected<DisplacementPlan> PlanOrErr = DisplacementPlan::create(Elf, Edits);
+  if (!PlanOrErr)
+    return PlanOrErr.takeError();
+  if (Error Err = validateKernelEntryMappings(Elf, *PlanOrErr))
+    return std::move(Err);
+
+  std::unique_ptr<WritableMemoryBuffer> Out =
+      WritableMemoryBuffer::getNewUninitMemBuffer(
+          PlanOrErr->newElfSize(Elf.size()));
+  if (!Out) {
+    return makeDisplacementError(
+        "failed to allocate displacement output buffer");
+  }
+  if (Error Err = applyTextDisplacement(Elf, LS, *PlanOrErr, *Out))
+    return std::move(Err);
+  return std::move(Out);
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -309,11 +309,9 @@ std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   return KD.VAddr - Magnitude;
 }
 
-static std::optional<bool>
-descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
-                                  const KernelDescriptorInfo &KD,
-                                  const LLVMState &LS,
-                                  ArrayRef<uint8_t> EntryStubPrefix) {
+static std::optional<bool> descriptorAlreadyTargetsEntryStub(
+    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS,
+    ArrayRef<uint8_t> EntryStubPrefix) {
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
@@ -338,8 +336,8 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
     return false;
 
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(Candidate, LS,
-                             Decoded, "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+                             "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;
@@ -403,8 +401,8 @@ totalTrampolineBytes(ArrayRef<Trampoline> Trampolines) {
   return Total;
 }
 
-static std::optional<int64_t>
-checkedSignedDifference(uint64_t LHS, uint64_t RHS, StringRef Context) {
+std::optional<int64_t> checkedSignedDifference(uint64_t LHS, uint64_t RHS,
+                                               StringRef Context) {
   if (LHS >= RHS) {
     uint64_t Diff = LHS - RHS;
     if (Diff > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
@@ -484,6 +482,73 @@ static bool appendPaddingTrampoline(std::vector<Trampoline> &Out,
     Pad.Bytes.append(Fill.begin(), Fill.end());
   Out.push_back(std::move(Pad));
   return true;
+}
+
+std::optional<uint32_t>
+collectKernelEntryDisplacements(const ElfView &Elf, const LLVMState &LS,
+                                std::vector<DisplacementEdit> &OutEdits) {
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  if (Descriptors.empty())
+    return 0;
+
+  SmallVector<uint8_t> Prefix = buildEntryStubBytePrefix(LS);
+  if (Prefix.empty())
+    return std::nullopt;
+
+  std::optional<uint64_t> TextEnd = checkedAddUint64(
+      Elf.textAddr(), Elf.textSize(), "entry displacement text end");
+  if (!TextEnd)
+    return std::nullopt;
+
+  uint32_t Added = 0;
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    std::optional<bool> AlreadyHasEntryStub =
+        descriptorAlreadyTargetsEntryStub(Elf, KD, LS, Prefix);
+    if (!AlreadyHasEntryStub)
+      return std::nullopt;
+    if (*AlreadyHasEntryStub)
+      continue;
+
+    std::optional<bool> PrologueHasWorkaround =
+        entryPrologueHasVmemWorkaround(Elf, KD, LS, Prefix);
+    if (!PrologueHasWorkaround)
+      return std::nullopt;
+    if (*PrologueHasWorkaround)
+      continue;
+
+    std::optional<uint64_t> Entry = entryVAddr(KD);
+    if (!Entry)
+      return std::nullopt;
+    if (*Entry < Elf.textAddr() || *Entry >= *TextEnd) {
+      log() << "hotswap: error: kernel-entry displacement for '"
+            << KD.KernelName << "' points outside .text at vaddr 0x"
+            << utohexstr(*Entry) << ".\n";
+      return std::nullopt;
+    }
+    const uint64_t TextOffset = *Entry - Elf.textAddr();
+
+    bool DuplicateOffset = false;
+    for (const DisplacementEdit &Existing : OutEdits) {
+      if (Existing.Offset == TextOffset && Existing.OriginalSize == 0) {
+        DuplicateOffset = true;
+        break;
+      }
+    }
+    if (DuplicateOffset)
+      continue;
+
+    DisplacementEdit Edit;
+    Edit.Offset = TextOffset;
+    Edit.OriginalSize = 0;
+    Edit.ReplacementBytes.assign(Prefix.begin(), Prefix.end());
+    OutEdits.push_back(std::move(Edit));
+    ++Added;
+  }
+
+  if (Added > 0)
+    log() << "hotswap: queued " << Added << " kernel-entry displacement"
+          << (Added == 1 ? "" : "s") << "\n";
+  return Added;
 }
 
 std::optional<uint32_t> appendKernelEntryTrampolines(

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -72,6 +72,8 @@
 namespace COMGR {
 namespace hotswap {
 
+class ElfView;
+
 // -- Logging ------------------------------------------------------------------
 //
 // Single output stream for all hotswap diagnostics (errors, warnings, and
@@ -332,6 +334,51 @@ struct Trampoline {
   bool HasFunctionRange = false;
   uint64_t FunctionStart = 0;
   uint64_t FunctionEnd = 0;
+};
+
+struct DisplacementEdit {
+  uint64_t Offset = 0;
+  uint32_t OriginalSize = 0;
+  llvm::SmallVector<uint8_t> ReplacementBytes;
+};
+
+enum class DisplacementMapBias {
+  BeforeInsertedBytes,
+  AfterInsertedBytes,
+};
+
+class DisplacementPlan {
+public:
+  static llvm::Expected<DisplacementPlan>
+  create(const ElfView &Elf, llvm::ArrayRef<DisplacementEdit> Edits);
+
+  llvm::ArrayRef<DisplacementEdit> edits() const { return Edits; }
+  uint64_t oldTextSize() const { return OldTextSize; }
+  uint64_t rawGrowth() const { return RawGrowth; }
+  uint64_t paddedGrowth() const { return PaddedGrowth; }
+  uint64_t newTextSize() const { return OldTextSize + RawGrowth; }
+  uint64_t paddedTextSize() const { return OldTextSize + PaddedGrowth; }
+  size_t newElfSize(size_t OldElfSize) const {
+    return OldElfSize + PaddedGrowth;
+  }
+
+  bool mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
+                 uint64_t &NewOffset) const;
+  bool rangeOverlapsReplacement(uint64_t OldOffset, uint64_t Size) const;
+
+  llvm::SmallVector<uint8_t> buildText(llvm::ArrayRef<uint8_t> OldText,
+                                       llvm::ArrayRef<uint8_t> SNopBytes) const;
+
+private:
+  DisplacementPlan(uint64_t OldTextSize, uint64_t RawGrowth,
+                   uint64_t PaddedGrowth, std::vector<DisplacementEdit> Edits)
+      : OldTextSize(OldTextSize), RawGrowth(RawGrowth),
+        PaddedGrowth(PaddedGrowth), Edits(std::move(Edits)) {}
+
+  uint64_t OldTextSize = 0;
+  uint64_t RawGrowth = 0;
+  uint64_t PaddedGrowth = 0;
+  std::vector<DisplacementEdit> Edits;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -1347,6 +1394,13 @@ bool hasKernelEntryTrampolinePrefix(llvm::ArrayRef<uint8_t> Bytes,
 /// mapped .text bytes.
 uint64_t computeKernelEntryPrefetchGuardBytes(uint32_t InstPrefLines);
 
+/// Queue one direct insertion of `global_wb; v_nop` at each kernel descriptor
+/// entry that does not already target either a direct entry prefix or an
+/// appended HotSwap entry stub.
+std::optional<uint32_t>
+collectKernelEntryDisplacements(const ElfView &Elf, const LLVMState &LS,
+                                std::vector<DisplacementEdit> &OutEdits);
+
 /// Append one entry stub per kernel descriptor that does not already target a
 /// HotSwap entry stub. The stubs are appended to \p Growth and descriptor
 /// rewrites are recorded in \p OutFixups for application after ELF growth.
@@ -1365,6 +1419,10 @@ bool rewriteKernelEntryDescriptorOffsets(
 /// Resolve the virtual address of a kernel descriptor's entry point. Shared by
 /// the MC and fast entry-trampoline paths.
 std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD);
+
+/// Compute LHS - RHS when the result is representable as int64_t.
+std::optional<int64_t> checkedSignedDifference(uint64_t LHS, uint64_t RHS,
+                                               llvm::StringRef Context);
 
 /// Round Value up to a multiple of Alignment, reporting overflow against
 /// Context. Shared by the MC and fast entry-trampoline paths.
@@ -1402,6 +1460,11 @@ std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex,
     uint64_t TextAddr, uint64_t OldTextSize,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+
+/// Apply direct .text displacement to a newly allocated output buffer.
+llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>>
+tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
+                                    llvm::ArrayRef<DisplacementEdit> Edits);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
@@ -1,4 +1,4 @@
-// COM: HotSwap entry trampolines are supported across gfx125x.
+// COM: Direct HotSwap entry displacement is supported across gfx125x.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib %s -o %t.gfx1251.elf
 // RUN: hotswap-rewrite %t.gfx1251.elf \
@@ -6,6 +6,18 @@
 // RUN:   --entry-trampolines --output %t.gfx1251.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // RUN: %llvm-objdump -d %t.gfx1251.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Direct displacement does not need scratch SGPRs, so it remains valid at
+// COM: the architectural SGPR limit.
+// RUN: sed 's/.sgpr_count: 1/.sgpr_count: 105/' %s > %t.highsgpr.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib \
+// RUN:   %t.highsgpr.s -o %t.highsgpr.elf
+// RUN: hotswap-rewrite %t.highsgpr.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1251 amdgcn-amd-amdhsa--gfx1251 \
+// RUN:   --entry-trampolines --output %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=DISASM %s
 
 // RUN: sed -e '/^\.amdgcn_target/d' \
 // RUN:   -e 's/gfx1251/gfx12-5-generic/g' %s > %t.generic.s
@@ -21,13 +33,11 @@
 // API: RESULT: SUCCESS
 
 // DISASM-LABEL: <entry_tramp_family_kernel>:
-// DISASM: s_endpgm
-// DISASM: global_wb
+// DISASM-NEXT: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2
-// DISASM-NEXT: s_add_co_ci_u32 s3
-// DISASM-NEXT: s_set_pc_i64 s[2:3]
+// DISASM-NEXT: v_mov_b32_e32 v0, 0
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: s_get_pc_i64
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1251"
 .text

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-mixed-existing.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-mixed-existing.s
@@ -1,0 +1,126 @@
+// COM: An object can contain an existing appended entry stub and a different
+// COM: raw kernel entry. Direct displacement would move the existing stub's
+// COM: body target without repairing the stub, so the whole rewrite must stay
+// COM: on the appended-stub path.
+
+// COM: First create an object where the pre-fixed first kernel is skipped and
+// COM: the second kernel receives a fast-path appended stub.
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.prefixed.elf
+// RUN: env AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 hotswap-rewrite \
+// RUN:   %t.prefixed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.seed.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+
+// COM: Replace only .text with an equal-sized raw variant. This preserves the
+// COM: second descriptor and appended stub while making the first entry need
+// COM: the workaround.
+// RUN: sed 's/^\.set raw_entry, 0$/.set raw_entry, 1/' \
+// RUN:   %s > %t.raw.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %t.raw.s \
+// RUN:   -o %t.raw.elf
+// RUN: %llvm-objcopy --dump-section .text=%t.raw.text %t.raw.elf
+// RUN: %llvm-objcopy --update-section .text=%t.raw.text %t.seed.elf \
+// RUN:   %t.mixed.elf
+
+// RUN: hotswap-rewrite %t.mixed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: Both original bodies keep their addresses; direct displacement would
+// COM: move mixed_second by 16 bytes and leave its old stub target stale.
+// RUN: (echo ORIGINAL; %llvm-readelf -Ws %t.mixed.elf; \
+// RUN:  echo REWRITTEN; %llvm-readelf -Ws %t.out.elf) \
+// RUN:  | %FileCheck --check-prefix=SYMBOL %s
+// SYMBOL: ORIGINAL
+// SYMBOL-DAG: [[FIRST:[0-9a-fA-F]+]] {{.*}} mixed_first
+// SYMBOL-DAG: [[SECOND:[0-9a-fA-F]+]] {{.*}} mixed_second
+// SYMBOL: REWRITTEN
+// SYMBOL-DAG: [[FIRST]] {{.*}} mixed_first
+// SYMBOL-DAG: [[SECOND]] {{.*}} mixed_second
+// SYMBOL-DAG: {{[0-9a-fA-F]+}} {{.*}} mixed_first.stub
+// SYMBOL-DAG: {{[0-9a-fA-F]+}} {{.*}} mixed_second.stub
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <mixed_first>:
+// DISASM-NEXT: s_nop 0
+// DISASM-LABEL: <mixed_second>:
+// DISASM-NEXT: v_mov_b32_e32 v0, 2
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.set raw_entry, 0
+.text
+.globl mixed_first
+.p2align 8
+.type mixed_first,@function
+mixed_first:
+.if raw_entry
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.else
+  global_wb
+.endif
+  v_nop
+  s_endpgm
+.Lmixed_first_end:
+.size mixed_first, .Lmixed_first_end-mixed_first
+
+.globl mixed_second
+.p2align 8
+.type mixed_second,@function
+mixed_second:
+  v_mov_b32_e32 v0, 2
+  s_endpgm
+.Lmixed_second_end:
+.size mixed_second, .Lmixed_second_end-mixed_second
+
+.rodata
+.p2align 8
+.amdhsa_kernel mixed_first
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel mixed_second
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: mixed_first
+      .symbol: mixed_first.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: mixed_second
+      .symbol: mixed_second.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
@@ -1,6 +1,6 @@
-// COM: The entry-trampoline rewrite must redirect every kernel descriptor in
-// COM: the code object, not just the first one. Each descriptor gets its own
-// COM: appended PC-relative entry stub.
+// COM: A 16-byte direct prefix before the first kernel would misalign the
+// COM: second kernel. HotSwap must retain the ABI's 256-byte entry alignment by
+// COM: falling back to aligned appended stubs for the whole object.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -13,21 +13,17 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
 // DISASM-LABEL: <entry_tramp_first>:
-// DISASM: s_endpgm
+// DISASM-NEXT: v_mov_b32_e32 v0, 1
+// DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <entry_tramp_second>:
-// DISASM: s_endpgm
-// DISASM: global_wb
+// DISASM-NEXT: v_mov_b32_e32 v0, 2
+// DISASM-NEXT: s_endpgm
+// DISASM: global_wb // {{[0-9a-fA-F]+00}}:
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2
-// DISASM-NEXT: s_add_co_ci_u32 s3
-// DISASM-NEXT: s_set_pc_i64 s[2:3]
-// DISASM: global_wb
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb // {{[0-9a-fA-F]+00}}:
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2
-// DISASM-NEXT: s_add_co_ci_u32 s3
-// DISASM-NEXT: s_set_pc_i64 s[2:3]
+// DISASM-NEXT: s_get_pc_i64
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-precompiled-workaround.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-precompiled-workaround.s
@@ -10,10 +10,9 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// COM: An installed trampoline gets a <kernel>.stub symbol: the plain kernel
-// COM: has one, the pre-fixed kernel does not.
+// COM: Direct displacement creates no appended-stub symbols.
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
-// SYMS: plain_kernel.stub
+// SYMS-NOT: plain_kernel.stub
 
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=NO-WA-STUB %s
 // NO-WA-STUB-NOT: precompiled_wa_kernel.stub
@@ -21,9 +20,13 @@
 // COM: The pre-fixed kernel keeps its in-place workaround, not a redirect stub.
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-LABEL: <precompiled_wa_kernel>:
-// DISASM: global_wb
+// DISASM-NEXT: global_wb
 // DISASM-NEXT: v_nop
 // DISASM-NEXT: s_endpgm
+// DISASM-LABEL: <plain_kernel>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_setreg_imm32_b32
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-relocation.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-relocation.s
@@ -1,0 +1,84 @@
+// COM: A dynamic relocation can write outside .text while its addend still
+// COM: references displaced code. Direct displacement must decline this input
+// COM: and use an appended entry stub so the relocation remains valid.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <relocation_kernel>:
+// DISASM-NEXT: s_endpgm
+// DISASM-LABEL: <pointed_helper>:
+// DISASM-NEXT: s_endpgm
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+
+// RUN: (echo ORIGINAL; %llvm-readelf -Ws %t.elf; \
+// RUN:  echo REWRITTEN; %llvm-readelf -Ws %t.out.elf) \
+// RUN:  | %FileCheck --check-prefix=SYMBOL %s
+// SYMBOL: ORIGINAL
+// SYMBOL: [[HELPER:[0-9a-fA-F]+]] {{.*}} pointed_helper
+// SYMBOL: REWRITTEN
+// SYMBOL: [[HELPER]] {{.*}} pointed_helper
+
+// RUN: (echo ORIGINAL; %llvm-readelf -r %t.elf; \
+// RUN:  echo REWRITTEN; %llvm-readelf -r %t.out.elf) \
+// RUN:  | %FileCheck --check-prefix=RELOCATION %s
+// RELOCATION: ORIGINAL
+// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}[[ADDEND:[0-9a-fA-F]+]]
+// RELOCATION: REWRITTEN
+// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}[[ADDEND]]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl relocation_kernel
+.p2align 8
+.type relocation_kernel,@function
+relocation_kernel:
+  s_endpgm
+.Lrelocation_kernel_end:
+.size relocation_kernel, .Lrelocation_kernel_end-relocation_kernel
+
+.local pointed_helper
+.type pointed_helper,@function
+pointed_helper:
+  s_endpgm
+.Lpointed_helper_end:
+.size pointed_helper, .Lpointed_helper_end-pointed_helper
+
+.data
+.p2align 3
+.globl helper_pointer
+.type helper_pointer,@object
+helper_pointer:
+  .quad pointed_helper
+.size helper_pointer, 8
+
+.rodata
+.p2align 8
+.amdhsa_kernel relocation_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: relocation_kernel
+      .symbol: relocation_kernel.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -1,5 +1,6 @@
-// COM: HotSwap redirects kernel descriptors to appended PC-relative entry
-// COM: stubs when the entry-trampoline flag is explicitly enabled.
+// COM: HotSwap applies the entry workaround when the entry-trampoline flag is
+// COM: enabled. This multi-kernel layout uses aligned appended stubs because a
+// COM: direct prefix would misalign later kernel entries.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -10,7 +11,8 @@
 // RUN: cmp %t.elf %t.default.elf
 // RUN: %llvm-objdump -d %t.default.elf | %FileCheck --check-prefix=NO-TRAMP %s
 // NO-TRAMP-LABEL: <entry_tramp_kernel>:
-// NO-TRAMP: s_endpgm
+// NO-TRAMP-NEXT: v_mov_b32_e32 v0, 0
+// NO-TRAMP-NEXT: s_endpgm
 // NO-TRAMP-LABEL: <hipblaslt_entry_kernel>:
 // NO-TRAMP: s_setreg_imm32_b32
 // NO-TRAMP-LABEL: <decoder_trip_kernel>:
@@ -24,7 +26,6 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-// RUN: %llvm-objdump -s -j .rodata %t.out.elf | %FileCheck --check-prefix=RODATA %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // COM: Entry trampolines are independent of the B0-to-A0 patch policy, so an
@@ -37,29 +38,30 @@
 // RUN: %llvm-objdump -d %t.b0a0.elf | %FileCheck --check-prefix=DISASM %s
 
 // DISASM-LABEL: <entry_tramp_kernel>:
-// DISASM: s_endpgm
+// DISASM-NEXT: v_mov_b32_e32 v0, 0
+// DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <hipblaslt_entry_kernel>:
-// DISASM: s_setreg_imm32_b32
+// DISASM-NEXT: s_setreg_imm32_b32
 // DISASM-LABEL: <decoder_trip_kernel>:
-// DISASM: .long 0xffffffff
+// DISASM-NEXT: .long 0xffffffff
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[8:9]
-// DISASM-NEXT: s_add_co_u32 s8
-// DISASM-NEXT: s_add_co_ci_u32 s9
-// DISASM-NEXT: s_set_pc_i64 s[8:9]
-
-// RODATA: Contents of section .rodata
-// RODATA: {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} 20000000
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
 
 // METADATA: .name:           entry_tramp_kernel
 // METADATA: .sgpr_count:     10
 
-// COM: Each appended stub gets a <kernel>.stub symbol so a dispatch whose entry
-// COM: points at the stub still resolves to a name (e.g. rocgdb info dispatches).
+// COM: The alignment fallback records each appended stub for debuggers.
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
-// SYMS-DAG: FUNC {{.*}} entry_tramp_kernel.stub
-// SYMS-DAG: FUNC {{.*}} hipblaslt_entry_kernel.stub
+// SYMS-DAG: entry_tramp_kernel.stub
+// SYMS-DAG: hipblaslt_entry_kernel.stub
+// SYMS-DAG: decoder_trip_kernel.stub
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -68,8 +70,7 @@
 // API2: RESULT: SUCCESS
 // RUN: cmp %t.out.elf %t.out2.elf
 
-// COM: If the requested entry trampoline cannot allocate an aligned scratch
-// COM: SGPR pair, the rewrite fails instead of returning a partial output.
+// COM: The alignment fallback needs a scratch SGPR pair for its appended stubs.
 // RUN: sed 's/.sgpr_count: 8/.sgpr_count: 105/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -14,6 +14,28 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
+// COM: Entry displacement is applied before ordinary instruction rewriting.
+// COM: Verify that the direct entry prefix and appended DS trampoline coexist
+// COM: with branch sites calculated from the displaced instruction layout.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.entry.elf \
+// RUN:   | %FileCheck --check-prefix=ENTRY-API %s
+// ENTRY-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.entry.elf | %FileCheck --check-prefix=ENTRY %s
+// ENTRY-LABEL: <test_ds_trampoline>:
+// ENTRY-NEXT: global_wb
+// ENTRY-NEXT: v_nop
+// ENTRY-NEXT: s_branch
+// ENTRY-NEXT: s_nop 0
+// ENTRY-NEXT: s_wait_dscnt 0x0
+// ENTRY-NEXT: s_endpgm
+// ENTRY: ds_load_b32 v0, v2 offset:256
+// ENTRY-NEXT: ds_load_b32 v1, v2 offset:768
+// ENTRY-NEXT: s_wait_dscnt 0x0
+// ENTRY-NEXT: s_branch
+// ENTRY-NOT: s_get_pc_i64
+
 // COM: The original DS2 is gone; s_branch forward replaces it. The drain
 // COM: s_wait_dscnt stays at the original position with imm unchanged (0x0).
 // DISASM-LABEL: <test_ds_trampoline>:

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -37,12 +37,21 @@ def _fwd(*parts):
     return os.path.join(*parts).replace("\\", "/")
 
 # %-prefixed substitutions for LLVM tools (used as %clang, %llvm-dis, etc.)
-config.substitutions.append(('%clang', _fwd(config.llvm_tools_dir, 'clang')))
-config.substitutions.append(('%llvm-dis', _fwd(config.llvm_tools_dir, 'llvm-dis')))
-config.substitutions.append(('%llvm-mc', _fwd(config.llvm_tools_dir, 'llvm-mc')))
-config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-objdump')))
-config.substitutions.append(('%llvm-readelf', _fwd(config.llvm_tools_dir, 'llvm-readelf')))
-config.substitutions.append(('%ld.lld', _fwd(config.llvm_tools_dir, 'ld.lld')))
-config.substitutions.append(('%yaml2obj', _fwd(config.llvm_tools_dir, 'yaml2obj')))
-config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
-config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))
+config.substitutions.append(("%clang", _fwd(config.llvm_tools_dir, "clang")))
+config.substitutions.append(("%llvm-dis", _fwd(config.llvm_tools_dir, "llvm-dis")))
+config.substitutions.append(("%llvm-mc", _fwd(config.llvm_tools_dir, "llvm-mc")))
+config.substitutions.append(
+    ("%llvm-objcopy", _fwd(config.llvm_tools_dir, "llvm-objcopy"))
+)
+config.substitutions.append(
+    ("%llvm-objdump", _fwd(config.llvm_tools_dir, "llvm-objdump"))
+)
+config.substitutions.append(
+    ("%llvm-readelf", _fwd(config.llvm_tools_dir, "llvm-readelf"))
+)
+config.substitutions.append(("%ld.lld", _fwd(config.llvm_tools_dir, "ld.lld")))
+config.substitutions.append(("%yaml2obj", _fwd(config.llvm_tools_dir, "yaml2obj")))
+config.substitutions.append(("%FileCheck", _fwd(config.llvm_tools_dir, "FileCheck")))
+config.substitutions.append(
+    ("%amd-llvm-spirv", _fwd(config.llvm_tools_dir, "amd-llvm-spirv"))
+)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -104,6 +104,7 @@ add_executable(HotswapMCTests
   HotswapOccupancyTest.cpp
   HotswapMCTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
+  ../src/comgr-hotswap-displacement.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -78,6 +78,201 @@ static uint32_t readDword(const uint8_t *Bytes) {
   return V;
 }
 
+static uint64_t alignTo8(uint64_t V) { return (V + 7) & ~uint64_t{7}; }
+
+static std::vector<uint8_t> makeDisplacementTestElf(
+    llvm::ArrayRef<uint8_t> Text, bool AddTextRelocation = false,
+    bool AddDebugSection = false, bool AddBoundaryTextSymbol = false) {
+  using namespace llvm::ELF;
+  namespace hsa = llvm::amdhsa;
+
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t PhOff = 0x200;
+  static constexpr uint64_t TextOff = 0x280;
+  static constexpr uint64_t TextAddr = 0x1000;
+  static constexpr uint64_t RodataAddr = 0x2000;
+  static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
+  const uint64_t SymCount = AddBoundaryTextSymbol ? 4 : 3;
+
+  const char StrTab[] = "\0kernel\0kernel.kd\0";
+  const char ShStrTabNoRel[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
+  const char ShStrTabRel[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.rela.text\0.shstrtab\0";
+  const char ShStrTabDebug[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.debug_info\0.shstrtab\0";
+
+  const uint64_t RodataOff = alignTo8(TextOff + Text.size());
+  const uint64_t StrTabOff = alignTo8(RodataOff + KdBytes);
+  const uint64_t SymTabOff = alignTo8(StrTabOff + sizeof(StrTab));
+  const uint64_t RelOff =
+      AddTextRelocation ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym))
+                        : 0;
+  const uint64_t DebugOff =
+      AddDebugSection ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym)) : 0;
+  const uint64_t ShStrTabOff =
+      AddTextRelocation ? alignTo8(RelOff + sizeof(Elf64_Rela))
+      : AddDebugSection ? alignTo8(DebugOff + 4)
+                        : alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t ShStrTabSize = AddTextRelocation ? sizeof(ShStrTabRel)
+                                : AddDebugSection ? sizeof(ShStrTabDebug)
+                                                  : sizeof(ShStrTabNoRel);
+  const uint64_t BufSize = alignTo8(ShStrTabOff + ShStrTabSize + 64);
+
+  std::vector<uint8_t> Buf(BufSize, 0);
+  const char *ShStrTab = AddTextRelocation ? ShStrTabRel
+                         : AddDebugSection ? ShStrTabDebug
+                                           : ShStrTabNoRel;
+  std::memcpy(Buf.data() + ShStrTabOff, ShStrTab, ShStrTabSize);
+  std::memcpy(Buf.data() + StrTabOff, StrTab, sizeof(StrTab));
+  std::memcpy(Buf.data() + TextOff, Text.data(), Text.size());
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_phoff = PhOff;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  Ehdr.e_phnum = 2;
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = AddTextRelocation || AddDebugSection ? 7 : 6;
+  Ehdr.e_shstrndx = AddTextRelocation || AddDebugSection ? 6 : 5;
+  std::memcpy(Buf.data(), &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr TextPh{};
+  TextPh.p_type = PT_LOAD;
+  TextPh.p_flags = PF_R | PF_X;
+  TextPh.p_offset = TextOff;
+  TextPh.p_vaddr = TextAddr;
+  TextPh.p_paddr = TextAddr;
+  TextPh.p_filesz = Text.size();
+  TextPh.p_memsz = Text.size() + 64;
+  TextPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff, &TextPh, sizeof(TextPh));
+
+  Elf64_Phdr RodataPh{};
+  RodataPh.p_type = PT_LOAD;
+  RodataPh.p_flags = PF_R;
+  RodataPh.p_offset = RodataOff;
+  RodataPh.p_vaddr = RodataAddr;
+  RodataPh.p_paddr = RodataAddr;
+  RodataPh.p_filesz = KdBytes;
+  RodataPh.p_memsz = KdBytes;
+  RodataPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff + sizeof(Elf64_Phdr), &RodataPh,
+              sizeof(RodataPh));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = 1;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_offset = TextOff;
+  TextSh.sh_addr = TextAddr;
+  TextSh.sh_size = Text.size();
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf.data() + ShOff + 1 * sizeof(Elf64_Shdr), &TextSh,
+              sizeof(TextSh));
+
+  Elf64_Shdr RodataSh{};
+  RodataSh.sh_name = 7;
+  RodataSh.sh_type = SHT_PROGBITS;
+  RodataSh.sh_flags = SHF_ALLOC;
+  RodataSh.sh_offset = RodataOff;
+  RodataSh.sh_addr = RodataAddr;
+  RodataSh.sh_size = KdBytes;
+  RodataSh.sh_addralign = 8;
+  std::memcpy(Buf.data() + ShOff + 2 * sizeof(Elf64_Shdr), &RodataSh,
+              sizeof(RodataSh));
+
+  Elf64_Shdr StrtabSh{};
+  StrtabSh.sh_name = 15;
+  StrtabSh.sh_type = SHT_STRTAB;
+  StrtabSh.sh_offset = StrTabOff;
+  StrtabSh.sh_size = sizeof(StrTab);
+  std::memcpy(Buf.data() + ShOff + 3 * sizeof(Elf64_Shdr), &StrtabSh,
+              sizeof(StrtabSh));
+
+  Elf64_Shdr SymtabSh{};
+  SymtabSh.sh_name = 23;
+  SymtabSh.sh_type = SHT_SYMTAB;
+  SymtabSh.sh_offset = SymTabOff;
+  SymtabSh.sh_size = SymCount * sizeof(Elf64_Sym);
+  SymtabSh.sh_link = 3;
+  SymtabSh.sh_entsize = sizeof(Elf64_Sym);
+  std::memcpy(Buf.data() + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
+              sizeof(SymtabSh));
+
+  unsigned ShStrIndex = AddTextRelocation || AddDebugSection ? 6 : 5;
+  if (AddTextRelocation) {
+    Elf64_Shdr RelaSh{};
+    RelaSh.sh_name = 31;
+    RelaSh.sh_type = SHT_RELA;
+    RelaSh.sh_offset = RelOff;
+    RelaSh.sh_size = sizeof(Elf64_Rela);
+    RelaSh.sh_link = 4;
+    RelaSh.sh_info = 1; // applies to .text
+    RelaSh.sh_entsize = sizeof(Elf64_Rela);
+    std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &RelaSh,
+                sizeof(RelaSh));
+  }
+  if (AddDebugSection) {
+    Elf64_Shdr DebugSh{};
+    DebugSh.sh_name = 31;
+    DebugSh.sh_type = SHT_PROGBITS;
+    DebugSh.sh_offset = DebugOff;
+    DebugSh.sh_size = 4;
+    DebugSh.sh_addralign = 1;
+    std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &DebugSh,
+                sizeof(DebugSh));
+  }
+
+  Elf64_Shdr ShstrSh{};
+  ShstrSh.sh_name = AddTextRelocation ? 42 : AddDebugSection ? 43 : 31;
+  ShstrSh.sh_type = SHT_STRTAB;
+  ShstrSh.sh_offset = ShStrTabOff;
+  ShstrSh.sh_size = ShStrTabSize;
+  std::memcpy(Buf.data() + ShOff + ShStrIndex * sizeof(Elf64_Shdr), &ShstrSh,
+              sizeof(ShstrSh));
+
+  int64_t EntryOffset = static_cast<int64_t>(TextAddr - RodataAddr);
+  std::memcpy(
+      Buf.data() + RodataOff +
+          offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
+      &EntryOffset, sizeof(EntryOffset));
+
+  Elf64_Sym KernelSym{};
+  KernelSym.st_name = 1;
+  KernelSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+  KernelSym.st_shndx = 1;
+  KernelSym.st_value = TextAddr;
+  KernelSym.st_size = Text.size();
+  std::memcpy(Buf.data() + SymTabOff + 1 * sizeof(Elf64_Sym), &KernelSym,
+              sizeof(KernelSym));
+
+  Elf64_Sym KdSym{};
+  KdSym.st_name = 8;
+  KdSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  KdSym.st_shndx = 2;
+  KdSym.st_value = RodataAddr;
+  KdSym.st_size = KdBytes;
+  std::memcpy(Buf.data() + SymTabOff + 2 * sizeof(Elf64_Sym), &KdSym,
+              sizeof(KdSym));
+
+  if (AddBoundaryTextSymbol) {
+    Elf64_Sym BoundarySym{};
+    BoundarySym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+    BoundarySym.st_shndx = 1;
+    BoundarySym.st_value = TextAddr;
+    BoundarySym.st_size = MinInstSize;
+    std::memcpy(Buf.data() + SymTabOff + 3 * sizeof(Elf64_Sym), &BoundarySym,
+                sizeof(BoundarySym));
+  }
+
+  return Buf;
+}
+
 // -- initLLVM ----------------------------------------------------------------
 
 TEST(InitLLVM, ValidGfx1250) {
@@ -1843,6 +2038,383 @@ TEST(BuildKernelEntryTrampoline, MatcherRejectsWrongOperandShape) {
   EXPECT_FALSE(isKernelEntryTrampoline(Bytes, S));
 }
 
+// -- DisplacementPlan ---------------------------------------------------------
+
+TEST(DisplacementPlan, MapsInsertionAndReplacementBoundaries) {
+  std::vector<uint8_t> Text(16, 0);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Insert;
+  Insert.Offset = 4;
+  Insert.OriginalSize = 0;
+  Insert.ReplacementBytes.assign(8, 0x11);
+
+  DisplacementEdit Replace;
+  Replace.Offset = 8;
+  Replace.OriginalSize = 4;
+  Replace.ReplacementBytes.assign(8, 0x22);
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Insert, Replace});
+  ASSERT_TRUE((bool)PlanOrErr) << llvm::toString(PlanOrErr.takeError());
+
+  uint64_t Mapped = 0;
+  ASSERT_TRUE(PlanOrErr->mapOffset(4, DisplacementMapBias::BeforeInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 4u);
+  ASSERT_TRUE(
+      PlanOrErr->mapOffset(4, DisplacementMapBias::AfterInsertedBytes, Mapped));
+  EXPECT_EQ(Mapped, 12u);
+  ASSERT_TRUE(PlanOrErr->mapOffset(8, DisplacementMapBias::BeforeInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 16u);
+  ASSERT_TRUE(PlanOrErr->mapOffset(12, DisplacementMapBias::AfterInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 24u);
+  EXPECT_FALSE(PlanOrErr->mapOffset(
+      10, DisplacementMapBias::BeforeInsertedBytes, Mapped));
+}
+
+TEST(DisplacementPlan, RejectsOverlappingEdits) {
+  std::vector<uint8_t> Text(16, 0);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit A;
+  A.Offset = 4;
+  A.OriginalSize = 8;
+  A.ReplacementBytes.assign(12, 0x11);
+
+  DisplacementEdit B;
+  B.Offset = 8;
+  B.OriginalSize = 4;
+  B.ReplacementBytes.assign(8, 0x22);
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {A, B});
+  ASSERT_FALSE((bool)PlanOrErr);
+  std::string Reason = llvm::toString(PlanOrErr.takeError());
+  EXPECT_NE(Reason.find("overlap"), std::string::npos) << Reason;
+}
+
+TEST(DisplacementPlan, RebuildsTextAndPadsToPostTextAlignment) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<uint8_t> Text(16);
+  for (unsigned I = 0; I < Text.size(); ++I)
+    Text[I] = I;
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 4;
+  Edit.OriginalSize = 4;
+  Edit.ReplacementBytes.assign(
+      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7});
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Edit});
+  ASSERT_TRUE((bool)PlanOrErr) << llvm::toString(PlanOrErr.takeError());
+  EXPECT_EQ(PlanOrErr->rawGrowth(), 4u);
+  EXPECT_EQ(PlanOrErr->paddedGrowth(), 8u);
+
+  llvm::SmallVector<uint8_t> NewText = PlanOrErr->buildText(Text, S.SNopBytes);
+  ASSERT_EQ(NewText.size(), 24u);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(NewText.data(), 4),
+            llvm::ArrayRef<uint8_t>(Text.data(), 4));
+  EXPECT_EQ(NewText[4], 0xA0);
+  EXPECT_EQ(NewText[11], 0xA7);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(NewText.data() + 12, 8),
+            llvm::ArrayRef<uint8_t>(Text.data() + 8, 8));
+  EXPECT_EQ(std::memcmp(NewText.data() + 20, S.SNopBytes.data(), MinInstSize),
+            0);
+}
+
+TEST(TextDisplacement, ReencodesForwardSBranchAcrossInsertion) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  llvm::SmallVector<uint8_t> Br = S.encodeSBranch(0, 8);
+  ASSERT_EQ(Br.size(), MinInstSize);
+  Text.append(Br.begin(), Br.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End.begin(), End.end());
+
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 4;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(
+      decodeTextSection(OutView->textData(), OutView->textSize(), S, Decoded));
+  ASSERT_GE(Decoded.size(), 4u);
+  ASSERT_TRUE(Decoded[0].Inst.getOperand(0).isImm());
+  EXPECT_EQ(Decoded[0].Inst.getOperand(0).getImm(), 2);
+  EXPECT_EQ(Decoded[3].Mnemonic, "s_endpgm");
+}
+
+TEST(TextDisplacement, PreservesSymbolEndingAtInsertionBoundary) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End.begin(), End.end());
+
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = MinInstSize;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  bool SawBoundarySymbol = false;
+  for (const ElfView::ELFT::Shdr &Shdr : OutView->sections()) {
+    if (Shdr.sh_type != llvm::ELF::SHT_SYMTAB)
+      continue;
+    llvm::Expected<ElfView::ELFT::SymRange> Symbols =
+        OutView->file().symbols(&Shdr);
+    ASSERT_TRUE((bool)Symbols) << llvm::toString(Symbols.takeError());
+    for (const ElfView::ELFT::Sym &Sym : *Symbols) {
+      if (Sym.st_shndx == OutView->textSectionIndex() &&
+          Sym.st_value == OutView->textAddr() && Sym.st_size == MinInstSize)
+        SawBoundarySymbol = true;
+    }
+  }
+  EXPECT_TRUE(SawBoundarySymbol);
+}
+
+TEST(TextDisplacement, UpdatesKernelDescriptorEntryOffset) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  const ElfView::ELFT::Shdr *OldRodata = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : ViewOrErr->sections()) {
+    llvm::Expected<llvm::StringRef> Name =
+        ViewOrErr->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".rodata")
+      OldRodata = &Shdr;
+  }
+  ASSERT_NE(OldRodata, nullptr);
+  const uint64_t OldRodataOffset = OldRodata->sh_offset;
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> OldPhdrs =
+      ViewOrErr->file().program_headers();
+  ASSERT_TRUE((bool)OldPhdrs) << llvm::toString(OldPhdrs.takeError());
+  const ElfView::ELFT::Phdr *OldRodataLoad = nullptr;
+  const ElfView::ELFT::Phdr *OldTextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *OldPhdrs) {
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x1000)
+      OldTextLoad = &Phdr;
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x2000)
+      OldRodataLoad = &Phdr;
+  }
+  ASSERT_NE(OldTextLoad, nullptr);
+  ASSERT_NE(OldRodataLoad, nullptr);
+  const uint64_t OldRodataLoadOffset = OldRodataLoad->p_offset;
+
+  llvm::SmallVector<uint8_t> Prefix =
+      assembleInstructions("global_wb\nv_nop", S);
+  ASSERT_FALSE(Prefix.empty());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(Prefix.begin(), Prefix.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  EXPECT_EQ(KDs[0].KernelName, "kernel");
+  EXPECT_EQ(KDs[0].VAddr, 0x2000u);
+  EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(0x1000 - 0x2000));
+
+  const ElfView::ELFT::Shdr *NewRodata = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : OutView->sections()) {
+    llvm::Expected<llvm::StringRef> Name = OutView->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".rodata")
+      NewRodata = &Shdr;
+  }
+  ASSERT_NE(NewRodata, nullptr);
+  EXPECT_EQ(NewRodata->sh_addr, OldRodata->sh_addr);
+  EXPECT_EQ(NewRodata->sh_offset, OldRodataOffset + Prefix.size());
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> NewPhdrs =
+      OutView->file().program_headers();
+  ASSERT_TRUE((bool)NewPhdrs) << llvm::toString(NewPhdrs.takeError());
+  const ElfView::ELFT::Phdr *NewRodataLoad = nullptr;
+  const ElfView::ELFT::Phdr *NewTextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *NewPhdrs) {
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x1000)
+      NewTextLoad = &Phdr;
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x2000)
+      NewRodataLoad = &Phdr;
+  }
+  ASSERT_NE(NewTextLoad, nullptr);
+  ASSERT_NE(NewRodataLoad, nullptr);
+  EXPECT_EQ(NewTextLoad->p_filesz, OldTextLoad->p_filesz + Prefix.size());
+  EXPECT_EQ(NewTextLoad->p_memsz, OldTextLoad->p_memsz);
+  EXPECT_EQ(NewRodataLoad->p_vaddr, OldRodataLoad->p_vaddr);
+  EXPECT_EQ(NewRodataLoad->p_paddr, OldRodataLoad->p_paddr);
+  EXPECT_EQ(NewRodataLoad->p_offset, OldRodataLoadOffset + Prefix.size());
+  EXPECT_EQ(NewRodataLoad->p_offset % NewRodataLoad->p_align,
+            NewRodataLoad->p_vaddr % NewRodataLoad->p_align);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(OutView->textData(), Prefix.size()),
+            llvm::ArrayRef<uint8_t>(Prefix));
+}
+
+TEST(TextDisplacement, RejectsPcSensitiveAddressMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text =
+      assembleSingleInst("s_get_pc_i64 s[8:9]", S);
+  ASSERT_FALSE(Text.empty());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("pc-sensitive"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsLaterFileContentInTextLoadSegment) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> Phdrs =
+      ViewOrErr->file().program_headers();
+  ASSERT_TRUE((bool)Phdrs) << llvm::toString(Phdrs.takeError());
+  const ElfView::ELFT::Phdr *TextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *Phdrs)
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x1000)
+      TextLoad = &Phdr;
+  ASSERT_NE(TextLoad, nullptr);
+
+  const size_t TextLoadOffset =
+      reinterpret_cast<const uint8_t *>(TextLoad) - ElfBytes.data();
+  llvm::ELF::Elf64_Phdr RawTextLoad;
+  std::memcpy(&RawTextLoad, ElfBytes.data() + TextLoadOffset,
+              sizeof(RawTextLoad));
+  RawTextLoad.p_filesz += 8;
+  RawTextLoad.p_memsz += 8;
+  std::memcpy(ElfBytes.data() + TextLoadOffset, &RawTextLoad,
+              sizeof(RawTextLoad));
+
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Edit});
+  EXPECT_FALSE((bool)PlanOrErr);
+  EXPECT_NE(
+      llvm::toString(PlanOrErr.takeError()).find("last file-backed content"),
+      std::string::npos);
+}
+
+TEST(TextDisplacement, RejectsDebugSectionsUntilAddressesCanBeRemapped) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find(".debug_info"), std::string::npos) << Reason;
+}
+
 TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   namespace hsa = llvm::amdhsa;
 
@@ -2303,6 +2875,95 @@ TEST(KernelEntryTrampoline, AppendFailsWithoutSgprScratchPair) {
   EXPECT_EQ(llvm::ArrayRef<uint8_t>(Growth[0].Bytes),
             llvm::ArrayRef<uint8_t>(Existing.Bytes));
   EXPECT_TRUE(Fixups.empty());
+}
+
+TEST(TextDisplacement, RejectsTextRelocationSections) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes =
+      makeDisplacementTestElf(Text, /*AddTextRelocation=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("relocation section"), std::string::npos);
+}
+
+TEST(TextDisplacement, RejectsDynamicRelocationTargetingText) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes =
+      makeDisplacementTestElf(Text, /*AddTextRelocation=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  const ElfView::ELFT::Shdr *RelaShdr = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : ViewOrErr->sections())
+    if (Shdr.sh_type == llvm::ELF::SHT_RELA)
+      RelaShdr = &Shdr;
+  ASSERT_NE(RelaShdr, nullptr);
+
+  const size_t ShdrOffset =
+      reinterpret_cast<const uint8_t *>(RelaShdr) - ElfBytes.data();
+  llvm::ELF::Elf64_Shdr RawShdr;
+  std::memcpy(&RawShdr, ElfBytes.data() + ShdrOffset, sizeof(RawShdr));
+  RawShdr.sh_info = 0;
+  std::memcpy(ElfBytes.data() + ShdrOffset, &RawShdr, sizeof(RawShdr));
+
+  llvm::ELF::Elf64_Rela Rela{};
+  Rela.r_offset = ViewOrErr->textAddr();
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+
+  llvm::Expected<ElfView> DynamicView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)DynamicView) << llvm::toString(DynamicView.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*DynamicView, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("dynamic relocation section"), std::string::npos);
+
+  Rela.r_offset = 0x2000;
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> NonTextView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)NonTextView) << llvm::toString(NonTextView.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(*NonTextView, S, {Edit});
+  EXPECT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+
+  Rela.setSymbolAndType(/*Symbol=*/0, llvm::ELF::R_AMDGPU_RELATIVE64);
+  Rela.r_addend = NonTextView->textAddr();
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> TextAddendView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)TextAddendView)
+      << llvm::toString(TextAddendView.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(*TextAddendView, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("addend references"), std::string::npos) << Reason;
 }
 
 // -- classifyWmmaNops ---------------------------------------------------------


### PR DESCRIPTION
## Summary
- Insert global_wb; v_nop directly at kernel entries when entry trampolines are enabled and displacement is provably safe.
- Keep ordinary B0-to-A0 and mask-workaround instruction patches on the existing NOP-sled and trampoline paths.
- Fall back to appended kernel-entry stubs when displacement would misalign any kernel entry, invalidate a text-referencing relocation, or encounter an existing entry stub outside .text.
- Preserve the B0-to-B0 no-MC fast append path.

## Scope
- Direct text displacement is gated by the entry-trampoline option.
- Entry displacement runs before ordinary instruction rewriting so later trampoline offsets use the shifted layout.
- Every mapped kernel entry must retain its required 256-byte alignment.
- Dynamic relocation destinations, symbols, and explicit addends are checked for references into displaced .text.
- Displacement errors use llvm::Expected consistently and every ELF repair failure carries a specific diagnostic.
- The focused diff against amd-staging is one commit and 15 files; unrelated HotSwap code and tests are unchanged.

## Stack
1. ROCm/llvm-project#3007: COMGR hotswap tool removal.
2. ROCm/llvm-project#3008: trampoline implementation.
3. This PR: entry-only displacement infrastructure.

GitHub cannot use fork-only branches as ROCm PR bases, so this PR targets amd-staging.

## Testing
- HotswapMCTests: 118/118 passed.
- HotswapElfTests: 30/30 passed.
- HotswapProfileTests: 9/9 passed.
- HotSwap lit slice: 91/91 passed.
- ASAN HotswapMCTests: 118/118 passed.
- ASAN HotswapElfTests: 30/30 passed.
- ASAN HotswapProfileTests: 9/9 passed.
- ASAN HotSwap lit slice: 91/91 passed.
- darker 1.7.2 and git clang-format against amd-staging: clean.
- git diff --check: clean.

## gfx1250 A0 hardware validation
- Tested commit af66cbc39441 on mi400 GPU 0: gfx1250, device 0x75c1, revision 0x00, 256 CUs.
- Compiled a one-kernel HIP code object with unwind tables disabled, then rewrote it with the PR-built COMGR and the entry-trampoline option.
- The verbose rewrite reported one direct kernel-entry displacement: 16 bytes raw growth and 4096 bytes aligned ELF growth.
- Disassembly starts with global_wb; v_nop at the original 0x1900 kernel entry, followed by the original prologue at 0x1910. No appended .stub symbol is present.
- Both the original and directly displaced code objects passed 20 launches over 1,048,576 elements against a CPU reference with checksum 0x00080012d0c00000.

Full check-comgr was attempted in both normal and ASAN standalone builds. Both passed every unit test and all HotSwap tests, then hit the same 13 unrelated embedded OpenCL/HIP compiler-pipeline crashes in this local checkout. CI remains the authoritative full-suite result.