### PR TITLE
[comgr][hotswap] scale hotswap rewrites for large code objects

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -107,7 +107,7 @@ static bool appendCodeEndGuard(std::vector<Trampoline> &Growth,
 
 static std::optional<uint32_t>
 getMaxOriginalKernelInstPrefSize(const ElfView &Elf, const LLVMState &LS) {
-  std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   uint32_t MaxOriginalInstPrefLines = 0;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     std::optional<uint32_t> OriginalInstPrefLines =
@@ -503,10 +503,47 @@ static bool instructionUsesVcc(const LLVMState &LS,
   return false;
 }
 
+static SafeSgprUsageSummary
+summarizeSafeSgprUsage(PatchContext &Ctx,
+                       ArrayRef<InternalDecodedInst> Instructions,
+                       StringRef Context) {
+  SafeSgprUsageSummary Summary;
+  for (const InternalDecodedInst &DI : Instructions) {
+    Summary.UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
+    Summary.HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
+    for (const MCOperand &Op : DI.Inst) {
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
+                                           Ctx.Config.MaxSgprs,
+                                           Summary.HighWatermark, Context)) {
+        Summary.Valid = false;
+        return Summary;
+      }
+    }
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs,
+                                           Summary.HighWatermark, Context)) {
+        Summary.Valid = false;
+        return Summary;
+      }
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs,
+                                           Summary.HighWatermark, Context)) {
+        Summary.Valid = false;
+        return Summary;
+      }
+  }
+  return Summary;
+}
+
 std::optional<SafeSgprScratchBlock>
-findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
-                         unsigned Count, unsigned Alignment,
-                         StringRef Context) {
+findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
+                         unsigned Alignment, StringRef Context) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
     log() << "hotswap: error: " << Context
           << ": invalid global SGPR block request (count=" << Count
@@ -519,45 +556,50 @@ findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
   std::string Owner =
       Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
   bool ScanWholeObject = Owner.empty() || !FunctionRange;
+  SafeSgprUsageSummary *Usage = nullptr;
   if (!ScanWholeObject) {
-    for (const InternalDecodedInst &DI : Ctx.Decoded) {
-      if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
-        continue;
-      if (Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst)) {
-        ScanWholeObject = true;
-        break;
-      }
+    using FunctionKey = std::pair<uint64_t, uint64_t>;
+    FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
+    DenseMap<FunctionKey, SafeSgprUsageSummary>::iterator Cached =
+        Ctx.FunctionSgprUsage.find(Key);
+    if (Cached == Ctx.FunctionSgprUsage.end()) {
+      std::vector<InternalDecodedInst>::const_iterator Begin = std::lower_bound(
+          Ctx.Decoded.cbegin(), Ctx.Decoded.cend(), FunctionRange->Begin,
+          [](const InternalDecodedInst &DI, uint64_t Offset) {
+            return DI.Offset < Offset;
+          });
+      std::vector<InternalDecodedInst>::const_iterator End =
+          std::lower_bound(Begin, Ctx.Decoded.cend(), FunctionRange->End,
+                           [](const InternalDecodedInst &DI, uint64_t Offset) {
+                             return DI.Offset < Offset;
+                           });
+      size_t BeginIndex = Begin - Ctx.Decoded.cbegin();
+      size_t InstructionCount = End - Begin;
+      SafeSgprUsageSummary Summary =
+          summarizeSafeSgprUsage(Ctx,
+                                 ArrayRef<InternalDecodedInst>(Ctx.Decoded)
+                                     .slice(BeginIndex, InstructionCount),
+                                 Context);
+      Cached = Ctx.FunctionSgprUsage.try_emplace(Key, Summary).first;
     }
+    Usage = &Cached->second;
+    ScanWholeObject = Usage->HasCall;
   }
 
-  bool UsesVcc = false;
-  unsigned HighWatermark = 0;
-  for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (!ScanWholeObject &&
-        (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End))
-      continue;
-    UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
-    for (const MCOperand &Op : DI.Inst) {
-      if (!Op.isReg() || !Op.getReg())
-        continue;
-      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
-                                           Ctx.Config.MaxSgprs, HighWatermark,
-                                           Context))
-        return std::nullopt;
-    }
-
-    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
-    for (MCPhysReg Reg : Desc.implicit_uses())
-      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
-                                           Ctx.Config.MaxSgprs, HighWatermark,
-                                           Context))
-        return std::nullopt;
-    for (MCPhysReg Reg : Desc.implicit_defs())
-      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
-                                           Ctx.Config.MaxSgprs, HighWatermark,
-                                           Context))
-        return std::nullopt;
+  if (ScanWholeObject) {
+    if (!Ctx.WholeObjectSgprUsage)
+      Ctx.WholeObjectSgprUsage = summarizeSafeSgprUsage(
+          Ctx, ArrayRef<InternalDecodedInst>(Ctx.Decoded), Context);
+    Usage = &*Ctx.WholeObjectSgprUsage;
   }
+  if (!Usage || !Usage->Valid) {
+    log() << "hotswap: error: " << Context
+          << ": cached SGPR usage analysis failed\n";
+    return std::nullopt;
+  }
+
+  bool UsesVcc = Usage->UsesVcc;
+  unsigned HighWatermark = Usage->HighWatermark;
 
   constexpr unsigned VccSgprs = 2;
   if (!Owner.empty()) {
@@ -608,7 +650,7 @@ findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
 bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 StringRef Context) {
-  std::vector<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
+  ArrayRef<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
   if (Descriptors.empty()) {
     log() << "hotswap: error: " << Context
           << ": code object has no kernel descriptors to charge for scratch "
@@ -692,14 +734,10 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
   // final pool offset (relative to .text) is known exactly now.
-  uint64_t PoolStart = Ctx.PoolBaseOffset;
-  for (const Trampoline &Prev : Ctx.OutTrampolines) {
-    std::optional<uint64_t> NextPoolStart = checkedAddUint64(
-        PoolStart, Prev.Bytes.size(), "trampoline pool layout");
-    if (!NextPoolStart)
-      return false;
-    PoolStart = *NextPoolStart;
-  }
+  std::optional<uint64_t> PoolStart = checkedAddUint64(
+      Ctx.PoolBaseOffset, Ctx.QueuedTrampolineBytes, "trampoline pool layout");
+  if (!PoolStart)
+    return false;
 
   // An s_branch encodes To - From as a signed simm16 dword field, in range iff
   // (To - From - MinInstSize) / MinInstSize fits [BranchOffsetMin,
@@ -707,13 +745,24 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   // short branch-back slot; the branch-back (pool tail -> site) is the farther
   // of the two. Go long only when a short branch cannot reach.
   std::optional<uint64_t> ShortBackFrom = checkedAddUint64(
-      PoolStart, Replacement.size(), "short trampoline return slot");
+      *PoolStart, Replacement.size(), "short trampoline return slot");
   std::optional<uint64_t> ReturnTo =
       checkedAddUint64(InstOffset, InstSize, "trampoline return target");
   if (!ShortBackFrom || !ReturnTo)
     return false;
-  const bool Far = !(isSBranchReachable(InstOffset, PoolStart) &&
+  const bool Far = !(isSBranchReachable(InstOffset, *PoolStart) &&
                      isSBranchReachable(*ShortBackFrom, *ReturnTo));
+
+  uint64_t ReturnReserve = Far ? SetPcReturnReserveBytes : MinInstSize;
+  std::optional<uint64_t> TrampolineSize = checkedAddUint64(
+      Replacement.size(), ReturnReserve, "queued trampoline size");
+  if (!TrampolineSize)
+    return false;
+  std::optional<uint64_t> QueuedBytes =
+      checkedAddUint64(Ctx.QueuedTrampolineBytes, *TrampolineSize,
+                       "queued trampoline byte count");
+  if (!QueuedBytes)
+    return false;
 
   Trampoline T;
   T.OriginalOffset = InstOffset;
@@ -742,6 +791,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     T.UsesSetPCBack = true;
     T.LongBranchSgprBase = Scratch->Base;
     Ctx.OutTrampolines.emplace_back(std::move(T));
+    Ctx.QueuedTrampolineBytes = *QueuedBytes;
     return true;
   }
   {
@@ -749,6 +799,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
   }
   Ctx.OutTrampolines.emplace_back(std::move(T));
+  Ctx.QueuedTrampolineBytes = *QueuedBytes;
   return true;
 }
 
@@ -1649,7 +1700,13 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       return std::nullopt;
   }
 
-  for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
+  struct ResourceCounts {
+    unsigned Vgprs;
+    unsigned Sgprs;
+  };
+  StringMap<ResourceCounts> CountsBefore;
+  StringMap<unsigned> RequiredSgprCounts;
+  for (const StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
     const KernelPatchStats &Stats = KV.second;
     if (KName.empty())
@@ -1657,6 +1714,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     std::optional<unsigned> VgprsBefore =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
     std::optional<unsigned> SgprsBefore = Elf.getKernelSgprCount(KName);
+    CountsBefore.try_emplace(KName, ResourceCounts{VgprsBefore.value_or(0),
+                                                   SgprsBefore.value_or(0)});
     if (Stats.ExtraVgprs > 0)
       Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs,
                                  Config.VgprGranuleSize);
@@ -1673,20 +1732,33 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
         return std::nullopt;
       }
       unsigned RequiredSgprs = *SgprsBefore + Stats.ExtraSgprs;
-      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs,
-                                               /*UpdateDescriptor=*/false)) {
-        log() << "hotswap: error: failed to update SGPR count for kernel "
-              << KName << "\n";
-        return std::nullopt;
-      }
+      RequiredSgprCounts.try_emplace(KName, RequiredSgprs);
+    }
+  }
+
+  if (!Elf.updateKernelMetadataSgprCounts(RequiredSgprCounts)) {
+    log() << "hotswap: error: failed to update kernel SGPR metadata\n";
+    return std::nullopt;
+  }
+
+  for (const StringMapEntry<KernelPatchStats> &KV : KernelStats) {
+    StringRef KName = KV.first();
+    const KernelPatchStats &Stats = KV.second;
+    if (KName.empty())
+      continue;
+    StringMap<ResourceCounts>::const_iterator Before = CountsBefore.find(KName);
+    if (Before == CountsBefore.end()) {
+      log() << "hotswap: error: missing cached resource counts for kernel "
+            << KName << "\n";
+      return std::nullopt;
     }
     std::optional<unsigned> VgprsAfter =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
     std::optional<unsigned> SgprsAfter = Elf.getKernelSgprCount(KName);
     log() << "hotswap: liveness: kernel " << KName
-          << ": vgprs_before=" << VgprsBefore.value_or(0)
+          << ": vgprs_before=" << Before->second.Vgprs
           << ", vgprs_after=" << VgprsAfter.value_or(0)
-          << ", sgprs_before=" << SgprsBefore.value_or(0)
+          << ", sgprs_before=" << Before->second.Sgprs
           << ", sgprs_after=" << SgprsAfter.value_or(0)
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -8,8 +8,9 @@
 ///
 /// \file
 /// Implementation of hotswap::ElfView and the free-function ELF helpers.
-/// Parses are delegated to llvm::object::ELFFile; there is no hand-rolled
-/// section/symbol cache.
+/// Parses are delegated to llvm::object::ELFFile. ElfView caches immutable
+/// symbol ranges and metadata-derived SGPR counts for the duration of one
+/// rewrite so large code objects do not repeatedly parse the same ELF data.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -121,12 +122,20 @@ readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
 
 using MetadataNoteMutator = function_ref<std::optional<bool>(
     msgpack::Document &, msgpack::MapDocNode &)>;
+using MetadataNoteValidator = function_ref<bool(bool)>;
+
+struct PendingMetadataWrite {
+  size_t Offset = 0;
+  std::string Blob;
+};
 
 /// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
-/// write changed notes back in place after checking that their encoded size and
-/// destination remain valid. Returns false after logging a specific failure.
+/// defer changed writes until \p Validator accepts the complete traversal.
+/// This keeps multi-note updates atomic while sharing the parsing, encoded-size
+/// and destination validation for every metadata mutation.
 static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
                                  StringRef Context, MetadataNoteMutator Mutator,
+                                 MetadataNoteValidator Validator,
                                  bool &SawMetadataNote) {
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   if (!PhdrsOrErr) {
@@ -134,7 +143,7 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
           << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
     return false;
   }
-
+  std::vector<PendingMetadataWrite> PendingWrites;
   for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
     if (Phdr.p_type != ELF::PT_NOTE)
       continue;
@@ -197,7 +206,7 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
               << ": metadata descriptor extends past the ELF buffer.\n";
         return false;
       }
-      std::memcpy(Elf + DescOffset, NewBlob.data(), NewBlob.size());
+      PendingWrites.push_back({DescOffset, std::move(NewBlob)});
     }
 
     if (Err) {
@@ -207,16 +216,24 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
       return false;
     }
   }
+
+  if (!Validator(SawMetadataNote))
+    return false;
+  for (const PendingMetadataWrite &Write : PendingWrites)
+    std::memcpy(Elf + Write.Offset, Write.Blob.data(), Write.Blob.size());
   return true;
 }
 
 static MetadataSgprUpdateStatus
-updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
-                              StringRef KernelName, unsigned RequiredSgprs) {
+rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
+                                const StringMap<unsigned> &RequiredSgprs) {
+  if (RequiredSgprs.empty())
+    return MetadataSgprUpdateStatus::Found;
+
   bool SawMetadataNote = false;
-  bool Found = false;
+  StringMap<bool> Found;
   bool Rewritten = rewriteMetadataNotes(
-      Elf, File, "updateKernelMetadataSgprCount",
+      Elf, File, "updateKernelMetadataSgprCounts",
       [&](msgpack::Document &,
           msgpack::MapDocNode &RootMap) -> std::optional<bool> {
         msgpack::DocNode::MapTy::iterator KernelsIt =
@@ -224,47 +241,59 @@ updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
         if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
           return false;
 
+        bool Changed = false;
         for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
           if (!KNode.isMap())
             continue;
           msgpack::MapDocNode &KMap = KNode.getMap();
           msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
-          if (NameIt == KMap.end() || !NameIt->second.isString() ||
-              NameIt->second.getString() != KernelName)
+          if (NameIt == KMap.end() || !NameIt->second.isString())
             continue;
 
-          Found = true;
+          StringRef KernelName = NameIt->second.getString();
+          StringMap<unsigned>::const_iterator Required =
+              RequiredSgprs.find(KernelName);
+          if (Required == RequiredSgprs.end() || Found.contains(KernelName))
+            continue;
+
           msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
           if (SgprIt == KMap.end()) {
-            log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
+            log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
                   << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
             return std::nullopt;
           }
 
           std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
-              SgprIt->second, KernelName, "updateKernelMetadataSgprCount");
+              SgprIt->second, KernelName, "updateKernelMetadataSgprCounts");
           if (!CurrentSgprs)
             return std::nullopt;
-          if (RequiredSgprs <= *CurrentSgprs)
-            return false;
+          Found.try_emplace(KernelName, true);
+          if (Required->second <= *CurrentSgprs)
+            continue;
 
-          SgprIt->second = static_cast<uint64_t>(RequiredSgprs);
-          return true;
+          SgprIt->second = static_cast<uint64_t>(Required->second);
+          Changed = true;
         }
-        return false;
+        return Changed;
+      },
+      [&](bool SawMetadata) {
+        if (!SawMetadata)
+          return true;
+        for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+          if (Found.contains(Required.first()))
+            continue;
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+                   "metadata has no entry for kernel '"
+                << Required.first() << "'.\n";
+          return false;
+        }
+        return true;
       },
       SawMetadataNote);
   if (!Rewritten)
     return MetadataSgprUpdateStatus::Error;
-  if (Found)
-    return MetadataSgprUpdateStatus::Found;
-
-  if (SawMetadataNote) {
-    log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU metadata "
-          << "has no entry for kernel '" << KernelName << "'.\n";
-    return MetadataSgprUpdateStatus::Error;
-  }
-  return MetadataSgprUpdateStatus::NotFound;
+  return SawMetadataNote ? MetadataSgprUpdateStatus::Found
+                         : MetadataSgprUpdateStatus::NotFound;
 }
 
 bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
@@ -299,7 +328,7 @@ bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
         }
         return Changed;
       },
-      SawMetadataNote);
+      [](bool) { return true; }, SawMetadataNote);
 }
 
 // -- applyByteReplace ---------------------------------------------------------
@@ -404,14 +433,18 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
 
 // -- ElfView::functionTextRanges ---------------------------------------------
 
-std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
+ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
+  if (FunctionRangeCache)
+    return *FunctionRangeCache;
+
   std::vector<FunctionTextRange> Ranges;
   uint64_t TextBegin = textAddr();
   uint64_t TextSizeValue = textSize();
   if (TextSizeValue > std::numeric_limits<uint64_t>::max() - TextBegin) {
     log() << "hotswap: error: function text range scan: .text virtual "
           << "address range overflows uint64_t.\n";
-    return Ranges;
+    FunctionRangeCache.emplace();
+    return *FunctionRangeCache;
   }
   uint64_t TextEnd = TextBegin + TextSizeValue;
 
@@ -464,32 +497,57 @@ std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
     }
   }
 
-  return Ranges;
+  llvm::stable_sort(
+      Ranges, [](const FunctionTextRange &LHS, const FunctionTextRange &RHS) {
+        return LHS.Begin < RHS.Begin;
+      });
+  FunctionRangeCache = std::move(Ranges);
+  return *FunctionRangeCache;
+}
+
+std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
+  ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
+  return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
 }
 
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
+const ElfView::FunctionTextRange *
+ElfView::findFunctionTextRangeAtAddress(uint64_t TextAddress) const {
+  ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
+  ArrayRef<FunctionTextRange>::const_iterator GroupEnd =
+      std::upper_bound(Ranges.begin(), Ranges.end(), TextAddress,
+                       [](uint64_t Address, const FunctionTextRange &Range) {
+                         return Address < Range.Begin;
+                       });
+
+  // Prefer the covering range with the greatest start address, matching the
+  // previous full scan. Preserve the stable symbol-table order for duplicate
+  // starts so aliases resolve exactly as before.
+  while (GroupEnd != Ranges.begin()) {
+    ArrayRef<FunctionTextRange>::const_iterator GroupBegin = GroupEnd - 1;
+    uint64_t Begin = GroupBegin->Begin;
+    while (GroupBegin != Ranges.begin() && (GroupBegin - 1)->Begin == Begin)
+      --GroupBegin;
+    for (ArrayRef<FunctionTextRange>::const_iterator It = GroupBegin;
+         It != GroupEnd; ++It)
+      if (TextAddress < It->End)
+        return &*It;
+    GroupEnd = GroupBegin;
+  }
+  return nullptr;
+}
+
 std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
-  bool Found = false;
-  uint64_t BestValue = 0;
-  std::string BestName;
-
-  std::vector<FunctionTextRange> Ranges = functionTextRanges();
-  for (const FunctionTextRange &Range : Ranges) {
-    if (TextAddress < Range.Begin || TextAddress >= Range.End)
-      continue;
-
-    const ELFT::Sym &Sym = *Range.Symbol;
-    if (Found && Sym.st_value <= BestValue)
-      continue;
-
+  const FunctionTextRange *Range = findFunctionTextRangeAtAddress(TextAddress);
+  if (Range) {
+    const ELFT::Sym &Sym = *Range->Symbol;
     Expected<StringRef> StrTabOrErr =
-        File.getStringTableForSymtab(*Range.Symtab, Sections);
+        File.getStringTableForSymtab(*Range->Symtab, Sections);
     if (!StrTabOrErr) {
       consumeError(StrTabOrErr.takeError());
-      continue;
+      return "";
     }
-
     Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
     if (!NameOrErr) {
       log() << "hotswap: error: findKernelAtAddress: function symbol "
@@ -498,12 +556,7 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
             << "\n";
       return "";
     }
-    Found = true;
-    BestValue = Sym.st_value;
-    BestName = NameOrErr->str();
-  }
-
-  if (Found) {
+    std::string BestName = NameOrErr->str();
     // Confirm the selected symbol is actually a kernel: every kernel carries a
     // "<name>.kd" descriptor symbol, whereas a plain device function does not.
     // This is the same descriptor lookup getKernelVgprCount performs, so a real
@@ -525,74 +578,25 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
 
 std::optional<ElfView::FunctionTextRange>
 ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
-  std::optional<FunctionTextRange> Best;
-  for (const FunctionTextRange &Range : functionTextRanges()) {
-    if (Range.Begin < textAddr() || Range.End < textAddr())
-      continue;
-    uint64_t Begin = Range.Begin - textAddr();
-    uint64_t End = Range.End - textAddr();
-    if (TextOffset < Begin || TextOffset >= End)
-      continue;
-    if (!Best || Begin > Best->Begin)
-      Best = FunctionTextRange{Begin, End};
-  }
-  return Best;
-}
-
-// -- ElfView::findKernelDescriptor --------------------------------------------
-
-uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
-  std::string KdName = (KernelName + ".kd").str();
-  for (const ELFT::Shdr &SymShdr : Sections) {
-    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
-        SymShdr.sh_type != ELF::SHT_DYNSYM)
-      continue;
-
-    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
-    if (!SymsOrErr) {
-      consumeError(SymsOrErr.takeError());
-      continue;
-    }
-    Expected<StringRef> StrTabOrErr =
-        File.getStringTableForSymtab(SymShdr, Sections);
-    if (!StrTabOrErr) {
-      consumeError(StrTabOrErr.takeError());
-      continue;
-    }
-
-    for (const ELFT::Sym &Sym : *SymsOrErr) {
-      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
-      if (!NameOrErr) {
-        consumeError(NameOrErr.takeError());
-        continue;
-      }
-      if (*NameOrErr != KdName)
-        continue;
-      unsigned Shndx = Sym.st_shndx;
-      Expected<const ELFT::Shdr *> HostShdrOrErr = File.getSection(Shndx);
-      if (!HostShdrOrErr) {
-        consumeError(HostShdrOrErr.takeError());
-        continue;
-      }
-      const ELFT::Shdr &HostShdr = **HostShdrOrErr;
-      std::optional<uint64_t> FileOffset = checkedSectionFileOffset(
-          HostShdr, Sym.st_value, KdSize, size(),
-          (Twine("findKernelDescriptor: descriptor symbol '") + *NameOrErr +
-           "'")
-              .str());
-      if (!FileOffset)
-        continue;
-      return data() + *FileOffset;
-    }
-  }
-  return nullptr;
+  if (TextOffset >= textSize() ||
+      TextOffset > std::numeric_limits<uint64_t>::max() - textAddr())
+    return std::nullopt;
+  const FunctionTextRange *Range =
+      findFunctionTextRangeAtAddress(textAddr() + TextOffset);
+  if (!Range || Range->Begin < textAddr() || Range->End < textAddr())
+    return std::nullopt;
+  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr()};
 }
 
 // -- ElfView::kernelDescriptors -----------------------------------------------
 
-std::vector<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
+void ElfView::initializeKernelDescriptorCache() const {
+  if (KernelDescriptorCache)
+    return;
+
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
+  StringMap<uint64_t> FileOffsets;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -653,10 +657,26 @@ std::vector<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
           });
       if (!Seen)
         Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
+      FileOffsets.try_emplace(NameOrErr->drop_back(3), *FileOffset);
     }
   }
 
-  return Result;
+  KernelDescriptorFileOffsetCache = std::move(FileOffsets);
+  KernelDescriptorCache = std::move(Result);
+}
+
+uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
+  initializeKernelDescriptorCache();
+  StringMap<uint64_t>::const_iterator It =
+      KernelDescriptorFileOffsetCache.find(KernelName);
+  if (It == KernelDescriptorFileOffsetCache.end())
+    return nullptr;
+  return data() + It->second;
+}
+
+ArrayRef<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
+  initializeKernelDescriptorCache();
+  return *KernelDescriptorCache;
 }
 
 std::optional<uint64_t>
@@ -680,6 +700,12 @@ bool ElfView::updateKernelDescriptorEntryOffset(StringRef KernelName,
   std::memcpy(
       Kd + offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
       &NewEntryOffset, sizeof(NewEntryOffset));
+  for (KernelDescriptorInfo &Info : *KernelDescriptorCache) {
+    if (Info.KernelName != KernelName)
+      continue;
+    Info.EntryOffset = NewEntryOffset;
+    break;
+  }
   return true;
 }
 
@@ -728,8 +754,10 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
     }
   }
 
+  StringMap<unsigned> RequiredSgprCounts;
+  RequiredSgprCounts.try_emplace(KernelName, RequiredSgprs);
   MetadataSgprUpdateStatus MetadataStatus =
-      updateKernelMetadataSgprCount(data(), File, KernelName, RequiredSgprs);
+      rewriteKernelMetadataSgprCounts(data(), File, RequiredSgprCounts);
   if (MetadataStatus == MetadataSgprUpdateStatus::Error)
     return false;
   if (!UpdateDescriptor &&
@@ -743,6 +771,16 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
   // On pre-gfx10 targets, NotFound is allowed for minimal code objects without
   // AMDGPU metadata because the descriptor remains the canonical count.
 
+  if (SgprCacheState == KernelSgprCacheState::Metadata &&
+      MetadataStatus == MetadataSgprUpdateStatus::Found) {
+    StringMap<std::optional<unsigned>>::iterator Cached =
+        KernelSgprCountCache.find(KernelName);
+    if (Cached == KernelSgprCountCache.end())
+      KernelSgprCountCache.try_emplace(KernelName, RequiredSgprs);
+    else if (!Cached->second || RequiredSgprs > *Cached->second)
+      Cached->second = RequiredSgprs;
+  }
+
   if (!RequiredGranulated)
     return true;
 
@@ -750,6 +788,33 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
                   *RequiredGranulated);
   std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               &Rsrc1, sizeof(Rsrc1));
+  if (SgprCacheState == KernelSgprCacheState::NoMetadata)
+    KernelSgprCountCache.erase(KernelName);
+  return true;
+}
+
+bool ElfView::updateKernelMetadataSgprCounts(
+    const StringMap<unsigned> &RequiredSgprs) {
+  MetadataSgprUpdateStatus MetadataStatus =
+      rewriteKernelMetadataSgprCounts(data(), File, RequiredSgprs);
+  if (MetadataStatus == MetadataSgprUpdateStatus::Error)
+    return false;
+  if (MetadataStatus == MetadataSgprUpdateStatus::NotFound) {
+    log() << "hotswap: error: updateKernelMetadataSgprCounts: code object "
+             "has no AMDGPU metadata note.\n";
+    return false;
+  }
+
+  if (SgprCacheState == KernelSgprCacheState::Metadata) {
+    for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+      StringMap<std::optional<unsigned>>::iterator Cached =
+          KernelSgprCountCache.find(Required.first());
+      if (Cached == KernelSgprCountCache.end())
+        KernelSgprCountCache.try_emplace(Required.first(), Required.second);
+      else if (!Cached->second || Required.second > *Cached->second)
+        Cached->second = Required.second;
+    }
+  }
   return true;
 }
 
@@ -889,9 +954,13 @@ ElfView::getKernelStaticLdsSize(StringRef KernelName) const {
 // preferred source. Falls back to the KD field when no metadata note is
 // present (e.g. minimal test ELFs assembled with -nostdlib).
 
-std::optional<unsigned>
-ElfView::getKernelSgprCount(StringRef KernelName) const {
-  // --- Try msgpack metadata note first. ---
+void ElfView::initializeKernelSgprCountCache() const {
+  if (SgprCacheState != KernelSgprCacheState::Uninitialized)
+    return;
+
+  // Default to Error so every malformed-note early return leaves an explicit
+  // terminal cache state instead of reparsing the same large blob.
+  SgprCacheState = KernelSgprCacheState::Error;
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   bool SawMetadataNote = false;
   if (PhdrsOrErr) {
@@ -907,25 +976,25 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
 
         ArrayRef<uint8_t> Desc = Note.getDesc(4);
         if (Desc.empty()) {
-          log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata note "
+          log() << "hotswap: error: SGPR cache: AMDGPU metadata note "
                 << "has an empty descriptor.\n";
-          return std::nullopt;
+          return;
         }
 
         StringRef Blob(reinterpret_cast<const char *>(Desc.data()),
                        Desc.size());
         msgpack::Document Doc;
         if (!Doc.readFromBlob(Blob, false)) {
-          log() << "hotswap: error: getKernelSgprCount: failed to parse "
+          log() << "hotswap: error: SGPR cache: failed to parse "
                 << "AMDGPU metadata note.\n";
-          return std::nullopt;
+          return;
         }
 
         msgpack::DocNode Root = Doc.getRoot();
         if (!Root.isMap()) {
-          log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata root "
+          log() << "hotswap: error: SGPR cache: AMDGPU metadata root "
                 << "is not a map.\n";
-          return std::nullopt;
+          return;
         }
         msgpack::MapDocNode &RootMap = Root.getMap();
         msgpack::DocNode::MapTy::iterator KernelsIt =
@@ -940,36 +1009,60 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
           msgpack::MapDocNode &KMap = KNode.getMap();
           msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
           if (NameIt == KMap.end() || !NameIt->second.isString() ||
-              NameIt->second.getString() != KernelName)
+              KernelSgprCountCache.find(NameIt->second.getString()) !=
+                  KernelSgprCountCache.end())
             continue;
 
           msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
           if (SgprIt == KMap.end()) {
-            log() << "hotswap: error: getKernelSgprCount: metadata for kernel '"
-                  << KernelName << "' has no .sgpr_count.\n";
-            return std::nullopt;
+            KernelSgprCountCache.try_emplace(NameIt->second.getString(),
+                                             std::nullopt);
+            continue;
           }
-          return readSgprCountMetadataNode(SgprIt->second, KernelName,
-                                           "getKernelSgprCount");
+          StringRef Name = NameIt->second.getString();
+          KernelSgprCountCache.try_emplace(
+              Name,
+              readSgprCountMetadataNode(SgprIt->second, Name, "SGPR cache"));
         }
       }
       if (Err) {
-        log() << "hotswap: error: getKernelSgprCount: failed to iterate "
+        log() << "hotswap: error: SGPR cache: failed to iterate "
               << "AMDGPU notes: " << toString(std::move(Err)) << "\n";
-        return std::nullopt;
+        return;
       }
     }
   } else {
-    log() << "hotswap: error: getKernelSgprCount: failed to read program "
+    log() << "hotswap: error: SGPR cache: failed to read program "
           << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
-    return std::nullopt;
+    return;
   }
 
-  if (SawMetadataNote) {
+  SgprCacheState = SawMetadataNote ? KernelSgprCacheState::Metadata
+                                   : KernelSgprCacheState::NoMetadata;
+}
+
+std::optional<unsigned>
+ElfView::getKernelSgprCount(StringRef KernelName) const {
+  initializeKernelSgprCountCache();
+  if (SgprCacheState == KernelSgprCacheState::Error)
+    return std::nullopt;
+
+  StringMap<std::optional<unsigned>>::const_iterator Cached =
+      KernelSgprCountCache.find(KernelName);
+  if (SgprCacheState == KernelSgprCacheState::Metadata) {
+    if (Cached != KernelSgprCountCache.end()) {
+      if (!Cached->second)
+        log() << "hotswap: error: getKernelSgprCount: metadata for kernel '"
+              << KernelName << "' has no valid .sgpr_count.\n";
+      return Cached->second;
+    }
     log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata has no "
           << ".sgpr_count entry for kernel '" << KernelName << "'.\n";
     return std::nullopt;
   }
+
+  if (Cached != KernelSgprCountCache.end())
+    return Cached->second;
 
   // --- Fallback: read the KD field. ---
   // The LLVM assembler populates GRANULATED_WAVEFRONT_SGPR_COUNT even on
@@ -977,8 +1070,10 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
   // ROCm-compiled code objects that lack a metadata note.
   namespace hsa = amdhsa;
   uint8_t *Kd = const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
-  if (!Kd)
+  if (!Kd) {
+    KernelSgprCountCache.try_emplace(KernelName, std::nullopt);
     return std::nullopt;
+  }
   uint32_t Rsrc1;
   std::memcpy(&Rsrc1,
               Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
@@ -992,7 +1087,9 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
           << KernelName << "' exceeds unsigned.\n";
     return std::nullopt;
   }
-  return static_cast<unsigned>(SgprCount);
+  std::optional<unsigned> Result = static_cast<unsigned>(SgprCount);
+  KernelSgprCountCache.try_emplace(KernelName, Result);
+  return Result;
 }
 
 // -- ElfView::getKernelClusterDims --------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -484,7 +484,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     const ElfView &Elf, const LLVMState &LS, unsigned MaxSgprs,
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups) {
-  std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   if (Descriptors.empty())
     return 0;
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
@@ -292,8 +293,9 @@ public:
   uint8_t *findKernelDescriptor(llvm::StringRef KernelName);
 
   /// Enumerate kernel descriptor symbols named "<kernel>.kd" and read their
-  /// current kernel_code_entry_byte_offset values.
-  std::vector<KernelDescriptorInfo> kernelDescriptors() const;
+  /// current kernel_code_entry_byte_offset values. The returned range remains
+  /// valid until this ElfView is destroyed.
+  llvm::ArrayRef<KernelDescriptorInfo> kernelDescriptors() const;
 
   /// Return the virtual address of the kernel descriptor symbol for
   /// \p KernelName, or std::nullopt when the descriptor is not present.
@@ -310,6 +312,11 @@ public:
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
                                        unsigned RequiredSgprs,
                                        bool UpdateDescriptor = true);
+
+  /// Update metadata SGPR counts for every named kernel in one parse and
+  /// serialization pass. All requested kernels must be present.
+  bool updateKernelMetadataSgprCounts(
+      const llvm::StringMap<unsigned> &RequiredSgprs);
 
   /// Retag every gfx1250 kernel in the AMDGPU metadata note with \p Revision.
   /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
@@ -391,15 +398,35 @@ public:
                       llvm::ArrayRef<uint8_t> SNopBytes) const;
 
 private:
+  enum class KernelSgprCacheState {
+    Uninitialized,
+    Metadata,
+    NoMetadata,
+    Error,
+  };
+
   ElfView(ELFFileT File, ELFT::ShdrRange Sections,
           const ELFT::Shdr *TextSection, unsigned TextSectionIndex)
       : File(std::move(File)), Sections(Sections), TextSection(TextSection),
         TextSectionIndex(TextSectionIndex) {}
 
+  llvm::ArrayRef<FunctionTextRange> cachedFunctionTextRanges() const;
+  const FunctionTextRange *
+  findFunctionTextRangeAtAddress(uint64_t TextAddress) const;
+  void initializeKernelDescriptorCache() const;
+  void initializeKernelSgprCountCache() const;
+
   ELFFileT File;
   ELFT::ShdrRange Sections;
   const ELFT::Shdr *TextSection;
   unsigned TextSectionIndex;
+  mutable std::optional<std::vector<FunctionTextRange>> FunctionRangeCache;
+  mutable std::optional<std::vector<KernelDescriptorInfo>>
+      KernelDescriptorCache;
+  mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
+  mutable KernelSgprCacheState SgprCacheState =
+      KernelSgprCacheState::Uninitialized;
+  mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;
 };
 
 // -- Free-function ELF helpers (no ELF state required) ------------------------
@@ -728,6 +755,13 @@ struct KernelPatchStats {
   unsigned ScratchAboveKd = 0;
 };
 
+struct SafeSgprUsageSummary {
+  bool Valid = true;
+  bool UsesVcc = false;
+  bool HasCall = false;
+  unsigned HighWatermark = 0;
+};
+
 /// Mutable per-run context threaded through all patch passes. Bundles the
 /// input config, decoded instruction stream, raw .text bytes, MC state,
 /// output streams (trampolines / scratch info), and the shared ELF view +
@@ -753,6 +787,16 @@ struct PatchContext {
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;
   bool RequiredPatchApplied = false;
+  // Sum of the bytes already queued in OutTrampolines. Keeping this in the
+  // per-rewrite context makes each new pool-position calculation constant
+  // time even for code objects with many thousands of patch sites.
+  uint64_t QueuedTrampolineBytes = 0;
+  // Safe far-return scratch allocation can be queried at many patch sites in
+  // one function. Cache the immutable decoded SGPR usage summaries so each
+  // function, and the whole-object fallback, is scanned at most once.
+  std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
+      FunctionSgprUsage{0};
 };
 
 /// A block of numbered SGPRs that is not referenced in the function being
@@ -766,9 +810,8 @@ struct SafeSgprScratchBlock {
 /// Find an aligned block of unused numbered SGPRs for \p TextOffset. Returns
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
-findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
-                         unsigned Count, unsigned Alignment,
-                         llvm::StringRef Context);
+findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
+                         unsigned Alignment, llvm::StringRef Context);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively

--- a/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
+++ b/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
@@ -1,0 +1,95 @@
+// COM: Exercise the large-object SGPR-usage caches with two patch sites in a
+// COM: function containing a direct call. The first site builds the per-function
+// COM: summary, the call promotes it to the whole-object summary, and the
+// COM: second site reuses both cached results. Non-NOP straight-line windows
+// COM: let each far site carry its set-PC sequence without a gateway.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: applied 2 instruction patches
+// LOG: hotswap: growWithTrampolines: appended 2 trampolines
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <test_large_usage_cache>:
+// DISASM: s_cselect_b32
+// DISASM: s_set_pc_i64
+// DISASM: s_call_i64
+// DISASM: s_cselect_b32
+// DISASM: s_set_pc_i64
+// DISASM: tensor_load_to_lds
+// DISASM: tensor_load_to_lds
+
+// META: .name:           test_large_usage_cache
+// META: .sgpr_count:     39
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_large_usage_cache
+.p2align 8
+.type test_large_usage_cache,@function
+test_large_usage_cache:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_call_i64 s[20:21], cache_helper
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_endpgm
+.Ltest_large_usage_cache_end:
+.size test_large_usage_cache, .Ltest_large_usage_cache_end-test_large_usage_cache
+
+.type cache_helper,@function
+cache_helper:
+  s_set_pc_i64 s[20:21]
+.Lcache_helper_end:
+.size cache_helper, .Lcache_helper_end-cache_helper
+
+// Keep the appended pool beyond short-branch reach without supplying NOP
+// padding that could bypass the straight-line expansion path above.
+.rept 70000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_large_usage_cache
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 34
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_large_usage_cache
+      .symbol: test_large_usage_cache.kd
+      .sgpr_count: 34
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -8,6 +8,21 @@
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
+// COM: Exercise the large-object planning path with verbose accounting. This
+// COM: fixture contains more than 250 KiB of text and requires a deterministic
+// COM: forward branch-island chain.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.scale.elf 2>&1 | %FileCheck --check-prefix=SCALE %s
+// SCALE: hotswap: assigned 1 forward s_branch island chain(s)
+// SCALE: hotswap: applied 1 instruction patches
+// SCALE: hotswap: growWithTrampolines: appended 1 trampoline
+
+// RUN: hotswap-rewrite %t.scale.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=SCALE-IDEM %s
+// SCALE-IDEM: IDEMPOTENT: YES
+
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -138,7 +138,7 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
   llvm::Expected<ElfView> ViewOrErr =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  std::vector<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   EXPECT_EQ(KDs[0].KernelName, "entry_kernel");
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr);
@@ -156,9 +156,14 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
           offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
       sizeof(ReadBack));
   EXPECT_EQ(ReadBack, NewOff);
+  ASSERT_EQ(ViewOrErr->kernelDescriptors().size(), 1u);
+  EXPECT_EQ(ViewOrErr->kernelDescriptors()[0].EntryOffset, NewOff);
 
+  // Prime the descriptor fallback cache before changing the encoded count.
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
   ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 16u);
 }
 
 TEST(ElfView, KernelDescriptorsSkipsKdWhenFileOffsetOverflows) {
@@ -207,7 +212,7 @@ TEST(ElfView, GrowWithTrampolinesKeepsAllocSectionSymbols) {
   llvm::Expected<ElfView> OutView =
       ElfView::create(OutData, Out->getBufferSize());
   ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
-  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr);
 }
@@ -306,7 +311,7 @@ TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
   const uint64_t IsaResolved =
       decodeReferencedVAddr(OutView->textData(), OutView->textAddr());
   // ...vs. the address the symbol table now reports for the same global.
-  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   const uint64_t SymbolVAddr = KDs[0].VAddr;
 
@@ -632,6 +637,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
+  // Prime the metadata cache before the in-place update.
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
   ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
@@ -680,6 +687,62 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 10u);
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset),
             DescriptorSgprsBefore);
+}
+
+TEST(ElfView, UpdateKernelMetadataSgprCountsKeepsPrimedCacheCoherent) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
+
+  llvm::StringMap<unsigned> RequiredSgprs;
+  RequiredSgprs.try_emplace("entry_kernel", 10u);
+  ASSERT_TRUE(ViewOrErr->updateKernelMetadataSgprCounts(RequiredSgprs));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 10u);
+}
+
+TEST(ElfView, UpdateKernelMetadataSgprCountsBatchesMixedRequirements) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataKernels = {{"needs_update", 8}, {"already_enough", 16}};
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::StringMap<unsigned> RequiredSgprs;
+  RequiredSgprs.try_emplace("needs_update", 10u);
+  RequiredSgprs.try_emplace("already_enough", 12u);
+  ASSERT_TRUE(ViewOrErr->updateKernelMetadataSgprCounts(RequiredSgprs));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("needs_update"), 10u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("already_enough"), 16u);
+}
+
+TEST(ElfView, UpdateKernelMetadataSgprCountsRejectsAbsentKernelAtomically) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataKernels = {{"needs_update", 8}, {"already_enough", 16}};
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::StringMap<unsigned> RequiredSgprs;
+  RequiredSgprs.try_emplace("needs_update", 10u);
+  RequiredSgprs.try_emplace("already_enough", 12u);
+  RequiredSgprs.try_emplace("absent_kernel", 4u);
+  EXPECT_FALSE(ViewOrErr->updateKernelMetadataSgprCounts(RequiredSgprs));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("needs_update"), 8u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("already_enough"), 16u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("absent_kernel"), std::nullopt);
 }
 
 TEST(ElfView, UpdateKernelDescriptorSgprCountMetadataOnlyRequiresMetadata) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -964,7 +964,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(OutRsrc1, Rsrc1Before);
   EXPECT_EQ(OutView->getKernelSgprCount("kernel"), Fixups[0].RequiredSgprs);
 
-  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   std::optional<uint64_t> KdVAddr = OutView->getKernelDescriptorVAddr("kernel");
   ASSERT_TRUE(KdVAddr.has_value());

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -49,6 +49,11 @@ inline uint64_t alignTo4(uint64_t V) { return llvm::alignTo(V, 4); }
 inline uint64_t alignTo8(uint64_t V) { return llvm::alignTo(V, 8); }
 
 struct KernelDescriptorElfOptions {
+  struct MetadataKernel {
+    std::string Name;
+    unsigned SgprCount = 0;
+  };
+
   uint16_t ElfType = llvm::ELF::ET_DYN;
   std::string KernelName = "kernel";
   uint64_t TextAddr = 0x1000;
@@ -66,6 +71,9 @@ struct KernelDescriptorElfOptions {
   std::optional<std::string> MetadataGfx1250Revision;
   bool MetadataOmitSgprCount = false;
   bool MetadataSgprCountAsString = false;
+  // When non-empty, emit these kernel metadata entries instead of the single
+  // entry described by MetadataKernelName / MetadataSgprCount.
+  std::vector<MetadataKernel> MetadataKernels;
 };
 
 struct KernelDescriptorElf {
@@ -80,23 +88,32 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
   llvm::msgpack::Document Doc;
   llvm::msgpack::MapDocNode Root = Doc.getRoot().getMap(/*Convert=*/true);
   llvm::msgpack::ArrayDocNode Kernels = Doc.getArrayNode();
-  llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
-
-  const std::string &MetadataKernelName = Options.MetadataKernelName
-                                              ? *Options.MetadataKernelName
-                                              : Options.KernelName;
-  Kernel[".name"] = Doc.getNode(MetadataKernelName, /*Copy=*/true);
-  if (!Options.MetadataOmitSgprCount) {
-    if (Options.MetadataSgprCountAsString)
-      Kernel[".sgpr_count"] = Doc.getNode("not-an-integer", /*Copy=*/true);
-    else
-      Kernel[".sgpr_count"] =
-          static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
+  if (!Options.MetadataKernels.empty()) {
+    for (const KernelDescriptorElfOptions::MetadataKernel &Spec :
+         Options.MetadataKernels) {
+      llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
+      Kernel[".name"] = Doc.getNode(Spec.Name, /*Copy=*/true);
+      Kernel[".sgpr_count"] = static_cast<uint64_t>(Spec.SgprCount);
+      Kernels.push_back(Kernel);
+    }
+  } else {
+    llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
+    const std::string &MetadataKernelName = Options.MetadataKernelName
+                                                ? *Options.MetadataKernelName
+                                                : Options.KernelName;
+    Kernel[".name"] = Doc.getNode(MetadataKernelName, /*Copy=*/true);
+    if (!Options.MetadataOmitSgprCount) {
+      if (Options.MetadataSgprCountAsString)
+        Kernel[".sgpr_count"] = Doc.getNode("not-an-integer", /*Copy=*/true);
+      else
+        Kernel[".sgpr_count"] =
+            static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
+    }
+    if (Options.MetadataGfx1250Revision)
+      Kernel[".gfx1250_revision"] =
+          Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
+    Kernels.push_back(Kernel);
   }
-  if (Options.MetadataGfx1250Revision)
-    Kernel[".gfx1250_revision"] =
-        Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
-  Kernels.push_back(Kernel);
   Root["amdhsa.kernels"] = Kernels;
 
   std::string Blob;
@@ -163,7 +180,8 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
 
   const bool HasMetadataNote =
       Options.MetadataSgprCount || Options.MetadataGfx1250Revision ||
-      Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString;
+      Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString ||
+      !Options.MetadataKernels.empty();
   std::vector<uint8_t> MetadataNote;
   if (HasMetadataNote) {
     std::string MetadataBlob = makeAmdgpuMetadataBlob(Options);


### PR DESCRIPTION
## Summary

- cache ELF metadata, function ranges, descriptor lookups, and SGPR usage
- track queued trampoline bytes incrementally to avoid repeated full scans of multi-megabyte objects
- batch metadata rewrites atomically across kernels and share the metadata-note traversal
- extend large-object LIT coverage and ELF/MC cache-coherence and layout-accounting unit tests

This is PR 5 of 5 in a stacked series and depends on the safe far-branch PR.

## Validation

- Review-update release `check-comgr` at this PR boundary:
  - COMGR LIT: 96 passed, 11 unsupported, 0 failed (107 total)
  - all COMGR unit tests passed
  - COMGR CTests: 31/31 passed
- Review-update ASan validation at the final stacked tip:
  - COMGR LIT: 97 passed, 11 unsupported, 0 failed (108 total)
  - all COMGR unit tests passed
  - 30/30 runnable COMGR CTests passed
  - `comgr_multithread_test` remains excluded because its ASan-runtime `unable to unmap` failure reproduces unchanged on untouched `amd-staging`
- Prior combined-stack A0 validation on physical GPU 2 with `ROCR_VISIBLE_DEVICES=2` and HotSwap enabled (`HSA_HOTSWAP_DISABLE` unset):
  - exact rocSPARSE reproducer with the #8213 ROCr overlay and `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`: 1/1 passed
  - focused rocSPARSE multiply families with entry trampolines: 998/998 passed
  - focused rocBLAS with entry trampolines: 1,416/1,416 passed
  - focused hipBLAS with entry trampolines: 1,512/1,512 passed
  - focused hipBLASLt under the same default-HotSwap configuration used by the prior split validation: 76/76 passed
- Known entry-trampoline limitation: one hipBLASLt FP8 case aborts with `HSA_STATUS_ERROR_INVALID_CODE_OBJECT`; the identical case reproduces with the pre-convention split tip, so this is not introduced by these fixes.

Reference only: this series was split from the work validated in #3328. That PR remains unchanged as the known-good reference.
