### PR TITLE
[WaveTransform] Recognize new artificial terminator opcodes

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -137,6 +137,8 @@ static bool isArtificialTerminator(MachineInstr &MI) {
   case AMDGPU::S_ANDN2_B32_term:
   case AMDGPU::S_AND_B32_term:
   case AMDGPU::S_AND_SAVEEXEC_B32_term:
+  case AMDGPU::V_CMPX_EQ_U32_nosdst_e32_term:
+  case AMDGPU::V_CMPX_EQ_U64_nosdst_e32_term:
     return true;
   default:
     return false;


### PR DESCRIPTION
AMDGPU backend has introduced two artificial terminator opcodes in the upstream. V_CMPX_EQ_U32_nosdst_e32_term and V_CMPX_EQ_U64_nosdst_e32_term. The `isArtificialTerminator` check in the wave transform pass needs to be updated to ensure consistent handling of wave-semantics within the pass. When the WaveTransform work is upstreamed, this function should be moved into a proper TargetInstrInfo hook. The duplicated inlined logic in `SIInstrInfo::analyzeBranch` can then be refactored to reuse this centralized check.


