### PR TITLE
[OpenMP] Remove stale OMPT source parts

### DIFF
--- a/offload/include/OpenMP/OMPT/Interface.h
+++ b/offload/include/OpenMP/OMPT/Interface.h
@@ -38,7 +38,6 @@
 /// target_task_data representing the target task region.
 typedef ompt_data_t *(*ompt_get_task_data_t)();
 typedef ompt_data_t *(*ompt_get_target_task_data_t)();
-typedef int (*ompt_set_frame_enter_t)(void *Address, int Flags, int State);
 
 namespace llvm {
 namespace omp {
@@ -49,7 +48,6 @@ namespace ompt {
 /// target_task_data.
 static ompt_get_task_data_t ompt_get_task_data_fn;
 static ompt_get_target_task_data_t ompt_get_target_task_data_fn;
-static ompt_set_frame_enter_t ompt_set_frame_enter_fn;
 
 /// OMPT global tracing status. Indicates if at least one device is traced.
 extern bool TracingActive;

--- a/offload/libomptarget/OpenMP/OMPT/Callback.cpp
+++ b/offload/libomptarget/OpenMP/OMPT/Callback.cpp
@@ -62,7 +62,6 @@ ompt_get_callback_t llvm::omp::target::ompt::lookupCallbackByCode = nullptr;
 ompt_function_lookup_t llvm::omp::target::ompt::lookupCallbackByName = nullptr;
 ompt_get_target_task_data_t ompt_get_target_task_data_fn = nullptr;
 ompt_get_task_data_t ompt_get_task_data_fn = nullptr;
-ompt_set_frame_enter_t ompt_set_frame_enter_fn = nullptr;
 
 /// Unique correlation id
 static std::atomic<uint64_t> IdCounter(1);
@@ -518,7 +517,6 @@ int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
   bindOmptFunctionName(ompt_get_callback, lookupCallbackByCode);
   bindOmptFunctionName(ompt_get_task_data, ompt_get_task_data_fn);
   bindOmptFunctionName(ompt_get_target_task_data, ompt_get_target_task_data_fn);
-  bindOmptFunctionName(ompt_set_frame_enter, ompt_set_frame_enter_fn);
 #undef bindOmptFunctionName
 
   // Store pointer of 'ompt_libomp_target_fn_lookup' for use by libomptarget
@@ -529,8 +527,6 @@ int llvm::omp::target::ompt::initializeLibrary(ompt_function_lookup_t lookup,
   assert(ompt_get_task_data_fn && "ompt_get_task_data_fn should be non-null");
   assert(ompt_get_target_task_data_fn &&
          "ompt_get_target_task_data_fn should be non-null");
-  assert(ompt_set_frame_enter_fn &&
-         "ompt_set_frame_enter_fn should be non-null");
   assert(LibraryFinalizer == nullptr &&
          "LibraryFinalizer should not be initialized yet");
 

--- a/openmp/runtime/src/ompt-general.cpp
+++ b/openmp/runtime/src/ompt-general.cpp
@@ -892,10 +892,6 @@ static ompt_interface_fn_t ompt_fn_lookup(const char *s) {
   return (ompt_interface_fn_t)0;
 }
 
-static int ompt_set_frame_enter(void *addr, int flags, int state) {
-  return __ompt_set_frame_enter_internal(addr, flags, state);
-}
-
 static ompt_data_t *ompt_get_task_data() { return __ompt_get_task_data(); }
 
 static ompt_data_t *ompt_get_target_task_data() {
@@ -911,7 +907,6 @@ static ompt_interface_fn_t ompt_libomp_target_fn_lookup(const char *s) {
   provide_fn(ompt_get_callback);
   provide_fn(ompt_get_task_data);
   provide_fn(ompt_get_target_task_data);
-  provide_fn(ompt_set_frame_enter);
 #undef provide_fn
 
 #define ompt_interface_fn(fn, type, code)                                      \

--- a/openmp/runtime/src/ompt-internal.h
+++ b/openmp/runtime/src/ompt-internal.h
@@ -26,12 +26,6 @@
   ((x == fork_context_gnu) ? ompt_parallel_invoker_program                     \
                            : ompt_parallel_invoker_runtime)
 
-#define OMPT_FRAME_SET(frame, which, ptr_value, flags)                         \
-  {                                                                            \
-    frame->which##_frame.ptr = ptr_value;                                      \
-    frame->which##_frame_flags = flags;                                        \
-  }
-
 #define OMPT_FRAME_CLEAR(frame, which) OMPT_FRAME_SET(frame, which, 0, 0)
 
 #define OMPT_FRAME_SET_P(frame, which) (frame->which##_frame.ptr != NULL)

--- a/openmp/runtime/src/ompt-specific.cpp
+++ b/openmp/runtime/src/ompt-specific.cpp
@@ -489,21 +489,6 @@ int __ompt_get_task_memory_internal(void **addr, size_t *size, int blocknum) {
 }
 
 //----------------------------------------------------------
-// target region support
-//----------------------------------------------------------
-
-int __ompt_set_frame_enter_internal(void *addr, int flags, int state) {
-  int gtid = __kmp_entry_gtid();
-  kmp_info_t *thr = __kmp_threads[gtid];
-
-  ompt_frame_t *ompt_frame = &OMPT_CUR_TASK_INFO(thr)->frame;
-  OMPT_FRAME_SET(ompt_frame, enter, addr, flags);
-  int old_state = thr->th.ompt_thread_info.state;
-  thr->th.ompt_thread_info.state = ompt_state_work_parallel;
-  return old_state;
-}
-
-//----------------------------------------------------------
 // team support
 //----------------------------------------------------------
 

--- a/openmp/runtime/src/ompt-specific.h
+++ b/openmp/runtime/src/ompt-specific.h
@@ -22,8 +22,6 @@
 
 void __ompt_force_initialization();
 
-int __ompt_set_frame_enter_internal(void *addr, int flags, int state);
-
 void __ompt_team_assign_id(kmp_team_t *team, ompt_data_t ompt_pid);
 
 void __ompt_thread_assign_wait_id(void *variable);


### PR DESCRIPTION
While upstreaming, it appeared that this part of the OMPT port is unneeded and not even wired.