### PR TITLE
Revert "[X86] combineAddOfPMADDWD - use MaskedVectorIsZero directly i…

### DIFF
--- a/llvm/lib/Target/X86/X86ISelLowering.cpp
+++ b/llvm/lib/Target/X86/X86ISelLowering.cpp
@@ -59467,12 +59467,15 @@ static SDValue combineAddOfPMADDWD(SelectionDAG &DAG, SDValue N0, SDValue N1,
 
   unsigned NumElts = VT.getVectorNumElements();
   MVT OpVT = N0.getOperand(0).getSimpleValueType();
+  APInt DemandedBits = APInt::getAllOnes(OpVT.getScalarSizeInBits());
   APInt DemandedHiElts = APInt::getSplat(2 * NumElts, APInt(2, 2));
 
-  bool Op0HiZero = DAG.MaskedVectorIsZero(N0.getOperand(0), DemandedHiElts) ||
-                   DAG.MaskedVectorIsZero(N0.getOperand(1), DemandedHiElts);
-  bool Op1HiZero = DAG.MaskedVectorIsZero(N1.getOperand(0), DemandedHiElts) ||
-                   DAG.MaskedVectorIsZero(N1.getOperand(1), DemandedHiElts);
+  bool Op0HiZero =
+      DAG.MaskedValueIsZero(N0.getOperand(0), DemandedBits, DemandedHiElts) ||
+      DAG.MaskedValueIsZero(N0.getOperand(1), DemandedBits, DemandedHiElts);
+  bool Op1HiZero =
+      DAG.MaskedValueIsZero(N1.getOperand(0), DemandedBits, DemandedHiElts) ||
+      DAG.MaskedValueIsZero(N1.getOperand(1), DemandedBits, DemandedHiElts);
 
   // TODO: Check for zero lower elements once we have actual codegen that
   // creates them.


### PR DESCRIPTION
…nstead of MaskedValueIsZero. NFC. (#205534)"

This reverts commit 1ad2d369d18da9cb65a0d518f5a1b8bd98577d3e.


