### PR TITLE
comgr: Use triple form of lookupTarget

### DIFF
--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -51,8 +51,7 @@ const Target *getAmdgcnTarget() {
   static const Target *const Tgt = []() -> const Target * {
     COMGR::ensureLLVMInitialized();
     std::string Err;
-    Triple T(AmdgcnLookupTriple);
-    return TargetRegistry::lookupTarget("amdgcn", T, Err);
+    return TargetRegistry::lookupTarget(AmdgcnLookupTriple, Err);
   }();
   return Tgt;
 }


### PR DESCRIPTION
The string forms of the various TargetRegistry functions should be avoided. The triple versions have better compatibilty guarantees and will continue working through the pending arch name change.


