### PR TITLE
[CI][Security] ROCM-26563: enforce HTTPS verification in PSDB trigger

### DIFF
--- a/.github/workflows/PSDB-amd-staging.yml
+++ b/.github/workflows/PSDB-amd-staging.yml
@@ -82,7 +82,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           COMMIT_HASH: ${{ github.event.after }}
         run: |
-          docker exec -e JENKINS_JOB_NAME=${{secrets.CI_JENKINS_JOB_NAME}}  -e PR_NUMBER=${{ github.event.pull_request.number }}  -e COMMIT_HASH=${{ github.event.after }} -e JENKINS_URL=${{secrets.CI_JENKINS_URL}} -e JENKINS_USER=${{secrets.CI_JENKINS_USER}} -e JENKINS_API_TOKEN=${{secrets.CI_JENKINS_TOKEN}}  "${{env.CONTAINER_NAME}}" /bin/bash -c "PYTHONHTTPSVERIFY=0 python3 cancel_previous_build.py"
+          docker exec -e JENKINS_JOB_NAME=${{secrets.CI_JENKINS_JOB_NAME}}  -e PR_NUMBER=${{ github.event.pull_request.number }}  -e COMMIT_HASH=${{ github.event.after }} -e JENKINS_URL=${{secrets.CI_JENKINS_URL}} -e JENKINS_USER=${{secrets.CI_JENKINS_USER}} -e JENKINS_API_TOKEN=${{secrets.CI_JENKINS_TOKEN}}  "${{env.CONTAINER_NAME}}" /bin/bash -c "python3 cancel_previous_build.py"
 
         
       # Runs a set of commands using the runners shell
@@ -113,7 +113,7 @@ jobs:
           echo "--Running jenkins_api.py with input sha - $input_sha for pull request - $input_pr_url" 
           docker exec -e GITHUB_REPOSITORY="$GITHUB_REPOSITORY" -e svc_acc_org_secret="$svc_acc_org_secret" -e input_sha="$input_sha" -e input_pr_url="$input_pr_url" -e pipeline_name="$pipeline_name" \
                      -e input_pr_num="$input_pr_num" -e PR_TITLE="$PR_TITLE" -e JENKINS_URL="$JENKINS_URL" -e GITHUB_PAT="$svc_acc_org_secret" "${{env.CONTAINER_NAME}}"  \
-                     /bin/bash -c 'echo \"PR NUM: "$input_pr_num"\" && PYTHONHTTPSVERIFY=0 python3 jenkins_api.py -s \"${JENKINS_URL}\" -jn "$pipeline_name" -ghr "$GITHUB_REPOSITORY" -ghsha "$input_sha" -ghprn "$input_pr_num" -ghpru "$input_pr_url" -ghprt "$PR_TITLE" -ghpat="$svc_acc_org_secret"'
+                     /bin/bash -c 'echo \"PR NUM: "$input_pr_num"\" && python3 jenkins_api.py -s \"${JENKINS_URL}\" -jn "$pipeline_name" -ghr "$GITHUB_REPOSITORY" -ghsha "$input_sha" -ghprn "$input_pr_num" -ghpru "$input_pr_url" -ghprt "$PR_TITLE" -ghpat="$svc_acc_org_secret"'
           
       - name: Stop and remove container
         if: always()


### PR DESCRIPTION
Fix for the issue "ROCM-26563 — PSDB Jenkins trigger: HTTPS verification disabled"

**End-to-end flow:** A PR to amd-staging runs the GitHub Actions workflow PSDB-amd-staging.yml on a self-hosted runner. It pulls an internal Docker image (JENKINS_TRIGGER_DOCKER_IMAGE) and runs two Python scripts inside it — cancel_previous_build.py and jenkins_api.py — which call the Jenkins server and the GitHub API to cancel stale builds and trigger the PSDB pipeline.

**Issue:** Both scripts were launched with PYTHONHTTPSVERIFY=0, which globally disables TLS certificate verification. This left the Jenkins and GitHub calls open to man-in-the-middle attacks and credential interception (CI_JENKINS_TOKEN, GitHub PAT). The flag is unnecessary — Jenkins presents a valid public DigiCert certificate.