### PR TITLE
[Comgr][Hotswap] Skip entry trampoline when prologue already has unclaused-VMEM workaround

### DIFF
--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -351,6 +351,43 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
   return *Target >= Elf.textAddr() && *Target < *TextEnd;
 }
 
+// True when the prologue already begins with the compile-time GFX1250
+// unclaused-VMEM workaround (llvm/llvm-project#208467): `global_wb` (cpol 0)
+// then `v_nop`. Unlike descriptorAlreadyTargetsEntryStub(), the descriptor
+// still points at the real kernel body, not a hotswap stub.
+static std::optional<bool> entryPrologueHasVmemWorkaround(
+    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS,
+    ArrayRef<uint8_t> EntryStubPrefix) {
+  if (EntryStubPrefix.empty())
+    return false;
+
+  std::optional<uint64_t> Entry = entryVAddr(KD);
+  if (!Entry)
+    return std::nullopt;
+
+  const uint8_t *Bytes = Elf.dataAtVAddr(*Entry, EntryStubPrefix.size());
+  if (!Bytes)
+    return false;
+  ArrayRef<uint8_t> Candidate(Bytes, EntryStubPrefix.size());
+  if (!startsWithBytes(Candidate, EntryStubPrefix))
+    return false;
+
+  // Confirm the prefix decodes to global_wb (cpol 0) + v_nop, not a byte match.
+  if (!hasResolvedEntryStubState(LS, "entry prologue workaround matcher"))
+    return false;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Bytes, EntryStubPrefix.size(), LS, Decoded) ||
+      Decoded.size() < 2)
+    return false;
+  const MCInst &GlobalWb = Decoded[0].Inst;
+  const MCInst &VNop = Decoded[1].Inst;
+  return GlobalWb.getOpcode() == LS.GlobalWbOpcode &&
+         GlobalWb.getNumOperands() == 1 && GlobalWb.getOperand(0).isImm() &&
+         GlobalWb.getOperand(0).getImm() == 0 &&
+         VNop.getOpcode() == LS.VNopInst.getOpcode() &&
+         VNop.getNumOperands() == 0;
+}
+
 static std::optional<uint64_t>
 totalTrampolineBytes(ArrayRef<Trampoline> Trampolines) {
   uint64_t Total = 0;
@@ -472,6 +509,18 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
       return std::nullopt;
     if (*AlreadyHasEntryStub)
       continue;
+    // Skip if the compiler already applied the workaround (#208467)
+    // in-prologue.
+    std::optional<bool> PrologueHasWorkaround =
+        entryPrologueHasVmemWorkaround(Elf, KD, LS, EntryStubPrefix);
+    if (!PrologueHasWorkaround)
+      return std::nullopt;
+    if (*PrologueHasWorkaround) {
+      log() << "hotswap: kernel '" << KD.KernelName
+            << "' prologue already carries the unclaused-VMEM workaround "
+            << "(global_wb; v_nop); skipping entry trampoline\n";
+      continue;
+    }
     std::optional<uint32_t> OriginalInstPrefLines =
         Elf.getKernelDescriptorInstPrefSize(KD.KernelName, LS.Cpu);
     if (!OriginalInstPrefLines)

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-precompiled-workaround.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-precompiled-workaround.s
@@ -1,0 +1,88 @@
+// COM: A `global_wb; v_nop` prologue (llvm/llvm-project#208467) already carries
+// COM: the workaround, so HotSwap skips its entry trampoline; a kernel without
+// COM: it still gets one.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: An installed trampoline gets a <kernel>.stub symbol: the plain kernel
+// COM: has one, the pre-fixed kernel does not.
+// RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
+// SYMS: plain_kernel.stub
+
+// RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=NO-WA-STUB %s
+// NO-WA-STUB-NOT: precompiled_wa_kernel.stub
+
+// COM: The pre-fixed kernel keeps its in-place workaround, not a redirect stub.
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <precompiled_wa_kernel>:
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_endpgm
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+// Prologue already carries the workaround: expect no trampoline.
+.globl precompiled_wa_kernel
+.p2align 8
+.type precompiled_wa_kernel,@function
+precompiled_wa_kernel:
+  global_wb
+  v_nop
+  s_endpgm
+.Lprecompiled_wa_kernel_end:
+.size precompiled_wa_kernel, .Lprecompiled_wa_kernel_end-precompiled_wa_kernel
+
+// No workaround: expect a trampoline.
+.globl plain_kernel
+.p2align 8
+.type plain_kernel,@function
+plain_kernel:
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  s_endpgm
+.Lplain_kernel_end:
+.size plain_kernel, .Lplain_kernel_end-plain_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel precompiled_wa_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel plain_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: precompiled_wa_kernel
+      .symbol: precompiled_wa_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: plain_kernel
+      .symbol: plain_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -884,11 +884,14 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   ASSERT_TRUE(Count1.has_value());
   ASSERT_EQ(*Count1, 1u);
 
+  std::optional<uint64_t> PoolVAddr = View1->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddr.has_value());
+
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
       View1->growWithTrampolines(Growth1, S.SNopBytes);
   ASSERT_NE(Grown, nullptr);
   ASSERT_TRUE(
-      rewriteKernelEntryDescriptorOffsets(*Grown, OldTextSize, S.Cpu, Fixups1));
+      rewriteKernelEntryDescriptorOffsets(*Grown, *PoolVAddr, S.Cpu, Fixups1));
   std::unique_ptr<llvm::WritableMemoryBuffer> Pass1 =
       addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
                                       Fixups1);
@@ -917,6 +920,73 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
                                       View2->textSize(), Fixups2);
   EXPECT_EQ(Pass2, nullptr);
   EXPECT_EQ(countSymtabSymbolsNamed(*Pass1, "kernel.stub"), 1u);
+}
+
+// A `global_wb; v_nop` prologue (llvm/llvm-project#208467) already satisfies
+// the workaround, so no trampoline is installed.
+TEST(KernelEntryTrampoline, SkipsWhenPrologueAlreadyHasVmemWorkaround) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> GlobalWb = assembleSingleInst("global_wb", S);
+  llvm::SmallVector<uint8_t> VNop = assembleSingleInst("v_nop", S);
+  llvm::SmallVector<uint8_t> EndPgm = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(GlobalWb.empty());
+  ASSERT_FALSE(VNop.empty());
+  ASSERT_EQ(EndPgm.size(), MinInstSize);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(GlobalWb.begin(), GlobalWb.end());
+  Text.append(VNop.begin(), VNop.end());
+  Text.append(EndPgm.begin(), EndPgm.end());
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  std::optional<uint32_t> Count =
+      appendKernelEntryTrampolines(*View, S, /*MaxSgprs=*/106, Growth, Fixups);
+  ASSERT_TRUE(Count.has_value());
+  EXPECT_EQ(*Count, 0u);
+  EXPECT_TRUE(Fixups.empty());
+  EXPECT_TRUE(Growth.empty());
+}
+
+// The same two instructions in the wrong order are not the workaround, so a
+// trampoline is still installed.
+TEST(KernelEntryTrampoline, InstallsWhenPrologueLacksVmemWorkaround) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> VNop = assembleSingleInst("v_nop", S);
+  llvm::SmallVector<uint8_t> GlobalWb = assembleSingleInst("global_wb", S);
+  llvm::SmallVector<uint8_t> EndPgm = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(VNop.empty());
+  ASSERT_FALSE(GlobalWb.empty());
+  ASSERT_EQ(EndPgm.size(), MinInstSize);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(VNop.begin(), VNop.end());
+  Text.append(GlobalWb.begin(), GlobalWb.end());
+  Text.append(EndPgm.begin(), EndPgm.end());
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  std::optional<uint32_t> Count =
+      appendKernelEntryTrampolines(*View, S, /*MaxSgprs=*/106, Growth, Fixups);
+  ASSERT_TRUE(Count.has_value());
+  EXPECT_EQ(*Count, 1u);
+  EXPECT_EQ(Fixups.size(), 1u);
 }
 
 TEST(KernelEntryTrampoline, AlignsStubByVirtualAddress) {


### PR DESCRIPTION
GFX1250 kernels compiled with the compiler-side unclaused-VMEM workaround (llvm/llvm-project#208467) already begin with `global_wb; v_nop`. 

Detect that prologue and skip installing the redundant catch-all entry trampoline for the kernel, while kernels lacking it still get one. Also fix the SecondPassAddsNoDuplicateStubSymbol unit test to pass the trampoline pool vaddr (as production does) instead of OldTextSize, and add unit + lit coverage for the new skip.

**NOTE:**
Strict check: `requires cpol == 0`. If a future compiler emits global_wb with a non-CU scope, the detector won't fire and a redundant trampoline gets installed (safe, just not skipped). Matches current #208467 behavior.
