### PR TITLE
[comgr][hotswap] harden gfx1250 A0 trampoline foundations

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -394,15 +394,182 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
   return {};
 }
 
+std::optional<SmallVector<uint8_t>>
+encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                           uint64_t TargetOffset, unsigned SgprBase) {
+  if ((SgprBase & 1u) != 0 ||
+      SgprBase == std::numeric_limits<unsigned>::max()) {
+    log() << "hotswap: error: SCC-neutral long branch requires an aligned "
+             "SGPR pair, got s"
+          << SgprBase << "\n";
+    return std::nullopt;
+  }
+
+  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
+                           std::to_string(SgprBase + 1) + "]";
+  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
+  if (GetPc.empty()) {
+    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
+             "s_get_pc_i64 for "
+          << Pair << "\n";
+    return std::nullopt;
+  }
+
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      FromOffset, GetPc.size(), "SCC-neutral long branch PC base");
+  if (!PcBase)
+    return std::nullopt;
+
+  // Unsigned subtraction intentionally materializes the two's-complement
+  // delta for backward branches.
+  const uint64_t Delta = TargetOffset - *PcBase;
+  SmallVector<uint8_t> Add = assembleSingleInst(
+      "s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" + utohexstr(Delta), LS);
+  if (Add.empty()) {
+    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
+             "s_add_nc_u64 for "
+          << Pair << "\n";
+    return std::nullopt;
+  }
+  SmallVector<uint8_t> SetPc = assembleSingleInst("s_set_pc_i64 " + Pair, LS);
+  if (SetPc.empty()) {
+    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
+             "s_set_pc_i64 for "
+          << Pair << "\n";
+    return std::nullopt;
+  }
+
+  SmallVector<uint8_t> Bytes;
+  Bytes.append(GetPc.begin(), GetPc.end());
+  Bytes.append(Add.begin(), Add.end());
+  Bytes.append(SetPc.begin(), SetPc.end());
+  return Bytes;
+}
+
+static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
+  return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
+}
+
+static bool instructionUsesVcc(const LLVMState &LS,
+                               const InternalDecodedInst &DI) {
+  for (const MCOperand &Op : DI.Inst)
+    if (Op.isReg() && Op.getReg() && isVccRegister(LS, MCRegister(Op.getReg())))
+      return true;
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  for (MCPhysReg Reg : Desc.implicit_uses())
+    if (isVccRegister(LS, MCRegister(Reg)))
+      return true;
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    if (isVccRegister(LS, MCRegister(Reg)))
+      return true;
+  return false;
+}
+
+static std::optional<SmallVector<uint8_t>>
+buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                   uint64_t BackStart) {
+  std::string KernelName =
+      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
+  if (KernelName.empty()) {
+    log() << "hotswap: error: safe far return: no kernel owns site 0x"
+          << utohexstr(InstOffset) << "\n";
+    return std::nullopt;
+  }
+
+  std::optional<unsigned> TotalSgprCount =
+      Ctx.Elf.getKernelSgprCount(KernelName);
+  if (!TotalSgprCount) {
+    log() << "hotswap: error: safe far return: invalid SGPR count for kernel "
+          << KernelName << "\n";
+    return std::nullopt;
+  }
+
+  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs adds two
+  // implicit SGPRs when VCC is used. They are not part of the numbered s0-s105
+  // register space. Inspect the owning function so scratch allocation starts
+  // above numbered SGPRs rather than above the metadata total. If VCC is only
+  // used by a callee, retaining the total as the allocation base is
+  // conservative; the call flag below keeps two implicit slots in the updated
+  // metadata.
+  bool UsesVcc = false;
+  bool HasCall = false;
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange) {
+    log() << "hotswap: error: safe far return: no function owns site 0x"
+          << utohexstr(InstOffset) << "\n";
+    return std::nullopt;
+  }
+
+  for (const InternalDecodedInst &DI : Ctx.Decoded) {
+    if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+      continue;
+    UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
+    HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
+  }
+
+  constexpr unsigned VccSgprs = 2;
+  if (UsesVcc && *TotalSgprCount < VccSgprs) {
+    log() << "hotswap: error: safe far return: VCC-using kernel " << KernelName
+          << " has invalid SGPR count " << *TotalSgprCount << "\n";
+    return std::nullopt;
+  }
+  unsigned NumberedSgprCount = *TotalSgprCount - (UsesVcc ? VccSgprs : 0);
+  if (NumberedSgprCount > Ctx.Config.MaxSgprs) {
+    log() << "hotswap: error: safe far return: numbered SGPR count for kernel "
+          << KernelName << " exceeds " << Ctx.Config.MaxSgprs << "\n";
+    return std::nullopt;
+  }
+
+  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. Allocate it above the
+  // kernel's declared registers so no live program register is repurposed.
+  // s_add_nc_u64 adjusts the captured PC without reading or writing SCC.
+  unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
+  if (ScratchPair + 1 >= Ctx.Config.MaxSgprs) {
+    log() << "hotswap: error: safe far return: kernel " << KernelName
+          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs << "\n";
+    return std::nullopt;
+  }
+
+  std::optional<uint64_t> ReturnTo =
+      checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
+  if (!ReturnTo)
+    return std::nullopt;
+  std::optional<SmallVector<uint8_t>> Bytes =
+      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, ScratchPair);
+  if (!Bytes)
+    return std::nullopt;
+
+  unsigned RequiredNumberedSgprs = ScratchPair + 2;
+  unsigned PreservedImplicitSgprs = (UsesVcc || HasCall) ? VccSgprs : 0;
+  unsigned RequiredSgprs = RequiredNumberedSgprs + PreservedImplicitSgprs;
+  if (RequiredSgprs < *TotalSgprCount) {
+    log() << "hotswap: error: safe far return: SGPR accounting underflow for "
+          << KernelName << "\n";
+    return std::nullopt;
+  }
+  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+  Stats.ExtraSgprs =
+      std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
+  const std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
+                           std::to_string(ScratchPair + 1) + "]";
+  log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
+        << Pair << "\n";
+  return std::move(*Bytes);
+}
+
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses an s_add_pc_i64 long branch (no scratch reg, no SCC) on both edges; its
-/// 8-byte forward branch overwrites the site in place, so a smaller site
-/// declines rather than clobbering the next instruction.
+/// uses s_add_pc_i64 on the forward edge. Required rewrites return through an
+/// SGPR pair with an SCC-neutral get-PC/add/set-PC sequence; optional rewrites
+/// decline. The 8-byte forward branch overwrites the site in place, so a
+/// smaller site declines rather than clobbering the next instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement) {
+                                    ArrayRef<uint8_t> Replacement,
+                                    bool AllowSafeFarReturn) {
   // This trampoline lands at the appended pool base and after every trampoline
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
@@ -433,14 +600,35 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 
   if (Far) {
     // HSV-009: the far pool's backward s_add_pc_i64 branch corrupts wave state
-    // on gfx1250 A0 (forward is fine). Decline the site (keep the original
-    // instruction) instead of emitting the crashing redirect; in-place and
-    // near-sled patches are unaffected. TODO: patch via an s_getpc/s_setpc
-    // backward branch once SGPR-liveness can supply the scratch registers.
-    log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
-          << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
-          << "HSV-009); site left unpatched\n";
-    return false;
+    // on gfx1250 A0 (forward is fine). Optional transformations decline the
+    // site; required transformations use the SGPR-backed safe return below.
+    if (!AllowSafeFarReturn) {
+      log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
+            << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
+            << "HSV-009); site left unpatched\n";
+      return false;
+    }
+    if (InstSize < LongBranchFwdBytes) {
+      log() << "hotswap: error: safe far trampoline site 0x"
+            << utohexstr(InstOffset) << " is " << InstSize
+            << " B, smaller than " << LongBranchFwdBytes
+            << " B forward branch\n";
+      return false;
+    }
+
+    std::optional<uint64_t> BackStart = checkedAddUint64(
+        PoolStart, Replacement.size(), "safe far return start offset");
+    if (!BackStart)
+      return false;
+    std::optional<SmallVector<uint8_t>> Back =
+        buildSafeFarReturn(Ctx, InstOffset, InstSize, *BackStart);
+    if (!Back)
+      return false;
+    T.Bytes.append(Back->begin(), Back->end());
+    T.Long = true;
+    T.PreEncodedBack = true;
+    Ctx.OutTrampolines.emplace_back(std::move(T));
+    return true;
   }
   {
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
@@ -456,7 +644,8 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
 /// deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement) {
+                                       ArrayRef<uint8_t> Replacement,
+                                       bool AllowSafeFarReturn) {
   // findNearestSled enforces sled headroom. emitToNopSled still validates
   // exact branch reachability because branch-back distance includes the
   // replacement size, not just the original instruction offset.
@@ -468,7 +657,8 @@ SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
           << utohexstr(Sled->WritePos)
           << " is not branch-reachable after assembly; using trampoline.\n";
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement,
+                          AllowSafeFarReturn);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -610,7 +800,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
         return std::nullopt;
       }
       unsigned RequiredSgprs = *SgprsBefore + Stats.ExtraSgprs;
-      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs)) {
+      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs,
+                                               /*UpdateDescriptor=*/false)) {
         log() << "hotswap: error: failed to update SGPR count for kernel "
               << KName << "\n";
         return std::nullopt;
@@ -649,35 +840,37 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
   // rewrite, so there is nothing useful to recover beyond it.
   //
   // Offsets are .text-relative; the pool begins at PoolBaseOffset
-  // (trampolinePoolVAddr() - textAddr()), which is far past .text, so both
-  // edges route through the s_add_pc_i64 long branch.
+  // (trampolinePoolVAddr() - textAddr()), which can be far past .text.
   uint64_t TrampOffset = PoolBaseOffset;
   for (Trampoline &T : Trampolines) {
     uint64_t TP = TrampOffset;
     TrampOffset += T.Bytes.size();
 
-    // Long trampolines reserve a wider branch-back slot and use s_add_pc_i64
-    // on both edges; short ones use s_branch. Both slots are s_nop-padded to
-    // their reserved size after the branch is written. (Long/far sites are
-    // currently declined in emitToTrampoline on gfx1250 A0 -- HSV-009.)
-    const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
-    const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
-    const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+    // Required far patches carry an SCC-neutral s_get_pc_i64/s_add_nc_u64/
+    // s_set_pc_i64 return assembled when the trampoline is queued. Other long
+    // returns are never queued on gfx1250 A0 because backward s_add_pc_i64 is
+    // unsafe.
+    if (!T.PreEncodedBack) {
+      const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
+      const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
+      const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
 
-    SmallVector<uint8_t> BrBack = T.Long
-                                      ? encodeLongBranch(LS, BackSlot, ReturnTo)
-                                      : LS.encodeSBranch(BackSlot, ReturnTo);
-    if (BrBack.empty() || BrBack.size() > BackReserve) {
-      log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
-            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
-      return false;
+      SmallVector<uint8_t> BrBack =
+          T.Long ? encodeLongBranch(LS, BackSlot, ReturnTo)
+                 : LS.encodeSBranch(BackSlot, ReturnTo);
+      if (BrBack.empty() || BrBack.size() > BackReserve) {
+        log() << "hotswap: error: trampoline branch-back encoding failed at "
+                 "0x"
+              << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+        return false;
+      }
+      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
+                  BrBack.size());
+      for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
+           I += MinInstSize)
+        std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
+                    LS.SNopBytes.data(), MinInstSize);
     }
-    std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
-                BrBack.size());
-    for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
-         I += MinInstSize)
-      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
-                  LS.SNopBytes.data(), MinInstSize);
 
     SmallVector<uint8_t> BrFwd =
         T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -636,52 +636,64 @@ bool ElfView::updateKernelDescriptorEntryOffset(StringRef KernelName,
 }
 
 bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
-                                              unsigned RequiredSgprs) {
+                                              unsigned RequiredSgprs,
+                                              bool UpdateDescriptor) {
   namespace hsa = amdhsa;
   if (RequiredSgprs == 0)
     return true;
 
-  uint8_t *Kd = findKernelDescriptor(KernelName);
-  if (!Kd) {
-    log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel "
-          << "descriptor symbol '" << KernelName << ".kd' not found.\n";
-    return false;
-  }
-
+  uint8_t *Kd = nullptr;
   uint32_t Rsrc1 = 0;
-  std::memcpy(&Rsrc1,
-              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
-              sizeof(Rsrc1));
-
-  uint32_t CurrentGranulated = AMDHSA_BITS_GET(
-      Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
-  uint64_t CurrentSgprs =
-      (static_cast<uint64_t>(CurrentGranulated) + 1) * SgprEncodingGranule;
-
   std::optional<uint32_t> RequiredGranulated;
-  if (RequiredSgprs > CurrentSgprs) {
-    uint64_t RequiredGranulated64 =
-        (static_cast<uint64_t>(RequiredSgprs) + SgprEncodingGranule - 1) /
-            SgprEncodingGranule -
-        1;
-    uint32_t MaxGranulated = static_cast<uint32_t>(
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT >>
-        hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT_SHIFT);
-    if (RequiredGranulated64 > MaxGranulated) {
-      log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
-            << KernelName << "' needs " << RequiredSgprs
-            << " SGPRs, which exceeds the descriptor encoding limit.\n";
+  if (UpdateDescriptor) {
+    Kd = findKernelDescriptor(KernelName);
+    if (!Kd) {
+      log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel "
+            << "descriptor symbol '" << KernelName << ".kd' not found.\n";
       return false;
     }
-    RequiredGranulated = static_cast<uint32_t>(RequiredGranulated64);
+
+    std::memcpy(&Rsrc1,
+                Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+                sizeof(Rsrc1));
+
+    uint32_t CurrentGranulated = AMDHSA_BITS_GET(
+        Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT);
+    uint64_t CurrentSgprs =
+        (static_cast<uint64_t>(CurrentGranulated) + 1) * SgprEncodingGranule;
+
+    if (RequiredSgprs > CurrentSgprs) {
+      uint64_t RequiredGranulated64 =
+          (static_cast<uint64_t>(RequiredSgprs) + SgprEncodingGranule - 1) /
+              SgprEncodingGranule -
+          1;
+      uint32_t MaxGranulated = static_cast<uint32_t>(
+          hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT >>
+          hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT_SHIFT);
+      if (RequiredGranulated64 > MaxGranulated) {
+        log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
+              << KernelName << "' needs " << RequiredSgprs
+              << " SGPRs, which exceeds the descriptor encoding limit.\n";
+        return false;
+      }
+      RequiredGranulated = static_cast<uint32_t>(RequiredGranulated64);
+    }
   }
 
   MetadataSgprUpdateStatus MetadataStatus =
       updateKernelMetadataSgprCount(data(), File, KernelName, RequiredSgprs);
   if (MetadataStatus == MetadataSgprUpdateStatus::Error)
     return false;
-  // NotFound is allowed for minimal code objects without AMDGPU metadata; in
-  // that case the descriptor field remains the only SGPR count to update.
+  if (!UpdateDescriptor &&
+      MetadataStatus == MetadataSgprUpdateStatus::NotFound) {
+    log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
+          << KernelName << "' requires " << RequiredSgprs
+          << " SGPRs, but gfx10+ code objects must carry .sgpr_count metadata "
+             "because the descriptor SGPR-count field is reserved.\n";
+    return false;
+  }
+  // On pre-gfx10 targets, NotFound is allowed for minimal code objects without
+  // AMDGPU metadata because the descriptor remains the canonical count.
 
   if (!RequiredGranulated)
     return true;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -623,7 +623,8 @@ bool rewriteKernelEntryDescriptorOffsets(
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
     bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
-        Fixup.KernelName, Fixup.RequiredSgprs);
+        Fixup.KernelName, Fixup.RequiredSgprs,
+        /*UpdateDescriptor=*/false);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -103,6 +103,9 @@ struct Trampoline {
   // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
   // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
   bool Long = false;
+  // The branch-back is already present at the end of Bytes. Used by required
+  // far patches whose backward edge cannot use s_add_pc_i64 on gfx1250 A0.
+  bool PreEncodedBack = false;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -285,9 +288,12 @@ public:
   bool updateKernelDescriptorEntryOffset(llvm::StringRef KernelName,
                                          int64_t NewEntryOffset);
 
-  /// Ensure the kernel descriptor reserves at least \p RequiredSgprs SGPRs.
+  /// Ensure kernel metadata reserves at least \p RequiredSgprs SGPRs. When
+  /// \p UpdateDescriptor is true, also update the pre-gfx10 kernel descriptor
+  /// field; it is reserved and must remain unchanged on gfx10+.
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
-                                       unsigned RequiredSgprs);
+                                       unsigned RequiredSgprs,
+                                       bool UpdateDescriptor = true);
 
   /// Read COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
   std::optional<uint32_t>
@@ -717,7 +723,8 @@ struct PatchContext {
                                  llvm::ArrayRef<uint8_t> Replacement);
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement);
+                                    llvm::ArrayRef<uint8_t> Replacement,
+                                    bool AllowSafeFarReturn = false);
 
 // Encode an s_add_pc_i64 PC-relative long branch from \p FromOffset to
 // \p TargetOffset (.text byte offsets). Exposed for unit testing the offset
@@ -725,9 +732,19 @@ struct PatchContext {
 llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
                                             uint64_t FromOffset,
                                             uint64_t TargetOffset);
+
+// Encode an SCC-neutral PC-relative long branch through an aligned SGPR pair.
+// s_get_pc_i64 captures the next instruction's PC, s_add_nc_u64 applies the
+// two's-complement delta without reading or writing SCC, and s_set_pc_i64
+// transfers control. Exposed for unit testing the offset math and register
+// constraints. Returns std::nullopt after logging the specific failure.
+std::optional<llvm::SmallVector<uint8_t>>
+encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                           uint64_t TargetOffset, unsigned SgprBase);
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement);
+                                       llvm::ArrayRef<uint8_t> Replacement,
+                                       bool AllowSafeFarReturn = false);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -697,10 +697,9 @@ void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
 // -- patchTensorLoadToLdsA0 -------------------------------------------------
 //
 // Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
-// descriptor's base SGPR. If the SGPR is live after the tensor_load, bracket
-// the sequence with s_mov_b32 through a scratch SGPR to save/restore it. (An
-// earlier version used a VGPR lane, but occupancy-1 kernels have no free VGPR
-// so the patch declined; a scratch SGPR is always available.)
+// descriptor's base SGPR. The A0 routing bits must remain clear for every
+// subsequent use of the descriptor, so normalize it persistently instead of
+// restoring the invalid B0 value after each tensor load.
 
 bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -716,8 +715,6 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   if (isAlreadyTensorMaskPatched(Ctx, Idx, BaseMCReg))
     return false;
 
-  SmallVector<unsigned, 8> DescriptorSgprs =
-      getDescriptorSgprIndices(DI.Inst, MRI);
   std::string BaseSreg = toAsmRegName(MRI, BaseMCReg);
 
   std::string PackAsm = "s_pack_hh_b32_b16 " + BaseSreg + ", 0, " + BaseSreg;
@@ -728,55 +725,18 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     return failRequiredPatch(Ctx);
   }
 
-  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
-
   const uint8_t *OrigInst = Ctx.Text + DI.Offset;
+  SmallVector<uint8_t> Replacement;
+  Replacement.append(PackBytes.begin(), PackBytes.end());
+  Replacement.append(OrigInst, OrigInst + DI.Size);
 
-  if (SgprLive) {
-    std::optional<SgprScratchAlloc> ScratchSgpr =
-        tryAllocScratchSgpr(Ctx, Idx, DescriptorSgprs);
-    if (!ScratchSgpr) {
-      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
-               "available\n";
-      return failRequiredPatch(Ctx);
-    }
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                           /*AllowSafeFarReturn=*/true))
+    return failRequiredPatch(Ctx);
 
-    std::string S = "s" + std::to_string(ScratchSgpr->Sgpr);
-    std::string SaveAsm = "s_mov_b32 " + S + ", " + BaseSreg;
-    std::string RestoreAsm = "s_mov_b32 " + BaseSreg + ", " + S;
-    SmallVector<uint8_t> Save = assembleSingleInst(SaveAsm, Ctx.LS);
-    SmallVector<uint8_t> Restore = assembleSingleInst(RestoreAsm, Ctx.LS);
-    if (Save.empty() || Restore.empty()) {
-      log() << "hotswap: tensor_load_to_lds: save/restore assembly failed\n";
-      return failRequiredPatch(Ctx);
-    }
-
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(Save.begin(), Save.end());
-    Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-    Replacement.append(Restore.begin(), Restore.end());
-
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-      return failRequiredPatch(Ctx);
-
-    // SGPRs above .sgpr_count need no KD bump on GFX10+; commit only after
-    // the patch is emitted, to keep per-kernel stats accurate.
-    commitScratchSgpr(Ctx, *ScratchSgpr);
-
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " live, save/restore via " << S << "\n";
-  } else {
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-      return failRequiredPatch(Ctx);
-
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " dead, no save/restore needed\n";
-  }
+  log() << "hotswap: tensor_load_to_lds: persistently cleared multicast bits "
+           "in "
+        << BaseSreg << "\n";
 
   Ctx.RequiredPatchApplied = true;
   DI.Mnemonic = "<replaced>";

--- a/amd/comgr/test-lit/hotswap-barrier-isfirst.s
+++ b/amd/comgr/test-lit/hotswap-barrier-isfirst.s
@@ -98,3 +98,20 @@ test_barrier_isfirst:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_barrier_isfirst
+      .symbol: test_barrier_isfirst.kd
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-f32-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-f32-fp8.s
@@ -145,3 +145,40 @@ test_cvt_f32_fp8_noclamp:
   .amdhsa_next_free_vgpr 12
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_f32_fp8_byte0
+      .symbol: test_cvt_f32_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 2
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte2
+      .symbol: test_cvt_f32_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_noclamp
+      .symbol: test_cvt_f32_fp8_noclamp.kd
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
@@ -299,3 +299,90 @@ test_cvt_f32_fp8_byte3:
   .amdhsa_next_free_vgpr 8
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_sr_fp8_byte0
+      .symbol: test_cvt_sr_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte1
+      .symbol: test_cvt_sr_fp8_byte1.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte2
+      .symbol: test_cvt_sr_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte3
+      .symbol: test_cvt_sr_fp8_byte3.kd
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte0
+      .symbol: test_cvt_f32_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 2
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte1
+      .symbol: test_cvt_f32_fp8_byte1.kd
+      .sgpr_count: 2
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte2
+      .symbol: test_cvt_f32_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_f32_fp8_byte3
+      .symbol: test_cvt_f32_fp8_byte3.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
@@ -230,3 +230,60 @@ test_cvt_sr_fp8_abs_src0:
   .amdhsa_next_free_vgpr 16
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_neg_src0
+      .symbol: test_cvt_pk_fp8_neg_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_abs_src1
+      .symbol: test_cvt_pk_fp8_abs_src1.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_negabs_both
+      .symbol: test_cvt_pk_fp8_negabs_both.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_neg_src0
+      .symbol: test_cvt_sr_fp8_neg_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_abs_src0
+      .symbol: test_cvt_sr_fp8_abs_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 16
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-multi.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-multi.s
@@ -129,3 +129,40 @@ test_multi_fp8_overlap:
   .amdhsa_next_free_vgpr 2
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_multi_fp8_same
+      .symbol: test_multi_fp8_same.kd
+      .sgpr_count: 2
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_multi_fp8_mixed
+      .symbol: test_multi_fp8_mixed.kd
+      .sgpr_count: 2
+      .vgpr_count: 10
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_multi_fp8_overlap
+      .symbol: test_multi_fp8_overlap.kd
+      .sgpr_count: 2
+      .vgpr_count: 2
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-nosled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-nosled.s
@@ -146,3 +146,40 @@ test_nosled_unpack:
   .amdhsa_next_free_vgpr 11
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_nosled_pk
+      .symbol: test_nosled_pk.kd
+      .sgpr_count: 2
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_nosled_sr
+      .symbol: test_nosled_sr.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_nosled_unpack
+      .symbol: test_nosled_unpack.kd
+      .sgpr_count: 2
+      .vgpr_count: 11
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
@@ -44,3 +44,20 @@ test_cvt_pk_fp8_zero_in_function:
   .amdhsa_next_free_vgpr 5
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_zero_in_function
+      .symbol: test_cvt_pk_fp8_zero_in_function.kd
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -74,3 +74,30 @@ test_cvt_pk_fp8_zero_fill_after:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_zero_fill_source
+      .symbol: test_cvt_pk_fp8_zero_fill_source.kd
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_zero_fill_after
+      .symbol: test_cvt_pk_fp8_zero_fill_after.kd
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -19,7 +19,7 @@
 // RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: hotswap: liveness: kernel test_cvt_pk_fp8_literal:
-// API-SAME: sgprs_before=8, sgprs_after=16
+// API-SAME: sgprs_before=2, sgprs_after=6
 // API: REWRITE: SUCCESS
 // API: IDEMPOTENT: YES
 
@@ -322,3 +322,80 @@ test_cvt_pk_fp8_inline_constants:
   .amdhsa_next_free_vgpr 25
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_pk_fp8_low
+      .symbol: test_cvt_pk_fp8_low.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_high
+      .symbol: test_cvt_pk_fp8_high.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_noclamp
+      .symbol: test_cvt_pk_fp8_noclamp.kd
+      .sgpr_count: 2
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_literal
+      .symbol: test_cvt_pk_fp8_literal.kd
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_literal_src0
+      .symbol: test_cvt_pk_fp8_literal_src0.kd
+      .sgpr_count: 2
+      .vgpr_count: 18
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_literal_src1
+      .symbol: test_cvt_pk_fp8_literal_src1.kd
+      .sgpr_count: 2
+      .vgpr_count: 22
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_pk_fp8_inline_constants
+      .symbol: test_cvt_pk_fp8_inline_constants.kd
+      .sgpr_count: 2
+      .vgpr_count: 25
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -159,3 +159,40 @@ test_cvt_sr_fp8_noclamp:
   .amdhsa_next_free_vgpr 13
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_cvt_sr_fp8_byte0
+      .symbol: test_cvt_sr_fp8_byte0.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_byte2
+      .symbol: test_cvt_sr_fp8_byte2.kd
+      .sgpr_count: 2
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_cvt_sr_fp8_noclamp
+      .symbol: test_cvt_sr_fp8_noclamp.kd
+      .sgpr_count: 2
+      .vgpr_count: 13
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-saddr.s
+++ b/amd/comgr/test-lit/hotswap-inplace-saddr.s
@@ -62,3 +62,20 @@ test_saddr_kernel:
   .amdhsa_next_free_vgpr 6
   .amdhsa_next_free_sgpr 4
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_saddr_kernel
+      .symbol: test_saddr_kernel.kd
+      .sgpr_count: 4
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
@@ -24,10 +24,10 @@
 // DISASM: s_endpgm
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[8:9]
-// DISASM-NEXT: s_add_co_u32 s8
-// DISASM-NEXT: s_add_co_ci_u32 s9
-// DISASM-NEXT: s_set_pc_i64 s[8:9]
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2
+// DISASM-NEXT: s_add_co_ci_u32 s3
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1251"
 .text
@@ -47,3 +47,20 @@ entry_tramp_family_kernel:
   .amdhsa_next_free_sgpr 1
   .amdhsa_inst_pref_size 7
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: entry_tramp_family_kernel
+      .symbol: entry_tramp_family_kernel.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
@@ -18,16 +18,16 @@
 // DISASM: s_endpgm
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[8:9]
-// DISASM-NEXT: s_add_co_u32 s8
-// DISASM-NEXT: s_add_co_ci_u32 s9
-// DISASM-NEXT: s_set_pc_i64 s[8:9]
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2
+// DISASM-NEXT: s_add_co_ci_u32 s3
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[8:9]
-// DISASM-NEXT: s_add_co_u32 s8
-// DISASM-NEXT: s_add_co_ci_u32 s9
-// DISASM-NEXT: s_set_pc_i64 s[8:9]
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2
+// DISASM-NEXT: s_add_co_ci_u32 s3
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -61,3 +61,30 @@ entry_tramp_second:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: entry_tramp_first
+      .symbol: entry_tramp_first.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: entry_tramp_second
+      .symbol: entry_tramp_second.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,13 +1,9 @@
-// COM: HSV-009 / PLAT-205406: on gfx1250 A0 the far trampoline's backward
-// COM: s_add_pc_i64 branch-back corrupts wave state (a GPU memory fault at
-// COM: runtime). Until a scratch-register-based long branch-back lands, a patch
-// COM: site beyond s_branch's +-128 KB reach of the appended pool is DECLINED
-// COM: instead of redirected through the long branch.
+// COM: HSV-009 / PLAT-205406: on gfx1250 A0 a backward s_add_pc_i64 corrupts
+// COM: wave state. Required far tensor patches use a forward s_add_pc_i64 and
+// COM: an SCC-neutral s_get_pc_i64/s_add_nc_u64/s_set_pc_i64 return instead.
 // COM:
-// COM: The A0 tensor_load_to_lds mask workaround is required for correctness, so
-// COM: hotswap must report ERROR if the trampoline patch cannot be emitted.
-// COM: Optional far trampoline rewrites are still allowed to decline and return
-// COM: success; hotswap-trampoline-ds-long-branch.s covers that behavior.
+// COM: Optional far trampoline rewrites are still allowed to decline;
+// COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
 // COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
 // COM: pushes the pool past s_branch's reach to force the far case.
 
@@ -15,9 +11,61 @@
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR \
+// RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: ERROR
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
+
+// DISASM-LABEL: <test_far>:
+// DISASM-NEXT: s_mov_b64 vcc, -1
+// DISASM-NEXT: s_add_pc_i64
+// DISASM-NOT: s_add_pc_i64
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_get_pc_i64 s[12:13]
+// DISASM-NEXT: s_add_nc_u64 s[12:13]
+// DISASM-NEXT: s_set_pc_i64 s[12:13]
+// DISASM-NOT: s_add_pc_i64
+
+// METADATA: .name:           test_far
+// METADATA: .sgpr_count:     16
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// COM: The far return still needs an aligned SGPR pair. Exhausting all 106
+// COM: numbered SGPRs must fail instead of clobbering a program register.
+// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
+// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.no-pair.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.no-pair.s -o %t.no-pair.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.no-pair.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NO-PAIR %s
+// NO-PAIR: hotswap: error: safe far return: kernel test_far has no aligned SGPR pair below s106
+// NO-PAIR: RESULT: ERROR
+
+// COM: gfx10+ cannot represent an increased SGPR count in the kernel
+// COM: descriptor because that field is reserved. A metadata-less object must
+// COM: therefore fail rather than emit an under-declared far-return scratch
+// COM: allocation or write the reserved descriptor field.
+// RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.nometa.s -o %t.nometa.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NO-METADATA %s
+// NO-METADATA: hotswap: error: updateKernelDescriptorSgprCount: kernel 'test_far' requires
+// NO-METADATA: descriptor SGPR-count field is reserved
+// NO-METADATA: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -25,6 +73,7 @@
 .p2align 8
 .type test_far,@function
 test_far:
+  s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
@@ -42,3 +91,20 @@ test_far:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_far
+      .symbol: test_far.kd
+      .sgpr_count: 14
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -1,8 +1,6 @@
-// COM: Test isSgprLiveAfter edge cases for tensor_load_to_lds patching.
-// COM: A branch instruction between the tensor_load and the next use of
-// COM: the descriptor SGPR forces the heuristic to conservatively assume
-// COM: the SGPR is live, producing save/restore even though the use may
-// COM: not execute on all paths.
+// COM: Test persistent tensor_load_to_lds descriptor normalization across a
+// COM: control-flow edge. The descriptor remains masked on either successor,
+// COM: so the rewrite needs no liveness-dependent save/restore sequence.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -14,17 +12,14 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load
-// COM: and s_mov (which reads s4). isSgprLiveAfter returns true at the
-// COM: branch, so save/restore is emitted conservatively.
+// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load and
+// COM: s_mov (which reads s4). The later read sees the normalized descriptor.
 // DISASM-LABEL: <test_tensor_branch_guard>:
 // DISASM: s_branch
 // DISASM: s_cbranch_scc1
 // DISASM: s_endpgm
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
@@ -1,15 +1,26 @@
-// COM: Live tensor_load_to_lds descriptor SGPRs require save/restore around
-// COM: the A0 D# Group 1 mask clear. If the kernel already consumes all
-// COM: user-addressable SGPRs, hotswap must fail instead of returning
-// COM: unsafe code.
+// COM: A0 descriptor multicast bits stay clear after normalization. Even a
+// COM: kernel declaring all user-addressable SGPRs therefore needs no scratch
+// COM: register and must rewrite successfully without changing SGPR metadata.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR \
+// RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: ERROR
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
+
+// DISASM-LABEL: <test_tensor_no_scratch>:
+// DISASM: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_branch
+
+// METADATA: .name:           test_tensor_no_scratch
+// METADATA: .sgpr_count:     106
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -1,8 +1,7 @@
 // COM: Test the true trampoline fallback path for tensor_load_to_lds
-// COM: when no NOP sled is available. Two variants:
-// COM:   dead SGPR — s_pack_hh + tensor_load appended via growWithTrampolines
-// COM:   live SGPR — save/pack/tensor/restore (4-instruction sequence)
-// COM:              appended via growWithTrampolines, the largest replacement
+// COM: when no NOP sled is available. Both live and dead descriptor variants
+// COM: append the persistent s_pack_hh + tensor_load normalization via
+// COM: growWithTrampolines.
 // COM: Both force emitReplacementCode to use emitToTrampoline.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -44,13 +43,10 @@
 // DISASM-NEXT: tensor_load_to_lds
 // DISASM-NEXT: s_branch
 
-// COM: Live-SGPR trampoline body (for kernel 2): also placed in the
-// COM: appended trampoline region. save + pack + tensor + restore +
-// COM: branch-back.
-// DISASM-NEXT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// COM: Live-SGPR trampoline body (for kernel 2): the same persistent mask and
+// COM: tensor sequence followed by branch-back.
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
@@ -71,7 +67,7 @@ test_tensor_trampoline:
 .Ltest_tensor_trampoline_end:
 .size test_tensor_trampoline, .Ltest_tensor_trampoline_end-test_tensor_trampoline
 
-// ---- Kernel 2: live SGPR, no NOP sled (trampoline + save/restore) ----------
+// ---- Kernel 2: live SGPR, no NOP sled (persistent mask trampoline) --------
 
 .globl test_tensor_trampoline_live
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,11 +1,11 @@
 // COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
 // COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
-// COM: the descriptor's base SGPR. Base operand variants via NOP sled:
-// COM:   dead SGPR - only s_pack_hh prepended (no save/restore)
-// COM:   live SGPR - s_mov save, s_pack_hh, tensor, s_mov restore
+// COM: the descriptor's base SGPR. The multicast bits remain clear after
+// COM: normalization, so live and dead descriptors use the same pack/tensor
+// COM: sequence without save/restore.
 // COM:   alt descriptor - different SGPR range (s[16:23]) for pack target
-// COM:   SGPR redef - descriptor SGPR overwritten before use (dead path)
-// COM:   zero-size FUNC - live path when the function symbol has st_size == 0
+// COM:   SGPR redef - descriptor SGPR overwritten before its next use
+// COM:   zero-size FUNC - kernel lookup when the function has st_size == 0
 // COM:   four-group tensor - operand 1 is still D# Group 1 and patches s4
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
 // COM: s_branch checks.
@@ -13,7 +13,7 @@
 // COM: Companion tests:
 // COM:   hotswap-trampoline-tensor-nosled.s     - trampoline fallback path
 // COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
-// COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
+// COM:   hotswap-trampoline-tensor-liveness.s   - control-flow edge case
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,7 +23,7 @@
 // RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API-NOT: kernel descriptor symbol '.kd' not found
-// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
+// API: hotswap: tensor_load_to_lds: persistently cleared multicast bits in s4
 // API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
@@ -46,17 +46,13 @@
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
 
-// COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
-// COM: tensor/restore sequence in sled area with branch-back.
-// COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
-// COM: save/restore via a scratch SGPR is required.
+// COM: Kernel 2 (live SGPR): s4 is used after tensor_load_to_lds, and observes
+// COM: the persistently normalized descriptor. No scratch SGPR is required.
 // DISASM-LABEL: <test_tensor_live>:
 // DISASM: s_branch
 // DISASM: s_endpgm
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Kernel 3 (alternate descriptor s[16:23]): verifies
@@ -73,8 +69,7 @@
 
 // COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
 // COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
-// COM: isSgprLiveAfter sees a def-before-use and takes the dead path
-// COM: - no save/restore needed.
+// COM: The persistent mask remains safe when the descriptor is redefined.
 // DISASM-LABEL: <test_tensor_sgpr_redef>:
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
@@ -88,7 +83,7 @@
 
 // COM: Kernel 5 (zero-size FUNC): real Tensile objects can omit `.size`,
 // COM: leaving the FUNC symbol with st_size == 0. Kernel lookup must still
-// COM: find the descriptor so scratch allocation succeeds. This kernel has no
+// COM: find its descriptor. This kernel has no
 // COM: bounded local sled, so the replacement body is emitted in the appended
 // COM: trampoline pool and checked after Kernel 6.
 // DISASM-LABEL: <test_tensor_zero_size>:
@@ -105,10 +100,8 @@
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
 // DISASM-NEXT: s_branch
 
-// DISASM: s_mov_b32 [[ZERO_SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_mov_b32 s4, [[ZERO_SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -640,6 +640,44 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
 }
 
+TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  const unsigned DescriptorSgprsBefore =
+      readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset);
+
+  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/false));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 10u);
+  EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset),
+            DescriptorSgprsBefore);
+}
+
+TEST(ElfView, UpdateKernelDescriptorSgprCountMetadataOnlyRequiresMetadata) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  const unsigned DescriptorSgprsBefore =
+      readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset);
+
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/false));
+  EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset),
+            DescriptorSgprsBefore);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMissingMetadataCount) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -242,6 +242,72 @@ TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
   EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
 }
 
+// -- encodeSccNeutralLongBranch ----------------------------------------------
+
+static uint64_t
+decodeSccNeutralLongBranchTarget(uint64_t From,
+                                 llvm::ArrayRef<InternalDecodedInst> Decoded) {
+  const uint64_t PcBase = From + Decoded[0].Size;
+  const uint64_t Delta =
+      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
+  return PcBase + Delta;
+}
+
+TEST(EncodeSccNeutralLongBranch, BackwardLandsOnTargetWithoutDefiningScc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x81000;
+  constexpr uint64_t To = 0x1008;
+  std::optional<llvm::SmallVector<uint8_t>> Out =
+      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_TRUE(Out);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Decoded[1].Mnemonic, "s_add_nc_u64");
+  EXPECT_EQ(Decoded[2].Mnemonic, "s_set_pc_i64");
+  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+
+  const llvm::MCRegister Pair = Decoded[0].Inst.getOperand(0).getReg();
+  EXPECT_EQ(Decoded[1].Inst.getOperand(0).getReg(), Pair);
+  EXPECT_EQ(Decoded[1].Inst.getOperand(1).getReg(), Pair);
+  EXPECT_EQ(Decoded[2].Inst.getOperand(0).getReg(), Pair);
+  for (const InternalDecodedInst &DI : Decoded) {
+    const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
+    for (llvm::MCPhysReg Reg : Desc.implicit_defs())
+      EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
+  }
+}
+
+TEST(EncodeSccNeutralLongBranch, ForwardLandsOnTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x1000;
+  constexpr uint64_t To = 0x81000;
+  std::optional<llvm::SmallVector<uint8_t>> Out =
+      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_TRUE(Out);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+}
+
+TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  EXPECT_FALSE(encodeSccNeutralLongBranch(S, 0x1000, 0x2000,
+                                          /*SgprBase=*/13));
+  EXPECT_FALSE(encodeSccNeutralLongBranch(
+      S, std::numeric_limits<uint64_t>::max() - 1, 0, /*SgprBase=*/12));
+}
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
                                 {100, 128, 100, 100, 128}};
@@ -708,6 +774,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   AMDHSA_BITS_SET(Rsrc3, hsa::COMPUTE_PGM_RSRC3_GFX125_TCP_SPLIT, 5);
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.ComputePgmRsrc3 = Rsrc3;
+  Opts.MetadataSgprCount = 8;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(Text, Opts);
   llvm::Expected<ElfView> ViewOrErr =
@@ -716,6 +783,10 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
 
   uint8_t *Kd = ViewOrErr->findKernelDescriptor("kernel");
   ASSERT_NE(Kd, nullptr);
+  uint32_t Rsrc1Before = 0;
+  std::memcpy(&Rsrc1Before,
+              Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              sizeof(Rsrc1Before));
 
   std::vector<Trampoline> Growth;
   std::vector<KernelEntryTrampolineFixup> Fixups;
@@ -780,12 +851,8 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   std::memcpy(&OutRsrc1,
               OutKd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               sizeof(OutRsrc1));
-  unsigned ReservedSgprs =
-      (AMDHSA_BITS_GET(OutRsrc1,
-                       hsa::COMPUTE_PGM_RSRC1_GRANULATED_WAVEFRONT_SGPR_COUNT) +
-       1) *
-      8;
-  EXPECT_GE(ReservedSgprs, Fixups[0].RequiredSgprs);
+  EXPECT_EQ(OutRsrc1, Rsrc1Before);
+  EXPECT_EQ(OutView->getKernelSgprCount("kernel"), Fixups[0].RequiredSgprs);
 
   std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
@@ -866,7 +933,10 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
   ASSERT_EQ(Text.size(), MinInstSize);
 
-  comgr_test::KernelDescriptorElf Obj = comgr_test::makeKernelDescriptorElf(Text);
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
 
   // -- First pass: append one stub, grow .text, rewrite the descriptor, and
   //    attach the stub symbol. --
@@ -883,12 +953,14 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
       *View1, S, /*MaxSgprs=*/106, Growth1, Fixups1);
   ASSERT_TRUE(Count1.has_value());
   ASSERT_EQ(*Count1, 1u);
+  std::optional<uint64_t> PoolVAddr = View1->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddr.has_value());
 
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
       View1->growWithTrampolines(Growth1, S.SNopBytes);
   ASSERT_NE(Grown, nullptr);
   ASSERT_TRUE(
-      rewriteKernelEntryDescriptorOffsets(*Grown, OldTextSize, S.Cpu, Fixups1));
+      rewriteKernelEntryDescriptorOffsets(*Grown, *PoolVAddr, S.Cpu, Fixups1));
   std::unique_ptr<llvm::WritableMemoryBuffer> Pass1 =
       addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
                                       Fixups1);


### PR DESCRIPTION
## Summary

- make gfx1250 A0 trampoline placement and NOP-sled ownership safe
- harden ELF growth and scratch-register allocation for B0-to-A0 rewrites
- add focused LIT fixtures and HotswapElf/HotswapMC unit coverage

This is PR 1 of 5 in a stacked series. It is based directly on `amd-staging`.

## Validation

- Release `check-comgr` at this PR boundary:
  - COMGR LIT: 89 passed, 11 unsupported, 0 failed (100 total)
  - all COMGR unit tests passed
  - COMGR CTests: 31/31 passed
- ASAN (`-DADDRESS_SANITIZER=On`) at this PR boundary:
  - all COMGR unit tests passed
  - COMGR LIT: 89 passed, 11 unsupported, 0 failed
  - 30/30 runnable COMGR CTests passed
  - `comgr_multithread_test` is excluded because its ASAN-runtime `unable to unmap` failure reproduces unchanged on untouched `amd-staging`
- Combined-stack A0 validation on physical GPU 2 with `ROCR_VISIBLE_DEVICES=2` and HotSwap enabled (`HSA_HOTSWAP_DISABLE` unset):
  - exact rocSPARSE reproducer with the #8213 ROCr overlay and `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`: 1/1 passed
  - focused rocSPARSE multiply families with entry trampolines: 998/998 passed
  - focused rocBLAS with entry trampolines: 1,416/1,416 passed
  - focused hipBLAS with entry trampolines: 1,512/1,512 passed
  - focused hipBLASLt under the same default-HotSwap configuration used by the prior split validation: 76/76 passed
- Tested combined-tip COMGR artifact SHA-256: `943b42d6559a3da4c303f1db0de3f284996571e9ab3c82bc45c16e5796465bf4`
- Known entry-trampoline limitation: one hipBLASLt FP8 case aborts with `HSA_STATUS_ERROR_INVALID_CODE_OBJECT`; the identical case reproduces with the pre-convention split tip, so this is not introduced by these fixes.

Reference only: this series was split from the work validated in #3328. That PR remains unchanged as the known-good reference.
