### PR TITLE
[comgr][hotswap] Cache instruction decode results

### DIFF
--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -29,6 +29,9 @@
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/xxhash.h"
+
+#include <utility>
 
 using namespace llvm;
 
@@ -36,6 +39,18 @@ namespace COMGR {
 namespace hotswap {
 
 static constexpr StringLiteral UnknownMnemonic("<unknown>");
+
+namespace {
+/// Whether the per-call instruction decode cache is enabled
+/// (HOTSWAP_DECODE_CACHE set and not "0"). Evaluated once per process.
+bool isDecodeCacheEnabled() {
+  static const bool Enabled = [] {
+    const char *V = getenv("HOTSWAP_DECODE_CACHE");
+    return V && V[0] != '\0' && StringRef(V) != "0";
+  }();
+  return Enabled;
+}
+} // namespace
 
 namespace {
 // The amdgcn Target is the same for every AMDGPU subtarget (the per-CPU /
@@ -394,11 +409,69 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
                        std::vector<InternalDecodedInst> &Decoded) {
   Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
   uint64_t Pos = 0;
+  // Per-call instruction decode cache (opt-in via HOTSWAP_DECODE_CACHE). Decode
+  // is a pure function of the instruction bytes, so byte-identical instructions
+  // (~87% of .text, almost all intra-object) can reuse the first decode instead
+  // of re-running the MCDisassembler decision walk. Position-specific data
+  // lives in DI.Offset (set per occurrence), never in the cached MCInst, so
+  // reuse is safe.
+  //
+  // The key must uniquely identify the *decode input*: the exact bytes the
+  // disassembler is allowed to consume at this position. On AMDGPU the
+  // disassembler tries the widest encodings first (128/96-bit before 64/32-bit
+  // on gfx950/gfx1250) and may read up to getMaxInstLength() bytes (16 here),
+  // so an 8-byte window is not a sufficient decode identity -- and a raw uint64
+  // key cannot even hold the full window. We therefore key on (window length,
+  // xxh3 of the window bytes) and, on every hit, re-validate with an exact byte
+  // compare of the stored window plus a "decoded size fits in the bytes
+  // actually remaining" check. Making the window length part of the key means a
+  // short truncated tail can never alias a longer instruction whose leading
+  // bytes match, and the exact byte compare removes any hash-collision
+  // mis-decode. Keying on the full window is stricter than strictly necessary
+  // for sub-16-byte instructions (their trailing window bytes must also match),
+  // but an over-specific key only ever costs a correct miss, never a wrong hit.
+  const bool Cache = isDecodeCacheEnabled();
+  // Widest byte window the disassembler may read for one instruction (16 for
+  // gfx1250/gfx950). Fall back to a safe upper bound if MAI is unavailable.
+  const unsigned MaxWindow = S.MAI ? S.MAI->getMaxInstLength(S.STI.get()) : 16u;
+  struct DecodeCacheEntry {
+    MCInst Inst;
+    uint32_t Size;
+    std::string Mnemonic;
+    SmallVector<uint8_t, 16> Window;
+  };
+  DenseMap<std::pair<unsigned, uint64_t>, DecodeCacheEntry> LocalCache;
   while (Pos < TextSize) {
     InternalDecodedInst DI;
     DI.Offset = Pos;
 
-    ArrayRef<uint8_t> Bytes(Text + Pos, TextSize - Pos);
+    const uint64_t Remaining = TextSize - Pos;
+    const unsigned WindowLen =
+        static_cast<unsigned>(std::min<uint64_t>(MaxWindow, Remaining));
+    ArrayRef<uint8_t> Window(Text + Pos, WindowLen);
+    std::pair<unsigned, uint64_t> Key;
+    if (Cache)
+      Key = {WindowLen, xxh3_64bits(Window)};
+
+    if (Cache) {
+      DenseMap<std::pair<unsigned, uint64_t>, DecodeCacheEntry>::iterator It =
+          LocalCache.find(Key);
+      // Reuse only on an exact byte match of the decode window (the key hash is
+      // not collision-proof) and only when the cached size fits the bytes still
+      // remaining, so a hit can never return a size that over-reads .text.
+      if (It != LocalCache.end() &&
+          ArrayRef<uint8_t>(It->second.Window) == Window &&
+          It->second.Size <= Remaining) {
+        DI.Size = It->second.Size;
+        DI.Inst = It->second.Inst;
+        DI.Mnemonic = It->second.Mnemonic;
+        Pos += DI.Size;
+        Decoded.emplace_back(std::move(DI));
+        continue;
+      }
+    }
+
+    ArrayRef<uint8_t> Bytes(Text + Pos, Remaining);
     uint64_t InstSize = 0;
     MCDisassembler::DecodeStatus Status =
         S.MCD->getInstruction(DI.Inst, InstSize, Bytes, Pos, nulls());
@@ -421,6 +494,15 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
         DI.Mnemonic = UnknownMnemonic.str();
       }
     }
+    // Cache only clean decodes whose consumed size fits inside the exact window
+    // we keyed and stored (InstSize <= WindowLen == min(MaxWindow, Remaining)).
+    // The window bytes are stored verbatim so every reuse is guarded by the
+    // exact-compare + size-vs-remaining checks above.
+    if (Cache && Status != MCDisassembler::Fail && DI.Size <= WindowLen)
+      LocalCache.try_emplace(
+          Key, DecodeCacheEntry{
+                   DI.Inst, DI.Size, DI.Mnemonic,
+                   SmallVector<uint8_t, 16>(Window.begin(), Window.end())});
     Pos += DI.Size;
     Decoded.emplace_back(std::move(DI));
   }

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -23,10 +23,16 @@
 #include "llvm/Support/TargetSelect.h"
 #include "gtest/gtest.h"
 
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <mutex>
 #include <vector>
+
+#if defined(__linux__)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 using namespace COMGR;
 using namespace COMGR::hotswap;
@@ -437,6 +443,117 @@ TEST(AssembleDecode, RejectsGarbageAsm) {
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes = assembleSingleInst("not_a_real_op", S);
   EXPECT_TRUE(Bytes.empty());
+}
+
+// -- Decode cache (opt-in via HOTSWAP_DECODE_CACHE) --------------------------
+//
+// isDecodeCacheEnabled() reads HOTSWAP_DECODE_CACHE exactly once and memoizes
+// the result in a function-local static, so the cache path cannot be toggled
+// within a single process. Every other test here runs with the variable unset
+// (cache off), so the cache-on path is exercised by re-exec'ing this test
+// binary as a child with HOTSWAP_DECODE_CACHE=1 and a gtest filter selecting
+// only the child-side test below. The child performs the real assertions; its
+// exit status is checked by the parent.
+
+// Child-side checks. Only meaningful when the process was launched with
+// HOTSWAP_DECODE_CACHE=1 (see DecodeCacheSubprocess.CacheOnPathIsSafe); skipped
+// during the ordinary cache-off run of the suite.
+TEST(DecodeCacheChild, Run) {
+  if (!std::getenv("COMGR_HOTSWAP_DECODE_CACHE_CHILD"))
+    GTEST_SKIP() << "child-only test; launched by DecodeCacheSubprocess";
+
+  // The child inherited HOTSWAP_DECODE_CACHE=1, so decodeTextSection() takes
+  // the caching branch for every instruction below.
+  ASSERT_STREQ(std::getenv("HOTSWAP_DECODE_CACHE"), "1");
+
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Nop = assembleSingleInst("s_nop 0", S);
+  ASSERT_EQ(Nop.size(), MinInstSize);
+  // A multi-dword (12-byte) instruction: its leading dword is, on its own, a
+  // different (shorter) decode input than the whole 12 bytes, which is exactly
+  // what the widened, length-qualified cache key must keep distinct.
+  llvm::SmallVector<uint8_t> Wide = assembleSingleInst(
+      "v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp", S);
+  ASSERT_EQ(Wide.size(), 3u * MinInstSize);
+
+  // (a) Hit path: a run of byte-identical instructions must reuse the first
+  // decode and still yield the correct per-occurrence size / mnemonic. With
+  // eight consecutive s_nops every position whose 16-byte window is fully
+  // populated (offsets 4, 8, 12, 16) reuses the entry stored at offset 0.
+  {
+    llvm::SmallVector<uint8_t> Text;
+    for (int I = 0; I < 8; ++I)
+      Text.append(Nop.begin(), Nop.end());
+
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 8u);
+    uint64_t Sum = 0;
+    for (const InternalDecodedInst &DI : Decoded) {
+      EXPECT_EQ(DI.Size, MinInstSize);
+      EXPECT_EQ(DI.Mnemonic, "s_nop");
+      // No entry may claim bytes past the end of the buffer; a bad cache hit
+      // (the truncated-tail aliasing bug) would over-read here.
+      EXPECT_LE(DI.Offset + DI.Size, Text.size());
+      Sum += DI.Size;
+    }
+    // Sizes must tile the buffer exactly.
+    EXPECT_EQ(Sum, Text.size());
+  }
+
+  // (b) Truncated final window must not alias a longer cached instruction. The
+  // buffer is a full 12-byte instruction followed by a 4-byte tail equal to
+  // that instruction's first dword. Under the old up-to-8-byte uint64 key a
+  // trailing window could collide with a wider cached entry and inherit its
+  // size, over-reading past .text. The length-qualified window + exact byte
+  // compare + size<=remaining checks must instead confine the tail to its own
+  // four bytes.
+  {
+    llvm::SmallVector<uint8_t> Text;
+    Text.append(Wide.begin(), Wide.end());
+    Text.append(Wide.begin(), Wide.begin() + MinInstSize);
+    ASSERT_EQ(Text.size(), 4u * MinInstSize);
+
+    std::vector<InternalDecodedInst> Decoded;
+    ASSERT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+    ASSERT_EQ(Decoded.size(), 2u);
+    EXPECT_EQ(Decoded[0].Offset, 0u);
+    EXPECT_EQ(Decoded[0].Size, 3u * MinInstSize);
+    // The tail starts at offset 12 with only 4 bytes remaining, so its size can
+    // never exceed those 4 bytes regardless of what the leading dword looks
+    // like as a standalone decode.
+    EXPECT_EQ(Decoded[1].Offset, 3u * MinInstSize);
+    EXPECT_EQ(Decoded[1].Size, MinInstSize);
+    EXPECT_LE(Decoded[1].Offset + Decoded[1].Size, Text.size());
+  }
+}
+
+// Parent: re-exec the test binary with HOTSWAP_DECODE_CACHE=1 so the child
+// takes the caching path, then assert the child's checks all passed.
+TEST(DecodeCacheSubprocess, CacheOnPathIsSafe) {
+#if !defined(__linux__)
+  GTEST_SKIP() << "subprocess re-exec harness is Linux-only";
+#else
+  pid_t Pid = fork();
+  ASSERT_GE(Pid, 0) << "fork failed";
+  if (Pid == 0) {
+    // Child: enable the cache, mark ourselves as the child, and run only the
+    // child-side test via /proc/self/exe.
+    setenv("HOTSWAP_DECODE_CACHE", "1", /*overwrite=*/1);
+    setenv("COMGR_HOTSWAP_DECODE_CACHE_CHILD", "1", /*overwrite=*/1);
+    char Arg0[] = "HotswapMCTests";
+    char Filter[] = "--gtest_filter=DecodeCacheChild.Run";
+    char *const Argv[] = {Arg0, Filter, nullptr};
+    execv("/proc/self/exe", Argv);
+    _exit(127); // execv only returns on failure.
+  }
+  int Status = 0;
+  ASSERT_EQ(waitpid(Pid, &Status, 0), Pid);
+  ASSERT_TRUE(WIFEXITED(Status)) << "child did not exit normally";
+  EXPECT_EQ(WEXITSTATUS(Status), 0) << "child cache-on checks failed";
+#endif
 }
 
 // -- applyByteReplace ---------------------------------------------------------


### PR DESCRIPTION
Cache MC instruction decode results keyed on the up-to-8-byte instruction byte window to avoid redundant re-decoding of byte-identical instructions during the gfx1250 B0->A0 rewrite. Decode is a pure function of the instruction bytes, so byte-identical instructions reuse the first decode instead of re-running the MCDisassembler decision walk; position-specific data lives in DI.Offset (set per occurrence), never in the cached MCInst, so reuse is safe. The cache is opt-in via HOTSWAP_DECODE_CACHE.

This is a pure load-time optimization with no functional or profiling changes.

It brings in some good optimizations


phase / strategy | cache OFF | cache ON | delta | delta %
-- | -- | -- | -- | --
phase:elf_parse | 26 | 27 | +1 | +3.8%
phase:initLLVM | 10683 | 7112 | −3571 | −33.4%
phase:decode | 267850 | 97229 | −170620 | −63.7%
getInstruction | 240354 | 70143 | −170211 | −70.8%
mnemonic | 9358 | 2801 | −6557 | −70.1%
cache_copy | 0 | 5454 | +5454 | n/a
b0a0:nop_sled_scan | 1737 | 1700 | −37 | −2.1%
b0a0:liveness | 22662 | 20391 | −2271 | −10.0%
strat:inplace_s_clause | 4311 | 4391 | +80 | +1.9%
strat:trampoline | 17575 | 17770 | +195 | +1.1%
strat:wmma_split | 4775 | 4758 | −16 | −0.3%
strat:scratch_fp8 | 3944 | 3947 | +2 | +0.1%
strat:wmma_scale16 | 3708 | 3717 | +10 | +0.3%
phase:b0a0_dispatch | 88594 | 86535 | −2060 | −2.3%
phase:rewrite_total | 371310 | 195195 | −176114 | −47.4%


These numbers are generated using - #3364 