### PR TITLE
[comgr][hotswap] preserve workgroup capacity across VGPR bumps

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -105,6 +105,7 @@ set(SOURCES
   src/comgr-hotswap-b0a0.cpp
   src/comgr-hotswap-entry-trampoline.cpp
   src/comgr-hotswap-entry-trampoline-fast.cpp
+  src/comgr-hotswap-occupancy.cpp
   src/comgr-hotswap-patch-trampoline.cpp
   src/comgr-hotswap-elf.cpp
   src/comgr-hotswap-llvm.cpp

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -520,7 +520,8 @@ static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
 }
 
 static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
-  return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
+  return Reg.isValid() && LS.VCCRegister.isValid() &&
+         LS.MRI->regsOverlap(Reg, LS.VCCRegister);
 }
 
 static bool instructionUsesVcc(const LLVMState &LS,

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -55,7 +55,8 @@ static constexpr unsigned Gfx1250MaxVgprs = 1024;
 // GFX1250 wave32 VGPR ENCODING granularity is 16 (per
 // AMDGPUBaseInfo::getVGPREncodingGranule with Feature1024AddressableVGPRs),
 // not the 8 used by earlier GFX10/11 wave32. Used by ElfView's KD
-// decode/encode helpers (getKernelVgprCount / updateKernelDescriptor) to
+// decode/encode helpers (getKernelVgprCount /
+// updateKernelDescriptorVgprCount) to
 // interpret COMPUTE_PGM_RSRC1.GRANULATED_WORKITEM_VGPR_COUNT.
 // GFX12 wave32: 106 user-addressable SGPRs (s0-s105); s106-s107 are VCC.
 static constexpr unsigned Gfx1250MaxSgprs = 106;
@@ -64,7 +65,7 @@ static constexpr unsigned Gfx1250VgprGranuleSize = 16;
 /// Build the default RewriteConfig used for the GFX1250 B0-to-A0 rewrite:
 /// fills in the identity source / target ISA (both gfx1250) and the
 /// AMDGPU register granularity constants consumed by
-/// ElfView::updateKernelDescriptor. Instruction-encoding state is not
+/// ElfView::updateKernelDescriptorVgprCount. Instruction-encoding state is not
 /// carried in RewriteConfig; see LLVMState for the s_branch opcode and
 /// pre-encoded s_nop bytes.
 static RewriteConfig makeGfx1250B0A0Config() {
@@ -1667,7 +1668,7 @@ static std::optional<uint32_t> runPerInstPass(uint32_t (*Fn)(PatchContext &,
 /// (in-place -> trampoline -> WMMA split -> scratch). Each pass gets a
 /// chance to claim the instruction; first non-zero return wins. Also runs
 /// the whole-function WMMA-hazard pass after the per-instruction loop and
-/// records per-kernel stats via ElfView::updateKernelDescriptor.
+/// records per-kernel stats via ElfView::updateKernelDescriptorVgprCount.
 /// Returns the total number of applied patches across all passes.
 static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     std::vector<InternalDecodedInst> &Decoded, uint8_t *Text, uint64_t TextSize,
@@ -1786,20 +1787,42 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     unsigned Sgprs;
   };
   StringMap<ResourceCounts> CountsBefore;
+  StringMap<unsigned> VgprGranules;
+  StringMap<unsigned> RequiredVgprCounts;
   StringMap<unsigned> RequiredSgprCounts;
   for (const StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
     const KernelPatchStats &Stats = KV.second;
     if (KName.empty())
       continue;
+    unsigned VgprGranule = getKernelVgprGranuleSize(Ctx, KName);
+    VgprGranules.try_emplace(KName, VgprGranule);
     std::optional<unsigned> VgprsBefore =
-        Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
+        Elf.getKernelVgprCount(KName, VgprGranule);
     std::optional<unsigned> SgprsBefore = Elf.getKernelSgprCount(KName);
     CountsBefore.try_emplace(KName, ResourceCounts{VgprsBefore.value_or(0),
                                                    SgprsBefore.value_or(0)});
-    if (Stats.ExtraVgprs > 0)
-      Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs,
-                                 Config.VgprGranuleSize);
+    if (Stats.ExtraVgprs > 0) {
+      // Every current VGPR-growing patch preflights before emitting bytes.
+      // Keep this required-policy check as a fail-safe so a future path cannot
+      // silently emit a kernel that no longer admits one maximum workgroup.
+      if (checkKernelVgprBump(Ctx, KName, Stats.ExtraVgprs,
+                              PatchRequirement::Required) !=
+          VgprBumpDecision::Apply)
+        return std::nullopt;
+      if (!VgprsBefore) {
+        log() << "hotswap: error: failed to read VGPR count for kernel "
+              << KName << "\n";
+        return std::nullopt;
+      }
+      if (Stats.ExtraVgprs >
+          std::numeric_limits<unsigned>::max() - *VgprsBefore) {
+        log() << "hotswap: error: VGPR count for kernel " << KName
+              << " overflows unsigned after hotswap scratch allocation\n";
+        return std::nullopt;
+      }
+      RequiredVgprCounts.try_emplace(KName, *VgprsBefore + Stats.ExtraVgprs);
+    }
     if (Stats.ExtraSgprs > 0) {
       if (!SgprsBefore) {
         log() << "hotswap: error: failed to read SGPR count for kernel "
@@ -1817,9 +1840,28 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     }
   }
 
+  if (!Elf.updateKernelMetadataVgprCounts(RequiredVgprCounts)) {
+    log() << "hotswap: error: failed to update kernel VGPR metadata\n";
+    return std::nullopt;
+  }
   if (!Elf.updateKernelMetadataSgprCounts(RequiredSgprCounts)) {
     log() << "hotswap: error: failed to update kernel SGPR metadata\n";
     return std::nullopt;
+  }
+  for (const StringMapEntry<unsigned> &Required : RequiredVgprCounts) {
+    StringMap<unsigned>::const_iterator Granule =
+        VgprGranules.find(Required.first());
+    if (Granule == VgprGranules.end()) {
+      log() << "hotswap: error: missing VGPR granule for kernel "
+            << Required.first() << "\n";
+      return std::nullopt;
+    }
+    if (!Elf.updateKernelDescriptorVgprCount(Required.first(), Required.second,
+                                             Granule->second)) {
+      log() << "hotswap: error: failed to update VGPR descriptor count for "
+            << Required.first() << "\n";
+      return std::nullopt;
+    }
   }
 
   for (const StringMapEntry<KernelPatchStats> &KV : KernelStats) {
@@ -1833,8 +1875,14 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
             << KName << "\n";
       return std::nullopt;
     }
+    StringMap<unsigned>::const_iterator Granule = VgprGranules.find(KName);
+    if (Granule == VgprGranules.end()) {
+      log() << "hotswap: error: missing VGPR granule for kernel " << KName
+            << "\n";
+      return std::nullopt;
+    }
     std::optional<unsigned> VgprsAfter =
-        Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
+        Elf.getKernelVgprCount(KName, Granule->second);
     std::optional<unsigned> SgprsAfter = Elf.getKernelSgprCount(KName);
     log() << "hotswap: liveness: kernel " << KName
           << ": vgprs_before=" << Before->second.Vgprs

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -53,7 +53,7 @@ static constexpr unsigned SgprEncodingGranule = 8;
 // offset, so its PT_LOAD segment maps consistently.
 static constexpr uint64_t TrampolinePoolAlign = 4096;
 
-enum class MetadataSgprUpdateStatus {
+enum class MetadataCountUpdateStatus {
   NotFound,
   Found,
   Error,
@@ -113,12 +113,6 @@ readUnsignedMetadataNode(const msgpack::DocNode &Node, StringRef KernelName,
   log() << "hotswap: error: " << Context << ": " << Key << " for '"
         << KernelName << "' is not an integer.\n";
   return std::nullopt;
-}
-
-static std::optional<unsigned>
-readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
-                          StringRef KernelName, StringRef Context) {
-  return readUnsignedMetadataNode(SgprNode, KernelName, ".sgpr_count", Context);
 }
 
 using MetadataNoteMutator = function_ref<std::optional<bool>(
@@ -225,16 +219,17 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
   return true;
 }
 
-static MetadataSgprUpdateStatus
-rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
-                                const StringMap<unsigned> &RequiredSgprs) {
-  if (RequiredSgprs.empty())
-    return MetadataSgprUpdateStatus::Found;
+static MetadataCountUpdateStatus
+rewriteKernelMetadataCounts(uint8_t *Elf, const ELFFileT &File,
+                            const StringMap<unsigned> &RequiredCounts,
+                            StringRef MetadataKey, StringRef Context) {
+  if (RequiredCounts.empty())
+    return MetadataCountUpdateStatus::Found;
 
   bool SawMetadataNote = false;
   StringMap<bool> Found;
   bool Rewritten = rewriteMetadataNotes(
-      Elf, File, "updateKernelMetadataSgprCounts",
+      Elf, File, Context,
       [&](msgpack::Document &,
           msgpack::MapDocNode &RootMap) -> std::optional<bool> {
         msgpack::DocNode::MapTy::iterator KernelsIt =
@@ -253,26 +248,26 @@ rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
 
           StringRef KernelName = NameIt->second.getString();
           StringMap<unsigned>::const_iterator Required =
-              RequiredSgprs.find(KernelName);
-          if (Required == RequiredSgprs.end() || Found.contains(KernelName))
+              RequiredCounts.find(KernelName);
+          if (Required == RequiredCounts.end() || Found.contains(KernelName))
             continue;
 
-          msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
-          if (SgprIt == KMap.end()) {
-            log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
-                  << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
+          msgpack::DocNode::MapTy::iterator CountIt = KMap.find(MetadataKey);
+          if (CountIt == KMap.end()) {
+            log() << "hotswap: error: " << Context << ": metadata for kernel '"
+                  << KernelName << "' has no " << MetadataKey << ".\n";
             return std::nullopt;
           }
 
-          std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
-              SgprIt->second, KernelName, "updateKernelMetadataSgprCounts");
-          if (!CurrentSgprs)
+          std::optional<unsigned> CurrentCount = readUnsignedMetadataNode(
+              CountIt->second, KernelName, MetadataKey, Context);
+          if (!CurrentCount)
             return std::nullopt;
           Found.try_emplace(KernelName, true);
-          if (Required->second <= *CurrentSgprs)
+          if (Required->second <= *CurrentCount)
             continue;
 
-          SgprIt->second = static_cast<uint64_t>(Required->second);
+          CountIt->second = static_cast<uint64_t>(Required->second);
           Changed = true;
         }
         return Changed;
@@ -280,11 +275,11 @@ rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
       [&](bool SawMetadata) {
         if (!SawMetadata)
           return true;
-        for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+        for (const StringMapEntry<unsigned> &Required : RequiredCounts) {
           if (Found.contains(Required.first()))
             continue;
-          log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
-                   "metadata has no entry for kernel '"
+          log() << "hotswap: error: " << Context
+                << ": AMDGPU metadata has no entry for kernel '"
                 << Required.first() << "'.\n";
           return false;
         }
@@ -292,9 +287,9 @@ rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
       },
       SawMetadataNote);
   if (!Rewritten)
-    return MetadataSgprUpdateStatus::Error;
-  return SawMetadataNote ? MetadataSgprUpdateStatus::Found
-                         : MetadataSgprUpdateStatus::NotFound;
+    return MetadataCountUpdateStatus::Error;
+  return SawMetadataNote ? MetadataCountUpdateStatus::Found
+                         : MetadataCountUpdateStatus::NotFound;
 }
 
 bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
@@ -770,12 +765,13 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
 
   StringMap<unsigned> RequiredSgprCounts;
   RequiredSgprCounts.try_emplace(KernelName, RequiredSgprs);
-  MetadataSgprUpdateStatus MetadataStatus =
-      rewriteKernelMetadataSgprCounts(data(), File, RequiredSgprCounts);
-  if (MetadataStatus == MetadataSgprUpdateStatus::Error)
+  MetadataCountUpdateStatus MetadataStatus = rewriteKernelMetadataCounts(
+      data(), File, RequiredSgprCounts, ".sgpr_count",
+      "updateKernelDescriptorSgprCount");
+  if (MetadataStatus == MetadataCountUpdateStatus::Error)
     return false;
   if (!UpdateDescriptor &&
-      MetadataStatus == MetadataSgprUpdateStatus::NotFound) {
+      MetadataStatus == MetadataCountUpdateStatus::NotFound) {
     log() << "hotswap: error: updateKernelDescriptorSgprCount: kernel '"
           << KernelName << "' requires " << RequiredSgprs
           << " SGPRs, but gfx10+ code objects must carry .sgpr_count metadata "
@@ -786,7 +782,7 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
   // AMDGPU metadata because the descriptor remains the canonical count.
 
   if (SgprCacheState == KernelSgprCacheState::Metadata &&
-      MetadataStatus == MetadataSgprUpdateStatus::Found) {
+      MetadataStatus == MetadataCountUpdateStatus::Found) {
     StringMap<std::optional<unsigned>>::iterator Cached =
         KernelSgprCountCache.find(KernelName);
     if (Cached == KernelSgprCountCache.end())
@@ -809,11 +805,12 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
 
 bool ElfView::updateKernelMetadataSgprCounts(
     const StringMap<unsigned> &RequiredSgprs) {
-  MetadataSgprUpdateStatus MetadataStatus =
-      rewriteKernelMetadataSgprCounts(data(), File, RequiredSgprs);
-  if (MetadataStatus == MetadataSgprUpdateStatus::Error)
+  MetadataCountUpdateStatus MetadataStatus =
+      rewriteKernelMetadataCounts(data(), File, RequiredSgprs, ".sgpr_count",
+                                  "updateKernelMetadataSgprCounts");
+  if (MetadataStatus == MetadataCountUpdateStatus::Error)
     return false;
-  if (MetadataStatus == MetadataSgprUpdateStatus::NotFound) {
+  if (MetadataStatus == MetadataCountUpdateStatus::NotFound) {
     log() << "hotswap: error: updateKernelMetadataSgprCounts: code object "
              "has no AMDGPU metadata note.\n";
     return false;
@@ -828,6 +825,21 @@ bool ElfView::updateKernelMetadataSgprCounts(
       else if (!Cached->second || Required.second > *Cached->second)
         Cached->second = Required.second;
     }
+  }
+  return true;
+}
+
+bool ElfView::updateKernelMetadataVgprCounts(
+    const StringMap<unsigned> &RequiredVgprs) {
+  MetadataCountUpdateStatus MetadataStatus =
+      rewriteKernelMetadataCounts(data(), File, RequiredVgprs, ".vgpr_count",
+                                  "updateKernelMetadataVgprCounts");
+  if (MetadataStatus == MetadataCountUpdateStatus::Error)
+    return false;
+  if (MetadataStatus == MetadataCountUpdateStatus::NotFound) {
+    log() << "hotswap: error: updateKernelMetadataVgprCounts: code object "
+             "has no AMDGPU metadata note.\n";
+    return false;
   }
   return true;
 }
@@ -909,7 +921,7 @@ ElfView::getKernelVgprCount(StringRef KernelName,
   }
   namespace hsa = amdhsa;
   // findKernelDescriptor never writes through the returned pointer in this
-  // call path but is shared (non-const) with updateKernelDescriptor. The
+  // call path but is shared (non-const) with descriptor update helpers. The
   // const_cast on `this` keeps the read-only accessor const-correct without
   // duplicating the lookup helper.
   uint8_t *Kd = const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
@@ -934,6 +946,102 @@ ElfView::getKernelVgprCount(StringRef KernelName,
   return static_cast<unsigned>(VgprCount);
 }
 
+static std::optional<unsigned> getKernelUnsignedMetadata(const ELFFileT &File,
+                                                         StringRef KernelName,
+                                                         StringRef Key,
+                                                         StringRef Context) {
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: " << Context
+          << ": failed to read program headers: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        continue;
+
+      ArrayRef<uint8_t> Desc = Note.getDesc(4);
+      if (Desc.empty()) {
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata note has an empty descriptor.\n";
+        return std::nullopt;
+      }
+
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false)) {
+        log() << "hotswap: error: " << Context
+              << ": failed to parse AMDGPU metadata note.\n";
+        return std::nullopt;
+      }
+
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap()) {
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata root is not a map.\n";
+        return std::nullopt;
+      }
+
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+        continue;
+
+      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
+      for (msgpack::DocNode &KernelNode : KernelArray) {
+        if (!KernelNode.isMap())
+          continue;
+        msgpack::MapDocNode &KernelMap = KernelNode.getMap();
+        msgpack::DocNode::MapTy::iterator NameIt = KernelMap.find(".name");
+        if (NameIt == KernelMap.end() || !NameIt->second.isString() ||
+            NameIt->second.getString() != KernelName)
+          continue;
+
+        msgpack::DocNode::MapTy::iterator ValueIt = KernelMap.find(Key);
+        if (ValueIt == KernelMap.end())
+          return std::nullopt;
+        return readUnsignedMetadataNode(ValueIt->second, KernelName, Key,
+                                        Context);
+      }
+    }
+
+    if (Err) {
+      log() << "hotswap: error: " << Context
+            << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
+            << "\n";
+      return std::nullopt;
+    }
+  }
+  return std::nullopt;
+}
+
+std::optional<unsigned>
+ElfView::getKernelMaxFlatWorkgroupSize(StringRef KernelName) const {
+  return getKernelUnsignedMetadata(File, KernelName, ".max_flat_workgroup_size",
+                                   "getKernelMaxFlatWorkgroupSize");
+}
+
+std::optional<unsigned>
+ElfView::getKernelMetadataVgprCount(StringRef KernelName) const {
+  return getKernelUnsignedMetadata(File, KernelName, ".vgpr_count",
+                                   "getKernelMetadataVgprCount");
+}
+
+std::optional<unsigned>
+ElfView::getKernelWavefrontSize(StringRef KernelName) const {
+  return getKernelUnsignedMetadata(File, KernelName, ".wavefront_size",
+                                   "getKernelWavefrontSize");
+}
+
 // Reads the static (compile-time-fixed) LDS allocation from the kernel
 // descriptor's group_segment_fixed_size field. Dynamic LDS is added by the
 // host at dispatch time and is not visible here -- see the declaration's
@@ -943,7 +1051,7 @@ std::optional<uint32_t>
 ElfView::getKernelStaticLdsSize(StringRef KernelName) const {
   namespace hsa = amdhsa;
   // findKernelDescriptor never writes through the returned pointer in this
-  // call path but is shared (non-const) with updateKernelDescriptor. The
+  // call path but is shared (non-const) with descriptor update helpers. The
   // const_cast on `this` keeps the read-only accessor const-correct without
   // duplicating the lookup helper.
   const uint8_t *Kd =
@@ -1035,8 +1143,8 @@ void ElfView::initializeKernelSgprCountCache() const {
           }
           StringRef Name = NameIt->second.getString();
           KernelSgprCountCache.try_emplace(
-              Name,
-              readSgprCountMetadataNode(SgprIt->second, Name, "SGPR cache"));
+              Name, readUnsignedMetadataNode(SgprIt->second, Name,
+                                             ".sgpr_count", "SGPR cache"));
         }
       }
       if (Err) {
@@ -1209,39 +1317,56 @@ ElfView::getKernelClusterDims(StringRef KernelName) const {
   return std::nullopt;
 }
 
-// -- ElfView::updateKernelDescriptor ------------------------------------------
+// -- ElfView::updateKernelDescriptorVgprCount ---------------------------------
 
-void ElfView::updateKernelDescriptor(StringRef KernelName, unsigned ExtraVgprs,
-                                     unsigned VgprGranuleSize) {
+bool ElfView::updateKernelDescriptorVgprCount(StringRef KernelName,
+                                              unsigned RequiredVgprs,
+                                              unsigned VgprGranuleSize) {
   namespace hsa = amdhsa;
-  uint8_t *Kd = findKernelDescriptor(KernelName);
-  if (!Kd) {
-    log() << "hotswap: error: updateKernelDescriptor: kernel descriptor "
-          << "symbol '" << KernelName << ".kd' not found; requested +"
-          << ExtraVgprs << " VGPRs silently dropped.\n";
-    return;
+  if (VgprGranuleSize == 0) {
+    log() << "hotswap: error: updateKernelDescriptorVgprCount: VGPR granule "
+             "is zero for kernel '"
+          << KernelName << "'.\n";
+    return false;
   }
 
-  if (ExtraVgprs == 0 || VgprGranuleSize == 0)
-    return;
+  uint8_t *Kd = findKernelDescriptor(KernelName);
+  if (!Kd) {
+    log() << "hotswap: error: updateKernelDescriptorVgprCount: kernel "
+             "descriptor symbol '"
+          << KernelName << ".kd' not found.\n";
+    return false;
+  }
 
   uint32_t Rsrc1;
   std::memcpy(&Rsrc1,
               Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               sizeof(Rsrc1));
-  uint32_t Current = AMDHSA_BITS_GET(
+  uint32_t CurrentGranulated = AMDHSA_BITS_GET(
       Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT);
+  uint64_t CurrentVgprs =
+      (static_cast<uint64_t>(CurrentGranulated) + 1) * VgprGranuleSize;
+  if (RequiredVgprs <= CurrentVgprs)
+    return true;
+
   uint32_t MaxGran = static_cast<uint32_t>(
       hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT >>
       hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT_SHIFT);
-  uint64_t Extra = (static_cast<uint64_t>(ExtraVgprs) + VgprGranuleSize - 1) /
-                   VgprGranuleSize;
   uint64_t NewGranulated =
-      std::min<uint64_t>(static_cast<uint64_t>(Current) + Extra, MaxGran);
+      (static_cast<uint64_t>(RequiredVgprs) + VgprGranuleSize - 1) /
+          VgprGranuleSize -
+      1;
+  if (NewGranulated > MaxGran) {
+    log() << "hotswap: error: updateKernelDescriptorVgprCount: kernel '"
+          << KernelName << "' needs " << RequiredVgprs
+          << " VGPRs, which exceeds the descriptor encoding limit.\n";
+    return false;
+  }
   AMDHSA_BITS_SET(Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT,
                   static_cast<uint32_t>(NewGranulated));
   std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               &Rsrc1, sizeof(Rsrc1));
+  return true;
 }
 
 // -- ElfView::dataAtVAddr -----------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -581,7 +581,8 @@ ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
       findFunctionTextRangeAtAddress(textAddr() + TextOffset);
   if (!Range || Range->Begin < textAddr() || Range->End < textAddr())
     return std::nullopt;
-  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr()};
+  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr(),
+                           Range->Symbol, Range->Symtab};
 }
 
 // -- ElfView::kernelDescriptors -----------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -444,6 +444,11 @@ static std::optional<unsigned> allocateEntryStubScratchSgprs(
     return std::nullopt;
   }
 
+  // getKernelSgprCount includes VCC's two implicit SGPRs when the kernel uses
+  // VCC. Unlike findSafeSgprScratchBlock, this pre-decode entry-stub path has
+  // no instruction usage summary that can prove whether those two slots are
+  // non-numbered. Treat the full metadata count as numbered and possibly skip
+  // two usable SGPRs rather than risk overlapping a declared register.
   unsigned ScratchBase = (*SgprCount + 1) & ~1u;
   if (ScratchBase > MaxSgprs || MaxSgprs - ScratchBase < ScratchSgprs) {
     log() << "hotswap: error: entry trampoline: kernel '" << KD.KernelName

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -13,6 +13,7 @@
 ///   comgr-hotswap-elf.cpp       ELF parsing, binary helpers, trampoline growth
 ///   comgr-hotswap-llvm.cpp      LLVM MC infrastructure (disasm/asm/encode)
 ///   comgr-hotswap-b0a0.cpp      GFX1250 B0-to-A0 policy + public API
+///   comgr-hotswap-occupancy.cpp VGPR/workgroup capacity policy
 ///
 //===----------------------------------------------------------------------===//
 
@@ -343,6 +344,11 @@ public:
   bool updateKernelMetadataSgprCounts(
       const llvm::StringMap<unsigned> &RequiredSgprs);
 
+  /// Update metadata VGPR counts for every named kernel in one parse and
+  /// serialization pass. All requested kernels must be present.
+  bool updateKernelMetadataVgprCounts(
+      const llvm::StringMap<unsigned> &RequiredVgprs);
+
   /// Retag every gfx1250 kernel in the AMDGPU metadata note with \p Revision.
   /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
   /// size, so this preserves the ELF layout.
@@ -362,6 +368,21 @@ public:
   /// Returns std::nullopt if the descriptor is not found.
   std::optional<unsigned> getKernelVgprCount(llvm::StringRef KernelName,
                                              unsigned VgprGranuleSize) const;
+
+  /// Read \c .vgpr_count from the AMDGPU metadata note for \p KernelName.
+  std::optional<unsigned>
+  getKernelMetadataVgprCount(llvm::StringRef KernelName) const;
+
+  /// Read \c .max_flat_workgroup_size from the AMDGPU metadata note for
+  /// \p KernelName. Returns std::nullopt if the note, kernel, or key is absent
+  /// or malformed.
+  std::optional<unsigned>
+  getKernelMaxFlatWorkgroupSize(llvm::StringRef KernelName) const;
+
+  /// Read \c .wavefront_size from the AMDGPU metadata note for \p KernelName.
+  /// Returns std::nullopt if the note, kernel, or key is absent or malformed.
+  std::optional<unsigned>
+  getKernelWavefrontSize(llvm::StringRef KernelName) const;
 
   /// Read `group_segment_fixed_size` from the kernel descriptor for
   /// \p KernelName, i.e. the **static** (compile-time-fixed) LDS allocation
@@ -396,11 +417,14 @@ public:
   std::optional<KernelClusterDims>
   getKernelClusterDims(llvm::StringRef KernelName) const;
 
-  /// Update the RSRC1 VGPR granule count in the kernel descriptor for
-  /// \p KernelName by adding \p ExtraVgprs. The SGPR granule field is
-  /// not updated because it is reserved on GFX10+.
-  void updateKernelDescriptor(llvm::StringRef KernelName, unsigned ExtraVgprs,
-                              unsigned VgprGranuleSize);
+  /// Ensure the RSRC1 VGPR granule count in the kernel descriptor for
+  /// \p KernelName covers \p RequiredVgprs. Returns false if the descriptor
+  /// is missing, the granule is invalid, or the required count cannot be
+  /// encoded. The SGPR granule field is not updated because it is reserved on
+  /// GFX10+.
+  bool updateKernelDescriptorVgprCount(llvm::StringRef KernelName,
+                                       unsigned RequiredVgprs,
+                                       unsigned VgprGranuleSize);
 
   /// Virtual address at which growWithTrampolines appends the trampoline pool:
   /// the first page-aligned address above every existing allocatable section.
@@ -781,6 +805,38 @@ struct KernelPatchStats {
   unsigned ScratchAboveKd = 0;
 };
 
+/// Hardware limits needed to determine whether a VGPR allocation can still
+/// admit every wave of one maximum-size workgroup.
+struct SubtargetOccupancyLimits {
+  unsigned EUsPerCU = 0;
+  unsigned MaxWavesPerCU = 0;
+  unsigned MaxFlatWorkgroupSize = 0;
+  unsigned VgprAllocGranule = 0;
+  unsigned TotalNumVgprs = 0;
+  bool Wave64HalvesVgprCapacity = false;
+};
+
+struct WorkgroupCapacity {
+  unsigned RequiredWavesPerEU = 0;
+  unsigned AchievableWavesPerEU = 0;
+};
+
+enum class PatchRequirement {
+  Optional,
+  Required,
+};
+
+enum class VgprBumpDecision {
+  Apply,
+  Decline,
+  Fail,
+};
+
+struct KernelWorkgroupMetadata {
+  unsigned MaxFlatWorkgroupSize = 0;
+  unsigned WavefrontSize = 0;
+};
+
 struct SafeSgprUsageSummary {
   bool Valid = true;
   bool UsesVcc = false;
@@ -829,7 +885,41 @@ struct PatchContext {
   std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
       FunctionSgprUsage{0};
+  // Occupancy checks may run at several patch sites in one kernel. Cache the
+  // immutable metadata so the AMDGPU note is parsed at most once per field.
+  llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
+      WorkgroupMetadataCache;
+  llvm::StringMap<unsigned> KernelVgprGranuleCache;
 };
+
+/// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
+std::optional<SubtargetOccupancyLimits>
+getSubtargetOccupancyLimits(llvm::StringRef Processor);
+
+/// Compute the VGPR-limited capacity after allocation rounding and the waves
+/// per EU needed to admit one maximum-size workgroup. Returns std::nullopt for
+/// invalid or unsupported inputs.
+std::optional<WorkgroupCapacity>
+computeWorkgroupCapacity(unsigned Vgprs, unsigned MaxFlatWorkgroupSize,
+                         unsigned WavefrontSize,
+                         const SubtargetOccupancyLimits &Limits);
+
+/// Apply when capacity is preserved; otherwise decline optional patches and
+/// fail required patches.
+VgprBumpDecision decideVgprBump(PatchRequirement Requirement,
+                                const WorkgroupCapacity &Capacity);
+
+/// Return the descriptor/allocation granule for the kernel's wavefront mode.
+/// Falls back to RewriteConfig::VgprGranuleSize for metadata-free objects; a
+/// growth check will still decline those objects because capacity is unknown.
+unsigned getKernelVgprGranuleSize(PatchContext &Ctx,
+                                  llvm::StringRef KernelName);
+
+/// Preflight a patch site's aggregate VGPR demand before it emits bytes.
+VgprBumpDecision checkKernelVgprBump(PatchContext &Ctx,
+                                     llvm::StringRef KernelName,
+                                     unsigned ExtraVgprs,
+                                     PatchRequirement Requirement);
 
 /// A block of numbered SGPRs that is not referenced in the function being
 /// patched, or anywhere in the code object when the site may be reached by a

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -337,7 +337,7 @@ public:
   /// field; it is reserved and must remain unchanged on gfx10+.
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
                                        unsigned RequiredSgprs,
-                                       bool UpdateDescriptor = true);
+                                       bool UpdateDescriptor);
 
   /// Update metadata SGPR counts for every named kernel in one parse and
   /// serialization pass. All requested kernels must be present.
@@ -594,6 +594,11 @@ struct LLVMState {
   /// SCC, recovered from the implicit definition on a parsed scalar compare.
   /// This avoids scanning target register names in policy code.
   llvm::MCRegister SCCRegister;
+
+  /// VCC super-register, recovered from the destination of a parsed scalar
+  /// move. Policy code uses regsOverlap against this cached identity so VCC_LO,
+  /// VCC_HI, and tuple aliases are handled by LLVM MC.
+  llvm::MCRegister VCCRegister;
 
   bool Valid = false;
 

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -395,6 +395,22 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
     return S;
   }
 
+  SmallVector<MCInst, 2> VccDefInsts = parseAsmToMCInsts("s_mov_b64 vcc, 0", S);
+  if (VccDefInsts.size() != 1 || VccDefInsts.front().getNumOperands() == 0 ||
+      !VccDefInsts.front().getOperand(0).isReg()) {
+    log() << "hotswap: error: initLLVM: failed to recover VCC from a scalar "
+             "move for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+  S.VCCRegister = MCRegister(VccDefInsts.front().getOperand(0).getReg());
+  if (!S.VCCRegister.isValid()) {
+    log() << "hotswap: error: initLLVM: scalar move has no valid VCC "
+             "destination for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+
   S.Valid = true;
   return S;
 }

--- a/amd/comgr/src/comgr-hotswap-occupancy.cpp
+++ b/amd/comgr/src/comgr-hotswap-occupancy.cpp
@@ -1,0 +1,232 @@
+//===- comgr-hotswap-occupancy.cpp - VGPR capacity policy -----------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Checks proposed hotswap VGPR growth against the waves needed to admit one
+/// maximum-size workgroup. Optional transformations are declined before they
+/// emit bytes when the growth would violate that invariant; required
+/// transformations fail the rewrite.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/StringRef.h"
+
+#include <algorithm>
+#include <limits>
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+std::optional<SubtargetOccupancyLimits>
+getSubtargetOccupancyLimits(StringRef Processor) {
+#define HANDLE_ISA(TARGET_TRIPLE, PROCESSOR, SRAMECC_SUPPORTED,                \
+                   XNACK_ON_OFF_MODES, ELF_MACHINE, TRAP_HANDLER_ENABLED,      \
+                   IMAGE_SUPPORT, LDS_SIZE, LDS_BANK_COUNT, EUS_PER_CU,        \
+                   MAX_WAVES_PER_CU, MAX_FLAT_WORK_GROUP_SIZE,                 \
+                   SGPR_ALLOC_GRANULE, TOTAL_NUM_SGPRS, ADDRESSABLE_NUM_SGPRS, \
+                   VGPR_ALLOC_GRANULE, TOTAL_NUM_VGPRS, ADDRESSABLE_NUM_VGPRS) \
+  if (Processor == PROCESSOR)                                                  \
+    return SubtargetOccupancyLimits{EUS_PER_CU,                                \
+                                    MAX_WAVES_PER_CU,                          \
+                                    MAX_FLAT_WORK_GROUP_SIZE,                  \
+                                    VGPR_ALLOC_GRANULE,                        \
+                                    TOTAL_NUM_VGPRS,                           \
+                                    StringRef(PROCESSOR).starts_with("gfx1")};
+#include "comgr-isa-metadata.def"
+#undef HANDLE_ISA
+
+  log() << "hotswap: error: no occupancy limits for processor '" << Processor
+        << "'.\n";
+  return std::nullopt;
+}
+
+std::optional<WorkgroupCapacity>
+computeWorkgroupCapacity(unsigned Vgprs, unsigned MaxFlatWorkgroupSize,
+                         unsigned WavefrontSize,
+                         const SubtargetOccupancyLimits &Limits) {
+  if (Vgprs == 0 || MaxFlatWorkgroupSize == 0 ||
+      (WavefrontSize != 32 && WavefrontSize != 64) || Limits.EUsPerCU == 0 ||
+      Limits.MaxWavesPerCU == 0 || Limits.MaxFlatWorkgroupSize == 0 ||
+      Limits.VgprAllocGranule == 0 || Limits.TotalNumVgprs == 0 ||
+      MaxFlatWorkgroupSize > Limits.MaxFlatWorkgroupSize) {
+    log() << "hotswap: error: invalid inputs to computeWorkgroupCapacity: "
+          << "vgprs=" << Vgprs
+          << ", max_flat_workgroup_size=" << MaxFlatWorkgroupSize
+          << ", wavefront_size=" << WavefrontSize
+          << ", eus_per_cu=" << Limits.EUsPerCU
+          << ", max_waves_per_cu=" << Limits.MaxWavesPerCU
+          << ", target_max_flat_workgroup_size=" << Limits.MaxFlatWorkgroupSize
+          << ", vgpr_granule=" << Limits.VgprAllocGranule
+          << ", total_vgprs=" << Limits.TotalNumVgprs << ".\n";
+    return std::nullopt;
+  }
+
+  unsigned VgprAllocGranule = Limits.VgprAllocGranule;
+  unsigned TotalNumVgprs = Limits.TotalNumVgprs;
+  if (WavefrontSize == 64 && Limits.Wave64HalvesVgprCapacity) {
+    if ((VgprAllocGranule % 2) != 0 || (TotalNumVgprs % 2) != 0) {
+      log() << "hotswap: error: wave64 cannot halve odd VGPR limits.\n";
+      return std::nullopt;
+    }
+    VgprAllocGranule /= 2;
+    TotalNumVgprs /= 2;
+  }
+
+  uint64_t RoundedVgprs =
+      ((static_cast<uint64_t>(Vgprs) + VgprAllocGranule - 1) /
+       VgprAllocGranule) *
+      VgprAllocGranule;
+  if (RoundedVgprs == 0 ||
+      RoundedVgprs > std::numeric_limits<unsigned>::max()) {
+    log() << "hotswap: error: rounded VGPR count " << RoundedVgprs
+          << " is outside unsigned range.\n";
+    return std::nullopt;
+  }
+
+  unsigned WavesPerWorkgroup = 1 + (MaxFlatWorkgroupSize - 1) / WavefrontSize;
+  unsigned RequiredWavesPerEU = 1 + (WavesPerWorkgroup - 1) / Limits.EUsPerCU;
+  unsigned HardwareWavesPerEU = Limits.MaxWavesPerCU / Limits.EUsPerCU;
+  if (HardwareWavesPerEU == 0) {
+    log()
+        << "hotswap: error: target has fewer maximum waves per CU than EUs.\n";
+    return std::nullopt;
+  }
+
+  unsigned VgprWavesPerEU = static_cast<unsigned>(
+      TotalNumVgprs / static_cast<unsigned>(RoundedVgprs));
+  return WorkgroupCapacity{
+      RequiredWavesPerEU,
+      std::min(VgprWavesPerEU, HardwareWavesPerEU),
+  };
+}
+
+VgprBumpDecision decideVgprBump(PatchRequirement Requirement,
+                                const WorkgroupCapacity &Capacity) {
+  if (Capacity.AchievableWavesPerEU >= Capacity.RequiredWavesPerEU)
+    return VgprBumpDecision::Apply;
+  return Requirement == PatchRequirement::Required ? VgprBumpDecision::Fail
+                                                   : VgprBumpDecision::Decline;
+}
+
+static VgprBumpDecision failOrDeclineVgprBump(PatchContext &Ctx,
+                                              PatchRequirement Requirement) {
+  if (Requirement == PatchRequirement::Required) {
+    Ctx.RequiredPatchFailed = true;
+    return VgprBumpDecision::Fail;
+  }
+  return VgprBumpDecision::Decline;
+}
+
+unsigned getKernelVgprGranuleSize(PatchContext &Ctx, StringRef KernelName) {
+  StringMap<unsigned>::const_iterator Cached =
+      Ctx.KernelVgprGranuleCache.find(KernelName);
+  if (Cached != Ctx.KernelVgprGranuleCache.end())
+    return Cached->second;
+
+  unsigned Granule = Ctx.Config.VgprGranuleSize;
+  std::optional<unsigned> WavefrontSize =
+      Ctx.Elf.getKernelWavefrontSize(KernelName);
+  std::optional<SubtargetOccupancyLimits> Limits =
+      getSubtargetOccupancyLimits(Ctx.Config.TargetCpu);
+  if (WavefrontSize && Limits && *WavefrontSize == 64 &&
+      Limits->Wave64HalvesVgprCapacity && (Limits->VgprAllocGranule % 2) == 0)
+    Granule = Limits->VgprAllocGranule / 2;
+  else if (WavefrontSize && Limits && *WavefrontSize == 32)
+    Granule = Limits->VgprAllocGranule;
+
+  Ctx.KernelVgprGranuleCache.try_emplace(KernelName, Granule);
+  return Granule;
+}
+
+VgprBumpDecision checkKernelVgprBump(PatchContext &Ctx, StringRef KernelName,
+                                     unsigned ExtraVgprs,
+                                     PatchRequirement Requirement) {
+  if (KernelName.empty() || ExtraVgprs == 0)
+    return VgprBumpDecision::Apply;
+
+  unsigned AggregateExtraVgprs = ExtraVgprs;
+  StringMap<KernelPatchStats>::const_iterator Stats =
+      Ctx.KernelStats.find(KernelName);
+  if (Stats != Ctx.KernelStats.end())
+    AggregateExtraVgprs =
+        std::max(AggregateExtraVgprs, Stats->second.ExtraVgprs);
+
+  unsigned VgprGranuleSize = getKernelVgprGranuleSize(Ctx, KernelName);
+  std::optional<unsigned> CurrentVgprs =
+      Ctx.Elf.getKernelVgprCount(KernelName, VgprGranuleSize);
+  if (!CurrentVgprs ||
+      AggregateExtraVgprs >
+          std::numeric_limits<unsigned>::max() - *CurrentVgprs) {
+    log() << "hotswap: error: cannot compute proposed VGPR count for kernel '"
+          << KernelName << "'.\n";
+    return failOrDeclineVgprBump(Ctx, Requirement);
+  }
+  unsigned ProposedVgprs = *CurrentVgprs + AggregateExtraVgprs;
+
+  std::optional<SubtargetOccupancyLimits> Limits =
+      getSubtargetOccupancyLimits(Ctx.Config.TargetCpu);
+  if (!Limits)
+    return failOrDeclineVgprBump(Ctx, Requirement);
+
+  StringMap<std::optional<KernelWorkgroupMetadata>>::iterator Cached =
+      Ctx.WorkgroupMetadataCache.find(KernelName);
+  if (Cached == Ctx.WorkgroupMetadataCache.end()) {
+    std::optional<unsigned> MaxFlatWorkgroupSize =
+        Ctx.Elf.getKernelMaxFlatWorkgroupSize(KernelName);
+    std::optional<unsigned> WavefrontSize =
+        Ctx.Elf.getKernelWavefrontSize(KernelName);
+    std::optional<KernelWorkgroupMetadata> Metadata;
+    if (MaxFlatWorkgroupSize && WavefrontSize)
+      Metadata = KernelWorkgroupMetadata{*MaxFlatWorkgroupSize, *WavefrontSize};
+    Cached = Ctx.WorkgroupMetadataCache.try_emplace(KernelName, Metadata).first;
+  }
+
+  if (!Cached->second) {
+    log() << "hotswap: "
+          << (Requirement == PatchRequirement::Required ? "error: " : "")
+          << "cannot verify VGPR capacity for kernel '" << KernelName
+          << "' because .max_flat_workgroup_size or .wavefront_size metadata "
+             "is unavailable; "
+          << (Requirement == PatchRequirement::Required
+                  ? "failing required patch"
+                  : "declining optional patch")
+          << ".\n";
+    return failOrDeclineVgprBump(Ctx, Requirement);
+  }
+
+  std::optional<WorkgroupCapacity> Capacity = computeWorkgroupCapacity(
+      ProposedVgprs, Cached->second->MaxFlatWorkgroupSize,
+      Cached->second->WavefrontSize, *Limits);
+  if (!Capacity)
+    return failOrDeclineVgprBump(Ctx, Requirement);
+
+  VgprBumpDecision Decision = decideVgprBump(Requirement, *Capacity);
+  if (Decision == VgprBumpDecision::Apply)
+    return Decision;
+  if (Decision == VgprBumpDecision::Fail)
+    Ctx.RequiredPatchFailed = true;
+
+  log() << "hotswap: " << (Decision == VgprBumpDecision::Fail ? "error: " : "")
+        << (Decision == VgprBumpDecision::Fail ? "required" : "optional")
+        << " patch for kernel '" << KernelName << "' would grow VGPRs from "
+        << *CurrentVgprs << " to " << ProposedVgprs
+        << " and reduce capacity to " << Capacity->AchievableWavesPerEU
+        << " waves/EU, below the " << Capacity->RequiredWavesPerEU
+        << " waves/EU needed for one maximum-size workgroup; "
+        << (Decision == VgprBumpDecision::Fail ? "failing rewrite"
+                                               : "declining patch")
+        << ".\n";
+  return Decision;
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-occupancy.cpp
+++ b/amd/comgr/src/comgr-hotswap-occupancy.cpp
@@ -150,7 +150,23 @@ unsigned getKernelVgprGranuleSize(PatchContext &Ctx, StringRef KernelName) {
 VgprBumpDecision checkKernelVgprBump(PatchContext &Ctx, StringRef KernelName,
                                      unsigned ExtraVgprs,
                                      PatchRequirement Requirement) {
-  if (KernelName.empty() || ExtraVgprs == 0)
+  if (KernelName.empty()) {
+    // TODO: Build a device-function call graph and propagate the transformed
+    // function's VGPR requirement to every reachable kernel. Until then, an
+    // allocator result relative to a fallback register count cannot prove that
+    // any caller's descriptor covers the selected scratch registers.
+    log() << "hotswap: "
+          << (Requirement == PatchRequirement::Required ? "error: " : "")
+          << "cannot verify VGPR capacity for a patch site outside a known "
+             "kernel because its calling kernels are unknown; "
+          << (Requirement == PatchRequirement::Required
+                  ? "failing required patch"
+                  : "declining optional patch")
+          << ".\n";
+    return failOrDeclineVgprBump(Ctx, Requirement);
+  }
+
+  if (ExtraVgprs == 0)
     return VgprBumpDecision::Apply;
 
   unsigned AggregateExtraVgprs = ExtraVgprs;

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -177,8 +177,8 @@ ScratchAllocation allocateScratch(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
   std::string KernelName =
       Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
-  std::optional<unsigned> KdVgprs =
-      Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize);
+  std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
+      KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
   unsigned VgprKdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
   VgprAllocator VgprAlloc(Ctx.Liveness.LiveBefore[Idx], VgprKdCount,
                           Ctx.Config.MaxVgprs);
@@ -403,12 +403,18 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
     return 0;
   }
 
+  unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
+  if (!SA.KernelName.empty() &&
+      checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
+                          PatchRequirement::Optional) !=
+          VgprBumpDecision::Apply)
+    return 0;
+
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {
     KernelPatchStats &Stats = Ctx.KernelStats[SA.KernelName];
-    unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
     Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, ExtraV);
     Stats.ExtraSgprs =
         std::max(Stats.ExtraSgprs, SA.SgprAlloc.extraSgprsNeeded());
@@ -596,12 +602,18 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
     return 0;
   }
 
+  unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
+  if (!SA.KernelName.empty() &&
+      checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
+                          PatchRequirement::Optional) !=
+          VgprBumpDecision::Apply)
+    return 0;
+
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {
     KernelPatchStats &Stats = Ctx.KernelStats[SA.KernelName];
-    unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
     Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, ExtraV);
     Stats.ExtraSgprs =
         std::max(Stats.ExtraSgprs, SA.SgprAlloc.extraSgprsNeeded());
@@ -760,12 +772,18 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
     return 0;
   }
 
+  unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
+  if (!SA.KernelName.empty() &&
+      checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
+                          PatchRequirement::Optional) !=
+          VgprBumpDecision::Apply)
+    return 0;
+
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {
     KernelPatchStats &Stats = Ctx.KernelStats[SA.KernelName];
-    unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
     Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, ExtraV);
     Stats.ExtraSgprs =
         std::max(Stats.ExtraSgprs, SA.SgprAlloc.extraSgprsNeeded());

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -404,10 +404,9 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   }
 
   unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
-  if (!SA.KernelName.empty() &&
-      checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
+  if (checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
                           PatchRequirement::Optional) !=
-          VgprBumpDecision::Apply)
+      VgprBumpDecision::Apply)
     return 0;
 
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
@@ -603,10 +602,9 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   }
 
   unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
-  if (!SA.KernelName.empty() &&
-      checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
+  if (checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
                           PatchRequirement::Optional) !=
-          VgprBumpDecision::Apply)
+      VgprBumpDecision::Apply)
     return 0;
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
@@ -773,10 +771,9 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   }
 
   unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
-  if (!SA.KernelName.empty() &&
-      checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
+  if (checkKernelVgprBump(Ctx, SA.KernelName, ExtraV,
                           PatchRequirement::Optional) !=
-          VgprBumpDecision::Apply)
+      VgprBumpDecision::Apply)
     return 0;
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -688,8 +688,8 @@ std::optional<ScratchAlloc> tryAllocScratchVgpr(PatchContext &Ctx, size_t Idx) {
   std::string KernelName =
       Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
   unsigned KdVgprs = 0;
-  if (std::optional<unsigned> Opt =
-          Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize))
+  if (std::optional<unsigned> Opt = Ctx.Elf.getKernelVgprCount(
+          KernelName, getKernelVgprGranuleSize(Ctx, KernelName)))
     KdVgprs = *Opt;
 
   VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdVgprs,
@@ -1357,6 +1357,12 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     std::string TmpName = ("v" + Twine(StoreScratch->Vgpr)).str();
     AsmLines = buildAddtidStoreAsm(TmpName, RegName, Offset, ToMnem);
   }
+
+  if (StoreScratch && checkKernelVgprBump(Ctx, StoreScratch->KernelName,
+                                          StoreScratch->ExtraVgprsNeeded,
+                                          PatchRequirement::Optional) !=
+                          VgprBumpDecision::Apply)
+    return false;
 
   std::string Combined;
   for (const std::string &Line : AsmLines)

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -189,8 +189,9 @@ static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
   // idempotency. Baking 0x100 here keeps wrap-emitted trampolines
   // bit-identical across passes and avoids the SALU stall. Same trick
   // PR #2 (VOP3PX2 wrap pass) uses in its LdScalePrefix bytes.
-  Rewritten[6] &= 0x03;                         // clear scale_src2[5:0]
-  Rewritten[7] = (Rewritten[7] & 0xF8) | 0x04;  // set scale_src2[8]=1, clear [7:6]
+  Rewritten[6] &= 0x03; // clear scale_src2[5:0]
+  Rewritten[7] =
+      (Rewritten[7] & 0xF8) | 0x04; // set scale_src2[8]=1, clear [7:6]
 
   return Rewritten;
 }
@@ -242,8 +243,8 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 
   std::string KernelName =
       Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
-  std::optional<unsigned> KdVgprs =
-      Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize);
+  std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
+      KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
   unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
 
   VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdCount,
@@ -313,11 +314,15 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
                      PreambleBytes.end());
   Replacement.insert(Replacement.end(), WmmaBytes.begin(), WmmaBytes.end());
 
+  unsigned Extra = Alloc.extraVgprsNeeded();
+  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Optional) !=
+      VgprBumpDecision::Apply)
+    return 0;
+
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
     return 0;
 
   KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-  unsigned Extra = Alloc.extraVgprsNeeded();
   if (Extra > Stats.ExtraVgprs)
     Stats.ExtraVgprs = Extra;
   Stats.ScratchReused += ScratchCount - Extra;
@@ -552,8 +557,8 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
 
   std::string KernelName =
       Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
-  std::optional<unsigned> KdVgprs =
-      Ctx.Elf.getKernelVgprCount(KernelName, Ctx.Config.VgprGranuleSize);
+  std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
+      KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
   unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
 
   VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdCount,
@@ -642,8 +647,8 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
 
     WOS << "v_wmma_scale_f32_16x16x128_f8f6f4" << " v[" << HalfD << ":"
         << (HalfD + 7) << "]," << " v[" << HalfA << ":" << (HalfA + 7) << "],"
-        << " v[" << BBase << ":" << (BBase + 7) << "]," << " " << CStr
-        << "," << " " << ScaleAStr << ", " << ScaleBStr
+        << " v[" << BBase << ":" << (BBase + 7) << "]," << " " << CStr << ","
+        << " " << ScaleAStr << ", " << ScaleBStr
         << " matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4";
 
     if (Half == 1)
@@ -697,11 +702,15 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
     Replacement.insert(Replacement.end(), HalfBytes.begin(), HalfBytes.end());
   }
 
+  unsigned Extra = Alloc.extraVgprsNeeded();
+  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Optional) !=
+      VgprBumpDecision::Apply)
+    return 0;
+
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
     return 0;
 
   KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-  unsigned Extra = Alloc.extraVgprsNeeded();
   if (Extra > Stats.ExtraVgprs)
     Stats.ExtraVgprs = Extra;
   Stats.ScratchReused += ScratchCount - Extra;

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -35,6 +35,22 @@ necessarily that the output bytes changed. If the source/target ISA pair and
 rewrite options select no enabled transformation, the output is a copy of the
 input.
 
+## Register accounting
+
+A patch that allocates VGPRs above the kernel descriptor's existing allocation
+is checked before any replacement bytes are emitted. The proposed allocation,
+rounded to the target and kernel wavefront mode's VGPR granule, must retain
+enough waves per execution unit to admit one workgroup at the kernel metadata's
+`.max_flat_workgroup_size`. Optional patches are declined when that invariant
+would be violated; required patches fail the rewrite. This also protects
+cluster dispatches, whose constituent workgroups must each remain schedulable.
+
+When a VGPR bump is committed, hotswap updates both the kernel descriptor and
+the runtime-visible `.vgpr_count` metadata. Missing or malformed workgroup
+metadata is not treated as permission to grow the allocation. SGPR and LDS
+usage are outside this differential check: SGPRs are not occupancy-limiting on
+the supported gfx125x path, and current hotswap patches do not increase LDS.
+
 ## Transpiler (cross-gen)
 
 The transpiler is the heavier sibling to the byte-level rewrite. It raises

--- a/amd/comgr/test-lit/hotswap-device-function-vgpr.s
+++ b/amd/comgr/test-lit/hotswap-device-function-vgpr.s
@@ -1,0 +1,58 @@
+// COM: A scratch-register patch in a device function cannot be charged to its
+// COM: caller kernels without reachability information. Keep the original
+// COM: instruction until device-function call-graph accounting is implemented.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: cannot verify VGPR capacity for a patch site outside a known kernel because its calling kernels are unknown; declining optional patch.
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <device_helper>:
+// DISASM-NEXT:  ds_store_addtid_b32
+// DISASM-NEXT:  s_set_pc_i64 s[0:1]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_device_function_vgpr
+.p2align 8
+.type test_device_function_vgpr,@function
+test_device_function_vgpr:
+  s_call_i64 s[0:1], device_helper
+  s_endpgm
+.Ltest_device_function_vgpr_end:
+.size test_device_function_vgpr, .Ltest_device_function_vgpr_end-test_device_function_vgpr
+
+.p2align 8
+.type device_helper,@function
+device_helper:
+  ds_store_addtid_b32 v2 offset:64
+  s_set_pc_i64 s[0:1]
+.Ldevice_helper_end:
+.size device_helper, .Ldevice_helper_end-device_helper
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_device_function_vgpr
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_device_function_vgpr
+      .symbol: test_device_function_vgpr.kd
+      .sgpr_count: 2
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -85,6 +85,7 @@ test_addtid_load:
 .amdhsa_kernel test_addtid_load
   .amdhsa_next_free_vgpr 6
   .amdhsa_next_free_sgpr 1
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
 
 // ---- Kernel 2: ds_load_addtid_b32 with offset:0 ------------------------------
@@ -136,6 +137,7 @@ test_addtid_load_zero:
 .amdhsa_kernel test_addtid_load_zero
   .amdhsa_next_free_vgpr 7
   .amdhsa_next_free_sgpr 1
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
 
 // ---- Kernel 3: ds_store_addtid_b32 ------------------------------------------
@@ -190,7 +192,45 @@ test_addtid_store:
 .amdhsa_kernel test_addtid_store
   .amdhsa_next_free_vgpr 9
   .amdhsa_next_free_sgpr 1
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_addtid_load
+      .symbol: test_addtid_load.kd
+      .sgpr_count: 1
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_addtid_load_zero
+      .symbol: test_addtid_load_zero.kd
+      .sgpr_count: 1
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_addtid_store
+      .symbol: test_addtid_store.kd
+      .sgpr_count: 1
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata
 
 // COM: Idempotency: rewriting the output a second time must produce
 // COM: identical bytes (the patched body has no ADDTID mnemonic so the

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -1,6 +1,8 @@
-// COM: A far patch can live in an ordinary device function shared by multiple
-// COM: kernels. The tensor descriptor save and set-PC return safely reuse one
-// COM: global scratch block, charged to both possible callers.
+// COM: A far patch can live in a zero-size ordinary device function shared by
+// COM: multiple kernels. The tensor descriptor save and set-PC return safely
+// COM: reuse one global scratch block, charged to both possible callers. The
+// COM: missing .size directive exercises zero-size function-range inference on
+// COM: the far path.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
@@ -52,8 +54,6 @@
 device_tensor:
   tensor_load_to_lds s[0:3], s[4:11]
   s_set_pc_i64 s[30:31]
-.Ldevice_tensor_end:
-.size device_tensor, .Ldevice_tensor_end-device_tensor
 
 .globl kernel_a
 .type kernel_a,@function

--- a/amd/comgr/test-lit/hotswap-vgpr-workgroup-capacity.s
+++ b/amd/comgr/test-lit/hotswap-vgpr-workgroup-capacity.s
@@ -1,0 +1,101 @@
+// COM: Verify that hotswap rejects an optional VGPR bump which would make a
+// COM: maximum-size workgroup unschedulable, while applying the same patch
+// COM: when the kernel has occupancy headroom. Also verify that an applied
+// COM: bump updates runtime-visible .vgpr_count metadata.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// LOG: optional patch for kernel 'capacity_limited' would grow VGPRs from 128 to 129 and reduce capacity to 7 waves/EU, below the 8 waves/EU needed for one maximum-size workgroup; declining patch.
+// LOG: RESULT: SUCCESS
+
+// DISASM-LABEL: <capacity_limited>:
+// DISASM-NEXT:  ds_store_addtid_b32 v127
+// DISASM-LABEL: <has_headroom>:
+// DISASM-NOT:   ds_store_addtid_b32
+// DISASM:       s_branch
+// DISASM:       ds_store_b32 v16, v15
+
+// META: .name:                   capacity_limited
+// META: .vgpr_count:             128
+// META: .name:                   has_headroom
+// META: .vgpr_count:             17
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl capacity_limited
+.p2align 8
+.type capacity_limited,@function
+capacity_limited:
+  ds_store_addtid_b32 v127
+.irp reg,v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15,v16,v17,v18,v19,v20,v21,v22,v23,v24,v25,v26,v27,v28,v29,v30,v31
+  v_cmp_eq_u32 vcc_lo, \reg, \reg
+.endr
+.irp reg,v32,v33,v34,v35,v36,v37,v38,v39,v40,v41,v42,v43,v44,v45,v46,v47,v48,v49,v50,v51,v52,v53,v54,v55,v56,v57,v58,v59,v60,v61,v62,v63
+  v_cmp_eq_u32 vcc_lo, \reg, \reg
+.endr
+.irp reg,v64,v65,v66,v67,v68,v69,v70,v71,v72,v73,v74,v75,v76,v77,v78,v79,v80,v81,v82,v83,v84,v85,v86,v87,v88,v89,v90,v91,v92,v93,v94,v95
+  v_cmp_eq_u32 vcc_lo, \reg, \reg
+.endr
+.irp reg,v96,v97,v98,v99,v100,v101,v102,v103,v104,v105,v106,v107,v108,v109,v110,v111,v112,v113,v114,v115,v116,v117,v118,v119,v120,v121,v122,v123,v124,v125,v126,v127
+  v_cmp_eq_u32 vcc_lo, \reg, \reg
+.endr
+  s_endpgm
+.Lcapacity_limited_end:
+.size capacity_limited, .Lcapacity_limited_end-capacity_limited
+
+.globl has_headroom
+.p2align 8
+.type has_headroom,@function
+has_headroom:
+  ds_store_addtid_b32 v15
+.irp reg,v0,v1,v2,v3,v4,v5,v6,v7,v8,v9,v10,v11,v12,v13,v14,v15
+  v_cmp_eq_u32 vcc_lo, \reg, \reg
+.endr
+  s_endpgm
+.Lhas_headroom_end:
+.size has_headroom, .Lhas_headroom_end-has_headroom
+
+.rodata
+.p2align 8
+.amdhsa_kernel capacity_limited
+  .amdhsa_next_free_vgpr 128
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+.amdhsa_kernel has_headroom
+  .amdhsa_next_free_vgpr 16
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: capacity_limited
+      .symbol: capacity_limited.kd
+      .sgpr_count: 2
+      .vgpr_count: 128
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 1024
+    - .name: has_headroom
+      .symbol: has_headroom.kd
+      .sgpr_count: 2
+      .vgpr_count: 16
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16.s
@@ -175,16 +175,67 @@ test_wmma_scale_16x16:
 .amdhsa_kernel test_wmma_scale16_16x16
   .amdhsa_next_free_vgpr 52
   .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
 .amdhsa_kernel test_wmma_scale16_32x16
   .amdhsa_next_free_vgpr 44
   .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
 .amdhsa_kernel test_wmma_scale16_32x16_src2_neg_half
   .amdhsa_next_free_vgpr 44
   .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
 .amdhsa_kernel test_wmma_scale_16x16
   .amdhsa_next_free_vgpr 52
   .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_16x16
+      .symbol: test_wmma_scale16_16x16.kd
+      .sgpr_count: 2
+      .vgpr_count: 52
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_wmma_scale16_32x16
+      .symbol: test_wmma_scale16_32x16.kd
+      .sgpr_count: 2
+      .vgpr_count: 44
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_wmma_scale16_32x16_src2_neg_half
+      .symbol: test_wmma_scale16_32x16_src2_neg_half.kd
+      .sgpr_count: 2
+      .vgpr_count: 44
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_wmma_scale_16x16
+      .symbol: test_wmma_scale_16x16.kd
+      .sgpr_count: 2
+      .vgpr_count: 52
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -101,12 +101,14 @@ comgr_configure_test_target(HotswapElfTests)
 # assemble / decode / encode primitives.
 
 add_executable(HotswapMCTests
+  HotswapOccupancyTest.cpp
   HotswapMCTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp
   ../src/comgr-hotswap-llvm.cpp
+  ../src/comgr-hotswap-occupancy.cpp
   ../src/comgr-hotswap-patch-f32-to-e5m3.cpp
   ../src/comgr-hotswap-patch-inplace.cpp
   ../src/comgr-hotswap-patch-trampoline.cpp

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -88,6 +88,13 @@ TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {
   // interior offset the zero-size symbol still resolves.
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x1000), "zero_size_kernel");
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x1000 + 4), "zero_size_kernel");
+  std::optional<ElfView::FunctionTextRange> Range =
+      ViewOrErr->findFunctionTextRangeAtOffset(4);
+  ASSERT_TRUE(Range.has_value());
+  EXPECT_EQ(Range->Begin, 0u);
+  EXPECT_EQ(Range->End, makeText().size());
+  EXPECT_NE(Range->Symbol, nullptr);
+  EXPECT_NE(Range->Symtab, nullptr);
   // An address before the symbol has no preceding function symbol to resolve.
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x0FF0), "");
 }
@@ -177,7 +184,8 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
 
   // Prime the descriptor fallback cache before changing the encoded count.
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
-  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 16u);
 }
@@ -716,7 +724,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
 
   // Prime the metadata cache before the in-place update.
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
-  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
   ASSERT_TRUE(MetadataSgprs.has_value());
@@ -922,7 +931,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMissingMetadataCount) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
 
@@ -939,7 +949,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMissingMetadataKernel) {
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), std::nullopt);
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
 
@@ -955,7 +966,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsNonIntegerMetadataCount) {
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), std::nullopt);
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
 
@@ -970,7 +982,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMetadataSizeChange) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 128));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 128, /*UpdateDescriptor=*/true));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
   ASSERT_TRUE(MetadataSgprs.has_value());
@@ -989,8 +1002,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsDescriptorLimitFirst) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  EXPECT_FALSE(
-      ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 100000));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 100000, /*UpdateDescriptor=*/true));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
   ASSERT_TRUE(MetadataSgprs.has_value());

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -34,6 +34,22 @@ static unsigned readReservedSgprs(const std::vector<uint8_t> &Bytes,
          8;
 }
 
+static unsigned readReservedVgprs(const std::vector<uint8_t> &Bytes,
+                                  uint64_t KernelDescriptorOffset,
+                                  unsigned Granule) {
+  namespace hsa = llvm::amdhsa;
+
+  uint32_t Rsrc1 = 0;
+  std::memcpy(&Rsrc1,
+              Bytes.data() + KernelDescriptorOffset +
+                  offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              sizeof(Rsrc1));
+  return (AMDHSA_BITS_GET(
+              Rsrc1, hsa::COMPUTE_PGM_RSRC1_GRANULATED_WORKITEM_VGPR_COUNT) +
+          1) *
+         Granule;
+}
+
 // -- ElfView::create ----------------------------------------------------------
 
 TEST(ElfView, RejectsTruncatedInput) {
@@ -570,10 +586,12 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   ASSERT_NE(Grown, nullptr);
 
   // One fixup per appended stub; the names need not match real kernels, since
-  // addKernelEntryTrampolineSymbols only attaches a symbol at each stub address.
+  // addKernelEntryTrampolineSymbols only attaches a symbol at each stub
+  // address.
   std::vector<KernelEntryTrampolineFixup> Fixups = {
       {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10},
-      {"kernel_b", /*StubTextOffset=*/KernelEntryStubStride, /*RequiredSgprs=*/12},
+      {"kernel_b", /*StubTextOffset=*/KernelEntryStubStride,
+       /*RequiredSgprs=*/12},
   };
   std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
       addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
@@ -704,6 +722,77 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   ASSERT_TRUE(MetadataSgprs.has_value());
   EXPECT_EQ(*MetadataSgprs, 10u);
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
+}
+
+TEST(ElfView, ReadsWorkgroupCapacityMetadata) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataVgprCount = 120;
+  Opts.MetadataMaxFlatWorkgroupSize = 1024;
+  Opts.MetadataWavefrontSize = 32;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("entry_kernel"), 120u);
+  EXPECT_EQ(ViewOrErr->getKernelMaxFlatWorkgroupSize("entry_kernel"), 1024u);
+  EXPECT_EQ(ViewOrErr->getKernelWavefrontSize("entry_kernel"), 32u);
+}
+
+TEST(ElfView, UpdateKernelDescriptorVgprCountIsChecked) {
+  static constexpr unsigned Granule = 16;
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(readReservedVgprs(Obj.Bytes, Obj.KernelDescriptorOffset, Granule),
+            16u);
+  ASSERT_TRUE(
+      ViewOrErr->updateKernelDescriptorVgprCount("entry_kernel", 17, Granule));
+  EXPECT_EQ(readReservedVgprs(Obj.Bytes, Obj.KernelDescriptorOffset, Granule),
+            32u);
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorVgprCount("entry_kernel", 4096,
+                                                          Granule));
+  EXPECT_EQ(readReservedVgprs(Obj.Bytes, Obj.KernelDescriptorOffset, Granule),
+            32u);
+}
+
+TEST(ElfView, UpdateKernelMetadataVgprCountsUpdatesInPlace) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataVgprCount = 9;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  llvm::StringMap<unsigned> RequiredVgprs;
+  RequiredVgprs.try_emplace("entry_kernel", 10u);
+  ASSERT_TRUE(ViewOrErr->updateKernelMetadataVgprCounts(RequiredVgprs));
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("entry_kernel"), 10u);
+}
+
+TEST(ElfView, UpdateKernelMetadataVgprCountsRejectsMissingCount) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataOmitVgprCount = true;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  llvm::StringMap<unsigned> RequiredVgprs;
+  RequiredVgprs.try_emplace("entry_kernel", 10u);
+  EXPECT_FALSE(ViewOrErr->updateKernelMetadataVgprCounts(RequiredVgprs));
 }
 
 TEST(ElfView, UpdateGfx1250RevisionMetadataRetagsKernelInPlace) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -714,6 +714,7 @@ TEST(SafeSgprScratchBlock, RejectsAlignmentOverflow) {
   LivenessInfo Liveness;
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
   PatchContext Ctx{Config,
                    Decoded,
                    View.textData(),
@@ -725,7 +726,8 @@ TEST(SafeSgprScratchBlock, RejectsAlignmentOverflow) {
                    View,
                    Liveness,
                    KernelStats,
-                   ScratchPatches};
+                   ScratchPatches,
+                   ControlFlow};
 
   EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
                                         /*Alignment=*/2, "unit test"));

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -97,6 +97,13 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_LT(S.SPrefetchInstPcRelOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SPrefetchDataPcRelOpcode, S.MCII->getNumOpcodes());
   EXPECT_TRUE(S.SCCRegister.isValid());
+  ASSERT_TRUE(S.VCCRegister.isValid());
+  bool SawVccSubregister = false;
+  for (llvm::MCPhysReg Sub : S.MRI->subregs(S.VCCRegister)) {
+    SawVccSubregister = true;
+    EXPECT_TRUE(S.MRI->regsOverlap(S.VCCRegister, llvm::MCRegister(Sub)));
+  }
+  EXPECT_TRUE(SawVccSubregister);
   EXPECT_EQ(S.SNopBytes.size(), MinInstSize);
 }
 
@@ -681,6 +688,47 @@ TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
 
   EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
                                         /*Alignment=*/1, "unit test"));
+}
+
+TEST(SafeSgprScratchBlock, RejectsAlignmentOverflow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_mov_b32 s4, s0", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElfOptions Options;
+  Options.MetadataSgprCount = std::numeric_limits<unsigned>::max();
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches};
+
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
+                                        /*Alignment=*/2, "unit test"));
 }
 
 TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {

--- a/amd/comgr/test-unit/HotswapOccupancyTest.cpp
+++ b/amd/comgr/test-unit/HotswapOccupancyTest.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
+#include "comgr-test-elf-utils.h"
 #include "gtest/gtest.h"
 
 using namespace COMGR::hotswap;
@@ -70,4 +71,46 @@ TEST(HotswapOccupancy, RejectsInvalidMetadata) {
   EXPECT_EQ(computeWorkgroupCapacity(128, 2048, 32, Limits), std::nullopt);
   EXPECT_EQ(computeWorkgroupCapacity(128, 1024, 0, Limits), std::nullopt);
   EXPECT_EQ(getSubtargetOccupancyLimits("not-a-gpu"), std::nullopt);
+}
+
+TEST(HotswapOccupancy, RejectsPatchOutsideKnownKernelWithZeroReportedGrowth) {
+  const std::vector<uint8_t> Text(4);
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  RewriteConfig Config;
+  LLVMState LS;
+  std::vector<InternalDecodedInst> Decoded;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   ViewOrErr->textData(),
+                   ViewOrErr->textSize(),
+                   /*PoolBaseOffset=*/0,
+                   LS,
+                   Trampolines,
+                   Sleds,
+                   *ViewOrErr,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches,
+                   ControlFlow};
+
+  EXPECT_EQ(checkKernelVgprBump(Ctx, /*KernelName=*/{}, /*ExtraVgprs=*/0,
+                                PatchRequirement::Optional),
+            VgprBumpDecision::Decline);
+  EXPECT_FALSE(Ctx.RequiredPatchFailed);
+
+  EXPECT_EQ(checkKernelVgprBump(Ctx, /*KernelName=*/{}, /*ExtraVgprs=*/0,
+                                PatchRequirement::Required),
+            VgprBumpDecision::Fail);
+  EXPECT_TRUE(Ctx.RequiredPatchFailed);
 }

--- a/amd/comgr/test-unit/HotswapOccupancyTest.cpp
+++ b/amd/comgr/test-unit/HotswapOccupancyTest.cpp
@@ -1,0 +1,73 @@
+//===- HotswapOccupancyTest.cpp - HotSwap capacity policy tests ----------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+#include "gtest/gtest.h"
+
+using namespace COMGR::hotswap;
+
+TEST(HotswapOccupancy, LoadsGfx1250LimitsFromComgrIsaMetadata) {
+  std::optional<SubtargetOccupancyLimits> Limits =
+      getSubtargetOccupancyLimits("gfx1250");
+  ASSERT_TRUE(Limits.has_value());
+  EXPECT_EQ(Limits->EUsPerCU, 4u);
+  EXPECT_EQ(Limits->MaxWavesPerCU, 40u);
+  EXPECT_EQ(Limits->MaxFlatWorkgroupSize, 1024u);
+  EXPECT_EQ(Limits->VgprAllocGranule, 16u);
+  EXPECT_EQ(Limits->TotalNumVgprs, 1024u);
+  EXPECT_TRUE(Limits->Wave64HalvesVgprCapacity);
+}
+
+TEST(HotswapOccupancy, PreservesExactWave32WorkgroupBoundary) {
+  const SubtargetOccupancyLimits Limits{4, 40, 1024, 16, 1024, true};
+  std::optional<WorkgroupCapacity> Capacity =
+      computeWorkgroupCapacity(128, 1024, 32, Limits);
+  ASSERT_TRUE(Capacity.has_value());
+  EXPECT_EQ(Capacity->RequiredWavesPerEU, 8u);
+  EXPECT_EQ(Capacity->AchievableWavesPerEU, 8u);
+  EXPECT_EQ(decideVgprBump(PatchRequirement::Optional, *Capacity),
+            VgprBumpDecision::Apply);
+  EXPECT_EQ(decideVgprBump(PatchRequirement::Required, *Capacity),
+            VgprBumpDecision::Apply);
+}
+
+TEST(HotswapOccupancy, DetectsOneVgprAcrossGranuleBoundary) {
+  const SubtargetOccupancyLimits Limits{4, 40, 1024, 16, 1024, true};
+  std::optional<WorkgroupCapacity> Capacity =
+      computeWorkgroupCapacity(129, 1024, 32, Limits);
+  ASSERT_TRUE(Capacity.has_value());
+  EXPECT_EQ(Capacity->RequiredWavesPerEU, 8u);
+  EXPECT_EQ(Capacity->AchievableWavesPerEU, 7u);
+  EXPECT_EQ(decideVgprBump(PatchRequirement::Optional, *Capacity),
+            VgprBumpDecision::Decline);
+  EXPECT_EQ(decideVgprBump(PatchRequirement::Required, *Capacity),
+            VgprBumpDecision::Fail);
+}
+
+TEST(HotswapOccupancy, HandlesWave64Workgroups) {
+  const SubtargetOccupancyLimits Limits{4, 40, 1024, 16, 1024, true};
+  std::optional<WorkgroupCapacity> Capacity =
+      computeWorkgroupCapacity(128, 1024, 64, Limits);
+  ASSERT_TRUE(Capacity.has_value());
+  EXPECT_EQ(Capacity->RequiredWavesPerEU, 4u);
+  EXPECT_EQ(Capacity->AchievableWavesPerEU, 4u);
+
+  std::optional<WorkgroupCapacity> TooMany =
+      computeWorkgroupCapacity(129, 1024, 64, Limits);
+  ASSERT_TRUE(TooMany.has_value());
+  EXPECT_EQ(TooMany->RequiredWavesPerEU, 4u);
+  EXPECT_EQ(TooMany->AchievableWavesPerEU, 3u);
+}
+
+TEST(HotswapOccupancy, RejectsInvalidMetadata) {
+  const SubtargetOccupancyLimits Limits{4, 40, 1024, 16, 1024, true};
+  EXPECT_EQ(computeWorkgroupCapacity(128, 0, 32, Limits), std::nullopt);
+  EXPECT_EQ(computeWorkgroupCapacity(128, 2048, 32, Limits), std::nullopt);
+  EXPECT_EQ(computeWorkgroupCapacity(128, 1024, 0, Limits), std::nullopt);
+  EXPECT_EQ(getSubtargetOccupancyLimits("not-a-gpu"), std::nullopt);
+}

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -66,15 +66,21 @@ struct KernelDescriptorElfOptions {
   bool ZeroSizeKernelSym = false;
   std::optional<uint64_t> KernelDescriptorSymbolValue;
   uint32_t GroupSegmentFixedSize = 0;
+  uint32_t ComputePgmRsrc1 = 0;
   uint32_t ComputePgmRsrc3 = 0;
   std::optional<std::string> MetadataKernelName;
   std::optional<unsigned> MetadataSgprCount;
+  std::optional<unsigned> MetadataVgprCount;
+  std::optional<unsigned> MetadataMaxFlatWorkgroupSize;
+  std::optional<unsigned> MetadataWavefrontSize;
   std::optional<std::string> MetadataGfx1250Revision;
   bool MetadataOmitSgprCount = false;
   bool MetadataSgprCountAsString = false;
   // When non-empty, emit these kernel metadata entries instead of the single
   // entry described by MetadataKernelName / MetadataSgprCount.
   std::vector<MetadataKernel> MetadataKernels;
+  bool MetadataOmitVgprCount = false;
+  bool MetadataVgprCountAsString = false;
 };
 
 struct KernelDescriptorElf {
@@ -110,6 +116,19 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
         Kernel[".sgpr_count"] =
             static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
     }
+    if (!Options.MetadataOmitVgprCount) {
+      if (Options.MetadataVgprCountAsString)
+        Kernel[".vgpr_count"] = Doc.getNode("not-an-integer", /*Copy=*/true);
+      else
+        Kernel[".vgpr_count"] =
+            static_cast<uint64_t>(Options.MetadataVgprCount.value_or(0));
+    }
+    if (Options.MetadataMaxFlatWorkgroupSize)
+      Kernel[".max_flat_workgroup_size"] =
+          static_cast<uint64_t>(*Options.MetadataMaxFlatWorkgroupSize);
+    if (Options.MetadataWavefrontSize)
+      Kernel[".wavefront_size"] =
+          static_cast<uint64_t>(*Options.MetadataWavefrontSize);
     if (Options.MetadataGfx1250Revision)
       Kernel[".gfx1250_revision"] =
           Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
@@ -182,7 +201,9 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   const bool HasMetadataNote =
       Options.MetadataSgprCount || Options.MetadataGfx1250Revision ||
       Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString ||
-      !Options.MetadataKernels.empty();
+      Options.MetadataMaxFlatWorkgroupSize || Options.MetadataWavefrontSize ||
+      Options.MetadataVgprCount || Options.MetadataOmitVgprCount ||
+      Options.MetadataVgprCountAsString || !Options.MetadataKernels.empty();
   std::vector<uint8_t> MetadataNote;
   if (HasMetadataNote) {
     std::string MetadataBlob = makeAmdgpuMetadataBlob(Options);
@@ -300,6 +321,9 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
                   offsetof(hsa::kernel_descriptor_t, group_segment_fixed_size),
               &Options.GroupSegmentFixedSize,
               sizeof(Options.GroupSegmentFixedSize));
+  std::memcpy(Buf + RodataOff +
+                  offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
+              &Options.ComputePgmRsrc1, sizeof(Options.ComputePgmRsrc1));
   std::memcpy(Buf + RodataOff +
                   offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
               &Options.ComputePgmRsrc3, sizeof(Options.ComputePgmRsrc3));


### PR DESCRIPTION
## Summary

- preflight every hotswap VGPR-growing transformation against the waves/EU needed to admit one kernel workgroup at `.max_flat_workgroup_size`
- decline optional transformations before emitting bytes and fail required transformations when the proposed VGPR allocation would violate that invariant
- use the kernel wavefront mode and COMGR ISA metadata for allocation granularity/capacity, including gfx125x wave64 accounting
- update both the kernel descriptor and runtime-visible `.vgpr_count` metadata when a VGPR bump is committed
- add pure occupancy-policy unit tests, ELF metadata/descriptor unit tests, end-to-end LIT coverage, and document the policy

## Scope

This is stacked on #3348.

The gate deliberately uses metadata that is present in the final code object: `.max_flat_workgroup_size` and `.wavefront_size`. `amdgpu-waves-per-eu` is an LLVM IR attribute and is not serialized into the HSACO metadata available to hotswap. For gfx125x cluster dispatches, preserving admission of one maximum-size workgroup per CU is the relevant co-residency safety invariant; comparing a cluster's flat size directly with waves/EU would mix CU and SIMD scopes.

SGPR and LDS are not part of this differential gate because SGPR allocation is not occupancy-limiting on the supported gfx125x path and the current hotswap patches do not increase LDS.

## Validation

- rebased onto current `amd-staging` including merged #3359; `git range-diff` confirms the stacked patches are unchanged
- release `check-comgr` on the rebased final stack: 97/97 supported LIT tests, all unit tests, and 31/31 CTests passed
- pre-rebase ASan validation of the unchanged patch stack: 97/97 supported LIT tests, all unit tests, and 30/30 runnable CTests passed (`comgr_multithread_test` excluded for its existing ASan runtime unmap incompatibility)
- MI400 physical GPU 2, hotswap enabled with entry trampolines: reported rocSPARSE `spgemm_reuse_csr` reproducer passed 1/1
- same GPU/library: rocBLAS F32 GEMM, hipBLAS F32 GEMM_EX, and rocSOLVER GESV smoke tests each passed 1/1
