### PR TITLE
AMDGPU: preserve data addresses for hotswap entry stubs

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -32,6 +32,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
 
+#include <algorithm>
 #include <limits>
 
 using namespace llvm;
@@ -74,6 +75,67 @@ static RewriteConfig makeGfx1250B0A0Config() {
   Config.MaxSgprs = Gfx1250MaxSgprs;
   Config.VgprGranuleSize = Gfx1250VgprGranuleSize;
   return Config;
+}
+
+static bool appendCodeEndGuard(std::vector<Trampoline> &Growth,
+                               uint64_t GuardBytes, const LLVMState &LS) {
+  if (GuardBytes == 0)
+    return true;
+
+  SmallVector<uint8_t> CodeEnd = assembleSingleInst("s_code_end", LS);
+  if (CodeEnd.empty()) {
+    log() << "hotswap: error: failed to assemble s_code_end for trampoline "
+          << "prefetch guard.\n";
+    return false;
+  }
+  if (GuardBytes % CodeEnd.size() != 0) {
+    log() << "hotswap: error: trampoline prefetch guard size " << GuardBytes
+          << " is not a multiple of s_code_end size " << CodeEnd.size()
+          << ".\n";
+    return false;
+  }
+  if (GuardBytes > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+    log() << "hotswap: error: trampoline prefetch guard size " << GuardBytes
+          << " exceeds size_t.\n";
+    return false;
+  }
+
+  Trampoline Guard;
+  while (static_cast<uint64_t>(Guard.Bytes.size()) < GuardBytes)
+    Guard.Bytes.append(CodeEnd.begin(), CodeEnd.end());
+  Growth.push_back(std::move(Guard));
+  return true;
+}
+
+static std::optional<uint32_t> getMaxKernelInstPrefSize(const ElfView &Elf,
+                                                        const LLVMState &LS) {
+  std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  uint32_t MaxInstPrefLines = 0;
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    std::optional<uint32_t> InstPrefLines =
+        Elf.getKernelDescriptorInstPrefSize(KD.KernelName, LS.Cpu);
+    if (!InstPrefLines)
+      return std::nullopt;
+    MaxInstPrefLines = std::max(MaxInstPrefLines, *InstPrefLines);
+  }
+  return MaxInstPrefLines;
+}
+
+static bool
+appendDeferredTrampolinePrefetchGuard(const ElfView &Elf, const LLVMState &LS,
+                                      std::vector<Trampoline> &Growth) {
+  std::optional<uint32_t> MaxInstPrefLines = getMaxKernelInstPrefSize(Elf, LS);
+  if (!MaxInstPrefLines)
+    return false;
+
+  uint64_t GuardBytes =
+      static_cast<uint64_t>(*MaxInstPrefLines) * KernelEntryInstPrefUnitBytes;
+  if (!appendCodeEndGuard(Growth, GuardBytes, LS))
+    return false;
+
+  log() << "hotswap: appended " << GuardBytes
+        << " trampoline prefetch guard bytes\n";
+  return true;
 }
 
 // -- Forward declarations for liveness/DWARF stubs ----------------------------
@@ -198,32 +260,58 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 
 // -- NOP sled scanning --------------------------------------------------------
 
+static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
+                                 uint64_t End,
+                                 FunctionTextRange FunctionRange) {
+  if (End - Start >= MinNopSledSize)
+    Sleds.push_back(
+        {Start, End, Start, FunctionRange.Start, FunctionRange.End});
+}
+
 /// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
-/// MinNopSledSize bytes long and return the resulting NopSled list (each
-/// sled records Start / End byte offsets in .text and the initial WritePos
-/// at Start). These sleds are the landing zones emitToNopSled targets for
-/// in-place rewrites. NOPs are identified by MC opcode (cached on \p LS at
-/// initLLVM() time) rather than mnemonic string, so the scanner is robust
-/// against printer aliasing / mnemonic formatting variations.
+/// MinNopSledSize bytes long and return the resulting NopSled list. Each sled
+/// records its owning function range so emitReplacementCode can only borrow
+/// padding from the same kernel as the instruction being patched. NOPs outside
+/// any sized function symbol are ignored.
 static std::vector<NopSled>
-buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS) {
+buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+                const ElfView &Elf) {
   std::vector<NopSled> Sleds;
-  const size_t N = Decoded.size();
-  size_t I = 0;
-  while (I < N) {
-    if (Decoded[I].Inst.getOpcode() == LS.SNopOpcode) {
-      uint64_t Start = Decoded[I].Offset;
-      uint64_t End = Start;
-      while (I < N && Decoded[I].Inst.getOpcode() == LS.SNopOpcode) {
-        End = Decoded[I].Offset + Decoded[I].Size;
-        ++I;
-      }
-      if (End - Start >= MinNopSledSize)
-        Sleds.push_back({Start, End, Start});
-    } else {
-      ++I;
+  bool HasActiveRange = false;
+  FunctionTextRange ActiveRange;
+  uint64_t Start = 0;
+  uint64_t End = 0;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Inst.getOpcode() != LS.SNopOpcode) {
+      if (HasActiveRange)
+        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+      HasActiveRange = false;
+      continue;
     }
+
+    std::optional<FunctionTextRange> Range =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    if (!Range || DI.Size > Range->End - DI.Offset) {
+      if (HasActiveRange)
+        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+      HasActiveRange = false;
+      continue;
+    }
+
+    if (!HasActiveRange || ActiveRange.Start != Range->Start ||
+        ActiveRange.End != Range->End || DI.Offset != End) {
+      if (HasActiveRange)
+        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+      ActiveRange = *Range;
+      HasActiveRange = true;
+      Start = DI.Offset;
+    }
+    End = DI.Offset + DI.Size;
   }
+
+  if (HasActiveRange)
+    appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
   return Sleds;
 }
 
@@ -335,7 +423,7 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
                         std::vector<ScratchPatchInfo> &OutScratchPatches,
                         const RewriteConfig &Config) {
   uint32_t Patched = 0;
-  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS);
+  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
 
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
   LivenessInfo Liveness =
@@ -614,6 +702,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   } else {
     log() << "hotswap: kernel-entry trampolines disabled for this rewrite\n";
   }
+
+  if (!Deferred.empty() &&
+      !appendDeferredTrampolinePrefetchGuard(Elf, LS, Growth))
+    return AMD_COMGR_STATUS_ERROR;
 
   if (!Growth.empty()) {
     Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -634,7 +634,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       GrowthTotal += T.Bytes.size();
     }
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(),
+    if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(), LS.Cpu,
                                              EntryFixups))
       return AMD_COMGR_STATUS_ERROR;
   } else {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -690,22 +690,41 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       return AMD_COMGR_STATUS_ERROR;
     }
     Growth = Deferred;
+    if (!appendDeferredTrampolinePrefetchGuard(Elf, LS, Growth))
+      return AMD_COMGR_STATUS_ERROR;
+  }
+
+  size_t GrowthTotal = 0;
+  for (const Trampoline &T : Growth) {
+    if (T.Bytes.size() > std::numeric_limits<size_t>::max() - GrowthTotal) {
+      log() << "hotswap: error: retargetCodeObject: growth byte count "
+            << "overflows size_t.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    GrowthTotal += T.Bytes.size();
   }
 
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
+  SmallVector<uint8_t> EntryBytes;
+  std::optional<ExecutableSegmentPlan> EntryPlan;
   if (Options.RunEntryTrampolines) {
-    std::optional<uint32_t> EntryCount = appendKernelEntryTrampolines(
-        Elf, LS, Config.MaxSgprs, Growth, EntryFixups);
-    if (!EntryCount)
-      return AMD_COMGR_STATUS_ERROR;
-    Count += *EntryCount;
+    if (!Elf.kernelDescriptors().empty()) {
+      EntryPlan = Elf.planExecutableSegment(
+          KernelEntryStubStride, KernelEntryStubSegmentAlign, GrowthTotal);
+      if (!EntryPlan)
+        return AMD_COMGR_STATUS_ERROR;
+      std::optional<uint32_t> EntryCount = appendKernelEntryTrampolines(
+          Elf, LS, Config.MaxSgprs, EntryPlan->PayloadVAddr, EntryBytes,
+          EntryFixups);
+      if (!EntryCount)
+        return AMD_COMGR_STATUS_ERROR;
+      if (EntryBytes.empty())
+        EntryPlan = std::nullopt;
+      Count += *EntryCount;
+    }
   } else {
     log() << "hotswap: kernel-entry trampolines disabled for this rewrite\n";
   }
-
-  if (!Deferred.empty() &&
-      !appendDeferredTrampolinePrefetchGuard(Elf, LS, Growth))
-    return AMD_COMGR_STATUS_ERROR;
 
   if (!Growth.empty()) {
     Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);
@@ -716,19 +735,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       return AMD_COMGR_STATUS_ERROR;
     }
 
-    size_t GrowthTotal = 0;
-    for (const Trampoline &T : Growth) {
-      if (T.Bytes.size() > std::numeric_limits<size_t>::max() - GrowthTotal) {
-        log() << "hotswap: error: retargetCodeObject: growth byte count "
-              << "overflows size_t.\n";
-        return AMD_COMGR_STATUS_ERROR;
-      }
-      GrowthTotal += T.Bytes.size();
-    }
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(), LS.Cpu,
-                                             EntryFixups))
-      return AMD_COMGR_STATUS_ERROR;
   } else {
     Result = WritableMemoryBuffer::getNewUninitMemBuffer(ElfSize);
     if (!Result) {
@@ -739,6 +746,30 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     }
     std::memcpy(Result->getBufferStart(), Buf.data(), ElfSize);
   }
+
+  if (!EntryBytes.empty()) {
+    uint8_t *OutData = reinterpret_cast<uint8_t *>(Result->getBufferStart());
+    Expected<ElfView> OutView =
+        ElfView::create(OutData, Result->getBufferSize());
+    if (!OutView) {
+      log() << "hotswap: error: retargetCodeObject: failed to reparse output "
+            << "before appending entry stubs: " << toString(OutView.takeError())
+            << "\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    std::unique_ptr<WritableMemoryBuffer> WithEntryStubs =
+        OutView->appendExecutableSegment(EntryBytes, *EntryPlan,
+                                         ".hotswap.entry");
+    if (!WithEntryStubs) {
+      log() << "hotswap: error: retargetCodeObject: failed to append "
+            << "kernel-entry trampoline segment.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    Result = std::move(WithEntryStubs);
+  }
+
+  if (!rewriteKernelEntryDescriptorOffsets(*Result, LS.Cpu, EntryFixups))
+    return AMD_COMGR_STATUS_ERROR;
 
   if (!ScratchPatches.empty())
     runScratchVerification(*Result, LS, ScratchPatches, Config.MaxVgprs);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -71,6 +71,42 @@ checkedAlignToSize(size_t Value, uint64_t Alignment, StringRef Context) {
   return static_cast<size_t>(*Aligned);
 }
 
+static std::optional<uint64_t>
+checkedAlignToU64(uint64_t Value, uint64_t Alignment, StringRef Context) {
+  if (Alignment <= 1)
+    return Value;
+  uint64_t Remainder = Value % Alignment;
+  if (Remainder == 0)
+    return Value;
+  return checkedAdd(Value, Alignment - Remainder, Context);
+}
+
+static std::optional<uint64_t> checkedMulU64(uint64_t LHS, uint64_t RHS,
+                                             StringRef Context) {
+  std::optional<uint64_t> Result = checkedMulUnsigned(LHS, RHS);
+  if (Result)
+    return Result;
+
+  log() << "hotswap: error: " << Context << " overflows uint64_t.\n";
+  return std::nullopt;
+}
+
+static bool isRangeInFile(uint64_t Offset, uint64_t RangeSize,
+                          uint64_t FileSize, StringRef Context) {
+  if (Offset > FileSize || RangeSize > FileSize - Offset) {
+    uint64_t End = Offset;
+    std::optional<uint64_t> EndOrErr =
+        checkedAdd(Offset, RangeSize, "diagnostic file range end");
+    if (EndOrErr)
+      End = *EndOrErr;
+    log() << "hotswap: error: " << Context << " range [0x" << utohexstr(Offset)
+          << ", 0x" << utohexstr(End) << ") exceeds ELF size 0x"
+          << utohexstr(FileSize) << ".\n";
+    return false;
+  }
+  return true;
+}
+
 static std::optional<uint64_t> checkedSectionFileOffset(const ELFT::Shdr &Sec,
                                                         uint64_t VAddr,
                                                         uint64_t AccessSize,
@@ -1138,6 +1174,356 @@ static bool adjustSymbolValues(uint8_t *Elf, size_t ElfSize,
     ++SectionIndex;
   }
   return true;
+}
+
+// -- ElfView::planExecutableSegment ------------------------------------------
+
+std::optional<ExecutableSegmentPlan>
+ElfView::planExecutableSegment(uint64_t PayloadAlign, uint64_t SegmentAlign,
+                               uint64_t ReservedVAddrGrowth) const {
+  if (PayloadAlign == 0 || SegmentAlign == 0) {
+    log() << "hotswap: error: planExecutableSegment: zero alignment "
+          << "(payload=" << PayloadAlign << ", segment=" << SegmentAlign
+          << ").\n";
+    return std::nullopt;
+  }
+
+  const ELFFileT::Elf_Ehdr &Header = File.getHeader();
+  if (Header.e_phnum == ELF::PN_XNUM) {
+    log() << "hotswap: error: planExecutableSegment: extended program-header "
+          << "counts are not supported.\n";
+    return std::nullopt;
+  }
+  if (Header.e_phnum == std::numeric_limits<uint16_t>::max()) {
+    log() << "hotswap: error: planExecutableSegment: program-header count "
+          << Header.e_phnum << " cannot grow by one.\n";
+    return std::nullopt;
+  }
+
+  uint64_t ChosenSegmentAlign = std::max(SegmentAlign, PayloadAlign);
+  uint64_t MaxAllocEnd = 0;
+  bool SawLoadSegment = false;
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: planExecutableSegment: failed to read program "
+          << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD)
+      continue;
+    SawLoadSegment = true;
+    std::optional<uint64_t> SegmentEnd = checkedAdd(
+        Phdr.p_vaddr, Phdr.p_memsz, "planExecutableSegment load segment end");
+    if (!SegmentEnd)
+      return std::nullopt;
+    MaxAllocEnd = std::max(MaxAllocEnd, *SegmentEnd);
+    if (Phdr.p_align > ChosenSegmentAlign)
+      ChosenSegmentAlign = Phdr.p_align;
+  }
+
+  if (!SawLoadSegment) {
+    for (const ELFT::Shdr &Shdr : Sections) {
+      if (!(Shdr.sh_flags & ELF::SHF_ALLOC))
+        continue;
+      std::optional<uint64_t> SectionEnd =
+          checkedAdd(Shdr.sh_addr, Shdr.sh_size,
+                     "planExecutableSegment alloc section end");
+      if (!SectionEnd)
+        return std::nullopt;
+      MaxAllocEnd = std::max(MaxAllocEnd, *SectionEnd);
+    }
+  }
+
+  std::optional<uint64_t> ReservedEnd =
+      checkedAdd(MaxAllocEnd, ReservedVAddrGrowth,
+                 "planExecutableSegment reserved vaddr growth");
+  if (!ReservedEnd)
+    return std::nullopt;
+
+  std::optional<uint64_t> NewPhdrCount =
+      checkedAdd(static_cast<uint64_t>(Header.e_phnum), 1,
+                 "planExecutableSegment program-header count");
+  if (!NewPhdrCount)
+    return std::nullopt;
+  std::optional<uint64_t> NewPhdrBytes =
+      checkedMulU64(*NewPhdrCount, sizeof(Phdr),
+                    "planExecutableSegment program-header byte count");
+  if (!NewPhdrBytes)
+    return std::nullopt;
+  std::optional<uint64_t> PayloadOffset = checkedAlignToU64(
+      *NewPhdrBytes, PayloadAlign, "planExecutableSegment payload offset");
+  if (!PayloadOffset)
+    return std::nullopt;
+  std::optional<uint64_t> SegmentVAddr = checkedAlignToU64(
+      *ReservedEnd, ChosenSegmentAlign, "planExecutableSegment segment vaddr");
+  if (!SegmentVAddr)
+    return std::nullopt;
+  std::optional<uint64_t> PayloadVAddr = checkedAdd(
+      *SegmentVAddr, *PayloadOffset, "planExecutableSegment payload vaddr");
+  if (!PayloadVAddr)
+    return std::nullopt;
+
+  return ExecutableSegmentPlan{*SegmentVAddr, *PayloadOffset, *PayloadVAddr,
+                               PayloadAlign, ChosenSegmentAlign};
+}
+
+// -- ElfView::appendExecutableSegment ----------------------------------------
+
+std::unique_ptr<WritableMemoryBuffer>
+ElfView::appendExecutableSegment(ArrayRef<uint8_t> PayloadBytes,
+                                 const ExecutableSegmentPlan &Plan,
+                                 StringRef SectionName) const {
+  if (PayloadBytes.empty()) {
+    log() << "hotswap: error: appendExecutableSegment: empty payload.\n";
+    return nullptr;
+  }
+  if (Plan.SegmentAlign == 0 || Plan.PayloadAlign == 0 ||
+      Plan.PayloadOffset == 0) {
+    log() << "hotswap: error: appendExecutableSegment: invalid segment plan.\n";
+    return nullptr;
+  }
+  std::optional<uint64_t> ExpectedPayloadVAddr =
+      checkedAdd(Plan.SegmentVAddr, Plan.PayloadOffset,
+                 "appendExecutableSegment payload vaddr");
+  if (!ExpectedPayloadVAddr || *ExpectedPayloadVAddr != Plan.PayloadVAddr) {
+    log() << "hotswap: error: appendExecutableSegment: inconsistent payload "
+          << "vaddr in segment plan.\n";
+    return nullptr;
+  }
+
+  const size_t InputSize = size();
+  const uint8_t *Input = data();
+  const ELFFileT::Elf_Ehdr &Header = File.getHeader();
+  if (Header.e_phnum == ELF::PN_XNUM ||
+      Header.e_phnum == std::numeric_limits<uint16_t>::max()) {
+    log() << "hotswap: error: appendExecutableSegment: program-header count "
+          << Header.e_phnum << " cannot grow by one.\n";
+    return nullptr;
+  }
+  if (Header.e_shnum == ELF::SHN_UNDEF ||
+      Header.e_shnum == std::numeric_limits<uint16_t>::max()) {
+    log() << "hotswap: error: appendExecutableSegment: section-header count "
+          << Header.e_shnum << " cannot grow by one.\n";
+    return nullptr;
+  }
+  if (Header.e_phnum != 0 && Header.e_phentsize < sizeof(Phdr)) {
+    log() << "hotswap: error: appendExecutableSegment: program-header entry "
+          << "size " << Header.e_phentsize << " is smaller than "
+          << sizeof(Phdr) << ".\n";
+    return nullptr;
+  }
+  if (Header.e_shentsize < sizeof(Shdr)) {
+    log() << "hotswap: error: appendExecutableSegment: section-header entry "
+          << "size " << Header.e_shentsize << " is smaller than "
+          << sizeof(Shdr) << ".\n";
+    return nullptr;
+  }
+
+  const uint16_t OldPhnum = Header.e_phnum;
+  const uint16_t NewPhnum = OldPhnum + 1;
+  const uint16_t OldShnum = Header.e_shnum;
+  const uint16_t NewShnum = OldShnum + 1;
+
+  std::optional<uint64_t> SegmentFileOff64 =
+      checkedAlignToU64(static_cast<uint64_t>(InputSize), Plan.SegmentAlign,
+                        "appendExecutableSegment segment file offset");
+  if (!SegmentFileOff64)
+    return nullptr;
+  if (*SegmentFileOff64 >
+      static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+    log() << "hotswap: error: appendExecutableSegment: segment file offset "
+          << "exceeds size_t.\n";
+    return nullptr;
+  }
+  size_t SegmentFileOff = static_cast<size_t>(*SegmentFileOff64);
+
+  std::optional<uint64_t> NewPhdrBytes =
+      checkedMulU64(NewPhnum, sizeof(Phdr),
+                    "appendExecutableSegment program-header byte count");
+  if (!NewPhdrBytes)
+    return nullptr;
+  if (Plan.PayloadOffset < *NewPhdrBytes) {
+    log() << "hotswap: error: appendExecutableSegment: payload offset "
+          << Plan.PayloadOffset << " overlaps relocated program headers ("
+          << *NewPhdrBytes << " bytes).\n";
+    return nullptr;
+  }
+
+  std::optional<uint64_t> PayloadFileOff64 =
+      checkedAdd(*SegmentFileOff64, Plan.PayloadOffset,
+                 "appendExecutableSegment payload file offset");
+  if (!PayloadFileOff64)
+    return nullptr;
+  std::optional<uint64_t> PayloadEnd64 =
+      checkedAdd(*PayloadFileOff64, PayloadBytes.size(),
+                 "appendExecutableSegment payload end");
+  if (!PayloadEnd64)
+    return nullptr;
+  std::optional<uint64_t> SegmentFileSize =
+      checkedAdd(Plan.PayloadOffset, PayloadBytes.size(),
+                 "appendExecutableSegment segment file size");
+  if (!SegmentFileSize)
+    return nullptr;
+
+  std::vector<Phdr> NewPhdrs(NewPhnum);
+  for (uint16_t I = 0; I < OldPhnum; ++I) {
+    std::optional<uint64_t> PhEntryDelta =
+        checkedMulU64(I, Header.e_phentsize,
+                      "appendExecutableSegment program-header entry offset");
+    if (!PhEntryDelta)
+      return nullptr;
+    std::optional<uint64_t> PhEntryOff =
+        checkedAdd(Header.e_phoff, *PhEntryDelta,
+                   "appendExecutableSegment program-header file offset");
+    if (!PhEntryOff)
+      return nullptr;
+    if (!isRangeInFile(*PhEntryOff, sizeof(Phdr), InputSize,
+                       "appendExecutableSegment program-header"))
+      return nullptr;
+    std::memcpy(&NewPhdrs[I], Input + *PhEntryOff, sizeof(Phdr));
+    if (NewPhdrs[I].p_type == ELF::PT_PHDR) {
+      NewPhdrs[I].p_offset = SegmentFileOff;
+      NewPhdrs[I].p_vaddr = Plan.SegmentVAddr;
+      NewPhdrs[I].p_paddr = Plan.SegmentVAddr;
+      NewPhdrs[I].p_filesz = *NewPhdrBytes;
+      NewPhdrs[I].p_memsz = *NewPhdrBytes;
+      NewPhdrs[I].p_flags = ELF::PF_R;
+      NewPhdrs[I].p_align = 8;
+    }
+  }
+
+  Phdr &NewLoad = NewPhdrs[OldPhnum];
+  NewLoad.p_type = ELF::PT_LOAD;
+  NewLoad.p_flags = ELF::PF_R | ELF::PF_X;
+  NewLoad.p_offset = SegmentFileOff;
+  NewLoad.p_vaddr = Plan.SegmentVAddr;
+  NewLoad.p_paddr = Plan.SegmentVAddr;
+  NewLoad.p_filesz = *SegmentFileSize;
+  NewLoad.p_memsz = *SegmentFileSize;
+  NewLoad.p_align = Plan.SegmentAlign;
+
+  std::vector<Shdr> NewShdrs(NewShnum);
+  for (uint16_t I = 0; I < OldShnum; ++I) {
+    std::optional<uint64_t> ShEntryDelta =
+        checkedMulU64(I, Header.e_shentsize,
+                      "appendExecutableSegment section-header entry offset");
+    if (!ShEntryDelta)
+      return nullptr;
+    std::optional<uint64_t> ShEntryOff =
+        checkedAdd(Header.e_shoff, *ShEntryDelta,
+                   "appendExecutableSegment section-header file offset");
+    if (!ShEntryOff)
+      return nullptr;
+    if (!isRangeInFile(*ShEntryOff, sizeof(Shdr), InputSize,
+                       "appendExecutableSegment section-header"))
+      return nullptr;
+    std::memcpy(&NewShdrs[I], Input + *ShEntryOff, sizeof(Shdr));
+  }
+
+  std::vector<uint8_t> NewShStr;
+  uint32_t NewSectionName = 0;
+  if (Header.e_shstrndx < OldShnum) {
+    const Shdr &OldShStr = NewShdrs[Header.e_shstrndx];
+    if (!isRangeInFile(OldShStr.sh_offset, OldShStr.sh_size, InputSize,
+                       "appendExecutableSegment shstrtab"))
+      return nullptr;
+    if (OldShStr.sh_size > std::numeric_limits<uint32_t>::max() ||
+        SectionName.size() + 1 >
+            std::numeric_limits<uint32_t>::max() - OldShStr.sh_size) {
+      log() << "hotswap: error: appendExecutableSegment: section-name string "
+            << "table is too large.\n";
+      return nullptr;
+    }
+    NewShStr.assign(Input + OldShStr.sh_offset,
+                    Input + OldShStr.sh_offset + OldShStr.sh_size);
+    NewSectionName = static_cast<uint32_t>(NewShStr.size());
+    NewShStr.insert(NewShStr.end(), SectionName.begin(), SectionName.end());
+    NewShStr.push_back('\0');
+  } else {
+    log() << "hotswap: appendExecutableSegment: no valid section-name string "
+          << "table; appending unnamed executable section.\n";
+  }
+
+  Shdr &PayloadSh = NewShdrs[OldShnum];
+  PayloadSh.sh_name = NewSectionName;
+  PayloadSh.sh_type = ELF::SHT_PROGBITS;
+  PayloadSh.sh_flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
+  PayloadSh.sh_addr = Plan.PayloadVAddr;
+  PayloadSh.sh_offset = *PayloadFileOff64;
+  PayloadSh.sh_size = PayloadBytes.size();
+  PayloadSh.sh_addralign = Plan.PayloadAlign;
+
+  uint64_t ShStrOff64 = *PayloadEnd64;
+  if (!NewShStr.empty()) {
+    if (Header.e_shstrndx < OldShnum) {
+      NewShdrs[Header.e_shstrndx].sh_offset = ShStrOff64;
+      NewShdrs[Header.e_shstrndx].sh_size = NewShStr.size();
+    }
+    std::optional<uint64_t> ShStrEnd64 = checkedAdd(
+        ShStrOff64, NewShStr.size(), "appendExecutableSegment shstrtab end");
+    if (!ShStrEnd64)
+      return nullptr;
+    ShStrOff64 = *ShStrEnd64;
+  }
+
+  std::optional<uint64_t> NewShOff64 = checkedAlignToU64(
+      ShStrOff64, 8, "appendExecutableSegment section-header table offset");
+  if (!NewShOff64)
+    return nullptr;
+  std::optional<uint64_t> NewShdrBytes =
+      checkedMulU64(NewShnum, sizeof(Shdr),
+                    "appendExecutableSegment section-header byte count");
+  if (!NewShdrBytes)
+    return nullptr;
+  std::optional<uint64_t> NewSize64 = checkedAdd(
+      *NewShOff64, *NewShdrBytes, "appendExecutableSegment output ELF size");
+  if (!NewSize64)
+    return nullptr;
+  if (*NewSize64 > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+    log() << "hotswap: error: appendExecutableSegment: output ELF size "
+          << "exceeds size_t.\n";
+    return nullptr;
+  }
+  const size_t NewSize = static_cast<size_t>(*NewSize64);
+
+  std::unique_ptr<WritableMemoryBuffer> Buf =
+      WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
+  if (!Buf) {
+    log() << "hotswap: error: appendExecutableSegment: "
+          << "WritableMemoryBuffer::getNewUninitMemBuffer(" << NewSize
+          << ") failed (out of memory).\n";
+    return nullptr;
+  }
+
+  uint8_t *Out = reinterpret_cast<uint8_t *>(Buf->getBufferStart());
+  std::memset(Out, 0, NewSize);
+  std::memcpy(Out, Input, InputSize);
+  std::memcpy(Out + SegmentFileOff, NewPhdrs.data(),
+              static_cast<size_t>(*NewPhdrBytes));
+  std::memcpy(Out + *PayloadFileOff64, PayloadBytes.data(),
+              PayloadBytes.size());
+  if (!NewShStr.empty())
+    std::memcpy(Out + *PayloadEnd64, NewShStr.data(), NewShStr.size());
+  std::memcpy(Out + *NewShOff64, NewShdrs.data(),
+              static_cast<size_t>(*NewShdrBytes));
+
+  Ehdr NewHeader;
+  std::memcpy(&NewHeader, Input, sizeof(NewHeader));
+  NewHeader.e_phoff = SegmentFileOff;
+  NewHeader.e_phentsize = sizeof(Phdr);
+  NewHeader.e_phnum = NewPhnum;
+  NewHeader.e_shoff = *NewShOff64;
+  NewHeader.e_shentsize = sizeof(Shdr);
+  NewHeader.e_shnum = NewShnum;
+  std::memcpy(Out, &NewHeader, sizeof(NewHeader));
+
+  log() << "hotswap: appendExecutableSegment: appended " << PayloadBytes.size()
+        << " executable payload bytes at vaddr 0x"
+        << utohexstr(Plan.PayloadVAddr) << "; ELF grew from " << InputSize
+        << " to " << NewSize << " bytes.\n";
+  return Buf;
 }
 
 // -- ElfView::growWithTrampolines ---------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -290,10 +290,18 @@ NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
   NopSled *Best = nullptr;
   int64_t BestDist = INT64_MAX;
   for (NopSled &Sled : Sleds) {
-    if (Sled.WritePos + Needed > Sled.End)
+    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
       continue;
-    int64_t Dist = std::abs(static_cast<int64_t>(Sled.WritePos) -
-                            static_cast<int64_t>(Offset));
+    if (Sled.WritePos > Sled.End || Needed > Sled.End - Sled.WritePos)
+      continue;
+    if (Sled.WritePos > Sled.FunctionEnd ||
+        Needed > Sled.FunctionEnd - Sled.WritePos)
+      continue;
+    uint64_t Dist64 = Sled.WritePos > Offset ? Sled.WritePos - Offset
+                                             : Offset - Sled.WritePos;
+    if (Dist64 > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
+      continue;
+    int64_t Dist = static_cast<int64_t>(Dist64);
     if (Dist < MaxSledDistance && Dist < BestDist) {
       Best = &Sled;
       BestDist = Dist;
@@ -385,6 +393,38 @@ std::string ElfView::findKernelAtOffset(uint64_t TextOffset) const {
   log() << "hotswap: findKernelAtOffset: no function symbol covers offset 0x"
         << utohexstr(TextOffset) << " in .text.\n";
   return "";
+}
+
+std::optional<FunctionTextRange>
+ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      consumeError(SymsOrErr.takeError());
+      continue;
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
+        continue;
+      if (Sym.st_shndx != TextSectionIndex || Sym.st_size == 0)
+        continue;
+      if (Sym.st_value < textAddr())
+        continue;
+
+      uint64_t Start = Sym.st_value - textAddr();
+      if (Sym.st_size > std::numeric_limits<uint64_t>::max() - Start)
+        continue;
+      uint64_t End = Start + Sym.st_size;
+      if (TextOffset >= Start && TextOffset < End)
+        return FunctionTextRange{Start, End};
+    }
+  }
+  return std::nullopt;
 }
 
 // -- ElfView::findKernelDescriptor --------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -616,6 +616,44 @@ ElfView::getKernelDescriptorInstPrefSize(StringRef KernelName,
   return std::nullopt;
 }
 
+bool ElfView::updateKernelDescriptorInstPrefSize(StringRef KernelName,
+                                                 StringRef TargetCpu,
+                                                 uint32_t InstPrefLines) {
+  namespace hsa = amdhsa;
+  uint8_t *Kd = findKernelDescriptor(KernelName);
+  if (!Kd) {
+    log() << "hotswap: error: updateKernelDescriptorInstPrefSize: kernel "
+          << "descriptor symbol '" << KernelName << ".kd' not found.\n";
+    return false;
+  }
+
+  if (!TargetCpu.starts_with("gfx12")) {
+    log() << "hotswap: error: updateKernelDescriptorInstPrefSize: unsupported "
+          << "target CPU '" << TargetCpu << "' for kernel '" << KernelName
+          << "'.\n";
+    return false;
+  }
+
+  uint32_t MaxInstPrefLines = static_cast<uint32_t>(
+      hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE >>
+      hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE_SHIFT);
+  if (InstPrefLines > MaxInstPrefLines) {
+    log() << "hotswap: error: updateKernelDescriptorInstPrefSize: value "
+          << InstPrefLines << " exceeds the gfx12 descriptor encoding limit.\n";
+    return false;
+  }
+
+  uint32_t Rsrc3 = 0;
+  std::memcpy(&Rsrc3,
+              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
+              sizeof(Rsrc3));
+  AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE,
+                  InstPrefLines);
+  std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
+              &Rsrc3, sizeof(Rsrc3));
+  return true;
+}
+
 // -- ElfView::getKernelVgprCount ----------------------------------------------
 
 std::optional<unsigned>

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -442,7 +442,12 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   if (Descriptors.empty())
     return 0;
 
-  std::vector<KernelDescriptorInfo> Work;
+  struct WorkItem {
+    KernelDescriptorInfo KD;
+    uint32_t InstPrefLines = 0;
+  };
+
+  std::vector<WorkItem> Work;
   uint32_t MaxInstPrefLines = 0;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     std::optional<bool> AlreadyHasEntryStub =
@@ -455,8 +460,10 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
         Elf.getKernelDescriptorInstPrefSize(KD.KernelName, LS.Cpu);
     if (!InstPrefLines)
       return std::nullopt;
-    MaxInstPrefLines = std::max(MaxInstPrefLines, *InstPrefLines);
-    Work.push_back(KD);
+    uint32_t StubInstPrefLines =
+        std::min(*InstPrefLines, KernelEntryStubInstPrefLines);
+    MaxInstPrefLines = std::max(MaxInstPrefLines, StubInstPrefLines);
+    Work.push_back({KD, StubInstPrefLines});
   }
   if (Work.empty())
     return 0;
@@ -486,7 +493,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     return std::nullopt;
   AppendOffset = StubStart;
 
-  for (const KernelDescriptorInfo &KD : Work) {
+  for (const WorkItem &Item : Work) {
+    const KernelDescriptorInfo &KD = Item.KD;
     std::optional<uint64_t> StubTextEnd = checkedAdd(
         Elf.textSize(), AppendOffset,
         (Twine("entry trampoline append offset for '") + KD.KernelName + "'")
@@ -517,7 +525,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     Trampoline T;
     T.Bytes.assign(Stub.begin(), Stub.end());
     LocalGrowth.push_back(std::move(T));
-    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2});
+    LocalFixups.push_back(
+        {KD.KernelName, AppendOffset, *ScratchSgpr + 2, Item.InstPrefLines});
     std::optional<uint64_t> NewAppendOffset = checkedAdd(
         AppendOffset, KernelEntryStubStride,
         (Twine("entry trampoline append offset after '") + KD.KernelName + "'")
@@ -556,7 +565,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 }
 
 bool rewriteKernelEntryDescriptorOffsets(
-    WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
+    WritableMemoryBuffer &OutBuf, uint64_t OldTextSize, StringRef TargetCpu,
     ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return true;
@@ -608,7 +617,9 @@ bool rewriteKernelEntryDescriptorOffsets(
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
     bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
         Fixup.KernelName, Fixup.RequiredSgprs);
-    Ok = UpdatedEntry && UpdatedSgprs && Ok;
+    bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
+        Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
+    Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;
   }
   return Ok;
 }

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -258,6 +258,18 @@ bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
          hasEntryStubOperandShape(Decoded, LS);
 }
 
+bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
+                                    const LLVMState &LS) {
+  SmallVector<uint8_t> Prefix;
+  if (!appendAsm(Prefix, "global_wb", LS))
+    return false;
+  if (!appendAsm(Prefix, "v_nop", LS))
+    return false;
+
+  return Bytes.size() >= Prefix.size() &&
+         std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
+}
+
 static std::optional<uint64_t>
 checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
   if (Alignment == 0)
@@ -307,10 +319,18 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
       KernelEntryStubStride > Elf.textSize() - TextOffset)
     return false;
 
+  ArrayRef<uint8_t> Candidate(Elf.textData() + TextOffset,
+                              KernelEntryStubStride);
+  // The full idempotency matcher uses LLVM's AMDGPU disassembler. Avoid
+  // running it over arbitrary original kernel entry bytes; real code objects
+  // can contain byte streams that are valid executable code but still trip
+  // decoder corner cases before COMGR can finish rewriting.
+  if (!hasKernelEntryTrampolinePrefix(Candidate, LS))
+    return false;
+
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(
-          ArrayRef<uint8_t>(Elf.textData() + TextOffset, KernelEntryStubStride),
-          LS, Decoded, "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+                             "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -270,17 +270,6 @@ bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
          std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
 }
 
-static std::optional<uint64_t>
-checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
-  if (Alignment == 0)
-    return Value;
-
-  uint64_t Remainder = Value % Alignment;
-  if (Remainder == 0)
-    return Value;
-  return checkedAdd(Value, Alignment - Remainder, Context);
-}
-
 static std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   if (KD.EntryOffset >= 0)
     return checkedAdd(
@@ -299,37 +288,54 @@ static std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   return KD.VAddr - Magnitude;
 }
 
-static std::optional<bool>
-descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
-                                  const KernelDescriptorInfo &KD,
-                                  const LLVMState &LS) {
+static std::optional<ArrayRef<uint8_t>>
+findExecutableBytesAtVAddr(const ElfView &Elf, uint64_t VAddr, uint64_t Size) {
+  for (const ElfView::ELFT::Shdr &Shdr : Elf.sections()) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) ||
+        !(Shdr.sh_flags & ELF::SHF_EXECINSTR) ||
+        Shdr.sh_type == ELF::SHT_NOBITS)
+      continue;
+    if (VAddr < Shdr.sh_addr)
+      continue;
+    uint64_t Delta = VAddr - Shdr.sh_addr;
+    if (Delta > Shdr.sh_size || Size > Shdr.sh_size - Delta)
+      continue;
+    if (Shdr.sh_offset > Elf.size() || Delta > Elf.size() - Shdr.sh_offset ||
+        Size > Elf.size() - Shdr.sh_offset - Delta) {
+      log() << "hotswap: error: executable section bytes for vaddr 0x"
+            << utohexstr(VAddr) << " extend past the ELF buffer.\n";
+      return std::nullopt;
+    }
+    return ArrayRef<uint8_t>(Elf.data() + Shdr.sh_offset + Delta, Size);
+  }
+  return std::nullopt;
+}
+
+static std::optional<bool> descriptorAlreadyTargetsEntryStub(
+    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS) {
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
-  if (*Entry < Elf.textAddr())
-    return false;
 
   std::optional<uint64_t> TextEnd =
       checkedAdd(Elf.textAddr(), Elf.textSize(), "entry trampoline text end");
   if (!TextEnd)
     return std::nullopt;
 
-  const uint64_t TextOffset = *Entry - Elf.textAddr();
-  if (TextOffset > Elf.textSize() ||
-      KernelEntryStubStride > Elf.textSize() - TextOffset)
+  std::optional<ArrayRef<uint8_t>> Candidate =
+      findExecutableBytesAtVAddr(Elf, *Entry, KernelEntryStubStride);
+  if (!Candidate)
     return false;
 
-  ArrayRef<uint8_t> Candidate(Elf.textData() + TextOffset,
-                              KernelEntryStubStride);
   // The full idempotency matcher uses LLVM's AMDGPU disassembler. Avoid
   // running it over arbitrary original kernel entry bytes; real code objects
   // can contain byte streams that are valid executable code but still trip
   // decoder corner cases before COMGR can finish rewriting.
-  if (!hasKernelEntryTrampolinePrefix(Candidate, LS))
+  if (!hasKernelEntryTrampolinePrefix(*Candidate, LS))
     return false;
 
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+  if (!decodeKernelEntryStub(*Candidate, LS, Decoded,
                              "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
@@ -340,20 +346,6 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
     return std::nullopt;
 
   return *Target >= Elf.textAddr() && *Target < *TextEnd && *Target < *Entry;
-}
-
-static std::optional<uint64_t>
-totalTrampolineBytes(ArrayRef<Trampoline> Trampolines) {
-  uint64_t Total = 0;
-  for (const Trampoline &T : Trampolines) {
-    std::optional<uint64_t> NewTotal =
-        checkedAdd(Total, static_cast<uint64_t>(T.Bytes.size()),
-                   "existing trampoline byte count");
-    if (!NewTotal)
-      return std::nullopt;
-    Total = *NewTotal;
-  }
-  return Total;
 }
 
 static std::optional<int64_t>
@@ -407,40 +399,51 @@ static std::optional<unsigned> allocateEntryStubScratchSgprs(
   return ScratchBase;
 }
 
-static bool appendPaddingTrampoline(std::vector<Trampoline> &Out,
-                                    uint64_t PadBytes, ArrayRef<uint8_t> Fill) {
-  if (PadBytes == 0)
+static bool appendFillBytes(SmallVectorImpl<uint8_t> &Out, uint64_t FillBytes,
+                            ArrayRef<uint8_t> Fill, StringRef Context) {
+  if (FillBytes < Out.size()) {
+    log() << "hotswap: error: " << Context << " target size " << FillBytes
+          << " is smaller than existing size " << Out.size() << ".\n";
+    return false;
+  }
+  uint64_t Needed = FillBytes - Out.size();
+  if (Needed == 0)
     return true;
   if (Fill.empty()) {
-    log() << "hotswap: error: entry-stub alignment padding requested without "
-          << "cached s_nop bytes.\n";
+    log() << "hotswap: error: " << Context
+          << " requested without fill bytes.\n";
     return false;
   }
-  if (PadBytes % Fill.size() != 0) {
-    log() << "hotswap: error: entry-stub alignment padding size " << PadBytes
-          << " is not a multiple of cached s_nop size " << Fill.size() << ".\n";
+  if (Needed % Fill.size() != 0) {
+    log() << "hotswap: error: " << Context << " size " << Needed
+          << " is not a multiple of fill size " << Fill.size() << ".\n";
     return false;
   }
-  if (PadBytes > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
-    log() << "hotswap: error: entry-stub alignment padding size " << PadBytes
+  if (Needed > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
+    log() << "hotswap: error: " << Context << " size " << Needed
           << " exceeds size_t.\n";
     return false;
   }
 
-  Trampoline Pad;
-  while (static_cast<uint64_t>(Pad.Bytes.size()) < PadBytes)
-    Pad.Bytes.append(Fill.begin(), Fill.end());
-  Out.push_back(std::move(Pad));
+  while (static_cast<uint64_t>(Out.size()) < FillBytes)
+    Out.append(Fill.begin(), Fill.end());
   return true;
 }
 
 std::optional<uint32_t> appendKernelEntryTrampolines(
     const ElfView &Elf, const LLVMState &LS, unsigned MaxSgprs,
-    std::vector<Trampoline> &Growth,
+    uint64_t StubBaseVAddr, SmallVectorImpl<uint8_t> &EntryBytes,
     std::vector<KernelEntryTrampolineFixup> &OutFixups) {
   std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   if (Descriptors.empty())
     return 0;
+
+  if (StubBaseVAddr % KernelEntryStubStride != 0) {
+    log() << "hotswap: error: entry trampoline stub base vaddr 0x"
+          << utohexstr(StubBaseVAddr) << " is not aligned to "
+          << KernelEntryStubStride << " bytes.\n";
+    return std::nullopt;
+  }
 
   struct WorkItem {
     KernelDescriptorInfo KD;
@@ -468,41 +471,14 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   if (Work.empty())
     return 0;
 
-  std::optional<uint64_t> ExistingGrowthBytes = totalTrampolineBytes(Growth);
-  if (!ExistingGrowthBytes)
-    return std::nullopt;
-  uint64_t AppendOffset = *ExistingGrowthBytes;
-  std::optional<uint64_t> TextEndVAddr =
-      checkedAdd(Elf.textAddr(), Elf.textSize(), "entry trampoline text end");
-  if (!TextEndVAddr)
-    return std::nullopt;
-  std::optional<uint64_t> StubPoolBaseVAddr =
-      checkedAdd(*TextEndVAddr, AppendOffset, "entry trampoline stub-pool base");
-  if (!StubPoolBaseVAddr)
-    return std::nullopt;
-  std::optional<uint64_t> AlignedStubPoolBaseVAddr =
-      checkedAlignTo(*StubPoolBaseVAddr, KernelEntryStubStride,
-                     "entry trampoline aligned stub-pool base");
-  if (!AlignedStubPoolBaseVAddr)
-    return std::nullopt;
-  const uint64_t StubStart = *AlignedStubPoolBaseVAddr - *TextEndVAddr;
-  std::vector<Trampoline> LocalGrowth;
   std::vector<KernelEntryTrampolineFixup> LocalFixups;
-  if (!appendPaddingTrampoline(LocalGrowth, StubStart - AppendOffset,
-                               LS.SNopBytes))
-    return std::nullopt;
-  AppendOffset = StubStart;
+  SmallVector<uint8_t> LocalBytes;
+  uint64_t AppendOffset = 0;
 
   for (const WorkItem &Item : Work) {
     const KernelDescriptorInfo &KD = Item.KD;
-    std::optional<uint64_t> StubTextEnd = checkedAdd(
-        Elf.textSize(), AppendOffset,
-        (Twine("entry trampoline append offset for '") + KD.KernelName + "'")
-            .str());
-    if (!StubTextEnd)
-      return std::nullopt;
     std::optional<uint64_t> StubVAddr = checkedAdd(
-        Elf.textAddr(), *StubTextEnd,
+        StubBaseVAddr, AppendOffset,
         (Twine("entry trampoline vaddr for '") + KD.KernelName + "'").str());
     if (!StubVAddr)
       return std::nullopt;
@@ -522,11 +498,16 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
       return std::nullopt;
     }
 
-    Trampoline T;
-    T.Bytes.assign(Stub.begin(), Stub.end());
-    LocalGrowth.push_back(std::move(T));
+    if (Stub.size() != KernelEntryStubStride) {
+      log() << "hotswap: error: kernel-entry trampoline for '" << KD.KernelName
+            << "' has size " << Stub.size() << ", expected "
+            << KernelEntryStubStride << ".\n";
+      return std::nullopt;
+    }
+
+    LocalBytes.append(Stub.begin(), Stub.end());
     LocalFixups.push_back(
-        {KD.KernelName, AppendOffset, *ScratchSgpr + 2, Item.InstPrefLines});
+        {KD.KernelName, *StubVAddr, *ScratchSgpr + 2, Item.InstPrefLines});
     std::optional<uint64_t> NewAppendOffset = checkedAdd(
         AppendOffset, KernelEntryStubStride,
         (Twine("entry trampoline append offset after '") + KD.KernelName + "'")
@@ -541,7 +522,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   if (GuardBytes != 0) {
     SmallVector<uint8_t> CodeEnd = getCodeEndBytes(LS);
     if (CodeEnd.empty() ||
-        !appendPaddingTrampoline(LocalGrowth, GuardBytes, CodeEnd))
+        !appendFillBytes(LocalBytes, AppendOffset + GuardBytes, CodeEnd,
+                         "entry-stub prefetch guard"))
       return std::nullopt;
   }
 
@@ -554,8 +536,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     return std::nullopt;
   }
 
-  for (Trampoline &T : LocalGrowth)
-    Growth.push_back(std::move(T));
+  EntryBytes.append(LocalBytes.begin(), LocalBytes.end());
   OutFixups.insert(OutFixups.end(), LocalFixups.begin(), LocalFixups.end());
 
   log() << "hotswap: installed " << LocalFixups.size()
@@ -565,7 +546,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 }
 
 bool rewriteKernelEntryDescriptorOffsets(
-    WritableMemoryBuffer &OutBuf, uint64_t OldTextSize, StringRef TargetCpu,
+    WritableMemoryBuffer &OutBuf, StringRef TargetCpu,
     ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return true;
@@ -589,23 +570,8 @@ bool rewriteKernelEntryDescriptorOffsets(
       Ok = false;
       continue;
     }
-    std::optional<uint64_t> StubTextOffset = checkedAdd(
-        OldTextSize, Fixup.StubTextOffset,
-        (Twine("entry trampoline text offset for '") + Fixup.KernelName + "'")
-            .str());
-    if (!StubTextOffset) {
-      Ok = false;
-      continue;
-    }
-    std::optional<uint64_t> StubVAddr = checkedAdd(
-        OutElf.textAddr(), *StubTextOffset,
-        (Twine("entry trampoline vaddr for '") + Fixup.KernelName + "'").str());
-    if (!StubVAddr) {
-      Ok = false;
-      continue;
-    }
     std::optional<int64_t> NewOffset = checkedSignedDifference(
-        *StubVAddr, *KdVAddr,
+        Fixup.StubVAddr, *KdVAddr,
         (Twine("entry trampoline descriptor offset for '") + Fixup.KernelName +
          "'")
             .str());

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -237,8 +237,8 @@ public:
   /// `group_segment_size` and propagated to the device via the
   /// `hidden_dynamic_lds_size` kernarg) and is *not* included here, so the
   /// returned value is a lower bound on the total LDS the kernel may
-  /// touch. Callers that need to flag potential overflow of A0's 16-bit M0
-  /// limit (DEGFXMI400-12025) can use this as a "definitely exceeds"
+  /// touch. Callers that need to flag potential overflow of gfx1250 A0's
+  /// 16-bit M0 limit can use this as a "definitely exceeds"
   /// check; "static fits, dynamic pushes over" cannot be detected
   /// statically. See AMDGPUUsage "Code Object V3 Kernel Descriptor"
   /// (GROUP_SEGMENT_FIXED_SIZE).

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -81,14 +81,25 @@ struct Trampoline {
   llvm::SmallVector<uint8_t> Bytes;
 };
 
-// Kernel-entry stubs are appended as normal .text growth. Keep each entry on
-// the same 256-byte alignment expected by AMDGPU kernel descriptors.
+// Kernel-entry stubs live in a separate executable load segment so existing
+// fully linked code/data references keep their already-resolved addresses.
+// Keep each entry on the same 256-byte alignment expected by AMDGPU kernel
+// descriptors.
 static constexpr uint64_t KernelEntryStubStride = 256;
+static constexpr uint64_t KernelEntryStubSegmentAlign = 4096;
 static constexpr uint64_t KernelEntryInstPrefUnitBytes = 128;
 static_assert(KernelEntryStubStride % KernelEntryInstPrefUnitBytes == 0,
               "entry-stub stride must be an integral prefetch span");
 static constexpr uint32_t KernelEntryStubInstPrefLines =
     KernelEntryStubStride / KernelEntryInstPrefUnitBytes;
+
+struct ExecutableSegmentPlan {
+  uint64_t SegmentVAddr = 0;
+  uint64_t PayloadOffset = 0;
+  uint64_t PayloadVAddr = 0;
+  uint64_t PayloadAlign = 0;
+  uint64_t SegmentAlign = 0;
+};
 
 struct KernelDescriptorInfo {
   std::string KernelName;
@@ -291,6 +302,23 @@ public:
   std::unique_ptr<llvm::WritableMemoryBuffer>
   growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines,
                       llvm::ArrayRef<uint8_t> SNopBytes) const;
+
+  /// Plan a new executable load segment above all existing allocated
+  /// addresses. \p ReservedVAddrGrowth accounts for any pending .text-growth
+  /// rewrite that will shift later allocated sections before the segment is
+  /// appended.
+  std::optional<ExecutableSegmentPlan>
+  planExecutableSegment(uint64_t PayloadAlign, uint64_t SegmentAlign,
+                        uint64_t ReservedVAddrGrowth) const;
+
+  /// Append \p PayloadBytes into a new executable PT_LOAD described by
+  /// \p Plan. Existing section virtual addresses, symbols, and program
+  /// headers are left unchanged; the ELF and section-header tables are
+  /// relocated to make room for one extra program and section header.
+  std::unique_ptr<llvm::WritableMemoryBuffer>
+  appendExecutableSegment(llvm::ArrayRef<uint8_t> PayloadBytes,
+                          const ExecutableSegmentPlan &Plan,
+                          llvm::StringRef SectionName) const;
 
 private:
   ElfView(ELFFileT File, ELFT::ShdrRange Sections,
@@ -699,7 +727,7 @@ HotswapPatchVTable &getHotswapPatchVTable();
 
 struct KernelEntryTrampolineFixup {
   std::string KernelName;
-  uint64_t StubTextOffset = 0;
+  uint64_t StubVAddr = 0;
   unsigned RequiredSgprs = 0;
   uint32_t InstPrefLines = 0;
 };
@@ -730,18 +758,18 @@ bool hasKernelEntryTrampolinePrefix(llvm::ArrayRef<uint8_t> Bytes,
 uint64_t computeKernelEntryPrefetchGuardBytes(uint32_t InstPrefLines);
 
 /// Append one entry stub per kernel descriptor that does not already target a
-/// HotSwap entry stub. The stubs are appended to \p Growth and descriptor
-/// rewrites are recorded in \p OutFixups for application after ELF growth.
+/// HotSwap entry stub. The stubs are appended to \p EntryBytes starting at
+/// \p StubBaseVAddr and descriptor rewrites are recorded in \p OutFixups for
+/// application after the executable stub segment is appended.
 std::optional<uint32_t> appendKernelEntryTrampolines(
     const ElfView &Elf, const LLVMState &LS, unsigned MaxSgprs,
-    std::vector<Trampoline> &Growth,
+    uint64_t StubBaseVAddr, llvm::SmallVectorImpl<uint8_t> &EntryBytes,
     std::vector<KernelEntryTrampolineFixup> &OutFixups);
 
 /// Apply descriptor rewrites recorded by appendKernelEntryTrampolines after
-/// the ELF has been grown.
+/// the ELF has been rewritten.
 bool rewriteKernelEntryDescriptorOffsets(
-    llvm::WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
-    llvm::StringRef TargetCpu,
+    llvm::WritableMemoryBuffer &OutBuf, llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -85,6 +85,10 @@ struct Trampoline {
 // the same 256-byte alignment expected by AMDGPU kernel descriptors.
 static constexpr uint64_t KernelEntryStubStride = 256;
 static constexpr uint64_t KernelEntryInstPrefUnitBytes = 128;
+static_assert(KernelEntryStubStride % KernelEntryInstPrefUnitBytes == 0,
+              "entry-stub stride must be an integral prefetch span");
+static constexpr uint32_t KernelEntryStubInstPrefLines =
+    KernelEntryStubStride / KernelEntryInstPrefUnitBytes;
 
 struct KernelDescriptorInfo {
   std::string KernelName;
@@ -221,6 +225,11 @@ public:
   std::optional<uint32_t>
   getKernelDescriptorInstPrefSize(llvm::StringRef KernelName,
                                   llvm::StringRef TargetCpu) const;
+
+  /// Rewrite COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
+  bool updateKernelDescriptorInstPrefSize(llvm::StringRef KernelName,
+                                          llvm::StringRef TargetCpu,
+                                          uint32_t InstPrefLines);
 
   /// Read the VGPR count from the kernel descriptor for \p KernelName.
   /// Returns std::nullopt if the descriptor is not found.
@@ -680,6 +689,7 @@ struct KernelEntryTrampolineFixup {
   std::string KernelName;
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
+  uint32_t InstPrefLines = 0;
 };
 
 /// Build a 256-byte, entry-aligned HotSwap kernel-entry stub at
@@ -715,10 +725,11 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups);
 
-/// Apply descriptor entry-offset rewrites recorded by
-/// appendKernelEntryTrampolines after the ELF has been grown.
+/// Apply descriptor rewrites recorded by appendKernelEntryTrampolines after
+/// the ELF has been grown.
 bool rewriteKernelEntryDescriptorOffsets(
     llvm::WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
+    llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -100,6 +100,13 @@ struct NopSled {
   uint64_t Start = 0;
   uint64_t End = 0;
   uint64_t WritePos = 0;
+  uint64_t FunctionStart = 0;
+  uint64_t FunctionEnd = 0;
+};
+
+struct FunctionTextRange {
+  uint64_t Start = 0;
+  uint64_t End = 0;
 };
 
 // -- Rewrite rule -------------------------------------------------------------
@@ -199,6 +206,11 @@ public:
   /// Find the kernel function symbol whose range includes \p TextOffset.
   /// Returns "" if no matching function symbol exists.
   std::string findKernelAtOffset(uint64_t TextOffset) const;
+
+  /// Find the section-relative `.text` range of the function containing
+  /// \p TextOffset, or std::nullopt if no sized function symbol covers it.
+  std::optional<FunctionTextRange>
+  findFunctionTextRangeAtOffset(uint64_t TextOffset) const;
 
   /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
   /// or nullptr if not found.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -695,6 +695,13 @@ llvm::SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
 bool isKernelEntryTrampoline(llvm::ArrayRef<uint8_t> Bytes,
                              const LLVMState &LS);
 
+/// Cheap raw-byte prefilter for the entry stubs produced by
+/// buildKernelEntryTrampoline. This is intentionally weaker than
+/// isKernelEntryTrampoline and exists to avoid running the disassembler over
+/// arbitrary original kernel entry bytes during idempotency checks.
+bool hasKernelEntryTrampolinePrefix(llvm::ArrayRef<uint8_t> Bytes,
+                                    const LLVMState &LS);
+
 /// Compute the trailing readable guard needed after an appended kernel-entry
 /// stub pool so CP instruction prefetches from the last stub cannot run past
 /// mapped .text bytes.

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -17,10 +17,10 @@
 ///     byte offsets scaled appropriately for each encoding.
 ///   - tensor_load_to_lds     : prepend s_pack_hh_b32_b16 to clear multicast
 ///     routing bits in the group descriptor's base SGPR
-///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
-///     issue a regular ds_*_b32, bypassing the A0 16-bit M0 truncation
-///     (DEGFXMI400-12025). On B0 the DS unit reads 20 bits of M0; on A0 it
-///     reads only 16, silently dropping bits [19:16].
+  ///   - ds_*_addtid_b32        : compute the LDS address through the ALU and
+  ///     issue a regular ds_*_b32, bypassing the gfx1250 A0 16-bit M0
+  ///     truncation. On B0 the DS unit reads 20 bits of M0; on A0 it reads only
+  ///     16, silently dropping bits [19:16].
 ///
 //===----------------------------------------------------------------------===//
 
@@ -768,8 +768,8 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       std::optional<uint32_t> LdsSize =
           Ctx.Elf.getKernelStaticLdsSize(KernelName);
       // Trampoline could not be applied: the original ds_*_addtid_b32 stays
-      // in the code object and will silently truncate M0 to 16 bits on A0
-      // (DEGFXMI400-12025) whenever the runtime LDS layout exceeds 64 KiB.
+      // in the code object and will silently truncate M0 to 16 bits on gfx1250
+      // A0 whenever the runtime LDS layout exceeds 64 KiB.
       // Static LDS is visible in the kernel descriptor; dynamic LDS added
       // by the host at dispatch (hidden_dynamic_lds_size kernarg or a
       // dynamic_shared_pointer user arg) is not. The warning therefore

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -20,6 +20,7 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-objdump -s -j .rodata %t.out.elf | %FileCheck --check-prefix=RODATA %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <entry_tramp_kernel>:
@@ -30,6 +31,9 @@
 // DISASM-NEXT: s_add_co_u32 s8
 // DISASM-NEXT: s_add_co_ci_u32 s9
 // DISASM-NEXT: s_set_pc_i64 s[8:9]
+
+// RODATA: Contents of section .rodata
+// RODATA: {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} 20000000
 
 // METADATA: .name:           entry_tramp_kernel
 // METADATA: .sgpr_count:     10

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -20,11 +20,15 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-// RUN: %llvm-objdump -s -j .rodata %t.out.elf | %FileCheck --check-prefix=RODATA %s
+// RUN: %llvm-readelf --section-headers --segments %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=SEGMENT %s
+// RUN: %llvm-readelf --symbols %t.elf %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=SYMBOLS %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <entry_tramp_kernel>:
 // DISASM: s_endpgm
+// DISASM: Disassembly of section .hotswap.entry:
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
 // DISASM-NEXT: s_get_pc_i64 s[8:9]
@@ -32,8 +36,15 @@
 // DISASM-NEXT: s_add_co_ci_u32 s9
 // DISASM-NEXT: s_set_pc_i64 s[8:9]
 
-// RODATA: Contents of section .rodata
-// RODATA: {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} 20000000
+// SEGMENT: .hotswap.entry
+// SEGMENT: LOAD
+
+// SYMBOLS-LABEL: File: {{.*}}.elf
+// SYMBOLS: [[MANAGED:[0-9a-f]+]] {{.*}} x.managed
+// SYMBOLS: [[X:[0-9a-f]+]] {{.*}} x
+// SYMBOLS-LABEL: File: {{.*}}.out.elf
+// SYMBOLS: [[MANAGED]] {{.*}} x.managed
+// SYMBOLS: [[X]] {{.*}} x
 
 // METADATA: .name:           entry_tramp_kernel
 // METADATA: .sgpr_count:     10
@@ -91,3 +102,19 @@ entry_tramp_kernel:
       .wavefront_size: 64
       .max_flat_workgroup_size: 256
 .end_amdgpu_metadata
+
+.data
+.globl x.managed
+.p2align 3
+.type x.managed,@object
+x.managed:
+  .quad 0
+.size x.managed, 8
+
+.bss
+.globl x
+.p2align 2
+.type x,@object
+x:
+  .long 0
+.size x, 4

--- a/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
@@ -1,0 +1,74 @@
+// COM: A NOP sled belongs to its containing kernel. The patchable DS
+// COM: instruction in second_kernel must not borrow first_kernel padding.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <first_kernel>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+
+// DISASM-LABEL: <second_kernel>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: s_endpgm
+
+// DISASM: ds_load_b32 v0
+// DISASM: ds_load_b32 v1
+// DISASM: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl first_kernel
+.p2align 8
+.type first_kernel,@function
+first_kernel:
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_endpgm
+.Lfirst_kernel_end:
+.size first_kernel, .Lfirst_kernel_end-first_kernel
+
+.globl second_kernel
+.p2align 8
+.type second_kernel,@function
+second_kernel:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.Lsecond_kernel_end:
+.size second_kernel, .Lsecond_kernel_end-second_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -1,11 +1,11 @@
 // COM: Test HotSwap trampoline patch: ds_*_addtid_b32 expansion.
 // COM:
-// COM: On A0 the DS unit truncates M0 to 16 bits, so ADDTID address
+// COM: On gfx1250 A0 the DS unit truncates M0 to 16 bits, so ADDTID address
 // COM: encodings (M0 + lane_id*4 + offset) silently wrap above 64KB
-// COM: (DEGFXMI400-12025). The trampoline materialises the lane-id math
-// COM: in the ALU using M0 masked to 20 bits (matching B0's DS-unit M0
-// COM: read width) and issues a regular ds_load_b32 / ds_store_b32,
-// COM: bypassing the buggy address path.
+// COM: on gfx1250. The trampoline materialises the lane-id math in the ALU
+// COM: using M0 masked to 20 bits (matching B0's DS-unit M0 read width) and
+// COM: issues a regular ds_load_b32 / ds_store_b32, bypassing the buggy
+// COM: address path.
 // COM:
 // COM: Coverage:
 // COM:   test_addtid_load        : ds_load_addtid_b32 + offset (NOP sled)

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -22,10 +22,13 @@
 // DISASM: s_wait_dscnt 0x0
 // DISASM: s_endpgm
 
-// COM: Trampoline body appended after .text: expanded DS loads + branch-back.
+// COM: Trampoline body appended after .text: expanded DS loads + branch-back,
+// COM: followed by an executable prefetch guard sized from inst_pref_size.
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
 // DISASM: s_branch
+// DISASM-NEXT: s_code_end
+// DISASM-NEXT: s_code_end
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \
@@ -51,4 +54,5 @@ test_ds_trampoline:
 .amdhsa_kernel test_ds_trampoline
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 1
+  .amdhsa_inst_pref_size 2
 .end_amdhsa_kernel

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -50,6 +50,20 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+// -- findNearestSled ----------------------------------------------------------
+
+TEST(FindNearestSled, SkipsSledsOutsideInstructionFunctionRange) {
+  std::vector<NopSled> Sleds;
+  Sleds.push_back({0, 32, 0, 0, 32});
+  Sleds.push_back({96, 128, 96, 96, 160});
+
+  NopSled *Sled = findNearestSled(Sleds, 108, 8);
+  ASSERT_NE(Sled, nullptr);
+  EXPECT_EQ(Sled->Start, 96u);
+
+  EXPECT_EQ(findNearestSled(Sleds, 64, 8), nullptr);
+}
+
 // -- ElfView::getKernelStaticLdsSize ------------------------------------------
 
 TEST(ElfView, GetKernelStaticLdsSizeReturnsNulloptWhenKdMissing) {

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -178,6 +178,83 @@ TEST(ElfView, GrowWithTrampolinesShiftsAllocSectionSymbols) {
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr + GrowthBytes);
 }
 
+TEST(ElfView, AppendExecutableSegmentPreservesAllocSectionSymbols) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  std::vector<KernelDescriptorInfo> InputKDs = ViewOrErr->kernelDescriptors();
+  ASSERT_EQ(InputKDs.size(), 1u);
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> InputPhdrsOrErr =
+      ViewOrErr->file().program_headers();
+  ASSERT_TRUE((bool)InputPhdrsOrErr)
+      << llvm::toString(InputPhdrsOrErr.takeError());
+  unsigned InputLoadCount = 0;
+  for (const ElfView::ELFT::Phdr &Phdr : *InputPhdrsOrErr) {
+    if (Phdr.p_type == llvm::ELF::PT_LOAD)
+      ++InputLoadCount;
+  }
+
+  std::optional<ExecutableSegmentPlan> Plan = ViewOrErr->planExecutableSegment(
+      KernelEntryStubStride, KernelEntryStubSegmentAlign, 0);
+  ASSERT_TRUE(Plan.has_value());
+  llvm::SmallVector<uint8_t> Payload(KernelEntryStubStride, 0xcc);
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      ViewOrErr->appendExecutableSegment(Payload, *Plan, ".hotswap.entry");
+  ASSERT_NE(Out, nullptr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  EXPECT_EQ(OutView->textAddr(), ViewOrErr->textAddr());
+  EXPECT_EQ(OutView->textSize(), ViewOrErr->textSize());
+  std::vector<KernelDescriptorInfo> OutputKDs = OutView->kernelDescriptors();
+  ASSERT_EQ(OutputKDs.size(), 1u);
+  EXPECT_EQ(OutputKDs[0].VAddr, InputKDs[0].VAddr);
+  EXPECT_EQ(OutputKDs[0].EntryOffset, InputKDs[0].EntryOffset);
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> OutputPhdrsOrErr =
+      OutView->file().program_headers();
+  ASSERT_TRUE((bool)OutputPhdrsOrErr)
+      << llvm::toString(OutputPhdrsOrErr.takeError());
+  unsigned OutputLoadCount = 0;
+  bool FoundNewLoad = false;
+  for (const ElfView::ELFT::Phdr &Phdr : *OutputPhdrsOrErr) {
+    if (Phdr.p_type != llvm::ELF::PT_LOAD)
+      continue;
+    ++OutputLoadCount;
+    if (Phdr.p_vaddr != Plan->SegmentVAddr)
+      continue;
+    FoundNewLoad = true;
+    EXPECT_EQ(Phdr.p_flags, llvm::ELF::PF_R | llvm::ELF::PF_X);
+    EXPECT_GE(Phdr.p_filesz, Plan->PayloadOffset + Payload.size());
+  }
+  EXPECT_EQ(OutputLoadCount, InputLoadCount + 1);
+  EXPECT_TRUE(FoundNewLoad);
+
+  bool FoundPayloadSection = false;
+  for (const ElfView::ELFT::Shdr &Shdr : OutView->sections()) {
+    llvm::Expected<llvm::StringRef> NameOrErr =
+        OutView->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)NameOrErr) << llvm::toString(NameOrErr.takeError());
+    if (*NameOrErr != ".hotswap.entry")
+      continue;
+    FoundPayloadSection = true;
+    EXPECT_EQ(Shdr.sh_type, llvm::ELF::SHT_PROGBITS);
+    EXPECT_EQ(Shdr.sh_flags, llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR);
+    EXPECT_EQ(Shdr.sh_addr, Plan->PayloadVAddr);
+    EXPECT_EQ(Shdr.sh_size, Payload.size());
+  }
+  EXPECT_TRUE(FoundPayloadSection);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -76,6 +76,297 @@ static uint32_t readDword(const uint8_t *Bytes) {
   return V;
 }
 
+static uint32_t appendString(std::string &Table, llvm::StringRef Value) {
+  uint32_t Offset = static_cast<uint32_t>(Table.size());
+  Table += Value;
+  Table.push_back('\0');
+  return Offset;
+}
+
+static std::optional<uint64_t> findSymbolVAddr(const ElfView &View,
+                                               llvm::StringRef Name) {
+  for (const ElfView::ELFT::Shdr &SymShdr : View.sections()) {
+    if (SymShdr.sh_type != llvm::ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != llvm::ELF::SHT_DYNSYM)
+      continue;
+
+    llvm::Expected<ElfView::ELFT::SymRange> SymsOrErr =
+        View.file().symbols(&SymShdr);
+    if (!SymsOrErr) {
+      llvm::consumeError(SymsOrErr.takeError());
+      return std::nullopt;
+    }
+    llvm::Expected<llvm::StringRef> StrTabOrErr =
+        View.file().getStringTableForSymtab(SymShdr, View.sections());
+    if (!StrTabOrErr) {
+      llvm::consumeError(StrTabOrErr.takeError());
+      return std::nullopt;
+    }
+
+    for (const ElfView::ELFT::Sym &Sym : *SymsOrErr) {
+      llvm::Expected<llvm::StringRef> SymNameOrErr = Sym.getName(*StrTabOrErr);
+      if (!SymNameOrErr) {
+        llvm::consumeError(SymNameOrErr.takeError());
+        return std::nullopt;
+      }
+      if (*SymNameOrErr == Name)
+        return Sym.st_value;
+    }
+  }
+  return std::nullopt;
+}
+
+static std::optional<uint64_t> findSectionVAddr(const ElfView &View,
+                                                llvm::StringRef Name) {
+  for (const ElfView::ELFT::Shdr &Shdr : View.sections()) {
+    llvm::Expected<llvm::StringRef> SectionNameOrErr =
+        View.file().getSectionName(Shdr);
+    if (!SectionNameOrErr) {
+      llvm::consumeError(SectionNameOrErr.takeError());
+      return std::nullopt;
+    }
+    if (*SectionNameOrErr == Name)
+      return Shdr.sh_addr;
+  }
+  return std::nullopt;
+}
+
+struct ManagedGlobalKernelElf {
+  std::vector<uint8_t> Bytes;
+  uint64_t TextAddr = 0;
+  uint64_t TextOffset = 0;
+  uint64_t TextSize = 0;
+  uint64_t DataAddr = 0;
+  uint64_t BssAddr = 0;
+  uint64_t LiteralOffset = 0;
+  uint64_t BakedDelta = 0;
+};
+
+static ManagedGlobalKernelElf makeManagedGlobalKernelElf(const LLVMState &S) {
+  using namespace llvm::ELF;
+  namespace hsa = llvm::amdhsa;
+
+  static constexpr uint64_t PhOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t TextOff = 0x240;
+  static constexpr uint64_t TextAddr = 0x1600;
+  static constexpr uint64_t TextSize = 64;
+  static constexpr uint64_t RodataAddr = 0x3000;
+  static constexpr uint64_t DataAddr = 0x3870;
+  static constexpr uint64_t BssAddr = 0x3878;
+  static constexpr uint64_t DataSize = 8;
+  static constexpr uint64_t BssSize = 4;
+  static constexpr uint64_t LiteralOffset = 16;
+  static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
+
+  std::vector<uint8_t> Text(TextSize, 0);
+  llvm::SmallVector<uint8_t> EndPgm = assembleSingleInst("s_endpgm", S);
+  std::memcpy(Text.data(), EndPgm.data(), EndPgm.size());
+  uint64_t BakedDelta = BssAddr - (TextAddr + LiteralOffset);
+  std::memcpy(Text.data() + LiteralOffset, &BakedDelta, sizeof(BakedDelta));
+
+  std::string StrTab;
+  StrTab.push_back('\0');
+  uint32_t KernelNameOff = appendString(StrTab, "GPU_func");
+  uint32_t KdNameOff = appendString(StrTab, "GPU_func.kd");
+  uint32_t ManagedNameOff = appendString(StrTab, "x.managed");
+  uint32_t XNameOff = appendString(StrTab, "x");
+
+  std::string ShStrTab;
+  ShStrTab.push_back('\0');
+  uint32_t TextNameOff = appendString(ShStrTab, ".text");
+  uint32_t RodataNameOff = appendString(ShStrTab, ".rodata");
+  uint32_t DataNameOff = appendString(ShStrTab, ".data");
+  uint32_t BssNameOff = appendString(ShStrTab, ".bss");
+  uint32_t StrTabNameOff = appendString(ShStrTab, ".strtab");
+  uint32_t SymTabNameOff = appendString(ShStrTab, ".symtab");
+  uint32_t ShStrTabNameOff = appendString(ShStrTab, ".shstrtab");
+
+  const uint64_t RodataOff = comgr_test::alignTo8(TextOff + Text.size());
+  const uint64_t DataOff = comgr_test::alignTo8(RodataOff + KdBytes);
+  const uint64_t StrTabOff = comgr_test::alignTo8(DataOff + DataSize);
+  static constexpr uint64_t SymCount = 5;
+  const uint64_t SymTabOff = comgr_test::alignTo8(StrTabOff + StrTab.size());
+  const uint64_t ShStrTabOff =
+      comgr_test::alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t ShOff = comgr_test::alignTo8(ShStrTabOff + ShStrTab.size());
+  static constexpr uint64_t ShCount = 8;
+  const uint64_t BufSize =
+      comgr_test::alignTo8(ShOff + ShCount * sizeof(Elf64_Shdr));
+
+  ManagedGlobalKernelElf Result;
+  Result.Bytes.assign(BufSize, 0);
+  Result.TextAddr = TextAddr;
+  Result.TextOffset = TextOff;
+  Result.TextSize = Text.size();
+  Result.DataAddr = DataAddr;
+  Result.BssAddr = BssAddr;
+  Result.LiteralOffset = LiteralOffset;
+  Result.BakedDelta = BakedDelta;
+
+  uint8_t *Buf = Result.Bytes.data();
+  std::memcpy(Buf + TextOff, Text.data(), Text.size());
+  std::memcpy(Buf + StrTabOff, StrTab.data(), StrTab.size());
+  std::memcpy(Buf + ShStrTabOff, ShStrTab.data(), ShStrTab.size());
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_phoff = PhOff;
+  Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  Ehdr.e_phnum = 3;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = ShCount;
+  Ehdr.e_shstrndx = 7;
+  std::memcpy(Buf, &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr PhdrTable{};
+  PhdrTable.p_type = PT_PHDR;
+  PhdrTable.p_offset = PhOff;
+  PhdrTable.p_vaddr = PhOff;
+  PhdrTable.p_paddr = PhOff;
+  PhdrTable.p_filesz = 3 * sizeof(Elf64_Phdr);
+  PhdrTable.p_memsz = 3 * sizeof(Elf64_Phdr);
+  PhdrTable.p_flags = PF_R;
+  PhdrTable.p_align = 8;
+  std::memcpy(Buf + PhOff, &PhdrTable, sizeof(PhdrTable));
+
+  Elf64_Phdr TextLoad{};
+  TextLoad.p_type = PT_LOAD;
+  TextLoad.p_flags = PF_R | PF_X;
+  TextLoad.p_offset = TextOff;
+  TextLoad.p_vaddr = TextAddr;
+  TextLoad.p_paddr = TextAddr;
+  TextLoad.p_filesz = Text.size();
+  TextLoad.p_memsz = Text.size();
+  TextLoad.p_align = 0x1000;
+  std::memcpy(Buf + PhOff + sizeof(Elf64_Phdr), &TextLoad, sizeof(TextLoad));
+
+  Elf64_Phdr DataLoad{};
+  DataLoad.p_type = PT_LOAD;
+  DataLoad.p_flags = PF_R | PF_W;
+  DataLoad.p_offset = RodataOff;
+  DataLoad.p_vaddr = RodataAddr;
+  DataLoad.p_paddr = RodataAddr;
+  DataLoad.p_filesz = DataOff + DataSize - RodataOff;
+  DataLoad.p_memsz = BssAddr + BssSize - RodataAddr;
+  DataLoad.p_align = 0x1000;
+  std::memcpy(Buf + PhOff + 2 * sizeof(Elf64_Phdr), &DataLoad,
+              sizeof(DataLoad));
+
+  int64_t EntryOffset =
+      static_cast<int64_t>(TextAddr) - static_cast<int64_t>(RodataAddr);
+  std::memcpy(
+      Buf + RodataOff +
+          offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
+      &EntryOffset, sizeof(EntryOffset));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = TextNameOff;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_addr = TextAddr;
+  TextSh.sh_offset = TextOff;
+  TextSh.sh_size = Text.size();
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf + ShOff + 1 * sizeof(Elf64_Shdr), &TextSh, sizeof(TextSh));
+
+  Elf64_Shdr RodataSh{};
+  RodataSh.sh_name = RodataNameOff;
+  RodataSh.sh_type = SHT_PROGBITS;
+  RodataSh.sh_flags = SHF_ALLOC;
+  RodataSh.sh_addr = RodataAddr;
+  RodataSh.sh_offset = RodataOff;
+  RodataSh.sh_size = KdBytes;
+  RodataSh.sh_addralign = 8;
+  std::memcpy(Buf + ShOff + 2 * sizeof(Elf64_Shdr), &RodataSh,
+              sizeof(RodataSh));
+
+  Elf64_Shdr DataSh{};
+  DataSh.sh_name = DataNameOff;
+  DataSh.sh_type = SHT_PROGBITS;
+  DataSh.sh_flags = SHF_ALLOC | SHF_WRITE;
+  DataSh.sh_addr = DataAddr;
+  DataSh.sh_offset = DataOff;
+  DataSh.sh_size = DataSize;
+  DataSh.sh_addralign = 8;
+  std::memcpy(Buf + ShOff + 3 * sizeof(Elf64_Shdr), &DataSh, sizeof(DataSh));
+
+  Elf64_Shdr BssSh{};
+  BssSh.sh_name = BssNameOff;
+  BssSh.sh_type = SHT_NOBITS;
+  BssSh.sh_flags = SHF_ALLOC | SHF_WRITE;
+  BssSh.sh_addr = BssAddr;
+  BssSh.sh_offset = DataOff + DataSize;
+  BssSh.sh_size = BssSize;
+  BssSh.sh_addralign = 4;
+  std::memcpy(Buf + ShOff + 4 * sizeof(Elf64_Shdr), &BssSh, sizeof(BssSh));
+
+  Elf64_Shdr StrTabSh{};
+  StrTabSh.sh_name = StrTabNameOff;
+  StrTabSh.sh_type = SHT_STRTAB;
+  StrTabSh.sh_offset = StrTabOff;
+  StrTabSh.sh_size = StrTab.size();
+  std::memcpy(Buf + ShOff + 5 * sizeof(Elf64_Shdr), &StrTabSh,
+              sizeof(StrTabSh));
+
+  Elf64_Shdr SymTabSh{};
+  SymTabSh.sh_name = SymTabNameOff;
+  SymTabSh.sh_type = SHT_SYMTAB;
+  SymTabSh.sh_offset = SymTabOff;
+  SymTabSh.sh_size = SymCount * sizeof(Elf64_Sym);
+  SymTabSh.sh_link = 5;
+  SymTabSh.sh_entsize = sizeof(Elf64_Sym);
+  std::memcpy(Buf + ShOff + 6 * sizeof(Elf64_Shdr), &SymTabSh,
+              sizeof(SymTabSh));
+
+  Elf64_Shdr ShStrTabSh{};
+  ShStrTabSh.sh_name = ShStrTabNameOff;
+  ShStrTabSh.sh_type = SHT_STRTAB;
+  ShStrTabSh.sh_offset = ShStrTabOff;
+  ShStrTabSh.sh_size = ShStrTab.size();
+  std::memcpy(Buf + ShOff + 7 * sizeof(Elf64_Shdr), &ShStrTabSh,
+              sizeof(ShStrTabSh));
+
+  Elf64_Sym KernelSym{};
+  KernelSym.st_name = KernelNameOff;
+  KernelSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+  KernelSym.st_shndx = 1;
+  KernelSym.st_value = TextAddr;
+  KernelSym.st_size = Text.size();
+  std::memcpy(Buf + SymTabOff + 1 * sizeof(Elf64_Sym), &KernelSym,
+              sizeof(KernelSym));
+
+  Elf64_Sym KdSym{};
+  KdSym.st_name = KdNameOff;
+  KdSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  KdSym.st_shndx = 2;
+  KdSym.st_value = RodataAddr;
+  KdSym.st_size = KdBytes;
+  std::memcpy(Buf + SymTabOff + 2 * sizeof(Elf64_Sym), &KdSym, sizeof(KdSym));
+
+  Elf64_Sym ManagedSym{};
+  ManagedSym.st_name = ManagedNameOff;
+  ManagedSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  ManagedSym.st_shndx = 3;
+  ManagedSym.st_value = DataAddr;
+  ManagedSym.st_size = DataSize;
+  std::memcpy(Buf + SymTabOff + 3 * sizeof(Elf64_Sym), &ManagedSym,
+              sizeof(ManagedSym));
+
+  Elf64_Sym XSym{};
+  XSym.st_name = XNameOff;
+  XSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  XSym.st_shndx = 4;
+  XSym.st_value = BssAddr;
+  XSym.st_size = BssSize;
+  std::memcpy(Buf + SymTabOff + 4 * sizeof(Elf64_Sym), &XSym, sizeof(XSym));
+
+  return Result;
+}
+
 // -- initLLVM ----------------------------------------------------------------
 
 TEST(InitLLVM, ValidGfx1250) {
@@ -268,15 +559,13 @@ static void expectSameOperands(const llvm::MCInst &Actual,
 }
 
 static void expectInstMatchesAsm(const llvm::MCInst &Actual,
-                                 llvm::StringRef Asm,
-                                 const LLVMState &S) {
+                                 llvm::StringRef Asm, const LLVMState &S) {
   llvm::MCInst Expected = assembleOne(Asm, S);
   expectSameOperands(Actual, Expected, Asm);
 }
 
 static bool appendSingleInstBytes(llvm::SmallVectorImpl<uint8_t> &Bytes,
-                                  llvm::StringRef Asm,
-                                  const LLVMState &S) {
+                                  llvm::StringRef Asm, const LLVMState &S) {
   llvm::SmallVector<uint8_t> Inst = assembleSingleInst(Asm, S);
   if (Inst.empty()) {
     ADD_FAILURE() << "failed to assemble: " << Asm.str();
@@ -477,10 +766,13 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   uint8_t *Kd = ViewOrErr->findKernelDescriptor("kernel");
   ASSERT_NE(Kd, nullptr);
 
-  std::vector<Trampoline> Growth;
+  std::optional<ExecutableSegmentPlan> Plan = ViewOrErr->planExecutableSegment(
+      KernelEntryStubStride, KernelEntryStubSegmentAlign, 0);
+  ASSERT_TRUE(Plan.has_value());
+  llvm::SmallVector<uint8_t> EntryBytes;
   std::vector<KernelEntryTrampolineFixup> Fixups;
   std::optional<uint32_t> Count = appendKernelEntryTrampolines(
-      *ViewOrErr, S, /*MaxSgprs=*/106, Growth, Fixups);
+      *ViewOrErr, S, /*MaxSgprs=*/106, Plan->PayloadVAddr, EntryBytes, Fixups);
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 1u);
   ASSERT_EQ(Fixups.size(), 1u);
@@ -489,30 +781,17 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   const uint64_t ExpectedGuard =
       computeKernelEntryPrefetchGuardBytes(KernelEntryStubInstPrefLines);
   EXPECT_EQ(ExpectedGuard, 0u);
-  ASSERT_FALSE(Growth.empty());
-
-  const uint64_t OldTextSize = ViewOrErr->textSize();
-  const uint64_t TextEndVAddr = ViewOrErr->textAddr() + OldTextSize;
-  const uint64_t ExpectedStubOffset =
-      ((TextEndVAddr + KernelEntryStubStride - 1) &
-       ~(KernelEntryStubStride - 1)) -
-      TextEndVAddr;
-  EXPECT_EQ(Fixups[0].StubTextOffset, ExpectedStubOffset);
-
-  uint64_t GrowthTotal = 0;
-  for (const Trampoline &T : Growth)
-    GrowthTotal += T.Bytes.size();
-  EXPECT_EQ(GrowthTotal,
-            ExpectedStubOffset + KernelEntryStubStride + ExpectedGuard);
+  EXPECT_EQ(EntryBytes.size(), KernelEntryStubStride + ExpectedGuard);
+  EXPECT_EQ(Fixups[0].StubVAddr, Plan->PayloadVAddr);
 
   std::unique_ptr<llvm::WritableMemoryBuffer> Out =
-      ViewOrErr->growWithTrampolines(Growth, S.SNopBytes);
+      ViewOrErr->appendExecutableSegment(EntryBytes, *Plan, ".hotswap.entry");
   ASSERT_NE(Out, nullptr);
 
-  ASSERT_TRUE(
-      rewriteKernelEntryDescriptorOffsets(*Out, OldTextSize, S.Cpu, Fixups));
+  ASSERT_TRUE(rewriteKernelEntryDescriptorOffsets(*Out, S.Cpu, Fixups));
 
-  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  uint8_t *OutData = const_cast<uint8_t *>(
+      reinterpret_cast<const uint8_t *>(Out->getBufferStart()));
   llvm::Expected<ElfView> OutView =
       ElfView::create(OutData, Out->getBufferSize());
   ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
@@ -551,9 +830,8 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   ASSERT_EQ(KDs.size(), 1u);
   std::optional<uint64_t> KdVAddr = OutView->getKernelDescriptorVAddr("kernel");
   ASSERT_TRUE(KdVAddr.has_value());
-  const uint64_t StubVAddr =
-      ViewOrErr->textAddr() + OldTextSize + Fixups[0].StubTextOffset;
-  EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(StubVAddr - *KdVAddr));
+  EXPECT_EQ(KDs[0].EntryOffset,
+            static_cast<int64_t>(Fixups[0].StubVAddr - *KdVAddr));
 }
 
 TEST(KernelEntryTrampoline, AlignsStubByVirtualAddress) {
@@ -571,20 +849,19 @@ TEST(KernelEntryTrampoline, AlignsStubByVirtualAddress) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  std::vector<Trampoline> Growth;
+  std::optional<ExecutableSegmentPlan> Plan = ViewOrErr->planExecutableSegment(
+      KernelEntryStubStride, KernelEntryStubSegmentAlign, 0);
+  ASSERT_TRUE(Plan.has_value());
+  llvm::SmallVector<uint8_t> EntryBytes;
   std::vector<KernelEntryTrampolineFixup> Fixups;
   std::optional<uint32_t> Count = appendKernelEntryTrampolines(
-      *ViewOrErr, S, /*MaxSgprs=*/106, Growth, Fixups);
+      *ViewOrErr, S, /*MaxSgprs=*/106, Plan->PayloadVAddr, EntryBytes, Fixups);
 
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 1u);
   ASSERT_EQ(Fixups.size(), 1u);
-  const uint64_t StubVAddr =
-      ViewOrErr->textAddr() + ViewOrErr->textSize() + Fixups[0].StubTextOffset;
-  EXPECT_EQ(StubVAddr % KernelEntryStubStride, 0u);
-  EXPECT_NE((ViewOrErr->textSize() + Fixups[0].StubTextOffset) %
-                KernelEntryStubStride,
-            0u);
+  EXPECT_EQ(Fixups[0].StubVAddr % KernelEntryStubStride, 0u);
+  EXPECT_EQ(Fixups[0].StubVAddr, Plan->PayloadVAddr);
 }
 
 TEST(KernelEntryTrampoline, AppendReturnsZeroWhenNoDescriptorsExist) {
@@ -602,14 +879,15 @@ TEST(KernelEntryTrampoline, AppendReturnsZeroWhenNoDescriptorsExist) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  std::vector<Trampoline> Growth;
+  llvm::SmallVector<uint8_t> EntryBytes;
   std::vector<KernelEntryTrampolineFixup> Fixups;
   std::optional<uint32_t> Count = appendKernelEntryTrampolines(
-      *ViewOrErr, S, /*MaxSgprs=*/106, Growth, Fixups);
+      *ViewOrErr, S, /*MaxSgprs=*/106, /*StubBaseVAddr=*/0x4000, EntryBytes,
+      Fixups);
 
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 0u);
-  EXPECT_TRUE(Growth.empty());
+  EXPECT_TRUE(EntryBytes.empty());
   EXPECT_TRUE(Fixups.empty());
 }
 
@@ -628,19 +906,75 @@ TEST(KernelEntryTrampoline, AppendFailsWithoutSgprScratchPair) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  Trampoline Existing;
-  Existing.Bytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
-  std::vector<Trampoline> Growth;
-  Growth.push_back(Existing);
+  llvm::SmallVector<uint8_t> EntryBytes;
   std::vector<KernelEntryTrampolineFixup> Fixups;
   std::optional<uint32_t> Count = appendKernelEntryTrampolines(
-      *ViewOrErr, S, /*MaxSgprs=*/106, Growth, Fixups);
+      *ViewOrErr, S, /*MaxSgprs=*/106, /*StubBaseVAddr=*/0x4000, EntryBytes,
+      Fixups);
 
   EXPECT_FALSE(Count.has_value());
-  ASSERT_EQ(Growth.size(), 1u);
-  EXPECT_EQ(llvm::ArrayRef<uint8_t>(Growth[0].Bytes),
-            llvm::ArrayRef<uint8_t>(Existing.Bytes));
+  EXPECT_TRUE(EntryBytes.empty());
   EXPECT_TRUE(Fixups.empty());
+}
+
+TEST(KernelEntryTrampoline, EntryRewritePreservesManagedGlobalReferences) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  ManagedGlobalKernelElf Obj = makeManagedGlobalKernelElf(S);
+  llvm::Expected<ElfView> InputView =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)InputView) << llvm::toString(InputView.takeError());
+  ASSERT_EQ(findSectionVAddr(*InputView, ".data"), Obj.DataAddr);
+  ASSERT_EQ(findSectionVAddr(*InputView, ".bss"), Obj.BssAddr);
+  ASSERT_EQ(findSymbolVAddr(*InputView, "x.managed"), Obj.DataAddr);
+  ASSERT_EQ(findSymbolVAddr(*InputView, "x"), Obj.BssAddr);
+
+  uint64_t InputBakedDelta = 0;
+  std::memcpy(&InputBakedDelta,
+              Obj.Bytes.data() + Obj.TextOffset + Obj.LiteralOffset,
+              sizeof(InputBakedDelta));
+  ASSERT_EQ(InputBakedDelta, Obj.BakedDelta);
+
+  Gfx1250RewriteOptions Options;
+  Options.RunB0A0Patches = false;
+  Options.RunEntryTrampolines = true;
+  std::unique_ptr<llvm::MemoryBuffer> Out;
+  amd_comgr_status_t Status = retargetCodeObject(
+      Obj.Bytes.data(), Obj.Bytes.size(), makeGfx1250Ident(), Options, Out);
+  ASSERT_EQ(Status, AMD_COMGR_STATUS_SUCCESS);
+  ASSERT_NE(Out, nullptr);
+
+  uint8_t *OutData = const_cast<uint8_t *>(
+      reinterpret_cast<const uint8_t *>(Out->getBufferStart()));
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  EXPECT_EQ(OutView->textAddr(), Obj.TextAddr);
+  EXPECT_EQ(OutView->textSize(), Obj.TextSize);
+  EXPECT_EQ(std::memcmp(OutView->textData(), Obj.Bytes.data() + Obj.TextOffset,
+                        Obj.TextSize),
+            0);
+
+  uint64_t OutputBakedDelta = 0;
+  std::memcpy(&OutputBakedDelta, OutView->textData() + Obj.LiteralOffset,
+              sizeof(OutputBakedDelta));
+  EXPECT_EQ(OutputBakedDelta, Obj.BakedDelta);
+
+  EXPECT_EQ(findSectionVAddr(*OutView, ".data"), Obj.DataAddr);
+  EXPECT_EQ(findSectionVAddr(*OutView, ".bss"), Obj.BssAddr);
+  EXPECT_EQ(findSymbolVAddr(*OutView, "x.managed"), Obj.DataAddr);
+  EXPECT_EQ(findSymbolVAddr(*OutView, "x"), Obj.BssAddr);
+
+  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  ASSERT_GE(KDs[0].EntryOffset, 0);
+  uint64_t NewEntryVAddr =
+      KDs[0].VAddr + static_cast<uint64_t>(KDs[0].EntryOffset);
+  EXPECT_GT(NewEntryVAddr, Obj.BssAddr);
+  EXPECT_EQ(findSectionVAddr(*OutView, ".hotswap.entry"),
+            NewEntryVAddr - (NewEntryVAddr % KernelEntryStubStride));
 }
 
 // -- classifyWmmaNops ---------------------------------------------------------

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -452,7 +452,7 @@ TEST(BuildKernelEntryTrampoline, MatcherRejectsWrongOperandShape) {
   EXPECT_FALSE(isKernelEntryTrampoline(Bytes, S));
 }
 
-TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
+TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   namespace hsa = llvm::amdhsa;
 
   LLVMState S = initLLVM(makeGfx1250Ident());
@@ -464,6 +464,8 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
   uint32_t Rsrc3 = 0;
   AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE, 7);
   Rsrc3 |= hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_GLG_EN;
+  AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX125_NAMED_BAR_CNT, 3);
+  AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX125_TCP_SPLIT, 5);
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.ComputePgmRsrc3 = Rsrc3;
   comgr_test::KernelDescriptorElf Obj =
@@ -482,12 +484,12 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 1u);
   ASSERT_EQ(Fixups.size(), 1u);
+  EXPECT_EQ(Fixups[0].InstPrefLines, KernelEntryStubInstPrefLines);
 
-  const uint64_t ExpectedGuard = computeKernelEntryPrefetchGuardBytes(7);
-  EXPECT_EQ(ExpectedGuard,
-            7u * KernelEntryInstPrefUnitBytes - KernelEntryStubStride);
+  const uint64_t ExpectedGuard =
+      computeKernelEntryPrefetchGuardBytes(KernelEntryStubInstPrefLines);
+  EXPECT_EQ(ExpectedGuard, 0u);
   ASSERT_FALSE(Growth.empty());
-  EXPECT_EQ(Growth.back().Bytes.size(), ExpectedGuard);
 
   const uint64_t OldTextSize = ViewOrErr->textSize();
   const uint64_t TextEndVAddr = ViewOrErr->textAddr() + OldTextSize;
@@ -507,7 +509,8 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
       ViewOrErr->growWithTrampolines(Growth, S.SNopBytes);
   ASSERT_NE(Out, nullptr);
 
-  ASSERT_TRUE(rewriteKernelEntryDescriptorOffsets(*Out, OldTextSize, Fixups));
+  ASSERT_TRUE(
+      rewriteKernelEntryDescriptorOffsets(*Out, OldTextSize, S.Cpu, Fixups));
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
   llvm::Expected<ElfView> OutView =
@@ -520,9 +523,17 @@ TEST(KernelEntryTrampoline, PreservesInstPrefSizeAndAddsPrefetchGuard) {
   std::memcpy(&OutRsrc3,
               OutKd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
               sizeof(OutRsrc3));
+  uint32_t ExpectedRsrc3 = Rsrc3;
+  AMDHSA_BITS_SET(ExpectedRsrc3,
+                  hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE,
+                  KernelEntryStubInstPrefLines);
+  EXPECT_EQ(OutRsrc3, ExpectedRsrc3);
   EXPECT_EQ(AMDHSA_BITS_GET(OutRsrc3,
                             hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE),
-            7u);
+            KernelEntryStubInstPrefLines);
+  EXPECT_EQ(
+      AMDHSA_BITS_GET(OutRsrc3, hsa::COMPUTE_PGM_RSRC3_GFX11_INST_PREF_SIZE),
+      KernelEntryStubInstPrefLines);
   EXPECT_NE(OutRsrc3 & hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_GLG_EN, 0u);
   EXPECT_EQ(Fixups[0].RequiredSgprs, 10u);
   uint32_t OutRsrc1 = 0;

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -395,6 +395,30 @@ TEST(BuildKernelEntryTrampoline, BuildsRecognizedPcRelativeStub) {
   expectInstMatchesAsm(Decoded[5].Inst, "s_set_pc_i64 s[8:9]", S);
 }
 
+TEST(BuildKernelEntryTrampoline, PrefixPrefiltersNonStubBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Stub =
+      buildKernelEntryTrampoline(/*StubVAddr=*/0x200000,
+                                 /*EntryVAddr=*/0x10100,
+                                 /*ScratchSgpr=*/8, S);
+  ASSERT_EQ(Stub.size(), KernelEntryStubStride);
+  EXPECT_TRUE(hasKernelEntryTrampolinePrefix(Stub, S));
+
+  llvm::SmallVector<uint8_t> NonStub;
+  ASSERT_TRUE(appendSingleInstBytes(NonStub, "s_endpgm", S));
+  while (NonStub.size() < KernelEntryStubStride)
+    NonStub.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  ASSERT_EQ(NonStub.size(), KernelEntryStubStride);
+
+  EXPECT_FALSE(hasKernelEntryTrampolinePrefix(NonStub, S));
+  EXPECT_FALSE(isKernelEntryTrampoline(NonStub, S));
+
+  llvm::ArrayRef<uint8_t> ShortCandidate(Stub.data(), MinInstSize);
+  EXPECT_FALSE(hasKernelEntryTrampolinePrefix(ShortCandidate, S));
+}
+
 TEST(BuildKernelEntryTrampoline, MatcherRejectsNonStubBytes) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -424,6 +448,7 @@ TEST(BuildKernelEntryTrampoline, MatcherRejectsWrongOperandShape) {
     Bytes.append(CodeEnd.begin(), CodeEnd.end());
   ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
 
+  EXPECT_TRUE(hasKernelEntryTrampolinePrefix(Bytes, S));
   EXPECT_FALSE(isKernelEntryTrampoline(Bytes, S));
 }
 

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -800,11 +800,11 @@ TEST(HotswapPatchVTable, ProcessSingletonIdentityAndEagerInstall) {
 
 // -- DS ADDTID trampoline support ---------------------------------------------
 //
-// Tests for the ds_load_addtid_b32 / ds_store_addtid_b32 trampoline patch
-// (DEGFXMI400-12025). Coverage is bottom-up: first that the encode/decode
-// of ADDTID instructions exposes the expected MCInst operand layout, then
-// that buildTrampoline assembles and decodes a full ADDTID replacement body
-// plus its branch-back tail.
+// Tests for the ds_load_addtid_b32 / ds_store_addtid_b32 gfx1250 trampoline
+// patch. Coverage is bottom-up: first that the encode/decode of ADDTID
+// instructions exposes the expected MCInst operand layout, then that
+// buildTrampoline assembles and decodes a full ADDTID replacement body plus
+// its branch-back tail.
 
 namespace {
 


### PR DESCRIPTION
Summary:
- Emit hotswap kernel-entry stubs in a separate executable load segment instead of growing .text.
- Keep existing allocated section, segment, and symbol virtual addresses unchanged so linked PC-relative references to globals/managed variables remain valid.
- Relocate the program-header table when needed, append a .hotswap.entry section, and continue to rewrite kernel descriptor entry offsets to the new absolute stub vaddrs.
- Add lit and unit coverage for the managed/global data-symbol corruption case and entry-stub idempotency.

Tests:
- build/bin/HotswapElfTests
- build/bin/HotswapMCTests
- build/bin/llvm-lit -sv build/tools/comgr/test-lit --filter hotswap-kernel-entry-trampoline
- build-asan/bin/HotswapElfTests
- build-asan/bin/HotswapMCTests

Stack:
- Builds on the existing hotswap entry-trampoline stack. Rebase after earlier PRs land so this PR shows only the segment append change.