### PR TITLE
[AMDGPU] Fix i8 overflow in SGPR-spill debug value byte offset

### DIFF
--- a/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
+++ b/llvm/lib/Target/AMDGPU/SILowerSGPRSpills.cpp
@@ -446,7 +446,6 @@ void SILowerSGPRSpills::updateDbgValueInst(MachineInstr &MI,
     // correct register value. It should be worked out later.
   } else {
     DIExprBuilder Builder(*MI.getDebugExpression());
-    IntegerType *TypeInt8 = IntegerType::get(Builder.getContext(), 8);
     IntegerType *TypeInt32 = IntegerType::get(Builder.getContext(), 32);
     for (auto &&I = Builder.begin(); I != Builder.end();) {
       if (auto *Arg = std::get_if<DIOp::Arg>(&*I++)) {
@@ -464,7 +463,7 @@ void SILowerSGPRSpills::updateDbgValueInst(MachineInstr &MI,
           // with DIOpConstant + DIOpByteOfset.
           Arg->setResultType(TypeInt32);
           ConstantData *C =
-              ConstantInt::get(TypeInt8, VGPRSpill.Lane * 8, true);
+              ConstantInt::get(TypeInt32, VGPRSpill.Lane * 8, true);
           const std::initializer_list<DIOp::Variant> Ops = {
               DIOp::Constant(C), DIOp::ByteOffset(TypeInt32)};
           I = Builder.insert(Builder.erase(I), Ops) + Ops.size();

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-high-lane.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-high-lane.mir
@@ -1,0 +1,102 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx908 -amdgpu-spill-sgpr-to-vgpr=true -verify-machineinstrs -run-pass=si-lower-sgpr-spills -o - %s | FileCheck -check-prefix=SGPR_SPILL %s
+
+# This function spills 17 single-lane SGPRs in order, so frame index 16 is
+# placed on lane 16 (16 * 8 = 128).
+
+# SGPR_SPILL-LABEL: name: test_high_lane
+# SGPR_SPILL: DBG_VALUE {{.+}}, 0, {{.+}}, !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 128), DIOpByteOffset(i32)), {{.+}}
+
+--- |
+  define amdgpu_kernel void @test_high_lane() { ret void }
+
+  !0 = distinct !DICompileUnit(language: DW_LANG_C99, file: !4, producer: "llvm", isOptimized: true, runtimeVersion: 0, emissionKind: FullDebug, enums: !4, retainedTypes: !4)
+  !1 = !DILocalVariable(name: "a", scope: !2, file: !4, line: 126, type: !6)
+  !2 = distinct !DISubprogram(name: "test_high_lane", scope: !4, file: !4, line: 1, type: !3, isLocal: false, isDefinition: true, scopeLine: 2, flags: DIFlagPrototyped, isOptimized: true, unit: !0, retainedNodes: !5)
+  !3 = !DISubroutineType(types: !4)
+  !4 = !{null}
+  !5 = !{!1}
+  !6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64, align: 32)
+  !7 = !DIBasicType(name: "int", size: 32, align: 32, encoding: DW_ATE_signed)
+  !8 = !DIExpression()
+  !9 = !DILocation(line: 10, column: 9, scope: !2)
+
+...
+---
+name:            test_high_lane
+tracksRegLiveness: true
+frameInfo:
+  maxAlignment:    4
+stack:
+  - { id: 0,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 1,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 2,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 3,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 4,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 5,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 6,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 7,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 8,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 9,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 10, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 11, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 12, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 13, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 14, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 15, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+  - { id: 16, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
+machineFunctionInfo:
+  maxKernArgAlign: 4
+  isEntryFunction: true
+  waveLimiter:     true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  frameOffsetReg: '$sgpr33'
+  hasSpilledSGPRs: true
+  argumentInfo:
+    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
+    dispatchPtr:     { reg: '$sgpr4_sgpr5' }
+    kernargSegmentPtr: { reg: '$sgpr6_sgpr7' }
+    workGroupIDX:    { reg: '$sgpr8' }
+    privateSegmentWaveByteOffset: { reg: '$sgpr9' }
+body:             |
+  bb.0:
+    renamable $sgpr10 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr11 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr11, %stack.1, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr12 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr12, %stack.2, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr13 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr13, %stack.3, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr14 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr14, %stack.4, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr15 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr15, %stack.5, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr16 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr16, %stack.6, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr17 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr17, %stack.7, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr18 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr18, %stack.8, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr19 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr19, %stack.9, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr20 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr20, %stack.10, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr21 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr21, %stack.11, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr22 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr22, %stack.12, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr23 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr23, %stack.13, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr24 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr24, %stack.14, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr25 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr25, %stack.15, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    renamable $sgpr26 = IMPLICIT_DEF
+    SI_SPILL_S32_SAVE killed $sgpr26, %stack.16, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    DBG_VALUE %stack.16, 0, !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(i32)), debug-location !9
+
+  bb.1:
+    renamable $sgpr26 = SI_SPILL_S32_RESTORE %stack.16, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    S_ENDPGM 0
+...

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-high-lane.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-high-lane.mir
@@ -24,8 +24,12 @@
 ---
 name:            test_high_lane
 tracksRegLiveness: true
-frameInfo:
-  maxAlignment:    4
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
+  stackPtrOffsetReg: '$sgpr32'
+  frameOffsetReg: '$sgpr33'
+  hasSpilledSGPRs: true
 stack:
   - { id: 0,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
   - { id: 1,  type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
@@ -44,59 +48,26 @@ stack:
   - { id: 14, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
   - { id: 15, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
   - { id: 16, type: spill-slot, size: 4, alignment: 4, stack-id: sgpr-spill }
-machineFunctionInfo:
-  maxKernArgAlign: 4
-  isEntryFunction: true
-  waveLimiter:     true
-  scratchRSrcReg:  '$sgpr96_sgpr97_sgpr98_sgpr99'
-  stackPtrOffsetReg: '$sgpr32'
-  frameOffsetReg: '$sgpr33'
-  hasSpilledSGPRs: true
-  argumentInfo:
-    privateSegmentBuffer: { reg: '$sgpr0_sgpr1_sgpr2_sgpr3' }
-    dispatchPtr:     { reg: '$sgpr4_sgpr5' }
-    kernargSegmentPtr: { reg: '$sgpr6_sgpr7' }
-    workGroupIDX:    { reg: '$sgpr8' }
-    privateSegmentWaveByteOffset: { reg: '$sgpr9' }
 body:             |
   bb.0:
-    renamable $sgpr10 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr11 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr11, %stack.1, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr12 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr12, %stack.2, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr13 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr13, %stack.3, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr14 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr14, %stack.4, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr15 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr15, %stack.5, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr16 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr16, %stack.6, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr17 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr17, %stack.7, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr18 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr18, %stack.8, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr19 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr19, %stack.9, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr20 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr20, %stack.10, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr21 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr21, %stack.11, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr22 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr22, %stack.12, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr23 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr23, %stack.13, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr24 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr24, %stack.14, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr25 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr25, %stack.15, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
-    renamable $sgpr26 = IMPLICIT_DEF
-    SI_SPILL_S32_SAVE killed $sgpr26, %stack.16, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    liveins: $sgpr10
+    SI_SPILL_S32_SAVE $sgpr10, %stack.0,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.1,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.2,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.3,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.4,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.5,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.6,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.7,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.8,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.9,  implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.10, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.11, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.12, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.13, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.14, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.15, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
+    SI_SPILL_S32_SAVE $sgpr10, %stack.16, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
     DBG_VALUE %stack.16, 0, !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(i32)), debug-location !9
-
-  bb.1:
-    renamable $sgpr26 = SI_SPILL_S32_RESTORE %stack.16, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
     S_ENDPGM 0
 ...

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-list.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value-list.mir
@@ -47,7 +47,7 @@ body:             |
     renamable $sgpr10 = IMPLICIT_DEF
     SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32
     ; Test the path we expect to work (Arg followed immediately by Deref)
-    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, i32), DIOpConstant(i8 0), DIOpByteOffset(i32)), [[DEF]], 0, {{.*}}
+    ; CHECK:   DBG_VALUE_LIST <{{.*}}>, !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 0), DIOpByteOffset(i32)), [[DEF]], 0, {{.*}}
     DBG_VALUE_LIST !1, !DIExpression(DIOpArg(0, ptr addrspace(5)), DIOpDeref(i32)), %stack.0, 0, debug-location !9
     S_NOP 0
     ; Test that we replace unhandled stack indexes with $noreg

--- a/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value.mir
+++ b/llvm/test/CodeGen/AMDGPU/sgpr-spill-dbg-value.mir
@@ -42,7 +42,7 @@ body:             |
   ; SGPR_SPILL-LABEL: name: test
   ; SGPR_SPILL: bb.0:
   ; SGPR_SPILL:   [[DEF:%[0-9]+]]:vgpr_32 = SI_SPILL_S32_TO_VGPR killed $sgpr10, 0, [[DEF]]
-  ; SGPR_SPILL-NEXT:   DBG_VALUE [[DEF]], 0, {{.+}}, !DIExpression(DIOpArg(0, i32), DIOpConstant(i8 0), DIOpByteOffset(i32)), {{.+}}
+  ; SGPR_SPILL-NEXT:   DBG_VALUE [[DEF]], 0, {{.+}}, !DIExpression(DIOpArg(0, i32), DIOpConstant(i32 0), DIOpByteOffset(i32)), {{.+}}
   bb.0:
     renamable $sgpr10 = IMPLICIT_DEF
     SI_SPILL_S32_SAVE killed $sgpr10, %stack.0, implicit $exec, implicit $sgpr96_sgpr97_sgpr98_sgpr99, implicit $sgpr32


### PR DESCRIPTION
The constant was created as a signed i8, so any lane >= 16 produces an offset >= 128 that overflows the signed 8-bit range


