### PR TITLE
amd-staging: Remove sram_ecc_legacy flags

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -6010,8 +6010,6 @@ def mcode_object_version_EQ : Joined<["-"], "mcode-object-version=">, Group<m_Gr
 defm cumode : SimpleMFlag<"cumode",
   "Specify CU wavefront", "Specify WGP wavefront",
   " execution mode (AMDGPU only)", m_amdgpu_Features_Group>;
-defm sram_ecc_legacy : SimpleMFlag<"sram-ecc", "", "",
-  "Legacy option to specify SRAM ECC mode (AMDGPU only)">;
 defm tgsplit : SimpleMFlag<"tgsplit", "Enable", "Disable",
   " threadgroup split execution mode (AMDGPU only)", m_amdgpu_Features_Group>;
 defm xnack : SimpleMFlag<"xnack", "Enable", "Disable",

--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -679,13 +679,6 @@ void amdgpu::getAMDGPUTargetFeatures(const Driver &D,
                    options::OPT_mno_wavefrontsize64, false))
     Features.push_back("+wavefrontsize64");
 
-  // TODO: Remove during upstreaming target id.
-  if (Args.getLastArg(options::OPT_msram_ecc_legacy)) {
-    Features.push_back("+sramecc");
-  }
-  if (Args.getLastArg(options::OPT_mno_sram_ecc_legacy)) {
-    Features.push_back("-sramecc");
-  }
   if (Args.hasFlag(options::OPT_mamdgpu_precise_memory_op,
                    options::OPT_mno_amdgpu_precise_memory_op, false))
     Features.push_back("+precise-memory");


### PR DESCRIPTION
These are not upstream, have no tests and have old comments to remove them. Additionally, upstream recently re-added a non-legacy name for the same purpose.


