### PR TITLE
[CI][Security] SEC-00864: Least-privilege secrets & permissions in AMD CI workflows (amd-staging)

### DIFF
--- a/.github/workflows/PSDB-amd-staging.yml
+++ b/.github/workflows/PSDB-amd-staging.yml
@@ -10,6 +10,11 @@ on:
     types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
+# Least-privilege default for the automatically provided GITHUB_TOKEN. This job
+# only triggers Jenkins via a dedicated PAT secret, so read-only access suffices.
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel, below is a single job called invoke jenkins jobs
 jobs:
   # This workflow contains a single job called "invoke_jenkins_PSDB"

--- a/.github/workflows/buildbot-psdb-trigger.yml
+++ b/.github/workflows/buildbot-psdb-trigger.yml
@@ -5,6 +5,10 @@ on:
     branches: [amd-debug]
     types: [opened, reopened, synchronize, ready_for_review]
 
+# Least-privilege default for the automatically provided GITHUB_TOKEN. Commit
+# statuses are set via a dedicated PAT secret, so read-only access suffices.
+permissions:
+  contents: read
 
 jobs:  
   trigger-build:

--- a/.github/workflows/ci_asan.yml
+++ b/.github/workflows/ci_asan.yml
@@ -47,7 +47,6 @@ jobs:
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.linux_variants) }}
     uses: ./.github/workflows/ci_linux.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.variant.family }}
       artifact_group: ${{ matrix.variant.artifact_group }}

--- a/.github/workflows/ci_linux.yml
+++ b/.github/workflows/ci_linux.yml
@@ -41,7 +41,6 @@ jobs:
     name: Build Artifacts
     if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
     uses: ./.github/workflows/build_portable_linux_artifacts.yml
-    secrets: inherit
     with:
       artifact_group: ${{ inputs.artifact_group }}
       package_version: ${{ inputs.rocm_package_version }}

--- a/.github/workflows/ci_nightly.yml
+++ b/.github/workflows/ci_nightly.yml
@@ -99,7 +99,6 @@ jobs:
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.linux_variants) }}
     uses: ./.github/workflows/ci_linux.yml
-    secrets: inherit
     with:
       amdgpu_families: ${{ matrix.variant.family }}
       artifact_group: ${{ matrix.variant.artifact_group }}
@@ -156,7 +155,8 @@ jobs:
       - linux_build_and_test
     with:
         JOB_NAME_TO_MATCH: "Linux::gfx94X-dcgpu::release / Build Artifacts / Build (xfail false)"
-    secrets: inherit
+    secrets:
+      AMD_STAGING_NIGHTLY_TEAMS_WEBHOOK_URL: ${{ secrets.AMD_STAGING_NIGHTLY_TEAMS_WEBHOOK_URL }}
 
 
   # build_python_packages:

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -41,7 +41,6 @@ jobs:
     name: Build Artifacts
     if: ${{ inputs.use_prebuilt_artifacts == 'false' }}
     uses: ./.github/workflows/build_windows_artifacts.yml
-    secrets: inherit
     with:
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}
@@ -74,7 +73,9 @@ jobs:
         inputs.benchmark_runs_on != ''
       }}
     uses: ./.github/workflows/test_benchmarks.yml
-    secrets: inherit
+    secrets:
+      BENCHMARK_DB_URL: ${{ secrets.BENCHMARK_DB_URL }}
+      BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     with:
       artifact_group: ${{ inputs.artifact_group }}
       amdgpu_families: ${{ inputs.amdgpu_families }}

--- a/.github/workflows/compute-rocm-dkmd-afar-trigger.yml
+++ b/.github/workflows/compute-rocm-dkmd-afar-trigger.yml
@@ -6,6 +6,11 @@ on:
       - amd-staging
   workflow_dispatch: # This allows manual triggering of the workflow
 
+# Least-privilege default for the automatically provided GITHUB_TOKEN. This job
+# only triggers a Jenkins job via dedicated secrets, so read-only access suffices.
+permissions:
+  contents: read
+
 jobs:
   trigger_jenkins:
     runs-on: 

--- a/.github/workflows/multi_arch_ci.yml
+++ b/.github/workflows/multi_arch_ci.yml
@@ -77,7 +77,6 @@ jobs:
       matrix:
         variant: ${{ fromJSON(needs.setup.outputs.linux_variants) }}
     uses: ./.github/workflows/multi_arch_build_portable_linux.yml
-    secrets: inherit
     with:
       matrix_per_family_json: ${{ matrix.variant.matrix_per_family_json }}
       dist_amdgpu_families: ${{ matrix.variant.dist_amdgpu_families }}

--- a/.github/workflows/test_benchmarks.yml
+++ b/.github/workflows/test_benchmarks.yml
@@ -23,6 +23,12 @@ on:
         type: string
       test_runs_on:
         type: string
+    secrets:
+      # Forwarded to test_component.yml for benchmark results submission.
+      BENCHMARK_DB_URL:
+        required: false
+      BENCHMARK_DB_FALLBACK_URL:
+        required: false
 
 permissions:
   contents: read
@@ -77,7 +83,9 @@ jobs:
       matrix:
         components: ${{ fromJSON(needs.configure_benchmark_matrix.outputs.components) }}
     uses: './.github/workflows/test_component.yml'
-    secrets: inherit
+    secrets:
+      BENCHMARK_DB_URL: ${{ secrets.BENCHMARK_DB_URL }}
+      BENCHMARK_DB_FALLBACK_URL: ${{ secrets.BENCHMARK_DB_FALLBACK_URL }}
     with:
       artifact_run_id: ${{ inputs.artifact_run_id }}
       artifact_group: ${{ inputs.artifact_group }}

--- a/.github/workflows/test_component.yml
+++ b/.github/workflows/test_component.yml
@@ -30,6 +30,13 @@ on:
       default_container_image:
         type: string
         default: "ghcr.io/rocm/no_rocm_image_ubuntu24_04@sha256:4150afe4759d14822f0e3f8930e1124f26e11f68b5c7b91ec9a02b20b1ebbb98"
+    secrets:
+      # Optional benchmark results database endpoints. Only required for benchmark
+      # results submission in nightly CI; other callers omit them and submission is skipped.
+      BENCHMARK_DB_URL:
+        required: false
+      BENCHMARK_DB_FALLBACK_URL:
+        required: false
 
 
 permissions:


### PR DESCRIPTION
## Summary

Ports the SEC-00864 fix from the release branch (#3044) onto the active **amd-staging** trunk so the hardening lands in mainline and does not regress.

Addresses Mythos AI finding **SEC-00864 (High)** — *Excessive Secret Inheritance and Missing Permissions in GitHub Actions Workflows*.

1. **Excessive secret inheritance.** Reusable-workflow calls used `secrets: inherit`, handing every repository secret to child workflows even though almost none are used. Audit of the build/test tree shows the only consumed secrets are `BENCHMARK_DB_URL` / `BENCHMARK_DB_FALLBACK_URL` (`test_component.yml`) and `AMD_STAGING_NIGHTLY_TEAMS_WEBHOOK_URL` (`teams_notifier.yml`). Everything else uses OIDC (`id-token`) or the auto-provided `GITHUB_TOKEN`.
2. **Missing top-level permissions.** Three AMD trigger workflows had no `permissions:` block.

## Changes

- Declared `BENCHMARK_DB_URL` / `BENCHMARK_DB_FALLBACK_URL` as optional `workflow_call` secrets in `test_component.yml` and `test_benchmarks.yml`.
- Forwarded only those two secrets by name on the benchmark path: `ci_windows.yml` → `test_benchmarks.yml` → `test_component.yml`.
- In `ci_nightly.yml`, forwarded only the already-declared `AMD_STAGING_NIGHTLY_TEAMS_WEBHOOK_URL` to `teams_notifier.yml` (instead of inheriting everything).
- Removed unused `secrets: inherit` from build/test chains that consume no secrets: `ci_linux.yml`, `ci_nightly.yml`→`ci_linux`, `ci_asan.yml`, `multi_arch_ci.yml`, and the Windows build call site.
- Added `permissions: contents: read` to `PSDB-amd-staging.yml`, `buildbot-psdb-trigger.yml`, `compute-rocm-dkmd-afar-trigger.yml`.

## Scope note

This is a faithful 1:1 port of the workflows covered by #3044. amd-staging is the active trunk and contains additional trunk-only workflows that also use `secrets: inherit` (`spirv-ci`, `multi_arch_release*`, `rockci_*` variants, `parameterised-sha-*`). Those are intentionally **out of scope** here and can be hardened in a follow-up if desired.

## Why this is safe

- Removing `secrets: inherit` does not affect `GITHUB_TOKEN` (always auto-provided) or OIDC (`id-token`), which the build jobs rely on.
- Benchmark DB secrets are `required: false`, preserving the existing "fail gracefully / skip submission" behavior.
- The entire `multi_arch_ci` → `multi_arch_build_portable_linux` → `*_artifacts` chain is build-only (AWS via OIDC), so it needs no inherited secrets.

## Test plan

- [ ] `pull_request` to `amd-staging` still triggers the PSDB Jenkins job.
- [ ] Nightly (`ci_nightly`) Linux + Windows build/test pass; benchmark DB submission works on the Windows benchmark path; Teams notification is delivered.
- [ ] `ci_asan` and `multi_arch_ci` runs build successfully.
- [ ] buildbot / afar trigger workflows still trigger their Buildbot/Jenkins jobs.

Made with [Cursor](https://cursor.com)