### PR TITLE
[test][Infra] startup failure on workflows

### DIFF
--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -65,19 +65,20 @@ concurrency:
 
 jobs:
   setup:
-    if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request &&
-       !(
-         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-         (
-           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-           (
-             contains(github.event.pull_request.body, 'Automated update of') &&
-             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-           )
-         )
-       ))
+      contains(fromJSON('["push","workflow_dispatch"]'), github.event_name) ||
+      (
+        github.event_name == 'pull_request' &&
+        !(
+          contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+          (
+            contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+            (
+              contains(github.event.pull_request.body, 'Automated update of') &&
+              contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+            )
+          )
+        )
+      )    
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -60,8 +60,9 @@ concurrency:
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit). The workflow name is prepended to avoid conflicts between
   # different workflows.
+
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
-  cancel-in-progress: false #Just temp false unti github support helps us on this
+  cancel-in-progress: true
 
 jobs:
   setup:

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -65,7 +65,7 @@ concurrency:
 
 jobs:
   setup:
-    # Temporary remove of the CI setup
+    # Temporary remove of the CI skip for LLVM revision update
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -79,6 +79,8 @@ jobs:
            )
          )
        ))
+
+
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -65,21 +65,7 @@ concurrency:
 
 jobs:
   setup:
-    if: >-    
-      contains(fromJSON('["push","workflow_dispatch"]'), github.event_name) ||
-      (
-        github.event_name == 'pull_request' &&
-        !(
-          contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
-          (
-            contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
-            (
-              contains(github.event.pull_request.body, 'Automated update of') &&
-              contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
-            )
-          )
-        )
-      )    
+    # Temporary remove of the CI setup
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -77,7 +77,7 @@ jobs:
              contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
            )
          )
-       ))    
+       ))
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -60,8 +60,8 @@ concurrency:
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit). The workflow name is prepended to avoid conflicts between
   # different workflows.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  cancel-in-progress: false #Just temp false unti github support helps us on this
 
 jobs:
   setup:
@@ -77,7 +77,7 @@ jobs:
              contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
            )
          )
-       ))
+       ))    
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -60,12 +60,24 @@ concurrency:
   # queued and in-progress runs for the same PR (presubmit) or commit
   # (postsubmit). The workflow name is prepended to avoid conflicts between
   # different workflows.
-  group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   setup:
-    # Temporary remove of the CI skip for LLVM revision update
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request &&
+       !(
+         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
+         (
+           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||
+           (
+             contains(github.event.pull_request.body, 'Automated update of') &&
+             contains(github.event.pull_request.body, 'LLVM_MAIN_REVISION')
+           )
+         )
+       ))    
     uses: ./.github/workflows/setup_multi_arch.yml
     with:
       build_variant: "release"

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -64,7 +64,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
-
 jobs:
   setup:
     if: >-

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -64,6 +64,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
+
 jobs:
   setup:
     if: >-

--- a/.github/workflows/rockci_multi_arch_amd_staging.yml
+++ b/.github/workflows/rockci_multi_arch_amd_staging.yml
@@ -65,6 +65,7 @@ concurrency:
 
 jobs:
   setup:
+    if: >-    
       contains(fromJSON('["push","workflow_dispatch"]'), github.event_name) ||
       (
         github.event_name == 'pull_request' &&


### PR DESCRIPTION
This is a temporary removal of the LLVM_REVISION skip CI. After the github updates we are seeing the workflow startup failure and thats breaking the workflow.

This shall be readded.