### PR TITLE
[Comgr/Caching/Support] Don't use `mmap` in `localCache`, on NFS

### DIFF
--- a/llvm/lib/Support/Caching.cpp
+++ b/llvm/lib/Support/Caching.cpp
@@ -37,6 +37,8 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
   TempFilePrefixRef.toVector(TempFilePrefix);
   CacheDirectoryPathRef.toVector(CacheDirectoryPath);
 
+  bool OnNFS = !sys::fs::is_local(CacheDirectoryPath);
+
   auto Func = [=](unsigned Task, StringRef Key,
                   const Twine &ModuleName) -> Expected<AddStreamFn> {
     // This choice of file name allows the cache to be pruned (see pruneCache()
@@ -52,7 +54,8 @@ Expected<FileCache> llvm::localCache(const Twine &CacheNameRef,
       ErrorOr<std::unique_ptr<MemoryBuffer>> MBOrErr =
           MemoryBuffer::getOpenFile(*FDOrErr, EntryPath,
                                     /*FileSize=*/-1,
-                                    /*RequiresNullTerminator=*/false);
+                                    /*RequiresNullTerminator=*/OnNFS,
+                                    /*IsVolatile=*/OnNFS);
       sys::fs::closeFile(*FDOrErr);
       if (MBOrErr) {
         AddBuffer(Task, ModuleName, std::move(*MBOrErr));


### PR DESCRIPTION
When the cache directory is on an NFS, we may hit a SIGBUS signal
when there is contention on the cache.

This happens typically with MPI jobs running on an NFS mounted $HOME
directory.

With NFS, the attributes are stored in a cache. The mmap call may
succeed, but when we try to access memory returned from this call we may
hit a SIGBUS because the file was modified by another process on another
machine.

If we execute through the regular `read()` path, we also fail with a
`Stale file descriptor` error. But at least this path is properly handled
and we can continue without using the cache.

To achieve this, we pass `OnNFS` to `IsVolatile` and `RequiresNullTerminator`,
which makes `shouldUseMmap` return `false`.

This is part of the patch I hope to upstream to fix the issue (at least to get guidance about how to move forward with this).

Related to [LCOMPILER-2307](https://amd-hub.atlassian.net/browse/LCOMPILER-2307) and [ROCM-30356](https://amd-hub.atlassian.net/browse/ROCM-30356).

[LCOMPILER-2307]: https://amd-hub.atlassian.net/browse/LCOMPILER-2307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROCM-30356]: https://amd-hub.atlassian.net/browse/ROCM-30356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ