### PR TITLE
[comgr][hotswap] add strict rewrite plumbing

### DIFF
--- a/amd/comgr/include/amd_comgr.h.in
+++ b/amd/comgr/include/amd_comgr.h.in
@@ -2978,6 +2978,12 @@ typedef enum amd_comgr_hotswap_rewrite_flag_s {
    * Redirect kernel descriptors through generated entry stubs.
    */
   AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES = 0x1,
+  /**
+   * Enable opt-in strict rewrite behavior. Selected strict rewrites fail
+   * instead of returning the original unpatched code object when a required
+   * patch cannot be emitted safely.
+   */
+  AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE = 0x2,
 } amd_comgr_hotswap_rewrite_flag_t;
 
 /**

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -476,11 +476,19 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 
 /// Per-instruction patch-pass trampoline: invokes \p Fn with (\p Ctx,
 /// \p Idx) if it is non-null, or returns 0 otherwise. nullptr means
-/// the corresponding pass family has no implementation linked in
-/// (e.g. scratch today), which the dispatcher treats as a no-op slot.
-static uint32_t runPerInstPass(uint32_t (*Fn)(PatchContext &, size_t),
-                               PatchContext &Ctx, size_t Idx) {
-  return Fn ? Fn(Ctx, Idx) : 0;
+/// the corresponding pass family has no implementation linked in,
+/// which the dispatcher treats as a no-op slot. std::nullopt means the
+/// pass found a required patch failure after logging a specific reason.
+static std::optional<uint32_t> runPerInstPass(uint32_t (*Fn)(PatchContext &,
+                                                             size_t),
+                                              PatchContext &Ctx, size_t Idx) {
+  if (!Fn)
+    return 0;
+
+  uint32_t PatchCount = Fn(Ctx, Idx);
+  if (Ctx.RequiredPatchFailed)
+    return std::nullopt;
+  return PatchCount;
 }
 
 /// Main per-instruction dispatcher for the GFX1250 B0-to-A0 rewrite.
@@ -491,12 +499,11 @@ static uint32_t runPerInstPass(uint32_t (*Fn)(PatchContext &, size_t),
 /// the whole-function WMMA-hazard pass after the per-instruction loop and
 /// records per-kernel stats via ElfView::updateKernelDescriptor.
 /// Returns the total number of applied patches across all passes.
-static std::optional<uint32_t>
-applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
-                        uint8_t *Text, uint64_t TextSize, const LLVMState &LS,
-                        std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
-                        std::vector<ScratchPatchInfo> &OutScratchPatches,
-                        const RewriteConfig &Config) {
+static std::optional<uint32_t> applyGfx1250B0toA0Rules(
+    std::vector<InternalDecodedInst> &Decoded, uint8_t *Text, uint64_t TextSize,
+    const LLVMState &LS, std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
+    std::vector<ScratchPatchInfo> &OutScratchPatches,
+    const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
   uint32_t Patched = 0;
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
 
@@ -536,31 +543,26 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
   // classify as a valid instruction; the dispatcher has nothing to match
   // against on these and we must not invoke the patch passes for them.
   constexpr StringLiteral UnknownMnemonic = "<unknown>";
+  using PerInstPatchFn = uint32_t (*)(PatchContext &, size_t);
+  PerInstPatchFn PerInstPasses[] = {
+      VT.applyInPlacePatches,     VT.applyTrampolinePatches,
+      VT.applyWmmaSplitPatches,   VT.applyScratchPatches,
+      VT.applyWmmaScale16Patches,
+  };
 
   for (size_t Idx = 0, E = Decoded.size(); Idx < E; ++Idx) {
     const InternalDecodedInst &DI = Decoded[Idx];
     if (DI.Mnemonic == UnknownMnemonic)
       continue;
 
-    if (uint32_t P = runPerInstPass(VT.applyInPlacePatches, Ctx, Idx)) {
-      Patched += P;
-      continue;
-    }
-    if (uint32_t P = runPerInstPass(VT.applyTrampolinePatches, Ctx, Idx)) {
-      Patched += P;
-      continue;
-    }
-    if (uint32_t P = runPerInstPass(VT.applyWmmaSplitPatches, Ctx, Idx)) {
-      Patched += P;
-      continue;
-    }
-    if (uint32_t P = runPerInstPass(VT.applyScratchPatches, Ctx, Idx)) {
-      Patched += P;
-      continue;
-    }
-    if (uint32_t P = runPerInstPass(VT.applyWmmaScale16Patches, Ctx, Idx)) {
-      Patched += P;
-      continue;
+    for (PerInstPatchFn Fn : PerInstPasses) {
+      std::optional<uint32_t> P = runPerInstPass(Fn, Ctx, Idx);
+      if (!P)
+        return std::nullopt;
+      if (*P == 0)
+        continue;
+      Patched += *P;
+      break;
     }
   }
 
@@ -621,6 +623,7 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";
   }
+  OutRequiredPatchApplied = Ctx.RequiredPatchApplied;
   return Patched;
 }
 
@@ -805,6 +808,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   uint64_t Count = 0;
   std::vector<Trampoline> Deferred;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  bool RequiredPatchApplied = false;
   if (Options.RunB0A0Patches) {
     std::vector<InternalDecodedInst> Decoded;
     if (!decodeTextSection(Text, Elf.textSize(), LS, Decoded)) {
@@ -813,9 +817,9 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       return AMD_COMGR_STATUS_ERROR;
     }
 
-    std::optional<uint32_t> Patched =
-        applyGfx1250B0toA0Rules(Decoded, Text, Elf.textSize(), LS, Deferred,
-                                Elf, ScratchPatches, Config);
+    std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
+        Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
+        Config, RequiredPatchApplied);
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;
@@ -843,6 +847,12 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   const uint64_t PoolBaseOffset = *PoolBaseOffsetOr;
   if (!Deferred.empty()) {
     if (!fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS)) {
+      if (RequiredPatchApplied) {
+        log() << "hotswap: error: required patch trampoline branch fixup "
+                 "failed; refusing to return the original unsafe code "
+                 "object\n";
+        return AMD_COMGR_STATUS_ERROR;
+      }
       // A trampoline branch could not be encoded, so the local `Buf` copy
       // is half-redirected; shipping it would run corrupted code. Fall back
       // to the pristine input object (`ElfData`, untouched) so the loader

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -684,6 +684,10 @@ struct PatchContext {
   const LivenessInfo &Liveness;
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
+  // Required patches are transformations whose unpatched original code is
+  // unsafe to return when the selected rewrite policy needs the patch.
+  bool RequiredPatchFailed = false;
+  bool RequiredPatchApplied = false;
 };
 
 // -- Trampoline emission helpers (defined in comgr-hotswap-b0a0.cpp) ----------
@@ -822,6 +826,8 @@ bool rewriteKernelEntryDescriptorOffsets(
 struct Gfx1250RewriteOptions {
   bool RunB0A0Patches = true;
   bool RunEntryTrampolines = false;
+  // Carried for opt-in rewrite policies that need fail-closed behaviour.
+  bool StrictMode = false;
 };
 
 /// Run the selected GFX1250 hotswap rewrite passes on \p ElfData / \p ElfSize.

--- a/amd/comgr/src/comgr-hotswap.cpp
+++ b/amd/comgr/src/comgr-hotswap.cpp
@@ -144,7 +144,8 @@ static amd_comgr_status_t validateHotswapRewriteOptions(
   }
 
   static constexpr uint64_t SupportedFlags =
-      AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES;
+      AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES |
+      AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE;
   if (RewriteOptions->flags & ~SupportedFlags) {
     hotswap::log() << "hotswap: error: amd_comgr_hotswap_rewrite_with_options: "
                       "unsupported rewrite option flags 0x";
@@ -163,6 +164,8 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
                const char *ApiName, amd_comgr_data_t *output) {
   const bool RunEntryTrampolines =
       RewriteFlags & AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES;
+  const bool StrictMode =
+      RewriteFlags & AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE;
 
   DataObject *InputP = DataObject::convert(input);
   if (!InputP) {
@@ -211,6 +214,7 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
   Options.RunB0A0Patches = SourceIdent.Ident.Processor == "gfx1250" &&
                            shouldRunB0A0Patches(SourceIdent, TargetIdent);
   Options.RunEntryTrampolines = RunEntryTrampolines;
+  Options.StrictMode = StrictMode;
 
   std::unique_ptr<llvm::MemoryBuffer> OutBuffer;
   amd_comgr_status_t Status = hotswap::retargetCodeObject(

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -25,6 +25,11 @@ Callers request optional gfx125x kernel descriptor entry redirection through
 `amd_comgr_hotswap_rewrite_with_options` with
 `AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES`.
 
+Callers request strict rewrite behavior through
+`AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE`. Selected strict rewrites fail
+instead of returning the original unpatched code object when a required patch
+cannot be emitted safely.
+
 `AMD_COMGR_STATUS_SUCCESS` means COMGR produced a valid output code object, not
 necessarily that the output bytes changed. If the source/target ISA pair and
 rewrite options select no enabled transformation, the output is a copy of the

--- a/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
@@ -16,30 +16,21 @@
 #include "amd_comgr.h"
 #include "common.h"
 
-enum RewriteOptionMode {
-  RewriteDefault,
-  RewriteEntryTrampolines,
-  RewriteBadOptionsSize,
-  RewriteBadOptionsFlags,
-};
-
-static amd_comgr_status_t runRewrite(amd_comgr_data_t InputData,
-                                     const char *SourceISA,
-                                     const char *TargetISA,
-                                     enum RewriteOptionMode OptionMode,
-                                     amd_comgr_data_t *OutputData) {
-  if (OptionMode == RewriteDefault)
+static amd_comgr_status_t
+runRewrite(amd_comgr_data_t InputData, const char *SourceISA,
+           const char *TargetISA, uint64_t RewriteFlags, int BadOptionsSize,
+           int BadOptionsFlags, amd_comgr_data_t *OutputData) {
+  if (RewriteFlags == AMD_COMGR_HOTSWAP_REWRITE_FLAG_NONE && !BadOptionsSize &&
+      !BadOptionsFlags)
     return amd_comgr_hotswap_rewrite(InputData, SourceISA, TargetISA,
                                      OutputData);
 
   amd_comgr_hotswap_rewrite_options_t Options = {
-      sizeof(amd_comgr_hotswap_rewrite_options_t), 0};
-  if (OptionMode == RewriteEntryTrampolines)
-    Options.flags = AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES;
-  else if (OptionMode == RewriteBadOptionsSize)
+      sizeof(amd_comgr_hotswap_rewrite_options_t), RewriteFlags};
+  if (BadOptionsSize)
     Options.size = 0;
-  else if (OptionMode == RewriteBadOptionsFlags)
-    Options.flags = 0x2;
+  if (BadOptionsFlags)
+    Options.flags = 0x4;
 
   return amd_comgr_hotswap_rewrite_with_options(InputData, SourceISA, TargetISA,
                                                 &Options, OutputData);
@@ -64,10 +55,11 @@ int main(int argc, char *argv[]) {
   }
 
   if (argc < 4)
-    fail("usage: hotswap-rewrite <elf_file> <source_isa> <target_isa> "
-         "[--entry-trampolines] [--bad-options-size] [--bad-options-flags] "
-         "[--zero-size] [--output <path>] [--dump <file>] "
-         "[--check-idempotent] [--expect-status <status>]");
+    fail(
+        "usage: hotswap-rewrite <elf_file> <source_isa> <target_isa> "
+        "[--entry-trampolines] [--strict-mode] [--bad-options-size] "
+        "[--bad-options-flags] [--zero-size] [--output <path>] [--dump <file>] "
+        "[--check-idempotent] [--expect-status <status>]");
 
   const char *ElfFile = argv[1];
   const char *SourceISA = argv[2];
@@ -77,17 +69,21 @@ int main(int argc, char *argv[]) {
   const char *DumpFile = NULL;
   const char *ExpectStatus = NULL;
   int CheckIdempotent = 0;
-  enum RewriteOptionMode OptionMode = RewriteDefault;
+  int BadOptionsSize = 0;
+  int BadOptionsFlags = 0;
+  uint64_t RewriteFlags = AMD_COMGR_HOTSWAP_REWRITE_FLAG_NONE;
 
   for (int I = 4; I < argc; ++I) {
     if (strcmp(argv[I], "--zero-size") == 0)
       ZeroSize = 1;
     else if (strcmp(argv[I], "--entry-trampolines") == 0)
-      OptionMode = RewriteEntryTrampolines;
+      RewriteFlags |= AMD_COMGR_HOTSWAP_REWRITE_FLAG_ENTRY_TRAMPOLINES;
+    else if (strcmp(argv[I], "--strict-mode") == 0)
+      RewriteFlags |= AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE;
     else if (strcmp(argv[I], "--bad-options-size") == 0)
-      OptionMode = RewriteBadOptionsSize;
+      BadOptionsSize = 1;
     else if (strcmp(argv[I], "--bad-options-flags") == 0)
-      OptionMode = RewriteBadOptionsFlags;
+      BadOptionsFlags = 1;
     else if (strcmp(argv[I], "--output") == 0 && I + 1 < argc)
       OutputPath = argv[++I];
     else if (strcmp(argv[I], "--dump") == 0 && I + 1 < argc)
@@ -113,7 +109,8 @@ int main(int argc, char *argv[]) {
 
   amd_comgr_data_t OutputData;
   amd_comgr_status_t Status =
-      runRewrite(InputData, SourceISA, TargetISA, OptionMode, &OutputData);
+      runRewrite(InputData, SourceISA, TargetISA, RewriteFlags, BadOptionsSize,
+                 BadOptionsFlags, &OutputData);
 
   const char *StatusString;
   amd_comgr_(status_string(Status, &StatusString));
@@ -153,8 +150,8 @@ int main(int argc, char *argv[]) {
 
     if (CheckIdempotent) {
       amd_comgr_data_t Output2Data;
-      Status = runRewrite(OutputData, SourceISA, TargetISA, OptionMode,
-                          &Output2Data);
+      Status = runRewrite(OutputData, SourceISA, TargetISA, RewriteFlags,
+                          BadOptionsSize, BadOptionsFlags, &Output2Data);
       if (Status != AMD_COMGR_STATUS_SUCCESS)
         fail("idempotent rewrite failed with status %d", (int)Status);
 

--- a/amd/comgr/test-lit/hotswap-inplace-noop.s
+++ b/amd/comgr/test-lit/hotswap-inplace-noop.s
@@ -11,6 +11,13 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
+// COM: Strict mode is accepted even when no strict rewrite matches.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.strict.elf \
+// RUN:   | %FileCheck --check-prefix=STRICT %s
+// STRICT: RESULT: SUCCESS
+
 // COM: No cluster_load or s_clause -- nothing should be patched
 // DISASM-NOT: cluster_load
 // DISASM-NOT: s_clause


### PR DESCRIPTION
## Stack
Base PR for #3297.

## Summary
- add `AMD_COMGR_HOTSWAP_REWRITE_FLAG_STRICT_MODE` and validate it in the rewrite options path
- add required-patch failure state so selected rewrite policies can fail closed when a required patch cannot be emitted
- extend the `hotswap-rewrite` lit helper and noop coverage for strict-mode acceptance

## Testing
- `git diff --check`
- `git clang-format --diff rocm/amd-staging -- amd/comgr/include/amd_comgr.h.in amd/comgr/src/comgr-hotswap.cpp amd/comgr/src/comgr-hotswap-internal.h amd/comgr/src/comgr-hotswap-b0a0.cpp amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c`
- `mi300x: cmake -S /home/harsh/codex-builds/llvm-project-pr3304-d01b96d-git/llvm -B /home/harsh/codex-builds/llvm-project-pr3304-d01b96d-build -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS="clang;lld" -DLLVM_EXTERNAL_PROJECTS="device-libs;comgr" -DLLVM_EXTERNAL_COMGR_SOURCE_DIR=/home/harsh/codex-builds/llvm-project-pr3304-d01b96d-git/amd/comgr -DLLVM_EXTERNAL_DEVICE_LIBS_SOURCE_DIR=/home/harsh/codex-builds/llvm-project-pr3304-d01b96d-git/amd/device-libs -DLLVM_TARGETS_TO_BUILD="AMDGPU;X86" -DLLVM_ENABLE_ASSERTIONS=OFF`
- `mi300x: cmake --build /home/harsh/codex-builds/llvm-project-pr3304-d01b96d-build --target clang lld llvm-mc llvm-objdump llvm-readelf FileCheck yaml2obj amd_comgr hotswap-rewrite -- -j64`
- `mi300x: cd /home/harsh/codex-builds/llvm-project-pr3304-d01b96d-build && bin/llvm-lit -sv tools/comgr/test-lit --filter "hotswap-inplace|hotswap-trampoline|hotswap-entry"` (20 passed)
