### PR TITLE
[Flang][OpenMP] Fix wrong stride in DistributeFor SPMD no-loop fast path

### DIFF
--- a/openmp/device/src/Workshare.cpp
+++ b/openmp/device/src/Workshare.cpp
@@ -953,6 +953,15 @@ public:
     Ty NumBlocks = mapping::getNumberOfBlocksInKernel();
     Ty BId = mapping::getBlockIdInKernel();
 
+    // In the SPMD no-loop fast path (OneIterationPerThread=1), the caller
+    // derives NumThreads from omp_get_num_threads() which is evaluated before
+    // the parallel region is active and returns 1 instead of the actual block
+    // size. This produces a stride of 1 in NormalizedLoopNestNoChunk, leaving
+    // iterations [NumBlocks+blocksize-1 .. NumIters-1] permanently unexecuted.
+    // Read the hardware block size directly, which is always correct here.
+    if (OneIterationPerThread)
+      NumThreads = static_cast<Ty>(mapping::getMaxTeamThreads());
+
     // If the block chunk is not specified we pick a default now.
     if (BlockChunk == 0)
       BlockChunk = NumThreads;


### PR DESCRIPTION
In the SPMD no-loop fast path (one_iteration_per_thread=1, triggered by -fopenmp-target-fast with both oversubscription flags), the NumThreads argument to DistributeFor derives from omp_get_num_threads() which is evaluated before the parallel region is active. At that point icv::Level=0 and the parallel team state has not been initialized, so omp_get_num_threads() returns 1 instead of the actual hardware block size.

NormalizedLoopNestNoChunk uses NumThreads as the per-block stride:
  IV = BId * NumThreads + TId     // = BId * 1 + TId  (wrong)
  KernelIteration = NumBlocks * NumThreads  // = NumBlocks * 1  (wrong)

With blocksize=32 and K=ceil(N/32) blocks this leaves iterations K+31 .. N-1 permanently unexecuted (output stays at zero).

Fix: when OneIterationPerThread=1, override NumThreads with mapping::getMaxTeamThreads() which reads directly from hardware registers and is always valid at kernel entry. This also corrects the BlockChunk default and the ASSERT that follow.

Reproducer (fails without fix, passes with fix on gfx90a / MI250X):

  integer, parameter :: N = 64
  integer :: out(N, 2), i, nerr
  !$omp target teams distribute parallel do map(from:out)
  do i = 1, N; out(i,:) = [i, i*2]; end do
  !$omp end target teams distribute parallel do
  ! Fails: 31 of 64 cells are zero (never written)

Verified on amdflang 23.1.0 / 23.2.0 / 23.2.1, gfx90a (MI250X).

Fixes: https://github.com/ROCm/llvm-project/issues/2601


Original PR: https://github.com/ROCm/llvm-project/pull/2602
Original Author: [Spencer Bryngelson](https://github.com/sbryngelson)
