### PR TITLE
comgr: Swap arguments of areTargetsCompatible

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1887,7 +1887,7 @@ amd_comgr_status_t AMDGPUCompiler::unpackage() {
         // compatible with it. areTargetsCompatible() reports false for an exact
         // match, so the equality check handles the common case.
         if (EntryTarget == FileTarget ||
-            llvm::object::areTargetsCompatible(EntryTarget, FileTarget)) {
+            llvm::object::areTargetsCompatible(FileTarget, EntryTarget)) {
           const char *FileExtension;
           amd_comgr_data_kind_t DataKind;
           if (auto Status = getUnpackagedImageInfo(Binary->getImage(),

--- a/amd/comgr/src/comgr-unpackage-command.cpp
+++ b/amd/comgr/src/comgr-unpackage-command.cpp
@@ -43,7 +43,7 @@ amd_comgr_status_t UnpackageCommand::execute(raw_ostream &LogS) {
     auto Match = Worklist.find(Target);
     if (Match == Worklist.end())
       Match = find_if(Worklist, [Target](const auto &KV) {
-        return object::areTargetsCompatible(KV.first, Target);
+        return object::areTargetsCompatible(Target, KV.first);
       });
 
     if (Match == Worklist.end())


### PR DESCRIPTION
Order this as result-target, input-target. This
matches the usage order of clang-linker-wrapper.

Currently the return value is symmetric, but soon it will not be. It's legal to merge generic objects into non-generic objects, but not the other way around.


