### PR TITLE
[comgr][hotswap] Add <kernel>.stub symbols for entry trampolines

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -874,6 +874,20 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(), LS.Cpu,
                                              EntryFixups))
       return AMD_COMGR_STATUS_ERROR;
+
+    // Give each appended entry stub a `<kernel>.stub` symbol so a dispatch
+    // whose entry now points at the stub still resolves to a name (e.g. rocgdb
+    // `info dispatches`). This grows only the non-alloc .symtab/.strtab and
+    // returns a new buffer; failure is non-fatal (the rewritten code object is
+    // still correct, just missing the debug-only symbol).
+    if (!EntryFixups.empty()) {
+      std::unique_ptr<WritableMemoryBuffer> WithSyms =
+          addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),
+                                          Elf.textAddr(), Elf.textSize(),
+                                          EntryFixups);
+      if (WithSyms)
+        Result = std::move(WithSyms);
+    }
   } else {
     Result = copyOutputBuffer(Buf.data(), ElfSize, "patched");
     if (!Result)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -1202,6 +1202,180 @@ static bool adjustSymbolValues(uint8_t *Elf, size_t ElfSize,
   return true;
 }
 
+// -- addKernelEntryTrampolineSymbols ------------------------------------------
+
+std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
+    WritableMemoryBuffer &In, unsigned TextSectionIndex, uint64_t TextAddr,
+    uint64_t OldTextSize, ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+  if (Fixups.empty())
+    return nullptr;
+
+  const uint8_t *Data = reinterpret_cast<const uint8_t *>(In.getBufferStart());
+  const size_t Size = In.getBufferSize();
+
+  Expected<ELFFileT> FileOrErr =
+      ELFFileT::create(StringRef(reinterpret_cast<const char *>(Data), Size));
+  if (!FileOrErr) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: failed to parse "
+          << "grown ELF: " << toString(FileOrErr.takeError()) << "\n";
+    return nullptr;
+  }
+  ELFFileT File = std::move(*FileOrErr);
+  Expected<ELFT::ShdrRange> SecsOrErr = File.sections();
+  if (!SecsOrErr) {
+    consumeError(SecsOrErr.takeError());
+    return nullptr;
+  }
+  ELFT::ShdrRange Secs = *SecsOrErr;
+
+  // Locate .symtab and its linked string table. Scan from the end, since the
+  // symbol table sits near the end of the section list in these code objects.
+  const ELFT::Shdr *SymShdr = nullptr;
+  unsigned SymIdx = 0;
+  for (unsigned I = Secs.size(); I-- > 0;)
+    if (Secs[I].sh_type == ELF::SHT_SYMTAB) {
+      SymShdr = &Secs[I];
+      SymIdx = I;
+      break;
+    }
+  if (!SymShdr) {
+    log() << "hotswap: addKernelEntryTrampolineSymbols: no .symtab present; "
+          << "skipping stub symbols.\n";
+    return nullptr;
+  }
+  const unsigned StrIdx = SymShdr->sh_link;
+  if (StrIdx == 0 || StrIdx >= Secs.size()) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: .symtab has an "
+          << "invalid sh_link (" << StrIdx << ").\n";
+    return nullptr;
+  }
+  if (SymShdr->sh_entsize != sizeof(ELF::Elf64_Sym)) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: unexpected "
+          << ".symtab entry size " << SymShdr->sh_entsize << ".\n";
+    return nullptr;
+  }
+  const ELFT::Shdr &StrShdr = Secs[StrIdx];
+
+  const uint64_t SymOff = SymShdr->sh_offset;
+  const uint64_t SymEnd = SymOff + SymShdr->sh_size;
+  const uint64_t StrOff = StrShdr.sh_offset;
+  const uint64_t StrEnd = StrOff + StrShdr.sh_size;
+  if (SymEnd > Size || StrEnd > Size || SymEnd < SymOff || StrEnd < StrOff) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: symbol/string "
+          << "table extends past the ELF buffer.\n";
+    return nullptr;
+  }
+
+  // Build the appended string names and symbol entries.
+  SmallVector<uint8_t> StrBlob, SymBlob;
+  for (const KernelEntryTrampolineFixup &F : Fixups) {
+    std::string Name = F.KernelName + ".stub";
+    uint32_t NameOff =
+        static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
+    StrBlob.append(Name.begin(), Name.end());
+    StrBlob.push_back(0);
+
+    std::optional<uint64_t> StubOff = checkedAddUint64(
+        OldTextSize, F.StubTextOffset, "stub symbol .text offset");
+    if (!StubOff)
+      return nullptr;
+    std::optional<uint64_t> StubVAddr =
+        checkedAddUint64(TextAddr, *StubOff, "stub symbol vaddr");
+    if (!StubVAddr)
+      return nullptr;
+
+    ELF::Elf64_Sym Sym{};
+    Sym.st_name = NameOff;
+    Sym.st_info = (ELF::STB_GLOBAL << 4) | ELF::STT_FUNC;
+    Sym.st_other = ELF::STV_DEFAULT;
+    Sym.st_shndx = static_cast<uint16_t>(TextSectionIndex);
+    Sym.st_value = *StubVAddr;
+    Sym.st_size = KernelEntryStubStride;
+    const uint8_t *P = reinterpret_cast<const uint8_t *>(&Sym);
+    SymBlob.append(P, P + sizeof(Sym));
+  }
+  // The section header table must stay 8-byte aligned (LLVM's ELF reader
+  // rejects a misaligned table). SymBlob is a multiple of 8 (24-byte entries),
+  // so pad the string blob up to a multiple of 8 with unreferenced NULs.
+  StrBlob.append((8 - (StrBlob.size() % 8)) % 8, 0);
+
+  const uint64_t SymDelta = SymBlob.size();
+  const uint64_t StrDelta = StrBlob.size();
+  const size_t NewSize = Size + SymDelta + StrDelta;
+
+  std::unique_ptr<WritableMemoryBuffer> Out =
+      WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
+  if (!Out) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: allocation of "
+          << NewSize << " bytes failed.\n";
+    return nullptr;
+  }
+  uint8_t *O = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+
+  // Insert the new symbol entries right after the existing .symtab contents and
+  // the new strings right after the existing .strtab contents. Both insertion
+  // points are expressed in original-file coordinates; copying in ascending
+  // order keeps the arithmetic order-independent (either table may come first).
+  struct Insertion {
+    uint64_t Pos;
+    const SmallVector<uint8_t> *Bytes;
+  };
+  Insertion A{SymEnd, &SymBlob}, B{StrEnd, &StrBlob};
+  if (A.Pos > B.Pos)
+    std::swap(A, B);
+
+  size_t OutPos = 0, InPos = 0;
+  auto CopyThrough = [&](uint64_t Upto) {
+    std::memcpy(O + OutPos, Data + InPos, Upto - InPos);
+    OutPos += Upto - InPos;
+    InPos = Upto;
+  };
+  CopyThrough(A.Pos);
+  std::memcpy(O + OutPos, A.Bytes->data(), A.Bytes->size());
+  OutPos += A.Bytes->size();
+  CopyThrough(B.Pos);
+  std::memcpy(O + OutPos, B.Bytes->data(), B.Bytes->size());
+  OutPos += B.Bytes->size();
+  std::memcpy(O + OutPos, Data + InPos, Size - InPos);
+
+  // Anything at or beyond an insertion point shifts by that insertion's size.
+  auto Shift = [&](uint64_t X) -> uint64_t {
+    return X + (X >= SymEnd ? SymDelta : 0) + (X >= StrEnd ? StrDelta : 0);
+  };
+
+  uint64_t Shoff;
+  uint16_t Shentsize, Shnum;
+  std::memcpy(&Shoff, O + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, O + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
+  std::memcpy(&Shnum, O + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+  uint64_t NewShoff = Shift(Shoff);
+  std::memcpy(O + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+  if (Shentsize < sizeof(Shdr))
+    return nullptr;
+
+  for (uint16_t I = 0; I < Shnum; ++I) {
+    uint64_t P = NewShoff + static_cast<uint64_t>(I) * Shentsize;
+    if (P + sizeof(Shdr) > NewSize)
+      break;
+    uint8_t *Sh = O + P;
+    uint64_t ShOffset;
+    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
+    uint64_t NewOff = Shift(ShOffset);
+    std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOff, sizeof(NewOff));
+
+    if (I == SymIdx || I == StrIdx) {
+      uint64_t ShSize;
+      std::memcpy(&ShSize, Sh + offsetof(Shdr, sh_size), sizeof(ShSize));
+      ShSize += (I == SymIdx) ? SymDelta : StrDelta;
+      std::memcpy(Sh + offsetof(Shdr, sh_size), &ShSize, sizeof(ShSize));
+    }
+  }
+
+  log() << "hotswap: added " << Fixups.size()
+        << " kernel-entry stub symbol(s) to .symtab\n";
+  return Out;
+}
+
 // -- ElfView::growWithTrampolines ---------------------------------------------
 
 std::unique_ptr<WritableMemoryBuffer>

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -788,6 +788,22 @@ bool rewriteKernelEntryDescriptorOffsets(
     llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
+/// Add a `<kernel_name>.stub` STT_FUNC symbol to the code object's `.symtab`
+/// for each appended kernel-entry stub, so tools that resolve a dispatch's
+/// entry address to a name (e.g. rocgdb `info dispatches`, which reads the
+/// non-alloc `.symtab`) report the stub instead of a bare address. Returns a
+/// newly allocated buffer with the grown `.symtab` / `.strtab`, or nullptr if
+/// no symbols were added (empty fixups, missing `.symtab`, or a structural
+/// problem) -- callers treat nullptr as "keep the existing buffer", since the
+/// symbol is a debugging aid and its absence is not a correctness failure.
+///
+/// Only the trailing non-alloc `.symtab` / `.strtab` sections grow, so no
+/// virtual addresses, program headers, or relocations change; `.dynsym` (used
+/// by the loader) is left untouched.
+std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
+    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex, uint64_t TextAddr,
+    uint64_t OldTextSize, llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 
 struct Gfx1250RewriteOptions {

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -46,6 +46,12 @@
 // METADATA: .name:           entry_tramp_kernel
 // METADATA: .sgpr_count:     10
 
+// COM: Each appended stub gets a <kernel>.stub symbol so a dispatch whose entry
+// COM: points at the stub still resolves to a name (e.g. rocgdb info dispatches).
+// RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
+// SYMS-DAG: FUNC {{.*}} entry_tramp_kernel.stub
+// SYMS-DAG: FUNC {{.*}} hipblaslt_entry_kernel.stub
+
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --entry-trampolines --output %t.out2.elf \

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -207,6 +207,101 @@ TEST(ElfView, GrowWithTrampolinesShiftsAllocSectionSymbols) {
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr + GrowthBytes);
 }
 
+// Covers: addKernelEntryTrampolineSymbols attaches a distinct, correctly
+// placed `<kernel>.stub` symbol for every appended entry-trampoline stub, so a
+// dispatch whose entry now points at a stub still resolves to a name.
+//
+// How: build a synthetic AMDGPU code object that has a .symtab, then grow .text
+// by two entry-stub-sized (KernelEntryStubStride) blocks with
+// growWithTrampolines -- mirroring the pass appending one stub per kernel.
+// Call addKernelEntryTrampolineSymbols with two fixups that use distinct kernel
+// names and the two stub offsets (0 and KernelEntryStubStride). Re-parse the
+// returned buffer with llvm::object::ELFFile and, for each fixup, assert a
+// "<name>.stub" symbol exists in .symtab that is (a) STT_FUNC, (b) defined in
+// the .text section (st_shndx), (c) located at TextAddr + OldTextSize +
+// StubTextOffset, and (d) sized to KernelEntryStubStride. Two fixups (rather
+// than one) prove each stub gets its own name at its own address, not a single
+// shared or mis-placed entry.
+TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  const unsigned TextIdx = ViewOrErr->textSectionIndex();
+  const uint64_t TextAddr = ViewOrErr->textAddr();
+  const uint64_t OldTextSize = ViewOrErr->textSize();
+
+  // Grow .text by two entry-stub-sized blocks, mirroring the entry-trampoline
+  // pass appending one stub per kernel.
+  Trampoline Stub;
+  Stub.Bytes.assign(2 * KernelEntryStubStride, 0);
+  std::vector<Trampoline> Growth{Stub};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
+      ViewOrErr->growWithTrampolines(Growth, SNop);
+  ASSERT_NE(Grown, nullptr);
+
+  // One fixup per appended stub; the names need not match real kernels, since
+  // addKernelEntryTrampolineSymbols only attaches a symbol at each stub address.
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10},
+      {"kernel_b", /*StubTextOffset=*/KernelEntryStubStride, /*RequiredSgprs=*/12},
+  };
+  std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
+      addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
+                                      Fixups);
+  ASSERT_NE(WithSyms, nullptr);
+
+  using ELFT = llvm::object::ELF64LE;
+  const uint8_t *Data =
+      reinterpret_cast<const uint8_t *>(WithSyms->getBufferStart());
+  llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
+      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
+          reinterpret_cast<const char *>(Data), WithSyms->getBufferSize()));
+  ASSERT_TRUE((bool)FileOrErr) << llvm::toString(FileOrErr.takeError());
+  llvm::object::ELFFile<ELFT> &File = *FileOrErr;
+
+  llvm::Expected<ELFT::ShdrRange> SecsOrErr = File.sections();
+  ASSERT_TRUE((bool)SecsOrErr) << llvm::toString(SecsOrErr.takeError());
+  const ELFT::Shdr *SymtabShdr = nullptr;
+  for (const ELFT::Shdr &S : *SecsOrErr)
+    if (S.sh_type == llvm::ELF::SHT_SYMTAB) {
+      SymtabShdr = &S;
+      break;
+    }
+  ASSERT_NE(SymtabShdr, nullptr);
+  llvm::Expected<ELFT::SymRange> SymsOrErr = File.symbols(SymtabShdr);
+  ASSERT_TRUE((bool)SymsOrErr) << llvm::toString(SymsOrErr.takeError());
+  llvm::Expected<llvm::StringRef> StrTabOrErr =
+      File.getStringTableForSymtab(*SymtabShdr);
+  ASSERT_TRUE((bool)StrTabOrErr) << llvm::toString(StrTabOrErr.takeError());
+
+  auto FindSym = [&](llvm::StringRef Name) -> const ELFT::Sym * {
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      llvm::Expected<llvm::StringRef> N = Sym.getName(*StrTabOrErr);
+      if (N && *N == Name)
+        return &Sym;
+    }
+    return nullptr;
+  };
+
+  // Every appended stub must have a <kernel>.stub STT_FUNC symbol covering the
+  // stub, in the .text section, at the stub's virtual address.
+  for (const KernelEntryTrampolineFixup &F : Fixups) {
+    const ELFT::Sym *Sym = FindSym(F.KernelName + ".stub");
+    ASSERT_NE(Sym, nullptr) << "missing stub symbol for " << F.KernelName;
+    EXPECT_EQ(static_cast<unsigned>(Sym->getType()),
+              static_cast<unsigned>(llvm::ELF::STT_FUNC));
+    EXPECT_EQ(Sym->st_shndx, TextIdx);
+    EXPECT_EQ(Sym->st_value, TextAddr + OldTextSize + F.StubTextOffset);
+    EXPECT_EQ(Sym->st_size, KernelEntryStubStride);
+  }
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -793,6 +793,130 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(StubVAddr - *KdVAddr));
 }
 
+// Count symbols named \p Name in the .symtab of the ELF held in \p Buf.
+// Returns ~0u if the ELF or its symbol table cannot be parsed, so a mis-parse
+// surfaces as a failed expectation rather than a silent zero.
+static unsigned countSymtabSymbolsNamed(llvm::WritableMemoryBuffer &Buf,
+                                        llvm::StringRef Name) {
+  using ELFT = llvm::object::ELF64LE;
+  llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
+      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
+          reinterpret_cast<const char *>(Buf.getBufferStart()),
+          Buf.getBufferSize()));
+  if (!FileOrErr) {
+    llvm::consumeError(FileOrErr.takeError());
+    return ~0u;
+  }
+  llvm::object::ELFFile<ELFT> &File = *FileOrErr;
+  llvm::Expected<ELFT::ShdrRange> Secs = File.sections();
+  if (!Secs) {
+    llvm::consumeError(Secs.takeError());
+    return ~0u;
+  }
+  const ELFT::Shdr *Symtab = nullptr;
+  for (const ELFT::Shdr &Sh : *Secs)
+    if (Sh.sh_type == llvm::ELF::SHT_SYMTAB) {
+      Symtab = &Sh;
+      break;
+    }
+  if (!Symtab)
+    return 0;
+  llvm::Expected<ELFT::SymRange> Syms = File.symbols(Symtab);
+  llvm::Expected<llvm::StringRef> Str = File.getStringTableForSymtab(*Symtab);
+  if (!Syms || !Str) {
+    if (!Syms)
+      llvm::consumeError(Syms.takeError());
+    if (!Str)
+      llvm::consumeError(Str.takeError());
+    return ~0u;
+  }
+  unsigned Count = 0;
+  for (const ELFT::Sym &Sym : *Syms) {
+    llvm::Expected<llvm::StringRef> N = Sym.getName(*Str);
+    if (!N) {
+      llvm::consumeError(N.takeError());
+      continue;
+    }
+    if (*N == Name)
+      ++Count;
+  }
+  return Count;
+}
+
+// Covers: the entry-trampoline rewrite is idempotent -- a second pass over an
+// already-rewritten code object installs no new stub, and therefore defines no
+// duplicate `<kernel>.stub` symbol. This backs the idempotency claim made by
+// the change that adds stub symbols.
+//
+// How: run the full first pass on a synthetic gfx1250 object
+// (appendKernelEntryTrampolines -> growWithTrampolines ->
+// rewriteKernelEntryDescriptorOffsets -> addKernelEntryTrampolineSymbols) and
+// confirm exactly one "kernel.stub" symbol. Then re-parse that output and run
+// appendKernelEntryTrampolines again: because the descriptor already targets
+// the appended stub, the second pass must report zero new stubs and produce no
+// fixups, so the symbol pass never runs. Feeding those empty fixups to
+// addKernelEntryTrampolineSymbols returns nullptr (no new buffer), and
+// "kernel.stub" remains defined exactly once -- i.e. no duplicate name.
+TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+
+  comgr_test::KernelDescriptorElf Obj = comgr_test::makeKernelDescriptorElf(Text);
+
+  // -- First pass: append one stub, grow .text, rewrite the descriptor, and
+  //    attach the stub symbol. --
+  llvm::Expected<ElfView> View1 =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View1) << llvm::toString(View1.takeError());
+  const unsigned TextIdx = View1->textSectionIndex();
+  const uint64_t TextAddr = View1->textAddr();
+  const uint64_t OldTextSize = View1->textSize();
+
+  std::vector<Trampoline> Growth1;
+  std::vector<KernelEntryTrampolineFixup> Fixups1;
+  std::optional<uint32_t> Count1 = appendKernelEntryTrampolines(
+      *View1, S, /*MaxSgprs=*/106, Growth1, Fixups1);
+  ASSERT_TRUE(Count1.has_value());
+  ASSERT_EQ(*Count1, 1u);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
+      View1->growWithTrampolines(Growth1, S.SNopBytes);
+  ASSERT_NE(Grown, nullptr);
+  ASSERT_TRUE(
+      rewriteKernelEntryDescriptorOffsets(*Grown, OldTextSize, S.Cpu, Fixups1));
+  std::unique_ptr<llvm::WritableMemoryBuffer> Pass1 =
+      addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
+                                      Fixups1);
+  ASSERT_NE(Pass1, nullptr);
+  ASSERT_EQ(countSymtabSymbolsNamed(*Pass1, "kernel.stub"), 1u);
+
+  // -- Second pass over the already-rewritten object. --
+  uint8_t *Pass1Data = reinterpret_cast<uint8_t *>(Pass1->getBufferStart());
+  llvm::Expected<ElfView> View2 =
+      ElfView::create(Pass1Data, Pass1->getBufferSize());
+  ASSERT_TRUE((bool)View2) << llvm::toString(View2.takeError());
+
+  std::vector<Trampoline> Growth2;
+  std::vector<KernelEntryTrampolineFixup> Fixups2;
+  std::optional<uint32_t> Count2 = appendKernelEntryTrampolines(
+      *View2, S, /*MaxSgprs=*/106, Growth2, Fixups2);
+  ASSERT_TRUE(Count2.has_value());
+  // The descriptor already targets a stub, so nothing new is installed.
+  EXPECT_EQ(*Count2, 0u);
+  EXPECT_TRUE(Fixups2.empty());
+
+  // With no fixups the symbol pass is a no-op (returns nullptr, keeping the
+  // existing buffer), so no second "kernel.stub" can be defined.
+  std::unique_ptr<llvm::WritableMemoryBuffer> Pass2 =
+      addKernelEntryTrampolineSymbols(*Pass1, TextIdx, TextAddr,
+                                      View2->textSize(), Fixups2);
+  EXPECT_EQ(Pass2, nullptr);
+  EXPECT_EQ(countSymtabSymbolsNamed(*Pass1, "kernel.stub"), 1u);
+}
+
 TEST(KernelEntryTrampoline, AlignsStubByVirtualAddress) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);


### PR DESCRIPTION
With entry trampolines installed, a kernel descriptor's entry now points at the appended stub instead of the kernel body. Tools that resolve a dispatch's entry address to a name -- e.g. rocgdb `info dispatches` -- then print a bare address because the stub has no symbol.

Add a `<kernel_name>.stub` STT_FUNC symbol (covering the 256-byte stub) to the code object's `.symtab` for each appended stub. rocgdb/amd-dbgapi reads the non-alloc `.symtab` and now reports the dispatch as e.g. `hello[stub]`.

Only the trailing non-alloc `.symtab` / `.strtab` sections grow, so no virtual addresses, program headers, or relocations change, and `.dynsym` (used by the HSA loader) is untouched -- the rewritten object still loads and runs identically. The string blob is padded so the section header table stays 8-byte aligned. Symbol addition is best-effort: on any structural problem the rewrite keeps the (correct) symbol-less object rather than failing.

Applies to every entry-trampoline rewrite. Idempotent: a second pass installs no new stubs and adds no duplicate symbols.

Verified that `info dispatches` shows `hello[stub]` and the kernel runs correctly through the trampoline.


