### PR TITLE
[Flang][OpenMP] Do not propagate present to descriptor maps

### DIFF
--- a/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
+++ b/flang/lib/Optimizer/OpenMP/MapInfoFinalization.cpp
@@ -778,7 +778,7 @@ public:
     }
 
     flags |= mapFlags::to | mapFlags::descriptor | mapFlags::always |
-             (mapTypeFlag & (mapFlags::implicit | mapFlags::present));
+             (mapTypeFlag & mapFlags::implicit);
 
     if (moduleRequiresUSM(target->getParentOfType<mlir::ModuleOp>()))
       flags |= mapFlags::close;

--- a/flang/test/Lower/OpenMP/defaultmap.f90
+++ b/flang/test/Lower/OpenMP/defaultmap.f90
@@ -4,7 +4,7 @@ subroutine defaultmap_allocatable_present()
     integer, dimension(:), allocatable :: arr
 
 ! CHECK: %[[MAP_1:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(implicit, present) capture(ByRef) var_ptr_ptr({{.*}}) bounds({{.*}}) -> !fir.llvm_ptr<!fir.ref<!fir.array<?xi32>>> {name = ""}
-! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(always, implicit, present, descriptor, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "arr"}
+! CHECK: %[[MAP_2:.*]] = omp.map.info var_ptr({{.*}} : !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>>, !fir.box<!fir.heap<!fir.array<?xi32>>>) map_clauses(always, implicit, descriptor, to) capture(ByRef) members({{.*}}) -> !fir.ref<!fir.box<!fir.heap<!fir.array<?xi32>>>> {name = "arr"}
 !$omp target defaultmap(present: allocatable)
     arr(1) = 10
 !$omp end target

--- a/offload/test/offloading/fortran/target-map-present-pointer.f90
+++ b/offload/test/offloading/fortran/target-map-present-pointer.f90
@@ -1,0 +1,24 @@
+! REQUIRES: flang, amdgpu
+! RUN: %libomptarget-compile-fortran-run-and-check-generic
+
+program map_present_pointer
+  implicit none
+  integer, target :: src(4) = [10, 20, 30, 40]
+  integer, pointer :: p(:)
+  integer :: out
+
+  p => src
+  out = -1
+
+!$omp target enter data map(to: src)
+!$omp target map(present, to: p) map(from: out)
+  out = p(2)
+!$omp end target
+!$omp target exit data map(delete: src)
+
+  if (out /= 20) stop 1
+  print *, "associated pointer ok"
+end program
+
+! CHECK-NOT: omptarget
+! CHECK: associated pointer ok


### PR DESCRIPTION
Apply present only to the mapped pointer target, allowing associated pointers whose data is already present without requiring their Fortran descriptor to be mapped.


