### PR TITLE
[comgr][hotswap] preserve DS2 operand dependencies

### DIFF
--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -746,6 +746,15 @@ encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
                                        llvm::ArrayRef<uint8_t> Replacement,
                                        bool AllowSafeFarReturn = false);
 
+/// Expand one decoded gfx1250 DS two-address instruction into the ordered
+/// single-address instruction sequence used by the trampoline patch. Exposed
+/// from the internal interface so unit tests can verify read-before-write
+/// dependency handling without constructing a complete ELF rewrite. Returns
+/// std::nullopt after logging a malformed or unsafe expansion.
+[[nodiscard]] std::optional<std::vector<std::string>>
+expandDs2Addr(const llvm::MCInst &Inst, llvm::StringRef FromMnem,
+              llvm::StringRef ToMnem, const LLVMState &LS);
+
 // -- Patch dispatch vtable ----------------------------------------------------
 //
 // Function-pointer dispatch table that replaces the prior LLVM_ATTRIBUTE_WEAK

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -233,75 +233,147 @@ extractDsOperands(const MCInst &Inst, StringRef FromMnem, const LLVMState &LS) {
 
 // Split a compound destination register into two formatted destination strings.
 // b32: VReg_64 -> ("v0", "v1"); b64: VReg_128 -> ("v[0:1]", "v[2:3]")
-std::pair<std::string, std::string>
+std::optional<std::pair<std::string, std::string>>
 splitDstPair(MCRegister CompoundReg, bool IsB64, const MCRegisterInfo &MRI) {
   SmallVector<MCRegister, 4> Subs = getDirectSubRegs(CompoundReg, MRI);
   if (IsB64) {
-    if (Subs.size() < 4)
-      return {};
-    return {fmtRegPair(MRI, Subs[0], Subs[1]),
-            fmtRegPair(MRI, Subs[2], Subs[3])};
+    if (Subs.size() < 4) {
+      log() << "hotswap: error: DS b64 destination " << MRI.getName(CompoundReg)
+            << " has " << Subs.size()
+            << " direct subregisters; expected at least 4\n";
+      return std::nullopt;
+    }
+    return std::pair<std::string, std::string>{
+        fmtRegPair(MRI, Subs[0], Subs[1]), fmtRegPair(MRI, Subs[2], Subs[3])};
   }
-  if (Subs.size() < 2)
-    return {};
-  return {toAsmRegName(MRI, Subs[0]), toAsmRegName(MRI, Subs[1])};
+  if (Subs.size() < 2) {
+    log() << "hotswap: error: DS b32 destination " << MRI.getName(CompoundReg)
+          << " has " << Subs.size()
+          << " direct subregisters; expected at least 2\n";
+    return std::nullopt;
+  }
+  return std::pair<std::string, std::string>{toAsmRegName(MRI, Subs[0]),
+                                             toAsmRegName(MRI, Subs[1])};
 }
 
 // Expand a DS 2-address load into two single-address loads (dst, addr).
-std::vector<std::string> expandDs2AddrLoad(const DsOperands &Ops,
-                                           StringRef ToMnem) {
-  if (Ops.Regs.size() < 2)
-    return {};
-  std::pair<std::string, std::string> Dst =
+std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
+                                                          StringRef ToMnem) {
+  if (Ops.Regs.size() < 2) {
+    log() << "hotswap: error: " << ToMnem << " expansion found "
+          << Ops.Regs.size() << " register operands; expected at least 2\n";
+    return std::nullopt;
+  }
+  std::optional<std::pair<std::string, std::string>> Dst =
       splitDstPair(Ops.Regs[0], Ops.IsB64, *Ops.MRI);
-  if (Dst.first.empty())
-    return {};
+  if (!Dst)
+    return std::nullopt;
   std::string Addr = toAsmRegName(*Ops.MRI, Ops.Regs[1]);
-  return {
-      ToMnem.str() + " " + Dst.first + ", " + Addr + fmtOffset(Ops.Off0),
-      ToMnem.str() + " " + Dst.second + ", " + Addr + fmtOffset(Ops.Off1),
-  };
+  std::string First =
+      ToMnem.str() + " " + Dst->first + ", " + Addr + fmtOffset(Ops.Off0);
+  std::string Second =
+      ToMnem.str() + " " + Dst->second + ", " + Addr + fmtOffset(Ops.Off1);
+
+  // A compound DS load reads its address once before writing either half of
+  // the destination. After splitting, the first single-address load must not
+  // overwrite the address needed by the second. If the address overlaps the
+  // first destination half, issue the independent second half first and put
+  // the self-overlapping load last. (If it overlaps the second half, the
+  // natural order is already safe.)
+  SmallVector<MCRegister, 4> DstSubs = getDirectSubRegs(Ops.Regs[0], *Ops.MRI);
+  const unsigned FirstHalfWidth = Ops.IsB64 ? 2 : 1;
+  bool AddrOverlapsFirst =
+      DstSubs.size() >= FirstHalfWidth &&
+      llvm::any_of(ArrayRef(DstSubs).take_front(FirstHalfWidth),
+                   [&](MCRegister Reg) {
+                     return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]);
+                   });
+  if (AddrOverlapsFirst)
+    return std::vector<std::string>{std::move(Second), std::move(First)};
+  return std::vector<std::string>{std::move(First), std::move(Second)};
 }
 
 // Expand a DS 2-address store into two single-address stores (addr, data).
-std::vector<std::string> expandDs2AddrStore(const DsOperands &Ops,
-                                            StringRef ToMnem) {
-  if (Ops.Regs.size() < 3)
-    return {};
+std::optional<std::vector<std::string>>
+expandDs2AddrStore(const DsOperands &Ops, StringRef ToMnem) {
+  if (Ops.Regs.size() < 3) {
+    log() << "hotswap: error: " << ToMnem << " expansion found "
+          << Ops.Regs.size() << " register operands; expected at least 3\n";
+    return std::nullopt;
+  }
   const MCRegisterInfo &MRI = *Ops.MRI;
   std::string Addr = toAsmRegName(MRI, Ops.Regs[0]);
   std::string Data0 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[1])
                                 : toAsmRegName(MRI, Ops.Regs[1]);
   std::string Data1 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[2])
                                 : toAsmRegName(MRI, Ops.Regs[2]);
-  return {
+  return std::vector<std::string>{
       ToMnem.str() + " " + Addr + ", " + Data0 + fmtOffset(Ops.Off0),
       ToMnem.str() + " " + Addr + ", " + Data1 + fmtOffset(Ops.Off1),
   };
 }
 
+bool registerSliceOverlaps(ArrayRef<MCRegister> Registers, unsigned Begin,
+                           unsigned Count, MCRegister Reg,
+                           const MCRegisterInfo &MRI) {
+  return llvm::any_of(Registers.slice(Begin, Count), [&](MCRegister DstReg) {
+    return MRI.regsOverlap(DstReg, Reg);
+  });
+}
+
 // Expand a DS 2-address exchange into two single-address exchanges
 // (dst, addr, data).
-std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
-                                           StringRef ToMnem) {
-  if (Ops.Regs.size() < 4)
-    return {};
+std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
+                                                          StringRef ToMnem) {
+  if (Ops.Regs.size() < 4) {
+    log() << "hotswap: error: " << ToMnem << " expansion found "
+          << Ops.Regs.size() << " register operands; expected at least 4\n";
+    return std::nullopt;
+  }
   const MCRegisterInfo &MRI = *Ops.MRI;
-  std::pair<std::string, std::string> Dst =
+  std::optional<std::pair<std::string, std::string>> Dst =
       splitDstPair(Ops.Regs[0], Ops.IsB64, MRI);
-  if (Dst.first.empty())
-    return {};
+  if (!Dst)
+    return std::nullopt;
   std::string Addr = toAsmRegName(MRI, Ops.Regs[1]);
   std::string Data0 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[2])
                                 : toAsmRegName(MRI, Ops.Regs[2]);
   std::string Data1 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[3])
                                 : toAsmRegName(MRI, Ops.Regs[3]);
-  return {
-      ToMnem.str() + " " + Dst.first + ", " + Addr + ", " + Data0 +
-          fmtOffset(Ops.Off0),
-      ToMnem.str() + " " + Dst.second + ", " + Addr + ", " + Data1 +
-          fmtOffset(Ops.Off1),
-  };
+  std::string First = ToMnem.str() + " " + Dst->first + ", " + Addr + ", " +
+                      Data0 + fmtOffset(Ops.Off0);
+  std::string Second = ToMnem.str() + " " + Dst->second + ", " + Addr + ", " +
+                       Data1 + fmtOffset(Ops.Off1);
+
+  SmallVector<MCRegister, 4> DstSubs = getDirectSubRegs(Ops.Regs[0], MRI);
+  const unsigned HalfWidth = Ops.IsB64 ? 2 : 1;
+  if (DstSubs.size() < 2 * HalfWidth) {
+    log() << "hotswap: error: " << ToMnem << " destination "
+          << MRI.getName(Ops.Regs[0]) << " has " << DstSubs.size()
+          << " direct subregisters; expected at least " << 2 * HalfWidth
+          << "\n";
+    return std::nullopt;
+  }
+
+  // Op0 writes the first destination half and op1 still needs addr + data1;
+  // op1 writes the second half and op0 still needs addr + data0. Pick the safe
+  // order when only one direction has a dependency. If both directions do,
+  // neither ordering preserves the compound instruction's read-before-write
+  // semantics without a scratch VGPR, so decline the rewrite.
+  const bool FirstClobbersSecond =
+      registerSliceOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[1], MRI) ||
+      registerSliceOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[3], MRI);
+  const bool SecondClobbersFirst =
+      registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
+      registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
+  if (FirstClobbersSecond && SecondClobbersFirst) {
+    log() << "hotswap: ds_storexchg_2addr has cyclic destination/source "
+             "overlap; leaving original instruction in place\n";
+    return std::nullopt;
+  }
+  if (FirstClobbersSecond)
+    return std::vector<std::string>{std::move(Second), std::move(First)};
+  return std::vector<std::string>{std::move(First), std::move(Second)};
 }
 
 // -- expandDs2Addr ----------------------------------------------------------
@@ -309,11 +381,13 @@ std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
 // Top-level expansion: extracts operands from the decoded MCInst, computes
 // scaled offsets, then dispatches to the appropriate layout-specific helper.
 
-std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
-                                       StringRef ToMnem, const LLVMState &LS) {
+std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
+                                                          StringRef FromMnem,
+                                                          StringRef ToMnem,
+                                                          const LLVMState &LS) {
   std::optional<DsOperands> Ops = extractDsOperands(Inst, FromMnem, LS);
   if (!Ops)
-    return {};
+    return std::nullopt;
 
   // Use the trailing underscore so the three prefixes are disjoint
   // ("ds_load_", "ds_store_", "ds_storexchg_"); without it "ds_store" is a
@@ -326,7 +400,7 @@ std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
     return expandDs2AddrStore(*Ops, ToMnem);
 
   log() << "hotswap: error: unrecognized DS mnemonic: " << FromMnem << "\n";
-  return {};
+  return std::nullopt;
 }
 
 // -- patchDs2Addr -----------------------------------------------------------
@@ -343,16 +417,13 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
     return false;
-  std::vector<std::string> Expanded =
-      expandDs2Addr(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
-  if (Expanded.empty()) {
-    log() << "hotswap: error: ds_2addr expansion failed for: " << DI.Mnemonic
-          << "\n";
+  std::optional<std::vector<std::string>> Expanded =
+      expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
+  if (!Expanded)
     return false;
-  }
 
   std::string Combined;
-  for (const std::string &Line : Expanded)
+  for (const std::string &Line : *Expanded)
     Combined += Line + "\n";
   // Drain the DS counter right after the split pair so both halves are
   // guaranteed complete before any downstream consumer. The original code
@@ -1288,6 +1359,13 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
 }
 
 } // anonymous namespace
+
+std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
+                                                      StringRef FromMnem,
+                                                      StringRef ToMnem,
+                                                      const LLVMState &LS) {
+  return expandDs2AddrImpl(Inst, FromMnem, ToMnem, LS);
+}
 
 // -- applyTrampolinePatches -------------------------------------------------
 //

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
@@ -1,0 +1,60 @@
+// COM: Splitting a compound DS instruction must preserve its read-before-write
+// COM: semantics when the address or data registers overlap a destination.
+// COM: This kernel deliberately has no nop sled, forcing the appended
+// COM: trampoline/growth path. Its cyclic exchange is the intentional no-op
+// COM: case: the original instruction must remain byte-stable.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// DISASM-LABEL: <test_ds_overlap>:
+
+// COM: A cyclic exchange dependency has no safe ordering and is declined.
+// DISASM: ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset1:1
+
+// COM: Address overlaps the first b64 destination half: issue half 1 first.
+// DISASM:      ds_load_b64 v[14:15], v12 offset:8
+// DISASM-NEXT: ds_load_b64 v[12:13], v12
+
+// COM: The same rule applies to b32.
+// DISASM:      ds_load_b32 v5, v4 offset:8
+// DISASM-NEXT: ds_load_b32 v4, v4 offset:4
+
+// COM: Address overlaps the second half: natural order is already safe.
+// DISASM:      ds_load_b64 v[16:17], v18
+// DISASM-NEXT: ds_load_b64 v[18:19], v18 offset:8
+
+// COM: Exchange op0 would clobber op1's address, so reverse the operations.
+// DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:8
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_overlap
+.p2align 8
+.type test_ds_overlap,@function
+test_ds_overlap:
+  ds_load_2addr_b64 v[12:15], v12 offset0:0 offset1:1
+  ds_load_2addr_b32 v[4:5], v4 offset0:1 offset1:2
+  ds_load_2addr_b64 v[16:19], v18 offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds_overlap_end:
+.size test_ds_overlap, .Ltest_ds_overlap_end-test_ds_overlap
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_overlap
+  .amdhsa_next_free_vgpr 25
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
@@ -32,18 +32,16 @@
 // COM: 16-bit limit, and the "leaving original instruction in place"
 // COM: closer) so a regression in the message format or the limit
 // COM: constant fails here, not in some downstream-symptoms test. The
-// COM: generic "ds_2addr expansion failed" line is the patchDs2Addr-level
-// COM: error that follows naturally from the overflow guard returning
-// COM: an empty expansion; pin it too so a refactor that reroutes the
-// COM: error path is caught. RESULT: SUCCESS comes last because the
-// COM: rewrite as a whole succeeds (the in-range kernel is patched).
+// COM: helper's specific message is the only diagnostic; patchDs2Addr does
+// COM: not mislabel this intentional safe decline with a second generic
+// COM: failure. RESULT: SUCCESS comes last because the rewrite as a whole
+// COM: succeeds (the in-range kernel is patched).
 // LOG:      hotswap: error: ds_load_2addr_stride64_b64 scaled offsets exceed
 // LOG-SAME: the single-address DS 16-bit field
 // LOG-SAME: off0=raw 128 * scale 512 = 65536
 // LOG-SAME: off1=raw 255 * scale 512 = 130560
 // LOG-SAME: max 65535
 // LOG-SAME: leaving original instruction in place
-// LOG:      hotswap: error: ds_2addr expansion failed for: ds_load_2addr_stride64_b64
 // LOG:      RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -607,6 +607,44 @@ TEST(BuildTrampoline, EmptyOnBadAsm) {
   EXPECT_TRUE(T.Bytes.empty());
 }
 
+// -- DS two-address expansion ------------------------------------------------
+
+TEST(ExpandDs2Addr, PreservesAddressNeededBySecondLoad) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(
+      "ds_load_2addr_b64 v[12:15], v12 offset0:0 offset1:1", S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  std::optional<std::vector<std::string>> Expanded =
+      expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic, "ds_load_b64", S);
+  ASSERT_TRUE(Expanded);
+  ASSERT_EQ(Expanded->size(), 2u);
+  EXPECT_EQ((*Expanded)[0], "ds_load_b64 v[14:15], v12 offset:8");
+  EXPECT_EQ((*Expanded)[1], "ds_load_b64 v[12:13], v12");
+}
+
+TEST(ExpandDs2Addr, RejectsCyclicExchangeDependency) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(
+      "ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] "
+      "offset0:0 offset1:1",
+      S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  EXPECT_FALSE(expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic,
+                             "ds_storexchg_rtn_b64", S));
+}
+
 // -- buildKernelEntryTrampoline -----------------------------------------------
 
 TEST(BuildKernelEntryTrampoline, BuildsRecognizedPcRelativeStub) {


### PR DESCRIPTION
## Summary

- choose a safe DS2 split order when destinations overlap address or data operands
- fail closed for cyclic exchanges that require unavailable scratch storage
- add a complete DS2 overlap LIT rewrite and focused MC unit tests

This is PR 2 of 5 in a stacked series and depends on the foundation PR.

## Validation

- Review-update release `check-comgr` at this PR boundary:
  - COMGR LIT: 92 passed, 11 unsupported, 0 failed (103 total)
  - all COMGR unit tests passed
  - COMGR CTests: 31/31 passed
- Review-update ASan validation at the final stacked tip:
  - COMGR LIT: 97 passed, 11 unsupported, 0 failed (108 total)
  - all COMGR unit tests passed
  - 30/30 runnable COMGR CTests passed
  - `comgr_multithread_test` remains excluded because its ASan-runtime `unable to unmap` failure reproduces unchanged on untouched `amd-staging`
- Prior combined-stack A0 validation on physical GPU 2 with `ROCR_VISIBLE_DEVICES=2` and HotSwap enabled (`HSA_HOTSWAP_DISABLE` unset):
  - exact rocSPARSE reproducer with the #8213 ROCr overlay and `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`: 1/1 passed
  - focused rocSPARSE multiply families with entry trampolines: 998/998 passed
  - focused rocBLAS with entry trampolines: 1,416/1,416 passed
  - focused hipBLAS with entry trampolines: 1,512/1,512 passed
  - focused hipBLASLt under the same default-HotSwap configuration used by the prior split validation: 76/76 passed
- Known entry-trampoline limitation: one hipBLASLt FP8 case aborts with `HSA_STATUS_ERROR_INVALID_CODE_OBJECT`; the identical case reproduces with the pre-convention split tip, so this is not introduced by these fixes.

Reference only: this series was split from the work validated in #3328. That PR remains unchanged as the known-good reference.
