### PR TITLE
[Flang][Offload][OpenMP] Update failing no-loop test

### DIFF
--- a/offload/test/offloading/fortran/target-no-loop.f90
+++ b/offload/test/offloading/fortran/target-no-loop.f90
@@ -91,7 +91,7 @@ end program main
 ! TODO: This kernel is currently incorrectly tagged as no-loop. This is a known issue in the
 !       Flang frontend that currently does not result in any known runtime problems.
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD-No-Loop mode
-! CHECK:  info: #Args: 3 Teams x Thrds:   1x  16
+! CHECK:  info: #Args: 3 Teams x Thrds:   16x  16
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} Generic mode
 ! CHECK:  info: #Args: 3 Teams x Thrds:   16x  16 {{.*}}
 ! CHECK:  PluginInterface device {{[0-9]+}} info: Launching kernel {{.*}} SPMD mode


### PR DESCRIPTION
Downstream behavior diverged from upstream, causing a slightly different output though results are still correct.