### PR TITLE
[Comgr] Fix XNACK_ON_OFF_MODES for gfx1250 and gfx1251

### DIFF
--- a/amd/comgr/src/comgr-isa-metadata.def
+++ b/amd/comgr/src/comgr-isa-metadata.def
@@ -76,8 +76,8 @@ HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1171",          false, false, EF_AMDGPU_MAC
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1172",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1172,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   16, 1024, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1200",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1200,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1201",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1201,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1250",          true,  false, EF_AMDGPU_MACH_AMDGCN_GFX1250,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1251",          true,  false, EF_AMDGPU_MACH_AMDGCN_GFX1251,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1250",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1250,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1251",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1251,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1310",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1310,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
 
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx9-generic",     false,  true, EF_AMDGPU_MACH_AMDGCN_GFX9_GENERIC,    true,  true, 65536,  32,  4,   40, 1024,   16, 800, 102,    4, 256, 256)
@@ -86,6 +86,6 @@ HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx10-1-generic",  false,  true, EF_AMDGPU_MAC
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx10-3-generic",  false, false, EF_AMDGPU_MACH_AMDGCN_GFX10_3_GENERIC, true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,    8, 1024, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx11-generic",    false, false, EF_AMDGPU_MACH_AMDGCN_GFX11_GENERIC,   true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   16, 1024, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx12-generic",    false, false, EF_AMDGPU_MACH_AMDGCN_GFX12_GENERIC,   true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx12-5-generic",  false,   true, EF_AMDGPU_MACH_AMDGCN_GFX12_5_GENERIC, true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx12-5-generic",  false,  true, EF_AMDGPU_MACH_AMDGCN_GFX12_5_GENERIC, true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
 
 #undef HANDLE_ISA


### PR DESCRIPTION
This sits on top of https://github.com/ROCm/llvm-project/pull/3242