### PR TITLE
AMDGPU: scope hotswap trampolines and clamp entry prefetch

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -841,7 +841,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       GrowthTotal += T.Bytes.size();
     }
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(),
+    if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(), LS.Cpu,
                                              EntryFixups))
       return AMD_COMGR_STATUS_ERROR;
   } else {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -78,6 +78,68 @@ static RewriteConfig makeGfx1250B0A0Config() {
   return Config;
 }
 
+static bool appendCodeEndGuard(std::vector<Trampoline> &Growth,
+                               uint64_t GuardBytes, const LLVMState &LS) {
+  if (GuardBytes == 0)
+    return true;
+
+  SmallVector<uint8_t> CodeEnd = assembleSingleInst("s_code_end", LS);
+  if (CodeEnd.empty()) {
+    log() << "hotswap: error: failed to assemble s_code_end for trampoline "
+          << "prefetch guard.\n";
+    return false;
+  }
+  if (GuardBytes % CodeEnd.size() != 0) {
+    log() << "hotswap: error: trampoline prefetch guard size " << GuardBytes
+          << " is not a multiple of s_code_end size " << CodeEnd.size()
+          << ".\n";
+    return false;
+  }
+
+  Trampoline Guard;
+  while (static_cast<uint64_t>(Guard.Bytes.size()) < GuardBytes)
+    Guard.Bytes.append(CodeEnd.begin(), CodeEnd.end());
+  Growth.push_back(std::move(Guard));
+  return true;
+}
+
+static std::optional<uint32_t>
+getMaxOriginalKernelInstPrefSize(const ElfView &Elf, const LLVMState &LS) {
+  std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  uint32_t MaxOriginalInstPrefLines = 0;
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    std::optional<uint32_t> OriginalInstPrefLines =
+        Elf.getKernelDescriptorInstPrefSize(KD.KernelName, LS.Cpu);
+    if (!OriginalInstPrefLines)
+      return std::nullopt;
+    MaxOriginalInstPrefLines =
+        std::max(MaxOriginalInstPrefLines, *OriginalInstPrefLines);
+  }
+  return MaxOriginalInstPrefLines;
+}
+
+static bool
+appendDeferredTrampolinePrefetchGuard(const ElfView &Elf, const LLVMState &LS,
+                                      std::vector<Trampoline> &Growth) {
+  // Deferred instruction-rewrite trampolines are reached from the original
+  // kernel entries, so their trailing guard follows the original descriptor
+  // prefetch size. Kernel-entry stubs clamp their own descriptor prefetch.
+  std::optional<uint32_t> MaxOriginalInstPrefLines =
+      getMaxOriginalKernelInstPrefSize(Elf, LS);
+  if (!MaxOriginalInstPrefLines)
+    return false;
+
+  uint64_t GuardBytes =
+      static_cast<uint64_t>(*MaxOriginalInstPrefLines) *
+      KernelEntryInstPrefUnitBytes;
+  if (!appendCodeEndGuard(Growth, GuardBytes, LS))
+    return false;
+
+  log() << "hotswap: appended " << GuardBytes
+        << " trampoline prefetch guard bytes\n";
+  return true;
+}
+
 // -- Forward declarations for liveness/DWARF stubs ----------------------------
 //
 // These have weak default definitions below. The apply* patch families use
@@ -200,92 +262,57 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 
 // -- NOP sled scanning --------------------------------------------------------
 
-static std::vector<ElfView::FunctionTextRange>
-buildMergedFunctionTextRanges(const ElfView &Elf) {
-  std::vector<ElfView::FunctionTextRange> Ranges = Elf.functionTextRanges();
-  llvm::sort(Ranges, [](const ElfView::FunctionTextRange &L,
-                        const ElfView::FunctionTextRange &R) {
-    if (L.Begin != R.Begin)
-      return L.Begin < R.Begin;
-    return L.End < R.End;
-  });
-
-  std::vector<ElfView::FunctionTextRange> MergedRanges;
-  for (const ElfView::FunctionTextRange &Range : Ranges) {
-    if (Range.Begin >= Range.End)
-      continue;
-    if (MergedRanges.empty() || Range.Begin > MergedRanges.back().End) {
-      MergedRanges.push_back(Range);
-      continue;
-    }
-    MergedRanges.back().End = std::max(MergedRanges.back().End, Range.End);
-  }
-  return MergedRanges;
+static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
+                                 uint64_t End,
+                                 const ElfView::FunctionTextRange &Range) {
+  if (End - Start >= MinNopSledSize)
+    Sleds.push_back({Start, End, Start, Range.Begin, Range.End});
 }
 
-static bool isInFunctionTextRange(ArrayRef<ElfView::FunctionTextRange> Ranges,
-                                  uint64_t TextAddress) {
-  ArrayRef<ElfView::FunctionTextRange>::iterator It =
-      std::upper_bound(Ranges.begin(), Ranges.end(), TextAddress,
-                       [](uint64_t Value, const ElfView::FunctionTextRange &R) {
-                         return Value < R.Begin;
-                       });
-  if (It == Ranges.begin())
-    return false;
-  --It;
-  return TextAddress < It->End;
-}
-
-static bool
-isZeroFillDword(const uint8_t *Text, uint64_t TextSize,
-                const InternalDecodedInst &DI, uint64_t TextAddr,
-                ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
-  if (FunctionRanges.empty() || DI.Size != MinInstSize ||
-      DI.Offset > TextSize || MinInstSize > TextSize - DI.Offset ||
-      DI.Offset > std::numeric_limits<uint64_t>::max() - TextAddr ||
-      isInFunctionTextRange(FunctionRanges, TextAddr + DI.Offset))
-    return false;
-  return std::all_of(Text + DI.Offset, Text + DI.Offset + MinInstSize,
-                     [](uint8_t B) { return B == 0; });
-}
-
-/// Scan \p Decoded for runs of consecutive `s_nop` instructions or undecoded
-/// zero-filled alignment padding at least MinNopSledSize bytes long and return
-/// the resulting NopSled list (each sled records Start / End byte offsets in
-/// .text and the initial WritePos at Start). These sleds are the landing zones
-/// emitToNopSled targets for in-place rewrites. NOPs are identified by MC
-/// opcode (cached on \p LS at initLLVM() time) rather than mnemonic string, so
-/// the scanner is robust against printer aliasing / mnemonic formatting
-/// variations. Zero-filled padding is accepted only when function-symbol ranges
-/// prove it is between functions; zero bytes inside a function are executable
-/// code and are not sled space.
+/// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
+/// MinNopSledSize bytes long and return the resulting NopSled list. Each sled
+/// records its owning function range so emitReplacementCode can only borrow
+/// padding from the same kernel as the instruction being patched. NOPs outside
+/// any sized function symbol are ignored.
 static std::vector<NopSled>
-buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const uint8_t *Text,
-                uint64_t TextSize, const LLVMState &LS, const ElfView &Elf) {
+buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+                const ElfView &Elf) {
   std::vector<NopSled> Sleds;
-  std::vector<ElfView::FunctionTextRange> FunctionRanges =
-      buildMergedFunctionTextRanges(Elf);
-  const size_t N = Decoded.size();
-  size_t I = 0;
-  while (I < N) {
-    bool IsSledInst = Decoded[I].Inst.getOpcode() == LS.SNopOpcode;
-    bool IsZeroFill = isZeroFillDword(Text, TextSize, Decoded[I],
-                                      Elf.textAddr(), FunctionRanges);
-    if (IsSledInst || IsZeroFill) {
-      uint64_t Start = Decoded[I].Offset;
-      uint64_t End = Start;
-      while (I < N && (Decoded[I].Inst.getOpcode() == LS.SNopOpcode ||
-                       isZeroFillDword(Text, TextSize, Decoded[I],
-                                       Elf.textAddr(), FunctionRanges))) {
-        End = Decoded[I].Offset + Decoded[I].Size;
-        ++I;
-      }
-      if (End - Start >= MinNopSledSize)
-        Sleds.push_back({Start, End, Start});
-    } else {
-      ++I;
+  bool HasActiveRange = false;
+  ElfView::FunctionTextRange ActiveRange;
+  uint64_t Start = 0;
+  uint64_t End = 0;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Inst.getOpcode() != LS.SNopOpcode) {
+      if (HasActiveRange)
+        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+      HasActiveRange = false;
+      continue;
     }
+
+    std::optional<ElfView::FunctionTextRange> Range =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    if (!Range || DI.Size > Range->End - DI.Offset) {
+      if (HasActiveRange)
+        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+      HasActiveRange = false;
+      continue;
+    }
+
+    if (!HasActiveRange || ActiveRange.Begin != Range->Begin ||
+        ActiveRange.End != Range->End || DI.Offset != End) {
+      if (HasActiveRange)
+        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+      ActiveRange = *Range;
+      HasActiveRange = true;
+      Start = DI.Offset;
+    }
+    End = DI.Offset + DI.Size;
   }
+
+  if (HasActiveRange)
+    appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
   return Sleds;
 }
 
@@ -470,8 +497,7 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
                         std::vector<ScratchPatchInfo> &OutScratchPatches,
                         const RewriteConfig &Config) {
   uint32_t Patched = 0;
-  std::vector<NopSled> Sleds =
-      buildNopSledMap(Decoded, Text, TextSize, LS, Elf);
+  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
 
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
   LivenessInfo Liveness =
@@ -821,6 +847,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   } else {
     log() << "hotswap: kernel-entry trampolines disabled for this rewrite\n";
   }
+
+  if (!Deferred.empty() &&
+      !appendDeferredTrampolinePrefetchGuard(Elf, LS, Growth))
+    return AMD_COMGR_STATUS_ERROR;
 
   if (!Growth.empty()) {
     Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -279,7 +279,10 @@ NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
   NopSled *Best = nullptr;
   uint64_t BestDist = std::numeric_limits<uint64_t>::max();
   for (NopSled &Sled : Sleds) {
-    if (Sled.WritePos > Sled.End || Needed > Sled.End - Sled.WritePos)
+    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+      continue;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
       continue;
     uint64_t Dist = Sled.WritePos > Offset ? Sled.WritePos - Offset
                                            : Offset - Sled.WritePos;
@@ -452,6 +455,38 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
   log() << "hotswap: findKernelAtAddress: no function symbol covers address 0x"
         << utohexstr(TextAddress) << " in .text.\n";
   return "";
+}
+
+std::optional<ElfView::FunctionTextRange>
+ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      consumeError(SymsOrErr.takeError());
+      continue;
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
+        continue;
+      if (Sym.st_shndx != TextSectionIndex || Sym.st_size == 0)
+        continue;
+      if (Sym.st_value < textAddr())
+        continue;
+
+      uint64_t Start = Sym.st_value - textAddr();
+      if (Sym.st_size > std::numeric_limits<uint64_t>::max() - Start)
+        continue;
+      uint64_t End = Start + Sym.st_size;
+      if (TextOffset >= Start && TextOffset < End)
+        return ElfView::FunctionTextRange{Start, End};
+    }
+  }
+  return std::nullopt;
 }
 
 // -- ElfView::findKernelDescriptor --------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -683,6 +683,44 @@ ElfView::getKernelDescriptorInstPrefSize(StringRef KernelName,
   return std::nullopt;
 }
 
+bool ElfView::updateKernelDescriptorInstPrefSize(StringRef KernelName,
+                                                 StringRef TargetCpu,
+                                                 uint32_t InstPrefLines) {
+  namespace hsa = amdhsa;
+  uint8_t *Kd = findKernelDescriptor(KernelName);
+  if (!Kd) {
+    log() << "hotswap: error: updateKernelDescriptorInstPrefSize: kernel "
+          << "descriptor symbol '" << KernelName << ".kd' not found.\n";
+    return false;
+  }
+
+  if (!TargetCpu.starts_with("gfx12")) {
+    log() << "hotswap: error: updateKernelDescriptorInstPrefSize: unsupported "
+          << "target CPU '" << TargetCpu << "' for kernel '" << KernelName
+          << "'.\n";
+    return false;
+  }
+
+  uint32_t MaxInstPrefLines = static_cast<uint32_t>(
+      hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE >>
+      hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE_SHIFT);
+  if (InstPrefLines > MaxInstPrefLines) {
+    log() << "hotswap: error: updateKernelDescriptorInstPrefSize: value "
+          << InstPrefLines << " exceeds the gfx12 descriptor encoding limit.\n";
+    return false;
+  }
+
+  uint32_t Rsrc3 = 0;
+  std::memcpy(&Rsrc3,
+              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
+              sizeof(Rsrc3));
+  AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE,
+                  InstPrefLines);
+  std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
+              &Rsrc3, sizeof(Rsrc3));
+  return true;
+}
+
 // -- ElfView::getKernelVgprCount ----------------------------------------------
 
 std::optional<unsigned>

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -458,8 +458,13 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     return std::nullopt;
   }
 
-  std::vector<KernelDescriptorInfo> Work;
-  uint32_t MaxInstPrefLines = 0;
+  struct WorkItem {
+    KernelDescriptorInfo KD;
+    uint32_t StubInstPrefLines = 0;
+  };
+
+  std::vector<WorkItem> Work;
+  uint32_t MaxStubInstPrefLines = 0;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     std::optional<bool> AlreadyHasEntryStub =
         descriptorAlreadyTargetsEntryStub(Elf, KD, LS, EntryStubPrefix);
@@ -467,12 +472,17 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
       return std::nullopt;
     if (*AlreadyHasEntryStub)
       continue;
-    std::optional<uint32_t> InstPrefLines =
+    std::optional<uint32_t> OriginalInstPrefLines =
         Elf.getKernelDescriptorInstPrefSize(KD.KernelName, LS.Cpu);
-    if (!InstPrefLines)
+    if (!OriginalInstPrefLines)
       return std::nullopt;
-    MaxInstPrefLines = std::max(MaxInstPrefLines, *InstPrefLines);
-    Work.push_back(KD);
+    // Entry stubs are 256-byte aligned and fit inside one stride, so clamp the
+    // descriptor prefetch to the stub stride. Deferred non-entry trampolines
+    // keep using the original descriptor prefetch guard.
+    uint32_t StubInstPrefLines =
+        std::min(*OriginalInstPrefLines, KernelEntryStubInstPrefLines);
+    MaxStubInstPrefLines = std::max(MaxStubInstPrefLines, StubInstPrefLines);
+    Work.push_back({KD, StubInstPrefLines});
   }
   if (Work.empty())
     return 0;
@@ -502,7 +512,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     return std::nullopt;
   AppendOffset = StubStart;
 
-  for (const KernelDescriptorInfo &KD : Work) {
+  for (const WorkItem &Item : Work) {
+    const KernelDescriptorInfo &KD = Item.KD;
     std::optional<uint64_t> StubTextEnd = checkedAddUint64(
         Elf.textSize(), AppendOffset,
         (Twine("entry trampoline append offset for '") + KD.KernelName + "'")
@@ -533,7 +544,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     Trampoline T;
     T.Bytes.assign(Stub.begin(), Stub.end());
     LocalGrowth.push_back(std::move(T));
-    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2});
+    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2,
+                           Item.StubInstPrefLines});
     std::optional<uint64_t> NewAppendOffset = checkedAddUint64(
         AppendOffset, KernelEntryStubStride,
         (Twine("entry trampoline append offset after '") + KD.KernelName + "'")
@@ -544,7 +556,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   }
 
   const uint64_t GuardBytes =
-      computeKernelEntryPrefetchGuardBytes(MaxInstPrefLines);
+      computeKernelEntryPrefetchGuardBytes(MaxStubInstPrefLines);
   if (GuardBytes != 0) {
     SmallVector<uint8_t> CodeEnd = getCodeEndBytes(LS);
     if (CodeEnd.empty() ||
@@ -572,7 +584,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 }
 
 bool rewriteKernelEntryDescriptorOffsets(
-    WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
+    WritableMemoryBuffer &OutBuf, uint64_t OldTextSize, StringRef TargetCpu,
     ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return true;
@@ -624,7 +636,9 @@ bool rewriteKernelEntryDescriptorOffsets(
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
     bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
         Fixup.KernelName, Fixup.RequiredSgprs);
-    Ok = UpdatedEntry && UpdatedSgprs && Ok;
+    bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
+        Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
+    Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;
   }
   return Ok;
 }

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -100,6 +100,10 @@ struct Trampoline {
 // the same 256-byte alignment expected by AMDGPU kernel descriptors.
 static constexpr uint64_t KernelEntryStubStride = 256;
 static constexpr uint64_t KernelEntryInstPrefUnitBytes = 128;
+static_assert(KernelEntryStubStride % KernelEntryInstPrefUnitBytes == 0,
+              "entry-stub stride must be an integral prefetch span");
+static constexpr uint32_t KernelEntryStubInstPrefLines =
+    KernelEntryStubStride / KernelEntryInstPrefUnitBytes;
 
 struct KernelDescriptorInfo {
   std::string KernelName;
@@ -255,6 +259,11 @@ public:
   std::optional<uint32_t>
   getKernelDescriptorInstPrefSize(llvm::StringRef KernelName,
                                   llvm::StringRef TargetCpu) const;
+
+  /// Rewrite COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
+  bool updateKernelDescriptorInstPrefSize(llvm::StringRef KernelName,
+                                          llvm::StringRef TargetCpu,
+                                          uint32_t InstPrefLines);
 
   /// Read the VGPR count from the kernel descriptor for \p KernelName.
   /// Returns std::nullopt if the descriptor is not found.
@@ -729,6 +738,7 @@ struct KernelEntryTrampolineFixup {
   std::string KernelName;
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
+  uint32_t InstPrefLines = 0;
 };
 
 /// Build a 256-byte, entry-aligned HotSwap kernel-entry stub at
@@ -764,10 +774,11 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups);
 
-/// Apply descriptor entry-offset rewrites recorded by
-/// appendKernelEntryTrampolines after the ELF has been grown.
+/// Apply descriptor rewrites recorded by appendKernelEntryTrampolines after
+/// the ELF has been grown.
 bool rewriteKernelEntryDescriptorOffsets(
     llvm::WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
+    llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -115,6 +115,8 @@ struct NopSled {
   uint64_t Start = 0;
   uint64_t End = 0;
   uint64_t WritePos = 0;
+  uint64_t FunctionStart = 0;
+  uint64_t FunctionEnd = 0;
 };
 
 // -- Rewrite rule -------------------------------------------------------------
@@ -233,6 +235,11 @@ public:
   /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.
   std::string findKernelAtAddress(uint64_t TextAddress) const;
+
+  /// Find the section-relative `.text` range of the function containing
+  /// \p TextOffset, or std::nullopt if no sized function symbol covers it.
+  std::optional<FunctionTextRange>
+  findFunctionTextRangeAtOffset(uint64_t TextOffset) const;
 
   /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
   /// or nullptr if not found.

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -1,10 +1,9 @@
-// COM: Test v_cvt_pk_fp8_f32 CLAMP=1 literal sources using zero-fill padding.
+// COM: Test v_cvt_pk_fp8_f32 CLAMP=1 literal sources with zero-fill padding.
 // COM:
-// COM: Generated hipblasLt initializer kernels can leave zero-filled alignment
-// COM: gaps between function-symbol ranges. Those gaps are writable .text
-// COM: space even though they are not decoded as s_nop instructions, and they
-// COM: are often the only local landing zones large enough for the expanded
-// COM: literal-source FP8 pack replacement.
+// COM: Zero-filled alignment gaps between function-symbol ranges are writable
+// COM: .text bytes, but they are not decoded s_nop instructions inside the
+// COM: source function. The rewriter should leave them alone and append a
+// COM: trampoline instead of branching into the zero bytes.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -15,7 +14,7 @@
 // API: REWRITE: SUCCESS
 // API: IDEMPOTENT: YES
 
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=ZERO %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -40,22 +39,25 @@ test_cvt_pk_fp8_zero_fill_after:
 .Ltest_cvt_pk_fp8_zero_fill_after_end:
 .size test_cvt_pk_fp8_zero_fill_after, .Ltest_cvt_pk_fp8_zero_fill_after_end-test_cvt_pk_fp8_zero_fill_after
 
-// ZERO-LABEL: <test_cvt_pk_fp8_zero_fill_source>:
-// ZERO-NEXT:  s_branch{{.*}}test_cvt_pk_fp8_zero_fill_sled
-// ZERO-NEXT:  s_nop
-// ZERO-NEXT:  s_nop
-// ZERO-NEXT:  s_endpgm
-// ZERO-LABEL: <test_cvt_pk_fp8_zero_fill_sled>:
-// ZERO:       s_mov_b32
-// ZERO-NEXT:  v_mov_b32{{.*}}0x477f0000
-// ZERO-NEXT:  v_mov_b32{{.*}}0x477f0000
-// ZERO-NEXT:  v_and_b32{{.*}}0x7fffffff
-// ZERO:       v_lshl_or_b32
-// ZERO-NEXT:  v_bfi_b32 v4,
-// ZERO-NEXT:  s_mov_b32
-// ZERO-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_zero_fill_source+0xc>
-// ZERO-LABEL: <test_cvt_pk_fp8_zero_fill_after>:
-// ZERO-NEXT:  s_endpgm
+// DISASM-LABEL: <test_cvt_pk_fp8_zero_fill_source>:
+// DISASM-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_zero_fill_after+0x4>
+// DISASM-NEXT:  s_nop
+// DISASM-NEXT:  s_nop
+// DISASM-NEXT:  s_endpgm
+// DISASM-LABEL: <test_cvt_pk_fp8_zero_fill_sled>:
+// DISASM-NOT:   s_mov_b32
+// DISASM-NOT:   v_mov_b32{{.*}}0x477f0000
+// DISASM-NOT:   v_lshl_or_b32
+// DISASM-LABEL: <test_cvt_pk_fp8_zero_fill_after>:
+// DISASM-NEXT:  s_endpgm
+// DISASM-NEXT:  s_mov_b32
+// DISASM-NEXT:  v_mov_b32{{.*}}0x477f0000
+// DISASM-NEXT:  v_mov_b32{{.*}}0x477f0000
+// DISASM-NEXT:  v_and_b32{{.*}}0x7fffffff
+// DISASM:       v_lshl_or_b32
+// DISASM-NEXT:  v_bfi_b32 v4,
+// DISASM-NEXT:  s_mov_b32
+// DISASM-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_zero_fill_source+0xc>
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -24,6 +24,7 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-objdump -s -j .rodata %t.out.elf | %FileCheck --check-prefix=RODATA %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <entry_tramp_kernel>:
@@ -38,6 +39,9 @@
 // DISASM-NEXT: s_add_co_u32 s8
 // DISASM-NEXT: s_add_co_ci_u32 s9
 // DISASM-NEXT: s_set_pc_i64 s[8:9]
+
+// RODATA: Contents of section .rodata
+// RODATA: {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} 20000000
 
 // METADATA: .name:           entry_tramp_kernel
 // METADATA: .sgpr_count:     10

--- a/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
@@ -1,0 +1,74 @@
+// COM: A NOP sled belongs to its containing kernel. The patchable DS
+// COM: instruction in second_kernel must not borrow first_kernel padding.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <first_kernel>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+
+// DISASM-LABEL: <second_kernel>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: s_endpgm
+
+// DISASM: ds_load_b32 v0
+// DISASM: ds_load_b32 v1
+// DISASM: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl first_kernel
+.p2align 8
+.type first_kernel,@function
+first_kernel:
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_endpgm
+.Lfirst_kernel_end:
+.size first_kernel, .Lfirst_kernel_end-first_kernel
+
+.globl second_kernel
+.p2align 8
+.type second_kernel,@function
+second_kernel:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.Lsecond_kernel_end:
+.size second_kernel, .Lsecond_kernel_end-second_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -22,10 +22,13 @@
 // DISASM: s_wait_dscnt 0x0
 // DISASM: s_endpgm
 
-// COM: Trampoline body appended after .text: expanded DS loads + branch-back.
+// COM: Trampoline body appended after .text: expanded DS loads + branch-back,
+// COM: followed by an executable prefetch guard sized from inst_pref_size.
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
 // DISASM: s_branch
+// DISASM-NEXT: s_code_end
+// DISASM-NEXT: s_code_end
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \
@@ -51,4 +54,5 @@ test_ds_trampoline:
 .amdhsa_kernel test_ds_trampoline
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 1
+  .amdhsa_inst_pref_size 2
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -15,33 +15,41 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (dead SGPR, no sled): original tensor_load replaced by
-// COM: s_branch forward. Trampoline body appended in alignment padding.
+// COM: Kernel 1 (dead SGPR, no in-function sled): original tensor_load
+// COM: replaced by s_branch forward. Inter-function alignment padding is not a
+// COM: borrowable sled, so trampoline bodies are appended after the original
+// COM: functions.
 // DISASM-LABEL: <test_tensor_trampoline>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
 // DISASM-NOT: tensor_load_to_lds
-// DISASM: s_branch
-// DISASM: s_endpgm
 
-// COM: Dead-SGPR trampoline body: s_pack_hh + tensor_load + branch-back.
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
+// COM: Kernel 2 (live SGPR, no in-function sled): the original tensor_load is
+// COM: replaced by s_branch forward to its appended trampoline body.
+// DISASM-LABEL: <test_tensor_trampoline_live>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_mov_b32
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: tensor_load_to_lds
+
+// COM: Dead-SGPR trampoline body: s_pack_hh + tensor_load + branch-back,
+// COM: appended after the original functions.
+// DISASM-NEXT: s_pack_hh_b32_b16
+// DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_branch
 
 // COM: Live-SGPR trampoline body (for kernel 2): also placed in the
-// COM: padding region. save + pack + tensor + restore + branch-back.
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// COM: appended trampoline region. save + pack + tensor + restore +
+// COM: branch-back.
+// DISASM-NEXT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
 // DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
-
-// COM: Kernel 2 (live SGPR, no sled): the original tensor_load is
-// COM: replaced by s_branch backward to the trampoline body above.
-// DISASM-LABEL: <test_tensor_trampoline_live>:
-// DISASM-NOT: tensor_load_to_lds
-// DISASM: s_branch
-// DISASM: s_mov_b32
-// DISASM: s_endpgm
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -76,6 +76,23 @@ TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x0FF0), "");
 }
 
+// -- findNearestSled ----------------------------------------------------------
+
+TEST(FindNearestSled, SkipsSledsOutsideInstructionFunctionRange) {
+  std::vector<NopSled> Sleds;
+  // {Start, End, WritePos, FunctionStart, FunctionEnd}
+  Sleds.push_back({/*Start=*/0, /*End=*/32, /*WritePos=*/0,
+                   /*FunctionStart=*/0, /*FunctionEnd=*/32});
+  Sleds.push_back({/*Start=*/96, /*End=*/128, /*WritePos=*/96,
+                   /*FunctionStart=*/96, /*FunctionEnd=*/160});
+
+  NopSled *Sled = findNearestSled(Sleds, 108, 8);
+  ASSERT_NE(Sled, nullptr);
+  EXPECT_EQ(Sled->Start, 96u);
+
+  EXPECT_EQ(findNearestSled(Sleds, 64, 8), nullptr);
+}
+
 // -- ElfView::getKernelStaticLdsSize ------------------------------------------
 
 TEST(ElfView, GetKernelStaticLdsSizeReturnsNulloptWhenKdMissing) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -243,16 +243,19 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
 }
 
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
-  std::vector<NopSled> Sleds = {{0, 64, 60}, {100, 128, 100}};
+  std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
+                                {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),
             nullptr);
 }
 
 TEST(FindNearestSled, HandlesLargeUnsignedOffsets) {
-  std::vector<NopSled> Sleds = {{100, 128, 100},
+  std::vector<NopSled> Sleds = {{100, 128, 100, 100, 128},
                                 {std::numeric_limits<uint64_t>::max() - 32,
                                  std::numeric_limits<uint64_t>::max(),
-                                 std::numeric_limits<uint64_t>::max() - 32}};
+                                 std::numeric_limits<uint64_t>::max() - 32,
+                                 std::numeric_limits<uint64_t>::max() - 64,
+                                 std::numeric_limits<uint64_t>::max()}};
   NopSled *Sled =
       findNearestSled(Sleds, std::numeric_limits<uint64_t>::max() - 40,
                       /*Needed=*/8);
@@ -768,9 +771,6 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(AMDHSA_BITS_GET(OutRsrc3,
                             hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE),
             KernelEntryStubInstPrefLines);
-  EXPECT_EQ(
-      AMDHSA_BITS_GET(OutRsrc3, hsa::COMPUTE_PGM_RSRC3_GFX11_INST_PREF_SIZE),
-      KernelEntryStubInstPrefLines);
   EXPECT_NE(OutRsrc3 & hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_GLG_EN, 0u);
   EXPECT_EQ(Fixups[0].RequiredSgprs, 10u);
   uint32_t OutRsrc1 = 0;

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -689,7 +689,7 @@ TEST(BuildKernelEntryTrampoline, MatcherRejectsWrongOperandShape) {
   EXPECT_FALSE(isKernelEntryTrampoline(Bytes, S));
 }
 
-TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
+TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   namespace hsa = llvm::amdhsa;
 
   LLVMState S = initLLVM(makeGfx1250Ident());
@@ -701,6 +701,8 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
   uint32_t Rsrc3 = 0;
   AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE, 7);
   Rsrc3 |= hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_GLG_EN;
+  AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX125_NAMED_BAR_CNT, 3);
+  AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX125_TCP_SPLIT, 5);
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.ComputePgmRsrc3 = Rsrc3;
   comgr_test::KernelDescriptorElf Obj =
@@ -719,12 +721,12 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 1u);
   ASSERT_EQ(Fixups.size(), 1u);
+  EXPECT_EQ(Fixups[0].InstPrefLines, KernelEntryStubInstPrefLines);
 
-  const uint64_t ExpectedGuard = computeKernelEntryPrefetchGuardBytes(7);
-  EXPECT_EQ(ExpectedGuard,
-            7u * KernelEntryInstPrefUnitBytes - KernelEntryStubStride);
+  const uint64_t ExpectedGuard =
+      computeKernelEntryPrefetchGuardBytes(KernelEntryStubInstPrefLines);
+  EXPECT_EQ(ExpectedGuard, 0u);
   ASSERT_FALSE(Growth.empty());
-  EXPECT_EQ(Growth.back().Bytes.size(), ExpectedGuard);
 
   const uint64_t OldTextSize = ViewOrErr->textSize();
   const uint64_t TextEndVAddr = ViewOrErr->textAddr() + OldTextSize;
@@ -744,7 +746,8 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
       ViewOrErr->growWithTrampolines(Growth, S.SNopBytes);
   ASSERT_NE(Out, nullptr);
 
-  ASSERT_TRUE(rewriteKernelEntryDescriptorOffsets(*Out, OldTextSize, Fixups));
+  ASSERT_TRUE(
+      rewriteKernelEntryDescriptorOffsets(*Out, OldTextSize, S.Cpu, Fixups));
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
   llvm::Expected<ElfView> OutView =
@@ -757,9 +760,17 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
   std::memcpy(&OutRsrc3,
               OutKd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
               sizeof(OutRsrc3));
+  uint32_t ExpectedRsrc3 = Rsrc3;
+  AMDHSA_BITS_SET(ExpectedRsrc3,
+                  hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE,
+                  KernelEntryStubInstPrefLines);
+  EXPECT_EQ(OutRsrc3, ExpectedRsrc3);
   EXPECT_EQ(AMDHSA_BITS_GET(OutRsrc3,
                             hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE),
-            7u);
+            KernelEntryStubInstPrefLines);
+  EXPECT_EQ(
+      AMDHSA_BITS_GET(OutRsrc3, hsa::COMPUTE_PGM_RSRC3_GFX11_INST_PREF_SIZE),
+      KernelEntryStubInstPrefLines);
   EXPECT_NE(OutRsrc3 & hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_GLG_EN, 0u);
   EXPECT_EQ(Fixups[0].RequiredSgprs, 10u);
   uint32_t OutRsrc1 = 0;


### PR DESCRIPTION
## Summary
- clamp gfx12 hotswap entry-stub INST_PREF_SIZE to the trampoline stub span so the descriptor no longer advertises prefetch past the appended trampoline/guard layout
- rewrite the descriptor in COMGR hotswap, keeping trampoline-related loader policy out of ROCr
- scope NOP-sled discovery and rewriting to the owning function so COMGR does not borrow sleds from adjacent code
- harden entry-trampoline idempotency decoding and add lit/unit coverage for descriptor preservation, NOP-sled function scoping, and related trampoline encodings

Depends on #3182. Review commit: d49d6b2dd49b.

## Testing
- cmake --build build --target HotswapMCTests hotswap-rewrite -j 32
- ./build/bin/HotswapMCTests
- ./build/bin/llvm-lit -sv build/tools/comgr/test-lit --filter hotswap-kernel-entry-trampoline
- ./build/bin/llvm-lit -sv build/tools/comgr/test-lit --filter hotswap-nop-sled-function-scope
- git diff --check
- TheRock gfx1250 final dist validation on mi400 GPU 1:
  - hipblaslt-test --gtest_filter=*_/matmul_test.matmul/smoke_matmul_gemm_tn_mxf8_dst_bf16_1250_smoke_* passed 16 tests
  - /mnt/ck-build/bin/example_gemm_multiply_multiply_xdl_fp8 passed; verbose hotswap log showed trampoline prefetch guard bytes appended
- ASAN (`build-asan`, `LLVM_USE_SANITIZER=Address`; `ASAN_OPTIONS=detect_leaks=0 LSAN_OPTIONS=detect_leaks=0` due local LSan/ptrace limitation):
  - built HotswapMCTests, HotswapElfTests, and hotswap-rewrite
  - ./build-asan/bin/HotswapMCTests passed 39 tests
  - ./build-asan/bin/HotswapElfTests passed 14 tests
  - ./build-asan/bin/llvm-lit -sv build-asan/tools/comgr/test-lit --filter hotswap-kernel-entry-trampoline passed 1/1
  - ./build-asan/bin/llvm-lit -sv build-asan/tools/comgr/test-lit --filter hotswap-nop-sled-function-scope passed 1/1
