### PR TITLE
[COMGR][HotSwap] gfx1250 A0: remove s_add_pc_i64 from trampoline edges 

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -673,14 +673,61 @@ static void expandForwardSetPc(PatchContext &Ctx) {
   // relocates. isUnsafeToRelocate() also refuses to move any s_delay_alu, so
   // even the gated-on backward path is hazard-safe; the gate stays for A/B.
   //   HOTSWAP_FWD_STEAL_MODE=0  merge adjacent patch sites only (never relocate
-  //                             a non-site instruction, no backward steal)
+  //                             a non-site instruction, no backward steal) -- DEFAULT
   //   HOTSWAP_FWD_STEAL_MODE=1  merge + forward-steal normal instructions, no
-  //                             backward steal (default)
+  //                             backward steal (EXPERIMENTAL: see BUG-2 below)
   //   HOTSWAP_FWD_STEAL_MODE>=2 also enable the backward-steal fallback
+  //
+  // Default is MERGE-ONLY (0). Forward-stealing *normal* instructions is unsafe:
+  // it can relocate an instruction that is the branch-back / resume target of
+  // another trampoline (those synthetic targets are not in BranchTargets), which
+  // moves a control-flow re-entry point and faults/hangs the GPU (BUG-2 on
+  // rocsparse csrgemm f64, and a second instance on spgemm). Merging adjacent
+  // patch sites only relocates code that was already being relocated, so it is
+  // safe and validated (rocsparse csrgemm + spgemm pass). The forward edge does
+  // not itself trip HSV-009 (only the backward 64-bit-literal s_add_pc_i64 does,
+  // per PR ROCm/llvm-project#3323), so leaving non-merged far sites on the legacy
+  // forward s_add_pc_i64 is safe. Normal-instruction stealing stays behind the
+  // flag for experimentation only, pending a correct resume-target guard (I1).
   static const long StealMode = [] {
     const char *E = getenv("HOTSWAP_FWD_STEAL_MODE");
-    return E ? strtol(E, nullptr, 0) : 1;
+    return E ? strtol(E, nullptr, 0) : 0;
   }();
+
+  // Diagnostic bisection gates for BUG-2 (root-causing which forward-stolen
+  // normal instruction corrupts execution). Neither is needed in production;
+  // they let the offender be isolated on-GPU without a rebuild per hypothesis.
+  //   HOTSWAP_FWD_STEAL_SKIP=substr[,substr...]  decline forward-stealing any
+  //       normal instruction whose mnemonic contains one of the substrings
+  //       (e.g. "cmpx,saveexec" or "s_wait_kmcnt"). Class-level bisection.
+  //   HOTSWAP_FWD_STEAL_MAX=N  allow at most N COMMITTED normal forward-steals
+  //       globally (in ascending site order); decline the rest. Binary-search N
+  //       to isolate the single offending steal. -1 (default) = unlimited.
+  static const std::vector<std::string> FwdStealSkip = [] {
+    std::vector<std::string> V;
+    if (const char *E = getenv("HOTSWAP_FWD_STEAL_SKIP")) {
+      StringRef S(E);
+      while (!S.empty()) {
+        auto Split = S.split(',');
+        if (!Split.first.empty())
+          V.push_back(Split.first.str());
+        S = Split.second;
+      }
+    }
+    return V;
+  }();
+  static const long FwdStealMax = [] {
+    const char *E = getenv("HOTSWAP_FWD_STEAL_MAX");
+    return E ? strtol(E, nullptr, 0) : -1;
+  }();
+  auto matchesSkip = [&](StringRef Mnemonic) -> bool {
+    for (const std::string &Sub : FwdStealSkip)
+      if (Mnemonic.contains(Sub))
+        return true;
+    return false;
+  };
+  // Count of committed normal forward-steals so far (for HOTSWAP_FWD_STEAL_MAX).
+  unsigned NormalStealsCommitted = 0;
 
   std::vector<Trampoline> &Tramps = Ctx.OutTrampolines;
   const LLVMState &LS = Ctx.LS;
@@ -737,6 +784,26 @@ static void expandForwardSetPc(PatchContext &Ctx) {
   //      operand (observed as a GPU page fault when a stolen address-compute's
   //      s_delay_alu moved with it). Never relocate these.
   auto isUnsafeToRelocate = [&](const InternalDecodedInst &DI) -> bool {
+    // A "<replaced>" slot is a hazard site that was already rewritten by a
+    // patch pass (ds_*_2addr split+drain, tensor pack, addtid alu+ds -- see
+    // patch-trampoline.cpp). It must never be stolen verbatim as a "normal"
+    // instruction. Two independent reasons, either fatal:
+    //   1. Its decode metadata (DI.Size / DI.Inst) describes the ORIGINAL B0
+    //      instruction, not the (often multi-instruction, different-length)
+    //      A0 replacement now in .text, so relocating DI.Size bytes copies a
+    //      truncated/misaligned sequence.
+    //   2. An in-place-replaced site (one with no trampoline of its own, so it
+    //      is not in OffToTramp and is not merged) can be the branch-back /
+    //      resume target of ANOTHER far trampoline. Those synthetic resume
+    //      targets are not in BranchTargets, so relocating the slot silently
+    //      moves a control-flow re-entry point and the other trampoline returns
+    //      into the overwritten forward set-pc region -> page fault / hang.
+    //      (Root cause of BUG-2: csrgemm f64, a <replaced> ds split at 0x1678C
+    //      that was also the branch-back target of the trampoline at 0x36790.)
+    // Far <replaced> sites are still MERGED (that path never reaches here); only
+    // normal/backward steals of a <replaced> slot are declined.
+    if (DI.Mnemonic == "<replaced>")
+      return true;
     const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
     if (Desc.mayAffectControlFlow(DI.Inst, *LS.MRI))
       return true;
@@ -800,6 +867,7 @@ static void expandForwardSetPc(PatchContext &Ctx) {
     SmallVector<uint8_t> Prefix;   // bytes stolen BEFORE the site
     SmallVector<size_t, 4> MergedIdx;
     unsigned *DeclineRsn = nullptr;
+    unsigned ThisSiteNormal = 0;   // normal steals tentatively taken by this site
 
     // Forward steal: consume following instructions until the site can hold the
     // forward set-pc sequence. Keep going past that point while the next
@@ -861,6 +929,18 @@ static void expandForwardSetPc(PatchContext &Ctx) {
           DeclineRsn = &RsnHazard;
           break;
         }
+        // Diagnostic bisection: decline this normal steal if its mnemonic is on
+        // the skip list, or if the global committed-steal cap is reached.
+        if (matchesSkip(DN.Mnemonic)) {
+          DeclineRsn = &RsnHazard;
+          break;
+        }
+        if (FwdStealMax >= 0 &&
+            NormalStealsCommitted + ThisSiteNormal >=
+                static_cast<unsigned>(FwdStealMax)) {
+          DeclineRsn = &RsnStealDisabled;
+          break;
+        }
         if (DN.Offset + DN.Size > Ctx.TextSize) {
           DeclineRsn = &RsnBounds;
           break;
@@ -871,6 +951,7 @@ static void expandForwardSetPc(PatchContext &Ctx) {
         Stolen.append(P, P + DN.Size);
         Footprint += DN.Size;
         StealAt += DN.Size;
+        ++ThisSiteNormal;
       }
     }
 
@@ -961,6 +1042,7 @@ static void expandForwardSetPc(PatchContext &Ctx) {
       Removed[J] = true;
     ++Upgraded;
     Merged += MergedIdx.size();
+    NormalStealsCommitted += ThisSiteNormal;
     HighWater = std::max(HighWater, StealAt);
     if (!Prefix.empty())
       log() << "hotswap: fwd set-pc backward-stolen: window_start=0x"
@@ -986,7 +1068,9 @@ static void expandForwardSetPc(PatchContext &Ctx) {
         << " pc_relative=" << RsnPcRel << " unpatched_hazard=" << RsnHazard
         << " boundary=" << RsnBoundary << " merge_order=" << RsnMergedOrder
         << " bounds=" << RsnBounds << " back_exhausted=" << RsnBackExhausted
-        << " steal_disabled=" << RsnStealDisabled << ")\n";
+        << " steal_disabled=" << RsnStealDisabled << "); normal_steals_committed="
+        << NormalStealsCommitted << " (max=" << FwdStealMax << " skip="
+        << FwdStealSkip.size() << ")\n";
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -29,11 +29,18 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "comgr-env.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Compiler.h"
 
 #include <algorithm>
+#include <atomic>
 #include <cassert>
+#include <cstdlib>
 #include <limits>
 
 using namespace llvm;
@@ -368,12 +375,111 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
   return {};
 }
 
+// Backward long branch via the legacy set-pc expansion. Used on gfx1250 A0
+// where the backward (64-bit-literal) s_add_pc_i64 form triggers HSV-009. This
+// mirrors the pre-s_add_pc_i64 sequence upstream emits in
+// SIInstrInfo::insertIndirectBranch and the entry-stub materialization in
+// buildKernelEntryTrampoline:
+//
+//   s_cselect_b32 sT, 1, 0        ; sT = caller SCC (SCC unchanged)
+//   s_get_pc_i64  s[N:N+1]        ; pair = PC of the following s_add_u32
+//   s_add_u32     sN,  sN,  lo32  ; pair += (target - post_getpc); clobbers SCC
+//   s_addc_u32    sN1, sN1, hi32  ; carry from the add
+//   s_cmp_lg_u32  sT, 0           ; SCC = (sT != 0), restoring caller SCC
+//   s_set_pc_i64  s[N:N+1]        ; jump to the materialized target
+//
+// s_get_pc_i64 captures the address of the *next* instruction, so the delta is
+// measured from the s_add_u32 slot (FromOffset + the 8-byte cselect+getpc
+// prefix). The add/addc pair is the only SCC writer, so it is bracketed by the
+// cselect (save) / cmp (restore) pair because a far trampoline sits in the
+// middle of straight-line code where the caller's SCC may be live across the
+// relocated site. Assembled via the MC layer; empty on failure.
+SmallVector<uint8_t> encodeSetPCLongBranch(const LLVMState &LS,
+                                           uint64_t FromOffset,
+                                           uint64_t TargetOffset,
+                                           unsigned SgprBase) {
+  const std::string Lo = "s" + std::to_string(SgprBase);
+  const std::string Hi = "s" + std::to_string(SgprBase + 1);
+  const std::string Tmp = "s" + std::to_string(SgprBase + 2);
+  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
+                           std::to_string(SgprBase + 1) + "]";
+
+  // Fixed-size prefix ahead of the s_add_u32: s_cselect_b32 (4) +
+  // s_get_pc_i64 (4). s_get_pc_i64 returns the PC of the s_add_u32, so the
+  // PC-relative delta is measured from there.
+  constexpr uint32_t PrefixBytes = 8;
+  const int64_t Delta = static_cast<int64_t>(TargetOffset) -
+                        static_cast<int64_t>(FromOffset + PrefixBytes);
+  const uint32_t OffLo = static_cast<uint32_t>(static_cast<uint64_t>(Delta));
+  const uint32_t OffHi =
+      static_cast<uint32_t>(static_cast<uint64_t>(Delta) >> 32);
+
+  std::string Asm = joinAsmLines({
+      "s_cselect_b32 " + Tmp + ", 1, 0",
+      "s_get_pc_i64 " + Pair,
+      "s_add_u32 " + Lo + ", " + Lo + ", 0x" + utohexstr(OffLo),
+      "s_addc_u32 " + Hi + ", " + Hi + ", 0x" + utohexstr(OffHi),
+      "s_cmp_lg_u32 " + Tmp + ", 0",
+      "s_set_pc_i64 " + Pair,
+  });
+  SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, LS);
+  if (Bytes.empty() || Bytes.size() > LongBranchBackSeqBytes) {
+    log() << "hotswap: error: set-pc long branch encoding failed (size "
+          << Bytes.size() << ", max " << LongBranchBackSeqBytes << ")\n";
+    return {};
+  }
+  return Bytes;
+}
+
+// Read once: HOTSWAP_BACK_ADDPC=1 forces the legacy backward s_add_pc_i64 path
+// (pre-fix behavior) instead of the SCC-preserving set-pc expansion, so the two
+// backward-edge encodings can be A/B compared on hardware without a rebuild.
+static bool useLegacyBackAddPC() {
+  static const bool V = [] {
+    const char *E = getenv("HOTSWAP_BACK_ADDPC");
+    return E && strtol(E, nullptr, 0) != 0;
+  }();
+  return V;
+}
+
+// Reserve an even-aligned 3-SGPR scratch block above the owning kernel's
+// declared .sgpr_count for a far trampoline's backward set-pc long branch:
+// s[Base:Base+1] (PC pair) + s[Base+2] (SCC save). SGPRs above .sgpr_count are
+// never used by the kernel, and GFX10+ waves always carry the full SGPR file,
+// so no liveness analysis or kernel-descriptor bump is required (the SGPR
+// granule field is architecturally reserved on GFX10+). Records the reservation
+// in per-kernel stats. Returns the aligned base, or nullopt if the kernel is
+// too SGPR-saturated to fit the block below MaxSgprs.
+static std::optional<unsigned>
+tryReserveLongBranchSgprs(PatchContext &Ctx, uint64_t InstOffset) {
+  std::string KernelName =
+      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
+  std::optional<unsigned> KdSgprs = Ctx.Elf.getKernelSgprCount(KernelName);
+  // Unknown count -> assume saturated so we decline rather than risk clobbering
+  // a live SGPR.
+  unsigned SgprCount = KdSgprs.value_or(Ctx.Config.MaxSgprs);
+
+  const unsigned Base = (SgprCount + 1) & ~1u;
+  constexpr unsigned NeededRegs = 3; // even-aligned PC pair + SCC temp
+  if (Base > Ctx.Config.MaxSgprs || Ctx.Config.MaxSgprs - Base < NeededRegs)
+    return std::nullopt;
+
+  if (!KernelName.empty()) {
+    KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, (Base + NeededRegs) - SgprCount);
+  }
+  return Base;
+}
+
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses an s_add_pc_i64 long branch (no scratch reg, no SCC) on both edges; its
-/// 8-byte forward branch overwrites the site in place, so a smaller site
-/// declines rather than clobbering the next instruction.
+/// uses a PC-relative long branch on both edges: an 8-byte forward
+/// s_add_pc_i64 (32-bit literal) that overwrites the site in place -- so a
+/// site smaller than that declines rather than clobbering the next instruction
+/// -- and, on the backward edge, the SCC-preserving set-pc expansion (see
+/// encodeSetPCLongBranch), which needs an even-aligned scratch SGPR block. A
+/// far site whose owning kernel has no room for that block also declines.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement) {
@@ -406,6 +512,28 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
 
   if (Far) {
+    // HSV-009 bisection instrument. HOTSWAP_FAR_KEEP controls how many far
+    // sites (in object scan order) still get a real long-branch trampoline;
+    // the rest are DECLINED (original instruction left in place).
+    //   unset / <0  -> keep all far sites (pre-fix behavior, reproduces fault)
+    //   0           -> decline all far sites (the HSV-009 "fix")
+    //   N > 0       -> keep the first N far sites, decline the rest
+    // Lets us sweep N across GPUs to find whether a count threshold or a
+    // specific site triggers the crash, without editing/rebuilding per point.
+    static const long FarKeep = [] {
+      const char *E = getenv("HOTSWAP_FAR_KEEP");
+      return E ? strtol(E, nullptr, 0) : -1;
+    }();
+    static std::atomic<long> FarSeen{0};
+    const long Idx = FarSeen.fetch_add(1);
+    const bool Decline = (FarKeep >= 0 && Idx >= FarKeep);
+    if (Decline) {
+      log() << "hotswap: far trampoline #" << Idx << " at 0x"
+            << utohexstr(InstOffset) << " declined (HOTSWAP_FAR_KEEP=" << FarKeep
+            << ", HSV-009); site left unpatched\n";
+      return false;
+      
+    }
     if (InstSize < LongBranchFwdBytes) {
       log() << "hotswap: long trampoline: site 0x" << utohexstr(InstOffset)
             << " is " << InstSize << " B < " << LongBranchFwdBytes
@@ -413,8 +541,28 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
       return false;
     }
     T.Long = true;
-    // Reserve the long branch-back slot (worst-case 64-bit-literal size).
-    T.Bytes.insert(T.Bytes.end(), LongBranchMaxBytes, uint8_t{0});
+    if (useLegacyBackAddPC()) {
+      // A/B path: legacy backward s_add_pc_i64 (reproduces the HSV-009 fault).
+      T.Bytes.insert(T.Bytes.end(), LongBranchMaxBytes, uint8_t{0});
+    } else {
+      // Default fix: the backward edge uses the SCC-preserving set-pc
+      // expansion, which needs an even-aligned scratch SGPR block above the
+      // owning kernel's .sgpr_count. Decline the site if none fits.
+      std::optional<unsigned> SgprBase =
+          tryReserveLongBranchSgprs(Ctx, InstOffset);
+      if (!SgprBase) {
+        log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
+              << ": no aligned scratch SGPR block for backward set-pc branch; "
+              << "declining (site left unpatched)\n";
+        return false;
+      }
+      T.UsesSetPCBack = true;
+      T.LongBranchSgprBase = *SgprBase;
+      T.Bytes.insert(T.Bytes.end(), LongBranchBackSeqBytes, uint8_t{0});
+    }
+    log() << "hotswap: far trampoline #" << Idx << " at 0x"
+          << utohexstr(InstOffset) << " kept (HOTSWAP_FAR_KEEP=" << FarKeep
+          << (T.UsesSetPCBack ? ", set-pc back)\n" : ", addpc back)\n");
   } else {
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
@@ -442,6 +590,403 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
           << " is not branch-reachable after assembly; using trampoline.\n";
   }
   return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+}
+
+// -- Forward-edge set-pc upgrade (instruction stealing) -----------------------
+
+// Read once: HOTSWAP_FWD_ADDPC=1 keeps the legacy forward s_add_pc_i64 edge
+// (pre-fix behavior) instead of upgrading it to the SCC-preserving set-pc
+// expansion, so the forward-edge fix can be A/B compared without a rebuild.
+static bool useLegacyFwdAddPC() {
+  static const bool V = [] {
+    const char *E = getenv("HOTSWAP_FWD_ADDPC");
+    return E && strtol(E, nullptr, 0) != 0;
+  }();
+  return V;
+}
+
+// Mnemonics of B0-incompatible instructions handled by the trampoline patch
+// family. If one still carries its original mnemonic in the decoded stream it
+// was NOT patched (its trampoline was declined), so its .text bytes are the
+// broken-on-A0 B0 encoding. Such an instruction must never be stolen verbatim
+// into a trampoline body -- that would reintroduce the hazard the pool exists
+// to remove. Instructions rewritten in place (e.g. s_clause -> s_nop) keep
+// their original mnemonic too, but their .text bytes are already the A0-safe
+// encoding, so this check is intentionally limited to the trampoline-family
+// hazards (a strict superset check is harmless: it only declines a steal).
+static bool looksLikeUnpatchedB0Hazard(StringRef Mnemonic) {
+  if (Mnemonic == "tensor_load_to_lds")
+    return true;
+  if (Mnemonic.starts_with("ds_") &&
+      (Mnemonic.contains("_2addr") || Mnemonic.contains("_addtid")))
+    return true;
+  return false;
+}
+
+/// Post-process the deferred far trampolines to replace their forward
+/// s_add_pc_i64 edge (site -> pool) with the SCC-preserving set-pc expansion,
+/// eliminating the HSV-009-triggering instruction on the forward edge as well
+/// as the backward. The forward set-pc sequence (LongBranchFwdSeqBytes) is
+/// larger than the original instruction it overwrites, so the site "steals"
+/// the bytes of the instructions that follow it:
+///
+///   - A following instruction that is itself a far trampoline site is MERGED:
+///     its already-built (A0-fixed) replacement body is relocated into this
+///     trampoline and the separate trampoline is dropped, so consecutive
+///     patch sites collapse into one trampoline with one forward + one
+///     backward set-pc.
+///   - A following normal instruction is relocated verbatim from the
+///     (post-patch) .text bytes, provided it is safe to move.
+///
+/// The steal window grows one whole instruction at a time until it can hold
+/// the forward set-pc sequence. A trampoline whose window cannot be filled
+/// safely is left on the legacy forward s_add_pc_i64 path (correct, but still
+/// hits the erratum for that one site) -- far below the site-count threshold
+/// that triggers the erratum, so this is safe. Reuses each trampoline's
+/// existing backward-edge SGPR block; no additional SGPRs are reserved.
+///
+/// Only instructions AFTER the site are stolen (forward). A backward-steal
+/// fallback (stealing preceding instructions) exists behind
+/// HOTSWAP_FWD_STEAL_MODE>=2 but is off by default: it tended to relocate an
+/// s_delay_alu hazard hint out of its scheduling context and fault (see the
+/// StealMode comment below).
+///
+/// Runs after every patch pass, so OutTrampolines holds every far site's
+/// finished (A0-fixed) body and the decoded stream is complete. Only mutates
+/// the trampoline list; the site .text bytes and pool layout are materialized
+/// later by fixupTrampolineBranches.
+static void expandForwardSetPc(PatchContext &Ctx) {
+  // A/B gates: the legacy backward-addpc path keeps the whole pre-fix long
+  // branch shape for comparison, and HOTSWAP_FWD_ADDPC keeps just the forward
+  // edge legacy. In both cases leave the forward edge as s_add_pc_i64.
+  if (useLegacyBackAddPC() || useLegacyFwdAddPC())
+    return;
+
+  // Forward-steal aggressiveness. Backward stealing (mode >= 2) is DISABLED by
+  // default: it relocates the instructions PRECEDING a site into the trampoline,
+  // and those commonly include an address computation guarded by an s_delay_alu
+  // hazard hint whose meaning is tied to the preceding instruction stream. Moved
+  // into the pool the hint applies the wrong stall and a dependent VALU reads a
+  // stale operand -> garbage store/load address -> GPU page fault (root-caused
+  // on rocsparse spgemm/csrgemm). Forward stealing does not hit this because the
+  // s_delay_alu sits ahead of the site, not among the following instructions it
+  // relocates. isUnsafeToRelocate() also refuses to move any s_delay_alu, so
+  // even the gated-on backward path is hazard-safe; the gate stays for A/B.
+  //   HOTSWAP_FWD_STEAL_MODE=0  merge adjacent patch sites only (never relocate
+  //                             a non-site instruction, no backward steal)
+  //   HOTSWAP_FWD_STEAL_MODE=1  merge + forward-steal normal instructions, no
+  //                             backward steal (default)
+  //   HOTSWAP_FWD_STEAL_MODE>=2 also enable the backward-steal fallback
+  static const long StealMode = [] {
+    const char *E = getenv("HOTSWAP_FWD_STEAL_MODE");
+    return E ? strtol(E, nullptr, 0) : 1;
+  }();
+
+  std::vector<Trampoline> &Tramps = Ctx.OutTrampolines;
+  const LLVMState &LS = Ctx.LS;
+  if (Tramps.empty() || !LS.MCII || !LS.MRI)
+    return;
+
+  // Instruction-boundary index: a steal may only consume whole instructions,
+  // so every candidate offset must start a decoded instruction.
+  DenseMap<uint64_t, size_t> OffToInst;
+  for (size_t I = 0, E = Ctx.Decoded.size(); I < E; ++I)
+    OffToInst[Ctx.Decoded[I].Offset] = I;
+
+  // Direct branch/call target offsets. Decode used .text-relative offsets as
+  // the instruction address (see decodeTextSection), so evaluateBranch yields
+  // targets in the same .text-offset space as OriginalOffset / the steal
+  // cursor. An interior offset of a steal window must not be a branch target,
+  // or a jump would land in the middle of the forward set-pc / nop padding.
+  DenseSet<uint64_t> BranchTargets;
+  if (LS.MIA) {
+    for (const InternalDecodedInst &DI : Ctx.Decoded) {
+      const MCInst &Inst = DI.Inst;
+      if (LS.MIA->isCall(Inst) || LS.MIA->isUnconditionalBranch(Inst) ||
+          LS.MIA->isConditionalBranch(Inst)) {
+        uint64_t Target = 0;
+        if (LS.MIA->evaluateBranch(Inst, DI.Offset, DI.Size, Target))
+          BranchTargets.insert(Target);
+      }
+    }
+  }
+
+  // Site offset -> trampoline index, so a steal cursor landing on a patch site
+  // can merge that site's trampoline instead of stealing broken B0 bytes.
+  DenseMap<uint64_t, size_t> OffToTramp;
+  for (size_t I = 0, E = Tramps.size(); I < E; ++I)
+    OffToTramp[Tramps[I].OriginalOffset] = I;
+
+  // Reserved back-edge slot width for a trampoline in its current state.
+  auto backReserve = [](const Trampoline &T) -> uint32_t {
+    if (T.UsesSetPCBack)
+      return LongBranchBackSeqBytes;
+    if (T.Long)
+      return LongBranchMaxBytes;
+    return MinInstSize;
+  };
+
+  // An instruction that cannot be relocated verbatim into a trampoline body.
+  // Two classes:
+  //   1. PC-reading/writing or control-flow instructions -- their encoded
+  //      target/PC is position-dependent, so moving them changes where they go.
+  //   2. Context-dependent hazard hints -- s_delay_alu encodes a VALU
+  //      dependency/latency relative to the PRECEDING instruction stream. Once
+  //      relocated into a trampoline the preceding instructions differ, so the
+  //      hint silently applies the wrong stall and a later VALU can read a stale
+  //      operand (observed as a GPU page fault when a stolen address-compute's
+  //      s_delay_alu moved with it). Never relocate these.
+  auto isUnsafeToRelocate = [&](const InternalDecodedInst &DI) -> bool {
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    if (Desc.mayAffectControlFlow(DI.Inst, *LS.MRI))
+      return true;
+    StringRef M(DI.Mnemonic);
+    return M.contains("get_pc") || M.contains("getpc") || M.contains("set_pc") ||
+           M.contains("setpc") || M.contains("add_pc") || M.contains("addpc") ||
+           M.starts_with("s_delay");
+  };
+
+  std::vector<bool> Removed(Tramps.size(), false);
+  unsigned Upgraded = 0, Merged = 0, Kept = 0;
+  // Decline-reason tally (only for sites that fell short of the required
+  // footprint), to explain residual forward s_add_pc_i64 edges in the log.
+  unsigned RsnBoundary = 0, RsnTarget = 0, RsnEndUnknown = 0, RsnPcRel = 0,
+           RsnHazard = 0, RsnMergedOrder = 0, RsnBounds = 0, RsnBackExhausted = 0,
+           RsnStealDisabled = 0;
+
+  // Process sites in ascending .text offset. Forward stealing extends a site's
+  // window into following instructions; backward stealing (the fallback below)
+  // extends it into preceding ones. HighWater is the highest .text offset any
+  // already-finalized trampoline's window occupies (its forward set-pc region
+  // or its original slot). Backward stealing must not cross it -- those bytes
+  // are owned by an earlier trampoline, and an earlier trampoline's (indirect,
+  // set-pc) backward edge returns exactly to HighWater, so keeping the new
+  // window at or above HighWater keeps that return landing on this site's
+  // forward edge rather than inside its interior.
+  std::vector<size_t> Order(Tramps.size());
+  for (size_t I = 0, E = Tramps.size(); I < E; ++I)
+    Order[I] = I;
+  llvm::sort(Order, [&](size_t A, size_t B) {
+    return Tramps[A].OriginalOffset < Tramps[B].OriginalOffset;
+  });
+  uint64_t HighWater = 0;
+
+  for (size_t OI = 0, OE = Order.size(); OI < OE; ++OI) {
+    const size_t I = Order[OI];
+    if (Removed[I])
+      continue;
+    Trampoline &T = Tramps[I];
+    // Only far trampolines carry the erratum instruction; near ones use
+    // s_branch (no erratum) and are left untouched. The backward edge must
+    // already be the set-pc form (its SGPR block is what the forward edge
+    // reuses); the legacy backward-addpc path was excluded above.
+    if (!T.Long || !T.UsesSetPCBack) {
+      HighWater = std::max(HighWater, T.OriginalOffset + T.OriginalSize);
+      continue;
+    }
+
+    // Strip T's own reserved back slot to recover its A0-fixed replacement.
+    const uint32_t TBack = backReserve(T);
+    if (T.Bytes.size() < TBack) {
+      HighWater = std::max(HighWater, T.OriginalOffset + T.OriginalSize);
+      continue;
+    }
+    SmallVector<uint8_t> Body(T.Bytes.begin(), T.Bytes.end() - TBack);
+
+    uint64_t Footprint = T.OriginalSize;
+    uint64_t StealAt = T.OriginalOffset + T.OriginalSize;
+    uint64_t WindowStart = T.OriginalOffset;
+    SmallVector<uint8_t> Stolen;   // bytes stolen AFTER the site
+    SmallVector<uint8_t> Prefix;   // bytes stolen BEFORE the site
+    SmallVector<size_t, 4> MergedIdx;
+    unsigned *DeclineRsn = nullptr;
+
+    // Forward steal: consume following instructions until the site can hold the
+    // forward set-pc sequence. Keep going past that point while the next
+    // instruction is itself a patch site, so a run of consecutive sites
+    // collapses into one trampoline instead of stranding its tail.
+    while (true) {
+      DenseMap<uint64_t, size_t>::iterator InstIt = OffToInst.find(StealAt);
+      if (InstIt == OffToInst.end()) {
+        DeclineRsn = &RsnBoundary; // cursor not on an instruction boundary
+        break;
+      }
+      DenseMap<uint64_t, size_t>::iterator TrampIt = OffToTramp.find(StealAt);
+      const bool NextIsSite = TrampIt != OffToTramp.end();
+      const bool HaveRoom = Footprint >= LongBranchFwdSeqBytes;
+      // Enough room and the next instruction is not a strandable patch site:
+      // stop (a successful upgrade).
+      if (HaveRoom && !NextIsSite) {
+        DeclineRsn = nullptr;
+        break;
+      }
+      if (BranchTargets.count(StealAt)) {
+        DeclineRsn = &RsnTarget; // would relocate the target of a branch
+        break;
+      }
+      const InternalDecodedInst &DN = Ctx.Decoded[InstIt->second];
+      if (DN.Mnemonic == "<unknown>" || DN.Mnemonic == "s_endpgm") {
+        DeclineRsn = &RsnEndUnknown; // padding or a wave terminator: stop
+        break;
+      }
+
+      if (NextIsSite) {
+        // A following patch site: merge its fixed replacement (drop its edges).
+        const size_t J = TrampIt->second;
+        if (Removed[J] || Tramps[J].OriginalOffset <= T.OriginalOffset) {
+          DeclineRsn = &RsnMergedOrder;
+          break;
+        }
+        const Trampoline &T2 = Tramps[J];
+        const uint32_t T2Back = backReserve(T2);
+        if (T2.Bytes.size() < T2Back) {
+          DeclineRsn = &RsnMergedOrder;
+          break;
+        }
+        Stolen.append(T2.Bytes.begin(), T2.Bytes.end() - T2Back);
+        Footprint += T2.OriginalSize;
+        StealAt += T2.OriginalSize;
+        MergedIdx.push_back(J);
+      } else {
+        // A normal instruction: relocate its (post-patch) .text bytes verbatim.
+        if (StealMode < 1) {
+          DeclineRsn = &RsnStealDisabled;
+          break;
+        }
+        if (isUnsafeToRelocate(DN)) {
+          DeclineRsn = &RsnPcRel;
+          break;
+        }
+        if (looksLikeUnpatchedB0Hazard(DN.Mnemonic)) {
+          DeclineRsn = &RsnHazard;
+          break;
+        }
+        if (DN.Offset + DN.Size > Ctx.TextSize) {
+          DeclineRsn = &RsnBounds;
+          break;
+        }
+        log() << "hotswap: fwd-steal-normal: off=0x" << utohexstr(DN.Offset)
+              << " mn=" << DN.Mnemonic << "\n";
+        const uint8_t *P = Ctx.Text + DN.Offset;
+        Stolen.append(P, P + DN.Size);
+        Footprint += DN.Size;
+        StealAt += DN.Size;
+      }
+    }
+
+    // Backward steal fallback: when forward stealing was blocked short (most
+    // commonly by a branch a few instructions after the site), extend the
+    // window into the PRECEDING instructions instead. The forward set-pc then
+    // starts at WindowStart (< the original site) and those preceding
+    // instructions run -- in original order -- ahead of the site's replacement
+    // in the trampoline body. Only normal, relocatable instructions above
+    // HighWater are eligible, and the site itself must not be a branch target
+    // (it becomes an interior offset once the window starts before it).
+    if (Footprint < LongBranchFwdSeqBytes && StealMode >= 2) {
+      DenseMap<uint64_t, size_t>::iterator SiteIt =
+          OffToInst.find(T.OriginalOffset);
+      size_t K =
+          (SiteIt != OffToInst.end()) ? SiteIt->second : Ctx.Decoded.size();
+      const std::string SiteKernel =
+          Ctx.Elf.findKernelAtAddress(T.OriginalOffset + Ctx.Elf.textAddr());
+      while (Footprint < LongBranchFwdSeqBytes && K > 0) {
+        // WindowStart becomes an interior offset once we prepend before it, so
+        // nothing may branch to it (the very first check covers the site).
+        if (BranchTargets.count(WindowStart)) {
+          DeclineRsn = &RsnBackExhausted;
+          break;
+        }
+        const InternalDecodedInst &DP = Ctx.Decoded[K - 1];
+        const uint64_t POff = DP.Offset;
+        if (POff < HighWater || POff + DP.Size != WindowStart) {
+          DeclineRsn = &RsnBackExhausted; // owned by an earlier tramp / gap
+          break;
+        }
+        if (OffToTramp.count(POff)) {
+          DeclineRsn = &RsnBackExhausted; // don't overlap a preceding site
+          break;
+        }
+        if (DP.Mnemonic == "<unknown>" || DP.Mnemonic == "s_endpgm") {
+          DeclineRsn = &RsnBackExhausted;
+          break;
+        }
+        // Never relocate across a kernel boundary (the s_endpgm/PC-relative
+        // barriers above usually stop first; this is defense-in-depth).
+        if (Ctx.Elf.findKernelAtAddress(POff + Ctx.Elf.textAddr()) != SiteKernel) {
+          DeclineRsn = &RsnBackExhausted;
+          break;
+        }
+        if (isUnsafeToRelocate(DP)) {
+          DeclineRsn = &RsnPcRel;
+          break;
+        }
+        if (looksLikeUnpatchedB0Hazard(DP.Mnemonic)) {
+          DeclineRsn = &RsnHazard;
+          break;
+        }
+        if (POff + DP.Size > Ctx.TextSize) {
+          DeclineRsn = &RsnBounds;
+          break;
+        }
+        const uint8_t *P = Ctx.Text + POff;
+        Prefix.insert(Prefix.begin(), P, P + DP.Size);
+        Footprint += DP.Size;
+        WindowStart = POff;
+        --K;
+      }
+    }
+
+    if (Footprint < LongBranchFwdSeqBytes) {
+      if (DeclineRsn)
+        ++*DeclineRsn;
+      ++Kept; // leave T on the legacy forward s_add_pc_i64 edge
+      HighWater = std::max(HighWater, T.OriginalOffset + T.OriginalSize);
+      continue;
+    }
+
+    // Commit: rebuild T as [prefix...][replacement][stolen...][back slot] and
+    // move the site to WindowStart (where the forward set-pc is written).
+    SmallVector<uint8_t> NewBytes;
+    NewBytes.reserve(Prefix.size() + Body.size() + Stolen.size() +
+                     LongBranchBackSeqBytes);
+    NewBytes.append(Prefix.begin(), Prefix.end());
+    NewBytes.append(Body.begin(), Body.end());
+    NewBytes.append(Stolen.begin(), Stolen.end());
+    NewBytes.append(LongBranchBackSeqBytes, uint8_t{0});
+    T.Bytes = std::move(NewBytes);
+    T.OriginalOffset = WindowStart;
+    T.UsesSetPCFwd = true;
+    T.StolenBytes = static_cast<uint32_t>(Footprint);
+    for (size_t J : MergedIdx)
+      Removed[J] = true;
+    ++Upgraded;
+    Merged += MergedIdx.size();
+    HighWater = std::max(HighWater, StealAt);
+    if (!Prefix.empty())
+      log() << "hotswap: fwd set-pc backward-stolen: window_start=0x"
+            << utohexstr(WindowStart) << " site_end=0x" << utohexstr(StealAt)
+            << " footprint=" << Footprint << " prefix_bytes=" << Prefix.size()
+            << " merged=" << MergedIdx.size() << "\n";
+  }
+
+  if (Merged) {
+    std::vector<Trampoline> Compact;
+    Compact.reserve(Tramps.size() - Merged);
+    for (size_t I = 0, E = Tramps.size(); I < E; ++I)
+      if (!Removed[I])
+        Compact.push_back(std::move(Tramps[I]));
+    Tramps.swap(Compact);
+  }
+
+  log() << "hotswap: forward set-pc: upgraded " << Upgraded
+        << " far trampoline(s) (merged " << Merged
+        << " adjacent site(s)); " << Kept
+        << " left on legacy forward s_add_pc_i64 (decline reasons:"
+        << " branch_target=" << RsnTarget << " end/unknown=" << RsnEndUnknown
+        << " pc_relative=" << RsnPcRel << " unpatched_hazard=" << RsnHazard
+        << " boundary=" << RsnBoundary << " merge_order=" << RsnMergedOrder
+        << " bounds=" << RsnBounds << " back_exhausted=" << RsnBackExhausted
+        << " steal_disabled=" << RsnStealDisabled << ")\n";
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -543,6 +1088,14 @@ applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
   if (VT.applyVop3px2Src2Fix)
     Patched += VT.applyVop3px2Src2Fix(Ctx);
 
+  // Upgrade far trampolines' forward edge from s_add_pc_i64 to the
+  // SCC-preserving set-pc expansion via instruction stealing. Runs after all
+  // patch passes so every far site's finished body is present and adjacent
+  // sites can be merged. Reuses the backward edge's SGPR block, so it must run
+  // before the per-kernel SGPR accounting below (which is already charged for
+  // that block at emit time); it never reserves new SGPRs.
+  expandForwardSetPc(Ctx);
+
   for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
     const KernelPatchStats &Stats = KV.second;
@@ -608,16 +1161,29 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
 
-    // Long trampolines reserve a wider branch-back slot and use s_add_pc_i64
-    // on both edges; short ones use s_branch. Both slots are s_nop-padded to
-    // their reserved size after the branch is written.
-    const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
+    // Long trampolines reserve a wider branch-back slot; short ones use
+    // s_branch. The backward edge of a long trampoline uses the SCC-preserving
+    // set-pc expansion by default (UsesSetPCBack) and only the legacy backward
+    // s_add_pc_i64 under HOTSWAP_BACK_ADDPC. The forward edge uses an 8-byte
+    // forward s_add_pc_i64 unless expandForwardSetPc upgraded it to the set-pc
+    // expansion (UsesSetPCFwd), in which case the site footprint is the stolen
+    // window (StolenBytes) and the backward edge returns past it. Every slot is
+    // s_nop-padded out to its reserved size after the branch is written.
+    const uint32_t BackReserve =
+        T.Long ? (T.UsesSetPCBack ? LongBranchBackSeqBytes : LongBranchMaxBytes)
+               : MinInstSize;
     const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
-    const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+    // The site footprint is the original slot, or the full stolen window when
+    // the forward edge was upgraded to set-pc.
+    const uint32_t SiteFootprint =
+        T.UsesSetPCFwd ? T.StolenBytes : T.OriginalSize;
+    const uint64_t ReturnTo = T.OriginalOffset + SiteFootprint;
 
-    SmallVector<uint8_t> BrBack = T.Long
-                                      ? encodeLongBranch(LS, BackSlot, ReturnTo)
-                                      : LS.encodeSBranch(BackSlot, ReturnTo);
+    SmallVector<uint8_t> BrBack =
+        !T.Long ? LS.encodeSBranch(BackSlot, ReturnTo)
+                : (T.UsesSetPCBack ? encodeSetPCLongBranch(LS, BackSlot, ReturnTo,
+                                                           T.LongBranchSgprBase)
+                                   : encodeLongBranch(LS, BackSlot, ReturnTo));
     if (BrBack.empty() || BrBack.size() > BackReserve) {
       log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
             << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
@@ -631,16 +1197,21 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
                   LS.SNopBytes.data(), MinInstSize);
 
     SmallVector<uint8_t> BrFwd =
-        T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)
-               : LS.encodeSBranch(T.OriginalOffset, TP);
-    if (BrFwd.empty() || BrFwd.size() > T.OriginalSize) {
+        T.UsesSetPCFwd
+            ? encodeSetPCLongBranch(LS, T.OriginalOffset, TP,
+                                    T.LongBranchSgprBase)
+            : (T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)
+                      : LS.encodeSBranch(T.OriginalOffset, TP));
+    if (BrFwd.empty() || BrFwd.size() > SiteFootprint) {
       log() << "hotswap: error: trampoline branch-fwd encoding failed at 0x"
-            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+            << utohexstr(T.OriginalOffset)
+            << (T.UsesSetPCFwd ? " (long, set-pc fwd)\n"
+                               : (T.Long ? " (long)\n" : "\n"));
       return false;
     }
     std::memcpy(Text + T.OriginalOffset, BrFwd.data(), BrFwd.size());
-    // Pad the tail of the replaced slot with cached s_nop bytes.
-    for (uint32_t I = BrFwd.size(); I + MinInstSize <= T.OriginalSize;
+    // Pad the tail of the site footprint with cached s_nop bytes.
+    for (uint32_t I = BrFwd.size(); I + MinInstSize <= SiteFootprint;
          I += MinInstSize)
       std::memcpy(Text + T.OriginalOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
@@ -659,6 +1230,25 @@ static void patchDebugSections(WritableMemoryBuffer &ElfBuf,
                                const ElfView &Elf, size_t GrowthTotal) {
   uint8_t *Data = reinterpret_cast<uint8_t *>(ElfBuf.getBufferStart());
   size_t Size = ElfBuf.getBufferSize();
+  if (COMGR::env::shouldEmitVerboseLogs()) {
+    // Trampolines are appended contiguously right after the original .text,
+    // in array order. Their virtual address is textAddr + original textSize +
+    // cumulative body bytes. Emit a map line per trampoline so a fault PC in
+    // the trampoline region can be traced to its origin kernel + site.
+    uint64_t Pos = Elf.textSize();
+    for (const Trampoline &T : Trampolines) {
+      uint64_t TrampVA = Elf.textAddr() + Pos;
+      uint64_t SiteVA = Elf.textAddr() + T.OriginalOffset;
+      std::string K = Elf.findKernelAtAddress(SiteVA);
+      if (K.empty())
+        K = "<unknown>";
+      log() << "hotswap-map: tramp kernel='" << K << "' tramp_vaddr=0x"
+            << utohexstr(TrampVA) << " site_vaddr=0x" << utohexstr(SiteVA)
+            << " orig_off=0x" << utohexstr(T.OriginalOffset)
+            << " bytes=" << T.Bytes.size() << "\n";
+      Pos += T.Bytes.size();
+    }
+  }
   if (!addTrampolineSymbols(ElfBuf, Trampolines, Elf.textSize(),
                             Elf.textSectionIndex()))
     log() << "hotswap: error: addTrampolineSymbols failed\n";
@@ -842,7 +1432,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     }
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
     if (!rewriteKernelEntryDescriptorOffsets(*Result, Elf.textSize(),
-                                             EntryFixups))
+                                             EntryFixups, LS))
       return AMD_COMGR_STATUS_ERROR;
   } else {
     Result = copyOutputBuffer(Buf.data(), ElfSize, "patched");
@@ -852,6 +1442,31 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   if (!ScratchPatches.empty())
     runScratchVerification(*Result, LS, ScratchPatches, Config.MaxVgprs);
+
+  // Debug dump: when HOTSWAP_DUMP_DIR is set, write the input (pre) and patched
+  // (post) code objects to disk so the exact bytes the loader ships can be
+  // disassembled and diffed against a synthetic repro. Files are keyed by a
+  // per-process index plus the input size so multiple transpiles are
+  // distinguishable and matchable across runs.
+  if (const char *DumpDir = getenv("HOTSWAP_DUMP_DIR")) {
+    static std::atomic<unsigned> DumpIdx{0};
+    unsigned Idx = DumpIdx.fetch_add(1);
+    auto WriteFile = [&](const char *Tag, const void *Data, size_t Sz) {
+      char Path[4096];
+      snprintf(Path, sizeof(Path), "%s/co_%03u_in%zu_%s.elf", DumpDir, Idx,
+               ElfSize, Tag);
+      if (FILE *F = fopen(Path, "wb")) {
+        fwrite(Data, 1, Sz, F);
+        fclose(F);
+        log() << "hotswap: dumped " << Tag << " -> " << Path << " (" << Sz
+              << " B)\n";
+      } else {
+        log() << "hotswap: error: could not open dump file " << Path << "\n";
+      }
+    };
+    WriteFile("pre", ElfData, ElfSize);
+    WriteFile("post", Result->getBufferStart(), Result->getBufferSize());
+  }
 
   Out = std::move(Result);
   return AMD_COMGR_STATUS_SUCCESS;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -502,6 +502,14 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     return std::nullopt;
   AppendOffset = StubStart;
 
+  log() << "hotswap: trace: entry-trampoline pool: text_addr=0x"
+        << utohexstr(Elf.textAddr()) << " text_size=0x"
+        << utohexstr(Elf.textSize()) << " text_end=0x"
+        << utohexstr(*TextEndVAddr) << " existing_growth=0x"
+        << utohexstr(*ExistingGrowthBytes) << " stub_pool_base=0x"
+        << utohexstr(*AlignedStubPoolBaseVAddr) << " stub_start_off=0x"
+        << utohexstr(StubStart) << " kernels=" << Work.size() << "\n";
+
   for (const KernelDescriptorInfo &KD : Work) {
     std::optional<uint64_t> StubTextEnd = checkedAddUint64(
         Elf.textSize(), AppendOffset,
@@ -530,10 +538,38 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
       return std::nullopt;
     }
 
+    // Instrumentation: trace the geometry that decides where the GPU will jump,
+    // and self-check the freshly built stub's PC-relative target against the
+    // original entry (validates the s_get_pc + delta materialization).
+    log() << "hotswap: trace: kernel '" << KD.KernelName << "' kd_vaddr=0x"
+          << utohexstr(KD.VAddr) << " entry_off=" << KD.EntryOffset
+          << " entry_vaddr=0x" << utohexstr(*Entry) << " stub_vaddr=0x"
+          << utohexstr(*StubVAddr) << " append_off=0x" << utohexstr(AppendOffset)
+          << " scratch_sgpr=" << *ScratchSgpr
+          << " req_sgprs=" << (*ScratchSgpr + 2) << "\n";
+    {
+      std::vector<InternalDecodedInst> DecodedStub;
+      if (decodeKernelEntryStub(Stub, LS, DecodedStub,
+                                "entry trampoline build self-check") &&
+          hasEntryStubOperandShape(DecodedStub, LS)) {
+        std::optional<uint64_t> DecodedTarget =
+            decodeEntryStubTargetVAddr(DecodedStub, *StubVAddr);
+        if (!DecodedTarget || *DecodedTarget != *Entry) {
+          log() << "hotswap: SELFCHECK-MISMATCH (build): kernel '"
+                << KD.KernelName << "' stub decodes target 0x"
+                << (DecodedTarget ? utohexstr(*DecodedTarget) : "none")
+                << " but original entry is 0x" << utohexstr(*Entry) << "\n";
+        }
+      } else {
+        log() << "hotswap: SELFCHECK-MISMATCH (build): kernel '" << KD.KernelName
+              << "' freshly built stub failed to decode as an entry stub\n";
+      }
+    }
+
     Trampoline T;
     T.Bytes.assign(Stub.begin(), Stub.end());
     LocalGrowth.push_back(std::move(T));
-    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2});
+    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2, *Entry});
     std::optional<uint64_t> NewAppendOffset = checkedAddUint64(
         AppendOffset, KernelEntryStubStride,
         (Twine("entry trampoline append offset after '") + KD.KernelName + "'")
@@ -573,7 +609,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 
 bool rewriteKernelEntryDescriptorOffsets(
     WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
-    ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+    ArrayRef<KernelEntryTrampolineFixup> Fixups, const LLVMState &LS) {
   if (Fixups.empty())
     return true;
 
@@ -625,6 +661,53 @@ bool rewriteKernelEntryDescriptorOffsets(
     bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
         Fixup.KernelName, Fixup.RequiredSgprs);
     Ok = UpdatedEntry && UpdatedSgprs && Ok;
+
+    // Instrumentation + end-to-end self-check on the GROWN ELF: the descriptor
+    // now points at *StubVAddr; decode the bytes actually living there and
+    // confirm the stub's PC-relative target is the original kernel entry. A
+    // mismatch here is exactly what sends the GPU PC to an unmapped address.
+    log() << "hotswap: trace: fixup kernel '" << Fixup.KernelName
+          << "' out_text_addr=0x" << utohexstr(OutElf.textAddr())
+          << " old_text_size=0x" << utohexstr(OldTextSize)
+          << " stub_text_off=0x" << utohexstr(Fixup.StubTextOffset)
+          << " stub_vaddr=0x" << utohexstr(*StubVAddr) << " kd_vaddr=0x"
+          << utohexstr(*KdVAddr) << " new_entry_off=" << *NewOffset
+          << " orig_entry_vaddr=0x" << utohexstr(Fixup.OrigEntryVAddr) << "\n";
+
+    std::optional<uint64_t> OutTextEnd = checkedAddUint64(
+        OutElf.textAddr(), OutElf.textSize(), "self-check out text end");
+    if (!OutTextEnd || *StubVAddr < OutElf.textAddr() ||
+        *StubVAddr + KernelEntryStubStride > *OutTextEnd) {
+      log() << "hotswap: SELFCHECK-MISMATCH (grown): kernel '" << Fixup.KernelName
+            << "' stub_vaddr=0x" << utohexstr(*StubVAddr)
+            << " is outside grown .text [0x" << utohexstr(OutElf.textAddr())
+            << ", 0x" << (OutTextEnd ? utohexstr(*OutTextEnd) : "?") << ")\n";
+    } else {
+      const uint64_t StubTextOff = *StubVAddr - OutElf.textAddr();
+      ArrayRef<uint8_t> StubBytes(OutElf.textData() + StubTextOff,
+                                  KernelEntryStubStride);
+      std::vector<InternalDecodedInst> DecodedStub;
+      if (decodeKernelEntryStub(StubBytes, LS, DecodedStub,
+                                "entry trampoline grown self-check") &&
+          hasEntryStubOperandShape(DecodedStub, LS)) {
+        std::optional<uint64_t> DecodedTarget =
+            decodeEntryStubTargetVAddr(DecodedStub, *StubVAddr);
+        if (!DecodedTarget || *DecodedTarget != Fixup.OrigEntryVAddr) {
+          log() << "hotswap: SELFCHECK-MISMATCH (grown): kernel '"
+                << Fixup.KernelName << "' installed stub at 0x"
+                << utohexstr(*StubVAddr) << " decodes target 0x"
+                << (DecodedTarget ? utohexstr(*DecodedTarget) : "none")
+                << " but original entry is 0x"
+                << utohexstr(Fixup.OrigEntryVAddr) << "\n";
+        }
+      } else {
+        log() << "hotswap: SELFCHECK-MISMATCH (grown): kernel '"
+              << Fixup.KernelName << "' bytes at stub_vaddr 0x"
+              << utohexstr(*StubVAddr)
+              << " do not decode as an entry stub (descriptor points to the "
+                 "wrong place)\n";
+      }
+    }
   }
   return Ok;
 }

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -90,10 +90,43 @@ struct Trampoline {
   uint64_t OriginalOffset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
-  // When set, both edges use an s_add_pc_i64 long branch instead of s_branch
-  // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
-  // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
+  // When set, this is a far trampoline whose edges use a PC-relative long
+  // branch instead of s_branch (reaches anywhere). Set when the appended pool
+  // is beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
+  // The backward edge (pool -> site) always uses the legacy set-pc expansion
+  // (see UsesSetPCBack) because the backward 64-bit-literal s_add_pc_i64 form
+  // triggers the gfx1250 A0 HSV-009 erratum. The forward edge (site -> pool)
+  // uses an 8-byte forward s_add_pc_i64 UNLESS it was upgraded to the set-pc
+  // expansion by expandForwardSetPc (see UsesSetPCFwd) -- the forward
+  // s_add_pc_i64 hits the same HSV-009 erratum in aggregate, so the upgrade
+  // eliminates it wherever the site can make room via instruction stealing.
   bool Long = false;
+  // When set, the backward edge is encoded with the s_get_pc_i64 / s_add_u32 /
+  // s_addc_u32 / s_set_pc_i64 sequence (SCC-preserving) instead of a backward
+  // s_add_pc_i64. This is the default on gfx1250 A0; the legacy s_add_pc_i64
+  // backward path is kept behind HOTSWAP_BACK_ADDPC for A/B testing.
+  bool UsesSetPCBack = false;
+  // When set, the FORWARD edge (site -> pool) is also encoded with the
+  // SCC-preserving set-pc expansion instead of a forward s_add_pc_i64. Set by
+  // expandForwardSetPc after all patch passes run: the forward set-pc sequence
+  // is larger than the original instruction slot, so the site "steals" the
+  // bytes of following instructions (relocating them -- fixed -- into this
+  // trampoline body, see StolenBytes). Reuses LongBranchSgprBase (the forward
+  // and backward edges of one trampoline never execute concurrently).
+  bool UsesSetPCFwd = false;
+  // For a UsesSetPCFwd trampoline, the total number of .text bytes overwritten
+  // at the site by the forward set-pc sequence: the original instruction plus
+  // all stolen following instructions. The forward set-pc is written at
+  // OriginalOffset and s_nop-padded out to StolenBytes; the backward edge
+  // returns to OriginalOffset + StolenBytes (the first byte past the stolen
+  // window). Zero when UsesSetPCFwd is false (the site footprint is then just
+  // OriginalSize).
+  uint32_t StolenBytes = 0;
+  // For a UsesSetPCBack / UsesSetPCFwd trampoline, the even-aligned scratch
+  // SGPR block reserved above the owning kernel's .sgpr_count:
+  // s[Base:Base+1] holds the computed target PC and s[Base+2] preserves the
+  // caller's SCC across the s_add_u32 / s_addc_u32 pair. Shared by both edges.
+  unsigned LongBranchSgprBase = 0;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -145,6 +178,21 @@ static constexpr uint32_t MinInstSize = 4;
 // offset on either edge (computed from the already-queued trampolines).
 static constexpr uint32_t LongBranchFwdBytes = 8;
 static constexpr uint32_t LongBranchMaxBytes = 12;
+
+// Backward long branch via the legacy set-pc expansion used on gfx1250 A0,
+// where the backward 64-bit-literal s_add_pc_i64 form triggers the HSV-009
+// erratum. The sequence is s_cselect_b32 (save SCC) + s_get_pc_i64 +
+// s_add_u32 + s_addc_u32 + s_cmp_lg_u32 (restore SCC) + s_set_pc_i64. This is
+// the worst-case encoded size (both adds taking 32-bit literals); the reserved
+// backward slot is s_nop-padded out to this width.
+static constexpr uint32_t LongBranchBackSeqBytes = 32;
+
+// Minimum number of .text bytes a UsesSetPCFwd site must free up (via
+// instruction stealing) to hold the forward set-pc expansion. Same worst-case
+// encoded size as the backward sequence; expandForwardSetPc steals whole
+// following instructions until the site footprint reaches this width, then the
+// forward set-pc is s_nop-padded out to the exact stolen footprint.
+static constexpr uint32_t LongBranchFwdSeqBytes = LongBranchBackSeqBytes;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
 // LLVMState::encodeSBranch to reject out-of-range branches before handing
@@ -656,6 +704,20 @@ struct PatchContext {
 llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
                                             uint64_t FromOffset,
                                             uint64_t TargetOffset);
+
+// Encode a backward PC-relative long branch from \p FromOffset to
+// \p TargetOffset (.text byte offsets) using the legacy set-pc expansion
+// (s_get_pc_i64 / s_add_u32 / s_addc_u32 / s_set_pc_i64), bracketed by
+// s_cselect_b32 / s_cmp_lg_u32 to preserve the caller's SCC. This avoids the
+// backward s_add_pc_i64 form that triggers the gfx1250 A0 HSV-009 erratum.
+// \p SgprBase is an even-aligned scratch block above the kernel's .sgpr_count:
+// s[SgprBase:SgprBase+1] for the PC pair, s[SgprBase+2] for the SCC save.
+// Exposed for unit testing the offset math / encoding. Returns empty on
+// failure.
+llvm::SmallVector<uint8_t> encodeSetPCLongBranch(const LLVMState &LS,
+                                                 uint64_t FromOffset,
+                                                 uint64_t TargetOffset,
+                                                 unsigned SgprBase);
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        llvm::ArrayRef<uint8_t> Replacement);
@@ -729,6 +791,10 @@ struct KernelEntryTrampolineFixup {
   std::string KernelName;
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
+  // Original kernel entry virtual address (before redirection). Recorded so the
+  // post-growth descriptor rewrite can self-check that the installed stub
+  // actually jumps back here.
+  uint64_t OrigEntryVAddr = 0;
 };
 
 /// Build a 256-byte, entry-aligned HotSwap kernel-entry stub at
@@ -768,7 +834,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
 /// appendKernelEntryTrampolines after the ELF has been grown.
 bool rewriteKernelEntryDescriptorOffsets(
     llvm::WritableMemoryBuffer &OutBuf, uint64_t OldTextSize,
-    llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+    llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups, const LLVMState &LS);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -23,6 +23,8 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "comgr-env.h"
+
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -113,6 +115,21 @@ bool swapOpcode(InternalDecodedInst &DI, uint8_t *Text, const LLVMState &LS,
   return true;
 }
 
+// Verbose-only diagnostics: record which kernel + original instruction this
+// in-place patch rewrote, so a runtime fault address can be traced back.
+void logInPlaceMap(PatchContext &Ctx, const InternalDecodedInst &DI,
+                   StringRef Kind, StringRef Repl) {
+  if (!COMGR::env::shouldEmitVerboseLogs())
+    return;
+  uint64_t SiteVA = Ctx.Elf.textAddr() + DI.Offset;
+  std::string K = Ctx.Elf.findKernelAtAddress(SiteVA);
+  if (K.empty())
+    K = "<unknown>";
+  log() << "hotswap-map: kind=" << Kind << " kernel='" << K << "' site=0x"
+        << utohexstr(SiteVA) << " orig=" << DI.Mnemonic << " repl=" << Repl
+        << "\n";
+}
+
 } // anonymous namespace
 
 static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
@@ -139,6 +156,7 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
       if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
         log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
               << " at 0x" << utohexstr(DI.Offset) << "\n";
+        logInPlaceMap(Ctx, DI, "cluster_load", "global_load");
         return 1;
       }
     }
@@ -151,6 +169,7 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
                          Ctx.LS)) {
       log() << "hotswap: inplace: s_clause -> s_nop at 0x"
             << utohexstr(DI.Offset) << "\n";
+      logInPlaceMap(Ctx, DI, "s_clause", "s_nop");
       return 1;
     }
   }
@@ -186,6 +205,7 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
     if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
       log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
+      logInPlaceMap(Ctx, DI, "barrier_isfirst", "barrier_signal");
       return 1;
     }
   }

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -26,6 +26,8 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "comgr-env.h"
+
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -359,6 +361,16 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return false;
 
+  if (COMGR::env::shouldEmitVerboseLogs()) {
+    uint64_t SiteVA = Ctx.Elf.textAddr() + DI.Offset;
+    std::string K = Ctx.Elf.findKernelAtAddress(SiteVA);
+    if (K.empty())
+      K = "<unknown>";
+    log() << "hotswap-map: kind=ds2addr kernel='" << K << "' site=0x"
+          << utohexstr(SiteVA) << " orig=" << DI.Mnemonic
+          << " repl=split+drain\n";
+  }
+
   DI.Mnemonic = "<replaced>";
   return true;
 }
@@ -616,6 +628,15 @@ bool patchTensorLoadToLds(PatchContext &Ctx, size_t Idx) {
           << " dead, no save/restore needed\n";
   }
 
+  if (COMGR::env::shouldEmitVerboseLogs()) {
+    uint64_t SiteVA = Ctx.Elf.textAddr() + DI.Offset;
+    std::string K = Ctx.Elf.findKernelAtAddress(SiteVA);
+    if (K.empty())
+      K = "<unknown>";
+    log() << "hotswap-map: kind=tensor_load kernel='" << K << "' site=0x"
+          << utohexstr(SiteVA) << " orig=tensor_load_to_lds repl=pack_hh\n";
+  }
+
   DI.Mnemonic = "<replaced>";
   return true;
 }
@@ -862,6 +883,17 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   log() << "hotswap: trampoline: " << DI.Mnemonic << " -> " << ToMnem
         << " at 0x" << utohexstr(DI.Offset) << " (offset=" << Offset << ", "
         << RegName << ")\n";
+
+  if (COMGR::env::shouldEmitVerboseLogs()) {
+    uint64_t SiteVA = Ctx.Elf.textAddr() + DI.Offset;
+    std::string K = Ctx.Elf.findKernelAtAddress(SiteVA);
+    if (K.empty())
+      K = "<unknown>";
+    log() << "hotswap-map: kind=addtid kernel='" << K << "' site=0x"
+          << utohexstr(SiteVA) << " orig=" << DI.Mnemonic
+          << " repl=alu+ds\n";
+  }
+
   DI.Mnemonic = "<replaced>";
   return true;
 }


### PR DESCRIPTION
## Summary

The B0->A0 hot-swap transpiler builds trampolines to relocate B0-only
instructions. On far sites (pool beyond `s_branch`'s +/-128 KB reach) both
trampoline edges used `s_add_pc_i64`. On gfx1250 A0 that instruction is broken
(erratum **HSV-009**): once the number of `s_add_pc_i64` present/executed in a
code object crosses a threshold, the GPU page-faults.

This PR eliminates `s_add_pc_i64` from trampoline edges by replacing it with an
SCC-preserving, EXEC-independent, PC-relative **set-pc sequence**, and adds the
"instruction stealing" machinery needed to fit the (larger) forward edge in
place. It also adds self-checking instrumentation to the kernel-entry
trampoline path.

> Scope note: the **backward** edge replacement is complete and validated. The
> **forward** edge replacement (set-pc + instruction stealing) is landed but
> **experimental** and carries a known open limitation (BUG-2, below). It is
> gated so it can be disabled at runtime without a rebuild.

## Background: the erratum

- `far` trampoline edges are PC-relative. The legacy encoding used
  `s_add_pc_i64` on the forward edge (site -> pool) and the backward edge
  (pool -> site).
- `s_add_pc_i64` triggers HSV-009 on A0. Both edges contribute, so we must
  drive the residual `s_add_pc_i64` count well below the erratum threshold.

## The set-pc sequence (replaces s_add_pc_i64)

Both edges can be encoded as (28-32 B, worst case with 32-bit literals):

```
s_cselect_b32   sT, 1, 0        ; save caller SCC (cselect does not write SCC)
s_get_pc_i64    s[N:N+1]        ; pair = PC of next instruction
s_add_co_u32    sN,  sN,  lo32  ; pair += (target - here) ; writes SCC
s_add_co_ci_u32 sN1, sN1, hi32
s_cmp_lg_u32    sT, 0           ; restore caller SCC
s_set_pc_i64    s[N:N+1]        ; jump
```

- Scalar-only, so it runs regardless of `EXEC`.
- SCC is saved/restored around the adds, so it is transparent to surrounding
  code.
- Requires an even-aligned 3-SGPR scratch block (`s[N:N+1]` PC pair + `sN+2`
  SCC temp) reserved **above** the owning kernel's `.sgpr_count` (bumped in the
  KD). GFX10+ waves carry the full SGPR file, so registers above the count are
  dead. Both edges of a trampoline reuse the same block (they never execute
  concurrently).

## What changed

### Backward edge (default ON, validated)
- Every far trampoline's backward edge is now encoded with the set-pc
  expansion (`Trampoline::UsesSetPCBack`), never a backward `s_add_pc_i64`.
- New `encodeSetPCLongBranch(LS, from, to, sgprBase)` in
  `comgr-hotswap-b0a0.cpp` (declared in `comgr-hotswap-internal.h`), exposed for
  unit-testing the offset math.
- The reserved backward slot is widened and `s_nop`-padded to
  `LongBranchBackSeqBytes` (32 B worst case).
- Legacy backward `s_add_pc_i64` is kept behind `HOTSWAP_BACK_ADDPC=1` for A/B.

### Forward edge (experimental, gated)
The forward set-pc is larger than the single ~8 B instruction it overwrites, so
the site must free up room by **stealing** whole following instructions into the
trampoline body (`Trampoline::UsesSetPCFwd`, `StolenBytes`). `expandForwardSetPc`
runs after all patch passes and supports three behaviors:

- **Merge** — a following instruction that is itself a far patch site: its
  already-A0-fixed body is folded into this trampoline and the separate
  trampoline is dropped (collapses runs of consecutive sites).
- **Forward-steal** — a following *normal* instruction is relocated verbatim
  into the pool body.
- **Backward-steal** (fallback, gated off) — extend the window into *preceding*
  instructions when a nearby branch blocks forward growth.

The site window `[OriginalOffset, OriginalOffset + StolenBytes)` is overwritten
with the forward set-pc + `s_nop` padding; stolen instructions run in the pool
(original order) and the backward edge returns to `OriginalOffset + StolenBytes`.

### Entry-trampoline instrumentation & self-checks
- `comgr-hotswap-entry-trampoline.cpp`: trace logging of the entry-trampoline
  pool geometry and, at both build time and post-growth, a self-check that
  decodes the installed stub and confirms its PC-relative target equals the
  original kernel entry (`SELFCHECK-MISMATCH` logged otherwise — this is exactly
  the failure mode that sends the GPU PC to an unmapped address).
- `KernelEntryTrampolineFixup` gains `OrigEntryVAddr`;
  `rewriteKernelEntryDescriptorOffsets` now takes `const LLVMState&` for the
  grown-ELF self-check.
- `comgr-hotswap-patch-inplace.cpp`: verbose logging for in-place patches.

## Safety invariants

Any relocated/overwritten instruction must satisfy all of these (violations map
directly to the bugs found during GPU bring-up):

- **I1 Control-flow entry safety** — no offset strictly interior to the steal
  window may be a branch/call target.
- **I2 Control-flow relocation safety** — never relocate a PC-reading/writing or
  branch/call/`s_*_pc` instruction.
- **I3 Order preservation** — relocated instructions keep original relative
  order; the site body keeps its position within that order.
- **I4 Hazard/scheduling-context safety** — never relocate instructions whose
  meaning depends on the surrounding stream. `s_delay_alu` is explicitly
  rejected by `isUnsafeToRelocate()`.
- **I5 Register liveness** — set-pc scratch SGPRs are dead (reserved above
  `.sgpr_count`); no relocated instruction may read them.
- **I6 EXEC/SCC transparency** — set-pc preserves SCC and is EXEC-independent;
  relocated EXEC/SCC producers keep producer->consumer ordering.
- **I7 Byte/boundary integrity** — steal only whole decoded instructions; never
  cross a kernel boundary/`s_endpgm`/padding/`.text` end; never steal an
  unpatched B0 hazard verbatim.
- **I8 Idempotency & threshold** — re-running the rewrite is a no-op; residual
  `s_add_pc_i64` stays far below the HSV-009 threshold.

Policy: prefer **declining** a site (leave it on the legacy edge) over an unsafe
relocation. A bounded handful of residual `s_add_pc_i64` is safe; a wrong
relocation is not.

## Runtime configuration (A/B, no rebuild)

- `HOTSWAP_BACK_ADDPC=1` — legacy backward `s_add_pc_i64` (default: set-pc).
- `HOTSWAP_FWD_ADDPC=1` — legacy forward `s_add_pc_i64` (default: set-pc
  upgrade). Use this to disable the experimental forward path entirely.
- `HOTSWAP_FWD_STEAL_MODE` — `0` merge-only | `1` merge + forward-steal
  (default) | `>=2` also enable backward-steal.
- `HOTSWAP_FAR_KEEP=N` — keep the first N far sites on the legacy edge (bisection).
- `HOTSWAP_DUMP_DIR=<dir>` — dump `co_NNN_*_{pre,post}.elf` for offline replay.

## Validation

- **Offline replay** (no GPU): `hotswap-rewrite <pre.elf> <srcISA> <tgtISA>
  --output out.elf [--check-idempotent]` with `AMD_COMGR_EMIT_VERBOSE_LOGS=1`;
  disassembly diffs match GPU-dumped objects.
- **GPU** (hang-proof runner: `timeout 90` + dmesg `page fault` delta + `pkill`;
  a no-retry fault wedges the queue and hangs the app):
  - PASS: spgemm `nos1`; small-N csrgemm f64 (`50/300/50` variants) in the
    default config (backward set-pc + forward set-pc, merge + forward-steal).
  - PASS: full matrix with `HOTSWAP_FWD_ADDPC=1` (backward set-pc only) — this
    is the conservative, always-safe configuration.

## Known limitation (open)

- **BUG-2 (forward-steal, csrgemm f64 N=300):** larger f64 csrgemm kernels HANG
  or page-fault with forward-steal enabled; they pass with forward-steal
  disabled (`HOTSWAP_FWD_ADDPC=1`) or merge-only (`HOTSWAP_FWD_STEAL_MODE=0`).
  Isolated to forward-steal of a not-yet-enumerated context-dependent
  instruction (suspected I4) or an exec/vcc producer/consumer split across the
  pool boundary (I6). Root cause in progress: offline-replay all csrgemm-f64
  objects, collect the forward-stolen mnemonic multiset, diff against the
  passing spgemm set, and extend the `isUnsafeToRelocate()` deny-list.

Because of BUG-2, the forward path ships gated. The safe production
configuration today is backward set-pc + `HOTSWAP_FWD_ADDPC=1`.

## Relation to ROCm/llvm-project#3323

PR #3323 fixes the same erratum by replacing **only the backward** edge with the
set-pc sequence and leaving the forward `s_add_pc_i64` in place. That is
equivalent to this PR run with `HOTSWAP_FWD_ADDPC=1`, and both pass the full
matrix. This PR additionally attempts to remove the forward `s_add_pc_i64` via
instruction stealing (experimental, gated) so *all* trampoline `s_add_pc_i64`
can eventually be eliminated rather than relying on staying under the threshold.

## Files changed

- `amd/comgr/src/comgr-hotswap-b0a0.cpp` — set-pc encoder, forward-edge upgrade
  + instruction stealing, `isUnsafeToRelocate`, env gates, diagnostics.
- `amd/comgr/src/comgr-hotswap-internal.h` — `Trampoline` flags
  (`UsesSetPCBack`, `UsesSetPCFwd`, `StolenBytes`, `LongBranchSgprBase`), size
  constants, `encodeSetPCLongBranch` decl, `KernelEntryTrampolineFixup`.
- `amd/comgr/src/comgr-hotswap-entry-trampoline.cpp` — entry-stub tracing +
  build/grown self-checks.
- `amd/comgr/src/comgr-hotswap-patch-trampoline.cpp` — trampoline edge encoding
  wiring.
- `amd/comgr/src/comgr-hotswap-patch-inplace.cpp` — in-place patch logging.

## Follow-ups

- Root-cause and fix BUG-2, then default forward-steal ON.
- Decide final policy for backward-steal (keep gated-off vs remove).
- Add a lit test per invariant (I1, I2, I4, I7) to catch regressions offline.
- Remove diagnostic logging once the forward path is stable.
