### PR TITLE
[Comgr] Remove dead find_package(hip) from test/CMakeLists.txt

### DIFF
--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -211,8 +211,6 @@ endif()
   endif()
 endmacro()
 
-find_package(hip CONFIG PATHS ${ROCM_INSTALL_PATH}/hip QUIET)
-
 add_comgr_test(data_test c)
 add_comgr_test(disasm_instr_test c)
 add_comgr_test(metadata_tp_test c)


### PR DESCRIPTION
## Problem

When building outside the manylinux container (reported in ROCm/TheRock#5197), Comgr configure fails with:

```
[amd-comgr configure] CMake Error at .../therock_subproject_dep_provider.cmake:68:
  Project contains find_package(amd_comgr) for a package available in the
  super-project but not declared
```

The root cause: `test/CMakeLists.txt` unconditionally calls `find_package(hip)`. Inside TheRock's super-project, the dep provider intercepts this call, which causes `hip-config.cmake` to run, which calls `find_dependency(amd_comgr)` — circular, and blocked by the provider's undeclared-dep check.

## Fix

Remove the `find_package(hip)` call. The result (`hip_FOUND`) is never checked or used anywhere in the file — it is dead code.