### PR TITLE
[Infra] Update the test runner to use ccs-csp

### DIFF
--- a/.github/workflows/rockci_multi_arch_nightly.yml
+++ b/.github/workflows/rockci_multi_arch_nightly.yml
@@ -132,7 +132,7 @@ jobs:
       - windows_build_and_test
       - linux_build_and_test
     with:
-        JOB_NAME_TO_MATCH: "Linux::release / Build Multi-Arch Stages / math-libs (gfx94X-dcgpu, gfx942, linux-gfx942-1gpu-ossci-rocm, false) / Stage - Math Libs (gfx94X-dcgpu)"
+        JOB_NAME_TO_MATCH: "Linux::release / Build Multi-Arch Stages / math-libs (gfx94X-dcgpu, gfx942, linux-gfx942-1gpu-ccs-csp-ossci-rocm, false) / Stage - Math Libs (gfx94X-dcgpu)"
     secrets: inherit
 
 

--- a/.github/workflows/setup_multi_arch.yml
+++ b/.github/workflows/setup_multi_arch.yml
@@ -57,7 +57,7 @@ jobs:
       linux_build_config: >-
         {
           "per_family_info": [
-            {"amdgpu_family": "gfx94X-dcgpu", "amdgpu_targets": "gfx942", "test-runs-on": "linux-gfx942-1gpu-ossci-rocm", "sanity_check_only_for_family": false},
+            {"amdgpu_family": "gfx94X-dcgpu", "amdgpu_targets": "gfx942", "test-runs-on": "linux-gfx942-1gpu-ccs-csp-ossci-rocm", "sanity_check_only_for_family": false},
             {"amdgpu_family": "gfx110X-all", "amdgpu_targets": "", "test-runs-on": "", "sanity_check_only_for_family": true, "bypass_tests_for_releases": true},
             {"amdgpu_family": "gfx90a", "amdgpu_targets": "", "test-runs-on": "", "sanity_check_only_for_family": true, "bypass_tests_for_releases": true}
           ],


### PR DESCRIPTION
Moving the test runner to linux-gfx942-1gpu-ccs-csp-ossci-rocm 

Reference: confirmed by the CI team and ROCm/therock-ci-config/blob/main/runner-config.json