### PR TITLE
[comgr][hotswap] speed up kernel-descriptor rewrites for large objects

### DIFF
--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -597,6 +597,7 @@ void ElfView::initializeKernelDescriptorCache() const {
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
   StringMap<uint64_t> FileOffsets;
+  StringMap<uint64_t> SeenVAddr;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -650,19 +651,30 @@ void ElfView::initializeKernelDescriptorCache() const {
               offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
           sizeof(EntryOffset));
 
-      std::string KernelName = NameOrErr->drop_back(3).str();
-      const bool Seen = std::any_of(
-          Result.begin(), Result.end(), [&](const KernelDescriptorInfo &Info) {
-            return Info.KernelName == KernelName && Info.VAddr == Sym.st_value;
-          });
-      if (!Seen)
+      StringRef KernelNameRef = NameOrErr->drop_back(3);
+      std::string KernelName = KernelNameRef.str();
+      // Dedup by (name, vaddr) via a map; a per-symbol O(n) scan made cache
+      // init O(n^2).
+      StringMap<uint64_t>::const_iterator SeenIt =
+          SeenVAddr.find(KernelNameRef);
+      const bool Seen =
+          SeenIt != SeenVAddr.end() && SeenIt->second == Sym.st_value;
+      if (!Seen) {
+        SeenVAddr[KernelNameRef] = Sym.st_value;
         Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
-      FileOffsets.try_emplace(NameOrErr->drop_back(3), *FileOffset);
+      }
+      FileOffsets.try_emplace(KernelNameRef, *FileOffset);
     }
   }
 
   KernelDescriptorFileOffsetCache = std::move(FileOffsets);
   KernelDescriptorCache = std::move(Result);
+
+  // Name -> vaddr map so getKernelDescriptorVAddr() is O(1) per call instead of
+  // a linear scan (O(n^2) over ~1000 per-fixup lookups).
+  KernelDescriptorVAddrCache.clear();
+  for (const KernelDescriptorInfo &Info : *KernelDescriptorCache)
+    KernelDescriptorVAddrCache.try_emplace(Info.KernelName, Info.VAddr);
 }
 
 uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
@@ -681,11 +693,12 @@ ArrayRef<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
 
 std::optional<uint64_t>
 ElfView::getKernelDescriptorVAddr(StringRef KernelName) const {
-  for (const KernelDescriptorInfo &Info : kernelDescriptors()) {
-    if (Info.KernelName == KernelName)
-      return Info.VAddr;
-  }
-  return std::nullopt;
+  initializeKernelDescriptorCache();
+  StringMap<uint64_t>::const_iterator It =
+      KernelDescriptorVAddrCache.find(KernelName);
+  if (It == KernelDescriptorVAddrCache.end())
+    return std::nullopt;
+  return It->second;
 }
 
 bool ElfView::updateKernelDescriptorEntryOffset(StringRef KernelName,

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -668,7 +668,11 @@ void ElfView::initializeKernelDescriptorCache() const {
   KernelDescriptorCache = std::move(Result);
 
   // Name -> vaddr map so getKernelDescriptorVAddr() is O(1) per call instead of
-  // a linear scan (O(n^2) over ~1000 per-fixup lookups).
+  // a linear scan (O(n^2) over ~1000 per-fixup lookups). When a name has more
+  // than one descriptor (the dedup set tracks (name, vaddr) pairs), try_emplace
+  // keeps the first in symtab order -- the same descriptor the prior linear
+  // scan returned, so the single-value lookup is unchanged. The multi-vaddr set
+  // matters only for enumeration/dedup, not this name->vaddr resolution.
   KernelDescriptorVAddrCache.clear();
   for (const KernelDescriptorInfo &Info : *KernelDescriptorCache)
     KernelDescriptorVAddrCache.try_emplace(Info.KernelName, Info.VAddr);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -16,6 +16,7 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
@@ -597,7 +598,7 @@ void ElfView::initializeKernelDescriptorCache() const {
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
   StringMap<uint64_t> FileOffsets;
-  StringMap<uint64_t> SeenVAddr;
+  StringMap<DenseSet<uint64_t>> SeenVAddr;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -653,16 +654,12 @@ void ElfView::initializeKernelDescriptorCache() const {
 
       StringRef KernelNameRef = NameOrErr->drop_back(3);
       std::string KernelName = KernelNameRef.str();
-      // Dedup by (name, vaddr) via a map; a per-symbol O(n) scan made cache
-      // init O(n^2).
-      StringMap<uint64_t>::const_iterator SeenIt =
-          SeenVAddr.find(KernelNameRef);
-      const bool Seen =
-          SeenIt != SeenVAddr.end() && SeenIt->second == Sym.st_value;
-      if (!Seen) {
-        SeenVAddr[KernelNameRef] = Sym.st_value;
+      // Dedup by (name, vaddr): a kernel name can legitimately map to more than
+      // one vaddr, so track the full vaddr set per name rather than only the
+      // last one. (The previous per-symbol linear scan over Result made cache
+      // init O(n^2).)
+      if (SeenVAddr[KernelNameRef].insert(Sym.st_value).second)
         Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
-      }
       FileOffsets.try_emplace(KernelNameRef, *FileOffset);
     }
   }

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -16,6 +16,7 @@
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/Twine.h"
 
 #include <algorithm>
@@ -644,6 +645,9 @@ bool rewriteKernelEntryDescriptorOffsets(
 
   bool Ok = true;
   ElfView &OutElf = *ViewOrErr;
+  // Collect SGPR bumps and apply them in one batched metadata rewrite after the
+  // loop; a per-fixup update reparses/reserializes the whole note (O(n^2)).
+  StringMap<unsigned> SgprBumps;
   for (const KernelEntryTrampolineFixup &Fixup : Fixups) {
     std::optional<uint64_t> KdVAddr =
         OutElf.getKernelDescriptorVAddr(Fixup.KernelName);
@@ -671,17 +675,16 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    // The fast path leaves the logical SGPR reservation unchanged (fixed
-    // s[100:101]), so skip the descriptor SGPR-count update entirely.
-    bool UpdatedSgprs = Fixup.SkipSgprReservation
-                            ? true
-                            : OutElf.updateKernelDescriptorSgprCount(
-                                  Fixup.KernelName, Fixup.RequiredSgprs,
-                                  /*UpdateDescriptor=*/false);
+    if (!Fixup.SkipSgprReservation && Fixup.RequiredSgprs != 0)
+      SgprBumps[Fixup.KernelName] =
+          std::max(SgprBumps.lookup(Fixup.KernelName), Fixup.RequiredSgprs);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
-    Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;
+    Ok = UpdatedEntry && UpdatedInstPref && Ok;
   }
+
+  if (!SgprBumps.empty())
+    Ok = OutElf.updateKernelMetadataSgprCounts(SgprBumps) && Ok;
   return Ok;
 }
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -675,9 +675,10 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    if (!Fixup.SkipSgprReservation && Fixup.RequiredSgprs != 0)
-      SgprBumps[Fixup.KernelName] =
-          std::max(SgprBumps.lookup(Fixup.KernelName), Fixup.RequiredSgprs);
+    if (!Fixup.SkipSgprReservation && Fixup.RequiredSgprs != 0) {
+      unsigned &Bump = SgprBumps[Fixup.KernelName];
+      Bump = std::max(Bump, Fixup.RequiredSgprs);
+    }
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -448,6 +448,7 @@ private:
   mutable std::optional<std::vector<KernelDescriptorInfo>>
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
+  mutable llvm::StringMap<uint64_t> KernelDescriptorVAddrCache;
   mutable KernelSgprCacheState SgprCacheState =
       KernelSgprCacheState::Uninitialized;
   mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -908,3 +908,40 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsDescriptorLimitFirst) {
   EXPECT_EQ(*MetadataSgprs, 200u);
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
+
+// -- kernel-descriptor cache dedup --------------------------------------------
+
+// The descriptor cache dedups by (name, vaddr): the same kernel name can appear
+// at more than one descriptor vaddr, and a repeat of an already-seen
+// (name, vaddr) pair must be dropped regardless of ordering. This pins the
+// A@x, A@y, A@x case, which a "remember only the last vaddr per name" dedup
+// would mishandle by re-adding the trailing A@x.
+TEST(ElfView, KernelDescriptorCacheDedupsByNameAndVAddrAcrossOrdering) {
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.TextAddr = 0x1000;
+  Opts.TextSize = 0x400;
+  Opts.RodataAddr = 0x2000;
+  // Distinct descriptor vaddrs for the two "A" instances, and a "B" in between,
+  // then a duplicate of the first A. Expect three unique descriptors:
+  // A@0x2000, B@0x2100, A@0x2200 -- the trailing A@0x2000 duplicate is dropped.
+  Opts.Kernels = {
+      {"kern_a", 0x1000, 0x2000, /*EntryOffset=*/-0x1000},
+      {"kern_b", 0x1100, 0x2100, /*EntryOffset=*/-0x1000},
+      {"kern_a", 0x1200, 0x2200, /*EntryOffset=*/-0x1000},
+      {"kern_a", 0x1000, 0x2000, /*EntryOffset=*/-0x1000}, // dup of first
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Bytes.data(), Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 3u);
+  EXPECT_EQ(KDs[0].KernelName, "kern_a");
+  EXPECT_EQ(KDs[0].VAddr, 0x2000u);
+  EXPECT_EQ(KDs[1].KernelName, "kern_b");
+  EXPECT_EQ(KDs[1].VAddr, 0x2100u);
+  EXPECT_EQ(KDs[2].KernelName, "kern_a");
+  EXPECT_EQ(KDs[2].VAddr, 0x2200u);
+}

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1158,6 +1158,81 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(StubVAddr - *KdVAddr));
 }
 
+// rewriteKernelEntryDescriptorOffsets aggregates per-kernel SGPR bumps into a
+// single batched metadata update. Drive it with a fixup list covering the
+// aggregation cases: a kernel appearing twice (take the max), a kernel that
+// skips the reservation, and a kernel with a zero requirement. Only the
+// max-aggregated kernel's metadata SGPR count should be raised.
+TEST(RewriteKernelEntryDescriptorOffsets, AggregatesSgprBumpsMaxSkipZero) {
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.Kernels = {
+      {"k_max", 0x1000, 0x2000, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+      {"k_skip", 0x1100, 0x2100, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+      {"k_zero", 0x1200, 0x2200, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Buf =
+      llvm::WritableMemoryBuffer::getNewUninitMemBuffer(Bytes.size());
+  ASSERT_NE(Buf, nullptr);
+  std::memcpy(Buf->getBufferStart(), Bytes.data(), Bytes.size());
+
+  // Two fixups name k_max with different RequiredSgprs -> aggregate to the max
+  // (12). k_skip sets SkipSgprReservation, k_zero has RequiredSgprs == 0; both
+  // must leave the metadata count untouched.
+  const uint64_t PoolVAddr = 0x4000;
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"k_max", /*StubTextOffset=*/0, /*RequiredSgprs=*/10, /*InstPrefLines=*/0,
+       /*SkipSgprReservation=*/false},
+      {"k_max", /*StubTextOffset=*/KernelEntryStubStride, /*RequiredSgprs=*/12,
+       /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+      {"k_skip", /*StubTextOffset=*/2 * KernelEntryStubStride,
+       /*RequiredSgprs=*/20, /*InstPrefLines=*/0, /*SkipSgprReservation=*/true},
+      {"k_zero", /*StubTextOffset=*/3 * KernelEntryStubStride,
+       /*RequiredSgprs=*/0, /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+  };
+
+  ASSERT_TRUE(
+      rewriteKernelEntryDescriptorOffsets(*Buf, PoolVAddr, "gfx1250", Fixups));
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Buf->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Buf->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  EXPECT_EQ(OutView->getKernelSgprCount("k_max"), 12u);
+  EXPECT_EQ(OutView->getKernelSgprCount("k_skip"), 8u);
+  EXPECT_EQ(OutView->getKernelSgprCount("k_zero"), 8u);
+}
+
+// A fixup naming a kernel with no descriptor must fail the whole rewrite, even
+// when another fixup in the batch is valid.
+TEST(RewriteKernelEntryDescriptorOffsets, PropagatesMissingDescriptorFailure) {
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.Kernels = {
+      {"present", 0x1000, 0x2000, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Buf =
+      llvm::WritableMemoryBuffer::getNewUninitMemBuffer(Bytes.size());
+  ASSERT_NE(Buf, nullptr);
+  std::memcpy(Buf->getBufferStart(), Bytes.data(), Bytes.size());
+
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"present", /*StubTextOffset=*/0, /*RequiredSgprs=*/10,
+       /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+      {"absent", /*StubTextOffset=*/KernelEntryStubStride, /*RequiredSgprs=*/10,
+       /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+  };
+
+  EXPECT_FALSE(rewriteKernelEntryDescriptorOffsets(*Buf, /*PoolVAddr=*/0x4000,
+                                                   "gfx1250", Fixups));
+}
+
 // Count symbols named \p Name in the .symtab of the ELF held in \p Buf.
 // Returns ~0u if the ELF or its symbol table cannot be parsed, so a mis-parse
 // surfaces as a failed expectation rather than a silent zero.

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -15,6 +15,7 @@
 #include "llvm/Support/AMDHSAKernelDescriptor.h"
 #include "llvm/Support/MathExtras.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -323,6 +324,220 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   }
 
   return Result;
+}
+
+// Options for an ELF carrying several kernel descriptors, for tests that need
+// more than one kernel (descriptor-cache dedup ordering, batched SGPR updates).
+// Kept separate from makeKernelDescriptorElf so the single-kernel fixture used
+// by most tests is untouched.
+struct MultiKernelDescriptorElfOptions {
+  struct Kernel {
+    std::string Name;
+    // STT_FUNC entry symbol value; must lie within [TextAddr,
+    // TextAddr+TextSize).
+    uint64_t EntryVAddr = 0;
+    // STT_OBJECT `<name>.kd` symbol value; must be >= RodataAddr. The dedup
+    // path keys on (name, KdVAddr), so repeat a (Name, KdVAddr) pair to emit a
+    // duplicate symbol and vary KdVAddr to emit a distinct descriptor.
+    uint64_t KdVAddr = 0;
+    int64_t EntryOffset = 0; // kernel_code_entry_byte_offset in the descriptor
+    uint32_t ComputePgmRsrc3 = 0;
+    // When true, add an amdhsa.kernels metadata entry (with SgprCount) for this
+    // kernel. Leave false to model a descriptor that has no metadata entry.
+    bool EmitMetadata = false;
+    unsigned MetadataSgprCount = 0;
+  };
+
+  uint16_t ElfType = llvm::ELF::ET_DYN;
+  uint64_t TextAddr = 0x1000;
+  uint64_t TextSize = 0x400;
+  uint64_t RodataAddr = 0x2000;
+  std::vector<Kernel> Kernels;
+};
+
+inline std::vector<uint8_t>
+makeMultiKernelMetadataBlob(const MultiKernelDescriptorElfOptions &Options) {
+  KernelDescriptorElfOptions MetaOpts;
+  for (const MultiKernelDescriptorElfOptions::Kernel &K : Options.Kernels)
+    if (K.EmitMetadata)
+      MetaOpts.MetadataKernels.push_back({K.Name, K.MetadataSgprCount});
+  if (MetaOpts.MetadataKernels.empty())
+    return {};
+  std::string Blob = makeAmdgpuMetadataBlob(MetaOpts);
+  return makeAmdgpuMetadataNote(Blob);
+}
+
+inline std::vector<uint8_t>
+makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
+  using namespace llvm::ELF;
+  namespace hsa = llvm::amdhsa;
+
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t TextOffset = 0x240;
+  static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
+  static constexpr char ShStrTab[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
+
+  const size_t NumKernels = Options.Kernels.size();
+  assert(NumKernels > 0 && "multi-kernel ELF needs at least one kernel");
+
+  // .rodata must span the highest descriptor block. Each KdVAddr must sit at or
+  // above RodataAddr; distinct KdVAddrs get distinct blocks, duplicates reuse.
+  uint64_t RodataSpan = KdBytes;
+  for (const MultiKernelDescriptorElfOptions::Kernel &K : Options.Kernels) {
+    assert(K.KdVAddr >= Options.RodataAddr && "kd vaddr below .rodata");
+    assert(K.EntryVAddr >= Options.TextAddr &&
+           K.EntryVAddr < Options.TextAddr + Options.TextSize &&
+           "entry vaddr outside .text");
+    RodataSpan = std::max(RodataSpan, K.KdVAddr - Options.RodataAddr + KdBytes);
+  }
+
+  // String table: null byte, then per kernel "<name>\0" and "<name>.kd\0".
+  // Duplicates are emitted verbatim so repeated symbols stay independent.
+  std::string StrTab;
+  StrTab.push_back('\0');
+  std::vector<uint32_t> FuncNameOff(NumKernels), KdNameOff(NumKernels);
+  for (size_t I = 0; I < NumKernels; ++I) {
+    FuncNameOff[I] = static_cast<uint32_t>(StrTab.size());
+    StrTab += Options.Kernels[I].Name;
+    StrTab.push_back('\0');
+    KdNameOff[I] = static_cast<uint32_t>(StrTab.size());
+    StrTab += Options.Kernels[I].Name;
+    StrTab += ".kd";
+    StrTab.push_back('\0');
+  }
+
+  std::vector<uint8_t> MetadataNote = makeMultiKernelMetadataBlob(Options);
+  const bool HasMetadataNote = !MetadataNote.empty();
+
+  // Symbols: null [0], then per kernel a STT_FUNC entry and STT_OBJECT .kd.
+  const uint64_t SymCount = 1 + 2 * NumKernels;
+
+  const uint64_t RodataOff = alignTo8(TextOffset + Options.TextSize);
+  const uint64_t StrTabOff = alignTo8(RodataOff + RodataSpan);
+  const uint64_t SymTabOff = alignTo8(StrTabOff + StrTab.size());
+  const uint64_t ShStrTabOff =
+      alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t NoteOff =
+      HasMetadataNote ? alignTo4(ShStrTabOff + sizeof(ShStrTab)) : 0;
+  const uint64_t PhOff =
+      HasMetadataNote ? alignTo8(NoteOff + MetadataNote.size()) : 0;
+  const uint64_t ContentEnd = HasMetadataNote ? PhOff + sizeof(Elf64_Phdr)
+                                              : ShStrTabOff + sizeof(ShStrTab);
+  const uint64_t BufSize = alignTo8(ContentEnd + 64);
+
+  std::vector<uint8_t> Bytes(BufSize, 0);
+  uint8_t *Buf = Bytes.data();
+  std::memcpy(Buf + StrTabOff, StrTab.data(), StrTab.size());
+  std::memcpy(Buf + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
+  if (HasMetadataNote)
+    std::memcpy(Buf + NoteOff, MetadataNote.data(), MetadataNote.size());
+
+  Elf64_Ehdr Ehdr = makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = Options.ElfType;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_shoff = ShOff;
+  if (HasMetadataNote) {
+    Ehdr.e_phoff = PhOff;
+    Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+    Ehdr.e_phnum = 1;
+  }
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = 6;
+  Ehdr.e_shstrndx = 5;
+  std::memcpy(Buf, &Ehdr, sizeof(Ehdr));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = 1;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_offset = TextOffset;
+  TextSh.sh_addr = Options.TextAddr;
+  TextSh.sh_size = Options.TextSize;
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf + ShOff + 1 * sizeof(Elf64_Shdr), &TextSh, sizeof(TextSh));
+
+  Elf64_Shdr RodataSh{};
+  RodataSh.sh_name = 7;
+  RodataSh.sh_type = SHT_PROGBITS;
+  RodataSh.sh_flags = SHF_ALLOC;
+  RodataSh.sh_offset = RodataOff;
+  RodataSh.sh_addr = Options.RodataAddr;
+  RodataSh.sh_size = RodataSpan;
+  RodataSh.sh_addralign = 8;
+  std::memcpy(Buf + ShOff + 2 * sizeof(Elf64_Shdr), &RodataSh,
+              sizeof(RodataSh));
+
+  Elf64_Shdr StrtabSh{};
+  StrtabSh.sh_name = 15;
+  StrtabSh.sh_type = SHT_STRTAB;
+  StrtabSh.sh_offset = StrTabOff;
+  StrtabSh.sh_size = StrTab.size();
+  std::memcpy(Buf + ShOff + 3 * sizeof(Elf64_Shdr), &StrtabSh,
+              sizeof(StrtabSh));
+
+  Elf64_Shdr SymtabSh{};
+  SymtabSh.sh_name = 23;
+  SymtabSh.sh_type = SHT_SYMTAB;
+  SymtabSh.sh_offset = SymTabOff;
+  SymtabSh.sh_size = SymCount * sizeof(Elf64_Sym);
+  SymtabSh.sh_link = 3; // .strtab section index
+  SymtabSh.sh_info = 1; // one past the last local symbol (only sym[0] is local)
+  SymtabSh.sh_entsize = sizeof(Elf64_Sym);
+  std::memcpy(Buf + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
+              sizeof(SymtabSh));
+
+  Elf64_Shdr ShstrSh{};
+  ShstrSh.sh_name = 31;
+  ShstrSh.sh_type = SHT_STRTAB;
+  ShstrSh.sh_offset = ShStrTabOff;
+  ShstrSh.sh_size = sizeof(ShStrTab);
+  std::memcpy(Buf + ShOff + 5 * sizeof(Elf64_Shdr), &ShstrSh, sizeof(ShstrSh));
+
+  if (HasMetadataNote) {
+    Elf64_Phdr NotePhdr{};
+    NotePhdr.p_type = PT_NOTE;
+    NotePhdr.p_offset = NoteOff;
+    NotePhdr.p_filesz = MetadataNote.size();
+    NotePhdr.p_memsz = MetadataNote.size();
+    NotePhdr.p_align = 4;
+    std::memcpy(Buf + PhOff, &NotePhdr, sizeof(NotePhdr));
+  }
+
+  // Descriptor blocks and symbols, one pair per kernel entry.
+  for (size_t I = 0; I < NumKernels; ++I) {
+    const MultiKernelDescriptorElfOptions::Kernel &K = Options.Kernels[I];
+    const uint64_t KdBlockOff = RodataOff + (K.KdVAddr - Options.RodataAddr);
+    std::memcpy(
+        Buf + KdBlockOff +
+            offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
+        &K.EntryOffset, sizeof(K.EntryOffset));
+    std::memcpy(Buf + KdBlockOff +
+                    offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
+                &K.ComputePgmRsrc3, sizeof(K.ComputePgmRsrc3));
+
+    Elf64_Sym FuncSym{};
+    FuncSym.st_name = FuncNameOff[I];
+    FuncSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+    FuncSym.st_shndx = 1;
+    FuncSym.st_value = K.EntryVAddr;
+    FuncSym.st_size = 0x40;
+    std::memcpy(Buf + SymTabOff + (1 + 2 * I) * sizeof(Elf64_Sym), &FuncSym,
+                sizeof(FuncSym));
+
+    Elf64_Sym KdSym{};
+    KdSym.st_name = KdNameOff[I];
+    KdSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+    KdSym.st_shndx = 2;
+    KdSym.st_value = K.KdVAddr;
+    KdSym.st_size = KdBytes;
+    std::memcpy(Buf + SymTabOff + (2 + 2 * I) * sizeof(Elf64_Sym), &KdSym,
+                sizeof(KdSym));
+  }
+
+  return Bytes;
 }
 
 } // namespace comgr_test


### PR DESCRIPTION
## Summary

Three algorithmic fixes to the shared kernel-descriptor rewrite path. They are independent of the B0-to-B0 fast path but are exercised heavily by it, by the MC entry-trampoline path, and by the B0-to-A0 instruction-patch path on large (1000+ kernel) code objects.

- **`getKernelDescriptorVAddr` was O(n²).** It linearly scanned all descriptors, once per fixup (N fixups × N descriptors). Now O(1) via a name→vaddr `StringMap` built during descriptor-cache init.
- **`initializeKernelDescriptorCache` was O(n²).** It deduped each descriptor with an `std::any_of` linear scan over everything seen so far. Now O(n) via a seen-set `StringMap`.
- **`rewriteKernelEntryDescriptorOffsets` did an O(n²) msgpack round-trip.** It applied each kernel's SGPR-reservation bump with a per-kernel call that reparsed and reserialized the *entire* AMDGPU metadata note (which holds every kernel). Now all bumps are collected in the loop and applied in a single batched `updateKernelMetadataSgprCounts` call.

The batched-msgpack SGPR update was independently developed in parallel by @rahjain-amd in #3380; this PR lands the equivalent fix on the fast-path stack. #3380 Should be encompassed by this PR now. 

This is the perf half of a two-PR pair, stacked on the B0-to-B0 fast-path PR #3361. #3361 adds the fast path itself; this PR restores/adds the load-time optimizations that make it (and the MC path) fast on large objects. They are meant to land together.

## Performance

Offline full rewrite of the gfx1250 hipBLASLt monolith (`Kernels.so-000-gfx1250.hsaco`, 8.7 MB, ~1093 kernels), measured with the in-tree `hotswap-rewrite` tool:

| path | without these opts | with these opts |
|---|---|---|
| B0-to-B0 fast path | +33 ms over parity (large object) | at parity with the ROCr loader |
| per-kernel SGPR reserve (msgpack) | ~14.5 s | ~0.09 s |

The two O(n²) descriptor scans were the bulk of the fast path's residual ~33 ms gap to the ROCr loader on the 1093-kernel object; with them fixed the fast path reaches load-time parity. The msgpack batching is what makes any path that bumps per-kernel SGPR reservations (MC entry-trampoline, and the per-kernel-SGPR fast-path variant) usable on large objects at all, resulting in a 150x+ reduction.

All three are pure algorithmic changes (identical output, lower complexity), verified by the existing hotswap LIT suite (74 tests) and `--check-idempotent`.

## Testing

- `make check-comgr` hotswap LIT suite: all pass (unchanged output).
- Offline `hotswap-rewrite` on the hipBLASLt and hipSPARSELt gfx1250 monoliths: RESULT SUCCESS, idempotent.
- Running now on full suite of rocm-libraries tests on A0, will update for total coverage

## Reproducing the benchmark

The load-time harness lives in the internal rocm-hotswap-testing repo under `perf-harness/` (AMD-ROCm-Internal/rocm-hotswap-testing#17).

TLDR:

```bash
DIST=/path/to/rocm/dist ./perf-harness/run_hsa_load_comparison.sh results/
python3 perf-harness/analyze_hsa_load.py results/
```

It sweeps baseline / rocr_loader / comgr_hotswap / comgr_hotswap_fast cells over the gfx1250 monolith libraries and prints the per-object load floor plus the fast-vs-loader and MC-vs-loader deltas. See `perf-harness/README.md` there for the cell definitions, env knobs, and the B0-vs-A0 measurement caveat.