### PR TITLE
[comgr][hotswap] Add opt-in HOTSWAP_PROFILE rewrite profiler

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -134,6 +134,13 @@ set(SOURCES
 option(COMGR_ENABLE_HOTSWAP_TRANSPILE
   "Build the hotswap-transpiler-backed amd_comgr_hotswap_transpile entry point" OFF)
 
+# HotSwap profiling instrumentation, opt-in. When ON, compiles the HotSwap
+# profiling helpers (timing + decode-repetition stats) into amd_comgr; they
+# remain gated at runtime by the HOTSWAP_PROFILE env var. When OFF (default),
+# the profiling code is compiled out entirely via no-op stubs.
+option(ENABLE_HOTSWAP_PROFILE
+  "Compile in HotSwap profiling instrumentation (runtime-gated by HOTSWAP_PROFILE)" OFF)
+
 # Add Windows resource file for version info
 if(WIN32)
   # Allow users to override the DLL name via -DCOMGR_DLL_NAME
@@ -220,6 +227,10 @@ target_include_directories(amd_comgr
 # link edge"), not here.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   target_compile_definitions(amd_comgr PRIVATE COMGR_ENABLE_HOTSWAP_TRANSPILE=1)
+endif()
+
+if(ENABLE_HOTSWAP_PROFILE)
+  target_compile_definitions(amd_comgr PRIVATE ENABLE_HOTSWAP_PROFILE)
 endif()
 
 message("")

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -34,12 +34,19 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
+#include <cstdio>
 #include <limits>
+#include <mutex>
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+
+// HotSwap rewrite profiling (opt-in via HOTSWAP_PROFILE) lives in
+// comgr-hotswap-internal.h so the sibling comgr-hotswap-patch-*.cpp TUs can
+// record per-rule timings into the same process-wide accumulator.
 
 // -- GFX1250 B0-to-A0 constants -----------------------------------------------
 //
@@ -358,6 +365,9 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
 
   Sled.WritePos += Replacement.size() + MinInstSize;
+  // Count-only row: patch placed in-line via a nearby NOP sled with a short
+  // s_branch to/from it (no appended trampoline needed).
+  Ctx.Profile.count(HotswapMetric::JumpNopSled);
   return true;
 }
 
@@ -603,6 +613,8 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
     // on gfx1250 A0 (forward is fine). Optional transformations decline the
     // site; required transformations use the SGPR-backed safe return below.
     if (!AllowSafeFarReturn) {
+      // Count-only row: the "calls" column is the number of sites.
+      Ctx.Profile.count(HotswapMetric::JumpDeclined);
       log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
             << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
             << "HSV-009); site left unpatched\n";
@@ -627,10 +639,12 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
     T.Bytes.append(Back->begin(), Back->end());
     T.Long = true;
     T.PreEncodedBack = true;
+    Ctx.Profile.count(HotswapMetric::JumpLong);
     Ctx.OutTrampolines.emplace_back(std::move(T));
     return true;
   }
   {
+    Ctx.Profile.count(HotswapMetric::JumpShort);
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
   }
@@ -688,17 +702,33 @@ static std::optional<uint32_t> runPerInstPass(uint32_t (*Fn)(PatchContext &,
 /// the whole-function WMMA-hazard pass after the per-instruction loop and
 /// records per-kernel stats via ElfView::updateKernelDescriptor.
 /// Returns the total number of applied patches across all passes.
-static std::optional<uint32_t> applyGfx1250B0toA0Rules(
-    std::vector<InternalDecodedInst> &Decoded, uint8_t *Text, uint64_t TextSize,
-    const LLVMState &LS, std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
-    std::vector<ScratchPatchInfo> &OutScratchPatches,
-    const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
+static std::optional<uint32_t>
+applyGfx1250B0toA0Rules(std::vector<InternalDecodedInst> &Decoded,
+                        uint8_t *Text, uint64_t TextSize, const LLVMState &LS,
+                        std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
+                        std::vector<ScratchPatchInfo> &OutScratchPatches,
+                        const RewriteConfig &Config, HotswapProfile &Profile,
+                        bool &OutRequiredPatchApplied) {
   uint32_t Patched = 0;
-  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
 
-  CFG Cfg = buildCfg(Decoded, *LS.MCII);
-  LivenessInfo Liveness =
-      computeLiveness(Decoded, Cfg, *LS.MCII, *LS.MRI, Config.MaxVgprs);
+  std::vector<NopSled> Sleds;
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::NopSledScan);
+    Sleds = buildNopSledMap(Decoded, LS, Elf);
+  }
+
+  CFG Cfg;
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::CfgBuild);
+    Cfg = buildCfg(Decoded, *LS.MCII);
+  }
+
+  LivenessInfo Liveness;
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::Liveness);
+    Liveness =
+        computeLiveness(Decoded, Cfg, *LS.MCII, *LS.MRI, Config.MaxVgprs);
+  }
 
   if (!Liveness.Converged) {
     log() << "hotswap: error: liveness analysis did not converge, using "
@@ -721,10 +751,10 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       *PoolVAddr, Elf.textAddr(), "trampoline pool base offset");
   if (!PoolBaseOffset)
     return std::nullopt;
-  PatchContext Ctx{Config,         Decoded,         Text,
-                   TextSize,       *PoolBaseOffset, LS,
-                   OutTrampolines, Sleds,           Elf,
-                   Liveness,       KernelStats,     OutScratchPatches};
+  PatchContext Ctx{
+      Config,      Decoded,           Text,   TextSize, *PoolBaseOffset,
+      LS,          OutTrampolines,    Sleds,  Elf,      Liveness,
+      KernelStats, OutScratchPatches, Profile};
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
 
@@ -733,15 +763,27 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   // against on these and we must not invoke the patch passes for them.
   constexpr StringLiteral UnknownMnemonic = "<unknown>";
   using PerInstPatchFn = uint32_t (*)(PatchContext &, size_t);
-  SmallVector<PerInstPatchFn, 5> PerInstPasses;
+  // One per-instruction pass plus the profiler bucket its wall time / patch
+  // count accumulate into. The metric replaces the old parallel name array;
+  // the trampoline / in-place passes further break their time down into
+  // typed child metrics at the matching sites (see the patch-*.cpp files).
+  struct TimedPass {
+    HotswapMetric Metric;
+    PerInstPatchFn Fn;
+  };
+  SmallVector<TimedPass, 5> PerInstPasses;
   if (Config.RunB0A0Patches) {
-    PerInstPasses.push_back(VT.applyInPlacePatches);
-    PerInstPasses.push_back(VT.applyTrampolinePatches);
-    PerInstPasses.push_back(VT.applyWmmaSplitPatches);
-    PerInstPasses.push_back(VT.applyScratchPatches);
-    PerInstPasses.push_back(VT.applyWmmaScale16Patches);
+    PerInstPasses.push_back({HotswapMetric::InPlace, VT.applyInPlacePatches});
+    PerInstPasses.push_back(
+        {HotswapMetric::Trampoline, VT.applyTrampolinePatches});
+    PerInstPasses.push_back(
+        {HotswapMetric::WmmaSplit, VT.applyWmmaSplitPatches});
+    PerInstPasses.push_back({HotswapMetric::Scratch, VT.applyScratchPatches});
+    PerInstPasses.push_back(
+        {HotswapMetric::WmmaScale16, VT.applyWmmaScale16Patches});
   } else {
-    PerInstPasses.push_back(VT.applyTrampolinePatches);
+    PerInstPasses.push_back(
+        {HotswapMetric::Trampoline, VT.applyTrampolinePatches});
   }
 
   for (size_t Idx = 0, E = Decoded.size(); Idx < E; ++Idx) {
@@ -749,8 +791,17 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     if (DI.Mnemonic == UnknownMnemonic)
       continue;
 
-    for (PerInstPatchFn Fn : PerInstPasses) {
-      std::optional<uint32_t> P = runPerInstPass(Fn, Ctx, Idx);
+    for (const TimedPass &Pass : PerInstPasses) {
+      std::optional<uint32_t> P;
+      {
+        // The Scope times the pass over this instruction and only reads the
+        // clock when profiling is enabled at runtime; a single merge into the
+        // process-wide sink happens after the whole rewrite finishes.
+        HotswapProfile::Scope S = Profile.time(Pass.Metric);
+        P = runPerInstPass(Pass.Fn, Ctx, Idx);
+        if (P)
+          S.addPatches(*P);
+      }
       if (!P)
         return std::nullopt;
       if (*P == 0)
@@ -771,10 +822,18 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   //    treat a branch as WMMA/VALU/VOP3PX2.
   // If a future patch family changes instruction boundaries, the Decoded
   // stream must be rebuilt before these passes run.
-  if (Config.RunB0A0Patches && VT.applyWmmaHazardPatch)
-    Patched += VT.applyWmmaHazardPatch(Ctx);
-  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix)
-    Patched += VT.applyVop3px2Src2Fix(Ctx);
+  if (Config.RunB0A0Patches && VT.applyWmmaHazardPatch) {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::WmmaHazard);
+    const uint32_t P = VT.applyWmmaHazardPatch(Ctx);
+    S.addPatches(P);
+    Patched += P;
+  }
+  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix) {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::Vop3px2Src2);
+    const uint32_t P = VT.applyVop3px2Src2Fix(Ctx);
+    S.addPatches(P);
+    Patched += P;
+  }
 
   for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
@@ -977,12 +1036,23 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_SUCCESS;
   }
 
+  // Profiling session for the whole rewrite: it times phase:rewrite_total on
+  // construction and, on destruction, merges every recorded metric into the
+  // process-wide sink exactly once -- covering all early-return paths via RAII.
+  // Every phase / strat / jump timing below records into this session, with no
+  // hot-path lock and (when disabled) no clock reads at all.
+  HotswapProfileSession ProfSession;
+  HotswapProfile &Profile = ProfSession.profile();
+
   // Take a working copy so the input is preserved and we have a mutable
   // buffer to parse / patch.
   std::vector<uint8_t> Buf(static_cast<const uint8_t *>(ElfData),
                            static_cast<const uint8_t *>(ElfData) + ElfSize);
 
-  Expected<ElfView> ViewOrErr = ElfView::create(Buf.data(), Buf.size());
+  Expected<ElfView> ViewOrErr = [&] {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::ElfParse);
+    return ElfView::create(Buf.data(), Buf.size());
+  }();
   if (!ViewOrErr) {
     log() << "hotswap: error: retargetCodeObject: input is not a "
           << "parseable ELF64 (" << toString(ViewOrErr.takeError()) << ").\n";
@@ -995,7 +1065,11 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   }
   ElfView &Elf = *ViewOrErr;
 
-  LLVMState LS = initLLVM(TargetIdent);
+  LLVMState LS;
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::InitLLVM);
+    LS = initLLVM(TargetIdent);
+  }
   if (!LS.Valid) {
     log() << "hotswap: error: retargetCodeObject: initLLVM failed "
           << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
@@ -1013,15 +1087,24 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   bool RequiredPatchApplied = false;
   if (RunInstructionPatches) {
     std::vector<InternalDecodedInst> Decoded;
-    if (!decodeTextSection(Text, Elf.textSize(), LS, Decoded)) {
+    bool Decoded_ok;
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::Decode);
+      Decoded_ok = decodeTextSection(Text, Elf.textSize(), LS, Decoded);
+    }
+    if (!Decoded_ok) {
       log() << "hotswap: error: retargetCodeObject: decodeTextSection "
             << "failed on .text (" << Elf.textSize() << " bytes).\n";
       return AMD_COMGR_STATUS_ERROR;
     }
 
-    std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
-        Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
-        Config, RequiredPatchApplied);
+    std::optional<uint32_t> Patched;
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::B0A0Dispatch);
+      Patched = applyGfx1250B0toA0Rules(Decoded, Text, Elf.textSize(), LS,
+                                        Deferred, Elf, ScratchPatches, Config,
+                                        Profile, RequiredPatchApplied);
+    }
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;
@@ -1048,7 +1131,12 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_ERROR;
   const uint64_t PoolBaseOffset = *PoolBaseOffsetOr;
   if (!Deferred.empty()) {
-    if (!fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS)) {
+    bool FixupOk;
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::FixupTrampolines);
+      FixupOk = fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS);
+    }
+    if (!FixupOk) {
       if (RequiredPatchApplied) {
         log() << "hotswap: error: required patch trampoline branch fixup "
                  "failed; refusing to return the original unsafe code "
@@ -1082,8 +1170,13 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
   if (Options.RunEntryTrampolines) {
-    std::optional<uint32_t> EntryCount = appendKernelEntryTrampolines(
-        Elf, LS, Config.MaxSgprs, Growth, EntryFixups);
+    std::optional<uint32_t> EntryCount;
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::EntryTrampolines);
+      EntryCount = appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs,
+                                                Growth, EntryFixups);
+      S.addPatches(EntryCount.value_or(0));
+    }
     if (!EntryCount)
       return AMD_COMGR_STATUS_ERROR;
     Count += *EntryCount;
@@ -1096,7 +1189,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_ERROR;
 
   if (!Growth.empty()) {
-    Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::GrowElf);
+      Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);
+    }
     if (!Result) {
       log() << "hotswap: error: retargetCodeObject: "
             << "ElfView::growWithTrampolines returned null with "
@@ -1113,9 +1209,18 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       }
       GrowthTotal += T.Bytes.size();
     }
-    patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr, LS.Cpu,
-                                             EntryFixups))
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::DebugSections);
+      patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
+    }
+
+    bool KdOk;
+    {
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::KdRewrite);
+      KdOk = rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr, LS.Cpu,
+                                                 EntryFixups);
+    }
+    if (!KdOk)
       return AMD_COMGR_STATUS_ERROR;
 
     // Give each appended entry stub a `<kernel>.stub` symbol so a dispatch
@@ -1137,8 +1242,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  if (!ScratchPatches.empty())
+  if (!ScratchPatches.empty()) {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::ScratchVerify);
     runScratchVerification(*Result, LS, ScratchPatches, Config.MaxVgprs);
+  }
 
   Out = std::move(Result);
   return AMD_COMGR_STATUS_SUCCESS;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -23,9 +23,16 @@
 #include "comgr-env.h"
 #include "comgr.h"
 
+#include <algorithm>
+#include <array>
+#include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
@@ -92,6 +99,386 @@ inline std::optional<uint64_t> checkedSubUint64(uint64_t LHS, uint64_t RHS,
   }
   return LHS - RHS;
 }
+
+// -- HotSwap rewrite profiling -----------------------------------------------
+//
+// Two-level gate:
+//   1. Compile time -- the whole facility is compiled in only when the build
+//      defines ENABLE_HOTSWAP_PROFILE (e.g. cmake -DENABLE_HOTSWAP_PROFILE=ON,
+//      which passes -DENABLE_HOTSWAP_PROFILE to the compiler). In a normal
+//      build every type below collapses to the no-op stubs in the #else
+//      branch, so there is no code, no static state, and no per-call overhead.
+//   2. Run time  -- when compiled in, it stays dormant until HOTSWAP_PROFILE is
+//      set (and not "0"); otherwise every hook is a no-op and, crucially, no
+//      clock is ever read (the Scope constructor only samples the clock when
+//      the owning session is enabled).
+//
+// Design: a typed, per-rewrite session (HotswapProfile) accumulates wall-clock
+// samples into a fixed std::array indexed by HotswapMetric -- no string keys,
+// no map lookups, and no mutex on the hot path. Each retargetCodeObject() call
+// owns one session (via HotswapProfileSession), threads it through PatchContext
+// so deep patch sites record with a single typed call, and merges the whole
+// array into the process-wide HotswapProfileSink exactly once at rewrite end
+// under a single lock. The sink aggregates across every code object rewritten
+// in the process and dumps to stderr at process exit.
+//
+// Row families (see HotswapMetric / the metricInfo() table for the full list):
+//   phase:*  coarse pipeline stages in retargetCodeObject (elf_parse, initLLVM,
+//            decode, b0a0_dispatch, grow_elf, ...). These partition
+//            phase:rewrite_total; phase:unaccounted (computed at dump time)
+//            absorbs the untimed remainder so the phases sum to the total.
+//   strat:*  the B0-to-A0 patch strategies (inplace, trampoline, wmma_*,
+//            scratch, ...). A strategy with sub-rules reports a parent total
+//            plus indented children (e.g. strat:trampoline/ds_2addr).
+//   jump:*   trampoline placement outcomes (nop_sled, short_s_branch,
+//            far_long_s_add_pc, declined_far); the "calls" column is the count.
+
+// Typed identifiers for every timed / counted bucket. HotswapProfile stores one
+// HotswapSample per value; enum order is the dump order, and children are
+// printed indented under the preceding parent (see metricInfo()). Keep \c Count
+// last: it is the array size, not a real metric.
+enum class HotswapMetric : uint8_t {
+  // phase:* -- coarse pipeline stages; these partition RewriteTotal.
+  RewriteTotal,
+  ElfParse,
+  InitLLVM,
+  Decode,
+  B0A0Dispatch,
+  NopSledScan, // child of B0A0Dispatch
+  CfgBuild,    // child of B0A0Dispatch
+  Liveness,    // child of B0A0Dispatch
+  FixupTrampolines,
+  EntryTrampolines,
+  GrowElf,
+  DebugSections,
+  KdRewrite,
+  ScratchVerify,
+  Unaccounted, // synthetic: RewriteTotal - sum(other phases), set at dump time
+  // strat:* -- B0-to-A0 patch strategies (parents followed by their children).
+  InPlace,
+  InPlaceSClause,     // child of InPlace
+  InPlaceClusterLoad, // child of InPlace
+  InPlaceSBarrier,    // child of InPlace
+  Trampoline,
+  TrampolineDs2Addr,     // child of Trampoline
+  TrampolineTensor,      // child of Trampoline
+  TrampolineClusterLoad, // child of Trampoline
+  TrampolineAddtid,      // child of Trampoline
+  WmmaSplit,
+  Scratch,
+  WmmaScale16,
+  WmmaHazard,
+  Vop3px2Src2,
+  // jump:* -- trampoline placement outcomes; the "calls" column is the count.
+  JumpNopSled,
+  JumpShort,
+  JumpLong,
+  JumpDeclined,
+  Count
+};
+
+// One accumulated bucket. Nanos / Calls / Patches are running sums; MinNanos /
+// MaxNanos bound a single timed scope's duration (kept for the richer dump).
+struct HotswapSample {
+  uint64_t Nanos = 0;
+  uint64_t Calls = 0;
+  uint64_t Patches = 0;
+  uint64_t MinNanos = std::numeric_limits<uint64_t>::max();
+  uint64_t MaxNanos = 0;
+};
+
+#ifdef ENABLE_HOTSWAP_PROFILE
+
+inline uint64_t profNowNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+// Static display metadata for one metric.
+struct HotswapMetricInfo {
+  const char *Name;     // dump label, e.g. "phase:elf_parse"
+  uint8_t Indent;       // 0 = top-level row, 1 = child (printed indented)
+  bool PartitionsTotal; // true for the coarse phases that sum to RewriteTotal
+};
+
+inline const HotswapMetricInfo &metricInfo(HotswapMetric M) {
+  static constexpr HotswapMetricInfo Table[] = {
+      {"phase:rewrite_total", 0, false},
+      {"phase:elf_parse", 0, true},
+      {"phase:initLLVM", 0, true},
+      {"phase:decode", 0, true},
+      {"phase:b0a0_dispatch", 0, true},
+      {"b0a0:nop_sled_scan", 1, false},
+      {"b0a0:cfg_build", 1, false},
+      {"b0a0:liveness", 1, false},
+      {"phase:fixup_trampolines", 0, true},
+      {"phase:entry_trampolines", 0, true},
+      {"phase:grow_elf", 0, true},
+      {"phase:debug_sections", 0, true},
+      {"phase:kd_rewrite", 0, true},
+      {"phase:scratch_verify", 0, true},
+      {"phase:unaccounted", 0, false},
+      {"strat:inplace", 0, false},
+      {"strat:inplace/s_clause", 1, false},
+      {"strat:inplace/cluster_load", 1, false},
+      {"strat:inplace/s_barrier", 1, false},
+      {"strat:trampoline", 0, false},
+      {"strat:trampoline/ds_2addr", 1, false},
+      {"strat:trampoline/tensor_tdm", 1, false},
+      {"strat:trampoline/cluster_load", 1, false},
+      {"strat:trampoline/addtid", 1, false},
+      {"strat:wmma_split", 0, false},
+      {"strat:scratch_fp8", 0, false},
+      {"strat:wmma_scale16", 0, false},
+      {"strat:wmma_hazard", 0, false},
+      {"strat:vop3px2_src2", 0, false},
+      {"jump:nop_sled", 0, false},
+      {"jump:short_s_branch", 0, false},
+      {"jump:far_long_s_add_pc", 0, false},
+      {"jump:declined_far", 0, false},
+  };
+  static_assert(sizeof(Table) / sizeof(Table[0]) ==
+                    static_cast<size_t>(HotswapMetric::Count),
+                "metricInfo table must have one row per HotswapMetric");
+  return Table[static_cast<size_t>(M)];
+}
+
+// Process-wide aggregator. One instance (a function-local static in get())
+// accumulates the per-rewrite sessions merged into it and dumps at process
+// exit. All mutation goes through merge(), which takes the lock exactly once
+// per rewrite -- the hot path never touches it.
+class HotswapProfileSink {
+public:
+  static constexpr size_t NumMetrics =
+      static_cast<size_t>(HotswapMetric::Count);
+
+  static HotswapProfileSink &get() {
+    static HotswapProfileSink Instance;
+    return Instance;
+  }
+
+  void merge(const std::array<HotswapSample, NumMetrics> &Samples) {
+    std::scoped_lock Lock(Mtx);
+    for (size_t I = 0; I < NumMetrics; ++I) {
+      const HotswapSample &S = Samples[I];
+      if (S.Calls == 0 && S.Nanos == 0)
+        continue;
+      HotswapSample &D = Totals[I];
+      D.Nanos += S.Nanos;
+      D.Calls += S.Calls;
+      D.Patches += S.Patches;
+      if (S.MinNanos != std::numeric_limits<uint64_t>::max())
+        D.MinNanos = std::min(D.MinNanos, S.MinNanos);
+      D.MaxNanos = std::max(D.MaxNanos, S.MaxNanos);
+      HasData = true;
+    }
+  }
+
+  // Read access to an accumulated bucket (used by the profile unit tests).
+  const HotswapSample &total(HotswapMetric M) const {
+    return Totals[static_cast<size_t>(M)];
+  }
+
+  ~HotswapProfileSink() { dump(); }
+
+private:
+  HotswapProfileSink() = default;
+
+  void printRow(llvm::StringRef Display, const HotswapSample &S,
+                unsigned Indent) const {
+    std::string Label = std::string(Indent * 2, ' ') + Display.str();
+    const double TotalUs = S.Nanos / 1000.0;
+    const double AvgUs = S.Calls ? TotalUs / S.Calls : 0.0;
+    const double MinUs = S.MinNanos == std::numeric_limits<uint64_t>::max()
+                             ? 0.0
+                             : S.MinNanos / 1000.0;
+    const double MaxUs = S.MaxNanos / 1000.0;
+    fprintf(stderr, "%-28s %8llu %12.1f %11.3f %11.3f %11.3f %9llu\n",
+            Label.c_str(), static_cast<unsigned long long>(S.Calls), TotalUs,
+            AvgUs, MinUs, MaxUs, static_cast<unsigned long long>(S.Patches));
+  }
+
+  void dump() {
+    if (!HasData)
+      return;
+    // #4: make the phases partition rewrite_total. Everything not covered by a
+    // timed phase (input copy, pool/guard setup, symbol insertion, no-growth
+    // copy, failure paths) lands in phase:unaccounted so the phase rows sum to
+    // the total.
+    const uint64_t TotalNanos =
+        Totals[static_cast<size_t>(HotswapMetric::RewriteTotal)].Nanos;
+    uint64_t PhaseSum = 0;
+    for (size_t I = 0; I < NumMetrics; ++I)
+      if (metricInfo(static_cast<HotswapMetric>(I)).PartitionsTotal)
+        PhaseSum += Totals[I].Nanos;
+    if (TotalNanos > PhaseSum) {
+      HotswapSample &U =
+          Totals[static_cast<size_t>(HotswapMetric::Unaccounted)];
+      U.Nanos = TotalNanos - PhaseSum;
+      U.Calls = std::max<uint64_t>(U.Calls, 1);
+    }
+
+    fprintf(stderr,
+            "\n=== HotSwap COMGR rewrite profile (HOTSWAP_PROFILE) ===\n");
+    fprintf(stderr, "%-28s %8s %12s %11s %11s %11s %9s\n", "name", "calls",
+            "total_us", "avg_us", "min_us", "max_us", "patches");
+    for (size_t I = 0; I < NumMetrics; ++I) {
+      const HotswapSample &S = Totals[I];
+      if (S.Calls == 0 && S.Nanos == 0)
+        continue;
+      const HotswapMetricInfo &Info = metricInfo(static_cast<HotswapMetric>(I));
+      printRow(Info.Name, S, Info.Indent);
+    }
+    fprintf(stderr,
+            "======================================================\n");
+  }
+
+  std::mutex Mtx;
+  std::array<HotswapSample, NumMetrics> Totals{};
+  bool HasData = false;
+};
+
+// Per-rewrite session. Accumulates locally into Samples (no lock, no string
+// lookup) and, when enabled, merges into the process-wide sink once via
+// merge(). The runtime gate (HOTSWAP_PROFILE) is read once here and consulted
+// by Scope so a disabled session never reads the clock.
+class HotswapProfile {
+public:
+  static constexpr size_t NumMetrics =
+      static_cast<size_t>(HotswapMetric::Count);
+
+  HotswapProfile() {
+    const char *V = getenv("HOTSWAP_PROFILE");
+    Enabled = V && V[0] != '\0' && llvm::StringRef(V) != "0";
+  }
+  HotswapProfile(const HotswapProfile &) = delete;
+  HotswapProfile &operator=(const HotswapProfile &) = delete;
+
+  bool enabled() const { return Enabled; }
+
+  // RAII wall-clock recorder for one metric. The constructor samples the clock
+  // only when the owning session is enabled (this centralizes the runtime
+  // gate), so a disabled session reads no clock at all. Records on destruction,
+  // including any patches attributed via addPatches().
+  class Scope {
+  public:
+    Scope(HotswapProfile *Profile, HotswapMetric Metric)
+        : Profile(Profile), Metric(Metric),
+          StartNs(Profile && Profile->Enabled ? profNowNs() : 0) {}
+    Scope(const Scope &) = delete;
+    Scope &operator=(const Scope &) = delete;
+    Scope(Scope &&) = delete;
+    Scope &operator=(Scope &&) = delete;
+    ~Scope() {
+      if (!Profile || !Profile->Enabled)
+        return;
+      const uint64_t Elapsed = profNowNs() - StartNs;
+      HotswapSample &S = Profile->Samples[static_cast<size_t>(Metric)];
+      S.Nanos += Elapsed;
+      S.Calls += 1;
+      S.Patches += Patches;
+      S.MinNanos = std::min(S.MinNanos, Elapsed);
+      S.MaxNanos = std::max(S.MaxNanos, Elapsed);
+    }
+
+    // Attribute \p N applied patches to this scope's bucket.
+    void addPatches(uint64_t N) { Patches += N; }
+
+  private:
+    HotswapProfile *Profile;
+    HotswapMetric Metric;
+    uint64_t StartNs;
+    uint64_t Patches = 0;
+  };
+
+  // Time the enclosing scope under \p Metric.
+  Scope time(HotswapMetric Metric) { return Scope(this, Metric); }
+
+  // Count \p N occurrences of \p Metric with no timing (used by the count-only
+  // jump:* outcome tallies). No-op when the session is disabled.
+  void count(HotswapMetric Metric, uint64_t N = 1) {
+    if (!Enabled)
+      return;
+    Samples[static_cast<size_t>(Metric)].Calls += N;
+  }
+
+  // Merge this session's samples into the process-wide sink under a single
+  // lock. No-op when disabled.
+  void merge() {
+    if (!Enabled)
+      return;
+    HotswapProfileSink::get().merge(Samples);
+  }
+
+  // Read access to a locally accumulated bucket (used by the profile tests).
+  const HotswapSample &sample(HotswapMetric Metric) const {
+    return Samples[static_cast<size_t>(Metric)];
+  }
+
+private:
+  bool Enabled = false;
+  std::array<HotswapSample, NumMetrics> Samples{};
+};
+
+// Per-rewrite RAII: opens the RewriteTotal timer on construction and, on
+// destruction, closes it and merges the session into the process-wide sink
+// exactly once. Member declaration order makes destruction close the timer
+// (Total) before the merge (MergeAtExit) runs.
+class HotswapProfileSession {
+public:
+  HotswapProfileSession() : Total(Profile.time(HotswapMetric::RewriteTotal)) {}
+
+  HotswapProfile &profile() { return Profile; }
+
+private:
+  struct Merger {
+    HotswapProfile &Profile;
+    explicit Merger(HotswapProfile &Profile) : Profile(Profile) {}
+    ~Merger() { Profile.merge(); }
+  };
+
+  HotswapProfile Profile;
+  Merger MergeAtExit{Profile};
+  HotswapProfile::Scope Total;
+};
+
+#else // !ENABLE_HOTSWAP_PROFILE
+
+// Profiling compiled out. These no-op shims keep every hotswap-*.cpp call site
+// valid at zero cost: enabled() is always false, time() yields an inert Scope,
+// and count() / merge() vanish. No static state, no atexit dump, no per-call
+// work, and -- since the Scope constructor takes no clock -- no timing calls.
+
+class HotswapProfile {
+public:
+  class Scope {
+  public:
+    Scope() = default;
+    Scope(const Scope &) = delete;
+    Scope &operator=(const Scope &) = delete;
+    // User-declared (empty) destructor so `Scope S = time(...)` locals are
+    // treated as RAII guards and not flagged -Wunused-variable in the
+    // compiled-out build; still trivially inlined away at zero cost.
+    ~Scope() {}
+    void addPatches(uint64_t) {}
+  };
+
+  bool enabled() const { return false; }
+  Scope time(HotswapMetric) { return Scope(); }
+  void count(HotswapMetric, uint64_t = 1) {}
+  void merge() {}
+};
+
+class HotswapProfileSession {
+public:
+  HotswapProfile &profile() { return Profile; }
+
+private:
+  HotswapProfile Profile;
+};
+
+#endif // ENABLE_HOTSWAP_PROFILE
 
 // -- Trampoline and NOP sled --------------------------------------------------
 
@@ -710,6 +1097,10 @@ struct PatchContext {
   const LivenessInfo &Liveness;
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
+  // Per-rewrite profiling session (opt-in via HOTSWAP_PROFILE; a no-op when
+  // profiling is compiled out). Patch passes record typed timings / counts
+  // through this without any string lookup or hot-path mutex.
+  HotswapProfile &Profile;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -121,6 +121,10 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   StringRef ReplacementAsm = getClusterLoadReplacementAsm(Mnemonic);
   if (!ReplacementAsm.empty()) {
+    // Time the cluster_load in-place rewrite under its own typed metric (this
+    // matching branch only, so scanning other instructions costs nothing).
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::InPlaceClusterLoad);
     // The replacement templates above are all the saddr=off encoding form
     // (global address in a 64-bit VGPR pair). The SGPR-relative (_SADDR)
     // cluster_load shares the mnemonic but has a different operand layout, so
@@ -138,20 +142,28 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
       if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
         log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
               << " at 0x" << utohexstr(DI.Offset) << "\n";
+        S.addPatches(1);
         return 1;
       }
     }
+    // Matched a cluster_load mnemonic but could not rewrite it in place (the
+    // _SADDR form, or a failed opcode swap). The mnemonic cannot also match
+    // the rules below, so hand it back to the dispatcher's next pass.
+    return 0;
   }
 
   if (Mnemonic == "s_clause") {
+    HotswapProfile::Scope S = Ctx.Profile.time(HotswapMetric::InPlaceSClause);
     RewriteRule Rule;
     Rule.ReplaceBytes.assign(Ctx.LS.SNopBytes.begin(), Ctx.LS.SNopBytes.end());
     if (applyByteReplace(Rule, DI.Offset, DI.Size, Ctx.Text, Ctx.TextSize,
                          Ctx.LS)) {
       log() << "hotswap: inplace: s_clause -> s_nop at 0x"
             << utohexstr(DI.Offset) << "\n";
+      S.addPatches(1);
       return 1;
     }
+    return 0;
   }
 
   // s_barrier_signal_isfirst -> s_barrier_signal: on A0, the isfirst
@@ -180,13 +192,16 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
   // and falls through to the dispatcher's "no match" return below.
   // The AMDGPU backend never emits the _M0 form for compute kernels.
   if (Mnemonic == "s_barrier_signal_isfirst") {
+    HotswapProfile::Scope S = Ctx.Profile.time(HotswapMetric::InPlaceSBarrier);
     std::optional<unsigned> NewOpcode =
         resolveOpcode("s_barrier_signal -1", Ctx.LS);
     if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
       log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
+      S.addPatches(1);
       return 1;
     }
+    return 0;
   }
 
   return 0;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -1305,21 +1305,51 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
-  if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty())
-    return patchDs2Addr(Ctx, Idx) ? 1 : 0;
-
-  if (Mnem == "tensor_load_to_lds") {
-    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0)
-      return patchTensorLoadToLdsA0(Ctx, Idx) ? 1 : 0;
-    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::B0)
-      return patchTensorLoadToLdsB0(Ctx, Idx) ? 1 : 0;
+  // Per-rule sub-buckets nested under the Trampoline parent total (which the
+  // dispatcher in comgr-hotswap-b0a0.cpp times). Each Scope reads the clock
+  // only at matching sites and only when profiling is enabled, so no cost is
+  // added scanning non-matching instructions and none inflates the parent
+  // timer (the local sample is merged once, after every scope has closed).
+  if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty()) {
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::TrampolineDs2Addr);
+    const uint32_t P = patchDs2Addr(Ctx, Idx) ? 1 : 0;
+    S.addPatches(P);
+    return P;
   }
 
-  if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0 && isClusterLoad(Mnem))
-    return patchClusterLoadMaskA0(Ctx, Idx) ? 1 : 0;
+  if (Mnem == "tensor_load_to_lds") {
+    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0) {
+      HotswapProfile::Scope S =
+          Ctx.Profile.time(HotswapMetric::TrampolineTensor);
+      const uint32_t P = patchTensorLoadToLdsA0(Ctx, Idx) ? 1 : 0;
+      S.addPatches(P);
+      return P;
+    }
+    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::B0) {
+      HotswapProfile::Scope S =
+          Ctx.Profile.time(HotswapMetric::TrampolineTensor);
+      const uint32_t P = patchTensorLoadToLdsB0(Ctx, Idx) ? 1 : 0;
+      S.addPatches(P);
+      return P;
+    }
+  }
 
-  if (Ctx.Config.RunB0A0Patches && !getAddtidReplacement(Mnem).empty())
-    return patchDsAddtid(Ctx, Idx) ? 1 : 0;
+  if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0 &&
+      isClusterLoad(Mnem)) {
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::TrampolineClusterLoad);
+    const uint32_t P = patchClusterLoadMaskA0(Ctx, Idx) ? 1 : 0;
+    S.addPatches(P);
+    return P;
+  }
+
+  if (Ctx.Config.RunB0A0Patches && !getAddtidReplacement(Mnem).empty()) {
+    HotswapProfile::Scope S = Ctx.Profile.time(HotswapMetric::TrampolineAddtid);
+    const uint32_t P = patchDsAddtid(Ctx, Idx) ? 1 : 0;
+    S.addPatches(P);
+    return P;
+  }
 
   return 0;
 }

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -142,6 +142,39 @@ target_include_directories(HotswapMCTests PRIVATE
 
 comgr_configure_test_target(HotswapMCTests)
 
+# -- HotswapProfileTests ------------------------------------------------------
+#
+# The opt-in HotSwap rewrite profiler (comgr-hotswap-internal.h) is compiled
+# in only under ENABLE_HOTSWAP_PROFILE, which the amd_comgr target sets
+# PRIVATE -- so the enabled #ifdef branch never reaches HotswapMCTests and is
+# dead in CI. This dedicated target defines the macro itself and exercises the
+# header-only profiler (session + sink) in both runtime-off and runtime-on
+# modes, keeping the enabled branch built and covered. It needs no MC state,
+# so it links only the lightweight ELF/Support components (comgr-env.cpp
+# supplies COMGR::env for the inline log() helper the header declares).
+
+add_executable(HotswapProfileTests
+  HotswapProfileTest.cpp
+  ../src/comgr-env.cpp)
+
+llvm_map_components_to_libnames(COMGR_TEST_UNIT_PROFILE_LIBS
+  BinaryFormat Object Support TargetParser)
+
+target_compile_definitions(HotswapProfileTests PRIVATE ENABLE_HOTSWAP_PROFILE)
+
+target_link_libraries(HotswapProfileTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  ${COMGR_TEST_UNIT_PROFILE_LIBS}
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(HotswapProfileTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+comgr_configure_test_target(HotswapProfileTests)
+
 # -- RaiserScaffoldingTests ---------------------------------------------------
 #
 # Pins the bare-bones raiser scaffolding contract (`hotswap/raiser.hpp`):
@@ -227,9 +260,10 @@ comgr_configure_test_target(LoggerTests)
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
   COMMAND $<TARGET_FILE:HotswapMCTests>
+  COMMAND $<TARGET_FILE:HotswapProfileTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>)
-add_dependencies(test-unit HotswapElfTests HotswapMCTests
+add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
   RaiserScaffoldingTests DemangleSymbolNameTest LoggerTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -1,0 +1,146 @@
+//===- HotswapProfileTest.cpp - Unit tests for the HotSwap profiler -------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Tests for the typed HotSwap rewrite profiler in comgr-hotswap-internal.h
+/// (HotswapProfile session, HotswapProfileSink, HotswapProfileSession). The
+/// profiler is compiled in only under ENABLE_HOTSWAP_PROFILE, which the
+/// amd_comgr library sets PRIVATE -- so the enabled branch never reaches the
+/// other unit-test binaries and would otherwise be dead in CI. This target
+/// defines the macro itself (see test-unit/CMakeLists.txt) and covers both
+/// runtime modes:
+///   * HOTSWAP_PROFILE unset -- the session is dormant and reads no clock;
+///   * HOTSWAP_PROFILE set   -- typed timings / counts accumulate locally and
+///                              merge into the process-wide sink once.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef ENABLE_HOTSWAP_PROFILE
+#error "HotswapProfileTest must be built with ENABLE_HOTSWAP_PROFILE"
+#endif
+
+#include "comgr-hotswap-internal.h"
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+
+using namespace COMGR::hotswap;
+
+namespace {
+
+// Portable set/clear of the HOTSWAP_PROFILE runtime gate. An empty value reads
+// back as disabled (the session checks for a non-empty, non-"0" value).
+void setProfileEnv(bool On) {
+#ifdef _WIN32
+  _putenv_s("HOTSWAP_PROFILE", On ? "1" : "");
+#else
+  if (On)
+    setenv("HOTSWAP_PROFILE", "1", /*overwrite=*/1);
+  else
+    unsetenv("HOTSWAP_PROFILE");
+#endif
+}
+
+} // namespace
+
+// A session constructed with the runtime gate off is inert: enabled() is false
+// and neither time() nor count() records anything. (The Scope constructor only
+// samples the clock when the session is enabled, so a disabled session performs
+// no clock reads at all.)
+TEST(HotswapProfile, RuntimeDisabledIsInert) {
+  setProfileEnv(false);
+  HotswapProfile Profile;
+  EXPECT_FALSE(Profile.enabled());
+
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::RewriteTotal);
+    S.addPatches(7);
+  }
+  Profile.count(HotswapMetric::JumpNopSled, 5);
+
+  const HotswapSample &Total = Profile.sample(HotswapMetric::RewriteTotal);
+  EXPECT_EQ(Total.Calls, 0u);
+  EXPECT_EQ(Total.Nanos, 0u);
+  EXPECT_EQ(Total.Patches, 0u);
+  EXPECT_EQ(Profile.sample(HotswapMetric::JumpNopSled).Calls, 0u);
+
+  // merge() on a disabled session is a no-op and must not touch the sink.
+  const uint64_t Before =
+      HotswapProfileSink::get().total(HotswapMetric::RewriteTotal).Calls;
+  Profile.merge();
+  EXPECT_EQ(HotswapProfileSink::get().total(HotswapMetric::RewriteTotal).Calls,
+            Before);
+}
+
+// A session constructed with the runtime gate on records typed timings and
+// counts into its local samples.
+TEST(HotswapProfile, RuntimeEnabledRecordsLocally) {
+  setProfileEnv(true);
+  HotswapProfile Profile;
+  ASSERT_TRUE(Profile.enabled());
+
+  for (int I = 0; I < 2; ++I) {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::TrampolineDs2Addr);
+    S.addPatches(1);
+  }
+  Profile.count(HotswapMetric::JumpShort, 3);
+
+  const HotswapSample &Ds2Addr =
+      Profile.sample(HotswapMetric::TrampolineDs2Addr);
+  EXPECT_EQ(Ds2Addr.Calls, 2u);
+  EXPECT_EQ(Ds2Addr.Patches, 2u);
+  // Both bounds were assigned from real clock reads, so the invariant holds
+  // (equal is fine when the scopes are faster than the clock resolution).
+  EXPECT_LE(Ds2Addr.MinNanos, Ds2Addr.MaxNanos);
+
+  EXPECT_EQ(Profile.sample(HotswapMetric::JumpShort).Calls, 3u);
+}
+
+// An enabled session merges its local samples into the process-wide sink
+// exactly once, adding to whatever the sink already holds.
+TEST(HotswapProfile, MergeAccumulatesIntoSink) {
+  setProfileEnv(true);
+  HotswapProfileSink &Sink = HotswapProfileSink::get();
+  const uint64_t CallsBefore =
+      Sink.total(HotswapMetric::TrampolineAddtid).Calls;
+  const uint64_t PatchesBefore =
+      Sink.total(HotswapMetric::TrampolineAddtid).Patches;
+  const uint64_t JumpBefore = Sink.total(HotswapMetric::JumpLong).Calls;
+
+  {
+    HotswapProfile Profile;
+    ASSERT_TRUE(Profile.enabled());
+    {
+      // Close the timed scope before merging so its sample is recorded.
+      HotswapProfile::Scope S = Profile.time(HotswapMetric::TrampolineAddtid);
+      S.addPatches(4);
+    }
+    Profile.count(HotswapMetric::JumpLong, 2);
+    Profile.merge();
+  }
+
+  EXPECT_EQ(Sink.total(HotswapMetric::TrampolineAddtid).Calls,
+            CallsBefore + 1u);
+  EXPECT_EQ(Sink.total(HotswapMetric::TrampolineAddtid).Patches,
+            PatchesBefore + 4u);
+  EXPECT_EQ(Sink.total(HotswapMetric::JumpLong).Calls, JumpBefore + 2u);
+}
+
+// The RAII session times phase:rewrite_total and merges exactly once when it
+// leaves scope.
+TEST(HotswapProfile, SessionTimesRewriteTotalOnce) {
+  setProfileEnv(true);
+  HotswapProfileSink &Sink = HotswapProfileSink::get();
+  const uint64_t Before = Sink.total(HotswapMetric::RewriteTotal).Calls;
+  {
+    HotswapProfileSession Session;
+    ASSERT_TRUE(Session.profile().enabled());
+    HotswapProfile::Scope S = Session.profile().time(HotswapMetric::Decode);
+  }
+  EXPECT_EQ(Sink.total(HotswapMetric::RewriteTotal).Calls, Before + 1u);
+}


### PR DESCRIPTION
### What this is
Introduces a profiler for the gfx1250 B0→A0 HotSwap rewrite. Every code object COMGR rewrites at load time goes through a pipeline (parse → decode → apply patch strategies → grow ELF), and until now that cost was a black box. This makes it measurable, so we can see where time goes and drive timing/perf optimization.

### How it works
Lightweight scoped timers around each pipeline stage and each patch strategy feed a single process-wide accumulator. Results aggregate across all rewritten code objects and print once to stderr at process exit. It reports three families:

- `phase:*` — pipeline stages (elf_parse, initLLVM, decode, b0a0_dispatch, grow_elf…), summing to `phase:rewrite_total`.
- `strat:*` — per patch strategy (s_clause, trampoline, wmma_*, scratch, vop3px2), with trampoline sub-rules nested (`ds_2addr`, `tensor_tdm`, `addtid`).
- `jump:*` — trampoline placement outcomes (short / long / declined / nop-sled).

### How to enable
Two gates, so a normal build has zero overhead:

```bash
# 1. compile it in (off by default → no-op stubs)
cmake -DENABLE_HOTSWAP_PROFILE=ON ...

# 2. turn it on at runtime
HOTSWAP_PROFILE=1 ./your_workload
```

When the macro is off the profiler is compiled out entirely; when on but the env var is unset it stays dormant.

### Sample output
```text
=== HotSwap COMGR rewrite profile (HOTSWAP_PROFILE) ===
name                       calls   total_us    avg_us  patches
phase:rewrite_total           11   830439.8  75494.5        0
phase:decode                  11   375898.2  34172.5        0
phase:b0a0_dispatch           11   137352.0  12486.5        0
strat:trampoline              11    83253.6   7568.5      456
  ds_2addr                   456    79747.6    174.8      456
strat:inplace_s_clause        11     3561.3    323.7      581
jump:short_s_branch          ...        -         -        -
======================================================
```

### Why it's useful
One run tells you which phase dominates and which rewrite strategy is expensive — the starting point for any HotSwap load-time optimization. It ships safely: off by default, no cost unless explicitly built and enabled.

### Test
- Builds clean with the macro **off** (no-op stubs; profiler absent from the binary) and **on**.
- A real gfx1250 B0→A0 run prints the tables above at exit.
- No linter errors.