### PR TITLE
[Flang][OpenMP] Update test checking for no GPU heap allocation, NFC

### DIFF
--- a/flang/test/Lower/OpenMP/no-malloc-private.f90
+++ b/flang/test/Lower/OpenMP/no-malloc-private.f90
@@ -1,5 +1,6 @@
-! RUN: %flang_fc1 -emit-llvm -fopenmp -o - -x f95 %s | FileCheck %s
-! XFAIL: *
+! REQUIRES: amdgpu-registered-target
+! RUN: %flang_fc1 -triple amdgcn-amd-amdhsa -emit-hlfir -fopenmp -fopenmp-is-target-device -o - %s | FileCheck %s
+
 subroutine foo(state,ilast,jlast,vals)
   real, intent(in) :: state(:,:)
   integer, intent(in) :: ilast, jlast
@@ -20,8 +21,13 @@ subroutine foo(state,ilast,jlast,vals)
   !$omp end target teams distribute parallel do
 end subroutine foo
 
-! Ensure that we do not generate a call to malloc
-!CHECK-LABEL: omp.private.init:
-!CHECK-NOT:   call {{.*}} @malloc
-!CHECK:       br label
+! Ensure that won't use heap allocations as part of the privatizer or anywhere
+! inside of the function.
 
+! CHECK: omp.private {type = private} @[[PRIVATIZER:.*]] : !fir.box<!fir.array<4xf32>> init {
+! CHECK-NOT: fir.allocmem
+! CHECK: omp.yield
+
+! CHECK: func.func @{{.*}}foo
+! CHECK-NOT: fir.allocmem
+! CHECK: return


### PR DESCRIPTION
This test has been checking the wrong thing for some time (code generated for the host device), but wasn't failing due to a basic block naming mismatch that recently started matching.

This patch updates the test so that it checks what the compiler produces for a GPU target, and makes sure it won't produce heap allocations there.

Co-authored-by: Dominik Adamski <dominik.adamski@amd.com>