### PR TITLE
[WaveTransform][DBG_INFO] Preserve debug value locations across multi-stage RA

### DIFF
--- a/llvm/include/llvm/CodeGen/LiveDebugVariables.h
+++ b/llvm/include/llvm/CodeGen/LiveDebugVariables.h
@@ -52,6 +52,13 @@ public:
   /// @param VRM Rename virtual registers according to map.
   LLVM_ABI void emitDebugValues(VirtRegMap *VRM);
 
+  /// In multi-stage register allocation pipelines (e.g. AMDGPU's
+  /// SGPR → WWM → VGPR), VRM is re-initialized between stages, losing
+  /// mappings from earlier stages. This method captures those mappings into
+  /// the internal UserValue data before VRM is cleared, so that the final
+  /// emitDebugValues only needs to resolve remaining (later-stage) vregs.
+  LLVM_ABI void resolveAssignedLocations(VirtRegMap *VRM);
+
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   /// dump - Print data structures to dbgs().
   void dump() const;

--- a/llvm/include/llvm/CodeGen/Passes.h
+++ b/llvm/include/llvm/CodeGen/Passes.h
@@ -206,7 +206,8 @@ LLVM_ABI extern char &RABasicID;
 /// VirtRegRewriter pass. Rewrite virtual registers to physical registers as
 /// assigned in VirtRegMap.
 LLVM_ABI extern char &VirtRegRewriterID;
-LLVM_ABI FunctionPass *createVirtRegRewriter(bool ClearVirtRegs = true);
+LLVM_ABI FunctionPass *createVirtRegRewriter(bool ClearVirtRegs = true,
+                                             bool ResolveDebugLocs = true);
 
 /// UnreachableMachineBlockElimination - This pass removes unreachable
 /// machine basic blocks.

--- a/llvm/include/llvm/CodeGen/VirtRegMap.h
+++ b/llvm/include/llvm/CodeGen/VirtRegMap.h
@@ -240,10 +240,11 @@ public:
 
 class VirtRegRewriterPass : public RequiredPassInfoMixin<VirtRegRewriterPass> {
   bool ClearVirtRegs = true;
+  bool ResolveDebugLocs = true;
 
 public:
-  VirtRegRewriterPass(bool ClearVirtRegs = true)
-      : ClearVirtRegs(ClearVirtRegs) {}
+  VirtRegRewriterPass(bool ClearVirtRegs = true, bool ResolveDebugLocs = true)
+      : ClearVirtRegs(ClearVirtRegs), ResolveDebugLocs(ResolveDebugLocs) {}
   LLVM_ABI PreservedAnalyses run(MachineFunction &MF,
                                  MachineFunctionAnalysisManager &MFAM);
 

--- a/llvm/lib/CodeGen/LiveDebugVariables.cpp
+++ b/llvm/lib/CodeGen/LiveDebugVariables.cpp
@@ -478,10 +478,16 @@ public:
   /// Rewrite virtual register locations according to the provided virtual
   /// register map. Record the stack slot offsets for the locations that
   /// were spilled.
+  ///
+  /// If \p SkipUnassignedVRegs is true, virtual registers not present in \p VRM
+  /// are left as-is rather than being set to $noreg. This supports
+  /// incremental resolution across multi-stage register allocation where
+  /// not all register classes have been allocated yet.
   void rewriteLocations(VirtRegMap &VRM, const MachineFunction &MF,
                         const TargetInstrInfo &TII,
                         const TargetRegisterInfo &TRI,
-                        SpillOffsetMap &SpillOffsets);
+                        SpillOffsetMap &SpillOffsets,
+                        bool SkipUnassignedVRegs = false);
 
   /// Recreate DBG_VALUE instruction from data structures.
   void emitDebugValues(VirtRegMap *VRM, LiveIntervals &LIS,
@@ -670,6 +676,10 @@ public:
 
   /// Recreate DBG_VALUE instruction from data structures.
   void emitDebugValues(VirtRegMap *VRM);
+
+  /// Resolve assigned virtual register locations in \p VRM, leaving
+  /// unassigned vregs intact for later allocation stages.
+  void resolveAssignedLocations(VirtRegMap &VRM);
 
   void print(raw_ostream&);
 };
@@ -1555,7 +1565,8 @@ splitRegister(Register OldReg, ArrayRef<Register> NewRegs, LiveIntervals &LIS) {
 void UserValue::rewriteLocations(VirtRegMap &VRM, const MachineFunction &MF,
                                  const TargetInstrInfo &TII,
                                  const TargetRegisterInfo &TRI,
-                                 SpillOffsetMap &SpillOffsets) {
+                                 SpillOffsetMap &SpillOffsets,
+                                 bool SkipUnassignedVRegs) {
   // Build a set of new locations with new numbers so we can coalesce our
   // IntervalMap if two vreg intervals collapse to the same physical location.
   // Use MapVector instead of SetVector because MapVector::insert returns the
@@ -1591,7 +1602,7 @@ void UserValue::rewriteLocations(VirtRegMap &VRM, const MachineFunction &MF,
 
         Loc = MachineOperand::CreateFI(VRM.getStackSlot(VirtReg));
         Spilled = true;
-      } else {
+      } else if (!SkipUnassignedVRegs) {
         Loc.setReg(0);
         Loc.setSubReg(0);
       }
@@ -1883,7 +1894,13 @@ void LiveDebugVariables::LDVImpl::emitDebugValues(VirtRegMap *VRM) {
     unsigned SubReg = It.second.SubReg;
 
     MachineBasicBlock *OrigMBB = Slots->getMBBFromIndex(Slot);
-    if (VRM->isAssignedReg(Reg) && VRM->hasPhys(Reg)) {
+    if (Reg.isPhysical()) {
+      // Already resolved by resolveAssignedLocations at an earlier RA stage.
+      auto Builder = BuildMI(*OrigMBB, OrigMBB->begin(), DebugLoc(),
+                             TII->get(TargetOpcode::DBG_PHI));
+      Builder.addReg(Reg);
+      Builder.addImm(InstNum);
+    } else if (VRM->isAssignedReg(Reg) && VRM->hasPhys(Reg)) {
       unsigned PhysReg = VRM->getPhys(Reg);
       if (SubReg != 0)
         PhysReg = TRI->getSubReg(PhysReg, SubReg);
@@ -1999,9 +2016,44 @@ void LiveDebugVariables::LDVImpl::emitDebugValues(VirtRegMap *VRM) {
   BBSkipInstsMap.clear();
 }
 
+void LiveDebugVariables::LDVImpl::resolveAssignedLocations(VirtRegMap &VRM) {
+  LLVM_DEBUG(
+      dbgs() << "********** RESOLVING ASSIGNED DEBUG LOCATIONS **********\n");
+  if (!MF)
+    return;
+
+  const TargetInstrInfo *TII = MF->getSubtarget().getInstrInfo();
+  SpillOffsetMap SpillOffsets;
+  for (auto &UV : userValues) {
+    LLVM_DEBUG(UV->print(dbgs(), TRI));
+    UV->rewriteLocations(VRM, *MF, *TII, *TRI, SpillOffsets,
+                         /*SkipUnassignedVRegs=*/true);
+  }
+
+  // Pre-resolve PHI entries whose vregs have been assigned with physregs.
+  for (auto &It : PHIValToPos) {
+    Register &Reg = It.second.Reg;
+    if (!Reg.isVirtual())
+      continue;
+    if (VRM.isAssignedReg(Reg) && VRM.hasPhys(Reg)) {
+      unsigned SubReg = It.second.SubReg;
+      Register PhysReg = VRM.getPhys(Reg);
+      if (SubReg != 0)
+        PhysReg = TRI->getSubReg(PhysReg, SubReg);
+      Reg = PhysReg;
+      It.second.SubReg = 0;
+    }
+  }
+}
+
 void LiveDebugVariables::emitDebugValues(VirtRegMap *VRM) {
   if (PImpl)
     PImpl->emitDebugValues(VRM);
+}
+
+void LiveDebugVariables::resolveAssignedLocations(VirtRegMap *VRM) {
+  if (PImpl)
+    PImpl->resolveAssignedLocations(*VRM);
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/llvm/lib/CodeGen/VirtRegMap.cpp
+++ b/llvm/lib/CodeGen/VirtRegMap.cpp
@@ -223,6 +223,7 @@ class VirtRegRewriter {
   LiveDebugVariables *DebugVars = nullptr;
   DenseSet<Register> RewriteRegs;
   bool ClearVirtRegs;
+  bool ResolveDebugLocs;
 
   void rewrite();
   void addMBBLiveIns();
@@ -236,11 +237,11 @@ class VirtRegRewriter {
       MCRegister PhysReg, const MachineInstr &MI) const;
 
 public:
-  VirtRegRewriter(bool ClearVirtRegs, SlotIndexes *Indexes, LiveIntervals *LIS,
-                  LiveRegMatrix *LRM, VirtRegMap *VRM,
-                  LiveDebugVariables *DebugVars)
+  VirtRegRewriter(bool ClearVirtRegs, bool ResolveDebugLocs,
+                  SlotIndexes *Indexes, LiveIntervals *LIS, LiveRegMatrix *LRM,
+                  VirtRegMap *VRM, LiveDebugVariables *DebugVars)
       : Indexes(Indexes), LIS(LIS), LRM(LRM), VRM(VRM), DebugVars(DebugVars),
-        ClearVirtRegs(ClearVirtRegs) {}
+        ClearVirtRegs(ClearVirtRegs), ResolveDebugLocs(ResolveDebugLocs) {}
 
   bool run(MachineFunction &);
 };
@@ -249,8 +250,10 @@ class VirtRegRewriterLegacy : public MachineFunctionPass {
 public:
   static char ID;
   bool ClearVirtRegs;
-  VirtRegRewriterLegacy(bool ClearVirtRegs = true)
-      : MachineFunctionPass(ID), ClearVirtRegs(ClearVirtRegs) {}
+  bool ResolveDebugLocs;
+  VirtRegRewriterLegacy(bool ClearVirtRegs = true, bool ResolveDebugLocs = true)
+      : MachineFunctionPass(ID), ClearVirtRegs(ClearVirtRegs),
+        ResolveDebugLocs(ResolveDebugLocs) {}
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
@@ -308,7 +311,8 @@ bool VirtRegRewriterLegacy::runOnMachineFunction(MachineFunction &MF) {
   LiveDebugVariables &DebugVars =
       getAnalysis<LiveDebugVariablesWrapperLegacy>().getLDV();
 
-  VirtRegRewriter R(ClearVirtRegs, &Indexes, &LIS, &LRM, &VRM, &DebugVars);
+  VirtRegRewriter R(ClearVirtRegs, ResolveDebugLocs, &Indexes, &LIS, &LRM, &VRM,
+                    &DebugVars);
   return R.run(MF);
 }
 
@@ -324,7 +328,8 @@ VirtRegRewriterPass::run(MachineFunction &MF,
   LiveDebugVariables &DebugVars =
       MFAM.getResult<LiveDebugVariablesAnalysis>(MF);
 
-  VirtRegRewriter R(ClearVirtRegs, &Indexes, &LIS, &LRM, &VRM, &DebugVars);
+  VirtRegRewriter R(ClearVirtRegs, ResolveDebugLocs, &Indexes, &LIS, &LRM, &VRM,
+                    &DebugVars);
   if (!R.run(MF))
     return PreservedAnalyses::all();
 
@@ -370,6 +375,12 @@ bool VirtRegRewriter::run(MachineFunction &fn) {
     // replaced. Remove the virtual registers and release all the transient data.
     VRM->clearAllVirt();
     MRI->clearVirtRegs();
+  } else if (ResolveDebugLocs) {
+    // Capture the current VRM mappings into LDV's internal data at intermediate
+    // rewriter passes of our multi-stage RA pipeline. This pre-resolves debug
+    // locations for register classes allocated in this stage before VRM is
+    // potentially re-initialized by subsequent allocation stages.
+    DebugVars->resolveAssignedLocations(VRM);
   }
 
   return true;
@@ -793,6 +804,7 @@ void VirtRegRewriterPass::printPipeline(
     OS << "<no-clear-vregs>";
 }
 
-FunctionPass *llvm::createVirtRegRewriter(bool ClearVirtRegs) {
-  return new VirtRegRewriterLegacy(ClearVirtRegs);
+FunctionPass *llvm::createVirtRegRewriter(bool ClearVirtRegs,
+                                          bool ResolveDebugLocs) {
+  return new VirtRegRewriterLegacy(ClearVirtRegs, ResolveDebugLocs);
 }

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -2087,7 +2087,9 @@ bool GCNPassConfig::addRegAssignAndRewriteOptimized() {
   // For allocating other whole wave mode registers.
   addPass(createWWMRegAllocPass(true));
   addPass(&SILowerWWMCopiesLegacyID);
-  addPass(createVirtRegRewriter(LateWaveTransform));
+  // Skip the LDV resolution as no source-level debug variables reference WWM
+  // vregs.
+  addPass(createVirtRegRewriter(LateWaveTransform, false));
   addPass(&AMDGPUReserveWWMRegsLegacyID);
 
   if (!LateWaveTransform) {


### PR DESCRIPTION
Our AMDGPU backend allocates registers in three stages (VGPR → SGPR → WWM), each followed by its own VirtRegRewriter.

However debug variable locations are only resolved to physical registers at the final (WWM) VirtRegRewriter, but by that point the VGPR & SGPR vreg-to-physreg mappings stored in the VirtRegMap (VRM) have been lost due to the intervening passes such as AMDGPULowerWQMOperations/ RegisterCoalescer clearing VRM between stages.

As a result, debug values that reference VGPR/SGPR variables emit `$noreg` instead of the correct $vgprN/$sgprN.

This patch attempts to fix this loss by incrementally resolving debug locations after VGPR VirtRegRewriter stage by rewriting assigned virtual registers to their physical counterparts inside LDV's internal data structures before VRM is cleared, so that the mappings from VGPR & SGPR stages survive into the final emission after WWM stage.