### PR TITLE
AMDGPU: add hotswap entry trampoline lit coverage

### DIFF
--- a/amd/comgr/test-lit/hotswap-barrier-isfirst.s
+++ b/amd/comgr/test-lit/hotswap-barrier-isfirst.s
@@ -35,6 +35,47 @@
 // API2: RESULT: SUCCESS
 // RUN: cmp %t.out.elf %t.out2.elf
 
+// COM: One-sided stepping annotations must also be honored. An explicit A0
+// COM: source with a generic target is not B0->A0, and a generic source with
+// COM: an explicit B0 target is not B0->A0 either.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.a0generic.elf \
+// RUN:   | %FileCheck --check-prefix=A0GENERIC-API %s
+// A0GENERIC-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.a0generic.elf | %FileCheck --check-prefix=NO-PATCH %s
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --output %t.genericb0.elf \
+// RUN:   | %FileCheck --check-prefix=GENERICB0-API %s
+// GENERICB0-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.genericb0.elf | %FileCheck --check-prefix=NO-PATCH %s
+
+// NO-PATCH: s_barrier_signal_isfirst -1
+// NO-PATCH-NEXT: s_barrier_wait 0xffff
+// NO-PATCH-NEXT: s_barrier_signal_isfirst -3
+// NO-PATCH-NEXT: s_barrier_wait 0xfffd
+// NO-PATCH-NEXT: s_endpgm
+
+// COM: With explicit B0->B0 stepping, entry trampolines must not accidentally
+// COM: enable B0-to-A0 instruction patches. The isfirst opcodes remain, while
+// COM: the kernel descriptor is still redirected through an appended entry stub.
+// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --output %t.b0b0.elf \
+// RUN:   | %FileCheck --check-prefix=B0B0-API %s
+// B0B0-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.b0b0.elf | %FileCheck --check-prefix=B0B0 %s
+// B0B0: s_barrier_signal_isfirst -1
+// B0B0-NEXT: s_barrier_wait 0xffff
+// B0B0-NEXT: s_barrier_signal_isfirst -3
+// B0B0-NEXT: s_barrier_wait 0xfffd
+// B0B0: global_wb
+
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
 .globl test_barrier_isfirst

--- a/amd/comgr/test-lit/hotswap-barrier-isfirst.s
+++ b/amd/comgr/test-lit/hotswap-barrier-isfirst.s
@@ -63,10 +63,10 @@
 // COM: With explicit B0->B0 stepping, entry trampolines must not accidentally
 // COM: enable B0-to-A0 instruction patches. The isfirst opcodes remain, while
 // COM: the kernel descriptor is still redirected through an appended entry stub.
-// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.elf \
+// RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
-// RUN:   --output %t.b0b0.elf \
+// RUN:   --entry-trampolines --output %t.b0b0.elf \
 // RUN:   | %FileCheck --check-prefix=B0B0-API %s
 // B0B0-API: RESULT: SUCCESS
 // RUN: %llvm-objdump -d %t.b0b0.elf | %FileCheck --check-prefix=B0B0 %s

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
@@ -1,9 +1,9 @@
 // COM: HotSwap entry trampolines are supported across gfx125x.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib %s -o %t.gfx1251.elf
-// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.gfx1251.elf \
+// RUN: hotswap-rewrite %t.gfx1251.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1251 amdgcn-amd-amdhsa--gfx1251 \
-// RUN:   --output %t.gfx1251.out.elf \
+// RUN:   --entry-trampolines --output %t.gfx1251.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // RUN: %llvm-objdump -d %t.gfx1251.out.elf | %FileCheck --check-prefix=DISASM %s
 
@@ -11,10 +11,10 @@
 // RUN:   -e 's/gfx1251/gfx12-5-generic/g' %s > %t.generic.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx12-5-generic -nostdlib \
 // RUN:   %t.generic.s -o %t.generic.elf
-// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.generic.elf \
+// RUN: hotswap-rewrite %t.generic.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx12-5-generic \
 // RUN:   amdgcn-amd-amdhsa--gfx12-5-generic \
-// RUN:   --output %t.generic.out.elf \
+// RUN:   --entry-trampolines --output %t.generic.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // RUN: %llvm-objdump -d %t.generic.out.elf | %FileCheck --check-prefix=DISASM %s
 

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
@@ -1,0 +1,49 @@
+// COM: HotSwap entry trampolines are supported across gfx125x.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib %s -o %t.gfx1251.elf
+// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.gfx1251.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1251 amdgcn-amd-amdhsa--gfx1251 \
+// RUN:   --output %t.gfx1251.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.gfx1251.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// RUN: sed -e '/^\.amdgcn_target/d' \
+// RUN:   -e 's/gfx1251/gfx12-5-generic/g' %s > %t.generic.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx12-5-generic -nostdlib \
+// RUN:   %t.generic.s -o %t.generic.elf
+// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.generic.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx12-5-generic \
+// RUN:   amdgcn-amd-amdhsa--gfx12-5-generic \
+// RUN:   --output %t.generic.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.generic.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// API: RESULT: SUCCESS
+
+// DISASM-LABEL: <entry_tramp_family_kernel>:
+// DISASM: s_endpgm
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64 s[8:9]
+// DISASM-NEXT: s_add_co_u32 s8
+// DISASM-NEXT: s_add_co_ci_u32 s9
+// DISASM-NEXT: s_set_pc_i64 s[8:9]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1251"
+.text
+.globl entry_tramp_family_kernel
+.p2align 8
+.type entry_tramp_family_kernel,@function
+entry_tramp_family_kernel:
+  v_mov_b32_e32 v0, 0
+  s_endpgm
+.Lentry_tramp_family_kernel_end:
+.size entry_tramp_family_kernel, .Lentry_tramp_family_kernel_end-entry_tramp_family_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel entry_tramp_family_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_inst_pref_size 7
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
@@ -1,0 +1,63 @@
+// COM: The entry-trampoline rewrite must redirect every kernel descriptor in
+// COM: the code object, not just the first one. Each descriptor gets its own
+// COM: appended PC-relative entry stub.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <entry_tramp_first>:
+// DISASM: s_endpgm
+// DISASM-LABEL: <entry_tramp_second>:
+// DISASM: s_endpgm
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64 s[8:9]
+// DISASM-NEXT: s_add_co_u32 s8
+// DISASM-NEXT: s_add_co_ci_u32 s9
+// DISASM-NEXT: s_set_pc_i64 s[8:9]
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64 s[8:9]
+// DISASM-NEXT: s_add_co_u32 s8
+// DISASM-NEXT: s_add_co_ci_u32 s9
+// DISASM-NEXT: s_set_pc_i64 s[8:9]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl entry_tramp_first
+.p2align 8
+.type entry_tramp_first,@function
+entry_tramp_first:
+  v_mov_b32_e32 v0, 1
+  s_endpgm
+.Lentry_tramp_first_end:
+.size entry_tramp_first, .Lentry_tramp_first_end-entry_tramp_first
+
+.globl entry_tramp_second
+.p2align 8
+.type entry_tramp_second,@function
+entry_tramp_second:
+  v_mov_b32_e32 v0, 2
+  s_endpgm
+.Lentry_tramp_second_end:
+.size entry_tramp_second, .Lentry_tramp_second_end-entry_tramp_second
+
+.rodata
+.p2align 8
+.amdhsa_kernel entry_tramp_first
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel entry_tramp_second
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
@@ -4,9 +4,9 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 hotswap-rewrite %t.elf \
+// RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.out.elf \
+// RUN:   --entry-trampolines --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -22,6 +22,15 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
+// COM: Entry trampolines are independent of the B0-to-A0 patch policy, so an
+// COM: explicit B0->A0 rewrite should still redirect the descriptor to a stub.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --entry-trampolines --output %t.b0a0.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.b0a0.elf | %FileCheck --check-prefix=DISASM %s
+
 // DISASM-LABEL: <entry_tramp_kernel>:
 // DISASM: s_endpgm
 // DISASM: global_wb

--- a/amd/comgr/test-lit/hotswap-rewrite-e2e.hip
+++ b/amd/comgr/test-lit/hotswap-rewrite-e2e.hip
@@ -4,16 +4,12 @@
 // COM: compile -> hotswap-rewrite -> verify chain using the in-tree
 // COM: clang + llvm-readelf + llvm-objdump substitutions.
 // COM:
-// COM: Patches in amd/comgr/src/comgr-hotswap-b0a0.cpp are weak stubs
-// COM: returning 0 until the concrete patch .cpp files land, so the
-// COM: dispatcher currently emits an output that is bytewise-identical
-// COM: to the input. Even with no patches applied we can assert that
-// COM: (1) the rewrite returns SUCCESS, (2) the output is a valid
-// COM: gfx1250 ELF that preserves the ISA identification, and (3) .text
-// COM: is still present and disassemblable as AMDGPU code. The
-// COM: per-patch PRs will layer in their own `llvm-objdump | FileCheck`
-// COM: stanzas on top of this harness to assert their specific opcode
-// COM: changes / trampolines.
+// COM: This kernel intentionally does not contain instructions matched by
+// COM: the current hotswap patch set. The test is still useful as a real
+// COM: code-object smoke test: it asserts that (1) rewrite returns SUCCESS,
+// COM: (2) the output remains a valid gfx1250 ELF with preserved ISA
+// COM: identification, and (3) .text is still present and disassemblable.
+// COM: Patch-specific LIT tests cover opcode changes and trampolines.
 
 // COM: Compile a tiny kernel targeting gfx1250 to a raw code object.
 // RUN: %clang --offload-arch=gfx1250 --offload-device-only \
@@ -25,7 +21,7 @@
 // RUN: %llvm-readelf -h %t.input.elf | %FileCheck --check-prefix=INPUT-FLAGS %s
 // INPUT-FLAGS: Flags:{{.*}}gfx1250
 // RUN: %llvm-readelf --notes %t.input.elf | %FileCheck --check-prefix=INPUT-META %s
-// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa-{{.*}}gfx1250
+// INPUT-META: amdhsa.target: amdgcn-amd-amdhsa{{--|-unknown-}}gfx1250
 
 // COM: Run hotswap-rewrite; save the output so we can inspect it.
 // RUN: hotswap-rewrite %t.input.elf \
@@ -34,14 +30,13 @@
 // RUN:   | %FileCheck --check-prefix=STATUS %s
 // STATUS: RESULT: SUCCESS
 
-// COM: Output ELF is valid and still identifies as gfx1250 (patches are
-// COM: weak stubs, so the identity should be preserved untouched; future
-// COM: patch PRs that intentionally change the target ISA note will
-// COM: update this stanza).
+// COM: Output ELF is valid and still identifies as gfx1250; this smoke
+// COM: kernel has no patch-triggering instructions, so the rewrite should
+// COM: preserve the target identification.
 // RUN: %llvm-readelf -h %t.output.elf | %FileCheck --check-prefix=OUTPUT-FLAGS %s
 // OUTPUT-FLAGS: Flags:{{.*}}gfx1250
 // RUN: %llvm-readelf --notes %t.output.elf | %FileCheck --check-prefix=OUTPUT-META %s
-// OUTPUT-META: amdhsa.target: amdgcn-amd-amdhsa-{{.*}}gfx1250
+// OUTPUT-META: amdhsa.target: amdgcn-amd-amdhsa{{--|-unknown-}}gfx1250
 
 // COM: .text section is still present and marked executable.
 // RUN: %llvm-readelf --section-headers %t.output.elf \


### PR DESCRIPTION
Summary:
- Expanded LIT coverage for the hotswap entry-trampoline support merged in #3008.
- Adds B0/A0 stepping interaction coverage for opt-in entry trampolines.
- Adds gfx125x target coverage for gfx1251 and generic gfx12.5 inputs.
- Adds multi-kernel descriptor rewrite coverage.
- Adds barrier/isfirst interaction coverage.
- Updates hotswap-rewrite-e2e.hip comments and target-note checks to match the current gfx1250 smoke-test behavior.

This PR is intentionally LIT-only. The implementation-redundancy feedback from #3008 is better handled in a follow-up refactor instead of mixing cleanup into this coverage PR.

Verification:
- Rebased onto amd-staging after #3008 merged.
- build/bin/llvm-lit -sv build/tools/comgr/test-lit --filter hotswap passed: 53 tests.
