### PR TITLE
[Driver][AMDGPU] Restore ROCm include paths for OpenMP offload

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.cpp
@@ -65,7 +65,26 @@ void AMDGPUOpenMPToolChain::AddClangCXXStdlibIncludeArgs(
 
 void AMDGPUOpenMPToolChain::AddClangSystemIncludeArgs(
     const ArgList &DriverArgs, ArgStringList &CC1Args) const {
+  // OpenMP offload code targeting AMDGPU frequently includes ROCm/HIP headers
+  // (e.g. <hip/hip_runtime.h>) directly. Add the ROCm include directories so
+  // those headers are found without requiring an explicit -I. The install is
+  // laid out as <root>/lib/llvm/bin/clang, so the HIP headers live in
+  // <root>/include (three levels up from the driver dir) and the toolchain's
+  // own headers in <root>/lib/llvm/include (one level up).
+  const Driver &D = HostTC.getDriver();
+  CC1Args.push_back("-internal-isystem");
+  CC1Args.push_back(DriverArgs.MakeArgString(D.Dir + "/../include"));
+  CC1Args.push_back("-internal-isystem");
+  CC1Args.push_back(DriverArgs.MakeArgString(D.Dir + "/../../../include"));
+
   HostTC.AddClangSystemIncludeArgs(DriverArgs, CC1Args);
+
+  // The HIP headers pull in the cuda_wrappers headers, which must precede the
+  // standard C++ headers added above.
+  CC1Args.push_back("-internal-isystem");
+  SmallString<128> P(HostTC.getDriver().ResourceDir);
+  llvm::sys::path::append(P, "include/cuda_wrappers");
+  CC1Args.push_back(DriverArgs.MakeArgString(P));
 }
 
 void AMDGPUOpenMPToolChain::AddIAMCUIncludeArgs(const ArgList &Args,


### PR DESCRIPTION
AMDGPUOpenMPToolChain::AddClangSystemIncludeArgs stopped adding the ROCm include directories, so OpenMP offload code that includes HIP headers (e.g. <hip/hip_runtime.h>) failed to compile. Re-add <root>/include, <root>/lib/llvm/include and the cuda_wrappers dir.

Fixes issue from https://github.com/ROCm/llvm-project/commit/1967549956fe62b53db696f04d6e0bdeaa5b1ce0

