### PR TITLE
[SPIRV][CI] Fix Windows zstd.dll runtime lookup for build and comgr tests

### DIFF
--- a/.github/workflows/spirv-ci-windows-amd-staging.yml
+++ b/.github/workflows/spirv-ci-windows-amd-staging.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
 
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
+
       - name: Checkout llvm-project (PR head)
         # On pull_request events: PR head from the (possibly fork) head repo.
         # On workflow_dispatch: the branch the dispatch was on.
@@ -86,6 +89,7 @@ jobs:
           cmake -G Ninja -S llvm-project/llvm -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DLLVM_ENABLE_ASSERTIONS=ON \
             -DLLVM_ENABLE_PROJECTS="clang;lld" \
             -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86;SPIRV" \
@@ -111,6 +115,7 @@ jobs:
           cmake -G Ninja -S llvm-project/amd/device-libs -B build-device-libs \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DCMAKE_PREFIX_PATH=$PWD_WIN/build \
             -DLLVM_DIR=$PWD_WIN/build/lib/cmake/llvm
 
@@ -123,6 +128,7 @@ jobs:
           cmake -G Ninja -S llvm-project/amd/comgr -B build-comgr \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_TOOLCHAIN_FILE="C:/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+            -DVCPKG_APPLOCAL_DEPS=OFF \
             -DCMAKE_PREFIX_PATH="$PWD_WIN/build;$PWD_WIN/build-device-libs" \
             -DLLVM_DIR=$PWD_WIN/build/lib/cmake/llvm \
             -DAMDDeviceLibs_DIR=$PWD_WIN/build-device-libs/lib/cmake/AMDDeviceLibs \
@@ -182,6 +188,9 @@ jobs:
       # build-edge input that ninja validates at planning time.
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
+
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
 
       - name: Checkout llvm-project (PR head)
         # On pull_request events: PR head from the (possibly fork) head repo.
@@ -310,6 +319,9 @@ jobs:
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
 
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
+
       - name: Checkout llvm-project (PR head)
         # On pull_request events: PR head from the (possibly fork) head repo.
         # On workflow_dispatch: the branch the dispatch was on.
@@ -382,6 +394,9 @@ jobs:
       # build-edge input that ninja validates at planning time.
       - name: Install zstd via vcpkg
         run: vcpkg install zstd:x64-windows
+
+      - name: Add vcpkg bin to PATH (zstd.dll runtime lookup)
+        run: echo 'C:\vcpkg\installed\x64-windows\bin' >> "$GITHUB_PATH"
 
       - name: Checkout llvm-project (PR head)
         # On pull_request events: PR head from the (possibly fork) head repo.

--- a/amd/comgr/test/CMakeLists.txt
+++ b/amd/comgr/test/CMakeLists.txt
@@ -200,14 +200,16 @@ endif()
   add_test(NAME ${test_name}
     COMMAND "${name}")
   add_dependencies(check-comgr ${name})
-  # Windows binaries have no equivalent to RPATH, so we must set their PATH to
-  # include the .lib/.dll directory.
+  # Windows binaries have no equivalent to RPATH, so we must prepend the
+  # .lib/.dll directory to their PATH. Use ENVIRONMENT_MODIFICATION so the
+  # inherited PATH is preserved (transitive DLL deps like zstd.dll live there).
   if (UNIX)
     set_tests_properties(${test_name}
       PROPERTIES ENVIRONMENT "AMD_COMGR_CACHE=0;")
   else()
-    set_tests_properties(${test_name}
-      PROPERTIES ENVIRONMENT "PATH=$<TARGET_LINKER_FILE_DIR:amd_comgr>;AMD_COMGR_CACHE=0;")
+    set_tests_properties(${test_name} PROPERTIES
+      ENVIRONMENT_MODIFICATION
+      "PATH=path_list_prepend:$<TARGET_LINKER_FILE_DIR:amd_comgr>;AMD_COMGR_CACHE=set:0")
   endif()
 endmacro()
 


### PR DESCRIPTION
Fixes the Windows SPIRV CI failures by combining two changes:

**1. Workflow (original fix by @chinmaydd, #3139)** — disable `VCPKG_APPLOCAL_DEPS` and put the vcpkg bin dir on `PATH`.

`VCPKG_APPLOCAL_DEPS=ON` runs a POST_BUILD step that copies `zstd.dll` next to every binary. In parallel builds those copies collide in `build/bin`, breaking `Windows::release / Build` (e.g. `clang-refactor.exe ... The process cannot access the file because it is being used by another process`). Turning applocal off removes the race; adding `C:\vcpkg\installed\x64-windows\bin` to `PATH` lets build-time tblgen and the lit test tools still resolve `zstd.dll`.

**2. Comgr test CMake (root-cause follow-up)** — switch the Windows test PATH from `ENVIRONMENT` to `ENVIRONMENT_MODIFICATION`.

Turning applocal off removes the accidental `zstd.dll` co-location that the comgr ctests relied on. `amd/comgr/test/CMakeLists.txt` sets the CTest `ENVIRONMENT` property with a bare `PATH`, which **replaces** `PATH` for the test subprocess — discarding the vcpkg bin entry. `amd_comgr.dll` is found but its transitive `zstd.dll` dependency is not, so all 31 comgr ctests fail at load time with `0xc0000135` (STATUS_DLL_NOT_FOUND). Using `ENVIRONMENT_MODIFICATION` with `path_list_prepend` preserves the inherited `PATH` so `zstd.dll` resolves. This lives in our code and helps any Windows comgr test consumer, not just this CI.

Supersedes #3139 (closed).
