### PR TITLE
Revert "[drops] amend --version with llvm/bin/.llvm-version-info contents"

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -103,7 +103,6 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Process.h"
-#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/StringSaver.h"
@@ -2436,42 +2435,12 @@ void Driver::PrintHelp(bool ShowHidden) const {
                       VisibilityMask);
 }
 
-/// Read and display additional version info from a local file if present.
-static void PrintLocalVersionInfo(StringRef ExecutablePath, raw_ostream &OS) {
-  SmallString<128> VersionInfoPath;
-
-  // Check if environment variable specifies a custom path
-  if (const char *EnvPath = ::getenv("LLVM_VERSION_INFO_FILE")) {
-    VersionInfoPath = EnvPath;
-  } else {
-    // Try same directory as executable
-    VersionInfoPath = llvm::sys::path::parent_path(ExecutablePath);
-    llvm::sys::path::append(VersionInfoPath, ".llvm-version-info");
-  }
-
-  // Read the version info file
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileOrErr =
-      llvm::MemoryBuffer::getFile(VersionInfoPath);
-
-  if (!FileOrErr)
-    return;
-
-  StringRef Contents = FileOrErr.get()->getBuffer();
-  if (Contents.empty())
-    return;
-
-  // Print the additional version info
-  OS << Contents.trim() << " ";
-}
-
 void Driver::PrintVersion(const Compilation &C, raw_ostream &OS) const {
   if (IsFlangMode()) {
-    PrintLocalVersionInfo(DriverExecutable, OS);
     OS << getClangToolFullVersion("flang") << '\n';
   } else {
     // FIXME: The following handlers should use a callback mechanism, we don't
     // know what the client would like to do.
-    PrintLocalVersionInfo(DriverExecutable, OS);
     OS << getClangFullVersion() << '\n';
   }
   const ToolChain &TC = C.getDefaultToolChain();


### PR DESCRIPTION
This reverts commit ff13f3215e13c6ce0b71cc696547a079c47dd532.

This is not upstream, has no tests, and no apparent PR or review. It does not seem reasonable for --version to query external state and not only report information about the binary itself.


