### PR TITLE
[comgr][hotswap] Add test for trampoline growth corruptions

### DIFF
--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -190,6 +190,118 @@ TEST(ElfView, GrowWithTrampolinesShiftsAllocSectionSymbols) {
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr + GrowthBytes);
 }
 
+// gfx1250 "address of a global" idiom, as emitted for e.g. `x++` on a
+// __managed__/__device__ global and observed in GPU_func of the
+// Unit_hipModuleGetGlobal_Functional reproducer:
+//
+//   s_get_pc_i64 s[0:1]                         ; s[0:1] = addr of next insn
+//   s_add_nc_u64 s[0:1], s[0:1], lit64(delta)   ; s[0:1] = that addr + delta
+//
+// The 64-bit literal is baked at link time (no relocation) and encodes the
+// distance from the s_add instruction to the referenced symbol. Reading it back
+// out of .text is exactly how the hardware resolves the global's address, so it
+// is the ground truth any rewrite must keep consistent with the symbol table.
+namespace {
+constexpr uint8_t SGetPcI64SS01[4] = {0xBE, 0x80, 0x47, 0x00};
+constexpr uint8_t SAddNcU64Lit[4] = {0xA9, 0x80, 0xFE, 0x00};
+constexpr size_t GetPcOffset = 0;
+constexpr size_t AddOpOffset = 4;  // s_get_pc_i64 is one dword
+constexpr size_t Lit64Offset = 8;  // + s_add_nc_u64 opcode dword
+constexpr size_t RefSeqSize = 16;  // + 8-byte lit64
+
+// Build a .text image containing the reference idiom. The literal is computed
+// so that, loaded at TextAddr, the ISA resolves the reference to TargetVAddr.
+std::vector<uint8_t> makeTextReferencing(uint64_t TextAddr,
+                                         uint64_t TargetVAddr) {
+  std::vector<uint8_t> Text(RefSeqSize, 0);
+  std::memcpy(Text.data() + GetPcOffset, SGetPcI64SS01, sizeof(SGetPcI64SS01));
+  std::memcpy(Text.data() + AddOpOffset, SAddNcU64Lit, sizeof(SAddNcU64Lit));
+  // s_get_pc_i64 returns the address of the *following* instruction (the
+  // s_add), so the PC base the add works from is TextAddr + AddOpOffset.
+  const uint64_t PcBase = TextAddr + AddOpOffset;
+  const uint64_t Lit = TargetVAddr - PcBase;  // two's-complement; forward here
+  std::memcpy(Text.data() + Lit64Offset, &Lit, sizeof(Lit));
+  return Text;
+}
+
+// Decode the reference idiom out of a .text image loaded at TextAddr and return
+// the virtual address the ISA resolves it to.
+uint64_t decodeReferencedVAddr(const uint8_t *Text, uint64_t TextAddr) {
+  uint64_t Lit = 0;
+  std::memcpy(&Lit, Text + Lit64Offset, sizeof(Lit));
+  return TextAddr + AddOpOffset + Lit;
+}
+}  // namespace
+
+// The real invariant: after appending trampolines, the address the *ISA*
+// resolves a global reference to (decoded from the PC-relative literal in .text)
+// must equal the address the *symbol table* reports for that global. How the
+// rewrite achieves this is deliberately not constrained -- it may leave both
+// untouched, relocate the whole image uniformly, or analyze the code and patch
+// the literal to follow a moved symbol. The test only checks the end state.
+//
+// This is the ELF-layer reproduction of Unit_hipModuleGetGlobal_Functional: the
+// entry-trampoline rewrite grew .text, which shifted the referenced symbol by
+// the trampoline size while leaving the baked literal pointing at the old
+// location, so the ISA and the symbol table disagreed and the kernel
+// dereferenced the wrong address. Here the descriptor symbol lives in .rodata
+// (after .text), standing in for a global in a post-.text data section.
+//
+// This FAILS against the current implementation (ISA resolves to RodataAddr, the
+// symbol reports RodataAddr + GrowthBytes) and is expected to pass once
+// growWithTrampolines stops moving the symbol out from under the reference. It
+// is the counterpart of GrowWithTrampolinesShiftsAllocSectionSymbols above,
+// which pins the buggy shifting behavior and should be removed when the fix
+// lands.
+TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
+  // One 256-byte entry stub (KernelEntryStubStride), matching the real
+  // Unit_hipModuleGetGlobal_Functional reproducer's 0x100 shift.
+  static constexpr uint64_t GrowthBytes = 0x100;
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  // .text (at TextAddr) references the descriptor symbol in .rodata (at
+  // RodataAddr), which sits after .text -- like a kernel referencing a global
+  // in a post-.text data section.
+  std::vector<uint8_t> Text =
+      makeTextReferencing(Opts.TextAddr, Opts.RodataAddr);
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  // Sanity: before the rewrite, the ISA reference and the symbol agree.
+  ASSERT_EQ(decodeReferencedVAddr(ViewOrErr->textData(), ViewOrErr->textAddr()),
+            Obj.RodataAddr);
+
+  Trampoline T;
+  T.Bytes.assign(GrowthBytes, 0);
+  std::vector<Trampoline> Trampolines{T};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+  ASSERT_NE(Out, nullptr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  // Decode whatever is now in .text -- the original literal, or one the rewrite
+  // patched to follow a moved symbol -- into the address the ISA resolves the
+  // reference to...
+  const uint64_t IsaResolved =
+      decodeReferencedVAddr(OutView->textData(), OutView->textAddr());
+  // ...vs. the address the symbol table now reports for the same global.
+  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  const uint64_t SymbolVAddr = KDs[0].VAddr;
+
+  EXPECT_EQ(IsaResolved, SymbolVAddr);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -302,6 +302,222 @@ TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
   EXPECT_EQ(IsaResolved, SymbolVAddr);
 }
 
+// A fully-linked code object's DWARF encodes *absolute* virtual addresses of
+// code and data (DW_AT_low_pc, DW_OP_addr, the .debug_addr pool, .debug_line
+// set_address) with no relocations. growWithTrampolines shifts post-.text
+// virtual addresses and symbols but leaves .debug_* contents untouched (the
+// patchDebug* hooks in comgr-hotswap-b0a0.cpp are weak no-op stubs), so any such
+// address goes stale by the trampoline size -- the debugger would resolve a
+// global to the pre-shift location. This is the debug-info analogue of the
+// ISA-literal corruption above.
+namespace {
+
+// Minimal ET_DYN AMDGPU object:
+//   [1] .text        (alloc, exec)  at TextAddr
+//   [2] .data        (alloc, write) at DataAddr -- holds global "g"
+//   [3] .debug_info  (non-alloc)    -- 8-byte absolute address DWARF would
+//                                       encode for "g" (stands in for a
+//                                       DW_AT_low_pc / DW_OP_addr / .debug_addr
+//                                       entry)
+//   [4] .symtab  [5] .strtab  [6] .shstrtab
+// Both .data and .debug_info follow .text, so growWithTrampolines shifts them.
+struct DwarfRefElf {
+  std::vector<uint8_t> Bytes;
+  uint64_t DataAddr = 0;
+  unsigned DebugSectionIndex = 3;
+  unsigned SymtabSectionIndex = 4;
+  unsigned GlobalSymIndex = 1;
+};
+
+DwarfRefElf makeDwarfRefElf(uint64_t TextAddr = 0x1000,
+                            uint64_t DataAddr = 0x2000) {
+  using namespace llvm::ELF;
+  constexpr uint64_t TextSize = 16;
+  constexpr unsigned SymCount = 2;  // null + "g"
+
+  static const char ShStr[] =
+      "\0.text\0.data\0.debug_info\0.symtab\0.strtab\0.shstrtab\0";
+  constexpr uint32_t NameText = 1;
+  constexpr uint32_t NameData = 7;
+  constexpr uint32_t NameDebug = 13;
+  constexpr uint32_t NameSymtab = 25;
+  constexpr uint32_t NameStrtab = 33;
+  constexpr uint32_t NameShstrtab = 41;
+
+  static const char Str[] = "\0g\0";
+  constexpr uint32_t GNameOff = 1;
+
+  constexpr unsigned ShNum = 7;
+  const uint64_t ShOff = sizeof(Elf64_Ehdr);
+  const uint64_t TextOff =
+      comgr_test::alignTo8(ShOff + ShNum * sizeof(Elf64_Shdr));
+  const uint64_t DataOff = comgr_test::alignTo8(TextOff + TextSize);
+  const uint64_t DebugOff = comgr_test::alignTo8(DataOff + 8);
+  const uint64_t StrOff = comgr_test::alignTo8(DebugOff + 8);
+  const uint64_t SymOff = comgr_test::alignTo8(StrOff + sizeof(Str));
+  const uint64_t ShStrOff =
+      comgr_test::alignTo8(SymOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t BufSize = comgr_test::alignTo8(ShStrOff + sizeof(ShStr) + 64);
+
+  DwarfRefElf R;
+  R.Bytes.assign(BufSize, 0);
+  R.DataAddr = DataAddr;
+  uint8_t *B = R.Bytes.data();
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = ShNum;
+  Ehdr.e_shstrndx = 6;
+  std::memcpy(B, &Ehdr, sizeof(Ehdr));
+
+  std::memcpy(B + StrOff, Str, sizeof(Str));
+  std::memcpy(B + ShStrOff, ShStr, sizeof(ShStr));
+
+  // The absolute address DWARF encodes for "g".
+  const uint64_t DebugAddr = DataAddr;
+  std::memcpy(B + DebugOff, &DebugAddr, sizeof(DebugAddr));
+
+  auto writeShdr = [&](unsigned Idx, const Elf64_Shdr &Sh) {
+    std::memcpy(B + ShOff + Idx * sizeof(Elf64_Shdr), &Sh, sizeof(Sh));
+  };
+
+  Elf64_Shdr Text{};
+  Text.sh_name = NameText;
+  Text.sh_type = SHT_PROGBITS;
+  Text.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  Text.sh_offset = TextOff;
+  Text.sh_addr = TextAddr;
+  Text.sh_size = TextSize;
+  Text.sh_addralign = 4;
+  writeShdr(1, Text);
+
+  Elf64_Shdr Data{};
+  Data.sh_name = NameData;
+  Data.sh_type = SHT_PROGBITS;
+  Data.sh_flags = SHF_ALLOC | SHF_WRITE;
+  Data.sh_offset = DataOff;
+  Data.sh_addr = DataAddr;
+  Data.sh_size = 8;
+  Data.sh_addralign = 8;
+  writeShdr(2, Data);
+
+  Elf64_Shdr Debug{};
+  Debug.sh_name = NameDebug;
+  Debug.sh_type = SHT_PROGBITS;
+  Debug.sh_flags = 0;  // non-alloc, like real .debug_* sections
+  Debug.sh_offset = DebugOff;
+  Debug.sh_size = 8;
+  Debug.sh_addralign = 1;
+  writeShdr(3, Debug);
+
+  Elf64_Shdr Symtab{};
+  Symtab.sh_name = NameSymtab;
+  Symtab.sh_type = SHT_SYMTAB;
+  Symtab.sh_offset = SymOff;
+  Symtab.sh_size = SymCount * sizeof(Elf64_Sym);
+  Symtab.sh_link = 5;  // .strtab
+  Symtab.sh_info = 1;
+  Symtab.sh_entsize = sizeof(Elf64_Sym);
+  writeShdr(4, Symtab);
+
+  Elf64_Shdr Strtab{};
+  Strtab.sh_name = NameStrtab;
+  Strtab.sh_type = SHT_STRTAB;
+  Strtab.sh_offset = StrOff;
+  Strtab.sh_size = sizeof(Str);
+  writeShdr(5, Strtab);
+
+  Elf64_Shdr Shstr{};
+  Shstr.sh_name = NameShstrtab;
+  Shstr.sh_type = SHT_STRTAB;
+  Shstr.sh_offset = ShStrOff;
+  Shstr.sh_size = sizeof(ShStr);
+  writeShdr(6, Shstr);
+
+  Elf64_Sym G{};
+  G.st_name = GNameOff;
+  G.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  G.st_shndx = 2;  // .data
+  G.st_value = DataAddr;
+  G.st_size = 8;
+  std::memcpy(B + SymOff + 1 * sizeof(Elf64_Sym), &G, sizeof(G));
+
+  return R;
+}
+
+// Read an 8-byte value from section [Idx] at intra-section byte offset Off.
+uint64_t readSectionU64(const ElfView &V, unsigned Idx, uint64_t Off) {
+  uint64_t Val = 0;
+  std::memcpy(&Val,
+              V.data() + static_cast<uint64_t>(V.sections()[Idx].sh_offset) + Off,
+              sizeof(Val));
+  return Val;
+}
+
+// Read st_value of symbol SymIdx in the symbol table at section [SymtabIdx].
+uint64_t readSymbolValue(const ElfView &V, unsigned SymtabIdx, unsigned SymIdx) {
+  llvm::ELF::Elf64_Sym Sym{};
+  std::memcpy(&Sym,
+              V.data() + static_cast<uint64_t>(V.sections()[SymtabIdx].sh_offset) +
+                  SymIdx * sizeof(llvm::ELF::Elf64_Sym),
+              sizeof(Sym));
+  return Sym.st_value;
+}
+
+}  // namespace
+
+// The invariant: after appending trampolines, the address the object's DWARF
+// encodes for a global must still equal the address the symbol table reports for
+// it. growWithTrampolines shifts the symbol but not the DWARF address, so they
+// disagree -- the debug-info analogue of Unit_hipModuleGetGlobal_Functional.
+//
+// This FAILS against the current implementation and is expected to pass once a
+// fix keeps DWARF and the symbol table in agreement -- by not moving the symbol
+// at all, or by relocating DWARF alongside it (see
+// GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol).
+TEST(ElfView, GrowWithTrampolinesKeepsDwarfConsistentWithSymbol) {
+  static constexpr uint64_t GrowthBytes = 0x100;
+
+  DwarfRefElf Obj = makeDwarfRefElf();
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  // Sanity: before the rewrite, DWARF and the symbol agree.
+  ASSERT_EQ(readSectionU64(*ViewOrErr, Obj.DebugSectionIndex, 0), Obj.DataAddr);
+  ASSERT_EQ(
+      readSymbolValue(*ViewOrErr, Obj.SymtabSectionIndex, Obj.GlobalSymIndex),
+      Obj.DataAddr);
+
+  Trampoline T;
+  T.Bytes.assign(GrowthBytes, 0);
+  std::vector<Trampoline> Trampolines{T};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+  ASSERT_NE(Out, nullptr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  // Address DWARF still encodes for "g" ...
+  const uint64_t DwarfAddr =
+      readSectionU64(*OutView, Obj.DebugSectionIndex, 0);
+  // ... vs. the (shifted) address the symbol table now reports for "g".
+  const uint64_t SymbolVAddr =
+      readSymbolValue(*OutView, Obj.SymtabSectionIndex, Obj.GlobalSymIndex);
+
+  EXPECT_EQ(DwarfAddr, SymbolVAddr);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";


### PR DESCRIPTION

    Follow-up to the ISA-literal corruption test: the same post-.text virtual
    address shift performed by growWithTrampolines also invalidates the absolute
    addresses embedded in the object's DWARF.

    A fully-linked AMDGPU code object's DWARF encodes absolute virtual addresses of
    code and data (DW_AT_low_pc, DW_OP_addr, the .debug_addr pool, .debug_line
    set_address) with no relocations. growWithTrampolines shifts post-.text section
    addresses and symbol values but never touches .debug_* contents -- the
    patchDebug* hooks in comgr-hotswap-b0a0.cpp are weak no-op stubs -- so every
    such address goes stale by the trampoline size. A debugger would then resolve a
    global to its pre-shift location, the debug-info analogue of the runtime
    hipModuleGetGlobal corruption.

    This adds GrowWithTrampolinesKeepsDwarfConsistentWithSymbol and a self-contained
    ELF builder (makeDwarfRefElf, kept local to the test rather than extending the
    shared helper). The synthetic object places, after .text, a .data section with
    a global "g" (and a .symtab entry) and a non-alloc .debug_info section holding
    the absolute address DWARF would encode for "g". After a 256-byte pool grows
    .text, the symbol reports g at 0x2100 while .debug_info still names 0x2000 --
    the two disagree by the 0x100 trampoline size.

    Like the ISA test, the invariant (DWARF address == symbol value) is checked
    strategy-agnostically with a plain EXPECT_EQ. It currently FAILS and is expected
    to pass once a fix keeps DWARF and the symbol table in agreement (by not moving
    the symbol, or by relocating DWARF alongside it).
    
        growWithTrampolines appends the kernel-entry / B0-to-A0 trampoline pool by
    growing .text and shifting everything after it -- every following section's
    sh_addr, every following segment's p_vaddr, and every post-.text symbol's
    st_value are bumped by the trampoline size (adjustSectionHeaders /
    adjustProgramHeaders / adjustSymbolValues in comgr-hotswap-elf.cpp).

    That is only correct if the code that references those moved locations is also
    updated, but a fully-linked AMDGPU code object carries no relocations: the
    compiler/linker has already folded the final PC-relative distances into the
    instruction stream. A global access such as `x++` on a __managed__/__device__
    variable compiles to

        s_get_pc_i64 s[0:1]                         ; s[0:1] = addr of next insn
        s_add_nc_u64 s[0:1], s[0:1], lit64(delta)   ; s[0:1] = that addr + delta

    where `delta` is a baked 64-bit literal with no relocation entry. When the
    rewrite shifts the variable's symbol but leaves the literal untouched, the ISA
    resolves the reference to the OLD location while the symbol table (and thus
    hipModuleGetGlobal) reports the NEW one. The kernel then reads/writes the wrong
    address.

    Observed via Unit_hipModuleGetGlobal_Functional on gfx1250 with entry
    trampolines enabled: a single 256-byte entry stub grows .text by 0x100, the
    managed variable `x` symbol moves +0x100, the kernel keeps dereferencing the
    pre-shift slot (which stays zero), the managed value never updates, and the
    test reads 10 instead of 11. The corruption is silent -- no crash, no
    diagnostic.

    This adds GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol to
    HotswapElfTest.cpp, an ELF-layer reproduction:

      * builds a .text with the real s_get_pc_i64 + s_add_nc_u64 lit64 idiom whose
        literal resolves to a descriptor symbol in .rodata (after .text, standing
        in for a global in a post-.text data section),
      * runs growWithTrampolines with a 256-byte pool,
      * decodes the address back out of the ISA literal and requires it (plain
        EXPECT_EQ) to equal the address the symbol table now reports.

    The check is deliberately strategy-agnostic: it asserts only that the ISA and
    the symbol table agree, so any correct fix passes -- leaving both untouched
    (append the pool without moving existing content), relocating the image
    uniformly, or analyzing the code and patching the literals to follow a moved
    symbol.

    The test currently FAILS (ISA resolves to 0x2000, the symbol reports 0x2100)
    and is expected to pass once growWithTrampolines stops moving the symbol out
    from under the reference. The sibling GrowWithTrampolinesShiftsAllocSectionSymbols
    still pins the current shifting behavior and should be removed when the fix
    lands.