### PR TITLE
[openmp] Fix device omp_lib.mod build to use host flang-rt modules

### DIFF
--- a/llvm/runtimes/CMakeLists.txt
+++ b/llvm/runtimes/CMakeLists.txt
@@ -455,6 +455,22 @@ function(runtime_register_target name)
   list(APPEND ${name}_extra_args -DLLVM_USE_LINKER=${LLVM_USE_LINKER})
   append_passthrough_options(${name}_extra_args RUNTIMES "${ARG_BASE_NAME};${name}")
 
+  # Device-side omp_lib.mod needs host flang-rt intrinsic modules. Device
+  # runtimes sub-builds are configured with LLVM_ENABLE_RUNTIMES=openmp only.
+  # Pass the host module path at configure time; order the build after the host
+  # runtimes build below (not flang-rt-mod directly, which would cycle configure).
+  if ("openmp" IN_LIST RUNTIMES_${name}_LLVM_ENABLE_RUNTIMES)
+    if ("${name}" MATCHES "^(amdgcn|nvptx)")
+      include(GetClangResourceDir)
+      include(GetToolchainDirs)
+      include(ExtendPath)
+      get_clang_resource_dir(_resource_dir PREFIX "${LLVM_BINARY_DIR}")
+      get_toolchain_module_subdir(_mod_subdir)
+      extend_path(_host_mod_dir "${_resource_dir}" "${_mod_subdir}/${LLVM_HOST_TRIPLE}")
+      list(APPEND ${name}_extra_args "-DLIBOMP_HOST_FLANG_RT_MODULE_DIR=${_host_mod_dir}")
+    endif()
+  endif()
+
   set_enable_per_target_runtime_dir()
 
   llvm_ExternalProject_Add(runtimes-${name}
@@ -798,6 +814,12 @@ if(build_runtimes)
         DEPENDS ${builtins_dep_name} ${extra_deps}
         CMAKE_ARGS -DLLVM_DEFAULT_TARGET_TRIPLE=${name} ${extra_cmake_args}
         EXTRA_ARGS TARGET_TRIPLE ${name} ${extra_args})
+    endforeach()
+
+    foreach(_device IN ITEMS amdgcn-amd-amdhsa nvptx64-nvidia-cuda)
+      if (TARGET runtimes-${_device}-build AND TARGET runtimes-build)
+        add_dependencies(runtimes-${_device}-build runtimes-build)
+      endif()
     endforeach()
 
     foreach(multilib ${LLVM_RUNTIME_MULTILIBS})

--- a/openmp/CMakeLists.txt
+++ b/openmp/CMakeLists.txt
@@ -117,6 +117,9 @@ set(LIBOMP_BUILD_DATE "No_Timestamp")
 set(LIBOMP_FORTRAN_MODULES "${RUNTIMES_FORTRAN_MODULES}" CACHE BOOL
   "Create Fortran module files? (requires fortran compiler)")
 
+set(LIBOMP_HOST_FLANG_RT_MODULE_DIR "" CACHE PATH
+  "Directory containing host flang-rt .mod files (e.g. iso_c_binding.mod) when building device-side omp_lib.mod")
+
 option(LIBOMP_FORTRAN_MODULES_ONLY
   "Build only Fortran modules without libomp runtime library" OFF)
 if(LIBOMP_FORTRAN_MODULES_ONLY)

--- a/openmp/cmake/OpenMPDeviceFortranModules.cmake
+++ b/openmp/cmake/OpenMPDeviceFortranModules.cmake
@@ -1,0 +1,61 @@
+#===-- openmp/cmake/OpenMPDeviceFortranModules.cmake ---------------------===#
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+#===------------------------------------------------------------------------===#
+#
+# Device-side OpenMP Fortran modules (omp_lib.mod) use iso_c_binding and other
+# intrinsic modules produced by the host flang-rt build. Device runtimes
+# sub-builds are typically configured with LLVM_ENABLE_RUNTIMES=openmp only, so
+# config-Fortran.cmake does not wire up flang-rt-mod automatically.
+#
+#===------------------------------------------------------------------------===#
+
+include_guard(DIRECTORY)
+
+function(openmp_get_host_flang_rt_module_dir out_var)
+  if (LIBOMP_HOST_FLANG_RT_MODULE_DIR)
+    set(${out_var} "${LIBOMP_HOST_FLANG_RT_MODULE_DIR}" PARENT_SCOPE)
+    return()
+  endif()
+
+  if (NOT LLVM_BINARY_DIR OR NOT LLVM_HOST_TRIPLE)
+    set(${out_var} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  include(GetClangResourceDir)
+  include(GetToolchainDirs)
+  include(ExtendPath)
+
+  get_clang_resource_dir(_resource_dir PREFIX "${LLVM_BINARY_DIR}")
+  get_toolchain_module_subdir(_mod_subdir)
+  extend_path(_host_mod_dir "${_resource_dir}" "${_mod_subdir}/${LLVM_HOST_TRIPLE}")
+
+  set(${out_var} "${_host_mod_dir}" PARENT_SCOPE)
+endfunction()
+
+function(openmp_require_host_flang_rt_modules_for_device_mod target)
+  if (NOT "${LLVM_DEFAULT_TARGET_TRIPLE}" MATCHES "^amdgcn|^nvptx|^spirv")
+    return()
+  endif()
+
+  # Same sub-build also builds flang-rt: flang_module_target() wiring is enough.
+  if ("flang-rt" IN_LIST LLVM_ENABLE_RUNTIMES)
+    return()
+  endif()
+
+  openmp_get_host_flang_rt_module_dir(_host_mod_dir)
+  if (NOT _host_mod_dir)
+    message(FATAL_ERROR
+      "Building device-side ${target} for ${LLVM_DEFAULT_TARGET_TRIPLE} requires "
+      "host Flang-RT intrinsic modules (e.g. iso_c_binding.mod). "
+      "Set -DLIBOMP_HOST_FLANG_RT_MODULE_DIR=<path-to-host-modules> or ensure the "
+      "host runtimes build (flang-rt-mod) completes before the device runtimes build.")
+  endif()
+
+  target_compile_options(${target} PRIVATE
+    "$<$<COMPILE_LANGUAGE:Fortran>:-fintrinsic-modules-path=${_host_mod_dir}>")
+endfunction()

--- a/openmp/module/CMakeLists.txt
+++ b/openmp/module/CMakeLists.txt
@@ -34,6 +34,9 @@ endif ()
 
 flang_module_target(libomp-mod PUBLIC)
 
+include(OpenMPDeviceFortranModules)
+openmp_require_host_flang_rt_modules_for_device_mod(libomp-mod)
+
 install(FILES
   "${RUNTIMES_OUTPUT_RESOURCE_MOD_DIR}/omp_lib.h"
   DESTINATION "${RUNTIMES_INSTALL_RESOURCE_MOD_PATH}"


### PR DESCRIPTION
Device runtimes sub-builds configure with LLVM_ENABLE_RUNTIMES=openmp only, so omp_lib.F90 for amdgcn/nvptx can compile before iso_c_binding.mod exists. Point libomp-mod at the host flang-rt module directory and order device runtimes builds after flang-rt-mod.


