### PR TITLE
[comgr][hotswap] make gfx1250 semantic rewrites fail-safe

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -446,6 +446,44 @@ encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
   return Bytes;
 }
 
+static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
+                                                 MCRegister Reg) {
+  // TODO(https://github.com/ROCm/llvm-project/issues/3350): Replace this
+  // register-name fallback with a public AMDGPU MC hardware-index helper.
+  if (!Reg.isValid())
+    return std::nullopt;
+  StringRef Name(MRI.getName(Reg));
+  if (!Name.consume_front("SGPR") || Name.empty() || Name.contains('_'))
+    return std::nullopt;
+  unsigned Index = 0;
+  if (Name.getAsInteger(10, Index))
+    return std::nullopt;
+  return Index;
+}
+
+static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
+                                            MCRegister Reg, unsigned MaxSgprs,
+                                            unsigned &HighWatermark,
+                                            StringRef Context) {
+  SmallVector<MCRegister, 8> Candidates;
+  Candidates.push_back(Reg);
+  for (MCPhysReg Sub : MRI.subregs(Reg))
+    Candidates.push_back(MCRegister(Sub));
+
+  for (MCRegister Candidate : Candidates) {
+    std::optional<unsigned> Index = numberedSgprIndex(MRI, Candidate);
+    if (!Index)
+      continue;
+    if (*Index >= MaxSgprs) {
+      log() << "hotswap: error: " << Context << ": numbered SGPR s" << *Index
+            << " exceeds the addressable limit s" << (MaxSgprs - 1) << "\n";
+      return false;
+    }
+    HighWatermark = std::max(HighWatermark, *Index + 1);
+  }
+  return true;
+}
+
 static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
   return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
 }
@@ -466,94 +504,176 @@ static bool instructionUsesVcc(const LLVMState &LS,
   return false;
 }
 
-static std::optional<SmallVector<uint8_t>>
-buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
-                   uint64_t BackStart) {
-  std::string KernelName =
-      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
-  if (KernelName.empty()) {
-    log() << "hotswap: error: safe far return: no kernel owns site 0x"
-          << utohexstr(InstOffset) << "\n";
+std::optional<SafeSgprScratchBlock>
+findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
+                         unsigned Count, unsigned Alignment,
+                         StringRef Context) {
+  if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
+    log() << "hotswap: error: " << Context
+          << ": invalid global SGPR block request (count=" << Count
+          << ", alignment=" << Alignment << ")\n";
     return std::nullopt;
   }
 
-  std::optional<unsigned> TotalSgprCount =
-      Ctx.Elf.getKernelSgprCount(KernelName);
-  if (!TotalSgprCount) {
-    log() << "hotswap: error: safe far return: invalid SGPR count for kernel "
-          << KernelName << "\n";
-    return std::nullopt;
-  }
-
-  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs adds two
-  // implicit SGPRs when VCC is used. They are not part of the numbered s0-s105
-  // register space. Inspect the owning function so scratch allocation starts
-  // above numbered SGPRs rather than above the metadata total. If VCC is only
-  // used by a callee, retaining the total as the allocation base is
-  // conservative; the call flag below keeps two implicit slots in the updated
-  // metadata.
-  bool UsesVcc = false;
-  bool HasCall = false;
   std::optional<ElfView::FunctionTextRange> FunctionRange =
-      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
-  if (!FunctionRange) {
-    log() << "hotswap: error: safe far return: no function owns site 0x"
-          << utohexstr(InstOffset) << "\n";
-    return std::nullopt;
+      Ctx.Elf.findFunctionTextRangeAtOffset(TextOffset);
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  bool ScanWholeObject = Owner.empty() || !FunctionRange;
+  if (!ScanWholeObject) {
+    for (const InternalDecodedInst &DI : Ctx.Decoded) {
+      if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+        continue;
+      if (Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst)) {
+        ScanWholeObject = true;
+        break;
+      }
+    }
   }
 
+  bool UsesVcc = false;
+  unsigned HighWatermark = 0;
   for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+    if (!ScanWholeObject &&
+        (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End))
       continue;
     UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
-    HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
+    for (const MCOperand &Op : DI.Inst) {
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           Context))
+        return std::nullopt;
+    }
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           Context))
+        return std::nullopt;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           Context))
+        return std::nullopt;
   }
 
   constexpr unsigned VccSgprs = 2;
-  if (UsesVcc && *TotalSgprCount < VccSgprs) {
-    log() << "hotswap: error: safe far return: VCC-using kernel " << KernelName
-          << " has invalid SGPR count " << *TotalSgprCount << "\n";
-    return std::nullopt;
-  }
-  unsigned NumberedSgprCount = *TotalSgprCount - (UsesVcc ? VccSgprs : 0);
-  if (NumberedSgprCount > Ctx.Config.MaxSgprs) {
-    log() << "hotswap: error: safe far return: numbered SGPR count for kernel "
-          << KernelName << " exceeds " << Ctx.Config.MaxSgprs << "\n";
-    return std::nullopt;
+  if (!Owner.empty()) {
+    std::optional<unsigned> Declared = Ctx.Elf.getKernelSgprCount(Owner);
+    if (!Declared) {
+      log() << "hotswap: error: " << Context
+            << ": failed to read SGPR count for kernel " << Owner << "\n";
+      return std::nullopt;
+    }
+    if (UsesVcc && *Declared < VccSgprs) {
+      log() << "hotswap: error: " << Context << ": VCC-using kernel " << Owner
+            << " has invalid SGPR count " << *Declared << "\n";
+      return std::nullopt;
+    }
+    unsigned DeclaredNumbered = *Declared - (UsesVcc ? VccSgprs : 0);
+    HighWatermark = std::max(HighWatermark, DeclaredNumbered);
+  } else {
+    // A device function can be reached from kernels with different declared
+    // register footprints. Without a complete call graph, keep the block above
+    // every declaration and charge every kernel in the commit step.
+    for (const KernelDescriptorInfo &KD : Ctx.Elf.kernelDescriptors()) {
+      std::optional<unsigned> Declared =
+          Ctx.Elf.getKernelSgprCount(KD.KernelName);
+      if (!Declared) {
+        log() << "hotswap: error: " << Context
+              << ": failed to read SGPR count for kernel " << KD.KernelName
+              << "\n";
+        return std::nullopt;
+      }
+      HighWatermark = std::max(HighWatermark, *Declared);
+    }
   }
 
-  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. Allocate it above the
-  // kernel's declared registers so no live program register is repurposed.
-  // s_add_nc_u64 adjusts the captured PC without reading or writing SCC.
-  unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
-  if (ScratchPair + 1 >= Ctx.Config.MaxSgprs) {
-    log() << "hotswap: error: safe far return: kernel " << KernelName
-          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs << "\n";
+  if (HighWatermark > std::numeric_limits<unsigned>::max() - (Alignment - 1)) {
+    log() << "hotswap: error: " << Context
+          << ": SGPR alignment calculation overflows unsigned\n";
     return std::nullopt;
   }
+  unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
+  if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
+    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
+          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    return std::nullopt;
+  }
+  return SafeSgprScratchBlock{Base, Count};
+}
+
+bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
+                                const SafeSgprScratchBlock &Block,
+                                StringRef Context) {
+  std::vector<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
+  if (Descriptors.empty()) {
+    log() << "hotswap: error: " << Context
+          << ": code object has no kernel descriptors to charge for scratch "
+             "SGPRs\n";
+    return false;
+  }
+
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  bool ChargedOwner = false;
+
+  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs returns
+  // two non-numbered VCC SGPRs on GFX1250. Always include them in the metadata
+  // requirement. This may conservatively overstate a kernel that does not use
+  // VCC, but never mistakes VCC for numbered s0-s105 registers.
+  constexpr unsigned VccSgprs = 2;
+  unsigned RequiredSgprs = Block.Base + Block.Count + VccSgprs;
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    if (!Owner.empty() && KD.KernelName != Owner)
+      continue;
+    ChargedOwner = true;
+
+    std::optional<unsigned> Current = Ctx.Elf.getKernelSgprCount(KD.KernelName);
+    if (!Current) {
+      log() << "hotswap: error: " << Context
+            << ": failed to read SGPR count for kernel " << KD.KernelName
+            << "\n";
+      return false;
+    }
+    if (*Current >= RequiredSgprs)
+      continue;
+    KernelPatchStats &Stats = Ctx.KernelStats[KD.KernelName];
+    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, RequiredSgprs - *Current);
+  }
+
+  if (!ChargedOwner) {
+    log() << "hotswap: error: " << Context << ": kernel '" << Owner
+          << "' has no descriptor\n";
+    return false;
+  }
+  return true;
+}
+
+static std::optional<SmallVector<uint8_t>>
+buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                   uint64_t BackStart) {
+  std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
+      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
+  if (!Scratch)
+    return std::nullopt;
 
   std::optional<uint64_t> ReturnTo =
       checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
   if (!ReturnTo)
     return std::nullopt;
   std::optional<SmallVector<uint8_t>> Bytes =
-      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, ScratchPair);
+      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, Scratch->Base);
   if (!Bytes)
     return std::nullopt;
-
-  unsigned RequiredNumberedSgprs = ScratchPair + 2;
-  unsigned PreservedImplicitSgprs = (UsesVcc || HasCall) ? VccSgprs : 0;
-  unsigned RequiredSgprs = RequiredNumberedSgprs + PreservedImplicitSgprs;
-  if (RequiredSgprs < *TotalSgprCount) {
-    log() << "hotswap: error: safe far return: SGPR accounting underflow for "
-          << KernelName << "\n";
+  if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
     return std::nullopt;
-  }
-  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-  Stats.ExtraSgprs =
-      std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
-  const std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
-                           std::to_string(ScratchPair + 1) + "]";
+
+  const std::string Pair = "s[" + std::to_string(Scratch->Base) + ":" +
+                           std::to_string(Scratch->Base + 1) + "]";
   log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
         << Pair << "\n";
   return std::move(*Bytes);
@@ -1029,6 +1149,13 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   } else {
     log() << "hotswap: instruction patches disabled for this rewrite\n";
   }
+
+  // gfx1250 revision is recorded per kernel in the AMDGPU metadata note.
+  // Running a B0 object on A0 requires retagging that metadata even when no
+  // machine instruction needed rewriting. Native A0 code generation preserves
+  // s_clause and emits the same instructions as B0 for valid clauses.
+  if (Options.RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
+    return AMD_COMGR_STATUS_ERROR;
 
   std::unique_ptr<WritableMemoryBuffer> Result;
   std::vector<Trampoline> Growth = Deferred;

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -15,6 +15,7 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
@@ -118,17 +119,22 @@ readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
   return readUnsignedMetadataNode(SgprNode, KernelName, ".sgpr_count", Context);
 }
 
-static MetadataSgprUpdateStatus
-updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
-                              StringRef KernelName, unsigned RequiredSgprs) {
+using MetadataNoteMutator = function_ref<std::optional<bool>(
+    msgpack::Document &, msgpack::MapDocNode &)>;
+
+/// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
+/// write changed notes back in place after checking that their encoded size and
+/// destination remain valid. Returns false after logging a specific failure.
+static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
+                                 StringRef Context, MetadataNoteMutator Mutator,
+                                 bool &SawMetadataNote) {
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   if (!PhdrsOrErr) {
-    log() << "hotswap: error: updateKernelMetadataSgprCount: failed to read "
-          << "program headers: " << toString(PhdrsOrErr.takeError()) << "\n";
-    return MetadataSgprUpdateStatus::Error;
+    log() << "hotswap: error: " << Context << ": failed to read program "
+          << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return false;
   }
 
-  bool SawMetadataNote = false;
   for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
     if (Phdr.p_type != ELF::PT_NOTE)
       continue;
@@ -142,93 +148,116 @@ updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
 
       ArrayRef<uint8_t> Desc = Note.getDesc(4);
       if (Desc.empty()) {
-        log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU "
-              << "metadata note has an empty descriptor.\n";
-        return MetadataSgprUpdateStatus::Error;
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata note has an empty descriptor.\n";
+        return false;
       }
 
       StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
       msgpack::Document Doc;
       if (!Doc.readFromBlob(Blob, false)) {
-        log() << "hotswap: error: updateKernelMetadataSgprCount: failed to "
-              << "parse AMDGPU metadata note.\n";
-        return MetadataSgprUpdateStatus::Error;
+        log() << "hotswap: error: " << Context
+              << ": failed to parse AMDGPU metadata note.\n";
+        return false;
       }
 
       msgpack::DocNode Root = Doc.getRoot();
       if (!Root.isMap()) {
-        log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU "
-              << "metadata root is not a map.\n";
-        return MetadataSgprUpdateStatus::Error;
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata root is not a map.\n";
+        return false;
       }
 
-      msgpack::MapDocNode &RootMap = Root.getMap();
-      msgpack::DocNode::MapTy::iterator KernelsIt =
-          RootMap.find("amdhsa.kernels");
-      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+      std::optional<bool> Changed = Mutator(Doc, Root.getMap());
+      if (!Changed)
+        return false;
+      if (!*Changed)
         continue;
 
-      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
-      for (msgpack::DocNode &KNode : KernelArray) {
-        if (!KNode.isMap())
-          continue;
-
-        msgpack::MapDocNode &KMap = KNode.getMap();
-        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
-        if (NameIt == KMap.end() || !NameIt->second.isString() ||
-            NameIt->second.getString() != KernelName)
-          continue;
-
-        msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
-        if (SgprIt == KMap.end()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
-                << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-
-        std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
-            SgprIt->second, KernelName, "updateKernelMetadataSgprCount");
-        if (!CurrentSgprs)
-          return MetadataSgprUpdateStatus::Error;
-        if (RequiredSgprs <= *CurrentSgprs)
-          return MetadataSgprUpdateStatus::Found;
-
-        SgprIt->second = static_cast<uint64_t>(RequiredSgprs);
-        std::string NewBlob;
-        Doc.writeToBlob(NewBlob);
-        if (NewBlob.size() != Blob.size()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: updating "
-                << ".sgpr_count for '" << KernelName << "' changes metadata "
-                << "note size from " << Blob.size() << " to " << NewBlob.size()
-                << " bytes; in-place rewrite cannot preserve ELF layout.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-
-        const uint8_t *DescBegin = Desc.data();
-        if (DescBegin < File.base() || DescBegin >= File.end()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
-                << "descriptor pointer is outside the ELF buffer.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-        size_t DescOffset = DescBegin - File.base();
-        if (Desc.size() > File.getBufSize() ||
-            DescOffset > File.getBufSize() - Desc.size()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
-                << "descriptor extends past the ELF buffer.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-
-        std::memcpy(Elf + DescOffset, NewBlob.data(), NewBlob.size());
-        return MetadataSgprUpdateStatus::Found;
+      std::string NewBlob;
+      Doc.writeToBlob(NewBlob);
+      if (NewBlob.size() != Blob.size()) {
+        log() << "hotswap: error: " << Context
+              << ": updating AMDGPU metadata changes note size from "
+              << Blob.size() << " to " << NewBlob.size()
+              << " bytes; in-place rewrite cannot preserve ELF layout.\n";
+        return false;
       }
+
+      const uint8_t *DescBegin = Desc.data();
+      if (DescBegin < File.base() || DescBegin >= File.end()) {
+        log() << "hotswap: error: " << Context
+              << ": metadata descriptor pointer is outside the ELF buffer.\n";
+        return false;
+      }
+      size_t DescOffset = DescBegin - File.base();
+      if (Desc.size() > File.getBufSize() ||
+          DescOffset > File.getBufSize() - Desc.size()) {
+        log() << "hotswap: error: " << Context
+              << ": metadata descriptor extends past the ELF buffer.\n";
+        return false;
+      }
+      std::memcpy(Elf + DescOffset, NewBlob.data(), NewBlob.size());
     }
 
     if (Err) {
-      log() << "hotswap: error: updateKernelMetadataSgprCount: failed to "
-            << "iterate AMDGPU notes: " << toString(std::move(Err)) << "\n";
-      return MetadataSgprUpdateStatus::Error;
+      log() << "hotswap: error: " << Context
+            << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
+            << "\n";
+      return false;
     }
   }
+  return true;
+}
+
+static MetadataSgprUpdateStatus
+updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
+                              StringRef KernelName, unsigned RequiredSgprs) {
+  bool SawMetadataNote = false;
+  bool Found = false;
+  bool Rewritten = rewriteMetadataNotes(
+      Elf, File, "updateKernelMetadataSgprCount",
+      [&](msgpack::Document &,
+          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
+        msgpack::DocNode::MapTy::iterator KernelsIt =
+            RootMap.find("amdhsa.kernels");
+        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+          return false;
+
+        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+          if (!KNode.isMap())
+            continue;
+          msgpack::MapDocNode &KMap = KNode.getMap();
+          msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
+          if (NameIt == KMap.end() || !NameIt->second.isString() ||
+              NameIt->second.getString() != KernelName)
+            continue;
+
+          Found = true;
+          msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
+          if (SgprIt == KMap.end()) {
+            log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
+                  << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
+            return std::nullopt;
+          }
+
+          std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
+              SgprIt->second, KernelName, "updateKernelMetadataSgprCount");
+          if (!CurrentSgprs)
+            return std::nullopt;
+          if (RequiredSgprs <= *CurrentSgprs)
+            return false;
+
+          SgprIt->second = static_cast<uint64_t>(RequiredSgprs);
+          return true;
+        }
+        return false;
+      },
+      SawMetadataNote);
+  if (!Rewritten)
+    return MetadataSgprUpdateStatus::Error;
+  if (Found)
+    return MetadataSgprUpdateStatus::Found;
 
   if (SawMetadataNote) {
     log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU metadata "
@@ -236,6 +265,41 @@ updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
     return MetadataSgprUpdateStatus::Error;
   }
   return MetadataSgprUpdateStatus::NotFound;
+}
+
+bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
+  bool SawMetadataNote = false;
+  return rewriteMetadataNotes(
+      data(), File, "updateGfx1250RevisionMetadata",
+      [&](msgpack::Document &Doc,
+          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
+        msgpack::DocNode::MapTy::iterator KernelsIt =
+            RootMap.find("amdhsa.kernels");
+        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+          return false;
+
+        bool Changed = false;
+        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+          if (!KNode.isMap())
+            continue;
+          msgpack::MapDocNode &KMap = KNode.getMap();
+          msgpack::DocNode::MapTy::iterator RevisionIt =
+              KMap.find(".gfx1250_revision");
+          if (RevisionIt == KMap.end())
+            continue;
+          if (!RevisionIt->second.isString()) {
+            log() << "hotswap: error: updateGfx1250RevisionMetadata: "
+                  << ".gfx1250_revision is not a string.\n";
+            return std::nullopt;
+          }
+          if (RevisionIt->second.getString() == Revision)
+            continue;
+          RevisionIt->second = Doc.getNode(Revision, /*Copy=*/true);
+          Changed = true;
+        }
+        return Changed;
+      },
+      SawMetadataNote);
 }
 
 // -- applyByteReplace ---------------------------------------------------------
@@ -461,34 +525,18 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
 
 std::optional<ElfView::FunctionTextRange>
 ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
-  for (const ELFT::Shdr &SymShdr : Sections) {
-    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
-        SymShdr.sh_type != ELF::SHT_DYNSYM)
+  std::optional<FunctionTextRange> Best;
+  for (const FunctionTextRange &Range : functionTextRanges()) {
+    if (Range.Begin < textAddr() || Range.End < textAddr())
       continue;
-
-    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
-    if (!SymsOrErr) {
-      consumeError(SymsOrErr.takeError());
+    uint64_t Begin = Range.Begin - textAddr();
+    uint64_t End = Range.End - textAddr();
+    if (TextOffset < Begin || TextOffset >= End)
       continue;
-    }
-
-    for (const ELFT::Sym &Sym : *SymsOrErr) {
-      if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
-        continue;
-      if (Sym.st_shndx != TextSectionIndex || Sym.st_size == 0)
-        continue;
-      if (Sym.st_value < textAddr())
-        continue;
-
-      uint64_t Start = Sym.st_value - textAddr();
-      if (Sym.st_size > std::numeric_limits<uint64_t>::max() - Start)
-        continue;
-      uint64_t End = Start + Sym.st_size;
-      if (TextOffset >= Start && TextOffset < End)
-        return ElfView::FunctionTextRange{Start, End};
-    }
+    if (!Best || Begin > Best->Begin)
+      Best = FunctionTextRange{Begin, End};
   }
-  return std::nullopt;
+  return Best;
 }
 
 // -- ElfView::findKernelDescriptor --------------------------------------------
@@ -1190,8 +1238,7 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
   SmallVector<uint8_t> StrBlob, SymBlob;
   for (const KernelEntryTrampolineFixup &F : Fixups) {
     std::string Name = F.KernelName + ".stub";
-    uint32_t NameOff =
-        static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
+    uint32_t NameOff = static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
     StrBlob.append(Name.begin(), Name.end());
     StrBlob.push_back(0);
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -295,6 +295,11 @@ public:
                                        unsigned RequiredSgprs,
                                        bool UpdateDescriptor = true);
 
+  /// Retag every gfx1250 kernel in the AMDGPU metadata note with \p Revision.
+  /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
+  /// size, so this preserves the ELF layout.
+  bool updateGfx1250RevisionMetadata(llvm::StringRef Revision);
+
   /// Read COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
   std::optional<uint32_t>
   getKernelDescriptorInstPrefSize(llvm::StringRef KernelName,
@@ -716,6 +721,29 @@ struct PatchContext {
   bool RequiredPatchApplied = false;
 };
 
+/// A block of numbered SGPRs that is not referenced in the function being
+/// patched, or anywhere in the code object when the site may be reached by a
+/// call whose register requirements cannot be bounded locally.
+struct SafeSgprScratchBlock {
+  unsigned Base = 0;
+  unsigned Count = 0;
+};
+
+/// Find an aligned block of unused numbered SGPRs for \p TextOffset. Returns
+/// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
+std::optional<SafeSgprScratchBlock>
+findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
+                         unsigned Count, unsigned Alignment,
+                         llvm::StringRef Context);
+
+/// Charge a previously selected global block to the kernel owning \p
+/// TextOffset. If the site is in an ordinary device function, conservatively
+/// charge every kernel descriptor because the ELF does not carry a complete
+/// call graph.
+bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
+                                const SafeSgprScratchBlock &Block,
+                                llvm::StringRef Context);
+
 // -- Trampoline emission helpers (defined in comgr-hotswap-b0a0.cpp) ----------
 
 [[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
@@ -880,8 +908,9 @@ bool rewriteKernelEntryDescriptorOffsets(
 /// virtual addresses, program headers, or relocations change; `.dynsym` (used
 /// by the loader) is left untouched.
 std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex, uint64_t TextAddr,
-    uint64_t OldTextSize, llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex,
+    uint64_t TextAddr, uint64_t OldTextSize,
+    llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -11,8 +11,6 @@
 ///
 ///   - cluster_load             -> global_load    (opcode swap via MCInst +
 ///                                                 MCCodeEmitter)
-///   - s_clause                 -> s_nop          (byte-level overwrite via
-///                                                 applyByteReplace)
 ///   - s_barrier_signal_isfirst -> s_barrier_signal
 ///                                                (opcode swap; same operand
 ///                                                 layout, drops SCC write)
@@ -140,17 +138,6 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
               << " at 0x" << utohexstr(DI.Offset) << "\n";
         return 1;
       }
-    }
-  }
-
-  if (Mnemonic == "s_clause") {
-    RewriteRule Rule;
-    Rule.ReplaceBytes.assign(Ctx.LS.SNopBytes.begin(), Ctx.LS.SNopBytes.end());
-    if (applyByteReplace(Rule, DI.Offset, DI.Size, Ctx.Text, Ctx.TextSize,
-                         Ctx.LS)) {
-      log() << "hotswap: inplace: s_clause -> s_nop at 0x"
-            << utohexstr(DI.Offset) << "\n";
-      return 1;
     }
   }
 

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -222,7 +222,7 @@ extractDsOperands(const MCInst &Inst, StringRef FromMnem, const LLVMState &LS) {
           << RawOff0 << " * scale " << Scale << " = " << Scaled0
           << ", off1=raw " << RawOff1 << " * scale " << Scale << " = "
           << Scaled1 << ", max " << Ds1AddrOffsetMax
-          << "); leaving original instruction in place\n";
+          << "); required A0 rewrite cannot continue\n";
     return std::nullopt;
   }
   Ops.Off0 = static_cast<uint32_t>(Scaled0);
@@ -282,12 +282,9 @@ std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
   // natural order is already safe.)
   SmallVector<MCRegister, 4> DstSubs = getDirectSubRegs(Ops.Regs[0], *Ops.MRI);
   const unsigned FirstHalfWidth = Ops.IsB64 ? 2 : 1;
-  bool AddrOverlapsFirst =
-      DstSubs.size() >= FirstHalfWidth &&
-      llvm::any_of(ArrayRef(DstSubs).take_front(FirstHalfWidth),
-                   [&](MCRegister Reg) {
-                     return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]);
-                   });
+  bool AddrOverlapsFirst = llvm::any_of(
+      ArrayRef(DstSubs).take_front(FirstHalfWidth),
+      [&](MCRegister Reg) { return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]); });
   if (AddrOverlapsFirst)
     return std::vector<std::string>{std::move(Second), std::move(First)};
   return std::vector<std::string>{std::move(First), std::move(Second)};
@@ -367,8 +364,9 @@ std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
       registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
       registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
   if (FirstClobbersSecond && SecondClobbersFirst) {
-    log() << "hotswap: ds_storexchg_2addr has cyclic destination/source "
-             "overlap; leaving original instruction in place\n";
+    log() << "hotswap: error: ds_storexchg_2addr has cyclic "
+             "destination/source overlap and cannot be split without scratch "
+             "VGPRs\n";
     return std::nullopt;
   }
   if (FirstClobbersSecond)
@@ -420,7 +418,7 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   std::optional<std::vector<std::string>> Expanded =
       expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
   if (!Expanded)
-    return false;
+    return failRequiredPatch(Ctx);
 
   std::string Combined;
   for (const std::string &Line : *Expanded)
@@ -440,12 +438,13 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-    return false;
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                           /*AllowSafeFarReturn=*/true))
+    return failRequiredPatch(Ctx);
 
   DI.Mnemonic = "<replaced>";
   return true;
@@ -768,9 +767,9 @@ void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
 // -- patchTensorLoadToLdsA0 -------------------------------------------------
 //
 // Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
-// descriptor's base SGPR. The A0 routing bits must remain clear for every
-// subsequent use of the descriptor, so normalize it persistently instead of
-// restoring the invalid B0 value after each tensor load.
+// descriptor's base SGPR. Preserve the architectural SGPR value when it is live
+// after the tensor instruction: the descriptor is a source operand, so the
+// rewrite must not make its temporary normalization visible to later code.
 
 bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -796,18 +795,56 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     return failRequiredPatch(Ctx);
   }
 
+  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
   const uint8_t *OrigInst = Ctx.Text + DI.Offset;
-  SmallVector<uint8_t> Replacement;
-  Replacement.append(PackBytes.begin(), PackBytes.end());
-  Replacement.append(OrigInst, OrigInst + DI.Size);
 
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                           /*AllowSafeFarReturn=*/true))
-    return failRequiredPatch(Ctx);
+  if (SgprLive) {
+    std::optional<SafeSgprScratchBlock> Scratch =
+        findSafeSgprScratchBlock(Ctx, DI.Offset, /*Count=*/1, /*Alignment=*/1,
+                                 "tensor_load_to_lds descriptor save");
+    if (!Scratch) {
+      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
+               "available\n";
+      return failRequiredPatch(Ctx);
+    }
 
-  log() << "hotswap: tensor_load_to_lds: persistently cleared multicast bits "
-           "in "
-        << BaseSreg << "\n";
+    std::string ScratchName = "s" + std::to_string(Scratch->Base);
+    SmallVector<uint8_t> Save = assembleSingleInst(
+        "s_mov_b32 " + ScratchName + ", " + BaseSreg, Ctx.LS);
+    SmallVector<uint8_t> Restore = assembleSingleInst(
+        "s_mov_b32 " + BaseSreg + ", " + ScratchName, Ctx.LS);
+    if (Save.empty() || Restore.empty()) {
+      log() << "hotswap: error: tensor_load_to_lds: failed to assemble "
+               "descriptor save/restore through "
+            << ScratchName << "\n";
+      return failRequiredPatch(Ctx);
+    }
+
+    SmallVector<uint8_t> Replacement;
+    Replacement.append(Save.begin(), Save.end());
+    Replacement.append(PackBytes.begin(), PackBytes.end());
+    Replacement.append(OrigInst, OrigInst + DI.Size);
+    Replacement.append(Restore.begin(), Restore.end());
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                             /*AllowSafeFarReturn=*/true))
+      return failRequiredPatch(Ctx);
+
+    if (!commitSafeSgprScratchBlock(Ctx, DI.Offset, *Scratch,
+                                    "tensor_load_to_lds descriptor save"))
+      return failRequiredPatch(Ctx);
+    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
+          << " live, save/restore via " << ScratchName << "\n";
+  } else {
+    SmallVector<uint8_t> Replacement;
+    Replacement.append(PackBytes.begin(), PackBytes.end());
+    Replacement.append(OrigInst, OrigInst + DI.Size);
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                             /*AllowSafeFarReturn=*/true))
+      return failRequiredPatch(Ctx);
+
+    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
+          << " dead, no save/restore needed\n";
+  }
 
   Ctx.RequiredPatchApplied = true;
   DI.Mnemonic = "<replaced>";

--- a/amd/comgr/test-lit/hotswap-inplace-mixed.s
+++ b/amd/comgr/test-lit/hotswap-inplace-mixed.s
@@ -1,5 +1,5 @@
-// COM: Test HotSwap in-place patches: cluster_load -> global_load and
-// COM: s_clause -> s_nop replacements on a kernel containing both.
+// COM: Test HotSwap in-place cluster_load -> global_load patches and verify
+// COM: that valid s_clause instructions are preserved.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -10,24 +10,27 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=METADATA %s
 
 // COM: cluster_load mnemonics should be gone, replaced by global_load
 // DISASM-NOT: cluster_load_b32
 // DISASM-NOT: cluster_load_b128
 
-// COM: s_clause should be gone, replaced by s_nop
-// DISASM-NOT: s_clause
-
 // COM: Replacement global_load instructions should be present
 // DISASM-DAG: global_load_b32 v0
 // DISASM-DAG: global_load_b128 v[4:7]
 
-// COM: The s_nop replacement for s_clause
-// DISASM-DAG: s_nop
+// COM: Native A0 code generation preserves valid clauses.
+// DISASM: s_clause 0x1
 
 // COM: Original global_load instructions should still be there
 // DISASM-DAG: global_load_b32 v10
 // DISASM-DAG: global_load_b32 v11
+
+// COM: Every rewritten gfx1250 kernel must be labeled for A0.
+// METADATA-NOT: .gfx1250_revision: B0
+// METADATA: .gfx1250_revision: A0
 
 // COM: Idempotency: rewriting the patched output again should produce
 // COM: identical bytes.
@@ -62,3 +65,21 @@ test_inplace_kernel:
   .amdhsa_next_free_vgpr 12
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_inplace_kernel
+      .symbol: test_inplace_kernel.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-noop.s
+++ b/amd/comgr/test-lit/hotswap-inplace-noop.s
@@ -1,5 +1,5 @@
-// COM: Test HotSwap passthrough: kernel with no cluster_load or s_clause
-// COM: should pass through unchanged.
+// COM: A kernel requiring no instruction rewrite still needs its gfx1250
+// COM: revision metadata retagged from B0 to A0.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -10,6 +10,8 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=METADATA %s
 
 // COM: Strict mode is accepted even when no strict rewrite matches.
 // RUN: hotswap-rewrite %t.elf \
@@ -23,6 +25,9 @@
 // DISASM-NOT: s_clause
 // DISASM: global_load_b32 v0
 // DISASM: s_endpgm
+
+// METADATA-NOT: .gfx1250_revision: B0
+// METADATA: .gfx1250_revision: A0
 
 // COM: Idempotency: output should be identical on second rewrite.
 // RUN: hotswap-rewrite %t.out.elf \
@@ -50,3 +55,21 @@ test_noop_kernel:
   .amdhsa_next_free_vgpr 4
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_noop_kernel
+      .symbol: test_noop_kernel.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 2
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -6,13 +6,9 @@
 // COM: branch whose BACKWARD branch-back corrupts wave state on gfx1250 A0,
 // COM: producing a GPU memory fault in ncclDevKernel_Generic_4 (0/10 runs).
 // COM:
-// COM: Fix: decline far ds_*_2addr sites (leave the original instruction) until
-// COM: a scratch-register long branch-back lands. The two kernels below force
-// COM: the far path for a 2-addr LOAD and STORE and assert the decline: the
-// COM: original ds_*_2addr stays, and neither an s_add_pc_i64 redirect nor the
-// COM: single-address split (ds_load_b64 / ds_store_b32) is emitted. The near
-// COM: (sled / short-s_branch) ds_*_2addr path is still exercised and split by
-// COM: hotswap-trampoline-ds.s; only the far path changes here.
+// COM: Required DS2 rewrites use the safe SCC-neutral scratch-SGPR return. The
+// COM: two kernels below force the far path for a 2-address load and store and
+// COM: verify both are split instead of returning unsafe B0 instructions.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,21 +19,35 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
-// COM: Case 1 (2-addr LOAD, RCCL's pattern): declined -- original op stays, no
-// COM: forward long branch, no single-address split.
+// COM: Case 1 (2-address load, RCCL's pattern).
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: ds_load_2addr_stride64_b64
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: ds_load_b64
+// DISASM-NEXT: s_add_pc_i64
 
-// COM: Case 2 (2-addr STORE): declined the same way.
+// COM: Case 2 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: ds_store_2addr_stride64_b32
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: ds_store_b32
+// DISASM-NEXT: s_add_pc_i64
 
-// COM: Idempotency: rewriting the declined output again is a no-op.
+// DISASM-NOT: ds_load_2addr
+// DISASM-NOT: ds_store_2addr
+// DISASM: ds_load_b64 v[0:1], v4 offset:512
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:1024
+// DISASM: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
+// DISASM: ds_store_b32 v2, v0 offset:256
+// DISASM-NEXT: ds_store_b32 v2, v1 offset:768
+// DISASM: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
+
+// METADATA: .name:           test_ds2addr_far_load
+// METADATA: .sgpr_count:     6
+// METADATA: .name:           test_ds2addr_far_store
+// METADATA: .sgpr_count:     6
+
+// COM: Idempotency: rewriting the split output again is a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
@@ -83,3 +93,30 @@ test_ds2addr_far_store:
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds2addr_far_load
+      .symbol: test_ds2addr_far_load.kd
+      .sgpr_count: 1
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_store
+      .symbol: test_ds2addr_far_store.kd
+      .sgpr_count: 1
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
@@ -1,0 +1,32 @@
+// COM: A cyclic destination/source dependency cannot be split into two
+// COM: sequential exchanges without scratch VGPRs. Returning the original B0
+// COM: DS2 instruction in an A0 object would be unsafe, so rewriting must fail.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+
+// CHECK: hotswap: error: ds_storexchg_2addr has cyclic destination/source overlap
+// CHECK-NOT: hotswap: error: ds_2addr expansion failed
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_overlap_cyclic
+.p2align 8
+.type test_ds_overlap_cyclic,@function
+test_ds_overlap_cyclic:
+  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  s_wait_dscnt 0
+  s_endpgm
+.Ltest_ds_overlap_cyclic_end:
+.size test_ds_overlap_cyclic, .Ltest_ds_overlap_cyclic_end-test_ds_overlap_cyclic
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_overlap_cyclic
+  .amdhsa_next_free_vgpr 25
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
@@ -17,9 +17,6 @@
 
 // DISASM-LABEL: <test_ds_overlap>:
 
-// COM: A cyclic exchange dependency has no safe ordering and is declined.
-// DISASM: ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset1:1
-
 // COM: Address overlaps the first b64 destination half: issue half 1 first.
 // DISASM:      ds_load_b64 v[14:15], v12 offset:8
 // DISASM-NEXT: ds_load_b64 v[12:13], v12
@@ -36,6 +33,21 @@
 // DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:8
 // DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13]
 
+// COM: A data1 dependency also reverses a b32 exchange.
+// DISASM:      ds_storexchg_rtn_b32 v31, v40, v30 offset:4
+// DISASM-NEXT: ds_storexchg_rtn_b32 v30, v40, v41
+
+// COM: A data0 dependency on destination half 1 keeps the natural order.
+// DISASM:      ds_storexchg_rtn_b32 v32, v40, v33
+// DISASM-NEXT: ds_storexchg_rtn_b32 v33, v40, v41 offset:4
+
+// COM: Stride64 loads and exchanges use the same dependency ordering while
+// COM: scaling offset1 by 64 elements.
+// DISASM:      ds_load_b64 v[44:45], v42 offset:512
+// DISASM-NEXT: ds_load_b64 v[42:43], v42
+// DISASM:      ds_storexchg_rtn_b64 v[48:49], v46, v[52:53] offset:512
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[46:47], v46, v[50:51]
+
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
 .globl test_ds_overlap
@@ -46,7 +58,10 @@ test_ds_overlap:
   ds_load_2addr_b32 v[4:5], v4 offset0:1 offset1:2
   ds_load_2addr_b64 v[16:19], v18 offset0:0 offset1:1
   ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b32 v[30:31], v40, v41, v30 offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b32 v[32:33], v40, v33, v41 offset0:0 offset1:1
+  ds_load_2addr_stride64_b64 v[42:45], v42 offset0:0 offset1:1
+  ds_storexchg_2addr_stride64_rtn_b64 v[46:49], v46, v[50:51], v[52:53] offset0:0 offset1:1
   s_wait_dscnt 0x0
   s_endpgm
 .Ltest_ds_overlap_end:
@@ -55,6 +70,6 @@ test_ds_overlap:
 .rodata
 .p2align 8
 .amdhsa_kernel test_ds_overlap
-  .amdhsa_next_free_vgpr 25
+  .amdhsa_next_free_vgpr 54
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
@@ -8,9 +8,9 @@
 // COM:   raw 128 * 512 = 65536  -- one past the limit
 // COM:   raw 255 * 512 = 130560 -- worst case
 // COM:
-// COM: When that happens the patch is not representable, so the trampoline
-// COM: must leave the original (broken-on-A0) instruction in place rather
-// COM: than emit a silently-truncated single-address replacement.
+// COM: When that happens the patch is not representable. Returning the
+// COM: original broken-on-A0 instruction would be unsafe, so the rewrite must
+// COM: fail rather than emit a silently truncated replacement.
 // COM:
 // COM: Coverage:
 // COM:   test_ds_load_b64_overflow : raw 128/255 -> scaled 65536/130560
@@ -26,25 +26,22 @@
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
 // RUN:   hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=LOG %s
 // COM: Pin the message shape (mnemonic, both raw + scaled values, the
-// COM: 16-bit limit, and the "leaving original instruction in place"
-// COM: closer) so a regression in the message format or the limit
-// COM: constant fails here, not in some downstream-symptoms test. The
-// COM: helper's specific message is the only diagnostic; patchDs2Addr does
-// COM: not mislabel this intentional safe decline with a second generic
-// COM: failure. RESULT: SUCCESS comes last because the rewrite as a whole
-// COM: succeeds (the in-range kernel is patched).
+// COM: 16-bit limit, and the required-rewrite failure closer) so a regression
+// COM: in the message format or the limit constant fails here, not in some
+// COM: downstream-symptoms test. The helper's specific message is the only
+// COM: diagnostic; patchDs2Addr does not add a second generic failure.
+// COM: RESULT: ERROR comes last because leaving the required A0 rewrite
+// COM: unapplied would be unsafe.
 // LOG:      hotswap: error: ds_load_2addr_stride64_b64 scaled offsets exceed
 // LOG-SAME: the single-address DS 16-bit field
 // LOG-SAME: off0=raw 128 * scale 512 = 65536
 // LOG-SAME: off1=raw 255 * scale 512 = 130560
 // LOG-SAME: max 65535
-// LOG-SAME: leaving original instruction in place
-// LOG:      RESULT: SUCCESS
-
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// LOG-SAME: required A0 rewrite cannot continue
+// LOG:      RESULT: ERROR
 
 // ---- Kernel 1: out-of-range -- patch must NOT fire --------------------------
 // COM: Both per-operand indices scale past 0xFFFF (off0:128 -> 65536,
@@ -132,12 +129,8 @@ test_ds_load_b64_inrange:
 // COM: the in-range kernel the body now uses plain ds_load_b64, which
 // COM: the dispatcher does not recognise, so it is also untouched. Net:
 // COM: byte-identical output between passes.
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
-// RUN:   hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
+// COM: No output is produced after a required-patch failure, so idempotency is
+// COM: intentionally not checked for the rejected object.
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -6,6 +6,8 @@
 // COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
 // COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
 // COM: pushes the pool past s_branch's reach to force the far case.
+// COM: The function intentionally has st_size == 0, matching Tensile objects
+// COM: that omit .size and exercising zero-size function-range recovery.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -49,7 +51,7 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=NO-PAIR %s
-// NO-PAIR: hotswap: error: safe far return: kernel test_far has no aligned SGPR pair below s106
+// NO-PAIR: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
 // NO-PAIR: RESULT: ERROR
 
 // COM: gfx10+ cannot represent an increased SGPR count in the kernel
@@ -83,7 +85,7 @@ test_far:
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:
-.size test_far, .Ltest_far_end-test_far
+// Deliberately no .size.
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -1,6 +1,8 @@
-// COM: Test persistent tensor_load_to_lds descriptor normalization across a
-// COM: control-flow edge. The descriptor remains masked on either successor,
-// COM: so the rewrite needs no liveness-dependent save/restore sequence.
+// COM: Test isSgprLiveAfter edge cases for tensor_load_to_lds patching.
+// COM: A branch instruction between the tensor_load and the next use of
+// COM: the descriptor SGPR forces the heuristic to conservatively assume
+// COM: the SGPR is live, producing save/restore even though the use may
+// COM: not execute on all paths.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -12,14 +14,17 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load and
-// COM: s_mov (which reads s4). The later read sees the normalized descriptor.
+// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load
+// COM: and s_mov (which reads s4). isSgprLiveAfter returns true at the
+// COM: branch, so save/restore is emitted conservatively.
 // DISASM-LABEL: <test_tensor_branch_guard>:
 // DISASM: s_branch
 // DISASM: s_cbranch_scc1
 // DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
@@ -65,3 +70,20 @@ test_tensor_branch_guard:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_branch_guard
+      .symbol: test_tensor_branch_guard.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
@@ -213,3 +213,40 @@ test_tensor_mixed_ds:
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_multi_different
+      .symbol: test_tensor_multi_different.kd
+      .sgpr_count: 24
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_multi_same
+      .symbol: test_tensor_multi_same.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_mixed_ds
+      .symbol: test_tensor_mixed_ds.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
@@ -1,26 +1,15 @@
-// COM: A0 descriptor multicast bits stay clear after normalization. Even a
-// COM: kernel declaring all user-addressable SGPRs therefore needs no scratch
-// COM: register and must rewrite successfully without changing SGPR metadata.
+// COM: Live tensor_load_to_lds descriptor SGPRs require save/restore around
+// COM: the A0 D# Group 1 mask clear. If the kernel consumes all addressable
+// COM: SGPRs, hotswap must fail instead of returning unsafe code.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.out.elf \
-// RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: SUCCESS
-
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
-
-// DISASM-LABEL: <test_tensor_no_scratch>:
-// DISASM: s_branch
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_branch
-
-// METADATA: .name:           test_tensor_no_scratch
-// METADATA: .sgpr_count:     106
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: error: tensor_load_to_lds descriptor save: no aligned block of 1 safe SGPRs fits below s106
+// API: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -1,7 +1,7 @@
 // COM: Test the true trampoline fallback path for tensor_load_to_lds
-// COM: when no NOP sled is available. Both live and dead descriptor variants
-// COM: append the persistent s_pack_hh + tensor_load normalization via
-// COM: growWithTrampolines.
+// COM: when no NOP sled is available. Two variants:
+// COM:   dead SGPR - s_pack_hh + tensor_load appended via growWithTrampolines
+// COM:   live SGPR - save/pack/tensor/restore appended via growWithTrampolines
 // COM: Both force emitReplacementCode to use emitToTrampoline.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -43,10 +43,12 @@
 // DISASM-NEXT: tensor_load_to_lds
 // DISASM-NEXT: s_branch
 
-// COM: Live-SGPR trampoline body (for kernel 2): the same persistent mask and
-// COM: tensor sequence followed by branch-back.
+// COM: Live-SGPR trampoline body (for kernel 2): save + pack + tensor + restore
+// COM: followed by branch-back.
+// DISASM-NEXT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
@@ -91,3 +93,30 @@ test_tensor_trampoline_live:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_trampoline
+      .symbol: test_tensor_trampoline.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_trampoline_live
+      .symbol: test_tensor_trampoline_live.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,11 +1,11 @@
 // COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
 // COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
-// COM: the descriptor's base SGPR. The multicast bits remain clear after
-// COM: normalization, so live and dead descriptors use the same pack/tensor
-// COM: sequence without save/restore.
+// COM: the descriptor's base SGPR. Base operand variants via NOP sled:
+// COM:   dead SGPR - only s_pack_hh prepended (no save/restore)
+// COM:   live SGPR - s_mov save, s_pack_hh, tensor, s_mov restore
 // COM:   alt descriptor - different SGPR range (s[16:23]) for pack target
-// COM:   SGPR redef - descriptor SGPR overwritten before its next use
-// COM:   zero-size FUNC - kernel lookup when the function has st_size == 0
+// COM:   SGPR redef - descriptor SGPR overwritten before use (dead path)
+// COM:   zero-size FUNC - live path when the function symbol has st_size == 0
 // COM:   four-group tensor - operand 1 is still D# Group 1 and patches s4
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
 // COM: s_branch checks.
@@ -13,7 +13,7 @@
 // COM: Companion tests:
 // COM:   hotswap-trampoline-tensor-nosled.s     - trampoline fallback path
 // COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
-// COM:   hotswap-trampoline-tensor-liveness.s   - control-flow edge case
+// COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,7 +23,7 @@
 // RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API-NOT: kernel descriptor symbol '.kd' not found
-// API: hotswap: tensor_load_to_lds: persistently cleared multicast bits in s4
+// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
 // API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
@@ -46,13 +46,17 @@
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
 
-// COM: Kernel 2 (live SGPR): s4 is used after tensor_load_to_lds, and observes
-// COM: the persistently normalized descriptor. No scratch SGPR is required.
+// COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
+// COM: tensor/restore sequence in sled area with branch-back.
+// COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
+// COM: save/restore via a scratch SGPR is required.
 // DISASM-LABEL: <test_tensor_live>:
 // DISASM: s_branch
 // DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Kernel 3 (alternate descriptor s[16:23]): verifies
@@ -69,7 +73,8 @@
 
 // COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
 // COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
-// COM: The persistent mask remains safe when the descriptor is redefined.
+// COM: isSgprLiveAfter sees a def-before-use and takes the dead path,
+// COM: so no save/restore is needed.
 // DISASM-LABEL: <test_tensor_sgpr_redef>:
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
@@ -83,13 +88,18 @@
 
 // COM: Kernel 5 (zero-size FUNC): real Tensile objects can omit `.size`,
 // COM: leaving the FUNC symbol with st_size == 0. Kernel lookup must still
-// COM: find its descriptor. This kernel has no
+// COM: find its descriptor so scratch allocation succeeds. This kernel has no
 // COM: bounded local sled, so the replacement body is emitted in the appended
 // COM: trampoline pool and checked after Kernel 6.
 // DISASM-LABEL: <test_tensor_zero_size>:
 // DISASM: s_branch
 // DISASM: s_mov_b32 s0, s4
 // DISASM-NEXT: s_endpgm
+// DISASM: s_mov_b32 [[ZERO_SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s4, [[ZERO_SCRATCH]]
+// DISASM-NEXT: s_branch
 
 // COM: Kernel 6 (four-group tensor): operand 1 is D# Group 1, so the
 // COM: patch must clear s4 even though additional SGPR tuple operands follow.
@@ -98,10 +108,6 @@
 // DISASM: s_endpgm
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
-// DISASM-NEXT: s_branch
-
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
@@ -313,3 +319,70 @@ test_tensor_four_group:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 20
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_dead
+      .symbol: test_tensor_dead.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_live
+      .symbol: test_tensor_live.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_alt_descriptor
+      .symbol: test_tensor_alt_descriptor.kd
+      .sgpr_count: 24
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_sgpr_redef
+      .symbol: test_tensor_sgpr_redef.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_zero_size
+      .symbol: test_tensor_zero_size.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_four_group
+      .symbol: test_tensor_four_group.kd
+      .sgpr_count: 20
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -640,6 +640,28 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
 }
 
+TEST(ElfView, UpdateGfx1250RevisionMetadataRetagsKernelInPlace) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8;
+  Opts.MetadataGfx1250Revision = "B0";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::StringRef Before(reinterpret_cast<const char *>(Obj.Bytes.data()),
+                         Obj.Bytes.size());
+  EXPECT_NE(Before.find("B0"), llvm::StringRef::npos);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ASSERT_TRUE(ViewOrErr->updateGfx1250RevisionMetadata("A0"));
+
+  llvm::StringRef After(reinterpret_cast<const char *>(Obj.Bytes.data()),
+                        Obj.Bytes.size());
+  EXPECT_EQ(After.find("B0"), llvm::StringRef::npos);
+  EXPECT_NE(After.find("A0"), llvm::StringRef::npos);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -308,6 +308,86 @@ TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
       S, std::numeric_limits<uint64_t>::max() - 1, 0, /*SgprBase=*/12));
 }
 
+TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_mov_b32 s4, s0", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 4;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches};
+
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
+                                        /*Alignment=*/1, "unit test"));
+}
+
+TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElfOptions Options;
+  Options.EmitKernelDescriptorSymbol = false;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches};
+
+  const SafeSgprScratchBlock Block{/*Base=*/4, /*Count=*/1};
+  EXPECT_FALSE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Block, "unit test"));
+}
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
                                 {100, 128, 100, 100, 128}};

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -63,6 +63,7 @@ struct KernelDescriptorElfOptions {
   uint32_t ComputePgmRsrc3 = 0;
   std::optional<std::string> MetadataKernelName;
   std::optional<unsigned> MetadataSgprCount;
+  std::optional<std::string> MetadataGfx1250Revision;
   bool MetadataOmitSgprCount = false;
   bool MetadataSgprCountAsString = false;
 };
@@ -92,6 +93,9 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
       Kernel[".sgpr_count"] =
           static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
   }
+  if (Options.MetadataGfx1250Revision)
+    Kernel[".gfx1250_revision"] =
+        Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
   Kernels.push_back(Kernel);
   Root["amdhsa.kernels"] = Kernels;
 
@@ -157,9 +161,9 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   StrTab += ".kd";
   StrTab.push_back('\0');
 
-  const bool HasMetadataNote = Options.MetadataSgprCount ||
-                               Options.MetadataOmitSgprCount ||
-                               Options.MetadataSgprCountAsString;
+  const bool HasMetadataNote =
+      Options.MetadataSgprCount || Options.MetadataGfx1250Revision ||
+      Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString;
   std::vector<uint8_t> MetadataNote;
   if (HasMetadataNote) {
     std::string MetadataBlob = makeAmdgpuMetadataBlob(Options);


### PR DESCRIPTION
## Summary

- fail closed when required gfx1250 A0 rewrites cannot be represented
- allocate SGPR scratch above declared and observed use
- preserve valid clauses and coherent kernel metadata
- add LIT failure-path, metadata, and clause coverage plus ELF metadata unit tests

This is PR 3 of 5 in the series. #3345 has merged, so this PR is now rebased
directly onto `amd-staging`; #3347 remains stacked on this branch for its
focused one-patch review diff.

## Validation

- Post-#3345 rebase: `git range-diff` confirms all remaining patches are
  unchanged, and final stacked-tip release `check-comgr` passed 97/97
  supported LIT tests, all unit tests, and 31/31 CTests.
- Review-update release `check-comgr` at this PR boundary:
  - COMGR LIT: 93 passed, 11 unsupported, 0 failed (104 total)
  - all COMGR unit tests passed
  - COMGR CTests: 31/31 passed
- Review-update ASan validation at the final stacked tip:
  - COMGR LIT: 97 passed, 11 unsupported, 0 failed (108 total)
  - all COMGR unit tests passed
  - 30/30 runnable COMGR CTests passed
  - `comgr_multithread_test` remains excluded because its ASan-runtime `unable to unmap` failure reproduces unchanged on untouched `amd-staging`
- Prior combined-stack A0 validation on physical GPU 2 with `ROCR_VISIBLE_DEVICES=2` and HotSwap enabled (`HSA_HOTSWAP_DISABLE` unset):
  - exact rocSPARSE reproducer with the #8213 ROCr overlay and `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`: 1/1 passed
  - focused rocSPARSE multiply families with entry trampolines: 998/998 passed
  - focused rocBLAS with entry trampolines: 1,416/1,416 passed
  - focused hipBLAS with entry trampolines: 1,512/1,512 passed
  - focused hipBLASLt under the same default-HotSwap configuration used by the prior split validation: 76/76 passed
- Known entry-trampoline limitation: one hipBLASLt FP8 case aborts with `HSA_STATUS_ERROR_INVALID_CODE_OBJECT`; the identical case reproduces with the pre-convention split tip, so this is not introduced by these fixes.

Reference only: this series was split from the work validated in #3328. That PR remains unchanged as the known-good reference.
