### PR TITLE
[Comgr] Fix comgr-isa-metadata.def for gfx12-5-generic

### DIFF
--- a/amd/comgr/src/comgr-isa-metadata.def
+++ b/amd/comgr/src/comgr-isa-metadata.def
@@ -86,6 +86,6 @@ HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx10-1-generic",  false,  true, EF_AMDGPU_MAC
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx10-3-generic",  false, false, EF_AMDGPU_MACH_AMDGCN_GFX10_3_GENERIC, true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,    8, 1024, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx11-generic",    false, false, EF_AMDGPU_MACH_AMDGCN_GFX11_GENERIC,   true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   16, 1024, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx12-generic",    false, false, EF_AMDGPU_MACH_AMDGCN_GFX12_GENERIC,   true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx12-5-generic",  true,   true, EF_AMDGPU_MACH_AMDGCN_GFX12_5_GENERIC, true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx12-5-generic",  false,   true, EF_AMDGPU_MACH_AMDGCN_GFX12_5_GENERIC, true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
 
 #undef HANDLE_ISA


### PR DESCRIPTION
gfx12-5-generic does not support SRAMECC


