### PR TITLE
[Driver][AMDGPU] Add ROCm include paths for OpenMP offload

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.cpp
+++ b/clang/lib/Driver/ToolChains/AMDGPU.cpp
@@ -992,7 +992,34 @@ void AMDGPUToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs,
   // In an offloading compilation the device toolchain must pick up the host's
   // system include paths, even when compiling device code.
   if (HostTC) {
+    // OpenMP offload code targeting AMDGPU frequently includes ROCm/HIP headers
+    // (e.g. <hip/hip_runtime.h>) directly. Add the ROCm include directories so
+    // those headers are found without requiring an explicit -I. The install is
+    // laid out as <root>/lib/llvm/bin/clang, so the HIP headers live in
+    // <root>/include (three levels up from the driver dir) and the toolchain's
+    // own headers in <root>/lib/llvm/include (one level up). For HIP these come
+    // from AddHIPIncludeArgs, so only do this for OpenMP.
+    const bool IsOpenMP =
+        DriverArgs.hasFlag(options::OPT_fopenmp, options::OPT_fopenmp_EQ,
+                           options::OPT_fno_openmp, false);
+    const Driver &D = HostTC->getDriver();
+    if (IsOpenMP) {
+      CC1Args.push_back("-internal-isystem");
+      CC1Args.push_back(DriverArgs.MakeArgString(D.Dir + "/../include"));
+      CC1Args.push_back("-internal-isystem");
+      CC1Args.push_back(DriverArgs.MakeArgString(D.Dir + "/../../../include"));
+    }
+
     HostTC->AddClangSystemIncludeArgs(DriverArgs, CC1Args);
+
+    // The HIP headers pull in the cuda_wrappers headers, which must precede the
+    // standard C++ headers added above.
+    if (IsOpenMP && !DriverArgs.hasArg(options::OPT_nobuiltininc)) {
+      SmallString<128> P(D.ResourceDir);
+      llvm::sys::path::append(P, "include", "cuda_wrappers");
+      CC1Args.push_back("-internal-isystem");
+      CC1Args.push_back(DriverArgs.MakeArgString(P));
+    }
     return;
   }
 

--- a/clang/test/Driver/amdgpu-openmp-system-include.c
+++ b/clang/test/Driver/amdgpu-openmp-system-include.c
@@ -1,0 +1,11 @@
+// OpenMP offload to AMDGPU must add the ROCm include directories (where the HIP
+// headers live) to both the host and device cc1 jobs.
+
+// RUN: %clang -### --target=x86_64-unknown-linux-gnu -fopenmp \
+// RUN:   -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa \
+// RUN:   -march=gfx906 -nogpulib %s 2>&1 | FileCheck %s
+
+// CHECK: "-cc1" "-triple" "x86_64-unknown-linux-gnu"
+// CHECK-SAME: "-internal-isystem" "{{.*}}/../../../include"
+// CHECK: "-cc1" "-triple" "amdgcn-amd-amdhsa"
+// CHECK-SAME: "-internal-isystem" "{{.*}}/../../../include"


### PR DESCRIPTION
Merging the AMDGPU toolchains (#204863) dropped the ROCm include dirs for OpenMP offload, so device code including HIP headers (e.g. <hip/hip_runtime.h>) failed to compile. Re-add them for OpenMP in the unified toolchain; HIP still gets them via AddHIPIncludeArgs.

Claude assisted with this patch.


