### PR TITLE
AMDGPU: guard hotswap entry stub idempotency decode

### DIFF
--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -258,6 +258,18 @@ bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
          hasEntryStubOperandShape(Decoded, LS);
 }
 
+bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
+                                    const LLVMState &LS) {
+  SmallVector<uint8_t> Prefix;
+  if (!appendAsm(Prefix, "global_wb", LS))
+    return false;
+  if (!appendAsm(Prefix, "v_nop", LS))
+    return false;
+
+  return Bytes.size() >= Prefix.size() &&
+         std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
+}
+
 static std::optional<uint64_t>
 checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
   if (Alignment == 0)
@@ -307,10 +319,18 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
       KernelEntryStubStride > Elf.textSize() - TextOffset)
     return false;
 
+  ArrayRef<uint8_t> Candidate(Elf.textData() + TextOffset,
+                              KernelEntryStubStride);
+  // The full idempotency matcher uses LLVM's AMDGPU disassembler. Avoid
+  // running it over arbitrary original kernel entry bytes; real code objects
+  // can contain byte streams that are valid executable code but still trip
+  // decoder corner cases before COMGR can finish rewriting.
+  if (!hasKernelEntryTrampolinePrefix(Candidate, LS))
+    return false;
+
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(
-          ArrayRef<uint8_t>(Elf.textData() + TextOffset, KernelEntryStubStride),
-          LS, Decoded, "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+                             "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -253,6 +253,9 @@ decodeEntryStubTargetVAddr(ArrayRef<InternalDecodedInst> Decoded,
 }
 
 bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
+  if (!hasKernelEntryTrampolinePrefix(Bytes, LS))
+    return false;
+
   std::vector<InternalDecodedInst> Decoded;
   return decodeKernelEntryStub(Bytes, LS, Decoded, "isKernelEntryTrampoline") &&
          hasEntryStubOperandShape(Decoded, LS);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -237,8 +237,8 @@ public:
   /// `group_segment_size` and propagated to the device via the
   /// `hidden_dynamic_lds_size` kernarg) and is *not* included here, so the
   /// returned value is a lower bound on the total LDS the kernel may
-  /// touch. Callers that need to flag potential overflow of A0's 16-bit M0
-  /// limit (DEGFXMI400-12025) can use this as a "definitely exceeds"
+  /// touch. Callers that need to flag potential overflow of gfx1250 A0's
+  /// 16-bit M0 limit can use this as a "definitely exceeds"
   /// check; "static fits, dynamic pushes over" cannot be detected
   /// statically. See AMDGPUUsage "Code Object V3 Kernel Descriptor"
   /// (GROUP_SEGMENT_FIXED_SIZE).

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -695,6 +695,13 @@ llvm::SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
 bool isKernelEntryTrampoline(llvm::ArrayRef<uint8_t> Bytes,
                              const LLVMState &LS);
 
+/// Cheap raw-byte prefilter for the entry stubs produced by
+/// buildKernelEntryTrampoline. This is intentionally weaker than
+/// isKernelEntryTrampoline and exists to avoid running the disassembler over
+/// arbitrary original kernel entry bytes during idempotency checks.
+bool hasKernelEntryTrampolinePrefix(llvm::ArrayRef<uint8_t> Bytes,
+                                    const LLVMState &LS);
+
 /// Compute the trailing readable guard needed after an appended kernel-entry
 /// stub pool so CP instruction prefetches from the last stub cannot run past
 /// mapped .text bytes.

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -17,10 +17,10 @@
 ///     byte offsets scaled appropriately for each encoding.
 ///   - tensor_load_to_lds     : prepend s_pack_hh_b32_b16 to clear multicast
 ///     routing bits in the group descriptor's base SGPR
-  ///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
-  ///     issue a regular ds_*_b32, bypassing the gfx1250 A0 16-bit M0
-  ///     truncation. On B0 the DS unit reads 20 bits of M0; on A0 it reads only
-  ///     16, silently dropping bits [19:16].
+///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
+///     issue a regular ds_*_b32, bypassing the gfx1250 A0 16-bit M0
+///     truncation. On B0 the DS unit reads 20 bits of M0; on A0 it reads only
+///     16, silently dropping bits [19:16].
 ///
 //===----------------------------------------------------------------------===//
 

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -17,10 +17,10 @@
 ///     byte offsets scaled appropriately for each encoding.
 ///   - tensor_load_to_lds     : prepend s_pack_hh_b32_b16 to clear multicast
 ///     routing bits in the group descriptor's base SGPR
-///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
-///     issue a regular ds_*_b32, bypassing the A0 16-bit M0 truncation
-///     (DEGFXMI400-12025). On B0 the DS unit reads 20 bits of M0; on A0 it
-///     reads only 16, silently dropping bits [19:16].
+  ///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
+  ///     issue a regular ds_*_b32, bypassing the gfx1250 A0 16-bit M0
+  ///     truncation. On B0 the DS unit reads 20 bits of M0; on A0 it reads only
+  ///     16, silently dropping bits [19:16].
 ///
 //===----------------------------------------------------------------------===//
 
@@ -768,8 +768,8 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       std::optional<uint32_t> LdsSize =
           Ctx.Elf.getKernelStaticLdsSize(KernelName);
       // Trampoline could not be applied: the original ds_*_addtid_b32 stays
-      // in the code object and will silently truncate M0 to 16 bits on A0
-      // (DEGFXMI400-12025) whenever the runtime LDS layout exceeds 64 KiB.
+      // in the code object and will silently truncate M0 to 16 bits on gfx1250
+      // A0 whenever the runtime LDS layout exceeds 64 KiB.
       // Static LDS is visible in the kernel descriptor; dynamic LDS added
       // by the host at dispatch (hidden_dynamic_lds_size kernarg or a
       // dynamic_shared_pointer user arg) is not. The warning therefore

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -11,6 +11,10 @@
 // RUN: %llvm-objdump -d %t.default.elf | %FileCheck --check-prefix=NO-TRAMP %s
 // NO-TRAMP-LABEL: <entry_tramp_kernel>:
 // NO-TRAMP: s_endpgm
+// NO-TRAMP-LABEL: <hipblaslt_entry_kernel>:
+// NO-TRAMP: s_setreg_imm32_b32
+// NO-TRAMP-LABEL: <decoder_trip_kernel>:
+// NO-TRAMP: .long 0xffffffff
 // NO-TRAMP-NOT: global_wb
 
 // RUN: hotswap-rewrite %t.elf \
@@ -24,6 +28,10 @@
 
 // DISASM-LABEL: <entry_tramp_kernel>:
 // DISASM: s_endpgm
+// DISASM-LABEL: <hipblaslt_entry_kernel>:
+// DISASM: s_setreg_imm32_b32
+// DISASM-LABEL: <decoder_trip_kernel>:
+// DISASM: .long 0xffffffff
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
 // DISASM-NEXT: s_get_pc_i64 s[8:9]
@@ -63,12 +71,51 @@ entry_tramp_kernel:
 .Lentry_tramp_kernel_end:
 .size entry_tramp_kernel, .Lentry_tramp_kernel_end-entry_tramp_kernel
 
+.globl hipblaslt_entry_kernel
+.p2align 8
+.type hipblaslt_entry_kernel,@function
+hipblaslt_entry_kernel:
+  // Reduced from the gfx1250 hipBLASLt MXF8/BF16 smoke kernel entry. This is
+  // real original kernel code, not an appended hotswap entry stub.
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  s_and_b32 s63, 0x3fffffff, s2
+  s_lshr_b32 s64, s2, 30
+  s_mov_b32 s65, s3
+  s_cmp_eq_u32 s64, 3
+  s_cbranch_scc1 .Lhipblaslt_entry_done
+  s_cmp_eq_u32 s64, 0
+  s_cbranch_scc0 .Lhipblaslt_entry_done
+.Lhipblaslt_entry_done:
+  s_endpgm
+.Lhipblaslt_entry_kernel_end:
+.size hipblaslt_entry_kernel, .Lhipblaslt_entry_kernel_end-hipblaslt_entry_kernel
+
+.globl decoder_trip_kernel
+.p2align 8
+.type decoder_trip_kernel,@function
+decoder_trip_kernel:
+  .long 0xffffffff
+  s_endpgm
+.Ldecoder_trip_kernel_end:
+.size decoder_trip_kernel, .Ldecoder_trip_kernel_end-decoder_trip_kernel
+
 .rodata
 .p2align 8
 .amdhsa_kernel entry_tramp_kernel
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 1
   .amdhsa_inst_pref_size 7
+.end_amdhsa_kernel
+
+.amdhsa_kernel hipblaslt_entry_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel decoder_trip_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel
 
 .amdgpu_metadata
@@ -78,6 +125,26 @@ entry_tramp_kernel:
   amdhsa.kernels:
     - .name: entry_tramp_kernel
       .symbol: entry_tramp_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: hipblaslt_entry_kernel
+      .symbol: hipblaslt_entry_kernel.kd
+      .sgpr_count: 66
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: decoder_trip_kernel
+      .symbol: decoder_trip_kernel.kd
       .sgpr_count: 8
       .vgpr_count: 1
       .kernarg_segment_size: 0

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -1,11 +1,11 @@
 // COM: Test HotSwap trampoline patch: ds_*_addtid_b32 expansion.
 // COM:
-// COM: On A0 the DS unit truncates M0 to 16 bits, so ADDTID address
+// COM: On gfx1250 A0 the DS unit truncates M0 to 16 bits, so ADDTID address
 // COM: encodings (M0 + lane_id*4 + offset) silently wrap above 64KB
-// COM: (DEGFXMI400-12025). The trampoline materialises the lane-id math
-// COM: in the ALU using M0 masked to 20 bits (matching B0's DS-unit M0
-// COM: read width) and issues a regular ds_load_b32 / ds_store_b32,
-// COM: bypassing the buggy address path.
+// COM: on gfx1250. The trampoline materialises the lane-id math in the ALU
+// COM: using M0 masked to 20 bits (matching B0's DS-unit M0 read width) and
+// COM: issues a regular ds_load_b32 / ds_store_b32, bypassing the buggy
+// COM: address path.
 // COM:
 // COM: Coverage:
 // COM:   test_addtid_load        : ds_load_addtid_b32 + offset (NOP sled)

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -419,6 +419,57 @@ TEST(BuildKernelEntryTrampoline, PrefixPrefiltersNonStubBytes) {
   EXPECT_FALSE(hasKernelEntryTrampolinePrefix(ShortCandidate, S));
 }
 
+TEST(BuildKernelEntryTrampoline, PrefixPrefiltersHipblasltSmokeEntryBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Reduced from the gfx1250 hipBLASLt MXF8/BF16 smoke kernel entry. The
+  // idempotency path should reject this by raw prefix before classifying it as
+  // a possible appended entry stub.
+  const uint8_t EntryBytes[] = {
+      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00,
+      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00,
+      0xff, 0x02, 0x3f, 0x8b, 0xff, 0xff, 0xff, 0x3f,
+      0x02, 0x9e, 0x40, 0x85, 0x03, 0x00, 0xc1, 0xbe,
+  };
+
+  llvm::SmallVector<uint8_t> Candidate;
+  Candidate.append(EntryBytes, EntryBytes + sizeof(EntryBytes));
+  while (Candidate.size() < KernelEntryStubStride)
+    Candidate.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  ASSERT_EQ(Candidate.size(), KernelEntryStubStride);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Candidate.data(), sizeof(EntryBytes), S,
+                                Decoded));
+  ASSERT_GE(Decoded.size(), 5u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "s_setreg_imm32_b32");
+  EXPECT_EQ(Decoded[1].Mnemonic, "s_setreg_imm32_b32");
+  EXPECT_EQ(Decoded[2].Mnemonic, "s_and_b32");
+  EXPECT_FALSE(hasKernelEntryTrampolinePrefix(Candidate, S));
+  EXPECT_FALSE(isKernelEntryTrampoline(Candidate, S));
+}
+
+TEST(BuildKernelEntryTrampoline, PrefixPrefiltersUnknownDecodeBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  const uint8_t UnknownInst[] = {0xff, 0xff, 0xff, 0xff};
+
+  llvm::SmallVector<uint8_t> Candidate;
+  Candidate.append(UnknownInst, UnknownInst + sizeof(UnknownInst));
+  while (Candidate.size() < KernelEntryStubStride)
+    Candidate.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  ASSERT_EQ(Candidate.size(), KernelEntryStubStride);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Candidate.data(), MinInstSize, S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "<unknown>");
+  EXPECT_FALSE(hasKernelEntryTrampolinePrefix(Candidate, S));
+  EXPECT_FALSE(isKernelEntryTrampoline(Candidate, S));
+}
+
 TEST(BuildKernelEntryTrampoline, MatcherRejectsNonStubBytes) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -395,6 +395,30 @@ TEST(BuildKernelEntryTrampoline, BuildsRecognizedPcRelativeStub) {
   expectInstMatchesAsm(Decoded[5].Inst, "s_set_pc_i64 s[8:9]", S);
 }
 
+TEST(BuildKernelEntryTrampoline, PrefixPrefiltersNonStubBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Stub =
+      buildKernelEntryTrampoline(/*StubVAddr=*/0x200000,
+                                 /*EntryVAddr=*/0x10100,
+                                 /*ScratchSgpr=*/8, S);
+  ASSERT_EQ(Stub.size(), KernelEntryStubStride);
+  EXPECT_TRUE(hasKernelEntryTrampolinePrefix(Stub, S));
+
+  llvm::SmallVector<uint8_t> NonStub;
+  ASSERT_TRUE(appendSingleInstBytes(NonStub, "s_endpgm", S));
+  while (NonStub.size() < KernelEntryStubStride)
+    NonStub.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  ASSERT_EQ(NonStub.size(), KernelEntryStubStride);
+
+  EXPECT_FALSE(hasKernelEntryTrampolinePrefix(NonStub, S));
+  EXPECT_FALSE(isKernelEntryTrampoline(NonStub, S));
+
+  llvm::ArrayRef<uint8_t> ShortCandidate(Stub.data(), MinInstSize);
+  EXPECT_FALSE(hasKernelEntryTrampolinePrefix(ShortCandidate, S));
+}
+
 TEST(BuildKernelEntryTrampoline, MatcherRejectsNonStubBytes) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -424,6 +448,7 @@ TEST(BuildKernelEntryTrampoline, MatcherRejectsWrongOperandShape) {
     Bytes.append(CodeEnd.begin(), CodeEnd.end());
   ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
 
+  EXPECT_TRUE(hasKernelEntryTrampolinePrefix(Bytes, S));
   EXPECT_FALSE(isKernelEntryTrampoline(Bytes, S));
 }
 

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -800,11 +800,11 @@ TEST(HotswapPatchVTable, ProcessSingletonIdentityAndEagerInstall) {
 
 // -- DS ADDTID trampoline support ---------------------------------------------
 //
-// Tests for the ds_load_addtid_b32 / ds_store_addtid_b32 trampoline patch
-// (DEGFXMI400-12025). Coverage is bottom-up: first that the encode/decode
-// of ADDTID instructions exposes the expected MCInst operand layout, then
-// that buildTrampoline assembles and decodes a full ADDTID replacement body
-// plus its branch-back tail.
+// Tests for the ds_load_addtid_b32 / ds_store_addtid_b32 gfx1250 trampoline
+// patch. Coverage is bottom-up: first that the encode/decode of ADDTID
+// instructions exposes the expected MCInst operand layout, then that
+// buildTrampoline assembles and decodes a full ADDTID replacement body plus
+// its branch-back tail.
 
 namespace {
 


### PR DESCRIPTION
## Summary

Guard the COMGR HotSwap kernel-entry trampoline idempotency matcher with a cheap raw-byte prefix check before invoking LLVM's AMDGPU disassembler.

The existing matcher disassembled `KernelEntryStubStride` bytes at every descriptor's current entry point to decide whether the descriptor already targeted an appended entry stub. Real gfx1250 code objects can contain valid kernel entry byte streams that still trip disassembler corner cases before HotSwap rewriting completes. The matcher only needs the full decode for plausible entry stubs, so this change first checks for the generated stub prefix (`global_wb; v_nop`) and treats all other entries as not already stubbed.

This preserves the existing full structural matcher for already-rewritten stubs, so rewrite idempotency remains intact.

## Testing

- `/tmp/llvm-pr3182-build/bin/HotswapMCTests --gtest_filter='BuildKernelEntryTrampoline.*'`
- Manual RUN-line replay of `amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s` using the existing COMGR lit helper
- Reproduced the gfx1250 GPU2 hipBLASLt MXF8/BF16 smoke failure with `ROCR_VISIBLE_DEVICES=2` and captured the reduced kernel-entry bytes used by the new regression
- On gfx1250 GPU0 with ROCr PR 8082 runtime plus this COMGR change:
  `hipblaslt-test --gtest_filter="*_/matmul_test.matmul/smoke_matmul_gemm_tn_mxf8_dst_bf16_1250_smoke_*"`
  passed 16/16 tests.
