### PR TITLE
Enable reliable auto-merge for main-to-amd-staging sync PRs

### DIFF
--- a/.github/workflows/merge-main-into-amd-staging.yml
+++ b/.github/workflows/merge-main-into-amd-staging.yml
@@ -1,16 +1,27 @@
-# Runs after rockci_multi_arch_amd_staging.yml ("Multi-Arch CI amd-staging") completes, then
-# merges "merge main into amd-staging" sync PRs as a merge commit, once this job has confirmed
-# the mandatory gating checks passed AND the PR has at least one approving review.
+# Auto-merges "merge main into amd-staging" sync PRs.
 #
-# NOTE on "wait for only the gating tests": GitHub's `workflow_run` trigger only supports the fixed
-# `types:` values (requested / in_progress / completed), so the TRIGGER must stay `completed`.
-# The "only the gating tests" requirement is enforced inside the job instead: rather than requiring
-# the whole upstream workflow to succeed, we only require the configured gating checks (see
-# REQUIRED_GATING_CHECKS below) to have passed (other test failures are ignored for the merge
-# decision).
+# Triggered by:
+#   - Completion of "Multi-Arch CI amd-staging"
+#   - PR approval submission
 #
-# Upstream workflow name must match exactly (see `name:` in that file):
-#   .github/workflows/rockci_multi_arch_amd_staging.yml → "Multi-Arch CI amd-staging"
+# Either event can wake this workflow. Before merging, it always re-checks the
+# live PR state:
+#   - All mandatory gating checks must have passed.
+#   - The PR must currently be approved.
+#
+# This makes the merge succeed regardless of whether tests or approval finish first.
+#
+# The workflow performs a direct admin merge because amd-* branches enforce linear
+# history. Native auto-merge cannot create a merge commit here.
+#
+# Prerequisite:
+#   ROCM_CCIAPP must be on the ruleset Bypass list for pull requests, or the merge
+#   will fail.
+#
+# Required secrets and variables:
+#   - vars.ROCM_CCIAPP_APP_ID
+#   - secrets.ROCM_CCIAPP_PRIVATE_KEY
+#   - vars.REQUIRED_GATING_CHECKS (one check name per line)
 #
 # IMPORTANT — why we do a direct merge here (NOT native `gh pr merge --auto`):
 # The branch ruleset `block-merge-commit-on-amd-*-branches` enforces required_linear_history on
@@ -19,24 +30,8 @@
 # explicitly on the ruleset's "Bypass list" — admin privilege alone does NOT bypass a ruleset.
 # Because this job already verifies the gating checks and the approving review itself, it performs
 # an immediate merge with `--admin` using the ROCM_CCIAPP App identity.
+# This makes the merge succeed regardless of whether tests or approval finish first.
 #
-# PREREQUISITE (one-time repo config, cannot be done from this file):
-#   The ROCM_CCIAPP GitHub App MUST be added to the Bypass list of the
-#   `block-merge-commit-on-amd-*-branches` ruleset (bypass mode "For pull requests only").
-#   Without this, the merge-commit merge below will be rejected by the ruleset.
-#
-# Requires: Variable ROCM_CCIAPP_APP_ID + Secret ROCM_CCIAPP_PRIVATE_KEY (same as other automerge).
-#
-# CONFIGURABLE GATING CHECKS:
-#   The mandatory gating checks are NOT hard-coded as the source of truth — they are read from the
-#   repository Variable REQUIRED_GATING_CHECKS (Settings → Secrets and variables → Actions →
-#   Variables). Put ONE check-run name per line, e.g.:
-#       gfx90a Test
-#       Linux::release / Build Multi-Arch Stages / math-libs (...) / Stage - Math Libs (gfx94X-dcgpu)
-#   Surrounding double or single quotes around a line are optional and are stripped, so
-#   "gfx90a Test" and gfx90a Test are treated the same. Blank lines are ignored.
-#   This lets the team change the required tests without editing this workflow. The Variable is
-#   mandatory: if it is empty/unset the job fails with an error (no merge is attempted).
 
 name: Auto-merge main-to-amd-staging after Multi-Arch CI (amd-staging)
 
@@ -45,26 +40,40 @@ on:
     workflows: ["Multi-Arch CI amd-staging"]
     types: [completed]
 
+  pull_request_review:
+    types: [submitted]
+
 permissions:
   contents: write
   pull-requests: write
   checks: read
 
 concurrency:
-  group: automerge-after-rockci-${{ github.event.workflow_run.head_sha }}
+  group: automerge-after-rockci-${{ github.event.pull_request.number || github.event.workflow_run.head_sha }}
   cancel-in-progress: true
 
 jobs:
   merge-after-multi-arch-ci:
     name: Merge after gating checks pass and PR is approved
     runs-on: ubuntu-latest
-    # Do NOT gate on workflow_run.conclusion == 'success': we only require the configured gating
-    # checks (enforced in the step below), not the full test matrix.
+    # Run only for same-repo PRs targeting amd-staging.
     if: >-
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.head_repository.full_name == github.repository &&
-      contains(github.event.workflow_run.display_title, 'merge main into amd-staging')
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        contains(github.event.workflow_run.display_title, 'merge main into amd-staging')
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.review.state == 'approved' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.title, 'merge main into amd-staging') &&
+        github.event.pull_request.base.ref == 'amd-staging'
+      )
+
     steps:
+      # Authenticate as the ROCM_CCIAPP GitHub App.
       - uses: actions/create-github-app-token@v2
         id: rocm-cciapp
         if: ${{ vars.ROCM_CCIAPP_APP_ID != '' }}
@@ -73,39 +82,50 @@ jobs:
           private-key: ${{ secrets.ROCM_CCIAPP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
+      # Resolve the PR, check required tests and approval, then merge.
       - name: Resolve PR, verify gating checks and approval, merge (merge commit)
         env:
           ROCM_CCIAPP_TOKEN: ${{ steps.rocm-cciapp.outputs.token }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           REPO: ${{ github.repository }}
-          PULL_REQUESTS_JSON: ${{ toJSON(github.event.workflow_run.pull_requests) }}
-          # Repository Variable holding the mandatory gating checks (one check name per line),
-          # so the team can change the required tests without editing this workflow. It is
-          # required: the job fails below if it is empty/unset.
           REQUIRED_CHECKS_VAR: ${{ vars.REQUIRED_GATING_CHECKS }}
         run: |
           set -euo pipefail
+
           if [ -z "${ROCM_CCIAPP_TOKEN:-}" ]; then
             echo "::error::Set Variable ROCM_CCIAPP_APP_ID and Secret ROCM_CCIAPP_PRIVATE_KEY."
             exit 1
           fi
           export GH_TOKEN="$ROCM_CCIAPP_TOKEN"
 
-          # Prefer workflow_run.pull_requests when GitHub attaches it (same-repo PRs).
           PR=""
-          if command -v jq >/dev/null 2>&1; then
-            PR=$(echo "${PULL_REQUESTS_JSON}" | jq -r '
-              if . == null or . == [] then empty
-              elif type == "array" then .[0].number | tostring
-              else empty end' 2>/dev/null || true)
+          HEAD_SHA=""
+          HEAD_BRANCH=""
+
+          # Determine the PR from the trigger.
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            HEAD_BRANCH="${{ github.event.workflow_run.head_branch }}"
+
+            PRS_JSON='${{ toJSON(github.event.workflow_run.pull_requests) }}'
+            if command -v jq >/dev/null 2>&1; then
+              PR=$(echo "${PRS_JSON}" | jq -r '
+                if . == null or . == [] then empty
+                elif type == "array" then .[0].number | tostring
+                else empty end' 2>/dev/null || true)
+            fi
+
+            if [ -z "${PR}" ] || [ "${PR}" = "null" ]; then
+              PR="$(gh pr list --repo "${REPO}" --head "${HEAD_BRANCH}" --base amd-staging --state open \
+                --json number -q '.[0].number // empty' 2>/dev/null || true)"
+            fi
+          else
+            PR="${{ github.event.pull_request.number }}"
+            HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+            HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
           fi
+
           if [ -z "${PR}" ] || [ "${PR}" = "null" ]; then
-            PR="$(gh pr list --repo "${REPO}" --head "${HEAD_BRANCH}" --base amd-staging --state open \
-              --json number -q '.[0].number // empty' 2>/dev/null || true)"
-          fi
-          if [ -z "${PR}" ] || [ "${PR}" = "null" ]; then
-            echo "No open PR found for head branch ${HEAD_BRANCH} → amd-staging; skipping."
+            echo "No open PR found for the triggering event; skipping."
             exit 0
           fi
 
@@ -122,17 +142,15 @@ jobs:
           fi
 
           echo "PR #${PR} head SHA: ${HEAD_SHA}"
+          echo "PR #${PR} head branch: ${HEAD_BRANCH}"
 
-          # Build the mandatory gating-check list from REQUIRED_GATING_CHECKS (see header for details).
+          # Build the required check list from the repository variable.
           REQUIRED_CHECKS=()
           if [ -n "${REQUIRED_CHECKS_VAR:-}" ]; then
-            # One check name per line. For each line: strip a trailing CR (CRLF), trim surrounding
-            # whitespace, then strip ONE layer of matching surrounding quotes (so values entered as
-            # "gfx90a Test" or 'gfx90a Test' match the real check-run name without the quotes).
             while IFS= read -r line; do
               line="${line%$'\r'}"
-              line="${line#"${line%%[![:space:]]*}"}"   # ltrim
-              line="${line%"${line##*[![:space:]]}"}"   # rtrim
+              line="${line#"${line%%[![:space:]]*}"}"
+              line="${line%"${line##*[![:space:]]}"}"
               case "${line}" in
                 '"'*'"') line="${line#\"}"; line="${line%\"}" ;;
                 "'"*"'") line="${line#\'}"; line="${line%\'}" ;;
@@ -141,33 +159,37 @@ jobs:
               REQUIRED_CHECKS+=("${line}")
             done <<< "${REQUIRED_CHECKS_VAR}"
           fi
+
           if [ "${#REQUIRED_CHECKS[@]}" -eq 0 ]; then
-            echo "::error::Variable REQUIRED_GATING_CHECKS is not set (or empty). Define it with one check-run name per line (Settings → Secrets and variables → Actions → Variables)."
+            echo "::error::Variable REQUIRED_GATING_CHECKS is not set or empty. Define one check name per line."
             exit 1
           fi
 
           echo "Mandatory gating checks (${#REQUIRED_CHECKS[@]}):"
-          for name in "${REQUIRED_CHECKS[@]}"; do echo "  - ${name}"; done
+          for name in "${REQUIRED_CHECKS[@]}"; do
+            echo "  - ${name}"
+          done
 
-          # The upstream workflow has completed, but a gating check may belong to a sibling
-          # workflow still finishing, so allow a short wait.
-          MAX_ATTEMPTS=30
-          SLEEP_SECONDS=60
-          attempt=0
+          # Wait up to 12 hours for the required checks to complete successfully.
+          DEADLINE=$(( $(date +%s) + 12 * 60 * 60 ))
+          SLEEP_SECONDS=300
+
           while :; do
-            attempt=$((attempt + 1))
             CHECKS_JSON="$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
               -q '.check_runs[] | {name: .name, status: .status, conclusion: .conclusion}' 2>/dev/null \
               | jq -s '.' || echo '[]')"
 
             all_done=true
             any_failed=false
+
             for name in "${REQUIRED_CHECKS[@]}"; do
               status="$(echo "${CHECKS_JSON}" | jq -r --arg n "$name" \
                 '[.[] | select(.name == $n)] | last | .status // "missing"')"
               conclusion="$(echo "${CHECKS_JSON}" | jq -r --arg n "$name" \
                 '[.[] | select(.name == $n)] | last | .conclusion // ""')"
+
               echo "Gating check '${name}': status=${status}, conclusion=${conclusion}"
+
               if [ "${status}" != "completed" ]; then
                 all_done=false
               elif [ "${conclusion}" != "success" ]; then
@@ -179,35 +201,34 @@ jobs:
               echo "::error::One or more mandatory gating checks failed for PR #${PR}; not merging."
               exit 1
             fi
+
             if [ "${all_done}" = "true" ]; then
               echo "All gating checks completed successfully for PR #${PR}."
               break
             fi
-            if [ "${attempt}" -ge "${MAX_ATTEMPTS}" ]; then
-              echo "::error::Timed out waiting for gating checks on PR #${PR}."
+
+            NOW=$(date +%s)
+            if [ "${NOW}" -ge "${DEADLINE}" ]; then
+              echo "::error::Timed out after 12 hours waiting for gating checks on PR #${PR}."
               exit 1
             fi
-            echo "Waiting for gating checks... attempt ${attempt}/${MAX_ATTEMPTS}; sleeping ${SLEEP_SECONDS}s."
+
+            echo "Waiting for gating checks... sleeping ${SLEEP_SECONDS}s."
             sleep "${SLEEP_SECONDS}"
           done
 
-          # Require at least one approving review (+1). reviewDecision is APPROVED only when the
-          # repo's review requirements are satisfied. Skip (non-fatal) if not yet approved: approval
-          # may simply not be in place when this runs.
+          # Re-check the current review state before merging.
           REVIEW_DECISION="$(gh pr view "${PR}" --repo "${REPO}" --json reviewDecision -q '.reviewDecision // ""')"
           echo "PR #${PR} reviewDecision: ${REVIEW_DECISION:-<none>}"
+
           if [ "${REVIEW_DECISION}" != "APPROVED" ]; then
-            echo "PR #${PR} does not have an approving review (reviewDecision=${REVIEW_DECISION:-<none>}); skipping."
+            echo "PR #${PR} is not currently approved; skipping."
             exit 0
           fi
 
-          echo "Merging (merge commit) PR #${PR} (${REPO}): gating checks passed and PR is approved."
-          # Direct merge with --admin (NOT --auto): native auto-merge can never land a merge commit
-          # while the block-merge-commit-on-amd-*-branches ruleset enforces required_linear_history.
-          # NOTE: --admin and --auto are mutually exclusive in gh, and admin privilege alone does not
-          # bypass a ruleset — the ROCM_CCIAPP App must be on the ruleset's Bypass list (see header).
+          echo "Merging PR #${PR} with admin privileges."
           if ! gh pr merge "${PR}" --repo "${REPO}" --merge --admin 2> merge_err.log; then
-            echo "::error::Merge failed for PR #${PR}. See diagnostics below."
+            echo "::error::Merge failed for PR #${PR}."
             echo "::group::gh pr merge error output"
             cat merge_err.log || true
             echo "::endgroup::"
@@ -218,4 +239,5 @@ jobs:
             echo "::endgroup::"
             exit 1
           fi
-          echo "Merge (merge commit) completed successfully for PR #${PR}."
+
+          echo "Merge completed successfully for PR #${PR}."


### PR DESCRIPTION
## Summary

This change improves the reliability of the `merge-main-into-amd-staging` workflow by ensuring sync PRs are automatically merged once both required conditions are satisfied, regardless of which occurs first.

## Changes
- Trigger merge evaluation on both Multi-Arch CI completion and PR approval.
- Re-validate mandatory gating checks and approval before performing the admin merge.
- Replace the fixed polling limit with a 12-hour wait window to accommodate long-running gating tests.
- Preserve the existing direct admin merge behavior using the ROCM_CCIAPP App.
- Simplify workflow comments for better readability and maintenance.

## Motivation
Previously, the workflow only ran after the CI workflow completed, requiring manual intervention. This change ensures the workflow is re-evaluated whenever either prerequisite changes, enabling automatic merging once both requirements are met.