### PR TITLE
[comgr][hotswap] remove duplicate PoolVAddr declaration

### DIFF
--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -956,9 +956,6 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   std::optional<uint64_t> PoolVAddr = View1->trampolinePoolVAddr();
   ASSERT_TRUE(PoolVAddr.has_value());
 
-  std::optional<uint64_t> PoolVAddr = View1->trampolinePoolVAddr();
-  ASSERT_TRUE(PoolVAddr.has_value());
-
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
       View1->growWithTrampolines(Growth1, S.SNopBytes);
   ASSERT_NE(Grown, nullptr);


### PR DESCRIPTION
## Summary

Remove the duplicate `PoolVAddr` declaration in `HotswapMCTest.cpp` so COMGR builds again on `amd-staging`.

The duplicate was created when #3344 and #3349, which independently added the same declaration, were combined by the #3344 squash merge without a textual conflict. Both original PR heads contained one valid declaration; the merged tree contained two.

## Validation

- release `check-comgr`: 91/91 supported LIT tests passed
- release `check-comgr`: 31/31 CTests passed

