### PR TITLE
[CI] Force LF checkout in Windows SPIRV CI

### DIFF
--- a/.github/workflows/spirv-ci-windows-amd-staging.yml
+++ b/.github/workflows/spirv-ci-windows-amd-staging.yml
@@ -20,9 +20,14 @@ jobs:
       run:
         shell: bash
     steps:
-      # Long path support for the deep llvm-project tree under runner workspace.
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       # Pinned ninja 1.12.1 — TheRock pins this version because 1.13.0 has a bug.
       - name: Install ninja
@@ -149,8 +154,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Install ninja
         run: choco install -y ninja --version 1.12.1
@@ -270,8 +281,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Install ninja
         run: choco install -y ninja --version 1.12.1
@@ -337,8 +354,14 @@ jobs:
         shell: bash
 
     steps:
-      - name: Enable git long paths
-        run: git config --global core.longpaths true
+      - name: Configure git (long paths, LF line endings)
+        # longpaths: llvm-project tree exceeds Windows' 260-char path limit.
+        # autocrlf=false/eol=lf: avoid CRLF checkout, which breaks clang's
+        # check_format_depend_* targets (clang-format emits LF).
+        run: |
+          git config --global core.longpaths true
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
       - name: Install ninja
         run: choco install -y ninja --version 1.12.1


### PR DESCRIPTION
## Problem

The `Windows::release / Build` job in the SPIRV Compiler CI fails at clang's `check_format_depend_*` targets. These run `clang-format` on the clang `Format` library sources and `diff -u` the result against the on-disk files. The Git-for-Windows default checks files out with **CRLF**; `clang-format` emits **LF**, so `diff` flags every line and the build aborts.

This is an environment-only failure — it reproduces on a no-op PR (#3011) with zero source changes, while Linux passes.

## Fix

Set `core.autocrlf=false` and `core.eol=lf` (alongside the existing `core.longpaths`) before checkout in all four Windows jobs (`build`, `test_translator_lit`, `test_codegen`, `test_comgr`), so the working tree uses LF and matches Linux.

## Validation note

This is a `pull_request`-triggered workflow, so this PR's own run still uses the base-branch (broken) workflow. The fix can be validated via `workflow_dispatch` once merged, or by inspecting a Windows run after merge.