### PR TITLE
[AMDGPU][COMGR] Use signed literal32 for gfx1250 far trampolines

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -394,6 +394,73 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
   return {};
 }
 
+SmallVector<uint8_t> encodeSccNeutralLongBranch(const LLVMState &LS,
+                                                uint64_t FromOffset,
+                                                uint64_t TargetOffset,
+                                                unsigned SgprBase) {
+  if ((SgprBase & 1u) != 0 ||
+      SgprBase == std::numeric_limits<unsigned>::max()) {
+    log() << "hotswap: error: SCC-neutral long branch requires an aligned "
+             "SGPR pair, got s"
+          << SgprBase << "\n";
+    return {};
+  }
+
+  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
+                           std::to_string(SgprBase + 1) + "]";
+  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
+  if (GetPc.empty()) {
+    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
+             "s_get_pc_i64 for "
+          << Pair << "\n";
+    return {};
+  }
+
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      FromOffset, GetPc.size(), "SCC-neutral long branch PC base");
+  if (!PcBase)
+    return {};
+
+  // Unsigned subtraction intentionally materializes the two's-complement
+  // delta for backward branches.
+  const uint64_t Delta = TargetOffset - *PcBase;
+  SmallVector<uint8_t> Add = assembleSingleInst(
+      "s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" + utohexstr(Delta), LS);
+  SmallVector<uint8_t> SetPc = assembleSingleInst("s_set_pc_i64 " + Pair, LS);
+  if (Add.empty() || SetPc.empty()) {
+    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
+             "add/set-PC sequence for "
+          << Pair << "\n";
+    return {};
+  }
+
+  SmallVector<uint8_t> Bytes;
+  Bytes.append(GetPc.begin(), GetPc.end());
+  Bytes.append(Add.begin(), Add.end());
+  Bytes.append(SetPc.begin(), SetPc.end());
+  return Bytes;
+}
+
+static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
+  return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
+}
+
+static bool instructionUsesVcc(const LLVMState &LS,
+                               const InternalDecodedInst &DI) {
+  for (const MCOperand &Op : DI.Inst)
+    if (Op.isReg() && Op.getReg() && isVccRegister(LS, MCRegister(Op.getReg())))
+      return true;
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  for (MCPhysReg Reg : Desc.implicit_uses())
+    if (isVccRegister(LS, MCRegister(Reg)))
+      return true;
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    if (isVccRegister(LS, MCRegister(Reg)))
+      return true;
+  return false;
+}
+
 static std::optional<SmallVector<uint8_t>>
 buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
                    uint64_t BackStart) {
@@ -429,28 +496,10 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
     return std::nullopt;
   }
 
-  auto IsVcc = [&](MCRegister Reg) {
-    return Reg.isValid() &&
-           StringRef(Ctx.LS.MRI->getName(Reg)).starts_with("VCC");
-  };
-  auto InstUsesVcc = [&](const InternalDecodedInst &DI) {
-    for (const MCOperand &Op : DI.Inst)
-      if (Op.isReg() && Op.getReg() && IsVcc(MCRegister(Op.getReg())))
-        return true;
-    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
-    for (MCPhysReg Reg : Desc.implicit_uses())
-      if (IsVcc(MCRegister(Reg)))
-        return true;
-    for (MCPhysReg Reg : Desc.implicit_defs())
-      if (IsVcc(MCRegister(Reg)))
-        return true;
-    return false;
-  };
-
   for (const InternalDecodedInst &DI : Ctx.Decoded) {
     if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
       continue;
-    UsesVcc |= InstUsesVcc(DI);
+    UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
     HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
   }
 
@@ -473,39 +522,17 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
   unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
   if (ScratchPair + 1 >= Ctx.Config.MaxSgprs) {
     log() << "hotswap: error: safe far return: kernel " << KernelName
-          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs
-          << "\n";
+          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs << "\n";
     return std::nullopt;
   }
 
-  std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
-                     std::to_string(ScratchPair + 1) + "]";
-  SmallVector<uint8_t> Bytes;
-  auto Append = [&](const std::string &Asm) {
-    SmallVector<uint8_t> Inst = assembleSingleInst(Asm, Ctx.LS);
-    if (Inst.empty()) {
-      log() << "hotswap: error: safe far return assembly failed: " << Asm
-            << "\n";
-      return false;
-    }
-    Bytes.append(Inst.begin(), Inst.end());
-    return true;
-  };
-
-  if (!Append("s_get_pc_i64 " + Pair))
+  std::optional<uint64_t> ReturnTo =
+      checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
+  if (!ReturnTo)
     return std::nullopt;
-
-  // s_get_pc_i64 returns the address of the following instruction.
-  std::optional<uint64_t> PcBase = checkedAddUint64(
-      BackStart, static_cast<uint64_t>(Bytes.size()), "safe far return PC");
-  if (!PcBase)
-    return std::nullopt;
-  uint64_t ReturnTo = InstOffset + InstSize;
-  uint64_t Delta = ReturnTo - *PcBase;
-
-  if (!Append("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
-              utohexstr(Delta)) ||
-      !Append("s_set_pc_i64 " + Pair))
+  SmallVector<uint8_t> Bytes =
+      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, ScratchPair);
+  if (Bytes.empty())
     return std::nullopt;
 
   unsigned RequiredNumberedSgprs = ScratchPair + 2;
@@ -519,6 +546,8 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
   KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
   Stats.ExtraSgprs =
       std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
+  const std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
+                           std::to_string(ScratchPair + 1) + "]";
   log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
         << Pair << "\n";
   return Bytes;
@@ -573,9 +602,20 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
             << "HSV-009); site left unpatched\n";
       return false;
     }
+    if (InstSize < LongBranchFwdBytes) {
+      log() << "hotswap: error: safe far trampoline site 0x"
+            << utohexstr(InstOffset) << " is " << InstSize
+            << " B, smaller than " << LongBranchFwdBytes
+            << " B forward branch\n";
+      return false;
+    }
 
-    std::optional<SmallVector<uint8_t>> Back = buildSafeFarReturn(
-        Ctx, InstOffset, InstSize, PoolStart + Replacement.size());
+    std::optional<uint64_t> BackStart = checkedAddUint64(
+        PoolStart, Replacement.size(), "safe far return start offset");
+    if (!BackStart)
+      return false;
+    std::optional<SmallVector<uint8_t>> Back =
+        buildSafeFarReturn(Ctx, InstOffset, InstSize, *BackStart);
     if (!Back)
       return false;
     T.Bytes.append(Back->begin(), Back->end());
@@ -754,9 +794,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
         return std::nullopt;
       }
       unsigned RequiredSgprs = *SgprsBefore + Stats.ExtraSgprs;
-      bool UpdateDescriptor = !StringRef(Config.TargetCpu).starts_with("gfx1");
       if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs,
-                                               UpdateDescriptor)) {
+                                               /*UpdateDescriptor=*/false)) {
         log() << "hotswap: error: failed to update SGPR count for kernel "
               << KName << "\n";
         return std::nullopt;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -363,207 +363,47 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
 
 // s_add_pc_i64 long branch from \p FromOffset to \p TargetOffset (.text
 // offsets). It adds a signed literal to the next instruction's PC, so the
-// offset is TargetOffset - (FromOffset + size); size is 8 (forward, 32-bit
-// literal) or 12 (backward, 64-bit literal), resolved by trying each. Encoded
-// via the MC assembler. Returns empty on failure.
+// offset is TargetOffset - (FromOffset + 8). MI400 sign-extends literal32 for
+// this instruction, giving the same 8-byte encoding in either direction.
 //
-// Precondition: callers only long-branch *far* sites, so the target is far
-// enough that s_add_pc_i64 always needs a real (>= 32-bit) literal. A tiny
-// offset would instead assemble to the 4-byte inline-constant form, match
-// neither candidate size, and yield empty. That is asserted here (assert
-// liberally); the empty return is kept as a release-build safety net so a
-// stray near target degrades to the unpatched-object fallback rather than
-// crashing the loader.
+// Callers use this only outside s_branch range, so the displacement requires a
+// literal rather than a 4-byte inline constant. Returns empty when the target
+// is outside signed literal32 range or encoding fails.
 SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
                                       uint64_t TargetOffset) {
-  [[maybe_unused]] const int64_t Distance =
-      static_cast<int64_t>(TargetOffset) - static_cast<int64_t>(FromOffset);
-  [[maybe_unused]] const int64_t MinLongDistance = LongBranchMaxBytes;
-  assert((Distance > MinLongDistance || Distance < -MinLongDistance) &&
-         "encodeLongBranch: target is not a far site; the long-branch path is "
-         "only valid for offsets beyond an s_add_pc_i64 instruction's reach");
-
-  for (uint32_t Size : {LongBranchFwdBytes, LongBranchMaxBytes}) {
-    int64_t Off = static_cast<int64_t>(TargetOffset) -
-                  static_cast<int64_t>(FromOffset + Size);
-    SmallVector<uint8_t> Bytes =
-        assembleSingleInst("s_add_pc_i64 " + std::to_string(Off), LS);
-    if (Bytes.size() == Size)
-      return Bytes;
-  }
-  return {};
-}
-
-SmallVector<uint8_t> encodeSccNeutralLongBranch(const LLVMState &LS,
-                                                uint64_t FromOffset,
-                                                uint64_t TargetOffset,
-                                                unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0 ||
-      SgprBase == std::numeric_limits<unsigned>::max()) {
-    log() << "hotswap: error: SCC-neutral long branch requires an aligned "
-             "SGPR pair, got s"
-          << SgprBase << "\n";
-    return {};
-  }
-
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
-  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
-  if (GetPc.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_get_pc_i64 for "
-          << Pair << "\n";
-    return {};
-  }
-
-  std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, GetPc.size(), "SCC-neutral long branch PC base");
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, LongBranchBytes, "s_add_pc_i64 PC base");
   if (!PcBase)
     return {};
 
-  // Unsigned subtraction intentionally materializes the two's-complement
-  // delta for backward branches.
-  const uint64_t Delta = TargetOffset - *PcBase;
-  SmallVector<uint8_t> Add = assembleSingleInst(
-      "s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" + utohexstr(Delta), LS);
-  SmallVector<uint8_t> SetPc = assembleSingleInst("s_set_pc_i64 " + Pair, LS);
-  if (Add.empty() || SetPc.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "add/set-PC sequence for "
-          << Pair << "\n";
-    return {};
+  int64_t Offset;
+  if (TargetOffset >= *PcBase) {
+    uint64_t Delta = TargetOffset - *PcBase;
+    if (Delta > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()))
+      return {};
+    Offset = static_cast<int64_t>(Delta);
+  } else {
+    uint64_t Delta = *PcBase - TargetOffset;
+    constexpr uint64_t MinInt32Magnitude = uint64_t{1} << 31;
+    if (Delta > MinInt32Magnitude)
+      return {};
+    Offset = -static_cast<int64_t>(Delta);
   }
 
-  SmallVector<uint8_t> Bytes;
-  Bytes.append(GetPc.begin(), GetPc.end());
-  Bytes.append(Add.begin(), Add.end());
-  Bytes.append(SetPc.begin(), SetPc.end());
-  return Bytes;
-}
-
-static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
-  return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
-}
-
-static bool instructionUsesVcc(const LLVMState &LS,
-                               const InternalDecodedInst &DI) {
-  for (const MCOperand &Op : DI.Inst)
-    if (Op.isReg() && Op.getReg() && isVccRegister(LS, MCRegister(Op.getReg())))
-      return true;
-
-  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
-  for (MCPhysReg Reg : Desc.implicit_uses())
-    if (isVccRegister(LS, MCRegister(Reg)))
-      return true;
-  for (MCPhysReg Reg : Desc.implicit_defs())
-    if (isVccRegister(LS, MCRegister(Reg)))
-      return true;
-  return false;
-}
-
-static std::optional<SmallVector<uint8_t>>
-buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
-                   uint64_t BackStart) {
-  std::string KernelName =
-      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
-  if (KernelName.empty()) {
-    log() << "hotswap: error: safe far return: no kernel owns site 0x"
-          << utohexstr(InstOffset) << "\n";
-    return std::nullopt;
-  }
-
-  std::optional<unsigned> TotalSgprCount =
-      Ctx.Elf.getKernelSgprCount(KernelName);
-  if (!TotalSgprCount) {
-    log() << "hotswap: error: safe far return: invalid SGPR count for kernel "
-          << KernelName << "\n";
-    return std::nullopt;
-  }
-
-  // LLVM metadata counts two implicit SGPRs when a kernel uses VCC, but those
-  // are not part of the numbered s0-s105 register space. Inspect the owning
-  // function so scratch allocation starts above numbered SGPRs rather than
-  // above the metadata total. If VCC is only used by a callee, retaining the
-  // total as the allocation base is conservative; the call flag below keeps
-  // two implicit slots in the updated metadata.
-  bool UsesVcc = false;
-  bool HasCall = false;
-  std::optional<ElfView::FunctionTextRange> FunctionRange =
-      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
-  if (!FunctionRange) {
-    log() << "hotswap: error: safe far return: no function owns site 0x"
-          << utohexstr(InstOffset) << "\n";
-    return std::nullopt;
-  }
-
-  for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
-      continue;
-    UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
-    HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
-  }
-
-  constexpr unsigned VccSgprs = 2;
-  if (UsesVcc && *TotalSgprCount < VccSgprs) {
-    log() << "hotswap: error: safe far return: VCC-using kernel " << KernelName
-          << " has invalid SGPR count " << *TotalSgprCount << "\n";
-    return std::nullopt;
-  }
-  unsigned NumberedSgprCount = *TotalSgprCount - (UsesVcc ? VccSgprs : 0);
-  if (NumberedSgprCount > Ctx.Config.MaxSgprs) {
-    log() << "hotswap: error: safe far return: numbered SGPR count for kernel "
-          << KernelName << " exceeds " << Ctx.Config.MaxSgprs << "\n";
-    return std::nullopt;
-  }
-
-  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. Allocate it above the
-  // kernel's declared registers so no live program register is repurposed.
-  // s_add_nc_u64 adjusts the captured PC without reading or writing SCC.
-  unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
-  if (ScratchPair + 1 >= Ctx.Config.MaxSgprs) {
-    log() << "hotswap: error: safe far return: kernel " << KernelName
-          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs << "\n";
-    return std::nullopt;
-  }
-
-  std::optional<uint64_t> ReturnTo =
-      checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
-  if (!ReturnTo)
-    return std::nullopt;
   SmallVector<uint8_t> Bytes =
-      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, ScratchPair);
-  if (Bytes.empty())
-    return std::nullopt;
-
-  unsigned RequiredNumberedSgprs = ScratchPair + 2;
-  unsigned PreservedImplicitSgprs = (UsesVcc || HasCall) ? VccSgprs : 0;
-  unsigned RequiredSgprs = RequiredNumberedSgprs + PreservedImplicitSgprs;
-  if (RequiredSgprs < *TotalSgprCount) {
-    log() << "hotswap: error: safe far return: SGPR accounting underflow for "
-          << KernelName << "\n";
-    return std::nullopt;
-  }
-  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-  Stats.ExtraSgprs =
-      std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
-  const std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
-                           std::to_string(ScratchPair + 1) + "]";
-  log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
-        << Pair << "\n";
-  return Bytes;
+      assembleSingleInst("s_add_pc_i64 " + std::to_string(Offset), LS);
+  return Bytes.size() == LongBranchBytes ? Bytes : SmallVector<uint8_t>{};
 }
 
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses s_add_pc_i64 on the forward edge. Required rewrites return through an
-/// SGPR pair with an SCC-neutral get-PC/add/set-PC sequence; optional rewrites
-/// decline. The 8-byte forward branch overwrites the site in place, so a
-/// smaller site declines rather than clobbering the next instruction.
+/// uses an 8-byte, signed-literal32 s_add_pc_i64 on both edges. The forward
+/// branch overwrites the site in place, so a smaller site declines rather than
+/// clobbering the next instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement,
-                                    bool AllowSafeFarReturn) {
+                                    ArrayRef<uint8_t> Replacement) {
   // This trampoline lands at the appended pool base and after every trampoline
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
@@ -593,34 +433,14 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
 
   if (Far) {
-    // HSV-009: the far pool's backward s_add_pc_i64 branch corrupts wave state
-    // on gfx1250 A0 (forward is fine). Optional transformations decline the
-    // site; required transformations use the SGPR-backed safe return below.
-    if (!AllowSafeFarReturn) {
-      log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
-            << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
-            << "HSV-009); site left unpatched\n";
+    if (InstSize < LongBranchBytes) {
+      log() << "hotswap: far trampoline site 0x" << utohexstr(InstOffset)
+            << " declined: " << InstSize << " B, smaller than "
+            << LongBranchBytes << " B forward branch\n";
       return false;
     }
-    if (InstSize < LongBranchFwdBytes) {
-      log() << "hotswap: error: safe far trampoline site 0x"
-            << utohexstr(InstOffset) << " is " << InstSize
-            << " B, smaller than " << LongBranchFwdBytes
-            << " B forward branch\n";
-      return false;
-    }
-
-    std::optional<uint64_t> BackStart = checkedAddUint64(
-        PoolStart, Replacement.size(), "safe far return start offset");
-    if (!BackStart)
-      return false;
-    std::optional<SmallVector<uint8_t>> Back =
-        buildSafeFarReturn(Ctx, InstOffset, InstSize, *BackStart);
-    if (!Back)
-      return false;
-    T.Bytes.append(Back->begin(), Back->end());
+    T.Bytes.insert(T.Bytes.end(), LongBranchBytes, uint8_t{0});
     T.Long = true;
-    T.PreEncodedBack = true;
     Ctx.OutTrampolines.emplace_back(std::move(T));
     return true;
   }
@@ -638,8 +458,7 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
 /// deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement,
-                                       bool AllowSafeFarReturn) {
+                                       ArrayRef<uint8_t> Replacement) {
   // findNearestSled enforces sled headroom. emitToNopSled still validates
   // exact branch reachability because branch-back distance includes the
   // replacement size, not just the original instruction offset.
@@ -651,8 +470,7 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
           << utohexstr(Sled->WritePos)
           << " is not branch-reachable after assembly; using trampoline.\n";
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement,
-                          AllowSafeFarReturn);
+  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -840,31 +658,20 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
 
-    // Required far patches carry an SCC-neutral s_get_pc_i64/s_add_nc_u64/
-    // s_set_pc_i64 return assembled when the trampoline is queued. Other long
-    // returns are never queued on gfx1250 A0 because backward s_add_pc_i64 is
-    // unsafe.
-    if (!T.PreEncodedBack) {
-      const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
-      const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
-      const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+    const uint32_t BackReserve = T.Long ? LongBranchBytes : MinInstSize;
+    const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
+    const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
 
-      SmallVector<uint8_t> BrBack =
-          T.Long ? encodeLongBranch(LS, BackSlot, ReturnTo)
-                 : LS.encodeSBranch(BackSlot, ReturnTo);
-      if (BrBack.empty() || BrBack.size() > BackReserve) {
-        log() << "hotswap: error: trampoline branch-back encoding failed at "
-                 "0x"
-              << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
-        return false;
-      }
-      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
-                  BrBack.size());
-      for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
-           I += MinInstSize)
-        std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
-                    LS.SNopBytes.data(), MinInstSize);
+    SmallVector<uint8_t> BrBack = T.Long
+                                      ? encodeLongBranch(LS, BackSlot, ReturnTo)
+                                      : LS.encodeSBranch(BackSlot, ReturnTo);
+    if (BrBack.empty() || BrBack.size() > BackReserve) {
+      log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
+            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+      return false;
     }
+    std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
+                BrBack.size());
 
     SmallVector<uint8_t> BrFwd =
         T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -394,6 +394,144 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
   return {};
 }
 
+static std::optional<SmallVector<uint8_t>>
+buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                   uint64_t BackStart) {
+  std::string KernelName =
+      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
+  if (KernelName.empty()) {
+    log() << "hotswap: error: safe far return: no kernel owns site 0x"
+          << utohexstr(InstOffset) << "\n";
+    return std::nullopt;
+  }
+
+  std::optional<unsigned> TotalSgprCount =
+      Ctx.Elf.getKernelSgprCount(KernelName);
+  if (!TotalSgprCount) {
+    log() << "hotswap: error: safe far return: invalid SGPR count for kernel "
+          << KernelName << "\n";
+    return std::nullopt;
+  }
+
+  // LLVM metadata counts two implicit SGPRs when a kernel uses VCC, but those
+  // are not part of the numbered s0-s105 register space. Inspect the owning
+  // function so scratch allocation starts above numbered SGPRs rather than
+  // above the metadata total. If VCC is only used by a callee, retaining the
+  // total as the allocation base is conservative; the call flag below keeps
+  // two implicit slots in the updated metadata.
+  bool UsesVcc = false;
+  bool HasCall = false;
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange) {
+    log() << "hotswap: error: safe far return: no function owns site 0x"
+          << utohexstr(InstOffset) << "\n";
+    return std::nullopt;
+  }
+
+  auto IsVcc = [&](MCRegister Reg) {
+    return Reg.isValid() &&
+           StringRef(Ctx.LS.MRI->getName(Reg)).starts_with("VCC");
+  };
+  auto InstUsesVcc = [&](const InternalDecodedInst &DI) {
+    for (const MCOperand &Op : DI.Inst)
+      if (Op.isReg() && Op.getReg() && IsVcc(MCRegister(Op.getReg())))
+        return true;
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (IsVcc(MCRegister(Reg)))
+        return true;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (IsVcc(MCRegister(Reg)))
+        return true;
+    return false;
+  };
+
+  for (const InternalDecodedInst &DI : Ctx.Decoded) {
+    if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+      continue;
+    UsesVcc |= InstUsesVcc(DI);
+    HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
+  }
+
+  constexpr unsigned VccSgprs = 2;
+  if (UsesVcc && *TotalSgprCount < VccSgprs) {
+    log() << "hotswap: error: safe far return: VCC-using kernel " << KernelName
+          << " has invalid SGPR count " << *TotalSgprCount << "\n";
+    return std::nullopt;
+  }
+  unsigned NumberedSgprCount = *TotalSgprCount - (UsesVcc ? VccSgprs : 0);
+  if (NumberedSgprCount > Ctx.Config.MaxSgprs) {
+    log() << "hotswap: error: safe far return: numbered SGPR count for kernel "
+          << KernelName << " exceeds " << Ctx.Config.MaxSgprs << "\n";
+    return std::nullopt;
+  }
+
+  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. A third scalar saves
+  // SCC across the add/addc sequence. All three come from above the kernel's
+  // declared allocation, so no live program register is repurposed.
+  unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
+  unsigned SccScratch = ScratchPair + 2;
+  if (ScratchPair >= Ctx.Config.MaxSgprs || SccScratch >= Ctx.Config.MaxSgprs) {
+    log() << "hotswap: error: safe far return: kernel " << KernelName
+          << " has no aligned SGPR pair plus SCC scratch below s"
+          << Ctx.Config.MaxSgprs << "\n";
+    return std::nullopt;
+  }
+
+  std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
+                     std::to_string(ScratchPair + 1) + "]";
+  std::string Lo = "s" + std::to_string(ScratchPair);
+  std::string Hi = "s" + std::to_string(ScratchPair + 1);
+  std::string SavedScc = "s" + std::to_string(SccScratch);
+  SmallVector<uint8_t> Bytes;
+  auto Append = [&](const std::string &Asm) {
+    SmallVector<uint8_t> Inst = assembleSingleInst(Asm, Ctx.LS);
+    if (Inst.empty()) {
+      log() << "hotswap: error: safe far return assembly failed: " << Asm
+            << "\n";
+      return false;
+    }
+    Bytes.append(Inst.begin(), Inst.end());
+    return true;
+  };
+
+  if (!Append("s_cselect_b32 " + SavedScc + ", 1, 0") ||
+      !Append("s_get_pc_i64 " + Pair))
+    return std::nullopt;
+
+  // s_get_pc_i64 returns the address of the following instruction.
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      BackStart, static_cast<uint64_t>(Bytes.size()), "safe far return PC");
+  if (!PcBase)
+    return std::nullopt;
+  uint64_t ReturnTo = InstOffset + InstSize;
+  uint64_t Delta = ReturnTo - *PcBase;
+  uint32_t DeltaLo = static_cast<uint32_t>(Delta);
+  uint32_t DeltaHi = static_cast<uint32_t>(Delta >> 32);
+
+  if (!Append("s_add_u32 " + Lo + ", " + Lo + ", 0x" + utohexstr(DeltaLo)) ||
+      !Append("s_addc_u32 " + Hi + ", " + Hi + ", 0x" + utohexstr(DeltaHi)) ||
+      !Append("s_cmp_lg_u32 " + SavedScc + ", 0") ||
+      !Append("s_set_pc_i64 " + Pair))
+    return std::nullopt;
+
+  unsigned RequiredNumberedSgprs = SccScratch + 1;
+  unsigned PreservedImplicitSgprs = (UsesVcc || HasCall) ? VccSgprs : 0;
+  unsigned RequiredSgprs = RequiredNumberedSgprs + PreservedImplicitSgprs;
+  if (RequiredSgprs < *TotalSgprCount) {
+    log() << "hotswap: error: safe far return: SGPR accounting underflow for "
+          << KernelName << "\n";
+    return std::nullopt;
+  }
+  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+  Stats.ExtraSgprs =
+      std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
+  log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
+        << Pair << ", SCC via " << SavedScc << "\n";
+  return Bytes;
+}
+
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
@@ -402,7 +540,8 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 /// declines rather than clobbering the next instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement) {
+                                    ArrayRef<uint8_t> Replacement,
+                                    bool AllowSafeFarReturn) {
   // This trampoline lands at the appended pool base and after every trampoline
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
@@ -433,14 +572,24 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 
   if (Far) {
     // HSV-009: the far pool's backward s_add_pc_i64 branch corrupts wave state
-    // on gfx1250 A0 (forward is fine). Decline the site (keep the original
-    // instruction) instead of emitting the crashing redirect; in-place and
-    // near-sled patches are unaffected. TODO: patch via an s_getpc/s_setpc
-    // backward branch once SGPR-liveness can supply the scratch registers.
-    log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
-          << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
-          << "HSV-009); site left unpatched\n";
-    return false;
+    // on gfx1250 A0 (forward is fine). Optional transformations decline the
+    // site; required transformations use the SGPR-backed safe return below.
+    if (!AllowSafeFarReturn) {
+      log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
+            << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
+            << "HSV-009); site left unpatched\n";
+      return false;
+    }
+
+    std::optional<SmallVector<uint8_t>> Back = buildSafeFarReturn(
+        Ctx, InstOffset, InstSize, PoolStart + Replacement.size());
+    if (!Back)
+      return false;
+    T.Bytes.append(Back->begin(), Back->end());
+    T.Long = true;
+    T.PreEncodedBack = true;
+    Ctx.OutTrampolines.emplace_back(std::move(T));
+    return true;
   }
   {
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
@@ -456,7 +605,8 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 /// deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement) {
+                                       ArrayRef<uint8_t> Replacement,
+                                       bool AllowSafeFarReturn) {
   // findNearestSled enforces sled headroom. emitToNopSled still validates
   // exact branch reachability because branch-back distance includes the
   // replacement size, not just the original instruction offset.
@@ -468,7 +618,8 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
           << utohexstr(Sled->WritePos)
           << " is not branch-reachable after assembly; using trampoline.\n";
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement,
+                          AllowSafeFarReturn);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -610,7 +761,9 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
         return std::nullopt;
       }
       unsigned RequiredSgprs = *SgprsBefore + Stats.ExtraSgprs;
-      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs)) {
+      bool UpdateDescriptor = !StringRef(Config.TargetCpu).starts_with("gfx1");
+      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs,
+                                               UpdateDescriptor)) {
         log() << "hotswap: error: failed to update SGPR count for kernel "
               << KName << "\n";
         return std::nullopt;
@@ -656,28 +809,30 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
 
-    // Long trampolines reserve a wider branch-back slot and use s_add_pc_i64
-    // on both edges; short ones use s_branch. Both slots are s_nop-padded to
-    // their reserved size after the branch is written. (Long/far sites are
-    // currently declined in emitToTrampoline on gfx1250 A0 -- HSV-009.)
-    const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
-    const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
-    const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+    // Required far patches carry an SCC-preserving s_get_pc_i64/s_set_pc_i64
+    // return assembled when the trampoline is queued. Other long returns are
+    // never queued on gfx1250 A0 because backward s_add_pc_i64 is unsafe.
+    if (!T.PreEncodedBack) {
+      const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
+      const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
+      const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
 
-    SmallVector<uint8_t> BrBack = T.Long
-                                      ? encodeLongBranch(LS, BackSlot, ReturnTo)
-                                      : LS.encodeSBranch(BackSlot, ReturnTo);
-    if (BrBack.empty() || BrBack.size() > BackReserve) {
-      log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
-            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
-      return false;
+      SmallVector<uint8_t> BrBack =
+          T.Long ? encodeLongBranch(LS, BackSlot, ReturnTo)
+                 : LS.encodeSBranch(BackSlot, ReturnTo);
+      if (BrBack.empty() || BrBack.size() > BackReserve) {
+        log() << "hotswap: error: trampoline branch-back encoding failed at "
+                 "0x"
+              << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+        return false;
+      }
+      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
+                  BrBack.size());
+      for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
+           I += MinInstSize)
+        std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
+                    LS.SNopBytes.data(), MinInstSize);
     }
-    std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
-                BrBack.size());
-    for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
-         I += MinInstSize)
-      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
-                  LS.SNopBytes.data(), MinInstSize);
 
     SmallVector<uint8_t> BrFwd =
         T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -467,23 +467,19 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
     return std::nullopt;
   }
 
-  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. A third scalar saves
-  // SCC across the add/addc sequence. All three come from above the kernel's
-  // declared allocation, so no live program register is repurposed.
+  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. Allocate it above the
+  // kernel's declared registers so no live program register is repurposed.
+  // s_add_nc_u64 adjusts the captured PC without reading or writing SCC.
   unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
-  unsigned SccScratch = ScratchPair + 2;
-  if (ScratchPair >= Ctx.Config.MaxSgprs || SccScratch >= Ctx.Config.MaxSgprs) {
+  if (ScratchPair + 1 >= Ctx.Config.MaxSgprs) {
     log() << "hotswap: error: safe far return: kernel " << KernelName
-          << " has no aligned SGPR pair plus SCC scratch below s"
-          << Ctx.Config.MaxSgprs << "\n";
+          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs
+          << "\n";
     return std::nullopt;
   }
 
   std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
                      std::to_string(ScratchPair + 1) + "]";
-  std::string Lo = "s" + std::to_string(ScratchPair);
-  std::string Hi = "s" + std::to_string(ScratchPair + 1);
-  std::string SavedScc = "s" + std::to_string(SccScratch);
   SmallVector<uint8_t> Bytes;
   auto Append = [&](const std::string &Asm) {
     SmallVector<uint8_t> Inst = assembleSingleInst(Asm, Ctx.LS);
@@ -496,8 +492,7 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
     return true;
   };
 
-  if (!Append("s_cselect_b32 " + SavedScc + ", 1, 0") ||
-      !Append("s_get_pc_i64 " + Pair))
+  if (!Append("s_get_pc_i64 " + Pair))
     return std::nullopt;
 
   // s_get_pc_i64 returns the address of the following instruction.
@@ -507,16 +502,13 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
     return std::nullopt;
   uint64_t ReturnTo = InstOffset + InstSize;
   uint64_t Delta = ReturnTo - *PcBase;
-  uint32_t DeltaLo = static_cast<uint32_t>(Delta);
-  uint32_t DeltaHi = static_cast<uint32_t>(Delta >> 32);
 
-  if (!Append("s_add_u32 " + Lo + ", " + Lo + ", 0x" + utohexstr(DeltaLo)) ||
-      !Append("s_addc_u32 " + Hi + ", " + Hi + ", 0x" + utohexstr(DeltaHi)) ||
-      !Append("s_cmp_lg_u32 " + SavedScc + ", 0") ||
+  if (!Append("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
+              utohexstr(Delta)) ||
       !Append("s_set_pc_i64 " + Pair))
     return std::nullopt;
 
-  unsigned RequiredNumberedSgprs = SccScratch + 1;
+  unsigned RequiredNumberedSgprs = ScratchPair + 2;
   unsigned PreservedImplicitSgprs = (UsesVcc || HasCall) ? VccSgprs : 0;
   unsigned RequiredSgprs = RequiredNumberedSgprs + PreservedImplicitSgprs;
   if (RequiredSgprs < *TotalSgprCount) {
@@ -528,16 +520,17 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
   Stats.ExtraSgprs =
       std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
   log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
-        << Pair << ", SCC via " << SavedScc << "\n";
+        << Pair << "\n";
   return Bytes;
 }
 
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses an s_add_pc_i64 long branch (no scratch reg, no SCC) on both edges; its
-/// 8-byte forward branch overwrites the site in place, so a smaller site
-/// declines rather than clobbering the next instruction.
+/// uses s_add_pc_i64 on the forward edge. Required rewrites return through an
+/// SGPR pair with an SCC-neutral get-PC/add/set-PC sequence; optional rewrites
+/// decline. The 8-byte forward branch overwrites the site in place, so a
+/// smaller site declines rather than clobbering the next instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement,
@@ -802,16 +795,16 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
   // rewrite, so there is nothing useful to recover beyond it.
   //
   // Offsets are .text-relative; the pool begins at PoolBaseOffset
-  // (trampolinePoolVAddr() - textAddr()), which is far past .text, so both
-  // edges route through the s_add_pc_i64 long branch.
+  // (trampolinePoolVAddr() - textAddr()), which can be far past .text.
   uint64_t TrampOffset = PoolBaseOffset;
   for (Trampoline &T : Trampolines) {
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
 
-    // Required far patches carry an SCC-preserving s_get_pc_i64/s_set_pc_i64
-    // return assembled when the trampoline is queued. Other long returns are
-    // never queued on gfx1250 A0 because backward s_add_pc_i64 is unsafe.
+    // Required far patches carry an SCC-neutral s_get_pc_i64/s_add_nc_u64/
+    // s_set_pc_i64 return assembled when the trampoline is queued. Other long
+    // returns are never queued on gfx1250 A0 because backward s_add_pc_i64 is
+    // unsafe.
     if (!T.PreEncodedBack) {
       const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
       const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -636,52 +636,64 @@ bool ElfView::updateKernelDescriptorEntryOffset(StringRef KernelName,
 }
 
 bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
-                                              unsigned RequiredSgprs) {
+                                              unsigned RequiredSgprs,
+                                              bool UpdateDescriptor) {
   namespace hsa = amdhsa;
   if (RequiredSgprs == 0)
     return true;
 
-  uint8_t *Kd = findKernelDescriptor(KernelName);
-  if (!Kd) {
-    log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel "
-          << "descriptor symbol '" << KernelName << ".kd' not found.\n";
-    return false;
-  }
-
+  uint8_t *Kd = nullptr;
   uint32_t Rsrc1 = 0;
-  std::memcpy(&Rsrc1,
-              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
-              sizeof(Rsrc1));
-
-  uint32_t CurrentGranulated = AMDHSA_BITS_GET(
-      Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
-  uint64_t CurrentSgprs =
-      (static_cast<uint64_t>(CurrentGranulated) + 1) * SgprEncodingGranule;
-
   std::optional<uint32_t> RequiredGranulated;
-  if (RequiredSgprs > CurrentSgprs) {
-    uint64_t RequiredGranulated64 =
-        (static_cast<uint64_t>(RequiredSgprs) + SgprEncodingGranule - 1) /
-            SgprEncodingGranule -
-        1;
-    uint32_t MaxGranulated = static_cast<uint32_t>(
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT >>
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT_SHIFT);
-    if (RequiredGranulated64 > MaxGranulated) {
-      log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
-            << KernelName << "' needs " << RequiredSgprs
-            << " SGPRs, which exceeds the descriptor encoding limit.\n";
+  if (UpdateDescriptor) {
+    Kd = findKernelDescriptor(KernelName);
+    if (!Kd) {
+      log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel "
+            << "descriptor symbol '" << KernelName << ".kd' not found.\n";
       return false;
     }
-    RequiredGranulated = static_cast<uint32_t>(RequiredGranulated64);
+
+    std::memcpy(&Rsrc1,
+                Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+                sizeof(Rsrc1));
+
+    uint32_t CurrentGranulated = AMDHSA_BITS_GET(
+        Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
+    uint64_t CurrentSgprs =
+        (static_cast<uint64_t>(CurrentGranulated) + 1) * SgprEncodingGranule;
+
+    if (RequiredSgprs > CurrentSgprs) {
+      uint64_t RequiredGranulated64 =
+          (static_cast<uint64_t>(RequiredSgprs) + SgprEncodingGranule - 1) /
+              SgprEncodingGranule -
+          1;
+      uint32_t MaxGranulated = static_cast<uint32_t>(
+          hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT >>
+          hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT_SHIFT);
+      if (RequiredGranulated64 > MaxGranulated) {
+        log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
+              << KernelName << "' needs " << RequiredSgprs
+              << " SGPRs, which exceeds the descriptor encoding limit.\n";
+        return false;
+      }
+      RequiredGranulated = static_cast<uint32_t>(RequiredGranulated64);
+    }
   }
 
   MetadataSgprUpdateStatus MetadataStatus =
       updateKernelMetadataSgprCount(data(), File, KernelName, RequiredSgprs);
   if (MetadataStatus == MetadataSgprUpdateStatus::Error)
     return false;
-  // NotFound is allowed for minimal code objects without AMDGPU metadata; in
-  // that case the descriptor field remains the only SGPR count to update.
+  if (!UpdateDescriptor &&
+      MetadataStatus == MetadataSgprUpdateStatus::NotFound) {
+    log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
+          << KernelName << "' requires " << RequiredSgprs
+          << " SGPRs, but gfx10+ code objects must carry .sgpr_count metadata "
+             "because the descriptor SGPR-count field is reserved.\n";
+    return false;
+  }
+  // On pre-gfx10 targets, NotFound is allowed for minimal code objects without
+  // AMDGPU metadata because the descriptor remains the canonical count.
 
   if (!RequiredGranulated)
     return true;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -622,9 +622,9 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    bool UpdateDescriptor = !TargetCpu.starts_with("gfx1");
     bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
-        Fixup.KernelName, Fixup.RequiredSgprs, UpdateDescriptor);
+        Fixup.KernelName, Fixup.RequiredSgprs,
+        /*UpdateDescriptor=*/false);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -622,8 +622,9 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
+    bool UpdateDescriptor = !TargetCpu.starts_with("gfx1");
     bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
-        Fixup.KernelName, Fixup.RequiredSgprs);
+        Fixup.KernelName, Fixup.RequiredSgprs, UpdateDescriptor);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -288,7 +288,9 @@ public:
   bool updateKernelDescriptorEntryOffset(llvm::StringRef KernelName,
                                          int64_t NewEntryOffset);
 
-  /// Ensure the kernel descriptor reserves at least \p RequiredSgprs SGPRs.
+  /// Ensure kernel metadata reserves at least \p RequiredSgprs SGPRs. When
+  /// \p UpdateDescriptor is true, also update the pre-gfx10 kernel descriptor
+  /// field; it is reserved and must remain unchanged on gfx10+.
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
                                        unsigned RequiredSgprs,
                                        bool UpdateDescriptor = true);
@@ -730,6 +732,16 @@ struct PatchContext {
 llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
                                             uint64_t FromOffset,
                                             uint64_t TargetOffset);
+
+// Encode an SCC-neutral PC-relative long branch through an aligned SGPR pair.
+// s_get_pc_i64 captures the next instruction's PC, s_add_nc_u64 applies the
+// two's-complement delta without reading or writing SCC, and s_set_pc_i64
+// transfers control. Exposed for unit testing the offset math and register
+// constraints. Returns empty on failure.
+llvm::SmallVector<uint8_t> encodeSccNeutralLongBranch(const LLVMState &LS,
+                                                      uint64_t FromOffset,
+                                                      uint64_t TargetOffset,
+                                                      unsigned SgprBase);
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        llvm::ArrayRef<uint8_t> Replacement,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -103,6 +103,9 @@ struct Trampoline {
   // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
   // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
   bool Long = false;
+  // The branch-back is already present at the end of Bytes. Used by required
+  // far patches whose backward edge cannot use s_add_pc_i64 on gfx1250 A0.
+  bool PreEncodedBack = false;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -287,7 +290,8 @@ public:
 
   /// Ensure the kernel descriptor reserves at least \p RequiredSgprs SGPRs.
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
-                                       unsigned RequiredSgprs);
+                                       unsigned RequiredSgprs,
+                                       bool UpdateDescriptor = true);
 
   /// Read COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
   std::optional<uint32_t>
@@ -717,7 +721,8 @@ struct PatchContext {
                                  llvm::ArrayRef<uint8_t> Replacement);
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement);
+                                    llvm::ArrayRef<uint8_t> Replacement,
+                                    bool AllowSafeFarReturn = false);
 
 // Encode an s_add_pc_i64 PC-relative long branch from \p FromOffset to
 // \p TargetOffset (.text byte offsets). Exposed for unit testing the offset
@@ -727,7 +732,8 @@ llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
                                             uint64_t TargetOffset);
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement);
+                                       llvm::ArrayRef<uint8_t> Replacement,
+                                       bool AllowSafeFarReturn = false);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -99,13 +99,10 @@ struct Trampoline {
   uint64_t OriginalOffset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
-  // When set, both edges use an s_add_pc_i64 long branch instead of s_branch
-  // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
-  // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
+  // When set, both edges use a signed-literal32 s_add_pc_i64 long branch
+  // instead of s_branch. Set when the appended pool is beyond s_branch's
+  // +-128 KB reach.
   bool Long = false;
-  // The branch-back is already present at the end of Bytes. Used by required
-  // far patches whose backward edge cannot use s_add_pc_i64 on gfx1250 A0.
-  bool PreEncodedBack = false;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -168,13 +165,11 @@ static constexpr uint64_t MinNopSledSize = 8;
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
 
-// s_add_pc_i64 long-branch encoded sizes: 8 bytes for a forward (32-bit
-// literal) offset, 12 for a backward (64-bit literal) one. The back slot
-// reserves the max; unused tail bytes are s_nop-padded. emitToTrampoline picks
-// the long path only when a short s_branch cannot reach the site's exact pool
-// offset on either edge (computed from the already-queued trampolines).
-static constexpr uint32_t LongBranchFwdBytes = 8;
-static constexpr uint32_t LongBranchMaxBytes = 12;
+// s_add_pc_i64 with a signed, sign-extended literal32 is 8 bytes in either
+// direction. emitToTrampoline picks the long path only when a short s_branch
+// cannot reach the site's exact pool offset on either edge (computed from the
+// already-queued trampolines).
+static constexpr uint32_t LongBranchBytes = 8;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
 // LLVMState::encodeSBranch to reject out-of-range branches before handing
@@ -723,8 +718,7 @@ struct PatchContext {
                                  llvm::ArrayRef<uint8_t> Replacement);
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement,
-                                    bool AllowSafeFarReturn = false);
+                                    llvm::ArrayRef<uint8_t> Replacement);
 
 // Encode an s_add_pc_i64 PC-relative long branch from \p FromOffset to
 // \p TargetOffset (.text byte offsets). Exposed for unit testing the offset
@@ -733,19 +727,9 @@ llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
                                             uint64_t FromOffset,
                                             uint64_t TargetOffset);
 
-// Encode an SCC-neutral PC-relative long branch through an aligned SGPR pair.
-// s_get_pc_i64 captures the next instruction's PC, s_add_nc_u64 applies the
-// two's-complement delta without reading or writing SCC, and s_set_pc_i64
-// transfers control. Exposed for unit testing the offset math and register
-// constraints. Returns empty on failure.
-llvm::SmallVector<uint8_t> encodeSccNeutralLongBranch(const LLVMState &LS,
-                                                      uint64_t FromOffset,
-                                                      uint64_t TargetOffset,
-                                                      unsigned SgprBase);
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement,
-                                       bool AllowSafeFarReturn = false);
+                                       llvm::ArrayRef<uint8_t> Replacement);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -697,10 +697,9 @@ void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
 // -- patchTensorLoadToLdsA0 -------------------------------------------------
 //
 // Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
-// descriptor's base SGPR. If the SGPR is live after the tensor_load, bracket
-// the sequence with s_mov_b32 through a scratch SGPR to save/restore it. (An
-// earlier version used a VGPR lane, but occupancy-1 kernels have no free VGPR
-// so the patch declined; a scratch SGPR is always available.)
+// descriptor's base SGPR. The A0 routing bits must remain clear for every
+// subsequent use of the descriptor, so normalize it persistently instead of
+// restoring the invalid B0 value after each tensor load.
 
 bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -716,8 +715,6 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   if (isAlreadyTensorMaskPatched(Ctx, Idx, BaseMCReg))
     return false;
 
-  SmallVector<unsigned, 8> DescriptorSgprs =
-      getDescriptorSgprIndices(DI.Inst, MRI);
   std::string BaseSreg = toAsmRegName(MRI, BaseMCReg);
 
   std::string PackAsm = "s_pack_hh_b32_b16 " + BaseSreg + ", 0, " + BaseSreg;
@@ -728,55 +725,18 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     return failRequiredPatch(Ctx);
   }
 
-  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
-
   const uint8_t *OrigInst = Ctx.Text + DI.Offset;
+  SmallVector<uint8_t> Replacement;
+  Replacement.append(PackBytes.begin(), PackBytes.end());
+  Replacement.append(OrigInst, OrigInst + DI.Size);
 
-  if (SgprLive) {
-    std::optional<SgprScratchAlloc> ScratchSgpr =
-        tryAllocScratchSgpr(Ctx, Idx, DescriptorSgprs);
-    if (!ScratchSgpr) {
-      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
-               "available\n";
-      return failRequiredPatch(Ctx);
-    }
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                           /*AllowSafeFarReturn=*/true))
+    return failRequiredPatch(Ctx);
 
-    std::string S = "s" + std::to_string(ScratchSgpr->Sgpr);
-    std::string SaveAsm = "s_mov_b32 " + S + ", " + BaseSreg;
-    std::string RestoreAsm = "s_mov_b32 " + BaseSreg + ", " + S;
-    SmallVector<uint8_t> Save = assembleSingleInst(SaveAsm, Ctx.LS);
-    SmallVector<uint8_t> Restore = assembleSingleInst(RestoreAsm, Ctx.LS);
-    if (Save.empty() || Restore.empty()) {
-      log() << "hotswap: tensor_load_to_lds: save/restore assembly failed\n";
-      return failRequiredPatch(Ctx);
-    }
-
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(Save.begin(), Save.end());
-    Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-    Replacement.append(Restore.begin(), Restore.end());
-
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-      return failRequiredPatch(Ctx);
-
-    // SGPRs above .sgpr_count need no KD bump on GFX10+; commit only after
-    // the patch is emitted, to keep per-kernel stats accurate.
-    commitScratchSgpr(Ctx, *ScratchSgpr);
-
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " live, save/restore via " << S << "\n";
-  } else {
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-      return failRequiredPatch(Ctx);
-
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " dead, no save/restore needed\n";
-  }
+  log() << "hotswap: tensor_load_to_lds: persistently cleared multicast bits "
+           "in "
+        << BaseSreg << "\n";
 
   Ctx.RequiredPatchApplied = true;
   DI.Mnemonic = "<replaced>";

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -730,8 +730,7 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   Replacement.append(PackBytes.begin(), PackBytes.end());
   Replacement.append(OrigInst, OrigInst + DI.Size);
 
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                           /*AllowSafeFarReturn=*/true))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return failRequiredPatch(Ctx);
 
   log() << "hotswap: tensor_load_to_lds: persistently cleared multicast bits "

--- a/amd/comgr/test-lit/hotswap-cvt-f32-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-f32-fp8.s
@@ -145,3 +145,40 @@ test_cvt_f32_fp8_noclamp:
   .amdhsa_next_free_vgpr 12
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_f32_fp8_byte0
+      .symbol: test_cvt_f32_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 2
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte2
+      .symbol: test_cvt_f32_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_noclamp
+      .symbol: test_cvt_f32_fp8_noclamp.kd
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
@@ -299,3 +299,90 @@ test_cvt_f32_fp8_byte3:
   .amdhsa_next_free_vgpr 8
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_sr_fp8_byte0
+      .symbol: test_cvt_sr_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte1
+      .symbol: test_cvt_sr_fp8_byte1.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte2
+      .symbol: test_cvt_sr_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte3
+      .symbol: test_cvt_sr_fp8_byte3.kd
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte0
+      .symbol: test_cvt_f32_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 2
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte1
+      .symbol: test_cvt_f32_fp8_byte1.kd
+      .sgpr_count: 2
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte2
+      .symbol: test_cvt_f32_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte3
+      .symbol: test_cvt_f32_fp8_byte3.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
@@ -230,3 +230,60 @@ test_cvt_sr_fp8_abs_src0:
   .amdhsa_next_free_vgpr 16
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_neg_src0
+      .symbol: test_cvt_pk_fp8_neg_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_abs_src1
+      .symbol: test_cvt_pk_fp8_abs_src1.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_negabs_both
+      .symbol: test_cvt_pk_fp8_negabs_both.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_neg_src0
+      .symbol: test_cvt_sr_fp8_neg_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_abs_src0
+      .symbol: test_cvt_sr_fp8_abs_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 16
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-multi.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-multi.s
@@ -129,3 +129,40 @@ test_multi_fp8_overlap:
   .amdhsa_next_free_vgpr 2
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_multi_fp8_same
+      .symbol: test_multi_fp8_same.kd
+      .sgpr_count: 2
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_multi_fp8_mixed
+      .symbol: test_multi_fp8_mixed.kd
+      .sgpr_count: 2
+      .vgpr_count: 10
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_multi_fp8_overlap
+      .symbol: test_multi_fp8_overlap.kd
+      .sgpr_count: 2
+      .vgpr_count: 2
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-nosled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-nosled.s
@@ -146,3 +146,40 @@ test_nosled_unpack:
   .amdhsa_next_free_vgpr 11
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_nosled_pk
+      .symbol: test_nosled_pk.kd
+      .sgpr_count: 2
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_nosled_sr
+      .symbol: test_nosled_sr.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_nosled_unpack
+      .symbol: test_nosled_unpack.kd
+      .sgpr_count: 2
+      .vgpr_count: 11
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
@@ -44,3 +44,20 @@ test_cvt_pk_fp8_zero_in_function:
   .amdhsa_next_free_vgpr 5
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_zero_in_function
+      .symbol: test_cvt_pk_fp8_zero_in_function.kd
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -74,3 +74,30 @@ test_cvt_pk_fp8_zero_fill_after:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_zero_fill_source
+      .symbol: test_cvt_pk_fp8_zero_fill_source.kd
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_zero_fill_after
+      .symbol: test_cvt_pk_fp8_zero_fill_after.kd
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -19,7 +19,7 @@
 // RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: hotswap: liveness: kernel test_cvt_pk_fp8_literal:
-// API-SAME: sgprs_before=8, sgprs_after=16
+// API-SAME: sgprs_before=2, sgprs_after=6
 // API: REWRITE: SUCCESS
 // API: IDEMPOTENT: YES
 
@@ -322,3 +322,80 @@ test_cvt_pk_fp8_inline_constants:
   .amdhsa_next_free_vgpr 25
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_low
+      .symbol: test_cvt_pk_fp8_low.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_high
+      .symbol: test_cvt_pk_fp8_high.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_noclamp
+      .symbol: test_cvt_pk_fp8_noclamp.kd
+      .sgpr_count: 2
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_literal
+      .symbol: test_cvt_pk_fp8_literal.kd
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_literal_src0
+      .symbol: test_cvt_pk_fp8_literal_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 18
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_literal_src1
+      .symbol: test_cvt_pk_fp8_literal_src1.kd
+      .sgpr_count: 2
+      .vgpr_count: 22
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_inline_constants
+      .symbol: test_cvt_pk_fp8_inline_constants.kd
+      .sgpr_count: 2
+      .vgpr_count: 25
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -159,3 +159,40 @@ test_cvt_sr_fp8_noclamp:
   .amdhsa_next_free_vgpr 13
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_sr_fp8_byte0
+      .symbol: test_cvt_sr_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte2
+      .symbol: test_cvt_sr_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_noclamp
+      .symbol: test_cvt_sr_fp8_noclamp.kd
+      .sgpr_count: 2
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-saddr.s
+++ b/amd/comgr/test-lit/hotswap-inplace-saddr.s
@@ -62,3 +62,20 @@ test_saddr_kernel:
   .amdhsa_next_free_vgpr 6
   .amdhsa_next_free_sgpr 4
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_saddr_kernel
+      .symbol: test_saddr_kernel.kd
+      .sgpr_count: 4
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -1,0 +1,100 @@
+// COM: A far patch can live in an ordinary device function shared by multiple
+// COM: kernels. The sign-extended literal32 s_add_pc_i64 return uses no SGPR,
+// COM: so it requires neither a device-function descriptor nor caller metadata
+// COM: changes.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <device_tensor>:
+// DISASM-NEXT: s_add_pc_i64
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_add_pc_i64 0xffff{{[0-9a-f]+}}
+
+// META: .name:           kernel_a
+// META: .sgpr_count:     48
+// META: .name:           kernel_b
+// META: .sgpr_count:     48
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.local device_tensor
+.type device_tensor,@function
+device_tensor:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_set_pc_i64 s[30:31]
+.Ldevice_tensor_end:
+.size device_tensor, .Ldevice_tensor_end-device_tensor
+
+.globl kernel_a
+.type kernel_a,@function
+kernel_a:
+  s_call_i64 s[30:31], device_tensor
+  s_endpgm
+.Lkernel_a_end:
+.size kernel_a, .Lkernel_a_end-kernel_a
+
+.globl kernel_b
+.type kernel_b,@function
+kernel_b:
+  s_call_i64 s[30:31], device_tensor
+  s_endpgm
+.Lkernel_b_end:
+.size kernel_b, .Lkernel_b_end-kernel_b
+
+// Push the appended trampoline pool beyond s_branch reach without extending
+// any function symbol range.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel kernel_a
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdhsa_kernel kernel_b
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: kernel_a
+      .symbol: kernel_a.kd
+      .sgpr_count: 48
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: kernel_b
+      .symbol: kernel_b.kd
+      .sgpr_count: 48
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -3,16 +3,14 @@
 // COM: device functions (e.g. runTreeUpDown) contain ds_*_2addr sites that sit
 // COM: far (> s_branch's +-128 KB reach) from the appended trampoline pool in
 // COM: the ~225 MB fatbin. Taking the far path emitted an s_add_pc_i64 long
-// COM: branch whose BACKWARD branch-back corrupts wave state on gfx1250 A0,
-// COM: producing a GPU memory fault in ncclDevKernel_Generic_4 (0/10 runs).
+// COM: branch whose 64-bit-literal BACKWARD branch-back corrupts wave state on
+// COM: gfx1250 A0, producing a GPU memory fault in ncclDevKernel_Generic_4
+// COM: (0/10 runs).
 // COM:
-// COM: Fix: decline far ds_*_2addr sites (leave the original instruction) until
-// COM: a scratch-register long branch-back lands. The two kernels below force
-// COM: the far path for a 2-addr LOAD and STORE and assert the decline: the
-// COM: original ds_*_2addr stays, and neither an s_add_pc_i64 redirect nor the
-// COM: single-address split (ds_load_b64 / ds_store_b32) is emitted. The near
-// COM: (sled / short-s_branch) ds_*_2addr path is still exercised and split by
-// COM: hotswap-trampoline-ds.s; only the far path changes here.
+// COM: Fix: encode negative displacements with MI400's sign-extended
+// COM: literal32 form. The two kernels below force the far path for a 2-addr
+// COM: LOAD and STORE and verify the transformations now complete without a
+// COM: scratch register.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -24,20 +22,24 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Case 1 (2-addr LOAD, RCCL's pattern): declined -- original op stays, no
-// COM: forward long branch, no single-address split.
+// COM: Case 1 (2-addr LOAD, RCCL's pattern): long forward edge.
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: ds_load_2addr_stride64_b64
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: ds_load_b64
+// DISASM-NEXT: s_add_pc_i64
 
-// COM: Case 2 (2-addr STORE): declined the same way.
+// COM: Case 2 (2-addr STORE): same shape.
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: ds_store_2addr_stride64_b32
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: ds_store_b32
+// DISASM-NEXT: s_add_pc_i64
 
-// COM: Idempotency: rewriting the declined output again is a no-op.
+// COM: Appended trampoline bodies retain scan order and return with an
+// COM: 8-byte negative literal32 s_add_pc_i64.
+// DISASM: ds_load_b64
+// DISASM-NEXT: ds_load_b64
+// DISASM-NEXT: s_add_pc_i64 0xffff{{[0-9a-f]+}}
+// DISASM: ds_store_b32
+// DISASM-NEXT: ds_store_b32
+// DISASM-NEXT: s_add_pc_i64 0xffff{{[0-9a-f]+}}
+
+// COM: Idempotency: rewriting the patched output again is a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
@@ -65,7 +67,7 @@ test_ds2addr_far_store:
   s_endpgm
   // ~160 KB of non-NOP filler (forms no usable sled) so the appended trampoline
   // pool is beyond s_branch's +-128 KB reach from both kernels above, forcing
-  // the far (long-branch) path -- which is declined on gfx1250 A0.
+  // the far (long-branch) path.
   .rept 40000
     s_mov_b32 s0, s1
   .endr

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,9 +1,9 @@
-// COM: HSV-009 / PLAT-205406: on gfx1250 A0 a backward s_add_pc_i64 corrupts
-// COM: wave state. Required far tensor patches use a forward s_add_pc_i64 and
-// COM: an SCC-neutral s_get_pc_i64/s_add_nc_u64/s_set_pc_i64 return instead.
-// COM:
-// COM: Optional far trampoline rewrites are still allowed to decline;
-// COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
+// COM: HSV-009 / PLAT-205406: LLVM used to encode a modest negative
+// COM: s_add_pc_i64 displacement with a 64-bit literal, while the equivalent
+// COM: positive displacement used a 32-bit literal. The 64-bit-literal return
+// COM: corrupts wave state on gfx1250 A0. MI400 defines the literal32 form as
+// COM: sign-extended, so both trampoline edges can use the safe 8-byte form
+// COM: without scratch SGPRs.
 // COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
 // COM: pushes the pool past s_branch's reach to force the far case.
 
@@ -24,13 +24,10 @@
 // DISASM-NOT: s_add_pc_i64
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_nc_u64 s[12:13]
-// DISASM-NEXT: s_set_pc_i64 s[12:13]
-// DISASM-NOT: s_add_pc_i64
+// DISASM-NEXT: s_add_pc_i64 0xffff{{[0-9a-f]+}}
 
 // METADATA: .name:           test_far
-// METADATA: .sgpr_count:     16
+// METADATA: .sgpr_count:     14
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -38,34 +35,32 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: The far return still needs an aligned SGPR pair. Exhausting all 106
-// COM: numbered SGPRs must fail instead of clobbering a program register.
+// COM: A kernel using all 106 numbered SGPRs still patches: control flow needs
+// COM: no register and metadata remains unchanged.
 // RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
 // RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.no-pair.s
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.no-pair.s -o %t.no-pair.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.no-pair.elf \
+// RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
+// RUN: hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefix=NO-PAIR %s
-// NO-PAIR: hotswap: error: safe far return: kernel test_far has no aligned SGPR pair below s106
-// NO-PAIR: RESULT: ERROR
+// RUN:   --output %t.full-sgpr.out.elf | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.full-sgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=FULL-SGPR %s
+// FULL-SGPR-LABEL: <test_far>:
+// FULL-SGPR: s_add_pc_i64
+// FULL-SGPR: tensor_load_to_lds
+// FULL-SGPR-NEXT: s_add_pc_i64 0xffff{{[0-9a-f]+}}
 
-// COM: gfx10+ cannot represent an increased SGPR count in the kernel
-// COM: descriptor because that field is reserved. A metadata-less object must
-// COM: therefore fail rather than emit an under-declared far-return scratch
-// COM: allocation or write the reserved descriptor field.
+// COM: A metadata-less object also patches because no resource count changes.
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.nometa.s -o %t.nometa.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefix=NO-METADATA %s
-// NO-METADATA: hotswap: error: updateKernelDescriptorSgprCount: kernel 'test_far' requires
-// NO-METADATA: descriptor SGPR-count field is reserved
-// NO-METADATA: RESULT: ERROR
+// RUN:   --output %t.nometa.out.elf | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.nometa.out.elf \
+// RUN:   | %FileCheck --check-prefix=FULL-SGPR %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -21,14 +21,22 @@
 // DISASM-LABEL: <test_far>:
 // DISASM-NEXT: s_mov_b64 vcc, -1
 // DISASM-NEXT: s_add_pc_i64
+// DISASM-NOT: s_add_pc_i64
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
 // DISASM-NEXT: s_get_pc_i64 s[12:13]
 // DISASM-NEXT: s_add_nc_u64 s[12:13]
 // DISASM-NEXT: s_set_pc_i64 s[12:13]
+// DISASM-NOT: s_add_pc_i64
 
 // METADATA: .name:           test_far
 // METADATA: .sgpr_count:     16
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
 
 // COM: The far return still needs an aligned SGPR pair. Exhausting all 106
 // COM: numbered SGPRs must fail instead of clobbering a program register.

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,6 +1,6 @@
 // COM: HSV-009 / PLAT-205406: on gfx1250 A0 a backward s_add_pc_i64 corrupts
 // COM: wave state. Required far tensor patches use a forward s_add_pc_i64 and
-// COM: an SCC-preserving s_get_pc_i64/s_set_pc_i64 return instead.
+// COM: an SCC-neutral s_get_pc_i64/s_add_nc_u64/s_set_pc_i64 return instead.
 // COM:
 // COM: Optional far trampoline rewrites are still allowed to decline;
 // COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
@@ -23,15 +23,26 @@
 // DISASM-NEXT: s_add_pc_i64
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_cselect_b32 s14, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_co_u32 s12
-// DISASM-NEXT: s_add_co_ci_u32 s13
-// DISASM-NEXT: s_cmp_lg_u32 s14, 0
+// DISASM-NEXT: s_add_nc_u64 s[12:13]
 // DISASM-NEXT: s_set_pc_i64 s[12:13]
 
 // METADATA: .name:           test_far
-// METADATA: .sgpr_count:     17
+// METADATA: .sgpr_count:     16
+
+// COM: The far return still needs an aligned SGPR pair. Exhausting all 106
+// COM: numbered SGPRs must fail instead of clobbering a program register.
+// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
+// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.no-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.no-pair.s -o %t.no-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.no-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NO-PAIR %s
+// NO-PAIR: hotswap: error: safe far return: kernel test_far has no aligned SGPR pair below s106
+// NO-PAIR: RESULT: ERROR
 
 // COM: gfx10+ cannot represent an increased SGPR count in the kernel
 // COM: descriptor because that field is reserved. A metadata-less object must

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,13 +1,9 @@
-// COM: HSV-009 / PLAT-205406: on gfx1250 A0 the far trampoline's backward
-// COM: s_add_pc_i64 branch-back corrupts wave state (a GPU memory fault at
-// COM: runtime). Until a scratch-register-based long branch-back lands, a patch
-// COM: site beyond s_branch's +-128 KB reach of the appended pool is DECLINED
-// COM: instead of redirected through the long branch.
+// COM: HSV-009 / PLAT-205406: on gfx1250 A0 a backward s_add_pc_i64 corrupts
+// COM: wave state. Required far tensor patches use a forward s_add_pc_i64 and
+// COM: an SCC-preserving s_get_pc_i64/s_set_pc_i64 return instead.
 // COM:
-// COM: The A0 tensor_load_to_lds mask workaround is required for correctness, so
-// COM: hotswap must report ERROR if the trampoline patch cannot be emitted.
-// COM: Optional far trampoline rewrites are still allowed to decline and return
-// COM: success; hotswap-trampoline-ds-long-branch.s covers that behavior.
+// COM: Optional far trampoline rewrites are still allowed to decline;
+// COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
 // COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
 // COM: pushes the pool past s_branch's reach to force the far case.
 
@@ -15,9 +11,42 @@
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR \
+// RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: ERROR
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
+
+// DISASM-LABEL: <test_far>:
+// DISASM-NEXT: s_mov_b64 vcc, -1
+// DISASM-NEXT: s_add_pc_i64
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_cselect_b32 s14, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[12:13]
+// DISASM-NEXT: s_add_co_u32 s12
+// DISASM-NEXT: s_add_co_ci_u32 s13
+// DISASM-NEXT: s_cmp_lg_u32 s14, 0
+// DISASM-NEXT: s_set_pc_i64 s[12:13]
+
+// METADATA: .name:           test_far
+// METADATA: .sgpr_count:     17
+
+// COM: gfx10+ cannot represent an increased SGPR count in the kernel
+// COM: descriptor because that field is reserved. A metadata-less object must
+// COM: therefore fail rather than emit an under-declared far-return scratch
+// COM: allocation or write the reserved descriptor field.
+// RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.nometa.s -o %t.nometa.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NO-METADATA %s
+// NO-METADATA: hotswap: error: updateKernelDescriptorSgprCount: kernel 'test_far' requires
+// NO-METADATA: descriptor SGPR-count field is reserved
+// NO-METADATA: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -25,6 +54,7 @@
 .p2align 8
 .type test_far,@function
 test_far:
+  s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
@@ -42,3 +72,20 @@ test_far:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_far
+      .symbol: test_far.kd
+      .sgpr_count: 14
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -1,8 +1,6 @@
-// COM: Test isSgprLiveAfter edge cases for tensor_load_to_lds patching.
-// COM: A branch instruction between the tensor_load and the next use of
-// COM: the descriptor SGPR forces the heuristic to conservatively assume
-// COM: the SGPR is live, producing save/restore even though the use may
-// COM: not execute on all paths.
+// COM: Test persistent tensor_load_to_lds descriptor normalization across a
+// COM: control-flow edge. The descriptor remains masked on either successor,
+// COM: so the rewrite needs no liveness-dependent save/restore sequence.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -14,17 +12,14 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load
-// COM: and s_mov (which reads s4). isSgprLiveAfter returns true at the
-// COM: branch, so save/restore is emitted conservatively.
+// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load and
+// COM: s_mov (which reads s4). The later read sees the normalized descriptor.
 // DISASM-LABEL: <test_tensor_branch_guard>:
 // DISASM: s_branch
 // DISASM: s_cbranch_scc1
 // DISASM: s_endpgm
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
@@ -1,15 +1,26 @@
-// COM: Live tensor_load_to_lds descriptor SGPRs require save/restore around
-// COM: the A0 D# Group 1 mask clear. If the kernel already consumes all
-// COM: user-addressable SGPRs, hotswap must fail instead of returning
-// COM: unsafe code.
+// COM: A0 descriptor multicast bits stay clear after normalization. Even a
+// COM: kernel declaring all user-addressable SGPRs therefore needs no scratch
+// COM: register and must rewrite successfully without changing SGPR metadata.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR \
+// RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: ERROR
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
+
+// DISASM-LABEL: <test_tensor_no_scratch>:
+// DISASM: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_branch
+
+// METADATA: .name:           test_tensor_no_scratch
+// METADATA: .sgpr_count:     106
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -1,8 +1,7 @@
 // COM: Test the true trampoline fallback path for tensor_load_to_lds
-// COM: when no NOP sled is available. Two variants:
-// COM:   dead SGPR — s_pack_hh + tensor_load appended via growWithTrampolines
-// COM:   live SGPR — save/pack/tensor/restore (4-instruction sequence)
-// COM:              appended via growWithTrampolines, the largest replacement
+// COM: when no NOP sled is available. Both live and dead descriptor variants
+// COM: append the persistent s_pack_hh + tensor_load normalization via
+// COM: growWithTrampolines.
 // COM: Both force emitReplacementCode to use emitToTrampoline.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -44,13 +43,10 @@
 // DISASM-NEXT: tensor_load_to_lds
 // DISASM-NEXT: s_branch
 
-// COM: Live-SGPR trampoline body (for kernel 2): also placed in the
-// COM: appended trampoline region. save + pack + tensor + restore +
-// COM: branch-back.
-// DISASM-NEXT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// COM: Live-SGPR trampoline body (for kernel 2): the same persistent mask and
+// COM: tensor sequence followed by branch-back.
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
@@ -71,7 +67,7 @@ test_tensor_trampoline:
 .Ltest_tensor_trampoline_end:
 .size test_tensor_trampoline, .Ltest_tensor_trampoline_end-test_tensor_trampoline
 
-// ---- Kernel 2: live SGPR, no NOP sled (trampoline + save/restore) ----------
+// ---- Kernel 2: live SGPR, no NOP sled (persistent mask trampoline) --------
 
 .globl test_tensor_trampoline_live
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,11 +1,11 @@
 // COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
 // COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
-// COM: the descriptor's base SGPR. Base operand variants via NOP sled:
-// COM:   dead SGPR - only s_pack_hh prepended (no save/restore)
-// COM:   live SGPR - s_mov save, s_pack_hh, tensor, s_mov restore
+// COM: the descriptor's base SGPR. The multicast bits remain clear after
+// COM: normalization, so live and dead descriptors use the same pack/tensor
+// COM: sequence without save/restore.
 // COM:   alt descriptor - different SGPR range (s[16:23]) for pack target
-// COM:   SGPR redef - descriptor SGPR overwritten before use (dead path)
-// COM:   zero-size FUNC - live path when the function symbol has st_size == 0
+// COM:   SGPR redef - descriptor SGPR overwritten before its next use
+// COM:   zero-size FUNC - kernel lookup when the function has st_size == 0
 // COM:   four-group tensor - operand 1 is still D# Group 1 and patches s4
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
 // COM: s_branch checks.
@@ -13,7 +13,7 @@
 // COM: Companion tests:
 // COM:   hotswap-trampoline-tensor-nosled.s     - trampoline fallback path
 // COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
-// COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
+// COM:   hotswap-trampoline-tensor-liveness.s   - control-flow edge case
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,7 +23,7 @@
 // RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API-NOT: kernel descriptor symbol '.kd' not found
-// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
+// API: hotswap: tensor_load_to_lds: persistently cleared multicast bits in s4
 // API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
@@ -46,17 +46,13 @@
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
 
-// COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
-// COM: tensor/restore sequence in sled area with branch-back.
-// COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
-// COM: save/restore via a scratch SGPR is required.
+// COM: Kernel 2 (live SGPR): s4 is used after tensor_load_to_lds, and observes
+// COM: the persistently normalized descriptor. No scratch SGPR is required.
 // DISASM-LABEL: <test_tensor_live>:
 // DISASM: s_branch
 // DISASM: s_endpgm
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Kernel 3 (alternate descriptor s[16:23]): verifies
@@ -73,8 +69,7 @@
 
 // COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
 // COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
-// COM: isSgprLiveAfter sees a def-before-use and takes the dead path
-// COM: - no save/restore needed.
+// COM: The persistent mask remains safe when the descriptor is redefined.
 // DISASM-LABEL: <test_tensor_sgpr_redef>:
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
@@ -88,7 +83,7 @@
 
 // COM: Kernel 5 (zero-size FUNC): real Tensile objects can omit `.size`,
 // COM: leaving the FUNC symbol with st_size == 0. Kernel lookup must still
-// COM: find the descriptor so scratch allocation succeeds. This kernel has no
+// COM: find its descriptor. This kernel has no
 // COM: bounded local sled, so the replacement body is emitted in the appended
 // COM: trampoline pool and checked after Kernel 6.
 // DISASM-LABEL: <test_tensor_zero_size>:
@@ -105,10 +100,8 @@
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
 // DISASM-NEXT: s_branch
 
-// DISASM: s_mov_b32 [[ZERO_SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_mov_b32 s4, [[ZERO_SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -1,10 +1,8 @@
 // COM: HSV-009 / PLAT-205406: WMMA-split shares emitToTrampoline with the other
-// COM: patch families, so a split site beyond s_branch's +-128 KB reach of the
-// COM: appended pool takes the far path -- which on gfx1250 A0 is DECLINED
-// COM: (left unpatched) because the backward s_add_pc_i64 branch-back corrupts
-// COM: wave state at runtime. The original v_wmma_f32_16x16x128_fp8_fp8 stays at
-// COM: the site; it is neither split into two K=64 halves nor redirected. A
-// COM: large .rept filler (~160 KB, non-NOP) forces the far case.
+// COM: patch families. A split site beyond s_branch's +-128 KB reach uses the
+// COM: same sign-extended literal32 return as DS and tensor patches, avoiding
+// COM: the 64-bit-literal form that corrupts wave state on gfx1250 A0. A large
+// COM: .rept filler (~160 KB, non-NOP) forces the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -16,13 +14,13 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Declined: the site keeps its original K=128 WMMA (it is NOT overwritten
-// COM: with an s_add_pc_i64 forward branch), and no split halves
-// COM: (v_wmma_f32_16x16x64_fp8_fp8) or long-branch redirect are emitted.
+// COM: The site redirects to two K=64 halves and returns with the 8-byte
+// COM: negative literal32 form.
 // DISASM-LABEL: <test_wsplit_far>:
-// DISASM-NEXT: v_wmma_f32_16x16x128_fp8_fp8
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_add_pc_i64
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_add_pc_i64 0xffff{{[0-9a-f]+}}
 
 // COM: Idempotency: rewriting the output again must be a no-op.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -640,6 +640,44 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
 }
 
+TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  const unsigned DescriptorSgprsBefore =
+      readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset);
+
+  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/false));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 10u);
+  EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset),
+            DescriptorSgprsBefore);
+}
+
+TEST(ElfView, UpdateKernelDescriptorSgprCountMetadataOnlyRequiresMetadata) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  const unsigned DescriptorSgprsBefore =
+      readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset);
+
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/false));
+  EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset),
+            DescriptorSgprsBefore);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMissingMetadataCount) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -184,19 +184,14 @@ TEST(EncodeSBranch, FailsOnInvalidState) {
 
 // -- encodeLongBranch (s_add_pc_i64) -----------------------------------------
 //
-// The long branch reaches anywhere via s_add_pc_i64, which adds a signed
-// literal to the PC of the next instruction: landing PC == From + size + imm.
-// A positive (forward) offset fits a 32-bit literal (8 bytes); a negative
-// (backward) offset needs a 64-bit literal (12 bytes). These verify the offset
-// math and encoding structurally rather than pinning exact bytes.
+// The long branch uses s_add_pc_i64, which adds a sign-extended literal32 to
+// the PC of the next instruction: landing PC == From + 8 + imm. Both forward
+// and backward forms are 8 bytes. These verify the offset math and encoding
+// structurally rather than pinning exact bytes.
 
 // Read the signed literal that follows the 4-byte opcode dword.
 static int64_t longBranchLiteral(llvm::ArrayRef<uint8_t> Out) {
-  if (Out.size() == LongBranchFwdBytes)
-    return static_cast<int32_t>(readDword(Out.data() + MinInstSize));
-  int64_t V = 0;
-  std::memcpy(&V, Out.data() + MinInstSize, sizeof(V));
-  return V;
+  return static_cast<int32_t>(readDword(Out.data() + MinInstSize));
 }
 
 TEST(EncodeLongBranch, ForwardLandsOnTarget) {
@@ -205,7 +200,7 @@ TEST(EncodeLongBranch, ForwardLandsOnTarget) {
   // ~512 KB forward -- well beyond s_branch's +-128 KB reach.
   const uint64_t From = 0x1000, To = 0x81000;
   llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_EQ(Out.size(), LongBranchFwdBytes);
+  ASSERT_EQ(Out.size(), LongBranchBytes);
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
 
   std::vector<InternalDecodedInst> Dec;
@@ -214,13 +209,13 @@ TEST(EncodeLongBranch, ForwardLandsOnTarget) {
   EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
 }
 
-TEST(EncodeLongBranch, BackwardUsesWideLiteralAndLandsOnTarget) {
+TEST(EncodeLongBranch, BackwardUsesSignedLiteral32AndLandsOnTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   // Backward jump (trampoline tail -> earlier return point).
   const uint64_t From = 0x81000, To = 0x1004;
   llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_EQ(Out.size(), LongBranchMaxBytes);
+  ASSERT_EQ(Out.size(), LongBranchBytes);
   EXPECT_EQ(static_cast<int64_t>(From) + static_cast<int64_t>(Out.size()) +
                 longBranchLiteral(Out),
             static_cast<int64_t>(To));
@@ -229,6 +224,8 @@ TEST(EncodeLongBranch, BackwardUsesWideLiteralAndLandsOnTarget) {
   ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
   ASSERT_EQ(Dec.size(), 1u);
   EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
+  EXPECT_EQ(Dec[0].Size, LongBranchBytes);
+  EXPECT_EQ(Dec[0].Inst.getOperand(0).getImm(), longBranchLiteral(Out));
 }
 
 TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
@@ -242,73 +239,13 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
 }
 
-// -- encodeSccNeutralLongBranch ----------------------------------------------
-
-static uint64_t
-decodeSccNeutralLongBranchTarget(uint64_t From,
-                                 llvm::ArrayRef<InternalDecodedInst> Decoded) {
-  const uint64_t PcBase = From + Decoded[0].Size;
-  const uint64_t Delta =
-      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
-  return PcBase + Delta;
-}
-
-TEST(EncodeSccNeutralLongBranch, BackwardLandsOnTargetWithoutDefiningScc) {
+TEST(EncodeLongBranch, RejectsOutOfSignedLiteral32RangeAndPcOverflow) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  constexpr uint64_t From = 0x81000;
-  constexpr uint64_t To = 0x1008;
-  llvm::SmallVector<uint8_t> Out =
-      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
-  ASSERT_FALSE(Out.empty());
-
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_EQ(Decoded[0].Mnemonic, "s_get_pc_i64");
-  EXPECT_EQ(Decoded[1].Mnemonic, "s_add_nc_u64");
-  EXPECT_EQ(Decoded[2].Mnemonic, "s_set_pc_i64");
-  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
-
-  const llvm::MCRegister Pair = Decoded[0].Inst.getOperand(0).getReg();
-  EXPECT_EQ(Decoded[1].Inst.getOperand(0).getReg(), Pair);
-  EXPECT_EQ(Decoded[1].Inst.getOperand(1).getReg(), Pair);
-  EXPECT_EQ(Decoded[2].Inst.getOperand(0).getReg(), Pair);
-  for (const InternalDecodedInst &DI : Decoded) {
-    const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
-    for (llvm::MCPhysReg Reg : Desc.implicit_defs())
-      EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
-  }
-}
-
-TEST(EncodeSccNeutralLongBranch, ForwardLandsOnTarget) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  constexpr uint64_t From = 0x1000;
-  constexpr uint64_t To = 0x81000;
-  llvm::SmallVector<uint8_t> Out =
-      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
-  ASSERT_FALSE(Out.empty());
-
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
-}
-
-TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  EXPECT_TRUE(encodeSccNeutralLongBranch(S, 0x1000, 0x2000,
-                                         /*SgprBase=*/13)
-                  .empty());
+  EXPECT_TRUE(encodeLongBranch(S, 0, (uint64_t{1} << 31) + 8).empty());
   EXPECT_TRUE(
-      encodeSccNeutralLongBranch(S, std::numeric_limits<uint64_t>::max() - 1, 0,
-                                 /*SgprBase=*/12)
-          .empty());
+      encodeLongBranch(S, std::numeric_limits<uint64_t>::max() - 1, 0).empty());
 }
 
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -242,6 +242,75 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
 }
 
+// -- encodeSccNeutralLongBranch ----------------------------------------------
+
+static uint64_t
+decodeSccNeutralLongBranchTarget(uint64_t From,
+                                 llvm::ArrayRef<InternalDecodedInst> Decoded) {
+  const uint64_t PcBase = From + Decoded[0].Size;
+  const uint64_t Delta =
+      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
+  return PcBase + Delta;
+}
+
+TEST(EncodeSccNeutralLongBranch, BackwardLandsOnTargetWithoutDefiningScc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x81000;
+  constexpr uint64_t To = 0x1008;
+  llvm::SmallVector<uint8_t> Out =
+      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_FALSE(Out.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Decoded[1].Mnemonic, "s_add_nc_u64");
+  EXPECT_EQ(Decoded[2].Mnemonic, "s_set_pc_i64");
+  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+
+  const llvm::MCRegister Pair = Decoded[0].Inst.getOperand(0).getReg();
+  EXPECT_EQ(Decoded[1].Inst.getOperand(0).getReg(), Pair);
+  EXPECT_EQ(Decoded[1].Inst.getOperand(1).getReg(), Pair);
+  EXPECT_EQ(Decoded[2].Inst.getOperand(0).getReg(), Pair);
+  for (const InternalDecodedInst &DI : Decoded) {
+    const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
+    for (llvm::MCPhysReg Reg : Desc.implicit_defs())
+      EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
+  }
+}
+
+TEST(EncodeSccNeutralLongBranch, ForwardLandsOnTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x1000;
+  constexpr uint64_t To = 0x81000;
+  llvm::SmallVector<uint8_t> Out =
+      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_FALSE(Out.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+}
+
+TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  EXPECT_TRUE(encodeSccNeutralLongBranch(S, 0x1000, 0x2000,
+                                         /*SgprBase=*/13)
+                  .empty());
+  EXPECT_TRUE(
+      encodeSccNeutralLongBranch(S, std::numeric_limits<uint64_t>::max() - 1, 0,
+                                 /*SgprBase=*/12)
+          .empty());
+}
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
                                 {100, 128, 100, 100, 128}};
@@ -708,6 +777,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX125_TCP_SPLIT, 5);
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.ComputePgmRsrc3 = Rsrc3;
+  Opts.MetadataSgprCount = 8;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(Text, Opts);
   llvm::Expected<ElfView> ViewOrErr =
@@ -716,6 +786,10 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
 
   uint8_t *Kd = ViewOrErr->findKernelDescriptor("kernel");
   ASSERT_NE(Kd, nullptr);
+  uint32_t Rsrc1Before = 0;
+  std::memcpy(&Rsrc1Before,
+              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              sizeof(Rsrc1Before));
 
   std::vector<Trampoline> Growth;
   std::vector<KernelEntryTrampolineFixup> Fixups;
@@ -780,12 +854,8 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   std::memcpy(&OutRsrc1,
               OutKd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               sizeof(OutRsrc1));
-  unsigned ReservedSgprs =
-      (AMDHSA_BITS_GET(OutRsrc1,
-                       hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT) +
-       1) *
-      8;
-  EXPECT_GE(ReservedSgprs, Fixups[0].RequiredSgprs);
+  EXPECT_EQ(OutRsrc1, Rsrc1Before);
+  EXPECT_EQ(OutView->getKernelSgprCount("kernel"), Fixups[0].RequiredSgprs);
 
   std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
@@ -866,7 +936,10 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
   ASSERT_EQ(Text.size(), MinInstSize);
 
-  comgr_test::KernelDescriptorElf Obj = comgr_test::makeKernelDescriptorElf(Text);
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
 
   // -- First pass: append one stub, grow .text, rewrite the descriptor, and
   //    attach the stub symbol. --
@@ -883,12 +956,14 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
       *View1, S, /*MaxSgprs=*/106, Growth1, Fixups1);
   ASSERT_TRUE(Count1.has_value());
   ASSERT_EQ(*Count1, 1u);
+  std::optional<uint64_t> PoolVAddr = View1->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddr.has_value());
 
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
       View1->growWithTrampolines(Growth1, S.SNopBytes);
   ASSERT_NE(Grown, nullptr);
   ASSERT_TRUE(
-      rewriteKernelEntryDescriptorOffsets(*Grown, OldTextSize, S.Cpu, Fixups1));
+      rewriteKernelEntryDescriptorOffsets(*Grown, *PoolVAddr, S.Cpu, Fixups1));
   std::unique_ptr<llvm::WritableMemoryBuffer> Pass1 =
       addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
                                       Fixups1);

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -567,6 +567,11 @@ void AMDGPUDisassembler::decodeImmOperands(MCInst &MI,
 
     if (Imm == AMDGPU::EncValues::LITERAL_CONST) {
       Op = decodeLiteralConstant(Desc, OpDesc);
+      // S_ADD_PC_I64 is the one i64 SALU operation whose literal32 is
+      // explicitly sign-extended by the hardware. Preserve that semantic in
+      // the decoded MC operand so disassembly and reassembly round-trip.
+      if (MI.getOpcode() == AMDGPU::S_ADD_PC_I64_gfx12 && Op.isImm())
+        Op.setImm(SignExtend64<32>(Op.getImm()));
       continue;
     }
 

--- a/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
+++ b/llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCCodeEmitter.cpp
@@ -314,8 +314,17 @@ std::optional<uint64_t> AMDGPUMCCodeEmitter::getLitEncoding(
 
   case AMDGPU::OPERAND_REG_IMM_INT64:
   case AMDGPU::OPERAND_REG_INLINE_C_INT64:
-  case AMDGPU::OPERAND_REG_IMM_V2INT64:
-    return getLit64Encoding(Desc, static_cast<uint64_t>(Imm), STI, false);
+  case AMDGPU::OPERAND_REG_IMM_V2INT64: {
+    uint64_t Encoding =
+        getLit64Encoding(Desc, static_cast<uint64_t>(Imm), STI, false);
+    // S_ADD_PC_I64 sign-extends a literal32. Prefer that shorter encoding for
+    // signed 32-bit displacements, including backward branches. Other i64
+    // operands do not have uniform literal32 extension semantics.
+    if (Desc.getOpcode() == AMDGPU::S_ADD_PC_I64_gfx12 && isInt<32>(Imm) &&
+        Encoding == AMDGPU::EncValues::LITERAL64_CONST)
+      return AMDGPU::EncValues::LITERAL_CONST;
+    return Encoding;
+  }
 
   case AMDGPU::OPERAND_REG_INLINE_C_FP64:
   case AMDGPU::OPERAND_REG_INLINE_AC_FP64:

--- a/llvm/test/MC/AMDGPU/gfx1250_asm_sop1.s
+++ b/llvm/test/MC/AMDGPU/gfx1250_asm_sop1.s
@@ -15,6 +15,10 @@ s_add_pc_i64 100
 // GFX12-ERR: :[[@LINE-1]]:1: error: instruction not supported on this GPU (gfx1200): s_add_pc_i64
 // GFX1250: s_add_pc_i64 0x64                       ; encoding: [0xff,0x4b,0x80,0xbe,0x64,0x00,0x00,0x00]
 
+s_add_pc_i64 -160000
+// GFX12-ERR: :[[@LINE-1]]:1: error: instruction not supported on this GPU (gfx1200): s_add_pc_i64
+// GFX1250: s_add_pc_i64 0xfffffffffffd8f00         ; encoding: [0xff,0x4b,0x80,0xbe,0x00,0x8f,0xfd,0xff]
+
 s_add_pc_i64 0x12345678abcd0
 // GFX12-ERR: :[[@LINE-1]]:1: error: instruction not supported on this GPU (gfx1200): s_add_pc_i64
 // GFX1250: s_add_pc_i64 0x12345678abcd0            ; encoding: [0xfe,0x4b,0x80,0xbe,0xd0,0xbc,0x8a,0x67,0x45,0x23,0x01,0x00]


### PR DESCRIPTION
## Summary

Fix gfx1250 A0 far HotSwap trampolines without scratch registers, instruction
stealing, or kernel-only assumptions.

The apparent forward/backward difference was an encoding-width difference:
LLVM encoded a positive `s_add_pc_i64` displacement with an 8-byte
sign-extended literal32, but widened a modest negative displacement to a
12-byte literal64. MI400 defines the instruction's source as signed I64 and
explicitly sign-extends its literal32 form.

This PR keeps the persistent tensor-descriptor normalization from #3323, but
encodes both trampoline edges with the architecturally defined 8-byte form.

## Changes

- Teach the AMDGPU MC encoder to select literal32 for signed 32-bit
  `S_ADD_PC_I64` displacements on gfx1250.
- Sign-extend that literal in the disassembler so assembly/disassembly
  round-trips preserve its meaning and width.
- Make COMGR's far branch encoder fixed-width (8 bytes) in both directions and
  reject targets outside signed literal32 range.
- Remove the far-return SGPR pair, VCC/call accounting, metadata growth, and
  kernel-ownership requirement.
- Enable the same safe far path for tensor, DS, WMMA, and ordinary device
  functions.
- Keep the existing 8-byte-site requirement; a smaller site still declines
  rather than overwriting the following instruction.
- Keep persistent tensor multicast-bit normalization, eliminating its old
  save/restore scratch requirement.

The resulting branch is PC-relative, EXEC-independent, SCC-neutral, and uses no
program register. It also does not relocate neighboring instructions.

## Relation to the other fixes

- #3305 safely declines far sites, but leaves required tensor corrections
  unresolved in large objects.
- #3323 uses an SGPR-backed get-PC/add/set-PC return for required tensor sites;
  that is kernel-specific and optional far DS/WMMA sites still decline.
- #3324 replaces PC additions with a larger set-PC sequence and experimental
  instruction stealing on the forward edge.
- This PR needs neither SGPR liveness nor instruction stealing because it fixes
  the literal selection at the source.

## Validation

- Rebuilt AMDGPU MC assembly/disassembly checks pass and show the exact
  negative literal32 encoding (`0xff` selector, 8 bytes).
- COMGR MC unit coverage checks forward/backward target math, fixed 8-byte
  width, signed-range rejection, and decoded negative semantics.
- ASan + leak detection: `HotswapMCTests` -- 53/53 passed against the rebuilt
  MC layer.
- LIT coverage checks required tensor patches, full-SGPR kernels,
  metadata-less kernels, optional far DS/WMMA patches, an ordinary device
  function shared by two kernels, metadata stability, and idempotency.
- All four modified/new far-path assembly fixtures assemble successfully.
- `git diff --check` passes.

## Remaining validation

Keep this PR in draft until the literal32 backward form is rerun on the exact
gfx1250 A0 production-object/RCCL matrix used for PLAT-205406.
