### PR TITLE
[Comgr] Fix hotswap-rewrite-e2e lit test

### DIFF
--- a/amd/comgr/test-lit/CMakeLists.txt
+++ b/amd/comgr/test-lit/CMakeLists.txt
@@ -9,6 +9,13 @@ endfunction()
 canonicalize_cmake_boolean(COMGR_SPIRV_BACKEND_AVAILABLE)
 canonicalize_cmake_boolean(COMGR_SPIRV_TRANSLATOR_AVAILABLE)
 
+if ("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
+    set(COMGR_AMDGPU_TARGET_AVAILABLE 1)
+else()
+    set(COMGR_AMDGPU_TARGET_AVAILABLE 0)
+endif()
+canonicalize_cmake_boolean(COMGR_AMDGPU_TARGET_AVAILABLE)
+
 configure_file(lit.site.cfg.py.in lit.site.cfg.py @ONLY)
 
 find_program(LLVM_LIT_PATH

--- a/amd/comgr/test-lit/hotswap-rewrite-e2e.hip
+++ b/amd/comgr/test-lit/hotswap-rewrite-e2e.hip
@@ -1,5 +1,5 @@
+// REQUIRES: comgr-has-amdgpu-target
 // COM: End-to-end coverage of the HotSwap rewrite pipeline on a real
-// XFAIL: *
 // COM: clang-produced gfx1250 code object. Drives the full
 // COM: compile -> hotswap-rewrite -> verify chain using the in-tree
 // COM: clang + llvm-readelf + llvm-objdump substitutions.
@@ -25,7 +25,7 @@
 // RUN: %llvm-readelf -h %t.input.elf | %FileCheck --check-prefix=INPUT-FLAGS %s
 // INPUT-FLAGS: Flags:{{.*}}gfx1250
 // RUN: %llvm-readelf --notes %t.input.elf | %FileCheck --check-prefix=INPUT-META %s
-// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa-{{.*}}gfx1250
 
 // COM: Run hotswap-rewrite; save the output so we can inspect it.
 // RUN: hotswap-rewrite %t.input.elf \
@@ -41,7 +41,7 @@
 // RUN: %llvm-readelf -h %t.output.elf | %FileCheck --check-prefix=OUTPUT-FLAGS %s
 // OUTPUT-FLAGS: Flags:{{.*}}gfx1250
 // RUN: %llvm-readelf --notes %t.output.elf | %FileCheck --check-prefix=OUTPUT-META %s
-// OUTPUT-META: amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+// OUTPUT-META: amdhsa.target: amdgcn-amd-amdhsa-{{.*}}gfx1250
 
 // COM: .text section is still present and marked executable.
 // RUN: %llvm-readelf --section-headers %t.output.elf \

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -16,6 +16,8 @@ if config.comgr_spirv_backend_available:
     config.available_features.add("comgr-has-spirv-backend")
 if config.comgr_spirv_translator_available:
     config.available_features.add("comgr-has-spirv-translator")
+if config.comgr_amdgpu_target_available:
+    config.available_features.add("comgr-has-amdgpu-target")
 
 if platform.system() == "Windows":
     config.available_features.add("system-windows")

--- a/amd/comgr/test-lit/lit.site.cfg.py.in
+++ b/amd/comgr/test-lit/lit.site.cfg.py.in
@@ -9,6 +9,7 @@ config.my_obj_root = _fwd(r'@CMAKE_CURRENT_BINARY_DIR@')
 
 config.comgr_spirv_backend_available = @COMGR_SPIRV_BACKEND_AVAILABLE@
 config.comgr_spirv_translator_available = @COMGR_SPIRV_TRANSLATOR_AVAILABLE@
+config.comgr_amdgpu_target_available = @COMGR_AMDGPU_TARGET_AVAILABLE@
 
 config.llvm_tools_dir = _fwd(r'@LLVM_TOOLS_BINARY_DIR@')
 config.comgr_obj_dir = config.my_obj_root


### PR DESCRIPTION
Upstream commits f8cb6be / b3022110 changed AMDGPU offload jobs to use
the effective triple, causing the amdhsa metadata to emit
`amdgcn-amd-amdhsa-unknown-gfx1250` instead of `amdgcn-amd-amdhsa--gfx1250`.
This broke the hardcoded FileCheck patterns and Ron patched it with `XFAIL: *`.

This PR fixes it properly:
- Use `{{.*}}` in the amdhsa.target patterns to match the OS field
- Replace `XFAIL: *` with `REQUIRES: comgr-has-amdgpu-target` so the test skips cleanly on non-AMDGPU builds
- Wire `comgr-has-amdgpu-target` through CMake via `LLVM_TARGETS_TO_BUILD`