### PR TITLE
[AMDGPU] comgr: fix SR FP8 carry-propagation in E5M3 stochastic rounding

### DIFF
--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -539,16 +539,15 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   AsmOS << "v_max_num_f32 " << OutName << ", 0, " << Src0Str << "\n";
 
   // --- Stochastic noise injection ---
-  // Replicate ISA pseudocode: add S1[31:12] to F32 mantissa, truncate back
-  // to 23 bits, then reconstruct the perturbed F32 via v_bfi_b32.
-  AsmOS << "v_and_b32 " << TmpName << ", 0x007FFFFF, " << OutName << "\n";
-  AsmOS << "v_lshrrev_b32 " << OutName << ", 12, " << Src1Str << "\n";
-  AsmOS << "v_add_u32 " << TmpName << ", " << TmpName << ", " << OutName
+  // Add S1[31:12] as integer noise directly to the F32 bitpattern.
+  // Adding to the whole value lets mantissa overflow carry into the
+  // exponent naturally, fixing a carry-propagation bug where the old
+  // extract/add/mask path discarded the carry with & 0x007FFFFF when
+  // mantissa + noise exceeded 23 bits.  This also reduces the emitted
+  // trampoline from 6 instructions to 2.
+  AsmOS << "v_lshrrev_b32 " << TmpName << ", 12, " << Src1Str << "\n";
+  AsmOS << "v_add_u32 " << OutName << ", " << OutName << ", " << TmpName
         << "\n";
-  AsmOS << "v_and_b32 " << TmpName << ", 0x007FFFFF, " << TmpName << "\n";
-  AsmOS << "v_max_num_f32 " << OutName << ", 0, " << Src0Str << "\n";
-  AsmOS << "v_bfi_b32 " << OutName << ", 0x007FFFFF, " << TmpName << ", "
-        << OutName << "\n";
 
   // --- High-range direct path ---
   // SR mode injects rounding noise before truncation, so exponent-31 values

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -539,12 +539,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   AsmOS << "v_max_num_f32 " << OutName << ", 0, " << Src0Str << "\n";
 
   // --- Stochastic noise injection ---
-  // Add S1[31:12] as integer noise directly to the F32 bitpattern.
-  // Adding to the whole value lets mantissa overflow carry into the
-  // exponent naturally, fixing a carry-propagation bug where the old
-  // extract/add/mask path discarded the carry with & 0x007FFFFF when
-  // mantissa + noise exceeded 23 bits.  This also reduces the emitted
-  // trampoline from 6 instructions to 2.
+  // Add S1[31:12] as noise directly to F32 bits — carry propagates into exponent naturally.
   AsmOS << "v_lshrrev_b32 " << TmpName << ", 12, " << Src1Str << "\n";
   AsmOS << "v_add_u32 " << OutName << ", " << OutName << ", " << TmpName
         << "\n";

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -539,7 +539,8 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   AsmOS << "v_max_num_f32 " << OutName << ", 0, " << Src0Str << "\n";
 
   // --- Stochastic noise injection ---
-  // Add S1[31:12] as noise directly to F32 bits — carry propagates into exponent naturally.
+  // Add S1[31:12] as noise directly to the F32 bitpattern; carry
+  // propagates into the exponent naturally.
   AsmOS << "v_lshrrev_b32 " << TmpName << ", 12, " << Src1Str << "\n";
   AsmOS << "v_add_u32 " << OutName << ", " << OutName << ", " << TmpName
         << "\n";

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
@@ -152,8 +152,7 @@ test_cvt_pk_fp8_negabs_both:
 // COM: --- NaN detection (anchor on v11) ---
 // SR_NEG:       v_and_b32{{.*}}0x7fffffff, v11
 // SR_NEG-NEXT:  v_cmp_lt_u32{{.*}}0x7f800000
-// COM: --- Stochastic noise injection ---
-// SR_NEG:       v_and_b32{{.*}}0x7fffff,
+// COM: --- Stochastic noise injection (direct F32 addition) ---
 // SR_NEG:       v_lshrrev_b32{{.*}}, 12, v12
 // COM: --- F32 -> F16 -> UE5M3 ---
 // SR_NEG:       v_cvt_f16_f32
@@ -186,8 +185,7 @@ test_cvt_sr_fp8_neg_src0:
 // COM: --- NaN detection (anchor on v14) ---
 // SR_ABS:       v_and_b32{{.*}}0x7fffffff, v14
 // SR_ABS-NEXT:  v_cmp_lt_u32{{.*}}0x7f800000
-// COM: --- Stochastic noise injection ---
-// SR_ABS:       v_and_b32{{.*}}0x7fffff,
+// COM: --- Stochastic noise injection (direct F32 addition) ---
 // SR_ABS:       v_lshrrev_b32{{.*}}, 12, v15
 // COM: --- F32 -> F16 -> UE5M3 ---
 // SR_ABS:       v_cvt_f16_f32

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -2,8 +2,9 @@
 // COM:
 // COM: Creates a minimal gfx1250 code object containing v_cvt_sr_fp8_f32
 // COM: with clamp (E5M3 mode), runs the hotswap rewrite, and verifies the
-// COM: replacement sequence covers: NaN detection, direct stochastic noise addition,
-// COM: F32->F16->UE5M3 conversion, overflow clamping, NaN override, and byte merge.
+// COM: replacement sequence covers: NaN detection, stochastic noise
+// COM: addition, F32->F16->UE5M3 conversion, overflow clamping, NaN
+// COM: override, and byte merge.
 // COM:
 // COM: Companion tests:
 // COM:   hotswap-cvt-fp8-modifiers.s - source modifier variants

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -2,7 +2,7 @@
 // COM:
 // COM: Creates a minimal gfx1250 code object containing v_cvt_sr_fp8_f32
 // COM: with clamp (E5M3 mode), runs the hotswap rewrite, and verifies the
-// COM: replacement sequence covers: NaN detection, stochastic noise injection,
+// COM: replacement sequence covers: NaN detection, direct stochastic noise addition,
 // COM: F32->F16->UE5M3 conversion, overflow clamping, NaN override, and byte merge.
 // COM:
 // COM: Companion tests:
@@ -41,12 +41,8 @@
 // COM: --- Clamp negative ---
 // BYTE0-NEXT:  v_max_num_f32{{.*}}, 0, v1
 // COM: --- Stochastic noise injection ---
-// BYTE0-NEXT:  v_and_b32{{.*}}0x7fffff
 // BYTE0-NEXT:  v_lshrrev_b32{{.*}}, 12, v2
 // BYTE0-NEXT:  v_add
-// BYTE0-NEXT:  v_and_b32{{.*}}0x7fffff
-// BYTE0-NEXT:  v_max_num_f32{{.*}}, 0, v1
-// BYTE0-NEXT:  v_bfi_b32
 // COM: --- High-range direct path ---
 // BYTE0-NEXT:  v_cmp_le_f32{{.*}}0x47800000
 // BYTE0-NEXT:  s_mov_b32
@@ -95,12 +91,8 @@ test_cvt_sr_fp8_byte0:
 // COM: --- Clamp negative ---
 // BYTE2-NEXT:  v_max_num_f32{{.*}}, 0, v6
 // COM: --- Stochastic noise injection ---
-// BYTE2-NEXT:  v_and_b32{{.*}}0x7fffff
 // BYTE2-NEXT:  v_lshrrev_b32{{.*}}, 12, v7
 // BYTE2-NEXT:  v_add
-// BYTE2-NEXT:  v_and_b32{{.*}}0x7fffff
-// BYTE2-NEXT:  v_max_num_f32{{.*}}, 0, v6
-// BYTE2-NEXT:  v_bfi_b32
 // COM: --- High-range direct path ---
 // BYTE2-NEXT:  v_cmp_le_f32{{.*}}0x47800000
 // BYTE2-NEXT:  s_mov_b32


### PR DESCRIPTION
## Summary

Fix carry-propagation bug in `patchCvtSrFp8F32`. The old stochastic noise injection path extracted the F32 mantissa, added noise, and masked back to 23 bits -- discarding the carry when mantissa + noise overflowed. This caused 3.1% of stochastic rounding results to be off by exactly 7 (the full UE5M3 mantissa range).

### Root cause

```
// OLD (buggy): extract, add, mask loses carry
v_and_b32 tmp, 0x007FFFFF, out    // extract mantissa
v_lshrrev_b32 out, 12, src1       // shift noise
v_add_u32 tmp, tmp, out           // add noise to mantissa
v_and_b32 tmp, 0x007FFFFF, tmp    // mask -- DISCARDS CARRY
v_max_num_f32 out, 0, src0        // reload source
v_bfi_b32 out, 0x007FFFFF, tmp, out  // reinsert mantissa
```

### Fix

```
// NEW (correct): add noise directly to F32 bitpattern
v_lshrrev_b32 tmp, 12, src1       // shift noise
v_add_u32 out, out, tmp           // carry propagates naturally
```

Integer addition on the whole F32 bitpattern lets mantissa overflow carry into the exponent, matching the ISA's stochastic rounding behavior. Also reduces trampoline from 6 to 2 instructions.

### Covered instructions

- `v_cvt_sr_fp8_f32` with CLAMP=1 (UE5M3 stochastic rounding)

### Changes

| File | Change |
|------|--------|
| `comgr-hotswap-patch-f32-to-e5m3.cpp` | Replace 6-instruction noise injection with 2-instruction direct add |
| `hotswap-cvt-sr-fp8.s` | Update CHECK patterns for shorter noise injection sequence |
| `hotswap-cvt-fp8-modifiers.s` | Update CHECK patterns for SR with neg/abs source modifiers |

## Test plan

- [x] Validated on gfx1250 A0 hardware via internal test suite (covers stochastic rounding with multiple seeds, edge cases including negative values, NaN, inf, boundary max, byte_sel variants, and source modifier combinations)
- [x] All hotswap lit tests pass (55/55 on MI300)
- [ ] PSDB CI green