### PR TITLE
[CI] Skip code format/lint checks on upstream-merge PRs

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -11,7 +11,8 @@ on:
 jobs:
   code_formatter:
     if: >-
-      !(
+      !contains(github.event.pull_request.head.ref, 'upstream_merge')
+      && !(
         contains(github.event.pull_request.labels.*.name, 'ci:skip') &&
         (
           contains(github.event.pull_request.title, 'Update LLVM_MAIN_REVISION') ||

--- a/.github/workflows/pr-code-lint.yml
+++ b/.github/workflows/pr-code-lint.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   code_linter:
+    if: >-
+      !contains(github.event.pull_request.head.ref, 'upstream_merge')
     runs-on: ubuntu-24.04
     defaults:
       run:


### PR DESCRIPTION
These checks diff `HEAD~1...HEAD`, which on merge PRs covers the whole upstream delta and flags upstream code we won't reformat. Skip both jobs when the PR head branch contains `upstream_merge`.