### PR TITLE
[comgr][hotswap] address foundation review follow-ups

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -485,7 +485,8 @@ static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
 }
 
 static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
-  return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
+  return Reg.isValid() && LS.VCCRegister.isValid() &&
+         LS.MRI->regsOverlap(Reg, LS.VCCRegister);
 }
 
 static bool instructionUsesVcc(const LLVMState &LS,

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -580,7 +580,8 @@ ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
       findFunctionTextRangeAtAddress(textAddr() + TextOffset);
   if (!Range || Range->Begin < textAddr() || Range->End < textAddr())
     return std::nullopt;
-  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr()};
+  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr(),
+                           Range->Symbol, Range->Symtab};
 }
 
 // -- ElfView::kernelDescriptors -----------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -443,6 +443,11 @@ static std::optional<unsigned> allocateEntryStubScratchSgprs(
     return std::nullopt;
   }
 
+  // getKernelSgprCount includes VCC's two implicit SGPRs when the kernel uses
+  // VCC. Unlike findSafeSgprScratchBlock, this pre-decode entry-stub path has
+  // no instruction usage summary that can prove whether those two slots are
+  // non-numbered. Treat the full metadata count as numbered and possibly skip
+  // two usable SGPRs rather than risk overlapping a declared register.
   unsigned ScratchBase = (*SgprCount + 1) & ~1u;
   if (ScratchBase > MaxSgprs || MaxSgprs - ScratchBase < ScratchSgprs) {
     log() << "hotswap: error: entry trampoline: kernel '" << KD.KernelName

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -312,7 +312,7 @@ public:
   /// field; it is reserved and must remain unchanged on gfx10+.
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
                                        unsigned RequiredSgprs,
-                                       bool UpdateDescriptor = true);
+                                       bool UpdateDescriptor);
 
   /// Update metadata SGPR counts for every named kernel in one parse and
   /// serialization pass. All requested kernels must be present.
@@ -568,6 +568,11 @@ struct LLVMState {
   /// SCC, recovered from the implicit definition on a parsed scalar compare.
   /// This avoids scanning target register names in policy code.
   llvm::MCRegister SCCRegister;
+
+  /// VCC super-register, recovered from the destination of a parsed scalar
+  /// move. Policy code uses regsOverlap against this cached identity so VCC_LO,
+  /// VCC_HI, and tuple aliases are handled by LLVM MC.
+  llvm::MCRegister VCCRegister;
 
   bool Valid = false;
 

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -395,6 +395,22 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
     return S;
   }
 
+  SmallVector<MCInst, 2> VccDefInsts = parseAsmToMCInsts("s_mov_b64 vcc, 0", S);
+  if (VccDefInsts.size() != 1 || VccDefInsts.front().getNumOperands() == 0 ||
+      !VccDefInsts.front().getOperand(0).isReg()) {
+    log() << "hotswap: error: initLLVM: failed to recover VCC from a scalar "
+             "move for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+  S.VCCRegister = MCRegister(VccDefInsts.front().getOperand(0).getReg());
+  if (!S.VCCRegister.isValid()) {
+    log() << "hotswap: error: initLLVM: scalar move has no valid VCC "
+             "destination for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+
   S.Valid = true;
   return S;
 }

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -1,6 +1,8 @@
-// COM: A far patch can live in an ordinary device function shared by multiple
-// COM: kernels. The tensor descriptor save and set-PC return safely reuse one
-// COM: global scratch block, charged to both possible callers.
+// COM: A far patch can live in a zero-size ordinary device function shared by
+// COM: multiple kernels. The tensor descriptor save and set-PC return safely
+// COM: reuse one global scratch block, charged to both possible callers. The
+// COM: missing .size directive exercises zero-size function-range inference on
+// COM: the far path.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
@@ -52,8 +54,6 @@
 device_tensor:
   tensor_load_to_lds s[0:3], s[4:11]
   s_set_pc_i64 s[30:31]
-.Ldevice_tensor_end:
-.size device_tensor, .Ldevice_tensor_end-device_tensor
 
 .globl kernel_a
 .type kernel_a,@function

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -88,6 +88,13 @@ TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {
   // interior offset the zero-size symbol still resolves.
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x1000), "zero_size_kernel");
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x1000 + 4), "zero_size_kernel");
+  std::optional<ElfView::FunctionTextRange> Range =
+      ViewOrErr->findFunctionTextRangeAtOffset(4);
+  ASSERT_TRUE(Range.has_value());
+  EXPECT_EQ(Range->Begin, 0u);
+  EXPECT_EQ(Range->End, makeText().size());
+  EXPECT_NE(Range->Symbol, nullptr);
+  EXPECT_NE(Range->Symtab, nullptr);
   // An address before the symbol has no preceding function symbol to resolve.
   EXPECT_EQ(ViewOrErr->findKernelAtAddress(0x0FF0), "");
 }
@@ -177,7 +184,8 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
 
   // Prime the descriptor fallback cache before changing the encoded count.
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
-  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 16u);
 }
@@ -716,7 +724,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
 
   // Prime the metadata cache before the in-place update.
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
-  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
   ASSERT_TRUE(MetadataSgprs.has_value());
@@ -922,7 +931,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMissingMetadataCount) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
 
@@ -939,7 +949,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMissingMetadataKernel) {
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), std::nullopt);
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
 
@@ -955,7 +966,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsNonIntegerMetadataCount) {
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), std::nullopt);
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 10, /*UpdateDescriptor=*/true));
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
 
@@ -970,7 +982,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsMetadataSizeChange) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 128));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 128, /*UpdateDescriptor=*/true));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
   ASSERT_TRUE(MetadataSgprs.has_value());
@@ -989,8 +1002,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsDescriptorLimitFirst) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
-  EXPECT_FALSE(
-      ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 100000));
+  EXPECT_FALSE(ViewOrErr->updateKernelDescriptorSgprCount(
+      "entry_kernel", 100000, /*UpdateDescriptor=*/true));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
   ASSERT_TRUE(MetadataSgprs.has_value());

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -97,6 +97,13 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_LT(S.SPrefetchInstPcRelOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SPrefetchDataPcRelOpcode, S.MCII->getNumOpcodes());
   EXPECT_TRUE(S.SCCRegister.isValid());
+  ASSERT_TRUE(S.VCCRegister.isValid());
+  bool SawVccSubregister = false;
+  for (llvm::MCPhysReg Sub : S.MRI->subregs(S.VCCRegister)) {
+    SawVccSubregister = true;
+    EXPECT_TRUE(S.MRI->regsOverlap(S.VCCRegister, llvm::MCRegister(Sub)));
+  }
+  EXPECT_TRUE(SawVccSubregister);
   EXPECT_EQ(S.SNopBytes.size(), MinInstSize);
 }
 
@@ -338,6 +345,47 @@ TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
 
   EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
                                         /*Alignment=*/1, "unit test"));
+}
+
+TEST(SafeSgprScratchBlock, RejectsAlignmentOverflow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_mov_b32 s4, s0", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElfOptions Options;
+  Options.MetadataSgprCount = std::numeric_limits<unsigned>::max();
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches};
+
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
+                                        /*Alignment=*/2, "unit test"));
 }
 
 TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {


### PR DESCRIPTION
## Summary

Follow up on the non-blocking review findings from #3344 and the follow-up reviews on #3345-#3348 after the existing hotswap stack:

- require every `updateKernelDescriptorSgprCount` caller to choose explicitly whether the pre-gfx10 descriptor field is updated, preventing a future gfx10+ caller from accidentally writing the reserved field
- recover and cache the VCC super-register through LLVM MC initialization, then use `regsOverlap` instead of register-name prefix matching
- turn the shared-device-function long-branch fixture into a zero-size `STT_FUNC`, exercising zero-size function-range inference and whole-object SGPR charging on a genuinely far trampoline path
- preserve the resolved `Symbol` and `Symtab` when `findFunctionTextRangeAtOffset` converts a cached range to section-relative bounds
- add unit coverage for cached VCC aliases, zero-size function range identity, and SGPR alignment overflow from an extreme metadata count
- document why entry-stub SGPR allocation conservatively treats the VCC-inclusive metadata count as numbered when no decoded usage summary is available

This PR is stacked on #3355.

## Follow-up audit of #3345-#3348

- **#3345:** the follow-up review confirms all findings are resolved; no additional change is needed here.
- **#3346:** this PR preserves `FunctionTextRange` symbol identity and adds the remaining reachable SGPR-alignment-overflow unit case. The shared-device-function fixture covers the `Owner.empty()` whole-object fallback and verifies that both possible caller kernels are charged. The per-kernel `kernel has no descriptor` fallback is not given a synthetic test: `findKernelAtAddress` returns a non-empty owner only after finding that same `.kd` descriptor, and an empty owner charges every non-empty descriptor, so the branch is not reachable from a consistent `ElfView`.
- **#3347:** the remaining `SgprBase` check is retained because `encodeSetPCLongBranch` is an independently callable internal helper and must reject inputs whose three-register arithmetic would overflow. The LIT driver/objdump spellings are consistent with the existing COMGR hotswap suite; the tests assert the absence of `s_add_pc_i64` and round-trip the emitted instructions, so changing flags alone would add no coverage.
- **#3348:** the zero-size shared-device-function fixture directly exercises the standalone device-function whole-object analysis and all-kernel charging caveat.

## Review findings not changed here

- **Dead `UINT_MAX` condition:** #3347 replaced the original condition with the three-register overflow guard used by the independently callable set-PC encoder.
- **Zero-size far-path behavior:** #3348 unified `findFunctionTextRangeAtOffset` with the cached range model that infers a zero-size function's end from the next symbol or `.text`; this PR adds end-to-end and direct unit coverage and preserves the symbol-table identity in the returned relative range.
- **Uncited persistent routing-bit claim:** #3346 removed that policy and preserves a live descriptor value through SGPR save/restore, so the claim no longer exists to cite.
- **Missing converging multi-far-site coverage:** #3347 added adjacent and conditional-entry multi-site far-path cases with metadata checks.
- **Duplicate `PoolVAddr` declaration from the #3344/#3349 squash integration:** resolved separately by merged hotfix #3359 and inherited by this rebased stack.

## Validation

- release `check-comgr`: all unit tests, 97/97 supported LIT tests, and 31/31 CTests passed
- ASan: all unit tests, 97/97 supported LIT tests, and 30/30 runnable CTests passed; `comgr_multithread_test` remains excluded for its existing ASan runtime unmap incompatibility
- the first five stacked patches remain unchanged from their reviewed rebases; this PR alone contains the additional follow-up changes described above
