### PR TITLE
amd-staging: Move isOFastUsed declarations out of AMDGPUOpenMP.h

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
+++ b/clang/lib/Driver/ToolChains/AMDGPUOpenMP.h
@@ -16,16 +16,6 @@
 namespace clang {
 namespace driver {
 
-/// Is -Ofast used?
-bool isOFastUsed(const llvm::opt::ArgList &Args);
-
-/// Is -fopenmp-target-fast or -Ofast used
-bool isTargetFastUsed(const llvm::opt::ArgList &Args);
-
-/// Ignore possibility of environment variables if either
-/// -fopenmp-target-fast or -Ofast is used.
-bool shouldIgnoreEnvVars(const llvm::opt::ArgList &Args);
-
 namespace toolchains {
 class AMDGPUOpenMPToolChain;
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "Clang.h"
-#include "AMDGPUOpenMP.h"
 #include "Arch/AArch64.h"
 #include "Arch/ARM.h"
 #include "Arch/LoongArch.h"

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -22,6 +22,16 @@ namespace clang {
 class ObjCRuntime;
 namespace driver {
 
+/// Is -Ofast used?
+bool isOFastUsed(const llvm::opt::ArgList &Args);
+
+/// Is -fopenmp-target-fast or -Ofast used
+bool isTargetFastUsed(const llvm::opt::ArgList &Args);
+
+/// Ignore possibility of environment variables if either
+/// -fopenmp-target-fast or -Ofast is used.
+bool shouldIgnoreEnvVars(const llvm::opt::ArgList &Args);
+
 namespace tools {
 
 /// Clang compiler tool.


### PR DESCRIPTION
The actual definition is in lib/Driver/ToolChains/Clang.cpp. This also should be upstreamed or deleted.


