### PR TITLE
[Comgr] Use memcpy in amd_comgr_symbol_get_info NAME handler

### DIFF
--- a/amd/comgr/src/comgr.cpp
+++ b/amd/comgr/src/comgr.cpp
@@ -1723,7 +1723,7 @@ amd_comgr_status_t AMD_COMGR_API
     *(size_t *)Value = strlen(Sym->Name);
     return AMD_COMGR_STATUS_SUCCESS;
   case AMD_COMGR_SYMBOL_INFO_NAME:
-    strcpy((char *)Value, Sym->Name);
+    memcpy((char *)Value, Sym->Name, strlen(Sym->Name) + 1);
     return AMD_COMGR_STATUS_SUCCESS;
   case AMD_COMGR_SYMBOL_INFO_TYPE:
     *(amd_comgr_symbol_type_t *)Value = Sym->Type;


### PR DESCRIPTION
Replace `strcpy` with a length-based `memcpy` in the `AMD_COMGR_SYMBOL_INFO_NAME` case of `amd_comgr_symbol_get_info`, matching the pattern used by the other `*_get_info` handlers.

Behavior is unchanged: `Value` is a caller-allocated buffer sized via `AMD_COMGR_SYMBOL_INFO_NAME_LENGTH` (+1 for the NUL) per the documented API contract. This is a cosmetic change to clear a static-scan signature; it is not a security fix (a true bound would require an API/ABI change, which is not warranted).

ISSUE ID: ROCM-26574