### PR TITLE
[Testing Only/Don't Merge] Make Clang HIP Runtime Wrapper Header compatible with ASAN RTC

### DIFF
--- a/clang/lib/Headers/__clang_hip_runtime_wrapper.h
+++ b/clang/lib/Headers/__clang_hip_runtime_wrapper.h
@@ -64,27 +64,25 @@ extern "C" {
 #if HIP_VERSION_MAJOR * 100 + HIP_VERSION_MINOR >= 405
 __device__ unsigned long long __ockl_dm_alloc(unsigned long long __size);
 __device__ void __ockl_dm_dealloc(unsigned long long __addr);
-#if __has_feature(address_sanitizer)
-__device__ unsigned long long __asan_malloc_impl(unsigned long long __size,
-                                                 unsigned long long __pc);
-__device__ void __asan_free_impl(unsigned long long __addr,
-                                 unsigned long long __pc);
+__attribute__((weak)) __device__ unsigned long long
+__asan_malloc_impl(unsigned long long __size, unsigned long long __pc);
+__attribute__((weak)) __device__ void
+__asan_free_impl(unsigned long long __addr, unsigned long long __pc);
 __attribute__((noinline, weak)) __device__ void *malloc(__hip_size_t __size) {
-  unsigned long long __pc = (unsigned long long)__builtin_return_address(0);
-  return (void *)__asan_malloc_impl(__size, __pc);
+  if (__asan_malloc_impl) {
+    unsigned long long __pc = (unsigned long long)__builtin_return_address(0);
+    return (void *)__asan_malloc_impl(__size, __pc);
+  }
+  return (void *)__ockl_dm_alloc(__size);
 }
 __attribute__((noinline, weak)) __device__ void free(void *__ptr) {
-  unsigned long long __pc = (unsigned long long)__builtin_return_address(0);
-  __asan_free_impl((unsigned long long)__ptr, __pc);
-}
-#else // __has_feature(address_sanitizer)
-__attribute__((weak)) inline __device__ void *malloc(__hip_size_t __size) {
-  return (void *) __ockl_dm_alloc(__size);
-}
-__attribute__((weak)) inline __device__ void free(void *__ptr) {
+  if (__asan_free_impl) {
+    unsigned long long __pc = (unsigned long long)__builtin_return_address(0);
+    __asan_free_impl((unsigned long long)__ptr, __pc);
+    return;
+  }
   __ockl_dm_dealloc((unsigned long long)__ptr);
 }
-#endif // __has_feature(address_sanitizer)
 #else  // HIP version check
 #if __HIP_ENABLE_DEVICE_MALLOC__
 __device__ void *__hip_malloc(__hip_size_t __size);

--- a/clang/test/Headers/hip-header.hip
+++ b/clang/test/Headers/hip-header.hip
@@ -162,15 +162,27 @@ __device__ double test_isnan() {
 
 // Check that device malloc and free do not conflict with std headers.
 #include <cstdlib>
-// MALLOC-LABEL: define{{.*}}@_Z11test_malloc
-// MALLOC: call {{.*}}ptr @malloc(i64
-// MALLOC: call {{.*}}ptr @malloc(i64
 // MALLOC-LABEL: define weak {{.*}}ptr @malloc(i64
+// MALLOC:  icmp ne ptr @__asan_malloc_impl, null
+// MALLOC:  call i64 @__asan_malloc_impl(i64 {{.*}}, i64 {{.*}})
 // MALLOC:  call i64 @__ockl_dm_alloc
 // NOMALLOC:  call void @llvm.trap
 // MALLOC-ASAN-LABEL: define weak {{.*}}ptr @malloc(i64
+// MALLOC-ASAN:  icmp ne ptr @__asan_malloc_impl, null
 // MALLOC-ASAN:  call ptr @llvm.returnaddress.p0(i32 0)
 // MALLOC-ASAN:  call i64 @__asan_malloc_impl(i64 {{.*}}, i64 {{.*}})
+// MALLOC-LABEL: define weak {{.*}}void @free(ptr
+// MALLOC:  icmp ne ptr @__asan_free_impl, null
+// MALLOC:  call void @__asan_free_impl(i64 {{.*}}, i64 {{.*}})
+// MALLOC:  call void @__ockl_dm_dealloc
+// NOMALLOC: call void @llvm.trap
+// MALLOC-ASAN-LABEL: define weak {{.*}}void @free(ptr
+// MALLOC-ASAN:  icmp ne ptr @__asan_free_impl, null
+// MALLOC-ASAN:  call ptr @llvm.returnaddress.p0(i32 0)
+// MALLOC-ASAN:  call void @__asan_free_impl(i64 {{.*}}, i64 {{.*}})
+// MALLOC-LABEL: define{{.*}}@_Z11test_malloc
+// MALLOC: call {{.*}}ptr @malloc(i64
+// MALLOC: call {{.*}}ptr @malloc(i64
 __device__ void test_malloc(void *a) {
   a = malloc(42);
   a = std::malloc(42);
@@ -179,12 +191,6 @@ __device__ void test_malloc(void *a) {
 // MALLOC-LABEL: define{{.*}}@_Z9test_free
 // MALLOC: call {{.*}}void @free(ptr
 // MALLOC: call {{.*}}void @free(ptr
-// MALLOC-LABEL: define weak {{.*}}void @free(ptr
-// MALLOC:  call void @__ockl_dm_dealloc
-// NOMALLOC: call void @llvm.trap
-// MALLOC-ASAN-LABEL: define weak {{.*}}void @free(ptr
-// MALLOC-ASAN:  call ptr @llvm.returnaddress.p0(i32 0)
-// MALLOC-ASAN:  call void @__asan_free_impl(i64 {{.*}}, i64 {{.*}})
 __device__ void test_free(void *a) {
   free(a);
   std::free(a);


### PR DESCRIPTION
Make ASAN symbols appear in the HIP Runtime Wrapper header unconditionally.

HIPRTC has the HIP runtime wrapper header file compiled at HIPRTC compile-time, so HIPRTC's version of the header will be stuck with only ASAN or only OCKL malloc/free symbols; however, HIPRTC can be used to compile either ASAN or non-ASAN kernels at runtime, so the choice of allocator might conflict from the header.