### PR TITLE
comgr: Use %clang to run clang in tests

### DIFF
--- a/amd/comgr/test-lit/unpackage-test.hip
+++ b/amd/comgr/test-lit/unpackage-test.hip
@@ -1,11 +1,10 @@
 // COM: create a bitcode package
 //
-// XFAIL: *
-// RUN: clang -c -x hip --offload-arch=gfx900 \
+// RUN: %clang -c -x hip --offload-arch=gfx900 \
 // RUN: -nogpulib -nogpuinc -emit-llvm \
 // RUN: --offload-device-only %s -o %t.gfx900.bc
 //
-// RUN: clang -c -x hip --offload-arch=gfx1030 \
+// RUN: %clang -c -x hip --offload-arch=gfx1030 \
 // RUN: -nogpulib -nogpuinc -emit-llvm \
 // RUN: --offload-device-only %s -o %t.gfx1030.bc
 //


### PR DESCRIPTION
This is the way to use the configuration expanded clang driver


