### PR TITLE
[Comgr] fix program header offset in addKernelEntryTrampolineSymbols

### DIFF
--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -1268,8 +1268,18 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
   std::memcpy(&Shoff, O + offsetof(Ehdr, e_shoff), sizeof(Shoff));
   std::memcpy(&Shentsize, O + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
   std::memcpy(&Shnum, O + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+
+  uint64_t Phoff;
+  uint16_t Phentsize, Phnum;
+  std::memcpy(&Phoff, O + offsetof(Ehdr, e_phoff), sizeof(Phoff));
+  std::memcpy(&Phentsize, O + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
+  std::memcpy(&Phnum, O + offsetof(Ehdr, e_phnum), sizeof(Phnum));
+
   uint64_t NewShoff = Shift(Shoff);
   std::memcpy(O + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+  uint64_t NewPhoff = Shift(Phoff);
+  std::memcpy(O + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
+
   if (Shentsize < sizeof(Shdr))
     return nullptr;
 
@@ -1288,6 +1298,20 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
       std::memcpy(&ShSize, Sh + offsetof(Shdr, sh_size), sizeof(ShSize));
       ShSize += (I == SymIdx) ? SymDelta : StrDelta;
       std::memcpy(Sh + offsetof(Shdr, sh_size), &ShSize, sizeof(ShSize));
+    }
+  }
+
+  if (Phentsize >= sizeof(Phdr)) {
+    for (uint16_t I = 0; I < Phnum; ++I) {
+      uint64_t P = NewPhoff + static_cast<uint64_t>(I) * Phentsize;
+      if (P + sizeof(Phdr) > NewSize)
+        break;
+      uint8_t *Ph = O + P;
+      uint64_t POffset;
+      std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
+      uint64_t NewPOffset = Shift(POffset);
+      std::memcpy(Ph + offsetof(Phdr, p_offset), &NewPOffset,
+                  sizeof(NewPOffset));
     }
   }
 

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -557,7 +557,7 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   // Grow .text by two entry-stub-sized blocks, mirroring the entry-trampoline
   // pass appending one stub per kernel.
   Trampoline Stub;
-  Stub.Bytes.assign(2 * KernelEntryStubStride, 0);
+  Stub.Bytes.assign(2 * KernelEntryStubStride, 0xAA);
   std::vector<Trampoline> Growth{Stub};
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
@@ -636,7 +636,7 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
   const uint64_t OldTextSize = ViewOrErr->textSize();
 
   Trampoline Stub;
-  Stub.Bytes.assign(2 * KernelEntryStubStride, 0);
+  Stub.Bytes.assign(2 * KernelEntryStubStride, 0xAA);
   std::vector<Trampoline> Growth{Stub};
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
@@ -669,7 +669,12 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
     if (Phdr.p_type == llvm::ELF::PT_LOAD && (Phdr.p_flags & llvm::ELF::PF_X)) {
       FoundPoolLoad = true;
       EXPECT_GT(Phdr.p_filesz, 0u);
-      EXPECT_LE(Phdr.p_offset + Phdr.p_filesz, WithSyms->getBufferSize());
+      ASSERT_LE(Phdr.p_offset + Phdr.p_filesz, WithSyms->getBufferSize());
+      const uint8_t *PoolBytes =
+          reinterpret_cast<const uint8_t *>(WithSyms->getBufferStart()) +
+          Phdr.p_offset;
+      for (uint64_t I = 0; I < Phdr.p_filesz; ++I)
+        EXPECT_EQ(PoolBytes[I], 0xAA) << "pool content mismatch at byte " << I;
     }
   }
   EXPECT_TRUE(FoundPoolLoad) << "no executable PT_LOAD segment found";

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -621,6 +621,60 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   }
 }
 
+TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  const unsigned TextIdx = ViewOrErr->textSectionIndex();
+  const uint64_t TextAddr = ViewOrErr->textAddr();
+  const uint64_t OldTextSize = ViewOrErr->textSize();
+
+  Trampoline Stub;
+  Stub.Bytes.assign(2 * KernelEntryStubStride, 0);
+  std::vector<Trampoline> Growth{Stub};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
+      ViewOrErr->growWithTrampolines(Growth, SNop);
+  ASSERT_NE(Grown, nullptr);
+
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10},
+      {"kernel_b", /*StubTextOffset=*/KernelEntryStubStride,
+       /*RequiredSgprs=*/12},
+  };
+  std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
+      addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
+                                      Fixups);
+  ASSERT_NE(WithSyms, nullptr);
+
+  using ELFT = llvm::object::ELF64LE;
+  llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
+      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
+          WithSyms->getBufferStart(), WithSyms->getBufferSize()));
+  ASSERT_TRUE((bool)FileOrErr) << llvm::toString(FileOrErr.takeError());
+
+  llvm::Expected<ELFT::PhdrRange> PhdrsOrErr = FileOrErr->program_headers();
+  ASSERT_TRUE((bool)PhdrsOrErr) << llvm::toString(PhdrsOrErr.takeError());
+  EXPECT_GE(PhdrsOrErr->size(), 2u);
+
+  bool FoundPoolLoad = false;
+  for (const auto &Phdr : *PhdrsOrErr) {
+    EXPECT_LE(Phdr.p_offset, WithSyms->getBufferSize());
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && (Phdr.p_flags & llvm::ELF::PF_X)) {
+      FoundPoolLoad = true;
+      EXPECT_GT(Phdr.p_filesz, 0u);
+      EXPECT_LE(Phdr.p_offset + Phdr.p_filesz, WithSyms->getBufferSize());
+    }
+  }
+  EXPECT_TRUE(FoundPoolLoad) << "no executable PT_LOAD segment found";
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";


### PR DESCRIPTION
## Summary

Fix a bug where `addKernelEntryTrampolineSymbols` corrupts the ELF
program header table by not updating `e_phoff` or segment `p_offset`
fields after inserting symbol and string table entries.

### Root cause

`addKernelEntryTrampolineSymbols` inserts new `.symtab` entries and
`.strtab` names for kernel-entry stub symbols. The `Shift` lambda
correctly adjusts `e_shoff` and every section's `sh_offset`, but does
not adjust `e_phoff` or the individual `p_offset` fields inside the
program header entries.

When `growWithTrampolines` has relocated the program headers to the
end of the file (after `.symtab`/`.strtab`), the insertions shift the
phdrs forward while `e_phoff` still points at the old location — now
occupied by `.strtab` content. The appended pool `PT_LOAD` segment's
`p_offset` is similarly stale. The HSA runtime reads garbage at the
stale offsets and rejects the code object with
`HSA_STATUS_ERROR_INVALID_CODE_OBJECT` (status 4112).

Code objects whose program headers sit at offset 64 (start of file)
are unaffected because the insertion points are all past the phdrs.

### Fix

- Apply the same `Shift` to `e_phoff` that is already applied to
  `e_shoff`.
- Loop over the program header table and `Shift` each `p_offset`,
  mirroring the existing `sh_offset` loop for section headers.
- Add `AddKernelEntryTrampolineSymbolsPreservesPhdr` unit test that
  grows a pool, inserts stub symbols, and verifies program headers
  parse correctly with valid segment offsets.

### Changes

| File | Change |
|------|--------|
| `comgr-hotswap-elf.cpp` | Shift `e_phoff` + loop over phdrs to shift `p_offset` |
| `HotswapElfTest.cpp` | New `AddKernelEntryTrampolineSymbolsPreservesPhdr` test |

### Reproduction

Without the fix, any code object that (a) has a `.symtab` section,
(b) receives kernel-entry trampolines, and (c) has program headers
placed after the symbol tables will have corrupted program headers.
This was observed on rocPRIM `test_device_radix_sort` (ROCM-27960)
and hipBLASLt `MatrixTransformTest` on gfx1250 A0 with
`AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=1`.

## Test plan

- [x] `HotswapElfTests`: 21/21 pass (including new phdr test)
- [x] `HotswapMCTests`: 59/59 pass
- [ ] CI `compiler-runtime` green