### PR TITLE
[CMake][CodeGen] Add PCH for Clang CodeGen (#206018)

### DIFF
--- a/clang/lib/CodeGen/CGCall.h
+++ b/clang/lib/CodeGen/CGCall.h
@@ -21,6 +21,7 @@
 #include "clang/AST/CanonicalType.h"
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/BitmaskEnum.h"
 #include "clang/CodeGen/ModuleLinker.h"
 #include "llvm/ADT/STLForwardCompat.h"
 #include "llvm/IR/Value.h"
@@ -411,27 +412,8 @@ enum class FnInfoOpts {
   IsInstanceMethod = 1 << 0,
   IsChainCall = 1 << 1,
   IsDelegateCall = 1 << 2,
+  LLVM_MARK_AS_BITMASK_ENUM(/*LargestValue=*/IsDelegateCall)
 };
-
-inline FnInfoOpts operator|(FnInfoOpts A, FnInfoOpts B) {
-  return static_cast<FnInfoOpts>(llvm::to_underlying(A) |
-                                 llvm::to_underlying(B));
-}
-
-inline FnInfoOpts operator&(FnInfoOpts A, FnInfoOpts B) {
-  return static_cast<FnInfoOpts>(llvm::to_underlying(A) &
-                                 llvm::to_underlying(B));
-}
-
-inline FnInfoOpts &operator|=(FnInfoOpts &A, FnInfoOpts B) {
-  A = A | B;
-  return A;
-}
-
-inline FnInfoOpts &operator&=(FnInfoOpts &A, FnInfoOpts B) {
-  A = A & B;
-  return A;
-}
 
 struct DisableDebugLocationUpdates {
   CodeGenFunction &CGF;

--- a/clang/lib/CodeGen/CMakeLists.txt
+++ b/clang/lib/CodeGen/CMakeLists.txt
@@ -164,6 +164,10 @@ add_clang_library(clangCodeGen
   TrapReasonBuilder.cpp
   VarBypassDetector.cpp
 
+  DISABLE_PCH_REUSE # PCH contains private headers
+  PRECOMPILE_HEADERS
+  [["pch.h"]]
+
   DEPENDS
   vt_gen
   intrinsics_gen

--- a/clang/lib/CodeGen/pch.h
+++ b/clang/lib/CodeGen/pch.h
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// Precompiled header for clangCodeGen. Uses private headers.
+///
+//===----------------------------------------------------------------------===//
+
+#include "ABIInfoImpl.h"
+#include "Address.h"
+#include "CGBuilder.h"
+#include "CGCXXABI.h"
+#include "CGValue.h"
+#include "CodeGenFunction.h"
+#include "CodeGenModule.h"
+#include "clang/AST/pch.h"
+#include "llvm/IR/pch.h"
+#include "llvm/Support/pch.h"


### PR DESCRIPTION
The change to CGCall is required to avoid collisions of operator|=.


