### PR TITLE
[OpenMP][DeviceRTL] Remove obsolete __keep_alive

### DIFF
--- a/openmp/device/src/DeviceUtils.cpp
+++ b/openmp/device/src/DeviceUtils.cpp
@@ -15,18 +15,6 @@
 
 using namespace ompx;
 
-extern "C" [[gnu::weak]] int IsSPMDMode;
-
-/// Helper to keep code alive without introducing a performance penalty.
-extern "C" __attribute__((weak, optnone, cold, used, retain)) void
-__keep_alive() {
-  __kmpc_get_hardware_thread_id_in_block();
-  __kmpc_get_hardware_num_threads_in_block();
-  __kmpc_get_warp_size();
-  __kmpc_barrier_simple_spmd(nullptr, IsSPMDMode);
-  __kmpc_barrier_simple_generic(nullptr, IsSPMDMode);
-}
-
 uint64_t utils::pack(uint32_t LowBits, uint32_t HighBits) {
   return (((uint64_t)HighBits) << 32) | (uint64_t)LowBits;
 }


### PR DESCRIPTION
__keep_alive is a never-executed anchor that keeps a handful of device
runtime functions from being removed.  This isn't an issue anymore, so
follow what upstream did in https://reviews.llvm.org/D151324.

Also follow upstream 755e1088258b030cdd00cfa1b184c58fe41b4287 and remove
the unused IsSPMDMode variable.

Also fixes the misleading AMDGPU backend warning "local memory global
used by non-kernel function" caused by IsSPMDMode.

Claude assisted with this patch.