### PR TITLE
ci(spirv-windows): disable PCH to fix MSVC C2855 on clang unit tests

### DIFF
--- a/.github/workflows/spirv-ci-windows-amd-staging.yml
+++ b/.github/workflows/spirv-ci-windows-amd-staging.yml
@@ -74,6 +74,13 @@ jobs:
       # zstd. FORCE_ON makes the configure fail loudly if zstd is missing
       # rather than silently building clang-offload-bundler without
       # compression.
+      # CMAKE_DISABLE_PRECOMPILE_HEADERS=ON: LLVM enables PCH by default, but the
+      # clang unit tests (built via clang-test-depends) reuse LLVMSupport's PCH.
+      # Upstream adds /utf-8 to the BasicTests target for unicode in test sources
+      # (llvm/llvm-project#206993); MSVC then rejects the PCH because its charset
+      # flags differ from the producer's (error C2855). Disabling PCH sidesteps
+      # this whole class of PCH consumer/producer flag-mismatch errors on MSVC.
+      # Mirrors ROCm/TheRock#6219, which disables PCH for the same reason (clang).
       - name: Configure LLVM
         run: |
           cmake -G Ninja -S llvm-project/llvm -B build \
@@ -85,7 +92,8 @@ jobs:
             -DLLVM_ENABLE_ZSTD=FORCE_ON \
             -DLLVM_INCLUDE_TESTS=ON \
             -DLLVM_INSTALL_GTEST=ON \
-            -DLLVM_LIT_ARGS="-sv --no-progress-bar"
+            -DLLVM_LIT_ARGS="-sv --no-progress-bar" \
+            -DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON
 
       - name: Build LLVM + Clang + amd-llvm-spirv + test deps
         run: ninja -C build llvm-test-depends clang-test-depends amd-llvm-spirv


### PR DESCRIPTION
## Summary

Disables precompiled headers in the Windows SPIRV-CI LLVM configure (`-DCMAKE_DISABLE_PRECOMPILE_HEADERS=ON`) to fix the MSVC build of the clang unit tests.

## Chain of events

1. Upstream `b8e5ea1ab3e2` ([llvm#206326](https://github.com/llvm/llvm-project/pull/206326)) added a supplementary-plane emoji to `clang/unittests/Basic/DiagnosticTest.cpp`. MSVC (non-UTF-8 by default) read it as a multi-char literal → `C2015`, breaking `Windows::release / Build`.
2. Upstream fixed that in `dd6d1112d940` ([llvm#206993](https://github.com/llvm/llvm-project/pull/206993)) by adding `/utf-8` to the `BasicTests` target. Now on `amd-staging` (via #3166).
3. But LLVM enables PCH by default, and the clang unit tests reuse `LLVMSupport`'s PCH (built **without** `/utf-8`). MSVC then rejects the mismatch → `C2855: command-line option '/source-charset' inconsistent with precompiled header`.

## Fix

Disable PCH for the SPIRV-CI Windows LLVM build. This sidesteps the entire class of PCH producer/consumer flag-mismatch errors on MSVC (charset here; also the optimization-level variant). Mirrors the approach in [ROCm/TheRock#6219](https://github.com/ROCm/TheRock/pull/6219), which disables PCH for the same class of problem (there, under clang).

## Result

Verified green on this PR's run — all Windows SPIRV-CI checks pass:

- `Windows::release / Build` ✅ (previously failed with `C2015`, then `C2855`)
- `Windows::release / Test Comgr` ✅
- `Windows::release / Test LLVM SPIRV codegen` ✅
- `Windows::release / Test SPIRV translator lit` ✅

Without this, `Windows::release / Build` is red on `amd-staging` itself, blocking the Windows SPIRV-CI for all PRs.
