### PR TITLE
[Comgr][hotswap] Append trampoline pool at a fresh vaddr instead of shifting post-.text addresses/symbols

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -404,11 +404,11 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement) {
-  // This trampoline lands right after .text and after every trampoline already
-  // queued -- later ones are appended behind it and cannot shift it, and
-  // fixupTrampolineBranches walks the same list in the same order -- so its
-  // final pool offset is known exactly now.
-  uint64_t PoolStart = Ctx.TextSize;
+  // This trampoline lands at the appended pool base and after every trampoline
+  // already queued -- later ones are appended behind it and cannot shift it,
+  // and fixupTrampolineBranches walks the same list in the same order -- so its
+  // final pool offset (relative to .text) is known exactly now.
+  uint64_t PoolStart = Ctx.PoolBaseOffset;
   for (const Trampoline &Prev : Ctx.OutTrampolines)
     PoolStart += Prev.Bytes.size();
 
@@ -515,9 +515,19 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
   }
 
   StringMap<KernelPatchStats> KernelStats;
-  PatchContext Ctx{Config,           Decoded, Text, TextSize, LS,
-                   OutTrampolines,   Sleds,   Elf,  Liveness, KernelStats,
-                   OutScratchPatches};
+  // Pool base as a .text-relative offset for trampoline branch math. The pool
+  // is always >= textAddr(); checkedSubUint64 guards a malformed object.
+  std::optional<uint64_t> PoolVAddr = Elf.trampolinePoolVAddr();
+  if (!PoolVAddr)
+    return std::nullopt;
+  std::optional<uint64_t> PoolBaseOffset = checkedSubUint64(
+      *PoolVAddr, Elf.textAddr(), "trampoline pool base offset");
+  if (!PoolBaseOffset)
+    return std::nullopt;
+  PatchContext Ctx{Config,         Decoded,         Text,
+                   TextSize,       *PoolBaseOffset, LS,
+                   OutTrampolines, Sleds,           Elf,
+                   Liveness,       KernelStats,     OutScratchPatches};
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
 
@@ -624,12 +634,16 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
 /// trampoline could not be fixed up.
 [[nodiscard]] static bool
 fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
-                        uint64_t TextSize, const LLVMState &LS) {
+                        uint64_t PoolBaseOffset, const LLVMState &LS) {
   // Fail-fast on the first encoding error: the position of later
   // trampolines depends on earlier ones, so a single bad branch would
   // cascade into incorrect layout. A single failure invalidates the whole
   // rewrite, so there is nothing useful to recover beyond it.
-  uint64_t TrampOffset = TextSize;
+  //
+  // Offsets are .text-relative; the pool begins at PoolBaseOffset
+  // (trampolinePoolVAddr() - textAddr()), which is far past .text, so both
+  // edges route through the s_add_pc_i64 long branch.
+  uint64_t TrampOffset = PoolBaseOffset;
   for (Trampoline &T : Trampolines) {
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
@@ -810,8 +824,23 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   std::unique_ptr<WritableMemoryBuffer> Result;
   std::vector<Trampoline> Growth = Deferred;
+  // The appended pool's fresh virtual address is the single reference point for
+  // all trampoline branch/stub targets (growWithTrampolines places it there).
+  std::optional<uint64_t> PoolVAddrOr = Elf.trampolinePoolVAddr();
+  if (!PoolVAddrOr) {
+    log() << "hotswap: error: retargetCodeObject: could not compute trampoline "
+          << "pool virtual address.\n";
+    return AMD_COMGR_STATUS_ERROR;
+  }
+  const uint64_t PoolVAddr = *PoolVAddrOr;
+  // Pool is always >= textAddr(); checkedSubUint64 guards a malformed object.
+  std::optional<uint64_t> PoolBaseOffsetOr = checkedSubUint64(
+      PoolVAddr, Elf.textAddr(), "trampoline pool base offset");
+  if (!PoolBaseOffsetOr)
+    return AMD_COMGR_STATUS_ERROR;
+  const uint64_t PoolBaseOffset = *PoolBaseOffsetOr;
   if (!Deferred.empty()) {
-    if (!fixupTrampolineBranches(Deferred, Text, Elf.textSize(), LS)) {
+    if (!fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS)) {
       // A trampoline branch could not be encoded, so the local `Buf` copy
       // is half-redirected; shipping it would run corrupted code. Fall back
       // to the pristine input object (`ElfData`, untouched) so the loader
@@ -871,7 +900,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       GrowthTotal += T.Bytes.size();
     }
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(), LS.Cpu,
+    if (!rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr, LS.Cpu,
                                              EntryFixups))
       return AMD_COMGR_STATUS_ERROR;
   } else {

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -35,30 +35,15 @@ using ELFFileT = ElfView::ELFFileT;
 
 static constexpr unsigned SgprEncodingGranule = 8;
 
+// Page alignment for the appended trampoline pool's virtual address and file
+// offset, so its PT_LOAD segment maps consistently.
+static constexpr uint64_t TrampolinePoolAlign = 4096;
+
 enum class MetadataSgprUpdateStatus {
   NotFound,
   Found,
   Error,
 };
-
-static std::optional<size_t>
-checkedAlignToSize(size_t Value, uint64_t Alignment, StringRef Context) {
-  if (Alignment <= 1)
-    return Value;
-  uint64_t Value64 = static_cast<uint64_t>(Value);
-  uint64_t Remainder = Value64 % Alignment;
-  if (Remainder == 0)
-    return Value;
-  std::optional<uint64_t> Aligned =
-      checkedAddUint64(Value64, Alignment - Remainder, Context);
-  if (!Aligned)
-    return std::nullopt;
-  if (*Aligned > static_cast<uint64_t>(std::numeric_limits<size_t>::max())) {
-    log() << "hotswap: error: " << Context << " exceeds size_t.\n";
-    return std::nullopt;
-  }
-  return static_cast<size_t>(*Aligned);
-}
 
 static std::optional<uint64_t> checkedSectionFileOffset(const ELFT::Shdr &Sec,
                                                         uint64_t VAddr,
@@ -968,238 +953,41 @@ void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,
               &Rsrc1, sizeof(Rsrc1));
 }
 
-// -- Section/program header adjustment for trampoline growth ------------------
+// -- ElfView::dataAtVAddr -----------------------------------------------------
 
-static bool adjustSectionHeaders(uint8_t *Elf, size_t ElfSize,
-                                 uint64_t TextOffset, uint64_t TextSize,
-                                 size_t TrampTotal) {
-  if (ElfSize < sizeof(Ehdr))
-    return true;
-
-  std::optional<uint64_t> TextEnd =
-      checkedAddUint64(TextOffset, TextSize, "section header .text end");
-  if (!TextEnd)
-    return false;
-  uint64_t Shoff;
-  uint16_t Shentsize;
-  uint16_t Shnum;
-  std::memcpy(&Shoff, Elf + offsetof(Ehdr, e_shoff), sizeof(Shoff));
-  std::memcpy(&Shentsize, Elf + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
-  std::memcpy(&Shnum, Elf + offsetof(Ehdr, e_shnum), sizeof(Shnum));
-  if (Shentsize < sizeof(Shdr))
-    return true;
-
-  if (Shoff >= *TextEnd) {
-    std::optional<uint64_t> NewShoff =
-        checkedAddUint64(Shoff, TrampTotal, "section header table offset");
-    if (!NewShoff)
-      return false;
-    uint64_t NewShoffValue = *NewShoff;
-    std::memcpy(Elf + offsetof(Ehdr, e_shoff), &NewShoffValue,
-                sizeof(NewShoffValue));
-    Shoff = NewShoffValue;
+const uint8_t *ElfView::dataAtVAddr(uint64_t VAddr, uint64_t Len) const {
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) || Shdr.sh_type == ELF::SHT_NOBITS)
+      continue;
+    if (VAddr < Shdr.sh_addr)
+      continue;
+    uint64_t Off = VAddr - Shdr.sh_addr;
+    if (Off > Shdr.sh_size || Len > Shdr.sh_size - Off)
+      continue;
+    if (Shdr.sh_offset > size() || Off > size() - Shdr.sh_offset ||
+        Len > size() - Shdr.sh_offset - Off)
+      continue;
+    return data() + Shdr.sh_offset + Off;
   }
-
-  for (uint16_t I = 0; I < Shnum; ++I) {
-    uint64_t ShTableDelta = static_cast<uint64_t>(I) * Shentsize;
-    std::optional<uint64_t> ShPos =
-        checkedAddUint64(Shoff, ShTableDelta, "section header entry offset");
-    if (!ShPos)
-      return false;
-    if (*ShPos > ElfSize || sizeof(Shdr) > ElfSize - *ShPos)
-      break;
-    uint8_t *Sh = Elf + *ShPos;
-    uint64_t ShOffset;
-    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
-
-    if (ShOffset == TextOffset) {
-      std::optional<uint64_t> NewTextSize =
-          checkedAddUint64(TextSize, TrampTotal, ".text section size");
-      if (!NewTextSize)
-        return false;
-      uint64_t NewTextSizeValue = *NewTextSize;
-      std::memcpy(Sh + offsetof(Shdr, sh_size), &NewTextSizeValue,
-                  sizeof(NewTextSizeValue));
-    } else if (ShOffset > TextOffset) {
-      std::optional<uint64_t> NewOffset =
-          checkedAddUint64(ShOffset, TrampTotal, "post-.text section offset");
-      if (!NewOffset)
-        return false;
-      uint64_t NewOffsetValue = *NewOffset;
-      std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffsetValue,
-                  sizeof(NewOffsetValue));
-      uint64_t ShFlags;
-      std::memcpy(&ShFlags, Sh + offsetof(Shdr, sh_flags), sizeof(ShFlags));
-      if (ShFlags & ELF::SHF_ALLOC) {
-        uint64_t ShAddr;
-        std::memcpy(&ShAddr, Sh + offsetof(Shdr, sh_addr), sizeof(ShAddr));
-        std::optional<uint64_t> NewAddr =
-            checkedAddUint64(ShAddr, TrampTotal, "post-.text section address");
-        if (!NewAddr)
-          return false;
-        ShAddr = *NewAddr;
-        std::memcpy(Sh + offsetof(Shdr, sh_addr), &ShAddr, sizeof(ShAddr));
-      }
-    }
-  }
-  return true;
+  return nullptr;
 }
 
-static bool adjustProgramHeaders(uint8_t *Elf, size_t ElfSize,
-                                 uint64_t TextOffset, uint64_t TextSize,
-                                 size_t TrampTotal) {
-  if (ElfSize < sizeof(Ehdr))
-    return true;
+// -- ElfView::trampolinePoolVAddr ---------------------------------------------
 
-  std::optional<uint64_t> TextEnd =
-      checkedAddUint64(TextOffset, TextSize, "program header .text end");
-  if (!TextEnd)
-    return false;
-  uint64_t Phoff;
-  uint16_t Phentsize;
-  uint16_t Phnum;
-  std::memcpy(&Phoff, Elf + offsetof(Ehdr, e_phoff), sizeof(Phoff));
-  std::memcpy(&Phentsize, Elf + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
-  std::memcpy(&Phnum, Elf + offsetof(Ehdr, e_phnum), sizeof(Phnum));
-  if (Phentsize < sizeof(Phdr))
-    return true;
-
-  for (uint16_t I = 0; I < Phnum; ++I) {
-    uint64_t PhTableDelta = static_cast<uint64_t>(I) * Phentsize;
-    std::optional<uint64_t> PhPos =
-        checkedAddUint64(Phoff, PhTableDelta, "program header entry offset");
-    if (!PhPos)
-      return false;
-    if (*PhPos > ElfSize || sizeof(Phdr) > ElfSize - *PhPos)
-      break;
-    uint8_t *Ph = Elf + *PhPos;
-    uint64_t POffset;
-    uint64_t PFilesz;
-    uint64_t PMemsz;
-    std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
-    std::memcpy(&PFilesz, Ph + offsetof(Phdr, p_filesz), sizeof(PFilesz));
-    std::memcpy(&PMemsz, Ph + offsetof(Phdr, p_memsz), sizeof(PMemsz));
-
-    std::optional<uint64_t> PEnd =
-        checkedAddUint64(POffset, PFilesz, "program header file end");
-    if (!PEnd)
-      return false;
-    if (POffset <= TextOffset && *PEnd >= *TextEnd) {
-      std::optional<uint64_t> NewPFilesz =
-          checkedAddUint64(PFilesz, TrampTotal, "program header file size");
-      std::optional<uint64_t> NewPMemsz =
-          checkedAddUint64(PMemsz, TrampTotal, "program header memory size");
-      if (!NewPFilesz || !NewPMemsz)
-        return false;
-      PFilesz = *NewPFilesz;
-      PMemsz = *NewPMemsz;
-      std::memcpy(Ph + offsetof(Phdr, p_filesz), &PFilesz, sizeof(PFilesz));
-      std::memcpy(Ph + offsetof(Phdr, p_memsz), &PMemsz, sizeof(PMemsz));
-    } else if (POffset > TextOffset) {
-      std::optional<uint64_t> NewPOffset =
-          checkedAddUint64(POffset, TrampTotal, "post-.text program offset");
-      if (!NewPOffset)
-        return false;
-      POffset = *NewPOffset;
-      std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
-      uint64_t PVaddr;
-      std::memcpy(&PVaddr, Ph + offsetof(Phdr, p_vaddr), sizeof(PVaddr));
-      std::optional<uint64_t> NewPVaddr =
-          checkedAddUint64(PVaddr, TrampTotal, "post-.text program vaddr");
-      if (!NewPVaddr)
-        return false;
-      PVaddr = *NewPVaddr;
-      std::memcpy(Ph + offsetof(Phdr, p_vaddr), &PVaddr, sizeof(PVaddr));
-      uint64_t PPaddr;
-      std::memcpy(&PPaddr, Ph + offsetof(Phdr, p_paddr), sizeof(PPaddr));
-      std::optional<uint64_t> NewPPaddr =
-          checkedAddUint64(PPaddr, TrampTotal, "post-.text program paddr");
-      if (!NewPPaddr)
-        return false;
-      PPaddr = *NewPPaddr;
-      std::memcpy(Ph + offsetof(Phdr, p_paddr), &PPaddr, sizeof(PPaddr));
-    }
-  }
-  return true;
-}
-
-static bool adjustSymbolValues(uint8_t *Elf, size_t ElfSize,
-                               uint64_t TextOffset, size_t TrampTotal) {
-  if (TrampTotal == 0)
-    return true;
-
-  Expected<ELFFileT> FileOrErr =
-      ELFFileT::create(StringRef(reinterpret_cast<const char *>(Elf), ElfSize));
-  if (!FileOrErr) {
-    log() << "hotswap: error: adjustSymbolValues: failed to parse grown ELF: "
-          << toString(FileOrErr.takeError()) << "\n";
-    return false;
-  }
-  ELFFileT File = std::move(*FileOrErr);
-
-  if (File.getHeader().e_type == ELF::ET_REL)
-    return true;
-
-  Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
-  if (!SectionsOrErr) {
-    log() << "hotswap: error: adjustSymbolValues: failed to read section "
-          << "headers: " << toString(SectionsOrErr.takeError()) << "\n";
-    return false;
-  }
-  ELFT::ShdrRange Sections = *SectionsOrErr;
-
-  unsigned SectionIndex = 0;
-  for (const ELFT::Shdr &SymShdr : Sections) {
-    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
-        SymShdr.sh_type != ELF::SHT_DYNSYM) {
-      ++SectionIndex;
+std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
+  uint64_t MaxAllocEnd = 0;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC))
       continue;
-    }
-
-    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
-    if (!SymsOrErr) {
-      log() << "hotswap: error: adjustSymbolValues: failed to read symbol "
-            << "table section " << SectionIndex << ": "
-            << toString(SymsOrErr.takeError()) << "\n";
-      ++SectionIndex;
-      continue;
-    }
-
-    for (const ELFT::Sym &Sym : *SymsOrErr) {
-      if (Sym.st_shndx == ELF::SHN_UNDEF || Sym.st_shndx >= ELF::SHN_LORESERVE)
-        continue;
-
-      Expected<const ELFT::Shdr *> DefShdrOrErr = File.getSection(Sym.st_shndx);
-      if (!DefShdrOrErr) {
-        log() << "hotswap: error: adjustSymbolValues: symbol references "
-              << "missing section " << Sym.st_shndx << ": "
-              << toString(DefShdrOrErr.takeError()) << "\n";
-        continue;
-      }
-      const ELFT::Shdr &DefShdr = **DefShdrOrErr;
-      if (!(DefShdr.sh_flags & ELF::SHF_ALLOC) ||
-          DefShdr.sh_offset <= TextOffset)
-        continue;
-
-      const uint8_t *SymBytes = reinterpret_cast<const uint8_t *>(&Sym);
-      if (SymBytes < File.base() || SymBytes + sizeof(ELFT::Sym) > File.end()) {
-        log() << "hotswap: error: adjustSymbolValues: symbol table entry is "
-              << "outside the ELF buffer.\n";
-        continue;
-      }
-
-      uint64_t SymOffset = SymBytes - File.base();
-      std::optional<uint64_t> Value =
-          checkedAddUint64(Sym.st_value, TrampTotal, "post-.text symbol value");
-      if (!Value)
-        return false;
-      uint64_t Value64 = *Value;
-      std::memcpy(Elf + SymOffset + offsetof(ELFT::Sym, st_value), &Value64,
-                  sizeof(Value64));
-    }
-    ++SectionIndex;
+    // Overflow would collapse MaxAllocEnd and overlap the pool with existing
+    // sections.
+    std::optional<uint64_t> End = checkedAddUint64(
+        Shdr.sh_addr, Shdr.sh_size, "allocatable section end for pool vaddr");
+    if (!End)
+      return std::nullopt;
+    MaxAllocEnd = std::max(MaxAllocEnd, *End);
   }
-  return true;
+  return alignTo(MaxAllocEnd, TrampolinePoolAlign);
 }
 
 // -- ElfView::growWithTrampolines ---------------------------------------------
@@ -1207,8 +995,19 @@ static bool adjustSymbolValues(uint8_t *Elf, size_t ElfSize,
 std::unique_ptr<WritableMemoryBuffer>
 ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
                              ArrayRef<uint8_t> SNopBytes) const {
+  // SNopBytes is unused in the append-at-end model: nothing between .text and
+  // the following sections moves, so there is no in-image gap to pad. It is
+  // retained in the signature for callers and for a future in-place variant.
+  (void)SNopBytes;
+
   const size_t InputSize = size();
   const uint8_t *Input = data();
+
+  if (InputSize < sizeof(Ehdr)) {
+    log() << "hotswap: error: growWithTrampolines: input (" << InputSize
+          << " bytes) is smaller than an ELF64 header.\n";
+    return nullptr;
+  }
 
   size_t TrampTotal = 0;
   for (const Trampoline &T : Trampolines) {
@@ -1224,83 +1023,163 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
           << "returning empty result.\n";
     return nullptr;
   }
-  if (TrampTotal > std::numeric_limits<size_t>::max() - InputSize) {
-    log() << "hotswap: error: growWithTrampolines: trampoline bytes ("
-          << TrampTotal << ") + existing ELF size (" << InputSize
-          << ") overflow size_t.\n";
-    return nullptr;
-  }
 
-  std::optional<uint64_t> TextEnd = checkedAddUint64(
-      textOffset(), textSize(), "growWithTrampolines .text end");
-  if (!TextEnd || *TextEnd > InputSize) {
-    log() << "hotswap: error: growWithTrampolines: .text range exceeds input "
-          << "ELF size.\n";
+  // Append the pool at a fresh virtual address above every existing
+  // allocatable section (trampolinePoolVAddr()). Because existing sections,
+  // symbols, and program headers keep their addresses, the baked PC-relative
+  // literals (and DWARF) that reference post-.text data stay valid. The
+  // previous scheme grew .text in place and shifted everything after it,
+  // silently corrupting those baked references (a fully-linked AMDGPU object
+  // carries no relocations) -- see
+  // ElfView.GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol.
+  //
+  // The vaddr and file offset are page-aligned (equal modulo the alignment) so
+  // the appended PT_LOAD maps consistently.
+  std::optional<uint64_t> PoolVAddrOr = trampolinePoolVAddr();
+  if (!PoolVAddrOr) {
+    log() << "hotswap: error: growWithTrampolines: could not compute a "
+          << "trampoline pool virtual address.\n";
     return nullptr;
   }
+  const uint64_t PoolVAddr = *PoolVAddrOr;
+  const uint64_t PoolFileOff =
+      alignTo(static_cast<uint64_t>(InputSize), TrampolinePoolAlign);
 
-  // Pad TrampTotal to the maximum alignment of all post-.text sections so
-  // that shifting file offsets preserves sh_addralign invariants. The
-  // sh_addr update in adjustSectionHeaders is still gated on SHF_ALLOC.
-  uint64_t MaxPostTextAlign = 1;
-  for (const ELFT::Shdr &Shdr : Sections) {
-    if (Shdr.sh_offset <= textOffset())
-      continue;
-    if (Shdr.sh_addralign > MaxPostTextAlign)
-      MaxPostTextAlign = Shdr.sh_addralign;
-  }
-  std::optional<size_t> PaddedTrampTotalOrErr = checkedAlignToSize(
-      TrampTotal, MaxPostTextAlign, "padded trampoline byte count");
-  if (!PaddedTrampTotalOrErr)
-    return nullptr;
-  size_t PaddedTrampTotal = *PaddedTrampTotalOrErr;
-  if (PaddedTrampTotal > std::numeric_limits<size_t>::max() - InputSize) {
-    log() << "hotswap: error: growWithTrampolines: padded trampoline bytes ("
-          << PaddedTrampTotal << ") + ELF size (" << InputSize
-          << ") overflow size_t.\n";
-    return nullptr;
-  }
-  size_t PadBytes = PaddedTrampTotal - TrampTotal;
+  // Copy the program-header and section-header tables to the end of the file,
+  // each with one new entry for the pool (a PT_LOAD segment so the loader maps
+  // it, and an SHF_ALLOC|SHF_EXECINSTR section so objdump/tools and a
+  // subsequent rewrite can see it), then repoint e_phoff / e_shoff. Those
+  // tables are metadata addressed via the ELF header, so relocating them moves
+  // nothing a baked literal can reference.
+  uint64_t Phoff, Shoff;
+  uint16_t Phentsize, Phnum, Shentsize, Shnum;
+  std::memcpy(&Phoff, Input + offsetof(Ehdr, e_phoff), sizeof(Phoff));
+  std::memcpy(&Phentsize, Input + offsetof(Ehdr, e_phentsize),
+              sizeof(Phentsize));
+  std::memcpy(&Phnum, Input + offsetof(Ehdr, e_phnum), sizeof(Phnum));
+  std::memcpy(&Shoff, Input + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, Input + offsetof(Ehdr, e_shentsize),
+              sizeof(Shentsize));
+  std::memcpy(&Shnum, Input + offsetof(Ehdr, e_shnum), sizeof(Shnum));
 
-  const size_t NewSize = InputSize + PaddedTrampTotal;
+  const bool HasPhdrs =
+      Phnum > 0 && Phoff != 0 && Phentsize >= sizeof(Phdr) &&
+      Phoff <= InputSize &&
+      static_cast<uint64_t>(Phnum) * Phentsize <= InputSize - Phoff;
+  const bool HasShdrs =
+      Shnum > 0 && Shoff != 0 && Shentsize >= sizeof(Shdr) &&
+      Shoff <= InputSize &&
+      static_cast<uint64_t>(Shnum) * Shentsize <= InputSize - Shoff;
+
+  std::optional<uint64_t> PoolEnd =
+      checkedAddUint64(PoolFileOff, TrampTotal, "trampoline pool file end");
+  if (!PoolEnd)
+    return nullptr;
+
+  // Lay out the relocated tables after the pool: [pool][phdrs][shdrs].
+  uint64_t Cursor = *PoolEnd;
+  const uint64_t NewPhnum = HasPhdrs ? static_cast<uint64_t>(Phnum) + 1 : Phnum;
+  const uint64_t NewShnum = HasShdrs ? static_cast<uint64_t>(Shnum) + 1 : Shnum;
+  uint64_t NewPhoff = Phoff;
+  uint64_t NewShoff = Shoff;
+  if (HasPhdrs) {
+    if (static_cast<uint64_t>(Phnum) >= std::numeric_limits<uint16_t>::max()) {
+      log() << "hotswap: error: growWithTrampolines: program-header count "
+            << Phnum << " leaves no room to append a PT_LOAD.\n";
+      return nullptr;
+    }
+    NewPhoff = alignTo(Cursor, static_cast<uint64_t>(alignof(Phdr)));
+    std::optional<uint64_t> End = checkedAddUint64(
+        NewPhoff, NewPhnum * Phentsize, "relocated phdr table end");
+    if (!End)
+      return nullptr;
+    Cursor = *End;
+  }
+  if (HasShdrs) {
+    if (static_cast<uint64_t>(Shnum) >= std::numeric_limits<uint16_t>::max()) {
+      log() << "hotswap: error: growWithTrampolines: section-header count "
+            << Shnum << " leaves no room to append the pool section.\n";
+      return nullptr;
+    }
+    NewShoff = alignTo(Cursor, static_cast<uint64_t>(alignof(Shdr)));
+    std::optional<uint64_t> End = checkedAddUint64(
+        NewShoff, NewShnum * Shentsize, "relocated shdr table end");
+    if (!End)
+      return nullptr;
+    Cursor = *End;
+  }
+  if (Cursor > std::numeric_limits<size_t>::max()) {
+    log()
+        << "hotswap: error: growWithTrampolines: grown size exceeds size_t.\n";
+    return nullptr;
+  }
+  const size_t NewSize = static_cast<size_t>(Cursor);
+
+  // getNewMemBuffer zero-initializes, so the alignment gaps between regions are
+  // well-defined padding without extra memsets.
   std::unique_ptr<WritableMemoryBuffer> Buf =
-      WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
+      WritableMemoryBuffer::getNewMemBuffer(NewSize);
   if (!Buf) {
     log() << "hotswap: error: growWithTrampolines: "
-          << "WritableMemoryBuffer::getNewUninitMemBuffer(" << NewSize
+          << "WritableMemoryBuffer::getNewMemBuffer(" << NewSize
           << ") failed (out of memory).\n";
     return nullptr;
   }
 
   uint8_t *Out = reinterpret_cast<uint8_t *>(Buf->getBufferStart());
-  size_t TextEndSize = static_cast<size_t>(*TextEnd);
-  std::memcpy(Out, Input, TextEndSize);
-  size_t Pos = TextEndSize;
+  // 1. Original bytes verbatim -- nothing shifts.
+  std::memcpy(Out, Input, InputSize);
+  // 2. Trampoline pool at its fresh, page-aligned file offset / vaddr.
+  size_t Pos = static_cast<size_t>(PoolFileOff);
   for (const Trampoline &T : Trampolines) {
     std::memcpy(Out + Pos, T.Bytes.data(), T.Bytes.size());
     Pos += T.Bytes.size();
   }
-  if (PadBytes > 0 && SNopBytes.size() == MinInstSize) {
-    for (size_t I = 0; I < PadBytes; I += MinInstSize)
-      std::memcpy(Out + Pos + I, SNopBytes.data(), MinInstSize);
-    Pos += PadBytes;
-  } else if (PadBytes > 0) {
-    std::memset(Out + Pos, 0, PadBytes);
-    Pos += PadBytes;
+  // 3. Relocated program-header table + appended PT_LOAD for the pool.
+  if (HasPhdrs) {
+    std::memcpy(Out + NewPhoff, Input + Phoff,
+                static_cast<size_t>(Phnum) * Phentsize);
+    Phdr PoolPhdr{};
+    PoolPhdr.p_type = ELF::PT_LOAD;
+    PoolPhdr.p_flags = ELF::PF_R | ELF::PF_X;
+    PoolPhdr.p_offset = PoolFileOff;
+    PoolPhdr.p_vaddr = PoolVAddr;
+    PoolPhdr.p_paddr = PoolVAddr;
+    PoolPhdr.p_filesz = TrampTotal;
+    PoolPhdr.p_memsz = TrampTotal;
+    PoolPhdr.p_align = TrampolinePoolAlign;
+    std::memcpy(Out + NewPhoff + static_cast<uint64_t>(Phnum) * Phentsize,
+                &PoolPhdr, sizeof(PoolPhdr));
+    std::memcpy(Out + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
+    uint16_t NewPhnum16 = static_cast<uint16_t>(NewPhnum);
+    std::memcpy(Out + offsetof(Ehdr, e_phnum), &NewPhnum16, sizeof(NewPhnum16));
   }
-  if (TextEndSize < InputSize)
-    std::memcpy(Out + Pos, Input + TextEndSize, InputSize - TextEndSize);
+  // 4. Relocated section-header table + appended pool section. The section has
+  // an empty name (sh_name == 0): the loader ignores section headers and tools
+  // still disassemble it by flags, so no .shstrtab surgery is needed.
+  if (HasShdrs) {
+    std::memcpy(Out + NewShoff, Input + Shoff,
+                static_cast<size_t>(Shnum) * Shentsize);
+    Shdr PoolShdr{};
+    PoolShdr.sh_name = 0;
+    PoolShdr.sh_type = ELF::SHT_PROGBITS;
+    PoolShdr.sh_flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
+    PoolShdr.sh_addr = PoolVAddr;
+    PoolShdr.sh_offset = PoolFileOff;
+    PoolShdr.sh_size = TrampTotal;
+    PoolShdr.sh_addralign = TrampolinePoolAlign;
+    std::memcpy(Out + NewShoff + static_cast<uint64_t>(Shnum) * Shentsize,
+                &PoolShdr, sizeof(PoolShdr));
+    std::memcpy(Out + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+    uint16_t NewShnum16 = static_cast<uint16_t>(NewShnum);
+    std::memcpy(Out + offsetof(Ehdr, e_shnum), &NewShnum16, sizeof(NewShnum16));
+  }
 
-  if (!adjustSectionHeaders(Out, NewSize, textOffset(), textSize(),
-                            PaddedTrampTotal) ||
-      !adjustProgramHeaders(Out, NewSize, textOffset(), textSize(),
-                            PaddedTrampTotal) ||
-      !adjustSymbolValues(Out, NewSize, textOffset(), PaddedTrampTotal))
-    return nullptr;
-  log() << "hotswap: growWithTrampolines: grew ELF from " << InputSize << " to "
-        << NewSize << " bytes (" << Trampolines.size() << " trampoline"
-        << (Trampolines.size() == 1 ? "" : "s") << ", " << TrampTotal
-        << " trampoline bytes + " << PadBytes << " alignment padding).\n";
+  log() << "hotswap: growWithTrampolines: appended " << Trampolines.size()
+        << (Trampolines.size() == 1 ? " trampoline (" : " trampolines (")
+        << TrampTotal << " bytes) at vaddr 0x" << utohexstr(PoolVAddr)
+        << " (file 0x" << utohexstr(PoolFileOff) << "); grew ELF from "
+        << InputSize << " to " << NewSize << " bytes.\n";
   return Buf;
 }
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -316,21 +316,20 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
-  if (*Entry < Elf.textAddr())
-    return false;
 
   std::optional<uint64_t> TextEnd = checkedAddUint64(
       Elf.textAddr(), Elf.textSize(), "entry trampoline text end");
   if (!TextEnd)
     return std::nullopt;
 
-  const uint64_t TextOffset = *Entry - Elf.textAddr();
-  if (TextOffset > Elf.textSize() ||
-      KernelEntryStubStride > Elf.textSize() - TextOffset)
+  // Read whatever the descriptor's entry points at: the real kernel prologue in
+  // .text on a never-rewritten object, or the entry stub in the appended
+  // trampoline pool on an already-rewritten one. dataAtVAddr resolves either
+  // through the covering allocatable section.
+  const uint8_t *StubBytes = Elf.dataAtVAddr(*Entry, KernelEntryStubStride);
+  if (!StubBytes)
     return false;
-
-  ArrayRef<uint8_t> Candidate(Elf.textData() + TextOffset,
-                              KernelEntryStubStride);
+  ArrayRef<uint8_t> Candidate(StubBytes, KernelEntryStubStride);
   // Avoid feeding arbitrary kernel-entry instructions into the stub matcher.
   // The full decode below is only needed once the bytes look like a hotswap
   // entry stub.
@@ -348,7 +347,8 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
   if (!Target)
     return std::nullopt;
 
-  return *Target >= Elf.textAddr() && *Target < *TextEnd && *Target < *Entry;
+  // A genuine entry stub jumps back to the original kernel body in .text.
+  return *Target >= Elf.textAddr() && *Target < *TextEnd;
 }
 
 static std::optional<uint64_t>
@@ -491,12 +491,14 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   if (!ExistingGrowthBytes)
     return std::nullopt;
   uint64_t AppendOffset = *ExistingGrowthBytes;
-  std::optional<uint64_t> TextEndVAddr = checkedAddUint64(
-      Elf.textAddr(), Elf.textSize(), "entry trampoline text end");
-  if (!TextEndVAddr)
+  // Stubs live in the appended trampoline pool at its fresh virtual address
+  // (trampolinePoolVAddr()), no longer immediately after .text.
+  std::optional<uint64_t> PoolVAddrOr = Elf.trampolinePoolVAddr();
+  if (!PoolVAddrOr)
     return std::nullopt;
+  const uint64_t PoolVAddr = *PoolVAddrOr;
   std::optional<uint64_t> StubPoolBaseVAddr = checkedAddUint64(
-      *TextEndVAddr, AppendOffset, "entry trampoline stub-pool base");
+      PoolVAddr, AppendOffset, "entry trampoline stub-pool base");
   if (!StubPoolBaseVAddr)
     return std::nullopt;
   std::optional<uint64_t> AlignedStubPoolBaseVAddr =
@@ -504,7 +506,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
                      "entry trampoline aligned stub-pool base");
   if (!AlignedStubPoolBaseVAddr)
     return std::nullopt;
-  const uint64_t StubStart = *AlignedStubPoolBaseVAddr - *TextEndVAddr;
+  const uint64_t StubStart = *AlignedStubPoolBaseVAddr - PoolVAddr;
   std::vector<Trampoline> LocalGrowth;
   std::vector<KernelEntryTrampolineFixup> LocalFixups;
   if (!appendPaddingTrampoline(LocalGrowth, StubStart - AppendOffset,
@@ -514,14 +516,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 
   for (const WorkItem &Item : Work) {
     const KernelDescriptorInfo &KD = Item.KD;
-    std::optional<uint64_t> StubTextEnd = checkedAddUint64(
-        Elf.textSize(), AppendOffset,
-        (Twine("entry trampoline append offset for '") + KD.KernelName + "'")
-            .str());
-    if (!StubTextEnd)
-      return std::nullopt;
     std::optional<uint64_t> StubVAddr = checkedAddUint64(
-        Elf.textAddr(), *StubTextEnd,
+        PoolVAddr, AppendOffset,
         (Twine("entry trampoline vaddr for '") + KD.KernelName + "'").str());
     if (!StubVAddr)
       return std::nullopt;
@@ -584,7 +580,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 }
 
 bool rewriteKernelEntryDescriptorOffsets(
-    WritableMemoryBuffer &OutBuf, uint64_t OldTextSize, StringRef TargetCpu,
+    WritableMemoryBuffer &OutBuf, uint64_t PoolVAddr, StringRef TargetCpu,
     ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return true;
@@ -608,16 +604,8 @@ bool rewriteKernelEntryDescriptorOffsets(
       Ok = false;
       continue;
     }
-    std::optional<uint64_t> StubTextOffset = checkedAddUint64(
-        OldTextSize, Fixup.StubTextOffset,
-        (Twine("entry trampoline text offset for '") + Fixup.KernelName + "'")
-            .str());
-    if (!StubTextOffset) {
-      Ok = false;
-      continue;
-    }
     std::optional<uint64_t> StubVAddr = checkedAddUint64(
-        OutElf.textAddr(), *StubTextOffset,
+        PoolVAddr, Fixup.StubTextOffset,
         (Twine("entry trampoline vaddr for '") + Fixup.KernelName + "'").str());
     if (!StubVAddr) {
       Ok = false;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -84,6 +84,15 @@ inline std::optional<uint64_t> checkedAddUint64(uint64_t LHS, uint64_t RHS,
   return std::nullopt;
 }
 
+inline std::optional<uint64_t> checkedSubUint64(uint64_t LHS, uint64_t RHS,
+                                                llvm::StringRef Context) {
+  if (LHS < RHS) {
+    log() << "hotswap: error: " << Context << " underflows uint64_t.\n";
+    return std::nullopt;
+  }
+  return LHS - RHS;
+}
+
 // -- Trampoline and NOP sled --------------------------------------------------
 
 struct Trampoline {
@@ -241,6 +250,12 @@ public:
   std::optional<FunctionTextRange>
   findFunctionTextRangeAtOffset(uint64_t TextOffset) const;
 
+  /// Return a pointer to \p Len bytes at virtual address \p VAddr, resolved
+  /// through the allocatable section that contains it (any section, not just
+  /// `.text` -- e.g. the appended trampoline pool). Returns nullptr if no
+  /// section covers the range or it falls outside the buffer.
+  const uint8_t *dataAtVAddr(uint64_t VAddr, uint64_t Len) const;
+
   /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
   /// or nullptr if not found.
   uint8_t *findKernelDescriptor(llvm::StringRef KernelName);
@@ -310,13 +325,22 @@ public:
   void updateKernelDescriptor(llvm::StringRef KernelName, unsigned ExtraVgprs,
                               unsigned VgprGranuleSize);
 
-  /// Grow the ELF by inserting trampoline bytes after `.text` and adjusting
-  /// all section and program headers. Returns a null unique_ptr on failure.
+  /// Virtual address at which growWithTrampolines appends the trampoline pool:
+  /// the first page-aligned address above every existing allocatable section.
+  /// Callers that pre-compute branch/stub targets (B0-to-A0 trampolines,
+  /// kernel-entry stubs) must resolve pool positions against this value so the
+  /// baked branches land on the pool's final location. Single source of truth
+  /// shared with growWithTrampolines. std::nullopt on sh_addr+sh_size overflow.
+  std::optional<uint64_t> trampolinePoolVAddr() const;
+
+  /// Grow the ELF by appending the trampoline pool at a fresh virtual address
+  /// (trampolinePoolVAddr()) in a new PT_LOAD segment, leaving every existing
+  /// section, symbol, and segment in place. Returns a null unique_ptr on
+  /// failure.
   ///
-  /// SHF_ALLOC sections after `.text` (e.g. `.dynamic` in clang/lld-produced
-  /// HSACOs) are handled: their file offsets, virtual addresses (sh_addr,
-  /// p_vaddr, p_paddr), and segment sizes are shifted by the total
-  /// trampoline size to keep the ELF layout consistent.
+  /// Appending (rather than growing `.text` and shifting everything after it)
+  /// preserves the absolute/PC-relative addresses baked into a fully-linked
+  /// AMDGPU code object, which carries no relocations to fix up.
   std::unique_ptr<llvm::WritableMemoryBuffer>
   growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines,
                       llvm::ArrayRef<uint8_t> SNopBytes) const;
@@ -648,6 +672,11 @@ struct PatchContext {
   std::vector<InternalDecodedInst> &Decoded;
   uint8_t *Text = nullptr;
   uint64_t TextSize = 0;
+  // .text-relative offset at which the appended trampoline pool begins
+  // (trampolinePoolVAddr() - textAddr()). Trampoline branch offsets are
+  // computed against this, not TextSize, since the pool no longer sits
+  // immediately after .text.
+  uint64_t PoolBaseOffset = 0;
   const LLVMState &LS;
   std::vector<Trampoline> &OutTrampolines;
   std::vector<NopSled> &NopSleds;
@@ -784,7 +813,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 /// Apply descriptor rewrites recorded by appendKernelEntryTrampolines after
 /// the ELF has been grown.
 bool rewriteKernelEntryDescriptorOffsets(
-    llvm::WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
+    llvm::WritableMemoryBuffer &OutBuf, uint64_t PoolVAddr,
     llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
@@ -11,8 +11,8 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
-// API: hotswap: growWithTrampolines: grew ELF
-// API-SAME: 1 trampoline
+// API: hotswap: growWithTrampolines: appended 1 trampoline
+// API-SAME: grew ELF
 // API: REWRITE: SUCCESS
 // API: IDEMPOTENT: YES
 

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -40,7 +40,10 @@ test_cvt_pk_fp8_zero_fill_after:
 .size test_cvt_pk_fp8_zero_fill_after, .Ltest_cvt_pk_fp8_zero_fill_after_end-test_cvt_pk_fp8_zero_fill_after
 
 // DISASM-LABEL: <test_cvt_pk_fp8_zero_fill_source>:
-// DISASM-NEXT:  s_branch{{.*}}<test_cvt_pk_fp8_zero_fill_after+0x4>
+// COM: The cvt is replaced by a forward branch into the appended trampoline
+// COM: pool (a fresh vaddr above .text); the pool section is unnamed, so
+// COM: objdump prints no symbol annotation for the target.
+// DISASM-NEXT:  s_branch
 // DISASM-NEXT:  s_nop
 // DISASM-NEXT:  s_nop
 // DISASM-NEXT:  s_endpgm
@@ -50,7 +53,9 @@ test_cvt_pk_fp8_zero_fill_after:
 // DISASM-NOT:   v_lshl_or_b32
 // DISASM-LABEL: <test_cvt_pk_fp8_zero_fill_after>:
 // DISASM-NEXT:  s_endpgm
-// DISASM-NEXT:  s_mov_b32
+// COM: Trampoline body lives in the appended pool section (fresh vaddr above
+// COM: .text), so objdump emits a section header here -- DISASM, not -NEXT.
+// DISASM:       s_mov_b32
 // DISASM-NEXT:  v_mov_b32{{.*}}0x477f0000
 // DISASM-NEXT:  v_mov_b32{{.*}}0x477f0000
 // DISASM-NEXT:  v_and_b32{{.*}}0x7fffffff

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -37,8 +37,10 @@
 // DISASM-NOT: tensor_load_to_lds
 
 // COM: Dead-SGPR trampoline body: s_pack_hh + tensor_load + branch-back,
-// COM: appended after the original functions.
-// DISASM-NEXT: s_pack_hh_b32_b16
+// COM: appended in the trampoline pool section (a fresh vaddr above .text), so
+// COM: objdump emits a section header between .text and the pool -- use DISASM
+// COM: (not DISASM-NEXT) to cross that boundary.
+// DISASM: s_pack_hh_b32_b16
 // DISASM-NEXT: tensor_load_to_lds
 // DISASM-NEXT: s_branch
 

--- a/amd/comgr/test-lit/hotswap-wmma-split.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split.s
@@ -29,26 +29,16 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Verify .text actually grew on the wire. Disassembly above shows the
-// COM: replacement mnemonics, but a buggy rewriter could leave the .text
-// COM: section header sh_size unchanged -- the disassembler walks raw bytes
-// COM: regardless, but downstream tools that respect section headers (the
-// COM: HSA loader's relocation pass, ELF strippers, debuggers) would then
-// COM: miss the appended trampolines. Assert .text in the output is strictly
-// COM: larger than .text in the input. Field 7 of llvm-readelf -S is the
-// COM: hex Size column; the trailing space after `\.text` skips
-// COM: `.text.<funcname>` would-be matches (none exist here, but cheap
-// COM: insurance).
-// COM: Drop `exit` from the awk one-liner: with `exit`, awk closes its
-// COM: stdin before llvm-readelf finishes writing, and LIT's pipefail
-// COM: shell propagates the SIGPIPE -> the test fails non-deterministically
-// COM: in standalone runs (only passes in the bulk LIT run because
-// COM: output buffering shifts the race). The `\.text ` pattern (with
-// COM: trailing space) matches at most one section header per ELF, so
-// COM: removing `exit` does not change the captured value.
-// RUN: SIZE_IN=$(%llvm-readelf -S %t.elf | awk '/\.text /{print $7}') && \
-// RUN:   SIZE_OUT=$(%llvm-readelf -S %t.out.elf | awk '/\.text /{print $7}') && \
-// RUN:   test $((16#$SIZE_OUT)) -gt $((16#$SIZE_IN))
+// COM: Verify the trampoline pool landed on the wire. The rewriter appends the
+// COM: pool as a new section at a fresh virtual address (it no longer grows
+// COM: .text in place and shifts everything after it, which would corrupt the
+// COM: absolute/PC-relative addresses baked into a fully-linked object). So
+// COM: assert the output gained a section header relative to the input; a
+// COM: buggy rewriter that dropped the pool would leave the count unchanged.
+// COM: "Number of section headers" from llvm-readelf -h is decimal.
+// RUN: NSEC_IN=$(%llvm-readelf -h %t.elf | awk '/Number of section headers/{print $NF}') && \
+// RUN:   NSEC_OUT=$(%llvm-readelf -h %t.out.elf | awk '/Number of section headers/{print $NF}') && \
+// RUN:   test "$NSEC_OUT" -gt "$NSEC_IN"
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -177,7 +177,12 @@ TEST(ElfView, KernelDescriptorsSkipsKdWhenFileOffsetOverflows) {
   EXPECT_EQ(ViewOrErr->findKernelDescriptor("overflow_kernel"), nullptr);
 }
 
-TEST(ElfView, GrowWithTrampolinesShiftsAllocSectionSymbols) {
+// growWithTrampolines appends the pool at a fresh high virtual address instead
+// of growing .text and shifting everything after it, so existing allocatable
+// symbols keep their addresses. (This replaces the earlier test that pinned the
+// buggy shifting behavior; the shift is exactly what corrupted the baked ISA
+// references -- see GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol.)
+TEST(ElfView, GrowWithTrampolinesKeepsAllocSectionSymbols) {
   static constexpr uint64_t GrowthBytes = 8;
 
   comgr_test::KernelDescriptorElfOptions Opts;
@@ -204,7 +209,321 @@ TEST(ElfView, GrowWithTrampolinesShiftsAllocSectionSymbols) {
   ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
   std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
-  EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr + GrowthBytes);
+  EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr);
+}
+
+// gfx1250 "address of a global" idiom, as emitted for e.g. `x++` on a
+// __managed__/__device__ global and observed in GPU_func of the
+// Unit_hipModuleGetGlobal_Functional reproducer:
+//
+//   s_get_pc_i64 s[0:1]                         ; s[0:1] = addr of next insn
+//   s_add_nc_u64 s[0:1], s[0:1], lit64(delta)   ; s[0:1] = that addr + delta
+//
+// The 64-bit literal is baked at link time (no relocation) and encodes the
+// distance from the s_add instruction to the referenced symbol. Reading it back
+// out of .text is exactly how the hardware resolves the global's address, so it
+// is the ground truth any rewrite must keep consistent with the symbol table.
+namespace {
+constexpr uint8_t SGetPcI64SS01[4] = {0xBE, 0x80, 0x47, 0x00};
+constexpr uint8_t SAddNcU64Lit[4] = {0xA9, 0x80, 0xFE, 0x00};
+constexpr size_t GetPcOffset = 0;
+constexpr size_t AddOpOffset = 4; // s_get_pc_i64 is one dword
+constexpr size_t Lit64Offset = 8; // + s_add_nc_u64 opcode dword
+constexpr size_t RefSeqSize = 16; // + 8-byte lit64
+
+// Build a .text image containing the reference idiom. The literal is computed
+// so that, loaded at TextAddr, the ISA resolves the reference to TargetVAddr.
+std::vector<uint8_t> makeTextReferencing(uint64_t TextAddr,
+                                         uint64_t TargetVAddr) {
+  std::vector<uint8_t> Text(RefSeqSize, 0);
+  std::memcpy(Text.data() + GetPcOffset, SGetPcI64SS01, sizeof(SGetPcI64SS01));
+  std::memcpy(Text.data() + AddOpOffset, SAddNcU64Lit, sizeof(SAddNcU64Lit));
+  // s_get_pc_i64 returns the address of the *following* instruction (the
+  // s_add), so the PC base the add works from is TextAddr + AddOpOffset.
+  const uint64_t PcBase = TextAddr + AddOpOffset;
+  const uint64_t Lit = TargetVAddr - PcBase; // two's-complement; forward here
+  std::memcpy(Text.data() + Lit64Offset, &Lit, sizeof(Lit));
+  return Text;
+}
+
+// Decode the reference idiom out of a .text image loaded at TextAddr and return
+// the virtual address the ISA resolves it to.
+uint64_t decodeReferencedVAddr(const uint8_t *Text, uint64_t TextAddr) {
+  uint64_t Lit = 0;
+  std::memcpy(&Lit, Text + Lit64Offset, sizeof(Lit));
+  return TextAddr + AddOpOffset + Lit;
+}
+} // namespace
+
+// The real invariant: after appending trampolines, the address the *ISA*
+// resolves a global reference to (decoded from the PC-relative literal in
+// .text) must equal the address the *symbol table* reports for that global.
+//
+// This is the ELF-layer reproduction of Unit_hipModuleGetGlobal_Functional: the
+// entry-trampoline rewrite grew .text, which shifted the referenced symbol by
+// the trampoline size while leaving the baked literal pointing at the old
+// location, so the ISA and the symbol table disagreed and the kernel
+// dereferenced the wrong address. Here the descriptor symbol lives in .rodata
+// (after .text), standing in for a global in a post-.text data section.
+TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
+  // One 256-byte entry stub, matching the real
+  // Unit_hipModuleGetGlobal_Functional reproducer's 0x100 shift.
+  static constexpr uint64_t GrowthBytes = 0x100;
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  // .text (at TextAddr) references the descriptor symbol in .rodata (at
+  // RodataAddr), which sits after .text -- like a kernel referencing a global
+  // in a post-.text data section.
+  std::vector<uint8_t> Text =
+      makeTextReferencing(Opts.TextAddr, Opts.RodataAddr);
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  // Sanity: before the rewrite, the ISA reference and the symbol agree.
+  ASSERT_EQ(decodeReferencedVAddr(ViewOrErr->textData(), ViewOrErr->textAddr()),
+            Obj.RodataAddr);
+
+  Trampoline T;
+  T.Bytes.assign(GrowthBytes, 0);
+  std::vector<Trampoline> Trampolines{T};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+  ASSERT_NE(Out, nullptr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  // Decode whatever is now in .text into the address the ISA resolves the
+  // reference to...
+  const uint64_t IsaResolved =
+      decodeReferencedVAddr(OutView->textData(), OutView->textAddr());
+  // ...vs. the address the symbol table now reports for the same global.
+  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  const uint64_t SymbolVAddr = KDs[0].VAddr;
+
+  EXPECT_EQ(IsaResolved, SymbolVAddr);
+}
+
+// A fully-linked code object's DWARF encodes *absolute* virtual addresses of
+// code and data (DW_AT_low_pc, DW_OP_addr, the .debug_addr pool, .debug_line
+// set_address) with no relocations. The old growWithTrampolines shifted
+// post-.text virtual addresses and symbols but left .debug_* contents
+// untouched, so any such address went stale by the trampoline size -- the
+// debugger would resolve a global to the pre-shift location. This is the
+// debug-info analogue of the ISA-literal corruption above; the no-shift model
+// keeps both in agreement.
+namespace {
+
+// Minimal ET_DYN AMDGPU object:
+//   [1] .text        (alloc, exec)  at TextAddr
+//   [2] .data        (alloc, write) at DataAddr -- holds global "g"
+//   [3] .debug_info  (non-alloc)    -- 8-byte absolute address DWARF would
+//                                       encode for "g" (stands in for a
+//                                       DW_AT_low_pc / DW_OP_addr / .debug_addr
+//                                       entry)
+//   [4] .symtab  [5] .strtab  [6] .shstrtab
+// Both .data and .debug_info follow .text.
+struct DwarfRefElf {
+  std::vector<uint8_t> Bytes;
+  uint64_t DataAddr = 0;
+  unsigned DebugSectionIndex = 3;
+  unsigned SymtabSectionIndex = 4;
+  unsigned GlobalSymIndex = 1;
+};
+
+DwarfRefElf makeDwarfRefElf(uint64_t TextAddr = 0x1000,
+                            uint64_t DataAddr = 0x2000) {
+  using namespace llvm::ELF;
+  constexpr uint64_t TextSize = 16;
+  constexpr unsigned SymCount = 2; // null + "g"
+
+  static const char ShStr[] =
+      "\0.text\0.data\0.debug_info\0.symtab\0.strtab\0.shstrtab\0";
+  constexpr uint32_t NameText = 1;
+  constexpr uint32_t NameData = 7;
+  constexpr uint32_t NameDebug = 13;
+  constexpr uint32_t NameSymtab = 25;
+  constexpr uint32_t NameStrtab = 33;
+  constexpr uint32_t NameShstrtab = 41;
+
+  static const char Str[] = "\0g\0";
+  constexpr uint32_t GNameOff = 1;
+
+  constexpr unsigned ShNum = 7;
+  const uint64_t ShOff = sizeof(Elf64_Ehdr);
+  const uint64_t TextOff =
+      comgr_test::alignTo8(ShOff + ShNum * sizeof(Elf64_Shdr));
+  const uint64_t DataOff = comgr_test::alignTo8(TextOff + TextSize);
+  const uint64_t DebugOff = comgr_test::alignTo8(DataOff + 8);
+  const uint64_t StrOff = comgr_test::alignTo8(DebugOff + 8);
+  const uint64_t SymOff = comgr_test::alignTo8(StrOff + sizeof(Str));
+  const uint64_t ShStrOff =
+      comgr_test::alignTo8(SymOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t BufSize = comgr_test::alignTo8(ShStrOff + sizeof(ShStr) + 64);
+
+  DwarfRefElf R;
+  R.Bytes.assign(BufSize, 0);
+  R.DataAddr = DataAddr;
+  uint8_t *B = R.Bytes.data();
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = ShNum;
+  Ehdr.e_shstrndx = 6;
+  std::memcpy(B, &Ehdr, sizeof(Ehdr));
+
+  std::memcpy(B + StrOff, Str, sizeof(Str));
+  std::memcpy(B + ShStrOff, ShStr, sizeof(ShStr));
+
+  // The absolute address DWARF encodes for "g".
+  const uint64_t DebugAddr = DataAddr;
+  std::memcpy(B + DebugOff, &DebugAddr, sizeof(DebugAddr));
+
+  auto writeShdr = [&](unsigned Idx, const Elf64_Shdr &Sh) {
+    std::memcpy(B + ShOff + Idx * sizeof(Elf64_Shdr), &Sh, sizeof(Sh));
+  };
+
+  Elf64_Shdr Text{};
+  Text.sh_name = NameText;
+  Text.sh_type = SHT_PROGBITS;
+  Text.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  Text.sh_offset = TextOff;
+  Text.sh_addr = TextAddr;
+  Text.sh_size = TextSize;
+  Text.sh_addralign = 4;
+  writeShdr(1, Text);
+
+  Elf64_Shdr Data{};
+  Data.sh_name = NameData;
+  Data.sh_type = SHT_PROGBITS;
+  Data.sh_flags = SHF_ALLOC | SHF_WRITE;
+  Data.sh_offset = DataOff;
+  Data.sh_addr = DataAddr;
+  Data.sh_size = 8;
+  Data.sh_addralign = 8;
+  writeShdr(2, Data);
+
+  Elf64_Shdr Debug{};
+  Debug.sh_name = NameDebug;
+  Debug.sh_type = SHT_PROGBITS;
+  Debug.sh_flags = 0; // non-alloc, like real .debug_* sections
+  Debug.sh_offset = DebugOff;
+  Debug.sh_size = 8;
+  Debug.sh_addralign = 1;
+  writeShdr(3, Debug);
+
+  Elf64_Shdr Symtab{};
+  Symtab.sh_name = NameSymtab;
+  Symtab.sh_type = SHT_SYMTAB;
+  Symtab.sh_offset = SymOff;
+  Symtab.sh_size = SymCount * sizeof(Elf64_Sym);
+  Symtab.sh_link = 5; // .strtab
+  Symtab.sh_info = 1;
+  Symtab.sh_entsize = sizeof(Elf64_Sym);
+  writeShdr(4, Symtab);
+
+  Elf64_Shdr Strtab{};
+  Strtab.sh_name = NameStrtab;
+  Strtab.sh_type = SHT_STRTAB;
+  Strtab.sh_offset = StrOff;
+  Strtab.sh_size = sizeof(Str);
+  writeShdr(5, Strtab);
+
+  Elf64_Shdr Shstr{};
+  Shstr.sh_name = NameShstrtab;
+  Shstr.sh_type = SHT_STRTAB;
+  Shstr.sh_offset = ShStrOff;
+  Shstr.sh_size = sizeof(ShStr);
+  writeShdr(6, Shstr);
+
+  Elf64_Sym G{};
+  G.st_name = GNameOff;
+  G.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  G.st_shndx = 2; // .data
+  G.st_value = DataAddr;
+  G.st_size = 8;
+  std::memcpy(B + SymOff + 1 * sizeof(Elf64_Sym), &G, sizeof(G));
+
+  return R;
+}
+
+// Read an 8-byte value from section [Idx] at intra-section byte offset Off.
+uint64_t readSectionU64(const ElfView &V, unsigned Idx, uint64_t Off) {
+  uint64_t Val = 0;
+  std::memcpy(
+      &Val, V.data() + static_cast<uint64_t>(V.sections()[Idx].sh_offset) + Off,
+      sizeof(Val));
+  return Val;
+}
+
+// Read st_value of symbol SymIdx in the symbol table at section [SymtabIdx].
+uint64_t readSymbolValue(const ElfView &V, unsigned SymtabIdx,
+                         unsigned SymIdx) {
+  llvm::ELF::Elf64_Sym Sym{};
+  std::memcpy(&Sym,
+              V.data() +
+                  static_cast<uint64_t>(V.sections()[SymtabIdx].sh_offset) +
+                  SymIdx * sizeof(llvm::ELF::Elf64_Sym),
+              sizeof(Sym));
+  return Sym.st_value;
+}
+
+} // namespace
+
+// The invariant: after appending trampolines, the address the object's DWARF
+// encodes for a global must still equal the address the symbol table reports
+// for it. The no-shift model leaves both untouched, so they agree (the old
+// shift moved the symbol but not the DWARF address). Debug-info analogue of
+// GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol.
+TEST(ElfView, GrowWithTrampolinesKeepsDwarfConsistentWithSymbol) {
+  static constexpr uint64_t GrowthBytes = 0x100;
+
+  DwarfRefElf Obj = makeDwarfRefElf();
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  // Sanity: before the rewrite, DWARF and the symbol agree.
+  ASSERT_EQ(readSectionU64(*ViewOrErr, Obj.DebugSectionIndex, 0), Obj.DataAddr);
+  ASSERT_EQ(
+      readSymbolValue(*ViewOrErr, Obj.SymtabSectionIndex, Obj.GlobalSymIndex),
+      Obj.DataAddr);
+
+  Trampoline T;
+  T.Bytes.assign(GrowthBytes, 0);
+  std::vector<Trampoline> Trampolines{T};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+  ASSERT_NE(Out, nullptr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  // Address DWARF still encodes for "g" ...
+  const uint64_t DwarfAddr = readSectionU64(*OutView, Obj.DebugSectionIndex, 0);
+  // ... vs. the address the symbol table now reports for "g".
+  const uint64_t SymbolVAddr =
+      readSymbolValue(*OutView, Obj.SymtabSectionIndex, Obj.GlobalSymIndex);
+
+  EXPECT_EQ(DwarfAddr, SymbolVAddr);
 }
 
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -731,12 +731,15 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(ExpectedGuard, 0u);
   ASSERT_FALSE(Growth.empty());
 
-  const uint64_t OldTextSize = ViewOrErr->textSize();
-  const uint64_t TextEndVAddr = ViewOrErr->textAddr() + OldTextSize;
+  // Stubs live in the appended pool at trampolinePoolVAddr(); the first stub's
+  // offset is the padding needed to reach a KernelEntryStubStride boundary from
+  // the pool base.
+  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddrOr.has_value());
+  const uint64_t PoolVAddr = *PoolVAddrOr;
   const uint64_t ExpectedStubOffset =
-      ((TextEndVAddr + KernelEntryStubStride - 1) &
-       ~(KernelEntryStubStride - 1)) -
-      TextEndVAddr;
+      ((PoolVAddr + KernelEntryStubStride - 1) & ~(KernelEntryStubStride - 1)) -
+      PoolVAddr;
   EXPECT_EQ(Fixups[0].StubTextOffset, ExpectedStubOffset);
 
   uint64_t GrowthTotal = 0;
@@ -750,7 +753,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   ASSERT_NE(Out, nullptr);
 
   ASSERT_TRUE(
-      rewriteKernelEntryDescriptorOffsets(*Out, OldTextSize, S.Cpu, Fixups));
+      rewriteKernelEntryDescriptorOffsets(*Out, PoolVAddr, S.Cpu, Fixups));
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
   llvm::Expected<ElfView> OutView =
@@ -788,8 +791,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   ASSERT_EQ(KDs.size(), 1u);
   std::optional<uint64_t> KdVAddr = OutView->getKernelDescriptorVAddr("kernel");
   ASSERT_TRUE(KdVAddr.has_value());
-  const uint64_t StubVAddr =
-      ViewOrErr->textAddr() + OldTextSize + Fixups[0].StubTextOffset;
+  const uint64_t StubVAddr = PoolVAddr + Fixups[0].StubTextOffset;
   EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(StubVAddr - *KdVAddr));
 }
 
@@ -816,12 +818,12 @@ TEST(KernelEntryTrampoline, AlignsStubByVirtualAddress) {
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 1u);
   ASSERT_EQ(Fixups.size(), 1u);
-  const uint64_t StubVAddr =
-      ViewOrErr->textAddr() + ViewOrErr->textSize() + Fixups[0].StubTextOffset;
+  // The stub is aligned by its virtual address: the pool base plus the stub's
+  // offset lands on a KernelEntryStubStride boundary.
+  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddrOr.has_value());
+  const uint64_t StubVAddr = *PoolVAddrOr + Fixups[0].StubTextOffset;
   EXPECT_EQ(StubVAddr % KernelEntryStubStride, 0u);
-  EXPECT_NE((ViewOrErr->textSize() + Fixups[0].StubTextOffset) %
-                KernelEntryStubStride,
-            0u);
 }
 
 TEST(KernelEntryTrampoline, AppendReturnsZeroWhenNoDescriptorsExist) {


### PR DESCRIPTION
Fixes baked ISA/DWARF ref corruption; ROCm/llvm-project#3240 tests pass.

## Problem

With kernel-entry trampolines enabled on gfx1250 (`AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`), a kernel that touches a `__managed__` or `__device__` global reads and writes the wrong address, silently, with no crash or diagnostic. `Unit_hipModuleGetGlobal_Functional` reads 10 instead of 11 for a kernel like `__managed__ int x = 10; __global__ void GPU_func() { x++; }`. 
This is the corruption that `ROCm/llvm-project#3240` added regression tests for (both the ISA-literal and the DWARF variants).

## Root cause

`ElfView::growWithTrampolines` appended the trampoline pool by growing `.text` in place and shifting everything after it, so every following section `sh_addr`, every segment `p_vaddr`, and every post-`.text` symbol `st_value` was bumped by the pool size. But a fully-linked AMDGPU code object carries no relocations: the linker has already baked final PC-relative distances into the instruction stream, so a global access compiles to `s_get_pc_i64 s[0:1]` followed by `s_add_nc_u64 s[0:1], s[0:1], lit64(delta)` where `delta` is a baked literal with no relocation. The rewrite moved the symbol but not the baked literal (nor the absolute addresses in DWARF `.debug_*`), so the ISA and the debugger resolved the reference to the old location while the symbol table and `hipModuleGetGlobal` reported the new one, and the kernel dereferenced a stale slot.

## Approach

Append the pool at a fresh, page-aligned virtual address above every existing allocatable section, and leave everything else exactly in place, so all baked absolute and PC-relative addresses (and DWARF) stay valid because nothing existing moves.

- A new `ElfView::trampolinePoolVAddr()` is the single source of truth for the pool base.
- The pool is emitted as a new `PT_LOAD` (R+X) segment and an `SHF_ALLOC|SHF_EXECINSTR` section, and the program-header and section-header tables are relocated to end-of-file (they are metadata addressed via the ELF header, so relocating them corrupts nothing); there is no `.text` growth and no shifting, so the old `adjustSectionHeaders`, `adjustProgramHeaders`, and `adjustSymbolValues` are removed.
- Because the pool now sits far from `.text`, B0-to-A0 trampoline branch edges route through the existing `s_add_pc_i64` long branch; the branch and stub math is threaded through `PoolBaseOffset` (poolVAddr minus textAddr) in `emitToTrampoline` and `fixupTrampolineBranches`, and through the pool vaddr in the entry-stub delta and kernel-descriptor entry offset. Kernel-entry stubs already materialize a full 64-bit delta, so they reach from anywhere.
- Entry-stub idempotency reads the stub via a new `ElfView::dataAtVAddr` (which locates it in the pool section, not just `.text`), so a repeated rewrite stays a no-op.

## Tested

- The #3240 regression tests now pass (they fail on the pre-fix code): `GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol` and `GrowWithTrampolinesKeepsDwarfConsistentWithSymbol`. The old `ShiftsAllocSectionSymbols` test was repurposed to `KeepsAllocSectionSymbols` (pins the no-shift behavior); the entry-stub MC tests and the wmma-split lit assertion were updated for the new layout.
- `HotswapMCTests` 44/44, `HotswapElfTests` 16/16, hotswap lit 53/53 (B0-to-A0 trampolines, long-branch, WMMA-split, and kernel-entry-trampoline including idempotency). clang-format clean.
- Remaining validation needs gfx1250 hardware: the host suite covers ELF well-formedness and address consistency, but the end-to-end `Unit_hipModuleGetGlobal_Functional` run (kernel reads 11, and the HSA loader maps the new `PT_LOAD` and relocated tables) should be confirmed on a gfx1250 device.