### PR TITLE
[Comgr][hotswap] Fix scratch VGPR misallocation and fail safe on branch overflow

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -597,9 +597,23 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   std::vector<Trampoline> Growth = Deferred;
   if (!Deferred.empty()) {
     if (!fixupTrampolineBranches(Deferred, Text, Elf.textSize(), LS)) {
-      log() << "hotswap: error: trampoline branch fixup failed; aborting "
-               "rewrite\n";
-      return AMD_COMGR_STATUS_ERROR;
+      // A trampoline branch could not be encoded, so the local `Buf` copy
+      // is half-redirected; shipping it would run corrupted code. Fall back
+      // to the pristine input object (`ElfData`, untouched) so the loader
+      // runs the original unpatched code instead.
+      log() << "hotswap: error: some trampolines could not be fixed up; "
+            << "falling back to the original (unpatched) code object\n";
+      std::unique_ptr<WritableMemoryBuffer> Orig =
+          WritableMemoryBuffer::getNewUninitMemBuffer(ElfSize);
+      if (!Orig) {
+        log() << "hotswap: error: retargetCodeObject: "
+              << "getNewUninitMemBuffer(" << ElfSize
+              << ") failed (out of memory) for the fallback copy.\n";
+        return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+      }
+      std::memcpy(Orig->getBufferStart(), ElfData, ElfSize);
+      Out = std::move(Orig);
+      return AMD_COMGR_STATUS_SUCCESS;
     }
     Growth = Deferred;
   }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
 
+#include <cassert>
 #include <limits>
 
 using namespace llvm;
@@ -278,14 +279,22 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS) {
 // literal) or 12 (backward, 64-bit literal), resolved by trying each. Encoded
 // via the MC assembler. Returns empty on failure.
 //
-// Invariant: callers only take this path for *far* sites (those a short
-// s_branch cannot reach, i.e. offsets well beyond the simm16 dword range), so
-// the literal never falls in the inline-constant range. A tiny offset would
-// assemble to the 4-byte inline-constant form, match neither candidate size,
-// and return empty; that is acceptable, since no caller passes such an offset
-// (see EncodeLongBranch.SmallOffsetReturnsEmpty).
+// Precondition: callers only long-branch *far* sites, so the target is far
+// enough that s_add_pc_i64 always needs a real (>= 32-bit) literal. A tiny
+// offset would instead assemble to the 4-byte inline-constant form, match
+// neither candidate size, and yield empty. That is asserted here (assert
+// liberally); the empty return is kept as a release-build safety net so a
+// stray near target degrades to the unpatched-object fallback rather than
+// crashing the loader.
 SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
                                       uint64_t TargetOffset) {
+  [[maybe_unused]] const int64_t Distance =
+      static_cast<int64_t>(TargetOffset) - static_cast<int64_t>(FromOffset);
+  [[maybe_unused]] const int64_t MinLongDistance = LongBranchMaxBytes;
+  assert((Distance > MinLongDistance || Distance < -MinLongDistance) &&
+         "encodeLongBranch: target is not a far site; the long-branch path is "
+         "only valid for offsets beyond an s_add_pc_i64 instruction's reach");
+
   for (uint32_t Size : {LongBranchFwdBytes, LongBranchMaxBytes}) {
     int64_t Off = static_cast<int64_t>(TargetOffset) -
                   static_cast<int64_t>(FromOffset + Size);
@@ -687,6 +696,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       }
       std::memcpy(Orig->getBufferStart(), ElfData, ElfSize);
       Out = std::move(Orig);
+      // SUCCESS here is misleading the returned buffer is the
+      // *unpatched* original, so callers cannot tell "rewrote successfully"
+      // from "declined and fell back". The status vocabulary needs a distinct
+      // "no-op / not-applied" code.
       return AMD_COMGR_STATUS_SUCCESS;
     }
     Growth = Deferred;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -272,23 +272,55 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS) {
   return true;
 }
 
-/// Queue a deferred trampoline for the instruction at [\p InstOffset,
-/// \p InstOffset + \p InstSize) with \p Replacement as its body. The final
-/// branch encoding (branch-back at the trampoline tail and branch-forward
-/// overwrite at the original site) is filled in by fixupTrampolineBranches
-/// once the post-.text trampoline layout is known -- we reserve
-/// MinInstSize zero bytes at the end of the trampoline body as a
-/// placeholder rather than encoding twice. Used when there is no reachable
-/// NOP sled for an in-place sled patch.
+// s_add_pc_i64 long branch from \p FromOffset to \p TargetOffset (.text
+// offsets). It adds a signed literal to the next instruction's PC, so the
+// offset is TargetOffset - (FromOffset + size); size is 8 (forward, 32-bit
+// literal) or 12 (backward, 64-bit literal), resolved by trying each. Encoded
+// via the MC assembler. Returns empty on failure.
+SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                                      uint64_t TargetOffset) {
+  for (uint32_t Size : {LongBranchFwdBytes, LongBranchMaxBytes}) {
+    int64_t Off = static_cast<int64_t>(TargetOffset) -
+                  static_cast<int64_t>(FromOffset + Size);
+    SmallVector<uint8_t> Bytes =
+        assembleSingleInst("s_add_pc_i64 " + std::to_string(Off), LS);
+    if (Bytes.size() == Size)
+      return Bytes;
+  }
+  return {};
+}
+
+/// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
+/// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
+/// the pool layout is known. A site beyond s_branch reach of the appended pool
+/// uses an s_add_pc_i64 long branch (no scratch reg, no SCC) on both edges; its
+/// 8-byte forward branch overwrites the site in place, so a smaller site
+/// declines rather than clobbering the next instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement) {
+  const bool Far =
+      static_cast<int64_t>(Ctx.TextSize - InstOffset) > LongBranchThreshold;
+
   Trampoline T;
   T.OriginalOffset = InstOffset;
   T.OriginalSize = InstSize;
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
-  // Reserve the branch-back slot; fixupTrampolineBranches fills it in.
-  T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
+
+  if (Far) {
+    if (InstSize < LongBranchFwdBytes) {
+      log() << "hotswap: long trampoline: site 0x" << utohexstr(InstOffset)
+            << " is " << InstSize << " B < " << LongBranchFwdBytes
+            << " B forward branch; declining (site left unpatched)\n";
+      return false;
+    }
+    T.Long = true;
+    // Reserve the long branch-back slot (worst-case 64-bit-literal size).
+    T.Bytes.insert(T.Bytes.end(), LongBranchMaxBytes, uint8_t{0});
+  } else {
+    // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
+    T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
+  }
   Ctx.OutTrampolines.emplace_back(std::move(T));
   return true;
 }
@@ -449,25 +481,40 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
 
-    SmallVector<uint8_t> BrBack = LS.encodeSBranch(
-        TP + T.Bytes.size() - MinInstSize, T.OriginalOffset + T.OriginalSize);
-    if (BrBack.empty()) {
+    // Long trampolines reserve a wider branch-back slot and use s_add_pc_i64
+    // on both edges; short ones use s_branch. Both slots are s_nop-padded to
+    // their reserved size after the branch is written.
+    const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
+    const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
+    const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+
+    SmallVector<uint8_t> BrBack = T.Long
+                                      ? encodeLongBranch(LS, BackSlot, ReturnTo)
+                                      : LS.encodeSBranch(BackSlot, ReturnTo);
+    if (BrBack.empty() || BrBack.size() > BackReserve) {
       log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
-            << utohexstr(T.OriginalOffset) << "\n";
+            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
       return false;
     }
-    std::memcpy(T.Bytes.data() + T.Bytes.size() - MinInstSize, BrBack.data(),
+    std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
                 BrBack.size());
+    for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
+         I += MinInstSize)
+      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
+                  LS.SNopBytes.data(), MinInstSize);
 
-    SmallVector<uint8_t> BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
-    if (BrFwd.empty()) {
+    SmallVector<uint8_t> BrFwd =
+        T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)
+               : LS.encodeSBranch(T.OriginalOffset, TP);
+    if (BrFwd.empty() || BrFwd.size() > T.OriginalSize) {
       log() << "hotswap: error: trampoline branch-fwd encoding failed at 0x"
-            << utohexstr(T.OriginalOffset) << "\n";
+            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
       return false;
     }
     std::memcpy(Text + T.OriginalOffset, BrFwd.data(), BrFwd.size());
     // Pad the tail of the replaced slot with cached s_nop bytes.
-    for (uint32_t I = MinInstSize; I < T.OriginalSize; I += MinInstSize)
+    for (uint32_t I = BrFwd.size(); I + MinInstSize <= T.OriginalSize;
+         I += MinInstSize)
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
   }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -277,6 +277,13 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS) {
 // offset is TargetOffset - (FromOffset + size); size is 8 (forward, 32-bit
 // literal) or 12 (backward, 64-bit literal), resolved by trying each. Encoded
 // via the MC assembler. Returns empty on failure.
+//
+// Invariant: callers only take this path for *far* sites (those a short
+// s_branch cannot reach, i.e. offsets well beyond the simm16 dword range), so
+// the literal never falls in the inline-constant range. A tiny offset would
+// assemble to the 4-byte inline-constant form, match neither candidate size,
+// and return empty; that is acceptable, since no caller passes such an offset
+// (see EncodeLongBranch.SmallOffsetReturnsEmpty).
 SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
                                       uint64_t TargetOffset) {
   for (uint32_t Size : {LongBranchFwdBytes, LongBranchMaxBytes}) {
@@ -299,8 +306,28 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement) {
-  const bool Far =
-      static_cast<int64_t>(Ctx.TextSize - InstOffset) > LongBranchThreshold;
+  // This trampoline lands right after .text and after every trampoline already
+  // queued -- later ones are appended behind it and cannot shift it, and
+  // fixupTrampolineBranches walks the same list in the same order -- so its
+  // final pool offset is known exactly now.
+  uint64_t PoolStart = Ctx.TextSize;
+  for (const Trampoline &Prev : Ctx.OutTrampolines)
+    PoolStart += Prev.Bytes.size();
+
+  // An s_branch encodes To - From as a signed simm16 dword field, in range iff
+  // (To - From - MinInstSize) / MinInstSize fits [BranchOffsetMin,
+  // BranchOffsetMax] (see LLVMState::encodeSBranch). Test both edges with the
+  // short branch-back slot; the branch-back (pool tail -> site) is the farther
+  // of the two. Go long only when a short branch cannot reach.
+  auto WithinSBranch = [](uint64_t From, uint64_t To) {
+    int64_t Dword = (static_cast<int64_t>(To) - static_cast<int64_t>(From) -
+                     static_cast<int64_t>(MinInstSize)) /
+                    static_cast<int64_t>(MinInstSize);
+    return Dword >= BranchOffsetMin && Dword <= BranchOffsetMax;
+  };
+  const uint64_t ShortBackFrom = PoolStart + Replacement.size();
+  const bool Far = !(WithinSBranch(InstOffset, PoolStart) &&
+                     WithinSBranch(ShortBackFrom, InstOffset + InstSize));
 
   Trampoline T;
   T.OriginalOffset = InstOffset;

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -347,6 +347,13 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
 // -- ElfView::findKernelAtOffset ----------------------------------------------
 
 std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
+  // Select the nearest-preceding STT_FUNC symbol (greatest st_value <=
+  // TextOffset). AMDGPU kernel entry symbols often have st_size == 0, so an
+  // exact containment test never matches; honor st_size only when non-zero.
+  bool Found = false;
+  uint64_t BestValue = 0;
+  std::string BestName;
+
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
         SymShdr.sh_type != ELF::SHT_DYNSYM)
@@ -369,19 +376,27 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
         continue;
       if (Sym.st_shndx != TextSectionIndex)
         continue;
-      if (TextOffset < Sym.st_value || TextOffset >= Sym.st_value + Sym.st_size)
+      if (TextOffset < Sym.st_value)
+        continue;
+      // Honor an explicit upper bound; skip it for zero-size symbols.
+      if (Sym.st_size != 0 && TextOffset >= Sym.st_value + Sym.st_size)
+        continue;
+      if (Found && Sym.st_value <= BestValue)
         continue;
       Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
       if (!NameOrErr) {
-        log() << "hotswap: error: findKernelAtOffset: function symbol "
-              << "covering offset 0x" << utohexstr(TextOffset)
-              << " has unreadable name: " << toString(NameOrErr.takeError())
-              << "\n";
-        return "";
+        consumeError(NameOrErr.takeError());
+        continue;
       }
-      return NameOrErr->str();
+      Found = true;
+      BestValue = Sym.st_value;
+      BestName = NameOrErr->str();
     }
   }
+
+  if (Found)
+    return BestName;
+
   log() << "hotswap: findKernelAtOffset: no function symbol covers offset 0x"
         << utohexstr(TextOffset) << " in .text.\n";
   return "";

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -350,6 +350,10 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
   // Select the nearest-preceding STT_FUNC symbol (greatest st_value <=
   // TextOffset). AMDGPU kernel entry symbols often have st_size == 0, so an
   // exact containment test never matches; honor st_size only when non-zero.
+  //
+  // The nearest-preceding function could be a non-kernel device function; the
+  // guard below rejects that case so callers never scratch-allocate against a
+  // non-kernel context.
   bool Found = false;
   uint64_t BestValue = 0;
   std::string BestName;
@@ -394,8 +398,20 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
     }
   }
 
-  if (Found)
-    return BestName;
+  if (Found) {
+    // Confirm the selected symbol is actually a kernel: every kernel carries a
+    // "<name>.kd" descriptor symbol, whereas a plain device function does not.
+    // This is the same descriptor lookup getKernelVgprCount performs, so a real
+    // kernel is never rejected; a non-kernel is reported as "not found" so the
+    // caller declines instead of scratch-allocating against a wrong context.
+    if (const_cast<ElfView *>(this)->findKernelDescriptor(BestName)) {
+      return BestName;
+    }
+    log() << "hotswap: findKernelAtOffset: nearest function symbol '"
+          << BestName << "' preceding offset 0x" << utohexstr(TextOffset)
+          << " has no .kd descriptor (not a kernel); treating as no match.\n";
+    return "";
+  }
 
   log() << "hotswap: findKernelAtOffset: no function symbol covers offset 0x"
         << utohexstr(TextOffset) << " in .text.\n";

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -129,14 +129,11 @@ static constexpr uint32_t MinInstSize = 4;
 
 // s_add_pc_i64 long-branch encoded sizes: 8 bytes for a forward (32-bit
 // literal) offset, 12 for a backward (64-bit literal) one. The back slot
-// reserves the max; unused tail bytes are s_nop-padded.
+// reserves the max; unused tail bytes are s_nop-padded. emitToTrampoline picks
+// the long path only when a short s_branch cannot reach the site's exact pool
+// offset on either edge (computed from the already-queued trampolines).
 static constexpr uint32_t LongBranchFwdBytes = 8;
 static constexpr uint32_t LongBranchMaxBytes = 12;
-
-// Take the long-branch path when the site is this far from .text end (i.e. the
-// appended pool may exceed s_branch reach). The margin below MaxSledDistance
-// covers pool growth so an in-range decision cannot later go out of range.
-static constexpr int64_t LongBranchThreshold = MaxSledDistance - 65536;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
 // LLVMState::encodeSBranch to reject out-of-range branches before handing
@@ -439,10 +436,18 @@ LLVMState initLLVM(const TargetIdentifier &TI);
 llvm::SmallVector<uint8_t> assembleSingleInst(llvm::StringRef AsmStr,
                                               const LLVMState &LS);
 
+/// Join \p AsmLines into a single newline-terminated assembly source string,
+/// as expected by assembleSingleInst (which accepts multiple instructions).
+std::string joinAsmLines(llvm::ArrayRef<std::string> AsmLines);
+
 /// Assemble \p AsmLines and append a branch-back to the next instruction
 /// after the original (\p OriginalOffset + \p OriginalSize). The branch-back
 /// is encoded via LLVMState::encodeSBranch, so no ISA-specific opcode needs
 /// to flow in from the caller.
+///
+/// NOTE: no production caller remains (WMMA-split now defers edge encoding to
+/// emitToTrampoline / fixupTrampolineBranches). Kept only as a self-contained
+/// helper exercised by the unit tests; prefer emitToTrampoline for new code.
 Trampoline buildTrampoline(llvm::ArrayRef<std::string> AsmLines,
                            uint64_t OriginalOffset, uint32_t OriginalSize,
                            uint64_t TrampolineTextOffset, const LLVMState &LS);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -79,6 +79,10 @@ struct Trampoline {
   uint64_t OriginalOffset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
+  // When set, both edges use an s_add_pc_i64 long branch instead of s_branch
+  // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
+  // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
+  bool Long = false;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -122,6 +126,17 @@ static constexpr uint64_t MinNopSledSize = 8;
 
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
+
+// s_add_pc_i64 long-branch encoded sizes: 8 bytes for a forward (32-bit
+// literal) offset, 12 for a backward (64-bit literal) one. The back slot
+// reserves the max; unused tail bytes are s_nop-padded.
+static constexpr uint32_t LongBranchFwdBytes = 8;
+static constexpr uint32_t LongBranchMaxBytes = 12;
+
+// Take the long-branch path when the site is this far from .text end (i.e. the
+// appended pool may exceed s_branch reach). The margin below MaxSledDistance
+// covers pool growth so an in-range decision cannot later go out of range.
+static constexpr int64_t LongBranchThreshold = MaxSledDistance - 65536;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
 // LLVMState::encodeSBranch to reject out-of-range branches before handing
@@ -607,6 +622,13 @@ struct PatchContext {
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     llvm::ArrayRef<uint8_t> Replacement);
+
+// Encode an s_add_pc_i64 PC-relative long branch from \p FromOffset to
+// \p TargetOffset (.text byte offsets). Exposed for unit testing the offset
+// math / encoding. Returns empty on failure.
+llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
+                                            uint64_t FromOffset,
+                                            uint64_t TargetOffset);
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        llvm::ArrayRef<uint8_t> Replacement);

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -450,6 +450,15 @@ SmallVector<uint8_t> assembleSingleInst(StringRef AsmStr, const LLVMState &S) {
 
 // -- buildTrampoline ----------------------------------------------------------
 
+std::string joinAsmLines(ArrayRef<std::string> AsmLines) {
+  std::string AsmSource;
+  for (StringRef Line : AsmLines) {
+    AsmSource += Line;
+    AsmSource += '\n';
+  }
+  return AsmSource;
+}
+
 Trampoline buildTrampoline(ArrayRef<std::string> AsmLines,
                            uint64_t OriginalOffset, uint32_t OriginalSize,
                            uint64_t TrampolineTextOffset, const LLVMState &S) {
@@ -457,13 +466,7 @@ Trampoline buildTrampoline(ArrayRef<std::string> AsmLines,
   Result.OriginalOffset = OriginalOffset;
   Result.OriginalSize = OriginalSize;
 
-  std::string AsmSource;
-  for (StringRef Line : AsmLines) {
-    AsmSource += Line;
-    AsmSource += '\n';
-  }
-
-  SmallVector<uint8_t> Bytes = assembleSingleInst(AsmSource, S);
+  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), S);
   if (Bytes.empty()) {
     log() << "hotswap: error: buildTrampoline: assembleSingleInst returned "
           << "empty for trampoline originating at offset 0x"

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -447,7 +447,12 @@ struct ScratchAlloc {
 
 std::optional<ScratchAlloc> tryAllocScratchVgpr(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
-  std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
+  // findKernelAtOffset matches against symbol virtual addresses, so bias the
+  // .text-relative DI.Offset by textAddr() (matching the other patches). A
+  // bare offset misses when .text has a non-zero sh_addr, leaving KdVgprs ==
+  // 0 and handing the allocator a live register.
+  std::string KernelName =
+      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
   unsigned KdVgprs = 0;
   if (std::optional<unsigned> Opt =
           Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize))
@@ -762,7 +767,8 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     // because the original data VGPR must be preserved as the store source.
     StoreScratch = tryAllocScratchVgpr(Ctx, Idx);
     if (!StoreScratch) {
-      std::string KernelName = Ctx.Elf.findKernelAtOffset(DI.Offset);
+      std::string KernelName =
+          Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
       StringRef KernelDisplay =
           KernelName.empty() ? StringRef("<unknown>") : StringRef(KernelName);
       std::optional<uint32_t> LdsSize =

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -487,6 +487,10 @@ void commitScratchVgpr(PatchContext &Ctx, const ScratchAlloc &Alloc) {
 // never used by the kernel, and GFX10+ waves always have the full SGPR file
 // (no KD bump needed), so unlike VGPRs this needs no liveness. Same strategy
 // the E5M3 patch uses.
+//
+// TODO: the E5M3 patch open-codes this same scratch-SGPR reservation. Hoist
+// SgprScratchAlloc / tryAllocScratchSgpr / commitScratchSgpr into shared
+// infrastructure both patches call, rather than duplicating it.
 
 struct SgprScratchAlloc {
   unsigned Sgpr = 0;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -481,12 +481,53 @@ void commitScratchVgpr(PatchContext &Ctx, const ScratchAlloc &Alloc) {
   Stats.ScratchAboveKd += Alloc.ExtraVgprsNeeded;
 }
 
+// -- scratch-SGPR allocation ------------------------------------------------
+//
+// Allocate a scratch SGPR above the kernel's .sgpr_count. Those SGPRs are
+// never used by the kernel, and GFX10+ waves always have the full SGPR file
+// (no KD bump needed), so unlike VGPRs this needs no liveness. Same strategy
+// the E5M3 patch uses.
+
+struct SgprScratchAlloc {
+  unsigned Sgpr = 0;
+  std::string KernelName;
+  unsigned ExtraSgprsNeeded = 0;
+};
+
+std::optional<SgprScratchAlloc> tryAllocScratchSgpr(PatchContext &Ctx,
+                                                    size_t Idx) {
+  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  std::string KernelName =
+      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+  std::optional<unsigned> KdSgprs = Ctx.Elf.getKernelSgprCount(KernelName);
+  unsigned SgprKdCount = KdSgprs.value_or(Ctx.Config.MaxSgprs);
+
+  SgprAllocator Alloc(SgprKdCount, Ctx.Config.MaxSgprs);
+  std::optional<unsigned> S = Alloc.alloc();
+  if (!S)
+    return std::nullopt;
+
+  SgprScratchAlloc Out;
+  Out.Sgpr = *S;
+  Out.KernelName = std::move(KernelName);
+  Out.ExtraSgprsNeeded = Alloc.extraSgprsNeeded();
+  return Out;
+}
+
+void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
+  if (Alloc.ExtraSgprsNeeded == 0 || Alloc.KernelName.empty())
+    return;
+  KernelPatchStats &Stats = Ctx.KernelStats[Alloc.KernelName];
+  Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, Alloc.ExtraSgprsNeeded);
+}
+
 // -- patchTensorLoadToLds ---------------------------------------------------
 //
 // Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
 // descriptor's base SGPR. If the SGPR is live after the tensor_load, bracket
-// the sequence with v_writelane/v_readlane to save and restore its value
-// through a scratch VGPR lane.
+// the sequence with s_mov_b32 through a scratch SGPR to save/restore it. (An
+// earlier version used a VGPR lane, but occupancy-1 kernels have no free VGPR
+// so the patch declined; a scratch SGPR is always available.)
 
 bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -499,10 +540,9 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
     return false;
   }
 
-  // Idempotency guard: check whether the immediately preceding instruction
-  // matches one of the specific patterns we emit during patching:
-  //   dead-SGPR path: s_pack_hh_b32_b16 sN, 0, sN  (dst == BaseMCReg)
-  //   live-SGPR path: v_writelane_b32 vX, sN, 0     (src == BaseMCReg)
+  // Idempotency guard: both paths emit `s_pack_hh_b32_b16 sN, 0, sN`
+  // (dst == BaseMCReg) right before the relocated instruction, so one check
+  // covers re-rewrites.
   if (Idx > 0) {
     const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
     const MCInst &PI = Prev.Inst;
@@ -510,11 +550,6 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
         PI.getOperand(0).isReg() &&
         MRI.regsOverlap(PI.getOperand(0).getReg(), BaseMCReg.id()) &&
         PI.getOperand(1).isImm() && PI.getOperand(1).getImm() == 0)
-      return false;
-    if (Prev.Mnemonic == "v_writelane_b32" && PI.getNumOperands() >= 3 &&
-        PI.getOperand(1).isReg() &&
-        MRI.regsOverlap(PI.getOperand(1).getReg(), BaseMCReg.id()) &&
-        PI.getOperand(2).isImm() && PI.getOperand(2).getImm() == 0)
       return false;
   }
 
@@ -533,16 +568,16 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
   const uint8_t *OrigInst = Ctx.Text + DI.Offset;
 
   if (SgprLive) {
-    std::optional<ScratchAlloc> ScratchVgpr = tryAllocScratchVgpr(Ctx, Idx);
-    if (!ScratchVgpr) {
-      log() << "hotswap: error: tensor_load_to_lds: no scratch VGPR "
+    std::optional<SgprScratchAlloc> ScratchSgpr = tryAllocScratchSgpr(Ctx, Idx);
+    if (!ScratchSgpr) {
+      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
                "available\n";
       return false;
     }
 
-    std::string V = "v" + std::to_string(ScratchVgpr->Vgpr);
-    std::string SaveAsm = "v_writelane_b32 " + V + ", " + BaseSreg + ", 0";
-    std::string RestoreAsm = "v_readlane_b32 " + BaseSreg + ", " + V + ", 0";
+    std::string S = "s" + std::to_string(ScratchSgpr->Sgpr);
+    std::string SaveAsm = "s_mov_b32 " + S + ", " + BaseSreg;
+    std::string RestoreAsm = "s_mov_b32 " + BaseSreg + ", " + S;
     SmallVector<uint8_t> Save = assembleSingleInst(SaveAsm, Ctx.LS);
     SmallVector<uint8_t> Restore = assembleSingleInst(RestoreAsm, Ctx.LS);
     if (Save.empty() || Restore.empty()) {
@@ -559,19 +594,12 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
     if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
       return false;
 
-    // Record the scratch reservation only after the patch is committed:
-    // any earlier failure (assembly, emission) leaves nothing at DI.Offset
-    // to back the reservation, and bumping the kernel descriptor would
-    // reserve VGPRs the code object never uses.
-    ScratchPatchInfo SPI;
-    SPI.Offset = DI.Offset;
-    SPI.ScratchRegs.resize(Ctx.Config.MaxVgprs);
-    SPI.ScratchRegs.set(ScratchVgpr->Vgpr);
-    Ctx.OutScratchPatches.push_back(std::move(SPI));
-    commitScratchVgpr(Ctx, *ScratchVgpr);
+    // SGPRs above .sgpr_count need no KD bump on GFX10+; commit only after
+    // the patch is emitted, to keep per-kernel stats accurate.
+    commitScratchSgpr(Ctx, *ScratchSgpr);
 
     log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " live, save/restore via " << V << "\n";
+          << " live, save/restore via " << S << "\n";
   } else {
     SmallVector<uint8_t> Replacement;
     Replacement.append(PackBytes.begin(), PackBytes.end());

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -655,12 +655,8 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   // Assemble the split sequence and defer trampoline emission to
   // emitToTrampoline, which picks a short s_branch or an s_add_pc_i64 long
   // branch based on the site's distance from the appended pool.
-  std::string AsmSource;
-  for (const std::string &Line : AsmLines) {
-    AsmSource += Line;
-    AsmSource += '\n';
-  }
-  SmallVector<uint8_t> Replacement = assembleSingleInst(AsmSource, Ctx.LS);
+  SmallVector<uint8_t> Replacement =
+      assembleSingleInst(joinAsmLines(AsmLines), Ctx.LS);
   if (Replacement.empty()) {
     log() << "hotswap: error: WMMA split: trampoline assembly failed for "
           << DI.Mnemonic << "\n";

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -652,21 +652,25 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (AsmLines.empty())
     return 0; // matched-but-failed (build*Asm rejected an unsupported modifier)
 
-  // Compute the trampoline's eventual .text offset so buildTrampoline can
-  // emit relative jumps. Same accumulation pattern as emitToTrampoline in
-  // b0a0.cpp.
-  uint64_t TrampTextOffset = Ctx.TextSize;
-  for (const Trampoline &T : Ctx.OutTrampolines)
-    TrampTextOffset += T.Bytes.size();
-
-  Trampoline T = buildTrampoline(AsmLines, DI.Offset, DI.Size, TrampTextOffset,
-                                 Ctx.LS);
-  if (T.Bytes.empty()) {
+  // Assemble the split sequence and defer trampoline emission to
+  // emitToTrampoline, which picks a short s_branch or an s_add_pc_i64 long
+  // branch based on the site's distance from the appended pool.
+  std::string AsmSource;
+  for (const std::string &Line : AsmLines) {
+    AsmSource += Line;
+    AsmSource += '\n';
+  }
+  SmallVector<uint8_t> Replacement = assembleSingleInst(AsmSource, Ctx.LS);
+  if (Replacement.empty()) {
     log() << "hotswap: error: WMMA split: trampoline assembly failed for "
           << DI.Mnemonic << "\n";
     return 0; // matched-but-failed
   }
-  Ctx.OutTrampolines.push_back(std::move(T));
+  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement)) {
+    log() << "hotswap: error: WMMA split: could not emit trampoline for "
+          << DI.Mnemonic << "\n";
+    return 0; // matched-but-failed
+  }
 
   log() << "hotswap: WMMA split: patched " << DI.Mnemonic << " at offset 0x"
         << utohexstr(DI.Offset) << "\n";

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,0 +1,61 @@
+// COM: Test the s_add_pc_i64 long-branch trampoline path. When the appended
+// COM: trampoline pool sits farther than s_branch's +-128 KB reach from the
+// COM: patch site, both trampoline edges use s_add_pc_i64 (a PC-relative long
+// COM: branch that reaches anywhere, needs no scratch register, and does not
+// COM: touch SCC) instead of s_branch. A large .rept filler (~80 KB, non-NOP
+// COM: so it forms no usable sled) pushes the pool out of range of the
+// COM: tensor_load_to_lds at the top of the kernel.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Forward edge: the site is overwritten in place with an 8-byte
+// COM: s_add_pc_i64 long branch (the 12-byte tensor slot leaves room, padded
+// COM: with s_nop), NOT an s_branch.
+// DISASM-LABEL: <test_far>:
+// DISASM: s_add_pc_i64
+// DISASM-NEXT: s_nop
+// DISASM-NEXT: s_endpgm
+
+// COM: Trampoline body (appended after .text): the relocated multicast
+// COM: mask-clear + tensor_load, then an s_add_pc_i64 long branch-back.
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_add_pc_i64
+
+// COM: Idempotency: rewriting the output again must be a no-op.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_far
+.p2align 8
+.type test_far,@function
+test_far:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+  // ~80 KB of non-NOP filler so the appended trampoline pool is beyond
+  // s_branch reach from the tensor_load above (forces the long-branch path).
+  .rept 20000
+    s_mov_b32 s0, s1
+  .endr
+.Ltest_far_end:
+.size test_far, .Ltest_far_end-test_far
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_far
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -2,9 +2,9 @@
 // COM: trampoline pool sits farther than s_branch's +-128 KB reach from the
 // COM: patch site, both trampoline edges use s_add_pc_i64 (a PC-relative long
 // COM: branch that reaches anywhere, needs no scratch register, and does not
-// COM: touch SCC) instead of s_branch. A large .rept filler (~80 KB, non-NOP
-// COM: so it forms no usable sled) pushes the pool out of range of the
-// COM: tensor_load_to_lds at the top of the kernel.
+// COM: touch SCC) instead of s_branch. A large .rept filler (~160 KB, non-NOP
+// COM: so it forms no usable sled) pushes the pool past s_branch's real reach
+// COM: from the tensor_load_to_lds at the top of the kernel.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -45,9 +45,10 @@
 test_far:
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
-  // ~80 KB of non-NOP filler so the appended trampoline pool is beyond
-  // s_branch reach from the tensor_load above (forces the long-branch path).
-  .rept 20000
+  // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
+  // s_branch's +-128 KB reach from the tensor_load above (forces the
+  // long-branch path).
+  .rept 40000
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -20,11 +20,12 @@
 // DISASM-LABEL: <test_tensor_branch_guard>:
 // DISASM: s_branch
 // DISASM: s_cbranch_scc1
-// DISASM: v_writelane_b32
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: v_readlane_b32
-// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
+// DISASM-NEXT: s_branch
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -29,11 +29,11 @@
 
 // COM: Live-SGPR trampoline body (for kernel 2): also placed in the
 // COM: padding region. save + pack + tensor + restore + branch-back.
-// DISASM: v_writelane_b32
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: v_readlane_b32
-// DISASM: s_branch
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
+// DISASM-NEXT: s_branch
 
 // COM: Kernel 2 (live SGPR, no sled): the original tensor_load is
 // COM: replaced by s_branch backward to the trampoline body above.

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -2,7 +2,7 @@
 // COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
 // COM: the descriptor's base SGPR. Base operand variants via NOP sled:
 // COM:   dead SGPR  — only s_pack_hh prepended (no save/restore)
-// COM:   live SGPR  — v_writelane save, s_pack_hh, tensor, v_readlane restore
+// COM:   live SGPR  — s_mov save, s_pack_hh, tensor, s_mov restore
 // COM:   alt descriptor — different SGPR range (s[16:23]) for pack target
 // COM:   SGPR redef — descriptor SGPR overwritten before use (dead path)
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
@@ -43,15 +43,15 @@
 // COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
 // COM: tensor/restore sequence in sled area with branch-back.
 // COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
-// COM: save/restore via scratch VGPR is required.
+// COM: save/restore via a scratch SGPR is required.
 // DISASM-LABEL: <test_tensor_live>:
 // DISASM: s_branch
-// DISASM: s_mov_b32
-// DISASM: v_writelane_b32
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: v_readlane_b32
-// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
+// DISASM-NEXT: s_branch
 
 // COM: Kernel 3 (alternate descriptor s[16:23]): verifies
 // COM: getDescriptorBaseSgpr correctly extracts s16 from a different

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -2,7 +2,8 @@
 // COM: emitToTrampoline with the other patch families, so a split site beyond
 // COM: s_branch's +-128 KB reach of the appended pool uses an s_add_pc_i64
 // COM: long branch on both edges instead of falling back. A large .rept filler
-// COM: (~80 KB, non-NOP) pushes the pool out of range of the WMMA at the top.
+// COM: (~160 KB, non-NOP) pushes the pool past s_branch's real reach from the
+// COM: WMMA at the top.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -41,9 +42,9 @@
 test_wsplit_far:
   v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[32:39]
   s_endpgm
-  // ~80 KB of non-NOP filler so the appended trampoline pool is beyond
-  // s_branch reach from the WMMA above (forces the long-branch path).
-  .rept 20000
+  // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
+  // s_branch's +-128 KB reach from the WMMA above (forces the long-branch path).
+  .rept 40000
     s_mov_b32 s0, s1
   .endr
 .size test_wsplit_far, .-test_wsplit_far

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -1,0 +1,49 @@
+// COM: WMMA-split over the s_add_pc_i64 long-branch path. WMMA-split shares
+// COM: emitToTrampoline with the other patch families, so a split site beyond
+// COM: s_branch's +-128 KB reach of the appended pool uses an s_add_pc_i64
+// COM: long branch on both edges instead of falling back. A large .rept filler
+// COM: (~80 KB, non-NOP) pushes the pool out of range of the WMMA at the top.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Forward edge: the 8-byte WMMA site is overwritten in place with an
+// COM: 8-byte s_add_pc_i64 long branch (NOT an s_branch).
+// DISASM-LABEL: <test_wsplit_far>:
+// DISASM: s_add_pc_i64
+// DISASM-NEXT: s_endpgm
+
+// COM: Trampoline body: the two K=64 split halves, then an s_add_pc_i64
+// COM: long branch-back.
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_add_pc_i64
+
+// COM: Idempotency: rewriting the output again must be a no-op.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wsplit_far
+.p2align 8
+.type test_wsplit_far,@function
+test_wsplit_far:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[32:39]
+  s_endpgm
+  // ~80 KB of non-NOP filler so the appended trampoline pool is beyond
+  // s_branch reach from the WMMA above (forces the long-branch path).
+  .rept 20000
+    s_mov_b32 s0, s1
+  .endr
+.size test_wsplit_far, .-test_wsplit_far

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -50,6 +50,32 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+// -- ElfView::findKernelAtOffset ----------------------------------------------
+
+TEST(ElfView, FindKernelAtOffsetResolvesNearestPrecedingForZeroSizeSymbol) {
+  // AMDGPU kernel entry symbols frequently have st_size == 0 (the size lives on
+  // the .kd object symbol), so an exact [st_value, st_value + st_size)
+  // containment test never matches. The lookup must resolve via the
+  // nearest-preceding STT_FUNC symbol instead.
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "zero_size_kernel";
+  Opts.TextAddr = 0x1000;
+  Opts.ZeroSizeKernelSym = true;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  // findKernelAtOffset takes a virtual address; at the entry and at an interior
+  // offset the zero-size symbol still resolves.
+  EXPECT_EQ(ViewOrErr->findKernelAtOffset(0x1000), "zero_size_kernel");
+  EXPECT_EQ(ViewOrErr->findKernelAtOffset(0x1000 + 4), "zero_size_kernel");
+  // An address before the symbol has no preceding function symbol to resolve.
+  EXPECT_EQ(ViewOrErr->findKernelAtOffset(0x0FF0), "");
+}
+
 // -- ElfView::getKernelStaticLdsSize ------------------------------------------
 
 TEST(ElfView, GetKernelStaticLdsSizeReturnsNulloptWhenKdMissing) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -156,6 +156,66 @@ TEST(EncodeSBranch, FailsOnInvalidState) {
   EXPECT_TRUE(S.encodeSBranch(0, 8).empty());
 }
 
+// -- encodeLongBranch (s_add_pc_i64) -----------------------------------------
+//
+// The long branch reaches anywhere via s_add_pc_i64, which adds a signed
+// literal to the PC of the next instruction: landing PC == From + size + imm.
+// A positive (forward) offset fits a 32-bit literal (8 bytes); a negative
+// (backward) offset needs a 64-bit literal (12 bytes). These verify the offset
+// math and encoding structurally rather than pinning exact bytes.
+
+// Read the signed literal that follows the 4-byte opcode dword.
+static int64_t longBranchLiteral(llvm::ArrayRef<uint8_t> Out) {
+  if (Out.size() == LongBranchFwdBytes)
+    return static_cast<int32_t>(readDword(Out.data() + MinInstSize));
+  int64_t V = 0;
+  std::memcpy(&V, Out.data() + MinInstSize, sizeof(V));
+  return V;
+}
+
+TEST(EncodeLongBranch, ForwardLandsOnTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  // ~512 KB forward -- well beyond s_branch's +-128 KB reach.
+  const uint64_t From = 0x1000, To = 0x81000;
+  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
+  ASSERT_EQ(Out.size(), LongBranchFwdBytes);
+  EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
+
+  std::vector<InternalDecodedInst> Dec;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
+  ASSERT_EQ(Dec.size(), 1u);
+  EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
+}
+
+TEST(EncodeLongBranch, BackwardUsesWideLiteralAndLandsOnTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  // Backward jump (trampoline tail -> earlier return point).
+  const uint64_t From = 0x81000, To = 0x1004;
+  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
+  ASSERT_EQ(Out.size(), LongBranchMaxBytes);
+  EXPECT_EQ(static_cast<int64_t>(From) + static_cast<int64_t>(Out.size()) +
+                longBranchLiteral(Out),
+            static_cast<int64_t>(To));
+
+  std::vector<InternalDecodedInst> Dec;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
+  ASSERT_EQ(Dec.size(), 1u);
+  EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
+}
+
+TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  // 4 MB: s_branch rejects it, the long branch encodes it.
+  const uint64_t From = 0, To = 0x400000;
+  EXPECT_TRUE(S.encodeSBranch(From, To).empty());
+  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
+  ASSERT_FALSE(Out.empty());
+  EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
+}
+
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -216,19 +216,6 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
 }
 
-// A near target whose literal lands in the inline-constant range assembles to
-// the 4-byte inline form, matches neither the 8- nor 12-byte candidate, and so
-// returns empty. This is the documented invariant that callers only take the
-// long-branch path for far sites (see encodeLongBranch in comgr-hotswap-b0a0).
-TEST(EncodeLongBranch, SmallOffsetReturnsEmpty) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // Landing PC == From + size + imm; keep imm tiny so the literal is an inline
-  // constant regardless of which candidate size is tried.
-  const uint64_t From = 0x1000, To = From + LongBranchFwdBytes + 4;
-  EXPECT_TRUE(encodeLongBranch(S, From, To).empty());
-}
-
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -216,6 +216,19 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
 }
 
+// A near target whose literal lands in the inline-constant range assembles to
+// the 4-byte inline form, matches neither the 8- nor 12-byte candidate, and so
+// returns empty. This is the documented invariant that callers only take the
+// long-branch path for far sites (see encodeLongBranch in comgr-hotswap-b0a0).
+TEST(EncodeLongBranch, SmallOffsetReturnsEmpty) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  // Landing PC == From + size + imm; keep imm tiny so the literal is an inline
+  // constant regardless of which candidate size is tried.
+  const uint64_t From = 0x1000, To = From + LongBranchFwdBytes + 4;
+  EXPECT_TRUE(encodeLongBranch(S, From, To).empty());
+}
+
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -54,6 +54,10 @@ struct KernelDescriptorElfOptions {
   uint64_t TextAddr = 0x1000;
   uint64_t RodataAddr = 0x2000;
   bool EmitKernelDescriptorSymbol = true;
+  // Emit the kernel entry STT_FUNC symbol with st_size == 0, matching AMDGPU
+  // HSACO objects where the size lives on the .kd object symbol. Exercises the
+  // nearest-preceding lookup in ElfView::findKernelAtOffset.
+  bool ZeroSizeKernelSym = false;
   std::optional<uint64_t> KernelDescriptorSymbolValue;
   uint32_t GroupSegmentFixedSize = 0;
   uint32_t ComputePgmRsrc3 = 0;
@@ -282,7 +286,7 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   KernelSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
   KernelSym.st_shndx = 1;
   KernelSym.st_value = Options.TextAddr;
-  KernelSym.st_size = Text.size();
+  KernelSym.st_size = Options.ZeroSizeKernelSym ? 0 : Text.size();
   std::memcpy(Buf + SymTabOff + 1 * sizeof(Elf64_Sym), &KernelSym,
               sizeof(KernelSym));
 


### PR DESCRIPTION
The tensor_load_to_lds B0->A0 patch corrupted live matrix data (NaN / wrong results on gfx1250 A0) because the kernel-symbol lookup used to size the scratch pool silently failed and the allocator handed out a live register. This PR fixes that root cause, applies the erratum transform without needing a free VGPR, and makes trampoline patching reach and fail safe correctly.

- findKernelAtOffset: AMDGPU kernel entry symbols frequently have st_size == 0 (the size lives on the .kd object symbol), so the exact [st_value, st_value + st_size) containment test never matched; select the nearest-preceding STT_FUNC symbol instead, honoring st_size only when non-zero.
- tryAllocScratchVgpr / patchDsAddtid: pass DI.Offset + textAddr() to findKernelAtOffset, which matches against symbol virtual addresses; a bare .text offset missed whenever .text had a non-zero sh_addr (the common HSACO case), leaving KdVgprs == 0, matching the existing wmma-scale16 / f32-to-e5m3 call sites.
- tensor_load_to_lds: save/restore the live descriptor base SGPR through a scratch SGPR allocated above .sgpr_count (s_mov_b32) instead of a v_writelane/v_readlane VGPR lane, which was impossible on occupancy-1 MX kernels that already use all 1024 VGPRs; GFX10+ waves always have the full SGPR file so no KD bump is needed, the same strategy the E5M3 patch uses.
- Long branches: emit an s_add_pc_i64 long branch on both trampoline edges for far sites (patch site beyond s_branch's +-128 KB reach of the appended pool); s_add_pc_i64 reaches anywhere, needs no scratch register, and does not touch SCC, avoiding the getpc/s_add/s_addc/setpc SCC-clobber that would corrupt control flow with no SCC liveness in hotswap.
- WMMA-split: route its trampoline through emitToTrampoline (the shared entry point) so far split sites take the s_add_pc_i64 long-branch path instead of the old buildTrampoline s_branch, which fell back to the unpatched object; near behavior is unchanged.
- Fail safe: when a trampoline branch cannot be encoded, fall back to the pristine input object so the loader runs the original unpatched code instead of shipping a half-rewritten (corrupted) one.