### PR TITLE
hipcc/hipconfig: Fix missing hsa include path in hipconfig

### DIFF
--- a/amd/hipcc/src/hipBin_amd.h
+++ b/amd/hipcc/src/hipBin_amd.h
@@ -91,6 +91,7 @@ HipBinAmd::HipBinAmd() {
   constructRoccmPath();
   constructCompilerPath();
   readHipVersion();
+  constructHsaPath();
 }
 
 // returns the Rocclr Home path


### PR DESCRIPTION
There is currently a bug where hipconfig -C produces the following output: 
`-D__HIP_PLATFORM_HCC__= -D__HIP_PLATFORM_AMD__= -I/opt/rocm/XYZ/include -I/include`

The last include path is not populated because the hsaPathEnv_ string is never filled and thus stays empty.

This breaks build using hipconfig -C.
