### PR TITLE
[Comgr][NFC] Disable CMake EXPORT_COMPILE_COMMANDS within HotSwap

### DIFF
--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.20)
 project(hotswap-transpiler LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # --- LLVM ---------------------------------------------------------------------

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.20)
 project(hotswap-transpiler LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # --- LLVM ---------------------------------------------------------------------
 if(NOT TARGET LLVMSupport)


### PR DESCRIPTION
The `EXPORT_COMPILE_COMMANDS` directs the build system to generate a `compile_commands.json` file. We'd like to disable it at the HotSwap project level for 2 reasons:

1. This is a developer decision, and ideally should not be enabled by default
2. The JSON file created for the HotSwap subproject may conflict with that created for the broader Comgr project.

EDIT: Credits to @MixedMatched for reporting this.