### PR TITLE
[Comgr][hotswap] Decline far s_add_pc_i64 trampolines

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -433,16 +433,17 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
 
   if (Far) {
-    if (InstSize < LongBranchFwdBytes) {
-      log() << "hotswap: long trampoline: site 0x" << utohexstr(InstOffset)
-            << " is " << InstSize << " B < " << LongBranchFwdBytes
-            << " B forward branch; declining (site left unpatched)\n";
-      return false;
-    }
-    T.Long = true;
-    // Reserve the long branch-back slot (worst-case 64-bit-literal size).
-    T.Bytes.insert(T.Bytes.end(), LongBranchMaxBytes, uint8_t{0});
-  } else {
+    // HSV-009: the far pool's backward s_add_pc_i64 branch corrupts wave state
+    // on gfx1250 A0 (forward is fine). Decline the site (keep the original
+    // instruction) instead of emitting the crashing redirect; in-place and
+    // near-sled patches are unaffected. TODO: patch via an s_getpc/s_setpc
+    // backward branch once SGPR-liveness can supply the scratch registers.
+    log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
+          << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
+          << "HSV-009); site left unpatched\n";
+    return false;
+  }
+  {
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
   }
@@ -650,7 +651,8 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
 
     // Long trampolines reserve a wider branch-back slot and use s_add_pc_i64
     // on both edges; short ones use s_branch. Both slots are s_nop-padded to
-    // their reserved size after the branch is written.
+    // their reserved size after the branch is written. (Long/far sites are
+    // currently declined in emitToTrampoline on gfx1250 A0 -- HSV-009.)
     const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
     const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
     const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -1,0 +1,85 @@
+// COM: HSV-009 / PLAT-205406 regression: this is the RCCL AllReduce crash
+// COM: scenario reduced to comgr lit form. On the 0708 llvmprstack build, RCCL
+// COM: device functions (e.g. runTreeUpDown) contain ds_*_2addr sites that sit
+// COM: far (> s_branch's +-128 KB reach) from the appended trampoline pool in
+// COM: the ~225 MB fatbin. Taking the far path emitted an s_add_pc_i64 long
+// COM: branch whose BACKWARD branch-back corrupts wave state on gfx1250 A0,
+// COM: producing a GPU memory fault in ncclDevKernel_Generic_4 (0/10 runs).
+// COM:
+// COM: Fix: decline far ds_*_2addr sites (leave the original instruction) until
+// COM: a scratch-register long branch-back lands. The two kernels below force
+// COM: the far path for a 2-addr LOAD and STORE and assert the decline: the
+// COM: original ds_*_2addr stays, and neither an s_add_pc_i64 redirect nor the
+// COM: single-address split (ds_load_b64 / ds_store_b32) is emitted. The near
+// COM: (sled / short-s_branch) ds_*_2addr path is still exercised and split by
+// COM: hotswap-trampoline-ds.s; only the far path changes here.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Case 1 (2-addr LOAD, RCCL's pattern): declined -- original op stays, no
+// COM: forward long branch, no single-address split.
+// DISASM-LABEL: <test_ds2addr_far_load>:
+// DISASM-NEXT: ds_load_2addr_stride64_b64
+// DISASM-NOT: s_add_pc_i64
+// DISASM-NOT: ds_load_b64
+
+// COM: Case 2 (2-addr STORE): declined the same way.
+// DISASM-LABEL: <test_ds2addr_far_store>:
+// DISASM-NEXT: ds_store_2addr_stride64_b32
+// DISASM-NOT: s_add_pc_i64
+// DISASM-NOT: ds_store_b32
+
+// COM: Idempotency: rewriting the declined output again is a no-op.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds2addr_far_load
+.p2align 8
+.type test_ds2addr_far_load,@function
+test_ds2addr_far_load:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_load_end:
+.size test_ds2addr_far_load, .Ltest_ds2addr_far_load_end-test_ds2addr_far_load
+
+.globl test_ds2addr_far_store
+.p2align 8
+.type test_ds2addr_far_store,@function
+test_ds2addr_far_store:
+  ds_store_2addr_stride64_b32 v2, v0, v1 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+  // ~160 KB of non-NOP filler (forms no usable sled) so the appended trampoline
+  // pool is beyond s_branch's +-128 KB reach from both kernels above, forcing
+  // the far (long-branch) path -- which is declined on gfx1250 A0.
+  .rept 40000
+    s_mov_b32 s0, s1
+  .endr
+.Ltest_ds2addr_far_store_end:
+.size test_ds2addr_far_store, .Ltest_ds2addr_far_store_end-test_ds2addr_far_store
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds2addr_far_load
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_store
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,10 +1,12 @@
-// COM: Test the s_add_pc_i64 long-branch trampoline path. When the appended
-// COM: trampoline pool sits farther than s_branch's +-128 KB reach from the
-// COM: patch site, both trampoline edges use s_add_pc_i64 (a PC-relative long
-// COM: branch that reaches anywhere, needs no scratch register, and does not
-// COM: touch SCC) instead of s_branch. A large .rept filler (~160 KB, non-NOP
-// COM: so it forms no usable sled) pushes the pool past s_branch's real reach
-// COM: from the tensor_load_to_lds at the top of the kernel.
+// COM: HSV-009 / PLAT-205406: on gfx1250 A0 the far trampoline's backward
+// COM: s_add_pc_i64 branch-back corrupts wave state (a GPU memory fault at
+// COM: runtime). Until a scratch-register-based long branch-back lands, a patch
+// COM: site beyond s_branch's +-128 KB reach of the appended pool is DECLINED
+// COM: (left unpatched) instead of redirected through the long branch: the
+// COM: original tensor_load_to_lds stays at the site and no s_add_pc_i64 (nor a
+// COM: relocated trampoline body) is emitted. Near sites and in-place patches
+// COM: are unaffected. A large .rept filler (~160 KB, non-NOP so it forms no
+// COM: usable sled) pushes the pool past s_branch's reach to force the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -16,19 +18,14 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Forward edge: the site is overwritten in place with an 8-byte
-// COM: s_add_pc_i64 long branch (the 12-byte tensor slot leaves room, padded
-// COM: with s_nop), NOT an s_branch.
+// COM: Declined: the site keeps its original tensor_load_to_lds (it is NOT
+// COM: overwritten with an s_add_pc_i64 forward branch), and no long-branch
+// COM: redirect or relocated trampoline body (s_pack_hh_b32_b16 mask-clear) is
+// COM: emitted anywhere.
 // DISASM-LABEL: <test_far>:
-// DISASM: s_add_pc_i64
-// DISASM-NEXT: s_nop
-// DISASM-NEXT: s_endpgm
-
-// COM: Trampoline body (appended after .text): the relocated multicast
-// COM: mask-clear + tensor_load, then an s_add_pc_i64 long branch-back.
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_add_pc_i64
+// DISASM-NOT: s_add_pc_i64
+// DISASM-NOT: s_pack_hh_b32_b16
 
 // COM: Idempotency: rewriting the output again must be a no-op.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -1,9 +1,10 @@
-// COM: WMMA-split over the s_add_pc_i64 long-branch path. WMMA-split shares
-// COM: emitToTrampoline with the other patch families, so a split site beyond
-// COM: s_branch's +-128 KB reach of the appended pool uses an s_add_pc_i64
-// COM: long branch on both edges instead of falling back. A large .rept filler
-// COM: (~160 KB, non-NOP) pushes the pool past s_branch's real reach from the
-// COM: WMMA at the top.
+// COM: HSV-009 / PLAT-205406: WMMA-split shares emitToTrampoline with the other
+// COM: patch families, so a split site beyond s_branch's +-128 KB reach of the
+// COM: appended pool takes the far path -- which on gfx1250 A0 is DECLINED
+// COM: (left unpatched) because the backward s_add_pc_i64 branch-back corrupts
+// COM: wave state at runtime. The original v_wmma_f32_16x16x128_fp8_fp8 stays at
+// COM: the site; it is neither split into two K=64 halves nor redirected. A
+// COM: large .rept filler (~160 KB, non-NOP) forces the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -15,17 +16,13 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Forward edge: the 8-byte WMMA site is overwritten in place with an
-// COM: 8-byte s_add_pc_i64 long branch (NOT an s_branch).
+// COM: Declined: the site keeps its original K=128 WMMA (it is NOT overwritten
+// COM: with an s_add_pc_i64 forward branch), and no split halves
+// COM: (v_wmma_f32_16x16x64_fp8_fp8) or long-branch redirect are emitted.
 // DISASM-LABEL: <test_wsplit_far>:
-// DISASM: s_add_pc_i64
-// DISASM-NEXT: s_endpgm
-
-// COM: Trampoline body: the two K=64 split halves, then an s_add_pc_i64
-// COM: long branch-back.
-// DISASM: v_wmma_f32_16x16x64_fp8_fp8
-// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
-// DISASM-NEXT: s_add_pc_i64
+// DISASM-NEXT: v_wmma_f32_16x16x128_fp8_fp8
+// DISASM-NOT: s_add_pc_i64
+// DISASM-NOT: v_wmma_f32_16x16x64_fp8_fp8
 
 // COM: Idempotency: rewriting the output again must be a no-op.
 // RUN: hotswap-rewrite %t.out.elf \


### PR DESCRIPTION
## Problem
On gfx1250 A0, RCCL `all_reduce_perf` faults **10/10** with hotswap enabled: every rank hits a GPU memory fault in `ncclDevKernel_Generic_4` (page-not-present at ~0x10000X000). `HSA_HOTSWAP_DISABLE=1` passes 10/10. 

Root cause (bisected on hardware + rocgdb): when a B0 to A0 patch site sits beyond `s_branch`'s +/-128 KB reach of the appended trampoline pool (only happens in huge objects like the ~225 MB RCCL fatbin), `emitToTrampoline` takes the far path, whose backward `s_add_pc_i64` branch-back corrupts wave state on gfx1250 A0. The forward positive-offset `s_add_pc_i64`, the DS-2addr expansion, and the near NOP-sled/short-`s_branch` path are all correct - only the far backward long branch is at fault. The faulting kernel is unchanged; a trampolined `ds_*_2addr` site in an RCCL device function (e.g. `runTreeUpDown`) corrupts data it reads.

## Fix
Decline far (`Long`) trampolines in `emitToTrampoline` - leave the site's original instruction in place rather than emit the crashing redirect. In-place patches (`s_clause` to `s_nop`, etc.) and near short-`s_branch` trampolines are unaffected. Unpatched `ds_*_2addr` is only incorrect on A0 for payload-unaligned offsets, which is strictly safer than a hard GPU fault. Small objects (rocBLAS/hipBLASLt/etc.) never hit the far path, so they are unchanged. Follow-up (tracked separately): patch far sites via a scratch-register `s_getpc_b64`/`s_setpc_b64` branch-back, gated on an SGPR-liveness pass so it also covers non-kernel device functions.

This is a gating mechanism; as a follow-up it's the getpc/setpc + SGPR-liveness work.

## Testing
- **RCCL** `all_reduce_perf` (float, 4x gfx1250), hotswap enabled: **10/10 PASS** (was 0/10), `#wrong=0`, ~4.3 GB/s.
- **comgr hotswap lit: 59/59**; new `hotswap-trampoline-ds-long-branch.s` regression test encodes the RCCL `ds_2addr` far-path scenario (load + store, declined).
- **HotswapElfTests 17/17**, **HotswapMCTests 51/51**, **rocr `hotswap_rewrite` 20/20** + `hotswap_gfx_query` 10/10.