### PR TITLE
[Comgr] Fix caching of Address Sanitizer bitcode in comgr-clang-command

### DIFF
--- a/amd/comgr/src/comgr-clang-command.cpp
+++ b/amd/comgr/src/comgr-clang-command.cpp
@@ -58,7 +58,8 @@ bool skipProblematicFlag(IteratorTy &It, const IteratorTy &End) {
   // Skip flags related to opencl-c headers or device-libs builtins.
   StringRef Arg = *It;
   static const StringSet<> FlagsWithPathArg = {"-I", "-dumpdir", "-include",
-                                               "-mlink-builtin-bitcode"};
+                                               "-mlink-builtin-bitcode",
+                                               "-mlink-bitcode-file"};
   bool IsFlagWithPathArg = It + 1 != End && FlagsWithPathArg.contains(Arg);
   if (IsFlagWithPathArg) {
     ++It;

--- a/amd/comgr/test-lit/cache-tests/compile-hip-asan-cached.hip
+++ b/amd/comgr/test-lit/cache-tests/compile-hip-asan-cached.hip
@@ -1,0 +1,30 @@
+// COM: Compile a HIP source with AddressSanitizer enabled while the Comgr
+// COM: command cache is active.
+
+// COM: Start from a clean cache and enable it for this test.
+// RUN: rm -fr %t.cache
+// RUN: export AMD_COMGR_CACHE=1
+// RUN: export AMD_COMGR_CACHE_DIR=%t.cache
+
+// COM: Compile with the cache enabled.
+// RUN: compile-hip-asan %s %t.bin
+
+// COM: Verify the kernel exists
+// RUN: %llvm-objdump -d %t.bin | %FileCheck %s
+// CHECK: <_Z3addPfS_S_>:
+// CHECK: s_endpgm
+
+// COM: Verify ASAN runtime symbols are present
+// RUN: %llvm-objdump -t %t.bin | %FileCheck %s --check-prefix=ASAN
+// ASAN: __asan_memcpy
+// ASAN: __asan_memmove
+// ASAN: __asan_load1
+// ASAN: __asan_store1
+
+// COM: The cache directory should have been populated.
+// RUN: [ -d %t.cache ]
+
+__attribute__((global))
+void add(float *A, float *B, float *C) {
+    *C = *A + *B;
+}


### PR DESCRIPTION
Add `-mlink-bitcode-file` to comgr-clang-command's path arguments whitelist. Also, add a cached version of the HIP ASAN test.

Because `asanrtl.bc`'s symbols have to be external, it's linked using `-mlink-bitcode-file`. That flag wasn't in the path args whitelist for comgr-clang-command, so the tmp paths assertion failed.