### PR TITLE
[comgr][hotswap] eliminate add-pc from far hotswap trampolines (amd-staging companion)

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -29,8 +29,10 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <cassert>
@@ -361,88 +363,85 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
   return true;
 }
 
-// s_add_pc_i64 long branch from \p FromOffset to \p TargetOffset (.text
-// offsets). It adds a signed literal to the next instruction's PC, so the
-// offset is TargetOffset - (FromOffset + size); size is 8 (forward, 32-bit
-// literal) or 12 (backward, 64-bit literal), resolved by trying each. Encoded
-// via the MC assembler. Returns empty on failure.
-//
-// Precondition: callers only long-branch *far* sites, so the target is far
-// enough that s_add_pc_i64 always needs a real (>= 32-bit) literal. A tiny
-// offset would instead assemble to the 4-byte inline-constant form, match
-// neither candidate size, and yield empty. That is asserted here (assert
-// liberally); the empty return is kept as a release-build safety net so a
-// stray near target degrades to the unpatched-object fallback rather than
-// crashing the loader.
-SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                                      uint64_t TargetOffset) {
-  [[maybe_unused]] const int64_t Distance =
-      static_cast<int64_t>(TargetOffset) - static_cast<int64_t>(FromOffset);
-  [[maybe_unused]] const int64_t MinLongDistance = LongBranchMaxBytes;
-  assert((Distance > MinLongDistance || Distance < -MinLongDistance) &&
-         "encodeLongBranch: target is not a far site; the long-branch path is "
-         "only valid for offsets beyond an s_add_pc_i64 instruction's reach");
-
-  for (uint32_t Size : {LongBranchFwdBytes, LongBranchMaxBytes}) {
-    int64_t Off = static_cast<int64_t>(TargetOffset) -
-                  static_cast<int64_t>(FromOffset + Size);
-    SmallVector<uint8_t> Bytes =
-        assembleSingleInst("s_add_pc_i64 " + std::to_string(Off), LS);
-    if (Bytes.size() == Size)
-      return Bytes;
+std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
+                                                          uint64_t FromOffset,
+                                                          uint64_t TargetOffset,
+                                                          unsigned SgprBase) {
+  if ((SgprBase & 1u) != 0 ||
+      SgprBase > std::numeric_limits<unsigned>::max() - 2) {
+    log() << "hotswap: error: set-PC long branch requires an aligned "
+             "three-SGPR block, got s"
+          << SgprBase << "\n";
+    return std::nullopt;
   }
-  return {};
+
+  const std::string Lo = "s" + std::to_string(SgprBase);
+  const std::string Hi = "s" + std::to_string(SgprBase + 1);
+  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
+                           std::to_string(SgprBase + 1) + "]";
+  const std::string SccSave = "s" + std::to_string(SgprBase + 2);
+
+  // Per the AMDGPU ISA, s_get_pc_i64 captures the address immediately after
+  // itself. EncodeSetPCLongBranch.ForwardLandsOnTarget pins this PC base.
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      FromOffset, 2 * MinInstSize, "set-PC long branch PC base");
+  if (!PcBase)
+    return std::nullopt;
+  uint64_t Delta = TargetOffset - *PcBase;
+  uint32_t LoDelta = static_cast<uint32_t>(Delta);
+  uint32_t HiDelta = static_cast<uint32_t>(Delta >> 32);
+
+  SmallVector<std::string, 6> AsmLines;
+  AsmLines.push_back("s_cselect_b32 " + SccSave + ", 1, 0");
+  AsmLines.push_back("s_get_pc_i64 " + Pair);
+  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
+                     utohexstr(LoDelta));
+  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
+                     utohexstr(HiDelta));
+  AsmLines.push_back("s_cmp_lg_u32 " + SccSave + ", 0");
+  AsmLines.push_back("s_set_pc_i64 " + Pair);
+  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
+  if (Bytes.empty()) {
+    log() << "hotswap: error: failed to assemble set-PC long branch via "
+          << Pair << "\n";
+    return std::nullopt;
+  }
+  return Bytes;
 }
 
-std::optional<SmallVector<uint8_t>>
-encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                           uint64_t TargetOffset, unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0 ||
-      SgprBase == std::numeric_limits<unsigned>::max()) {
-    log() << "hotswap: error: SCC-neutral long branch requires an aligned "
+static std::optional<SmallVector<uint8_t>>
+encodeSetPCLongBranchClobberSCC(const LLVMState &LS, uint64_t FromOffset,
+                                uint64_t TargetOffset, unsigned SgprBase) {
+  if ((SgprBase & 1u) != 0) {
+    log() << "hotswap: error: SCC-dead set-PC branch requires an aligned "
              "SGPR pair, got s"
           << SgprBase << "\n";
     return std::nullopt;
   }
 
+  const std::string Lo = "s" + std::to_string(SgprBase);
+  const std::string Hi = "s" + std::to_string(SgprBase + 1);
   const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
                            std::to_string(SgprBase + 1) + "]";
-  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
-  if (GetPc.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_get_pc_i64 for "
-          << Pair << "\n";
-    return std::nullopt;
-  }
-
   std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, GetPc.size(), "SCC-neutral long branch PC base");
+      FromOffset, MinInstSize, "SCC-dead set-PC branch PC base");
   if (!PcBase)
     return std::nullopt;
+  uint64_t Delta = TargetOffset - *PcBase;
 
-  // Unsigned subtraction intentionally materializes the two's-complement
-  // delta for backward branches.
-  const uint64_t Delta = TargetOffset - *PcBase;
-  SmallVector<uint8_t> Add = assembleSingleInst(
-      "s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" + utohexstr(Delta), LS);
-  if (Add.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_add_nc_u64 for "
+  SmallVector<std::string, 4> AsmLines;
+  AsmLines.push_back("s_get_pc_i64 " + Pair);
+  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
+                     utohexstr(static_cast<uint32_t>(Delta)));
+  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
+                     utohexstr(static_cast<uint32_t>(Delta >> 32)));
+  AsmLines.push_back("s_set_pc_i64 " + Pair);
+  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
+  if (Bytes.empty()) {
+    log() << "hotswap: error: failed to assemble SCC-dead set-PC branch via "
           << Pair << "\n";
     return std::nullopt;
   }
-  SmallVector<uint8_t> SetPc = assembleSingleInst("s_set_pc_i64 " + Pair, LS);
-  if (SetPc.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_set_pc_i64 for "
-          << Pair << "\n";
-    return std::nullopt;
-  }
-
-  SmallVector<uint8_t> Bytes;
-  Bytes.append(GetPc.begin(), GetPc.end());
-  Bytes.append(Add.begin(), Add.end());
-  Bytes.append(SetPc.begin(), SetPc.end());
   return Bytes;
 }
 
@@ -653,100 +652,95 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
   return true;
 }
 
-static std::optional<SmallVector<uint8_t>>
-buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
-                   uint64_t BackStart) {
+static std::optional<SafeSgprScratchBlock>
+reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
+      Ctx, InstOffset, /*Count=*/3, /*Alignment=*/2, "safe far return");
   if (!Scratch)
-    return std::nullopt;
-
-  std::optional<uint64_t> ReturnTo =
-      checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
-  if (!ReturnTo)
-    return std::nullopt;
-  std::optional<SmallVector<uint8_t>> Bytes =
-      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, Scratch->Base);
-  if (!Bytes)
     return std::nullopt;
   if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
     return std::nullopt;
+  return Scratch;
+}
 
-  const std::string Pair = "s[" + std::to_string(Scratch->Base) + ":" +
-                           std::to_string(Scratch->Base + 1) + "]";
-  log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
-        << Pair << "\n";
-  return std::move(*Bytes);
+bool isSBranchReachable(uint64_t From, uint64_t To) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(From, MinInstSize, "short branch PC base");
+  if (!PcBase)
+    return false;
+  uint64_t Delta = To >= *PcBase ? To - *PcBase : *PcBase - To;
+  if (Delta % MinInstSize != 0)
+    return false;
+  uint64_t MaxDelta =
+      To >= *PcBase ? static_cast<uint64_t>(BranchOffsetMax) * MinInstSize
+                    : static_cast<uint64_t>(-BranchOffsetMin) * MinInstSize;
+  return Delta <= MaxDelta;
 }
 
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses s_add_pc_i64 on the forward edge. Required rewrites return through an
-/// SGPR pair with an SCC-neutral get-PC/add/set-PC sequence; optional rewrites
-/// decline. The 8-byte forward branch overwrites the site in place, so a
-/// smaller site declines rather than clobbering the next instruction.
+/// uses an SCC-preserving get-PC/add/set-PC sequence on the backward edge.
+/// Adjacent far sites are coalesced after patching to reduce gateway pressure.
+/// Every far source edge then uses a short branch to nearby safe NOP padding;
+/// that gateway uses the pre-Gen5 SGPR-backed set-PC sequence. No source or
+/// return edge executes gfx1250's broken s_add_pc_i64 instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement,
-                                    bool AllowSafeFarReturn) {
+                                    ArrayRef<uint8_t> Replacement) {
   // This trampoline lands at the appended pool base and after every trampoline
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
   // final pool offset (relative to .text) is known exactly now.
   uint64_t PoolStart = Ctx.PoolBaseOffset;
-  for (const Trampoline &Prev : Ctx.OutTrampolines)
-    PoolStart += Prev.Bytes.size();
+  for (const Trampoline &Prev : Ctx.OutTrampolines) {
+    std::optional<uint64_t> NextPoolStart = checkedAddUint64(
+        PoolStart, Prev.Bytes.size(), "trampoline pool layout");
+    if (!NextPoolStart)
+      return false;
+    PoolStart = *NextPoolStart;
+  }
 
   // An s_branch encodes To - From as a signed simm16 dword field, in range iff
   // (To - From - MinInstSize) / MinInstSize fits [BranchOffsetMin,
   // BranchOffsetMax] (see LLVMState::encodeSBranch). Test both edges with the
   // short branch-back slot; the branch-back (pool tail -> site) is the farther
   // of the two. Go long only when a short branch cannot reach.
-  auto WithinSBranch = [](uint64_t From, uint64_t To) {
-    int64_t Dword = (static_cast<int64_t>(To) - static_cast<int64_t>(From) -
-                     static_cast<int64_t>(MinInstSize)) /
-                    static_cast<int64_t>(MinInstSize);
-    return Dword >= BranchOffsetMin && Dword <= BranchOffsetMax;
-  };
-  const uint64_t ShortBackFrom = PoolStart + Replacement.size();
-  const bool Far = !(WithinSBranch(InstOffset, PoolStart) &&
-                     WithinSBranch(ShortBackFrom, InstOffset + InstSize));
+  std::optional<uint64_t> ShortBackFrom = checkedAddUint64(
+      PoolStart, Replacement.size(), "short trampoline return slot");
+  std::optional<uint64_t> ReturnTo =
+      checkedAddUint64(InstOffset, InstSize, "trampoline return target");
+  if (!ShortBackFrom || !ReturnTo)
+    return false;
+  const bool Far = !(isSBranchReachable(InstOffset, PoolStart) &&
+                     isSBranchReachable(*ShortBackFrom, *ReturnTo));
 
   Trampoline T;
   T.OriginalOffset = InstOffset;
   T.OriginalSize = InstSize;
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
+  if (std::optional<ElfView::FunctionTextRange> Range =
+          Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset)) {
+    T.HasFunctionRange = true;
+    T.FunctionStart = Range->Begin;
+    T.FunctionEnd = Range->End;
+  }
 
   if (Far) {
-    // HSV-009: the far pool's backward s_add_pc_i64 branch corrupts wave state
-    // on gfx1250 A0 (forward is fine). Optional transformations decline the
-    // site; required transformations use the SGPR-backed safe return below.
-    if (!AllowSafeFarReturn) {
-      log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
-            << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
-            << "HSV-009); site left unpatched\n";
-      return false;
-    }
-    if (InstSize < LongBranchFwdBytes) {
-      log() << "hotswap: error: safe far trampoline site 0x"
-            << utohexstr(InstOffset) << " is " << InstSize
-            << " B, smaller than " << LongBranchFwdBytes
+    if (InstSize < MinInstSize) {
+      log() << "hotswap: far trampoline site 0x" << utohexstr(InstOffset)
+            << " declined: " << InstSize << " B, smaller than " << MinInstSize
             << " B forward branch\n";
       return false;
     }
-
-    std::optional<uint64_t> BackStart = checkedAddUint64(
-        PoolStart, Replacement.size(), "safe far return start offset");
-    if (!BackStart)
+    std::optional<SafeSgprScratchBlock> Scratch =
+        reserveSafeFarReturn(Ctx, InstOffset);
+    if (!Scratch)
       return false;
-    std::optional<SmallVector<uint8_t>> Back =
-        buildSafeFarReturn(Ctx, InstOffset, InstSize, *BackStart);
-    if (!Back)
-      return false;
-    T.Bytes.append(Back->begin(), Back->end());
+    T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
     T.Long = true;
-    T.PreEncodedBack = true;
+    T.UsesSetPCBack = true;
+    T.LongBranchSgprBase = Scratch->Base;
     Ctx.OutTrampolines.emplace_back(std::move(T));
     return true;
   }
@@ -758,27 +752,773 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
   return true;
 }
 
+std::optional<uint64_t>
+evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                const LLVMState &LS) {
+  uint64_t Target = 0;
+  if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
+    return Target;
+
+  // TODO(https://github.com/ROCm/llvm-project/issues/3351): Remove this
+  // fallback when AMDGPUMCInstrAnalysis::evaluateBranch locates the descriptor
+  // operand marked MCOI::OPERAND_PCREL. Its current operand-zero restriction
+  // is in llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp.
+  // GFX1250 s_call_i64 instead has its destination SGPR pair in slot zero and
+  // its simm16 dword displacement in slot one; the operand layout and width
+  // are pinned by llvm/test/MC/AMDGPU/gfx1250_asm_sopk.s.
+  if (DI.Inst.getOpcode() != LS.SCallI64Opcode ||
+      DI.Inst.getNumOperands() == 0 ||
+      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+    return std::nullopt;
+
+  uint64_t Encoded =
+      static_cast<uint64_t>(
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
+      0xFFFFu;
+  int64_t DwordDelta = SignExtend64<16>(Encoded);
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      DI.Offset, DI.Size, "direct control-flow target PC base");
+  if (!PcBase)
+    return std::nullopt;
+  if (DwordDelta >= 0)
+    return checkedAddUint64(*PcBase,
+                            static_cast<uint64_t>(DwordDelta) * MinInstSize,
+                            "direct control-flow target");
+  return checkedSubUint64(*PcBase,
+                          static_cast<uint64_t>(-DwordDelta) * MinInstSize,
+                          "direct control-flow target");
+}
+
+/// Collect statically known direct branch and call destinations so an interior
+/// entry point is never swallowed by coalescing.
+static std::optional<DenseSet<uint64_t>>
+collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
+                           const LLVMState &LS) {
+  if (!LS.MIA) {
+    log() << "hotswap: MC branch analysis is unavailable; adjacent far "
+             "trampolines will not be coalesced\n";
+    return std::nullopt;
+  }
+
+  DenseSet<uint64_t> Targets;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Op : DI.Inst)
+      HasImmediate |= Op.isImm();
+    if (!LS.MIA->isCall(DI.Inst) && !HasImmediate)
+      continue;
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (!Target) {
+      log() << "hotswap: MC analysis could not evaluate direct control-flow "
+               "instruction at 0x"
+            << utohexstr(DI.Offset)
+            << "; adjacent far trampolines will not be coalesced\n";
+      return std::nullopt;
+    }
+    Targets.insert(*Target);
+  }
+  return Targets;
+}
+
+/// Coalesce runs of adjacent far patch sites when the same SGPR scratch block
+/// is safe at every site. Removing each interior return reservation preserves
+/// replacement order and reduces the number of required forward gateways.
+/// This deliberately never steals an unpatched neighboring instruction.
+static void
+mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
+                             const DenseSet<uint64_t> &DirectBranchTargets) {
+  std::vector<Trampoline> Merged;
+  Merged.reserve(Trampolines.size());
+  uint64_t MergeCount = 0;
+
+  for (Trampoline &T : Trampolines) {
+    bool Adjacent = false;
+    if (!Merged.empty()) {
+      Trampoline &Prev = Merged.back();
+      std::optional<uint64_t> PrevEnd = checkedAddUint64(
+          Prev.OriginalOffset, Prev.OriginalSize, "adjacent trampoline end");
+      Adjacent = PrevEnd && *PrevEnd == T.OriginalOffset && Prev.Long &&
+                 T.Long && Prev.UsesSetPCBack && T.UsesSetPCBack &&
+                 Prev.LongBranchSgprBase == T.LongBranchSgprBase &&
+                 Prev.HasFunctionRange && T.HasFunctionRange &&
+                 Prev.FunctionStart == T.FunctionStart &&
+                 Prev.FunctionEnd == T.FunctionEnd &&
+                 !DirectBranchTargets.contains(T.OriginalOffset) &&
+                 Prev.Bytes.size() >= SetPcReturnReserveBytes &&
+                 T.Bytes.size() >= SetPcReturnReserveBytes;
+    }
+
+    if (!Adjacent) {
+      Merged.emplace_back(std::move(T));
+      continue;
+    }
+
+    Trampoline &Prev = Merged.back();
+    if (T.OriginalSize >
+        std::numeric_limits<uint32_t>::max() - Prev.OriginalSize) {
+      Merged.emplace_back(std::move(T));
+      continue;
+    }
+    Prev.Bytes.resize(Prev.Bytes.size() - SetPcReturnReserveBytes);
+    Prev.Bytes.append(T.Bytes.begin(), T.Bytes.end());
+    Prev.OriginalSize += T.OriginalSize;
+    ++MergeCount;
+  }
+
+  Trampolines = std::move(Merged);
+  if (MergeCount != 0)
+    log() << "hotswap: coalesced " << MergeCount
+          << " adjacent far trampoline edge(s)\n";
+}
+
+static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
+  for (Trampoline &T : Trampolines) {
+    if (!T.Long)
+      continue;
+    T.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
+    T.HasPoolBranchIsland = true;
+  }
+}
+
+static bool isEndProgram(const InternalDecodedInst &DI, const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  return Opcode == LS.SEndPgmOpcode || Opcode == LS.SEndPgmSavedOpcode;
+}
+
+static bool isPcSensitive(const InternalDecodedInst &DI, const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  return Opcode == LS.SAddPcI64Opcode || Opcode == LS.SGetPcI64Opcode ||
+         Opcode == LS.SSetPcI64Opcode || Opcode == LS.SSwapPcI64Opcode ||
+         Opcode == LS.SPrefetchInstPcRelOpcode ||
+         Opcode == LS.SPrefetchDataPcRelOpcode;
+}
+
+static bool isSafeStraightLineRelocation(const InternalDecodedInst &DI,
+                                         const LLVMState &LS,
+                                         const DenseSet<uint64_t> &Protected) {
+  if (!LS.MIA || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+    return false;
+  unsigned Opcode = DI.Inst.getOpcode();
+  return DI.DecodeSucceeded && !Protected.contains(DI.Offset) &&
+         Opcode != LS.SClauseOpcode && Opcode != LS.SDelayAluOpcode &&
+         !isPcSensitive(DI, LS);
+}
+
+/// Decode the bytes currently present at an original instruction site. Earlier
+/// rewrite passes may have changed Ctx.Text after Ctx.Decoded was populated, so
+/// relocation decisions must not classify the stale MCInst and then copy a
+/// different instruction. A size change is conservatively non-relocatable.
+static std::optional<InternalDecodedInst>
+decodeCurrentInstruction(const PatchContext &Ctx,
+                         const InternalDecodedInst &Original) {
+  if (Original.Offset > Ctx.TextSize ||
+      Original.Size > Ctx.TextSize - Original.Offset)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst> Current;
+  if (!decodeTextSection(Ctx.Text + Original.Offset, Original.Size, Ctx.LS,
+                         Current) ||
+      Current.size() != 1 || Current[0].Size != Original.Size)
+    return std::nullopt;
+  Current[0].Offset = Original.Offset;
+  return std::move(Current[0]);
+}
+
+/// Instructions covered by a hard clause or a delay directive must remain in
+/// place relative to that directive. Mark the complete encoded clause and the
+/// maximum six-instruction forward span addressable by s_delay_alu.
+static DenseSet<uint64_t>
+collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
+                                  const LLVMState &LS) {
+  DenseSet<uint64_t> Protected;
+  unsigned ClauseRemaining = 0;
+  unsigned DelayRemaining = 0;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (ClauseRemaining != 0) {
+      Protected.insert(DI.Offset);
+      --ClauseRemaining;
+    }
+    if (DelayRemaining != 0) {
+      Protected.insert(DI.Offset);
+      --DelayRemaining;
+    }
+
+    if (DI.Inst.getOpcode() == LS.SClauseOpcode &&
+        DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isImm())
+      ClauseRemaining =
+          (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 63u) + 1;
+    else if (DI.Inst.getOpcode() == LS.SDelayAluOpcode)
+      DelayRemaining = 6;
+  }
+  return Protected;
+}
+
+/// Relocating an instruction changes its address. In a function containing a
+/// register-based PC transfer, MC cannot prove that the instruction is not an
+/// indirect destination, so leave the complete function in place.
+static DenseSet<uint64_t>
+collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
+                                    const LLVMState &LS, const ElfView &Elf) {
+  DenseSet<uint64_t> Functions;
+  if (!LS.MIA)
+    return Functions;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
+      continue;
+    if (!LS.MIA->isIndirectBranch(DI.Inst) &&
+        !(LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+          isPcSensitive(DI, LS)))
+      continue;
+    std::optional<ElfView::FunctionTextRange> Range =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    if (Range && Functions.insert(Range->Begin).second)
+      log() << "hotswap: source relocation disabled for function at 0x"
+            << utohexstr(Range->Begin) << " by " << DI.Mnemonic << " at 0x"
+            << utohexstr(DI.Offset) << "\n";
+  }
+  return Functions;
+}
+
+/// Grow undersized far-site windows only through proven straight-line code.
+/// Patched neighbors are merged; ordinary instructions are copied verbatim
+/// into the trampoline body and retain their original order. This is bounded
+/// to the 28 bytes required by the accepted pre-Gen5 forward sequence.
+static void
+expandStraightLineTrampolines(PatchContext &Ctx,
+                              const DenseSet<uint64_t> &DirectBranchTargets) {
+  DenseMap<uint64_t, size_t> DecodedAt;
+  for (size_t I = 0; I != Ctx.Decoded.size(); ++I)
+    DecodedAt[Ctx.Decoded[I].Offset] = I;
+  DenseSet<uint64_t> Protected =
+      collectRelocationProtectedOffsets(Ctx.Decoded, Ctx.LS);
+  DenseSet<uint64_t> IndirectControlFlowFunctions =
+      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    if (Ctx.OutTrampolines[I].HasFunctionRange &&
+        IndirectControlFlowFunctions.contains(
+            Ctx.OutTrampolines[I].FunctionStart))
+      continue;
+    while (Ctx.OutTrampolines[I].Long &&
+           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+      Trampoline &T = Ctx.OutTrampolines[I];
+      std::optional<uint64_t> End = checkedAddUint64(
+          T.OriginalOffset, T.OriginalSize, "straight-line expansion end");
+      if (!End || DirectBranchTargets.contains(*End))
+        break;
+
+      if (I + 1 < Ctx.OutTrampolines.size() &&
+          Ctx.OutTrampolines[I + 1].OriginalOffset == *End) {
+        Trampoline &Next = Ctx.OutTrampolines[I + 1];
+        if (!Next.Long || !Next.UsesSetPCBack ||
+            Next.LongBranchSgprBase != T.LongBranchSgprBase ||
+            !T.HasFunctionRange || !Next.HasFunctionRange ||
+            T.FunctionStart != Next.FunctionStart ||
+            T.FunctionEnd != Next.FunctionEnd ||
+            Next.Bytes.size() < SetPcReturnReserveBytes)
+          break;
+        T.Bytes.resize(T.Bytes.size() - SetPcReturnReserveBytes);
+        T.Bytes.append(Next.Bytes.begin(), Next.Bytes.end());
+        T.OriginalSize += Next.OriginalSize;
+        Ctx.OutTrampolines.erase(Ctx.OutTrampolines.begin() + I + 1);
+        continue;
+      }
+
+      DenseMap<uint64_t, size_t>::const_iterator It = DecodedAt.find(*End);
+      if (It == DecodedAt.end())
+        break;
+      const InternalDecodedInst &Original = Ctx.Decoded[It->second];
+      std::optional<InternalDecodedInst> Current =
+          decodeCurrentInstruction(Ctx, Original);
+      if (!Current)
+        break;
+      const InternalDecodedInst &DI = *Current;
+      std::optional<ElfView::FunctionTextRange> Range =
+          Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
+      if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
+          Range->End != T.FunctionEnd ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected) ||
+          T.Bytes.size() < SetPcReturnReserveBytes)
+        break;
+
+      T.Bytes.insert(T.Bytes.end() - SetPcReturnReserveBytes,
+                     Ctx.Text + DI.Offset, Ctx.Text + DI.Offset + DI.Size);
+      T.OriginalSize += DI.Size;
+    }
+
+    while (Ctx.OutTrampolines[I].Long &&
+           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+      Trampoline &T = Ctx.OutTrampolines[I];
+      if (DirectBranchTargets.contains(T.OriginalOffset))
+        break;
+      DenseMap<uint64_t, size_t>::const_iterator It =
+          DecodedAt.find(T.OriginalOffset);
+      if (It == DecodedAt.end() || It->second == 0)
+        break;
+      const InternalDecodedInst &Original = Ctx.Decoded[It->second - 1];
+      std::optional<InternalDecodedInst> Current =
+          decodeCurrentInstruction(Ctx, Original);
+      if (!Current)
+        break;
+      const InternalDecodedInst &DI = *Current;
+      if (DI.Offset + DI.Size != T.OriginalOffset ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected))
+        break;
+      if (I != 0) {
+        const Trampoline &Previous = Ctx.OutTrampolines[I - 1];
+        if (Previous.OriginalOffset + Previous.OriginalSize > DI.Offset)
+          break;
+      }
+      std::optional<ElfView::FunctionTextRange> Range =
+          Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
+      if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
+          Range->End != T.FunctionEnd)
+        break;
+      T.Bytes.insert(T.Bytes.begin(), Ctx.Text + DI.Offset,
+                     Ctx.Text + DI.Offset + DI.Size);
+      T.OriginalOffset = DI.Offset;
+      T.OriginalSize += DI.Size;
+    }
+  }
+}
+
+static bool hasNoFallthrough(const InternalDecodedInst &DI,
+                             const LLVMState &LS) {
+  return isEndProgram(DI, LS) ||
+         (LS.MIA &&
+          (LS.MIA->isUnconditionalBranch(DI.Inst) ||
+           LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+           LS.MIA->isBarrier(DI.Inst)));
+}
+
+static void appendGatewaySled(std::vector<NopSled> &Sleds, uint64_t Start,
+                              uint64_t End, uint64_t TextSize, bool Safe,
+                              bool HasTarget) {
+  if (Safe && !HasTarget && End - Start >= MinInstSize)
+    Sleds.push_back({Start, End, Start, 0, TextSize});
+}
+
+/// Find zero-filled alignment holes, including holes covered by an oversized
+/// function symbol, and s_nop padding outside every function. Such padding is
+/// a safe branch gateway only when it follows a no-fallthrough instruction and
+/// contains no direct branch/call target. In-function s_nop runs are added from
+/// Ctx.NopSleds separately.
+static std::vector<NopSled>
+buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
+                          const LLVMState &LS, const ElfView &Elf,
+                          ArrayRef<uint8_t> Text,
+                          const DenseSet<uint64_t> &DirectBranchTargets) {
+  std::vector<NopSled> Sleds;
+  const InternalDecodedInst *Previous = nullptr;
+  bool Active = false;
+  bool Safe = false;
+  bool HasTarget = false;
+  uint64_t Start = 0;
+  uint64_t End = 0;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    bool ZeroPadding =
+        DI.Offset <= Text.size() && DI.Size <= Text.size() - DI.Offset;
+    if (ZeroPadding)
+      for (uint8_t Byte : Text.slice(DI.Offset, DI.Size))
+        ZeroPadding &= Byte == 0;
+    bool IsExternalNop = DI.Inst.getOpcode() == LS.SNopOpcode &&
+                         !Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    bool GatewayPadding = ZeroPadding || IsExternalNop;
+    if (!GatewayPadding || (Active && DI.Offset != End)) {
+      if (Active)
+        appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
+      Active = false;
+    }
+    if (!GatewayPadding) {
+      Previous = &DI;
+      continue;
+    }
+    if (!Active) {
+      Active = true;
+      Start = DI.Offset;
+      Safe = Previous && hasNoFallthrough(*Previous, LS);
+      HasTarget = false;
+    }
+    HasTarget |= DirectBranchTargets.contains(DI.Offset);
+    End = DI.Offset + DI.Size;
+  }
+  if (Active)
+    appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
+  return Sleds;
+}
+
+enum class SccScanResult {
+  Unresolved,
+  Used,
+  Defined,
+};
+
+static SccScanResult scanSccInstruction(const InternalDecodedInst &DI,
+                                        const LLVMState &LS, MCRegister SCC) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  if (Desc.hasImplicitUseOfPhysReg(SCC))
+    return SccScanResult::Used;
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = DefCount; I != DI.Inst.getNumOperands(); ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
+      return SccScanResult::Used;
+  }
+
+  if (Desc.hasImplicitDefOfPhysReg(SCC, LS.MRI.get()))
+    return SccScanResult::Defined;
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
+      return SccScanResult::Defined;
+  }
+  return SccScanResult::Unresolved;
+}
+
+/// Prove that clobbering SCC on the forward edge cannot affect the replacement
+/// body or its continuation. Stop conservatively at unresolved control flow.
+static bool isIncomingSccDead(const PatchContext &Ctx, const Trampoline &T) {
+  MCRegister SCC = Ctx.LS.SCCRegister;
+  uint64_t TrailingBytes = SetPcReturnReserveBytes +
+                           (T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0);
+  if (!SCC || T.Bytes.size() < TrailingBytes)
+    return false;
+
+  uint64_t BodySize = T.Bytes.size() - TrailingBytes;
+  std::vector<InternalDecodedInst> Body;
+  if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body))
+    return false;
+  for (const InternalDecodedInst &DI : Body) {
+    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
+    if (Result == SccScanResult::Used)
+      return false;
+    if (Result == SccScanResult::Defined)
+      return true;
+    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+      return false;
+  }
+
+  std::optional<uint64_t> End = checkedAddUint64(
+      T.OriginalOffset, T.OriginalSize, "SCC-dead continuation start");
+  if (!End)
+    return false;
+  for (const InternalDecodedInst &DI : Ctx.Decoded) {
+    if (DI.Offset < *End)
+      continue;
+    if (T.HasFunctionRange && DI.Offset >= T.FunctionEnd)
+      break;
+    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
+    if (Result == SccScanResult::Used)
+      return false;
+    if (Result == SccScanResult::Defined)
+      return true;
+    if (isEndProgram(DI, Ctx.LS))
+      return true;
+    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+      return false;
+  }
+  return true;
+}
+
+static uint64_t countReachableGatewaySlots(ArrayRef<NopSled> Gateways,
+                                           uint64_t Offset, uint64_t Needed) {
+  uint64_t Slots = 0;
+  for (const NopSled &Sled : Gateways) {
+    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+      continue;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
+      continue;
+    uint64_t Distance = Sled.WritePos > Offset ? Sled.WritePos - Offset
+                                               : Offset - Sled.WritePos;
+    if (Distance >= MaxSledDistance)
+      continue;
+    Slots += (UsableEnd - Sled.WritePos) / Needed;
+  }
+  return Slots;
+}
+
+static std::optional<SmallVector<uint64_t, 4>>
+allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
+                             uint64_t FromOffset, uint64_t TargetOffset) {
+  struct Allocation {
+    size_t SledIndex = 0;
+    uint64_t PreviousWritePos = 0;
+  };
+  SmallVector<Allocation, 4> Allocations;
+  SmallVector<uint64_t, 4> Islands;
+  DenseSet<size_t> UsedSleds;
+  uint64_t Current = FromOffset;
+
+  while (!isSBranchReachable(Current, TargetOffset)) {
+    size_t BestIndex = Gateways.size();
+    uint64_t BestOffset = 0;
+    for (size_t I = 0; I != Gateways.size(); ++I) {
+      NopSled &Sled = Gateways[I];
+      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
+          FromOffset >= Sled.FunctionEnd)
+        continue;
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
+          Sled.WritePos > UsableEnd ||
+          MinInstSize > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(Current, Sled.WritePos))
+        continue;
+      if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset) {
+        BestIndex = I;
+        BestOffset = Sled.WritePos;
+      }
+    }
+
+    if (BestIndex == Gateways.size()) {
+      for (size_t I = Allocations.size(); I != 0; --I) {
+        const Allocation &A = Allocations[I - 1];
+        Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+      }
+      return std::nullopt;
+    }
+
+    NopSled &Best = Gateways[BestIndex];
+    Allocations.push_back({BestIndex, Best.WritePos});
+    Islands.push_back(Best.WritePos);
+    Current = Best.WritePos;
+    Best.WritePos += MinInstSize;
+    UsedSleds.insert(BestIndex);
+  }
+  return Islands;
+}
+
+static bool
+assignLongBranchGateways(PatchContext &Ctx,
+                         const DenseSet<uint64_t> &DirectBranchTargets) {
+  std::vector<NopSled> Gateways = buildExternalGatewaySleds(
+      Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+      DirectBranchTargets);
+  for (const NopSled &Sled : Ctx.NopSleds)
+    Gateways.push_back(Sled);
+
+  DenseMap<uint64_t, size_t> PoolIslandOwners;
+  uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    std::optional<uint64_t> Next = checkedAddUint64(
+        IslandLayoutOffset, T.Bytes.size(), "pool branch-island layout");
+    if (!Next)
+      return false;
+    if (T.HasPoolBranchIsland) {
+      T.PoolBranchIslandOffset = *Next - PoolBranchIslandBytes;
+      PoolIslandOwners[T.PoolBranchIslandOffset] = I;
+      Gateways.push_back({T.PoolBranchIslandOffset,
+                          T.PoolBranchIslandOffset + PoolBranchIslandBytes,
+                          T.PoolBranchIslandOffset, 0,
+                          std::numeric_limits<uint64_t>::max()});
+    }
+    IslandLayoutOffset = *Next;
+  }
+
+  struct PendingGateway {
+    size_t TrampolineIndex = 0;
+    uint64_t TargetOffset = 0;
+    bool IncomingSccDead = false;
+    uint64_t NeededBytes = 0;
+    uint64_t InitialCandidateSlots = 0;
+  };
+  std::vector<PendingGateway> Pending;
+  uint64_t TrampOffset = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t TP = TrampOffset;
+    std::optional<uint64_t> Next = checkedAddUint64(
+        TrampOffset, T.Bytes.size(), "gateway trampoline layout");
+    if (!Next)
+      return false;
+    TrampOffset = *Next;
+    if (!T.Long)
+      continue;
+
+    if (isSBranchReachable(T.OriginalOffset, TP)) {
+      T.UsesShortBranchForward = true;
+      continue;
+    }
+    bool IncomingSccDead = isIncomingSccDead(Ctx, T);
+    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+        Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
+    if (Direct && Direct->size() <= T.OriginalSize) {
+      T.UsesDirectSetPCForward = true;
+      T.DirectSetPCForwardBytes = std::move(*Direct);
+      continue;
+    }
+    if (IncomingSccDead) {
+      Direct = encodeSetPCLongBranchClobberSCC(Ctx.LS, T.OriginalOffset, TP,
+                                               T.LongBranchSgprBase);
+      if (Direct && Direct->size() <= T.OriginalSize) {
+        T.UsesDirectSetPCForward = true;
+        T.DirectSetPCForwardBytes = std::move(*Direct);
+        continue;
+      }
+    }
+
+    uint64_t Needed =
+        IncomingSccDead ? SetPcMinGatewayBytes : SetPcForwardSequenceBytes;
+    Pending.push_back(
+        {I, TP, IncomingSccDead, Needed,
+         countReachableGatewaySlots(Gateways, T.OriginalOffset, Needed)});
+  }
+
+  std::vector<PendingGateway> StillPending;
+  StillPending.reserve(Pending.size());
+  uint64_t BranchIslandChains = 0;
+  for (const PendingGateway &P : Pending) {
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    std::optional<SmallVector<uint64_t, 4>> Islands =
+        allocateForwardBranchIslands(Gateways, T.OriginalOffset,
+                                     P.TargetOffset);
+    if (!Islands || Islands->empty()) {
+      StillPending.push_back(P);
+      continue;
+    }
+    T.ForwardBranchIslands = std::move(*Islands);
+    T.ForwardBranchTargetOffset = P.TargetOffset;
+    ++BranchIslandChains;
+  }
+  Pending = std::move(StillPending);
+
+  // Allocate SCC-preserving gateways first. They need more contiguous bytes
+  // and have fewer placement options; SCC-dead gateways can fill the remaining
+  // 20-byte fragments afterward.
+  std::stable_sort(Pending.begin(), Pending.end(),
+                   [](const PendingGateway &LHS, const PendingGateway &RHS) {
+                     if (LHS.NeededBytes != RHS.NeededBytes)
+                       return LHS.NeededBytes > RHS.NeededBytes;
+                     return LHS.InitialCandidateSlots <
+                            RHS.InitialCandidateSlots;
+                   });
+
+  uint64_t PreservingGateways = 0;
+  uint64_t SccDeadGateways = 0;
+  for (const PendingGateway &P : Pending) {
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    NopSled *Sled = findNearestSled(Gateways, T.OriginalOffset, P.NeededBytes);
+    if (!Sled ||
+        Ctx.LS.encodeSBranch(T.OriginalOffset, Sled->WritePos).empty()) {
+      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
+            << " initial candidate slot(s))\n";
+      return false;
+    }
+    std::optional<SmallVector<uint8_t>> Gateway =
+        P.IncomingSccDead
+            ? encodeSetPCLongBranchClobberSCC(
+                  Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase)
+            : encodeSetPCLongBranch(Ctx.LS, Sled->WritePos, P.TargetOffset,
+                                    T.LongBranchSgprBase);
+    if (!Gateway || Gateway->size() > P.NeededBytes) {
+      log() << "hotswap: error: failed to encode far-site gateway at 0x"
+            << utohexstr(Sled->WritePos) << "\n";
+      return false;
+    }
+    T.HasForwardGateway = true;
+    T.ForwardGatewayOffset = Sled->WritePos;
+    T.ForwardGatewayBytes = std::move(*Gateway);
+    Sled->WritePos += T.ForwardGatewayBytes.size();
+    if (P.IncomingSccDead)
+      ++SccDeadGateways;
+    else
+      ++PreservingGateways;
+  }
+  if (!Pending.empty())
+    log() << "hotswap: assigned " << PreservingGateways
+          << " SCC-preserving and " << SccDeadGateways
+          << " SCC-dead forward gateway(s)\n";
+  if (BranchIslandChains != 0)
+    log() << "hotswap: assigned " << BranchIslandChains
+          << " forward s_branch island chain(s)\n";
+
+  for (Trampoline &T : Ctx.OutTrampolines) {
+    if (T.HasForwardGateway) {
+      if (T.ForwardGatewayOffset > Ctx.TextSize ||
+          T.ForwardGatewayBytes.size() >
+              Ctx.TextSize - T.ForwardGatewayOffset) {
+        log() << "hotswap: error: forward gateway at 0x"
+              << utohexstr(T.ForwardGatewayOffset) << " extends past .text.\n";
+        return false;
+      }
+      std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
+                  T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
+    }
+    for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
+      uint64_t From = T.ForwardBranchIslands[I];
+      uint64_t To = I + 1 == T.ForwardBranchIslands.size()
+                        ? T.ForwardBranchTargetOffset
+                        : T.ForwardBranchIslands[I + 1];
+      SmallVector<uint8_t> Branch = Ctx.LS.encodeSBranch(From, To);
+      if (Branch.size() != MinInstSize) {
+        log() << "hotswap: error: failed to encode forward branch island at "
+                 "0x"
+              << utohexstr(From) << "\n";
+        return false;
+      }
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          PoolIslandOwners.find(From);
+      if (Owner != PoolIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+        std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
+                        PoolBranchIslandBytes,
+                    Branch.data(), Branch.size());
+      } else {
+        if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
+          log() << "hotswap: error: forward branch island at 0x"
+                << utohexstr(From) << " is outside .text and trampoline pool\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + From, Branch.data(), Branch.size());
+      }
+    }
+  }
+  return true;
+}
+
 /// Emit \p Replacement for the instruction at [\p InstOffset,
 /// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
 /// reachable sled with sufficient headroom exists; otherwise falls back to a
 /// deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement,
-                                       bool AllowSafeFarReturn) {
-  // findNearestSled enforces sled headroom. emitToNopSled still validates
-  // exact branch reachability because branch-back distance includes the
-  // replacement size, not just the original instruction offset.
-  uint64_t Needed = Replacement.size() + MinInstSize;
-  if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
-    if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
-      return true;
-    log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
-          << utohexstr(Sled->WritePos)
-          << " is not branch-reachable after assembly; using trampoline.\n";
+                                       ArrayRef<uint8_t> Replacement) {
+  std::optional<uint64_t> ReturnTo = checkedAddUint64(
+      InstOffset, InstSize, "replacement trampoline return target");
+  std::optional<uint64_t> PoolReturnFrom =
+      checkedAddUint64(Ctx.PoolBaseOffset, Replacement.size(),
+                       "replacement trampoline return slot");
+  if (!ReturnTo || !PoolReturnFrom)
+    return false;
+
+  // When the pool base is already out of short-branch reach, defer every site
+  // to the global trampoline pass. That pass can coalesce adjacent patches
+  // before allocating gateways; consuming NOP padding greedily here can strand
+  // a later small or clause/delay-constrained source window.
+  bool PoolBaseFar = !isSBranchReachable(InstOffset, Ctx.PoolBaseOffset) ||
+                     !isSBranchReachable(*PoolReturnFrom, *ReturnTo);
+  if (!PoolBaseFar) {
+    // findNearestSled enforces sled headroom. emitToNopSled still validates
+    // exact branch reachability because branch-back distance includes the
+    // replacement size, not just the original instruction offset.
+    uint64_t Needed = Replacement.size() + MinInstSize;
+    if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
+      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
+        return true;
+      log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
+            << utohexstr(Sled->WritePos)
+            << " is not branch-reachable after assembly; using trampoline.\n";
+    }
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement,
-                          AllowSafeFarReturn);
+  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -896,6 +1636,19 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix)
     Patched += VT.applyVop3px2Src2Fix(Ctx);
 
+  if (!OutTrampolines.empty()) {
+    std::optional<DenseSet<uint64_t>> DirectBranchTargets =
+        collectDirectBranchTargets(Decoded, LS);
+    if (!DirectBranchTargets)
+      return std::nullopt;
+    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
+    expandStraightLineTrampolines(Ctx, *DirectBranchTargets);
+    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
+    appendPoolBranchIslands(OutTrampolines);
+    if (!assignLongBranchGateways(Ctx, *DirectBranchTargets))
+      return std::nullopt;
+  }
+
   for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
     const KernelPatchStats &Stats = KV.second;
@@ -964,37 +1717,73 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
   uint64_t TrampOffset = PoolBaseOffset;
   for (Trampoline &T : Trampolines) {
     uint64_t TP = TrampOffset;
-    TrampOffset += T.Bytes.size();
+    std::optional<uint64_t> NextTrampOffset = checkedAddUint64(
+        TrampOffset, T.Bytes.size(), "trampoline fixup layout");
+    if (!NextTrampOffset)
+      return false;
+    TrampOffset = *NextTrampOffset;
 
-    // Required far patches carry an SCC-neutral s_get_pc_i64/s_add_nc_u64/
-    // s_set_pc_i64 return assembled when the trampoline is queued. Other long
-    // returns are never queued on gfx1250 A0 because backward s_add_pc_i64 is
-    // unsafe.
-    if (!T.PreEncodedBack) {
-      const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
-      const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
-      const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+    if (T.Long && !T.UsesSetPCBack) {
+      log() << "hotswap: error: far trampoline lacks safe set-PC return at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    const uint32_t BackReserve =
+        T.UsesSetPCBack ? SetPcReturnReserveBytes : MinInstSize;
+    const uint32_t TrailingIsland =
+        T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0;
+    if (T.Bytes.size() < BackReserve + TrailingIsland) {
+      log() << "hotswap: error: trampoline return reservation is truncated at "
+               "0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    const uint64_t BackSlot = TrampOffset - TrailingIsland - BackReserve;
+    const size_t BackOffset = T.Bytes.size() - TrailingIsland - BackReserve;
+    std::optional<uint64_t> ReturnTo = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "trampoline return target");
+    if (!ReturnTo)
+      return false;
 
-      SmallVector<uint8_t> BrBack =
-          T.Long ? encodeLongBranch(LS, BackSlot, ReturnTo)
-                 : LS.encodeSBranch(BackSlot, ReturnTo);
-      if (BrBack.empty() || BrBack.size() > BackReserve) {
-        log() << "hotswap: error: trampoline branch-back encoding failed at "
-                 "0x"
-              << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+    std::optional<SmallVector<uint8_t>> BrBack;
+    if (T.UsesSetPCBack) {
+      BrBack =
+          encodeSetPCLongBranch(LS, BackSlot, *ReturnTo, T.LongBranchSgprBase);
+    } else {
+      SmallVector<uint8_t> ShortBranch = LS.encodeSBranch(BackSlot, *ReturnTo);
+      if (!ShortBranch.empty())
+        BrBack = std::move(ShortBranch);
+    }
+    if (!BrBack || BrBack->size() > BackReserve) {
+      log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
+            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+      return false;
+    }
+    std::memcpy(T.Bytes.data() + BackOffset, BrBack->data(), BrBack->size());
+    for (uint32_t I = BrBack->size(); I + MinInstSize <= BackReserve;
+         I += MinInstSize)
+      std::memcpy(T.Bytes.data() + BackOffset + I, LS.SNopBytes.data(),
+                  MinInstSize);
+
+    SmallVector<uint8_t> BrFwd;
+    if (T.Long) {
+      if (T.UsesShortBranchForward) {
+        BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
+      } else if (!T.ForwardBranchIslands.empty()) {
+        BrFwd =
+            LS.encodeSBranch(T.OriginalOffset, T.ForwardBranchIslands.front());
+      } else if (T.UsesDirectSetPCForward) {
+        BrFwd = T.DirectSetPCForwardBytes;
+      } else if (T.HasForwardGateway) {
+        BrFwd = LS.encodeSBranch(T.OriginalOffset, T.ForwardGatewayOffset);
+      } else {
+        log() << "hotswap: error: far trampoline has no forward gateway at 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
         return false;
       }
-      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
-                  BrBack.size());
-      for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
-           I += MinInstSize)
-        std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
-                    LS.SNopBytes.data(), MinInstSize);
+    } else {
+      BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
     }
-
-    SmallVector<uint8_t> BrFwd =
-        T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)
-               : LS.encodeSBranch(T.OriginalOffset, TP);
     if (BrFwd.empty() || BrFwd.size() > T.OriginalSize) {
       log() << "hotswap: error: trampoline branch-fwd encoding failed at 0x"
             << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -99,13 +99,27 @@ struct Trampoline {
   uint64_t OriginalOffset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
-  // When set, both edges use an s_add_pc_i64 long branch instead of s_branch
-  // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
-  // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
+  // When set, the pool is beyond s_branch reach. The source site branches to a
+  // nearby NOP gateway, which uses the scratch-backed pre-Gen5 set-PC sequence
+  // to reach the pool without executing s_add_pc_i64.
   bool Long = false;
-  // The branch-back is already present at the end of Bytes. Used by required
-  // far patches whose backward edge cannot use s_add_pc_i64 on gfx1250 A0.
-  bool PreEncodedBack = false;
+  bool UsesSetPCBack = false;
+  unsigned LongBranchSgprBase = 0;
+  bool HasPoolBranchIsland = false;
+  uint64_t PoolBranchIslandOffset = 0;
+  bool UsesShortBranchForward = false;
+  bool UsesDirectSetPCForward = false;
+  llvm::SmallVector<uint8_t> DirectSetPCForwardBytes;
+  llvm::SmallVector<uint64_t, 4> ForwardBranchIslands;
+  uint64_t ForwardBranchTargetOffset = 0;
+  bool HasForwardGateway = false;
+  uint64_t ForwardGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> ForwardGatewayBytes;
+  // A far-site run may only be coalesced within one known function. Unknown
+  // ranges stay unmerged because adjacent symbols are independent entries.
+  bool HasFunctionRange = false;
+  uint64_t FunctionStart = 0;
+  uint64_t FunctionEnd = 0;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -168,13 +182,15 @@ static constexpr uint64_t MinNopSledSize = 8;
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
 
-// s_add_pc_i64 long-branch encoded sizes: 8 bytes for a forward (32-bit
-// literal) offset, 12 for a backward (64-bit literal) one. The back slot
-// reserves the max; unused tail bytes are s_nop-padded. emitToTrampoline picks
-// the long path only when a short s_branch cannot reach the site's exact pool
-// offset on either edge (computed from the already-queued trampolines).
-static constexpr uint32_t LongBranchFwdBytes = 8;
-static constexpr uint32_t LongBranchMaxBytes = 12;
+// Fixed reservation for the SCC-preserving set-PC return. The assembled
+// sequence is 28 bytes for a same-object forward or backward delta.
+static constexpr uint32_t SetPcReturnReserveBytes = 28;
+
+// A gateway needs at least 20 bytes when incoming SCC is proven dead. Live SCC
+// uses the 28-byte preserving sequence.
+static constexpr uint32_t SetPcMinGatewayBytes = 20;
+static constexpr uint32_t SetPcForwardSequenceBytes = 28;
+static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
 // LLVMState::encodeSBranch to reject out-of-range branches before handing
@@ -485,6 +501,23 @@ struct LLVMState {
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
 
+  /// MC identities used by far-trampoline relocation analysis. Each opcode is
+  /// resolved once through the asm parser so policy code never compares
+  /// disassembled mnemonic strings.
+  unsigned SClauseOpcode = 0;
+  unsigned SDelayAluOpcode = 0;
+  unsigned SEndPgmOpcode = 0;
+  unsigned SEndPgmSavedOpcode = 0;
+  unsigned SAddPcI64Opcode = 0;
+  unsigned SCallI64Opcode = 0;
+  unsigned SSwapPcI64Opcode = 0;
+  unsigned SPrefetchInstPcRelOpcode = 0;
+  unsigned SPrefetchDataPcRelOpcode = 0;
+
+  /// SCC, recovered from the implicit definition on a parsed scalar compare.
+  /// This avoids scanning target register names in policy code.
+  llvm::MCRegister SCCRegister;
+
   bool Valid = false;
 
   /// Encode a relative `s_branch` from \p FromOffset to \p ToOffset and
@@ -506,6 +539,7 @@ struct InternalDecodedInst {
   uint32_t Size = 0;
   llvm::MCInst Inst;
   std::string Mnemonic;
+  bool DecodeSucceeded = false;
 };
 
 // -- Function declarations (LLVM MC layer) ------------------------------------
@@ -751,28 +785,30 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                  llvm::ArrayRef<uint8_t> Replacement);
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement,
-                                    bool AllowSafeFarReturn = false);
+                                    llvm::ArrayRef<uint8_t> Replacement);
 
-// Encode an s_add_pc_i64 PC-relative long branch from \p FromOffset to
-// \p TargetOffset (.text byte offsets). Exposed for unit testing the offset
-// math / encoding. Returns empty on failure.
-llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
-                                            uint64_t FromOffset,
-                                            uint64_t TargetOffset);
-
-// Encode an SCC-neutral PC-relative long branch through an aligned SGPR pair.
-// s_get_pc_i64 captures the next instruction's PC, s_add_nc_u64 applies the
-// two's-complement delta without reading or writing SCC, and s_set_pc_i64
-// transfers control. Exposed for unit testing the offset math and register
-// constraints. Returns std::nullopt after logging the specific failure.
+/// Encode an SCC-preserving indirect long branch using three numbered SGPRs:
+/// an aligned PC pair at \p SgprBase and an SCC-save temporary at Base + 2.
+/// The displacement is materialized as two 32-bit literals; no
+/// s_add_pc_i64 or 64-bit literal is emitted.
 std::optional<llvm::SmallVector<uint8_t>>
-encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                           uint64_t TargetOffset, unsigned SgprBase);
+encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                      uint64_t TargetOffset, unsigned SgprBase);
+
+/// Return whether an s_branch at \p From can encode \p To, including the
+/// instruction-relative PC base, alignment, signed range, and overflow checks.
+bool isSBranchReachable(uint64_t From, uint64_t To);
+
+/// Evaluate a statically direct branch or call target from its decoded MCInst.
+/// Uses MCInstrAnalysis where supported and the documented gfx1250 s_call_i64
+/// operand fallback otherwise.
+std::optional<uint64_t>
+evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                const LLVMState &LS);
+
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement,
-                                       bool AllowSafeFarReturn = false);
+                                       llvm::ArrayRef<uint8_t> Replacement);
 
 /// Expand one decoded gfx1250 DS two-address instruction into the ordered
 /// single-address instruction sequence used by the trampoline patch. Exposed

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -340,6 +340,60 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_set_pc_i64 s[0:1]", "s_set_pc_i64", S,
                                      S.SSetPcI64Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_clause 0", "s_clause", S,
+                                     S.SClauseOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_delay_alu instid0(VALU_DEP_1)",
+                                     "s_delay_alu", S, S.SDelayAluOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_endpgm", "s_endpgm", S,
+                                     S.SEndPgmOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_endpgm_saved", "s_endpgm_saved", S,
+                                     S.SEndPgmSavedOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_pc_i64 0", "s_add_pc_i64", S,
+                                     S.SAddPcI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[0:1], 0", "s_call_i64", S,
+                                     S.SCallI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[0:1], s[2:3]",
+                                     "s_swap_pc_i64", S, S.SSwapPcI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_prefetch_inst_pc_rel 100, s10, 7",
+                                     "s_prefetch_inst_pc_rel", S,
+                                     S.SPrefetchInstPcRelOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_prefetch_data_pc_rel 100, s10, 7",
+                                     "s_prefetch_data_pc_rel", S,
+                                     S.SPrefetchDataPcRelOpcode))
+    return S;
+
+  SmallVector<MCInst, 2> SccDefInsts =
+      parseAsmToMCInsts("s_cmp_eq_u32 s0, s0", S);
+  if (SccDefInsts.size() != 1) {
+    log() << "hotswap: error: initLLVM: failed to parse an SCC-defining "
+             "scalar compare for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+  const MCInstrDesc &SccDefDesc = S.MCII->get(SccDefInsts.front().getOpcode());
+  for (MCPhysReg Reg : SccDefDesc.implicit_defs()) {
+    if (S.SCCRegister.isValid()) {
+      log() << "hotswap: error: initLLVM: scalar compare has multiple "
+               "implicit definitions for CPU '"
+            << S.Cpu << "'.\n";
+      return S;
+    }
+    S.SCCRegister = MCRegister(Reg);
+  }
+  if (!S.SCCRegister.isValid()) {
+    log() << "hotswap: error: initLLVM: scalar compare has no implicit SCC "
+             "definition for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
 
   S.Valid = true;
   return S;
@@ -407,6 +461,7 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Size = MinInstSize;
       DI.Mnemonic = UnknownMnemonic.str();
     } else {
+      DI.DecodeSucceeded = true;
       DI.Size = static_cast<uint32_t>(InstSize);
       // MCInstPrinter::getMnemonic returns a pointer into the generated AsmStrs
       // table. Storage is process-lifetime static; the trailing whitespace

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -442,8 +442,7 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   }
 
   SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                           /*AllowSafeFarReturn=*/true))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return failRequiredPatch(Ctx);
 
   DI.Mnemonic = "<replaced>";
@@ -825,8 +824,7 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     Replacement.append(PackBytes.begin(), PackBytes.end());
     Replacement.append(OrigInst, OrigInst + DI.Size);
     Replacement.append(Restore.begin(), Restore.end());
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                             /*AllowSafeFarReturn=*/true))
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
       return failRequiredPatch(Ctx);
 
     if (!commitSafeSgprScratchBlock(Ctx, DI.Offset, *Scratch,
@@ -838,8 +836,7 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     SmallVector<uint8_t> Replacement;
     Replacement.append(PackBytes.begin(), PackBytes.end());
     Replacement.append(OrigInst, OrigInst + DI.Size);
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                             /*AllowSafeFarReturn=*/true))
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
       return failRequiredPatch(Ctx);
 
     log() << "hotswap: tensor_load_to_lds: " << BaseSreg

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -160,13 +160,13 @@ struct VOP3PWmmaLayout {
 // HasMatrixReuse=1 profile).
 constexpr VOP3PWmmaLayout LayoutK128Fp8Bf8 = {
     /*NumOperands=*/7, /*VDst=*/0, /*Src0=*/1, /*Src1=*/2,
-    /*Src2Mods=*/3, /*Src2=*/4};
+    /*Src2Mods=*/3,    /*Src2=*/4};
 
 // 32x16x128 f4: vdst, src0, src1, src2_modifiers, src2 (5 operands; no
 // matrix_*_reuse -- HasMatrixReuse=0 on the F4 profile).
 constexpr VOP3PWmmaLayout Layout32x16F4 = {
     /*NumOperands=*/5, /*VDst=*/0, /*Src0=*/1, /*Src1=*/2,
-    /*Src2Mods=*/3, /*Src2=*/4};
+    /*Src2Mods=*/3,    /*Src2=*/4};
 
 const VOP3PWmmaLayout &layoutFor(SplitKind Kind) {
   switch (Kind) {
@@ -182,8 +182,8 @@ const VOP3PWmmaLayout &layoutFor(SplitKind Kind) {
 
 constexpr unsigned VgprRegIdxMask = 0x3ff;
 
-const MCRegisterClass *
-findSmallestEnclosingClass(MCRegister Reg, const MCRegisterInfo &MRI) {
+const MCRegisterClass *findSmallestEnclosingClass(MCRegister Reg,
+                                                  const MCRegisterInfo &MRI) {
   thread_local const MCRegisterInfo *CachedMRI = nullptr;
   thread_local DenseMap<unsigned, const MCRegisterClass *> Cache;
 
@@ -236,8 +236,8 @@ struct WmmaOps {
 };
 
 std::optional<WmmaOps> extractWmmaOps(const MCInst &Inst,
-                                      const MCRegisterInfo &MRI,
-                                      SplitKind Kind, StringRef Mnemonic) {
+                                      const MCRegisterInfo &MRI, SplitKind Kind,
+                                      StringRef Mnemonic) {
   WmmaOps R;
   const VOP3PWmmaLayout &L = layoutFor(Kind);
 
@@ -285,7 +285,7 @@ std::optional<WmmaOps> extractWmmaOps(const MCInst &Inst,
 
 struct PrintedAsm {
   StringRef Mnemonic;
-  StringRef Operands[4]; // vdst, src0, src1, src2 (printer-canonical form)
+  StringRef Operands[4];    // vdst, src0, src1, src2 (printer-canonical form)
   StringRef ModifierSuffix; // includes leading space if non-empty
 };
 
@@ -392,16 +392,15 @@ std::optional<std::string> transformModifierSuffix(StringRef Suffix,
   std::string Out;
   for (StringRef T : tokenizeModifiers(Suffix)) {
     if (!isKnownSplitterModifier(T)) {
-      log() << "hotswap: error: WMMA split: unsupported modifier token \""
-            << T << "\" -- splitter modifier set must be updated\n";
+      log() << "hotswap: error: WMMA split: unsupported modifier token \"" << T
+            << "\" -- splitter modifier set must be updated\n";
       return std::nullopt;
     }
     if (T == "matrix_a_reuse" || T == "matrix_b_reuse")
       continue;
     std::array<StringRef, 3> Bits;
-    if (KSplitSecondHalf &&
-        (parsePackedModifier(T, "neg_lo", Bits) ||
-         parsePackedModifier(T, "neg_hi", Bits))) {
+    if (KSplitSecondHalf && (parsePackedModifier(T, "neg_lo", Bits) ||
+                             parsePackedModifier(T, "neg_hi", Bits))) {
       // Clear the src2 bit (third element of the [X,Y,Z] tuple). If the
       // remaining bits are all zero, drop the modifier entirely (matches
       // the printer's behavior of omitting an all-zero packed modifier).
@@ -548,8 +547,8 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
   Out.reserve(2);
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first, DstHalf),
-                        formatVgprRange(R.Src0.first, AHalf), B, CLo,
-                        FmtSuffix, *Mod)
+                        formatVgprRange(R.Src0.first, AHalf), B, CLo, FmtSuffix,
+                        *Mod)
                     .str());
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first + DstHalf, DstHalf),
@@ -653,8 +652,8 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
     return 0; // matched-but-failed (build*Asm rejected an unsupported modifier)
 
   // Assemble the split sequence and defer trampoline emission to
-  // emitToTrampoline, which picks a short s_branch or an s_add_pc_i64 long
-  // branch based on the site's distance from the appended pool.
+  // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
+  // gateway based on the site's distance from the appended pool.
   SmallVector<uint8_t> Replacement =
       assembleSingleInst(joinAsmLines(AsmLines), Ctx.LS);
   if (Replacement.empty()) {

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -1,0 +1,94 @@
+// COM: A far source and trampoline can be connected entirely with short
+// COM: branches through safe alignment holes. Each hop preserves SCC and the
+// COM: trampoline return uses the accepted SGPR-backed set-PC sequence.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+
+// DISASM-LABEL: <test_branch_islands>:
+// DISASM-NEXT: s_delay_alu
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_0>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_1>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_cselect_b32 s16, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[14:15]
+// DISASM-NEXT: s_add_co_u32 s14, s14,
+// DISASM-NEXT: s_add_co_ci_u32 s15, s15,
+// DISASM-NEXT: s_cmp_lg_u32 s16, 0
+// DISASM-NEXT: s_set_pc_i64 s[14:15]
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_branch_islands
+.p2align 8
+.type test_branch_islands,@function
+test_branch_islands:
+  s_delay_alu instid0(SALU_CYCLE_1)
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+.size test_branch_islands, .-test_branch_islands
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.type gateway_0,@function
+gateway_0:
+  s_endpgm
+.size gateway_0, .-gateway_0
+.fill 4, 1, 0
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.type gateway_1,@function
+gateway_1:
+  s_endpgm
+.size gateway_1, .-gateway_1
+.fill 4, 1, 0
+
+.rept 15000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_branch_islands
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_branch_islands
+      .symbol: test_branch_islands.kd
+      .sgpr_count: 14
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -1,0 +1,123 @@
+// COM: A far patch can live in an ordinary device function shared by multiple
+// COM: kernels. The tensor descriptor save and set-PC return safely reuse one
+// COM: global scratch block, charged to both possible callers.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <device_tensor>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-NEXT: s_nop
+// DISASM-LABEL: <kernel_b>:
+// DISASM: s_endpgm
+// DISASM-NEXT: s_cselect_b32 s68, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[66:67]
+// DISASM-NEXT: s_add_co_u32 s66, s66,
+// DISASM-NEXT: s_add_co_ci_u32 s67, s67,
+// DISASM-NEXT: s_cmp_lg_u32 s68, 0
+// DISASM-NEXT: s_set_pc_i64 s[66:67]
+// DISASM: s_mov_b32 s66, s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s4, s66
+// DISASM-NEXT: s_cselect_b32 s68, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[66:67]
+// DISASM-NEXT: s_add_co_u32 s66, s66,
+// DISASM-NEXT: s_add_co_ci_u32 s67, s67,
+// DISASM-NEXT: s_cmp_lg_u32 s68, 0
+// DISASM-NEXT: s_set_pc_i64 s[66:67]
+
+// META: .name:           kernel_a
+// META: .sgpr_count:     71
+// META: .name:           kernel_b
+// META: .sgpr_count:     71
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.local device_tensor
+.type device_tensor,@function
+device_tensor:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_set_pc_i64 s[30:31]
+.Ldevice_tensor_end:
+.size device_tensor, .Ldevice_tensor_end-device_tensor
+
+.globl kernel_a
+.type kernel_a,@function
+kernel_a:
+  s_call_i64 s[30:31], device_tensor
+  s_endpgm
+.Lkernel_a_end:
+.size kernel_a, .Lkernel_a_end-kernel_a
+
+.globl kernel_b
+.type kernel_b,@function
+kernel_b:
+  s_call_i64 s[30:31], device_tensor
+  s_endpgm
+.Lkernel_b_end:
+.size kernel_b, .Lkernel_b_end-kernel_b
+
+// Safe external gateway space: it follows a no-fallthrough instruction and is
+// outside every function range, so it cannot be executed by fallthrough.
+.rept 8
+  s_nop 0
+.endr
+
+// Push the appended trampoline pool beyond s_branch reach without extending
+// any function symbol range.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel kernel_a
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdhsa_kernel kernel_b
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: kernel_a
+      .symbol: kernel_a.kd
+      .sgpr_count: 48
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: kernel_b
+      .symbol: kernel_b.kd
+      .sgpr_count: 48
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -3,12 +3,14 @@
 // COM: device functions (e.g. runTreeUpDown) contain ds_*_2addr sites that sit
 // COM: far (> s_branch's +-128 KB reach) from the appended trampoline pool in
 // COM: the ~225 MB fatbin. Taking the far path emitted an s_add_pc_i64 long
-// COM: branch whose BACKWARD branch-back corrupts wave state on gfx1250 A0,
-// COM: producing a GPU memory fault in ncclDevKernel_Generic_4 (0/10 runs).
+// COM: branch. On affected gfx1250 parts, even one execution can corrupt SGPR
+// COM: forwarding in another wave on the same SIMD, causing wrong results,
+// COM: hangs, or a GPU page fault.
 // COM:
-// COM: Required DS2 rewrites use the safe SCC-neutral scratch-SGPR return. The
-// COM: two kernels below force the far path for a 2-address load and store and
-// COM: verify both are split instead of returning unsafe B0 instructions.
+// COM: Fix: use the pre-Gen5 SGPR-backed set-PC sequence on both edges. Merge
+// COM: adjacent sites and bounded straight-line neighbors when they provide
+// COM: enough source bytes; otherwise short-branch through safe NOP padding.
+// COM: No path emits the broken instruction.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -22,32 +24,74 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // COM: Case 1 (2-address load, RCCL's pattern).
+// DISASM-NOT: s_add_pc_i64
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: s_add_pc_i64
+// DISASM-NEXT: s_branch
 
-// COM: Case 2 (2-address store).
+// COM: Case 2 (adjacent sites coalesced into a set-PC forward gateway).
+// DISASM-LABEL: <test_ds2addr_far_adjacent>:
+// DISASM-NEXT: s_cselect_b32 s4, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2, s2,
+// DISASM-NEXT: s_add_co_ci_u32 s3, s3, 0
+// DISASM-NEXT: s_cmp_lg_u32 s4, 0
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
+
+// COM: Case 3 (an interior direct-branch target must prevent coalescing).
+// DISASM-LABEL: <test_ds2addr_far_branch_target>:
+// DISASM-NEXT: s_cbranch_scc1
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+
+// COM: Case 4 (a direct-call target is also an interior entry point).
+// DISASM-LABEL: <test_ds2addr_far_call_target>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+
+// COM: Case 5 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: s_add_pc_i64
+// DISASM-NEXT: s_branch
 
 // DISASM-NOT: ds_load_2addr
 // DISASM-NOT: ds_store_2addr
-// DISASM: ds_load_b64 v[0:1], v4 offset:512
-// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:1024
-// DISASM: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM: ds_load_b64 v[8:9], v12 offset:2560
+// DISASM-NEXT: ds_load_b64 v[10:11], v12 offset:3072
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: ds_load_b64 v[12:13], v16 offset:3584
+// DISASM-NEXT: ds_load_b64 v[14:15], v16 offset:4096
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_cselect_b32 s4, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2, s2,
+// DISASM-NEXT: s_add_co_ci_u32 s3, s3,
+// DISASM-NEXT: s_cmp_lg_u32 s4, 0
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 // DISASM: ds_store_b32 v2, v0 offset:256
 // DISASM-NEXT: ds_store_b32 v2, v1 offset:768
-// DISASM: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_cselect_b32 s4, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2, s2,
+// DISASM-NEXT: s_add_co_ci_u32 s3, s3,
+// DISASM-NEXT: s_cmp_lg_u32 s4, 0
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 
 // METADATA: .name:           test_ds2addr_far_load
-// METADATA: .sgpr_count:     6
+// METADATA: .sgpr_count:     7
 // METADATA: .name:           test_ds2addr_far_store
-// METADATA: .sgpr_count:     6
+// METADATA: .sgpr_count:     7
+// METADATA: .name:           test_ds2addr_far_adjacent
+// METADATA: .sgpr_count:     7
+// METADATA: .name:           test_ds2addr_far_branch_target
+// METADATA: .sgpr_count:     7
+// METADATA: .name:           test_ds2addr_far_call_target
+// METADATA: .sgpr_count:     7
 
-// COM: Idempotency: rewriting the split output again is a no-op.
+// COM: Idempotency: rewriting the patched output again is a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
@@ -66,6 +110,45 @@ test_ds2addr_far_load:
 .Ltest_ds2addr_far_load_end:
 .size test_ds2addr_far_load, .Ltest_ds2addr_far_load_end-test_ds2addr_far_load
 
+.globl test_ds2addr_far_adjacent
+.p2align 8
+.type test_ds2addr_far_adjacent,@function
+test_ds2addr_far_adjacent:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  ds_load_2addr_stride64_b64 v[8:11], v12 offset0:5 offset1:6
+  ds_load_2addr_stride64_b64 v[12:15], v16 offset0:7 offset1:8
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_adjacent_end:
+.size test_ds2addr_far_adjacent, .Ltest_ds2addr_far_adjacent_end-test_ds2addr_far_adjacent
+
+.globl test_ds2addr_far_branch_target
+.p2align 8
+.type test_ds2addr_far_branch_target,@function
+test_ds2addr_far_branch_target:
+  s_cbranch_scc1 .Lsecond_ds2addr
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lsecond_ds2addr:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_branch_target_end:
+.size test_ds2addr_far_branch_target, .Ltest_ds2addr_far_branch_target_end-test_ds2addr_far_branch_target
+
+.globl test_ds2addr_far_call_target
+.p2align 8
+.type test_ds2addr_far_call_target,@function
+test_ds2addr_far_call_target:
+  s_call_i64 s[0:1], .Lcalled_ds2addr
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lcalled_ds2addr:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_call_target_end:
+.size test_ds2addr_far_call_target, .Ltest_ds2addr_far_call_target_end-test_ds2addr_far_call_target
+
 .globl test_ds2addr_far_store
 .p2align 8
 .type test_ds2addr_far_store,@function
@@ -75,7 +158,7 @@ test_ds2addr_far_store:
   s_endpgm
   // ~160 KB of non-NOP filler (forms no usable sled) so the appended trampoline
   // pool is beyond s_branch's +-128 KB reach from both kernels above, forcing
-  // the far (long-branch) path -- which is declined on gfx1250 A0.
+  // the far (long-branch) path.
   .rept 40000
     s_mov_b32 s0, s1
   .endr
@@ -92,6 +175,21 @@ test_ds2addr_far_store:
 .amdhsa_kernel test_ds2addr_far_store
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_adjacent
+  .amdhsa_next_free_vgpr 17
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_branch_target
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_call_target
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
 
 .amdgpu_metadata
@@ -113,6 +211,36 @@ test_ds2addr_far_store:
       .symbol: test_ds2addr_far_store.kd
       .sgpr_count: 1
       .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_adjacent
+      .symbol: test_ds2addr_far_adjacent.kd
+      .sgpr_count: 1
+      .vgpr_count: 17
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_branch_target
+      .symbol: test_ds2addr_far_branch_target.kd
+      .sgpr_count: 1
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_call_target
+      .symbol: test_ds2addr_far_call_target.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,13 +1,8 @@
-// COM: HSV-009 / PLAT-205406: on gfx1250 A0 a backward s_add_pc_i64 corrupts
-// COM: wave state. Required far tensor patches use a forward s_add_pc_i64 and
-// COM: an SCC-neutral s_get_pc_i64/s_add_nc_u64/s_set_pc_i64 return instead.
-// COM:
-// COM: Optional far trampoline rewrites are still allowed to decline;
-// COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
-// COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
+// COM: A0 cannot execute s_add_pc_i64. Both edges use an SGPR-backed set-PC
+// COM: sequence; the short source slot reaches that sequence through safe
+// COM: external zero-filled gateway space. A large non-NOP .rept filler
+// COM: (~160 KB)
 // COM: pushes the pool past s_branch's reach to force the far case.
-// COM: The function intentionally has st_size == 0, matching Tensile objects
-// COM: that omit .size and exercising zero-size function-range recovery.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -17,22 +12,30 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <test_far>:
-// DISASM-NEXT: s_mov_b64 vcc, -1
-// DISASM-NEXT: s_add_pc_i64
-// DISASM-NOT: s_add_pc_i64
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
 // DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_nc_u64 s[12:13]
+// DISASM-NEXT: s_add_co_u32 s12, s12,
+// DISASM-NEXT: s_add_co_ci_u32 s13, s13,
 // DISASM-NEXT: s_set_pc_i64 s[12:13]
-// DISASM-NOT: s_add_pc_i64
+// DISASM: s_mov_b64 vcc, -1
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_cselect_b32 s14, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[12:13]
+// DISASM-NEXT: s_add_co_u32 s12, s12,
+// DISASM-NEXT: s_add_co_ci_u32 s13, s13,
+// DISASM-NEXT: s_cmp_lg_u32 s14, 0
+// DISASM-NEXT: s_set_pc_i64 s[12:13]
 
 // METADATA: .name:           test_far
-// METADATA: .sgpr_count:     16
+// METADATA: .sgpr_count:     17
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -40,34 +43,26 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: The far return still needs an aligned SGPR pair. Exhausting all 106
-// COM: numbered SGPRs must fail instead of clobbering a program register.
+// COM: A kernel with no aligned three-SGPR block fails closed instead of
+// COM: emitting the unsafe return or clobbering a live register.
 // RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
 // RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.no-pair.s
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.no-pair.s -o %t.no-pair.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.no-pair.elf \
+// RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
+// RUN: hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefix=NO-PAIR %s
-// NO-PAIR: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
-// NO-PAIR: RESULT: ERROR
+// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
+// FAIL: RESULT: ERROR
 
-// COM: gfx10+ cannot represent an increased SGPR count in the kernel
-// COM: descriptor because that field is reserved. A metadata-less object must
-// COM: therefore fail rather than emit an under-declared far-return scratch
-// COM: allocation or write the reserved descriptor field.
+// COM: A metadata-less object also fails closed because scratch usage cannot
+// COM: be charged to its owning kernel.
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.nometa.s -o %t.nometa.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefix=NO-METADATA %s
-// NO-METADATA: hotswap: error: updateKernelDescriptorSgprCount: kernel 'test_far' requires
-// NO-METADATA: descriptor SGPR-count field is reserved
-// NO-METADATA: RESULT: ERROR
+// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -78,6 +73,16 @@ test_far:
   s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
+.size test_far, .-test_far
+
+// Provide external zero-filled alignment space after a separate
+// no-fallthrough function.
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 32, 1, 0
+
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the tensor_load above (forces the
   // long-branch path).
@@ -85,7 +90,6 @@ test_far:
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:
-// Deliberately no .size.
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -1,10 +1,7 @@
-// COM: HSV-009 / PLAT-205406: WMMA-split shares emitToTrampoline with the other
-// COM: patch families, so a split site beyond s_branch's +-128 KB reach of the
-// COM: appended pool takes the far path -- which on gfx1250 A0 is DECLINED
-// COM: (left unpatched) because the backward s_add_pc_i64 branch-back corrupts
-// COM: wave state at runtime. The original v_wmma_f32_16x16x128_fp8_fp8 stays at
-// COM: the site; it is neither split into two K=64 halves nor redirected. A
-// COM: large .rept filler (~160 KB, non-NOP) forces the far case.
+// COM: WMMA-split shares emitToTrampoline with the other patch families. A
+// COM: split site beyond s_branch's +-128 KB reach uses SGPR-backed set-PC
+// COM: sequences on both edges and never executes s_add_pc_i64. External NOP
+// COM: space supplies the forward gateway; non-NOP filler forces the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -14,15 +11,25 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
 
-// COM: Declined: the site keeps its original K=128 WMMA (it is NOT overwritten
-// COM: with an s_add_pc_i64 forward branch), and no split halves
-// COM: (v_wmma_f32_16x16x64_fp8_fp8) or long-branch redirect are emitted.
+// COM: The site redirects through a safe gateway to two K=64 halves and
+// COM: returns through the SCC-preserving set-PC sequence.
 // DISASM-LABEL: <test_wsplit_far>:
-// DISASM-NEXT: v_wmma_f32_16x16x128_fp8_fp8
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_branch
+// DISASM: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_co_u32 s0, s0,
+// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_cselect_b32 s2, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_co_u32 s0, s0,
+// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
+// DISASM-NEXT: s_cmp_lg_u32 s2, 0
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
 
 // COM: Idempotency: rewriting the output again must be a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
@@ -39,9 +46,39 @@
 test_wsplit_far:
   v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[32:39]
   s_endpgm
+.size test_wsplit_far, .-test_wsplit_far
+
+// Safe external gateway space after the kernel's no-fallthrough terminator.
+.rept 8
+  s_nop 0
+.endr
+
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the WMMA above (forces the long-branch path).
   .rept 40000
     s_mov_b32 s0, s1
   .endr
-.size test_wsplit_far, .-test_wsplit_far
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wsplit_far
+  .amdhsa_next_free_vgpr 40
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wsplit_far
+      .symbol: test_wsplit_far.kd
+      .sgpr_count: 0
+      .vgpr_count: 40
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -87,6 +87,16 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_NE(S.Target, nullptr);
   ASSERT_NE(S.MCII, nullptr);
   EXPECT_LT(S.SBranchOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SClauseOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SDelayAluOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SEndPgmOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SEndPgmSavedOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SAddPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SCallI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SSwapPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SPrefetchInstPcRelOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SPrefetchDataPcRelOpcode, S.MCII->getNumOpcodes());
+  EXPECT_TRUE(S.SCCRegister.isValid());
   EXPECT_EQ(S.SNopBytes.size(), MinInstSize);
 }
 
@@ -182,130 +192,113 @@ TEST(EncodeSBranch, FailsOnInvalidState) {
   EXPECT_TRUE(S.encodeSBranch(0, 8).empty());
 }
 
-// -- encodeLongBranch (s_add_pc_i64) -----------------------------------------
-//
-// The long branch reaches anywhere via s_add_pc_i64, which adds a signed
-// literal to the PC of the next instruction: landing PC == From + size + imm.
-// A positive (forward) offset fits a 32-bit literal (8 bytes); a negative
-// (backward) offset needs a 64-bit literal (12 bytes). These verify the offset
-// math and encoding structurally rather than pinning exact bytes.
+// -- encodeSetPCLongBranch ---------------------------------------------------
 
-// Read the signed literal that follows the 4-byte opcode dword.
-static int64_t longBranchLiteral(llvm::ArrayRef<uint8_t> Out) {
-  if (Out.size() == LongBranchFwdBytes)
-    return static_cast<int32_t>(readDword(Out.data() + MinInstSize));
-  int64_t V = 0;
-  std::memcpy(&V, Out.data() + MinInstSize, sizeof(V));
-  return V;
-}
-
-TEST(EncodeLongBranch, ForwardLandsOnTarget) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // ~512 KB forward -- well beyond s_branch's +-128 KB reach.
-  const uint64_t From = 0x1000, To = 0x81000;
-  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_EQ(Out.size(), LongBranchFwdBytes);
-  EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
-
-  std::vector<InternalDecodedInst> Dec;
-  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
-  ASSERT_EQ(Dec.size(), 1u);
-  EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
-}
-
-TEST(EncodeLongBranch, BackwardUsesWideLiteralAndLandsOnTarget) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // Backward jump (trampoline tail -> earlier return point).
-  const uint64_t From = 0x81000, To = 0x1004;
-  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_EQ(Out.size(), LongBranchMaxBytes);
-  EXPECT_EQ(static_cast<int64_t>(From) + static_cast<int64_t>(Out.size()) +
-                longBranchLiteral(Out),
-            static_cast<int64_t>(To));
-
-  std::vector<InternalDecodedInst> Dec;
-  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
-  ASSERT_EQ(Dec.size(), 1u);
-  EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
-}
-
-TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // 4 MB: s_branch rejects it, the long branch encodes it.
-  const uint64_t From = 0, To = 0x400000;
-  EXPECT_TRUE(S.encodeSBranch(From, To).empty());
-  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_FALSE(Out.empty());
-  EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
-}
-
-// -- encodeSccNeutralLongBranch ----------------------------------------------
-
-static uint64_t
-decodeSccNeutralLongBranchTarget(uint64_t From,
-                                 llvm::ArrayRef<InternalDecodedInst> Decoded) {
-  const uint64_t PcBase = From + Decoded[0].Size;
-  const uint64_t Delta =
-      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
-  return PcBase + Delta;
-}
-
-TEST(EncodeSccNeutralLongBranch, BackwardLandsOnTargetWithoutDefiningScc) {
+TEST(EncodeSetPCLongBranch, UsesSccPreservingSequenceWithoutAddPc) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  constexpr uint64_t From = 0x81000;
-  constexpr uint64_t To = 0x1008;
+  const uint64_t From = 0x81000;
+  const uint64_t To = 0x1004;
   std::optional<llvm::SmallVector<uint8_t>> Out =
-      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
   ASSERT_TRUE(Out);
 
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_EQ(Decoded[0].Mnemonic, "s_get_pc_i64");
-  EXPECT_EQ(Decoded[1].Mnemonic, "s_add_nc_u64");
-  EXPECT_EQ(Decoded[2].Mnemonic, "s_set_pc_i64");
-  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+  std::vector<InternalDecodedInst> Dec;
+  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Dec));
+  ASSERT_EQ(Dec.size(), 6u);
+  EXPECT_EQ(Dec[0].Mnemonic, "s_cselect_b32");
+  EXPECT_EQ(Dec[1].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Dec[2].Mnemonic, "s_add_co_u32");
+  EXPECT_EQ(Dec[3].Mnemonic, "s_add_co_ci_u32");
+  EXPECT_EQ(Dec[4].Mnemonic, "s_cmp_lg_u32");
+  EXPECT_EQ(Dec[5].Mnemonic, "s_set_pc_i64");
+  for (const InternalDecodedInst &DI : Dec)
+    EXPECT_NE(DI.Mnemonic, "s_add_pc_i64");
 
-  const llvm::MCRegister Pair = Decoded[0].Inst.getOperand(0).getReg();
-  EXPECT_EQ(Decoded[1].Inst.getOperand(0).getReg(), Pair);
-  EXPECT_EQ(Decoded[1].Inst.getOperand(1).getReg(), Pair);
-  EXPECT_EQ(Decoded[2].Inst.getOperand(0).getReg(), Pair);
-  for (const InternalDecodedInst &DI : Decoded) {
-    const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
-    for (llvm::MCPhysReg Reg : Desc.implicit_defs())
-      EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
-  }
+  // s_get_pc_i64 is the second dword and captures From + 8. The two add
+  // immediates materialize this exact two's-complement displacement.
+  uint64_t Delta = To - (From + 2 * MinInstSize);
+  EXPECT_EQ(static_cast<uint32_t>(Delta), 0xFFF7FFFCu);
+  EXPECT_EQ(static_cast<uint32_t>(Delta >> 32), 0xFFFFFFFFu);
 }
 
-TEST(EncodeSccNeutralLongBranch, ForwardLandsOnTarget) {
+TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
   constexpr uint64_t From = 0x1000;
   constexpr uint64_t To = 0x81000;
   std::optional<llvm::SmallVector<uint8_t>> Out =
-      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
   ASSERT_TRUE(Out);
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+  ASSERT_EQ(Decoded.size(), 6u);
+  ASSERT_TRUE(Decoded[2].Inst.getOperand(2).isImm());
+  ASSERT_TRUE(Decoded[3].Inst.getOperand(2).isImm());
+  uint64_t Lo = static_cast<uint32_t>(Decoded[2].Inst.getOperand(2).getImm());
+  uint64_t Hi = static_cast<uint32_t>(Decoded[3].Inst.getOperand(2).getImm());
+  uint64_t Delta = Lo | (Hi << 32);
+  EXPECT_EQ(From + 2 * MinInstSize + Delta, To);
 }
 
-TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
+TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
+  EXPECT_FALSE(encodeSetPCLongBranch(
+      S, std::numeric_limits<uint64_t>::max() - MinInstSize, 0,
+      /*SgprBase=*/12));
+}
 
-  EXPECT_FALSE(encodeSccNeutralLongBranch(S, 0x1000, 0x2000,
-                                          /*SgprBase=*/13));
-  EXPECT_FALSE(encodeSccNeutralLongBranch(
-      S, std::numeric_limits<uint64_t>::max() - 1, 0, /*SgprBase=*/12));
+TEST(EncodeSetPCLongBranch, RejectsMisalignedScratchPair) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  EXPECT_FALSE(encodeSetPCLongBranch(S, 0, 0x1000, /*SgprBase=*/3));
+}
+
+TEST(IsSBranchReachable, CoversBoundariesAlignmentAndPcOverflow) {
+  constexpr uint64_t PositiveLimit =
+      static_cast<uint64_t>(BranchOffsetMax + 1) * MinInstSize;
+  EXPECT_TRUE(isSBranchReachable(/*From=*/0, PositiveLimit));
+  EXPECT_FALSE(isSBranchReachable(/*From=*/0, PositiveLimit + MinInstSize));
+  EXPECT_FALSE(isSBranchReachable(/*From=*/0, /*To=*/7));
+
+  constexpr uint64_t NegativeFrom =
+      static_cast<uint64_t>(-(BranchOffsetMin + 1)) * MinInstSize;
+  EXPECT_TRUE(isSBranchReachable(NegativeFrom, /*To=*/0));
+  EXPECT_FALSE(isSBranchReachable(NegativeFrom + MinInstSize, /*To=*/0));
+  EXPECT_FALSE(isSBranchReachable(std::numeric_limits<uint64_t>::max() - 1,
+                                  /*To=*/0));
+}
+
+TEST(EvaluateDirectControlFlowTarget, EvaluatesImmediateBranch) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst("s_branch 1", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  Decoded[0].Offset = 0x100;
+  EXPECT_EQ(evaluateDirectControlFlowTarget(Decoded[0], S), 0x108u);
+}
+
+TEST(EvaluateDirectControlFlowTarget, EvaluatesGfx1250CallOperandFallback) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[0:1], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  Decoded[0].Offset = 0x200;
+  EXPECT_EQ(evaluateDirectControlFlowTarget(Decoded[0], S),
+            0x200u + Decoded[0].Size + 2 * MinInstSize);
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
@@ -389,8 +382,7 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
 }
 
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
-  std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
-                                {100, 128, 100, 100, 128}};
+  std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64}, {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),
             nullptr);
 }
@@ -424,6 +416,7 @@ TEST(AssembleDecode, SNopRoundTrip) {
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_TRUE(Decoded[0].DecodeSucceeded);
   EXPECT_EQ(Decoded[0].Size, MinInstSize);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
 }
@@ -800,10 +793,9 @@ TEST(BuildKernelEntryTrampoline, PrefixPrefiltersHipblasltSmokeEntryBytes) {
   // idempotency path should reject this by raw prefix before classifying it as
   // a possible appended entry stub.
   const uint8_t EntryBytes[] = {
-      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00,
-      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00,
-      0xff, 0x02, 0x3f, 0x8b, 0xff, 0xff, 0xff, 0x3f,
-      0x02, 0x9e, 0x40, 0x85, 0x03, 0x00, 0xc1, 0xbe,
+      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00, 0x1a, 0x08, 0x80,
+      0xb9, 0x02, 0x00, 0x00, 0x00, 0xff, 0x02, 0x3f, 0x8b, 0xff, 0xff,
+      0xff, 0x3f, 0x02, 0x9e, 0x40, 0x85, 0x03, 0x00, 0xc1, 0xbe,
   };
 
   llvm::SmallVector<uint8_t> Candidate;
@@ -813,8 +805,8 @@ TEST(BuildKernelEntryTrampoline, PrefixPrefiltersHipblasltSmokeEntryBytes) {
   ASSERT_EQ(Candidate.size(), KernelEntryStubStride);
 
   std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Candidate.data(), sizeof(EntryBytes), S,
-                                Decoded));
+  ASSERT_TRUE(
+      decodeTextSection(Candidate.data(), sizeof(EntryBytes), S, Decoded));
   ASSERT_GE(Decoded.size(), 5u);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_setreg_imm32_b32");
   EXPECT_EQ(Decoded[1].Mnemonic, "s_setreg_imm32_b32");
@@ -987,9 +979,9 @@ static unsigned countSymtabSymbolsNamed(llvm::WritableMemoryBuffer &Buf,
                                         llvm::StringRef Name) {
   using ELFT = llvm::object::ELF64LE;
   llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
-      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
-          reinterpret_cast<const char *>(Buf.getBufferStart()),
-          Buf.getBufferSize()));
+      llvm::object::ELFFile<ELFT>::create(
+          llvm::StringRef(reinterpret_cast<const char *>(Buf.getBufferStart()),
+                          Buf.getBufferSize()));
   if (!FileOrErr) {
     llvm::consumeError(FileOrErr.takeError());
     return ~0u;


### PR DESCRIPTION
## Purpose

Direct-to-`amd-staging` companion for the focused stacked review in #3347.

This PR exists so the full `amd-staging` CI workflows evaluate the cumulative
remaining stack through #3347. #3345 is already merged. Please use #3347 for
review of the safe far-branch patch itself; its base is #3346 so that focused
diff contains only one stack entry.

## Included stack

- #3346 — make gfx1250 semantic rewrites fail-safe
- #3347 — eliminate add-pc from far hotswap trampolines

This companion should not merge before #3346. Once #3346 lands in
`amd-staging`, GitHub will reduce this PR to the remaining focused change.

## Local validation

- rebased onto current `amd-staging`, including merged #3345 and #3359
- `git range-diff` confirms the reviewed patches are unchanged
- final stacked-tip release `check-comgr`: 97/97 supported LIT tests, all unit tests, and 31/31 CTests passed
