### PR TITLE
[Comgr] Document API versioning rule in AGENT_CONVENTIONS.md

### DIFF
--- a/amd/comgr/AGENT_CONVENTIONS.md
+++ b/amd/comgr/AGENT_CONVENTIONS.md
@@ -144,6 +144,25 @@ a feature PR.
 **Tests required.** Each PR is accompanied by tests aiming for 100%
 code coverage of the change being added.
 
+**Bump the version when adding a public API.** Any commit that adds a
+new `AMD_COMGR_API` function must bump the minor version in
+`VERSION.txt` and tag the new prototype(s) with a fresh
+`AMD_COMGR_VERSION_X_Y` macro in `include/amd_comgr.h.in`:
+
+- One bump per commit, not per function — a commit adding several APIs
+  bumps once and tags them all with the same new version.
+- Never reuse the current version's macro for a new API in a later
+  commit. The previous version is already owned by whatever shipped it.
+- Don't wait for an official release to bump. We don't know which
+  commit hash lands in each release, so the version must advance at the
+  moment the API is introduced.
+- Add the symbol to `src/exportmap.in` under a version node matching the
+  new tag (e.g. `@amd_comgr_NAME@_X.Y { global: ...; } @prev;`), not the
+  previous node.
+- `utils/check_api_consistency.py` only enforces `VERSION.txt >=` the
+  highest macro, so it will NOT catch a new API that reuses the current
+  version. Verify the bump by hand.
+
 **Keep the branch rebased.** Resolve conflicts before requesting
 review.
 


### PR DESCRIPTION
## Summary

Adds an explicit API-versioning rule to `amd/comgr/AGENT_CONVENTIONS.md` (section 4, PR workflow): every commit that adds a public `AMD_COMGR_API` function must bump the minor version in `VERSION.txt` and tag the new prototype with a fresh `AMD_COMGR_VERSION_X_Y` macro.

This codifies the policy that surfaced when #3008 added `amd_comgr_hotswap_rewrite_with_options` under the already-used `3.3` version without bumping (fixed in its follow-up #3134).

The rule captures:
- One bump per commit, not per function.
- Never reuse the current version's macro for a new API in a later commit.
- Don't wait for an official release to bump — we don't know which commit lands in each release, so the version advances when the API is introduced.
- Add the symbol to `exportmap.in` under a version node matching the new tag.
- `check_api_consistency.py` only enforces `VERSION.txt >=` the highest macro, so it cannot catch version reuse — verify the bump by hand.

## Changes

- `AGENT_CONVENTIONS.md`: add the "Bump the version when adding a public API" subsection.
