### PR TITLE
AMDGPU: support literal sources in FP8 pack hotswap

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -205,8 +205,8 @@ struct FunctionTextRange {
   uint64_t End = 0;
 };
 
-static std::vector<FunctionTextRange> buildFunctionTextRanges(
-    const ElfView &Elf) {
+static std::vector<FunctionTextRange>
+buildFunctionTextRanges(const ElfView &Elf) {
   std::vector<FunctionTextRange> Ranges;
   uint64_t TextBegin = Elf.textAddr();
   uint64_t TextEnd = TextBegin + Elf.textSize();
@@ -215,8 +215,7 @@ static std::vector<FunctionTextRange> buildFunctionTextRanges(
         SymShdr.sh_type != ELF::SHT_DYNSYM)
       continue;
 
-    Expected<ElfView::ELFT::SymRange> SymsOrErr =
-        Elf.file().symbols(&SymShdr);
+    Expected<ElfView::ELFT::SymRange> SymsOrErr = Elf.file().symbols(&SymShdr);
     if (!SymsOrErr) {
       consumeError(SymsOrErr.takeError());
       continue;
@@ -230,12 +229,12 @@ static std::vector<FunctionTextRange> buildFunctionTextRanges(
         continue;
       FuncSyms.push_back(&Sym);
     }
-    llvm::sort(FuncSyms, [](const ElfView::ELFT::Sym *A,
-                            const ElfView::ELFT::Sym *B) {
-      if (A->st_value != B->st_value)
-        return A->st_value < B->st_value;
-      return A->st_size > B->st_size;
-    });
+    llvm::sort(FuncSyms,
+               [](const ElfView::ELFT::Sym *A, const ElfView::ELFT::Sym *B) {
+                 if (A->st_value != B->st_value)
+                   return A->st_value < B->st_value;
+                 return A->st_size > B->st_size;
+               });
 
     for (size_t I = 0, E = FuncSyms.size(); I != E; ++I) {
       const ElfView::ELFT::Sym &Sym = *FuncSyms[I];
@@ -251,8 +250,8 @@ static std::vector<FunctionTextRange> buildFunctionTextRanges(
       } else {
         for (size_t J = I + 1; J != E; ++J) {
           if (FuncSyms[J]->st_value > BeginVA) {
-            EndVA = std::min(static_cast<uint64_t>(FuncSyms[J]->st_value),
-                             TextEnd);
+            EndVA =
+                std::min(static_cast<uint64_t>(FuncSyms[J]->st_value), TextEnd);
             break;
           }
         }
@@ -260,21 +259,22 @@ static std::vector<FunctionTextRange> buildFunctionTextRanges(
       Ranges.push_back({BeginVA - TextBegin, EndVA - TextBegin});
     }
   }
-  llvm::sort(Ranges, [](const FunctionTextRange &L, const FunctionTextRange &R) {
-    if (L.Begin != R.Begin)
-      return L.Begin < R.Begin;
-    return L.End < R.End;
-  });
+  llvm::sort(Ranges,
+             [](const FunctionTextRange &L, const FunctionTextRange &R) {
+               if (L.Begin != R.Begin)
+                 return L.Begin < R.Begin;
+               return L.End < R.End;
+             });
   return Ranges;
 }
 
 static bool isInFunctionTextRange(ArrayRef<FunctionTextRange> Ranges,
                                   uint64_t Offset) {
-  auto It = std::upper_bound(
-      Ranges.begin(), Ranges.end(), Offset,
-      [](uint64_t Value, const FunctionTextRange &R) {
-        return Value < R.Begin;
-      });
+  ArrayRef<FunctionTextRange>::iterator It =
+      std::upper_bound(Ranges.begin(), Ranges.end(), Offset,
+                       [](uint64_t Value, const FunctionTextRange &R) {
+                         return Value < R.Begin;
+                       });
   if (It == Ranges.begin())
     return false;
   --It;
@@ -302,9 +302,9 @@ static bool isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
 /// variations. Zero-filled padding appears in generated code between
 /// function-symbol ranges; it decodes as v_illegal but is still writable .text
 /// space once hotswap redirects control to an assembled replacement.
-static std::vector<NopSled> buildNopSledMap(
-    ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
-    uint64_t TextSize, const LLVMState &LS, const ElfView &Elf) {
+static std::vector<NopSled>
+buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
+                uint64_t TextSize, const LLVMState &LS, const ElfView &Elf) {
   std::vector<NopSled> Sleds;
   std::vector<FunctionTextRange> FunctionRanges = buildFunctionTextRanges(Elf);
   const size_t N = Decoded.size();
@@ -807,9 +807,9 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       return AMD_COMGR_STATUS_ERROR;
     }
 
-    std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
-        Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
-        Config);
+    std::optional<uint32_t> Patched =
+        applyGfx1250B0toA0Rules(Decoded, Text, Elf.textSize(), LS, Deferred,
+                                Elf, ScratchPatches, Config);
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -200,79 +200,18 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 
 // -- NOP sled scanning --------------------------------------------------------
 
-struct FunctionTextRange {
-  uint64_t Begin = 0;
-  uint64_t End = 0;
-};
+static std::vector<ElfView::FunctionTextRange>
+buildMergedFunctionTextRanges(const ElfView &Elf) {
+  std::vector<ElfView::FunctionTextRange> Ranges = Elf.functionTextRanges();
+  llvm::sort(Ranges, [](const ElfView::FunctionTextRange &L,
+                        const ElfView::FunctionTextRange &R) {
+    if (L.Begin != R.Begin)
+      return L.Begin < R.Begin;
+    return L.End < R.End;
+  });
 
-static std::vector<FunctionTextRange>
-buildFunctionTextRanges(const ElfView &Elf) {
-  std::vector<FunctionTextRange> Ranges;
-  uint64_t TextBegin = Elf.textAddr();
-  uint64_t TextSize = Elf.textSize();
-  if (TextSize > std::numeric_limits<uint64_t>::max() - TextBegin) {
-    log() << "hotswap: error: function text range scan: .text virtual "
-          << "address range overflows uint64_t.\n";
-    return Ranges;
-  }
-  uint64_t TextEnd = TextBegin + TextSize;
-  for (const ElfView::ELFT::Shdr &SymShdr : Elf.sections()) {
-    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
-        SymShdr.sh_type != ELF::SHT_DYNSYM)
-      continue;
-
-    Expected<ElfView::ELFT::SymRange> SymsOrErr = Elf.file().symbols(&SymShdr);
-    if (!SymsOrErr) {
-      consumeError(SymsOrErr.takeError());
-      continue;
-    }
-
-    std::vector<const ElfView::ELFT::Sym *> FuncSyms;
-    for (const ElfView::ELFT::Sym &Sym : *SymsOrErr) {
-      if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
-        continue;
-      if (Sym.st_shndx != Elf.textSectionIndex())
-        continue;
-      FuncSyms.push_back(&Sym);
-    }
-    llvm::sort(FuncSyms,
-               [](const ElfView::ELFT::Sym *A, const ElfView::ELFT::Sym *B) {
-                 if (A->st_value != B->st_value)
-                   return A->st_value < B->st_value;
-                 return A->st_size > B->st_size;
-               });
-
-    for (size_t I = 0, E = FuncSyms.size(); I != E; ++I) {
-      const ElfView::ELFT::Sym &Sym = *FuncSyms[I];
-      uint64_t BeginVA = Sym.st_value;
-      if (BeginVA < TextBegin || BeginVA >= TextEnd)
-        continue;
-      uint64_t EndVA = TextEnd;
-      if (Sym.st_size != 0) {
-        EndVA = Sym.st_value + Sym.st_size;
-        if (EndVA < BeginVA)
-          EndVA = TextEnd;
-        EndVA = std::min(EndVA, TextEnd);
-      } else {
-        for (size_t J = I + 1; J != E; ++J) {
-          if (FuncSyms[J]->st_value > BeginVA) {
-            EndVA =
-                std::min(static_cast<uint64_t>(FuncSyms[J]->st_value), TextEnd);
-            break;
-          }
-        }
-      }
-      Ranges.push_back({BeginVA - TextBegin, EndVA - TextBegin});
-    }
-  }
-  llvm::sort(Ranges,
-             [](const FunctionTextRange &L, const FunctionTextRange &R) {
-               if (L.Begin != R.Begin)
-                 return L.Begin < R.Begin;
-               return L.End < R.End;
-             });
-  std::vector<FunctionTextRange> MergedRanges;
-  for (const FunctionTextRange &Range : Ranges) {
+  std::vector<ElfView::FunctionTextRange> MergedRanges;
+  for (const ElfView::FunctionTextRange &Range : Ranges) {
     if (Range.Begin >= Range.End)
       continue;
     if (MergedRanges.empty() || Range.Begin > MergedRanges.back().End) {
@@ -284,25 +223,27 @@ buildFunctionTextRanges(const ElfView &Elf) {
   return MergedRanges;
 }
 
-static bool isInFunctionTextRange(ArrayRef<FunctionTextRange> Ranges,
-                                  uint64_t Offset) {
-  ArrayRef<FunctionTextRange>::iterator It =
-      std::upper_bound(Ranges.begin(), Ranges.end(), Offset,
-                       [](uint64_t Value, const FunctionTextRange &R) {
+static bool isInFunctionTextRange(ArrayRef<ElfView::FunctionTextRange> Ranges,
+                                  uint64_t TextAddress) {
+  ArrayRef<ElfView::FunctionTextRange>::iterator It =
+      std::upper_bound(Ranges.begin(), Ranges.end(), TextAddress,
+                       [](uint64_t Value, const ElfView::FunctionTextRange &R) {
                          return Value < R.Begin;
                        });
   if (It == Ranges.begin())
     return false;
   --It;
-  return Offset < It->End;
+  return TextAddress < It->End;
 }
 
-static bool isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
-                            const InternalDecodedInst &DI,
-                            ArrayRef<FunctionTextRange> FunctionRanges) {
+static bool
+isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
+                const InternalDecodedInst &DI, uint64_t TextAddr,
+                ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
   if (FunctionRanges.empty() || DI.Size != MinInstSize ||
       DI.Offset > TextSize || MinInstSize > TextSize - DI.Offset ||
-      isInFunctionTextRange(FunctionRanges, DI.Offset))
+      DI.Offset > std::numeric_limits<uint64_t>::max() - TextAddr ||
+      isInFunctionTextRange(FunctionRanges, TextAddr + DI.Offset))
     return false;
   return std::all_of(Text + DI.Offset, Text + DI.Offset + MinInstSize,
                      [](uint8_t B) { return B == 0; });
@@ -322,19 +263,20 @@ static std::vector<NopSled>
 buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
                 uint64_t TextSize, const LLVMState &LS, const ElfView &Elf) {
   std::vector<NopSled> Sleds;
-  std::vector<FunctionTextRange> FunctionRanges = buildFunctionTextRanges(Elf);
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      buildMergedFunctionTextRanges(Elf);
   const size_t N = Decoded.size();
   size_t I = 0;
   while (I < N) {
     bool IsSledInst = Decoded[I].Inst.getOpcode() == LS.SNopOpcode;
-    bool IsZeroFill =
-        isZeroFillDword(Text, TextSize, Decoded[I], FunctionRanges);
+    bool IsZeroFill = isZeroFillDword(Text, TextSize, Decoded[I],
+                                      Elf.textAddr(), FunctionRanges);
     if (IsSledInst || IsZeroFill) {
       uint64_t Start = Decoded[I].Offset;
       uint64_t End = Start;
-      while (I < N &&
-             (Decoded[I].Inst.getOpcode() == LS.SNopOpcode ||
-              isZeroFillDword(Text, TextSize, Decoded[I], FunctionRanges))) {
+      while (I < N && (Decoded[I].Inst.getOpcode() == LS.SNopOpcode ||
+                       isZeroFillDword(Text, TextSize, Decoded[I],
+                                       Elf.textAddr(), FunctionRanges))) {
         End = Decoded[I].Offset + Decoded[I].Size;
         ++I;
       }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -209,7 +209,13 @@ static std::vector<FunctionTextRange>
 buildFunctionTextRanges(const ElfView &Elf) {
   std::vector<FunctionTextRange> Ranges;
   uint64_t TextBegin = Elf.textAddr();
-  uint64_t TextEnd = TextBegin + Elf.textSize();
+  uint64_t TextSize = Elf.textSize();
+  if (TextSize > std::numeric_limits<uint64_t>::max() - TextBegin) {
+    log() << "hotswap: error: function text range scan: .text virtual "
+          << "address range overflows uint64_t.\n";
+    return Ranges;
+  }
+  uint64_t TextEnd = TextBegin + TextSize;
   for (const ElfView::ELFT::Shdr &SymShdr : Elf.sections()) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
         SymShdr.sh_type != ELF::SHT_DYNSYM)
@@ -265,7 +271,17 @@ buildFunctionTextRanges(const ElfView &Elf) {
                  return L.Begin < R.Begin;
                return L.End < R.End;
              });
-  return Ranges;
+  std::vector<FunctionTextRange> MergedRanges;
+  for (const FunctionTextRange &Range : Ranges) {
+    if (Range.Begin >= Range.End)
+      continue;
+    if (MergedRanges.empty() || Range.Begin > MergedRanges.back().End) {
+      MergedRanges.push_back(Range);
+      continue;
+    }
+    MergedRanges.back().End = std::max(MergedRanges.back().End, Range.End);
+  }
+  return MergedRanges;
 }
 
 static bool isInFunctionTextRange(ArrayRef<FunctionTextRange> Ranges,
@@ -284,8 +300,8 @@ static bool isInFunctionTextRange(ArrayRef<FunctionTextRange> Ranges,
 static bool isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
                             const InternalDecodedInst &DI,
                             ArrayRef<FunctionTextRange> FunctionRanges) {
-  if (DI.Size != MinInstSize || DI.Offset > TextSize ||
-      MinInstSize > TextSize - DI.Offset ||
+  if (FunctionRanges.empty() || DI.Size != MinInstSize ||
+      DI.Offset > TextSize || MinInstSize > TextSize - DI.Offset ||
       isInFunctionTextRange(FunctionRanges, DI.Offset))
     return false;
   return std::all_of(Text + DI.Offset, Text + DI.Offset + MinInstSize,
@@ -299,9 +315,9 @@ static bool isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
 /// emitToNopSled targets for in-place rewrites. NOPs are identified by MC
 /// opcode (cached on \p LS at initLLVM() time) rather than mnemonic string, so
 /// the scanner is robust against printer aliasing / mnemonic formatting
-/// variations. Zero-filled padding appears in generated code between
-/// function-symbol ranges; it decodes as v_illegal but is still writable .text
-/// space once hotswap redirects control to an assembled replacement.
+/// variations. Zero-filled padding is accepted only when function-symbol ranges
+/// prove it is between functions; zero bytes inside a function are executable
+/// code and are not sled space.
 static std::vector<NopSled>
 buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
                 uint64_t TextSize, const LLVMState &LS, const ElfView &Elf) {
@@ -339,13 +355,12 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
 /// original site, overwrites the original site with a branch-forward to the
 /// sled, and pads the leftover bytes of the original slot with cached s_nop
 /// bytes. Advances \c Sled.WritePos by the amount consumed. Returns false if
-/// either branch encoding fails, leaving \c Ctx.Text partially written.
+/// either branch encoding fails. Branches are encoded before any bytes are
+/// written so a failure leaves \c Ctx.Text and \c Sled.WritePos unchanged.
 [[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
                                  uint64_t InstOffset, uint32_t InstSize,
                                  ArrayRef<uint8_t> Replacement) {
   const LLVMState &LS = Ctx.LS;
-  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Replacement.size());
-
   SmallVector<uint8_t> BrBack = LS.encodeSBranch(
       Sled.WritePos + Replacement.size(), InstOffset + InstSize);
   if (BrBack.empty()) {
@@ -355,8 +370,6 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
           << utohexstr(InstOffset + InstSize) << " failed.\n";
     return false;
   }
-  std::memcpy(Ctx.Text + Sled.WritePos + Replacement.size(), BrBack.data(),
-              BrBack.size());
 
   SmallVector<uint8_t> BrFwd = LS.encodeSBranch(InstOffset, Sled.WritePos);
   if (BrFwd.empty()) {
@@ -365,6 +378,10 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
           << utohexstr(Sled.WritePos) << " failed.\n";
     return false;
   }
+
+  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Replacement.size());
+  std::memcpy(Ctx.Text + Sled.WritePos + Replacement.size(), BrBack.data(),
+              BrBack.size());
   std::memcpy(Ctx.Text + InstOffset, BrFwd.data(), BrFwd.size());
 
   // Pad the tail of the replaced instruction slot with cached s_nop bytes
@@ -471,12 +488,17 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        ArrayRef<uint8_t> Replacement) {
-  // findNearestSled already enforces that the returned sled has at least
-  // `Needed` bytes of headroom, so a non-null result is sufficient to take
-  // the in-place path.
+  // findNearestSled enforces sled headroom. emitToNopSled still validates
+  // exact branch reachability because branch-back distance includes the
+  // replacement size, not just the original instruction offset.
   uint64_t Needed = Replacement.size() + MinInstSize;
-  if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed))
-    return emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement);
+  if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
+    if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
+      return true;
+    log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
+          << utohexstr(Sled->WritePos)
+          << " is not branch-reachable after assembly; using trampoline.\n";
+  }
   return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
 }
 

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
 
+#include <algorithm>
 #include <cassert>
 #include <limits>
 
@@ -199,23 +200,125 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 
 // -- NOP sled scanning --------------------------------------------------------
 
-/// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
-/// MinNopSledSize bytes long and return the resulting NopSled list (each
-/// sled records Start / End byte offsets in .text and the initial WritePos
-/// at Start). These sleds are the landing zones emitToNopSled targets for
-/// in-place rewrites. NOPs are identified by MC opcode (cached on \p LS at
-/// initLLVM() time) rather than mnemonic string, so the scanner is robust
-/// against printer aliasing / mnemonic formatting variations.
-static std::vector<NopSled>
-buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS) {
+struct FunctionTextRange {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+};
+
+static std::vector<FunctionTextRange> buildFunctionTextRanges(
+    const ElfView &Elf) {
+  std::vector<FunctionTextRange> Ranges;
+  uint64_t TextBegin = Elf.textAddr();
+  uint64_t TextEnd = TextBegin + Elf.textSize();
+  for (const ElfView::ELFT::Shdr &SymShdr : Elf.sections()) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ElfView::ELFT::SymRange> SymsOrErr =
+        Elf.file().symbols(&SymShdr);
+    if (!SymsOrErr) {
+      consumeError(SymsOrErr.takeError());
+      continue;
+    }
+
+    std::vector<const ElfView::ELFT::Sym *> FuncSyms;
+    for (const ElfView::ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
+        continue;
+      if (Sym.st_shndx != Elf.textSectionIndex())
+        continue;
+      FuncSyms.push_back(&Sym);
+    }
+    llvm::sort(FuncSyms, [](const ElfView::ELFT::Sym *A,
+                            const ElfView::ELFT::Sym *B) {
+      if (A->st_value != B->st_value)
+        return A->st_value < B->st_value;
+      return A->st_size > B->st_size;
+    });
+
+    for (size_t I = 0, E = FuncSyms.size(); I != E; ++I) {
+      const ElfView::ELFT::Sym &Sym = *FuncSyms[I];
+      uint64_t BeginVA = Sym.st_value;
+      if (BeginVA < TextBegin || BeginVA >= TextEnd)
+        continue;
+      uint64_t EndVA = TextEnd;
+      if (Sym.st_size != 0) {
+        EndVA = Sym.st_value + Sym.st_size;
+        if (EndVA < BeginVA)
+          EndVA = TextEnd;
+        EndVA = std::min(EndVA, TextEnd);
+      } else {
+        for (size_t J = I + 1; J != E; ++J) {
+          if (FuncSyms[J]->st_value > BeginVA) {
+            EndVA = std::min(static_cast<uint64_t>(FuncSyms[J]->st_value),
+                             TextEnd);
+            break;
+          }
+        }
+      }
+      Ranges.push_back({BeginVA - TextBegin, EndVA - TextBegin});
+    }
+  }
+  llvm::sort(Ranges, [](const FunctionTextRange &L, const FunctionTextRange &R) {
+    if (L.Begin != R.Begin)
+      return L.Begin < R.Begin;
+    return L.End < R.End;
+  });
+  return Ranges;
+}
+
+static bool isInFunctionTextRange(ArrayRef<FunctionTextRange> Ranges,
+                                  uint64_t Offset) {
+  auto It = std::upper_bound(
+      Ranges.begin(), Ranges.end(), Offset,
+      [](uint64_t Value, const FunctionTextRange &R) {
+        return Value < R.Begin;
+      });
+  if (It == Ranges.begin())
+    return false;
+  --It;
+  return Offset < It->End;
+}
+
+static bool isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
+                            const InternalDecodedInst &DI,
+                            ArrayRef<FunctionTextRange> FunctionRanges) {
+  if (DI.Size != MinInstSize || DI.Offset > TextSize ||
+      MinInstSize > TextSize - DI.Offset ||
+      isInFunctionTextRange(FunctionRanges, DI.Offset))
+    return false;
+  return std::all_of(Text + DI.Offset, Text + DI.Offset + MinInstSize,
+                     [](uint8_t B) { return B == 0; });
+}
+
+/// Scan \p Decoded for runs of consecutive `s_nop` instructions or undecoded
+/// zero-filled alignment padding at least MinNopSledSize bytes long and return
+/// the resulting NopSled list (each sled records Start / End byte offsets in
+/// .text and the initial WritePos at Start). These sleds are the landing zones
+/// emitToNopSled targets for in-place rewrites. NOPs are identified by MC
+/// opcode (cached on \p LS at initLLVM() time) rather than mnemonic string, so
+/// the scanner is robust against printer aliasing / mnemonic formatting
+/// variations. Zero-filled padding appears in generated code between
+/// function-symbol ranges; it decodes as v_illegal but is still writable .text
+/// space once hotswap redirects control to an assembled replacement.
+static std::vector<NopSled> buildNopSledMap(
+    ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
+    uint64_t TextSize, const LLVMState &LS, const ElfView &Elf) {
   std::vector<NopSled> Sleds;
+  std::vector<FunctionTextRange> FunctionRanges = buildFunctionTextRanges(Elf);
   const size_t N = Decoded.size();
   size_t I = 0;
   while (I < N) {
-    if (Decoded[I].Inst.getOpcode() == LS.SNopOpcode) {
+    bool IsSledInst = Decoded[I].Inst.getOpcode() == LS.SNopOpcode;
+    bool IsZeroFill =
+        isZeroFillDword(Text, TextSize, Decoded[I], FunctionRanges);
+    if (IsSledInst || IsZeroFill) {
       uint64_t Start = Decoded[I].Offset;
       uint64_t End = Start;
-      while (I < N && Decoded[I].Inst.getOpcode() == LS.SNopOpcode) {
+      while (I < N &&
+             (Decoded[I].Inst.getOpcode() == LS.SNopOpcode ||
+              isZeroFillDword(Text, TextSize, Decoded[I], FunctionRanges))) {
         End = Decoded[I].Offset + Decoded[I].Size;
         ++I;
       }
@@ -396,14 +499,15 @@ static uint32_t runPerInstPass(uint32_t (*Fn)(PatchContext &, size_t),
 /// the whole-function WMMA-hazard pass after the per-instruction loop and
 /// records per-kernel stats via ElfView::updateKernelDescriptor.
 /// Returns the total number of applied patches across all passes.
-static uint32_t
+static std::optional<uint32_t>
 applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
                         uint8_t *Text, uint64_t TextSize, const LLVMState &LS,
                         std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
                         std::vector<ScratchPatchInfo> &OutScratchPatches,
                         const RewriteConfig &Config) {
   uint32_t Patched = 0;
-  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS);
+  std::vector<NopSled> Sleds =
+      buildNopSledMap(Decoded, Text, TextSize, LS, Elf);
 
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
   LivenessInfo Liveness =
@@ -482,14 +586,37 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
       continue;
     std::optional<unsigned> VgprsBefore =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
+    std::optional<unsigned> SgprsBefore = Elf.getKernelSgprCount(KName);
     if (Stats.ExtraVgprs > 0)
       Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs,
                                  Config.VgprGranuleSize);
+    if (Stats.ExtraSgprs > 0) {
+      if (!SgprsBefore) {
+        log() << "hotswap: error: failed to read SGPR count for kernel "
+              << KName << "\n";
+        return std::nullopt;
+      }
+      if (Stats.ExtraSgprs >
+          std::numeric_limits<unsigned>::max() - *SgprsBefore) {
+        log() << "hotswap: error: SGPR count for kernel " << KName
+              << " overflows unsigned after hotswap scratch allocation\n";
+        return std::nullopt;
+      }
+      unsigned RequiredSgprs = *SgprsBefore + Stats.ExtraSgprs;
+      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs)) {
+        log() << "hotswap: error: failed to update SGPR count for kernel "
+              << KName << "\n";
+        return std::nullopt;
+      }
+    }
     std::optional<unsigned> VgprsAfter =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
+    std::optional<unsigned> SgprsAfter = Elf.getKernelSgprCount(KName);
     log() << "hotswap: liveness: kernel " << KName
           << ": vgprs_before=" << VgprsBefore.value_or(0)
           << ", vgprs_after=" << VgprsAfter.value_or(0)
+          << ", sgprs_before=" << SgprsBefore.value_or(0)
+          << ", sgprs_after=" << SgprsAfter.value_or(0)
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";
   }
@@ -680,8 +807,12 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       return AMD_COMGR_STATUS_ERROR;
     }
 
-    Count = applyGfx1250B0toA0Rules(Decoded, Text, Elf.textSize(), LS, Deferred,
-                                    Elf, ScratchPatches, Config);
+    std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
+        Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
+        Config);
+    if (!Patched)
+      return AMD_COMGR_STATUS_ERROR;
+    Count = *Patched;
     log() << "hotswap: applied " << Count << " B0-to-A0 patches\n";
   } else {
     log() << "hotswap: B0-to-A0 patches disabled for this rewrite\n";

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -283,7 +283,7 @@ NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
       continue;
     uint64_t Dist = Sled.WritePos > Offset ? Sled.WritePos - Offset
                                            : Offset - Sled.WritePos;
-    if (Dist < static_cast<uint64_t>(MaxSledDistance) && Dist < BestDist) {
+    if (Dist < MaxSledDistance && Dist < BestDist) {
       Best = &Sled;
       BestDist = Dist;
     }
@@ -333,20 +333,18 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
   return ElfView(std::move(*FileOrErr), Sections, Text, TextIdx);
 }
 
-// -- ElfView::findKernelAtAddress ---------------------------------------------
+// -- ElfView::functionTextRanges ---------------------------------------------
 
-std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
+std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
+  std::vector<FunctionTextRange> Ranges;
   uint64_t TextBegin = textAddr();
   uint64_t TextSizeValue = textSize();
   if (TextSizeValue > std::numeric_limits<uint64_t>::max() - TextBegin) {
-    log() << "hotswap: error: findKernelAtAddress: .text virtual address "
-          << "range overflows uint64_t.\n";
-    return "";
+    log() << "hotswap: error: function text range scan: .text virtual "
+          << "address range overflows uint64_t.\n";
+    return Ranges;
   }
   uint64_t TextEnd = TextBegin + TextSizeValue;
-  bool Found = false;
-  uint64_t BestValue = 0;
-  std::string BestName;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -356,12 +354,6 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
     Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
     if (!SymsOrErr) {
       consumeError(SymsOrErr.takeError());
-      continue;
-    }
-    Expected<StringRef> StrTabOrErr =
-        File.getStringTableForSymtab(SymShdr, Sections);
-    if (!StrTabOrErr) {
-      consumeError(StrTabOrErr.takeError());
       continue;
     }
 
@@ -399,22 +391,47 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
           }
         }
       }
-      if (TextAddress < Begin || TextAddress >= End)
-        continue;
-      if (Found && Sym.st_value <= BestValue)
-        continue;
-      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
-      if (!NameOrErr) {
-        log() << "hotswap: error: findKernelAtAddress: function symbol "
-              << "covering address 0x" << utohexstr(TextAddress)
-              << " has unreadable name: " << toString(NameOrErr.takeError())
-              << "\n";
-        return "";
-      }
-      Found = true;
-      BestValue = Sym.st_value;
-      BestName = NameOrErr->str();
+      Ranges.push_back({Begin, End, &Sym, &SymShdr});
     }
+  }
+
+  return Ranges;
+}
+
+// -- ElfView::findKernelAtAddress ---------------------------------------------
+
+std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
+  bool Found = false;
+  uint64_t BestValue = 0;
+  std::string BestName;
+
+  std::vector<FunctionTextRange> Ranges = functionTextRanges();
+  for (const FunctionTextRange &Range : Ranges) {
+    if (TextAddress < Range.Begin || TextAddress >= Range.End)
+      continue;
+
+    const ELFT::Sym &Sym = *Range.Symbol;
+    if (Found && Sym.st_value <= BestValue)
+      continue;
+
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(*Range.Symtab, Sections);
+    if (!StrTabOrErr) {
+      consumeError(StrTabOrErr.takeError());
+      continue;
+    }
+
+    Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+    if (!NameOrErr) {
+      log() << "hotswap: error: findKernelAtAddress: function symbol "
+            << "covering address 0x" << utohexstr(TextAddress)
+            << " has unreadable name: " << toString(NameOrErr.takeError())
+            << "\n";
+      return "";
+    }
+    Found = true;
+    BestValue = Sym.st_value;
+    BestName = NameOrErr->str();
   }
 
   if (Found) {

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -277,13 +277,13 @@ bool applyByteReplace(const RewriteRule &Rule, uint64_t InstOffset,
 NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
                          uint64_t Needed) {
   NopSled *Best = nullptr;
-  int64_t BestDist = INT64_MAX;
+  uint64_t BestDist = std::numeric_limits<uint64_t>::max();
   for (NopSled &Sled : Sleds) {
-    if (Sled.WritePos + Needed > Sled.End)
+    if (Sled.WritePos > Sled.End || Needed > Sled.End - Sled.WritePos)
       continue;
-    int64_t Dist = std::abs(static_cast<int64_t>(Sled.WritePos) -
-                            static_cast<int64_t>(Offset));
-    if (Dist < MaxSledDistance && Dist < BestDist) {
+    uint64_t Dist = Sled.WritePos > Offset ? Sled.WritePos - Offset
+                                           : Offset - Sled.WritePos;
+    if (Dist < static_cast<uint64_t>(MaxSledDistance) && Dist < BestDist) {
       Best = &Sled;
       BestDist = Dist;
     }
@@ -333,10 +333,17 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
   return ElfView(std::move(*FileOrErr), Sections, Text, TextIdx);
 }
 
-// -- ElfView::findKernelAtOffset ----------------------------------------------
+// -- ElfView::findKernelAtAddress ---------------------------------------------
 
-std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
-  uint64_t TextEnd = textAddr() + textSize();
+std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
+  uint64_t TextBegin = textAddr();
+  uint64_t TextSizeValue = textSize();
+  if (TextSizeValue > std::numeric_limits<uint64_t>::max() - TextBegin) {
+    log() << "hotswap: error: findKernelAtAddress: .text virtual address "
+          << "range overflows uint64_t.\n";
+    return "";
+  }
+  uint64_t TextEnd = TextBegin + TextSizeValue;
   bool Found = false;
   uint64_t BestValue = 0;
   std::string BestName;
@@ -375,6 +382,8 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
     for (size_t I = 0, E = FuncSyms.size(); I != E; ++I) {
       const ELFT::Sym &Sym = *FuncSyms[I];
       uint64_t Begin = Sym.st_value;
+      if (Begin < TextBegin || Begin >= TextEnd)
+        continue;
       uint64_t End = TextEnd;
       if (Sym.st_size != 0) {
         End = Sym.st_value + Sym.st_size;
@@ -384,20 +393,23 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
       } else {
         for (size_t J = I + 1; J != E; ++J) {
           if (FuncSyms[J]->st_value > Begin) {
-            End = std::min(static_cast<uint64_t>(FuncSyms[J]->st_value),
-                           TextEnd);
+            End =
+                std::min(static_cast<uint64_t>(FuncSyms[J]->st_value), TextEnd);
             break;
           }
         }
       }
-      if (TextOffset < Begin || TextOffset >= End)
+      if (TextAddress < Begin || TextAddress >= End)
         continue;
       if (Found && Sym.st_value <= BestValue)
         continue;
       Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
       if (!NameOrErr) {
-        consumeError(NameOrErr.takeError());
-        continue;
+        log() << "hotswap: error: findKernelAtAddress: function symbol "
+              << "covering address 0x" << utohexstr(TextAddress)
+              << " has unreadable name: " << toString(NameOrErr.takeError())
+              << "\n";
+        return "";
       }
       Found = true;
       BestValue = Sym.st_value;
@@ -414,14 +426,14 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
     if (const_cast<ElfView *>(this)->findKernelDescriptor(BestName)) {
       return BestName;
     }
-    log() << "hotswap: findKernelAtOffset: nearest function symbol '"
-          << BestName << "' preceding offset 0x" << utohexstr(TextOffset)
+    log() << "hotswap: findKernelAtAddress: nearest function symbol '"
+          << BestName << "' preceding address 0x" << utohexstr(TextAddress)
           << " has no .kd descriptor (not a kernel); treating as no match.\n";
     return "";
   }
 
-  log() << "hotswap: findKernelAtOffset: no function symbol covers offset 0x"
-        << utohexstr(TextOffset) << " in .text.\n";
+  log() << "hotswap: findKernelAtAddress: no function symbol covers address 0x"
+        << utohexstr(TextAddress) << " in .text.\n";
   return "";
 }
 

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -336,13 +336,7 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
 // -- ElfView::findKernelAtOffset ----------------------------------------------
 
 std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
-  // Select the nearest-preceding STT_FUNC symbol (greatest st_value <=
-  // TextOffset). AMDGPU kernel entry symbols often have st_size == 0, so an
-  // exact containment test never matches; honor st_size only when non-zero.
-  //
-  // The nearest-preceding function could be a non-kernel device function; the
-  // guard below rejects that case so callers never scratch-allocate against a
-  // non-kernel context.
+  uint64_t TextEnd = textAddr() + textSize();
   bool Found = false;
   uint64_t BestValue = 0;
   std::string BestName;
@@ -364,15 +358,39 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
       continue;
     }
 
+    std::vector<const ELFT::Sym *> FuncSyms;
     for (const ELFT::Sym &Sym : *SymsOrErr) {
       if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
         continue;
       if (Sym.st_shndx != TextSectionIndex)
         continue;
-      if (TextOffset < Sym.st_value)
-        continue;
-      // Honor an explicit upper bound; skip it for zero-size symbols.
-      if (Sym.st_size != 0 && TextOffset >= Sym.st_value + Sym.st_size)
+      FuncSyms.push_back(&Sym);
+    }
+    llvm::sort(FuncSyms, [](const ELFT::Sym *A, const ELFT::Sym *B) {
+      if (A->st_value != B->st_value)
+        return A->st_value < B->st_value;
+      return A->st_size > B->st_size;
+    });
+
+    for (size_t I = 0, E = FuncSyms.size(); I != E; ++I) {
+      const ELFT::Sym &Sym = *FuncSyms[I];
+      uint64_t Begin = Sym.st_value;
+      uint64_t End = TextEnd;
+      if (Sym.st_size != 0) {
+        End = Sym.st_value + Sym.st_size;
+        if (End < Begin)
+          End = TextEnd;
+        End = std::min(End, TextEnd);
+      } else {
+        for (size_t J = I + 1; J != E; ++J) {
+          if (FuncSyms[J]->st_value > Begin) {
+            End = std::min(static_cast<uint64_t>(FuncSyms[J]->st_value),
+                           TextEnd);
+            break;
+          }
+        }
+      }
+      if (TextOffset < Begin || TextOffset >= End)
         continue;
       if (Found && Sym.st_value <= BestValue)
         continue;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -163,6 +163,23 @@ static bool decodeKernelEntryStub(ArrayRef<uint8_t> Bytes, const LLVMState &LS,
   return Decoded.size() >= 6;
 }
 
+static bool startsWithBytes(ArrayRef<uint8_t> Bytes, ArrayRef<uint8_t> Prefix) {
+  return Bytes.size() >= Prefix.size() &&
+         std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
+}
+
+static SmallVector<uint8_t> buildEntryStubBytePrefix(const LLVMState &LS) {
+  SmallVector<uint8_t> GlobalWb = assembleSingleInst("global_wb", LS);
+  SmallVector<uint8_t> VNop = assembleSingleInst("v_nop", LS);
+  if (GlobalWb.empty() || VNop.empty())
+    return {};
+
+  SmallVector<uint8_t> Prefix;
+  Prefix.append(GlobalWb.begin(), GlobalWb.end());
+  Prefix.append(VNop.begin(), VNop.end());
+  return Prefix;
+}
+
 static bool hasRegOperand(const MCInst &Inst, unsigned Index) {
   return Inst.getNumOperands() > Index && Inst.getOperand(Index).isReg();
 }
@@ -291,8 +308,11 @@ static std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   return KD.VAddr - Magnitude;
 }
 
-static std::optional<bool> descriptorAlreadyTargetsEntryStub(
-    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS) {
+static std::optional<bool>
+descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
+                                  const KernelDescriptorInfo &KD,
+                                  const LLVMState &LS,
+                                  ArrayRef<uint8_t> EntryStubPrefix) {
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
@@ -311,16 +331,15 @@ static std::optional<bool> descriptorAlreadyTargetsEntryStub(
 
   ArrayRef<uint8_t> Candidate(Elf.textData() + TextOffset,
                               KernelEntryStubStride);
-  // The full idempotency matcher uses LLVM's AMDGPU disassembler. Avoid
-  // running it over arbitrary original kernel entry bytes; real code objects
-  // can contain byte streams that are valid executable code but still trip
-  // decoder corner cases before COMGR can finish rewriting.
-  if (!hasKernelEntryTrampolinePrefix(Candidate, LS))
+  // Avoid feeding arbitrary kernel-entry instructions into the stub matcher.
+  // The full decode below is only needed once the bytes look like a hotswap
+  // entry stub.
+  if (!startsWithBytes(Candidate, EntryStubPrefix))
     return false;
 
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
-                             "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS,
+                             Decoded, "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;
@@ -432,11 +451,18 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   if (Descriptors.empty())
     return 0;
 
+  SmallVector<uint8_t> EntryStubPrefix = buildEntryStubBytePrefix(LS);
+  if (EntryStubPrefix.empty()) {
+    log() << "hotswap: error: entry trampoline: failed to assemble byte "
+          << "prefix for idempotency matching.\n";
+    return std::nullopt;
+  }
+
   std::vector<KernelDescriptorInfo> Work;
   uint32_t MaxInstPrefLines = 0;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     std::optional<bool> AlreadyHasEntryStub =
-        descriptorAlreadyTargetsEntryStub(Elf, KD, LS);
+        descriptorAlreadyTargetsEntryStub(Elf, KD, LS, EntryStubPrefix);
     if (!AlreadyHasEntryStub)
       return std::nullopt;
     if (*AlreadyHasEntryStub)

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -165,7 +165,7 @@ static bool decodeKernelEntryStub(ArrayRef<uint8_t> Bytes, const LLVMState &LS,
 
 static bool startsWithBytes(ArrayRef<uint8_t> Bytes, ArrayRef<uint8_t> Prefix) {
   return Bytes.size() >= Prefix.size() &&
-         std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
+         Bytes.take_front(Prefix.size()).equals(Prefix);
 }
 
 static SmallVector<uint8_t> buildEntryStubBytePrefix(const LLVMState &LS) {

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -215,9 +215,9 @@ public:
   uint8_t *textData() { return data() + textOffset(); }
   const uint8_t *textData() const { return data() + textOffset(); }
 
-  /// Find the kernel function symbol whose range includes \p TextOffset.
+  /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.
-  std::string findKernelAtOffset(uint64_t TextOffset) const;
+  std::string findKernelAtAddress(uint64_t TextAddress) const;
 
   /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
   /// or nullptr if not found.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -130,7 +130,7 @@ static constexpr uint64_t KdSize = sizeof(llvm::amdhsa::kernel_descriptor_t);
 
 // Maximum distance (bytes) between an instruction and a NOP sled for the
 // sled to be considered reachable by a single s_branch.
-static constexpr int64_t MaxSledDistance = 131072;
+static constexpr uint64_t MaxSledDistance = 131072;
 
 // Minimum size (bytes) of a consecutive NOP run to be usable as a sled.
 static constexpr uint64_t MinNopSledSize = 8;
@@ -175,6 +175,13 @@ public:
   using ELFT = llvm::object::ELF64LE;
   using ELFFileT = llvm::object::ELFFile<ELFT>;
 
+  struct FunctionTextRange {
+    uint64_t Begin = 0;
+    uint64_t End = 0;
+    const ELFT::Sym *Symbol = nullptr;
+    const ELFT::Shdr *Symtab = nullptr;
+  };
+
   /// Parse \p Data / \p Size into an ElfView. Fails if the bytes are not a
   /// valid ELF64 or if no `.text` section is found.
   static llvm::Expected<ElfView> create(uint8_t *Data, size_t Size);
@@ -214,6 +221,10 @@ public:
   /// Pointer into the buffer for the first byte of `.text`.
   uint8_t *textData() { return data() + textOffset(); }
   const uint8_t *textData() const { return data() + textOffset(); }
+
+  /// Enumerate function symbol ranges in `.text` using virtual addresses.
+  /// Zero-size symbols extend to the next function symbol or `.text` end.
+  std::vector<FunctionTextRange> functionTextRanges() const;
 
   /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -78,6 +78,40 @@ std::string fmtModifiedSrc(StringRef BareReg, unsigned Mods) {
   return R;
 }
 
+std::string fmtLiteral32(int64_t Imm) {
+  return "0x" + utohexstr(static_cast<uint32_t>(Imm));
+}
+
+bool isRegOrImm(const MCOperand &Op) { return Op.isReg() || Op.isImm(); }
+
+/// Format a register or literal F32 source for replacement assembly. Literal
+/// VOP3 operands are materialized into \p TempReg so the emulation sequence can
+/// freely use integer ALU instructions that otherwise cannot carry multiple
+/// literal operands.
+bool materializeF32Source(raw_string_ostream &OS, const MCOperand &Op,
+                          unsigned Mods, StringRef TempReg,
+                          const MCRegisterInfo &MRI, uint64_t Offset,
+                          StringRef InstName, std::string &BareSrc,
+                          std::string &ModifiedSrc) {
+  if (Op.isReg()) {
+    BareSrc = toAsmRegName(MRI, Op.getReg());
+    ModifiedSrc = fmtModifiedSrc(BareSrc, Mods);
+    return true;
+  }
+
+  if (Op.isImm()) {
+    BareSrc = TempReg.str();
+    OS << "v_mov_b32 " << BareSrc << ", " << fmtLiteral32(Op.getImm())
+       << "\n";
+    ModifiedSrc = fmtModifiedSrc(BareSrc, Mods);
+    return true;
+  }
+
+  log() << "hotswap: error: " << InstName
+        << ": unsupported source operand at 0x" << utohexstr(Offset) << "\n";
+  return false;
+}
+
 // -- VOP3 operand layout structs -------------------------------------------
 //
 // Mirrors the MCInst operand order produced by the AMDGPU disassembler for
@@ -234,12 +268,6 @@ void emitF32ToUE5M3(raw_string_ostream &OS, StringRef Src, StringRef BareSrc,
 
 uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
-  if (DI.Size != 8) {
-    log() << "hotswap: error: cvt_pk_fp8_f32: unexpected inst size " << DI.Size
-          << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
-
   const MCInst &Inst = DI.Inst;
   const VOP3Fp8TwoSrcLayout &L = TwoSrcFp8Layout;
 
@@ -254,6 +282,12 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
       Inst.getOperand(L.Clamp).getImm() == 0)
     return 0;
 
+  if (DI.Size != 8 && DI.Size != 12) {
+    log() << "hotswap: error: cvt_pk_fp8_f32: unexpected inst size " << DI.Size
+          << " at offset 0x" << utohexstr(DI.Offset) << "\n";
+    return 0;
+  }
+
   // OPSEL[3] (write-high) is folded into src0_mods by the disassembler.
   // SISrcMods encodes OP_SEL_1 at bit 3 (value 8).
   unsigned Src0Mods = Inst.getOperand(L.Src0Mods).isImm()
@@ -262,20 +296,17 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   bool WriteHigh = (Src0Mods >> 3) & 1;
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  if (!Inst.getOperand(L.VDst).isReg() || !Inst.getOperand(L.Src0).isReg() ||
-      !Inst.getOperand(L.Src1).isReg()) {
+  if (!Inst.getOperand(L.VDst).isReg() ||
+      !isRegOrImm(Inst.getOperand(L.Src0)) ||
+      !isRegOrImm(Inst.getOperand(L.Src1))) {
     log() << "hotswap: error: cvt_pk_fp8_f32: unexpected imm operand at 0x"
           << utohexstr(DI.Offset) << "\n";
     return 0;
   }
   std::string VdstStr = toAsmRegName(MRI, Inst.getOperand(L.VDst).getReg());
-  std::string Src0Bare = toAsmRegName(MRI, Inst.getOperand(L.Src0).getReg());
-  std::string Src1Bare = toAsmRegName(MRI, Inst.getOperand(L.Src1).getReg());
   unsigned Src1Mods = Inst.getOperand(L.Src1Mods).isImm()
                           ? Inst.getOperand(L.Src1Mods).getImm()
                           : 0;
-  std::string Src0Str = fmtModifiedSrc(Src0Bare, Src0Mods);
-  std::string Src1Str = fmtModifiedSrc(Src1Bare, Src1Mods);
 
   ScratchAllocation SA = allocateScratch(Ctx, Idx);
 
@@ -313,6 +344,18 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   // Save VCC before clobbering it with v_cmp_* instructions.
   AsmOS << "s_mov_b32 " << VccSaveName << ", vcc_lo\n";
 
+  std::string Src0Bare;
+  std::string Src1Bare;
+  std::string Src0Str;
+  std::string Src1Str;
+  if (!materializeF32Source(AsmOS, Inst.getOperand(L.Src0), Src0Mods, T0Name,
+                            MRI, DI.Offset, "cvt_pk_fp8_f32", Src0Bare,
+                            Src0Str) ||
+      !materializeF32Source(AsmOS, Inst.getOperand(L.Src1), Src1Mods, T1Name,
+                            MRI, DI.Offset, "cvt_pk_fp8_f32", Src1Bare,
+                            Src1Str))
+    return 0;
+
   // --- src0 → byte in T0 (scratch: T2) ---
   emitF32ToUE5M3(AsmOS, Src0Str, Src0Bare, T0Name, T2Name, NaN0Name);
 
@@ -343,7 +386,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
     return 0;
   }
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -11,14 +11,14 @@
 ///
 /// GFX1250 B0 added a CLAMP bit to three FP8 conversion instructions that
 /// selects UE5M3 format (CLAMP=1) instead of E4M3 (CLAMP=0). On A0 the
-/// CLAMP bit is non-functional — CLAMP=1 silently produces E4M3. This file
+/// CLAMP bit is non-functional: CLAMP=1 silently produces E4M3. This file
 /// provides the strong override of applyScratchPatches that detects CLAMP=1
 /// FP8 conversions and emits software emulation sequences.
 ///
 /// Covered instructions:
-///   1. v_cvt_pk_fp8_f32  — F32 pack to FP8
-///   2. v_cvt_sr_fp8_f32  — F32 stochastic-round to FP8
-///   3. v_cvt_f32_fp8     — FP8 unpack to F32
+///   1. v_cvt_pk_fp8_f32  - F32 pack to FP8
+///   2. v_cvt_sr_fp8_f32  - F32 stochastic-round to FP8
+///   3. v_cvt_f32_fp8     - FP8 unpack to F32
 ///
 //===----------------------------------------------------------------------===//
 
@@ -41,7 +41,7 @@ namespace {
 std::string vgprName(unsigned N) { return ("v" + Twine(N)).str(); }
 std::string sgprName(unsigned N) { return ("s" + Twine(N)).str(); }
 
-/// Convert an MCRegister to its assembly name (e.g. VGPR0 → "v0").
+/// Convert an MCRegister to its assembly name (e.g. VGPR0 to "v0").
 /// The MCRegisterInfo name is the tablegen C identifier (e.g. "VGPR0",
 /// "SGPR0", "VCC_LO"); we map it to the assembler name used in inline asm.
 /// True16 sub-register names ("VGPR0_LO16") are mapped to the 32-bit
@@ -54,7 +54,7 @@ std::string toAsmRegName(const MCRegisterInfo &MRI, MCRegister Reg) {
   if (!N)
     return {};
   StringRef S(N);
-  // True16 sub-registers: VGPR0_LO16 / VGPR0_HI16 → use 32-bit parent.
+  // True16 sub-registers: VGPR0_LO16 / VGPR0_HI16 use 32-bit parent.
   if (S.contains("_LO16") || S.contains("_HI16"))
     S = S.take_until([](char C) { return C == '_'; });
   if (S.consume_front("VGPR"))
@@ -101,8 +101,7 @@ bool materializeF32Source(raw_string_ostream &OS, const MCOperand &Op,
 
   if (Op.isImm()) {
     BareSrc = TempReg.str();
-    OS << "v_mov_b32 " << BareSrc << ", " << fmtLiteral32(Op.getImm())
-       << "\n";
+    OS << "v_mov_b32 " << BareSrc << ", " << fmtLiteral32(Op.getImm()) << "\n";
     ModifiedSrc = fmtModifiedSrc(BareSrc, Mods);
     return true;
   }
@@ -126,12 +125,12 @@ bool materializeF32Source(raw_string_ostream &OS, const MCOperand &Op,
 //
 // MCInst operand order (verified at runtime):
 //   [0] vdst       (reg)
-//   [1] src0_mods  (imm – SISrcMods flags including OP_SEL bits)
+//   [1] src0_mods  (imm - SISrcMods flags including OP_SEL bits)
 //   [2] src0       (reg)
 //   [3] src1_mods  (imm)
 //   [4] src1       (reg)
 //   [5] clamp      (imm)
-//   [6] vdst_in    (reg – tied to vdst)
+//   [6] vdst_in    (reg - tied to vdst)
 struct VOP3Fp8TwoSrcLayout {
   unsigned NumOperands;
   unsigned VDst;
@@ -143,7 +142,7 @@ struct VOP3Fp8TwoSrcLayout {
   unsigned VDstIn;
 };
 
-// v_cvt_f32_fp8 (gfx1250, VOP3 unpack – no source modifiers):
+// v_cvt_f32_fp8 (gfx1250, VOP3 unpack - no source modifiers):
 //   [0] vdst       (reg)
 //   [1] src0       (reg)
 //   [2] clamp      (imm)
@@ -177,7 +176,7 @@ struct ScratchAllocation {
 ScratchAllocation allocateScratch(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
   std::string KernelName =
-      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
   std::optional<unsigned> KdVgprs =
       Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize);
   unsigned VgprKdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
@@ -193,40 +192,55 @@ ScratchAllocation allocateScratch(PatchContext &Ctx, size_t Idx) {
 }
 
 // ---------------------------------------------------------------------------
-// Per-source F32 → UE5M3 conversion with full fixups
+// Per-source F32 to UE5M3 conversion with full fixups
 // ---------------------------------------------------------------------------
 
 /// Emit assembly for converting one F32 source to a UE5M3 byte in \p Out.
 ///
-/// Handles NaN (→ 0xFF), overflow/Inf (→ 0xFE), RTE rounding of the 7
+/// Handles NaN (to 0xFF), overflow/Inf (to 0xFE), RTE rounding of the 7
 /// discarded F16 mantissa bits, and source modifiers (neg/abs forwarded
 /// from the original instruction via \p Src).
 ///
 /// Register contract:
-///   \p Out   — output VGPR, receives UE5M3 byte in bits [7:0]
-///   \p Tmp   — scratch VGPR, clobbered
-///   \p NanSgpr — SGPR name (e.g. "s0") for saving/restoring the NaN flag
-///   \p Src   — full operand with modifiers (used in v_max_num_f32)
-///   \p BareSrc — bare register name (used in v_and_b32 for NaN detect)
+///   \p Out - output VGPR, receives UE5M3 byte in bits [7:0]
+///   \p Tmp - scratch VGPR, clobbered
+///   \p TopByte - scratch VGPR, clobbered
+///   \p NanSgpr - SGPR name (e.g. "s0") for saving/restoring the NaN flag
+///   \p TopSgpr - SGPR name for saving/restoring the high-range flag
+///   \p Src - full operand with modifiers (used in v_max_num_f32)
+///   \p BareSrc - bare register name (used in v_and_b32 for NaN detect)
 ///   VCC is clobbered.
 ///
 /// RTE rounding shortcut: rather than extracting round_bit, sticky, and lsb
-/// into separate registers (which would require a 3rd VGPR per source), we
-/// use the identity: round_up = (guard_bits * 2 + lsb) > 128, where
+/// into separate low-path registers, we use the identity:
+/// round_up = (guard_bits * 2 + lsb) > 128, where
 /// guard_bits = F16[6:0].  This collapses the entire RTE decision into a
 /// single integer comparison via v_bfi_b32 + v_cmp + v_add_co_ci_u32.
 void emitF32ToUE5M3(raw_string_ostream &OS, StringRef Src, StringRef BareSrc,
-                    StringRef Out, StringRef Tmp, StringRef NanSgpr) {
-  // NaN detection: (|src| > 0x7F800000) ⇒ NaN.
+                    StringRef Out, StringRef Tmp, StringRef TopByte,
+                    StringRef NanSgpr, StringRef TopSgpr) {
+  // NaN detection: (|src| > 0x7F800000) means NaN.
   // v_and_b32 strips the sign, so neg/abs modifiers don't affect this test.
   // VOPC form: literal in src0, VGPR in src1 (implicit VCC write).
   OS << "v_and_b32 " << Tmp << ", 0x7FFFFFFF, " << BareSrc << "\n";
   OS << "v_cmp_lt_u32 0x7F800000, " << Tmp << "\n";
   OS << "s_mov_b32 " << NanSgpr << ", vcc_lo\n";
 
-  // Clamp to non-negative → F16.  Source modifiers are applied by
-  // v_max_num_f32.
+  // Clamp to non-negative. Source modifiers are applied by v_max_num_f32.
   OS << "v_max_num_f32 " << Out << ", 0, " << Src << "\n";
+
+  // UE5M3 values 0xF8..0xFE represent the exponent-31 finite range that an
+  // F16 intermediate cannot encode. For the PK instruction's RTE mode, select
+  // this direct path at the 0xF7/0xF8 midpoint (63488.0) and compute:
+  //   byte = min(0xFE, 0xF0 + round_nearest_even(src / 8192.0)).
+  // The low-range F16 path below is still used for all smaller values.
+  OS << "v_cmp_le_f32 0x47780000, " << Out << "\n";
+  OS << "s_mov_b32 " << TopSgpr << ", vcc_lo\n";
+  OS << "v_mul_f32 " << TopByte << ", 0x39000000, " << Out << "\n";
+  OS << "v_cvt_nearest_i32_f32 " << TopByte << ", " << TopByte << "\n";
+  OS << "v_add_u32 " << TopByte << ", 0xF0, " << TopByte << "\n";
+  OS << "v_min_u32 " << TopByte << ", 0xFE, " << TopByte << "\n";
+
   OS << "v_cvt_f16_f32 " << Out << ", " << Out << "\n";
 
   // RTE rounding: extract guard_bits = F16[6:0], shift to get preliminary
@@ -238,25 +252,19 @@ void emitF32ToUE5M3(raw_string_ostream &OS, StringRef Src, StringRef BareSrc,
   OS << "v_bfe_u32 " << Out << ", " << Out << ", 7, 9\n";
   OS << "v_lshlrev_b32 " << Tmp << ", 1, " << Tmp << "\n";
   // v_bfi_b32: dst = (mask & insert) | (~mask & background)
-  // With mask=0xFFFFFFFE: copies Tmp[31:1] and Out[0] → guard*2 + lsb
+  // With mask=0xFFFFFFFE: copies Tmp[31:1] and Out[0] to guard*2 + lsb.
   OS << "v_bfi_b32 " << Tmp << ", 0xFFFFFFFE, " << Tmp << ", " << Out << "\n";
   // v_add_co_ci_u32 adds VCC as carry-in, collapsing the conditional
   // increment into one instruction: Out += (guard*2 + lsb > 128) ? 1 : 0.
   OS << "v_cmp_lt_u32 0x80, " << Tmp << "\n";
   OS << "v_add_co_ci_u32 " << Out << ", 0, " << Out << "\n";
 
-  // Safety clamp: cap at UE5M3 max finite (0xFE) so NaN override works.
-  //
-  // Accepted limitation: this is effectively a no-op for overflow/Inf
-  // because the F16 intermediate clips large F32 values to F16 +Inf
-  // (0x7C00), which yields 0xF8 (= 0x7C00 >> 7), not 0xFE.  B0 hardware
-  // would produce 0xFE for the same inputs via its native F32 → UE5M3
-  // path.  The practical impact is that the 7 UE5M3 values 0xF9–0xFE
-  // (the exponent-31 octave above +Inf's F16 projection) are unreachable
-  // via our F16 intermediate.  This is a known precision gap affecting
-  // only extreme finite values (> 57344.0); ML inference workloads
-  // normalize inputs to ranges well below this threshold.
+  // Select the direct exponent-31 result when the source is in the UE5M3
+  // high range. The min remains as a defensive cap for the low path's carry
+  // out and for any saturated direct-path integer conversion.
   OS << "v_min_u32 " << Out << ", 0xFE, " << Out << "\n";
+  OS << "s_mov_b32 vcc_lo, " << TopSgpr << "\n";
+  OS << "v_cndmask_b32 " << Out << ", " << Out << ", " << TopByte << "\n";
 
   // NaN override: if original F32 was NaN, force 0xFF.
   // Load the NaN byte into Tmp (avoids literal in v_cndmask src1).
@@ -313,13 +321,14 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
 
   ScratchAllocation SA = allocateScratch(Ctx, Idx);
 
-  // 3 scratch VGPRs: T0 (src0 byte), T1 (src1 byte), T2 (shared scratch
-  // for NaN detection and RTE rounding intermediates within each source).
+  // 4 scratch VGPRs: T0 (src0 byte), T1 (src1 byte), T2 (shared scratch
+  // for NaN detection and RTE rounding intermediates), T3 (high-range byte).
   std::optional<unsigned> T0 = SA.VgprAlloc.alloc();
   std::optional<unsigned> T1 = SA.VgprAlloc.alloc();
   std::optional<unsigned> T2 = SA.VgprAlloc.alloc();
-  if (!T0 || !T1 || !T2) {
-    log() << "hotswap: error: cvt_pk_fp8_f32: unable to allocate 3 scratch "
+  std::optional<unsigned> T3 = SA.VgprAlloc.alloc();
+  if (!T0 || !T1 || !T2 || !T3) {
+    log() << "hotswap: error: cvt_pk_fp8_f32: unable to allocate 4 scratch "
           << "VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
     return 0;
   }
@@ -327,18 +336,21 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   std::string T0Name = vgprName(*T0);
   std::string T1Name = vgprName(*T1);
   std::string T2Name = vgprName(*T2);
+  std::string T3Name = vgprName(*T3);
 
   std::optional<unsigned> NaN0Sgpr = SA.SgprAlloc.alloc();
   std::optional<unsigned> NaN1Sgpr = SA.SgprAlloc.alloc();
+  std::optional<unsigned> TopSgpr = SA.SgprAlloc.alloc();
   std::optional<unsigned> VccSaveSgpr = SA.SgprAlloc.alloc();
-  if (!NaN0Sgpr || !NaN1Sgpr || !VccSaveSgpr) {
-    log() << "hotswap: error: cvt_pk_fp8_f32: unable to allocate 3 scratch "
+  if (!NaN0Sgpr || !NaN1Sgpr || !TopSgpr || !VccSaveSgpr) {
+    log() << "hotswap: error: cvt_pk_fp8_f32: unable to allocate 4 scratch "
           << "SGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
     return 0;
   }
 
   std::string NaN0Name = sgprName(*NaN0Sgpr);
   std::string NaN1Name = sgprName(*NaN1Sgpr);
+  std::string TopName = sgprName(*TopSgpr);
   std::string VccSaveName = sgprName(*VccSaveSgpr);
 
   std::string Asm;
@@ -359,11 +371,13 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
                             Src1Str))
     return 0;
 
-  // --- src0 → byte in T0 (scratch: T2) ---
-  emitF32ToUE5M3(AsmOS, Src0Str, Src0Bare, T0Name, T2Name, NaN0Name);
+  // --- src0 to byte in T0 (scratch: T2) ---
+  emitF32ToUE5M3(AsmOS, Src0Str, Src0Bare, T0Name, T2Name, T3Name, NaN0Name,
+                 TopName);
 
-  // --- src1 → byte in T1 (scratch: T2) ---
-  emitF32ToUE5M3(AsmOS, Src1Str, Src1Bare, T1Name, T2Name, NaN1Name);
+  // --- src1 to byte in T1 (scratch: T2) ---
+  emitF32ToUE5M3(AsmOS, Src1Str, Src1Bare, T1Name, T2Name, T3Name, NaN1Name,
+                 TopName);
 
   // Pack: T0[15:0] = { byte1, byte0 }
   AsmOS << "v_lshl_or_b32 " << T0Name << ", " << T1Name << ", 8, " << T0Name
@@ -398,7 +412,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
     Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, ExtraV);
     Stats.ExtraSgprs =
         std::max(Stats.ExtraSgprs, SA.SgprAlloc.extraSgprsNeeded());
-    Stats.ScratchReused += 3 - ExtraV;
+    Stats.ScratchReused += 4 - ExtraV;
     Stats.ScratchAboveKd += ExtraV;
   }
 
@@ -409,8 +423,8 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
 
   log() << "hotswap: cvt_pk_fp8_f32: patched CLAMP=1 (E5M3) at offset 0x"
         << utohexstr(DI.Offset) << " (" << ReplacementBytes.size()
-        << " bytes, scratch v" << *T0 << "/v" << *T1 << "/v" << *T2
-        << ", half=" << (WriteHigh ? "high" : "low") << ")\n";
+        << " bytes, scratch v" << *T0 << "/v" << *T1 << "/v" << *T2 << "/v"
+        << *T3 << ", half=" << (WriteHigh ? "high" : "low") << ")\n";
 
   return 1;
 }
@@ -419,16 +433,17 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
 // v_cvt_sr_fp8_f32 patch  (Case 1, instruction 2)
 // ---------------------------------------------------------------------------
 
-/// Patch a CLAMP=1 `v_cvt_sr_fp8_f32` (stochastic-round F32 → UE5M3).
+/// Patch a CLAMP=1 `v_cvt_sr_fp8_f32` (stochastic-round F32 to UE5M3).
 ///
 /// The SR path injects stochastic noise into the F32 mantissa before the
-/// F16 intermediate conversion, replicating the ISA pseudocode (§17.6.94).
-/// Unlike the PK path, no explicit RTE rounding block is needed — the
+/// F16 intermediate conversion, replicating the ISA pseudocode (17.6.94).
+/// Unlike the PK path, no explicit RTE rounding block is needed; the
 /// stochastic noise makes simple truncation statistically equivalent to
 /// unbiased rounding (the noise carry already provides the correct
 /// rounding probability without guard-bit extraction).
 ///
-/// Scratch: 2 VGPRs (Out + Tmp), 1 SGPR (s0 for NaN flag).
+/// Scratch: 3 VGPRs (Out + Tmp + high-range byte), 3 SGPRs (NaN flag,
+/// high-range flag, and VCC save).
 uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
   if (DI.Size != 8) {
@@ -453,7 +468,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
 
   // byte_sel = OPSEL[3:2] in the VOP3 dword-0 encoding (bits [13:12]).
   // Unlike WriteHigh (OPSEL[3] at SISrcMods bit 3), the disassembler does
-  // NOT fold byte_sel's OPSEL[3:2] into src0_mods for v_cvt_sr_fp8_f32 —
+  // NOT fold byte_sel's OPSEL[3:2] into src0_mods for v_cvt_sr_fp8_f32:
   // they are only accessible from the raw encoding.
   const uint8_t *Raw = Ctx.Text + DI.Offset;
   unsigned ByteSel = (Raw[1] >> 5) & 0x3;
@@ -471,7 +486,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   }
   std::string VdstStr = toAsmRegName(MRI, Inst.getOperand(L.VDst).getReg());
   std::string Src0Bare = toAsmRegName(MRI, Inst.getOperand(L.Src0).getReg());
-  // src1 is U32 stochastic noise — ISA does not define NEG/ABS on integer
+  // src1 is U32 stochastic noise; ISA does not define NEG/ABS on integer
   // operands (OPF_NEG_1/OPF_ABS_1 absent for this opcode), so we use the
   // bare register name without modifier wrapping.
   std::string Src1Str = toAsmRegName(MRI, Inst.getOperand(L.Src1).getReg());
@@ -479,28 +494,32 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
 
   ScratchAllocation SA = allocateScratch(Ctx, Idx);
 
-  // 2 scratch VGPRs: Out (conversion result + noise intermediate), Tmp (NaN
-  // flag save + noise computation).
+  // 3 scratch VGPRs: Out (conversion result + noise intermediate), Tmp (NaN
+  // flag save + noise computation), TopByte (high-range byte).
   std::optional<unsigned> Out = SA.VgprAlloc.alloc();
   std::optional<unsigned> Tmp = SA.VgprAlloc.alloc();
-  if (!Out || !Tmp) {
-    log() << "hotswap: error: cvt_sr_fp8_f32: unable to allocate 2 scratch "
+  std::optional<unsigned> TopByte = SA.VgprAlloc.alloc();
+  if (!Out || !Tmp || !TopByte) {
+    log() << "hotswap: error: cvt_sr_fp8_f32: unable to allocate 3 scratch "
           << "VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
     return 0;
   }
 
   std::string OutName = vgprName(*Out);
   std::string TmpName = vgprName(*Tmp);
+  std::string TopByteName = vgprName(*TopByte);
 
   std::optional<unsigned> NaNSgpr = SA.SgprAlloc.alloc();
+  std::optional<unsigned> TopSgpr = SA.SgprAlloc.alloc();
   std::optional<unsigned> VccSaveSgpr = SA.SgprAlloc.alloc();
-  if (!NaNSgpr || !VccSaveSgpr) {
-    log() << "hotswap: error: cvt_sr_fp8_f32: unable to allocate 2 scratch "
+  if (!NaNSgpr || !TopSgpr || !VccSaveSgpr) {
+    log() << "hotswap: error: cvt_sr_fp8_f32: unable to allocate 3 scratch "
           << "SGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
     return 0;
   }
 
   std::string NaNName = sgprName(*NaNSgpr);
+  std::string TopName = sgprName(*TopSgpr);
   std::string VccSaveName = sgprName(*VccSaveSgpr);
 
   std::string Asm;
@@ -531,12 +550,26 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   AsmOS << "v_bfi_b32 " << OutName << ", 0x007FFFFF, " << TmpName << ", "
         << OutName << "\n";
 
-  // --- F32 → F16 → UE5M3 (truncation, not RTE — SR noise handles rounding) ---
+  // --- High-range direct path ---
+  // SR mode injects rounding noise before truncation, so exponent-31 values
+  // use floor(src / 8192.0) rather than the PK path's nearest conversion.
+  AsmOS << "v_cmp_le_f32 0x47800000, " << OutName << "\n";
+  AsmOS << "s_mov_b32 " << TopName << ", vcc_lo\n";
+  AsmOS << "v_mul_f32 " << TopByteName << ", 0x39000000, " << OutName << "\n";
+  AsmOS << "v_cvt_floor_i32_f32 " << TopByteName << ", " << TopByteName << "\n";
+  AsmOS << "v_add_u32 " << TopByteName << ", 0xF0, " << TopByteName << "\n";
+  AsmOS << "v_min_u32 " << TopByteName << ", 0xFE, " << TopByteName << "\n";
+
+  // --- F32 to F16 to UE5M3 ---
+  // Truncation is used here; SR noise handles rounding.
   AsmOS << "v_cvt_f16_f32 " << OutName << ", " << OutName << "\n";
   AsmOS << "v_bfe_u32 " << OutName << ", " << OutName << ", 7, 9\n";
 
-  // --- Overflow clamp (safety) ---
+  // --- Overflow clamp and high-range select ---
   AsmOS << "v_min_u32 " << OutName << ", 0xFE, " << OutName << "\n";
+  AsmOS << "s_mov_b32 vcc_lo, " << TopName << "\n";
+  AsmOS << "v_cndmask_b32 " << OutName << ", " << OutName << ", " << TopByteName
+        << "\n";
 
   // --- NaN override ---
   AsmOS << "s_mov_b32 vcc_lo, " << NaNName << "\n";
@@ -577,7 +610,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
     Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, ExtraV);
     Stats.ExtraSgprs =
         std::max(Stats.ExtraSgprs, SA.SgprAlloc.extraSgprsNeeded());
-    Stats.ScratchReused += 2 - ExtraV;
+    Stats.ScratchReused += 3 - ExtraV;
     Stats.ScratchAboveKd += ExtraV;
   }
 
@@ -588,7 +621,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
 
   log() << "hotswap: cvt_sr_fp8_f32: patched CLAMP=1 (E5M3) at offset 0x"
         << utohexstr(DI.Offset) << " (" << ReplacementBytes.size()
-        << " bytes, scratch v" << *Out << "/v" << *Tmp
+        << " bytes, scratch v" << *Out << "/v" << *Tmp << "/v" << *TopByte
         << ", byte_sel=" << ByteSel << ")\n";
 
   return 1;
@@ -598,12 +631,12 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
 // v_cvt_f32_fp8 patch  (Case 1, instruction 3)
 // ---------------------------------------------------------------------------
 
-/// Patch a CLAMP=1 `v_cvt_f32_fp8` (UE5M3 → F32 unpack).
+/// Patch a CLAMP=1 `v_cvt_f32_fp8` (UE5M3 to F32 unpack).
 ///
 /// The unpack path extracts a UE5M3 byte from the source VGPR (position
-/// selected by byte_sel), converts it to F32 via a left-shift-7 → F16 →
+/// selected by byte_sel), converts it to F32 via a left-shift-7 to F16 to
 /// F32 pipeline, and applies fixups for the exponent-31 octave (bytes
-/// 0xF8–0xFE, which the F16 path maps to +Inf instead of finite values)
+/// 0xF8-0xFE, which the F16 path maps to +Inf instead of finite values)
 /// and UE5M3 NaN (byte 0xFF).
 ///
 /// Only VOP3 (_e64) encoding can carry CLAMP=1; VOP1 has no CLAMP bit and
@@ -646,7 +679,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
 
   ScratchAllocation SA = allocateScratch(Ctx, Idx);
 
-  // 2 scratch VGPRs: Out (byte extraction → F16 path → result),
+  // 2 scratch VGPRs: Out (byte extraction to F16 path to result),
   // Tmp (exp-31 direct construction + NaN constant).
   std::optional<unsigned> Out = SA.VgprAlloc.alloc();
   std::optional<unsigned> Tmp = SA.VgprAlloc.alloc();
@@ -707,7 +740,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   AsmOS << "v_lshlrev_b32 " << TmpName << ", 20, " << TmpName << "\n";
   AsmOS << "v_or_b32 " << TmpName << ", 0x47800000, " << TmpName << "\n";
 
-  // --- F16 base path (handles bytes 0x00–0xF7 correctly) ---
+  // --- F16 base path (handles bytes 0x00-0xF7 correctly) ---
   AsmOS << "v_lshlrev_b32 " << OutName << ", 7, " << OutName << "\n";
   AsmOS << "v_cvt_f32_f16 " << OutName << ", " << OutName << "\n";
 
@@ -716,7 +749,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   AsmOS << "v_cndmask_b32 " << OutName << ", " << OutName << ", " << TmpName
         << "\n";
 
-  // --- NaN override (byte 0xFF → hardware qNaN 0x7FA3D000) ---
+  // --- NaN override (byte 0xFF to hardware qNaN 0x7FA3D000) ---
   AsmOS << "s_mov_b32 vcc_lo, " << NaNName << "\n";
   AsmOS << "v_mov_b32 " << TmpName << ", 0x7FA3D000\n";
   AsmOS << "v_cndmask_b32 " << VdstStr << ", " << OutName << ", " << TmpName
@@ -761,7 +794,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
 } // anonymous namespace
 
 // ---------------------------------------------------------------------------
-// applyScratchPatches — strong override
+// applyScratchPatches - strong override
 // ---------------------------------------------------------------------------
 
 uint32_t applyScratchPatches(PatchContext &Ctx, size_t Idx) {

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -231,8 +231,11 @@ void emitF32ToUE5M3(raw_string_ostream &OS, StringRef Src, StringRef BareSrc,
 
   // RTE rounding: extract guard_bits = F16[6:0], shift to get preliminary
   // byte, then compute round_up = (guard_bits*2 + lsb) > 128.
+  // GFX1250 encodes v_cvt_f16_f32 as a True16 low-half write, so use a
+  // bitfield extract for F16[15:7] instead of a 32-bit shift that would pull
+  // preserved high-half bits into the FP8 byte.
   OS << "v_and_b32 " << Tmp << ", 0x7F, " << Out << "\n";
-  OS << "v_lshrrev_b32 " << Out << ", 7, " << Out << "\n";
+  OS << "v_bfe_u32 " << Out << ", " << Out << ", 7, 9\n";
   OS << "v_lshlrev_b32 " << Tmp << ", 1, " << Tmp << "\n";
   // v_bfi_b32: dst = (mask & insert) | (~mask & background)
   // With mask=0xFFFFFFFE: copies Tmp[31:1] and Out[0] → guard*2 + lsb
@@ -530,7 +533,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
 
   // --- F32 → F16 → UE5M3 (truncation, not RTE — SR noise handles rounding) ---
   AsmOS << "v_cvt_f16_f32 " << OutName << ", " << OutName << "\n";
-  AsmOS << "v_lshrrev_b32 " << OutName << ", 7, " << OutName << "\n";
+  AsmOS << "v_bfe_u32 " << OutName << ", " << OutName << ", 7, 9\n";
 
   // --- Overflow clamp (safety) ---
   AsmOS << "v_min_u32 " << OutName << ", 0xFE, " << OutName << "\n";

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -447,12 +447,12 @@ struct ScratchAlloc {
 
 std::optional<ScratchAlloc> tryAllocScratchVgpr(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
-  // findKernelAtOffset matches against symbol virtual addresses, so bias the
+  // findKernelAtAddress matches against symbol virtual addresses, so bias the
   // .text-relative DI.Offset by textAddr() (matching the other patches). A
   // bare offset misses when .text has a non-zero sh_addr, leaving KdVgprs ==
   // 0 and handing the allocator a live register.
   std::string KernelName =
-      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
   unsigned KdVgprs = 0;
   if (std::optional<unsigned> Opt =
           Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize))
@@ -502,7 +502,7 @@ std::optional<SgprScratchAlloc> tryAllocScratchSgpr(PatchContext &Ctx,
                                                     size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   std::string KernelName =
-      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
   std::optional<unsigned> KdSgprs = Ctx.Elf.getKernelSgprCount(KernelName);
   unsigned SgprKdCount = KdSgprs.value_or(Ctx.Config.MaxSgprs);
 
@@ -800,7 +800,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     StoreScratch = tryAllocScratchVgpr(Ctx, Idx);
     if (!StoreScratch) {
       std::string KernelName =
-          Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+          Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
       StringRef KernelDisplay =
           KernelName.empty() ? StringRef("<unknown>") : StringRef(KernelName);
       std::optional<uint32_t> LdsSize =

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -241,7 +241,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   unsigned Src1Hi = Src1Lo + 1;
 
   std::string KernelName =
-      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
   std::optional<unsigned> KdVgprs =
       Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize);
   unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
@@ -551,7 +551,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   unsigned NegFlags = extractNegFlags(Raw);
 
   std::string KernelName =
-      Ctx.Elf.findKernelAtOffset(DI.Offset + Ctx.Elf.textAddr());
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
   std::optional<unsigned> KdVgprs =
       Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize);
   unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
@@ -11,8 +11,8 @@
 // COM:   Unpack byte_sel=3 -> v_lshrrev_b32 (shift=24)
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-cvt-sr-fp8.s   — base SR conversion (byte_sel=0 and 2)
-// COM:   hotswap-cvt-f32-fp8.s  — base unpack conversion (byte_sel=0 and 2)
+// COM:   hotswap-cvt-sr-fp8.s   - base SR conversion (byte_sel=0 and 2)
+// COM:   hotswap-cvt-f32-fp8.s  - base unpack conversion (byte_sel=0 and 2)
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -34,15 +34,20 @@
 
 // ---- Kernel 1: SR byte_sel=0 (single v_bfi_b32 merge) ------------------------
 //
-// COM: byte_sel=0 merges via a single v_bfi_b32 (mask 0xFF) — no shift needed.
+// COM: byte_sel=0 merges via a single v_bfi_b32 (mask 0xFF) with no shift.
 
 // SR0-LABEL: <test_cvt_sr_fp8_byte0>:
 // SR0:       s_branch
 // COM: --- VCC save ---
 // SR0:       s_mov_b32
 // SR0-NEXT:  v_and_b32{{.*}}0x7fffffff, v1
-// COM: --- Byte merge (byte_sel=0: single bfi) ---
+// COM: --- High-range direct encode, then final NaN select ---
+// SR0:       v_cmp_le_f32{{.*}}0x47800000
 // SR0:       v_cndmask_b32
+// COM: --- Byte merge (byte_sel=0: single bfi) ---
+// SR0-NEXT:  s_mov_b32
+// SR0-NEXT:  v_mov_b32
+// SR0-NEXT:  v_cndmask_b32
 // SR0-NEXT:  v_bfi_b32 v0,
 // COM: --- VCC restore ---
 // SR0-NEXT:  s_mov_b32
@@ -67,8 +72,13 @@ test_cvt_sr_fp8_byte0:
 // SR1:       s_branch
 // COM: --- VCC save + NaN detection (anchor on unique src v4) ---
 // SR1:       v_and_b32{{.*}}0x7fffffff, v4
-// COM: --- Byte merge (byte_sel=1: shift + bfi) ---
+// COM: --- High-range direct encode, then final NaN select ---
+// SR1:       v_cmp_le_f32{{.*}}0x47800000
 // SR1:       v_cndmask_b32
+// COM: --- Byte merge (byte_sel=1: shift + bfi) ---
+// SR1-NEXT:  s_mov_b32
+// SR1-NEXT:  v_mov_b32
+// SR1-NEXT:  v_cndmask_b32
 // SR1-NEXT:  v_lshlrev_b32
 // SR1-NEXT:  v_bfi_b32 v3,
 // COM: --- VCC restore ---
@@ -96,8 +106,13 @@ test_cvt_sr_fp8_byte1:
 // SR2:       s_branch
 // COM: --- VCC save + NaN detection (anchor on unique src v7) ---
 // SR2:       v_and_b32{{.*}}0x7fffffff, v7
-// COM: --- Byte merge (byte_sel=2: shift + bfi) ---
+// COM: --- High-range direct encode, then final NaN select ---
+// SR2:       v_cmp_le_f32{{.*}}0x47800000
 // SR2:       v_cndmask_b32
+// COM: --- Byte merge (byte_sel=2: shift + bfi) ---
+// SR2-NEXT:  s_mov_b32
+// SR2-NEXT:  v_mov_b32
+// SR2-NEXT:  v_cndmask_b32
 // SR2-NEXT:  v_lshlrev_b32
 // SR2-NEXT:  v_bfi_b32 v6,
 // COM: --- VCC restore ---
@@ -125,8 +140,13 @@ test_cvt_sr_fp8_byte2:
 // SR3:       s_branch
 // COM: --- VCC save + NaN detection (anchor on unique src v10) ---
 // SR3:       v_and_b32{{.*}}0x7fffffff, v10
-// COM: --- Byte merge (byte_sel=3: shift + bfi) ---
+// COM: --- High-range direct encode, then final NaN select ---
+// SR3:       v_cmp_le_f32{{.*}}0x47800000
 // SR3:       v_cndmask_b32
+// COM: --- Byte merge (byte_sel=3: shift + bfi) ---
+// SR3-NEXT:  s_mov_b32
+// SR3-NEXT:  v_mov_b32
+// SR3-NEXT:  v_cndmask_b32
 // SR3-NEXT:  v_lshlrev_b32
 // SR3-NEXT:  v_bfi_b32 v9,
 // COM: --- VCC restore ---

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
@@ -1,0 +1,46 @@
+// COM: Test that zero bytes inside a function symbol are not treated as a
+// COM: zero-fill NOP sled for v_cvt_pk_fp8_f32 literal-source expansion.
+// COM:
+// COM: The zero block below is executable .text covered by the function's
+// COM: STT_FUNC range, so the rewriter must leave it alone and append a
+// COM: trampoline instead of branching into the zero bytes.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: growWithTrampolines: grew ELF
+// API-SAME: 1 trampoline
+// API: REWRITE: SUCCESS
+// API: IDEMPOTENT: YES
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_cvt_pk_fp8_zero_in_function
+.type test_cvt_pk_fp8_zero_in_function,@function
+test_cvt_pk_fp8_zero_in_function:
+  v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp
+  s_endpgm
+  .zero 768
+.Ltest_cvt_pk_fp8_zero_in_function_end:
+.size test_cvt_pk_fp8_zero_in_function, .Ltest_cvt_pk_fp8_zero_in_function_end-test_cvt_pk_fp8_zero_in_function
+
+// DISASM-LABEL: <test_cvt_pk_fp8_zero_in_function>:
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  s_nop
+// DISASM-NEXT:  s_nop
+// DISASM-NEXT:  s_endpgm
+// DISASM:       v_mov_b32{{.*}}0x477f0000
+// DISASM:       v_lshl_or_b32
+// DISASM:       s_branch{{.*}}<test_cvt_pk_fp8_zero_in_function+0xc>
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_cvt_pk_fp8_zero_in_function
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -1,0 +1,69 @@
+// COM: Test v_cvt_pk_fp8_f32 CLAMP=1 literal sources using zero-fill padding.
+// COM:
+// COM: Generated hipblasLt initializer kernels can leave zero-filled alignment
+// COM: gaps between function-symbol ranges. Those gaps are writable .text
+// COM: space even though they are not decoded as s_nop instructions, and they
+// COM: are often the only local landing zones large enough for the expanded
+// COM: literal-source FP8 pack replacement.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --dump %t.out.elf --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: REWRITE: SUCCESS
+// API: IDEMPOTENT: YES
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=ZERO %s
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_cvt_pk_fp8_zero_fill_source
+.p2align 8
+.type test_cvt_pk_fp8_zero_fill_source,@function
+test_cvt_pk_fp8_zero_fill_source:
+  v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp
+  s_endpgm
+.Ltest_cvt_pk_fp8_zero_fill_source_end:
+.size test_cvt_pk_fp8_zero_fill_source, .Ltest_cvt_pk_fp8_zero_fill_source_end-test_cvt_pk_fp8_zero_fill_source
+
+.globl test_cvt_pk_fp8_zero_fill_sled
+test_cvt_pk_fp8_zero_fill_sled:
+  .zero 256
+
+.globl test_cvt_pk_fp8_zero_fill_after
+.p2align 8
+.type test_cvt_pk_fp8_zero_fill_after,@function
+test_cvt_pk_fp8_zero_fill_after:
+  s_endpgm
+.Ltest_cvt_pk_fp8_zero_fill_after_end:
+.size test_cvt_pk_fp8_zero_fill_after, .Ltest_cvt_pk_fp8_zero_fill_after_end-test_cvt_pk_fp8_zero_fill_after
+
+// ZERO-LABEL: <test_cvt_pk_fp8_zero_fill_source>:
+// ZERO-NEXT:  s_branch{{.*}}test_cvt_pk_fp8_zero_fill_sled
+// ZERO-NEXT:  s_nop
+// ZERO-NEXT:  s_nop
+// ZERO-NEXT:  s_endpgm
+// ZERO-LABEL: <test_cvt_pk_fp8_zero_fill_sled>:
+// ZERO:       s_mov_b32
+// ZERO-NEXT:  v_mov_b32{{.*}}0x477f0000
+// ZERO-NEXT:  v_mov_b32{{.*}}0x477f0000
+// ZERO-NEXT:  v_and_b32{{.*}}0x7fffffff
+// ZERO:       v_lshl_or_b32
+// ZERO-NEXT:  v_bfi_b32 v4,
+// ZERO-NEXT:  s_mov_b32
+// ZERO-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_zero_fill_source+0xc>
+// ZERO-LABEL: <test_cvt_pk_fp8_zero_fill_after>:
+// ZERO-NEXT:  s_endpgm
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_cvt_pk_fp8_zero_fill_source
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+.amdhsa_kernel test_cvt_pk_fp8_zero_fill_after
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -30,7 +30,7 @@ test_cvt_pk_fp8_zero_fill_source:
 
 .globl test_cvt_pk_fp8_zero_fill_sled
 test_cvt_pk_fp8_zero_fill_sled:
-  .zero 256
+  .zero 768
 
 .globl test_cvt_pk_fp8_zero_fill_after
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -6,9 +6,9 @@
 // COM: conversion, RTE rounding, overflow clamping, and NaN override.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-cvt-fp8-modifiers.s — source modifier variants
-// COM:   hotswap-cvt-fp8-nosled.s    — trampoline fallback path
-// COM:   hotswap-cvt-fp8-multi.s     — multi-site stacking
+// COM:   hotswap-cvt-fp8-modifiers.s - source modifier variants
+// COM:   hotswap-cvt-fp8-nosled.s    - trampoline fallback path
+// COM:   hotswap-cvt-fp8-multi.s     - multi-site stacking
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -29,7 +29,7 @@
 // ---- Kernel 1: CLAMP=1, low half (should be patched) --------------------------
 //
 // COM: Original site is replaced with s_branch. Trampoline body: VCC save,
-// COM: two per-source F32→UE5M3 conversions (15 instructions each), pack
+// COM: two per-source F32->UE5M3 conversions (23 instructions each), pack
 // COM: into 16-bit pair, merge into low half of vdst via v_bfi_b32, VCC restore.
 
 // LOW-LABEL: <test_cvt_pk_fp8_low>:
@@ -41,6 +41,12 @@
 // LOW-NEXT:  v_cmp_lt_u32{{.*}}0x7f800000
 // LOW-NEXT:  s_mov_b32
 // LOW-NEXT:  v_max_num_f32{{.*}}, 0, v1
+// LOW-NEXT:  v_cmp_le_f32{{.*}}0x47780000
+// LOW-NEXT:  s_mov_b32
+// LOW-NEXT:  v_mul_f32{{.*}}0x39000000
+// LOW-NEXT:  v_cvt_nearest_i32_f32
+// LOW-NEXT:  v_add{{.*}}0xf0
+// LOW-NEXT:  v_min_u32{{.*}}0xfe
 // LOW-NEXT:  v_cvt_f16_f32
 // LOW-NEXT:  v_and_b32
 // LOW-NEXT:  v_bfe_u32
@@ -48,7 +54,9 @@
 // LOW-NEXT:  v_bfi_b32
 // LOW-NEXT:  v_cmp_lt_u32{{.*}}0x80
 // LOW-NEXT:  v_add_co_ci_u32
-// LOW-NEXT:  v_min_u32
+// LOW-NEXT:  v_min_u32{{.*}}0xfe
+// LOW-NEXT:  s_mov_b32
+// LOW-NEXT:  v_cndmask_b32
 // LOW-NEXT:  s_mov_b32
 // LOW-NEXT:  v_mov_b32
 // LOW-NEXT:  v_cndmask_b32
@@ -57,6 +65,12 @@
 // LOW-NEXT:  v_cmp_lt_u32{{.*}}0x7f800000
 // LOW-NEXT:  s_mov_b32
 // LOW-NEXT:  v_max_num_f32{{.*}}, 0, v2
+// LOW-NEXT:  v_cmp_le_f32{{.*}}0x47780000
+// LOW-NEXT:  s_mov_b32
+// LOW-NEXT:  v_mul_f32{{.*}}0x39000000
+// LOW-NEXT:  v_cvt_nearest_i32_f32
+// LOW-NEXT:  v_add{{.*}}0xf0
+// LOW-NEXT:  v_min_u32{{.*}}0xfe
 // LOW-NEXT:  v_cvt_f16_f32
 // LOW-NEXT:  v_and_b32
 // LOW-NEXT:  v_bfe_u32
@@ -64,7 +78,9 @@
 // LOW-NEXT:  v_bfi_b32
 // LOW-NEXT:  v_cmp_lt_u32{{.*}}0x80
 // LOW-NEXT:  v_add_co_ci_u32
-// LOW-NEXT:  v_min_u32
+// LOW-NEXT:  v_min_u32{{.*}}0xfe
+// LOW-NEXT:  s_mov_b32
+// LOW-NEXT:  v_cndmask_b32
 // LOW-NEXT:  s_mov_b32
 // LOW-NEXT:  v_mov_b32
 // LOW-NEXT:  v_cndmask_b32
@@ -97,6 +113,12 @@ test_cvt_pk_fp8_low:
 // HIGH-NEXT:  v_cmp_lt_u32{{.*}}0x7f800000
 // HIGH-NEXT:  s_mov_b32
 // HIGH-NEXT:  v_max_num_f32{{.*}}, 0, v6
+// HIGH-NEXT:  v_cmp_le_f32{{.*}}0x47780000
+// HIGH-NEXT:  s_mov_b32
+// HIGH-NEXT:  v_mul_f32{{.*}}0x39000000
+// HIGH-NEXT:  v_cvt_nearest_i32_f32
+// HIGH-NEXT:  v_add{{.*}}0xf0
+// HIGH-NEXT:  v_min_u32{{.*}}0xfe
 // HIGH-NEXT:  v_cvt_f16_f32
 // HIGH-NEXT:  v_and_b32
 // HIGH-NEXT:  v_bfe_u32
@@ -104,7 +126,9 @@ test_cvt_pk_fp8_low:
 // HIGH-NEXT:  v_bfi_b32
 // HIGH-NEXT:  v_cmp_lt_u32{{.*}}0x80
 // HIGH-NEXT:  v_add_co_ci_u32
-// HIGH-NEXT:  v_min_u32
+// HIGH-NEXT:  v_min_u32{{.*}}0xfe
+// HIGH-NEXT:  s_mov_b32
+// HIGH-NEXT:  v_cndmask_b32
 // HIGH-NEXT:  s_mov_b32
 // HIGH-NEXT:  v_mov_b32
 // HIGH-NEXT:  v_cndmask_b32
@@ -113,6 +137,12 @@ test_cvt_pk_fp8_low:
 // HIGH-NEXT:  v_cmp_lt_u32{{.*}}0x7f800000
 // HIGH-NEXT:  s_mov_b32
 // HIGH-NEXT:  v_max_num_f32{{.*}}, 0, v7
+// HIGH-NEXT:  v_cmp_le_f32{{.*}}0x47780000
+// HIGH-NEXT:  s_mov_b32
+// HIGH-NEXT:  v_mul_f32{{.*}}0x39000000
+// HIGH-NEXT:  v_cvt_nearest_i32_f32
+// HIGH-NEXT:  v_add{{.*}}0xf0
+// HIGH-NEXT:  v_min_u32{{.*}}0xfe
 // HIGH-NEXT:  v_cvt_f16_f32
 // HIGH-NEXT:  v_and_b32
 // HIGH-NEXT:  v_bfe_u32
@@ -120,7 +150,9 @@ test_cvt_pk_fp8_low:
 // HIGH-NEXT:  v_bfi_b32
 // HIGH-NEXT:  v_cmp_lt_u32{{.*}}0x80
 // HIGH-NEXT:  v_add_co_ci_u32
-// HIGH-NEXT:  v_min_u32
+// HIGH-NEXT:  v_min_u32{{.*}}0xfe
+// HIGH-NEXT:  s_mov_b32
+// HIGH-NEXT:  v_cndmask_b32
 // HIGH-NEXT:  s_mov_b32
 // HIGH-NEXT:  v_mov_b32
 // HIGH-NEXT:  v_cndmask_b32
@@ -163,25 +195,22 @@ test_cvt_pk_fp8_noclamp:
 // COM: Literal VOP3 operands are decoded as immediate MC operands and extend
 // COM: the instruction to 12 bytes. The patch materializes the literal into
 // COM: scratch VGPRs before running the normal per-source conversion sequence.
-// COM: The replacement body can be emitted into any nearby NOP sled; in this
-// COM: fixture it uses the sled after test_cvt_pk_fp8_noclamp and branches
-// COM: back to test_cvt_pk_fp8_literal+0xc.
+// COM: The replacement body can be emitted into any nearby NOP sled, so this
+// COM: check verifies the original 12-byte slot and the generated body rather
+// COM: than a specific sled label.
 
-// LITERAL-LABEL: <test_cvt_pk_fp8_noclamp>:
-// LITERAL:       v_cvt_pk_fp8_f32
-// LITERAL:       s_endpgm
-// LITERAL-NEXT:  s_mov_b32
-// LITERAL-NEXT:  v_mov_b32{{.*}}0x477f0000
-// LITERAL-NEXT:  v_mov_b32{{.*}}0x477f0000
-// LITERAL-NEXT:  v_and_b32{{.*}}0x7fffffff
-// LITERAL:       v_lshl_or_b32
-// LITERAL-NEXT:  v_bfi_b32 v4,
-// LITERAL:       s_branch{{.*}}<test_cvt_pk_fp8_literal+0xc>
 // LITERAL-LABEL: <test_cvt_pk_fp8_literal>:
-// LITERAL-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_noclamp+0xc>
+// LITERAL-NEXT:  s_branch
 // LITERAL-NEXT:  s_nop
 // LITERAL-NEXT:  s_nop
 // LITERAL-NEXT:  s_endpgm
+// LITERAL:       v_mov_b32{{.*}}0x477f0000
+// LITERAL-NEXT:  v_mov_b32{{.*}}0x477f0000
+// LITERAL-NEXT:  v_and_b32{{.*}}0x7fffffff
+// LITERAL:       v_cmp_le_f32{{.*}}0x47780000
+// LITERAL:       v_lshl_or_b32
+// LITERAL-NEXT:  v_bfi_b32 v4,
+// LITERAL:       s_branch{{.*}}<test_cvt_pk_fp8_literal+0xc>
 
 .globl test_cvt_pk_fp8_literal
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -12,10 +12,12 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --dump %t.out.elf --check-idempotent \
+// RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: liveness: kernel test_cvt_pk_fp8_literal:
+// API-SAME: sgprs_before=8, sgprs_after=16
 // API: REWRITE: SUCCESS
 // API: IDEMPOTENT: YES
 
@@ -41,7 +43,7 @@
 // LOW-NEXT:  v_max_num_f32{{.*}}, 0, v1
 // LOW-NEXT:  v_cvt_f16_f32
 // LOW-NEXT:  v_and_b32
-// LOW-NEXT:  v_lshrrev_b32
+// LOW-NEXT:  v_bfe_u32
 // LOW-NEXT:  v_lshlrev_b32
 // LOW-NEXT:  v_bfi_b32
 // LOW-NEXT:  v_cmp_lt_u32{{.*}}0x80
@@ -57,7 +59,7 @@
 // LOW-NEXT:  v_max_num_f32{{.*}}, 0, v2
 // LOW-NEXT:  v_cvt_f16_f32
 // LOW-NEXT:  v_and_b32
-// LOW-NEXT:  v_lshrrev_b32
+// LOW-NEXT:  v_bfe_u32
 // LOW-NEXT:  v_lshlrev_b32
 // LOW-NEXT:  v_bfi_b32
 // LOW-NEXT:  v_cmp_lt_u32{{.*}}0x80
@@ -97,7 +99,7 @@ test_cvt_pk_fp8_low:
 // HIGH-NEXT:  v_max_num_f32{{.*}}, 0, v6
 // HIGH-NEXT:  v_cvt_f16_f32
 // HIGH-NEXT:  v_and_b32
-// HIGH-NEXT:  v_lshrrev_b32
+// HIGH-NEXT:  v_bfe_u32
 // HIGH-NEXT:  v_lshlrev_b32
 // HIGH-NEXT:  v_bfi_b32
 // HIGH-NEXT:  v_cmp_lt_u32{{.*}}0x80
@@ -113,7 +115,7 @@ test_cvt_pk_fp8_low:
 // HIGH-NEXT:  v_max_num_f32{{.*}}, 0, v7
 // HIGH-NEXT:  v_cvt_f16_f32
 // HIGH-NEXT:  v_and_b32
-// HIGH-NEXT:  v_lshrrev_b32
+// HIGH-NEXT:  v_bfe_u32
 // HIGH-NEXT:  v_lshlrev_b32
 // HIGH-NEXT:  v_bfi_b32
 // HIGH-NEXT:  v_cmp_lt_u32{{.*}}0x80

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -22,6 +22,7 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=LOW %s
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=HIGH %s
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=NOCLAMP %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=LITERAL %s
 
 // ---- Kernel 1: CLAMP=1, low half (should be patched) --------------------------
 //
@@ -155,6 +156,40 @@ test_cvt_pk_fp8_noclamp:
 .Ltest_cvt_pk_fp8_noclamp_end:
 .size test_cvt_pk_fp8_noclamp, .Ltest_cvt_pk_fp8_noclamp_end-test_cvt_pk_fp8_noclamp
 
+// ---- Kernel 4: CLAMP=1 with literal F32 sources (12-byte encoding) -----------
+//
+// COM: Literal VOP3 operands are decoded as immediate MC operands and extend
+// COM: the instruction to 12 bytes. The patch materializes the literal into
+// COM: scratch VGPRs before running the normal per-source conversion sequence.
+// COM: The replacement body can be emitted into any nearby NOP sled; in this
+// COM: fixture it uses the sled after test_cvt_pk_fp8_noclamp and branches
+// COM: back to test_cvt_pk_fp8_literal+0xc.
+
+// LITERAL-LABEL: <test_cvt_pk_fp8_noclamp>:
+// LITERAL:       v_cvt_pk_fp8_f32
+// LITERAL:       s_endpgm
+// LITERAL-NEXT:  s_mov_b32
+// LITERAL-NEXT:  v_mov_b32{{.*}}0x477f0000
+// LITERAL-NEXT:  v_mov_b32{{.*}}0x477f0000
+// LITERAL-NEXT:  v_and_b32{{.*}}0x7fffffff
+// LITERAL:       v_lshl_or_b32
+// LITERAL-NEXT:  v_bfi_b32 v4,
+// LITERAL:       s_branch{{.*}}<test_cvt_pk_fp8_literal+0xc>
+// LITERAL-LABEL: <test_cvt_pk_fp8_literal>:
+// LITERAL-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_noclamp+0xc>
+// LITERAL-NEXT:  s_nop
+// LITERAL-NEXT:  s_nop
+// LITERAL-NEXT:  s_endpgm
+
+.globl test_cvt_pk_fp8_literal
+.p2align 8
+.type test_cvt_pk_fp8_literal,@function
+test_cvt_pk_fp8_literal:
+  v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp
+  s_endpgm
+.Ltest_cvt_pk_fp8_literal_end:
+.size test_cvt_pk_fp8_literal, .Ltest_cvt_pk_fp8_literal_end-test_cvt_pk_fp8_literal
+
 .rodata
 .p2align 8
 .amdhsa_kernel test_cvt_pk_fp8_low
@@ -167,5 +202,9 @@ test_cvt_pk_fp8_noclamp:
 .end_amdhsa_kernel
 .amdhsa_kernel test_cvt_pk_fp8_noclamp
   .amdhsa_next_free_vgpr 13
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+.amdhsa_kernel test_cvt_pk_fp8_literal
+  .amdhsa_next_free_vgpr 5
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -3,7 +3,9 @@
 // COM: Creates a minimal gfx1250 code object containing v_cvt_pk_fp8_f32
 // COM: with clamp (E5M3 mode), runs the hotswap rewrite, and verifies the
 // COM: replacement sequence covers: NaN detection, base F32->F16->UE5M3
-// COM: conversion, RTE rounding, overflow clamping, and NaN override.
+// COM: conversion, RTE rounding, overflow clamping, NaN override, literal
+// COM: sources, mixed literal/register sources, non-inline fractional
+// COM: literals, and inline F32 constants.
 // COM:
 // COM: Companion tests:
 // COM:   hotswap-cvt-fp8-modifiers.s - source modifier variants
@@ -25,6 +27,9 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=HIGH %s
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=NOCLAMP %s
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=LITERAL %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=MIXED0 %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=MIXED1 %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=INLINE %s
 
 // ---- Kernel 1: CLAMP=1, low half (should be patched) --------------------------
 //
@@ -221,6 +226,72 @@ test_cvt_pk_fp8_literal:
 .Ltest_cvt_pk_fp8_literal_end:
 .size test_cvt_pk_fp8_literal, .Ltest_cvt_pk_fp8_literal_end-test_cvt_pk_fp8_literal
 
+// ---- Kernel 5: 12-byte literal src0, register src1 --------------------------
+
+// MIXED0-LABEL: <test_cvt_pk_fp8_literal_src0>:
+// MIXED0-NEXT:  s_branch
+// MIXED0-NEXT:  s_nop
+// MIXED0-NEXT:  s_nop
+// MIXED0-NEXT:  s_endpgm
+// MIXED0:       v_mov_b32{{.*}}0x477f0000
+// MIXED0:       v_and_b32{{.*}}0x7fffffff
+// MIXED0:       v_and_b32{{.*}}0x7fffffff, v17
+// MIXED0:       v_bfi_b32 v16,
+// MIXED0:       s_branch{{.*}}<test_cvt_pk_fp8_literal_src0+0xc>
+
+.globl test_cvt_pk_fp8_literal_src0
+.p2align 8
+.type test_cvt_pk_fp8_literal_src0,@function
+test_cvt_pk_fp8_literal_src0:
+  v_cvt_pk_fp8_f32 v16, 0x477f0000, v17 clamp
+  s_endpgm
+.Ltest_cvt_pk_fp8_literal_src0_end:
+.size test_cvt_pk_fp8_literal_src0, .Ltest_cvt_pk_fp8_literal_src0_end-test_cvt_pk_fp8_literal_src0
+
+// ---- Kernel 6: register src0, 12-byte literal src1 --------------------------
+
+// MIXED1-LABEL: <test_cvt_pk_fp8_literal_src1>:
+// MIXED1-NEXT:  s_branch
+// MIXED1-NEXT:  s_nop
+// MIXED1-NEXT:  s_nop
+// MIXED1-NEXT:  s_endpgm
+// MIXED1:       v_mov_b32{{.*}}0x3eaaaaab
+// MIXED1:       v_and_b32{{.*}}0x7fffffff, v21
+// MIXED1:       v_and_b32{{.*}}0x7fffffff
+// MIXED1:       v_bfi_b32 v20,
+// MIXED1:       s_branch{{.*}}<test_cvt_pk_fp8_literal_src1+0xc>
+
+.globl test_cvt_pk_fp8_literal_src1
+.p2align 8
+.type test_cvt_pk_fp8_literal_src1,@function
+test_cvt_pk_fp8_literal_src1:
+  v_cvt_pk_fp8_f32 v20, v21, 0.3333333432674408 clamp
+  s_endpgm
+.Ltest_cvt_pk_fp8_literal_src1_end:
+.size test_cvt_pk_fp8_literal_src1, .Ltest_cvt_pk_fp8_literal_src1_end-test_cvt_pk_fp8_literal_src1
+
+// ---- Kernel 7: inline fractional constants (8-byte encoding) ----------------
+
+// INLINE-LABEL: <test_cvt_pk_fp8_inline_constants>:
+// INLINE-NEXT:  s_branch
+// INLINE-NEXT:  s_nop
+// INLINE-NEXT:  s_endpgm
+// INLINE:       v_mov_b32{{.*}}1.0
+// INLINE-NEXT:  v_mov_b32{{.*}}0.5
+// INLINE-NEXT:  v_and_b32{{.*}}0x7fffffff
+// INLINE:       v_lshl_or_b32
+// INLINE-NEXT:  v_bfi_b32 v24,
+// INLINE:       s_branch{{.*}}<test_cvt_pk_fp8_inline_constants+0x8>
+
+.globl test_cvt_pk_fp8_inline_constants
+.p2align 8
+.type test_cvt_pk_fp8_inline_constants,@function
+test_cvt_pk_fp8_inline_constants:
+  v_cvt_pk_fp8_f32 v24, 1.0, 0.5 clamp
+  s_endpgm
+.Ltest_cvt_pk_fp8_inline_constants_end:
+.size test_cvt_pk_fp8_inline_constants, .Ltest_cvt_pk_fp8_inline_constants_end-test_cvt_pk_fp8_inline_constants
+
 .rodata
 .p2align 8
 .amdhsa_kernel test_cvt_pk_fp8_low
@@ -237,5 +308,17 @@ test_cvt_pk_fp8_literal:
 .end_amdhsa_kernel
 .amdhsa_kernel test_cvt_pk_fp8_literal
   .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+.amdhsa_kernel test_cvt_pk_fp8_literal_src0
+  .amdhsa_next_free_vgpr 18
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+.amdhsa_kernel test_cvt_pk_fp8_literal_src1
+  .amdhsa_next_free_vgpr 22
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+.amdhsa_kernel test_cvt_pk_fp8_inline_constants
+  .amdhsa_next_free_vgpr 25
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -6,9 +6,9 @@
 // COM: F32->F16->UE5M3 conversion, overflow clamping, NaN override, and byte merge.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-cvt-fp8-modifiers.s — source modifier variants
-// COM:   hotswap-cvt-fp8-nosled.s    — trampoline fallback path
-// COM:   hotswap-cvt-fp8-multi.s     — multi-site stacking
+// COM:   hotswap-cvt-fp8-modifiers.s - source modifier variants
+// COM:   hotswap-cvt-fp8-nosled.s    - trampoline fallback path
+// COM:   hotswap-cvt-fp8-multi.s     - multi-site stacking
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -27,7 +27,7 @@
 //
 // COM: Original site is replaced with s_branch forward to trampoline.
 // COM: Trampoline body: VCC save, NaN detection, clamp negative, stochastic
-// COM: noise injection, F32→F16→UE5M3 conversion, overflow clamping,
+// COM: noise injection, F32->F16->UE5M3 conversion, overflow clamping,
 // COM: NaN override, byte merge (single bfi for byte_sel=0), VCC restore.
 
 // BYTE0-LABEL: <test_cvt_sr_fp8_byte0>:
@@ -47,11 +47,20 @@
 // BYTE0-NEXT:  v_and_b32{{.*}}0x7fffff
 // BYTE0-NEXT:  v_max_num_f32{{.*}}, 0, v1
 // BYTE0-NEXT:  v_bfi_b32
+// COM: --- High-range direct path ---
+// BYTE0-NEXT:  v_cmp_le_f32{{.*}}0x47800000
+// BYTE0-NEXT:  s_mov_b32
+// BYTE0-NEXT:  v_mul_f32{{.*}}0x39000000
+// BYTE0-NEXT:  v_cvt_floor_i32_f32
+// BYTE0-NEXT:  v_add{{.*}}0xf0
+// BYTE0-NEXT:  v_min_u32{{.*}}0xfe
 // COM: --- F32 -> F16 -> UE5M3 ---
 // BYTE0-NEXT:  v_cvt_f16_f32
 // BYTE0-NEXT:  v_bfe_u32
-// COM: --- Overflow clamp ---
-// BYTE0-NEXT:  v_min_u32
+// COM: --- Overflow clamp and high-range select ---
+// BYTE0-NEXT:  v_min_u32{{.*}}0xfe
+// BYTE0-NEXT:  s_mov_b32
+// BYTE0-NEXT:  v_cndmask_b32
 // COM: --- NaN override ---
 // BYTE0-NEXT:  s_mov_b32
 // BYTE0-NEXT:  v_mov_b32
@@ -92,11 +101,20 @@ test_cvt_sr_fp8_byte0:
 // BYTE2-NEXT:  v_and_b32{{.*}}0x7fffff
 // BYTE2-NEXT:  v_max_num_f32{{.*}}, 0, v6
 // BYTE2-NEXT:  v_bfi_b32
+// COM: --- High-range direct path ---
+// BYTE2-NEXT:  v_cmp_le_f32{{.*}}0x47800000
+// BYTE2-NEXT:  s_mov_b32
+// BYTE2-NEXT:  v_mul_f32{{.*}}0x39000000
+// BYTE2-NEXT:  v_cvt_floor_i32_f32
+// BYTE2-NEXT:  v_add{{.*}}0xf0
+// BYTE2-NEXT:  v_min_u32{{.*}}0xfe
 // COM: --- F32 -> F16 -> UE5M3 ---
 // BYTE2-NEXT:  v_cvt_f16_f32
 // BYTE2-NEXT:  v_bfe_u32
-// COM: --- Overflow clamp ---
-// BYTE2-NEXT:  v_min_u32
+// COM: --- Overflow clamp and high-range select ---
+// BYTE2-NEXT:  v_min_u32{{.*}}0xfe
+// BYTE2-NEXT:  s_mov_b32
+// BYTE2-NEXT:  v_cndmask_b32
 // COM: --- NaN override ---
 // BYTE2-NEXT:  s_mov_b32
 // BYTE2-NEXT:  v_mov_b32

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -49,7 +49,7 @@
 // BYTE0-NEXT:  v_bfi_b32
 // COM: --- F32 -> F16 -> UE5M3 ---
 // BYTE0-NEXT:  v_cvt_f16_f32
-// BYTE0-NEXT:  v_lshrrev_b32
+// BYTE0-NEXT:  v_bfe_u32
 // COM: --- Overflow clamp ---
 // BYTE0-NEXT:  v_min_u32
 // COM: --- NaN override ---
@@ -94,7 +94,7 @@ test_cvt_sr_fp8_byte0:
 // BYTE2-NEXT:  v_bfi_b32
 // COM: --- F32 -> F16 -> UE5M3 ---
 // BYTE2-NEXT:  v_cvt_f16_f32
-// BYTE2-NEXT:  v_lshrrev_b32
+// BYTE2-NEXT:  v_bfe_u32
 // COM: --- Overflow clamp ---
 // BYTE2-NEXT:  v_min_u32
 // COM: --- NaN override ---

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,18 +1,18 @@
 // COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
 // COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
 // COM: the descriptor's base SGPR. Base operand variants via NOP sled:
-// COM:   dead SGPR  — only s_pack_hh prepended (no save/restore)
-// COM:   live SGPR  — s_mov save, s_pack_hh, tensor, s_mov restore
-// COM:   alt descriptor — different SGPR range (s[16:23]) for pack target
-// COM:   SGPR redef — descriptor SGPR overwritten before use (dead path)
-// COM:   zero-size FUNC — live path when the function symbol has st_size == 0
+// COM:   dead SGPR - only s_pack_hh prepended (no save/restore)
+// COM:   live SGPR - s_mov save, s_pack_hh, tensor, s_mov restore
+// COM:   alt descriptor - different SGPR range (s[16:23]) for pack target
+// COM:   SGPR redef - descriptor SGPR overwritten before use (dead path)
+// COM:   zero-size FUNC - live path when the function symbol has st_size == 0
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
 // COM: s_branch checks.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-trampoline-tensor-nosled.s     — trampoline fallback path
-// COM:   hotswap-trampoline-tensor-multi.s      — multi-site stacking
-// COM:   hotswap-trampoline-tensor-liveness.s   — isSgprLiveAfter edge cases
+// COM:   hotswap-trampoline-tensor-nosled.s     - trampoline fallback path
+// COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
+// COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -22,7 +22,7 @@
 // RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API-NOT: kernel descriptor symbol '.kd' not found
-// API: hotswap: tensor_load_to_lds: s4 live, save/restore via v{{[1-9][0-9]*}}
+// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
 // API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
@@ -73,7 +73,7 @@
 // COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
 // COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
 // COM: isSgprLiveAfter sees a def-before-use and takes the dead path
-// COM: — no save/restore needed.
+// COM: - no save/restore needed.
 // DISASM-LABEL: <test_tensor_sgpr_redef>:
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
@@ -90,12 +90,12 @@
 // COM: find the descriptor so scratch allocation does not fall back to v0.
 // DISASM-LABEL: <test_tensor_zero_size>:
 // DISASM: s_branch
-// DISASM: s_mov_b32
-// DISASM: v_writelane_b32
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: v_readlane_b32
-// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: s_mov_b32 [[ZERO_SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[ZERO_SCRATCH]]
+// DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -5,6 +5,7 @@
 // COM:   live SGPR  — s_mov save, s_pack_hh, tensor, s_mov restore
 // COM:   alt descriptor — different SGPR range (s[16:23]) for pack target
 // COM:   SGPR redef — descriptor SGPR overwritten before use (dead path)
+// COM:   zero-size FUNC — live path when the function symbol has st_size == 0
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
 // COM: s_branch checks.
 // COM:
@@ -15,10 +16,14 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
+// RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
+// API-NOT: kernel descriptor symbol '.kd' not found
+// API: hotswap: tensor_load_to_lds: s4 live, save/restore via v{{[1-9][0-9]*}}
+// API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
@@ -79,6 +84,18 @@
 // DISASM: s_branch
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
+
+// COM: Kernel 5 (zero-size FUNC): real Tensile objects can omit `.size`,
+// COM: leaving the FUNC symbol with st_size == 0. Kernel lookup must still
+// COM: find the descriptor so scratch allocation does not fall back to v0.
+// DISASM-LABEL: <test_tensor_zero_size>:
+// DISASM: s_branch
+// DISASM: s_mov_b32
+// DISASM: v_writelane_b32
+// DISASM: s_pack_hh_b32_b16
+// DISASM: tensor_load_to_lds
+// DISASM: v_readlane_b32
+// DISASM: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
 // RUN: hotswap-rewrite %t.out.elf \
@@ -199,6 +216,33 @@ test_tensor_sgpr_redef:
 .Ltest_tensor_sgpr_redef_end:
 .size test_tensor_sgpr_redef, .Ltest_tensor_sgpr_redef_end-test_tensor_sgpr_redef
 
+// ---- Kernel 5: tensor_load_to_lds with zero-sized FUNC symbol ---------------
+
+.globl test_tensor_zero_size
+.p2align 8
+.type test_tensor_zero_size,@function
+test_tensor_zero_size:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+// Deliberately no `.size`: this models Tensile objects that emit st_size == 0.
+
 .rodata
 .p2align 8
 .amdhsa_kernel test_tensor_dead
@@ -220,6 +264,12 @@ test_tensor_sgpr_redef:
 
 .p2align 8
 .amdhsa_kernel test_tensor_sgpr_redef
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_tensor_zero_size
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -50,9 +50,9 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
-// -- ElfView::findKernelAtOffset ----------------------------------------------
+// -- ElfView::findKernelAtAddress ---------------------------------------------
 
-TEST(ElfView, FindKernelAtOffsetResolvesNearestPrecedingForZeroSizeSymbol) {
+TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {
   // AMDGPU kernel entry symbols frequently have st_size == 0 (the size lives on
   // the .kd object symbol), so an exact [st_value, st_value + st_size)
   // containment test never matches. The lookup must resolve via the
@@ -68,12 +68,12 @@ TEST(ElfView, FindKernelAtOffsetResolvesNearestPrecedingForZeroSizeSymbol) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  // findKernelAtOffset takes a virtual address; at the entry and at an interior
-  // offset the zero-size symbol still resolves.
-  EXPECT_EQ(ViewOrErr->findKernelAtOffset(0x1000), "zero_size_kernel");
-  EXPECT_EQ(ViewOrErr->findKernelAtOffset(0x1000 + 4), "zero_size_kernel");
+  // findKernelAtAddress takes a virtual address; at the entry and at an
+  // interior offset the zero-size symbol still resolves.
+  EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x1000), "zero_size_kernel");
+  EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x1000 + 4), "zero_size_kernel");
   // An address before the symbol has no preceding function symbol to resolve.
-  EXPECT_EQ(ViewOrErr->findKernelAtOffset(0x0FF0), "");
+  EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x0FF0), "");
 }
 
 // -- ElfView::getKernelStaticLdsSize ------------------------------------------

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -24,7 +24,9 @@
 #include "gtest/gtest.h"
 
 #include <cstring>
+#include <limits>
 #include <mutex>
+#include <vector>
 
 using namespace COMGR;
 using namespace COMGR::hotswap;
@@ -151,6 +153,30 @@ TEST(EncodeSBranch, OutOfRangeFails) {
   EXPECT_TRUE(S.encodeSBranch(0, 500000).empty());
 }
 
+TEST(EncodeSBranch, PositiveBoundaryRoundTrip) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  constexpr uint64_t To =
+      static_cast<uint64_t>(BranchOffsetMax + 1) * MinInstSize;
+  llvm::SmallVector<uint8_t> Out = S.encodeSBranch(0, To);
+  ASSERT_EQ(Out.size(), MinInstSize);
+  uint32_t Encoded = readDword(Out.data());
+  EXPECT_EQ(static_cast<int16_t>(Encoded & 0xFFFFu), BranchOffsetMax);
+  EXPECT_TRUE(S.encodeSBranch(0, To + MinInstSize).empty());
+}
+
+TEST(EncodeSBranch, NegativeBoundaryRoundTrip) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  constexpr uint64_t From =
+      static_cast<uint64_t>(-(BranchOffsetMin + 1)) * MinInstSize;
+  llvm::SmallVector<uint8_t> Out = S.encodeSBranch(From, 0);
+  ASSERT_EQ(Out.size(), MinInstSize);
+  uint32_t Encoded = readDword(Out.data());
+  EXPECT_EQ(static_cast<int16_t>(Encoded & 0xFFFFu), BranchOffsetMin);
+  EXPECT_TRUE(S.encodeSBranch(From + MinInstSize, 0).empty());
+}
+
 TEST(EncodeSBranch, FailsOnInvalidState) {
   LLVMState S; // default-constructed, Valid = false
   EXPECT_TRUE(S.encodeSBranch(0, 8).empty());
@@ -214,6 +240,24 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
   llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
   ASSERT_FALSE(Out.empty());
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
+}
+
+TEST(FindNearestSled, RejectsOverflowingHeadroom) {
+  std::vector<NopSled> Sleds = {{0, 64, 60}, {100, 128, 100}};
+  EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),
+            nullptr);
+}
+
+TEST(FindNearestSled, HandlesLargeUnsignedOffsets) {
+  std::vector<NopSled> Sleds = {{100, 128, 100},
+                                {std::numeric_limits<uint64_t>::max() - 32,
+                                 std::numeric_limits<uint64_t>::max(),
+                                 std::numeric_limits<uint64_t>::max() - 32}};
+  NopSled *Sled =
+      findNearestSled(Sleds, std::numeric_limits<uint64_t>::max() - 40,
+                      /*Needed=*/8);
+  ASSERT_NE(Sled, nullptr);
+  EXPECT_EQ(Sled, &Sleds[1]);
 }
 
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
@@ -354,15 +398,13 @@ static void expectSameOperands(const llvm::MCInst &Actual,
 }
 
 static void expectInstMatchesAsm(const llvm::MCInst &Actual,
-                                 llvm::StringRef Asm,
-                                 const LLVMState &S) {
+                                 llvm::StringRef Asm, const LLVMState &S) {
   llvm::MCInst Expected = assembleOne(Asm, S);
   expectSameOperands(Actual, Expected, Asm);
 }
 
 static bool appendSingleInstBytes(llvm::SmallVectorImpl<uint8_t> &Bytes,
-                                  llvm::StringRef Asm,
-                                  const LLVMState &S) {
+                                  llvm::StringRef Asm, const LLVMState &S) {
   llvm::SmallVector<uint8_t> Inst = assembleSingleInst(Asm, S);
   if (Inst.empty()) {
     ADD_FAILURE() << "failed to assemble: " << Asm.str();

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -305,6 +305,64 @@ TEST(AssembleDecode, CvtPkFp8LiteralSourcesDecodeAsTwelveBytes) {
   EXPECT_EQ(Inst.getOperand(5).getImm(), 1);
 }
 
+TEST(AssembleDecode, CvtPkFp8MixedLiteralSourcesDecodeAsTwelveBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Src0LiteralBytes =
+      assembleSingleInst("v_cvt_pk_fp8_f32 v4, 0x477f0000, v5 clamp", S);
+  ASSERT_EQ(Src0LiteralBytes.size(), 3u * MinInstSize);
+
+  std::vector<InternalDecodedInst> Src0LiteralDecoded;
+  ASSERT_TRUE(decodeTextSection(
+      Src0LiteralBytes.data(), Src0LiteralBytes.size(), S, Src0LiteralDecoded));
+  ASSERT_EQ(Src0LiteralDecoded.size(), 1u);
+  const llvm::MCInst &Src0LiteralInst = Src0LiteralDecoded[0].Inst;
+  ASSERT_GE(Src0LiteralInst.getNumOperands(), 7u);
+  ASSERT_TRUE(Src0LiteralInst.getOperand(2).isImm());
+  EXPECT_EQ(Src0LiteralInst.getOperand(2).getImm(), 0x477f0000);
+  EXPECT_TRUE(Src0LiteralInst.getOperand(4).isReg());
+
+  llvm::SmallVector<uint8_t> Src1LiteralBytes = assembleSingleInst(
+      "v_cvt_pk_fp8_f32 v4, v5, 0.3333333432674408 clamp", S);
+  ASSERT_EQ(Src1LiteralBytes.size(), 3u * MinInstSize);
+
+  std::vector<InternalDecodedInst> Src1LiteralDecoded;
+  ASSERT_TRUE(decodeTextSection(
+      Src1LiteralBytes.data(), Src1LiteralBytes.size(), S, Src1LiteralDecoded));
+  ASSERT_EQ(Src1LiteralDecoded.size(), 1u);
+  const llvm::MCInst &Src1LiteralInst = Src1LiteralDecoded[0].Inst;
+  ASSERT_GE(Src1LiteralInst.getNumOperands(), 7u);
+  EXPECT_TRUE(Src1LiteralInst.getOperand(2).isReg());
+  ASSERT_TRUE(Src1LiteralInst.getOperand(4).isImm());
+  EXPECT_EQ(Src1LiteralInst.getOperand(4).getImm(), 0x3eaaaaab);
+}
+
+TEST(AssembleDecode, CvtPkFp8InlineConstantsDecodeAsEightBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("v_cvt_pk_fp8_f32 v4, 1.0, 0.5 clamp", S);
+  ASSERT_EQ(Bytes.size(), 2u * MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  const InternalDecodedInst &DI = Decoded[0];
+  EXPECT_EQ(DI.Size, 2u * MinInstSize);
+  EXPECT_EQ(DI.Mnemonic, "v_cvt_pk_fp8_f32");
+
+  const llvm::MCInst &Inst = DI.Inst;
+  ASSERT_GE(Inst.getNumOperands(), 7u);
+  ASSERT_TRUE(Inst.getOperand(2).isImm());
+  EXPECT_EQ(Inst.getOperand(2).getImm(), 0x3f800000);
+  ASSERT_TRUE(Inst.getOperand(4).isImm());
+  EXPECT_EQ(Inst.getOperand(4).getImm(), 0x3f000000);
+  ASSERT_TRUE(Inst.getOperand(5).isImm());
+  EXPECT_EQ(Inst.getOperand(5).getImm(), 1);
+}
+
 TEST(AssembleDecode, RejectsGarbageAsm) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -235,6 +235,32 @@ TEST(AssembleDecode, SNopRoundTrip) {
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
 }
 
+TEST(AssembleDecode, CvtPkFp8LiteralSourcesDecodeAsTwelveBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(
+      "v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp", S);
+  ASSERT_EQ(Bytes.size(), 3u * MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  const InternalDecodedInst &DI = Decoded[0];
+  EXPECT_EQ(DI.Size, 3u * MinInstSize);
+  EXPECT_EQ(DI.Mnemonic, "v_cvt_pk_fp8_f32");
+
+  const llvm::MCInst &Inst = DI.Inst;
+  ASSERT_GE(Inst.getNumOperands(), 7u);
+  EXPECT_TRUE(Inst.getOperand(0).isReg());
+  ASSERT_TRUE(Inst.getOperand(2).isImm());
+  EXPECT_EQ(Inst.getOperand(2).getImm(), 0x477f0000);
+  ASSERT_TRUE(Inst.getOperand(4).isImm());
+  EXPECT_EQ(Inst.getOperand(4).getImm(), 0x477f0000);
+  ASSERT_TRUE(Inst.getOperand(5).isImm());
+  EXPECT_EQ(Inst.getOperand(5).getImm(), 1);
+}
+
 TEST(AssembleDecode, RejectsGarbageAsm) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -56,7 +56,7 @@ struct KernelDescriptorElfOptions {
   bool EmitKernelDescriptorSymbol = true;
   // Emit the kernel entry STT_FUNC symbol with st_size == 0, matching AMDGPU
   // HSACO objects where the size lives on the .kd object symbol. Exercises the
-  // nearest-preceding lookup in ElfView::findKernelAtOffset.
+  // nearest-preceding lookup in ElfView::findKernelAtAddress.
   bool ZeroSizeKernelSym = false;
   std::optional<uint64_t> KernelDescriptorSymbolValue;
   uint32_t GroupSegmentFixedSize = 0;


### PR DESCRIPTION
Summary:
- Add COMGR hotswap support for 12-byte v_cvt_pk_fp8_f32 encodings with literal sources.
- Allow zero-filled .text padding outside function ranges to be used as hotswap sled space.
- Harden gfx1250 rewrite paths needed by hipBLASLt smoke kernels: true16 FP8 extraction, zero-size FUNC symbol lookup, VA-based kernel lookup, SGPR descriptor updates, and entry-stub idempotency matching.
- Add unit/lit coverage for literal-source decode, mixed literal/register sources, non-inline fractional literals, inline constants, zero-fill sled rewriting, SGPR growth, and zero-size FUNC tensor scratch allocation.

Validation:
- /tmp/llvm-pr3189-build/bin/HotswapMCTests: 45/45 passed.
- /tmp/llvm-pr3189-build/bin/llvm-lit -sv /tmp/llvm-pr3189-build/tools/comgr/test-lit --filter "hotswap-cvt-pk-fp8": 3/84 selected tests passed.
- gfx1250 GPU1 hipblaslt-test --gtest_filter="*_/matmul_test.matmul/smoke_matmul_gemm_tn_mxf8_dst_bf16_1250_smoke_*" passed 16/16 with AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1 HSA_HOTSWAP_VERBOSE=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1.
- Remote COMGR override checksum: 208738fc2659503871acaebee19e6af73aa6e4b9f42f64e8e4e75d8b5c21d5f1.