### PR TITLE
amd-staging: Drop upstream divergence in unbundling arch cache key

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6315,8 +6315,7 @@ InputInfoList Driver::BuildJobsForActionNoCache(
       // Get the unique string identifier for this dependence and cache the
       // result.
       BoundArch Arch;
-      if (TargetDeviceOffloadKind == Action::OFK_HIP ||
-          TargetDeviceOffloadKind == Action::OFK_OpenMP) {
+      if (TargetDeviceOffloadKind == Action::OFK_HIP) {
         if (UI.DependentOffloadKind == Action::OFK_Host)
           Arch = BoundArch();
         else


### PR DESCRIPTION
Remove the OFK_OpenMP case from the unbundling-result cache-key computation in BuildJobsForActionNoCache, restoring the upstream HIP-only check. This case is unreachable for OpenMP, and would be more naturally expressed as !host anyway rather than a specific language.


