### PR TITLE
[COMGR] Harden gfx1250 HotSwap rewriting and fail closed

### DIFF
--- a/amd/comgr/docs/ReleaseNotes.md
+++ b/amd/comgr/docs/ReleaseNotes.md
@@ -40,6 +40,9 @@ File System (VFS).
 
 Bug Fixes
 ---------
+- Added conservative control-flow, register-liveness, patch-ownership, and
+  idempotency checks to GFX1250 HotSwap stepping rewrites, including safe
+  handling of entry trampolines and generated executable pools.
 
 New APIs
 --------

--- a/amd/comgr/include/amd_comgr.h.in
+++ b/amd/comgr/include/amd_comgr.h.in
@@ -2935,6 +2935,18 @@ amd_comgr_map_elf_virtual_address_to_code_object_offset(
  * @{
  *
  * APIs for load-time GPU ISA binary rewriting and transpilation.
+ *
+ * Input code objects must follow the AMDGPU callable-control-flow ABI. In
+ * particular, an @c s_swap_pc_i64 instruction that writes the standard link
+ * register pair @c s[30:31] must be a call whose register target is a callable
+ * function entry represented by the code object. Using that ABI call form for
+ * an arbitrary interior transfer is unsupported and may produce invalid
+ * rewritten code.
+ *
+ * HotSwap assumes the input was produced by a trusted compiler or an earlier
+ * trusted HotSwap invocation. Structural provenance notes written by HotSwap
+ * describe generated layout and rewrite state; they do not authenticate an
+ * otherwise untrusted code object.
  */
 
 /**

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -34,7 +34,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Endian.h"
 
 #include <algorithm>
 #include <cassert>
@@ -65,9 +65,381 @@ static constexpr unsigned Gfx1250MaxVgprs = 1024;
 // decode/encode helpers (getKernelVgprCount /
 // updateKernelDescriptorVgprCount) to
 // interpret COMPUTE_PGM_RSRC1.GRANULATED_WORKITEM_VGPR_COUNT.
-// GFX12 wave32: 106 user-addressable SGPRs (s0-s105); s106-s107 are VCC.
-static constexpr unsigned Gfx1250MaxSgprs = 106;
 static constexpr unsigned Gfx1250VgprGranuleSize = 16;
+
+struct OriginalIngressInfo {
+  DenseSet<uint64_t> CrossRangeEntryFunctions;
+  std::vector<std::pair<uint64_t, uint64_t>> ExternalEntries;
+  std::vector<std::pair<uint64_t, uint64_t>> ControlFlowEdges;
+};
+
+/// Proof facts produced by the later amd-staging control-flow analysis.  The
+/// PR's whole-object analysis deliberately accepts only ABI-standard link calls;
+/// these records carry the separately proven arbitrary-link calls and bounded
+/// returns through the richer production pipeline instead of reducing them to
+/// a target-only compatibility summary.
+struct ResolvedCompatibilityCall {
+  size_t InstIndex = 0;
+  uint64_t Site = 0;
+  uint64_t SequenceStart = 0;
+  uint64_t SequenceEnd = 0;
+  std::optional<uint64_t> TextTarget;
+  uint64_t Continuation = 0;
+  MCRegister ReturnRegister;
+};
+
+struct CompatibilityControlFlowFacts {
+  DirectControlFlowInfo Summary;
+  SmallVector<ResolvedCompatibilityCall, 4> ResolvedCalls;
+  SmallVector<size_t, 4> UnresolvedCallIndices;
+  DenseSet<uint64_t> BoundedReturnOffsets;
+};
+
+static const ResolvedCompatibilityCall *
+findResolvedCompatibilityCall(const CompatibilityControlFlowFacts &Facts,
+                              size_t InstIndex) {
+  auto It = llvm::find_if(Facts.ResolvedCalls, [&](const auto &Call) {
+    return Call.InstIndex == InstIndex;
+  });
+  return It == Facts.ResolvedCalls.end() ? nullptr : &*It;
+}
+
+static std::optional<MaterializedPcTransfer>
+getResolvedCompatibilityTransfer(const CompatibilityControlFlowFacts &Facts,
+                                 size_t InstIndex) {
+  const ResolvedCompatibilityCall *Call =
+      findResolvedCompatibilityCall(Facts, InstIndex);
+  if (!Call || !Call->TextTarget)
+    return std::nullopt;
+  return MaterializedPcTransfer{Call->SequenceStart, Call->SequenceEnd,
+                                *Call->TextTarget};
+}
+
+static std::optional<uint64_t>
+kernelEntryVAddr(const KernelDescriptorInfo &KD) {
+  if (KD.EntryOffset >= 0)
+    return checkedAddUint64(KD.VAddr, static_cast<uint64_t>(KD.EntryOffset),
+                            "kernel entry address");
+
+  const uint64_t Magnitude =
+      KD.EntryOffset == std::numeric_limits<int64_t>::min()
+          ? uint64_t{1} << 63
+          : static_cast<uint64_t>(-KD.EntryOffset);
+  if (KD.VAddr < Magnitude)
+    return std::nullopt;
+  return KD.VAddr - Magnitude;
+}
+
+static std::optional<DenseSet<uint64_t>>
+collectResolvedKernelEntryOffsets(ElfView &Elf, const LLVMState &LS) {
+  if (!Elf.kernelDescriptorCacheIsComplete())
+    return std::nullopt;
+
+  std::optional<uint64_t> TextEnd =
+      checkedAddUint64(Elf.textAddr(), Elf.textSize(), "kernel entry text end");
+  if (!TextEnd)
+    return std::nullopt;
+
+  DenseSet<uint64_t> Result;
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> Entry = kernelEntryVAddr(KD);
+    if (!Entry)
+      return std::nullopt;
+    if (*Entry >= Elf.textAddr() && *Entry < *TextEnd) {
+      Result.insert(*Entry - Elf.textAddr());
+      continue;
+    }
+
+    const uint8_t *Stub = Elf.dataAtVAddr(*Entry, KernelEntryStubStride);
+    if (!Stub)
+      return std::nullopt;
+    std::optional<uint64_t> OriginalEntry = getKernelEntryTrampolineTargetVAddr(
+        ArrayRef<uint8_t>(Stub, KernelEntryStubStride), *Entry, LS);
+    if (!OriginalEntry || *OriginalEntry < Elf.textAddr() ||
+        *OriginalEntry >= *TextEnd)
+      return std::nullopt;
+    Result.insert(*OriginalEntry - Elf.textAddr());
+  }
+  return Result;
+}
+
+static bool
+isExternallyVisibleCallable(const ElfView::FunctionTextRange &Range) {
+  if (!Range.Symbol || Range.Symbol->getBinding() == ELF::STB_LOCAL)
+    return false;
+  const unsigned Visibility = Range.Symbol->getVisibility();
+  return Visibility == ELF::STV_DEFAULT || Visibility == ELF::STV_PROTECTED;
+}
+
+static std::vector<KernelTextRange> collectKernelTextRanges(
+    ElfView &Elf, const LLVMState &LS,
+    ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges,
+    bool HasUnknownArbitraryIndirectTarget,
+    bool HasUnresolvedStandardLinkCall) {
+  std::optional<DenseSet<uint64_t>> EntryOffsets =
+      collectResolvedKernelEntryOffsets(Elf, LS);
+  if (!EntryOffsets)
+    return {};
+
+  std::vector<KernelTextRange> Result;
+  for (uint64_t Entry : *EntryOffsets) {
+    std::optional<ElfView::FunctionTextRange> Owner =
+        Elf.findFunctionTextRangeAtOffset(Entry);
+    if (!Owner || Owner->End <= Owner->Begin)
+      continue;
+    auto Existing = llvm::find_if(Result, [&](const KernelTextRange &Range) {
+      return Range.Begin == Owner->Begin && Range.End == Owner->End;
+    });
+    if (Existing == Result.end()) {
+      Result.push_back(
+          {Owner->Begin, Owner->End, {}, HasUnknownArbitraryIndirectTarget});
+      Existing = std::prev(Result.end());
+    }
+    if (!llvm::is_contained(Existing->Entries, Entry))
+      Existing->Entries.push_back(Entry);
+  }
+
+  for (KernelTextRange &Candidate : Result) {
+    for (const auto &[Source, Target] : OriginalControlFlowEdges) {
+      if (Target < Candidate.Begin || Target >= Candidate.End ||
+          (Source >= Candidate.Begin && Source < Candidate.End))
+        continue;
+      if (!llvm::is_contained(Candidate.Entries, Target))
+        Candidate.Entries.push_back(Target);
+    }
+    for (const ElfView::FunctionTextRange &Callable :
+         Elf.functionTextRanges()) {
+      if (Callable.Begin < Elf.textAddr() ||
+          (!HasUnresolvedStandardLinkCall &&
+           !isExternallyVisibleCallable(Callable)))
+        continue;
+      const uint64_t Entry = Callable.Begin - Elf.textAddr();
+      if (Entry >= Candidate.Begin && Entry < Candidate.End &&
+          !llvm::is_contained(Candidate.Entries, Entry))
+        Candidate.Entries.push_back(Entry);
+    }
+    llvm::sort(Candidate.Entries);
+  }
+  return Result;
+}
+
+static std::vector<TensorAnalysisRange> collectTensorAnalysisRanges(
+    ElfView &Elf, const LLVMState &LS, const DenseSet<uint64_t> &CodeEntries,
+    const DenseSet<uint64_t> &IndirectControlFlowFunctions,
+    const DenseSet<uint64_t> &CrossRangeEntryFunctions,
+    ArrayRef<std::pair<uint64_t, uint64_t>> ExternalEntries,
+    ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges,
+    bool HasUnknownArbitraryIndirectTarget) {
+  if (HasUnknownArbitraryIndirectTarget)
+    return {};
+
+  DenseSet<uint64_t> EntryVAddrs;
+  std::vector<TensorDispatchStub> DispatchStubs;
+  std::vector<uint64_t> VirtualExternalEntries;
+  std::optional<uint64_t> TextEnd = checkedAddUint64(
+      Elf.textAddr(), Elf.textSize(), "tensor analysis .text end");
+  if (!TextEnd)
+    return {};
+
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> Entry = kernelEntryVAddr(KD);
+    if (!Entry)
+      return {};
+    if (*Entry >= Elf.textAddr() && *Entry < *TextEnd) {
+      EntryVAddrs.insert(*Entry);
+      continue;
+    }
+    if (*Entry < Elf.textAddr())
+      return {};
+    const uint64_t EntryOffset = *Entry - Elf.textAddr();
+
+    const uint8_t *Stub = Elf.dataAtVAddr(*Entry, KernelEntryStubStride);
+    if (!Stub) {
+      if (!llvm::is_contained(VirtualExternalEntries, EntryOffset))
+        VirtualExternalEntries.push_back(EntryOffset);
+      continue;
+    }
+    std::optional<KernelEntryTrampolineInfo> Info =
+        getKernelEntryTrampolineInfo(
+            ArrayRef<uint8_t>(Stub, KernelEntryStubStride), *Entry, LS);
+    if (!Info) {
+      if (!llvm::is_contained(VirtualExternalEntries, EntryOffset))
+        VirtualExternalEntries.push_back(EntryOffset);
+      continue;
+    }
+    if (Info->TargetVAddr < Elf.textAddr())
+      return {};
+
+    std::optional<uint64_t> StubOffset = checkedSubUint64(
+        *Entry, Elf.textAddr(), "tensor kernel-entry stub offset");
+    if (!StubOffset)
+      return {};
+    std::optional<uint64_t> StubEnd = checkedAddUint64(
+        *StubOffset, KernelEntryStubStride, "tensor kernel-entry stub end");
+    std::optional<uint64_t> TerminalOffset =
+        checkedSubUint64(Info->TerminalVAddr, Elf.textAddr(),
+                         "tensor kernel-entry terminal offset");
+    if (!StubEnd || !TerminalOffset || *TerminalOffset < *StubOffset ||
+        *TerminalOffset >= *StubEnd)
+      return {};
+    const uint64_t TargetOffset = Info->TargetVAddr - Elf.textAddr();
+    if (Info->TargetVAddr < *TextEnd)
+      EntryVAddrs.insert(Info->TargetVAddr);
+    TensorDispatchStub Dispatch{*StubOffset, *StubEnd, *TerminalOffset,
+                                TargetOffset};
+    auto Existing = llvm::find_if(DispatchStubs, [&](const auto &Other) {
+      return Other.Begin == Dispatch.Begin;
+    });
+    if (Existing == DispatchStubs.end()) {
+      DispatchStubs.push_back(Dispatch);
+    } else if (Existing->End != Dispatch.End ||
+               Existing->Terminal != Dispatch.Terminal ||
+               Existing->Target != Dispatch.Target) {
+      return {};
+    }
+  }
+
+  llvm::sort(DispatchStubs,
+             [](const TensorDispatchStub &L, const TensorDispatchStub &R) {
+               return L.Begin < R.Begin;
+             });
+  for (size_t I = 1; I < DispatchStubs.size(); ++I)
+    if (DispatchStubs[I - 1].End > DispatchStubs[I].Begin)
+      return {};
+  if (llvm::any_of(ExternalEntries, [&](const auto &Edge) {
+        return llvm::any_of(DispatchStubs, [&](const auto &Stub) {
+          return Edge.second >= Stub.Begin && Edge.second < Stub.End;
+        });
+      }))
+    return {};
+
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Elf.functionTextRanges();
+  std::vector<uint64_t> OriginalCodeEntries(CodeEntries.begin(),
+                                            CodeEntries.end());
+  llvm::sort(OriginalCodeEntries);
+  std::vector<TensorAnalysisRange> Result;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    if (!EntryVAddrs.contains(Range.Begin) || Range.Begin < Elf.textAddr() ||
+        Range.End <= Range.Begin || Range.End < Elf.textAddr())
+      continue;
+    TensorAnalysisRange Candidate{Range.Begin - Elf.textAddr(),
+                                  Range.End - Elf.textAddr()};
+    Candidate.VirtualExternalEntries = VirtualExternalEntries;
+    Candidate.OriginalControlFlowEdges.assign(OriginalControlFlowEdges.begin(),
+                                              OriginalControlFlowEdges.end());
+    Candidate.OriginalCodeEntries = OriginalCodeEntries;
+    Candidate.DispatchStubs = DispatchStubs;
+    if (IndirectControlFlowFunctions.contains(Candidate.Begin))
+      continue;
+    if (llvm::any_of(CodeEntries, [&](uint64_t Entry) {
+          return Entry > Candidate.Begin && Entry < Candidate.End;
+        }))
+      continue;
+    if (llvm::any_of(EntryVAddrs, [&](uint64_t Entry) {
+          return Entry > Range.Begin && Entry < Range.End;
+        }))
+      continue;
+    if (CrossRangeEntryFunctions.contains(Candidate.Begin))
+      continue;
+    if (llvm::any_of(
+            FunctionRanges, [&](const ElfView::FunctionTextRange &Other) {
+              if (Other.Begin == Range.Begin && Other.End == Range.End)
+                return false;
+              return Other.Begin < Range.End && Range.Begin < Other.End;
+            }))
+      continue;
+    if (!llvm::any_of(Result, [&](const TensorAnalysisRange &Existing) {
+          return Existing.Begin == Candidate.Begin &&
+                 Existing.End == Candidate.End;
+        })) {
+      for (const auto &[Source, Target] : ExternalEntries)
+        if (Source < Candidate.Begin || Source >= Candidate.End)
+          if (!llvm::is_contained(Candidate.ForeignExternalEntries, Target))
+            Candidate.ForeignExternalEntries.push_back(Target);
+      Result.push_back(Candidate);
+    }
+  }
+  return Result;
+}
+
+/// Decode all executable sections into one .text-relative instruction view.
+/// The original .text stream remains the only mutable input; appended HotSwap
+/// pools are included only for conservative control-flow analyses.
+static bool
+buildHotswapAnalysisDecoded(const ElfView &Elf, const LLVMState &LS,
+                            ArrayRef<InternalDecodedInst> TextDecoded,
+                            std::vector<InternalDecodedInst> &Out) {
+  Out.assign(TextDecoded.begin(), TextDecoded.end());
+  std::optional<uint64_t> TextEnd = checkedAddUint64(
+      Elf.textAddr(), Elf.textSize(), "HotSwap analysis .text end");
+  if (!TextEnd)
+    return false;
+
+  for (const ElfView::ELFT::Shdr &Shdr : Elf.sections()) {
+    if (&Shdr == Elf.textSection() || !(Shdr.sh_flags & ELF::SHF_EXECINSTR) ||
+        Shdr.sh_type == ELF::SHT_NOBITS || Shdr.sh_size == 0)
+      continue;
+    std::optional<uint64_t> SectionEnd = checkedAddUint64(
+        Shdr.sh_addr, Shdr.sh_size, "HotSwap analysis executable section end");
+    if (!SectionEnd)
+      return false;
+    if (Shdr.sh_addr < *TextEnd) {
+      if (*SectionEnd > Elf.textAddr()) {
+        log() << "hotswap: error: executable analysis section at "
+                 "vaddr 0x"
+              << utohexstr(Shdr.sh_addr) << " overlaps .text\n";
+        return false;
+      }
+      // Sections entirely below .text cannot be represented in the unsigned
+      // .text-relative analysis view. Any path to them remains unknown and
+      // therefore fails the range proof closed.
+      continue;
+    }
+    if (Shdr.sh_offset > Elf.size() ||
+        Shdr.sh_size > Elf.size() - Shdr.sh_offset)
+      return false;
+
+    std::vector<InternalDecodedInst> SectionDecoded;
+    if (!decodeTextSection(Elf.data() + Shdr.sh_offset, Shdr.sh_size, LS,
+                           SectionDecoded)) {
+      log() << "hotswap: error: failed to decode executable analysis "
+               "section at vaddr 0x"
+            << utohexstr(Shdr.sh_addr) << "\n";
+      return false;
+    }
+
+    const uint64_t Base = Shdr.sh_addr - Elf.textAddr();
+    for (InternalDecodedInst &DI : SectionDecoded) {
+      std::optional<uint64_t> Rebased = checkedAddUint64(
+          Base, DI.Offset, "HotSwap analysis instruction offset");
+      if (!Rebased)
+        return false;
+      DI.Offset = *Rebased;
+      Out.push_back(std::move(DI));
+    }
+  }
+
+  llvm::sort(Out,
+             [](const InternalDecodedInst &L, const InternalDecodedInst &R) {
+               return L.Offset < R.Offset;
+             });
+  if (!Out.empty() && Out.front().Size == 0)
+    return false;
+  for (size_t I = 1; I < Out.size(); ++I) {
+    if (Out[I].Size == 0)
+      return false;
+    std::optional<uint64_t> PreviousEnd = checkedAddUint64(
+        Out[I - 1].Offset, Out[I - 1].Size, "HotSwap analysis instruction end");
+    if (!PreviousEnd || *PreviousEnd > Out[I].Offset) {
+      log() << "hotswap: error: overlapping executable analysis "
+               "instruction at 0x"
+            << utohexstr(Out[I].Offset) << "\n";
+      return false;
+    }
+  }
+  return true;
+}
 
 /// Build the default RewriteConfig used for the GFX1250 B0-to-A0 rewrite:
 /// fills in the identity source / target ISA (both gfx1250) and the
@@ -273,94 +645,265 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 // -- NOP sled scanning --------------------------------------------------------
 
 static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
-                                 uint64_t End, uint64_t FunctionStart,
-                                 uint64_t FunctionEnd) {
+                                 uint64_t End,
+                                 const ElfView::FunctionTextRange &Range,
+                                 bool GlobalPostFunction = false) {
   if (End - Start >= MinNopSledSize)
-    Sleds.push_back({Start, End, Start, FunctionStart, FunctionEnd});
+    Sleds.push_back({Start, End, Start, Range.Begin, Range.End,
+                     /*GatewayOnly=*/false,
+                     /*GlobalGateway=*/GlobalPostFunction,
+                     /*GlobalBody=*/GlobalPostFunction});
 }
 
-static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
-                                 uint64_t End,
-                                 const ElfView::FunctionTextRange &Range) {
-  appendNopSledIfLarge(Sleds, Start, End, Range.Begin, Range.End);
+static bool hasNoFallthrough(const InternalDecodedInst &DI,
+                             const LLVMState &LS);
+
+static bool overlapsTextSymbolExtent(ArrayRef<ElfView::TextOffsetRange> Extents,
+                                     const InternalDecodedInst &DI) {
+  auto It =
+      llvm::lower_bound(Extents, DI.Offset,
+                        [](const ElfView::TextOffsetRange &Extent,
+                           uint64_t Offset) { return Extent.End <= Offset; });
+  return It != Extents.end() &&
+         (It->Begin <= DI.Offset || It->Begin - DI.Offset < DI.Size);
 }
 
 /// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
 /// MinNopSledSize bytes long and return the resulting NopSled list. Each sled
-/// records its owning function range so emitReplacementCode can only borrow
-/// padding from the same kernel as the instruction being patched. NOPs outside
-/// any sized function symbol are ignored.
+/// records its owner range so ordinary replacement bodies use source-owned
+/// padding. A strictly proven explicit-NOP run immediately after a sized
+/// function remains owned by that function and is also globally usable for
+/// branch gateways and explicitly opted-in PC-independent relocation bodies.
 static std::vector<NopSled>
 buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-                const ElfView &Elf) {
+                const ElfView &Elf,
+                const DenseSet<uint64_t> &DirectBranchTargets,
+                const DenseSet<uint64_t> &IndirectControlFlowFunctions,
+                ArrayRef<uint64_t> TextSymbolOffsets,
+                ArrayRef<ElfView::TextOffsetRange> TextSymbolExtents) {
+  enum class Ownership { None, InFunction, PostFunction };
   std::vector<NopSled> Sleds;
-  bool HasActiveRange = false;
+  Ownership ActiveOwnership = Ownership::None;
+  bool ActiveSafe = false;
+  bool ActiveHasTarget = false;
   ElfView::FunctionTextRange ActiveRange;
   uint64_t Start = 0;
   uint64_t End = 0;
 
-  for (const InternalDecodedInst &DI : Decoded) {
+  SmallVector<uint64_t, 16> SortedDirectTargets(DirectBranchTargets.begin(),
+                                                DirectBranchTargets.end());
+  llvm::sort(SortedDirectTargets);
+
+  auto HasOffsetInInstruction = [](ArrayRef<uint64_t> Offsets,
+                                   const InternalDecodedInst &DI) {
+    auto It = llvm::lower_bound(Offsets, DI.Offset);
+    return It != Offsets.end() && *It - DI.Offset < DI.Size;
+  };
+
+  auto Flush = [&] {
+    if (ActiveOwnership != Ownership::None && ActiveSafe && !ActiveHasTarget &&
+        (ActiveOwnership == Ownership::PostFunction || End == ActiveRange.End))
+      appendNopSledIfLarge(Sleds, Start, End, ActiveRange,
+                           /*GlobalPostFunction=*/ActiveOwnership ==
+                               Ownership::PostFunction);
+    ActiveOwnership = Ownership::None;
+  };
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
     if (DI.Inst.getOpcode() != LS.SNopOpcode) {
-      if (HasActiveRange)
-        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
-      HasActiveRange = false;
+      Flush();
       continue;
     }
 
     std::optional<ElfView::FunctionTextRange> Range =
         Elf.findFunctionTextRangeAtOffset(DI.Offset);
-    if (!Range || DI.Size > Range->End - DI.Offset) {
-      if (HasActiveRange)
-        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
-      HasActiveRange = false;
+    const bool InFunction =
+        Range && DI.Offset < Range->End && DI.Size <= Range->End - DI.Offset;
+    const bool HasSymbol = HasOffsetInInstruction(TextSymbolOffsets, DI);
+    const bool HasSymbolExtent =
+        overlapsTextSymbolExtent(TextSymbolExtents, DI);
+    const bool HasDirectTarget =
+        HasOffsetInInstruction(SortedDirectTargets, DI);
+    const bool HasProtectedEntry =
+        HasSymbol || HasSymbolExtent || HasDirectTarget;
+
+    if (ActiveOwnership == Ownership::InFunction && InFunction &&
+        ActiveRange.Begin == Range->Begin && ActiveRange.End == Range->End &&
+        DI.Offset == End) {
+      // Donor storage may not overwrite any symbol boundary. Exact-start
+      // aliases are permitted only for the original replacement source in
+      // emitReplacementCode, never for independently discovered storage.
+      ActiveHasTarget |= HasProtectedEntry;
+      End = DI.Offset + DI.Size;
       continue;
     }
-
-    if (!HasActiveRange || ActiveRange.Begin != Range->Begin ||
-        ActiveRange.End != Range->End || DI.Offset != End) {
-      if (HasActiveRange)
-        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
-      ActiveRange = *Range;
-      HasActiveRange = true;
-      Start = DI.Offset;
+    if (ActiveOwnership == Ownership::PostFunction && !InFunction &&
+        DI.Offset == End) {
+      ActiveHasTarget |= HasProtectedEntry;
+      End = DI.Offset + DI.Size;
+      continue;
     }
+    Flush();
+
+    if (InFunction) {
+      ActiveRange = *Range;
+      ActiveOwnership = Ownership::InFunction;
+      Start = DI.Offset;
+      ActiveSafe = I != 0 &&
+                   Decoded[I - 1].Offset + Decoded[I - 1].Size == DI.Offset &&
+                   hasNoFallthrough(Decoded[I - 1], LS) &&
+                   !IndirectControlFlowFunctions.contains(Range->Begin);
+      ActiveHasTarget = false;
+    } else if (I != 0 &&
+               Decoded[I - 1].Offset + Decoded[I - 1].Size == DI.Offset) {
+      std::optional<ElfView::FunctionTextRange> PreviousRange =
+          Elf.findFunctionTextRangeAtOffset(Decoded[I - 1].Offset);
+      if (!PreviousRange || !PreviousRange->Symbol ||
+          PreviousRange->Symbol->st_size == 0 ||
+          PreviousRange->End != DI.Offset ||
+          IndirectControlFlowFunctions.contains(PreviousRange->Begin) ||
+          !hasNoFallthrough(Decoded[I - 1], LS))
+        continue;
+      ActiveRange = *PreviousRange;
+      ActiveOwnership = Ownership::PostFunction;
+      Start = DI.Offset;
+      ActiveSafe = true;
+      ActiveHasTarget = false;
+    } else {
+      continue;
+    }
+    ActiveHasTarget |= HasProtectedEntry;
     End = DI.Offset + DI.Size;
   }
 
-  if (HasActiveRange)
-    appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+  Flush();
   return Sleds;
 }
 
-/// A direct branch/call target into a NOP run makes that offset and every
-/// following byte in the run reachable by fallthrough, so only the prefix
-/// before the first target remains available as scratch padding.
-static void
-truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
-                                const DenseSet<uint64_t> &DirectBranchTargets) {
-  if (DirectBranchTargets.empty() || Sleds.empty())
-    return;
+// -- Sled-or-trampoline code emission -----------------------------------------
 
-  std::vector<NopSled> Filtered;
-  Filtered.reserve(Sleds.size());
-  uint64_t Truncated = 0;
-  for (const NopSled &Sled : Sleds) {
-    uint64_t End = Sled.End;
-    for (uint64_t Target : DirectBranchTargets)
-      if (Target >= Sled.Start && Target < End)
-        End = Target;
-    if (End != Sled.End)
-      ++Truncated;
-    appendNopSledIfLarge(Filtered, Sled.Start, End, Sled.FunctionStart,
-                         Sled.FunctionEnd);
-  }
-  if (Truncated != 0)
-    log() << "hotswap: protected " << Truncated
-          << " NOP sled(s) containing direct branch/call target(s)\n";
-  Sleds = std::move(Filtered);
+struct NopSledEmissionLayout {
+  size_t BodySize = 0;
+  size_t SourceTailOffset = 0;
+  size_t SourceTailSize = 0;
+
+  uint64_t sledBytes() const { return BodySize + MinInstSize; }
+};
+
+static bool isDs2SourceMnemonic(StringRef Mnemonic) {
+  return Mnemonic == "ds_load_2addr_b32" || Mnemonic == "ds_load_2addr_b64" ||
+         Mnemonic == "ds_load_2addr_stride64_b32" ||
+         Mnemonic == "ds_load_2addr_stride64_b64" ||
+         Mnemonic == "ds_store_2addr_b32" || Mnemonic == "ds_store_2addr_b64" ||
+         Mnemonic == "ds_store_2addr_stride64_b32" ||
+         Mnemonic == "ds_store_2addr_stride64_b64" ||
+         Mnemonic == "ds_storexchg_2addr_rtn_b32" ||
+         Mnemonic == "ds_storexchg_2addr_rtn_b64" ||
+         Mnemonic == "ds_storexchg_2addr_stride64_rtn_b32" ||
+         Mnemonic == "ds_storexchg_2addr_stride64_rtn_b64";
 }
 
-// -- Sled-or-trampoline code emission -----------------------------------------
+/// Keep a structurally validated replacement suffix in the bytes after the
+/// source branch. An ordinary DS2 keeps its final DS-counter drain. A validated
+/// combined-delay window keeps the reconstructed standalone delay together
+/// with the instruction it protects. In both cases the relocated prefix
+/// branches back to the retained suffix and execution falls through the padded
+/// remainder of the original window.
+static NopSledEmissionLayout
+getNopSledEmissionLayout(const PatchContext &Ctx, uint64_t InstOffset,
+                         uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+                         ReplacementPlacement Placement) {
+  NopSledEmissionLayout Layout{Replacement.size(), 0, 0};
+  if (Placement == ReplacementPlacement::Default ||
+      InstSize < 2 * MinInstSize || Replacement.size() < MinInstSize ||
+      Ctx.HasUnknownArbitraryIndirectTarget || !Ctx.DirectControlFlowTargets)
+    return Layout;
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  std::optional<uint64_t> InstEnd =
+      checkedAddUint64(InstOffset, InstSize, "NOP sled source-tail end");
+  if (!Function || !InstEnd || *InstEnd > Function->End)
+    return Layout;
+  for (uint64_t Offset = InstOffset + MinInstSize; Offset < *InstEnd;
+       Offset += MinInstSize)
+    if (Ctx.DirectControlFlowTargets->contains(Offset))
+      return Layout;
+
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), Ctx.LS,
+                         Decoded) ||
+      Decoded.empty())
+    return Layout;
+  if (Placement == ReplacementPlacement::Ds2SourceTail) {
+    auto Source =
+        llvm::lower_bound(Ctx.Decoded, InstOffset,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    uint64_t ExpectedSourceOffset = InstOffset;
+    while (ExpectedSourceOffset < *InstEnd) {
+      if (Source == Ctx.Decoded.end() ||
+          Source->Offset != ExpectedSourceOffset ||
+          !isDs2SourceMnemonic(Source->Mnemonic))
+        return Layout;
+      ExpectedSourceOffset += Source->Size;
+      ++Source;
+    }
+    if (ExpectedSourceOffset != *InstEnd)
+      return Layout;
+    for (uint64_t Offset = InstOffset + MinInstSize; Offset < *InstEnd;
+         Offset += MinInstSize)
+      if (Ctx.RelocationProtectedOffsets.contains(Offset))
+        return Layout;
+
+    const InternalDecodedInst &Wait = Decoded.back();
+    if (Wait.Offset + Wait.Size != Replacement.size() ||
+        Wait.Size != MinInstSize || Wait.Mnemonic != "s_wait_dscnt" ||
+        Wait.Inst.getNumOperands() != 1 || !Wait.Inst.getOperand(0).isImm() ||
+        Wait.Inst.getOperand(0).getImm() != 0 ||
+        Replacement.size() == MinInstSize)
+      return Layout;
+    Layout.SourceTailOffset = MinInstSize;
+    Layout.SourceTailSize = MinInstSize;
+    Layout.BodySize -= MinInstSize;
+    return Layout;
+  }
+
+  if (Placement != ReplacementPlacement::ProtectedCombinedDelay ||
+      Decoded.size() < 2)
+    return Layout;
+  const InternalDecodedInst &Delay = Decoded[Decoded.size() - 2];
+  const InternalDecodedInst &Protected = Decoded.back();
+  if (Delay.Mnemonic != "s_delay_alu" || Delay.Size != MinInstSize ||
+      getDelayProtectedSpan(Delay) != 1 ||
+      Delay.Offset + Delay.Size != Protected.Offset ||
+      Protected.Offset + Protected.Size != Replacement.size() ||
+      Protected.Mnemonic == "<unknown>" || Protected.Mnemonic == "<replaced>" ||
+      Protected.Mnemonic == "s_delay_alu" || Protected.Mnemonic == "s_clause" ||
+      Protected.Mnemonic == "s_set_vgpr_msb" ||
+      StringRef(Protected.Mnemonic).contains("_pc_") ||
+      (Ctx.LS.MIA &&
+       Ctx.LS.MIA->mayAffectControlFlow(Protected.Inst, *Ctx.LS.MRI)))
+    return Layout;
+  const uint64_t TailSize = Delay.Size + Protected.Size;
+  if (TailSize > std::numeric_limits<uint32_t>::max() ||
+      TailSize >= Replacement.size() || TailSize > InstSize - MinInstSize)
+    return Layout;
+  Layout.SourceTailSize = static_cast<uint32_t>(TailSize);
+  Layout.SourceTailOffset = InstSize - TailSize;
+  Layout.BodySize -= TailSize;
+  return Layout;
+}
+
+uint64_t getNopSledBytesNeeded(const PatchContext &Ctx, uint64_t InstOffset,
+                               uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+                               ReplacementPlacement Placement) {
+  return getNopSledEmissionLayout(Ctx, InstOffset, InstSize, Replacement,
+                                  Placement)
+      .sledBytes();
+}
 
 /// Emit the replacement code for the instruction at [\p InstOffset,
 /// \p InstOffset + \p InstSize) into a nearby NOP sled: writes \p Replacement
@@ -370,17 +913,46 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
 /// bytes. Advances \c Sled.WritePos by the amount consumed. Returns false if
 /// either branch encoding fails. Branches are encoded before any bytes are
 /// written so a failure leaves \c Ctx.Text and \c Sled.WritePos unchanged.
-[[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
-                                 uint64_t InstOffset, uint32_t InstSize,
-                                 ArrayRef<uint8_t> Replacement) {
+[[nodiscard]] static bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
+                                        uint64_t InstOffset, uint32_t InstSize,
+                                        ArrayRef<uint8_t> Replacement,
+                                        ReplacementPlacement Placement) {
+  const bool AllowGlobalBody = Placement != ReplacementPlacement::Default;
+  if (Sled.GatewayOnly) {
+    log() << "hotswap: error: emitToNopSled: gateway-only padding cannot "
+             "hold a replacement body\n";
+    return false;
+  }
+  if (!Sled.canHoldBodyFrom(InstOffset, AllowGlobalBody)) {
+    log() << "hotswap: error: emitToNopSled: source does not own replacement "
+             "body storage\n";
+    return false;
+  }
   const LLVMState &LS = Ctx.LS;
-  SmallVector<uint8_t> BrBack = LS.encodeSBranch(
-      Sled.WritePos + Replacement.size(), InstOffset + InstSize);
+  const NopSledEmissionLayout Layout = getNopSledEmissionLayout(
+      Ctx, InstOffset, InstSize, Replacement, Placement);
+  const uint64_t UsableEnd = Sled.End;
+  if (Sled.WritePos < Sled.Start || Sled.WritePos > UsableEnd ||
+      UsableEnd > Ctx.TextSize || Layout.BodySize > UsableEnd - Sled.WritePos ||
+      MinInstSize > UsableEnd - Sled.WritePos - Layout.BodySize) {
+    log() << "hotswap: error: emitToNopSled: replacement exceeds owned sled "
+             "capacity\n";
+    return false;
+  }
+  if (InstOffset > Ctx.TextSize || InstSize > Ctx.TextSize - InstOffset) {
+    log() << "hotswap: error: emitToNopSled: replacement site is outside "
+             ".text\n";
+    return false;
+  }
+  const uint64_t ResumeOffset = Layout.SourceTailSize != 0
+                                    ? InstOffset + Layout.SourceTailOffset
+                                    : InstOffset + InstSize;
+  SmallVector<uint8_t> BrBack =
+      LS.encodeSBranch(Sled.WritePos + Layout.BodySize, ResumeOffset);
   if (BrBack.empty()) {
     log() << "hotswap: error: emitToNopSled: encodeSBranch for branch-back "
-          << "at sled offset 0x"
-          << utohexstr(Sled.WritePos + Replacement.size()) << " -> 0x"
-          << utohexstr(InstOffset + InstSize) << " failed.\n";
+          << "at sled offset 0x" << utohexstr(Sled.WritePos + Layout.BodySize)
+          << " -> 0x" << utohexstr(ResumeOffset) << " failed.\n";
     return false;
   }
 
@@ -392,59 +964,668 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
     return false;
   }
 
-  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Replacement.size());
-  std::memcpy(Ctx.Text + Sled.WritePos + Replacement.size(), BrBack.data(),
+  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Layout.BodySize);
+  std::memcpy(Ctx.Text + Sled.WritePos + Layout.BodySize, BrBack.data(),
               BrBack.size());
   std::memcpy(Ctx.Text + InstOffset, BrFwd.data(), BrFwd.size());
 
-  // Pad the tail of the replaced instruction slot with cached s_nop bytes
-  // (pre-encoded in LLVMState at initLLVM() time).
+  // Pad every unused source dword with the cached s_nop encoding. The retained
+  // suffix, when present, is copied after this loop and therefore remains
+  // contiguous even when it sits at the end of a larger source window.
   for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
     std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
+  if (Layout.SourceTailSize != 0)
+    std::memcpy(Ctx.Text + InstOffset + Layout.SourceTailOffset,
+                Replacement.data() + Layout.BodySize, Layout.SourceTailSize);
 
-  Sled.WritePos += Replacement.size() + MinInstSize;
+  Sled.WritePos += Layout.sledBytes();
   // Count-only row: patch placed in-line via a nearby NOP sled, no trampoline.
   Ctx.Profile.count(HotswapMetric::JumpNopSled);
   return true;
 }
 
-std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
-                                                          uint64_t FromOffset,
-                                                          uint64_t TargetOffset,
-                                                          unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0) {
-    log() << "hotswap: error: set-PC long branch requires an aligned "
-             "SGPR pair, got s"
-          << SgprBase << "\n";
+bool isSBranchReachable(uint64_t From, uint64_t To);
+
+/// Place a validated, PC-independent DS2 replacement body through independently
+/// routed short-branch entry and return paths. Gateway reservations are exact
+/// instruction intervals, so non-overlapping roles may share certified padding
+/// and either route may use zero or several hops. A validated suffix remains in
+/// the source window. Every edge is encoded before bytes or cursors change.
+static bool emitDs2ThroughNopSledGateways(PatchContext &Ctx,
+                                          uint64_t InstOffset,
+                                          uint32_t InstSize,
+                                          ArrayRef<uint8_t> Replacement,
+                                          ReplacementPlacement Placement) {
+  if (Placement != ReplacementPlacement::Ds2SourceTail &&
+      Placement != ReplacementPlacement::ProtectedCombinedDelay)
+    return false;
+  const bool AllowDs2SourceTailWait =
+      Placement == ReplacementPlacement::Ds2SourceTail;
+  const NopSledEmissionLayout Layout = getNopSledEmissionLayout(
+      Ctx, InstOffset, InstSize, Replacement, Placement);
+  constexpr uint64_t DsInstSize = 2 * MinInstSize;
+  if (Layout.BodySize > std::numeric_limits<uint64_t>::max() - MinInstSize)
+    return false;
+  const uint64_t BodyBytes = Layout.sledBytes();
+  const uint64_t ResumeOffset = Layout.SourceTailSize != 0
+                                    ? InstOffset + Layout.SourceTailOffset
+                                    : InstOffset + InstSize;
+  if (!Ctx.LS.MIA || Ctx.RelocationProtectedOffsets.contains(InstOffset) ||
+      InstOffset > Ctx.TextSize || InstSize > Ctx.TextSize - InstOffset ||
+      InstSize < MinInstSize || InstSize % MinInstSize != 0 ||
+      Replacement.size() != Layout.BodySize + Layout.SourceTailSize)
+    return false;
+
+  const size_t ValidatedSize =
+      AllowDs2SourceTailWait ? Layout.BodySize : Replacement.size();
+  std::vector<InternalDecodedInst> Body;
+  if (!decodeTextSection(Replacement.data(), ValidatedSize, Ctx.LS, Body))
+    return false;
+
+  if (AllowDs2SourceTailWait) {
+    const uint64_t SourceCount = InstSize / DsInstSize;
+    if (InstSize % DsInstSize != 0 || SourceCount == 0 ||
+        Layout.SourceTailSize != MinInstSize ||
+        Layout.BodySize !=
+            SourceCount * 2 * DsInstSize + (SourceCount - 1) * MinInstSize)
+      return false;
+
+    size_t BodyIndex = 0;
+    uint64_t ExpectedOffset = 0;
+    for (uint64_t Source = 0; Source != SourceCount; ++Source) {
+      for (unsigned Half = 0; Half != 2; ++Half) {
+        if (BodyIndex >= Body.size())
+          return false;
+        const InternalDecodedInst &Single = Body[BodyIndex++];
+        if (Single.Offset != ExpectedOffset || Single.Size != DsInstSize ||
+            !StringRef(Single.Mnemonic).starts_with("ds_") ||
+            isDs2SourceMnemonic(Single.Mnemonic))
+          return false;
+        ExpectedOffset += DsInstSize;
+      }
+      if (Source + 1 == SourceCount)
+        continue;
+      if (BodyIndex >= Body.size())
+        return false;
+      const InternalDecodedInst &Wait = Body[BodyIndex++];
+      if (Wait.Offset != ExpectedOffset || Wait.Size != MinInstSize ||
+          Wait.Mnemonic != "s_wait_dscnt" || Wait.Inst.getNumOperands() != 1 ||
+          !Wait.Inst.getOperand(0).isImm() ||
+          Wait.Inst.getOperand(0).getImm() != 0)
+        return false;
+      ExpectedOffset += MinInstSize;
+    }
+    if (BodyIndex != Body.size() || ExpectedOffset != Layout.BodySize)
+      return false;
+  } else {
+    // The only whole-window caller is the validated combined-delay DS2
+    // demerge. Keep the relay defensive: its reconstructed body must remain
+    // straight-line and position-independent, and both standalone delays must
+    // protect only their immediately following instruction.
+    unsigned DelayCount = 0;
+    unsigned SplitDsCount = 0;
+    for (const InternalDecodedInst &DI : Body) {
+      if (DI.Mnemonic == "<unknown>" || DI.Mnemonic == "<replaced>" ||
+          DI.Mnemonic == "s_clause" || DI.Mnemonic == "s_set_vgpr_msb" ||
+          StringRef(DI.Mnemonic).contains("_pc_") ||
+          (Ctx.LS.MIA &&
+           Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)))
+        return false;
+      if (DI.Mnemonic == "s_delay_alu") {
+        if (getDelayProtectedSpan(DI) != 1)
+          return false;
+        ++DelayCount;
+      }
+      if (StringRef(DI.Mnemonic).starts_with("ds_") &&
+          !isDs2SourceMnemonic(DI.Mnemonic))
+        ++SplitDsCount;
+    }
+    if (DelayCount != 2 || SplitDsCount < 2)
+      return false;
+  }
+
+  struct ByteInterval {
+    uint64_t Begin = 0;
+    uint64_t End = 0;
+  };
+  struct GatewaySlot {
+    size_t Sled = 0;
+    uint64_t Offset = 0;
+  };
+  struct GatewayPlan {
+    size_t BodySled = 0;
+    uint64_t BodyOffset = 0;
+    SmallVector<GatewaySlot, 4> EntryPath;
+    SmallVector<GatewaySlot, 4> ReturnPath;
+    uint64_t CursorBytes = 0;
+    uint64_t MaxEdgeDistance = 0;
+  };
+
+  auto Distance = [](uint64_t A, uint64_t B) { return A > B ? A - B : B - A; };
+  auto Overlaps = [](ByteInterval A, ByteInterval B) {
+    return A.Begin < B.End && B.Begin < A.End;
+  };
+  auto IsReserved = [&](ByteInterval Candidate,
+                        ArrayRef<ByteInterval> Reserved) {
+    return llvm::any_of(Reserved, [&](ByteInterval Existing) {
+      return Overlaps(Candidate, Existing);
+    });
+  };
+  auto BetterPlan = [](const GatewayPlan &A, const GatewayPlan &B) {
+    const size_t AGateways = A.EntryPath.size() + A.ReturnPath.size();
+    const size_t BGateways = B.EntryPath.size() + B.ReturnPath.size();
+    if (AGateways != BGateways)
+      return AGateways < BGateways;
+    if (A.CursorBytes != B.CursorBytes)
+      return A.CursorBytes < B.CursorBytes;
+    if (A.MaxEdgeDistance != B.MaxEdgeDistance)
+      return A.MaxEdgeDistance < B.MaxEdgeDistance;
+    return A.BodyOffset < B.BodyOffset;
+  };
+
+  // A placement has two independent gateway roles, entry and return, so expose
+  // two leading branch slots from each certified sled. Moving the body past
+  // zero, one, or two prefix slots also permits those disjoint roles and the
+  // body to share one allocation cursor.
+  constexpr unsigned MaxGatewaySlotsPerSled = 2;
+  constexpr unsigned MaxNextAlternatives = 16;
+  constexpr unsigned MaxCompletedPaths = 64;
+  constexpr unsigned MaxSearchStates = 32768;
+  std::optional<GatewayPlan> Best;
+
+  auto MinimumGatewayCount = [&](uint64_t From, uint64_t To) {
+    if (isSBranchReachable(From, To))
+      return uint64_t{0};
+    const uint64_t DistanceBytes = Distance(From, To);
+    const uint64_t EdgeSpan =
+        To > From ? (static_cast<uint64_t>(BranchOffsetMax) + 1) * MinInstSize
+                  : static_cast<uint64_t>(-BranchOffsetMin) * MinInstSize -
+                        MinInstSize;
+    const uint64_t Edges =
+        DistanceBytes / EdgeSpan + (DistanceBytes % EdgeSpan != 0);
+    return Edges - 1;
+  };
+  auto BodyGatewayLowerBound = [&](size_t BI) {
+    const uint64_t BodyOffset = Ctx.NopSleds[BI].WritePos;
+    return MinimumGatewayCount(InstOffset, BodyOffset) +
+           MinimumGatewayCount(BodyOffset + Layout.BodySize, ResumeOffset);
+  };
+
+  SmallVector<size_t, 32> BodyOrder;
+  for (size_t BI = 0; BI != Ctx.NopSleds.size(); ++BI) {
+    const NopSled &BodySled = Ctx.NopSleds[BI];
+    if (BodySled.GatewayOnly ||
+        !BodySled.canHoldBodyFrom(InstOffset, /*AllowGlobalBody=*/true) ||
+        BodySled.End > Ctx.TextSize || BodySled.WritePos < BodySled.Start ||
+        BodySled.WritePos > BodySled.End ||
+        BodyBytes > BodySled.End - BodySled.WritePos)
+      continue;
+    BodyOrder.push_back(BI);
+  }
+  llvm::sort(BodyOrder, [&](size_t A, size_t B) {
+    const uint64_t ALowerBound = BodyGatewayLowerBound(A);
+    const uint64_t BLowerBound = BodyGatewayLowerBound(B);
+    if (ALowerBound != BLowerBound)
+      return ALowerBound < BLowerBound;
+    const uint64_t AOffset = Ctx.NopSleds[A].WritePos;
+    const uint64_t BOffset = Ctx.NopSleds[B].WritePos;
+    const uint64_t ADistance =
+        std::max(Distance(InstOffset, AOffset),
+                 Distance(AOffset + Layout.BodySize, ResumeOffset));
+    const uint64_t BDistance =
+        std::max(Distance(InstOffset, BOffset),
+                 Distance(BOffset + Layout.BodySize, ResumeOffset));
+    return std::tie(ADistance, AOffset, A) < std::tie(BDistance, BOffset, B);
+  });
+
+  bool FoundResourceOptimalPlan = false;
+  for (size_t BI : BodyOrder) {
+    const NopSled &BodySled = Ctx.NopSleds[BI];
+    for (unsigned PrefixSlots = 0; PrefixSlots <= MaxGatewaySlotsPerSled;
+         ++PrefixSlots) {
+      const uint64_t PrefixBytes = PrefixSlots * MinInstSize;
+      if (PrefixBytes > BodySled.End - BodySled.WritePos ||
+          BodyBytes > BodySled.End - BodySled.WritePos - PrefixBytes)
+        continue;
+      const uint64_t BodyOffset = BodySled.WritePos + PrefixBytes;
+      const uint64_t BodyEnd = BodyOffset + BodyBytes;
+      const uint64_t BodyReturn = BodyOffset + Layout.BodySize;
+      const ByteInterval BodyInterval{BodyOffset, BodyEnd};
+      const ByteInterval SourceInterval{InstOffset, InstOffset + InstSize};
+      if (Overlaps(BodyInterval, SourceInterval))
+        continue;
+
+      SmallVector<GatewaySlot, 32> Slots;
+      for (size_t SI = 0; SI != Ctx.NopSleds.size(); ++SI) {
+        const NopSled &Sled = Ctx.NopSleds[SI];
+        if (!Sled.canGatewayFrom(InstOffset) || Sled.End > Ctx.TextSize ||
+            Sled.WritePos < Sled.Start || Sled.WritePos > Sled.End)
+          continue;
+
+        auto AppendSlots = [&](uint64_t Start, unsigned Count) {
+          for (unsigned I = 0; I != Count; ++I) {
+            if (Start > Sled.End || MinInstSize > Sled.End - Start)
+              break;
+            ByteInterval SlotInterval{Start, Start + MinInstSize};
+            if (!Overlaps(SlotInterval, BodyInterval) &&
+                !Overlaps(SlotInterval, SourceInterval))
+              Slots.push_back({SI, Start});
+            Start += MinInstSize;
+          }
+        };
+
+        if (SI == BI) {
+          AppendSlots(Sled.WritePos, PrefixSlots);
+          AppendSlots(BodyEnd, MaxGatewaySlotsPerSled);
+        } else {
+          AppendSlots(Sled.WritePos, MaxGatewaySlotsPerSled);
+        }
+      }
+      llvm::sort(Slots, [](const GatewaySlot &A, const GatewaySlot &B) {
+        return std::tie(A.Offset, A.Sled) < std::tie(B.Offset, B.Sled);
+      });
+
+      SmallVector<ByteInterval, 4> PermanentReservations{BodyInterval,
+                                                         SourceInterval};
+      // Enumerate a bounded set of progressively closer routes. Backtracking
+      // over several next-hop choices avoids the old nearest-island greediness;
+      // running the joint search in both path orders avoids privileging entry
+      // over return when the two routes contend for the same interval.
+      auto SearchPath = [&](uint64_t Start, uint64_t Target,
+                            ArrayRef<ByteInterval> Reservations,
+                            unsigned &StatesRemaining, auto &&OnComplete) {
+        SmallVector<size_t, 8> Path;
+        unsigned CompletedPaths = 0;
+        auto Visit = [&](auto &&Self, uint64_t Current) -> bool {
+          if (StatesRemaining == 0 || CompletedPaths >= MaxCompletedPaths)
+            return false;
+          --StatesRemaining;
+
+          if (isSBranchReachable(Current, Target)) {
+            ++CompletedPaths;
+            if (OnComplete(ArrayRef<size_t>(Path)))
+              return true;
+          }
+
+          SmallVector<size_t, MaxNextAlternatives> Next;
+          const uint64_t CurrentDistance = Distance(Current, Target);
+          for (size_t I = 0; I != Slots.size(); ++I) {
+            const GatewaySlot &Slot = Slots[I];
+            const ByteInterval SlotInterval{Slot.Offset,
+                                            Slot.Offset + MinInstSize};
+            if (Distance(Slot.Offset, Target) >= CurrentDistance ||
+                !isSBranchReachable(Current, Slot.Offset) ||
+                IsReserved(SlotInterval, Reservations))
+              continue;
+            bool ConflictsWithPath = llvm::any_of(Path, [&](size_t PI) {
+              const GatewaySlot &Used = Slots[PI];
+              return Overlaps(SlotInterval,
+                              {Used.Offset, Used.Offset + MinInstSize});
+            });
+            if (!ConflictsWithPath)
+              Next.push_back(I);
+          }
+          llvm::sort(Next, [&](size_t A, size_t B) {
+            const uint64_t ADistance = Distance(Slots[A].Offset, Target);
+            const uint64_t BDistance = Distance(Slots[B].Offset, Target);
+            return std::tie(ADistance, Slots[A].Offset, Slots[A].Sled) <
+                   std::tie(BDistance, Slots[B].Offset, Slots[B].Sled);
+          });
+          if (Next.size() > MaxNextAlternatives)
+            Next.resize(MaxNextAlternatives);
+          for (size_t I : Next) {
+            Path.push_back(I);
+            if (Self(Self, Slots[I].Offset))
+              return true;
+            Path.pop_back();
+          }
+          return false;
+        };
+        return Visit(Visit, Start);
+      };
+
+      SmallVector<size_t, 8> EntryIndices;
+      SmallVector<size_t, 8> ReturnIndices;
+      auto FindJointPaths = [&](bool EntryFirst) {
+        unsigned StatesRemaining = MaxSearchStates;
+        if (EntryFirst) {
+          return SearchPath(
+              InstOffset, BodyOffset, PermanentReservations, StatesRemaining,
+              [&](ArrayRef<size_t> Entry) {
+                SmallVector<ByteInterval, 12> Reserved(
+                    PermanentReservations.begin(), PermanentReservations.end());
+                for (size_t I : Entry)
+                  Reserved.push_back(
+                      {Slots[I].Offset, Slots[I].Offset + MinInstSize});
+                return SearchPath(
+                    BodyReturn, ResumeOffset, Reserved, StatesRemaining,
+                    [&](ArrayRef<size_t> Return) {
+                      EntryIndices.assign(Entry.begin(), Entry.end());
+                      ReturnIndices.assign(Return.begin(), Return.end());
+                      return true;
+                    });
+              });
+        }
+        return SearchPath(
+            BodyReturn, ResumeOffset, PermanentReservations, StatesRemaining,
+            [&](ArrayRef<size_t> Return) {
+              SmallVector<ByteInterval, 12> Reserved(
+                  PermanentReservations.begin(), PermanentReservations.end());
+              for (size_t I : Return)
+                Reserved.push_back(
+                    {Slots[I].Offset, Slots[I].Offset + MinInstSize});
+              return SearchPath(
+                  InstOffset, BodyOffset, Reserved, StatesRemaining,
+                  [&](ArrayRef<size_t> Entry) {
+                    EntryIndices.assign(Entry.begin(), Entry.end());
+                    ReturnIndices.assign(Return.begin(), Return.end());
+                    return true;
+                  });
+            });
+      };
+      if (!FindJointPaths(/*EntryFirst=*/true) &&
+          !FindJointPaths(/*EntryFirst=*/false))
+        continue;
+
+      GatewayPlan Plan;
+      Plan.BodySled = BI;
+      Plan.BodyOffset = BodyOffset;
+      for (size_t I : EntryIndices)
+        Plan.EntryPath.push_back(Slots[I]);
+      for (size_t I : ReturnIndices)
+        Plan.ReturnPath.push_back(Slots[I]);
+
+      SmallVector<uint64_t, 32> CommittedPositions(Ctx.NopSleds.size());
+      for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+        CommittedPositions[I] = Ctx.NopSleds[I].WritePos;
+      CommittedPositions[BI] = BodyEnd;
+      for (const GatewaySlot &Slot : Plan.EntryPath)
+        CommittedPositions[Slot.Sled] =
+            std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+      for (const GatewaySlot &Slot : Plan.ReturnPath)
+        CommittedPositions[Slot.Sled] =
+            std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+      for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+        Plan.CursorBytes += CommittedPositions[I] - Ctx.NopSleds[I].WritePos;
+
+      auto RecordEdgeDistance = [&](uint64_t From, uint64_t To) {
+        Plan.MaxEdgeDistance =
+            std::max(Plan.MaxEdgeDistance, Distance(From, To));
+      };
+      uint64_t From = InstOffset;
+      for (const GatewaySlot &Slot : Plan.EntryPath) {
+        RecordEdgeDistance(From, Slot.Offset);
+        From = Slot.Offset;
+      }
+      RecordEdgeDistance(From, BodyOffset);
+      From = BodyReturn;
+      for (const GatewaySlot &Slot : Plan.ReturnPath) {
+        RecordEdgeDistance(From, Slot.Offset);
+        From = Slot.Offset;
+      }
+      RecordEdgeDistance(From, ResumeOffset);
+
+      const size_t GatewayCount =
+          Plan.EntryPath.size() + Plan.ReturnPath.size();
+      const uint64_t GatewayLowerBound =
+          MinimumGatewayCount(InstOffset, BodyOffset) +
+          MinimumGatewayCount(BodyReturn, ResumeOffset);
+      const uint64_t CursorLowerBound =
+          BodyBytes + GatewayCount * static_cast<uint64_t>(MinInstSize);
+      const bool PlanIsResourceOptimal = GatewayCount == GatewayLowerBound &&
+                                         Plan.CursorBytes == CursorLowerBound;
+      if (!Best || BetterPlan(Plan, *Best))
+        Best = std::move(Plan);
+      // Every body byte and gateway instruction occupies a disjoint interval,
+      // so this is an absolute lower bound on aggregate cursor advancement.
+      // Do not stop merely because the route uses the fewest gateways: a plan
+      // with the same gateway count can still strand later rewrites by skipping
+      // otherwise reusable bytes at one or more allocation cursors.
+      if (PlanIsResourceOptimal) {
+        FoundResourceOptimalPlan = true;
+        break;
+      }
+    }
+    // If no cursor-perfect route exists for this body sled, compare all of its
+    // bounded prefix layouts but do not scan every sled with the same gateway
+    // lower bound. That preserves large-object scaling while avoiding the
+    // first-prefix cursor bias; later required patches still fail closed if the
+    // selected valid route leaves insufficient storage.
+    if (!FoundResourceOptimalPlan && Best) {
+      const size_t BestGatewayCount =
+          Best->EntryPath.size() + Best->ReturnPath.size();
+      FoundResourceOptimalPlan = BestGatewayCount == BodyGatewayLowerBound(BI);
+    }
+    if (FoundResourceOptimalPlan)
+      break;
+  }
+  if (!Best)
+    return false;
+
+  struct EncodedBranch {
+    uint64_t Offset = 0;
+    SmallVector<uint8_t, MinInstSize> Bytes;
+  };
+  SmallVector<EncodedBranch, 12> Branches;
+  auto EncodeEdge = [&](uint64_t From, uint64_t To) {
+    SmallVector<uint8_t> Bytes = Ctx.LS.encodeSBranch(From, To);
+    if (Bytes.size() != MinInstSize)
+      return false;
+    Branches.push_back({From, {Bytes.begin(), Bytes.end()}});
+    return true;
+  };
+
+  uint64_t From = InstOffset;
+  for (const GatewaySlot &Slot : Best->EntryPath) {
+    if (!EncodeEdge(From, Slot.Offset))
+      return false;
+    From = Slot.Offset;
+  }
+  if (!EncodeEdge(From, Best->BodyOffset))
+    return false;
+  From = Best->BodyOffset + Layout.BodySize;
+  for (const GatewaySlot &Slot : Best->ReturnPath) {
+    if (!EncodeEdge(From, Slot.Offset))
+      return false;
+    From = Slot.Offset;
+  }
+  if (!EncodeEdge(From, ResumeOffset))
+    return false;
+
+  // Branch encoding and interval planning are complete. From this point no
+  // operation can fail, so bytes and then all participating cursors commit as
+  // one placement transaction.
+  std::memcpy(Ctx.Text + Best->BodyOffset, Replacement.data(), Layout.BodySize);
+  for (const EncodedBranch &Branch :
+       ArrayRef<EncodedBranch>(Branches).drop_front())
+    std::memcpy(Ctx.Text + Branch.Offset, Branch.Bytes.data(), MinInstSize);
+  for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
+    std::memcpy(Ctx.Text + InstOffset + I, Ctx.LS.SNopBytes.data(),
+                MinInstSize);
+  if (Layout.SourceTailSize != 0)
+    std::memcpy(Ctx.Text + InstOffset + Layout.SourceTailOffset,
+                Replacement.data() + Layout.BodySize, Layout.SourceTailSize);
+  // The source edge is the first encoded branch. Write it after source padding
+  // and suffix retention so no source-window copy can overwrite it.
+  std::memcpy(Ctx.Text + InstOffset, Branches.front().Bytes.data(),
+              MinInstSize);
+
+  SmallVector<uint64_t, 32> CommittedPositions(Ctx.NopSleds.size());
+  for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+    CommittedPositions[I] = Ctx.NopSleds[I].WritePos;
+  CommittedPositions[Best->BodySled] = Best->BodyOffset + BodyBytes;
+  for (const GatewaySlot &Slot : Best->EntryPath)
+    CommittedPositions[Slot.Sled] =
+        std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+  for (const GatewaySlot &Slot : Best->ReturnPath)
+    CommittedPositions[Slot.Sled] =
+        std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+  for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+    Ctx.NopSleds[I].WritePos = CommittedPositions[I];
+
+  log() << "hotswap: DS2 gateway plan: used " << Best->EntryPath.size()
+        << " entry gateway(s), " << Best->ReturnPath.size()
+        << " return gateway(s), and body sled at 0x"
+        << utohexstr(Best->BodyOffset) << " for site 0x"
+        << utohexstr(InstOffset) << "\n";
+  Ctx.Profile.count(HotswapMetric::JumpNopSled);
+  return true;
+}
+
+static std::optional<std::string>
+getLongBranchPairName(unsigned SgprBase, StringRef Context) {
+  if ((SgprBase & 1u) != 0 ||
+      SgprBase > std::numeric_limits<unsigned>::max() - 2) {
+    log() << "hotswap: error: " << Context
+          << " requires an aligned SGPR pair, got s" << SgprBase << "\n";
     return std::nullopt;
   }
 
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
-  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
-  if (GetPc.empty())
-    return std::nullopt;
+  return SgprBase == Gfx1250MaxSgprs
+             ? "vcc"
+             : "s[" + std::to_string(SgprBase) + ":" +
+                   std::to_string(SgprBase + 1) + "]";
+}
+
+static SmallVector<uint8_t>
+encodeLinkRelativeSetPCTail(const LLVMState &LS, uint64_t LinkOffset,
+                            uint64_t TargetOffset, unsigned SgprBase) {
+  std::optional<std::string> Pair =
+      getLongBranchPairName(SgprBase, "set-PC long branch tail");
+  if (!Pair)
+    return {};
+
+  const uint64_t Delta = TargetOffset - LinkOffset;
+  std::string Asm = "s_add_nc_u64 " + *Pair + ", " + *Pair + ", 0x" +
+                    utohexstr(Delta) + "\n" + "s_set_pc_i64 " + *Pair +
+                    "\n";
+  SmallVector<uint8_t> Tail = assembleInstructions(Asm, LS);
+  if (Tail.empty() ||
+      Tail.size() > SetPcReturnReserveBytes - MinInstSize) {
+    log() << "hotswap: error: failed to assemble SCC-neutral set-PC tail via "
+          << *Pair << "\n";
+    return {};
+  }
+  return Tail;
+}
+
+SmallVector<uint8_t> encodeSetPCLongBranch(const LLVMState &LS,
+                                           uint64_t FromOffset,
+                                           uint64_t TargetOffset,
+                                           unsigned SgprBase) {
+  std::optional<std::string> Pair =
+      getLongBranchPairName(SgprBase, "set-PC long branch");
+  if (!Pair)
+    return {};
+
+  SmallVector<uint8_t> GetPc =
+      assembleSingleInst("s_get_pc_i64 " + *Pair, LS);
+  if (GetPc.size() != MinInstSize)
+    return {};
+
   std::optional<uint64_t> PcBase =
       checkedAddUint64(FromOffset, GetPc.size(), "set-PC long branch PC base");
   if (!PcBase)
-    return std::nullopt;
-  uint64_t Delta = TargetOffset - *PcBase;
-  // AMDGPU/SOPInstructions.td defines S_ADD_U64 as an SOP2_64 outside the
-  // Defs = [SCC] scope and maps its gfx12 encoding to s_add_nc_u64. It can
-  // therefore add the complete PC displacement without saving or clobbering
-  // SCC.
-  SmallVector<std::string, 3> AsmLines;
-  AsmLines.push_back("s_get_pc_i64 " + Pair);
-  AsmLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
-                     utohexstr(Delta));
-  AsmLines.push_back("s_set_pc_i64 " + Pair);
-  SmallVector<uint8_t> Bytes = assembleInstructions(joinAsmLines(AsmLines), LS);
-  if (Bytes.empty() || Bytes.size() > SetPcReturnReserveBytes) {
-    log() << "hotswap: error: failed to assemble SCC-neutral set-PC branch via "
-          << Pair << "\n";
-    return std::nullopt;
+    return {};
+  SmallVector<uint8_t> Tail =
+      encodeLinkRelativeSetPCTail(LS, *PcBase, TargetOffset, SgprBase);
+  if (Tail.empty())
+    return {};
+  SmallVector<uint8_t> Bytes = std::move(GetPc);
+  llvm::append_range(Bytes, Tail);
+  return Bytes;
+}
+
+SmallVector<uint8_t> encodeSCallI64(const LLVMState &LS, uint64_t FromOffset,
+                                    uint64_t TargetOffset,
+                                    unsigned SgprBase) {
+  std::optional<std::string> Pair =
+      getLongBranchPairName(SgprBase, "s_call_i64");
+  if (!Pair)
+    return {};
+
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, MinInstSize, "s_call_i64 PC base");
+  if (!PcBase)
+    return {};
+
+  const bool Forward = TargetOffset >= *PcBase;
+  const uint64_t ByteDistance =
+      Forward ? TargetOffset - *PcBase : *PcBase - TargetOffset;
+  if (ByteDistance % MinInstSize != 0) {
+    log() << "hotswap: error: s_call_i64 has unaligned byte distance "
+          << ByteDistance << " from 0x" << utohexstr(FromOffset) << " to 0x"
+          << utohexstr(TargetOffset) << "\n";
+    return {};
+  }
+
+  const uint64_t DwordDistance = ByteDistance / MinInstSize;
+  const uint64_t MaxDwordDistance =
+      Forward ? static_cast<uint64_t>(BranchOffsetMax)
+              : static_cast<uint64_t>(-static_cast<int64_t>(BranchOffsetMin));
+  if (DwordDistance > MaxDwordDistance) {
+    log() << "hotswap: error: s_call_i64 target is out of simm16 range from 0x"
+          << utohexstr(FromOffset) << " to 0x" << utohexstr(TargetOffset)
+          << "\n";
+    return {};
+  }
+  const int64_t DwordOffset =
+      Forward ? static_cast<int64_t>(DwordDistance)
+              : -static_cast<int64_t>(DwordDistance);
+
+  // RDNA4 S_CALL_B64 writes the address after the call to SDST before making
+  // the PC-relative transfer. It takes no SCC operand, so an add/set-PC tail
+  // encoded from the same next-instruction address preserves SCC exactly.
+  SmallVector<uint8_t> Bytes = assembleSingleInst(
+      "s_call_i64 " + *Pair + ", " + std::to_string(DwordOffset), LS);
+  if (Bytes.size() != MinInstSize) {
+    log() << "hotswap: error: failed to assemble four-byte s_call_i64 via "
+          << *Pair << "\n";
+    return {};
   }
   return Bytes;
+}
+
+static std::optional<SmallVector<uint8_t>>
+extractSetPCCallTail(ArrayRef<uint8_t> Direct, const LLVMState &LS) {
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Direct.data(), Direct.size(), LS, Decoded) ||
+      Decoded.size() != 3 || Decoded[0].Offset != 0 ||
+      Decoded[0].Size != MinInstSize ||
+      Decoded[0].Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      Decoded[1].Offset != MinInstSize ||
+      Decoded[1].Inst.getOpcode() != LS.SAddNcU64Opcode ||
+      Decoded[2].Offset + Decoded[2].Size != Direct.size() ||
+      Decoded[2].Size != MinInstSize ||
+      Decoded[2].Inst.getOpcode() != LS.SSetPcI64Opcode ||
+      Decoded[0].Inst.getNumOperands() != 1 ||
+      Decoded[1].Inst.getNumOperands() != 3 ||
+      Decoded[2].Inst.getNumOperands() != 1 ||
+      !Decoded[0].Inst.getOperand(0).isReg() ||
+      !Decoded[1].Inst.getOperand(0).isReg() ||
+      !Decoded[1].Inst.getOperand(1).isReg() ||
+      !Decoded[2].Inst.getOperand(0).isReg()) {
+    log() << "hotswap: error: set-PC call tail has unexpected instruction "
+             "structure\n";
+    return std::nullopt;
+  }
+
+  const unsigned Pair = Decoded[0].Inst.getOperand(0).getReg();
+  if (!Pair || Decoded[1].Inst.getOperand(0).getReg() != Pair ||
+      Decoded[1].Inst.getOperand(1).getReg() != Pair ||
+      Decoded[2].Inst.getOperand(0).getReg() != Pair) {
+    log() << "hotswap: error: set-PC call tail does not preserve one SGPR pair\n";
+    return std::nullopt;
+  }
+
+  SmallVector<uint8_t> Tail;
+  llvm::append_range(Tail, Direct.drop_front(MinInstSize));
+  if (Tail.size() != 12 && Tail.size() != 16) {
+    log() << "hotswap: error: set-PC call tail has unsupported size "
+          << Tail.size() << "\n";
+    return std::nullopt;
+  }
+  return Tail;
 }
 
 Expected<std::optional<EncodedSetPcGateway>>
@@ -455,9 +1636,9 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
   SmallVector<uint8_t> BestBytes;
   uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
   for (NopSled &Sled : Gateways) {
-    if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
+    if (!Sled.canGatewayFrom(FromOffset))
       continue;
-    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    uint64_t UsableEnd = Sled.End;
     if (Sled.WritePos > UsableEnd)
       continue;
     uint64_t Distance = Sled.WritePos > FromOffset ? Sled.WritePos - FromOffset
@@ -465,16 +1646,16 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
     if (Distance >= MaxSledDistance || Distance >= BestDistance ||
         LS.encodeSBranch(FromOffset, Sled.WritePos).empty())
       continue;
-    std::optional<SmallVector<uint8_t>> Bytes =
+    SmallVector<uint8_t> Bytes =
         encodeSetPCLongBranch(LS, Sled.WritePos, TargetOffset, SgprBase);
-    if (!Bytes)
+    if (Bytes.empty())
       return createStringError(
           Twine("failed to encode set-PC gateway at candidate offset 0x") +
           utohexstr(Sled.WritePos));
-    if (Bytes->size() > UsableEnd - Sled.WritePos)
+    if (Bytes.size() > UsableEnd - Sled.WritePos)
       continue;
     Best = &Sled;
-    BestBytes = std::move(*Bytes);
+    BestBytes = std::move(Bytes);
     BestDistance = Distance;
   }
   if (!Best)
@@ -483,10 +1664,41 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
       EncodedSetPcGateway{Best, std::move(BestBytes)});
 }
 
+Expected<uint64_t>
+countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
+                                uint64_t FromOffset, uint64_t TargetOffset,
+                                unsigned SgprBase, uint64_t MaxSlots) {
+  uint64_t Slots = 0;
+  for (const NopSled &Sled : Gateways) {
+    if (!Sled.canGatewayFrom(FromOffset))
+      continue;
+    uint64_t Candidate = Sled.WritePos;
+    while (Candidate <= Sled.End && Slots < MaxSlots) {
+      uint64_t Distance = Candidate > FromOffset ? Candidate - FromOffset
+                                                 : FromOffset - Candidate;
+      if (Distance >= MaxSledDistance ||
+          LS.encodeSBranch(FromOffset, Candidate).empty())
+        break;
+      SmallVector<uint8_t> Bytes =
+          encodeSetPCLongBranch(LS, Candidate, TargetOffset, SgprBase);
+      if (Bytes.empty())
+        return createStringError(
+            Twine("failed to encode set-PC gateway while counting candidate "
+                  "offset 0x") +
+            utohexstr(Candidate));
+      if (Bytes.size() > Sled.End - Candidate)
+        break;
+      ++Slots;
+      Candidate += Bytes.size();
+    }
+    if (Slots == MaxSlots)
+      break;
+  }
+  return Slots;
+}
+
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
                                                  MCRegister Reg) {
-  // TODO(https://github.com/ROCm/llvm-project/issues/3350): Replace this
-  // register-name fallback with a public AMDGPU MC hardware-index helper.
   if (!Reg.isValid())
     return std::nullopt;
   StringRef Name(MRI.getName(Reg));
@@ -542,12 +1754,1471 @@ static bool instructionUsesVcc(const LLVMState &LS,
   return false;
 }
 
+static uint8_t registerPairMask(const MCRegisterInfo &MRI,
+                                ArrayRef<MCRegister> PairRegs, MCRegister Reg) {
+  uint8_t Mask = 0;
+  for (unsigned Half = 0; Half < PairRegs.size(); ++Half)
+    if (Reg.isValid() && MRI.regsOverlap(Reg.id(), PairRegs[Half].id()))
+      Mask |= uint8_t{1} << Half;
+  return Mask;
+}
+
+struct RegisterPairAccess {
+  uint8_t Uses = 0;
+  uint8_t Defs = 0;
+};
+
+/// Classify one decoded instruction's semantic accesses to a physical register
+/// pair. Decoded MC operands do not always retain tied read-modify-write
+/// inputs, so recover those uses from the descriptor and fail closed when an
+/// omitted register operand cannot be accounted for.
+static std::optional<RegisterPairAccess>
+getRegisterPairAccess(const LLVMState &LS, const InternalDecodedInst &DI,
+                      ArrayRef<MCRegister> PairRegs,
+                      bool PairIsAbiVcc = false) {
+  if (!LS.MCII || !LS.MRI || PairRegs.size() != 2 || !PairRegs[0].isValid() ||
+      !PairRegs[1].isValid() || DI.Mnemonic == "<unknown>")
+    return std::nullopt;
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  auto PairMask = [&](MCRegister Reg, bool IsImplicit = false) {
+    // GFX1250 is wave32. MC descriptors spell the implicit predicate as the
+    // composite VCC register even though only VCC_LO participates.
+    if (PairIsAbiVcc && IsImplicit && Reg.isValid() &&
+        StringRef(LS.MRI->getName(Reg)) == "VCC")
+      return uint8_t{1};
+    if (PairIsAbiVcc && Reg.isValid() &&
+        StringRef(LS.MRI->getName(Reg)).starts_with("SRC_VCCZ"))
+      return uint8_t{1};
+    return registerPairMask(*LS.MRI, PairRegs, Reg);
+  };
+
+  RegisterPairAccess Access;
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned OpIdx = 0; OpIdx < DI.Inst.getNumOperands(); ++OpIdx) {
+    const MCOperand &Op = DI.Inst.getOperand(OpIdx);
+    if (!Op.isReg() || !Op.getReg())
+      continue;
+    uint8_t Mask = PairMask(MCRegister(Op.getReg()));
+    if (OpIdx < NumDefs)
+      Access.Defs |= Mask;
+    else
+      Access.Uses |= Mask;
+  }
+
+  for (unsigned OpIdx = NumDefs; OpIdx < Desc.getNumOperands(); ++OpIdx) {
+    int TiedTo = Desc.getOperandConstraint(OpIdx, MCOI::TIED_TO);
+    if (TiedTo < 0)
+      continue;
+    if (static_cast<unsigned>(TiedTo) >= NumDefs ||
+        static_cast<unsigned>(TiedTo) >= DI.Inst.getNumOperands())
+      return std::nullopt;
+    const MCOperand &Def = DI.Inst.getOperand(TiedTo);
+    if (!Def.isReg() || !Def.getReg())
+      return std::nullopt;
+    Access.Uses |= PairMask(MCRegister(Def.getReg()));
+  }
+
+  // Some AMDGPU disassembly forms omit a tied input even when the MC
+  // descriptor still declares it. Match such operands to an explicit
+  // definition by register class; an unaccounted operand is not safe to infer.
+  for (unsigned OpIdx = DI.Inst.getNumOperands(); OpIdx < Desc.getNumOperands();
+       ++OpIdx) {
+    const MCOperandInfo &Missing = Desc.operands()[OpIdx];
+    if (Missing.RegClass < 0)
+      continue;
+    bool MatchedDefinition = false;
+    for (unsigned DefIdx = 0; DefIdx < NumDefs; ++DefIdx) {
+      if (Desc.operands()[DefIdx].RegClass != Missing.RegClass)
+        continue;
+      const MCOperand &Def = DI.Inst.getOperand(DefIdx);
+      if (!Def.isReg() || !Def.getReg())
+        return std::nullopt;
+      Access.Uses |= PairMask(MCRegister(Def.getReg()));
+      MatchedDefinition = true;
+    }
+    if (!MatchedDefinition)
+      return std::nullopt;
+  }
+
+  for (MCPhysReg Reg : Desc.implicit_uses())
+    Access.Uses |= PairMask(MCRegister(Reg), /*IsImplicit=*/true);
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    Access.Defs |= PairMask(MCRegister(Reg), /*IsImplicit=*/true);
+  return Access;
+}
+
+std::optional<uint64_t>
+evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                const LLVMState &LS);
+
+static bool isStandardLinkCall(const InternalDecodedInst &DI,
+                               const LLVMState &LS);
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS);
+
+std::optional<int64_t> getAbsoluteOperandValue(const MCOperand &Operand,
+                                               const InternalDecodedInst &DI,
+                                               ArrayRef<uint8_t> Text) {
+  if (Operand.isImm())
+    return Operand.getImm();
+  if (!Operand.isExpr() ||
+      (DI.Size != 2 * MinInstSize && DI.Size != 3 * MinInstSize))
+    return std::nullopt;
+
+  std::optional<uint64_t> End =
+      checkedAddUint64(DI.Offset, DI.Size, "literal instruction end");
+  if (!End || *End > Text.size())
+    return std::nullopt;
+  // AMDGPU's binary decoder represents trailing literal dwords as an MCExpr
+  // whose storage is not guaranteed to outlive getInstruction(). Read the
+  // encoded literal32 or literal64 instead of dereferencing that transient
+  // expression. The callers only accept scalar add opcodes whose base
+  // encoding is one dword.
+  if (DI.Size == 2 * MinInstSize)
+    return static_cast<int64_t>(
+        support::endian::read32le(Text.data() + *End - MinInstSize));
+  return static_cast<int64_t>(
+      support::endian::read64le(Text.data() + *End - 2 * MinInstSize));
+}
+
+static std::optional<uint64_t> evaluateMaterializedSetPcTarget(
+    ArrayRef<InternalDecodedInst> Function, unsigned SetPcIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, bool AllowOutsideText = false) {
+  if (SetPcIndex < 3 || !LS.MRI)
+    return std::nullopt;
+  const InternalDecodedInst &GetPc = Function[SetPcIndex - 3];
+  const InternalDecodedInst &AddLo = Function[SetPcIndex - 2];
+  const InternalDecodedInst &AddHi = Function[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Function[SetPcIndex];
+  if (GetPc.Offset + GetPc.Size != AddLo.Offset ||
+      AddLo.Offset + AddLo.Size != AddHi.Offset ||
+      AddHi.Offset + AddHi.Size != SetPc.Offset ||
+      GetPc.Mnemonic != "s_get_pc_i64" || AddLo.Mnemonic != "s_add_co_u32" ||
+      AddHi.Mnemonic != "s_add_co_ci_u32" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || SetPc.Inst.getNumOperands() != 1 ||
+      !GetPc.Inst.getOperand(0).isReg() || !SetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != SetPc.Inst.getOperand(0).getReg() ||
+      AddLo.Inst.getNumOperands() != 3 || AddHi.Inst.getNumOperands() != 3 ||
+      !AddLo.Inst.getOperand(0).isReg() || !AddLo.Inst.getOperand(1).isReg() ||
+      !AddHi.Inst.getOperand(0).isReg() || !AddHi.Inst.getOperand(1).isReg() ||
+      AddLo.Inst.getOperand(0).getReg() != AddLo.Inst.getOperand(1).getReg() ||
+      AddHi.Inst.getOperand(0).getReg() != AddHi.Inst.getOperand(1).getReg())
+    return std::nullopt;
+
+  std::optional<int64_t> LoValue =
+      getAbsoluteOperandValue(AddLo.Inst.getOperand(2), AddLo, Text);
+  std::optional<int64_t> HiValue =
+      getAbsoluteOperandValue(AddHi.Inst.getOperand(2), AddHi, Text);
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      SetPc.Offset, SetPc.Size, "materialized set-PC sequence end");
+  if (!LoValue || !HiValue || !SequenceEnd)
+    return std::nullopt;
+  for (uint64_t DirectTarget : DirectTargets)
+    if (DirectTarget > GetPc.Offset && DirectTarget < *SequenceEnd)
+      return std::nullopt;
+
+  MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
+  std::optional<unsigned> Lo =
+      numberedSgprIndex(*LS.MRI, MCRegister(AddLo.Inst.getOperand(0).getReg()));
+  std::optional<unsigned> Hi =
+      numberedSgprIndex(*LS.MRI, MCRegister(AddHi.Inst.getOperand(0).getReg()));
+  if (!Lo || !Hi || *Hi != *Lo + 1 ||
+      !LS.MRI->regsOverlap(Pair.id(), AddLo.Inst.getOperand(0).getReg()) ||
+      !LS.MRI->regsOverlap(Pair.id(), AddHi.Inst.getOperand(0).getReg()))
+    return std::nullopt;
+
+  uint64_t Delta =
+      static_cast<uint32_t>(*LoValue) |
+      (static_cast<uint64_t>(static_cast<uint32_t>(*HiValue)) << 32);
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(GetPc.Offset, GetPc.Size, "materialized set-PC PC base");
+  if (!PcBase)
+    return std::nullopt;
+  uint64_t Target = *PcBase + Delta;
+
+  if (Target >= Text.size())
+    return AllowOutsideText ? std::optional<uint64_t>(Target) : std::nullopt;
+
+  // Only model a transfer to a decoded instruction boundary owned by this
+  // function. The unsigned addition above intentionally has ISA wraparound
+  // semantics; the range check rejects a wrapped target outside the function.
+  if (Function.empty() || Target < Function.front().Offset)
+    return std::nullopt;
+  std::optional<uint64_t> FunctionEnd =
+      checkedAddUint64(Function.back().Offset, Function.back().Size,
+                       "materialized set-PC function end");
+  if (!FunctionEnd || Target >= *FunctionEnd)
+    return std::nullopt;
+  ArrayRef<InternalDecodedInst>::iterator TargetIt = llvm::lower_bound(
+      Function, Target, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  if (TargetIt == Function.end() || TargetIt->Offset != Target)
+    return std::nullopt;
+  return Target;
+}
+
+static bool isDecodedInstructionBoundary(ArrayRef<InternalDecodedInst> Decoded,
+                                         uint64_t Target) {
+  ArrayRef<InternalDecodedInst>::iterator It = llvm::lower_bound(
+      Decoded, Target, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  return It != Decoded.end() && It->Offset == Target;
+}
+
+struct SgprPairHalves {
+  std::array<MCRegister, 2> Regs;
+  bool IsVcc = false;
+};
+
+static std::optional<SgprPairHalves> getSgprPairHalves(const LLVMState &LS,
+                                                       MCRegister Pair) {
+  if (!LS.MRI || !Pair.isValid())
+    return std::nullopt;
+
+  if (StringRef(LS.MRI->getName(Pair)) == "VCC") {
+    std::array<MCRegister, 2> Regs;
+    for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+      StringRef Name(LS.MRI->getName(Reg));
+      if (Name == "VCC_LO")
+        Regs[0] = MCRegister(Reg);
+      else if (Name == "VCC_HI")
+        Regs[1] = MCRegister(Reg);
+    }
+    if (!Regs[0].isValid() || !Regs[1].isValid())
+      return std::nullopt;
+    return SgprPairHalves{Regs, /*IsVcc=*/true};
+  }
+
+  SmallVector<std::pair<unsigned, MCRegister>, 2> Halves;
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    MCRegister Candidate(Reg);
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, Candidate);
+    if (Index && LS.MRI->regsOverlap(Pair.id(), Candidate.id()))
+      Halves.emplace_back(*Index, Candidate);
+  }
+  llvm::sort(Halves, llvm::less_first());
+  Halves.erase(llvm::unique(Halves,
+                            [](const auto &Lhs, const auto &Rhs) {
+                              return Lhs.first == Rhs.first;
+                            }),
+               Halves.end());
+  if (Halves.size() != 2 || Halves[1].first != Halves[0].first + 1)
+    return std::nullopt;
+  return SgprPairHalves{{Halves[0].second, Halves[1].second},
+                        /*IsVcc=*/false};
+}
+
+static bool hasOffsetInside(ArrayRef<uint64_t> SortedOffsets, uint64_t Begin,
+                            uint64_t End) {
+  auto It = llvm::upper_bound(SortedOffsets, Begin);
+  return It != SortedOffsets.end() && *It < End;
+}
+
+static bool overlapsTextSymbolExtent(ArrayRef<ElfView::TextOffsetRange> Extents,
+                                     uint64_t Begin, uint64_t End) {
+  auto It =
+      llvm::lower_bound(Extents, Begin,
+                        [](const ElfView::TextOffsetRange &Extent,
+                           uint64_t Offset) { return Extent.End <= Offset; });
+  return It != Extents.end() && It->Begin < End;
+}
+
+/// Recognize the split gateway emitted for an undersized far source:
+///
+///   source: s_call_i64 pair, tail
+///   tail:   s_add_nc_u64 pair, pair, target - (source + 4)
+///           s_set_pc_i64 pair
+///
+/// The tail is not self-initializing, so accept it only in unowned gateway
+/// padding with one exact compatible call ingress and a no-fallthrough
+/// predecessor. These conditions distinguish generated tails from ordinary
+/// ABI returns, including the s[30:31] case.
+static std::optional<MaterializedPcTransfer> evaluateCallTailTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex, size_t AddIndex,
+    MCRegister TargetPair, const DenseSet<uint64_t> &DirectTargets,
+    ArrayRef<uint8_t> Text, const LLVMState &LS, const ElfView &Elf,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  if (!TextSymbolOffsets || !TextSymbolExtents || AddIndex == 0 ||
+      AddIndex + 1 != TransferIndex || TransferIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Add = Decoded[AddIndex];
+  const InternalDecodedInst &Transfer = Decoded[TransferIndex];
+  const InternalDecodedInst &Previous = Decoded[AddIndex - 1];
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      Transfer.Offset, Transfer.Size, "call-tail transfer end");
+  if (!SequenceEnd || Elf.findFunctionTextRangeAtOffset(Add.Offset) ||
+      Previous.Offset + Previous.Size != Add.Offset ||
+      !hasNoFallthrough(Previous, LS) ||
+      Add.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+      Add.Inst.getNumOperands() != 3 ||
+      !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() ||
+      Add.Inst.getOperand(0).getReg() != TargetPair.id() ||
+      Add.Inst.getOperand(1).getReg() != TargetPair.id() ||
+      Transfer.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+      Transfer.Inst.getNumOperands() != 1 ||
+      !Transfer.Inst.getOperand(0).isReg() ||
+      Transfer.Inst.getOperand(0).getReg() != TargetPair.id() ||
+      Add.Offset + Add.Size != Transfer.Offset ||
+      !DirectTargets.contains(Add.Offset))
+    return std::nullopt;
+
+  for (uint64_t DirectTarget : DirectTargets)
+    if (DirectTarget > Add.Offset && DirectTarget < *SequenceEnd)
+      return std::nullopt;
+  auto Symbol = llvm::lower_bound(*TextSymbolOffsets, Add.Offset);
+  if ((Symbol != TextSymbolOffsets->end() && *Symbol < *SequenceEnd) ||
+      overlapsTextSymbolExtent(*TextSymbolExtents, Add.Offset, *SequenceEnd))
+    return std::nullopt;
+
+  const uint64_t SourceLower =
+      Add.Offset > MaxSledDistance ? Add.Offset - MaxSledDistance : 0;
+  const uint64_t SourceUpper =
+      Add.Offset > std::numeric_limits<uint64_t>::max() -
+                       (MaxSledDistance - MinInstSize)
+          ? std::numeric_limits<uint64_t>::max()
+          : Add.Offset + MaxSledDistance - MinInstSize;
+  auto Source = llvm::lower_bound(
+      Decoded, SourceLower,
+      [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  std::optional<uint64_t> LinkOffset;
+  unsigned MatchingCalls = 0;
+  for (; Source != Decoded.end() && Source->Offset <= SourceUpper; ++Source) {
+    if ((!LS.MIA->isBranch(Source->Inst) && !LS.MIA->isCall(Source->Inst)) ||
+        LS.MIA->isIndirectBranch(Source->Inst) ||
+        LS.MIA->isReturn(Source->Inst))
+      continue;
+    std::optional<uint64_t> EdgeTarget =
+        evaluateDirectControlFlowTarget(*Source, LS);
+    if (!EdgeTarget || *EdgeTarget != Add.Offset)
+      continue;
+    if (Source->Inst.getOpcode() != LS.SCallI64Opcode ||
+        Source->Inst.getNumOperands() != 2 ||
+        !Source->Inst.getOperand(0).isReg() ||
+        Source->Inst.getOperand(0).getReg() != TargetPair.id())
+      return std::nullopt;
+    LinkOffset = checkedAddUint64(Source->Offset, Source->Size,
+                                  "call-tail link offset");
+    if (!LinkOffset)
+      return std::nullopt;
+    ++MatchingCalls;
+  }
+  if (MatchingCalls != 1)
+    return std::nullopt;
+
+  std::optional<int64_t> Delta =
+      getAbsoluteOperandValue(Add.Inst.getOperand(2), Add, Text);
+  if (!Delta)
+    return std::nullopt;
+  const uint64_t Target = *LinkOffset + static_cast<uint64_t>(*Delta);
+  std::optional<uint64_t> TargetVAddr = checkedAddUint64(
+      Elf.textAddr(), Target, "call-tail gateway target vaddr");
+  if (Target < Text.size() || !TargetVAddr ||
+      (Target & (MinInstSize - 1)) != 0 ||
+      !Elf.isExecutableVAddrRange(*TargetVAddr, MinInstSize))
+    return std::nullopt;
+  return MaterializedPcTransfer{Add.Offset, *SequenceEnd, Target};
+}
+
+/// Recognize a compiler-emitted get-PC/add-nc/straight-line/set-or-swap-PC
+/// transfer. The exact register and layout checks make the computed
+/// destination as trustworthy as a direct branch target; malformed
+/// near-matches fail closed.
+static std::optional<MaterializedPcTransfer> evaluateMaterializedAddNcTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  if (!LS.MCII || !LS.MIA || !LS.MRI || TransferIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Transfer = Decoded[TransferIndex];
+  const bool IsSetPc = Transfer.Inst.getOpcode() == LS.SSetPcI64Opcode;
+  const bool IsSwapPc = Transfer.Inst.getOpcode() == LS.SSwapPcI64Opcode;
+  if (!IsSetPc && !IsSwapPc)
+    return std::nullopt;
+
+  MCRegister TargetPair;
+  if (IsSetPc) {
+    if (Transfer.Inst.getNumOperands() != 1 ||
+        !Transfer.Inst.getOperand(0).isReg())
+      return std::nullopt;
+    TargetPair = MCRegister(Transfer.Inst.getOperand(0).getReg());
+  } else {
+    if (Transfer.Inst.getNumOperands() != 2 ||
+        !Transfer.Inst.getOperand(0).isReg() ||
+        !Transfer.Inst.getOperand(1).isReg() ||
+        StringRef(LS.MRI->getName(Transfer.Inst.getOperand(0).getReg())) !=
+            "SGPR30_SGPR31")
+      return std::nullopt;
+    TargetPair = MCRegister(Transfer.Inst.getOperand(1).getReg());
+    if (LS.MRI->regsOverlap(Transfer.Inst.getOperand(0).getReg(),
+                            TargetPair.id()))
+      return std::nullopt;
+  }
+
+  std::optional<SgprPairHalves> PairRegs = getSgprPairHalves(LS, TargetPair);
+  if (!PairRegs)
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> TransferOwner =
+      Elf.findFunctionTextRangeAtOffset(Transfer.Offset);
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      Transfer.Offset, Transfer.Size, "materialized PC transfer end");
+  if (!SequenceEnd || (TransferOwner && *SequenceEnd > TransferOwner->End))
+    return std::nullopt;
+
+  size_t AddIndex = TransferIndex;
+  uint64_t NextOffset = Transfer.Offset;
+  for (size_t I = TransferIndex; I-- > 0;) {
+    const InternalDecodedInst &Candidate = Decoded[I];
+    std::optional<uint64_t> CandidateEnd = checkedAddUint64(
+        Candidate.Offset, Candidate.Size, "materialized transfer member end");
+    if (!CandidateEnd || *CandidateEnd != NextOffset ||
+        (TransferOwner && Candidate.Offset < TransferOwner->Begin))
+      return std::nullopt;
+
+    if (Candidate.Inst.getOpcode() == LS.SAddNcU64Opcode &&
+        Candidate.Inst.getNumOperands() == 3 &&
+        Candidate.Inst.getOperand(0).isReg() &&
+        Candidate.Inst.getOperand(1).isReg() &&
+        Candidate.Inst.getOperand(0).getReg() == TargetPair.id() &&
+        Candidate.Inst.getOperand(1).getReg() == TargetPair.id()) {
+      AddIndex = I;
+      break;
+    }
+
+    // An unowned sequence is accepted only for the exact gateway form below;
+    // never search arbitrary section contents for a matching definition.
+    if (!TransferOwner)
+      return std::nullopt;
+
+    const MCInstrDesc &Desc = LS.MCII->get(Candidate.Inst.getOpcode());
+    std::optional<RegisterPairAccess> Access =
+        getRegisterPairAccess(LS, Candidate, PairRegs->Regs, PairRegs->IsVcc);
+    if (!Access || Candidate.Mnemonic == "<unknown>" ||
+        Candidate.Mnemonic == "<replaced>" || Access->Uses != 0 ||
+        Access->Defs != 0 || Desc.mayAffectControlFlow(Candidate.Inst, *LS.MRI))
+      return std::nullopt;
+    NextOffset = Candidate.Offset;
+  }
+  if (AddIndex == TransferIndex)
+    return std::nullopt;
+
+  if (std::optional<MaterializedPcTransfer> CallTail =
+          evaluateCallTailTransfer(
+              Decoded, TransferIndex, AddIndex, TargetPair, DirectTargets, Text,
+              LS, Elf, TextSymbolOffsets, TextSymbolExtents))
+    return CallTail;
+  if (AddIndex == 0)
+    return std::nullopt;
+
+  const bool DelayOnly = AddIndex + 2 == TransferIndex &&
+                         Decoded[AddIndex + 1].Mnemonic == "s_delay_alu";
+  const bool RequiresTailEntry =
+      IsSetPc && AddIndex + 1 != TransferIndex && !DelayOnly;
+
+  const size_t GetPcIndex = AddIndex - 1;
+  const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
+  const InternalDecodedInst &Add = Decoded[AddIndex];
+  if (GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      GetPc.Offset + GetPc.Size != Add.Offset ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != TargetPair.id() ||
+      Add.Inst.getNumOperands() != 3 || !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() ||
+      Add.Inst.getOperand(0).getReg() != TargetPair.id() ||
+      Add.Inst.getOperand(1).getReg() != TargetPair.id())
+    return std::nullopt;
+
+  std::optional<int64_t> Delta =
+      getAbsoluteOperandValue(Add.Inst.getOperand(2), Add, Text);
+  if (!Delta)
+    return std::nullopt;
+  for (uint64_t DirectTarget : DirectTargets)
+    if (DirectTarget > GetPc.Offset && DirectTarget < *SequenceEnd)
+      return std::nullopt;
+  if ((TextSymbolOffsets &&
+       hasOffsetInside(*TextSymbolOffsets, GetPc.Offset, *SequenceEnd)) ||
+      (TextSymbolExtents &&
+       overlapsTextSymbolExtent(*TextSymbolExtents, GetPc.Offset,
+                                *SequenceEnd)))
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Owner =
+      Elf.findFunctionTextRangeAtOffset(GetPc.Offset);
+
+  uint64_t Target = GetPc.Offset + GetPc.Size + static_cast<uint64_t>(*Delta);
+  if ((Target > GetPc.Offset && Target < *SequenceEnd) ||
+      (Target < Text.size() && !isDecodedInstructionBoundary(Decoded, Target)))
+    return std::nullopt;
+
+  const bool HasCommonOwner = Owner && TransferOwner &&
+                              Owner->Begin == TransferOwner->Begin &&
+                              Owner->End == TransferOwner->End;
+  bool IsCertifiedExternalGateway = false;
+  if (IsSetPc && !Owner && !TransferOwner && AddIndex + 1 == TransferIndex &&
+      DirectTargets.contains(GetPc.Offset) && GetPcIndex != 0 &&
+      TextSymbolOffsets) {
+    const InternalDecodedInst &Previous = Decoded[GetPcIndex - 1];
+    const bool PreviousDoesNotFallThrough =
+        Previous.Offset + Previous.Size == GetPc.Offset &&
+        (hasNoFallthrough(Previous, LS) ||
+         Previous.Inst.getOpcode() == LS.SSetPcI64Opcode);
+    auto InteriorSymbol = llvm::upper_bound(*TextSymbolOffsets, GetPc.Offset);
+    const bool HasNoInteriorSymbol =
+        InteriorSymbol == TextSymbolOffsets->end() ||
+        *InteriorSymbol >= *SequenceEnd;
+    std::optional<uint64_t> TargetVAddr = checkedAddUint64(
+        Elf.textAddr(), Target, "materialized gateway target vaddr");
+    IsCertifiedExternalGateway =
+        PreviousDoesNotFallThrough && HasNoInteriorSymbol &&
+        Target >= Text.size() && TargetVAddr &&
+        (Target & (MinInstSize - 1)) == 0 &&
+        Elf.isExecutableVAddrRange(*TargetVAddr, MinInstSize);
+  }
+  if (!HasCommonOwner && !IsCertifiedExternalGateway)
+    return std::nullopt;
+
+  if (Target < Text.size()) {
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(Target);
+    if (!HasCommonOwner || !TargetOwner)
+      return std::nullopt;
+    if (RequiresTailEntry &&
+        (*SequenceEnd != Owner->End || TargetOwner->Begin != Target ||
+         TargetOwner->Begin == Owner->Begin))
+      return std::nullopt;
+    if (!RequiresTailEntry && TargetOwner->Begin != Owner->Begin &&
+        TargetOwner->Begin != Target)
+      return std::nullopt;
+  } else if (!IsCertifiedExternalGateway && RequiresTailEntry) {
+    return std::nullopt;
+  }
+
+  return MaterializedPcTransfer{GetPc.Offset, *SequenceEnd, Target};
+}
+
+/// Recognize the older scalar 64-bit-add lowering:
+///   s_get_pc_i64 pair
+///   s_add_co_u32 lo, lo, delta_lo
+///   s_add_co_ci_u32 hi, hi, delta_hi
+///   s_set_pc_i64 pair
+/// The low add's SCC carry is consumed immediately by the high add. Exact
+/// pair, adjacency, target-boundary, and interior-entry checks keep this as
+/// precise as a decoded direct branch.
+static std::optional<MaterializedPcTransfer> evaluateMaterializedCarryTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf) {
+  if (TransferIndex < 3 || TransferIndex >= Decoded.size())
+    return std::nullopt;
+  std::optional<uint64_t> Target = evaluateMaterializedSetPcTarget(
+      Decoded, TransferIndex, DirectTargets, Text, LS,
+      /*AllowOutsideText=*/true);
+  if (!Target)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[TransferIndex - 3];
+  const InternalDecodedInst &SetPc = Decoded[TransferIndex];
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      SetPc.Offset, SetPc.Size, "materialized carry transfer end");
+  std::optional<ElfView::FunctionTextRange> Owner =
+      Elf.findFunctionTextRangeAtOffset(GetPc.Offset);
+  std::optional<ElfView::FunctionTextRange> TransferOwner =
+      Elf.findFunctionTextRangeAtOffset(SetPc.Offset);
+  if (!SequenceEnd || !Owner || !TransferOwner ||
+      Owner->Begin != TransferOwner->Begin ||
+      Owner->End != TransferOwner->End ||
+      (*Target > GetPc.Offset && *Target < *SequenceEnd))
+    return std::nullopt;
+  if (*Target < Text.size()) {
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(*Target);
+    if (!TargetOwner ||
+        (TargetOwner->Begin != Owner->Begin && TargetOwner->Begin != *Target))
+      return std::nullopt;
+  }
+  return MaterializedPcTransfer{GetPc.Offset, *SequenceEnd, *Target};
+}
+
+std::optional<MaterializedPcTransfer> evaluateMaterializedPcTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  if (std::optional<MaterializedPcTransfer> Transfer =
+          evaluateMaterializedAddNcTransfer(
+              Decoded, TransferIndex, DirectTargets, Text, LS, Elf,
+              TextSymbolOffsets, TextSymbolExtents))
+    return Transfer;
+  return evaluateMaterializedCarryTransfer(Decoded, TransferIndex,
+                                           DirectTargets, Text, LS, Elf);
+}
+
+/// Combine the PR's ELF-aware materialized-transfer proof with the later
+/// amd-staging arbitrary-link call proof.  The latter is indexed by the actual
+/// transfer instruction, so only the exact call accepted by its ingress and
+/// bounded-return analysis gains direct-transfer semantics.
+static std::optional<MaterializedPcTransfer> evaluateProvenPcTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    const CompatibilityControlFlowFacts &CompatibilityFacts,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets = std::nullopt,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents =
+        std::nullopt) {
+  if (std::optional<MaterializedPcTransfer> Transfer =
+          getResolvedCompatibilityTransfer(CompatibilityFacts, TransferIndex))
+    return Transfer;
+  return evaluateMaterializedPcTransfer(
+      Decoded, TransferIndex, DirectTargets, Text, LS, Elf, TextSymbolOffsets,
+      TextSymbolExtents);
+}
+
+static OriginalIngressInfo collectOriginalIngress(
+    ArrayRef<InternalDecodedInst> Decoded,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    const CompatibilityControlFlowFacts &CompatibilityFacts,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  OriginalIngressInfo Result;
+  auto Record = [&](uint64_t Source, uint64_t Target) {
+    Result.ControlFlowEdges.emplace_back(Source, Target);
+    if (Target >= Text.size()) {
+      Result.ExternalEntries.emplace_back(Source, Target);
+      return;
+    }
+    std::optional<ElfView::FunctionTextRange> SourceOwner =
+        Elf.findFunctionTextRangeAtOffset(Source);
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(Target);
+    if (TargetOwner &&
+        (!SourceOwner || SourceOwner->Begin != TargetOwner->Begin ||
+         SourceOwner->End != TargetOwner->End))
+      Result.CrossRangeEntryFunctions.insert(TargetOwner->Begin);
+  };
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if ((LS.MIA->isBranch(DI.Inst) || LS.MIA->isCall(DI.Inst)) &&
+        !LS.MIA->isIndirectBranch(DI.Inst) && !LS.MIA->isReturn(DI.Inst))
+      if (std::optional<uint64_t> Target =
+              evaluateDirectControlFlowTarget(DI, LS))
+        Record(DI.Offset, *Target);
+
+    // A call or ordinary fallthrough immediately into another function's
+    // entry is not kernel dispatch and therefore cannot carry the nonempty
+    // EXEC seed used by the tensor proof.
+    if (!hasNoFallthrough(DI, LS) &&
+        Elf.findFunctionTextRangeAtOffset(DI.Offset)) {
+      std::optional<uint64_t> Next = checkedAddUint64(
+          DI.Offset, DI.Size, "tensor cross-range fallthrough");
+      if (Next)
+        Record(DI.Offset, *Next);
+    }
+  }
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            evaluateProvenPcTransfer(Decoded, I, DirectTargets, Text, LS, Elf,
+                                     CompatibilityFacts, TextSymbolOffsets,
+                                     TextSymbolExtents))
+      Record(Transfer->Begin, Transfer->Target);
+  return Result;
+}
+
+std::optional<BitVector> collectTouchedNumberedSgprs(ArrayRef<uint8_t> Bytes,
+                                                     unsigned NumberedSgprLimit,
+                                                     const LLVMState &LS) {
+  if (!LS.MCII || !LS.MRI || NumberedSgprLimit == 0) {
+    log() << "hotswap: error: cannot collect replacement SGPR usage with "
+             "invalid LLVM state or register limit\n";
+    return std::nullopt;
+  }
+
+  SmallVector<MCRegister> NumberedSgprs(NumberedSgprLimit);
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, MCRegister(Reg));
+    if (Index && *Index < NumberedSgprLimit)
+      NumberedSgprs[*Index] = MCRegister(Reg);
+  }
+  if (!llvm::all_of(NumberedSgprs,
+                    [](MCRegister Reg) { return Reg.isValid(); })) {
+    log() << "hotswap: error: cannot map every numbered SGPR while checking "
+             "replacement usage\n";
+    return std::nullopt;
+  }
+
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Bytes.data(), Bytes.size(), LS, Decoded)) {
+    log() << "hotswap: error: cannot decode replacement while checking SGPR "
+             "usage\n";
+    return std::nullopt;
+  }
+
+  BitVector Touched(NumberedSgprLimit);
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Mnemonic == "<unknown>") {
+      log() << "hotswap: error: unknown replacement instruction prevents "
+               "SGPR usage proof\n";
+      return std::nullopt;
+    }
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    SmallVector<MCRegister, 16> Regs;
+    for (const MCOperand &Op : DI.Inst)
+      if (Op.isReg() && Op.getReg())
+        Regs.push_back(MCRegister(Op.getReg()));
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      Regs.push_back(MCRegister(Reg));
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      Regs.push_back(MCRegister(Reg));
+
+    for (MCRegister Reg : Regs)
+      for (unsigned I = 0; I < NumberedSgprLimit; ++I)
+        if (Reg.isValid() &&
+            LS.MRI->regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+          Touched.set(I);
+  }
+  return Touched;
+}
+
+static bool isRegisterPairDeadFrom(ArrayRef<InternalDecodedInst> Function,
+                                   size_t ResumeIndex,
+                                   ArrayRef<MCRegister> PairRegs,
+                                   ArrayRef<uint8_t> Text, const LLVMState &LS,
+                                   bool PairIsAbiVcc = false) {
+  if (!LS.MCII || !LS.MRI || !LS.MIA || PairRegs.size() != 2 ||
+      !PairRegs[0].isValid() || !PairRegs[1].isValid() ||
+      ResumeIndex >= Function.size())
+    return false;
+
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  for (unsigned I = 0; I < Function.size(); ++I)
+    OffsetToIndex.try_emplace(Function[I].Offset, I);
+  DenseSet<uint64_t> DirectTargets;
+  DenseSet<uint64_t> NoTargets;
+  for (unsigned I = 3; I < Function.size(); ++I) {
+    std::optional<uint64_t> Target =
+        evaluateMaterializedSetPcTarget(Function, I, NoTargets, Text, LS);
+    if (!Target)
+      continue;
+    // Entering after getpc would use a stale address, so a replacement may
+    // not resume in the middle of a sequence that this proof recognizes.
+    if (ResumeIndex > I - 3 && ResumeIndex <= I)
+      return false;
+    DirectTargets.insert(*Target);
+  }
+  for (const InternalDecodedInst &DI : Function) {
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Operand : DI.Inst)
+      HasImmediate |= Operand.isImm();
+    // Register-target control flow such as s_swap_pc_i64 and s_set_pc_i64
+    // has no direct target. Exact materialized set-PC sequences were handled
+    // above; other indirect transfers make the path proof fail when reached.
+    if (!HasImmediate)
+      continue;
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (!Target) {
+      log() << "hotswap: site-dead pair proof cannot resolve direct "
+               "control flow at 0x"
+            << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+      return false;
+    }
+    DirectTargets.insert(*Target);
+  }
+
+  SmallVector<std::pair<unsigned, uint8_t>, 32> Worklist;
+  std::vector<uint8_t> Seen(Function.size() * 4);
+  Worklist.emplace_back(ResumeIndex, uint8_t{3});
+  for (size_t Next = 0; Next < Worklist.size(); ++Next) {
+    unsigned I = Worklist[Next].first;
+    uint8_t LiveMask = Worklist[Next].second;
+    if (I >= Function.size())
+      return false;
+    uint8_t &WasSeen = Seen[I * 4 + LiveMask];
+    if (WasSeen)
+      continue;
+    WasSeen = 1;
+
+    const InternalDecodedInst &DI = Function[I];
+    if (DI.Mnemonic == "<unknown>") {
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof reached unknown instruction at 0x"
+              << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsKnownNonControlFlow =
+        DI.Mnemonic == "s_set_vgpr_msb" ||
+        (DI.Mnemonic == "s_set_pc_i64" && DI.Inst.getNumOperands() == 1 &&
+         DI.Inst.getOperand(0).isImm());
+    std::optional<RegisterPairAccess> Access =
+        getRegisterPairAccess(LS, DI, PairRegs, PairIsAbiVcc);
+    if (!Access)
+      return false;
+
+    if (Access->Uses & LiveMask) {
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof found use-before-def at 0x"
+              << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+      return false;
+    }
+    LiveMask &= ~Access->Defs;
+    if (!LiveMask)
+      continue;
+    if (PairIsAbiVcc && isStandardLinkReturn(DI, LS))
+      continue;
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      std::optional<uint64_t> Materialized =
+          evaluateMaterializedSetPcTarget(Function, I, DirectTargets, Text, LS);
+      if (Materialized) {
+        DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+            OffsetToIndex.find(*Materialized);
+        if (TargetIt == OffsetToIndex.end()) {
+          if (PairIsAbiVcc)
+            log() << "hotswap: VCC lifetime proof reached outside materialized "
+                     "target at 0x"
+                  << utohexstr(DI.Offset) << "\n";
+          return false;
+        }
+        Worklist.emplace_back(TargetIt->second, LiveMask);
+        continue;
+      }
+    }
+
+    if (LS.MIA->isCall(DI.Inst)) {
+      if (PairIsAbiVcc && (evaluateDirectControlFlowTarget(DI, LS) ||
+                           isStandardLinkCall(DI, LS)))
+        continue;
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof reached unresolved call at 0x"
+              << utohexstr(DI.Offset) << "\n";
+      // MC classifies every s_swap_pc_i64 as a call, including hand-written
+      // register transfers whose target and ABI provenance are unknowable.
+      // Without a proven cross-function entry set, no call is a safe lifetime
+      // boundary for this post-link proof.
+      return false;
+    }
+
+    if (DI.Mnemonic == "s_endpgm" || LS.MIA->isReturn(DI.Inst)) {
+      if (PairIsAbiVcc)
+        continue;
+      return false;
+    }
+
+    if (!IsKnownNonControlFlow && LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (LS.MIA->isIndirectBranch(DI.Inst) ||
+          !LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        if (PairIsAbiVcc)
+          log() << "hotswap: VCC lifetime proof reached unresolved branch at 0x"
+                << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+        return false;
+      }
+      DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+          OffsetToIndex.find(Target);
+      if (TargetIt == OffsetToIndex.end()) {
+        if (PairIsAbiVcc)
+          log() << "hotswap: VCC lifetime proof reached outside branch target "
+                   "at 0x"
+                << utohexstr(DI.Offset) << "\n";
+        return false;
+      }
+      Worklist.emplace_back(TargetIt->second, LiveMask);
+      if (LS.MIA->isConditionalBranch(DI.Inst)) {
+        if (I + 1 >= Function.size())
+          return false;
+        Worklist.emplace_back(I + 1, LiveMask);
+      } else if (!LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        return false;
+      }
+      continue;
+    }
+
+    if ((!IsKnownNonControlFlow &&
+         (Desc.isTerminator() ||
+          LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))) ||
+        I + 1 >= Function.size()) {
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof reached opaque control flow at 0x"
+              << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+      return false;
+    }
+    Worklist.emplace_back(I + 1, LiveMask);
+  }
+  return true;
+}
+
+static std::optional<std::array<MCRegister, 2>>
+findNumberedSgprPair(const LLVMState &LS, unsigned SgprBase) {
+  if (!LS.MRI || (SgprBase & 1u) != 0 ||
+      SgprBase == std::numeric_limits<unsigned>::max())
+    return std::nullopt;
+
+  std::array<MCRegister, 2> PairRegs;
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, MCRegister(Reg));
+    if (Index && *Index >= SgprBase && *Index <= SgprBase + 1)
+      PairRegs[*Index - SgprBase] = MCRegister(Reg);
+  }
+  if (!PairRegs[0].isValid() || !PairRegs[1].isValid())
+    return std::nullopt;
+  return PairRegs;
+}
+
+bool isSgprPairDeadFrom(ArrayRef<InternalDecodedInst> Function,
+                        size_t ResumeIndex, unsigned SgprBase,
+                        const LLVMState &LS, ArrayRef<uint8_t> Text) {
+  std::optional<std::array<MCRegister, 2>> PairRegs =
+      findNumberedSgprPair(LS, SgprBase);
+  if (!PairRegs)
+    return false;
+  return isRegisterPairDeadFrom(Function, ResumeIndex, *PairRegs, Text, LS);
+}
+
+using NumberedSgprMask = std::array<uint64_t, 2>;
+
+static NumberedSgprMask allNumberedSgprs(unsigned Limit) {
+  NumberedSgprMask Result{};
+  for (unsigned I = 0; I < Limit; ++I)
+    Result[I / 64] |= uint64_t{1} << (I % 64);
+  return Result;
+}
+
+static void addOverlappingNumberedSgprs(NumberedSgprMask &Mask, MCRegister Reg,
+                                        ArrayRef<MCRegister> NumberedSgprs,
+                                        const MCRegisterInfo &MRI) {
+  if (!Reg.isValid())
+    return;
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I)
+    if (MRI.regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+      Mask[I / 64] |= uint64_t{1} << (I % 64);
+}
+
+static bool masksEqual(const NumberedSgprMask &A, const NumberedSgprMask &B) {
+  return A[0] == B[0] && A[1] == B[1];
+}
+
+static std::optional<SiteDeadSgprFunctionFacts>
+computeSiteDeadSgprFunctionFacts(PatchContext &Ctx,
+                                 const ElfView::FunctionTextRange &Range) {
+  if (!Ctx.LS.MCII || !Ctx.LS.MRI || !Ctx.LS.MIA || Ctx.Config.MaxSgprs == 0 ||
+      Ctx.Config.MaxSgprs > 128)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst>::const_iterator First =
+      llvm::lower_bound(Ctx.Decoded, Range.Begin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  std::vector<InternalDecodedInst>::const_iterator After =
+      llvm::lower_bound(Ctx.Decoded, Range.End,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  if (First == After)
+    return std::nullopt;
+  ArrayRef<InternalDecodedInst> Function(&*First,
+                                         static_cast<size_t>(After - First));
+  const unsigned Count = Function.size();
+
+  SmallVector<MCRegister, 128> NumberedSgprs(Ctx.Config.MaxSgprs);
+  for (unsigned Reg = 1, End = Ctx.LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    std::optional<unsigned> Index =
+        numberedSgprIndex(*Ctx.LS.MRI, MCRegister(Reg));
+    if (Index && *Index < NumberedSgprs.size())
+      NumberedSgprs[*Index] = MCRegister(Reg);
+  }
+  if (!llvm::all_of(NumberedSgprs,
+                    [](MCRegister Reg) { return Reg.isValid(); }))
+    return std::nullopt;
+
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  for (unsigned I = 0; I != Count; ++I)
+    OffsetToIndex.try_emplace(Function[I].Offset, I);
+
+  DenseSet<uint64_t> DirectTargets;
+  DenseSet<uint64_t> NoTargets;
+  BitVector ForbiddenResume(Count);
+  for (unsigned I = 3; I < Count; ++I)
+    if (std::optional<uint64_t> Target = evaluateMaterializedSetPcTarget(
+            Function, I, NoTargets, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+            Ctx.LS)) {
+      DirectTargets.insert(*Target);
+      // A resume inside get-PC/add/set-PC is invalid even when a direct target
+      // into that sequence prevents recognizing it as a CFG edge below.
+      ForbiddenResume.set(I - 2, I + 1);
+    }
+  for (const InternalDecodedInst &DI : Function) {
+    if ((!Ctx.LS.MIA->isBranch(DI.Inst) && !Ctx.LS.MIA->isCall(DI.Inst)) ||
+        Ctx.LS.MIA->isIndirectBranch(DI.Inst) || Ctx.LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Operand : DI.Inst)
+      HasImmediate |= Operand.isImm();
+    if (!HasImmediate)
+      continue;
+    if (std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, Ctx.LS))
+      DirectTargets.insert(*Target);
+  }
+
+  DenseMap<unsigned, unsigned> MaterializedSuccessor;
+  for (unsigned I = 3; I < Count; ++I) {
+    std::optional<uint64_t> Target = evaluateMaterializedSetPcTarget(
+        Function, I, DirectTargets, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+        Ctx.LS);
+    if (!Target)
+      continue;
+    DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+        OffsetToIndex.find(*Target);
+    if (TargetIt == OffsetToIndex.end())
+      continue;
+    MaterializedSuccessor.try_emplace(I, TargetIt->second);
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  std::vector<SmallVector<unsigned, 2>> Predecessors(Count);
+  for (unsigned I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = Function[I];
+    DenseMap<unsigned, unsigned>::const_iterator Materialized =
+        MaterializedSuccessor.find(I);
+    if (Materialized != MaterializedSuccessor.end()) {
+      Successors[I].push_back(Materialized->second);
+    } else if (DI.Mnemonic == "<unknown>" || Ctx.LS.MIA->isCall(DI.Inst) ||
+               DI.Mnemonic == "s_endpgm" || Ctx.LS.MIA->isReturn(DI.Inst)) {
+      // Calls and exits are fail-closed lifetime boundaries.
+    } else if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (!Ctx.LS.MIA->isIndirectBranch(DI.Inst) &&
+          Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+            OffsetToIndex.find(Target);
+        if (TargetIt != OffsetToIndex.end()) {
+          Successors[I].push_back(TargetIt->second);
+          if (Ctx.LS.MIA->isConditionalBranch(DI.Inst) && I + 1 < Count)
+            Successors[I].push_back(I + 1);
+          else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+            Successors[I].clear();
+        }
+      }
+    } else {
+      const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+      if (!Desc.isTerminator() &&
+          !Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI) &&
+          I + 1 < Count)
+        Successors[I].push_back(I + 1);
+    }
+    for (unsigned Succ : Successors[I])
+      Predecessors[Succ].push_back(I);
+  }
+
+  NumberedSgprMask All = allNumberedSgprs(Ctx.Config.MaxSgprs);
+  std::vector<NumberedSgprMask> Defs(Count);
+  std::vector<NumberedSgprMask> Uses(Count);
+  for (unsigned I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = Function[I];
+    if (DI.Mnemonic == "<unknown>") {
+      Uses[I] = All;
+      continue;
+    }
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    unsigned NumDefs =
+        std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+    for (unsigned OpIdx = 0; OpIdx < DI.Inst.getNumOperands(); ++OpIdx) {
+      const MCOperand &Op = DI.Inst.getOperand(OpIdx);
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      addOverlappingNumberedSgprs(OpIdx < NumDefs ? Defs[I] : Uses[I],
+                                  MCRegister(Op.getReg()), NumberedSgprs,
+                                  *Ctx.LS.MRI);
+    }
+
+    bool Malformed = false;
+    for (unsigned OpIdx = NumDefs; OpIdx < Desc.getNumOperands(); ++OpIdx) {
+      int TiedTo = Desc.getOperandConstraint(OpIdx, MCOI::TIED_TO);
+      if (TiedTo < 0)
+        continue;
+      if (static_cast<unsigned>(TiedTo) >= NumDefs ||
+          static_cast<unsigned>(TiedTo) >= DI.Inst.getNumOperands()) {
+        Malformed = true;
+        break;
+      }
+      const MCOperand &Def = DI.Inst.getOperand(TiedTo);
+      if (!Def.isReg() || !Def.getReg()) {
+        Malformed = true;
+        break;
+      }
+      addOverlappingNumberedSgprs(Uses[I], MCRegister(Def.getReg()),
+                                  NumberedSgprs, *Ctx.LS.MRI);
+    }
+    for (unsigned OpIdx = DI.Inst.getNumOperands();
+         !Malformed && OpIdx < Desc.getNumOperands(); ++OpIdx) {
+      const MCOperandInfo &Missing = Desc.operands()[OpIdx];
+      if (Missing.RegClass < 0)
+        continue;
+      bool MatchedDefinition = false;
+      for (unsigned DefIdx = 0; DefIdx < NumDefs; ++DefIdx) {
+        if (Desc.operands()[DefIdx].RegClass != Missing.RegClass)
+          continue;
+        const MCOperand &Def = DI.Inst.getOperand(DefIdx);
+        if (!Def.isReg() || !Def.getReg()) {
+          Malformed = true;
+          break;
+        }
+        addOverlappingNumberedSgprs(Uses[I], MCRegister(Def.getReg()),
+                                    NumberedSgprs, *Ctx.LS.MRI);
+        MatchedDefinition = true;
+      }
+      if (!MatchedDefinition)
+        Malformed = true;
+    }
+    if (Malformed) {
+      Uses[I] = All;
+      continue;
+    }
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      addOverlappingNumberedSgprs(Uses[I], MCRegister(Reg), NumberedSgprs,
+                                  *Ctx.LS.MRI);
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      addOverlappingNumberedSgprs(Defs[I], MCRegister(Reg), NumberedSgprs,
+                                  *Ctx.LS.MRI);
+  }
+
+  std::vector<NumberedSgprMask> SafeBefore(Count, All);
+  SmallVector<unsigned, 128> Worklist;
+  BitVector Queued(Count, true);
+  for (unsigned I = 0; I != Count; ++I)
+    Worklist.push_back(I);
+  while (!Worklist.empty()) {
+    unsigned I = Worklist.pop_back_val();
+    Queued.reset(I);
+    NumberedSgprMask SafeOut{};
+    if (!Successors[I].empty()) {
+      SafeOut = All;
+      for (unsigned Succ : Successors[I]) {
+        SafeOut[0] &= SafeBefore[Succ][0];
+        SafeOut[1] &= SafeBefore[Succ][1];
+      }
+    }
+    NumberedSgprMask New{(SafeOut[0] | Defs[I][0]) & ~Uses[I][0],
+                         (SafeOut[1] | Defs[I][1]) & ~Uses[I][1]};
+    New[0] &= All[0];
+    New[1] &= All[1];
+    if (masksEqual(New, SafeBefore[I]))
+      continue;
+    SafeBefore[I] = New;
+    for (unsigned Pred : Predecessors[I])
+      if (!Queued.test(Pred)) {
+        Queued.set(Pred);
+        Worklist.push_back(Pred);
+      }
+  }
+
+  SiteDeadSgprFunctionFacts Facts;
+  Facts.Begin = Range.Begin;
+  Facts.End = Range.End;
+  Facts.GlobalFirst = First - Ctx.Decoded.cbegin();
+  unsigned HighWatermark = 0;
+  for (const InternalDecodedInst &DI : Function) {
+    for (const MCOperand &Op : DI.Inst) {
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           "site-dead SGPR analysis"))
+        return std::nullopt;
+    }
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           "site-dead SGPR analysis"))
+        return std::nullopt;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           "site-dead SGPR analysis"))
+        return std::nullopt;
+  }
+  Facts.NumberedLimit = HighWatermark;
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(Range.Begin + Ctx.Elf.textAddr());
+  if (!Owner.empty()) {
+    std::optional<unsigned> Declared = Ctx.Elf.getKernelSgprCount(Owner);
+    if (!Declared || *Declared < 2)
+      return std::nullopt;
+    // The descriptor count may include VCC. Subtracting it unconditionally
+    // gives a conservative numbered-register limit.
+    Facts.NumberedLimit = std::max(
+        Facts.NumberedLimit, std::min(*Declared - 2, Ctx.Config.MaxSgprs));
+  }
+  Facts.SafeBefore = std::move(SafeBefore);
+  Facts.ForbiddenResume = std::move(ForbiddenResume);
+  return Facts;
+}
+
+void precomputeSiteDeadSgprFacts(PatchContext &Ctx) {
+  const uint64_t TextAddr = Ctx.Elf.textAddr();
+  for (const ElfView::FunctionTextRange &Absolute :
+       Ctx.Elf.functionTextRanges()) {
+    if (Absolute.Begin < TextAddr || Absolute.End <= Absolute.Begin)
+      continue;
+    uint64_t Begin = Absolute.Begin - TextAddr;
+    uint64_t End = std::min(Absolute.End - TextAddr, Ctx.TextSize);
+    if (Begin >= End)
+      continue;
+    std::pair<uint64_t, uint64_t> Key{Begin, End};
+    if (Ctx.SiteDeadSgprFacts.find(Key) != Ctx.SiteDeadSgprFacts.end())
+      continue;
+    ElfView::FunctionTextRange Relative{Begin, End, Absolute.Symbol,
+                                        Absolute.Symtab};
+    std::optional<SiteDeadSgprFunctionFacts> Facts =
+        computeSiteDeadSgprFunctionFacts(Ctx, Relative);
+    if (Facts)
+      Ctx.SiteDeadSgprFacts.try_emplace(Key, std::move(*Facts));
+  }
+}
+
+std::optional<BitVector> getSiteDeadNumberedSgprs(PatchContext &Ctx,
+                                                  uint64_t InstOffset,
+                                                  uint32_t InstSize) {
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!Range)
+    return std::nullopt;
+  using FunctionKey = std::pair<uint64_t, uint64_t>;
+  FunctionKey Key{Range->Begin, Range->End};
+  auto It = Ctx.SiteDeadSgprFacts.find(Key);
+  // Facts are deliberately computed from the immutable decoded stream before
+  // any instruction is relabeled as replaced.
+  if (It == Ctx.SiteDeadSgprFacts.end())
+    return std::nullopt;
+
+  std::optional<uint64_t> ResumeOffset =
+      checkedAddUint64(InstOffset, InstSize, "site-dead SGPR resume offset");
+  if (!ResumeOffset)
+    return std::nullopt;
+  const SiteDeadSgprFunctionFacts &Facts = It->second;
+  std::vector<InternalDecodedInst>::const_iterator First =
+      Ctx.Decoded.cbegin() + Facts.GlobalFirst;
+  std::vector<InternalDecodedInst>::const_iterator After =
+      First + Facts.SafeBefore.size();
+  std::vector<InternalDecodedInst>::const_iterator Resume =
+      std::lower_bound(First, After, *ResumeOffset,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (Resume == After || Resume->Offset != *ResumeOffset)
+    return std::nullopt;
+  size_t ResumeIndex = Resume - First;
+  BitVector Result(Ctx.Config.MaxSgprs);
+  if (Facts.ForbiddenResume.test(ResumeIndex))
+    return Result;
+  const NumberedSgprMask &Mask = Facts.SafeBefore[ResumeIndex];
+  for (unsigned I = 0; I != Ctx.Config.MaxSgprs; ++I)
+    if (Mask[I / 64] & (uint64_t{1} << (I % 64)))
+      Result.set(I);
+  return Result;
+}
+
+static std::optional<std::pair<ArrayRef<InternalDecodedInst>, size_t>>
+findFunctionContinuation(const PatchContext &Ctx, uint64_t InstOffset,
+                         uint32_t InstSize) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst>::const_iterator FunctionFirst =
+      llvm::lower_bound(Ctx.Decoded, FunctionRange->Begin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  std::vector<InternalDecodedInst>::const_iterator FunctionAfter =
+      llvm::lower_bound(Ctx.Decoded, FunctionRange->End,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  if (FunctionFirst == FunctionAfter)
+    return std::nullopt;
+
+  std::optional<uint64_t> ResumeOffset =
+      checkedAddUint64(InstOffset, InstSize, "site-dead pair resume offset");
+  if (!ResumeOffset)
+    return std::nullopt;
+  std::vector<InternalDecodedInst>::const_iterator Resume =
+      std::lower_bound(FunctionFirst, FunctionAfter, *ResumeOffset,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (Resume == FunctionAfter || Resume->Offset != *ResumeOffset)
+    return std::nullopt;
+
+  ArrayRef<InternalDecodedInst> Function(
+      &*FunctionFirst, static_cast<size_t>(FunctionAfter - FunctionFirst));
+  return std::pair{Function, static_cast<size_t>(Resume - FunctionFirst)};
+}
+
+static std::optional<std::array<MCRegister, 2>>
+findVccLoHiPair(const LLVMState &LS) {
+  if (!LS.MRI)
+    return std::nullopt;
+  std::array<MCRegister, 2> Pair;
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    StringRef Name(LS.MRI->getName(Reg));
+    if (Name == "VCC_LO")
+      Pair[0] = MCRegister(Reg);
+    else if (Name == "VCC_HI")
+      Pair[1] = MCRegister(Reg);
+  }
+  if (!Pair[0].isValid() || !Pair[1].isValid())
+    return std::nullopt;
+  return Pair;
+}
+
+bool isVccPairDeadFrom(ArrayRef<InternalDecodedInst> Function,
+                       size_t ResumeIndex, const LLVMState &LS,
+                       ArrayRef<uint8_t> Text) {
+  std::optional<std::array<MCRegister, 2>> Pair = findVccLoHiPair(LS);
+  return Pair && isRegisterPairDeadFrom(Function, ResumeIndex, *Pair, Text, LS,
+                                        /*PairIsAbiVcc=*/true);
+}
+
+static std::optional<bool> replacementTouchesVcc(ArrayRef<uint8_t> Replacement,
+                                                 const LLVMState &LS) {
+  if (!LS.MCII || !LS.MRI)
+    return std::nullopt;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded))
+    return std::nullopt;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Mnemonic == "<unknown>")
+      return std::nullopt;
+    for (const MCOperand &Op : DI.Inst)
+      if (Op.isReg() && Op.getReg() &&
+          isVccRegister(LS, MCRegister(Op.getReg())))
+        return true;
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (isVccRegister(LS, MCRegister(Reg)))
+        return true;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (isVccRegister(LS, MCRegister(Reg)))
+        return true;
+  }
+  return false;
+}
+
+static bool isVccPairDeadAfter(PatchContext &Ctx, uint64_t InstOffset,
+                               uint32_t InstSize) {
+  std::optional<std::pair<ArrayRef<InternalDecodedInst>, size_t>> Continuation =
+      findFunctionContinuation(Ctx, InstOffset, InstSize);
+  if (!Continuation ||
+      !llvm::any_of(Continuation->first, [&](const InternalDecodedInst &DI) {
+        return instructionUsesVcc(Ctx.LS, DI);
+      }))
+    return false;
+
+  // Using VCC for the trampoline must not introduce a new special-register
+  // allocation. An original VCC reference in the owning function ensures the
+  // compiler already propagated the VCC resource requirement to its callers.
+  return isVccPairDeadFrom(Continuation->first, Continuation->second, Ctx.LS,
+                           ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize));
+}
+
+static bool findSiteDeadVccPair(PatchContext &Ctx, uint64_t InstOffset,
+                                uint32_t InstSize,
+                                ArrayRef<uint8_t> Replacement) {
+  std::optional<bool> ReplacementTouches =
+      replacementTouchesVcc(Replacement, Ctx.LS);
+  if (!ReplacementTouches || *ReplacementTouches ||
+      !isVccPairDeadAfter(Ctx, InstOffset, InstSize))
+    return false;
+  log() << "hotswap: safe far return: reusing site-dead vcc after 0x"
+        << utohexstr(InstOffset) << "\n";
+  return true;
+}
+
+static std::optional<unsigned>
+findSiteDeadOriginalPair(PatchContext &Ctx, uint64_t InstOffset,
+                         uint32_t InstSize, ArrayRef<uint8_t> Replacement) {
+  std::optional<std::pair<ArrayRef<InternalDecodedInst>, size_t>> Continuation =
+      findFunctionContinuation(Ctx, InstOffset, InstSize);
+  if (!Continuation)
+    return std::nullopt;
+
+  std::optional<BitVector> ReplacementTouched =
+      collectTouchedNumberedSgprs(Replacement, Ctx.Config.MaxSgprs, Ctx.LS);
+  if (!ReplacementTouched)
+    return std::nullopt;
+  std::optional<BitVector> SiteDead =
+      getSiteDeadNumberedSgprs(Ctx, InstOffset, InstSize);
+  if (!SiteDead)
+    return std::nullopt;
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+  auto Facts = Ctx.SiteDeadSgprFacts.find(
+      std::pair{FunctionRange->Begin, FunctionRange->End});
+  if (Facts == Ctx.SiteDeadSgprFacts.end())
+    return std::nullopt;
+  unsigned NumberedLimit = Facts->second.NumberedLimit;
+
+  if (NumberedLimit < 2)
+    return std::nullopt;
+
+  unsigned Pair = (NumberedLimit - 2) & ~1u;
+  for (;;) {
+    if (!ReplacementTouched->test(Pair) &&
+        !ReplacementTouched->test(Pair + 1) && SiteDead->test(Pair) &&
+        SiteDead->test(Pair + 1)) {
+#ifndef NDEBUG
+      assert(isSgprPairDeadFrom(
+          Continuation->first, Continuation->second, Pair, Ctx.LS,
+          ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize))));
+#endif
+      log() << "hotswap: safe far return: reusing original site-dead s[" << Pair
+            << ':' << Pair + 1 << "] after 0x" << utohexstr(InstOffset)
+            << " (defined before every exit)\n";
+      return Pair;
+    }
+    if (Pair < 2)
+      break;
+    Pair -= 2;
+  }
+  return std::nullopt;
+}
+
 static SafeSgprUsageSummary
 summarizeSafeSgprUsage(PatchContext &Ctx,
                        ArrayRef<InternalDecodedInst> Instructions,
                        StringRef Context) {
   SafeSgprUsageSummary Summary;
   for (const InternalDecodedInst &DI : Instructions) {
+    if (DI.Mnemonic == "<unknown>") {
+      log() << "hotswap: error: " << Context
+            << ": undecoded instruction prevents SGPR usage proof at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      Summary.Valid = false;
+      return Summary;
+    }
     Summary.UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
     Summary.HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
     for (const MCOperand &Op : DI.Inst) {
@@ -582,11 +3253,13 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
 
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, StringRef Context) {
+                         unsigned Alignment, StringRef Context,
+                         bool DiagnoseFailure) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
-    log() << "hotswap: error: " << Context
-          << ": invalid global SGPR block request (count=" << Count
-          << ", alignment=" << Alignment << ")\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context
+            << ": invalid global SGPR block request (count=" << Count
+            << ", alignment=" << Alignment << ")\n";
     return std::nullopt;
   }
 
@@ -632,8 +3305,9 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
     Usage = &*Ctx.WholeObjectSgprUsage;
   }
   if (!Usage || !Usage->Valid) {
-    log() << "hotswap: error: " << Context
-          << ": cached SGPR usage analysis failed\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context
+            << ": cached SGPR usage analysis failed\n";
     return std::nullopt;
   }
 
@@ -644,13 +3318,15 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   if (!Owner.empty()) {
     std::optional<unsigned> Declared = Ctx.Elf.getKernelSgprCount(Owner);
     if (!Declared) {
-      log() << "hotswap: error: " << Context
-            << ": failed to read SGPR count for kernel " << Owner << "\n";
+      if (DiagnoseFailure)
+        log() << "hotswap: error: " << Context
+              << ": failed to read SGPR count for kernel " << Owner << "\n";
       return std::nullopt;
     }
     if (UsesVcc && *Declared < VccSgprs) {
-      log() << "hotswap: error: " << Context << ": VCC-using kernel " << Owner
-            << " has invalid SGPR count " << *Declared << "\n";
+      if (DiagnoseFailure)
+        log() << "hotswap: error: " << Context << ": VCC-using kernel " << Owner
+              << " has invalid SGPR count " << *Declared << "\n";
       return std::nullopt;
     }
     unsigned DeclaredNumbered = *Declared - (UsesVcc ? VccSgprs : 0);
@@ -659,13 +3335,20 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
     // A device function can be reached from kernels with different declared
     // register footprints. Without a complete call graph, keep the block above
     // every declaration and charge every kernel in the commit step.
+    if (!Ctx.Elf.kernelDescriptorCacheIsComplete()) {
+      if (DiagnoseFailure)
+        log() << "hotswap: error: " << Context
+              << ": kernel descriptor set is incomplete or ambiguous\n";
+      return std::nullopt;
+    }
     for (const KernelDescriptorInfo &KD : Ctx.Elf.kernelDescriptors()) {
       std::optional<unsigned> Declared =
           Ctx.Elf.getKernelSgprCount(KD.KernelName);
       if (!Declared) {
-        log() << "hotswap: error: " << Context
-              << ": failed to read SGPR count for kernel " << KD.KernelName
-              << "\n";
+        if (DiagnoseFailure)
+          log() << "hotswap: error: " << Context
+                << ": failed to read SGPR count for kernel " << KD.KernelName
+                << "\n";
         return std::nullopt;
       }
       HighWatermark = std::max(HighWatermark, *Declared);
@@ -673,14 +3356,17 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   }
 
   if (HighWatermark > std::numeric_limits<unsigned>::max() - (Alignment - 1)) {
-    log() << "hotswap: error: " << Context
-          << ": SGPR alignment calculation overflows unsigned\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context
+            << ": SGPR alignment calculation overflows unsigned\n";
     return std::nullopt;
   }
   unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
   if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
-    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
-          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context << ": no aligned block of "
+            << Count << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs
+            << "\n";
     return std::nullopt;
   }
   return SafeSgprScratchBlock{Base, Count};
@@ -689,6 +3375,11 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
 bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 StringRef Context) {
+  if (!Ctx.Elf.kernelDescriptorCacheIsComplete()) {
+    log() << "hotswap: error: " << Context
+          << ": kernel descriptor set is incomplete or ambiguous\n";
+    return false;
+  }
   ArrayRef<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
   if (Descriptors.empty()) {
     log() << "hotswap: error: " << Context
@@ -701,12 +3392,13 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
       Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
   bool ChargedOwner = false;
 
-  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs returns
-  // two non-numbered VCC SGPRs on GFX1250. Always include them in the metadata
-  // requirement. This may conservatively overstate a kernel that does not use
-  // VCC, but never mistakes VCC for numbered s0-s105 registers.
+  // GFX1250 has two non-numbered VCC SGPRs (GCNSubtarget::getNumExtraSGPRs).
+  // Always include them in the metadata requirement. This may conservatively
+  // overstate a kernel that does not use VCC, but never mistakes VCC for
+  // numbered s0-s105 registers.
   constexpr unsigned VccSgprs = 2;
   unsigned RequiredSgprs = Block.Base + Block.Count + VccSgprs;
+  SmallVector<std::pair<StringRef, unsigned>, 4> PendingCharges;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     if (!Owner.empty() && KD.KernelName != Owner)
       continue;
@@ -719,10 +3411,8 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
             << "\n";
       return false;
     }
-    if (*Current >= RequiredSgprs)
-      continue;
-    KernelPatchStats &Stats = Ctx.KernelStats[KD.KernelName];
-    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, RequiredSgprs - *Current);
+    if (*Current < RequiredSgprs)
+      PendingCharges.emplace_back(KD.KernelName, RequiredSgprs - *Current);
   }
 
   if (!ChargedOwner) {
@@ -730,13 +3420,29 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
           << "' has no descriptor\n";
     return false;
   }
+  for (const auto &[KernelName, ExtraSgprs] : PendingCharges) {
+    KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, ExtraSgprs);
+  }
   return true;
 }
 
 static std::optional<SafeSgprScratchBlock>
-reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
-  std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
+reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                     ArrayRef<uint8_t> Replacement,
+                     bool DiagnoseFailure = true) {
+  if (std::optional<unsigned> ReusedPair =
+          findSiteDeadOriginalPair(Ctx, InstOffset, InstSize, Replacement))
+    return SafeSgprScratchBlock{*ReusedPair, 2,
+                                /*IsSiteProven=*/true};
+
+  if (findSiteDeadVccPair(Ctx, InstOffset, InstSize, Replacement))
+    return SafeSgprScratchBlock{Gfx1250MaxSgprs, 2,
+                                /*IsSiteProven=*/true};
+
+  std::optional<SafeSgprScratchBlock> Scratch =
+      findSafeSgprScratchBlock(Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2,
+                               "safe far return", DiagnoseFailure);
   if (!Scratch)
     return std::nullopt;
   if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
@@ -758,21 +3464,41 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   return Delta <= MaxDelta;
 }
 
+bool canEmitShortTrampoline(const PatchContext &Ctx, uint64_t InstOffset,
+                            uint32_t InstSize, uint64_t ReplacementSize) {
+  std::optional<uint64_t> PoolStart =
+      checkedAddUint64(Ctx.PoolBaseOffset, Ctx.QueuedTrampolineBytes,
+                       "short trampoline pool position");
+  std::optional<uint64_t> PoolReturn =
+      PoolStart ? checkedAddUint64(*PoolStart, ReplacementSize,
+                                   "short trampoline return position")
+                : std::nullopt;
+  std::optional<uint64_t> ReturnTo = checkedAddUint64(
+      InstOffset, InstSize, "short trampoline source return target");
+  return PoolStart && PoolReturn && ReturnTo &&
+         isSBranchReachable(InstOffset, *PoolStart) &&
+         isSBranchReachable(*PoolReturn, *ReturnTo);
+}
+
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
 /// uses an SCC-neutral get-PC/add/set-PC sequence on the backward edge.
 /// Adjacent far sites are coalesced after patching to reduce gateway pressure.
 /// Every far source edge then uses a short branch to nearby safe NOP padding;
-/// that gateway uses the gfx12 SGPR-backed set-PC sequence. No source or return
-/// edge executes gfx1250's broken s_add_pc_i64 instruction.
-[[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
-                                    uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement) {
-  // This trampoline lands at the appended pool base and after every trampoline
-  // already queued -- later ones are appended behind it and cannot shift it,
-  // and fixupTrampolineBranches walks the same list in the same order -- so its
-  // final pool offset (relative to .text) is known exactly now.
+/// that gateway uses the pre-Gen5 SGPR-backed set-PC sequence. No source or
+/// return edge executes gfx1250's broken s_add_pc_i64 instruction.
+static bool emitToTrampolineRaw(PatchContext &Ctx, uint64_t InstOffset,
+                                uint32_t InstSize,
+                                ArrayRef<uint8_t> Replacement,
+                                ReplacementPlacement Placement,
+                                bool DiagnoseFailure) {
+  const bool AllowGlobalBody = Placement != ReplacementPlacement::Default;
+  // This trampoline lands at the appended pool base after every trampoline
+  // already queued. QueuedTrampolineBytes is a conservative upper bound: far
+  // entries reserve the island appended during final layout and enough room
+  // for straight-line source-window growth. The actual pool position can only
+  // be earlier, which can only improve both branch directions.
   std::optional<uint64_t> PoolStart = checkedAddUint64(
       Ctx.PoolBaseOffset, Ctx.QueuedTrampolineBytes, "trampoline pool layout");
   if (!PoolStart)
@@ -789,17 +3515,42 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
       checkedAddUint64(InstOffset, InstSize, "trampoline return target");
   if (!ShortBackFrom || !ReturnTo)
     return false;
-  const bool Far = !(isSBranchReachable(InstOffset, *PoolStart) &&
-                     isSBranchReachable(*ShortBackFrom, *ReturnTo));
+  const bool Far =
+      !canEmitShortTrampoline(Ctx, InstOffset, InstSize, Replacement.size());
 
   uint64_t ReturnReserve = Far ? SetPcReturnReserveBytes : MinInstSize;
   std::optional<uint64_t> TrampolineSize = checkedAddUint64(
       Replacement.size(), ReturnReserve, "queued trampoline size");
   if (!TrampolineSize)
     return false;
-  std::optional<uint64_t> QueuedBytes =
-      checkedAddUint64(Ctx.QueuedTrampolineBytes, *TrampolineSize,
-                       "queued trampoline byte count");
+  uint64_t LayoutReserve = *TrampolineSize;
+  if (Far) {
+    std::optional<uint64_t> WithIsland =
+        checkedAddUint64(LayoutReserve, PoolBranchIslandBytes,
+                         "queued trampoline branch-island reserve");
+    if (!WithIsland)
+      return false;
+    LayoutReserve = *WithIsland;
+
+    // Expansion stops as soon as the source window reaches the set-PC forward
+    // sequence size. Instruction sizes are dword multiples, so the last copied
+    // instruction starts no later than one dword below that threshold.
+    if (InstSize < SetPcForwardSequenceBytes) {
+      std::optional<uint64_t> MaxExpandedSize = checkedAddUint64(
+          SetPcForwardSequenceBytes - MinInstSize, Ctx.MaxDecodedInstSize,
+          "queued trampoline source-growth bound");
+      if (!MaxExpandedSize || *MaxExpandedSize < InstSize)
+        return false;
+      std::optional<uint64_t> WithGrowth =
+          checkedAddUint64(LayoutReserve, *MaxExpandedSize - InstSize,
+                           "queued trampoline source-growth reserve");
+      if (!WithGrowth)
+        return false;
+      LayoutReserve = *WithGrowth;
+    }
+  }
+  std::optional<uint64_t> QueuedBytes = checkedAddUint64(
+      Ctx.QueuedTrampolineBytes, LayoutReserve, "queued trampoline byte count");
   if (!QueuedBytes)
     return false;
 
@@ -827,14 +3578,37 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     if (InstSize < MinInstSize)
       return declineFar(Twine(InstSize) + " B, smaller than " +
                         Twine(MinInstSize) + " B forward branch");
-    std::optional<SafeSgprScratchBlock> Scratch =
-        reserveSafeFarReturn(Ctx, InstOffset);
-    if (!Scratch)
-      return declineFar("no safe SGPR triple for set-PC return");
+    std::optional<SafeSgprScratchBlock> Scratch = reserveSafeFarReturn(
+        Ctx, InstOffset, InstSize, Replacement, /*DiagnoseFailure=*/false);
+    if (!Scratch) {
+      uint64_t Needed = getNopSledBytesNeeded(Ctx, InstOffset, InstSize,
+                                              Replacement, Placement);
+      NopSledUse SledUse =
+          AllowGlobalBody ? NopSledUse::RelocationBody : NopSledUse::OwnerBody;
+      if (NopSled *Sled =
+              findNearestSled(Ctx.NopSleds, InstOffset, Needed, SledUse)) {
+        if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement,
+                          Placement)) {
+          log() << "hotswap: safe far return: used local NOP sled at 0x"
+                << utohexstr(Sled->WritePos - Needed) << " for site 0x"
+                << utohexstr(InstOffset) << "\n";
+          return true;
+        }
+      }
+      if (AllowGlobalBody &&
+          emitDs2ThroughNopSledGateways(Ctx, InstOffset, InstSize, Replacement,
+                                        Placement))
+        return true;
+      if (DiagnoseFailure)
+        (void)reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement,
+                                   /*DiagnoseFailure=*/true);
+      return declineFar("no safe SGPR pair or fallback placement");
+    }
     T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
     T.Long = true;
     T.UsesSetPCBack = true;
     T.LongBranchSgprBase = Scratch->Base;
+    T.LongBranchScratchIsSiteProven = Scratch->IsSiteProven;
     Ctx.Profile.count(HotswapMetric::JumpLong);
     Ctx.OutTrampolines.emplace_back(std::move(T));
     Ctx.QueuedTrampolineBytes = *QueuedBytes;
@@ -850,6 +3624,153 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   return true;
 }
 
+struct PreparedSiteReplacement {
+  SmallVector<uint8_t> Bytes;
+  bool ComposesWmmaHazard = false;
+};
+
+static std::optional<PreparedSiteReplacement>
+prepareSiteReplacement(const PatchContext &Ctx, uint64_t InstOffset,
+                       uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+                       bool DiagnoseFailure) {
+  std::optional<uint64_t> InstEnd = checkedAddUint64(
+      InstOffset, InstSize, "site replacement source interval");
+  if (!InstEnd)
+    return std::nullopt;
+
+  auto IsActive = [](const SiteReplacementState &State) {
+    return State.Committed || State.RequiredLeadingVNops != 0;
+  };
+  auto DiagnoseOverlap = [&](uint64_t Offset,
+                             const SiteReplacementState &State) {
+    std::optional<uint64_t> End = checkedAddUint64(
+        Offset, State.OriginalSize, "owned replacement source interval");
+    if (!End)
+      return false;
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source [0x" << utohexstr(InstOffset)
+            << ", 0x" << utohexstr(*InstEnd) << ") overlaps reserved source [0x"
+            << utohexstr(Offset) << ", 0x" << utohexstr(*End) << ")\n";
+    return true;
+  };
+
+  // Replacement intervals are inserted only after a successful emission or
+  // by whole-pass precomputation, and central ownership keeps them disjoint.
+  // An ordered map therefore needs only the predecessor plus entries whose
+  // starts fall inside the requested interval, instead of scanning every
+  // patched instruction in a large code object.
+  auto It = Ctx.SiteReplacements.lower_bound(InstOffset);
+  if (It != Ctx.SiteReplacements.begin()) {
+    auto Prev = std::prev(It);
+    if (IsActive(Prev->second)) {
+      std::optional<uint64_t> PrevEnd =
+          checkedAddUint64(Prev->first, Prev->second.OriginalSize,
+                           "owned replacement source interval");
+      if (!PrevEnd)
+        return std::nullopt;
+      if (*PrevEnd > InstOffset) {
+        DiagnoseOverlap(Prev->first, Prev->second);
+        return std::nullopt;
+      }
+    }
+  }
+
+  const SiteReplacementState *Exact = nullptr;
+  if (It != Ctx.SiteReplacements.end() && It->first == InstOffset) {
+    Exact = &It->second;
+    ++It;
+  }
+  for (; It != Ctx.SiteReplacements.end() && It->first < *InstEnd; ++It) {
+    if (!IsActive(It->second))
+      continue;
+    DiagnoseOverlap(It->first, It->second);
+    return std::nullopt;
+  }
+
+  if (Exact && Exact->Committed) {
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source at 0x"
+            << utohexstr(InstOffset) << " already has a committed owner\n";
+    return std::nullopt;
+  }
+  if (Exact && Exact->OriginalSize != InstSize) {
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source at 0x"
+            << utohexstr(InstOffset) << " has reserved size "
+            << Exact->OriginalSize << " but owner requested " << InstSize
+            << " bytes\n";
+    return std::nullopt;
+  }
+
+  PreparedSiteReplacement Prepared;
+  const unsigned VNops = Exact ? Exact->RequiredLeadingVNops : 0;
+  if (VNops != 0) {
+    SmallVector<uint8_t> VNopBytes = assembleSingleInst("v_nop", Ctx.LS);
+    if (VNopBytes.size() != MinInstSize) {
+      if (DiagnoseFailure)
+        log() << "hotswap: error: could not encode v_nop requirement for "
+                 "replacement source at 0x"
+              << utohexstr(InstOffset) << "\n";
+      return std::nullopt;
+    }
+    for (unsigned I = 0; I != VNops; ++I)
+      Prepared.Bytes.append(VNopBytes.begin(), VNopBytes.end());
+    Prepared.ComposesWmmaHazard = true;
+  }
+  Prepared.Bytes.append(Replacement.begin(), Replacement.end());
+  return Prepared;
+}
+
+static bool commitSiteReplacement(PatchContext &Ctx, uint64_t InstOffset,
+                                  uint32_t InstSize,
+                                  const PreparedSiteReplacement &Prepared) {
+  SiteReplacementState &State = Ctx.SiteReplacements[InstOffset];
+  if (State.Committed ||
+      (State.OriginalSize != 0 && State.OriginalSize != InstSize) ||
+      (Prepared.ComposesWmmaHazard && State.RequiredLeadingVNops == 0) ||
+      (!Prepared.ComposesWmmaHazard && State.RequiredLeadingVNops != 0)) {
+    log() << "hotswap: error: replacement ownership changed while committing "
+             "source at 0x"
+          << utohexstr(InstOffset) << "\n";
+    Ctx.RequiredPatchFailed = true;
+    return false;
+  }
+
+  State.OriginalSize = InstSize;
+  State.Committed = true;
+  if (Prepared.ComposesWmmaHazard) {
+    State.WmmaHazardComposed = true;
+    ++Ctx.WmmaHazardsComposed;
+    log() << "hotswap: WMMA co-exec requirement composed into replacement at "
+             "0x"
+          << utohexstr(InstOffset) << " (" << State.RequiredLeadingVNops
+          << " leading v_nop(s))\n";
+  }
+  Ctx.RequiredPatchApplied = true;
+  return true;
+}
+
+bool hasSiteReplacementReservation(const PatchContext &Ctx, uint64_t Offset) {
+  auto It = Ctx.SiteReplacements.find(Offset);
+  return It != Ctx.SiteReplacements.end() &&
+         (It->second.Committed || It->second.RequiredLeadingVNops != 0);
+}
+
+[[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
+                                    uint32_t InstSize,
+                                    ArrayRef<uint8_t> Replacement,
+                                    ReplacementPlacement Placement,
+                                    bool DiagnoseFailure) {
+  std::optional<PreparedSiteReplacement> Prepared = prepareSiteReplacement(
+      Ctx, InstOffset, InstSize, Replacement, DiagnoseFailure);
+  if (!Prepared)
+    return false;
+  if (!emitToTrampolineRaw(Ctx, InstOffset, InstSize, Prepared->Bytes,
+                           Placement, DiagnoseFailure))
+    return false;
+  return commitSiteReplacement(Ctx, InstOffset, InstSize, *Prepared);
+}
+
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS) {
@@ -857,23 +3778,21 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
   if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
     return Target;
 
-  // TODO(https://github.com/ROCm/llvm-project/issues/3351): Remove this
-  // fallback when AMDGPUMCInstrAnalysis::evaluateBranch locates the descriptor
-  // operand marked MCOI::OPERAND_PCREL. Its current operand-zero restriction
-  // is in llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp.
-  // GFX1250 s_call_i64 instead has its destination SGPR pair in slot zero and
-  // its simm16 dword displacement in slot one; the operand layout and width
-  // are pinned by llvm/test/MC/AMDGPU/gfx1250_asm_sopk.s.
-  if (DI.Inst.getOpcode() != LS.SCallI64Opcode ||
-      DI.Inst.getNumOperands() == 0 ||
-      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+  // AMDGPUMCInstrAnalysis currently only accepts a PC-relative operand in
+  // slot zero. GFX1250 s_call_i64 instead has its destination SGPR pair in
+  // slot zero and its simm16 dword displacement in slot one. Keep this narrow
+  // workaround private to hotswap.
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  if (DI.Inst.getOpcode() != LS.SCallI64Opcode || !Desc.isCall() ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isReg() ||
+      !DI.Inst.getOperand(0).getReg() || !DI.Inst.getOperand(1).isImm())
     return std::nullopt;
 
   uint64_t Encoded =
-      static_cast<uint64_t>(
-          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
-      0xFFFFu;
-  int64_t DwordDelta = SignExtend64<16>(Encoded);
+      static_cast<uint64_t>(DI.Inst.getOperand(1).getImm()) & 0xFFFFu;
+  int64_t DwordDelta = Encoded < 0x8000u
+                           ? static_cast<int64_t>(Encoded)
+                           : static_cast<int64_t>(Encoded) - 0x10000;
   std::optional<uint64_t> PcBase = checkedAddUint64(
       DI.Offset, DI.Size, "direct control-flow target PC base");
   if (!PcBase)
@@ -928,6 +3847,10 @@ struct DeclaredTextEntryInfo {
   SmallVector<uint64_t, 16> ExternalEntries;
 };
 
+/// Collect every declared in-text function and kernel entry.  The external
+/// subset is kept separately because an externally reachable alias invalidates
+/// a local helper's call-defined return-link proof even when both symbols begin
+/// at the same address.
 static std::optional<DeclaredTextEntryInfo>
 collectDeclaredTextEntries(const ElfView &Elf) {
   std::optional<uint64_t> TextEnd =
@@ -938,7 +3861,7 @@ collectDeclaredTextEntries(const ElfView &Elf) {
   DeclaredTextEntryInfo Info;
   for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges())
     if (Range.Begin >= Elf.textAddr() && Range.Begin < *TextEnd) {
-      uint64_t Entry = Range.Begin - Elf.textAddr();
+      const uint64_t Entry = Range.Begin - Elf.textAddr();
       Info.Entries.push_back(Entry);
       if (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL)
         Info.ExternalEntries.push_back(Entry);
@@ -951,7 +3874,7 @@ collectDeclaredTextEntries(const ElfView &Elf) {
           Descriptor.VAddr, static_cast<uint64_t>(Descriptor.EntryOffset),
           "kernel descriptor entry address");
     } else {
-      uint64_t Magnitude =
+      const uint64_t Magnitude =
           Descriptor.EntryOffset == std::numeric_limits<int64_t>::min()
               ? uint64_t{1} << 63
               : static_cast<uint64_t>(-Descriptor.EntryOffset);
@@ -961,7 +3884,7 @@ collectDeclaredTextEntries(const ElfView &Elf) {
     if (!EntryAddress)
       return std::nullopt;
     if (*EntryAddress >= Elf.textAddr() && *EntryAddress < *TextEnd) {
-      uint64_t Entry = *EntryAddress - Elf.textAddr();
+      const uint64_t Entry = *EntryAddress - Elf.textAddr();
       Info.Entries.push_back(Entry);
       Info.ExternalEntries.push_back(Entry);
     }
@@ -1454,17 +4377,91 @@ hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
 }
 
 /// Collect statically known direct branch and call destinations so an interior
-/// entry point is never swallowed by coalescing.
-std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
+/// entry point is never swallowed by coalescing.  This is the PR's richer
+/// whole-object analysis used by production rewriting.
+static std::optional<DenseSet<uint64_t>> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
-    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<uint64_t> ExternalEntries) {
+    ArrayRef<uint8_t> Text, const ElfView &Elf,
+    const DenseSet<uint64_t> &CodeEntries, ArrayRef<uint64_t> TextSymbolOffsets,
+    ArrayRef<ElfView::TextOffsetRange> TextSymbolExtents,
+    const CompatibilityControlFlowFacts &CompatibilityFacts) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
     return std::nullopt;
   }
+
+  DenseSet<uint64_t> Targets = CodeEntries;
+  Targets.insert(CompatibilityFacts.Summary.Targets.begin(),
+                 CompatibilityFacts.Summary.Targets.end());
+  DenseSet<uint64_t> DecodedBoundaries;
+  for (const InternalDecodedInst &DI : Decoded)
+    DecodedBoundaries.insert(DI.Offset);
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "call continuation control-flow target");
+      if (!Continuation || *Continuation >= Text.size() ||
+          !DecodedBoundaries.contains(*Continuation)) {
+        log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
+              << " has no exact in-text continuation; source relocation and "
+                 "donated sleds are disabled\n";
+        return std::nullopt;
+      }
+      Targets.insert(*Continuation);
+    }
+    // Absolute and arbitrary-link materialized calls were resolved by the
+    // later analysis. Their text targets are already in Targets; do not feed
+    // their non-PC-relative immediates back through the PR evaluator.
+    if (findResolvedCompatibilityCall(CompatibilityFacts, I))
+      continue;
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Op : DI.Inst)
+      HasImmediate |= Op.isImm();
+    if (!HasImmediate)
+      continue;
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (!Target) {
+      log() << "hotswap: MC analysis could not evaluate direct control-flow "
+               "instruction at 0x"
+            << utohexstr(DI.Offset)
+            << "; source relocation and donated sleds are disabled\n";
+      return std::nullopt;
+    }
+    Targets.insert(*Target);
+  }
+
+  SmallVector<MaterializedPcTransfer> Candidates;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            evaluateProvenPcTransfer(Decoded, I, Targets, Text, LS, Elf,
+                                     CompatibilityFacts, TextSymbolOffsets,
+                                     TextSymbolExtents))
+      Candidates.push_back(*Transfer);
+
+  DenseSet<uint64_t> CombinedTargets = Targets;
+  for (const MaterializedPcTransfer &Transfer : Candidates)
+    CombinedTargets.insert(Transfer.Target);
+  return CombinedTargets;
+}
+
+/// Run the later amd-staging arbitrary-link call analysis and retain the proof
+/// records needed by the PR's production pipeline.  Reducing this result to
+/// DirectControlFlowInfo alone loses which indirect calls and returns were
+/// proven, causing downstream analysis to classify them as arbitrary again.
+static std::optional<CompatibilityControlFlowFacts>
+collectCompatibilityControlFlowFacts(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> ExternalEntries) {
+  if (!LS.MIA)
+    return std::nullopt;
 
   std::optional<uint64_t> TextEnd =
       checkedAddUint64(TextAddr, TextSize, "direct target text end");
@@ -1487,16 +4484,19 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   if (!BoundedReturns)
     return std::nullopt;
 
-  DirectControlFlowInfo Info;
+  CompatibilityControlFlowFacts Facts;
+  DirectControlFlowInfo &Info = Facts.Summary;
+  for (const BoundedSetPcReturn &Return : *BoundedReturns) {
+    if (Return.InstIndex >= Decoded.size())
+      return std::nullopt;
+    Facts.BoundedReturnOffsets.insert(Decoded[Return.InstIndex].Offset);
+  }
+
   for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isReturn(DI.Inst))
       continue;
-    // Existing indirect branches are handled by
-    // collectIndirectControlFlowFunctions(), which protects their containing
-    // function from source relocation. Calls without a statically resolvable
-    // target are handled below.
     if (LS.MIA->isIndirectBranch(DI.Inst))
       continue;
 
@@ -1504,12 +4504,10 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     for (const MCOperandInfo &Op : LS.MCII->get(DI.Inst.getOpcode()).operands())
       HasPcRelativeOperand |= Op.OperandType == MCOI::OPERAND_PCREL;
     if (!HasPcRelativeOperand) {
-      // Preserve the established handling for non-call indirect transfers
-      // such as s_set_pc_i64. collectIndirectControlFlowFunctions() prevents
-      // source relocation in their containing function.
       if (!LS.MIA->isCall(DI.Inst))
         continue;
       std::optional<uint64_t> Target;
+      bool IsMaterialized = false;
       if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
           DI.Inst.getNumOperands() != 0 &&
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
@@ -1522,36 +4520,65 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                      MaterializedCalls[InstIndex]->SequenceStart,
                      MaterializedCalls[InstIndex]->SequenceEnd)) {
         Target = MaterializedCalls[InstIndex]->Target;
+        IsMaterialized = true;
       }
       if (!Target) {
-        log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
-              << " (" << DI.Mnemonic << ")\n";
+        Facts.UnresolvedCallIndices.push_back(InstIndex);
         Info.HasUnresolvedTargets = true;
         continue;
       }
 
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "resolved compatibility call continuation");
+      std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
+      if (!Continuation || !ReturnRegister)
+        return std::nullopt;
+      ResolvedCompatibilityCall Call;
+      Call.InstIndex = InstIndex;
+      Call.Site = DI.Offset;
+      Call.SequenceStart = IsMaterialized
+                               ? MaterializedCalls[InstIndex]->SequenceStart
+                               : DI.Offset;
+      Call.SequenceEnd = *Continuation;
+      Call.Continuation = *Continuation;
+      Call.ReturnRegister = *ReturnRegister;
       if (*Target >= TextAddr && *Target < *TextEnd) {
         uint64_t RelativeTarget = *Target - TextAddr;
+        Call.TextTarget = RelativeTarget;
         Info.Targets.insert(RelativeTarget);
-        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
+        if (IsMaterialized)
           log() << "hotswap: resolved PC-materialized call at 0x"
                 << utohexstr(DI.Offset) << " to .text+0x"
                 << utohexstr(RelativeTarget) << "\n";
       }
+      Facts.ResolvedCalls.push_back(std::move(Call));
       continue;
     }
 
     std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
-    if (!Target) {
-      log() << "hotswap: MC analysis could not evaluate direct control-flow "
-               "instruction at 0x"
-            << utohexstr(DI.Offset)
-            << "; adjacent far trampolines will not be coalesced\n";
+    if (!Target)
       return std::nullopt;
-    }
     Info.Targets.insert(*Target);
   }
-  return Info;
+  return Facts;
+}
+
+/// Compatibility entry point retained for later amd-staging callers and the
+/// focused unit tests.  Production consumes the full fact set above.
+std::optional<DirectControlFlowInfo>
+collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
+                           const LLVMState &LS, uint64_t TextAddr,
+                           uint64_t TextSize,
+                           ArrayRef<uint64_t> DeclaredEntries,
+                           ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+                           ArrayRef<uint64_t> ExternalEntries) {
+  std::optional<CompatibilityControlFlowFacts> Facts =
+      collectCompatibilityControlFlowFacts(
+          Decoded, LS, TextAddr, TextSize, DeclaredEntries, FunctionRanges,
+          ExternalEntries);
+  if (!Facts)
+    return std::nullopt;
+  return std::move(Facts->Summary);
 }
 
 /// Coalesce runs of adjacent far patch sites when the same SGPR scratch block
@@ -1560,7 +4587,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
 /// This deliberately never steals an unpatched neighboring instruction.
 static void
 mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
-                             const DenseSet<uint64_t> &DirectBranchTargets) {
+                             const DenseSet<uint64_t> &DirectBranchTargets,
+                             const DenseSet<uint64_t> &IncompleteFunctions) {
   std::vector<Trampoline> Merged;
   Merged.reserve(Trampolines.size());
   uint64_t MergeCount = 0;
@@ -1574,9 +4602,12 @@ mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
       Adjacent = PrevEnd && *PrevEnd == T.OriginalOffset && Prev.Long &&
                  T.Long && Prev.UsesSetPCBack && T.UsesSetPCBack &&
                  Prev.LongBranchSgprBase == T.LongBranchSgprBase &&
+                 Prev.LongBranchScratchIsSiteProven ==
+                     T.LongBranchScratchIsSiteProven &&
                  Prev.HasFunctionRange && T.HasFunctionRange &&
                  Prev.FunctionStart == T.FunctionStart &&
                  Prev.FunctionEnd == T.FunctionEnd &&
+                 !IncompleteFunctions.contains(T.FunctionStart) &&
                  !DirectBranchTargets.contains(T.OriginalOffset) &&
                  Prev.Bytes.size() >= SetPcReturnReserveBytes &&
                  T.Bytes.size() >= SetPcReturnReserveBytes;
@@ -1614,101 +4645,524 @@ static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
   }
 }
 
-static bool isEndProgram(const InternalDecodedInst &DI, const LLVMState &LS) {
-  unsigned Opcode = DI.Inst.getOpcode();
-  return Opcode == LS.SEndPgmOpcode || Opcode == LS.SEndPgmSavedOpcode;
-}
-
-static bool isPcSensitive(const InternalDecodedInst &DI, const LLVMState &LS) {
-  unsigned Opcode = DI.Inst.getOpcode();
-  return Opcode == LS.SAddPcI64Opcode || Opcode == LS.SGetPcI64Opcode ||
-         Opcode == LS.SSetPcI64Opcode || Opcode == LS.SSwapPcI64Opcode ||
-         Opcode == LS.SPrefetchInstPcRelOpcode ||
-         Opcode == LS.SPrefetchDataPcRelOpcode;
-}
-
 static bool isSafeStraightLineRelocation(const InternalDecodedInst &DI,
                                          const LLVMState &LS,
                                          const DenseSet<uint64_t> &Protected) {
   if (!LS.MIA || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
     return false;
-  unsigned Opcode = DI.Inst.getOpcode();
-  return DI.DecodeSucceeded && !Protected.contains(DI.Offset) &&
-         Opcode != LS.SClauseOpcode && Opcode != LS.SDelayAluOpcode &&
-         !isPcSensitive(DI, LS);
+  return !Protected.contains(DI.Offset) && DI.Mnemonic != "<unknown>" &&
+         DI.Mnemonic != "<replaced>" && DI.Mnemonic != "s_clause" &&
+         DI.Mnemonic != "s_delay_alu" &&
+         !StringRef(DI.Mnemonic).contains("_pc_");
 }
 
-/// Decode the bytes currently present at an original instruction site. Earlier
-/// rewrite passes may have changed Ctx.Text after Ctx.Decoded was populated, so
-/// relocation decisions must not classify the stale MCInst and then copy a
-/// different instruction. A size change is conservatively non-relocatable.
+/// Re-decode the bytes that source growth would actually copy. Per-instruction
+/// patching runs before source-window expansion, so the original Decoded entry
+/// may no longer describe this interval. Requiring one same-size current
+/// instruction prevents relocation of a newly installed branch or a
+/// multi-instruction replacement under stale dataflow semantics.
 static std::optional<InternalDecodedInst>
-decodeCurrentInstruction(const PatchContext &Ctx,
-                         const InternalDecodedInst &Original) {
+decodeCurrentRelocationCandidate(const PatchContext &Ctx,
+                                 const InternalDecodedInst &Original) {
   if (Original.Offset > Ctx.TextSize ||
       Original.Size > Ctx.TextSize - Original.Offset)
     return std::nullopt;
-
   std::vector<InternalDecodedInst> Current;
   if (!decodeTextSection(Ctx.Text + Original.Offset, Original.Size, Ctx.LS,
                          Current) ||
-      Current.size() != 1 || Current[0].Size != Original.Size)
+      Current.size() != 1 || Current.front().Offset != 0 ||
+      Current.front().Size != Original.Size)
     return std::nullopt;
-  Current[0].Offset = Original.Offset;
-  return std::move(Current[0]);
+  Current.front().Offset = Original.Offset;
+  return std::move(Current.front());
+}
+
+/// Return the number of following instructions whose relative positions are
+/// significant to an s_delay_alu encoding. Instid0 names the immediately
+/// following instruction. Instid1 names the instruction selected by instskip,
+/// so every instruction through that target must stay in place. Malformed or
+/// undecodable immediates retain the conservative six-instruction bound.
+unsigned getDelayProtectedSpan(const InternalDecodedInst &DI) {
+  if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+    return 6;
+
+  uint64_t Imm = static_cast<uint64_t>(DI.Inst.getOperand(0).getImm());
+  if ((Imm & ~uint64_t{0x7FF}) != 0)
+    return 6;
+
+  unsigned InstId0 = Imm & 0xF;
+  unsigned Skip = (Imm >> 4) & 0x7;
+  unsigned InstId1 = (Imm >> 7) & 0xF;
+  if (InstId0 >= 12 || InstId1 >= 12 || Skip > 5 || (InstId1 == 0 && Skip != 0))
+    return 6;
+
+  unsigned Span = InstId0 != 0 ? 1 : 0;
+  if (InstId1 != 0)
+    Span = std::max(Span, Skip + 1);
+  return Span;
 }
 
 /// Instructions covered by a hard clause or a delay directive must remain in
-/// place relative to that directive. B0-to-A0 rewrites have already replaced
-/// clauses with s_nop, so only preserve clause members when requested. Always
-/// mark the maximum six-instruction forward span addressable by s_delay_alu.
-static DenseSet<uint64_t>
+/// place relative to that directive. Mark the complete encoded clause and the
+/// exact s_delay_alu span when its immediate is well formed. The blanket
+/// B0-to-A0 s_clause rewrite releases each clause's member protections only
+/// after that directive has been replaced successfully.
+static void
 collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
-                                  const LLVMState &LS,
-                                  bool ProtectClauseMembers) {
-  DenseSet<uint64_t> Protected;
-  unsigned ClauseRemaining = 0;
+                                  PatchContext &Ctx) {
   unsigned DelayRemaining = 0;
 
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (ClauseRemaining != 0) {
-      Protected.insert(DI.Offset);
-      --ClauseRemaining;
-    }
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
     if (DelayRemaining != 0) {
-      Protected.insert(DI.Offset);
+      protectNonClauseRelocationOffset(Ctx, DI.Offset);
       --DelayRemaining;
     }
 
-    if (ProtectClauseMembers && DI.Inst.getOpcode() == LS.SClauseOpcode &&
-        DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isImm())
-      ClauseRemaining =
+    if (DI.Mnemonic == "s_clause" && DI.Inst.getNumOperands() == 1 &&
+        DI.Inst.getOperand(0).isImm()) {
+      const unsigned MemberCount =
           (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 63u) + 1;
-    else if (DI.Inst.getOpcode() == LS.SDelayAluOpcode)
-      DelayRemaining = 6;
+      const size_t Available =
+          std::min<size_t>(MemberCount, Decoded.size() - I - 1);
+      for (size_t Member = I + 1, End = I + 1 + Available; Member != End;
+           ++Member) {
+        const uint64_t Offset = Decoded[Member].Offset;
+        ++Ctx.ClauseRelocationProtectionCounts[Offset];
+        Ctx.RelocationProtectedOffsets.insert(Offset);
+      }
+    } else if (DI.Mnemonic == "s_delay_alu") {
+      DelayRemaining = std::max(DelayRemaining, getDelayProtectedSpan(DI));
+    }
   }
-  return Protected;
+}
+
+/// Under the public HotSwap API's callable-control-flow precondition, this is
+/// an ABI call and its register target is a callable function entry. This is a
+/// control-flow geometry fact only: all liveness and value analyses continue
+/// to treat the instruction as an opaque call boundary.
+static bool isStandardLinkCall(const InternalDecodedInst &DI,
+                               const LLVMState &LS) {
+  return DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+         DI.Inst.getNumOperands() == 2 && DI.Inst.getOperand(0).isReg() &&
+         DI.Inst.getOperand(0).getReg() &&
+         StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+             "SGPR30_SGPR31";
+}
+
+static std::optional<std::pair<unsigned, SgprPairHalves>>
+getNumberedSgprPair(const LLVMState &LS, const MCOperand &Operand) {
+  if (!Operand.isReg() || !Operand.getReg())
+    return std::nullopt;
+  std::optional<SgprPairHalves> Halves =
+      getSgprPairHalves(LS, MCRegister(Operand.getReg()));
+  if (!Halves || Halves->IsVcc)
+    return std::nullopt;
+  std::optional<unsigned> Lo = numberedSgprIndex(*LS.MRI, Halves->Regs[0]);
+  std::optional<unsigned> Hi = numberedSgprIndex(*LS.MRI, Halves->Regs[1]);
+  if (!Lo || !Hi || *Hi != *Lo + 1)
+    return std::nullopt;
+  return std::make_pair(*Lo, *Halves);
+}
+
+static bool hasUnresolvedStandardLinkCall(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const ElfView &Elf, const DenseSet<uint64_t> &DirectControlFlowTargets,
+    ArrayRef<uint8_t> Text, std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents,
+    const CompatibilityControlFlowFacts &CompatibilityFacts) {
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    if (!isStandardLinkCall(Decoded[I], LS))
+      continue;
+    if (!findResolvedCompatibilityCall(CompatibilityFacts, I) &&
+        !evaluateMaterializedPcTransfer(Decoded, I, DirectControlFlowTargets,
+                                        Text, LS, Elf, TextSymbolOffsets,
+                                        TextSymbolExtents))
+      return true;
+  }
+  return false;
+}
+
+/// Prove nonstandard s_set_pc_i64 returns only when every modeled ingress
+/// carries the exact link written by an in-text s_call_i64 using the same
+/// physical SGPR pair. Any alternate entry, clobber, or unmodeled indirect
+/// transfer invalidates the proof globally.
+static DenseSet<uint64_t> collectProvenDirectCallReturns(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS, ElfView &Elf,
+    const DenseSet<uint64_t> &DirectControlFlowTargets, ArrayRef<uint8_t> Text,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents,
+    bool HasUnresolvedStandardLinkCall,
+    const CompatibilityControlFlowFacts &CompatibilityFacts) {
+  // The compatibility analysis supplies candidates and teaches the PR-wide
+  // dataflow about call forms it cannot otherwise resolve.  It is not an
+  // independent fallback: an unmodeled standard-link ingress can carry an
+  // arbitrary value in the candidate return pair.
+  DenseSet<uint64_t> CompatibilityCandidates;
+  if (!CompatibilityFacts.Summary.HasUnresolvedTargets &&
+      !HasUnresolvedStandardLinkCall)
+    CompatibilityCandidates = CompatibilityFacts.BoundedReturnOffsets;
+  DenseSet<uint64_t> Proven;
+  DenseSet<uint64_t> ValidatedCompatibilityProven;
+  if (!LS.MIA || !LS.MCII || !LS.MRI || Decoded.empty())
+    return {};
+
+  // AMDGPU's instruction metadata does not classify RFE as a branch or a
+  // terminator. It can nevertheless resume at an arbitrary PC with arbitrary
+  // SGPR contents. An undecodable word may hide the same behavior, so no
+  // nonstandard link-pair proof survives either condition.
+  if (llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+        return DI.Mnemonic == "<unknown>" ||
+               StringRef(DI.Mnemonic).starts_with("s_rfe");
+      }))
+    return {};
+
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  OffsetToIndex.reserve(Decoded.size());
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    if (Decoded[I].Size == 0 ||
+        !OffsetToIndex.try_emplace(Decoded[I].Offset, I).second)
+      return {};
+  }
+
+  std::vector<std::optional<MaterializedPcTransfer>> Materialized(
+      Decoded.size());
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    Materialized[I] = evaluateProvenPcTransfer(
+        Decoded, I, DirectControlFlowTargets, Text, LS, Elf,
+        CompatibilityFacts, TextSymbolOffsets, TextSymbolExtents);
+
+  std::vector<std::optional<unsigned>> ReturnPairs(Decoded.size());
+  SmallVector<std::pair<unsigned, SgprPairHalves>, 4> Pairs;
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        isStandardLinkReturn(DI, LS) || Materialized[I] ||
+        DI.Inst.getNumOperands() != 1)
+      continue;
+    std::optional<std::pair<unsigned, SgprPairHalves>> Pair =
+        getNumberedSgprPair(LS, DI.Inst.getOperand(0));
+    if (!Pair)
+      continue;
+    ReturnPairs[I] = Pair->first;
+    if (!llvm::any_of(Pairs, [&](const auto &Existing) {
+          return Existing.first == Pair->first;
+        }))
+      Pairs.push_back(*Pair);
+  }
+  if (Pairs.empty())
+    return {};
+
+  std::optional<DenseSet<uint64_t>> DescriptorEntries =
+      collectResolvedKernelEntryOffsets(Elf, LS);
+  if (!DescriptorEntries)
+    return {};
+  SmallVector<unsigned, 8> DescriptorEntryIndices;
+  for (uint64_t Entry : *DescriptorEntries) {
+    auto It = OffsetToIndex.find(Entry);
+    if (It == OffsetToIndex.end())
+      return {};
+    DescriptorEntryIndices.push_back(It->second);
+  }
+
+  SmallVector<unsigned, 16> CallableEntryIndices;
+  for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges()) {
+    if (Range.Begin < Elf.textAddr() ||
+        (!HasUnresolvedStandardLinkCall && !isExternallyVisibleCallable(Range)))
+      continue;
+    const uint64_t Entry = Range.Begin - Elf.textAddr();
+    if (Entry >= Text.size())
+      continue;
+    auto It = OffsetToIndex.find(Entry);
+    if (It == OffsetToIndex.end())
+      return {};
+    if (!llvm::is_contained(CallableEntryIndices, It->second))
+      CallableEntryIndices.push_back(It->second);
+  }
+
+  struct CallIngress {
+    unsigned TargetIndex = 0;
+    std::optional<unsigned> ExactLinkPair;
+  };
+  SmallVector<unsigned, 16> CallContinuationIndices;
+  SmallVector<CallIngress, 16> CallIngresses;
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!LS.MIA->isCall(DI.Inst))
+      continue;
+
+    std::optional<uint64_t> Continuation = checkedAddUint64(
+        DI.Offset, DI.Size, "direct-call return proof continuation");
+    if (!Continuation || *Continuation >= Text.size())
+      return {};
+    auto ContinuationIt = OffsetToIndex.find(*Continuation);
+    if (ContinuationIt == OffsetToIndex.end())
+      return {};
+    if (!llvm::is_contained(CallContinuationIndices, ContinuationIt->second))
+      CallContinuationIndices.push_back(ContinuationIt->second);
+
+    std::optional<uint64_t> Target;
+    std::optional<unsigned> ExactPair;
+    if (DI.Inst.getOpcode() == LS.SCallI64Opcode) {
+      Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target)
+        return {};
+      if (DI.Inst.getNumOperands() == 2)
+        if (std::optional<std::pair<unsigned, SgprPairHalves>> Pair =
+                getNumberedSgprPair(LS, DI.Inst.getOperand(0)))
+          ExactPair = Pair->first;
+    } else if (Materialized[I]) {
+      Target = Materialized[I]->Target;
+      if (DI.Inst.getNumOperands() != 0)
+        if (std::optional<std::pair<unsigned, SgprPairHalves>> Pair =
+                getNumberedSgprPair(LS, DI.Inst.getOperand(0)))
+          ExactPair = Pair->first;
+    } else if (!LS.MIA->isIndirectBranch(DI.Inst)) {
+      Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target)
+        return {};
+    }
+    if (!Target || *Target >= Text.size())
+      continue;
+    auto TargetIt = OffsetToIndex.find(*Target);
+    if (TargetIt == OffsetToIndex.end())
+      return {};
+    CallIngresses.push_back({TargetIt->second, ExactPair});
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Decoded.size());
+  auto AddFallthrough = [&](unsigned I) {
+    std::optional<uint64_t> Next =
+        checkedAddUint64(Decoded[I].Offset, Decoded[I].Size,
+                         "direct-call return proof fallthrough");
+    if (!Next)
+      return false;
+    // A trailing padding instruction can end exactly at the .text boundary.
+    // That is a terminal edge, not an incomplete in-text successor; accepting
+    // it does not create a new ingress into any proven return.
+    if (*Next == Text.size())
+      return I + 1 == Decoded.size();
+    if (*Next > Text.size() || I + 1 >= Decoded.size() ||
+        Decoded[I + 1].Offset != *Next)
+      return false;
+    Successors[I].push_back(I + 1);
+    return true;
+  };
+  auto AddTarget = [&](unsigned I, uint64_t Target) {
+    if (Target >= Text.size())
+      return true;
+    auto It = OffsetToIndex.find(Target);
+    if (It == OffsetToIndex.end())
+      return false;
+    Successors[I].push_back(It->second);
+    return true;
+  };
+
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    if (LS.MIA->isCall(DI.Inst) || DI.Mnemonic == "s_code_end" ||
+        DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (Materialized[I]) {
+      if (!AddTarget(I, Materialized[I]->Target))
+        return {};
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode)
+      continue;
+    if (LS.MIA->isBranch(DI.Inst)) {
+      if (LS.MIA->isIndirectBranch(DI.Inst))
+        continue;
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target || !AddTarget(I, *Target))
+        return {};
+      if (LS.MIA->isConditionalBranch(DI.Inst)) {
+        if (!AddFallthrough(I))
+          return {};
+      } else if (!LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        return {};
+      }
+      continue;
+    }
+    if (StringRef(DI.Mnemonic).starts_with("s_trap") || Desc.isTrap()) {
+      if (!AddFallthrough(I))
+        return {};
+      continue;
+    }
+    if (Desc.isTerminator() || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+      return {};
+    if (!AddFallthrough(I))
+      return {};
+  }
+
+  constexpr uint8_t ExactDirectCallLink = 1;
+  constexpr uint8_t UnknownLink = 2;
+  for (const auto &[PairBase, PairHalves] : Pairs) {
+    SmallVector<uint8_t> In(Decoded.size(), 0);
+    SmallVector<unsigned, 64> Worklist;
+    auto Merge = [&](unsigned Index, uint8_t State) {
+      const uint8_t Merged = In[Index] | State;
+      if (Merged == In[Index])
+        return;
+      In[Index] = Merged;
+      Worklist.push_back(Index);
+    };
+
+    for (unsigned Entry : DescriptorEntryIndices)
+      Merge(Entry, UnknownLink);
+    for (unsigned Entry : CallableEntryIndices)
+      Merge(Entry, UnknownLink);
+    for (unsigned Continuation : CallContinuationIndices)
+      Merge(Continuation, UnknownLink);
+    for (const CallIngress &Ingress : CallIngresses)
+      Merge(Ingress.TargetIndex,
+            Ingress.ExactLinkPair && *Ingress.ExactLinkPair == PairBase
+                ? ExactDirectCallLink
+                : UnknownLink);
+
+    for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+      const unsigned I = Worklist[Next];
+      const InternalDecodedInst &DI = Decoded[I];
+      if (ReturnPairs[I] && *ReturnPairs[I] == PairBase) {
+        if (In[I] == ExactDirectCallLink) {
+          if (CompatibilityCandidates.contains(DI.Offset))
+            ValidatedCompatibilityProven.insert(DI.Offset);
+          else
+            Proven.insert(DI.Offset);
+        } else {
+          Proven.erase(DI.Offset);
+          ValidatedCompatibilityProven.erase(DI.Offset);
+        }
+        continue;
+      }
+
+      uint8_t Out = In[I];
+      const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+      if (DI.Mnemonic == "<unknown>" ||
+          StringRef(DI.Mnemonic).starts_with("s_trap") || Desc.isTrap()) {
+        Out = UnknownLink;
+      } else if (Out != 0) {
+        std::optional<RegisterPairAccess> Access = getRegisterPairAccess(
+            LS, DI, PairHalves.Regs, /*PairIsAbiVcc=*/false);
+        if (!Access || Access->Defs != 0)
+          Out = UnknownLink;
+      }
+      for (unsigned Succ : Successors[I])
+        Merge(Succ, Out);
+    }
+  }
+
+  // A genuinely arbitrary transfer can enter any instruction with an unknown
+  // link value, invalidating every otherwise-local direct-return proof.
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved")
+      continue;
+    const bool HasOpaqueControlFlow =
+        DI.Mnemonic == "<unknown>" ||
+        StringRef(DI.Mnemonic).starts_with("s_rfe");
+    if (!HasOpaqueControlFlow && !LS.MIA->isIndirectBranch(DI.Inst) &&
+        !(LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+          StringRef(DI.Mnemonic).contains("_pc_")))
+      continue;
+    if (isStandardLinkReturn(DI, LS) || Materialized[I] ||
+        findResolvedCompatibilityCall(CompatibilityFacts, I) ||
+        isStandardLinkCall(DI, LS) || Proven.contains(DI.Offset) ||
+        ValidatedCompatibilityProven.contains(DI.Offset))
+      continue;
+    return {};
+  }
+  Proven.insert(ValidatedCompatibilityProven.begin(),
+                ValidatedCompatibilityProven.end());
+  return Proven;
 }
 
 /// Relocating an instruction changes its address. In a function containing a
 /// register-based PC transfer, MC cannot prove that the instruction is not an
 /// indirect destination, so leave the complete function in place.
-static DenseSet<uint64_t>
-collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
-                                    const LLVMState &LS, const ElfView &Elf) {
+static DenseSet<uint64_t> collectIndirectControlFlowFunctions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const ElfView &Elf, const DenseSet<uint64_t> &DirectControlFlowTargets,
+    ArrayRef<uint8_t> Text, std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents,
+    const DenseSet<uint64_t> &ProvenDirectCallReturns,
+    const CompatibilityControlFlowFacts &CompatibilityFacts,
+    bool &HasUnknownArbitraryIndirectTarget) {
   DenseSet<uint64_t> Functions;
+  HasUnknownArbitraryIndirectTarget = false;
   if (!LS.MIA)
     return Functions;
 
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved")
       continue;
-    if (!LS.MIA->isIndirectBranch(DI.Inst) &&
+    const bool HasOpaqueControlFlow =
+        DI.Mnemonic == "<unknown>" ||
+        StringRef(DI.Mnemonic).starts_with("s_rfe");
+    if (!HasOpaqueControlFlow && !LS.MIA->isIndirectBranch(DI.Inst) &&
         !(LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
-          isPcSensitive(DI, LS)))
+          StringRef(DI.Mnemonic).contains("_pc_")))
       continue;
     std::optional<ElfView::FunctionTextRange> Range =
         Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    const bool IsSetPc = DI.Inst.getOpcode() == LS.SSetPcI64Opcode;
+    const bool UsesStandardLinkPair =
+        IsSetPc && DI.Inst.getNumOperands() == 1 &&
+        DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg() &&
+        StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+            "SGPR30_SGPR31";
+    if (IsSetPc && ProvenDirectCallReturns.contains(DI.Offset)) {
+      log() << "hotswap: recognized proven direct-call return at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      continue;
+    }
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            evaluateProvenPcTransfer(
+                Decoded, I, DirectControlFlowTargets, Text, LS, Elf,
+                CompatibilityFacts, TextSymbolOffsets, TextSymbolExtents)) {
+      const bool CompatibilityResolved =
+          findResolvedCompatibilityCall(CompatibilityFacts, I) != nullptr;
+      // Arbitrary-link calls proven by the later analysis may intentionally
+      // enter a protected instruction boundary. ABI-standard link calls remain
+      // subject to the PR's public callable-entry contract even when the later
+      // pattern matcher recovered an exact address.
+      if (LS.MIA->isCall(DI.Inst) &&
+          (!CompatibilityResolved || isStandardLinkCall(DI, LS))) {
+        std::optional<ElfView::FunctionTextRange> TargetRange =
+            Elf.findFunctionTextRangeAtOffset(Transfer->Target);
+        if (!TargetRange || Transfer->Target != TargetRange->Begin) {
+          HasUnknownArbitraryIndirectTarget = true;
+          if (Range && Functions.insert(Range->Begin).second)
+            log() << "hotswap: source relocation disabled for function at 0x"
+                  << utohexstr(Range->Begin)
+                  << " by materialized call to a non-entry target at 0x"
+                  << utohexstr(DI.Offset) << "\n";
+          continue;
+        }
+      }
+      log() << "hotswap: recognized materialized PC transfer [0x"
+            << utohexstr(Transfer->Begin) << ", 0x" << utohexstr(Transfer->End)
+            << ") -> 0x" << utohexstr(Transfer->Target) << "\n";
+      continue;
+    }
+    if (findResolvedCompatibilityCall(CompatibilityFacts, I)) {
+      log() << "hotswap: recognized resolved direct call at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      continue;
+    }
+    // A standard-link return can leave from any basic block, but a recognized
+    // call-tail gateway using s[30:31] must be classified above first.
+    if (IsSetPc && UsesStandardLinkPair)
+      continue;
+    if (isStandardLinkCall(DI, LS)) {
+      log() << "hotswap: recognized ABI standard-link indirect call at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      continue;
+    }
+    HasUnknownArbitraryIndirectTarget = true;
     if (Range && Functions.insert(Range->Begin).second)
       log() << "hotswap: source relocation disabled for function at 0x"
             << utohexstr(Range->Begin) << " by " << DI.Mnemonic << " at 0x"
@@ -1717,24 +5171,502 @@ collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
   return Functions;
 }
 
+struct VgprMsbState {
+  int8_t Dst = VgprMsbUnreachable;
+  int8_t Src0 = VgprMsbUnreachable;
+  int8_t Src1 = VgprMsbUnreachable;
+  int8_t Src2 = VgprMsbUnreachable;
+};
+
+static VgprMsbState vgprMsbStateFromMode(unsigned Mode) {
+  Mode &= 0xff;
+  return {static_cast<int8_t>((Mode >> 6) & 0x3),
+          static_cast<int8_t>(Mode & 0x3),
+          static_cast<int8_t>((Mode >> 2) & 0x3),
+          static_cast<int8_t>((Mode >> 4) & 0x3)};
+}
+
+static VgprMsbState unknownVgprMsbState() {
+  return {VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown};
+}
+
+static int16_t exactVgprMsbMode(VgprMsbState State) {
+  if (State.Dst < 0 || State.Src0 < 0 || State.Src1 < 0 || State.Src2 < 0)
+    return VgprMsbUnknown;
+  return static_cast<int16_t>(State.Src0 | (State.Src1 << 2) |
+                              (State.Src2 << 4) | (State.Dst << 6));
+}
+
+// COMGR intentionally does not depend on AMDGPU's backend-private
+// AMDGPUBaseInfo.h. Mirror the gfx1250 SETREG-to-VGPR-MSB conversion here:
+// the simm16 low six bits select HW_REG_WAVE_MODE (ID 1), and gfx1250's
+// setreg-vgpr-msb-fixup makes an immediate MODE write load all four two-bit
+// fields from immediate bits [19:12], rotated into s_set_vgpr_msb order.
+static std::optional<unsigned>
+decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI) {
+  if (DI.Mnemonic != "s_setreg_imm32_b32" || DI.Inst.getNumOperands() != 2 ||
+      !DI.Inst.getOperand(0).isImm() || !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+  constexpr unsigned ModeHwregId = 1;
+  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
+  if ((Simm16 & 0x3f) != ModeHwregId)
+    return std::nullopt;
+  unsigned Raw =
+      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> 12) & 0xff;
+  return ((Raw >> 2) | (Raw << 6)) & 0xff;
+}
+
+static std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI) {
+  if (!StringRef(DI.Mnemonic).starts_with("s_setreg") ||
+      DI.Inst.getNumOperands() == 0 ||
+      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+    return std::nullopt;
+  return static_cast<unsigned>(
+             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
+         0x3f;
+}
+
+static bool instructionDefinesNamedRegister(const InternalDecodedInst &DI,
+                                            StringRef Name,
+                                            const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() &&
+        StringRef(LS.MRI->getName(Op.getReg())) == Name)
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Reg) {
+    return StringRef(LS.MRI->getName(Reg)) == Name;
+  });
+}
+
+static std::optional<unsigned>
+getExactVgprMsbModeWritten(const InternalDecodedInst &DI) {
+  if (DI.Mnemonic == "s_set_vgpr_msb") {
+    if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+      return std::nullopt;
+    return static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 0xff;
+  }
+  return decodeSetregImmVgprMsbMode(DI);
+}
+
+static VgprMsbState transferVgprMsbState(VgprMsbState In,
+                                         const InternalDecodedInst &DI,
+                                         const LLVMState &LS) {
+  if (In.Dst == VgprMsbUnreachable)
+    return In;
+  if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(DI))
+    return vgprMsbStateFromMode(*Mode);
+  if (DI.Mnemonic == "s_set_vgpr_msb")
+    return unknownVgprMsbState();
+  if (StringRef(DI.Mnemonic).starts_with("s_setreg")) {
+    std::optional<unsigned> HwregId = getSetregHwregId(DI);
+    if (!HwregId)
+      return unknownVgprMsbState();
+    constexpr unsigned ModeHwregId = 1;
+    if (*HwregId != ModeHwregId)
+      return In;
+    return unknownVgprMsbState();
+  }
+  if (DI.Mnemonic == "<unknown>" ||
+      instructionDefinesNamedRegister(DI, "MODE", LS) ||
+      (LS.MIA && LS.MIA->isCall(DI.Inst)))
+    return unknownVgprMsbState();
+  return In;
+}
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS) {
+  return DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+         DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isReg() &&
+         DI.Inst.getOperand(0).getReg() &&
+         StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+             "SGPR30_SGPR31";
+}
+
+static int8_t mergeVgprMsbValue(int8_t Old, int8_t Incoming) {
+  if (Old == VgprMsbUnreachable)
+    return Incoming;
+  if (Incoming == VgprMsbUnreachable || Old == Incoming)
+    return Old;
+  return VgprMsbUnknown;
+}
+
+static VgprMsbState mergeVgprMsbState(VgprMsbState Old, VgprMsbState Incoming) {
+  return {mergeVgprMsbValue(Old.Dst, Incoming.Dst),
+          mergeVgprMsbValue(Old.Src0, Incoming.Src0),
+          mergeVgprMsbValue(Old.Src1, Incoming.Src1),
+          mergeVgprMsbValue(Old.Src2, Incoming.Src2)};
+}
+
+static void clearNumberedSgprAliases(BitVector &Aligned, MCRegister Reg,
+                                     const MCRegisterInfo &MRI) {
+  auto Clear = [&](MCRegister Candidate) {
+    if (std::optional<unsigned> Index = numberedSgprIndex(MRI, Candidate))
+      if (*Index < Aligned.size())
+        Aligned.reset(*Index);
+  };
+  Clear(Reg);
+  for (MCPhysReg Sub : MRI.subregs(Reg))
+    Clear(MCRegister(Sub));
+  for (MCPhysReg Super : MRI.superregs(Reg))
+    Clear(MCRegister(Super));
+}
+
+/// Track numbered SGPR values that are known to be divisible by eight. Calls
+/// lose every fact because post-link code has no IPRA regmask; ordinary defs
+/// kill aliases, and an exact s_mul_i32 by an aligned immediate regenerates
+/// the destination fact independently of its other operand.
+static BitVector transferSgprAlignment(BitVector In,
+                                       const InternalDecodedInst &DI,
+                                       ArrayRef<uint8_t> Text,
+                                       const LLVMState &LS) {
+  if (DI.Mnemonic == "<unknown>" || LS.MIA->isCall(DI.Inst)) {
+    In.reset();
+    return In;
+  }
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg())
+      clearNumberedSgprAliases(In, MCRegister(Op.getReg()), *LS.MRI);
+  }
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    clearNumberedSgprAliases(In, MCRegister(Reg), *LS.MRI);
+
+  if (DI.Mnemonic != "s_mul_i32" || NumDefs != 1 ||
+      !DI.Inst.getOperand(0).isReg())
+    return In;
+  std::optional<unsigned> Dst =
+      numberedSgprIndex(*LS.MRI, MCRegister(DI.Inst.getOperand(0).getReg()));
+  if (!Dst || *Dst >= In.size())
+    return In;
+  for (unsigned I = NumDefs; I != DI.Inst.getNumOperands(); ++I) {
+    std::optional<int64_t> Value =
+        getAbsoluteOperandValue(DI.Inst.getOperand(I), DI, Text);
+    if (Value && (static_cast<uint32_t>(*Value) & 7u) == 0) {
+      In.set(*Dst);
+      break;
+    }
+  }
+  return In;
+}
+
+static bool isAlignedSgprSource(const MCOperand &Op, const BitVector &Aligned,
+                                const MCRegisterInfo &MRI) {
+  if (!Op.isReg() || !Op.getReg())
+    return false;
+  std::optional<unsigned> Index =
+      numberedSgprIndex(MRI, MCRegister(Op.getReg()));
+  return Index && *Index < Aligned.size() && Aligned.test(*Index);
+}
+
+static void recordAlignedVgprCopies(const InternalDecodedInst &DI,
+                                    size_t GlobalIndex,
+                                    const BitVector &Aligned,
+                                    const LLVMState &LS, BitVector &Def0,
+                                    BitVector &Def1) {
+  Def0.reset(GlobalIndex);
+  Def1.reset(GlobalIndex);
+  if (DI.Mnemonic == "v_mov_b32") {
+    if (DI.Inst.getNumOperands() == 2 &&
+        isAlignedSgprSource(DI.Inst.getOperand(1), Aligned, *LS.MRI))
+      Def0.set(GlobalIndex);
+    return;
+  }
+  if (DI.Mnemonic != "v_dual_mov_b32" || DI.Inst.getNumOperands() != 4)
+    return;
+  if (isAlignedSgprSource(DI.Inst.getOperand(2), Aligned, *LS.MRI))
+    Def0.set(GlobalIndex);
+  if (isAlignedSgprSource(DI.Inst.getOperand(3), Aligned, *LS.MRI))
+    Def1.set(GlobalIndex);
+}
+
+/// Recover the persistent VGPR bank selectors on every path. The complete
+/// four-field state feeds WMMA splitting, while the independently merged
+/// dst/src0 fields also prove the equality needed by DS address rewrites.
+/// Unknown MODE definitions and calls lose the affected proof, and functions
+/// with arbitrary indirect entries are rejected.
+static BitVector computeVgprMsbDstSrc0Equality(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const ElfView &Elf, const DenseSet<uint64_t> &DirectControlFlowTargets,
+    const DenseSet<uint64_t> &CodeEntries,
+    const DenseSet<uint64_t> &IndirectControlFlowFunctions,
+    ArrayRef<uint8_t> Text,
+    const CompatibilityControlFlowFacts &CompatibilityFacts,
+    BitVector &VgprDef0AlignedTo8,
+    BitVector &VgprDef1AlignedTo8, std::vector<int8_t> &VgprMsbDstBefore,
+    std::vector<int8_t> &VgprMsbSrc0Before,
+    std::vector<int16_t> &VgprMsbModeBefore,
+    DenseSet<uint64_t> &CrossFunctionInteriorEntryFunctions) {
+  BitVector ProvenEqual(Decoded.size());
+  VgprDef0AlignedTo8 = BitVector(Decoded.size());
+  VgprDef1AlignedTo8 = BitVector(Decoded.size());
+  VgprMsbDstBefore.assign(Decoded.size(), VgprMsbUnknown);
+  VgprMsbSrc0Before.assign(Decoded.size(), VgprMsbUnknown);
+  VgprMsbModeBefore.assign(Decoded.size(), VgprMsbUnanalyzed);
+  if (!LS.MIA || !LS.MCII || !LS.MRI)
+    return ProvenEqual;
+
+  DenseSet<uint64_t> CrossFunctionInteriorEntries;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    std::optional<uint64_t> Target;
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            getResolvedCompatibilityTransfer(CompatibilityFacts, I)) {
+      Target = Transfer->Target;
+    } else {
+      if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+          LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+        continue;
+      Target = evaluateDirectControlFlowTarget(DI, LS);
+    }
+    if (!Target || *Target >= Text.size())
+      continue;
+    std::optional<ElfView::FunctionTextRange> SourceOwner =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(*Target);
+    if (TargetOwner && *Target != TargetOwner->Begin &&
+        (!SourceOwner || SourceOwner->Begin != TargetOwner->Begin ||
+         SourceOwner->End != TargetOwner->End))
+      CrossFunctionInteriorEntries.insert(TargetOwner->Begin);
+  }
+  CrossFunctionInteriorEntryFunctions = CrossFunctionInteriorEntries;
+
+  DenseSet<std::pair<uint64_t, uint64_t>> SeenRanges;
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Elf.functionTextRanges();
+  for (size_t RangeIndex = 0; RangeIndex != FunctionRanges.size();
+       ++RangeIndex) {
+    const ElfView::FunctionTextRange &VirtualRange = FunctionRanges[RangeIndex];
+    if (VirtualRange.Begin < Elf.textAddr() ||
+        VirtualRange.End < VirtualRange.Begin ||
+        VirtualRange.End > Elf.textAddr() + Text.size())
+      continue;
+    uint64_t Begin = VirtualRange.Begin - Elf.textAddr();
+    uint64_t End = VirtualRange.End - Elf.textAddr();
+    if (Begin >= End || !SeenRanges.insert({Begin, End}).second ||
+        IndirectControlFlowFunctions.contains(Begin) ||
+        CrossFunctionInteriorEntries.contains(Begin))
+      continue;
+
+    // An outer symbol must not donate facts to instructions owned by a nested
+    // function symbol. The ranges are sorted by start address, so the first
+    // later distinct start is sufficient to detect an overlap.
+    size_t NextRange = RangeIndex + 1;
+    while (NextRange != FunctionRanges.size() &&
+           FunctionRanges[NextRange].Begin == VirtualRange.Begin)
+      ++NextRange;
+    if (NextRange != FunctionRanges.size() &&
+        FunctionRanges[NextRange].Begin < VirtualRange.End)
+      continue;
+
+    // Ignore an overlapping/alias range unless ElfView would select it as the
+    // owner of its first instruction. This keeps the CFG and the later patch
+    // site's function identity consistent.
+    std::optional<ElfView::FunctionTextRange> Owner =
+        Elf.findFunctionTextRangeAtOffset(Begin);
+    if (!Owner || Owner->Begin != Begin || Owner->End != End)
+      continue;
+
+    auto First = llvm::lower_bound(
+        Decoded, Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    auto After = llvm::lower_bound(
+        Decoded, End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (First == After || First->Offset != Begin)
+      continue;
+
+    const size_t GlobalFirst = static_cast<size_t>(First - Decoded.begin());
+    const size_t Count = static_cast<size_t>(After - First);
+    DenseMap<uint64_t, unsigned> OffsetToLocalIndex;
+    OffsetToLocalIndex.reserve(Count);
+    bool Valid = true;
+    for (unsigned I = 0; I != Count; ++I) {
+      OffsetToLocalIndex.try_emplace(First[I].Offset, I);
+      if (First[I].Mnemonic == "<unknown>")
+        Valid = false;
+    }
+    if (!Valid)
+      continue;
+
+    std::vector<SmallVector<unsigned, 2>> Successors(Count);
+    BitVector CallableEntries(Count);
+    auto AddTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+      if (Target < Begin || Target >= End)
+        return true;
+      auto It = OffsetToLocalIndex.find(Target);
+      if (It == OffsetToLocalIndex.end())
+        return false;
+      Out.push_back(It->second);
+      return true;
+    };
+    auto AddFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+      if (I + 1 < Count)
+        Out.push_back(I + 1);
+    };
+
+    for (unsigned I = 0; I != Count && Valid; ++I) {
+      const InternalDecodedInst &DI = First[I];
+      SmallVectorImpl<unsigned> &Out = Successors[I];
+      if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+          LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, LS))
+        continue;
+      if (LS.MIA->isCall(DI.Inst)) {
+        std::optional<uint64_t> Target;
+        if (std::optional<MaterializedPcTransfer> Transfer =
+                getResolvedCompatibilityTransfer(CompatibilityFacts,
+                                                 GlobalFirst + I))
+          Target = Transfer->Target;
+        else if (!LS.MIA->isIndirectBranch(DI.Inst))
+          Target = evaluateDirectControlFlowTarget(DI, LS);
+        if (Target && *Target >= Begin && *Target < End)
+          if (auto It = OffsetToLocalIndex.find(*Target);
+              It != OffsetToLocalIndex.end())
+            CallableEntries.set(It->second);
+        AddFallthrough(Out, I);
+        continue;
+      }
+      if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target;
+        std::optional<MaterializedPcTransfer> Materialized =
+            evaluateProvenPcTransfer(
+                Decoded, GlobalFirst + I, DirectControlFlowTargets, Text, LS,
+                Elf, CompatibilityFacts);
+        if (Materialized) {
+          Target = Materialized->Target;
+        } else if (LS.MIA->isIndirectBranch(DI.Inst)) {
+          Valid = false;
+          break;
+        } else {
+          Target = evaluateDirectControlFlowTarget(DI, LS);
+          if (!Target) {
+            Valid = false;
+            break;
+          }
+        }
+        Valid &= AddTarget(Out, *Target);
+        if (LS.MIA->isConditionalBranch(DI.Inst))
+          AddFallthrough(Out, I);
+        else if (!Materialized && !LS.MIA->isUnconditionalBranch(DI.Inst) &&
+                 !LS.MIA->isIndirectBranch(DI.Inst))
+          Valid = false;
+        continue;
+      }
+      if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+        Valid = false;
+        break;
+      }
+      AddFallthrough(Out, I);
+    }
+    if (!Valid)
+      continue;
+
+    // A validated function CFG distinguishes dead instructions from sites we
+    // could not analyze at all. Mandatory rewrites may use that distinction to
+    // transform semantically unreachable instructions without treating an
+    // ambiguous reachable MODE value as the ABI default.
+    for (size_t I = 0; I != Count; ++I)
+      VgprMsbModeBefore[GlobalFirst + I] = VgprMsbUnreachable;
+
+    std::vector<VgprMsbState> In(Count);
+    std::vector<BitVector> AlignedIn(Count, BitVector(Gfx1250MaxSgprs));
+    BitVector AlignmentReachable(Count);
+    SmallVector<unsigned, 64> Worklist;
+    // LLVM's gfx1250 VGPR-lowering ABI explicitly requires all four MSB fields
+    // to be zero on function entry. Calls still transfer to Unknown above
+    // because this object-level proof does not inspect the callee's return.
+    auto SeedAbiEntry = [&](unsigned I) {
+      VgprMsbState Seed = vgprMsbStateFromMode(0);
+      In[I] = mergeVgprMsbState(In[I], Seed);
+      AlignmentReachable.set(I);
+      Worklist.push_back(I);
+    };
+    SeedAbiEntry(0);
+    for (uint64_t Entry : CodeEntries)
+      if (Entry >= Begin && Entry < End)
+        if (auto It = OffsetToLocalIndex.find(Entry);
+            It != OffsetToLocalIndex.end() && It->second != 0)
+          SeedAbiEntry(It->second);
+    for (int I = CallableEntries.find_first(); I >= 0;
+         I = CallableEntries.find_next(I))
+      if (I != 0)
+        SeedAbiEntry(static_cast<unsigned>(I));
+    for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+      unsigned I = Worklist[Next];
+      size_t GlobalI = GlobalFirst + I;
+      VgprMsbDstBefore[GlobalI] = In[I].Dst;
+      VgprMsbSrc0Before[GlobalI] = In[I].Src0;
+      VgprMsbModeBefore[GlobalI] = exactVgprMsbMode(In[I]);
+      if (In[I].Dst >= 0 && In[I].Dst == In[I].Src0)
+        ProvenEqual.set(GlobalI);
+      else
+        ProvenEqual.reset(GlobalI);
+      recordAlignedVgprCopies(Decoded[GlobalI], GlobalI, AlignedIn[I], LS,
+                              VgprDef0AlignedTo8, VgprDef1AlignedTo8);
+      VgprMsbState Out = transferVgprMsbState(In[I], Decoded[GlobalI], LS);
+      BitVector AlignedOut =
+          transferSgprAlignment(AlignedIn[I], Decoded[GlobalI], Text, LS);
+      for (unsigned Succ : Successors[I]) {
+        VgprMsbState Merged = mergeVgprMsbState(In[Succ], Out);
+        bool Changed =
+            Merged.Dst != In[Succ].Dst || Merged.Src0 != In[Succ].Src0 ||
+            Merged.Src1 != In[Succ].Src1 || Merged.Src2 != In[Succ].Src2;
+        if (Changed)
+          In[Succ] = Merged;
+        if (!AlignmentReachable.test(Succ)) {
+          AlignedIn[Succ] = AlignedOut;
+          AlignmentReachable.set(Succ);
+          Changed = true;
+        } else {
+          BitVector AlignedMerged = AlignedIn[Succ];
+          AlignedMerged &= AlignedOut;
+          if (AlignedMerged != AlignedIn[Succ]) {
+            AlignedIn[Succ] = std::move(AlignedMerged);
+            Changed = true;
+          }
+        }
+        if (Changed)
+          Worklist.push_back(Succ);
+      }
+    }
+  }
+  return ProvenEqual;
+}
+
 /// Grow undersized far-site windows only through proven straight-line code.
 /// Patched neighbors are merged; ordinary instructions are copied verbatim
-/// into the trampoline body and retain their original order. This is bounded
-/// to the 20 bytes required by the gfx12 SCC-neutral forward sequence.
+/// into the trampoline body and retain their original order. Growth is bounded
+/// by the space required for the selected SCC-neutral set-PC sequence.
 static void
 expandStraightLineTrampolines(PatchContext &Ctx,
                               const DenseSet<uint64_t> &DirectBranchTargets) {
   DenseMap<uint64_t, size_t> DecodedAt;
   for (size_t I = 0; I != Ctx.Decoded.size(); ++I)
     DecodedAt[Ctx.Decoded[I].Offset] = I;
-  DenseSet<uint64_t> Protected = collectRelocationProtectedOffsets(
-      Ctx.Decoded, Ctx.LS, !Ctx.Config.RunB0A0Patches);
-  DenseSet<uint64_t> IndirectControlFlowFunctions =
-      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+
+  SmallVector<uint64_t, 16> SortedDirectTargets(DirectBranchTargets.begin(),
+                                                DirectBranchTargets.end());
+  llvm::sort(SortedDirectTargets);
+  auto HasTargetInRange = [&](uint64_t Begin, uint64_t End, bool IncludeBegin) {
+    auto It = llvm::lower_bound(SortedDirectTargets, Begin);
+    if (!IncludeBegin && It != SortedDirectTargets.end() && *It == Begin)
+      ++It;
+    return It != SortedDirectTargets.end() && *It < End;
+  };
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     if (Ctx.OutTrampolines[I].HasFunctionRange &&
-        IndirectControlFlowFunctions.contains(
+        Ctx.IndirectControlFlowFunctions.contains(
             Ctx.OutTrampolines[I].FunctionStart))
       continue;
     while (Ctx.OutTrampolines[I].Long &&
@@ -1750,6 +5682,8 @@ expandStraightLineTrampolines(PatchContext &Ctx,
         Trampoline &Next = Ctx.OutTrampolines[I + 1];
         if (!Next.Long || !Next.UsesSetPCBack ||
             Next.LongBranchSgprBase != T.LongBranchSgprBase ||
+            Next.LongBranchScratchIsSiteProven !=
+                T.LongBranchScratchIsSiteProven ||
             !T.HasFunctionRange || !Next.HasFunctionRange ||
             T.FunctionStart != Next.FunctionStart ||
             T.FunctionEnd != Next.FunctionEnd ||
@@ -1765,19 +5699,56 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       DenseMap<uint64_t, size_t>::const_iterator It = DecodedAt.find(*End);
       if (It == DecodedAt.end())
         break;
-      const InternalDecodedInst &Original = Ctx.Decoded[It->second];
-      std::optional<InternalDecodedInst> Current =
-          decodeCurrentInstruction(Ctx, Original);
-      if (!Current)
+      const InternalDecodedInst &OriginalDI = Ctx.Decoded[It->second];
+      std::optional<InternalDecodedInst> CurrentDI =
+          decodeCurrentRelocationCandidate(Ctx, OriginalDI);
+      if (!CurrentDI)
         break;
-      const InternalDecodedInst &DI = *Current;
+      const InternalDecodedInst &DI = *CurrentDI;
       std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
           Range->End != T.FunctionEnd ||
-          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected) ||
+          hasSiteReplacementReservation(Ctx, DI.Offset) ||
+          HasTargetInRange(DI.Offset, DI.Offset + DI.Size,
+                           /*IncludeBegin=*/true) ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS,
+                                        Ctx.RelocationProtectedOffsets) ||
+          DI.Offset > Ctx.TextSize || DI.Size > Ctx.TextSize - DI.Offset ||
           T.Bytes.size() < SetPcReturnReserveBytes)
         break;
+
+      if (T.LongBranchScratchIsSiteProven) {
+        // The original proof is tied to the old resume offset. Re-prove the
+        // chosen pair after every prospective moved instruction. The forward
+        // set-PC edge executes before the moved instruction, so also reject a
+        // semantic read of that pair. A pure definition is safe only when the
+        // new resume-point proof shows that its value is dead.
+        unsigned Pair = T.LongBranchSgprBase;
+        if (Pair == Gfx1250MaxSgprs) {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findVccLoHiPair(Ctx.LS);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs,
+                                               /*PairIsAbiVcc=*/true)
+                       : std::nullopt;
+          if (!Access || Access->Uses ||
+              !isVccPairDeadAfter(Ctx, DI.Offset, DI.Size))
+            break;
+        } else {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findNumberedSgprPair(Ctx.LS, Pair);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs)
+                       : std::nullopt;
+          std::optional<BitVector> SiteDead =
+              getSiteDeadNumberedSgprs(Ctx, DI.Offset, DI.Size);
+          if (!Access || Access->Uses || !SiteDead ||
+              Pair + 1 >= SiteDead->size() || !SiteDead->test(Pair) ||
+              !SiteDead->test(Pair + 1))
+            break;
+        }
+      }
 
       T.Bytes.insert(T.Bytes.end() - SetPcReturnReserveBytes,
                      Ctx.Text + DI.Offset, Ctx.Text + DI.Offset + DI.Size);
@@ -1787,20 +5758,29 @@ expandStraightLineTrampolines(PatchContext &Ctx,
     while (Ctx.OutTrampolines[I].Long &&
            Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
       Trampoline &T = Ctx.OutTrampolines[I];
+      // A target at the current window start may remain there, but prepending
+      // another instruction would turn it into an interior entry. The selected
+      // predecessor may itself be a target because it becomes the new start.
       if (DirectBranchTargets.contains(T.OriginalOffset))
         break;
       DenseMap<uint64_t, size_t>::const_iterator It =
           DecodedAt.find(T.OriginalOffset);
       if (It == DecodedAt.end() || It->second == 0)
         break;
-      const InternalDecodedInst &Original = Ctx.Decoded[It->second - 1];
-      std::optional<InternalDecodedInst> Current =
-          decodeCurrentInstruction(Ctx, Original);
-      if (!Current)
+      const InternalDecodedInst &OriginalDI = Ctx.Decoded[It->second - 1];
+      if (OriginalDI.Offset + OriginalDI.Size != T.OriginalOffset)
         break;
-      const InternalDecodedInst &DI = *Current;
+      std::optional<InternalDecodedInst> CurrentDI =
+          decodeCurrentRelocationCandidate(Ctx, OriginalDI);
+      if (!CurrentDI)
+        break;
+      const InternalDecodedInst &DI = *CurrentDI;
       if (DI.Offset + DI.Size != T.OriginalOffset ||
-          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected))
+          hasSiteReplacementReservation(Ctx, DI.Offset) ||
+          HasTargetInRange(DI.Offset, DI.Offset + DI.Size,
+                           /*IncludeBegin=*/false) ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS,
+                                        Ctx.RelocationProtectedOffsets))
         break;
       if (I != 0) {
         const Trampoline &Previous = Ctx.OutTrampolines[I - 1];
@@ -1810,8 +5790,36 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
-          Range->End != T.FunctionEnd)
+          Range->End != T.FunctionEnd || DI.Offset > Ctx.TextSize ||
+          DI.Size > Ctx.TextSize - DI.Offset)
         break;
+
+      if (T.LongBranchScratchIsSiteProven) {
+        // Growing backward leaves the resume point unchanged, so the original
+        // dead-after-resume proof remains valid. The new forward set-PC edge
+        // clobbers the pair before the prepended instruction executes, so the
+        // instruction may define the pair but must not read its old value.
+        unsigned Pair = T.LongBranchSgprBase;
+        if (Pair == Gfx1250MaxSgprs) {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findVccLoHiPair(Ctx.LS);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs,
+                                               /*PairIsAbiVcc=*/true)
+                       : std::nullopt;
+          if (!Access || Access->Uses)
+            break;
+        } else {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findNumberedSgprPair(Ctx.LS, Pair);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs)
+                       : std::nullopt;
+          if (!Access || Access->Uses)
+            break;
+        }
+      }
+
       T.Bytes.insert(T.Bytes.begin(), Ctx.Text + DI.Offset,
                      Ctx.Text + DI.Offset + DI.Size);
       T.OriginalOffset = DI.Offset;
@@ -1822,39 +5830,105 @@ expandStraightLineTrampolines(PatchContext &Ctx,
 
 static bool hasNoFallthrough(const InternalDecodedInst &DI,
                              const LLVMState &LS) {
-  return isEndProgram(DI, LS) ||
-         (LS.MIA &&
-          (LS.MIA->isUnconditionalBranch(DI.Inst) ||
-           LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
-           LS.MIA->isBarrier(DI.Inst)));
+  if (DI.Mnemonic == "s_code_end" || DI.Mnemonic == "s_endpgm" ||
+      DI.Mnemonic == "s_endpgm_saved")
+    return true;
+  if (!LS.MIA || LS.MIA->isCall(DI.Inst))
+    return false;
+  if (LS.MIA->isUnconditionalBranch(DI.Inst) &&
+      !LS.MIA->isIndirectBranch(DI.Inst))
+    return true;
+  return DI.Inst.getOpcode() == LS.SSetPcI64Opcode;
 }
 
 static void appendGatewaySled(std::vector<NopSled> &Sleds, uint64_t Start,
                               uint64_t End, uint64_t TextSize, bool Safe,
                               bool HasTarget) {
   if (Safe && !HasTarget && End - Start >= MinInstSize)
-    Sleds.push_back({Start, End, Start, 0, TextSize});
+    Sleds.push_back({Start, End, Start, 0, TextSize,
+                     /*GatewayOnly=*/true});
+}
+
+static std::optional<DenseSet<uint64_t>>
+collectCodeObjectEntryOffsets(const ElfView &Elf, uint64_t TextSize) {
+  if (!Elf.kernelDescriptorCacheIsComplete()) {
+    log() << "hotswap: incomplete kernel descriptor set prevents complete "
+             "code-entry discovery\n";
+    return std::nullopt;
+  }
+
+  DenseSet<uint64_t> Entries;
+  const uint64_t TextAddr = Elf.textAddr();
+
+  // A zero-filled function body is indistinguishable from alignment padding
+  // to the decoder. Preserve every callable symbol entry, including aliases
+  // and zero-sized functions, independently of whether direct control flow in
+  // this object names it.
+  for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges()) {
+    if (Range.Begin >= TextAddr && Range.Begin - TextAddr < TextSize)
+      Entries.insert(Range.Begin - TextAddr);
+  }
+
+  // Kernel descriptors may name an entry that has no STT_FUNC symbol. The
+  // signed entry offset is relative to the descriptor address.
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    uint64_t Entry = 0;
+    if (KD.EntryOffset >= 0) {
+      uint64_t Delta = static_cast<uint64_t>(KD.EntryOffset);
+      if (Delta > std::numeric_limits<uint64_t>::max() - KD.VAddr)
+        continue;
+      Entry = KD.VAddr + Delta;
+    } else {
+      uint64_t Magnitude =
+          KD.EntryOffset == std::numeric_limits<int64_t>::min()
+              ? static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1
+              : static_cast<uint64_t>(-KD.EntryOffset);
+      if (Magnitude > KD.VAddr)
+        continue;
+      Entry = KD.VAddr - Magnitude;
+    }
+    if (Entry >= TextAddr && Entry - TextAddr < TextSize)
+      Entries.insert(Entry - TextAddr);
+  }
+  return Entries;
 }
 
 /// Find zero-filled alignment holes, including holes covered by an oversized
 /// function symbol, and s_nop padding outside every function. Such padding is
 /// a safe branch gateway only when it follows a no-fallthrough instruction and
-/// contains no direct branch/call target. In-function s_nop runs are added from
-/// Ctx.NopSleds separately.
+/// contains no known control-flow target or callable entry. Body-owned
+/// s_nop runs are excluded so one physical range never has two allocation
+/// cursors.
 static std::vector<NopSled>
 buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
                           const LLVMState &LS, const ElfView &Elf,
                           ArrayRef<uint8_t> Text,
-                          const DenseSet<uint64_t> &DirectBranchTargets) {
+                          const DenseSet<uint64_t> &DirectBranchTargets,
+                          ArrayRef<uint64_t> TextSymbolOffsets,
+                          ArrayRef<ElfView::TextOffsetRange> TextSymbolExtents,
+                          ArrayRef<NopSled> OwnedSleds) {
   std::vector<NopSled> Sleds;
+  SmallVector<uint64_t, 16> ProtectedEntries(DirectBranchTargets.begin(),
+                                             DirectBranchTargets.end());
+  llvm::sort(ProtectedEntries);
+  ProtectedEntries.erase(
+      std::unique(ProtectedEntries.begin(), ProtectedEntries.end()),
+      ProtectedEntries.end());
+
   const InternalDecodedInst *Previous = nullptr;
   bool Active = false;
   bool Safe = false;
   bool HasTarget = false;
   uint64_t Start = 0;
   uint64_t End = 0;
-
+  size_t OwnedIndex = 0;
   for (const InternalDecodedInst &DI : Decoded) {
+    while (OwnedIndex != OwnedSleds.size() &&
+           OwnedSleds[OwnedIndex].End <= DI.Offset)
+      ++OwnedIndex;
+    const bool BodyOwned = OwnedIndex != OwnedSleds.size() &&
+                           OwnedSleds[OwnedIndex].Start <= DI.Offset &&
+                           DI.Offset < OwnedSleds[OwnedIndex].End;
     bool ZeroPadding =
         DI.Offset <= Text.size() && DI.Size <= Text.size() - DI.Offset;
     if (ZeroPadding)
@@ -1862,7 +5936,7 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
         ZeroPadding &= Byte == 0;
     bool IsExternalNop = DI.Inst.getOpcode() == LS.SNopOpcode &&
                          !Elf.findFunctionTextRangeAtOffset(DI.Offset);
-    bool GatewayPadding = ZeroPadding || IsExternalNop;
+    bool GatewayPadding = !BodyOwned && (ZeroPadding || IsExternalNop);
     if (!GatewayPadding || (Active && DI.Offset != End)) {
       if (Active)
         appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
@@ -1878,7 +5952,18 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
       Safe = Previous && hasNoFallthrough(*Previous, LS);
       HasTarget = false;
     }
-    HasTarget |= DirectBranchTargets.contains(DI.Offset);
+    auto Entry = llvm::lower_bound(ProtectedEntries, DI.Offset);
+    const bool HasHardEntry =
+        Entry != ProtectedEntries.end() && *Entry - DI.Offset < DI.Size;
+    auto Symbol = llvm::lower_bound(TextSymbolOffsets, DI.Offset);
+    const bool HasSymbol =
+        Symbol != TextSymbolOffsets.end() && *Symbol - DI.Offset < DI.Size;
+    const bool HasSymbolExtent =
+        overlapsTextSymbolExtent(TextSymbolExtents, DI);
+    // External gateways are donor storage, so even an exact-start symbol
+    // blocks the range. Only an original replacement source may preserve such
+    // an alias while changing the bytes at that same address.
+    HasTarget |= HasHardEntry || HasSymbol || HasSymbolExtent;
     End = DI.Offset + DI.Size;
   }
   if (Active)
@@ -1886,102 +5971,358 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
-Expected<uint64_t>
-countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
-                                uint64_t FromOffset, uint64_t TargetOffset,
-                                unsigned SgprBase, uint64_t MaxSlots) {
-  uint64_t Slots = 0;
-  for (const NopSled &Sled : Gateways) {
-    if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
-      continue;
-    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-    uint64_t Candidate = Sled.WritePos;
-    while (Candidate <= UsableEnd && Slots < MaxSlots) {
-      uint64_t Distance = Candidate > FromOffset ? Candidate - FromOffset
-                                                 : FromOffset - Candidate;
-      if (Distance >= MaxSledDistance ||
-          LS.encodeSBranch(FromOffset, Candidate).empty())
-        break;
-      std::optional<SmallVector<uint8_t>> Bytes =
-          encodeSetPCLongBranch(LS, Candidate, TargetOffset, SgprBase);
-      if (!Bytes)
-        return createStringError(
-            Twine("failed to encode set-PC gateway while counting candidate "
-                  "offset 0x") +
-            utohexstr(Candidate));
-      if (Bytes->size() > UsableEnd - Candidate)
-        break;
-      ++Slots;
-      Candidate += Bytes->size();
-    }
-    if (Slots == MaxSlots)
-      break;
-  }
-  return Slots;
+static uint64_t countReachableGatewaySlots(const NopSled &Sled, uint64_t Offset,
+                                           uint64_t Needed) {
+  if (!Sled.canGatewayFrom(Offset) || Sled.WritePos > Sled.End ||
+      Needed > Sled.End - Sled.WritePos)
+    return 0;
+  uint64_t Distance =
+      Sled.WritePos > Offset ? Sled.WritePos - Offset : Offset - Sled.WritePos;
+  if (Distance >= MaxSledDistance)
+    return 0;
+  return (Sled.End - Sled.WritePos) / Needed;
 }
 
-static std::optional<SmallVector<uint64_t, 4>>
-allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
-                             uint64_t FromOffset, uint64_t TargetOffset) {
+bool canEverReachGatewaySlot(const NopSled &Sled, uint64_t Offset,
+                             uint64_t Needed) {
+  if (!Sled.canGatewayFrom(Offset) || Sled.WritePos > Sled.End ||
+      Needed > Sled.End - Sled.WritePos)
+    return false;
+
+  uint64_t LastWritePos = Sled.End - Needed;
+  uint64_t Reach = MaxSledDistance - 1;
+  uint64_t ReachableStart = Offset > Reach ? Offset - Reach : 0;
+  uint64_t ReachableEnd = Offset > std::numeric_limits<uint64_t>::max() - Reach
+                              ? std::numeric_limits<uint64_t>::max()
+                              : Offset + Reach;
+  return Sled.WritePos <= ReachableEnd && ReachableStart <= LastWritePos;
+}
+
+struct GatewaySlotOwner {
+  size_t OwnerIndex = 0;
+  uint64_t SourceOffset = 0;
+  uint64_t NeededBytes = 0;
+};
+
+using GatewaySlotOwnerList = SmallVector<GatewaySlotOwner, 2>;
+
+static bool
+wouldConsumeLastGatewaySlot(ArrayRef<NopSled> Gateways, size_t SledIndex,
+                            uint64_t Bytes,
+                            ArrayRef<GatewaySlotOwnerList> OwnersBySled,
+                            ArrayRef<uint64_t> CurrentViableSleds,
+                            ArrayRef<uint8_t> Done, size_t CurrentOwner) {
+  if (SledIndex >= Gateways.size() || SledIndex >= OwnersBySled.size())
+    return false;
+  const NopSled &Sled = Gateways[SledIndex];
+  if (Sled.WritePos > Sled.End || Bytes > Sled.End - Sled.WritePos)
+    return false;
+
+  NopSled Advanced = Sled;
+  Advanced.WritePos += Bytes;
+  for (const GatewaySlotOwner &Owner : OwnersBySled[SledIndex]) {
+    if (Owner.OwnerIndex == CurrentOwner ||
+        (Owner.OwnerIndex < Done.size() && Done[Owner.OwnerIndex]))
+      continue;
+    uint64_t TotalBefore = CurrentViableSleds[Owner.OwnerIndex];
+    if (TotalBefore == 0)
+      continue;
+    uint64_t SledBefore =
+        canEverReachGatewaySlot(Sled, Owner.SourceOffset, Owner.NeededBytes);
+    uint64_t SledAfter = canEverReachGatewaySlot(Advanced, Owner.SourceOffset,
+                                                 Owner.NeededBytes);
+    assert(SledBefore <= TotalBefore && "gateway slot count is inconsistent");
+    if (TotalBefore - SledBefore + SledAfter == 0)
+      return true;
+  }
+  return false;
+}
+
+struct GatewaySlotStateChange {
+  size_t OwnerIndex = 0;
+  uint64_t PreviousCandidateSlots = 0;
+  uint64_t PreviousViableSleds = 0;
+  std::optional<size_t> PreviousLastDestroyer;
+};
+
+using GatewaySlotStateChangeList = SmallVector<GatewaySlotStateChange, 4>;
+
+static GatewaySlotStateChangeList advanceGatewaySled(
+    NopSled &Sled, uint64_t NewWritePos, ArrayRef<GatewaySlotOwner> SledOwners,
+    MutableArrayRef<uint64_t> CurrentCandidateSlots, ArrayRef<uint8_t> Done,
+    MutableArrayRef<uint64_t> CurrentViableSleds, size_t CurrentOwner,
+    MutableArrayRef<std::optional<size_t>> LastDestroyer) {
+  assert(Sled.WritePos <= NewWritePos && NewWritePos <= Sled.End &&
+         "invalid gateway sled cursor advance");
+  NopSled Advanced = Sled;
+  Advanced.WritePos = NewWritePos;
+  GatewaySlotStateChangeList Changes;
+  for (const GatewaySlotOwner &Owner : SledOwners) {
+    uint64_t SledBefore =
+        countReachableGatewaySlots(Sled, Owner.SourceOffset, Owner.NeededBytes);
+    uint64_t SledAfter = countReachableGatewaySlots(
+        Advanced, Owner.SourceOffset, Owner.NeededBytes);
+    uint64_t ViableBefore =
+        canEverReachGatewaySlot(Sled, Owner.SourceOffset, Owner.NeededBytes);
+    uint64_t ViableAfter = canEverReachGatewaySlot(Advanced, Owner.SourceOffset,
+                                                   Owner.NeededBytes);
+    if (SledBefore == SledAfter && ViableBefore == ViableAfter)
+      continue;
+    uint64_t TotalBefore = CurrentCandidateSlots[Owner.OwnerIndex];
+    assert(SledBefore <= TotalBefore && "gateway slot count is inconsistent");
+    uint64_t TotalViableBefore = CurrentViableSleds[Owner.OwnerIndex];
+    assert(ViableBefore <= TotalViableBefore &&
+           "gateway viable-sled count is inconsistent");
+    Changes.push_back({Owner.OwnerIndex, TotalBefore, TotalViableBefore,
+                       LastDestroyer[Owner.OwnerIndex]});
+    uint64_t TotalAfter = TotalBefore - SledBefore + SledAfter;
+    uint64_t TotalViableAfter = TotalViableBefore - ViableBefore + ViableAfter;
+    CurrentCandidateSlots[Owner.OwnerIndex] = TotalAfter;
+    CurrentViableSleds[Owner.OwnerIndex] = TotalViableAfter;
+    if (TotalViableBefore == 0 && TotalViableAfter != 0)
+      LastDestroyer[Owner.OwnerIndex].reset();
+    else if (Owner.OwnerIndex != CurrentOwner && !Done[Owner.OwnerIndex] &&
+             TotalViableBefore != 0 && TotalViableAfter == 0)
+      LastDestroyer[Owner.OwnerIndex] = CurrentOwner;
+  }
+  Sled.WritePos = NewWritePos;
+  return Changes;
+}
+
+static void
+restoreGatewaySled(NopSled &Sled, uint64_t PreviousWritePos,
+                   ArrayRef<GatewaySlotStateChange> Changes,
+                   MutableArrayRef<uint64_t> CurrentCandidateSlots,
+                   MutableArrayRef<uint64_t> CurrentViableSleds,
+                   MutableArrayRef<std::optional<size_t>> LastDestroyer) {
+  Sled.WritePos = PreviousWritePos;
+  for (const GatewaySlotStateChange &Change : Changes) {
+    CurrentCandidateSlots[Change.OwnerIndex] = Change.PreviousCandidateSlots;
+    CurrentViableSleds[Change.OwnerIndex] = Change.PreviousViableSleds;
+    LastDestroyer[Change.OwnerIndex] = Change.PreviousLastDestroyer;
+  }
+}
+
+static std::optional<SmallVector<uint64_t, 4>> allocateForwardBranchIslands(
+    std::vector<NopSled> &Gateways, uint64_t FromOffset, uint64_t TargetOffset,
+    ArrayRef<GatewaySlotOwnerList> OwnersBySled,
+    MutableArrayRef<uint64_t> CurrentCandidateSlots,
+    MutableArrayRef<uint64_t> CurrentViableSleds, ArrayRef<uint8_t> Done,
+    size_t CurrentOwner, MutableArrayRef<std::optional<size_t>> LastDestroyer,
+    bool ProtectSlots, size_t MaxAlternateStates, bool LogSearchLimit) {
+  static constexpr size_t MaxPathDepth = 2048;
+
+  // Precompute the forward DAG nodes that have any suffix path to the target,
+  // ignoring reservations. For a fixed source, the nearest reachable suffix
+  // node dominates every farther one, so this reverse scan is linear after
+  // sorting and rejects impossible relay routes before bounded backtracking.
+  SmallVector<size_t, 64> ForwardSleds;
+  for (size_t I = 0; I != Gateways.size(); ++I) {
+    const NopSled &Sled = Gateways[I];
+    if (!Sled.canGatewayFrom(FromOffset) || Sled.WritePos <= FromOffset ||
+        Sled.WritePos >= TargetOffset || Sled.WritePos > Sled.End ||
+        MinInstSize > Sled.End - Sled.WritePos)
+      continue;
+    ForwardSleds.push_back(I);
+  }
+  llvm::sort(ForwardSleds, [&](size_t LHS, size_t RHS) {
+    if (Gateways[LHS].WritePos != Gateways[RHS].WritePos)
+      return Gateways[LHS].WritePos < Gateways[RHS].WritePos;
+    return LHS < RHS;
+  });
+
+  std::vector<uint8_t> CanReachTarget(Gateways.size(), 0);
+  std::optional<size_t> NearestReachable;
+  size_t GroupEnd = ForwardSleds.size();
+  while (GroupEnd != 0) {
+    size_t GroupBegin = GroupEnd - 1;
+    uint64_t Position = Gateways[ForwardSleds[GroupBegin]].WritePos;
+    while (GroupBegin != 0 &&
+           Gateways[ForwardSleds[GroupBegin - 1]].WritePos == Position)
+      --GroupBegin;
+    bool HasSuffix = isSBranchReachable(Position, TargetOffset);
+    if (!HasSuffix && NearestReachable)
+      HasSuffix =
+          isSBranchReachable(Position, Gateways[*NearestReachable].WritePos);
+    if (HasSuffix) {
+      for (size_t I = GroupBegin; I != GroupEnd; ++I)
+        CanReachTarget[ForwardSleds[I]] = 1;
+      NearestReachable = ForwardSleds[GroupBegin];
+    }
+    GroupEnd = GroupBegin;
+  }
+
+  bool HasRoute = isSBranchReachable(FromOffset, TargetOffset);
+  if (!HasRoute)
+    for (size_t I : ForwardSleds)
+      if (CanReachTarget[I] &&
+          isSBranchReachable(FromOffset, Gateways[I].WritePos)) {
+        HasRoute = true;
+        break;
+      }
+  if (!HasRoute)
+    return std::nullopt;
+
   struct Allocation {
     size_t SledIndex = 0;
     uint64_t PreviousWritePos = 0;
+    GatewaySlotStateChangeList SlotChanges;
   };
-  SmallVector<Allocation, 4> Allocations;
   SmallVector<uint64_t, 4> Islands;
-  DenseSet<size_t> UsedSleds;
-  uint64_t Current = FromOffset;
 
-  while (!isSBranchReachable(Current, TargetOffset)) {
-    size_t BestIndex = Gateways.size();
-    uint64_t BestOffset = 0;
-    for (size_t I = 0; I != Gateways.size(); ++I) {
+  // Preserve the former farthest-first path as the common fast path. It
+  // commits on success and restores every cursor and owner count on failure.
+  auto TryGreedy = [&] {
+    SmallVector<Allocation, 4> Allocations;
+    DenseSet<size_t> UsedSleds;
+    uint64_t Current = FromOffset;
+    while (!isSBranchReachable(Current, TargetOffset)) {
+      size_t BestIndex = Gateways.size();
+      uint64_t BestOffset = 0;
+      for (size_t I : ForwardSleds) {
+        NopSled &Sled = Gateways[I];
+        if (!CanReachTarget[I] || UsedSleds.contains(I) ||
+            Sled.WritePos <= Current ||
+            !isSBranchReachable(Current, Sled.WritePos))
+          continue;
+        if (ProtectSlots &&
+            wouldConsumeLastGatewaySlot(Gateways, I, MinInstSize, OwnersBySled,
+                                        CurrentViableSleds, Done, CurrentOwner))
+          continue;
+        if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset ||
+            (Sled.WritePos == BestOffset && I < BestIndex)) {
+          BestIndex = I;
+          BestOffset = Sled.WritePos;
+        }
+      }
+      if (BestIndex == Gateways.size()) {
+        for (size_t I = Allocations.size(); I != 0; --I) {
+          const Allocation &A = Allocations[I - 1];
+          restoreGatewaySled(Gateways[A.SledIndex], A.PreviousWritePos,
+                             A.SlotChanges, CurrentCandidateSlots,
+                             CurrentViableSleds, LastDestroyer);
+        }
+        Islands.clear();
+        return false;
+      }
+
+      NopSled &Best = Gateways[BestIndex];
+      uint64_t PreviousWritePos = Best.WritePos;
+      GatewaySlotStateChangeList Changes = advanceGatewaySled(
+          Best, Best.WritePos + MinInstSize, OwnersBySled[BestIndex],
+          CurrentCandidateSlots, Done, CurrentViableSleds, CurrentOwner,
+          LastDestroyer);
+      Allocations.push_back({BestIndex, PreviousWritePos, std::move(Changes)});
+      Islands.push_back(PreviousWritePos);
+      UsedSleds.insert(BestIndex);
+      Current = PreviousWritePos;
+    }
+    return true;
+  };
+
+  if (TryGreedy())
+    return Islands;
+  if (MaxAlternateStates == 0)
+    return std::nullopt;
+
+  DenseSet<size_t> UsedSleds;
+  size_t ExploredStates = 0;
+  bool HitSearchLimit = false;
+
+  auto Search = [&](auto &&Self, uint64_t Current) -> bool {
+    if (isSBranchReachable(Current, TargetOffset))
+      return true;
+    if (Islands.size() >= MaxPathDepth) {
+      HitSearchLimit = true;
+      return false;
+    }
+
+    SmallVector<size_t, 32> Candidates;
+    for (size_t I : ForwardSleds) {
       NopSled &Sled = Gateways[I];
-      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
-          FromOffset >= Sled.FunctionEnd)
+      if (!CanReachTarget[I] || UsedSleds.contains(I))
         continue;
-      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
-          Sled.WritePos > UsableEnd ||
-          MinInstSize > UsableEnd - Sled.WritePos ||
+      if (Sled.WritePos <= Current ||
           !isSBranchReachable(Current, Sled.WritePos))
         continue;
-      if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset) {
-        BestIndex = I;
-        BestOffset = Sled.WritePos;
-      }
+      if (ProtectSlots &&
+          wouldConsumeLastGatewaySlot(Gateways, I, MinInstSize, OwnersBySled,
+                                      CurrentViableSleds, Done, CurrentOwner))
+        continue;
+      Candidates.push_back(I);
     }
+    llvm::sort(Candidates, [&](size_t LHS, size_t RHS) {
+      if (Gateways[LHS].WritePos != Gateways[RHS].WritePos)
+        return Gateways[LHS].WritePos > Gateways[RHS].WritePos;
+      return LHS < RHS;
+    });
 
-    if (BestIndex == Gateways.size()) {
-      for (size_t I = Allocations.size(); I != 0; --I) {
-        const Allocation &A = Allocations[I - 1];
-        Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+    for (size_t SledIndex : Candidates) {
+      if (ExploredStates >= MaxAlternateStates) {
+        HitSearchLimit = true;
+        return false;
       }
-      return std::nullopt;
+      ++ExploredStates;
+      NopSled &Sled = Gateways[SledIndex];
+      uint64_t PreviousWritePos = Sled.WritePos;
+      GatewaySlotStateChangeList Changes = advanceGatewaySled(
+          Sled, Sled.WritePos + MinInstSize, OwnersBySled[SledIndex],
+          CurrentCandidateSlots, Done, CurrentViableSleds, CurrentOwner,
+          LastDestroyer);
+      Islands.push_back(PreviousWritePos);
+      UsedSleds.insert(SledIndex);
+      if (Self(Self, PreviousWritePos))
+        return true;
+      UsedSleds.erase(SledIndex);
+      Islands.pop_back();
+      restoreGatewaySled(Sled, PreviousWritePos, Changes, CurrentCandidateSlots,
+                         CurrentViableSleds, LastDestroyer);
     }
+    return false;
+  };
 
-    NopSled &Best = Gateways[BestIndex];
-    Allocations.push_back({BestIndex, Best.WritePos});
-    Islands.push_back(Best.WritePos);
-    Current = Best.WritePos;
-    Best.WritePos += MinInstSize;
-    UsedSleds.insert(BestIndex);
+  if (!Search(Search, FromOffset)) {
+    if (HitSearchLimit && LogSearchLimit)
+      log() << "hotswap: branch-island search limit reached for site 0x"
+            << utohexstr(FromOffset) << " after " << ExploredStates
+            << " explored state(s)\n";
+    return std::nullopt;
   }
   return Islands;
 }
 
-static bool
-assignLongBranchGateways(PatchContext &Ctx,
-                         const DenseSet<uint64_t> &DirectBranchTargets,
-                         bool AllowTextGateways) {
-  std::vector<NopSled> Gateways;
-  if (AllowTextGateways) {
-    Gateways = buildExternalGatewaySleds(
-        Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
-        DirectBranchTargets);
-    for (const NopSled &Sled : Ctx.NopSleds)
-      Gateways.push_back(Sled);
+static std::optional<size_t> findNearestGatewaySled(
+    ArrayRef<NopSled> Gateways, uint64_t Offset, uint64_t Needed,
+    ArrayRef<GatewaySlotOwnerList> OwnersBySled,
+    ArrayRef<uint64_t> CurrentViableSleds, ArrayRef<uint8_t> Done,
+    size_t CurrentOwner, bool ProtectSlots, bool RequireExternalGateway) {
+  std::optional<size_t> Best;
+  uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+  for (size_t I = 0; I != Gateways.size(); ++I) {
+    const NopSled &Sled = Gateways[I];
+    if ((RequireExternalGateway && !Sled.GlobalGateway && !Sled.GatewayOnly) ||
+        !Sled.canGatewayFrom(Offset) || Sled.WritePos > Sled.End ||
+        Needed > Sled.End - Sled.WritePos)
+      continue;
+    uint64_t Distance = Sled.WritePos > Offset ? Sled.WritePos - Offset
+                                               : Offset - Sled.WritePos;
+    if (Distance >= MaxSledDistance || Distance >= BestDistance)
+      continue;
+    if (ProtectSlots &&
+        wouldConsumeLastGatewaySlot(Gateways, I, Needed, OwnersBySled,
+                                    CurrentViableSleds, Done, CurrentOwner))
+      continue;
+    Best = I;
+    BestDistance = Distance;
   }
+  return Best;
+}
+
+static bool assignLongBranchGateways(PatchContext &Ctx) {
+  // This is a snapshot of the one padding map built before any rewrite. It
+  // preserves every allocation already made by direct sled emission and never
+  // reinterprets the stale decoded stream after Ctx.Text has been modified.
+  std::vector<NopSled> Gateways = Ctx.NopSleds;
 
   DenseMap<uint64_t, size_t> PoolIslandOwners;
   uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
@@ -1997,7 +6338,8 @@ assignLongBranchGateways(PatchContext &Ctx,
       Gateways.push_back({T.PoolBranchIslandOffset,
                           T.PoolBranchIslandOffset + PoolBranchIslandBytes,
                           T.PoolBranchIslandOffset, 0,
-                          std::numeric_limits<uint64_t>::max()});
+                          std::numeric_limits<uint64_t>::max(),
+                          /*GatewayOnly=*/true});
     }
     IslandLayoutOffset = *Next;
   }
@@ -2005,7 +6347,11 @@ assignLongBranchGateways(PatchContext &Ctx,
   struct PendingGateway {
     size_t TrampolineIndex = 0;
     uint64_t TargetOffset = 0;
+    uint64_t NeededBytes = 0;
     uint64_t InitialCandidateSlots = 0;
+    bool UsesCallTail = false;
+    SmallVector<uint8_t> CallTailBytes;
+    SmallVector<size_t, 4> CandidateSleds;
   };
   std::vector<PendingGateway> Pending;
   uint64_t TrampOffset = Ctx.PoolBaseOffset;
@@ -2024,79 +6370,341 @@ assignLongBranchGateways(PatchContext &Ctx,
       T.UsesShortBranchForward = true;
       continue;
     }
-    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+    SmallVector<uint8_t> Direct = encodeSetPCLongBranch(
         Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
-    if (Direct && Direct->size() <= T.OriginalSize) {
+    if (!Direct.empty() && Direct.size() <= T.OriginalSize) {
       T.UsesDirectSetPCForward = true;
-      T.DirectSetPCForwardBytes = std::move(*Direct);
+      T.DirectSetPCForwardBytes = std::move(Direct);
       continue;
     }
-    Pending.push_back({I, TP, 0});
-  }
-  for (PendingGateway &P : Pending) {
-    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    Expected<uint64_t> CandidateSlots = countReachableSetPcGatewaySlots(
-        Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
-        T.LongBranchSgprBase, Pending.size());
-    if (!CandidateSlots) {
-      log() << "hotswap: error: failed to count gateways for far site 0x"
-            << utohexstr(T.OriginalOffset) << ": "
-            << toString(CandidateSlots.takeError()) << "\n";
+    PendingGateway P;
+    P.TrampolineIndex = I;
+    P.TargetOffset = TP;
+    // The full sequence's MC width depends on the gateway displacement.
+    // Reserve the maximum here; only the owner-stable call tail below may use
+    // its exact 12/16-byte size.
+    P.NeededBytes = SetPcForwardSequenceBytes;
+
+    // S_CALL_B64 writes the address immediately after the call to SDST. The
+    // get-PC instruction at the head of Direct produces that same address, so
+    // a source call followed by the source-relative add/set-PC tail at a nearby
+    // sled is the same SCC-neutral transfer. Unlike re-encoding the full
+    // sequence at each sled cursor, the 12/16-byte tail is owner-stable across
+    // literal-width boundaries because its addend remains
+    // Target - (OriginalOffset + 4).
+    std::optional<uint64_t> SourceContinuation = checkedAddUint64(
+        T.OriginalOffset, MinInstSize, "forward call-gateway continuation");
+    std::optional<uint64_t> SourceEnd = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "forward call-gateway source end");
+    if (!SourceContinuation || !SourceEnd)
+      return false;
+    if (*SourceContinuation < *SourceEnd && Ctx.DirectControlFlowTargets &&
+        Ctx.DirectControlFlowTargets->contains(*SourceContinuation)) {
+      log() << "hotswap: error: forward call-gateway source [0x"
+            << utohexstr(T.OriginalOffset) << ", 0x" << utohexstr(*SourceEnd)
+            << ") contains protected call continuation 0x"
+            << utohexstr(*SourceContinuation) << "\n";
       return false;
     }
-    P.InitialCandidateSlots = *CandidateSlots;
-  }
-
-  std::vector<PendingGateway> StillPending;
-  StillPending.reserve(Pending.size());
-  uint64_t BranchIslandChains = 0;
-  for (const PendingGateway &P : Pending) {
-    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    std::optional<SmallVector<uint64_t, 4>> Islands =
-        allocateForwardBranchIslands(Gateways, T.OriginalOffset,
-                                     P.TargetOffset);
-    if (!Islands || Islands->empty()) {
-      StillPending.push_back(P);
-      continue;
+    std::optional<SmallVector<uint8_t>> ExtractedTail =
+        Direct.empty() ? std::nullopt : extractSetPCCallTail(Direct, Ctx.LS);
+    SmallVector<uint8_t> EncodedTail = encodeLinkRelativeSetPCTail(
+        Ctx.LS, *SourceContinuation, TP, T.LongBranchSgprBase);
+    if (ExtractedTail && *ExtractedTail == EncodedTail &&
+        T.OriginalSize >= MinInstSize &&
+        encodeSCallI64(Ctx.LS, T.OriginalOffset, *SourceContinuation,
+                       T.LongBranchSgprBase)
+                .size() == MinInstSize) {
+      P.UsesCallTail = true;
+      P.CallTailBytes = std::move(EncodedTail);
+      P.NeededBytes = P.CallTailBytes.size();
     }
-    T.ForwardBranchIslands = std::move(*Islands);
-    T.ForwardBranchTargetOffset = P.TargetOffset;
-    ++BranchIslandChains;
+
+    for (size_t SledIndex = 0; SledIndex != Gateways.size(); ++SledIndex) {
+      if (P.UsesCallTail && !Gateways[SledIndex].GlobalGateway &&
+          !Gateways[SledIndex].GatewayOnly)
+        continue;
+      uint64_t Slots = countReachableGatewaySlots(
+          Gateways[SledIndex], T.OriginalOffset, P.NeededBytes);
+      P.InitialCandidateSlots += Slots;
+      if (canEverReachGatewaySlot(Gateways[SledIndex], T.OriginalOffset,
+                                  P.NeededBytes))
+        P.CandidateSleds.push_back(SledIndex);
+    }
+    Pending.push_back(std::move(P));
   }
-  Pending = std::move(StillPending);
 
   std::stable_sort(Pending.begin(), Pending.end(),
                    [](const PendingGateway &LHS, const PendingGateway &RHS) {
+                     if (LHS.NeededBytes != RHS.NeededBytes)
+                       return LHS.NeededBytes > RHS.NeededBytes;
                      return LHS.InitialCandidateSlots <
                             RHS.InitialCandidateSlots;
                    });
 
-  uint64_t AssignedGateways = 0;
-  for (const PendingGateway &P : Pending) {
-    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
-        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase);
-    if (!GatewayOrErr) {
-      log() << "hotswap: error: failed to plan gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << ": "
-            << toString(GatewayOrErr.takeError()) << "\n";
-      return false;
-    }
-    std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
-    if (!Gateway) {
-      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
-            << " initial candidate slot(s))\n";
-      return false;
-    }
-    T.HasForwardGateway = true;
-    T.ForwardGatewayOffset = Gateway->Sled->WritePos;
-    T.ForwardGatewayBytes = std::move(Gateway->Bytes);
-    Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
-    ++AssignedGateways;
+  const std::vector<NopSled> BaseGateways = Gateways;
+  std::vector<GatewaySlotOwnerList> OwnersBySled(Gateways.size());
+  std::vector<uint64_t> InitialCandidateSlots;
+  std::vector<uint64_t> InitialViableSleds;
+  InitialCandidateSlots.reserve(Pending.size());
+  InitialViableSleds.reserve(Pending.size());
+  for (size_t I = 0; I != Pending.size(); ++I) {
+    const PendingGateway &P = Pending[I];
+    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    InitialCandidateSlots.push_back(P.InitialCandidateSlots);
+    InitialViableSleds.push_back(P.CandidateSleds.size());
+    for (size_t SledIndex : P.CandidateSleds)
+      OwnersBySled[SledIndex].push_back({I, T.OriginalOffset, P.NeededBytes});
   }
-  if (!Pending.empty())
+
+  std::vector<SmallVector<size_t, 2>> Prerequisites(Pending.size());
+  std::vector<SmallVector<size_t, 2>> Successors(Pending.size());
+  uint64_t BranchIslandChains = 0;
+  uint64_t AssignedGateways = 0;
+  uint64_t ProtectedPasses = 0;
+  uint64_t AlternateRelayPasses = 0;
+  uint64_t UnrestrictedCycleBreaks = 0;
+  uint64_t DependencyRetries = 0;
+  static constexpr size_t NormalAlternateStates = 256;
+  static constexpr size_t StalledAlternateStates = 16384;
+  const size_t MaxDependencyRetries = std::min(Pending.size(), size_t{64});
+
+  auto HasDependencyPath = [&](size_t From, size_t To) {
+    std::vector<uint8_t> Seen(Pending.size(), 0);
+    SmallVector<size_t, 16> Worklist;
+    Worklist.push_back(From);
+    while (!Worklist.empty()) {
+      size_t Current = Worklist.pop_back_val();
+      if (Current == To)
+        return true;
+      if (Seen[Current])
+        continue;
+      Seen[Current] = 1;
+      llvm::append_range(Worklist, Successors[Current]);
+    }
+    return false;
+  };
+
+  for (;;) {
+    Gateways = BaseGateways;
+    std::vector<uint64_t> CurrentCandidateSlots = InitialCandidateSlots;
+    std::vector<uint64_t> CurrentViableSleds = InitialViableSleds;
+    std::vector<uint8_t> Done(Pending.size(), 0);
+    std::vector<std::optional<size_t>> LastDestroyer(Pending.size());
+    for (const PendingGateway &P : Pending) {
+      Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+      T.ForwardBranchIslands.clear();
+      T.ForwardBranchTargetOffset = 0;
+      T.HasForwardGateway = false;
+      T.ForwardGatewayOffset = 0;
+      T.ForwardGatewayCallBytes.clear();
+      T.ForwardGatewayBytes.clear();
+    }
+
+    BranchIslandChains = 0;
+    AssignedGateways = 0;
+    ProtectedPasses = 0;
+    AlternateRelayPasses = 0;
+    UnrestrictedCycleBreaks = 0;
+    bool FatalAllocationError = false;
+    auto IsEligible = [&](size_t I) {
+      for (size_t Prerequisite : Prerequisites[I])
+        if (!Done[Prerequisite])
+          return false;
+      return true;
+    };
+
+    auto TryRelay = [&](size_t I, bool ProtectSlots, size_t MaxAlternateStates,
+                        bool LogSearchLimit) {
+      const PendingGateway &P = Pending[I];
+      Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+      std::optional<SmallVector<uint64_t, 4>> Islands =
+          allocateForwardBranchIslands(
+              Gateways, T.OriginalOffset, P.TargetOffset, OwnersBySled,
+              CurrentCandidateSlots, CurrentViableSleds, Done, I, LastDestroyer,
+              ProtectSlots, MaxAlternateStates, LogSearchLimit);
+      if (!Islands || Islands->empty())
+        return false;
+      T.ForwardBranchIslands = std::move(*Islands);
+      T.ForwardBranchTargetOffset = P.TargetOffset;
+      Done[I] = 1;
+      ++BranchIslandChains;
+      return true;
+    };
+
+    auto TryGateway = [&](size_t I, bool ProtectSlots) {
+      const PendingGateway &P = Pending[I];
+      Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+      std::optional<size_t> SledIndex = findNearestGatewaySled(
+          Gateways, T.OriginalOffset, P.NeededBytes, OwnersBySled,
+          CurrentViableSleds, Done, I, ProtectSlots,
+          /*RequireExternalGateway=*/P.UsesCallTail);
+      if (!SledIndex)
+        return false;
+      NopSled &Sled = Gateways[*SledIndex];
+      uint64_t GatewayOffset = Sled.WritePos;
+      SmallVector<uint8_t> Call;
+      SmallVector<uint8_t> Gateway;
+      if (P.UsesCallTail) {
+        Call = encodeSCallI64(Ctx.LS, T.OriginalOffset, GatewayOffset,
+                             T.LongBranchSgprBase);
+        Gateway = P.CallTailBytes;
+      } else {
+        Call = Ctx.LS.encodeSBranch(T.OriginalOffset, GatewayOffset);
+        Gateway = encodeSetPCLongBranch(Ctx.LS, GatewayOffset, P.TargetOffset,
+                                        T.LongBranchSgprBase);
+      }
+      if (Call.size() != MinInstSize || Gateway.empty() ||
+          Gateway.size() > P.NeededBytes ||
+          (P.UsesCallTail && Gateway.size() != P.NeededBytes)) {
+        log() << "hotswap: error: failed to encode far-site gateway at 0x"
+              << utohexstr(GatewayOffset) << "\n";
+        FatalAllocationError = true;
+        return false;
+      }
+      T.HasForwardGateway = true;
+      T.ForwardGatewayOffset = GatewayOffset;
+      if (P.UsesCallTail)
+        T.ForwardGatewayCallBytes = std::move(Call);
+      T.ForwardGatewayBytes = std::move(Gateway);
+      advanceGatewaySled(Sled, Sled.WritePos + T.ForwardGatewayBytes.size(),
+                         OwnersBySled[*SledIndex], CurrentCandidateSlots, Done,
+                         CurrentViableSleds, I, LastDestroyer);
+      Done[I] = 1;
+      ++AssignedGateways;
+      return true;
+    };
+
+    // Drain allocations that preserve a full gateway for every unfinished
+    // owner. If that reaches a dependency stall, permit one allocation to
+    // break it. A later failure learns which owner must precede that breaker
+    // and restarts from the pristine sled cursors.
+    size_t Remaining = Pending.size();
+    size_t FailedOwner = Pending.size();
+    while (Remaining != 0) {
+      ++ProtectedPasses;
+      bool Progress = false;
+      for (size_t I = 0; I != Pending.size(); ++I) {
+        if (Done[I] || !IsEligible(I))
+          continue;
+        if (TryRelay(I, /*ProtectSlots=*/true, NormalAlternateStates,
+                     /*LogSearchLimit=*/false) ||
+            TryGateway(I, /*ProtectSlots=*/true)) {
+          --Remaining;
+          Progress = true;
+        }
+        if (FatalAllocationError)
+          return false;
+      }
+      if (Progress)
+        continue;
+
+      ++AlternateRelayPasses;
+      for (size_t I = 0; I != Pending.size(); ++I) {
+        if (Done[I] || !IsEligible(I))
+          continue;
+        if (TryRelay(I, /*ProtectSlots=*/true, StalledAlternateStates,
+                     /*LogSearchLimit=*/true)) {
+          --Remaining;
+          Progress = true;
+        }
+      }
+      if (Progress)
+        continue;
+
+      for (size_t I = 0; I != Pending.size(); ++I) {
+        if (Done[I] || !IsEligible(I))
+          continue;
+        if (TryRelay(I, /*ProtectSlots=*/false,
+                     /*MaxAlternateStates=*/0,
+                     /*LogSearchLimit=*/false) ||
+            TryGateway(I, /*ProtectSlots=*/false)) {
+          --Remaining;
+          Progress = true;
+          ++UnrestrictedCycleBreaks;
+          log() << "hotswap: gateway reservation solver: unrestricted cycle "
+                   "break at site 0x"
+                << utohexstr(Ctx.OutTrampolines[Pending[I].TrampolineIndex]
+                                 .OriginalOffset)
+                << "\n";
+          break;
+        }
+        if (FatalAllocationError)
+          return false;
+      }
+      if (Progress)
+        continue;
+
+      size_t FirstEligible = Pending.size();
+      for (size_t I = 0; I != Pending.size(); ++I) {
+        if (!Done[I] && IsEligible(I)) {
+          if (FirstEligible == Pending.size())
+            FirstEligible = I;
+          if (LastDestroyer[I]) {
+            FailedOwner = I;
+            break;
+          }
+        }
+      }
+      if (FailedOwner == Pending.size())
+        FailedOwner = FirstEligible;
+      break;
+    }
+
+    if (Remaining == 0)
+      break;
+    if (FailedOwner == Pending.size()) {
+      log() << "hotswap: error: gateway allocation dependency cycle\n";
+      return false;
+    }
+
+    const PendingGateway &Failed = Pending[FailedOwner];
+    const Trampoline &FailedT = Ctx.OutTrampolines[Failed.TrampolineIndex];
+    auto LogFailedOwner = [&] {
+      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+            << utohexstr(FailedT.OriginalOffset) << " ("
+            << Failed.InitialCandidateSlots << " initial candidate slot(s))\n";
+    };
+    if (!LastDestroyer[FailedOwner]) {
+      LogFailedOwner();
+      return false;
+    }
+    size_t Destroyer = *LastDestroyer[FailedOwner];
+    bool Duplicate = llvm::is_contained(Successors[FailedOwner], Destroyer);
+    if (Destroyer == FailedOwner || Duplicate ||
+        HasDependencyPath(Destroyer, FailedOwner)) {
+      log() << "hotswap: error: gateway allocation dependency cycle between "
+               "sites 0x"
+            << utohexstr(FailedT.OriginalOffset) << " and 0x"
+            << utohexstr(Ctx.OutTrampolines[Pending[Destroyer].TrampolineIndex]
+                             .OriginalOffset)
+            << "\n";
+      LogFailedOwner();
+      return false;
+    }
+    if (DependencyRetries >= MaxDependencyRetries) {
+      log() << "hotswap: error: gateway allocation dependency retry limit "
+               "reached\n";
+      LogFailedOwner();
+      return false;
+    }
+
+    Prerequisites[Destroyer].push_back(FailedOwner);
+    Successors[FailedOwner].push_back(Destroyer);
+    ++DependencyRetries;
+    log() << "hotswap: gateway reservation solver: retrying with site 0x"
+          << utohexstr(FailedT.OriginalOffset) << " before site 0x"
+          << utohexstr(Ctx.OutTrampolines[Pending[Destroyer].TrampolineIndex]
+                           .OriginalOffset)
+          << "\n";
+  }
+
+  log() << "hotswap: gateway reservation solver: " << ProtectedPasses
+        << " protected pass(es), " << AlternateRelayPasses
+        << " alternate relay pass(es), " << UnrestrictedCycleBreaks
+        << " unrestricted cycle-break allocation(s), " << DependencyRetries
+        << " conflict-directed retry/retries\n";
+  if (AssignedGateways != 0)
     log() << "hotswap: assigned " << AssignedGateways
           << " SCC-neutral forward gateway(s)\n";
   if (BranchIslandChains != 0)
@@ -2104,17 +6712,9 @@ assignLongBranchGateways(PatchContext &Ctx,
           << " forward s_branch island chain(s)\n";
 
   for (Trampoline &T : Ctx.OutTrampolines) {
-    if (T.HasForwardGateway) {
-      if (T.ForwardGatewayOffset > Ctx.TextSize ||
-          T.ForwardGatewayBytes.size() >
-              Ctx.TextSize - T.ForwardGatewayOffset) {
-        log() << "hotswap: error: forward gateway at 0x"
-              << utohexstr(T.ForwardGatewayOffset) << " extends past .text.\n";
-        return false;
-      }
+    if (T.HasForwardGateway)
       std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
                   T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
-    }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
       uint64_t From = T.ForwardBranchIslands[I];
       uint64_t To = I + 1 == T.ForwardBranchIslands.size()
@@ -2151,9 +6751,19 @@ assignLongBranchGateways(PatchContext &Ctx,
 /// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
 /// reachable sled with sufficient headroom exists; otherwise falls back to a
 /// deferred trampoline.
-[[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
-                                       uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement) {
+static bool emitReplacementCodeRaw(PatchContext &Ctx, uint64_t InstOffset,
+                                   uint32_t InstSize,
+                                   ArrayRef<uint8_t> Replacement,
+                                   ReplacementPlacement Placement,
+                                   bool DiagnoseFailure) {
+  const bool AllowGlobalBody = Placement != ReplacementPlacement::Default;
+  if (Ctx.RelocationProtectedOffsets.contains(InstOffset)) {
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source at 0x"
+            << utohexstr(InstOffset) << " is relocation-protected\n";
+    return false;
+  }
+
   std::optional<uint64_t> ReturnTo = checkedAddUint64(
       InstOffset, InstSize, "replacement trampoline return target");
   std::optional<uint64_t> PoolReturnFrom =
@@ -2161,6 +6771,23 @@ assignLongBranchGateways(PatchContext &Ctx,
                        "replacement trampoline return slot");
   if (!ReturnTo || !PoolReturnFrom)
     return false;
+
+  // The address at the start remains a valid alias for the replacement or
+  // redirect, and the end is outside the rewritten half-open interval. Any
+  // entry strictly inside would instead land in a moved instruction, branch
+  // tail, or padding, so every patch family must reject the complete window.
+  if (Ctx.DirectControlFlowTargets && *ReturnTo > InstOffset) {
+    uint64_t Offset = InstOffset;
+    while (++Offset < *ReturnTo)
+      if (Ctx.DirectControlFlowTargets->contains(Offset)) {
+        if (DiagnoseFailure)
+          log() << "hotswap: error: replacement source [0x"
+                << utohexstr(InstOffset) << ", 0x" << utohexstr(*ReturnTo)
+                << ") contains protected interior entry 0x" << utohexstr(Offset)
+                << "\n";
+        return false;
+      }
+  }
 
   // When the pool base is already out of short-branch reach, defer every site
   // to the global trampoline pass. That pass can coalesce adjacent patches
@@ -2172,16 +6799,37 @@ assignLongBranchGateways(PatchContext &Ctx,
     // findNearestSled enforces sled headroom. emitToNopSled still validates
     // exact branch reachability because branch-back distance includes the
     // replacement size, not just the original instruction offset.
-    uint64_t Needed = Replacement.size() + MinInstSize;
-    if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
-      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
+    uint64_t Needed = getNopSledBytesNeeded(Ctx, InstOffset, InstSize,
+                                            Replacement, Placement);
+    NopSledUse SledUse =
+        AllowGlobalBody ? NopSledUse::RelocationBody : NopSledUse::OwnerBody;
+    if (NopSled *Sled =
+            findNearestSled(Ctx.NopSleds, InstOffset, Needed, SledUse)) {
+      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement,
+                        Placement))
         return true;
       log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
             << utohexstr(Sled->WritePos)
             << " is not branch-reachable after assembly; using trampoline.\n";
     }
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+  return emitToTrampolineRaw(Ctx, InstOffset, InstSize, Replacement, Placement,
+                             DiagnoseFailure);
+}
+
+[[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
+                                       uint32_t InstSize,
+                                       ArrayRef<uint8_t> Replacement,
+                                       ReplacementPlacement Placement,
+                                       bool DiagnoseFailure) {
+  std::optional<PreparedSiteReplacement> Prepared = prepareSiteReplacement(
+      Ctx, InstOffset, InstSize, Replacement, DiagnoseFailure);
+  if (!Prepared)
+    return false;
+  if (!emitReplacementCodeRaw(Ctx, InstOffset, InstSize, Prepared->Bytes,
+                              Placement, DiagnoseFailure))
+    return false;
+  return commitSiteReplacement(Ctx, InstOffset, InstSize, *Prepared);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -2218,30 +6866,121 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     const RewriteConfig &Config, bool &OutRequiredPatchApplied,
     HotswapProfile &Profile) {
   uint32_t Patched = 0;
-
-  HotswapProfile::Scope SledScope = Profile.time(HotswapMetric::NopSledScan);
-  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
-  SledScope.finish();
-
+  std::optional<DenseSet<uint64_t>> CodeEntries =
+      collectCodeObjectEntryOffsets(Elf, TextSize);
+  std::optional<std::vector<uint64_t>> TextSymbolOffsets =
+      Elf.textSymbolOffsets();
+  std::optional<std::vector<ElfView::TextOffsetRange>> TextSymbolExtents =
+      Elf.textSymbolExtents();
   std::optional<DeclaredTextEntryInfo> DeclaredEntries =
       collectDeclaredTextEntries(Elf);
   if (!DeclaredEntries)
     return std::nullopt;
   std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Elf.functionTextRanges();
-  std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
-      Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
-      FunctionRanges, DeclaredEntries->ExternalEntries);
-  if (!ControlFlow)
+  std::optional<CompatibilityControlFlowFacts> CompatibilityFacts =
+      collectCompatibilityControlFlowFacts(
+          Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
+          FunctionRanges, DeclaredEntries->ExternalEntries);
+  if (!CompatibilityFacts)
     return std::nullopt;
-  if (ControlFlow->HasUnresolvedTargets) {
+
+  std::optional<DenseSet<uint64_t>> DirectControlFlowTargets;
+  if (CodeEntries && TextSymbolOffsets && TextSymbolExtents)
+    DirectControlFlowTargets = collectDirectBranchTargets(
+        Decoded, LS, ArrayRef<uint8_t>(Text, TextSize), Elf, *CodeEntries,
+        *TextSymbolOffsets, *TextSymbolExtents, *CompatibilityFacts);
+  DenseSet<uint64_t> EmptyTargets;
+  const DenseSet<uint64_t> &KnownDirectTargets =
+      DirectControlFlowTargets ? *DirectControlFlowTargets : EmptyTargets;
+  const std::optional<ArrayRef<uint64_t>> OptionalTextSymbolOffsets =
+      TextSymbolOffsets ? std::optional<ArrayRef<uint64_t>>(*TextSymbolOffsets)
+                        : std::nullopt;
+  const std::optional<ArrayRef<ElfView::TextOffsetRange>>
+      OptionalTextSymbolExtents =
+          TextSymbolExtents ? std::optional<ArrayRef<ElfView::TextOffsetRange>>(
+                                  *TextSymbolExtents)
+                            : std::nullopt;
+  const ArrayRef<uint8_t> TextBytes(Text, TextSize);
+
+  // The later analyzer is deliberately stricter than the PR's public callable
+  // contract and does not recognize PR call-tail/materialized forms. Reconcile
+  // each unresolved call independently: only an exact PR materialization proof
+  // or the ABI-standard link-call contract discharges that site. Every other
+  // site retains the later global fail-closed policy.
+  bool HasRemainingCompatibilityUnresolvedCall = false;
+  for (size_t I : CompatibilityFacts->UnresolvedCallIndices) {
+    if (I >= Decoded.size())
+      return std::nullopt;
+    const bool ResolvedByPr =
+        isStandardLinkCall(Decoded[I], LS) ||
+        (DirectControlFlowTargets &&
+         evaluateMaterializedPcTransfer(
+             Decoded, I, KnownDirectTargets, TextBytes, LS, Elf,
+             OptionalTextSymbolOffsets, OptionalTextSymbolExtents)
+             .has_value());
+    if (ResolvedByPr)
+      continue;
+    log() << "hotswap: unresolved call target at 0x"
+          << utohexstr(Decoded[I].Offset) << " (" << Decoded[I].Mnemonic
+          << ")\n";
+    HasRemainingCompatibilityUnresolvedCall = true;
+  }
+  CompatibilityFacts->Summary.HasUnresolvedTargets =
+      HasRemainingCompatibilityUnresolvedCall;
+
+  const bool HasUnresolvedStandardLinkCall =
+      DirectControlFlowTargets
+          ? hasUnresolvedStandardLinkCall(Decoded, LS, Elf, KnownDirectTargets,
+                                          TextBytes, OptionalTextSymbolOffsets,
+                                          OptionalTextSymbolExtents,
+                                          *CompatibilityFacts)
+          : llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+              return isStandardLinkCall(DI, LS);
+            });
+  DenseSet<uint64_t> ProvenDirectCallReturns;
+  if (DirectControlFlowTargets && TextSymbolOffsets && TextSymbolExtents)
+    ProvenDirectCallReturns = collectProvenDirectCallReturns(
+        Decoded, LS, Elf, KnownDirectTargets, TextBytes,
+        OptionalTextSymbolOffsets, OptionalTextSymbolExtents,
+        HasUnresolvedStandardLinkCall, *CompatibilityFacts);
+  bool PrHasUnknownArbitraryIndirectTarget = false;
+  DenseSet<uint64_t> IndirectControlFlowFunctions =
+      collectIndirectControlFlowFunctions(
+          Decoded, LS, Elf, KnownDirectTargets, TextBytes,
+          OptionalTextSymbolOffsets, OptionalTextSymbolExtents,
+          ProvenDirectCallReturns, *CompatibilityFacts,
+          PrHasUnknownArbitraryIndirectTarget);
+  const bool HasUnknownArbitraryIndirectTarget =
+      PrHasUnknownArbitraryIndirectTarget ||
+      CompatibilityFacts->Summary.HasUnresolvedTargets;
+  const bool HasIncompleteControlFlow =
+      !DirectControlFlowTargets || HasUnknownArbitraryIndirectTarget;
+  if (HasIncompleteControlFlow)
+    for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges())
+      if (Range.Begin >= Elf.textAddr())
+        IndirectControlFlowFunctions.insert(Range.Begin - Elf.textAddr());
+  if (HasUnknownArbitraryIndirectTarget)
     log() << "hotswap: unresolved control-flow target disables NOP-sled "
              "emission, trampoline coalescing, source relocation, and .text "
              "gateways\n";
-    Sleds.clear();
+  HotswapProfile::Scope SledScope =
+      Profile.time(HotswapMetric::NopSledScan);
+  std::vector<NopSled> Sleds;
+  if (DirectControlFlowTargets && TextSymbolOffsets && TextSymbolExtents &&
+      !HasUnknownArbitraryIndirectTarget) {
+    Sleds = buildNopSledMap(Decoded, LS, Elf, KnownDirectTargets,
+                            IndirectControlFlowFunctions, *TextSymbolOffsets,
+                            *TextSymbolExtents);
+    std::vector<NopSled> ExternalSleds = buildExternalGatewaySleds(
+        Decoded, LS, Elf, ArrayRef<uint8_t>(Text, TextSize), KnownDirectTargets,
+        *TextSymbolOffsets, *TextSymbolExtents, Sleds);
+    Sleds.insert(Sleds.end(), ExternalSleds.begin(), ExternalSleds.end());
   } else {
-    truncateNopSledsAtDirectTargets(Sleds, ControlFlow->Targets);
+    log() << "hotswap: incomplete control-flow targets disable NOP padding "
+             "donation\n";
   }
+  SledScope.finish();
 
   HotswapProfile::Scope CfgScope = Profile.time(HotswapMetric::CfgBuild);
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
@@ -2263,6 +7002,65 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     }
   }
 
+  TensorDescriptorMustAnalysis TensorDescriptorAnalysis;
+  InitialVmemMustAnalysis InitialVmemAnalysis;
+  const bool HasClause =
+      Config.RunB0A0Patches &&
+      llvm::any_of(Decoded, [](const InternalDecodedInst &DI) {
+        return DI.Mnemonic == "s_clause";
+      });
+  const bool HasTensorLoad =
+      llvm::any_of(Decoded, [](const InternalDecodedInst &DI) {
+        return DI.Mnemonic == "tensor_load_to_lds";
+      });
+  std::vector<InternalDecodedInst> HotswapAnalysisDecoded;
+  if ((HasClause || HasTensorLoad) &&
+      !buildHotswapAnalysisDecoded(Elf, LS, Decoded, HotswapAnalysisDecoded))
+    return std::nullopt;
+  OriginalIngressInfo OriginalIngress;
+  if (HasClause || HasTensorLoad)
+    OriginalIngress = collectOriginalIngress(
+        Decoded, KnownDirectTargets, ArrayRef<uint8_t>(Text, TextSize), LS, Elf,
+        *CompatibilityFacts,
+        TextSymbolOffsets
+            ? std::optional<ArrayRef<uint64_t>>(*TextSymbolOffsets)
+            : std::nullopt,
+        TextSymbolExtents ? std::optional<ArrayRef<ElfView::TextOffsetRange>>(
+                                *TextSymbolExtents)
+                          : std::nullopt);
+  if (HasClause) {
+    std::vector<KernelTextRange> KernelRanges = collectKernelTextRanges(
+        Elf, LS, OriginalIngress.ControlFlowEdges,
+        HasUnknownArbitraryIndirectTarget, HasUnresolvedStandardLinkCall);
+    InitialVmemAnalysis = computeInitialVmemMustAnalysis(
+        Decoded, HotswapAnalysisDecoded, KernelRanges, LS);
+  }
+  if (HasTensorLoad) {
+    const bool TensorHasUnknownOwnedInstruction =
+        llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+          return DI.Mnemonic == "<unknown>" &&
+                 Elf.findFunctionTextRangeAtOffset(DI.Offset).has_value();
+        });
+    const bool TensorHasTrapOrRfe =
+        llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+          return StringRef(DI.Mnemonic).starts_with("s_rfe") ||
+                 StringRef(DI.Mnemonic).starts_with("s_trap") ||
+                 (LS.MCII && LS.MCII->get(DI.Inst.getOpcode()).isTrap());
+        });
+    std::vector<TensorAnalysisRange> TensorRanges;
+    if (CodeEntries && DirectControlFlowTargets)
+      TensorRanges = collectTensorAnalysisRanges(
+          Elf, LS, *CodeEntries, IndirectControlFlowFunctions,
+          OriginalIngress.CrossRangeEntryFunctions,
+          OriginalIngress.ExternalEntries, OriginalIngress.ControlFlowEdges,
+          HasUnknownArbitraryIndirectTarget ||
+              TensorHasUnknownOwnedInstruction ||
+              HasUnresolvedStandardLinkCall || TensorHasTrapOrRfe);
+    TensorDescriptorAnalysis = computeTensorDescriptorMustAnalysis(
+        Decoded, HotswapAnalysisDecoded, TensorRanges, LS, KnownDirectTargets,
+        Config.MaxSgprs, Config.MaxVgprs);
+  }
+
   StringMap<KernelPatchStats> KernelStats;
   // Pool base as a .text-relative offset for trampoline branch math. The pool
   // is always >= textAddr(); checkedSubUint64 guards a malformed object.
@@ -2273,12 +7071,67 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       *PoolVAddr, Elf.textAddr(), "trampoline pool base offset");
   if (!PoolBaseOffset)
     return std::nullopt;
-  PatchContext Ctx{
-      Config,      Decoded,           Text,         TextSize, *PoolBaseOffset,
-      LS,          OutTrampolines,    Sleds,        Elf,      Liveness,
-      KernelStats, OutScratchPatches, *ControlFlow, Profile};
+  DirectControlFlowInfo CompatibilityControlFlow = CompatibilityFacts->Summary;
+  CompatibilityControlFlow.Targets = KnownDirectTargets;
+  CompatibilityControlFlow.HasUnresolvedTargets |=
+      !DirectControlFlowTargets || HasUnknownArbitraryIndirectTarget ||
+      HasUnresolvedStandardLinkCall;
+  PatchContext Ctx{Config,         Decoded,         Text,
+                   TextSize,       *PoolBaseOffset, LS,
+                   OutTrampolines, Sleds,           Elf,
+                   Liveness,       KernelStats,     OutScratchPatches,
+                   CompatibilityControlFlow, Profile};
+  Ctx.InitialVmemAnalysis = &InitialVmemAnalysis;
+  Ctx.TensorDescriptorAnalysis = &TensorDescriptorAnalysis;
+  for (const InternalDecodedInst &DI : Decoded)
+    Ctx.MaxDecodedInstSize = std::max(Ctx.MaxDecodedInstSize, DI.Size);
+  Ctx.DirectControlFlowTargets = DirectControlFlowTargets;
+  if (TextSymbolExtents)
+    Ctx.TextSymbolExtents = *TextSymbolExtents;
+  Ctx.IndirectControlFlowFunctions = std::move(IndirectControlFlowFunctions);
+  Ctx.HasUnknownArbitraryIndirectTarget = HasUnknownArbitraryIndirectTarget;
+  if (Ctx.DirectControlFlowTargets && !Ctx.HasUnknownArbitraryIndirectTarget)
+    Ctx.VgprMsbDstSrc0EqualBefore = computeVgprMsbDstSrc0Equality(
+        Decoded, LS, Elf, *DirectControlFlowTargets, *CodeEntries,
+        Ctx.IndirectControlFlowFunctions, ArrayRef<uint8_t>(Text, TextSize),
+        *CompatibilityFacts,
+        Ctx.VgprDef0AlignedTo8, Ctx.VgprDef1AlignedTo8, Ctx.VgprMsbDstBefore,
+        Ctx.VgprMsbSrc0Before, Ctx.VgprMsbModeBefore,
+        Ctx.CrossFunctionInteriorEntryFunctions);
+  collectRelocationProtectedOffsets(Decoded, Ctx);
+
+  // Patch placement needs a conservative entry-boundary set, not just the
+  // edges used to build the CFG. Keep ordinary symbols out of control-flow
+  // analysis, then include them here so moving a source window can never
+  // swallow an addressable interior boundary.
+  if (Ctx.DirectControlFlowTargets && TextSymbolOffsets)
+    Ctx.DirectControlFlowTargets->insert(TextSymbolOffsets->begin(),
+                                         TextSymbolOffsets->end());
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
+  // Whole-function requirements must be discovered from the immutable stream
+  // before any same-size or relocating pass mutates the source bytes. Their
+  // reserved sites then participate in every atomic-window ownership check.
+  if (Config.RunB0A0Patches && VT.precomputeWmmaHazards &&
+      !VT.precomputeWmmaHazards(Ctx))
+    return std::nullopt;
+
+  precomputeDs2AddressAlignment(Ctx);
+  precomputeSiteDeadSgprFacts(Ctx);
+
+  // VOP3PX2 is a same-size bit-field correction. Apply it before any atomic
+  // source-window relocation so those windows copy already-correct current
+  // bytes rather than forcing a later overlapping rewrite.
+  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix) {
+    HotswapProfile::Scope Vop3Scope =
+        Ctx.Profile.time(HotswapMetric::Vop3px2Src2);
+    const uint32_t P = VT.applyVop3px2Src2Fix(Ctx);
+    Vop3Scope.addPatches(P);
+    Vop3Scope.finish();
+    Patched += P;
+  }
+  if (Ctx.RequiredPatchFailed)
+    return std::nullopt;
 
   // Skip undecoded slots produced by the decoder for bytes it could not
   // classify as a valid instruction; the dispatcher has nothing to match
@@ -2308,7 +7161,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
 
   for (size_t Idx = 0, E = Decoded.size(); Idx < E; ++Idx) {
     const InternalDecodedInst &DI = Decoded[Idx];
-    if (DI.Mnemonic == UnknownMnemonic)
+    if (DI.Mnemonic == UnknownMnemonic ||
+        Ctx.ClaimedReplacementOffsets.contains(DI.Offset))
       continue;
 
     for (TimedPass &Pass : Passes) {
@@ -2331,17 +7185,9 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     for (const TimedPass &Pass : Passes)
       Ctx.Profile.add(Pass.Metric, Pass.Nanos, Pass.Patches);
 
-  // Whole-kernel passes below run after per-instruction patches. Earlier
-  // passes may have modified Text bytes, but the Decoded stream still holds
-  // the original MCInst/Mnemonic/Offset entries. This is safe because:
-  //  - In-place patches only change opcodes within the same encoding size,
-  //    preserving instruction boundaries and offsets.
-  //  - Trampoline patches replace the original instruction with a branch
-  //    (same size), so the Decoded entry's Offset still points at the
-  //    branch site; the WMMA classifier and VOP3PX2 mnemonic match won't
-  //    treat a branch as WMMA/VALU/VOP3PX2.
-  // If a future patch family changes instruction boundaries, the Decoded
-  // stream must be rebuilt before these passes run.
+  // Finalize requirements that no ordinary per-instruction owner composed.
+  // The hazard pass copies current post-in-place bytes for those sites; it
+  // never rebuilds a replacement from stale MCInst state.
   if (Config.RunB0A0Patches && VT.applyWmmaHazardPatch) {
     HotswapProfile::Scope HazardScope =
         Ctx.Profile.time(HotswapMetric::WmmaHazard);
@@ -2350,24 +7196,31 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     HazardScope.finish();
     Patched += P;
   }
-  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix) {
-    HotswapProfile::Scope Vop3Scope =
-        Ctx.Profile.time(HotswapMetric::Vop3px2Src2);
-    const uint32_t P = VT.applyVop3px2Src2Fix(Ctx);
-    Vop3Scope.addPatches(P);
-    Vop3Scope.finish();
-    Patched += P;
-  }
+  if (Ctx.RequiredPatchFailed)
+    return std::nullopt;
 
   if (!OutTrampolines.empty()) {
-    if (!ControlFlow->HasUnresolvedTargets) {
-      mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
-      expandStraightLineTrampolines(Ctx, ControlFlow->Targets);
-      mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
+    if (!Ctx.DirectControlFlowTargets)
+      return std::nullopt;
+    // Whole-function passes append after the per-instruction walk and can
+    // therefore add an earlier site at the end of this vector. Neighbor-based
+    // coalescing and source growth require address order, independent of which
+    // patch family discovered each site.
+    llvm::stable_sort(OutTrampolines,
+                      [](const Trampoline &LHS, const Trampoline &RHS) {
+                        return LHS.OriginalOffset < RHS.OriginalOffset;
+                      });
+    if (!Ctx.HasUnknownArbitraryIndirectTarget) {
+      mergeAdjacentLongTrampolines(
+          OutTrampolines, *Ctx.DirectControlFlowTargets,
+          Ctx.IndirectControlFlowFunctions);
+      expandStraightLineTrampolines(Ctx, *Ctx.DirectControlFlowTargets);
+      mergeAdjacentLongTrampolines(
+          OutTrampolines, *Ctx.DirectControlFlowTargets,
+          Ctx.IndirectControlFlowFunctions);
     }
     appendPoolBranchIslands(OutTrampolines);
-    if (!assignLongBranchGateways(Ctx, ControlFlow->Targets,
-                                  !ControlFlow->HasUnresolvedTargets))
+    if (!assignLongBranchGateways(Ctx))
       return std::nullopt;
   }
 
@@ -2535,22 +7388,17 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     if (!ReturnTo)
       return false;
 
-    std::optional<SmallVector<uint8_t>> BrBack;
-    if (T.UsesSetPCBack) {
-      BrBack =
-          encodeSetPCLongBranch(LS, BackSlot, *ReturnTo, T.LongBranchSgprBase);
-    } else {
-      SmallVector<uint8_t> ShortBranch = LS.encodeSBranch(BackSlot, *ReturnTo);
-      if (!ShortBranch.empty())
-        BrBack = std::move(ShortBranch);
-    }
-    if (!BrBack || BrBack->size() > BackReserve) {
+    SmallVector<uint8_t> BrBack =
+        T.UsesSetPCBack ? encodeSetPCLongBranch(LS, BackSlot, *ReturnTo,
+                                                T.LongBranchSgprBase)
+                        : LS.encodeSBranch(BackSlot, *ReturnTo);
+    if (BrBack.empty() || BrBack.size() > BackReserve) {
       log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
             << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
       return false;
     }
-    std::memcpy(T.Bytes.data() + BackOffset, BrBack->data(), BrBack->size());
-    for (uint32_t I = BrBack->size(); I + MinInstSize <= BackReserve;
+    std::memcpy(T.Bytes.data() + BackOffset, BrBack.data(), BrBack.size());
+    for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
          I += MinInstSize)
       std::memcpy(T.Bytes.data() + BackOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
@@ -2565,7 +7413,10 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
       } else if (T.UsesDirectSetPCForward) {
         BrFwd = T.DirectSetPCForwardBytes;
       } else if (T.HasForwardGateway) {
-        BrFwd = LS.encodeSBranch(T.OriginalOffset, T.ForwardGatewayOffset);
+        BrFwd = T.ForwardGatewayCallBytes.empty()
+                    ? LS.encodeSBranch(T.OriginalOffset,
+                                       T.ForwardGatewayOffset)
+                    : T.ForwardGatewayCallBytes;
       } else {
         log() << "hotswap: error: far trampoline has no forward gateway at 0x"
               << utohexstr(T.OriginalOffset) << "\n";
@@ -2642,9 +7493,8 @@ copyOutputBuffer(const void *Data, size_t Size, StringRef CopyKind) {
   std::unique_ptr<WritableMemoryBuffer> Result =
       WritableMemoryBuffer::getNewUninitMemBuffer(Size);
   if (!Result) {
-    log() << "hotswap: error: retargetCodeObject: "
-          << "getNewUninitMemBuffer(" << Size
-          << ") failed (out of memory) for the " << CopyKind
+    log() << "hotswap: error: retargetCodeObject: " << "getNewUninitMemBuffer("
+          << Size << ") failed (out of memory) for the " << CopyKind
           << " output copy.\n";
     return nullptr;
   }
@@ -2664,9 +7514,6 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   // initializer binds every register*Patch slot on first access, so no
   // explicit install step is needed here.
 
-  const bool RunInstructionPatches =
-      Options.RunB0A0Patches ||
-      Options.MaskPolicy != MaskWorkaroundPolicy::None;
   const bool Prof = Profile.enabled();
 
   // Take a working copy so the input is preserved and we have a mutable
@@ -2692,6 +7539,52 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   ElfView &Elf = *ViewOrErr;
   if (Prof)
     Profile.add(HotswapMetric::ElfParse, profNowNs() - ParseT0, 0);
+
+  // Validate every executable region covered by the requested B0-to-A0
+  // operation before metadata can short-circuit instruction rewriting. The
+  // metadata certificate must not allow an incompatible or forged external
+  // pool to bypass structural provenance checks.
+  if (Options.RunB0A0Patches) {
+    std::optional<bool> CompatibleExternalCode =
+        Elf.executableCodeOutsideTextIsCompatibleWith(
+            ExecutablePoolTargetState::A0);
+    if (!CompatibleExternalCode)
+      return AMD_COMGR_STATUS_ERROR;
+    if (!*CompatibleExternalCode) {
+      log() << "hotswap: error: B0-to-A0 rewrite found unprovenanced or "
+               "target-incompatible executable code outside .text; refusing "
+               "to issue an incomplete A0 target-state certificate\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+  }
+
+  bool RunB0A0Patches = Options.RunB0A0Patches;
+  MaskWorkaroundPolicy MaskPolicy = Options.MaskPolicy;
+  if (RunB0A0Patches) {
+    std::optional<bool> AlreadyA0 = Elf.allKernelsHaveGfx1250Revision("A0");
+    if (!AlreadyA0)
+      return AMD_COMGR_STATUS_ERROR;
+    if (*AlreadyA0) {
+      // The metadata retag is committed only on a successfully returned
+      // rewrite. It is therefore an object-wide target-state certificate, not
+      // a heuristic derived from instruction patterns in transformed code.
+      log() << "hotswap: every kernel already reports gfx1250 revision A0; "
+               "skipping B0-to-A0 instruction rewrites\n";
+      RunB0A0Patches = false;
+      if (MaskPolicy == MaskWorkaroundPolicy::A0)
+        MaskPolicy = MaskWorkaroundPolicy::None;
+    }
+  }
+  const bool RunInstructionPatches =
+      RunB0A0Patches || MaskPolicy != MaskWorkaroundPolicy::None;
+  if (!RunInstructionPatches && !Options.RunEntryTrampolines) {
+    std::unique_ptr<WritableMemoryBuffer> Result =
+        copyOutputBuffer(ElfData, ElfSize, "already-targeted");
+    if (!Result)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    Out = std::move(Result);
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
 
   // The CPU name and s_nop padding bytes are the only rewrite state the fast
   // path needs; both are also carried by LLVMState on the MC path. Holding them
@@ -2769,8 +7662,8 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   }
 
   RewriteConfig Config = makeGfx1250B0A0Config();
-  Config.RunB0A0Patches = Options.RunB0A0Patches;
-  Config.MaskPolicy = Options.MaskPolicy;
+  Config.RunB0A0Patches = RunB0A0Patches;
+  Config.MaskPolicy = MaskPolicy;
 
   uint8_t *Text = Elf.textData();
   uint64_t Count = 0;
@@ -2806,7 +7699,7 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   // gfx1250 revision is recorded per kernel in the AMDGPU metadata note.
   // Running a B0 object on A0 requires retagging that metadata even when no
   // machine instruction needed rewriting.
-  if (Options.RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
+  if (RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
     return AMD_COMGR_STATUS_ERROR;
 
   std::unique_ptr<WritableMemoryBuffer> Result;
@@ -2895,8 +7788,26 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   }
 
   if (!Growth.empty()) {
+    ExecutablePoolTargetState PoolTargetState =
+        ExecutablePoolTargetState::Neutral;
+    if (!Deferred.empty()) {
+      if (RunB0A0Patches || MaskPolicy == MaskWorkaroundPolicy::A0)
+        PoolTargetState = ExecutablePoolTargetState::A0;
+      else if (MaskPolicy == MaskWorkaroundPolicy::B0)
+        PoolTargetState = ExecutablePoolTargetState::B0;
+      if (PoolTargetState == ExecutablePoolTargetState::Neutral) {
+        log() << "hotswap: error: stepping-dependent deferred trampolines "
+                 "require an explicit A0 or B0 executable-pool target state.\n";
+        return AMD_COMGR_STATUS_ERROR;
+      }
+    } else if (EntryFixups.empty()) {
+      log() << "hotswap: error: a stepping-neutral executable pool must be "
+               "proven to contain kernel-entry stubs.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
     uint64_t GrowT0 = Prof ? profNowNs() : 0;
-    Result = Elf.growWithTrampolines(Growth, SNopBytes);
+    Result =
+        Elf.growWithTrampolines(Growth, SNopBytes, PoolTargetState);
     if (Prof)
       Profile.add(HotswapMetric::GrowElf, profNowNs() - GrowT0, 0);
     if (!Result) {

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -16,11 +16,10 @@
 
 #include "comgr-hotswap-internal.h"
 
-#include "llvm/ADT/DenseSet.h"
-#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Support/Endian.h"
 
 #include <algorithm>
 #include <limits>
@@ -52,6 +51,57 @@ static constexpr unsigned SgprEncodingGranule = 8;
 // Page alignment for the appended trampoline pool's virtual address and file
 // offset, so its PT_LOAD segment maps consistently.
 static constexpr uint64_t TrampolinePoolAlign = 4096;
+
+// Standard ELF note identifying one executable pool produced by HotSwap. The
+// description is a fixed little-endian schema:
+//   u32 version, u32 target state, u64 pool vaddr, u64 pool size.
+// The section carrying the note is deliberately non-allocating; loaders need
+// not map provenance that is consumed only by a later rewrite.
+static constexpr StringLiteral HotswapPoolNoteName = "AMDGPU";
+static constexpr uint32_t HotswapPoolNoteType = 0x48535750; // "HSWP"
+static constexpr uint32_t HotswapPoolNoteVersion = 1;
+static constexpr uint32_t HotswapPoolNoteDescSize = 24;
+
+static std::optional<uint64_t> checkedAlignToUint64(uint64_t Value,
+                                                    uint64_t Alignment,
+                                                    StringRef Context) {
+  if (Alignment == 0) {
+    log() << "hotswap: error: " << Context << " has zero alignment.\n";
+    return std::nullopt;
+  }
+  const uint64_t Remainder = Value % Alignment;
+  if (Remainder == 0)
+    return Value;
+  return checkedAddUint64(Value, Alignment - Remainder, Context);
+}
+
+static SmallVector<uint8_t, 48>
+buildHotswapPoolNote(uint64_t PoolVAddr, uint64_t PoolSize,
+                     ExecutablePoolTargetState TargetState) {
+  const uint32_t NameSize = HotswapPoolNoteName.size() + 1;
+  const uint32_t NameStorageSize = alignTo(NameSize, uint32_t{4});
+  SmallVector<uint8_t, 48> Bytes(12 + NameStorageSize +
+                                    HotswapPoolNoteDescSize,
+                                0);
+  support::endian::write32le(Bytes.data(), NameSize);
+  support::endian::write32le(Bytes.data() + 4, HotswapPoolNoteDescSize);
+  support::endian::write32le(Bytes.data() + 8, HotswapPoolNoteType);
+  std::memcpy(Bytes.data() + 12, HotswapPoolNoteName.data(),
+              HotswapPoolNoteName.size());
+  uint8_t *Desc = Bytes.data() + 12 + NameStorageSize;
+  support::endian::write32le(Desc, HotswapPoolNoteVersion);
+  support::endian::write32le(Desc + 4,
+                             static_cast<uint32_t>(TargetState));
+  support::endian::write64le(Desc + 8, PoolVAddr);
+  support::endian::write64le(Desc + 16, PoolSize);
+  return Bytes;
+}
+
+enum class MetadataSgprUpdateStatus {
+  NotFound,
+  Found,
+  Error,
+};
 
 enum class MetadataCountUpdateStatus {
   NotFound,
@@ -115,6 +165,375 @@ readUnsignedMetadataNode(const msgpack::DocNode &Node, StringRef KernelName,
   return std::nullopt;
 }
 
+static std::optional<unsigned>
+readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
+                          StringRef KernelName, StringRef Context) {
+  return readUnsignedMetadataNode(SgprNode, KernelName, ".sgpr_count", Context);
+}
+
+static MetadataSgprUpdateStatus
+rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
+                                const StringMap<unsigned> &RequiredSgprs) {
+  if (RequiredSgprs.empty())
+    return MetadataSgprUpdateStatus::Found;
+
+  struct PendingWrite {
+    size_t Offset;
+    std::string Blob;
+  };
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: updateKernelMetadataSgprCounts: failed to read "
+          << "program headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return MetadataSgprUpdateStatus::Error;
+  }
+
+  bool SawMetadataNote = false;
+  StringMap<bool> Found;
+  std::vector<PendingWrite> PendingWrites;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        continue;
+      SawMetadataNote = true;
+
+      ArrayRef<uint8_t> Desc = Note.getDesc(4);
+      if (Desc.empty()) {
+        log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+              << "metadata note has an empty descriptor.\n";
+        return MetadataSgprUpdateStatus::Error;
+      }
+
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false)) {
+        log() << "hotswap: error: updateKernelMetadataSgprCounts: failed to "
+              << "parse AMDGPU metadata note.\n";
+        return MetadataSgprUpdateStatus::Error;
+      }
+
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap()) {
+        log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+              << "metadata root is not a map.\n";
+        return MetadataSgprUpdateStatus::Error;
+      }
+
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+        continue;
+
+      bool Modified = false;
+      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
+      for (msgpack::DocNode &KNode : KernelArray) {
+        if (!KNode.isMap())
+          continue;
+
+        msgpack::MapDocNode &KMap = KNode.getMap();
+        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
+        if (NameIt == KMap.end() || !NameIt->second.isString())
+          continue;
+        StringRef KernelName = NameIt->second.getString();
+        StringMap<unsigned>::const_iterator Required =
+            RequiredSgprs.find(KernelName);
+        if (Required == RequiredSgprs.end() || Found.contains(KernelName))
+          continue;
+
+        msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
+        if (SgprIt == KMap.end()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
+                << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+
+        std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
+            SgprIt->second, KernelName, "updateKernelMetadataSgprCounts");
+        if (!CurrentSgprs)
+          return MetadataSgprUpdateStatus::Error;
+        Found.try_emplace(KernelName, true);
+        if (Required->second <= *CurrentSgprs)
+          continue;
+
+        SgprIt->second = static_cast<uint64_t>(Required->second);
+        Modified = true;
+      }
+
+      if (Modified) {
+        std::string NewBlob;
+        Doc.writeToBlob(NewBlob);
+        if (NewBlob.size() != Blob.size()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: updating "
+                   ".sgpr_count changes metadata note size from "
+                << Blob.size() << " to " << NewBlob.size()
+                << " bytes; in-place rewrite cannot preserve ELF layout.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+
+        const uint8_t *DescBegin = Desc.data();
+        if (DescBegin < File.base() || DescBegin >= File.end()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
+                << "descriptor pointer is outside the ELF buffer.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+        size_t DescOffset = DescBegin - File.base();
+        if (Desc.size() > File.getBufSize() ||
+            DescOffset > File.getBufSize() - Desc.size()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
+                << "descriptor extends past the ELF buffer.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+        PendingWrites.push_back({DescOffset, std::move(NewBlob)});
+      }
+
+      if (Found.size() == RequiredSgprs.size())
+        break;
+    }
+
+    if (Err) {
+      log() << "hotswap: error: updateKernelMetadataSgprCounts: failed to "
+            << "iterate AMDGPU notes: " << toString(std::move(Err)) << "\n";
+      return MetadataSgprUpdateStatus::Error;
+    }
+    if (Found.size() == RequiredSgprs.size())
+      break;
+  }
+
+  if (SawMetadataNote) {
+    for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+      if (Found.contains(Required.first()))
+        continue;
+      log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+               "metadata has no entry for kernel '"
+            << Required.first() << "'.\n";
+      return MetadataSgprUpdateStatus::Error;
+    }
+    for (const PendingWrite &Write : PendingWrites)
+      std::memcpy(Elf + Write.Offset, Write.Blob.data(), Write.Blob.size());
+    return MetadataSgprUpdateStatus::Found;
+  }
+  return MetadataSgprUpdateStatus::NotFound;
+}
+
+bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: updateGfx1250RevisionMetadata: failed to read "
+          << "program headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return false;
+  }
+
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        continue;
+
+      ArrayRef<uint8_t> Desc = Note.getDesc(4);
+      if (Desc.empty()) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: AMDGPU "
+              << "metadata note has an empty descriptor.\n";
+        return false;
+      }
+
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false)) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: failed to "
+              << "parse AMDGPU metadata note.\n";
+        return false;
+      }
+
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap()) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: AMDGPU "
+              << "metadata root is not a map.\n";
+        return false;
+      }
+
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+        continue;
+
+      bool Changed = false;
+      for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+        if (!KNode.isMap())
+          continue;
+        msgpack::MapDocNode &KMap = KNode.getMap();
+        msgpack::DocNode::MapTy::iterator RevisionIt =
+            KMap.find(".gfx1250_revision");
+        if (RevisionIt == KMap.end())
+          continue;
+        if (!RevisionIt->second.isString()) {
+          log() << "hotswap: error: updateGfx1250RevisionMetadata: "
+                << ".gfx1250_revision is not a string.\n";
+          return false;
+        }
+        if (RevisionIt->second.getString() == Revision)
+          continue;
+        RevisionIt->second = Doc.getNode(Revision, /*Copy=*/true);
+        Changed = true;
+      }
+
+      if (!Changed)
+        continue;
+
+      std::string NewBlob;
+      Doc.writeToBlob(NewBlob);
+      if (NewBlob.size() != Blob.size()) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: updating "
+              << ".gfx1250_revision changes metadata note size from "
+              << Blob.size() << " to " << NewBlob.size()
+              << " bytes; in-place rewrite cannot preserve ELF layout.\n";
+        return false;
+      }
+
+      const uint8_t *DescBegin = Desc.data();
+      if (DescBegin < File.base() || DescBegin >= File.end()) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: metadata "
+              << "descriptor pointer is outside the ELF buffer.\n";
+        return false;
+      }
+      size_t DescOffset = DescBegin - File.base();
+      if (Desc.size() > File.getBufSize() ||
+          DescOffset > File.getBufSize() - Desc.size()) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: metadata "
+              << "descriptor extends past the ELF buffer.\n";
+        return false;
+      }
+      std::memcpy(data() + DescOffset, NewBlob.data(), NewBlob.size());
+    }
+
+    if (Err) {
+      log() << "hotswap: error: updateGfx1250RevisionMetadata: failed to "
+            << "iterate AMDGPU notes: " << toString(std::move(Err)) << "\n";
+      return false;
+    }
+  }
+  return true;
+}
+
+std::optional<bool>
+ElfView::allKernelsHaveGfx1250Revision(StringRef Revision) const {
+  if (!kernelDescriptorCacheIsComplete())
+    return false;
+
+  StringMap<bool> DescriptorSeen;
+  for (const KernelDescriptorInfo &Descriptor : kernelDescriptors())
+    DescriptorSeen.try_emplace(Descriptor.KernelName, false);
+  if (DescriptorSeen.empty())
+    return false;
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: allKernelsHaveGfx1250Revision: failed to read "
+             "program headers: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+
+  bool FoundKernel = false;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        continue;
+
+      ArrayRef<uint8_t> Desc = Note.getDesc(4);
+      if (Desc.empty()) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: AMDGPU "
+                 "metadata note has an empty descriptor.\n";
+        return std::nullopt;
+      }
+
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false)) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: failed to "
+                 "parse AMDGPU metadata note.\n";
+        return std::nullopt;
+      }
+
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap()) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: AMDGPU "
+                 "metadata root is not a map.\n";
+        return std::nullopt;
+      }
+
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end())
+        continue;
+      if (!KernelsIt->second.isArray()) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: "
+                 "amdhsa.kernels is not an array.\n";
+        return std::nullopt;
+      }
+
+      for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+        if (!KNode.isMap()) {
+          log() << "hotswap: error: allKernelsHaveGfx1250Revision: kernel "
+                   "metadata entry is not a map.\n";
+          return std::nullopt;
+        }
+        msgpack::MapDocNode &KMap = KNode.getMap();
+        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
+        if (NameIt == KMap.end() || !NameIt->second.isString()) {
+          log() << "hotswap: error: allKernelsHaveGfx1250Revision: kernel "
+                   "metadata has no string .name.\n";
+          return std::nullopt;
+        }
+        StringMap<bool>::iterator DescriptorIt =
+            DescriptorSeen.find(NameIt->second.getString());
+        if (DescriptorIt == DescriptorSeen.end())
+          return false;
+        DescriptorIt->second = true;
+
+        msgpack::DocNode::MapTy::iterator RevisionIt =
+            KMap.find(".gfx1250_revision");
+        if (RevisionIt == KMap.end())
+          return false;
+        if (!RevisionIt->second.isString()) {
+          log() << "hotswap: error: allKernelsHaveGfx1250Revision: "
+                   ".gfx1250_revision is not a string.\n";
+          return std::nullopt;
+        }
+        FoundKernel = true;
+        if (RevisionIt->second.getString() != Revision)
+          return false;
+      }
+    }
+    if (Err) {
+      log() << "hotswap: error: allKernelsHaveGfx1250Revision: failed to "
+               "iterate AMDGPU notes: "
+            << toString(std::move(Err)) << "\n";
+      return std::nullopt;
+    }
+  }
+  return FoundKernel &&
+         llvm::all_of(DescriptorSeen,
+                      [](const auto &Entry) { return Entry.getValue(); });
+}
+
 using MetadataNoteMutator = function_ref<std::optional<bool>(
     msgpack::Document &, msgpack::MapDocNode &)>;
 using MetadataNoteValidator = function_ref<bool(bool)>;
@@ -127,7 +546,7 @@ struct PendingMetadataWrite {
 /// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
 /// defer changed writes until \p Validator accepts the complete traversal.
 /// This keeps multi-note updates atomic while sharing the parsing, encoded-size
-/// and destination validation for every metadata mutation.
+/// and destination validation for count mutations.
 static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
                                  StringRef Context, MetadataNoteMutator Mutator,
                                  MetadataNoteValidator Validator,
@@ -292,41 +711,6 @@ rewriteKernelMetadataCounts(uint8_t *Elf, const ELFFileT &File,
                          : MetadataCountUpdateStatus::NotFound;
 }
 
-bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
-  bool SawMetadataNote = false;
-  return rewriteMetadataNotes(
-      data(), File, "updateGfx1250RevisionMetadata",
-      [&](msgpack::Document &Doc,
-          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
-        msgpack::DocNode::MapTy::iterator KernelsIt =
-            RootMap.find("amdhsa.kernels");
-        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
-          return false;
-
-        bool Changed = false;
-        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
-          if (!KNode.isMap())
-            continue;
-          msgpack::MapDocNode &KMap = KNode.getMap();
-          msgpack::DocNode::MapTy::iterator RevisionIt =
-              KMap.find(".gfx1250_revision");
-          if (RevisionIt == KMap.end())
-            continue;
-          if (!RevisionIt->second.isString()) {
-            log() << "hotswap: error: updateGfx1250RevisionMetadata: "
-                  << ".gfx1250_revision is not a string.\n";
-            return std::nullopt;
-          }
-          if (RevisionIt->second.getString() == Revision)
-            continue;
-          RevisionIt->second = Doc.getNode(Revision, /*Copy=*/true);
-          Changed = true;
-        }
-        return Changed;
-      },
-      [](bool) { return true; }, SawMetadataNote);
-}
-
 // -- applyByteReplace ---------------------------------------------------------
 
 bool applyByteReplace(const RewriteRule &Rule, uint64_t InstOffset,
@@ -366,20 +750,35 @@ bool applyByteReplace(const RewriteRule &Rule, uint64_t InstOffset,
 // -- findNearestSled ----------------------------------------------------------
 
 NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
-                         uint64_t Needed) {
+                         uint64_t Needed, NopSledUse Use) {
   NopSled *Best = nullptr;
   uint64_t BestDist = std::numeric_limits<uint64_t>::max();
+  bool BestOwned = false;
   for (NopSled &Sled : Sleds) {
-    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+    if (Sled.GatewayOnly && Use != NopSledUse::Gateway)
       continue;
-    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-    if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
+    const bool Eligible =
+        Use == NopSledUse::Gateway
+            ? Sled.canGatewayFrom(Offset)
+            : Sled.canHoldBodyFrom(
+                  Offset, Use == NopSledUse::RelocationBody);
+    if (!Eligible)
+      continue;
+    if (Sled.WritePos > Sled.End || Needed > Sled.End - Sled.WritePos)
       continue;
     uint64_t Dist = Sled.WritePos > Offset ? Sled.WritePos - Offset
                                            : Offset - Sled.WritePos;
-    if (Dist < MaxSledDistance && Dist < BestDist) {
+    const bool Owned = Sled.ownsSource(Offset);
+    const bool PreferOwned = Use == NopSledUse::RelocationBody;
+    const bool Better =
+        !Best ||
+        (PreferOwned ? (Owned && !BestOwned) ||
+                           (Owned == BestOwned && Dist < BestDist)
+                     : Dist < BestDist);
+    if (Dist < MaxSledDistance && Better) {
       Best = &Sled;
       BestDist = Dist;
+      BestOwned = Owned;
     }
   }
   return Best;
@@ -404,6 +803,25 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
     return SectionsOrErr.takeError();
   ELFT::ShdrRange Sections = *SectionsOrErr;
 
+  // HotSwap rewrites reason about symbol ownership by section index. Silently
+  // treating SHN_XINDEX as a reserved/non-.text index would omit protected
+  // entries and extents. Extended symbol indices are uncommon in code objects;
+  // reject them until every symbol-table mutation preserves the associated
+  // SHT_SYMTAB_SHNDX table.
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (Shdr.sh_type != ELF::SHT_SYMTAB && Shdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&Shdr);
+    if (!SymsOrErr)
+      return SymsOrErr.takeError();
+    if (llvm::any_of(*SymsOrErr, [](const ELFT::Sym &Sym) {
+          return Sym.st_shndx == ELF::SHN_XINDEX;
+        }))
+      return createStringError(
+          object::object_error::parse_failed,
+          "HotSwap does not support SHN_XINDEX symbol section indices");
+  }
+
   const ELFT::Shdr *Text = nullptr;
   unsigned TextIdx = 0;
   unsigned Idx = 0;
@@ -414,7 +832,8 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
       ++Idx;
       continue;
     }
-    if (*NameOrErr == ".text" && Shdr.sh_offset + Shdr.sh_size <= Size) {
+    if (*NameOrErr == ".text" && Shdr.sh_offset <= Size &&
+        Shdr.sh_size <= Size - Shdr.sh_offset) {
       Text = &Shdr;
       TextIdx = Idx;
       break;
@@ -506,6 +925,83 @@ std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
   return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
 }
 
+std::optional<std::vector<uint64_t>> ElfView::textSymbolOffsets() const {
+  const uint64_t TextBegin = textAddr();
+  if (textSize() > std::numeric_limits<uint64_t>::max() - TextBegin) {
+    log() << "hotswap: error: .text symbol scan address range overflows\n";
+    return std::nullopt;
+  }
+  const uint64_t TextEnd = TextBegin + textSize();
+  std::vector<uint64_t> Offsets;
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      log() << "hotswap: error: failed to enumerate .text symbols: "
+            << toString(SymsOrErr.takeError()) << "\n";
+      return std::nullopt;
+    }
+    for (const ELFT::Sym &Sym : *SymsOrErr)
+      if (Sym.st_shndx == TextSectionIndex && Sym.st_value >= TextBegin &&
+          Sym.st_value < TextEnd)
+        Offsets.push_back(Sym.st_value - TextBegin);
+  }
+  llvm::sort(Offsets);
+  Offsets.erase(std::unique(Offsets.begin(), Offsets.end()), Offsets.end());
+  return Offsets;
+}
+
+std::optional<std::vector<ElfView::TextOffsetRange>>
+ElfView::textSymbolExtents() const {
+  const uint64_t TextBegin = textAddr();
+  if (textSize() > std::numeric_limits<uint64_t>::max() - TextBegin) {
+    log() << "hotswap: error: .text symbol extent scan address range "
+             "overflows\n";
+    return std::nullopt;
+  }
+  const uint64_t TextEnd = TextBegin + textSize();
+  std::vector<TextOffsetRange> Extents;
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      log() << "hotswap: error: failed to enumerate .text symbol extents: "
+            << toString(SymsOrErr.takeError()) << "\n";
+      return std::nullopt;
+    }
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.st_shndx != TextSectionIndex || Sym.st_size == 0 ||
+          Sym.getType() == ELF::STT_FUNC || Sym.getType() == ELF::STT_GNU_IFUNC)
+        continue;
+      if (Sym.st_size > std::numeric_limits<uint64_t>::max() - Sym.st_value) {
+        log() << "hotswap: error: .text symbol extent overflows\n";
+        return std::nullopt;
+      }
+      const uint64_t SymbolEnd = Sym.st_value + Sym.st_size;
+      const uint64_t Begin = std::max<uint64_t>(Sym.st_value, TextBegin);
+      const uint64_t End = std::min<uint64_t>(SymbolEnd, TextEnd);
+      if (Begin < End)
+        Extents.push_back({Begin - TextBegin, End - TextBegin});
+    }
+  }
+  llvm::sort(
+      Extents, [](const TextOffsetRange &LHS, const TextOffsetRange &RHS) {
+        return std::tie(LHS.Begin, LHS.End) < std::tie(RHS.Begin, RHS.End);
+      });
+  std::vector<TextOffsetRange> Coalesced;
+  for (const TextOffsetRange &Extent : Extents) {
+    if (Coalesced.empty() || Extent.Begin > Coalesced.back().End)
+      Coalesced.push_back(Extent);
+    else
+      Coalesced.back().End = std::max(Coalesced.back().End, Extent.End);
+  }
+  return Coalesced;
+}
+
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
 const ElfView::FunctionTextRange *
@@ -594,7 +1090,8 @@ void ElfView::initializeKernelDescriptorCache() const {
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
   StringMap<uint64_t> FileOffsets;
-  StringMap<DenseSet<uint64_t>> SeenVAddr;
+  StringMap<std::pair<uint64_t, uint64_t>> SeenLocations;
+  bool Complete = true;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -605,6 +1102,7 @@ void ElfView::initializeKernelDescriptorCache() const {
     if (!SymsOrErr) {
       log() << "hotswap: error: kernelDescriptors: failed to read symbols: "
             << toString(SymsOrErr.takeError()) << "\n";
+      Complete = false;
       continue;
     }
     Expected<StringRef> StrTabOrErr =
@@ -612,6 +1110,7 @@ void ElfView::initializeKernelDescriptorCache() const {
     if (!StrTabOrErr) {
       log() << "hotswap: error: kernelDescriptors: failed to read symbol "
             << "string table: " << toString(StrTabOrErr.takeError()) << "\n";
+      Complete = false;
       continue;
     }
 
@@ -620,6 +1119,7 @@ void ElfView::initializeKernelDescriptorCache() const {
       if (!NameOrErr) {
         log() << "hotswap: error: kernelDescriptors: failed to read symbol "
               << "name: " << toString(NameOrErr.takeError()) << "\n";
+        Complete = false;
         continue;
       }
       if (!NameOrErr->ends_with(".kd"))
@@ -631,6 +1131,7 @@ void ElfView::initializeKernelDescriptorCache() const {
         log() << "hotswap: error: kernelDescriptors: descriptor symbol '"
               << *NameOrErr << "' has unreadable section index " << Sym.st_shndx
               << ": " << toString(HostShdrOrErr.takeError()) << "\n";
+        Complete = false;
         continue;
       }
       const ELFT::Shdr &HostShdr = **HostShdrOrErr;
@@ -638,8 +1139,10 @@ void ElfView::initializeKernelDescriptorCache() const {
           HostShdr, Sym.st_value, KdSize, size(),
           (Twine("kernelDescriptors: descriptor symbol '") + *NameOrErr + "'")
               .str());
-      if (!FileOffset)
+      if (!FileOffset) {
+        Complete = false;
         continue;
+      }
 
       int64_t EntryOffset = 0;
       std::memcpy(
@@ -649,26 +1152,27 @@ void ElfView::initializeKernelDescriptorCache() const {
           sizeof(EntryOffset));
 
       StringRef KernelNameRef = NameOrErr->drop_back(3);
-      std::string KernelName = KernelNameRef.str();
-      // Dedup by (name, vaddr): a kernel name can legitimately map to more than
-      // one vaddr, so track the full vaddr set per name rather than only the
-      // last one. (The previous per-symbol linear scan over Result made cache
-      // init O(n^2).)
-      if (SeenVAddr[KernelNameRef].insert(Sym.st_value).second)
-        Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
-      FileOffsets.try_emplace(KernelNameRef, *FileOffset);
+      auto Seen = SeenLocations.try_emplace(
+          KernelNameRef, std::make_pair(Sym.st_value, *FileOffset));
+      if (Seen.second) {
+        Result.push_back(
+            {KernelNameRef.str(), Sym.st_value, *FileOffset, EntryOffset});
+        FileOffsets.try_emplace(KernelNameRef, *FileOffset);
+      } else if (Seen.first->second.first != Sym.st_value ||
+                 Seen.first->second.second != *FileOffset) {
+        log() << "hotswap: error: kernelDescriptors: descriptor name '"
+              << KernelNameRef << "' resolves to multiple locations\n";
+        Complete = false;
+      }
     }
   }
 
   KernelDescriptorFileOffsetCache = std::move(FileOffsets);
+  KernelDescriptorCacheComplete = Complete;
   KernelDescriptorCache = std::move(Result);
 
-  // Name -> vaddr map so getKernelDescriptorVAddr() is O(1) per call instead of
-  // a linear scan (O(n^2) over ~1000 per-fixup lookups). When a name has more
-  // than one descriptor (the dedup set tracks (name, vaddr) pairs), try_emplace
-  // keeps the first in symtab order -- the same descriptor the prior linear
-  // scan returned, so the single-value lookup is unchanged. The multi-vaddr set
-  // matters only for enumeration/dedup, not this name->vaddr resolution.
+  // Name -> vaddr map keeps per-fixup lookup O(1). Ambiguous duplicate names
+  // are rejected above, so every retained name has exactly one location.
   KernelDescriptorVAddrCache.clear();
   for (const KernelDescriptorInfo &Info : *KernelDescriptorCache)
     KernelDescriptorVAddrCache.try_emplace(Info.KernelName, Info.VAddr);
@@ -686,6 +1190,11 @@ uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
 ArrayRef<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
   initializeKernelDescriptorCache();
   return *KernelDescriptorCache;
+}
+
+bool ElfView::kernelDescriptorCacheIsComplete() const {
+  initializeKernelDescriptorCache();
+  return KernelDescriptorCacheComplete;
 }
 
 std::optional<uint64_t>
@@ -1389,6 +1898,344 @@ const uint8_t *ElfView::dataAtVAddr(uint64_t VAddr, uint64_t Len) const {
   return nullptr;
 }
 
+bool ElfView::isExecutableVAddrRange(uint64_t VAddr, uint64_t Len) const {
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    consumeError(PhdrsOrErr.takeError());
+    return false;
+  }
+
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD || !(Phdr.p_flags & ELF::PF_X) ||
+        VAddr < Phdr.p_vaddr)
+      continue;
+    uint64_t Offset = VAddr - Phdr.p_vaddr;
+    if (Offset <= Phdr.p_filesz && Len <= Phdr.p_filesz - Offset &&
+        Phdr.p_offset <= size() && Offset <= size() - Phdr.p_offset &&
+        Len <= size() - Phdr.p_offset - Offset)
+      return true;
+  }
+  return false;
+}
+
+std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
+    ExecutablePoolTargetState TargetState) const {
+  struct ExecutableRegion {
+    uint64_t VAddr;
+    uint64_t Size;
+    uint64_t FileOffset;
+  };
+  struct PoolProvenance {
+    uint64_t VAddr;
+    uint64_t Size;
+    ExecutablePoolTargetState State;
+  };
+
+  if (TargetState != ExecutablePoolTargetState::A0 &&
+      TargetState != ExecutablePoolTargetState::B0) {
+    log() << "hotswap: error: executable pool compatibility requires an "
+             "explicit A0 or B0 target state.\n";
+    return std::nullopt;
+  }
+
+  const uint64_t FileSize = size();
+  if (textOffset() > FileSize || textSize() > FileSize - textOffset()) {
+    log() << "hotswap: error: .text extends past the end of the ELF buffer.\n";
+    return std::nullopt;
+  }
+  if (textSize() > std::numeric_limits<uint64_t>::max() - textAddr()) {
+    log() << "hotswap: error: .text virtual-address range overflows.\n";
+    return std::nullopt;
+  }
+  const uint64_t TextAddrEnd = textAddr() + textSize();
+  const uint64_t TextFileEnd = textOffset() + textSize();
+  if (TextSectionIndex >= Sections.size()) {
+    log() << "hotswap: error: cached .text section index is out of range.\n";
+    return std::nullopt;
+  }
+  const ELFT::Shdr &TextShdr = Sections[TextSectionIndex];
+  if (TextShdr.sh_type != ELF::SHT_PROGBITS ||
+      !(TextShdr.sh_flags & ELF::SHF_ALLOC) ||
+      !(TextShdr.sh_flags & ELF::SHF_EXECINSTR) ||
+      (TextShdr.sh_flags & ELF::SHF_WRITE)) {
+    log() << "hotswap: error: .text is not a non-writable allocatable "
+             "SHT_PROGBITS executable section.\n";
+    return std::nullopt;
+  }
+
+  SmallVector<ExecutableRegion, 4> ExternalSections;
+  SmallVector<ExecutableRegion, 4> ExternalSegments;
+
+  unsigned SectionIndex = 0;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    const bool IsFileBackedExecutable =
+        (Shdr.sh_flags & ELF::SHF_EXECINSTR) &&
+        Shdr.sh_type != ELF::SHT_NOBITS && Shdr.sh_size != 0;
+    if (!IsFileBackedExecutable) {
+      ++SectionIndex;
+      continue;
+    }
+    if (Shdr.sh_offset > FileSize ||
+        Shdr.sh_size > FileSize - Shdr.sh_offset) {
+      log() << "hotswap: error: executable section " << SectionIndex
+            << " extends past the end of the ELF buffer.\n";
+      return std::nullopt;
+    }
+    if (Shdr.sh_size > std::numeric_limits<uint64_t>::max() - Shdr.sh_addr) {
+      log() << "hotswap: error: executable section " << SectionIndex
+            << " virtual-address range overflows.\n";
+      return std::nullopt;
+    }
+    if (SectionIndex != TextSectionIndex) {
+      if (Shdr.sh_type != ELF::SHT_PROGBITS ||
+          !(Shdr.sh_flags & ELF::SHF_ALLOC) ||
+          (Shdr.sh_flags & ELF::SHF_WRITE)) {
+        log() << "hotswap: error: external executable section " << SectionIndex
+              << " is not a non-writable allocatable SHT_PROGBITS pool.\n";
+        return false;
+      }
+      ExternalSections.push_back(
+          {Shdr.sh_addr, Shdr.sh_size, Shdr.sh_offset});
+    }
+    ++SectionIndex;
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: failed to enumerate program headers while "
+             "checking executable coverage: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+  unsigned TextSegmentCount = 0;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD || !(Phdr.p_flags & ELF::PF_X))
+      continue;
+    if (Phdr.p_offset > FileSize ||
+        Phdr.p_filesz > FileSize - Phdr.p_offset) {
+      log() << "hotswap: error: executable PT_LOAD extends past the end of "
+               "the ELF buffer.\n";
+      return std::nullopt;
+    }
+    if (Phdr.p_filesz == 0)
+      continue;
+    if (Phdr.p_filesz != Phdr.p_memsz ||
+        Phdr.p_filesz > std::numeric_limits<uint64_t>::max() - Phdr.p_vaddr) {
+      log() << "hotswap: error: executable PT_LOAD has unequal file/memory "
+               "sizes or an invalid virtual-address range.\n";
+      return std::nullopt;
+    }
+    const uint64_t SegmentAddrEnd = Phdr.p_vaddr + Phdr.p_filesz;
+    const uint64_t SegmentFileEnd = Phdr.p_offset + Phdr.p_filesz;
+    const bool ContainsText =
+        Phdr.p_vaddr <= textAddr() && TextAddrEnd <= SegmentAddrEnd &&
+        Phdr.p_offset <= textOffset() && TextFileEnd <= SegmentFileEnd &&
+        textAddr() - Phdr.p_vaddr == textOffset() - Phdr.p_offset;
+    if (!(Phdr.p_flags & ELF::PF_R) || (Phdr.p_flags & ELF::PF_W)) {
+      log() << "hotswap: error: executable PT_LOAD is not read-only "
+               "executable.\n";
+      return false;
+    }
+    if (ContainsText) {
+      if (Phdr.p_vaddr != textAddr() || Phdr.p_offset != textOffset() ||
+          Phdr.p_filesz != textSize()) {
+        log() << "hotswap: error: executable PT_LOAD containing .text also "
+                 "covers bytes outside the rewritten section.\n";
+        return false;
+      }
+      ++TextSegmentCount;
+      continue;
+    }
+    ExternalSegments.push_back(
+        {Phdr.p_vaddr, Phdr.p_filesz, Phdr.p_offset});
+  }
+  if (TextSegmentCount != 1) {
+    log() << "hotswap: error: .text must have exactly one exact RX PT_LOAD "
+             "mapping; found "
+          << TextSegmentCount << ".\n";
+    return false;
+  }
+
+  auto RangesOverlap = [](uint64_t AStart, uint64_t ASize,
+                          uint64_t BStart, uint64_t BSize) {
+    // All range ends were checked above before regions were collected.
+    return ASize != 0 && BSize != 0 && AStart < BStart + BSize &&
+           BStart < AStart + ASize;
+  };
+  auto ValidateDisjointExecutableRegions =
+      [&](ArrayRef<ExecutableRegion> Regions, StringRef Kind) {
+        for (size_t I = 0; I != Regions.size(); ++I) {
+          const ExecutableRegion &Region = Regions[I];
+          if (RangesOverlap(Region.VAddr, Region.Size, textAddr(), textSize()) ||
+              RangesOverlap(Region.FileOffset, Region.Size, textOffset(),
+                            textSize())) {
+            log() << "hotswap: error: external executable " << Kind << " " << I
+                  << " overlaps or aliases .text.\n";
+            return false;
+          }
+          for (size_t J = 0; J != I; ++J) {
+            const ExecutableRegion &Other = Regions[J];
+            if (RangesOverlap(Region.VAddr, Region.Size, Other.VAddr,
+                              Other.Size) ||
+                RangesOverlap(Region.FileOffset, Region.Size,
+                              Other.FileOffset, Other.Size)) {
+              log() << "hotswap: error: external executable " << Kind << " "
+                    << I << " overlaps or aliases " << Kind << " " << J
+                    << ".\n";
+              return false;
+            }
+          }
+        }
+        return true;
+      };
+  if (!ValidateDisjointExecutableRegions(ExternalSections, "section") ||
+      !ValidateDisjointExecutableRegions(ExternalSegments, "PT_LOAD"))
+    return false;
+
+  SmallVector<PoolProvenance, 4> Provenance;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (Shdr.sh_type != ELF::SHT_NOTE)
+      continue;
+    if (Shdr.sh_offset > FileSize ||
+        Shdr.sh_size > FileSize - Shdr.sh_offset) {
+      log() << "hotswap: error: SHT_NOTE section extends past the end of the "
+               "ELF buffer.\n";
+      return std::nullopt;
+    }
+    if (Shdr.sh_addralign != 0 && Shdr.sh_addralign != 1 &&
+        Shdr.sh_addralign != 4 && Shdr.sh_addralign != 8) {
+      log() << "hotswap: error: SHT_NOTE section has unsupported alignment "
+            << Shdr.sh_addralign << ".\n";
+      return std::nullopt;
+    }
+    const uint64_t RecordAlign = std::max<uint64_t>(Shdr.sh_addralign, 4);
+
+    ArrayRef<uint8_t> NoteBytes(data() + Shdr.sh_offset,
+                                static_cast<size_t>(Shdr.sh_size));
+    uint64_t Cursor = 0;
+    while (Cursor != NoteBytes.size()) {
+      if (Cursor > NoteBytes.size() || NoteBytes.size() - Cursor < 12) {
+        log() << "hotswap: error: malformed SHT_NOTE record header.\n";
+        return std::nullopt;
+      }
+      const uint8_t *Header = NoteBytes.data() + Cursor;
+      const uint32_t NameSize = support::endian::read32le(Header);
+      const uint32_t DescSize = support::endian::read32le(Header + 4);
+      const uint32_t Type = support::endian::read32le(Header + 8);
+      const uint64_t NameStorageSize =
+          alignTo(uint64_t{NameSize}, RecordAlign);
+      const uint64_t DescStorageSize =
+          alignTo(uint64_t{DescSize}, RecordAlign);
+      const uint64_t BytesAfterHeader = NoteBytes.size() - Cursor - 12;
+      if (NameStorageSize > BytesAfterHeader ||
+          DescStorageSize > BytesAfterHeader - NameStorageSize) {
+        log() << "hotswap: error: malformed SHT_NOTE record payload.\n";
+        return std::nullopt;
+      }
+      const uint64_t NameOffset = Cursor + 12;
+      const uint64_t DescOffset = NameOffset + NameStorageSize;
+      const uint64_t RecordEnd = DescOffset + DescStorageSize;
+      ArrayRef<uint8_t> NameBytes =
+          NoteBytes.slice(static_cast<size_t>(NameOffset), NameSize);
+      const bool HasHotswapVendorSpelling =
+          NameBytes.size() >= HotswapPoolNoteName.size() &&
+          std::memcmp(NameBytes.data(), HotswapPoolNoteName.data(),
+                      HotswapPoolNoteName.size()) == 0;
+
+      if (Type == HotswapPoolNoteType && HasHotswapVendorSpelling) {
+        const bool HasExactTerminatedName =
+            NameBytes.size() == HotswapPoolNoteName.size() + 1 &&
+            NameBytes.back() == 0;
+        if (!HasExactTerminatedName || Shdr.sh_addralign != 4 ||
+            Shdr.sh_entsize != 0 ||
+            (Shdr.sh_flags & (ELF::SHF_ALLOC | ELF::SHF_EXECINSTR)) ||
+            Cursor != 0 || RecordEnd != NoteBytes.size()) {
+          log() << "hotswap: error: HotSwap pool provenance does not use the "
+                   "canonical non-allocating ELF-note layout.\n";
+          return std::nullopt;
+        }
+        if (DescSize != HotswapPoolNoteDescSize) {
+          log() << "hotswap: error: HotSwap pool provenance has descriptor "
+                   "size "
+                << DescSize << ", expected " << HotswapPoolNoteDescSize
+                << ".\n";
+          return std::nullopt;
+        }
+        const uint8_t *Desc = NoteBytes.data() + DescOffset;
+        const uint32_t Version = support::endian::read32le(Desc);
+        const uint32_t RawState = support::endian::read32le(Desc + 4);
+        const uint64_t VAddr = support::endian::read64le(Desc + 8);
+        const uint64_t RegionSize = support::endian::read64le(Desc + 16);
+        if (Version != HotswapPoolNoteVersion ||
+            RawState >
+                static_cast<uint32_t>(ExecutablePoolTargetState::B0) ||
+            RegionSize == 0 ||
+            RegionSize > std::numeric_limits<uint64_t>::max() - VAddr) {
+          log() << "hotswap: error: malformed or unsupported HotSwap pool "
+                   "provenance.\n";
+          return std::nullopt;
+        }
+        if (llvm::any_of(Provenance, [&](const PoolProvenance &Existing) {
+              return Existing.VAddr == VAddr && Existing.Size == RegionSize;
+            })) {
+          log() << "hotswap: error: duplicate HotSwap pool provenance for "
+                   "vaddr 0x"
+                << utohexstr(VAddr) << ".\n";
+          return std::nullopt;
+        }
+        Provenance.push_back(
+            {VAddr, RegionSize,
+             static_cast<ExecutablePoolTargetState>(RawState)});
+      }
+      Cursor = RecordEnd;
+    }
+  }
+
+  if (Provenance.size() != ExternalSections.size() ||
+      Provenance.size() != ExternalSegments.size()) {
+    log() << "hotswap: error: external executable pool section/segment/note "
+             "counts do not match.\n";
+    return false;
+  }
+
+  for (const PoolProvenance &Pool : Provenance) {
+    const ExecutableRegion *Section = nullptr;
+    const ExecutableRegion *Segment = nullptr;
+    unsigned SectionMatches = 0;
+    unsigned SegmentMatches = 0;
+    for (const ExecutableRegion &Region : ExternalSections)
+      if (Region.VAddr == Pool.VAddr && Region.Size == Pool.Size) {
+        Section = &Region;
+        ++SectionMatches;
+      }
+    for (const ExecutableRegion &Region : ExternalSegments)
+      if (Region.VAddr == Pool.VAddr && Region.Size == Pool.Size) {
+        Segment = &Region;
+        ++SegmentMatches;
+      }
+    if (SectionMatches != 1 || SegmentMatches != 1) {
+      log() << "hotswap: error: HotSwap pool provenance at vaddr 0x"
+            << utohexstr(Pool.VAddr)
+            << " does not have one exact RX section/PT_LOAD mapping.\n";
+      return false;
+    }
+    if (Section->FileOffset != Segment->FileOffset) {
+      log() << "hotswap: error: HotSwap pool section/PT_LOAD at vaddr 0x"
+            << utohexstr(Pool.VAddr)
+            << " refer to different file bytes.\n";
+      return false;
+    }
+    if (Pool.State != ExecutablePoolTargetState::Neutral &&
+        Pool.State != TargetState) {
+      log() << "hotswap: error: executable HotSwap pool at vaddr 0x"
+            << utohexstr(Pool.VAddr)
+            << " was produced for an incompatible target stepping.\n";
+      return false;
+    }
+  }
+  return true;
+}
+
 // -- ElfView::trampolinePoolVAddr ---------------------------------------------
 
 std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
@@ -1404,14 +2251,35 @@ std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
       return std::nullopt;
     MaxAllocEnd = std::max(MaxAllocEnd, *End);
   }
-  return alignTo(MaxAllocEnd, TrampolinePoolAlign);
+
+  // A PT_LOAD may reserve a zero-fill tail that is not represented by any
+  // section (p_memsz > p_filesz), or may cover mapped bytes without a section
+  // header at all. The appended pool must be above those ranges as well.
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: failed to enumerate load segments for pool "
+             "vaddr: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD)
+      continue;
+    std::optional<uint64_t> End = checkedAddUint64(
+        Phdr.p_vaddr, Phdr.p_memsz, "load segment end for pool vaddr");
+    if (!End)
+      return std::nullopt;
+    MaxAllocEnd = std::max(MaxAllocEnd, *End);
+  }
+  return checkedAlignToUint64(MaxAllocEnd, TrampolinePoolAlign,
+                              "trampoline pool virtual address");
 }
 
 // -- addKernelEntryTrampolineSymbols ------------------------------------------
 
-std::unique_ptr<WritableMemoryBuffer>
-addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
-                                ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
+    WritableMemoryBuffer &In, uint64_t PoolVAddr,
+    ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return nullptr;
 
@@ -1422,7 +2290,8 @@ addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
       ELFFileT::create(StringRef(reinterpret_cast<const char *>(Data), Size));
   if (!FileOrErr) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: failed to parse "
-          << "grown ELF: " << toString(FileOrErr.takeError()) << "\n";
+             "grown ELF: "
+          << toString(FileOrErr.takeError()) << "\n";
     return nullptr;
   }
   ELFFileT File = std::move(*FileOrErr);
@@ -1432,39 +2301,6 @@ addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
     return nullptr;
   }
   ELFT::ShdrRange Secs = *SecsOrErr;
-
-  // Locate the appended trampoline-pool section by its virtual address: the
-  // stubs live there (at PoolVAddr + StubTextOffset), not immediately after
-  // .text, so the stub symbols must reference this section, not .text.
-  //
-  // Match by containment (sh_addr <= PoolVAddr < sh_addr + sh_size), not by an
-  // exact sh_addr == PoolVAddr scan: a zero-sized allocatable section can begin
-  // at PoolVAddr (trampolinePoolVAddr() would still pick that address, and
-  // growWithTrampolines() appends the real pool after it). An exact-address
-  // scan could select that empty section, leaving the symbols' values outside
-  // their declared section. The pool is the only allocatable section that
-  // actually spans PoolVAddr, since PoolVAddr is aligned past every
-  // pre-existing allocatable section's end.
-  unsigned PoolSectionIndex = 0;
-  for (unsigned I = 0; I < Secs.size(); ++I) {
-    if (!(Secs[I].sh_flags & ELF::SHF_ALLOC))
-      continue;
-    std::optional<uint64_t> SecEnd = checkedAddUint64(
-        Secs[I].sh_addr, Secs[I].sh_size, "trampoline-pool section end");
-    if (!SecEnd)
-      return nullptr;
-    if (Secs[I].sh_addr <= PoolVAddr && PoolVAddr < *SecEnd) {
-      PoolSectionIndex = I;
-      break;
-    }
-  }
-  if (PoolSectionIndex == 0) {
-    log()
-        << "hotswap: addKernelEntryTrampolineSymbols: trampoline-pool section "
-        << "at vaddr 0x" << utohexstr(PoolVAddr) << " not found; skipping "
-        << "stub symbols.\n";
-    return nullptr;
-  }
 
   // Locate .symtab and its linked string table. Scan from the end, since the
   // symbol table sits near the end of the section list in these code objects.
@@ -1478,155 +2314,197 @@ addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
     }
   if (!SymShdr) {
     log() << "hotswap: addKernelEntryTrampolineSymbols: no .symtab present; "
-          << "skipping stub symbols.\n";
+             "skipping stub symbols.\n";
+    return nullptr;
+  }
+  for (const ELFT::Shdr &Shdr : Secs) {
+    if (Shdr.sh_type != ELF::SHT_SYMTAB_SHNDX || Shdr.sh_link != SymIdx)
+      continue;
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: cannot append "
+             "symbols while a linked SHT_SYMTAB_SHNDX table is present.\n";
     return nullptr;
   }
   const unsigned StrIdx = SymShdr->sh_link;
   if (StrIdx == 0 || StrIdx >= Secs.size()) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: .symtab has an "
-          << "invalid sh_link (" << StrIdx << ").\n";
+             "invalid sh_link ("
+          << StrIdx << ").\n";
     return nullptr;
   }
   if (SymShdr->sh_entsize != sizeof(ELF::Elf64_Sym)) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: unexpected "
-          << ".symtab entry size " << SymShdr->sh_entsize << ".\n";
+             ".symtab entry size "
+          << SymShdr->sh_entsize << ".\n";
     return nullptr;
   }
   const ELFT::Shdr &StrShdr = Secs[StrIdx];
-
-  const uint64_t SymOff = SymShdr->sh_offset;
-  const uint64_t SymEnd = SymOff + SymShdr->sh_size;
-  const uint64_t StrOff = StrShdr.sh_offset;
-  const uint64_t StrEnd = StrOff + StrShdr.sh_size;
-  if (SymEnd > Size || StrEnd > Size || SymEnd < SymOff || StrEnd < StrOff) {
-    log() << "hotswap: error: addKernelEntryTrampolineSymbols: symbol/string "
-          << "table extends past the ELF buffer.\n";
+  if (StrShdr.sh_type != ELF::SHT_STRTAB) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: .symtab links "
+             "to a non-string-table section.\n";
+    return nullptr;
+  }
+  if ((SymShdr->sh_flags | StrShdr.sh_flags) & ELF::SHF_ALLOC) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: refusing to "
+             "relocate an allocatable symbol or string table.\n";
     return nullptr;
   }
 
-  // Build the appended string names and symbol entries.
+  const uint64_t SymOff = SymShdr->sh_offset;
+  const uint64_t StrOff = StrShdr.sh_offset;
+  std::optional<uint64_t> SymEnd = checkedAddUint64(
+      SymOff, SymShdr->sh_size, "kernel-entry stub input .symtab end");
+  std::optional<uint64_t> StrEnd = checkedAddUint64(
+      StrOff, StrShdr.sh_size, "kernel-entry stub input .strtab end");
+  if (!SymEnd || !StrEnd || *SymEnd > Size || *StrEnd > Size) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: symbol/string "
+             "table extends past the ELF buffer.\n";
+    return nullptr;
+  }
+
   SmallVector<uint8_t> StrBlob, SymBlob;
   for (const KernelEntryTrampolineFixup &F : Fixups) {
-    std::string Name = F.KernelName + ".stub";
-    uint32_t NameOff = static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
-    StrBlob.append(Name.begin(), Name.end());
-    StrBlob.push_back(0);
-
-    std::optional<uint64_t> StubVAddr =
-        checkedAddUint64(PoolVAddr, F.StubTextOffset, "stub symbol vaddr");
+    std::optional<uint64_t> StubVAddr = checkedAddUint64(
+        PoolVAddr, F.StubTextOffset, "kernel-entry stub symbol vaddr");
     if (!StubVAddr)
       return nullptr;
 
+    std::optional<unsigned> StubSectionIndex;
+    for (unsigned I = 0; I != Secs.size(); ++I) {
+      const ELFT::Shdr &Section = Secs[I];
+      if (Section.sh_type != ELF::SHT_PROGBITS ||
+          (Section.sh_flags & (ELF::SHF_ALLOC | ELF::SHF_EXECINSTR)) !=
+              (ELF::SHF_ALLOC | ELF::SHF_EXECINSTR) ||
+          *StubVAddr < Section.sh_addr)
+        continue;
+
+      const uint64_t SectionOffset = *StubVAddr - Section.sh_addr;
+      if (SectionOffset > Section.sh_size ||
+          KernelEntryStubStride > Section.sh_size - SectionOffset)
+        continue;
+      std::optional<uint64_t> StubFileOffset = checkedAddUint64(
+          Section.sh_offset, SectionOffset,
+          "kernel-entry stub symbol file offset");
+      if (!StubFileOffset || *StubFileOffset > Size ||
+          KernelEntryStubStride > Size - *StubFileOffset)
+        continue;
+
+      if (StubSectionIndex) {
+        log() << "hotswap: error: addKernelEntryTrampolineSymbols: stub for '"
+              << F.KernelName
+              << "' is covered by multiple executable sections.\n";
+        return nullptr;
+      }
+      StubSectionIndex = I;
+    }
+    if (!StubSectionIndex) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: stub for '"
+            << F.KernelName
+            << "' is not fully contained in a file-backed executable "
+               "section.\n";
+      return nullptr;
+    }
+    if (*StubSectionIndex >= ELF::SHN_LORESERVE) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: executable "
+               "stub section index requires unsupported SHN_XINDEX.\n";
+      return nullptr;
+    }
+
+    std::string Name = F.KernelName + ".stub";
+    std::optional<uint64_t> NameOff = checkedAddUint64(
+        StrShdr.sh_size, StrBlob.size(), "kernel-entry stub symbol name offset");
+    if (!NameOff || *NameOff > std::numeric_limits<uint32_t>::max()) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: string-table "
+               "offset exceeds Elf64_Sym::st_name.\n";
+      return nullptr;
+    }
+    StrBlob.append(Name.begin(), Name.end());
+    StrBlob.push_back(0);
+
     ELF::Elf64_Sym Sym{};
-    Sym.st_name = NameOff;
+    Sym.st_name = static_cast<uint32_t>(*NameOff);
     Sym.st_info = (ELF::STB_GLOBAL << 4) | ELF::STT_FUNC;
     Sym.st_other = ELF::STV_DEFAULT;
-    Sym.st_shndx = static_cast<uint16_t>(PoolSectionIndex);
+    Sym.st_shndx = static_cast<uint16_t>(*StubSectionIndex);
     Sym.st_value = *StubVAddr;
     Sym.st_size = KernelEntryStubStride;
     const uint8_t *P = reinterpret_cast<const uint8_t *>(&Sym);
     SymBlob.append(P, P + sizeof(Sym));
   }
-  // The section header table must stay 8-byte aligned (LLVM's ELF reader
-  // rejects a misaligned table). SymBlob is a multiple of 8 (24-byte entries),
-  // so pad the string blob up to a multiple of 8 with unreferenced NULs.
-  StrBlob.append((8 - (StrBlob.size() % 8)) % 8, 0);
 
-  const uint64_t SymDelta = SymBlob.size();
-  const uint64_t StrDelta = StrBlob.size();
-  const size_t NewSize = Size + SymDelta + StrDelta;
+  std::optional<uint64_t> NewStrSize = checkedAddUint64(
+      StrShdr.sh_size, StrBlob.size(), "relocated stub .strtab size");
+  std::optional<uint64_t> NewSymSize = checkedAddUint64(
+      SymShdr->sh_size, SymBlob.size(), "relocated stub .symtab size");
+  if (!NewStrSize || !NewSymSize)
+    return nullptr;
+
+  auto SectionAlignment = [](uint64_t Alignment, uint64_t Minimum,
+                             StringRef Name) -> std::optional<uint64_t> {
+    Alignment = std::max(Alignment, Minimum);
+    if (!isPowerOf2_64(Alignment)) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: " << Name
+            << " alignment " << Alignment << " is not a power of two.\n";
+      return std::nullopt;
+    }
+    return Alignment;
+  };
+  std::optional<uint64_t> StrAlign =
+      SectionAlignment(StrShdr.sh_addralign, 1, ".strtab");
+  std::optional<uint64_t> SymAlign = SectionAlignment(
+      SymShdr->sh_addralign, alignof(ELF::Elf64_Sym), ".symtab");
+  if (!StrAlign || !SymAlign)
+    return nullptr;
+
+  // Relocate these non-allocating tables after the complete grown ELF. This
+  // leaves the executable pool, e_phoff, and every PT_LOAD p_offset unchanged.
+  std::optional<uint64_t> NewStrOff = checkedAlignToUint64(
+      Size, *StrAlign, "relocated kernel-entry stub .strtab offset");
+  if (!NewStrOff)
+    return nullptr;
+  std::optional<uint64_t> AfterStr = checkedAddUint64(
+      *NewStrOff, *NewStrSize, "relocated kernel-entry stub .strtab end");
+  if (!AfterStr)
+    return nullptr;
+  std::optional<uint64_t> NewSymOff = checkedAlignToUint64(
+      *AfterStr, *SymAlign, "relocated kernel-entry stub .symtab offset");
+  if (!NewSymOff)
+    return nullptr;
+  std::optional<uint64_t> NewSizeOr = checkedAddUint64(
+      *NewSymOff, *NewSymSize, "kernel-entry stub symbol ELF size");
+  if (!NewSizeOr || *NewSizeOr > std::numeric_limits<size_t>::max())
+    return nullptr;
+  const size_t NewSize = static_cast<size_t>(*NewSizeOr);
 
   std::unique_ptr<WritableMemoryBuffer> Out =
-      WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
+      WritableMemoryBuffer::getNewMemBuffer(NewSize);
   if (!Out) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: allocation of "
           << NewSize << " bytes failed.\n";
     return nullptr;
   }
   uint8_t *O = reinterpret_cast<uint8_t *>(Out->getBufferStart());
-
-  // Insert the new symbol entries right after the existing .symtab contents and
-  // the new strings right after the existing .strtab contents. Both insertion
-  // points are expressed in original-file coordinates; copying in ascending
-  // order keeps the arithmetic order-independent (either table may come first).
-  struct Insertion {
-    uint64_t Pos;
-    const SmallVector<uint8_t> *Bytes;
-  };
-  Insertion A{SymEnd, &SymBlob}, B{StrEnd, &StrBlob};
-  if (A.Pos > B.Pos)
-    std::swap(A, B);
-
-  size_t OutPos = 0, InPos = 0;
-  auto CopyThrough = [&](uint64_t Upto) {
-    std::memcpy(O + OutPos, Data + InPos, Upto - InPos);
-    OutPos += Upto - InPos;
-    InPos = Upto;
-  };
-  CopyThrough(A.Pos);
-  std::memcpy(O + OutPos, A.Bytes->data(), A.Bytes->size());
-  OutPos += A.Bytes->size();
-  CopyThrough(B.Pos);
-  std::memcpy(O + OutPos, B.Bytes->data(), B.Bytes->size());
-  OutPos += B.Bytes->size();
-  std::memcpy(O + OutPos, Data + InPos, Size - InPos);
-
-  // Anything at or beyond an insertion point shifts by that insertion's size.
-  auto Shift = [&](uint64_t X) -> uint64_t {
-    return X + (X >= SymEnd ? SymDelta : 0) + (X >= StrEnd ? StrDelta : 0);
-  };
+  std::memcpy(O, Data, Size);
+  std::memcpy(O + *NewStrOff, Data + StrOff, StrShdr.sh_size);
+  std::memcpy(O + *NewStrOff + StrShdr.sh_size, StrBlob.data(), StrBlob.size());
+  std::memcpy(O + *NewSymOff, Data + SymOff, SymShdr->sh_size);
+  std::memcpy(O + *NewSymOff + SymShdr->sh_size, SymBlob.data(), SymBlob.size());
 
   uint64_t Shoff;
   uint16_t Shentsize, Shnum;
   std::memcpy(&Shoff, O + offsetof(Ehdr, e_shoff), sizeof(Shoff));
   std::memcpy(&Shentsize, O + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
   std::memcpy(&Shnum, O + offsetof(Ehdr, e_shnum), sizeof(Shnum));
-
-  uint64_t Phoff;
-  uint16_t Phentsize, Phnum;
-  std::memcpy(&Phoff, O + offsetof(Ehdr, e_phoff), sizeof(Phoff));
-  std::memcpy(&Phentsize, O + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
-  std::memcpy(&Phnum, O + offsetof(Ehdr, e_phnum), sizeof(Phnum));
-
-  uint64_t NewShoff = Shift(Shoff);
-  std::memcpy(O + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
-  uint64_t NewPhoff = Shift(Phoff);
-  std::memcpy(O + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
-
-  if (Shentsize < sizeof(Shdr))
+  if (Shentsize < sizeof(Shdr) || Shoff > Size ||
+      static_cast<uint64_t>(Shnum) * Shentsize > Size - Shoff)
     return nullptr;
 
-  for (uint16_t I = 0; I < Shnum; ++I) {
-    uint64_t P = NewShoff + static_cast<uint64_t>(I) * Shentsize;
-    if (P + sizeof(Shdr) > NewSize)
-      break;
-    uint8_t *Sh = O + P;
-    uint64_t ShOffset;
-    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
-    uint64_t NewOff = Shift(ShOffset);
-    std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOff, sizeof(NewOff));
-
-    if (I == SymIdx || I == StrIdx) {
-      uint64_t ShSize;
-      std::memcpy(&ShSize, Sh + offsetof(Shdr, sh_size), sizeof(ShSize));
-      ShSize += (I == SymIdx) ? SymDelta : StrDelta;
-      std::memcpy(Sh + offsetof(Shdr, sh_size), &ShSize, sizeof(ShSize));
-    }
-  }
-
-  if (Phentsize >= sizeof(Phdr)) {
-    for (uint16_t I = 0; I < Phnum; ++I) {
-      uint64_t P = NewPhoff + static_cast<uint64_t>(I) * Phentsize;
-      if (P + sizeof(Phdr) > NewSize)
-        break;
-      uint8_t *Ph = O + P;
-      uint64_t POffset;
-      std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
-      uint64_t NewPOffset = Shift(POffset);
-      std::memcpy(Ph + offsetof(Phdr, p_offset), &NewPOffset,
-                  sizeof(NewPOffset));
-    }
-  }
+  auto RelocateSection = [&](unsigned Index, uint64_t Offset, uint64_t Size) {
+    uint8_t *Sh = O + Shoff + static_cast<uint64_t>(Index) * Shentsize;
+    std::memcpy(Sh + offsetof(Shdr, sh_offset), &Offset, sizeof(Offset));
+    std::memcpy(Sh + offsetof(Shdr, sh_size), &Size, sizeof(Size));
+  };
+  RelocateSection(StrIdx, *NewStrOff, *NewStrSize);
+  RelocateSection(SymIdx, *NewSymOff, *NewSymSize);
 
   log() << "hotswap: added " << Fixups.size()
         << " kernel-entry stub symbol(s) to .symtab\n";
@@ -1637,7 +2515,8 @@ addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
 
 std::unique_ptr<WritableMemoryBuffer>
 ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
-                             ArrayRef<uint8_t> SNopBytes) const {
+                             ArrayRef<uint8_t> SNopBytes,
+                             ExecutablePoolTargetState TargetState) const {
   // SNopBytes is unused in the append-at-end model: nothing between .text and
   // the following sections moves, so there is no in-image gap to pad. It is
   // retained in the signature for callers and for a future in-place variant.
@@ -1645,6 +2524,13 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
 
   const size_t InputSize = size();
   const uint8_t *Input = data();
+
+  if (static_cast<uint32_t>(TargetState) >
+      static_cast<uint32_t>(ExecutablePoolTargetState::B0)) {
+    log() << "hotswap: error: growWithTrampolines: invalid executable pool "
+             "target state.\n";
+    return nullptr;
+  }
 
   if (InputSize < sizeof(Ehdr)) {
     log() << "hotswap: error: growWithTrampolines: input (" << InputSize
@@ -1685,15 +2571,19 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
     return nullptr;
   }
   const uint64_t PoolVAddr = *PoolVAddrOr;
-  const uint64_t PoolFileOff =
-      alignTo(static_cast<uint64_t>(InputSize), TrampolinePoolAlign);
+  std::optional<uint64_t> PoolFileOffOr = checkedAlignToUint64(
+      static_cast<uint64_t>(InputSize), TrampolinePoolAlign,
+      "trampoline pool file offset");
+  if (!PoolFileOffOr)
+    return nullptr;
+  const uint64_t PoolFileOff = *PoolFileOffOr;
 
-  // Copy the program-header and section-header tables to the end of the file,
-  // each with one new entry for the pool (a PT_LOAD segment so the loader maps
-  // it, and an SHF_ALLOC|SHF_EXECINSTR section so objdump/tools and a
-  // subsequent rewrite can see it), then repoint e_phoff / e_shoff. Those
-  // tables are metadata addressed via the ELF header, so relocating them moves
-  // nothing a baked literal can reference.
+  // Copy the program-header and section-header tables to the end of the file.
+  // Add a PT_LOAD and SHF_ALLOC|SHF_EXECINSTR section for the pool, plus a
+  // non-allocating SHT_NOTE that records its exact range and target state for a
+  // subsequent rewrite. Then repoint e_phoff / e_shoff. Those tables and the
+  // note are metadata addressed through the ELF header, so relocating them
+  // moves nothing a baked literal can reference.
   uint64_t Phoff, Shoff;
   uint16_t Phentsize, Phnum, Shentsize, Shnum;
   std::memcpy(&Phoff, Input + offsetof(Ehdr, e_phoff), sizeof(Phoff));
@@ -1713,44 +2603,72 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
       Shnum > 0 && Shoff != 0 && Shentsize >= sizeof(Shdr) &&
       Shoff <= InputSize &&
       static_cast<uint64_t>(Shnum) * Shentsize <= InputSize - Shoff;
+  if (!HasPhdrs || !HasShdrs) {
+    log() << "hotswap: error: growWithTrampolines: cannot record executable "
+             "pool provenance without valid program- and section-header "
+             "tables.\n";
+    return nullptr;
+  }
 
   std::optional<uint64_t> PoolEnd =
       checkedAddUint64(PoolFileOff, TrampTotal, "trampoline pool file end");
-  if (!PoolEnd)
+  std::optional<uint64_t> PoolVAddrEnd = checkedAddUint64(
+      PoolVAddr, TrampTotal, "trampoline pool virtual-address end");
+  if (!PoolEnd || !PoolVAddrEnd)
+    return nullptr;
+  SmallVector<uint8_t, 48> PoolNote =
+      buildHotswapPoolNote(PoolVAddr, TrampTotal, TargetState);
+  std::optional<uint64_t> PoolNoteFileOffOr = checkedAlignToUint64(
+      *PoolEnd, uint64_t{4}, "trampoline pool provenance note offset");
+  if (!PoolNoteFileOffOr)
+    return nullptr;
+  const uint64_t PoolNoteFileOff = *PoolNoteFileOffOr;
+  std::optional<uint64_t> PoolNoteEnd = checkedAddUint64(
+      PoolNoteFileOff, PoolNote.size(), "trampoline pool provenance note end");
+  if (!PoolNoteEnd)
     return nullptr;
 
-  // Lay out the relocated tables after the pool: [pool][phdrs][shdrs].
-  uint64_t Cursor = *PoolEnd;
-  const uint64_t NewPhnum = HasPhdrs ? static_cast<uint64_t>(Phnum) + 1 : Phnum;
-  const uint64_t NewShnum = HasShdrs ? static_cast<uint64_t>(Shnum) + 1 : Shnum;
-  uint64_t NewPhoff = Phoff;
-  uint64_t NewShoff = Shoff;
-  if (HasPhdrs) {
-    if (static_cast<uint64_t>(Phnum) >= std::numeric_limits<uint16_t>::max()) {
-      log() << "hotswap: error: growWithTrampolines: program-header count "
-            << Phnum << " leaves no room to append a PT_LOAD.\n";
-      return nullptr;
-    }
-    NewPhoff = alignTo(Cursor, static_cast<uint64_t>(alignof(Phdr)));
-    std::optional<uint64_t> End = checkedAddUint64(
-        NewPhoff, NewPhnum * Phentsize, "relocated phdr table end");
-    if (!End)
-      return nullptr;
-    Cursor = *End;
+  // Lay out metadata after the pool: [pool][note][phdrs][shdrs].
+  uint64_t Cursor = *PoolNoteEnd;
+  const uint64_t NewPhnum = static_cast<uint64_t>(Phnum) + 1;
+  const uint64_t NewShnum = static_cast<uint64_t>(Shnum) + 2;
+  if (NewPhnum >= ELF::PN_XNUM) {
+    log() << "hotswap: error: growWithTrampolines: program-header count "
+          << NewPhnum
+          << " after appending a PT_LOAD requires unsupported extended "
+             "numbering.\n";
+    return nullptr;
   }
-  if (HasShdrs) {
-    if (static_cast<uint64_t>(Shnum) >= std::numeric_limits<uint16_t>::max()) {
-      log() << "hotswap: error: growWithTrampolines: section-header count "
-            << Shnum << " leaves no room to append the pool section.\n";
-      return nullptr;
-    }
-    NewShoff = alignTo(Cursor, static_cast<uint64_t>(alignof(Shdr)));
-    std::optional<uint64_t> End = checkedAddUint64(
-        NewShoff, NewShnum * Shentsize, "relocated shdr table end");
-    if (!End)
-      return nullptr;
-    Cursor = *End;
+  std::optional<uint64_t> NewPhoffOr = checkedAlignToUint64(
+      Cursor, static_cast<uint64_t>(alignof(Phdr)),
+      "relocated phdr table offset");
+  if (!NewPhoffOr)
+    return nullptr;
+  const uint64_t NewPhoff = *NewPhoffOr;
+  std::optional<uint64_t> PhdrEnd = checkedAddUint64(
+      NewPhoff, NewPhnum * Phentsize, "relocated phdr table end");
+  if (!PhdrEnd)
+    return nullptr;
+  Cursor = *PhdrEnd;
+
+  if (NewShnum >= ELF::SHN_LORESERVE) {
+    log() << "hotswap: error: growWithTrampolines: section-header count "
+          << NewShnum
+          << " after appending the pool and provenance sections requires "
+             "unsupported extended numbering.\n";
+    return nullptr;
   }
+  std::optional<uint64_t> NewShoffOr = checkedAlignToUint64(
+      Cursor, static_cast<uint64_t>(alignof(Shdr)),
+      "relocated shdr table offset");
+  if (!NewShoffOr)
+    return nullptr;
+  const uint64_t NewShoff = *NewShoffOr;
+  std::optional<uint64_t> ShdrEnd = checkedAddUint64(
+      NewShoff, NewShnum * Shentsize, "relocated shdr table end");
+  if (!ShdrEnd)
+    return nullptr;
+  Cursor = *ShdrEnd;
   if (Cursor > std::numeric_limits<size_t>::max()) {
     log()
         << "hotswap: error: growWithTrampolines: grown size exceeds size_t.\n";
@@ -1778,51 +2696,72 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
     std::memcpy(Out + Pos, T.Bytes.data(), T.Bytes.size());
     Pos += T.Bytes.size();
   }
-  // 3. Relocated program-header table + appended PT_LOAD for the pool.
-  if (HasPhdrs) {
-    std::memcpy(Out + NewPhoff, Input + Phoff,
-                static_cast<size_t>(Phnum) * Phentsize);
-    Phdr PoolPhdr{};
-    PoolPhdr.p_type = ELF::PT_LOAD;
-    PoolPhdr.p_flags = ELF::PF_R | ELF::PF_X;
-    PoolPhdr.p_offset = PoolFileOff;
-    PoolPhdr.p_vaddr = PoolVAddr;
-    PoolPhdr.p_paddr = PoolVAddr;
-    PoolPhdr.p_filesz = TrampTotal;
-    PoolPhdr.p_memsz = TrampTotal;
-    PoolPhdr.p_align = TrampolinePoolAlign;
-    std::memcpy(Out + NewPhoff + static_cast<uint64_t>(Phnum) * Phentsize,
-                &PoolPhdr, sizeof(PoolPhdr));
-    std::memcpy(Out + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
-    uint16_t NewPhnum16 = static_cast<uint16_t>(NewPhnum);
-    std::memcpy(Out + offsetof(Ehdr, e_phnum), &NewPhnum16, sizeof(NewPhnum16));
+  // 3. Non-allocating standard ELF note describing the executable pool.
+  std::memcpy(Out + PoolNoteFileOff, PoolNote.data(), PoolNote.size());
+  // 4. Relocated program-header table + appended PT_LOAD for the pool.
+  std::memcpy(Out + NewPhoff, Input + Phoff,
+              static_cast<size_t>(Phnum) * Phentsize);
+  // PT_PHDR promises that the program-header table is part of the process
+  // image at the address recorded in that entry. The relocated table is
+  // metadata after the pool and is deliberately not mapped by a PT_LOAD, so an
+  // inherited PT_PHDR would describe the obsolete table. PT_PHDR is optional;
+  // remove the stale promise while preserving the remaining table slots.
+  for (uint16_t I = 0; I != Phnum; ++I) {
+    uint8_t *Entry = Out + NewPhoff + static_cast<uint64_t>(I) * Phentsize;
+    Phdr Existing{};
+    std::memcpy(&Existing, Entry, sizeof(Existing));
+    if (Existing.p_type != ELF::PT_PHDR)
+      continue;
+    Phdr Null{};
+    std::memcpy(Entry, &Null, sizeof(Null));
   }
-  // 4. Relocated section-header table + appended pool section. The section has
-  // an empty name (sh_name == 0): the loader ignores section headers and tools
-  // still disassemble it by flags, so no .shstrtab surgery is needed.
-  if (HasShdrs) {
-    std::memcpy(Out + NewShoff, Input + Shoff,
-                static_cast<size_t>(Shnum) * Shentsize);
-    Shdr PoolShdr{};
-    PoolShdr.sh_name = 0;
-    PoolShdr.sh_type = ELF::SHT_PROGBITS;
-    PoolShdr.sh_flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
-    PoolShdr.sh_addr = PoolVAddr;
-    PoolShdr.sh_offset = PoolFileOff;
-    PoolShdr.sh_size = TrampTotal;
-    PoolShdr.sh_addralign = TrampolinePoolAlign;
-    std::memcpy(Out + NewShoff + static_cast<uint64_t>(Shnum) * Shentsize,
-                &PoolShdr, sizeof(PoolShdr));
-    std::memcpy(Out + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
-    uint16_t NewShnum16 = static_cast<uint16_t>(NewShnum);
-    std::memcpy(Out + offsetof(Ehdr, e_shnum), &NewShnum16, sizeof(NewShnum16));
-  }
+  Phdr PoolPhdr{};
+  PoolPhdr.p_type = ELF::PT_LOAD;
+  PoolPhdr.p_flags = ELF::PF_R | ELF::PF_X;
+  PoolPhdr.p_offset = PoolFileOff;
+  PoolPhdr.p_vaddr = PoolVAddr;
+  PoolPhdr.p_paddr = PoolVAddr;
+  PoolPhdr.p_filesz = TrampTotal;
+  PoolPhdr.p_memsz = TrampTotal;
+  PoolPhdr.p_align = TrampolinePoolAlign;
+  std::memcpy(Out + NewPhoff + static_cast<uint64_t>(Phnum) * Phentsize,
+              &PoolPhdr, sizeof(PoolPhdr));
+  std::memcpy(Out + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
+  uint16_t NewPhnum16 = static_cast<uint16_t>(NewPhnum);
+  std::memcpy(Out + offsetof(Ehdr, e_phnum), &NewPhnum16, sizeof(NewPhnum16));
+  // 5. Relocated section-header table + appended pool and provenance sections.
+  // Both have empty names (sh_name == 0), avoiding .shstrtab surgery.
+  std::memcpy(Out + NewShoff, Input + Shoff,
+              static_cast<size_t>(Shnum) * Shentsize);
+  Shdr PoolShdr{};
+  PoolShdr.sh_name = 0;
+  PoolShdr.sh_type = ELF::SHT_PROGBITS;
+  PoolShdr.sh_flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
+  PoolShdr.sh_addr = PoolVAddr;
+  PoolShdr.sh_offset = PoolFileOff;
+  PoolShdr.sh_size = TrampTotal;
+  PoolShdr.sh_addralign = TrampolinePoolAlign;
+  std::memcpy(Out + NewShoff + static_cast<uint64_t>(Shnum) * Shentsize,
+              &PoolShdr, sizeof(PoolShdr));
+  Shdr NoteShdr{};
+  NoteShdr.sh_name = 0;
+  NoteShdr.sh_type = ELF::SHT_NOTE;
+  NoteShdr.sh_offset = PoolNoteFileOff;
+  NoteShdr.sh_size = PoolNote.size();
+  NoteShdr.sh_addralign = 4;
+  std::memcpy(Out + NewShoff +
+                  (static_cast<uint64_t>(Shnum) + 1) * Shentsize,
+              &NoteShdr, sizeof(NoteShdr));
+  std::memcpy(Out + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+  uint16_t NewShnum16 = static_cast<uint16_t>(NewShnum);
+  std::memcpy(Out + offsetof(Ehdr, e_shnum), &NewShnum16, sizeof(NewShnum16));
 
   log() << "hotswap: growWithTrampolines: appended " << Trampolines.size()
         << (Trampolines.size() == 1 ? " trampoline (" : " trampolines (")
         << TrampTotal << " bytes) at vaddr 0x" << utohexstr(PoolVAddr)
         << " (file 0x" << utohexstr(PoolFileOff) << "); grew ELF from "
-        << InputSize << " to " << NewSize << " bytes.\n";
+        << InputSize << " to " << NewSize << " bytes with target-state "
+        << static_cast<uint32_t>(TargetState) << " provenance.\n";
   return Buf;
 }
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
@@ -10,9 +10,9 @@
 /// no assembler, no disassembler): the stub is emitted from a pre-encoded
 /// gfx1250 byte template with the two PC-relative delta immediates and the
 /// per-kernel scratch SGPR register fields patched in. Like the MC path, the
-/// scratch pair is allocated above each kernel's SGPR count (never a live
-/// kernel input, including preloaded kernargs) and the descriptor's SGPR
-/// reservation is bumped accordingly. Idempotency and the
+/// scratch pair is selected from numbered SGPRs or logical VCC (never a live
+/// kernel input, including preloaded kernargs) and the metadata SGPR total is
+/// bumped conservatively. Idempotency and the
 /// compile-time-workaround skip are decided by raw byte comparison rather than
 /// decoding.
 ///
@@ -67,6 +67,13 @@ static_assert(sizeof(StubTemplate) >= FastEntryPrefixBytes,
 SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
                                                     uint64_t EntryVAddr,
                                                     unsigned ScratchSgpr) {
+  if ((ScratchSgpr & 1u) != 0 || ScratchSgpr > Gfx1250MaxNumberedSgprs) {
+    log() << "hotswap: error: fast kernel-entry stub requires an aligned "
+             "scratch SGPR pair at or below logical base "
+          << Gfx1250MaxNumberedSgprs << ", got " << ScratchSgpr << ".\n";
+    return {};
+  }
+
   SmallVector<uint8_t> Bytes;
   Bytes.resize(KernelEntryStubStride);
   std::memcpy(Bytes.data(), StubTemplate, FastEntryStubBodyBytes);
@@ -74,8 +81,9 @@ SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
   // Patch the scratch SGPR pair s[N:N+1] into the register fields. The template
   // is spelled with s[100:101]; only the six field bytes change with N (see the
   // FastEntry*Offset encoding table in comgr-hotswap-internal.h). ScratchSgpr
-  // is an even base <= 104 (guaranteed by the aligned-pair allocation in
-  // appendKernelEntryTrampolinesFast).
+  // is an even base <= 106 (guaranteed by the aligned-pair allocation in
+  // appendKernelEntryTrampolinesFast). Logical base 106 encodes the
+  // non-numbered VCC/VCC_LO/VCC_HI registers in these same fields.
   const uint8_t N = static_cast<uint8_t>(ScratchSgpr);
   Bytes[FastEntryGetPcSdstOffset] = 0x80 | N;
   Bytes[FastEntryAddLoSrc0Offset] = N;
@@ -125,31 +133,37 @@ entryHasWorkaroundPrefixFast(const ElfView &Elf,
 // SGPR count, exactly like the MC path's allocateEntryStubScratchSgprs. This is
 // the correctness guarantee over a fixed s[100:101]: N is above every live
 // input (system/user SGPRs and preloaded kernargs), so the stub never clobbers
-// one. Declines (returns nullopt) if no aligned pair fits below MaxSgprs.
+// one. At the top of the numbered file, logical base 106 selects VCC. Declines
+// (returns nullopt) only for malformed metadata or when a non-gfx1250 limit has
+// no aligned pair.
 static std::optional<unsigned> allocateEntryStubScratchSgprsFast(
     const ElfView &Elf, const KernelDescriptorInfo &KD, unsigned MaxSgprs) {
-  constexpr unsigned ScratchSgprs = 2;
   std::optional<unsigned> SgprCount = Elf.getKernelSgprCount(KD.KernelName);
   if (!SgprCount) {
     log() << "hotswap: error: fast entry trampoline: failed to read SGPR count "
           << "for '" << KD.KernelName << "'.\n";
     return std::nullopt;
   }
-  if (*SgprCount > MaxSgprs) {
+  const unsigned MaxTotalSgprs =
+      MaxSgprs == Gfx1250MaxNumberedSgprs ? Gfx1250MaxTotalSgprs : MaxSgprs;
+  if (*SgprCount > MaxTotalSgprs) {
     log() << "hotswap: error: fast entry trampoline: kernel '" << KD.KernelName
-          << "' uses " << *SgprCount << " SGPRs, above max " << MaxSgprs
-          << ".\n";
+          << "' declares malformed total SGPR count " << *SgprCount
+          << ", above max " << MaxTotalSgprs << ".\n";
     return std::nullopt;
   }
 
   unsigned ScratchBase = (*SgprCount + 1) & ~1u;
-  if (ScratchBase > MaxSgprs || MaxSgprs - ScratchBase < ScratchSgprs) {
-    log() << "hotswap: error: fast entry trampoline: kernel '" << KD.KernelName
-          << "' uses " << *SgprCount << " SGPRs; no aligned scratch pair fits "
-          << "below max " << MaxSgprs << ".\n";
-    return std::nullopt;
-  }
-  return ScratchBase;
+  if (ScratchBase <= MaxSgprs &&
+      MaxSgprs - ScratchBase >= EntryStubScratchSgprs)
+    return ScratchBase;
+  if (MaxSgprs == Gfx1250MaxNumberedSgprs)
+    return Gfx1250MaxNumberedSgprs;
+
+  log() << "hotswap: error: fast entry trampoline: kernel '" << KD.KernelName
+        << "' uses " << *SgprCount << " SGPRs; no aligned scratch pair fits "
+        << "below max numbered count " << MaxSgprs << ".\n";
+  return std::nullopt;
 }
 
 static bool appendPaddingFast(std::vector<Trampoline> &Out, uint64_t PadBytes) {
@@ -172,6 +186,11 @@ std::optional<uint32_t> appendKernelEntryTrampolinesFast(
     const ElfView &Elf, StringRef TargetCpu, unsigned MaxSgprs,
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups) {
+  if (!Elf.kernelDescriptorCacheIsComplete()) {
+    log() << "hotswap: error: fast entry trampoline: kernel descriptor set is "
+             "incomplete or ambiguous\n";
+    return std::nullopt;
+  }
   ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   if (Descriptors.empty())
     return 0;
@@ -248,13 +267,14 @@ std::optional<uint32_t> appendKernelEntryTrampolinesFast(
 
     Trampoline T;
     T.Bytes = buildKernelEntryTrampolineFast(*StubVAddr, *Entry, *ScratchSgpr);
+    if (T.Bytes.empty())
+      return std::nullopt;
     LocalGrowth.push_back(std::move(T));
 
-    // Per-kernel scratch pair s[*ScratchSgpr:*ScratchSgpr+1]: bump the
-    // descriptor SGPR reservation (SkipSgprReservation=false) so the shared
-    // rewriteKernelEntryDescriptorOffsets records the pair, exactly like the MC
-    // path.
-    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2,
+    // Conservatively reserve VCC alongside a numbered pair because metadata
+    // reports only the combined total. Logical base 106 is VCC itself.
+    LocalFixups.push_back({KD.KernelName, AppendOffset,
+                           requiredEntryStubSgprCount(*ScratchSgpr),
                            Item.StubInstPrefLines,
                            /*SkipSgprReservation=*/false});
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -51,18 +51,23 @@ SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
                                                 uint64_t EntryVAddr,
                                                 unsigned ScratchSgpr,
                                                 const LLVMState &LS) {
-  if (ScratchSgpr == std::numeric_limits<unsigned>::max()) {
-    log() << "hotswap: error: kernel-entry stub scratch SGPR pair overflows "
-          << "unsigned.\n";
+  if ((ScratchSgpr & 1u) != 0 || ScratchSgpr > Gfx1250MaxNumberedSgprs) {
+    log() << "hotswap: error: kernel-entry stub requires an aligned scratch "
+             "SGPR pair at or below logical base "
+          << Gfx1250MaxNumberedSgprs << ", got " << ScratchSgpr << ".\n";
     return {};
   }
 
   SmallVector<uint8_t> Bytes;
-  std::string ScratchPair =
-      (Twine("s[") + Twine(ScratchSgpr) + ":" + Twine(ScratchSgpr + 1) + "]")
-          .str();
-  std::string ScratchLo = (Twine("s") + Twine(ScratchSgpr)).str();
-  std::string ScratchHi = (Twine("s") + Twine(ScratchSgpr + 1)).str();
+  const bool UsesVcc = ScratchSgpr == Gfx1250MaxNumberedSgprs;
+  std::string ScratchPair = UsesVcc ? "vcc"
+                                    : (Twine("s[") + Twine(ScratchSgpr) + ":" +
+                                       Twine(ScratchSgpr + 1) + "]")
+                                          .str();
+  std::string ScratchLo =
+      UsesVcc ? "vcc_lo" : (Twine("s") + Twine(ScratchSgpr)).str();
+  std::string ScratchHi =
+      UsesVcc ? "vcc_hi" : (Twine("s") + Twine(ScratchSgpr + 1)).str();
 
   // Assemble through the MC layer instead of spelling encoded bytes; the LIT
   // test pins the generated stub's disassembly.
@@ -259,13 +264,59 @@ decodeEntryStubTargetVAddr(ArrayRef<InternalDecodedInst> Decoded,
   return *PcBase + Delta;
 }
 
-bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
-  if (!hasKernelEntryTrampolinePrefix(Bytes, LS))
+static bool hasExactEntryStubPadding(ArrayRef<uint8_t> Bytes,
+                                     ArrayRef<InternalDecodedInst> Decoded,
+                                     const LLVMState &LS) {
+  if (Decoded.size() < 6 ||
+      Decoded[5].Offset > std::numeric_limits<uint64_t>::max() -
+                              Decoded[5].Size)
     return false;
+  const uint64_t BodyEnd = Decoded[5].Offset + Decoded[5].Size;
+  SmallVector<uint8_t> CodeEnd = getCodeEndBytes(LS);
+  if (CodeEnd.empty() || BodyEnd > KernelEntryStubStride ||
+      (KernelEntryStubStride - BodyEnd) % CodeEnd.size() != 0)
+    return false;
+  for (uint64_t Offset = BodyEnd; Offset < KernelEntryStubStride;
+       Offset += CodeEnd.size())
+    if (!Bytes.slice(Offset, CodeEnd.size()).equals(CodeEnd))
+      return false;
+  return true;
+}
+
+bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
+  return getKernelEntryTrampolineInfo(Bytes, 0, LS).has_value();
+}
+
+std::optional<KernelEntryTrampolineInfo>
+getKernelEntryTrampolineInfo(ArrayRef<uint8_t> Bytes, uint64_t StubVAddr,
+                             const LLVMState &LS) {
+  if (!hasKernelEntryTrampolinePrefix(Bytes, LS))
+    return std::nullopt;
 
   std::vector<InternalDecodedInst> Decoded;
-  return decodeKernelEntryStub(Bytes, LS, Decoded, "isKernelEntryTrampoline") &&
-         hasEntryStubOperandShape(Decoded, LS);
+  if (!decodeKernelEntryStub(Bytes, LS, Decoded,
+                             "kernel entry target matcher") ||
+      !hasEntryStubOperandShape(Decoded, LS) ||
+      !hasExactEntryStubPadding(Bytes, Decoded, LS))
+    return std::nullopt;
+  std::optional<uint64_t> Target =
+      decodeEntryStubTargetVAddr(Decoded, StubVAddr);
+  std::optional<uint64_t> Terminal = checkedAddUint64(
+      StubVAddr, Decoded[5].Offset, "kernel entry terminal address");
+  if (!Target || !Terminal)
+    return std::nullopt;
+  return KernelEntryTrampolineInfo{*Target, *Terminal};
+}
+
+std::optional<uint64_t>
+getKernelEntryTrampolineTargetVAddr(ArrayRef<uint8_t> Bytes,
+                                    uint64_t StubVAddr,
+                                    const LLVMState &LS) {
+  std::optional<KernelEntryTrampolineInfo> Info =
+      getKernelEntryTrampolineInfo(Bytes, StubVAddr, LS);
+  if (!Info)
+    return std::nullopt;
+  return Info->TargetVAddr;
 }
 
 bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
@@ -428,17 +479,18 @@ std::optional<int64_t> checkedSignedDifference(uint64_t LHS, uint64_t RHS,
 
 static std::optional<unsigned> allocateEntryStubScratchSgprs(
     const ElfView &Elf, const KernelDescriptorInfo &KD, unsigned MaxSgprs) {
-  constexpr unsigned ScratchSgprs = 2;
   std::optional<unsigned> SgprCount = Elf.getKernelSgprCount(KD.KernelName);
   if (!SgprCount) {
     log() << "hotswap: error: entry trampoline: failed to read SGPR count for '"
           << KD.KernelName << "'.\n";
     return std::nullopt;
   }
-  if (*SgprCount > MaxSgprs) {
+  const unsigned MaxTotalSgprs =
+      MaxSgprs == Gfx1250MaxNumberedSgprs ? Gfx1250MaxTotalSgprs : MaxSgprs;
+  if (*SgprCount > MaxTotalSgprs) {
     log() << "hotswap: error: entry trampoline: kernel '" << KD.KernelName
-          << "' uses " << *SgprCount << " SGPRs, above max " << MaxSgprs
-          << ".\n";
+          << "' declares malformed total SGPR count " << *SgprCount
+          << ", above max " << MaxTotalSgprs << ".\n";
     return std::nullopt;
   }
 
@@ -448,13 +500,20 @@ static std::optional<unsigned> allocateEntryStubScratchSgprs(
   // non-numbered. Treat the full metadata count as numbered and possibly skip
   // two usable SGPRs rather than risk overlapping a declared register.
   unsigned ScratchBase = (*SgprCount + 1) & ~1u;
-  if (ScratchBase > MaxSgprs || MaxSgprs - ScratchBase < ScratchSgprs) {
-    log() << "hotswap: error: entry trampoline: kernel '" << KD.KernelName
-          << "' uses " << *SgprCount << " SGPRs; no aligned scratch pair fits "
-          << "below max " << MaxSgprs << ".\n";
-    return std::nullopt;
-  }
-  return ScratchBase;
+  if (ScratchBase <= MaxSgprs &&
+      MaxSgprs - ScratchBase >= EntryStubScratchSgprs)
+    return ScratchBase;
+
+  // .sgpr_count includes the two non-numbered VCC halves. At the top of the
+  // numbered file, use VCC as the entry-only temporary and reserve the full
+  // metadata total. VCC has no defined kernel-entry value to preserve.
+  if (MaxSgprs == Gfx1250MaxNumberedSgprs)
+    return Gfx1250MaxNumberedSgprs;
+
+  log() << "hotswap: error: entry trampoline: kernel '" << KD.KernelName
+        << "' uses " << *SgprCount << " SGPRs; no aligned scratch pair fits "
+        << "below max numbered count " << MaxSgprs << ".\n";
+  return std::nullopt;
 }
 
 static bool appendPaddingTrampoline(std::vector<Trampoline> &Out,
@@ -555,6 +614,11 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     const ElfView &Elf, const LLVMState &LS, unsigned MaxSgprs,
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups) {
+  if (!Elf.kernelDescriptorCacheIsComplete()) {
+    log() << "hotswap: error: entry trampoline: kernel descriptor set is "
+             "incomplete or ambiguous\n";
+    return std::nullopt;
+  }
   ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   if (Descriptors.empty())
     return 0;
@@ -660,7 +724,8 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     Trampoline T;
     T.Bytes.assign(Stub.begin(), Stub.end());
     LocalGrowth.push_back(std::move(T));
-    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2,
+    LocalFixups.push_back({KD.KernelName, AppendOffset,
+                           requiredEntryStubSgprCount(*ScratchSgpr),
                            Item.StubInstPrefLines});
     std::optional<uint64_t> NewAppendOffset = checkedAddUint64(
         AppendOffset, KernelEntryStubStride,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -34,6 +34,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -71,6 +72,10 @@
 
 namespace COMGR {
 namespace hotswap {
+
+inline constexpr int8_t VgprMsbUnanalyzed = -3;
+inline constexpr int8_t VgprMsbUnreachable = -2;
+inline constexpr int8_t VgprMsbUnknown = -1;
 
 class ElfView;
 
@@ -319,6 +324,10 @@ struct Trampoline {
   bool Long = false;
   bool UsesSetPCBack = false;
   unsigned LongBranchSgprBase = 0;
+  // The scratch pair was proven dead only at the original resume point.
+  // Backward source growth is safe only across instructions that do not touch
+  // the pair; forward growth must re-prove it at the moved resume point.
+  bool LongBranchScratchIsSiteProven = false;
   bool HasPoolBranchIsland = false;
   uint64_t PoolBranchIslandOffset = 0;
   bool UsesShortBranchForward = false;
@@ -328,6 +337,7 @@ struct Trampoline {
   uint64_t ForwardBranchTargetOffset = 0;
   bool HasForwardGateway = false;
   uint64_t ForwardGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> ForwardGatewayCallBytes;
   llvm::SmallVector<uint8_t> ForwardGatewayBytes;
   // A far-site run may only be coalesced within one known function. Unknown
   // ranges stay unmerged because adjacent symbols are independent entries.
@@ -401,8 +411,9 @@ static constexpr uint64_t FastEntryDeltaLoOffset = 24; // s_add_co_u32 imm32
 static constexpr uint64_t FastEntryDeltaHiOffset = 32; // s_add_co_ci_u32 imm32
 
 // SGPR register-field byte offsets within the stub body. The scratch pair is
-// s[N:N+1] with N = ScratchBase (even). Verified by llvm-mc round-trip on
-// gfx1250 (see the encoding table in comgr-hotswap-entry-trampoline-fast.cpp):
+// s[N:N+1] with N = ScratchBase (even), except that logical base 106 names VCC.
+// Verified by llvm-mc round-trip on gfx1250 (see the encoding table in
+// comgr-hotswap-entry-trampoline-fast.cpp):
 //   s_get_pc_i64 sdst         : byte = 0x80 | N
 //   s_add_co_u32 src0/sdst    : byte = N
 //   s_add_co_ci_u32 src0/sdst : byte = N + 1
@@ -417,6 +428,7 @@ static constexpr uint64_t FastEntrySetPcSrcOffset = 36;
 struct KernelDescriptorInfo {
   std::string KernelName;
   uint64_t VAddr = 0;
+  uint64_t FileOffset = 0;
   int64_t EntryOffset = 0;
 };
 
@@ -426,18 +438,60 @@ struct KernelClusterDims {
   unsigned Z = 0;
 };
 
+enum class NopSledUse {
+  OwnerBody,
+  RelocationBody,
+  Gateway,
+};
+
+enum class ReplacementPlacement {
+  Default,
+  Ds2SourceTail,
+  ProtectedCombinedDelay,
+};
+
 struct NopSled {
   uint64_t Start = 0;
   uint64_t End = 0;
   uint64_t WritePos = 0;
-  uint64_t FunctionStart = 0;
-  uint64_t FunctionEnd = 0;
+  uint64_t OwnerStart = 0;
+  uint64_t OwnerEnd = 0;
+  // This storage may contain branch gateways only, never a replacement body.
+  // It covers certified external padding and appended-pool branch islands.
+  bool GatewayOnly = false;
+  // Explicit NOP padding immediately after a proven no-fallthrough function
+  // boundary remains body-owned by that function, but any function may use
+  // the same allocation cursor for branch-only gateway instructions.
+  bool GlobalGateway = false;
+  // Strictly proven post-function NOP padding may also hold straight-line,
+  // PC-independent relocation bodies when the patch pass explicitly opts in.
+  bool GlobalBody = false;
+
+  bool ownsSource(uint64_t Offset) const {
+    return OwnerStart <= Offset && Offset < OwnerEnd;
+  }
+
+  bool canGatewayFrom(uint64_t Offset) const {
+    return GlobalGateway || ownsSource(Offset);
+  }
+
+  bool canHoldBodyFrom(uint64_t Offset, bool AllowGlobalBody) const {
+    return ownsSource(Offset) || (AllowGlobalBody && GlobalBody);
+  }
 };
 
 enum class MaskWorkaroundPolicy {
   None,
   A0,
   B0,
+};
+
+/// Target dependence of an executable pool emitted by HotSwap. Neutral pools
+/// contain only stepping-independent code such as kernel-entry stubs.
+enum class ExecutablePoolTargetState : uint32_t {
+  Neutral = 0,
+  A0 = 1,
+  B0 = 2,
 };
 
 // -- Rewrite rule -------------------------------------------------------------
@@ -465,10 +519,31 @@ static constexpr uint64_t MinNopSledSize = 8;
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
 
-// Fixed reservation for the SCC-neutral set-PC sequence.
-static constexpr uint32_t SetPcReturnReserveBytes = 20;
+// GFX12 wave32 has 106 numbered user SGPRs (s0-s105), followed by the two
+// non-numbered VCC halves. AMDGPU metadata's .sgpr_count includes VCC, so its
+// valid total reaches 108 even though numbered-register allocation stops at
+// 106. Keep the historical name as an alias for code whose limit is explicitly
+// the numbered register file.
+static constexpr unsigned Gfx1250MaxNumberedSgprs = 106;
+static constexpr unsigned Gfx1250VccSgprs = 2;
+static constexpr unsigned Gfx1250MaxTotalSgprs =
+    Gfx1250MaxNumberedSgprs + Gfx1250VccSgprs;
+static constexpr unsigned Gfx1250MaxSgprs = Gfx1250MaxNumberedSgprs;
+static constexpr unsigned EntryStubScratchSgprs = 2;
 
-static constexpr uint32_t SetPcForwardSequenceBytes = SetPcReturnReserveBytes;
+// .sgpr_count does not identify how many of its total are the non-numbered VCC
+// halves. Conservatively retain room for VCC when a numbered scratch pair is
+// added. Logical base 106 is VCC itself, so its required total is exactly 108.
+static constexpr unsigned requiredEntryStubSgprCount(unsigned ScratchBase) {
+  return ScratchBase == Gfx1250MaxNumberedSgprs
+             ? Gfx1250MaxTotalSgprs
+             : ScratchBase + EntryStubScratchSgprs + Gfx1250VccSgprs;
+}
+
+// Maximum reservation for the SCC-neutral get-PC/add/set-PC sequence. The
+// gfx1250 s_add_nc_u64 form is either 16 or 20 bytes depending on its literal.
+static constexpr uint32_t SetPcReturnReserveBytes = 20;
+static constexpr uint32_t SetPcForwardSequenceBytes = 20;
 static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
@@ -505,6 +580,11 @@ public:
     uint64_t End = 0;
     const ELFT::Sym *Symbol = nullptr;
     const ELFT::Shdr *Symtab = nullptr;
+  };
+
+  struct TextOffsetRange {
+    uint64_t Begin = 0;
+    uint64_t End = 0;
   };
 
   /// Parse \p Data / \p Size into an ElfView. Fails if the bytes are not a
@@ -551,6 +631,15 @@ public:
   /// Zero-size symbols extend to the next function symbol or `.text` end.
   std::vector<FunctionTextRange> functionTextRanges() const;
 
+  /// Return every defined symbol offset in `.text`, irrespective of symbol
+  /// type. A missing value means symbol-table discovery was incomplete.
+  std::optional<std::vector<uint64_t>> textSymbolOffsets() const;
+
+  /// Return sorted, coalesced half-open extents for sized, non-callable
+  /// symbols defined in `.text`. Extents are clipped to `.text`; a missing
+  /// value means discovery was incomplete or an extent overflowed.
+  std::optional<std::vector<TextOffsetRange>> textSymbolExtents() const;
+
   /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.
   std::string findKernelAtAddress(uint64_t TextAddress) const;
@@ -566,6 +655,19 @@ public:
   /// section covers the range or it falls outside the buffer.
   const uint8_t *dataAtVAddr(uint64_t VAddr, uint64_t Len) const;
 
+  /// Return true when the complete virtual-address range is backed by bytes
+  /// in an executable PT_LOAD segment. Segment validation is still required
+  /// even when the range also has an executable section header.
+  bool isExecutableVAddrRange(uint64_t VAddr, uint64_t Len) const;
+
+  /// Return true when every file-backed executable region outside the `.text`
+  /// section analyzed by the instruction rewriter has valid HotSwap provenance
+  /// and is either stepping-neutral or built for \p TargetState. Unmarked,
+  /// stale, conflicting, or malformed provenance fails closed; structurally
+  /// malformed ELF data returns std::nullopt.
+  std::optional<bool> executableCodeOutsideTextIsCompatibleWith(
+      ExecutablePoolTargetState TargetState) const;
+
   /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
   /// or nullptr if not found.
   uint8_t *findKernelDescriptor(llvm::StringRef KernelName);
@@ -574,6 +676,10 @@ public:
   /// current kernel_code_entry_byte_offset values. The returned range remains
   /// valid until this ElfView is destroyed.
   llvm::ArrayRef<KernelDescriptorInfo> kernelDescriptors() const;
+
+  /// True only when every descriptor symbol was parsed and duplicate names
+  /// resolved to the same descriptor location.
+  bool kernelDescriptorCacheIsComplete() const;
 
   /// Return the virtual address of the kernel descriptor symbol for
   /// \p KernelName, or std::nullopt when the descriptor is not present.
@@ -605,6 +711,12 @@ public:
   /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
   /// size, so this preserves the ELF layout.
   bool updateGfx1250RevisionMetadata(llvm::StringRef Revision);
+
+  /// Return true only when metadata contains at least one kernel and every
+  /// kernel explicitly records \p Revision. Missing revision keys return
+  /// false; malformed metadata returns std::nullopt.
+  std::optional<bool>
+  allKernelsHaveGfx1250Revision(llvm::StringRef Revision) const;
 
   /// Read COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
   std::optional<uint32_t>
@@ -679,11 +791,13 @@ public:
                                        unsigned VgprGranuleSize);
 
   /// Virtual address at which growWithTrampolines appends the trampoline pool:
-  /// the first page-aligned address above every existing allocatable section.
+  /// the first page-aligned address above every existing allocatable section
+  /// and PT_LOAD memory range.
   /// Callers that pre-compute branch/stub targets (B0-to-A0 trampolines,
   /// kernel-entry stubs) must resolve pool positions against this value so the
   /// baked branches land on the pool's final location. Single source of truth
-  /// shared with growWithTrampolines. std::nullopt on sh_addr+sh_size overflow.
+  /// shared with growWithTrampolines. std::nullopt on section or segment range
+  /// overflow.
   std::optional<uint64_t> trampolinePoolVAddr() const;
 
   /// Grow the ELF by appending the trampoline pool at a fresh virtual address
@@ -696,7 +810,8 @@ public:
   /// AMDGPU code object, which carries no relocations to fix up.
   std::unique_ptr<llvm::WritableMemoryBuffer>
   growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines,
-                      llvm::ArrayRef<uint8_t> SNopBytes) const;
+                      llvm::ArrayRef<uint8_t> SNopBytes,
+                      ExecutablePoolTargetState TargetState) const;
 
 private:
   enum class KernelSgprCacheState {
@@ -726,6 +841,7 @@ private:
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorVAddrCache;
+  mutable bool KernelDescriptorCacheComplete = false;
   mutable KernelSgprCacheState SgprCacheState =
       KernelSgprCacheState::Uninitialized;
   mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;
@@ -744,9 +860,18 @@ struct LLVMState;
                                     const LLVMState &LS);
 
 /// Find the nearest NOP sled to \p Offset with at least \p Needed bytes of
-/// free space. Returns nullptr if none found within MaxSledDistance.
+/// free space. \p Use controls whether selection is restricted to owner-local
+/// bodies, allows certified relocation bodies in post-function padding, or
+/// allows branch-only gateways. Returns nullptr if none is found within
+/// MaxSledDistance.
 NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
-                         uint64_t Needed);
+                         uint64_t Needed,
+                         NopSledUse Use = NopSledUse::OwnerBody);
+
+/// Return whether advancing \p Sled's cursor could leave \p Needed bytes at a
+/// position within short-branch reach of \p Offset.
+bool canEverReachGatewaySlot(const NopSled &Sled, uint64_t Offset,
+                             uint64_t Needed);
 
 // -- RewriteConfig ------------------------------------------------------------
 //
@@ -830,6 +955,8 @@ struct LLVMState {
   unsigned SAddU32Opcode = 0;
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
+  unsigned SSwapPcI64Opcode = 0;
+  unsigned SCallI64Opcode = 0;
 
   /// MC identities used by far-trampoline relocation analysis. Each opcode is
   /// resolved once through the asm parser so policy code never compares
@@ -839,13 +966,10 @@ struct LLVMState {
   unsigned SEndPgmOpcode = 0;
   unsigned SEndPgmSavedOpcode = 0;
   unsigned SAddPcI64Opcode = 0;
-  unsigned SCallI64Opcode = 0;
-  unsigned SSwapPcI64Opcode = 0;
   unsigned SPrefetchInstPcRelOpcode = 0;
   unsigned SPrefetchDataPcRelOpcode = 0;
 
-  /// SCC, recovered from the implicit definition on a parsed scalar compare.
-  /// This avoids scanning target register names in policy code.
+  /// SCC identity recovered from an instruction with one implicit SCC def.
   llvm::MCRegister SCCRegister;
 
   /// VCC super-register, recovered from the destination of a parsed scalar
@@ -944,6 +1068,12 @@ struct WmmaNopReq {
 /// Classify the A0/B0 v_nop requirement for a WMMA/SWMMAC mnemonic.
 WmmaNopReq classifyWmmaNops(llvm::StringRef Mnemonic);
 
+/// Record a WMMA spacing deficit for a candidate VALU and return the maximum
+/// requirement seen for that candidate. Multiple WMMA scans must compose the
+/// strongest requirement rather than letting discovery order weaken it.
+int updateWmmaHazardDeficit(llvm::DenseMap<size_t, int> &MaxDeficits,
+                            size_t ValuIndex, int Deficit);
+
 /// Patch the VOP3PX2 scale_src2 field (bits [58:50]) to VGPR0 encoding
 /// (0x100) in a 16-byte instruction buffer. Returns true if the field
 /// was modified (false if already set to the target value).
@@ -978,6 +1108,26 @@ struct CFG {
   std::vector<BasicBlock> Blocks;
   llvm::DenseMap<uint64_t, unsigned> OffsetToBlock;
 };
+
+struct MaterializedPcTransfer {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  uint64_t Target = 0;
+};
+
+std::optional<int64_t> getAbsoluteOperandValue(const llvm::MCOperand &Operand,
+                                               const InternalDecodedInst &DI,
+                                               llvm::ArrayRef<uint8_t> Text);
+
+std::optional<MaterializedPcTransfer> evaluateMaterializedPcTransfer(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const llvm::DenseSet<uint64_t> &DirectTargets, llvm::ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<llvm::ArrayRef<uint64_t>> TextSymbolOffsets = std::nullopt,
+    std::optional<llvm::ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents =
+        std::nullopt);
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS);
 
 /// Dataflow-liveness result for a kernel's VGPR set. \c LiveBefore[i] and
 /// \c LiveAfter[i] are the live-in / live-out bitvectors for Decoded[i].
@@ -1077,6 +1227,17 @@ struct ScratchPatchInfo {
   llvm::BitVector ScratchRegs;
 };
 
+/// Transactional ownership and composition state for one replacement source.
+/// A whole-function requirement may reserve a site before its ordinary
+/// per-instruction owner is known. The first successful emission commits that
+/// owner and composes every pending requirement into the same body.
+struct SiteReplacementState {
+  uint32_t OriginalSize = 0;
+  unsigned RequiredLeadingVNops = 0;
+  bool Committed = false;
+  bool WmmaHazardComposed = false;
+};
+
 // -- Patch types --------------------------------------------------------------
 
 /// Per-kernel counters accumulated by the patch passes. Reported via log()
@@ -1128,6 +1289,95 @@ struct SafeSgprUsageSummary {
   unsigned HighWatermark = 0;
 };
 
+struct SiteDeadSgprFunctionFacts {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  size_t GlobalFirst = 0;
+  unsigned NumberedLimit = 0;
+  std::vector<std::array<uint64_t, 2>> SafeBefore;
+  llvm::BitVector ForbiddenResume;
+};
+
+struct KernelTextRange {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  std::vector<uint64_t> Entries;
+  bool HasArbitraryIndirectIngress = false;
+};
+
+/// Forward must-analysis used by the gfx1250 initial-VMEM workaround. The
+/// bitvectors are indexed like the mutable .text decode. DescriptorCovered
+/// distinguishes dead code in a known kernel from helpers whose entry
+/// semantics cannot be proven.
+struct InitialVmemMustAnalysis {
+  llvm::BitVector DescriptorCovered;
+  llvm::BitVector Reachable;
+  llvm::BitVector MustHavePriorVmem;
+};
+
+InitialVmemMustAnalysis
+computeInitialVmemMustAnalysis(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                               llvm::ArrayRef<InternalDecodedInst> AllDecoded,
+                               llvm::ArrayRef<KernelTextRange> KernelRanges,
+                               const LLVMState &LS);
+
+/// Forward must-analysis for the low 16 bits of tensor group descriptors.
+/// A set bit means every modeled path to the tensor instruction provides a
+/// group-1 base register whose low half is zero. MaskDefinitionOffsets records
+/// the single reaching v_readfirstlane definition when every path agrees, so
+/// one persistent mask can be shared by later tensor operations.
+struct TensorDescriptorMustAnalysis {
+  llvm::BitVector Low16KnownZero;
+  std::vector<uint64_t> MaskDefinitionOffsets;
+};
+
+/// Exact, byte-validated kernel-entry stub metadata. Offsets are relative to
+/// .text, including stubs in appended executable sections. The descriptor's
+/// virtual dispatch edge enters Begin; Terminal is the stub's only decoded
+/// transfer and resolves to Target.
+struct TensorDispatchStub {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  uint64_t Terminal = 0;
+  uint64_t Target = 0;
+};
+
+struct TensorAnalysisRange {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  // Original-.text control transfers from outside this range that target an
+  // appended executable segment. A generated path rooted in this range may
+  // not share one of these segment entries: the foreign path would carry an
+  // unmodeled descriptor and EXEC state to the same re-entry tail.
+  std::vector<uint64_t> ForeignExternalEntries;
+  // Hardware dispatch roots from kernel descriptors that do not name an exact
+  // validated HotSwap entry stub. They have no decoded predecessor edge and
+  // therefore may not enter a candidate-owned external subgraph.
+  std::vector<uint64_t> VirtualExternalEntries;
+  // Complete set of resolved original-.text control-flow and fallthrough
+  // edges. Source provenance distinguishes exact split-relay entry from an
+  // arbitrary join into its address-materialization tail.
+  std::vector<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges;
+  // Callable and kernel roots in original .text. A root may enter a computed
+  // PC sequence only at a self-initializing get-PC prefix.
+  std::vector<uint64_t> OriginalCodeEntries;
+  // Complete immutable set of validated dispatch stubs in this code object.
+  // The range analysis uses it both to admit its own virtual dispatch edge
+  // and to classify carry-form set-PC terminals belonging to other kernels.
+  std::vector<TensorDispatchStub> DispatchStubs;
+};
+
+TensorDescriptorMustAnalysis computeTensorDescriptorMustAnalysis(
+    llvm::ArrayRef<InternalDecodedInst> Decoded,
+    llvm::ArrayRef<InternalDecodedInst> AllDecoded,
+    llvm::ArrayRef<TensorAnalysisRange> KernelRanges, const LLVMState &LS,
+    const llvm::DenseSet<uint64_t> &DirectControlFlowTargets, unsigned MaxSgprs,
+    unsigned MaxVgprs);
+
+// Retain the later amd-staging API as a compatibility view for callers and
+// unit tests added after the PR's base.  The rebased implementation keeps the
+// PR's richer control-flow analysis and maps its conservative result into this
+// small public-internal summary.
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
   bool HasUnresolvedTargets = false;
@@ -1154,30 +1404,116 @@ struct PatchContext {
   const LivenessInfo &Liveness;
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
+  // Later amd-staging consumers use this compatibility summary.  Keep it next
+  // to the original aggregate fields so their target-side initializers remain
+  // source-compatible while the PR's richer facts below stay authoritative.
   const DirectControlFlowInfo &DirectControlFlow;
   // Per-rewrite profiling session (inert unless AMD_COMGR_TIME_STATISTICS is
   // set). Deep patch sites record into its lock-free local array.
   HotswapProfile &Profile;
+  const InitialVmemMustAnalysis *InitialVmemAnalysis = nullptr;
+  const TensorDescriptorMustAnalysis *TensorDescriptorAnalysis = nullptr;
+  // Indexed once from the original instruction stream. CFG analyses use these
+  // sets to model predecessor merges and indirect entries without rescanning
+  // the complete code object for every patch site.
+  std::optional<llvm::DenseSet<uint64_t>> DirectControlFlowTargets;
+  // Sized, non-callable .text data/object extents. Moving any overlapping
+  // byte would violate symbol ownership even when the symbol starts before a
+  // candidate instruction window.
+  std::optional<llvm::ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents;
+  llvm::DenseSet<uint64_t> IndirectControlFlowFunctions;
+  llvm::DenseSet<uint64_t> CrossFunctionInteriorEntryFunctions;
+  bool HasUnknownArbitraryIndirectTarget = false;
+  // True before an instruction only when forward must-dataflow proves that
+  // MODE selects the same physical VGPR bank for VALU destinations and DS
+  // address operands on every reachable path.
+  llvm::BitVector VgprMsbDstSrc0EqualBefore;
+  // Exact persistent bank selectors before each instruction, or -1 when a
+  // path merge, call, or unknown MODE definition prevents recovery. Long
+  // range DS2 proofs compare a VALU definition's dst selector with the later
+  // DS address operand's src0 selector.
+  std::vector<int8_t> VgprMsbDstBefore;
+  std::vector<int8_t> VgprMsbSrc0Before;
+  // Exact packed src0/src1/src2/dst VGPR-MSB mode before each instruction.
+  // Negative sentinels distinguish unanalyzed functions, CFG-unreachable
+  // instructions, and reachable paths with an unknown field. WMMA splitting
+  // uses the complete mode while DS2 alignment can still consume the
+  // independently merged dst/src0 facts.
+  std::vector<int16_t> VgprMsbModeBefore;
+  // Set at a VALU copy when its corresponding destination is known to receive
+  // an 8-byte-aligned numbered SGPR value on every path. The two vectors keep
+  // the slots of v_dual_mov_b32 independent.
+  llvm::BitVector VgprDef0AlignedTo8;
+  llvm::BitVector VgprDef1AlignedTo8;
+  // DS2 alignment exemptions are decided from the immutable decoded stream
+  // before any earlier patch relabels an instruction as <replaced>.
+  llvm::BitVector Ds2AddressProvenAligned;
+  // Source-window expansion must not split clause/delay geometry or move a
+  // patch site whose replacement has explicitly position-sensitive state.
+  llvm::DenseSet<uint64_t> RelocationProtectedOffsets;
+  // Keep the source of relocation protection so removing an unsafe clause
+  // releases only that clause's members. Counts preserve overlapping or
+  // malformed clause ranges; delay and dynamically added protections remain
+  // independent and must survive clause removal.
+  llvm::DenseMap<uint64_t, unsigned> ClauseRelocationProtectionCounts{0};
+  llvm::DenseSet<uint64_t> NonClauseRelocationProtectedOffsets;
+  // Instructions whose execution was moved into a larger atomic replacement
+  // window. Keep their immutable MC description available to analyses that
+  // reason about the relocated instruction order, but prevent later patch
+  // families from emitting a second replacement at the stale linked address.
+  llvm::DenseSet<uint64_t> ClaimedReplacementOffsets;
+  // Descriptor definitions already extended by this pass with the persistent
+  // A0 low-half mask. A must-analysis may reuse one for a later tensor site,
+  // but may not use the reaching-definition fact to authorize a fresh move.
+  llvm::DenseSet<uint64_t> TensorMaskedDefinitionOffsets;
+  // Single source of truth for exact replacement ownership and pending
+  // whole-function composition requirements. This also covers NOP-sled
+  // placements, which do not appear in OutTrampolines.
+  std::map<uint64_t, SiteReplacementState> SiteReplacements;
+  llvm::SmallVector<uint64_t, 16> WmmaHazardSites;
+  uint32_t WmmaHazardsComposed = 0;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;
   bool RequiredPatchApplied = false;
-  // Sum of the bytes already queued in OutTrampolines. Keeping this in the
-  // per-rewrite context makes each new pool-position calculation constant
-  // time even for code objects with many thousands of patch sites.
+  // Conservative upper bound for the final bytes occupied by trampolines
+  // already queued in OutTrampolines. Far entries also reserve their eventual
+  // pool-island slot and bounded straight-line growth, so a later short-branch
+  // decision cannot be invalidated when the final pool is laid out.
   uint64_t QueuedTrampolineBytes = 0;
+  // Largest instruction in the immutable decoded stream. Source-window growth
+  // stops after crossing SetPcForwardSequenceBytes, so this bounds its final
+  // overshoot without assuming an ISA-wide maximum encoding size.
+  uint32_t MaxDecodedInstSize = 0;
   // Safe far-return scratch allocation can be queried at many patch sites in
   // one function. Cache the immutable decoded SGPR usage summaries so each
   // function, and the whole-object fallback, is scanned at most once.
   std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
       FunctionSgprUsage{0};
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, SiteDeadSgprFunctionFacts>
+      SiteDeadSgprFacts{0};
   // Occupancy checks may run at several patch sites in one kernel. Cache the
   // immutable metadata so the AMDGPU note is parsed at most once per field.
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
       WorkgroupMetadataCache;
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
 };
+
+inline void protectNonClauseRelocationOffset(PatchContext &Ctx,
+                                             uint64_t Offset) {
+  Ctx.NonClauseRelocationProtectedOffsets.insert(Offset);
+  Ctx.RelocationProtectedOffsets.insert(Offset);
+}
+
+/// Return whether \p Mnemonic is one of the A0-incompatible WMMA forms owned
+/// by the split patch.
+bool isWmmaSplitPatchCandidate(llvm::StringRef Mnemonic);
+
+/// Return whether the instruction at \p Idx owns a precomputed whole-pass
+/// requirement or still needs an independent configured HotSwap rewrite.
+/// Atomic source-window relocation uses this to avoid claiming its source.
+bool requiresIndependentInstructionRewrite(const PatchContext &Ctx, size_t Idx);
 
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
 std::optional<SubtargetOccupancyLimits>
@@ -1214,13 +1550,15 @@ VgprBumpDecision checkKernelVgprBump(PatchContext &Ctx,
 struct SafeSgprScratchBlock {
   unsigned Base = 0;
   unsigned Count = 0;
+  bool IsSiteProven = false;
 };
 
 /// Find an aligned block of unused numbered SGPRs for \p TextOffset. Returns
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, llvm::StringRef Context);
+                         unsigned Alignment, llvm::StringRef Context,
+                         bool DiagnoseFailure = true);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively
@@ -1230,21 +1568,75 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 llvm::StringRef Context);
 
+/// Decode \p Bytes and return every numbered SGPR touched by an explicit or
+/// implicit operand. Returns nullopt after logging if the sequence cannot be
+/// decoded completely.
+std::optional<llvm::BitVector>
+collectTouchedNumberedSgprs(llvm::ArrayRef<uint8_t> Bytes,
+                            unsigned NumberedSgprLimit, const LLVMState &LS);
+
+/// Return true when both halves of the aligned numbered SGPR pair beginning at
+/// \p SgprBase are defined before any reachable use from \p ResumeIndex. A call
+/// reached while either half remains live fails closed because its outgoing
+/// argument registers are not explicit in the machine instruction.
+bool isSgprPairDeadFrom(llvm::ArrayRef<InternalDecodedInst> Function,
+                        size_t ResumeIndex, unsigned SgprBase,
+                        const LLVMState &LS, llvm::ArrayRef<uint8_t> Text = {});
+
+/// Return true when both VCC halves are dead from \p ResumeIndex. On gfx1250
+/// wave32, implicit composite VCC operands affect VCC_LO; explicit VCC and
+/// VCC_HI operands retain their full register semantics. Proven ABI calls and
+/// returns terminate the caller-clobbered VCC lifetime.
+bool isVccPairDeadFrom(llvm::ArrayRef<InternalDecodedInst> Function,
+                       size_t ResumeIndex, const LLVMState &LS,
+                       llvm::ArrayRef<uint8_t> Text = {});
+
+/// Return the numbered SGPRs that every path from the original resume point
+/// defines before a use, call, or exit. Facts are cached per function.
+std::optional<llvm::BitVector> getSiteDeadNumberedSgprs(PatchContext &Ctx,
+                                                        uint64_t InstOffset,
+                                                        uint32_t InstSize);
+
+/// Build immutable site-dead facts before any patch relabels Decoded entries.
+void precomputeSiteDeadSgprFacts(PatchContext &Ctx);
+
 // -- Trampoline emission helpers (defined in comgr-hotswap-b0a0.cpp) ----------
 
-[[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
-                                 uint64_t InstOffset, uint32_t InstSize,
-                                 llvm::ArrayRef<uint8_t> Replacement);
-[[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
-                                    uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement);
+uint64_t getNopSledBytesNeeded(
+    const PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+    llvm::ArrayRef<uint8_t> Replacement,
+    ReplacementPlacement Placement = ReplacementPlacement::Default);
 
-/// Encode an SCC-neutral indirect long branch using the aligned SGPR pair at
-/// \p SgprBase. The displacement uses gfx12's s_add_nc_u64; no s_add_pc_i64
-/// is emitted.
-std::optional<llvm::SmallVector<uint8_t>>
-encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                      uint64_t TargetOffset, unsigned SgprBase);
+[[nodiscard]] bool
+emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                 llvm::ArrayRef<uint8_t> Replacement,
+                 ReplacementPlacement Placement = ReplacementPlacement::Default,
+                 bool DiagnoseFailure = true);
+
+/// Return the encoded s_delay_alu dependency span, or the conservative ISA
+/// maximum when the immediate cannot be interpreted safely.
+unsigned getDelayProtectedSpan(const InternalDecodedInst &DI);
+
+/// Return true when direct-control-flow information is unavailable, the
+/// half-open window is malformed, or a direct edge enters after \p Begin and
+/// before \p End. An edge to Begin is allowed because the replacement branch
+/// remains there; an edge to any later instruction or literal slot is not.
+bool hasDirectControlFlowTargetInWindowInterior(
+    const std::optional<llvm::DenseSet<uint64_t>> &Targets, uint64_t Begin,
+    uint64_t End);
+
+/// Return true when both edges of a replacement at \p InstOffset can use
+/// s_branch with the trampoline's current queued pool position.
+bool canEmitShortTrampoline(const PatchContext &Ctx, uint64_t InstOffset,
+                            uint32_t InstSize, uint64_t ReplacementSize);
+
+/// Encode an SCC-neutral indirect long branch using the aligned numbered SGPR
+/// pair at \p SgprBase. The displacement is applied with s_add_nc_u64; no
+/// s_add_pc_i64 is emitted and no third SGPR is needed to save SCC.
+llvm::SmallVector<uint8_t> encodeSetPCLongBranch(const LLVMState &LS,
+                                                 uint64_t FromOffset,
+                                                 uint64_t TargetOffset,
+                                                 unsigned SgprBase);
 
 struct EncodedSetPcGateway {
   NopSled *Sled = nullptr;
@@ -1271,11 +1663,29 @@ llvm::Expected<uint64_t> countReachableSetPcGatewaySlots(
 bool isSBranchReachable(uint64_t From, uint64_t To);
 
 /// Evaluate a statically direct branch or call target from its decoded MCInst.
-/// Uses MCInstrAnalysis where supported and the documented gfx1250 s_call_i64
-/// operand fallback otherwise.
+/// Uses MCInstrAnalysis where supported and the gfx1250 s_call_i64 operand
+/// fallback otherwise.
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
+
+/// Encode a four-byte PC-relative s_call_i64 through the aligned numbered SGPR
+/// pair at \p SgprBase, or VCC when \p SgprBase is Gfx1250MaxSgprs. The call
+/// stores the address after itself in the pair and does not modify SCC.
+llvm::SmallVector<uint8_t> encodeSCallI64(const LLVMState &LS,
+                                         uint64_t FromOffset,
+                                         uint64_t TargetOffset,
+                                         unsigned SgprBase);
+[[nodiscard]] bool emitReplacementCode(
+    PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+    llvm::ArrayRef<uint8_t> Replacement,
+    ReplacementPlacement Placement = ReplacementPlacement::Default,
+    bool DiagnoseFailure = true);
+
+/// Whether p Offset is reserved by a pending requirement or already owns a
+/// committed replacement. Relocation windows may not move such a site, while
+/// its exact per-instruction owner may still emit through the shared helpers.
+bool hasSiteReplacementReservation(const PatchContext &Ctx, uint64_t Offset);
 
 /// Collect branch and call targets used to protect interior entry points from
 /// trampoline coalescing. Absolute addresses in TextAddr .. TextAddr +
@@ -1298,19 +1708,6 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<uint64_t> DeclaredEntries,
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
     llvm::ArrayRef<uint64_t> ExternalEntries = {});
-
-[[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
-                                       uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement);
-
-/// Expand one decoded gfx1250 DS two-address instruction into the ordered
-/// single-address instruction sequence used by the trampoline patch. Exposed
-/// from the internal interface so unit tests can verify read-before-write
-/// dependency handling without constructing a complete ELF rewrite. Returns
-/// std::nullopt after logging a malformed or unsafe expansion.
-[[nodiscard]] std::optional<std::vector<std::string>>
-expandDs2Addr(const llvm::MCInst &Inst, llvm::StringRef FromMnem,
-              llvm::StringRef ToMnem, const LLVMState &LS);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //
@@ -1344,6 +1741,7 @@ struct HotswapPatchVTable {
 
   // Whole-kernel passes: called once per kernel after the per-instruction
   // loop completes.
+  bool (*precomputeWmmaHazards)(PatchContext &) = nullptr;
   uint32_t (*applyWmmaHazardPatch)(PatchContext &) = nullptr;
   uint32_t (*applyVop3px2Src2Fix)(PatchContext &) = nullptr;
 };
@@ -1375,6 +1773,9 @@ HotswapPatchVTable &getHotswapPatchVTable();
 #include "comgr-hotswap-patches.def"
 #undef HOTSWAP_PATCH
 
+/// Cache every DS2 alignment exemption before the patch loop mutates Decoded.
+void precomputeDs2AddressAlignment(PatchContext &Ctx);
+
 // -- Function declarations (kernel-entry trampoline pass) ---------------------
 
 struct KernelEntryTrampolineFixup {
@@ -1382,10 +1783,10 @@ struct KernelEntryTrampolineFixup {
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
   uint32_t InstPrefLines = 0;
-  // Both the MC path and the fast path allocate a per-kernel scratch pair above
-  // the kernel's live SGPR count and bump the descriptor SGPR reservation, so
-  // this is normally false. It stays reserved for a caller that installs a stub
-  // using a pair already counted in the reservation (no bump needed).
+  // Both paths allocate either a numbered per-kernel scratch pair or the
+  // logical VCC pair and conservatively bump the metadata total, so this is
+  // normally false. It stays reserved for a caller that installs a stub using
+  // a pair already counted in the reservation (no bump needed).
   bool SkipSgprReservation = false;
 };
 
@@ -1401,6 +1802,26 @@ llvm::SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
 /// buildKernelEntryTrampoline, used to keep the rewrite idempotent.
 bool isKernelEntryTrampoline(llvm::ArrayRef<uint8_t> Bytes,
                              const LLVMState &LS);
+
+struct KernelEntryTrampolineInfo {
+  uint64_t TargetVAddr = 0;
+  uint64_t TerminalVAddr = 0;
+};
+
+/// Return the resolved target and terminal instruction address of an exact
+/// HotSwap entry stub. Besides validating the generated instruction shape,
+/// this requires the remainder of the fixed-size stub to contain only the
+/// exact generated s_code_end padding.
+std::optional<KernelEntryTrampolineInfo>
+getKernelEntryTrampolineInfo(llvm::ArrayRef<uint8_t> Bytes, uint64_t StubVAddr,
+                             const LLVMState &LS);
+
+/// Return the original kernel entry encoded by a structurally valid HotSwap
+/// entry stub at \p StubVAddr. Returns std::nullopt for a non-stub or malformed
+/// candidate.
+std::optional<uint64_t>
+getKernelEntryTrampolineTargetVAddr(llvm::ArrayRef<uint8_t> Bytes,
+                                    uint64_t StubVAddr, const LLVMState &LS);
 
 /// Cheap raw-byte prefilter for the entry stubs produced by
 /// buildKernelEntryTrampoline. This is intentionally weaker than
@@ -1451,9 +1872,9 @@ std::optional<uint64_t> checkedAlignTo(uint64_t Value, uint64_t Alignment,
 
 /// B0->B0 FAST PATH (comgr-hotswap-entry-trampoline-fast.cpp): emit entry stubs
 /// from a pre-encoded gfx1250 byte template with no LLVM MC layer. Same
-/// append/fixup contract as appendKernelEntryTrampolines: the scratch pair is
-/// allocated per kernel above its live SGPR count and \p ScratchSgpr is patched
-/// into the stub's SGPR register fields, so the descriptor SGPR reservation is
+/// append/fixup contract as appendKernelEntryTrampolines: a numbered scratch
+/// pair or logical VCC pair is selected per kernel and \p ScratchSgpr is
+/// patched into the stub's SGPR register fields, so the metadata total is
 /// bumped exactly like the MC path. Selected automatically for pure B0->B0
 /// entry-only rewrites.
 llvm::SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
@@ -1473,9 +1894,9 @@ std::optional<uint32_t> appendKernelEntryTrampolinesFast(
 /// problem) -- callers treat nullptr as "keep the existing buffer", since the
 /// symbol is a debugging aid and its absence is not a correctness failure.
 ///
-/// Only the trailing non-alloc `.symtab` / `.strtab` sections grow, so no
-/// virtual addresses, program headers, or relocations change; `.dynsym` (used
-/// by the loader) is left untouched.
+/// The non-allocating `.symtab` / `.strtab` copies are relocated after the
+/// existing ELF bytes, so the executable pool and all program-header mappings
+/// remain unchanged; `.dynsym` (used by the loader) is left untouched.
 /// \p PoolVAddr is the virtual address of the appended trampoline pool (the
 /// same base rewriteKernelEntryDescriptorOffsets() redirects each descriptor
 /// to); each stub symbol is placed at PoolVAddr + StubTextOffset in the pool's

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -413,7 +413,6 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
           << S.Cpu << "'.\n";
     return S;
   }
-
   S.Valid = true;
   return S;
 }

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -34,6 +34,11 @@ namespace hotswap {
 
 namespace {
 
+uint32_t failRequiredFp8Patch(PatchContext &Ctx) {
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -282,42 +287,54 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   const MCInst &Inst = DI.Inst;
   const VOP3Fp8TwoSrcLayout &L = TwoSrcFp8Layout;
 
+  if (DI.Size != 8 && DI.Size != 12) {
+    log() << "hotswap: error: cvt_pk_fp8_f32: unexpected inst size " << DI.Size
+          << " at offset 0x" << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
+
   if (Inst.getNumOperands() < L.NumOperands) {
     log() << "hotswap: error: cvt_pk_fp8_f32: operand count mismatch: "
           << "expected " << L.NumOperands << ", got " << Inst.getNumOperands()
           << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   if (!Inst.getOperand(L.Clamp).isImm() ||
-      Inst.getOperand(L.Clamp).getImm() == 0)
-    return 0;
-
-  if (DI.Size != 8 && DI.Size != 12) {
-    log() << "hotswap: error: cvt_pk_fp8_f32: unexpected inst size " << DI.Size
-          << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+      (Inst.getOperand(L.Clamp).getImm() != 0 &&
+       Inst.getOperand(L.Clamp).getImm() != 1)) {
+    log() << "hotswap: error: cvt_pk_fp8_f32: malformed CLAMP operand at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
   }
+  if (Inst.getOperand(L.Clamp).getImm() == 0)
+    return 0;
 
   // OPSEL[3] (write-high) is folded into src0_mods by the disassembler.
   // SISrcMods encodes OP_SEL_1 at bit 3 (value 8).
-  unsigned Src0Mods = Inst.getOperand(L.Src0Mods).isImm()
-                          ? Inst.getOperand(L.Src0Mods).getImm()
-                          : 0;
+  if (!Inst.getOperand(L.Src0Mods).isImm() ||
+      !Inst.getOperand(L.Src1Mods).isImm() ||
+      !Inst.getOperand(L.VDstIn).isReg() ||
+      !Inst.getOperand(L.VDst).isReg() ||
+      Inst.getOperand(L.VDstIn).getReg() !=
+          Inst.getOperand(L.VDst).getReg()) {
+    log() << "hotswap: error: cvt_pk_fp8_f32: malformed modifier or tied "
+             "destination operand at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
+  unsigned Src0Mods = Inst.getOperand(L.Src0Mods).getImm();
   bool WriteHigh = (Src0Mods >> 3) & 1;
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  if (!Inst.getOperand(L.VDst).isReg() ||
-      !isRegOrImm(Inst.getOperand(L.Src0)) ||
+  if (!isRegOrImm(Inst.getOperand(L.Src0)) ||
       !isRegOrImm(Inst.getOperand(L.Src1))) {
     log() << "hotswap: error: cvt_pk_fp8_f32: unexpected imm operand at 0x"
           << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
   std::string VdstStr = toAsmRegName(MRI, Inst.getOperand(L.VDst).getReg());
-  unsigned Src1Mods = Inst.getOperand(L.Src1Mods).isImm()
-                          ? Inst.getOperand(L.Src1Mods).getImm()
-                          : 0;
+  unsigned Src1Mods = Inst.getOperand(L.Src1Mods).getImm();
 
   ScratchAllocation SA = allocateScratch(Ctx, Idx);
 
@@ -330,7 +347,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   if (!T0 || !T1 || !T2 || !T3) {
     log() << "hotswap: error: cvt_pk_fp8_f32: unable to allocate 4 scratch "
           << "VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   std::string T0Name = vgprName(*T0);
@@ -345,7 +362,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   if (!NaN0Sgpr || !NaN1Sgpr || !TopSgpr || !VccSaveSgpr) {
     log() << "hotswap: error: cvt_pk_fp8_f32: unable to allocate 4 scratch "
           << "SGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   std::string NaN0Name = sgprName(*NaN0Sgpr);
@@ -369,7 +386,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
       !materializeF32Source(AsmOS, Inst.getOperand(L.Src1), Src1Mods, T1Name,
                             MRI, DI.Offset, "cvt_pk_fp8_f32", Src1Bare,
                             Src1Str))
-    return 0;
+    return failRequiredFp8Patch(Ctx);
 
   // --- src0 to byte in T0 (scratch: T2) ---
   emitF32ToUE5M3(AsmOS, Src0Str, Src0Bare, T0Name, T2Name, T3Name, NaN0Name,
@@ -400,7 +417,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   if (ReplacementBytes.empty()) {
     log() << "hotswap: error: cvt_pk_fp8_f32: assembly failed for "
           << "replacement at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
@@ -410,7 +427,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
     return 0;
 
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
-    return 0;
+    return failRequiredFp8Patch(Ctx);
 
   if (!SA.KernelName.empty()) {
     KernelPatchStats &Stats = Ctx.KernelStats[SA.KernelName];
@@ -454,7 +471,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   if (DI.Size != 8) {
     log() << "hotswap: error: cvt_sr_fp8_f32: unexpected inst size " << DI.Size
           << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   const MCInst &Inst = DI.Inst;
@@ -464,11 +481,17 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
     log() << "hotswap: error: cvt_sr_fp8_f32: operand count mismatch: "
           << "expected " << L.NumOperands << ", got " << Inst.getNumOperands()
           << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   if (!Inst.getOperand(L.Clamp).isImm() ||
-      Inst.getOperand(L.Clamp).getImm() == 0)
+      (Inst.getOperand(L.Clamp).getImm() != 0 &&
+       Inst.getOperand(L.Clamp).getImm() != 1)) {
+    log() << "hotswap: error: cvt_sr_fp8_f32: malformed CLAMP operand at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
+  if (Inst.getOperand(L.Clamp).getImm() == 0)
     return 0;
 
   // byte_sel = OPSEL[3:2] in the VOP3 dword-0 encoding (bits [13:12]).
@@ -478,16 +501,23 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   const uint8_t *Raw = Ctx.Text + DI.Offset;
   unsigned ByteSel = (Raw[1] >> 5) & 0x3;
 
-  unsigned Src0Mods = Inst.getOperand(L.Src0Mods).isImm()
-                          ? Inst.getOperand(L.Src0Mods).getImm()
-                          : 0;
+  if (!Inst.getOperand(L.Src0Mods).isImm() ||
+      !Inst.getOperand(L.VDstIn).isReg() ||
+      !Inst.getOperand(L.VDst).isReg() ||
+      Inst.getOperand(L.VDstIn).getReg() !=
+          Inst.getOperand(L.VDst).getReg()) {
+    log() << "hotswap: error: cvt_sr_fp8_f32: malformed modifier or tied "
+             "destination operand at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
+  unsigned Src0Mods = Inst.getOperand(L.Src0Mods).getImm();
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  if (!Inst.getOperand(L.VDst).isReg() || !Inst.getOperand(L.Src0).isReg() ||
-      !Inst.getOperand(L.Src1).isReg()) {
+  if (!Inst.getOperand(L.Src0).isReg() || !Inst.getOperand(L.Src1).isReg()) {
     log() << "hotswap: error: cvt_sr_fp8_f32: unexpected imm operand at 0x"
           << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
   std::string VdstStr = toAsmRegName(MRI, Inst.getOperand(L.VDst).getReg());
   std::string Src0Bare = toAsmRegName(MRI, Inst.getOperand(L.Src0).getReg());
@@ -507,7 +537,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   if (!Out || !Tmp || !TopByte) {
     log() << "hotswap: error: cvt_sr_fp8_f32: unable to allocate 3 scratch "
           << "VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   std::string OutName = vgprName(*Out);
@@ -520,7 +550,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   if (!NaNSgpr || !TopSgpr || !VccSaveSgpr) {
     log() << "hotswap: error: cvt_sr_fp8_f32: unable to allocate 3 scratch "
           << "SGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   std::string NaNName = sgprName(*NaNSgpr);
@@ -598,7 +628,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   if (ReplacementBytes.empty()) {
     log() << "hotswap: error: cvt_sr_fp8_f32: assembly failed for "
           << "replacement at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
@@ -608,7 +638,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
     return 0;
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
-    return 0;
+    return failRequiredFp8Patch(Ctx);
 
   if (!SA.KernelName.empty()) {
     KernelPatchStats &Stats = Ctx.KernelStats[SA.KernelName];
@@ -652,32 +682,48 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
 uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
   // VOP1 (4 bytes) has no CLAMP bit; only VOP3 (8 bytes) needs patching.
-  if (DI.Size != 8)
+  if (DI.Size == 4)
     return 0;
+  if (DI.Size != 8) {
+    log() << "hotswap: error: cvt_f32_fp8: unexpected inst size " << DI.Size
+          << " at offset 0x" << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
 
   const MCInst &Inst = DI.Inst;
   const VOP3Fp8UnpackLayout &L = UnpackFp8Layout;
 
-  if (Inst.getNumOperands() < L.NumOperands) {
+  if (Inst.getNumOperands() != L.NumOperands) {
     log() << "hotswap: error: cvt_f32_fp8: operand count mismatch: "
           << "expected " << L.NumOperands << ", got " << Inst.getNumOperands()
           << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   if (!Inst.getOperand(L.Clamp).isImm() ||
-      Inst.getOperand(L.Clamp).getImm() == 0)
+      (Inst.getOperand(L.Clamp).getImm() != 0 &&
+       Inst.getOperand(L.Clamp).getImm() != 1)) {
+    log() << "hotswap: error: cvt_f32_fp8: malformed CLAMP operand at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
+  if (Inst.getOperand(L.Clamp).getImm() == 0)
     return 0;
 
-  unsigned ByteSel = Inst.getOperand(L.ByteSel).isImm()
-                         ? Inst.getOperand(L.ByteSel).getImm()
-                         : 0;
+  if (!Inst.getOperand(L.ByteSel).isImm() ||
+      Inst.getOperand(L.ByteSel).getImm() < 0 ||
+      Inst.getOperand(L.ByteSel).getImm() > 3) {
+    log() << "hotswap: error: cvt_f32_fp8: malformed byte_sel at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return failRequiredFp8Patch(Ctx);
+  }
+  unsigned ByteSel = Inst.getOperand(L.ByteSel).getImm();
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
   if (!Inst.getOperand(L.VDst).isReg() || !Inst.getOperand(L.Src0).isReg()) {
     log() << "hotswap: error: cvt_f32_fp8: unexpected imm operand at 0x"
           << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
   std::string VdstStr = toAsmRegName(MRI, Inst.getOperand(L.VDst).getReg());
   std::string Src0Str = toAsmRegName(MRI, Inst.getOperand(L.Src0).getReg());
@@ -691,7 +737,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   if (!Out || !Tmp) {
     log() << "hotswap: error: cvt_f32_fp8: unable to allocate 2 scratch "
           << "VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   std::string OutName = vgprName(*Out);
@@ -703,7 +749,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   if (!NaNSgpr || !Exp31Sgpr || !VccSaveSgpr) {
     log() << "hotswap: error: cvt_f32_fp8: unable to allocate 3 scratch "
           << "SGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   std::string NaNName = sgprName(*NaNSgpr);
@@ -767,7 +813,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   if (ReplacementBytes.empty()) {
     log() << "hotswap: error: cvt_f32_fp8: assembly failed for "
           << "replacement at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredFp8Patch(Ctx);
   }
 
   unsigned ExtraV = SA.VgprAlloc.extraVgprsNeeded();
@@ -777,7 +823,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
     return 0;
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
-    return 0;
+    return failRequiredFp8Patch(Ctx);
 
   if (!SA.KernelName.empty()) {
     KernelPatchStats &Stats = Ctx.KernelStats[SA.KernelName];

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -12,6 +12,7 @@
 ///   - s_clause                 -> s_nop 0
 ///   - cluster_load             -> global_load    (opcode swap via MCInst +
 ///                                                 MCCodeEmitter)
+///   - unsafe s_clause          -> s_nop          (byte-level overwrite)
 ///   - s_barrier_signal_isfirst -> s_barrier_signal
 ///                                                (opcode swap; same operand
 ///                                                 layout, drops SCC write)
@@ -22,18 +23,30 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
 namespace {
+
+uint32_t failRequiredInPlacePatch(PatchContext &Ctx, StringRef Mnemonic,
+                                  uint64_t Offset) {
+  log() << "hotswap: error: required in-place patch for " << Mnemonic
+        << " failed at 0x" << utohexstr(Offset) << "\n";
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
 
 /// Map a B0-only cluster_load mnemonic to the assembly string of its
 /// A0-compatible global_load equivalent (with a dummy operand to resolve
@@ -112,19 +125,657 @@ bool swapOpcode(InternalDecodedInst &DI, uint8_t *Text, const LLVMState &LS,
   return true;
 }
 
+enum class ClauseScope { CU, SE, Device, System };
+enum class ClauseFamily { VMEM, Flat, SMEM };
+
+std::optional<ClauseFamily> getClauseFamily(StringRef Mnemonic) {
+  if (Mnemonic.starts_with("buffer_") || Mnemonic.starts_with("tbuffer_") ||
+      Mnemonic.starts_with("global_") || Mnemonic.starts_with("scratch_") ||
+      Mnemonic.starts_with("image_") || Mnemonic.starts_with("cluster_") ||
+      Mnemonic.starts_with("tensor_"))
+    return ClauseFamily::VMEM;
+  if (Mnemonic.starts_with("flat_"))
+    return ClauseFamily::Flat;
+  if (Mnemonic.starts_with("s_load") || Mnemonic.starts_with("s_buffer_load"))
+    return ClauseFamily::SMEM;
+  return std::nullopt;
+}
+
+std::optional<ClauseFamily> getClauseFamily(const InternalDecodedInst &DI,
+                                            const LLVMState &LS) {
+  // Some GLOBAL_WB encodings do not have a stable printed mnemonic, but they
+  // are unclaused VMEM operations and therefore establish the entry workaround.
+  if (DI.Inst.getOpcode() == LS.GlobalWbOpcode)
+    return ClauseFamily::VMEM;
+  return getClauseFamily(DI.Mnemonic);
+}
+
+std::optional<ClauseScope> getClauseScope(const MCInst &Inst,
+                                          const LLVMState &LS) {
+  if (!LS.MCIP)
+    return std::nullopt;
+
+  SmallString<256> PrintedBuf;
+  raw_svector_ostream OS(PrintedBuf);
+  LS.MCIP->printInst(&Inst, /*Address=*/0, /*Annot=*/"", *LS.STI, OS);
+  StringRef Printed(PrintedBuf);
+  constexpr StringLiteral ScopePrefix("scope:");
+  size_t ScopePos = Printed.find(ScopePrefix);
+  if (ScopePos == StringRef::npos)
+    return ClauseScope::CU;
+
+  StringRef Scope = Printed.drop_front(ScopePos + ScopePrefix.size());
+  Scope = Scope.take_while([](char C) { return llvm::isAlnum(C) || C == '_'; });
+  return StringSwitch<std::optional<ClauseScope>>(Scope)
+      .Case("SCOPE_CU", ClauseScope::CU)
+      .Case("SCOPE_SE", ClauseScope::SE)
+      .Case("SCOPE_DEV", ClauseScope::Device)
+      .Case("SCOPE_SYS", ClauseScope::System)
+      .Default(std::nullopt);
+}
+
+/// Retain a hard clause only when its complete encoded membership is known,
+/// all non-NOP members are memory operations from one instruction family and
+/// cache scope, and no member needs a relocating rewrite.
+bool clauseHasUniformScope(const PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &Clause = Ctx.Decoded[Idx];
+  if (Clause.Inst.getNumOperands() == 0 || !Clause.Inst.getOperand(0).isImm())
+    return false;
+
+  const uint64_t MemberCount =
+      (static_cast<uint64_t>(Clause.Inst.getOperand(0).getImm()) & 63) + 1;
+  if (MemberCount > 63 || MemberCount > Ctx.Decoded.size() - Idx - 1)
+    return false;
+
+  std::optional<ClauseScope> Scope;
+  std::optional<ClauseFamily> Family;
+  bool SawMemory = false;
+  for (size_t I = Idx + 1; I <= Idx + MemberCount; ++I) {
+    const InternalDecodedInst &Member = Ctx.Decoded[I];
+    if (Member.Inst.getOpcode() == Ctx.LS.SNopOpcode)
+      continue;
+
+    if (requiresIndependentInstructionRewrite(Ctx, I)) {
+      const StringRef Mnemonic(Member.Mnemonic);
+      const bool WillBeRewrittenInPlace =
+          !getClusterLoadReplacementAsm(Mnemonic).empty() &&
+          !usesSgprBaseAddress(Member.Inst, *Ctx.LS.MRI);
+      if (!WillBeRewrittenInPlace)
+        return false;
+    }
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(Member.Inst.getOpcode());
+    if (!Desc.mayLoad() && !Desc.mayStore())
+      return false;
+
+    std::optional<ClauseFamily> MemberFamily = getClauseFamily(Member, Ctx.LS);
+    if (!MemberFamily || (Family && *Family != *MemberFamily))
+      return false;
+    Family = MemberFamily;
+
+    std::optional<ClauseScope> MemberScope =
+        getClauseScope(Member.Inst, Ctx.LS);
+    if (!MemberScope || (Scope && *Scope != *MemberScope))
+      return false;
+    Scope = MemberScope;
+    SawMemory = true;
+  }
+  return SawMemory;
+}
+
+bool clauseContainsVmem(ArrayRef<InternalDecodedInst> Decoded, size_t Idx,
+                        const LLVMState &LS) {
+  const InternalDecodedInst &Clause = Decoded[Idx];
+  if (Clause.Inst.getNumOperands() == 0 || !Clause.Inst.getOperand(0).isImm())
+    return false;
+
+  const uint64_t MemberCount =
+      (static_cast<uint64_t>(Clause.Inst.getOperand(0).getImm()) & 63) + 1;
+  if (MemberCount > 63 || MemberCount > Decoded.size() - Idx - 1)
+    return false;
+
+  for (size_t I = Idx + 1; I <= Idx + MemberCount; ++I) {
+    std::optional<ClauseFamily> Family = getClauseFamily(Decoded[I], LS);
+    if (Family == ClauseFamily::VMEM || Family == ClauseFamily::Flat)
+      return true;
+  }
+  return false;
+}
+
+bool isVmemOrFlat(const InternalDecodedInst &DI, const LLVMState &LS) {
+  std::optional<ClauseFamily> Family = getClauseFamily(DI, LS);
+  return Family == ClauseFamily::VMEM || Family == ClauseFamily::Flat;
+}
+
+void addCfgEdge(unsigned From, unsigned To,
+                std::vector<SmallVector<unsigned, 2>> &Successors,
+                std::vector<SmallVector<unsigned, 2>> &Predecessors) {
+  if (llvm::is_contained(Successors[From], To))
+    return;
+  Successors[From].push_back(To);
+  Predecessors[To].push_back(From);
+}
+
+std::optional<uint64_t> applySignedPcDelta(uint64_t CapturedPc, int64_t Delta) {
+  if (Delta >= 0)
+    return checkedAddUint64(CapturedPc, static_cast<uint64_t>(Delta),
+                            "HotSwap set-PC target");
+  const uint64_t Magnitude = Delta == std::numeric_limits<int64_t>::min()
+                                 ? uint64_t{1} << 63
+                                 : static_cast<uint64_t>(-Delta);
+  if (CapturedPc < Magnitude)
+    return std::nullopt;
+  return CapturedPc - Magnitude;
+}
+
+std::optional<std::pair<MCRegister, int64_t>>
+getHotswapAddSetPc(ArrayRef<InternalDecodedInst> Decoded,
+                   size_t SetPcGlobalIndex) {
+  if (SetPcGlobalIndex == 0 || SetPcGlobalIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Add = Decoded[SetPcGlobalIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcGlobalIndex];
+  if (Add.Mnemonic != "s_add_nc_u64" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      Add.Offset > std::numeric_limits<uint64_t>::max() - Add.Size ||
+      Add.Offset + Add.Size != SetPc.Offset || Add.Inst.getNumOperands() != 3 ||
+      SetPc.Inst.getNumOperands() != 1 || !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() || !Add.Inst.getOperand(2).isImm() ||
+      !SetPc.Inst.getOperand(0).isReg())
+    return std::nullopt;
+
+  MCRegister Pair = Add.Inst.getOperand(0).getReg();
+  if (!Pair.isValid() || Add.Inst.getOperand(1).getReg() != Pair.id() ||
+      SetPc.Inst.getOperand(0).getReg() != Pair.id())
+    return std::nullopt;
+  return std::pair<MCRegister, int64_t>{Pair, Add.Inst.getOperand(2).getImm()};
+}
+
+std::optional<uint64_t>
+resolveContiguousHotswapSetPcTarget(ArrayRef<InternalDecodedInst> Decoded,
+                                    size_t SetPcGlobalIndex) {
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getHotswapAddSetPc(Decoded, SetPcGlobalIndex);
+  if (!AddSet || SetPcGlobalIndex < 2)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[SetPcGlobalIndex - 2];
+  const InternalDecodedInst &Add = Decoded[SetPcGlobalIndex - 1];
+  if (GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size ||
+      GetPc.Offset + GetPc.Size != Add.Offset ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id())
+    return std::nullopt;
+  return applySignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+}
+
+std::optional<size_t>
+findDecodedIndexAtOffset(ArrayRef<InternalDecodedInst> Decoded,
+                         uint64_t Offset) {
+  auto It = llvm::lower_bound(Decoded, Offset,
+                              [](const InternalDecodedInst &DI,
+                                 uint64_t Value) { return DI.Offset < Value; });
+  if (It == Decoded.end() || It->Offset != Offset)
+    return std::nullopt;
+  return It - Decoded.begin();
+}
+
+std::optional<uint64_t>
+resolveHotswapSetPcTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                          uint64_t SetPcOffset) {
+  std::optional<size_t> Index =
+      findDecodedIndexAtOffset(AllDecoded, SetPcOffset);
+  if (!Index)
+    return std::nullopt;
+  return resolveContiguousHotswapSetPcTarget(AllDecoded, *Index);
+}
+
+/// Resolve a get-PC/s_branch relay whose add/set-PC pair is in another
+/// executable section. The displacement still uses the PC captured at source.
+std::optional<uint64_t>
+resolveHotswapRelayTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                          const InternalDecodedInst &GetPc,
+                          uint64_t RelayOffset) {
+  std::optional<size_t> AddIndex =
+      findDecodedIndexAtOffset(AllDecoded, RelayOffset);
+  if (!AddIndex || *AddIndex + 1 >= AllDecoded.size())
+    return std::nullopt;
+  const size_t SetPcIndex = *AddIndex + 1;
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getHotswapAddSetPc(AllDecoded, SetPcIndex);
+  if (!AddSet || GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id() ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size)
+    return std::nullopt;
+  return applySignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+}
+
+struct HotswapTrampolineResume {
+  uint64_t Offset = 0;
+  bool HasVmem = false;
+};
+
+std::optional<HotswapTrampolineResume>
+findHotswapTrampolineResume(ArrayRef<InternalDecodedInst> Decoded,
+                            uint64_t Target, const KernelTextRange &Range,
+                            const LLVMState &LS) {
+  if (!LS.MIA)
+    return std::nullopt;
+
+  size_t RemainingInstructions = Decoded.size();
+  bool HasVmem = false;
+  DenseSet<uint64_t> VisitedOffsets;
+  while (RemainingInstructions != 0) {
+    auto It = llvm::lower_bound(
+        Decoded, Target, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (It == Decoded.end() || It->Offset != Target)
+      return std::nullopt;
+
+    uint64_t ExpectedOffset = Target;
+    bool FollowedHop = false;
+    for (; It != Decoded.end(); ++It) {
+      if (RemainingInstructions == 0)
+        return std::nullopt;
+      --RemainingInstructions;
+      if (!VisitedOffsets.insert(It->Offset).second ||
+          It->Offset != ExpectedOffset || It->Size == 0 ||
+          It->Offset > std::numeric_limits<uint64_t>::max() - It->Size)
+        return std::nullopt;
+      ExpectedOffset = It->Offset + It->Size;
+      const size_t GlobalIndex = It - Decoded.begin();
+      if (It->Mnemonic == "<unknown>")
+        return std::nullopt;
+      HasVmem |= isVmemOrFlat(*It, LS);
+
+      if (It->Mnemonic == "s_set_pc_i64") {
+        std::optional<uint64_t> Next =
+            resolveContiguousHotswapSetPcTarget(Decoded, GlobalIndex);
+        if (!Next)
+          return std::nullopt;
+        if (*Next >= Range.Begin && *Next < Range.End)
+          return HotswapTrampolineResume{*Next, HasVmem};
+        Target = *Next;
+        FollowedHop = true;
+        break;
+      }
+
+      const MCInstrDesc &Desc = LS.MCII->get(It->Inst.getOpcode());
+      const bool IsCall = LS.MIA->isCall(It->Inst);
+      const bool IsReturn = LS.MIA->isReturn(It->Inst);
+      const bool IsBranch = LS.MIA->isBranch(It->Inst);
+      if (IsCall || IsReturn || Desc.isTrap())
+        return std::nullopt;
+      if (IsBranch) {
+        uint64_t Next = 0;
+        if (!LS.MIA->isUnconditionalBranch(It->Inst) ||
+            LS.MIA->isIndirectBranch(It->Inst) ||
+            !LS.MIA->evaluateBranch(It->Inst, It->Offset, It->Size, Next))
+          return std::nullopt;
+        if (Next >= Range.Begin && Next < Range.End)
+          return HotswapTrampolineResume{Next, HasVmem};
+        Target = Next;
+        FollowedHop = true;
+        break;
+      }
+      if (Desc.isTerminator() ||
+          LS.MIA->mayAffectControlFlow(It->Inst, *LS.MRI))
+        return std::nullopt;
+    }
+    if (!FollowedHop)
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+/// Analyze one descriptor-backed kernel range. Unknown control flow is modeled
+/// as reaching every instruction in the range, so a prior-VMEM fact is retained
+/// only when every modeled path proves it.
+void analyzeKernelRange(ArrayRef<InternalDecodedInst> Decoded,
+                        ArrayRef<InternalDecodedInst> AllDecoded,
+                        const KernelTextRange &Range, const LLVMState &LS,
+                        InitialVmemMustAnalysis &Result) {
+  SmallVector<size_t> GlobalIndices;
+  auto First = llvm::lower_bound(
+      Decoded, Range.Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto Last = llvm::lower_bound(
+      Decoded, Range.End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  for (auto It = First; It != Last; ++It)
+    GlobalIndices.push_back(It - Decoded.begin());
+  if (GlobalIndices.empty())
+    return;
+
+  for (size_t GlobalIdx : GlobalIndices)
+    Result.DescriptorCovered.set(GlobalIdx);
+
+  auto MergeConservativeRange = [&] {
+    for (size_t GlobalIdx : GlobalIndices) {
+      Result.Reachable.set(GlobalIdx);
+      Result.MustHavePriorVmem.reset(GlobalIdx);
+    }
+  };
+  if (Decoded[GlobalIndices.front()].Offset != Range.Begin ||
+      Range.HasArbitraryIndirectIngress) {
+    MergeConservativeRange();
+    return;
+  }
+
+  const unsigned Count = GlobalIndices.size();
+  DenseMap<uint64_t, unsigned> OffsetToLocal;
+  for (unsigned I = 0; I < Count; ++I)
+    OffsetToLocal.try_emplace(Decoded[GlobalIndices[I]].Offset, I);
+
+  BitVector EntryNodes(Count);
+  for (uint64_t Entry : Range.Entries) {
+    auto It = OffsetToLocal.find(Entry);
+    if (It == OffsetToLocal.end()) {
+      MergeConservativeRange();
+      return;
+    }
+    EntryNodes.set(It->second);
+  }
+  if (EntryNodes.none()) {
+    MergeConservativeRange();
+    return;
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  std::vector<SmallVector<unsigned, 2>> Predecessors(Count);
+  BitVector UnknownSuccessors(Count);
+  BitVector IsVmem(Count);
+  SmallVector<unsigned> HotswapSetPcCandidates;
+
+  for (unsigned I = 0; I < Count; ++I) {
+    const InternalDecodedInst &DI = Decoded[GlobalIndices[I]];
+    if (isVmemOrFlat(DI, LS))
+      IsVmem.set(I);
+
+    const bool HasFallthrough = I + 1 < Count;
+    if (DI.Mnemonic == "<unknown>") {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsCall = LS.MIA ? LS.MIA->isCall(DI.Inst) : Desc.isCall();
+    const bool IsReturn = LS.MIA ? LS.MIA->isReturn(DI.Inst) : Desc.isReturn();
+    const bool IsBranch = LS.MIA ? LS.MIA->isBranch(DI.Inst) : Desc.isBranch();
+    if (IsReturn)
+      continue;
+
+    // A debug trap can resume at the following instruction.
+    if (Desc.isTrap()) {
+      if (HasFallthrough)
+        addCfgEdge(I, I + 1, Successors, Predecessors);
+      continue;
+    }
+
+    if (IsCall) {
+      if (!Desc.isTerminator() && HasFallthrough)
+        addCfgEdge(I, I + 1, Successors, Predecessors);
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      HotswapSetPcCandidates.push_back(I);
+      continue;
+    }
+
+    if (IsBranch) {
+      const bool IsIndirect =
+          LS.MIA ? LS.MIA->isIndirectBranch(DI.Inst) : Desc.isIndirectBranch();
+      const bool IsConditional = LS.MIA ? LS.MIA->isConditionalBranch(DI.Inst)
+                                        : Desc.isConditionalBranch();
+      const bool IsUnconditional = LS.MIA
+                                       ? LS.MIA->isUnconditionalBranch(DI.Inst)
+                                       : Desc.isUnconditionalBranch();
+
+      bool TargetKnown = false;
+      if (!IsIndirect && LS.MIA) {
+        uint64_t Target = 0;
+        if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+          TargetKnown = true;
+          if (Target >= Range.Begin && Target < Range.End) {
+            auto TargetIt = OffsetToLocal.find(Target);
+            if (TargetIt == OffsetToLocal.end()) {
+              UnknownSuccessors.set(I);
+              TargetKnown = false;
+            } else {
+              addCfgEdge(I, TargetIt->second, Successors, Predecessors);
+            }
+          } else if (IsUnconditional) {
+            std::optional<HotswapTrampolineResume> Resume =
+                findHotswapTrampolineResume(AllDecoded, Target, Range, LS);
+            if (!Resume && I != 0 && DI.Mnemonic == "s_branch") {
+              const InternalDecodedInst &GetPc = Decoded[GlobalIndices[I - 1]];
+              if (GetPc.Offset <=
+                      std::numeric_limits<uint64_t>::max() - GetPc.Size &&
+                  GetPc.Offset + GetPc.Size == DI.Offset &&
+                  GetPc.Mnemonic == "s_get_pc_i64") {
+                std::optional<uint64_t> PoolTarget =
+                    resolveHotswapRelayTarget(AllDecoded, GetPc, Target);
+                if (PoolTarget)
+                  Resume = findHotswapTrampolineResume(AllDecoded, *PoolTarget,
+                                                       Range, LS);
+              }
+            }
+            if (Resume) {
+              auto ResumeIt = OffsetToLocal.find(Resume->Offset);
+              if (ResumeIt == OffsetToLocal.end()) {
+                UnknownSuccessors.set(I);
+                TargetKnown = false;
+              } else {
+                addCfgEdge(I, ResumeIt->second, Successors, Predecessors);
+                if (Resume->HasVmem)
+                  IsVmem.set(I);
+              }
+            } else {
+              UnknownSuccessors.set(I);
+              TargetKnown = false;
+            }
+          }
+        }
+      }
+      if (!TargetKnown)
+        UnknownSuccessors.set(I);
+
+      if (IsConditional && HasFallthrough)
+        addCfgEdge(I, I + 1, Successors, Predecessors);
+      else if (!IsConditional && !IsUnconditional)
+        UnknownSuccessors.set(I);
+      continue;
+    }
+
+    if (Desc.isTerminator())
+      continue;
+    if (LS.MIA && LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (HasFallthrough)
+      addCfgEdge(I, I + 1, Successors, Predecessors);
+  }
+
+  for (unsigned I : HotswapSetPcCandidates) {
+    const InternalDecodedInst &SetPc = Decoded[GlobalIndices[I]];
+    std::optional<uint64_t> Target =
+        resolveHotswapSetPcTarget(AllDecoded, SetPc.Offset);
+    if (!Target) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (*Target >= Range.Begin && *Target < Range.End) {
+      auto TargetIt = OffsetToLocal.find(*Target);
+      if (TargetIt == OffsetToLocal.end())
+        UnknownSuccessors.set(I);
+      else
+        addCfgEdge(I, TargetIt->second, Successors, Predecessors);
+      continue;
+    }
+
+    std::optional<HotswapTrampolineResume> Resume =
+        findHotswapTrampolineResume(AllDecoded, *Target, Range, LS);
+    if (!Resume) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    auto ResumeIt = OffsetToLocal.find(Resume->Offset);
+    if (ResumeIt == OffsetToLocal.end()) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    addCfgEdge(I, ResumeIt->second, Successors, Predecessors);
+    if (Resume->HasVmem)
+      IsVmem.set(I);
+  }
+
+  BitVector Reachable(Count);
+  SmallVector<unsigned> Worklist;
+  for (int Entry = EntryNodes.find_first(); Entry != -1;
+       Entry = EntryNodes.find_next(Entry)) {
+    Reachable.set(Entry);
+    Worklist.push_back(Entry);
+  }
+  for (size_t Next = 0; Next < Worklist.size(); ++Next) {
+    const unsigned I = Worklist[Next];
+    if (UnknownSuccessors.test(I)) {
+      Reachable.set();
+      break;
+    }
+    for (unsigned Target : Successors[I]) {
+      if (!Reachable.test(Target)) {
+        Reachable.set(Target);
+        Worklist.push_back(Target);
+      }
+    }
+  }
+
+  SmallVector<uint8_t> MustIn(Count, 1);
+  SmallVector<uint8_t> MustOut(Count, 1);
+  for (int Entry = EntryNodes.find_first(); Entry != -1;
+       Entry = EntryNodes.find_next(Entry)) {
+    MustIn[Entry] = 0;
+    MustOut[Entry] = IsVmem.test(Entry);
+  }
+
+  bool Changed = true;
+  while (Changed) {
+    Changed = false;
+    bool HasReachableUnknown = false;
+    bool UnknownMustOut = true;
+    for (int Pred = UnknownSuccessors.find_first(); Pred != -1;
+         Pred = UnknownSuccessors.find_next(Pred)) {
+      if (!Reachable.test(Pred))
+        continue;
+      HasReachableUnknown = true;
+      UnknownMustOut &= MustOut[Pred] != 0;
+    }
+
+    for (unsigned I = 0; I < Count; ++I) {
+      if (!Reachable.test(I))
+        continue;
+      bool NewIn = !EntryNodes.test(I);
+      bool SawPredecessor = EntryNodes.test(I);
+      if (!EntryNodes.test(I)) {
+        for (unsigned Pred : Predecessors[I]) {
+          if (!Reachable.test(Pred))
+            continue;
+          SawPredecessor = true;
+          NewIn &= MustOut[Pred] != 0;
+        }
+        if (HasReachableUnknown) {
+          SawPredecessor = true;
+          NewIn &= UnknownMustOut;
+        }
+        if (!SawPredecessor)
+          NewIn = false;
+      }
+      const bool NewOut = NewIn || IsVmem.test(I);
+      if (MustIn[I] != NewIn || MustOut[I] != NewOut) {
+        MustIn[I] = NewIn;
+        MustOut[I] = NewOut;
+        Changed = true;
+      }
+    }
+  }
+
+  for (unsigned I = 0; I < Count; ++I) {
+    if (!Reachable.test(I))
+      continue;
+    const size_t GlobalIdx = GlobalIndices[I];
+    if (Result.Reachable.test(GlobalIdx)) {
+      if (!MustIn[I])
+        Result.MustHavePriorVmem.reset(GlobalIdx);
+    } else {
+      Result.Reachable.set(GlobalIdx);
+      if (MustIn[I])
+        Result.MustHavePriorVmem.set(GlobalIdx);
+      else
+        Result.MustHavePriorVmem.reset(GlobalIdx);
+    }
+  }
+}
+
+bool isInitialVmemClause(const PatchContext &Ctx, size_t Idx) {
+  if (!clauseContainsVmem(Ctx.Decoded, Idx, Ctx.LS))
+    return false;
+  if (!Ctx.InitialVmemAnalysis ||
+      Idx >= Ctx.InitialVmemAnalysis->DescriptorCovered.size() ||
+      !Ctx.InitialVmemAnalysis->DescriptorCovered.test(Idx))
+    return true;
+  if (!Ctx.InitialVmemAnalysis->Reachable.test(Idx))
+    return false;
+  return !Ctx.InitialVmemAnalysis->MustHavePriorVmem.test(Idx);
+}
+
+void releaseClauseMemberRelocationProtection(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &Clause = Ctx.Decoded[Idx];
+  if (Clause.Inst.getNumOperands() == 0 || !Clause.Inst.getOperand(0).isImm())
+    return;
+
+  const size_t MemberCount =
+      (static_cast<uint64_t>(Clause.Inst.getOperand(0).getImm()) & 63) + 1;
+  const size_t Available = std::min(MemberCount, Ctx.Decoded.size() - Idx - 1);
+  const size_t End = Idx + 1 + Available;
+  for (size_t I = Idx + 1; I != End; ++I) {
+    const uint64_t Offset = Ctx.Decoded[I].Offset;
+    auto It = Ctx.ClauseRelocationProtectionCounts.find(Offset);
+    if (It == Ctx.ClauseRelocationProtectionCounts.end())
+      continue;
+    if (--It->second != 0)
+      continue;
+    Ctx.ClauseRelocationProtectionCounts.erase(It);
+    if (!Ctx.NonClauseRelocationProtectedOffsets.contains(Offset))
+      Ctx.RelocationProtectedOffsets.erase(Offset);
+  }
+}
+
 } // anonymous namespace
+
+InitialVmemMustAnalysis
+computeInitialVmemMustAnalysis(ArrayRef<InternalDecodedInst> Decoded,
+                               ArrayRef<InternalDecodedInst> AllDecoded,
+                               ArrayRef<KernelTextRange> KernelRanges,
+                               const LLVMState &LS) {
+  InitialVmemMustAnalysis Result{BitVector(Decoded.size()),
+                                 BitVector(Decoded.size()),
+                                 BitVector(Decoded.size())};
+  for (const KernelTextRange &Range : KernelRanges)
+    analyzeKernelRange(Decoded, AllDecoded, Range, LS, Result);
+  return Result;
+}
 
 static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   StringRef Mnemonic(DI.Mnemonic);
-
-  if (DI.Inst.getOpcode() == Ctx.LS.SClauseOpcode) {
-    std::memcpy(Ctx.Text + DI.Offset, Ctx.LS.SNopBytes.data(),
-                Ctx.LS.SNopBytes.size());
-    log() << "hotswap: inplace: s_clause -> s_nop 0 at 0x"
-          << utohexstr(DI.Offset) << "\n";
-    return 1;
-  }
 
   StringRef ReplacementAsm = getClusterLoadReplacementAsm(Mnemonic);
   if (!ReplacementAsm.empty()) {
@@ -147,10 +798,33 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
       if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
         log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
               << " at 0x" << utohexstr(DI.Offset) << "\n";
+        Ctx.RequiredPatchApplied = true;
         S.addPatches(1);
         return 1;
       }
+      return failRequiredInPlacePatch(Ctx, Mnemonic, DI.Offset);
     }
+  }
+
+  if (DI.Inst.getOpcode() == Ctx.LS.SClauseOpcode) {
+    const bool InitialVmemClause = isInitialVmemClause(Ctx, Idx);
+    const bool UniformScope = clauseHasUniformScope(Ctx, Idx);
+
+    RewriteRule Rule;
+    Rule.ReplaceBytes.assign(Ctx.LS.SNopBytes.begin(), Ctx.LS.SNopBytes.end());
+    if (applyByteReplace(Rule, DI.Offset, DI.Size, Ctx.Text, Ctx.TextSize,
+                         Ctx.LS)) {
+      releaseClauseMemberRelocationProtection(Ctx, Idx);
+      log() << "hotswap: inplace: "
+            << (InitialVmemClause
+                    ? "initial-VMEM"
+                    : (UniformScope ? "uniform-scope"
+                                    : "mixed/unsupported-scope"))
+            << " s_clause -> s_nop 0 at 0x" << utohexstr(DI.Offset) << "\n";
+      Ctx.RequiredPatchApplied = true;
+      return 1;
+    }
+    return failRequiredInPlacePatch(Ctx, Mnemonic, DI.Offset);
   }
 
   // s_barrier_signal_isfirst -> s_barrier_signal: on A0, the isfirst
@@ -186,9 +860,11 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
     if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
       log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
+      Ctx.RequiredPatchApplied = true;
       S.addPatches(1);
       return 1;
     }
+    return failRequiredInPlacePatch(Ctx, Mnemonic, DI.Offset);
   }
 
   return 0;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -47,6 +47,7 @@ using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+
 namespace {
 
 bool failRequiredPatch(PatchContext &Ctx) {
@@ -233,46 +234,34 @@ extractDsOperands(const MCInst &Inst, StringRef FromMnem, const LLVMState &LS) {
 
 // Split a compound destination register into two formatted destination strings.
 // b32: VReg_64 -> ("v0", "v1"); b64: VReg_128 -> ("v[0:1]", "v[2:3]")
-std::optional<std::pair<std::string, std::string>>
+std::pair<std::string, std::string>
 splitDstPair(MCRegister CompoundReg, bool IsB64, const MCRegisterInfo &MRI) {
   SmallVector<MCRegister, 4> Subs = getDirectSubRegs(CompoundReg, MRI);
   if (IsB64) {
-    if (Subs.size() < 4) {
-      log() << "hotswap: error: DS b64 destination " << MRI.getName(CompoundReg)
-            << " has " << Subs.size()
-            << " direct subregisters; expected at least 4\n";
-      return std::nullopt;
-    }
-    return std::pair<std::string, std::string>{
-        fmtRegPair(MRI, Subs[0], Subs[1]), fmtRegPair(MRI, Subs[2], Subs[3])};
+    if (Subs.size() < 4)
+      return {};
+    return {fmtRegPair(MRI, Subs[0], Subs[1]),
+            fmtRegPair(MRI, Subs[2], Subs[3])};
   }
-  if (Subs.size() < 2) {
-    log() << "hotswap: error: DS b32 destination " << MRI.getName(CompoundReg)
-          << " has " << Subs.size()
-          << " direct subregisters; expected at least 2\n";
-    return std::nullopt;
-  }
-  return std::pair<std::string, std::string>{toAsmRegName(MRI, Subs[0]),
-                                             toAsmRegName(MRI, Subs[1])};
+  if (Subs.size() < 2)
+    return {};
+  return {toAsmRegName(MRI, Subs[0]), toAsmRegName(MRI, Subs[1])};
 }
 
 // Expand a DS 2-address load into two single-address loads (dst, addr).
-std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
-                                                          StringRef ToMnem) {
-  if (Ops.Regs.size() < 2) {
-    log() << "hotswap: error: " << ToMnem << " expansion found "
-          << Ops.Regs.size() << " register operands; expected at least 2\n";
-    return std::nullopt;
-  }
-  std::optional<std::pair<std::string, std::string>> Dst =
+std::vector<std::string> expandDs2AddrLoad(const DsOperands &Ops,
+                                           StringRef ToMnem) {
+  if (Ops.Regs.size() < 2)
+    return {};
+  std::pair<std::string, std::string> Dst =
       splitDstPair(Ops.Regs[0], Ops.IsB64, *Ops.MRI);
-  if (!Dst)
-    return std::nullopt;
+  if (Dst.first.empty())
+    return {};
   std::string Addr = toAsmRegName(*Ops.MRI, Ops.Regs[1]);
   std::string First =
-      ToMnem.str() + " " + Dst->first + ", " + Addr + fmtOffset(Ops.Off0);
+      ToMnem.str() + " " + Dst.first + ", " + Addr + fmtOffset(Ops.Off0);
   std::string Second =
-      ToMnem.str() + " " + Dst->second + ", " + Addr + fmtOffset(Ops.Off1);
+      ToMnem.str() + " " + Dst.second + ", " + Addr + fmtOffset(Ops.Off1);
 
   // A compound DS load reads its address once before writing either half of
   // the destination. After splitting, the first single-address load must not
@@ -286,71 +275,57 @@ std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
       ArrayRef(DstSubs).take_front(FirstHalfWidth),
       [&](MCRegister Reg) { return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]); });
   if (AddrOverlapsFirst)
-    return std::vector<std::string>{std::move(Second), std::move(First)};
-  return std::vector<std::string>{std::move(First), std::move(Second)};
+    return {std::move(Second), std::move(First)};
+  return {std::move(First), std::move(Second)};
 }
 
 // Expand a DS 2-address store into two single-address stores (addr, data).
-std::optional<std::vector<std::string>>
-expandDs2AddrStore(const DsOperands &Ops, StringRef ToMnem) {
-  if (Ops.Regs.size() < 3) {
-    log() << "hotswap: error: " << ToMnem << " expansion found "
-          << Ops.Regs.size() << " register operands; expected at least 3\n";
-    return std::nullopt;
-  }
+std::vector<std::string> expandDs2AddrStore(const DsOperands &Ops,
+                                            StringRef ToMnem) {
+  if (Ops.Regs.size() < 3)
+    return {};
   const MCRegisterInfo &MRI = *Ops.MRI;
   std::string Addr = toAsmRegName(MRI, Ops.Regs[0]);
   std::string Data0 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[1])
                                 : toAsmRegName(MRI, Ops.Regs[1]);
   std::string Data1 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[2])
                                 : toAsmRegName(MRI, Ops.Regs[2]);
-  return std::vector<std::string>{
+  return {
       ToMnem.str() + " " + Addr + ", " + Data0 + fmtOffset(Ops.Off0),
       ToMnem.str() + " " + Addr + ", " + Data1 + fmtOffset(Ops.Off1),
   };
 }
 
-bool registerSliceOverlaps(ArrayRef<MCRegister> Registers, unsigned Begin,
-                           unsigned Count, MCRegister Reg,
-                           const MCRegisterInfo &MRI) {
-  return llvm::any_of(Registers.slice(Begin, Count), [&](MCRegister DstReg) {
+// Expand a DS 2-address exchange into two single-address exchanges
+// (dst, addr, data).
+bool halfOverlaps(ArrayRef<MCRegister> DstSubs, unsigned Begin, unsigned Width,
+                  MCRegister Reg, const MCRegisterInfo &MRI) {
+  return llvm::any_of(DstSubs.slice(Begin, Width), [&](MCRegister DstReg) {
     return MRI.regsOverlap(DstReg, Reg);
   });
 }
 
-// Expand a DS 2-address exchange into two single-address exchanges
-// (dst, addr, data).
-std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
-                                                          StringRef ToMnem) {
-  if (Ops.Regs.size() < 4) {
-    log() << "hotswap: error: " << ToMnem << " expansion found "
-          << Ops.Regs.size() << " register operands; expected at least 4\n";
-    return std::nullopt;
-  }
+std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
+                                           StringRef ToMnem) {
+  if (Ops.Regs.size() < 4)
+    return {};
   const MCRegisterInfo &MRI = *Ops.MRI;
-  std::optional<std::pair<std::string, std::string>> Dst =
+  std::pair<std::string, std::string> Dst =
       splitDstPair(Ops.Regs[0], Ops.IsB64, MRI);
-  if (!Dst)
-    return std::nullopt;
+  if (Dst.first.empty())
+    return {};
   std::string Addr = toAsmRegName(MRI, Ops.Regs[1]);
   std::string Data0 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[2])
                                 : toAsmRegName(MRI, Ops.Regs[2]);
   std::string Data1 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[3])
                                 : toAsmRegName(MRI, Ops.Regs[3]);
-  std::string First = ToMnem.str() + " " + Dst->first + ", " + Addr + ", " +
+  std::string First = ToMnem.str() + " " + Dst.first + ", " + Addr + ", " +
                       Data0 + fmtOffset(Ops.Off0);
-  std::string Second = ToMnem.str() + " " + Dst->second + ", " + Addr + ", " +
+  std::string Second = ToMnem.str() + " " + Dst.second + ", " + Addr + ", " +
                        Data1 + fmtOffset(Ops.Off1);
 
   SmallVector<MCRegister, 4> DstSubs = getDirectSubRegs(Ops.Regs[0], MRI);
   const unsigned HalfWidth = Ops.IsB64 ? 2 : 1;
-  if (DstSubs.size() < 2 * HalfWidth) {
-    log() << "hotswap: error: " << ToMnem << " destination "
-          << MRI.getName(Ops.Regs[0]) << " has " << DstSubs.size()
-          << " direct subregisters; expected at least " << 2 * HalfWidth
-          << "\n";
-    return std::nullopt;
-  }
 
   // Op0 writes the first destination half and op1 still needs addr + data1;
   // op1 writes the second half and op0 still needs addr + data0. Pick the safe
@@ -358,20 +333,20 @@ std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
   // neither ordering preserves the compound instruction's read-before-write
   // semantics without a scratch VGPR, so decline the rewrite.
   const bool FirstClobbersSecond =
-      registerSliceOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[1], MRI) ||
-      registerSliceOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[3], MRI);
+      halfOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[1], MRI) ||
+      halfOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[3], MRI);
   const bool SecondClobbersFirst =
-      registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
-      registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
+      halfOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
+      halfOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
   if (FirstClobbersSecond && SecondClobbersFirst) {
     log() << "hotswap: error: ds_storexchg_2addr has cyclic "
              "destination/source overlap and cannot be split without scratch "
              "VGPRs\n";
-    return std::nullopt;
+    return {};
   }
   if (FirstClobbersSecond)
-    return std::vector<std::string>{std::move(Second), std::move(First)};
-  return std::vector<std::string>{std::move(First), std::move(Second)};
+    return {std::move(Second), std::move(First)};
+  return {std::move(First), std::move(Second)};
 }
 
 // -- expandDs2Addr ----------------------------------------------------------
@@ -379,13 +354,11 @@ std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
 // Top-level expansion: extracts operands from the decoded MCInst, computes
 // scaled offsets, then dispatches to the appropriate layout-specific helper.
 
-std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
-                                                          StringRef FromMnem,
-                                                          StringRef ToMnem,
-                                                          const LLVMState &LS) {
+std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
+                                       StringRef ToMnem, const LLVMState &LS) {
   std::optional<DsOperands> Ops = extractDsOperands(Inst, FromMnem, LS);
   if (!Ops)
-    return std::nullopt;
+    return {};
 
   // Use the trailing underscore so the three prefixes are disjoint
   // ("ds_load_", "ds_store_", "ds_storexchg_"); without it "ds_store" is a
@@ -398,7 +371,563 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
     return expandDs2AddrStore(*Ops, ToMnem);
 
   log() << "hotswap: error: unrecognized DS mnemonic: " << FromMnem << "\n";
-  return std::nullopt;
+  return {};
+}
+
+bool definesRegister(const InternalDecodedInst &DI, MCRegister Reg,
+                     const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() && LS.MRI->regsOverlap(Op.getReg(), Reg.id()))
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Implicit) {
+    return LS.MRI->regsOverlap(Implicit, Reg.id());
+  });
+}
+
+bool definesModeOrExec(const InternalDecodedInst &DI, const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  auto IsModeOrExec = [&](MCRegister Reg) {
+    StringRef Name = LS.MRI->getName(Reg.id());
+    return Name == "MODE" || Name == "EXEC" || Name == "EXEC_LO" ||
+           Name == "EXEC_HI";
+  };
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() && IsModeOrExec(MCRegister(Op.getReg())))
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Implicit) {
+    return IsModeOrExec(MCRegister(Implicit));
+  });
+}
+
+bool isAlignedConstantAddressDef(const InternalDecodedInst &DI,
+                                 MCRegister Address, unsigned Alignment,
+                                 const PatchContext &Ctx, size_t Idx,
+                                 bool RequireEqualMode = true) {
+  if (RequireEqualMode && (Idx >= Ctx.VgprMsbDstSrc0EqualBefore.size() ||
+                           !Ctx.VgprMsbDstSrc0EqualBefore.test(Idx)))
+    return false;
+  if (DI.Mnemonic == "v_add_nc_u32" && DI.Inst.getNumOperands() == 4) {
+    const MCOperand &Dst = DI.Inst.getOperand(0);
+    const MCOperand &Src0 = DI.Inst.getOperand(1);
+    const MCOperand &Src1 = DI.Inst.getOperand(2);
+    const MCOperand &Modifiers = DI.Inst.getOperand(3);
+    if (!Dst.isReg() || Dst.getReg() != Address.id() || !Src0.isImm() ||
+        !Src1.isImm() || !Modifiers.isImm() || Modifiers.getImm() != 0)
+      return false;
+    uint32_t Value = static_cast<uint32_t>(Src0.getImm()) +
+                     static_cast<uint32_t>(Src1.getImm());
+    return Alignment != 0 && Value % Alignment == 0;
+  }
+
+  if (DI.Mnemonic == "v_mov_b32" && DI.Inst.getNumOperands() == 2) {
+    const MCOperand &Dst = DI.Inst.getOperand(0);
+    if (!Dst.isReg() || Dst.getReg() != Address.id() || Alignment == 0)
+      return false;
+    std::optional<int64_t> Value = getAbsoluteOperandValue(
+        DI.Inst.getOperand(1), DI, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize));
+    return Value && static_cast<uint32_t>(*Value) % Alignment == 0;
+  }
+
+  if (DI.Mnemonic == "v_mul_lo_u32" &&
+      (DI.Inst.getNumOperands() == 3 || DI.Inst.getNumOperands() == 4)) {
+    const MCOperand &Dst = DI.Inst.getOperand(0);
+    const MCOperand &Src0 = DI.Inst.getOperand(1);
+    const MCOperand &Src1 = DI.Inst.getOperand(2);
+    if (!Dst.isReg() || Dst.getReg() != Address.id() || Alignment == 0 ||
+        (DI.Inst.getNumOperands() == 4 &&
+         (!DI.Inst.getOperand(3).isImm() ||
+          DI.Inst.getOperand(3).getImm() != 0)))
+      return false;
+    return (Src0.isImm() &&
+            static_cast<uint32_t>(Src0.getImm()) % Alignment == 0) ||
+           (Src1.isImm() &&
+            static_cast<uint32_t>(Src1.getImm()) % Alignment == 0);
+  }
+
+  if (DI.Mnemonic != "v_dual_mov_b32" || DI.Inst.getNumOperands() != 4)
+    return false;
+  for (unsigned Def = 0; Def != 2; ++Def) {
+    const MCOperand &Dst = DI.Inst.getOperand(Def);
+    const MCOperand &Src = DI.Inst.getOperand(Def + 2);
+    if (!Dst.isReg() || Dst.getReg() != Address.id())
+      continue;
+    return Alignment != 0 && Src.isImm() &&
+           static_cast<uint32_t>(Src.getImm()) % Alignment == 0;
+  }
+  return false;
+}
+
+static bool isAlignedSgprCopyAddressDef(const InternalDecodedInst &DI,
+                                        MCRegister Address, unsigned Alignment,
+                                        const PatchContext &Ctx, size_t Idx) {
+  if (Alignment == 0 || Alignment > 8 ||
+      Idx >= Ctx.VgprMsbDstSrc0EqualBefore.size() ||
+      !Ctx.VgprMsbDstSrc0EqualBefore.test(Idx) ||
+      Idx >= Ctx.VgprDef0AlignedTo8.size() ||
+      Idx >= Ctx.VgprDef1AlignedTo8.size())
+    return false;
+
+  if (DI.Mnemonic == "v_mov_b32")
+    return DI.Inst.getNumOperands() == 2 && DI.Inst.getOperand(0).isReg() &&
+           DI.Inst.getOperand(0).getReg() == Address.id() &&
+           Ctx.VgprDef0AlignedTo8.test(Idx);
+
+  if (DI.Mnemonic != "v_dual_mov_b32" || DI.Inst.getNumOperands() != 4)
+    return false;
+  for (unsigned Def = 0; Def != 2; ++Def) {
+    const MCOperand &Dst = DI.Inst.getOperand(Def);
+    if (Dst.isReg() && Dst.getReg() == Address.id())
+      return (Def == 0 ? Ctx.VgprDef0AlignedTo8 : Ctx.VgprDef1AlignedTo8)
+          .test(Idx);
+  }
+  return false;
+}
+
+static bool isAlignedAddressDef(const InternalDecodedInst &DI,
+                                MCRegister Address, unsigned Alignment,
+                                const PatchContext &Ctx, size_t Idx) {
+  return isAlignedConstantAddressDef(DI, Address, Alignment, Ctx, Idx) ||
+         isAlignedSgprCopyAddressDef(DI, Address, Alignment, Ctx, Idx);
+}
+
+/// A0 only needs the DS2 split when the effective address may be unaligned.
+/// Preserve the compact original instruction when a same-block constant or a
+/// proven aligned SGPR copy defines the address. Equality of MODE's destination
+/// and src0 bank selectors is a must-dataflow fact; unchanged MODE and EXEC
+/// then guarantee that the VALU definition and DS address name the same
+/// physical VGPRs for the same active lanes.
+bool computeDs2AddressProvenAligned(PatchContext &Ctx, size_t Idx) {
+  if (Ctx.HasUnknownArbitraryIndirectTarget || !Ctx.DirectControlFlowTargets ||
+      Idx >= Ctx.VgprMsbDstSrc0EqualBefore.size())
+    return false;
+  const InternalDecodedInst &DS = Ctx.Decoded[Idx];
+  StringRef Mnem = DS.Mnemonic;
+  if (Mnem != "ds_load_2addr_b32" && Mnem != "ds_load_2addr_b64" &&
+      Mnem != "ds_store_2addr_b32" && Mnem != "ds_store_2addr_b64")
+    return false;
+  if (DS.Inst.getNumOperands() == 0 ||
+      !DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).isImm() ||
+      DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).getImm() != 0)
+    return false; // GDS and malformed operand layouts are never exempt.
+
+  std::optional<DsOperands> Ops =
+      extractDsOperands(DS.Inst, DS.Mnemonic, Ctx.LS);
+  if (!Ops)
+    return false;
+  unsigned AddrIndex = StringRef(DS.Mnemonic).starts_with("ds_store_") ? 0 : 1;
+  if (Ops->Regs.size() <= AddrIndex)
+    return false;
+  MCRegister Address = Ops->Regs[AddrIndex];
+  unsigned Alignment = Ops->IsB64 ? 8 : 4;
+  if (Ops->Off0 % Alignment != 0 || Ops->Off1 % Alignment != 0)
+    return false;
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(DS.Offset);
+  if (!Function || Ctx.IndirectControlFlowFunctions.contains(Function->Begin) ||
+      Ctx.DirectControlFlowTargets->contains(DS.Offset))
+    return false;
+
+  for (size_t I = Idx; I-- > 0;) {
+    const InternalDecodedInst &DI = Ctx.Decoded[I];
+    if (DI.Offset < Function->Begin)
+      break;
+    if (Ctx.DirectControlFlowTargets->contains(DI.Offset) ||
+        definesModeOrExec(DI, Ctx.LS) ||
+        StringRef(DI.Mnemonic).starts_with("s_setreg") ||
+        DI.Mnemonic == "<unknown>" || DI.Mnemonic == "<replaced>" ||
+        (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)))
+      break;
+    if (definesRegister(DI, Address, Ctx.LS))
+      return isAlignedAddressDef(DI, Address, Alignment, Ctx, I);
+  }
+  return false;
+}
+
+bool isDs2AddressProvenAligned(PatchContext &Ctx, size_t Idx) {
+  if (Ctx.Ds2AddressProvenAligned.size() == Ctx.Decoded.size())
+    return Ctx.Ds2AddressProvenAligned.test(Idx);
+  return computeDs2AddressProvenAligned(Ctx, Idx);
+}
+
+struct Ds2FlowEdge {
+  unsigned Successor = 0;
+  bool IsBranchTarget = false;
+};
+
+struct Ds2FunctionFlow {
+  size_t GlobalFirst = 0;
+  std::vector<SmallVector<Ds2FlowEdge, 2>> Successors;
+  bool Valid = false;
+};
+
+static Ds2FunctionFlow
+buildDs2FunctionFlow(PatchContext &Ctx,
+                     const ElfView::FunctionTextRange &Function) {
+  Ds2FunctionFlow Flow;
+  auto First =
+      llvm::lower_bound(Ctx.Decoded, Function.Begin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  auto After =
+      llvm::lower_bound(Ctx.Decoded, Function.End,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  if (First == After || First->Offset != Function.Begin || !Ctx.LS.MIA)
+    return Flow;
+
+  Flow.GlobalFirst = static_cast<size_t>(First - Ctx.Decoded.begin());
+  const unsigned Count = static_cast<unsigned>(After - First);
+  Flow.Successors.resize(Count);
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  OffsetToIndex.reserve(Count);
+  for (unsigned I = 0; I != Count; ++I) {
+    if (First[I].Mnemonic == "<unknown>")
+      return Flow;
+    OffsetToIndex.try_emplace(First[I].Offset, I);
+  }
+
+  auto AddFallthrough = [&](unsigned I) {
+    if (I + 1 < Count)
+      Flow.Successors[I].push_back({I + 1, false});
+  };
+  for (unsigned I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = First[I];
+    if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+        Ctx.LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, Ctx.LS))
+      continue;
+    if (Ctx.LS.MIA->isCall(DI.Inst)) {
+      AddFallthrough(I);
+      continue;
+    }
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (Ctx.LS.MIA->isIndirectBranch(DI.Inst)) {
+        std::optional<MaterializedPcTransfer> Transfer;
+        if (Ctx.DirectControlFlowTargets)
+          Transfer = evaluateMaterializedPcTransfer(
+              Ctx.Decoded, Flow.GlobalFirst + I, *Ctx.DirectControlFlowTargets,
+              ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize), Ctx.LS, Ctx.Elf);
+        if (!Transfer)
+          return Flow;
+        Target = Transfer->Target;
+      } else if (!Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size,
+                                             Target))
+        return Flow;
+      auto It = OffsetToIndex.find(Target);
+      if (It == OffsetToIndex.end() && Target >= Function.Begin &&
+          Target < Function.End)
+        return Flow;
+      if (It != OffsetToIndex.end())
+        Flow.Successors[I].push_back({It->second, true});
+      if (Ctx.LS.MIA->isConditionalBranch(DI.Inst))
+        AddFallthrough(I);
+      else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        return Flow;
+      continue;
+    }
+    if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+      return Flow;
+    AddFallthrough(I);
+  }
+  Flow.Valid = true;
+  return Flow;
+}
+
+static std::optional<unsigned> ds2NumberedSgprIndex(const MCRegisterInfo &MRI,
+                                                    MCRegister Reg,
+                                                    unsigned MaxSgprs) {
+  if (!Reg.isValid())
+    return std::nullopt;
+  StringRef Name(MRI.getName(Reg));
+  if (!Name.consume_front("SGPR") || Name.empty() || Name.contains('_'))
+    return std::nullopt;
+  unsigned Index = 0;
+  if (Name.getAsInteger(10, Index) || Index >= MaxSgprs)
+    return std::nullopt;
+  return Index;
+}
+
+static SmallVector<MCRegister, 128>
+getDs2NumberedSgprs(const PatchContext &Ctx) {
+  SmallVector<MCRegister, 128> Registers(Ctx.Config.MaxSgprs);
+  for (unsigned Reg = 1, End = Ctx.LS.MRI->getNumRegs(); Reg != End; ++Reg) {
+    std::optional<unsigned> Index =
+        ds2NumberedSgprIndex(*Ctx.LS.MRI, MCRegister(Reg), Ctx.Config.MaxSgprs);
+    if (Index)
+      Registers[*Index] = MCRegister(Reg);
+  }
+  return Registers;
+}
+
+struct Ds2MaskTaint {
+  bool Reachable = false;
+  bool ExecUnsafe = true;
+  BitVector UnsafeMasks;
+
+  explicit Ds2MaskTaint(unsigned MaskCount = 0) : UnsafeMasks(MaskCount) {}
+};
+
+static bool getDs2MaskUnsafe(const MCOperand &Op, const Ds2MaskTaint &State,
+                             const PatchContext &Ctx,
+                             ArrayRef<MCRegister> NumberedSgprs) {
+  if (Op.isImm())
+    return Op.getImm() != 0;
+  if (!Op.isReg() || !Op.getReg())
+    return true;
+  MCRegister Reg(Op.getReg());
+  StringRef Name(Ctx.LS.MRI->getName(Reg));
+  if (Name.starts_with("EXEC"))
+    return State.ExecUnsafe;
+  if (Name.starts_with("VCC"))
+    return State.UnsafeMasks.test(Ctx.Config.MaxSgprs);
+  bool Found = false;
+  bool Unsafe = false;
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I) {
+    if (!NumberedSgprs[I].isValid() ||
+        !Ctx.LS.MRI->regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+      continue;
+    Found = true;
+    Unsafe |= State.UnsafeMasks.test(I);
+  }
+  return !Found || Unsafe;
+}
+
+static bool setDs2MaskUnsafe(MCRegister Reg, bool Unsafe, Ds2MaskTaint &State,
+                             const PatchContext &Ctx,
+                             ArrayRef<MCRegister> NumberedSgprs) {
+  if (!Reg.isValid())
+    return false;
+  StringRef Name(Ctx.LS.MRI->getName(Reg));
+  if (Name.starts_with("EXEC")) {
+    State.ExecUnsafe = Unsafe;
+    return true;
+  }
+  if (Name.starts_with("VCC")) {
+    if (Unsafe)
+      State.UnsafeMasks.set(Ctx.Config.MaxSgprs);
+    else
+      State.UnsafeMasks.reset(Ctx.Config.MaxSgprs);
+    return true;
+  }
+  bool Found = false;
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I) {
+    if (!NumberedSgprs[I].isValid() ||
+        !Ctx.LS.MRI->regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+      continue;
+    if (Unsafe)
+      State.UnsafeMasks.set(I);
+    else
+      State.UnsafeMasks.reset(I);
+    Found = true;
+  }
+  return Found;
+}
+
+static void setDs2MaskDefsUnsafe(const InternalDecodedInst &DI, bool Unsafe,
+                                 Ds2MaskTaint &State, const PatchContext &Ctx,
+                                 ArrayRef<MCRegister> NumberedSgprs) {
+  const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg())
+      setDs2MaskUnsafe(MCRegister(Op.getReg()), Unsafe, State, Ctx,
+                       NumberedSgprs);
+  }
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    setDs2MaskUnsafe(MCRegister(Reg), Unsafe, State, Ctx, NumberedSgprs);
+}
+
+static Ds2MaskTaint transferDs2MaskTaint(PatchContext &Ctx,
+                                         const Ds2FunctionFlow &Flow,
+                                         unsigned I, unsigned Candidate,
+                                         ArrayRef<MCRegister> NumberedSgprs,
+                                         Ds2MaskTaint State) {
+  const size_t GlobalI = Flow.GlobalFirst + I;
+  const InternalDecodedInst &DI = Ctx.Decoded[GlobalI];
+  if (I == Candidate)
+    State.ExecUnsafe = false;
+
+  if (Ctx.LS.MIA->isCall(DI.Inst)) {
+    State.ExecUnsafe = true;
+    State.UnsafeMasks.set();
+    return State;
+  }
+
+  StringRef Mnem(DI.Mnemonic);
+  if ((Mnem == "s_and_saveexec_b32" || Mnem == "s_and_not1_saveexec_b32" ||
+       Mnem == "s_or_saveexec_b32" || Mnem == "s_xor_saveexec_b32") &&
+      DI.Inst.getNumOperands() >= 2 && DI.Inst.getOperand(0).isReg()) {
+    const bool OldExecUnsafe = State.ExecUnsafe;
+    const bool SourceUnsafe =
+        getDs2MaskUnsafe(DI.Inst.getOperand(1), State, Ctx, NumberedSgprs);
+    setDs2MaskUnsafe(MCRegister(DI.Inst.getOperand(0).getReg()), OldExecUnsafe,
+                     State, Ctx, NumberedSgprs);
+    if (Mnem == "s_and_saveexec_b32")
+      State.ExecUnsafe = OldExecUnsafe && SourceUnsafe;
+    else if (Mnem == "s_and_not1_saveexec_b32")
+      State.ExecUnsafe = OldExecUnsafe;
+    else
+      State.ExecUnsafe = OldExecUnsafe || SourceUnsafe;
+    return State;
+  }
+
+  if (Mnem.starts_with("v_cmpx")) {
+    setDs2MaskDefsUnsafe(DI, State.ExecUnsafe, State, Ctx, NumberedSgprs);
+    return State; // EXEC only narrows.
+  }
+  if (Mnem.starts_with("v_cmp")) {
+    setDs2MaskDefsUnsafe(DI, State.ExecUnsafe, State, Ctx, NumberedSgprs);
+    return State;
+  }
+
+  auto TransferBinary = [&](StringRef Opcode) {
+    if (Mnem != Opcode || DI.Inst.getNumOperands() < 3 ||
+        !DI.Inst.getOperand(0).isReg())
+      return false;
+    const bool Left =
+        getDs2MaskUnsafe(DI.Inst.getOperand(1), State, Ctx, NumberedSgprs);
+    const bool Right =
+        getDs2MaskUnsafe(DI.Inst.getOperand(2), State, Ctx, NumberedSgprs);
+    bool Unsafe = true;
+    if (Opcode == "s_and_b32")
+      Unsafe = Left && Right;
+    else if (Opcode == "s_and_not1_b32")
+      Unsafe = Left;
+    else if (Opcode == "s_or_b32" || Opcode == "s_xor_b32")
+      Unsafe = Left || Right;
+    setDs2MaskUnsafe(MCRegister(DI.Inst.getOperand(0).getReg()), Unsafe, State,
+                     Ctx, NumberedSgprs);
+    return true;
+  };
+  if (TransferBinary("s_and_b32") || TransferBinary("s_and_not1_b32") ||
+      TransferBinary("s_or_b32") || TransferBinary("s_xor_b32"))
+    return State;
+
+  if (Mnem == "s_mov_b32" && DI.Inst.getNumOperands() >= 2 &&
+      DI.Inst.getOperand(0).isReg()) {
+    setDs2MaskUnsafe(
+        MCRegister(DI.Inst.getOperand(0).getReg()),
+        getDs2MaskUnsafe(DI.Inst.getOperand(1), State, Ctx, NumberedSgprs),
+        State, Ctx, NumberedSgprs);
+    return State;
+  }
+
+  setDs2MaskDefsUnsafe(DI, true, State, Ctx, NumberedSgprs);
+  return State;
+}
+
+static bool mergeDs2MaskTaint(Ds2MaskTaint &Into,
+                              const Ds2MaskTaint &Incoming) {
+  if (!Incoming.Reachable)
+    return false;
+  if (!Into.Reachable) {
+    Into = Incoming;
+    return true;
+  }
+  const bool OldExecUnsafe = Into.ExecUnsafe;
+  BitVector OldMasks = Into.UnsafeMasks;
+  Into.ExecUnsafe |= Incoming.ExecUnsafe;
+  Into.UnsafeMasks |= Incoming.UnsafeMasks;
+  return OldExecUnsafe != Into.ExecUnsafe || OldMasks != Into.UnsafeMasks;
+}
+
+static void proveLongRangeDs2Alignment(PatchContext &Ctx, size_t CandidateIdx,
+                                       MCRegister Address,
+                                       ArrayRef<size_t> Uses,
+                                       BitVector &Proven) {
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Ctx.Decoded[CandidateIdx].Offset);
+  if (!Function || Ctx.IndirectControlFlowFunctions.contains(Function->Begin) ||
+      Ctx.CrossFunctionInteriorEntryFunctions.contains(Function->Begin) ||
+      CandidateIdx >= Ctx.VgprMsbDstBefore.size())
+    return;
+  const int8_t CandidateDst = Ctx.VgprMsbDstBefore[CandidateIdx];
+  if (CandidateDst < 0)
+    return;
+
+  Ds2FunctionFlow Flow = buildDs2FunctionFlow(Ctx, *Function);
+  if (!Flow.Valid || CandidateIdx < Flow.GlobalFirst)
+    return;
+  const unsigned Candidate =
+      static_cast<unsigned>(CandidateIdx - Flow.GlobalFirst);
+  if (Candidate >= Flow.Successors.size())
+    return;
+
+  // Address redefinitions are independent of lane-mask coverage. Propagate a
+  // monotone may-clobber fact from Candidate so a loop cannot hide a clobber
+  // by executing Candidate again for a disjoint set of lanes.
+  std::vector<uint8_t> AddressFlow(Flow.Successors.size());
+  SmallVector<unsigned, 128> AddressWorklist;
+  AddressFlow[Candidate] = 1; // bit 0: reachable, bit 1: clobbered
+  AddressWorklist.push_back(Candidate);
+  for (size_t Next = 0; Next != AddressWorklist.size(); ++Next) {
+    const unsigned I = AddressWorklist[Next];
+    uint8_t Out = AddressFlow[I];
+    if (I != Candidate &&
+        (definesRegister(Ctx.Decoded[Flow.GlobalFirst + I], Address, Ctx.LS) ||
+         Ctx.LS.MIA->isCall(Ctx.Decoded[Flow.GlobalFirst + I].Inst)))
+      Out |= 2;
+    for (const Ds2FlowEdge &Edge : Flow.Successors[I]) {
+      uint8_t Merged = AddressFlow[Edge.Successor] | Out;
+      if (Merged != AddressFlow[Edge.Successor]) {
+        AddressFlow[Edge.Successor] = Merged;
+        AddressWorklist.push_back(Edge.Successor);
+      }
+    }
+  }
+
+  const unsigned MaskCount = Ctx.Config.MaxSgprs + 1;
+  SmallVector<MCRegister, 128> NumberedSgprs = getDs2NumberedSgprs(Ctx);
+  std::vector<Ds2MaskTaint> In;
+  In.reserve(Flow.Successors.size());
+  for (size_t I = 0; I != Flow.Successors.size(); ++I)
+    In.emplace_back(MaskCount);
+  In[0].Reachable = true;
+  In[0].ExecUnsafe = true;
+  In[0].UnsafeMasks.set();
+  SmallVector<unsigned, 128> Worklist;
+  Worklist.push_back(0);
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    const unsigned I = Worklist[Next];
+    Ds2MaskTaint Out =
+        transferDs2MaskTaint(Ctx, Flow, I, Candidate, NumberedSgprs, In[I]);
+    for (const Ds2FlowEdge &Edge : Flow.Successors[I]) {
+      Ds2MaskTaint EdgeOut = Out;
+      StringRef Mnem(Ctx.Decoded[Flow.GlobalFirst + I].Mnemonic);
+      if ((Mnem == "s_cbranch_execz" && Edge.IsBranchTarget) ||
+          (Mnem == "s_cbranch_execnz" && !Edge.IsBranchTarget))
+        EdgeOut.ExecUnsafe = false; // This edge proves EXEC is empty.
+      if (mergeDs2MaskTaint(In[Edge.Successor], EdgeOut))
+        Worklist.push_back(Edge.Successor);
+    }
+  }
+
+  for (size_t UseIdx : Uses) {
+    if (UseIdx < Flow.GlobalFirst ||
+        UseIdx - Flow.GlobalFirst >= Flow.Successors.size() ||
+        UseIdx >= Ctx.VgprMsbSrc0Before.size())
+      continue;
+    const unsigned Use = static_cast<unsigned>(UseIdx - Flow.GlobalFirst);
+    if (!In[Use].Reachable || In[Use].ExecUnsafe ||
+        (AddressFlow[Use] & 2) != 0 ||
+        Ctx.VgprMsbSrc0Before[UseIdx] != CandidateDst)
+      continue;
+    Proven.set(UseIdx);
+  }
 }
 
 // -- patchDs2Addr -----------------------------------------------------------
@@ -410,18 +939,21 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
 // that later s_wait_dscnt immediates encode; the local drain sidesteps that
 // entirely (see the rationale in the body below).
 
-bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
-  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+SmallVector<uint8_t> buildDs2AddrReplacement(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
-    return false;
-  std::optional<std::vector<std::string>> Expanded =
-      expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
-  if (!Expanded)
-    return failRequiredPatch(Ctx);
+    return {};
+  std::vector<std::string> Expanded =
+      expandDs2Addr(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
+  if (Expanded.empty()) {
+    log() << "hotswap: error: ds_2addr expansion failed for: " << DI.Mnemonic
+          << "\n";
+    return {};
+  }
 
   std::string Combined;
-  for (const std::string &Line : *Expanded)
+  for (const std::string &Line : Expanded)
     Combined += Line + "\n";
   // Drain the DS counter right after the split pair so both halves are
   // guaranteed complete before any downstream consumer. The original code
@@ -438,15 +970,293 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   SmallVector<uint8_t> Bytes = assembleInstructions(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
-    return failRequiredPatch(Ctx);
+    return {};
+  }
+  return Bytes;
+}
+
+struct ProtectedDs2DelayWindow {
+  size_t DelayIndex = 0;
+  size_t LastIndex = 0;
+  uint32_t SourceSize = 0;
+  unsigned FirstDependency = 0;
+  unsigned SecondDependency = 0;
+  SmallVector<size_t, 4> Ds2Indices;
+};
+
+/// A combined s_delay_alu names the immediately following instruction and a
+/// later instruction selected by instskip. LLVM forms it by folding a second
+/// standalone delay into the first. A DS2 split between those two targets
+/// changes the instruction count, so restore the two standalone delays and
+/// relocate the complete protected window as one unit.
+static std::optional<ProtectedDs2DelayWindow>
+findProtectedDs2DelayWindow(PatchContext &Ctx, size_t Ds2Index) {
+  if (Ds2Index == 0 || !Ctx.DirectControlFlowTargets || !Ctx.LS.MIA)
+    return std::nullopt;
+
+  // Locate the owner from encoded delay geometry rather than assuming the DS2
+  // immediately follows the first protected target. Demerging preserves both
+  // dependencies only when DS2 is strictly between those targets: replacing a
+  // target itself would change the operation named by that dependency.
+  std::optional<ProtectedDs2DelayWindow> Window;
+  constexpr size_t MaxClauseSpan = 64;
+  const size_t FirstPossibleOwner =
+      Ds2Index > MaxClauseSpan ? Ds2Index - MaxClauseSpan : 0;
+  unsigned DelayOwners = 0;
+  for (size_t I = FirstPossibleOwner; I != Ds2Index; ++I) {
+    const InternalDecodedInst &Candidate = Ctx.Decoded[I];
+    if (Candidate.Mnemonic == "s_delay_alu") {
+      const unsigned CandidateSpan = getDelayProtectedSpan(Candidate);
+      if (CandidateSpan < Ds2Index - I)
+        continue;
+      ++DelayOwners;
+
+      if (Candidate.Inst.getNumOperands() != 1 ||
+          !Candidate.Inst.getOperand(0).isImm())
+        continue;
+      const uint64_t Imm =
+          static_cast<uint64_t>(Candidate.Inst.getOperand(0).getImm());
+      if ((Imm & ~uint64_t{0x7FF}) != 0)
+        continue;
+      const unsigned FirstDependency = Imm & 0xF;
+      const unsigned Skip = (Imm >> 4) & 0x7;
+      const unsigned SecondDependency = (Imm >> 7) & 0xF;
+      if (FirstDependency == 0 || FirstDependency >= 12 || Skip > 5 ||
+          SecondDependency == 0 || SecondDependency >= 12)
+        continue;
+
+      const unsigned Span = Skip + 1;
+      if (getDelayProtectedSpan(Candidate) != Span ||
+          Span > Ctx.Decoded.size() - I - 1)
+        continue;
+      const size_t FirstTargetIndex = I + 1;
+      const size_t SecondTargetIndex = I + Span;
+      if (Ds2Index <= FirstTargetIndex || Ds2Index >= SecondTargetIndex)
+        continue;
+      if (Window)
+        return std::nullopt;
+      Window = ProtectedDs2DelayWindow{
+          I, SecondTargetIndex, 0, FirstDependency, SecondDependency, {}};
+      continue;
+    }
+    if (Candidate.Mnemonic != "s_clause" ||
+        Candidate.Inst.getNumOperands() != 1 ||
+        !Candidate.Inst.getOperand(0).isImm())
+      continue;
+    const unsigned ClauseSpan =
+        (static_cast<unsigned>(Candidate.Inst.getOperand(0).getImm()) & 63u) +
+        1;
+    if (ClauseSpan >= Ds2Index - I)
+      return std::nullopt;
+  }
+  if (DelayOwners != 1 || !Window)
+    return std::nullopt;
+
+  const size_t DelayIndex = Window->DelayIndex;
+  const size_t LastIndex = Window->LastIndex;
+  const InternalDecodedInst &Delay = Ctx.Decoded[DelayIndex];
+
+  // Reject an owner whose directive is itself covered by an earlier delay or
+  // hard clause. Such nested geometry cannot be preserved by this demerge.
+  if (Ctx.RelocationProtectedOffsets.contains(Delay.Offset))
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Delay.Offset);
+  if (!Function || Ctx.IndirectControlFlowFunctions.contains(Function->Begin))
+    return std::nullopt;
+
+  uint64_t ExpectedOffset = Delay.Offset;
+  uint64_t WindowEnd = Delay.Offset;
+  for (size_t I = DelayIndex; I <= LastIndex; ++I) {
+    const InternalDecodedInst &Member = Ctx.Decoded[I];
+    const bool IsDs2 = !getDs2AddrReplacement(Member.Mnemonic).empty();
+    const bool NeedsDs2Rewrite = IsDs2 && !isDs2AddressProvenAligned(Ctx, I);
+    std::optional<ElfView::FunctionTextRange> MemberFunction =
+        Ctx.Elf.findFunctionTextRangeAtOffset(Member.Offset);
+    if (!MemberFunction || MemberFunction->Begin != Function->Begin ||
+        MemberFunction->End != Function->End ||
+        Member.Offset != ExpectedOffset || Member.Offset > Ctx.TextSize ||
+        Member.Size > Ctx.TextSize - Member.Offset ||
+        Member.Mnemonic == "<unknown>" || Member.Mnemonic == "<replaced>")
+      return std::nullopt;
+    if (I != DelayIndex &&
+        (Member.Mnemonic == "s_delay_alu" || Member.Mnemonic == "s_clause" ||
+         Member.Mnemonic == "s_set_vgpr_msb" ||
+         Member.Mnemonic == "tensor_load_to_lds" ||
+         StringRef(Member.Mnemonic).contains("_pc_") ||
+         Ctx.LS.MIA->mayAffectControlFlow(Member.Inst, *Ctx.LS.MRI)))
+      return std::nullopt;
+    if (NeedsDs2Rewrite) {
+      // Demerging keeps the original dependency targets as single
+      // instructions. Required DS2 rewrites are therefore composable only
+      // at interior positions, where every replacement can move as part of
+      // the same atomic window.
+      if (I == DelayIndex + 1 || I == LastIndex ||
+          Ctx.ClaimedReplacementOffsets.contains(Member.Offset) ||
+          hasSiteReplacementReservation(Ctx, Member.Offset))
+        return std::nullopt;
+      Window->Ds2Indices.push_back(I);
+    }
+    // The outer dispatcher skips every member after this atomic relocation.
+    // Reject any as-yet-unvisited member that would need its own patch rather
+    // than silently copying the incompatible instruction into the body.
+    if (I > Ds2Index && !NeedsDs2Rewrite &&
+        requiresIndependentInstructionRewrite(Ctx, I)) {
+      log() << "hotswap: error: ds_2addr: combined-delay window member at 0x"
+            << utohexstr(Member.Offset)
+            << " requires a separate HotSwap patch\n";
+      return std::nullopt;
+    }
+    ExpectedOffset += Member.Size;
+    WindowEnd = ExpectedOffset;
   }
 
-  SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-    return failRequiredPatch(Ctx);
+  if (WindowEnd < Delay.Offset ||
+      WindowEnd - Delay.Offset > std::numeric_limits<uint32_t>::max())
+    return std::nullopt;
+  for (uint64_t Offset = Delay.Offset + MinInstSize; Offset < WindowEnd;
+       Offset += MinInstSize)
+    if (Ctx.DirectControlFlowTargets->contains(Offset))
+      return std::nullopt;
 
-  DI.Mnemonic = "<replaced>";
+  Window->SourceSize = static_cast<uint32_t>(WindowEnd - Delay.Offset);
+  if (Window->Ds2Indices.empty() ||
+      !llvm::is_contained(Window->Ds2Indices, Ds2Index))
+    return std::nullopt;
+  return Window;
+}
+
+static bool
+patchProtectedDs2DelayWindow(PatchContext &Ctx, size_t Ds2Index,
+                             ArrayRef<uint8_t> Ds2Replacement,
+                             const ProtectedDs2DelayWindow &Window) {
+  SmallVector<uint8_t> FirstDelay = assembleSingleInst(
+      "s_delay_alu " + std::to_string(Window.FirstDependency), Ctx.LS);
+  SmallVector<uint8_t> SecondDelay = assembleSingleInst(
+      "s_delay_alu " + std::to_string(Window.SecondDependency), Ctx.LS);
+  if (FirstDelay.size() != MinInstSize || SecondDelay.size() != MinInstSize)
+    return false;
+
+  SmallVector<uint8_t> Replacement;
+  Replacement.append(FirstDelay.begin(), FirstDelay.end());
+  for (size_t I = Window.DelayIndex + 1; I <= Window.LastIndex; ++I) {
+    if (I == Window.LastIndex)
+      Replacement.append(SecondDelay.begin(), SecondDelay.end());
+    if (llvm::is_contained(Window.Ds2Indices, I)) {
+      if (I == Ds2Index) {
+        Replacement.append(Ds2Replacement.begin(), Ds2Replacement.end());
+        continue;
+      }
+      SmallVector<uint8_t> MemberReplacement = buildDs2AddrReplacement(Ctx, I);
+      if (MemberReplacement.empty())
+        return false;
+      Replacement.append(MemberReplacement.begin(), MemberReplacement.end());
+      continue;
+    }
+    const InternalDecodedInst &Member = Ctx.Decoded[I];
+    Replacement.append(Ctx.Text + Member.Offset,
+                       Ctx.Text + Member.Offset + Member.Size);
+  }
+
+  const uint64_t SourceOffset = Ctx.Decoded[Window.DelayIndex].Offset;
+  if (!emitReplacementCode(Ctx, SourceOffset, Window.SourceSize, Replacement,
+                           ReplacementPlacement::ProtectedCombinedDelay))
+    return false;
+
+  const uint64_t Ds2Offset = Ctx.Decoded[Ds2Index].Offset;
+  for (size_t I = Window.DelayIndex; I <= Window.LastIndex; ++I)
+    Ctx.Decoded[I].Mnemonic = "<replaced>";
+  Ctx.RequiredPatchApplied = true;
+  log() << "hotswap: ds_2addr: demerged combined s_delay_alu at 0x"
+        << utohexstr(SourceOffset) << " around protected site 0x"
+        << utohexstr(Ds2Offset) << " with " << Window.Ds2Indices.size()
+        << " DS2 rewrite(s)\n";
   return true;
+}
+
+uint32_t patchDs2Addr(PatchContext &Ctx, size_t Idx) {
+  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  SmallVector<uint8_t> Replacement = buildDs2AddrReplacement(Ctx, Idx);
+  if (Replacement.empty()) {
+    failRequiredPatch(Ctx);
+    return 0;
+  }
+
+  if (Ctx.RelocationProtectedOffsets.contains(DI.Offset)) {
+    std::optional<ProtectedDs2DelayWindow> Window =
+        findProtectedDs2DelayWindow(Ctx, Idx);
+    if (!Window) {
+      log() << "hotswap: error: ds_2addr: protected source at 0x"
+            << utohexstr(DI.Offset)
+            << " has no supported combined-delay window\n";
+      failRequiredPatch(Ctx);
+      return 0;
+    }
+    if (!patchProtectedDs2DelayWindow(Ctx, Idx, Replacement, *Window)) {
+      failRequiredPatch(Ctx);
+      return 0;
+    }
+    return Window->Ds2Indices.size();
+  }
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
+
+  // Adjacent required DS2 rewrites need one branch-back, not one per original
+  // instruction. This preserves replacement order and every local DS drain
+  // while reducing padding pressure. Never erase a possible interior entry.
+  if (!Ctx.HasUnknownArbitraryIndirectTarget && Ctx.DirectControlFlowTargets &&
+      Function && !Ctx.IndirectControlFlowFunctions.contains(Function->Begin) &&
+      Idx + 1 < Ctx.Decoded.size()) {
+    size_t Next = Idx + 1;
+    std::optional<uint64_t> ExpectedOffset =
+        checkedAddUint64(DI.Offset, DI.Size, "adjacent ds_2addr source window");
+    if (ExpectedOffset) {
+      InternalDecodedInst &NextDI = Ctx.Decoded[Next];
+      std::optional<uint64_t> NextEnd = checkedAddUint64(
+          NextDI.Offset, NextDI.Size, "adjacent ds_2addr source end");
+      std::optional<ElfView::FunctionTextRange> NextFunction =
+          Ctx.Elf.findFunctionTextRangeAtOffset(NextDI.Offset);
+      if (NextDI.Offset == *ExpectedOffset && NextEnd &&
+          *NextEnd <= Function->End &&
+          !Ctx.DirectControlFlowTargets->contains(NextDI.Offset) &&
+          !Ctx.RelocationProtectedOffsets.contains(NextDI.Offset) &&
+          !getDs2AddrReplacement(NextDI.Mnemonic).empty() &&
+          !isDs2AddressProvenAligned(Ctx, Next) && NextFunction &&
+          NextFunction->Begin == Function->Begin &&
+          NextFunction->End == Function->End &&
+          NextDI.Size <= std::numeric_limits<uint32_t>::max() - DI.Size) {
+        SmallVector<uint8_t> NextReplacement =
+            buildDs2AddrReplacement(Ctx, Next);
+        if (!NextReplacement.empty()) {
+          SmallVector<uint8_t> Combined = Replacement;
+          Combined.append(NextReplacement.begin(), NextReplacement.end());
+          uint32_t CombinedOriginalSize = DI.Size + NextDI.Size;
+          if (emitReplacementCode(Ctx, DI.Offset, CombinedOriginalSize,
+                                  Combined, ReplacementPlacement::Ds2SourceTail,
+                                  /*DiagnoseFailure=*/false)) {
+            Ctx.RequiredPatchApplied = true;
+            DI.Mnemonic = "<replaced>";
+            NextDI.Mnemonic = "<replaced>";
+            log() << "hotswap: coalesced 2 adjacent ds_2addr rewrites at 0x"
+                  << utohexstr(DI.Offset) << "\n";
+            return 2;
+          }
+        }
+      }
+    }
+  }
+
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                           ReplacementPlacement::Ds2SourceTail)) {
+    failRequiredPatch(Ctx);
+    return 0;
+  }
+
+  Ctx.RequiredPatchApplied = true;
+  DI.Mnemonic = "<replaced>";
+  return 1;
 }
 
 // -- getDescriptorBaseSgpr --------------------------------------------------
@@ -515,20 +1325,210 @@ SmallVector<unsigned, 8> getSgprOperandIndices(const MCInst &Inst,
   return Result;
 }
 
+bool isTensorDescriptorMask(const InternalDecodedInst &DI, MCRegister BaseMCReg,
+                            const MCRegisterInfo &MRI) {
+  const MCInst &Inst = DI.Inst;
+  if (DI.Mnemonic != "s_pack_hh_b32_b16" || Inst.getNumOperands() < 3 ||
+      !Inst.getOperand(0).isReg() ||
+      !MRI.regsOverlap(Inst.getOperand(0).getReg(), BaseMCReg.id()) ||
+      !Inst.getOperand(1).isImm() || Inst.getOperand(1).getImm() != 0 ||
+      !Inst.getOperand(2).isReg())
+    return false;
+  return MRI.regsOverlap(Inst.getOperand(2).getReg(), BaseMCReg.id());
+}
+
 bool isAlreadyTensorMaskPatched(const PatchContext &Ctx, size_t Idx,
                                 MCRegister BaseMCReg) {
   if (Idx == 0)
     return false;
+  const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+  return Prev.Offset + Prev.Size == Ctx.Decoded[Idx].Offset &&
+         isTensorDescriptorMask(Prev, BaseMCReg, *Ctx.LS.MRI);
+}
+
+bool instructionTouchesRegister(const InternalDecodedInst &DI, MCRegister Reg,
+                                const LLVMState &LS) {
+  const MCRegisterInfo &MRI = *LS.MRI;
+  for (const MCOperand &Op : DI.Inst)
+    if (Op.isReg() && Op.getReg() && MRI.regsOverlap(Op.getReg(), Reg.id()))
+      return true;
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  for (MCPhysReg Implicit : Desc.implicit_uses())
+    if (MRI.regsOverlap(Implicit, Reg.id()))
+      return true;
+  for (MCPhysReg Implicit : Desc.implicit_defs())
+    if (MRI.regsOverlap(Implicit, Reg.id()))
+      return true;
+  return false;
+}
+
+struct LocalTensorMaskDefinition {
+  size_t Index = 0;
+  bool AlreadyMasked = false;
+};
+
+bool isDirectControlFlowTarget(const PatchContext &Ctx, uint64_t Offset) {
+  return !Ctx.DirectControlFlowTargets ||
+         Ctx.DirectControlFlowTargets->contains(Offset);
+}
+
+bool functionHasIndirectControlFlow(const PatchContext &Ctx, uint64_t Offset) {
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Offset);
+  return !Range || Ctx.IndirectControlFlowFunctions.contains(Range->Begin);
+}
+
+bool isRelocatedTensorMaskDefinition(const PatchContext &Ctx,
+                                     const InternalDecodedInst &Branch,
+                                     MCRegister BaseMCReg) {
+  if (!Ctx.LS.MIA || Branch.Mnemonic != "s_branch" ||
+      !Ctx.LS.MIA->isUnconditionalBranch(Branch.Inst) ||
+      Ctx.LS.MIA->isIndirectBranch(Branch.Inst))
+    return false;
+
+  uint64_t Target = 0;
+  if (!Ctx.LS.MIA->evaluateBranch(Branch.Inst, Branch.Offset, Branch.Size,
+                                  Target))
+    return false;
+
+  constexpr uint64_t SequenceBytes = 3 * MinInstSize;
+  std::optional<uint64_t> TargetVAddr = checkedAddUint64(
+      Ctx.Elf.textAddr(), Target, "tensor mask trampoline target");
+  if (!TargetVAddr)
+    return false;
+  const uint8_t *Bytes = Ctx.Elf.dataAtVAddr(*TargetVAddr, SequenceBytes);
+  if (!Bytes)
+    return false;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Bytes, SequenceBytes, Ctx.LS, Decoded) ||
+      Decoded.size() != 3)
+    return false;
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
-  const MCInst &PI = Prev.Inst;
-  if (Prev.Mnemonic != "s_pack_hh_b32_b16" || PI.getNumOperands() < 3)
+  const InternalDecodedInst &Def = Decoded[0];
+  const MCInstrDesc &DefDesc = Ctx.LS.MCII->get(Def.Inst.getOpcode());
+  if (Def.Mnemonic != "v_readfirstlane_b32" || DefDesc.getNumDefs() != 1 ||
+      Def.Inst.getNumOperands() < 2 || !Def.Inst.getOperand(0).isReg() ||
+      Def.Inst.getOperand(0).getReg() != BaseMCReg.id() ||
+      !isTensorDescriptorMask(Decoded[1], BaseMCReg, MRI) ||
+      Decoded[2].Mnemonic != "s_branch")
     return false;
-  if (!PI.getOperand(0).isReg() ||
-      !MRI.regsOverlap(PI.getOperand(0).getReg(), BaseMCReg.id()))
+
+  uint64_t Resume = 0;
+  if (!Ctx.LS.MIA->evaluateBranch(Decoded[2].Inst, Target + Decoded[2].Offset,
+                                  Decoded[2].Size, Resume))
     return false;
-  return PI.getOperand(1).isImm() && PI.getOperand(1).getImm() == 0;
+  return Resume == Branch.Offset + Branch.Size;
+}
+
+bool isTransparentShortTrampoline(const PatchContext &Ctx,
+                                  const InternalDecodedInst &Branch,
+                                  MCRegister BaseMCReg) {
+  if (!Ctx.LS.MIA || Branch.Mnemonic != "s_branch" ||
+      !Ctx.LS.MIA->isUnconditionalBranch(Branch.Inst) ||
+      Ctx.LS.MIA->isIndirectBranch(Branch.Inst))
+    return false;
+
+  uint64_t Target = 0;
+  if (!Ctx.LS.MIA->evaluateBranch(Branch.Inst, Branch.Offset, Branch.Size,
+                                  Target) ||
+      Target < Ctx.TextSize)
+    return false;
+  std::optional<uint64_t> TargetVAddr =
+      checkedAddUint64(Ctx.Elf.textAddr(), Target, "tensor trampoline target");
+  if (!TargetVAddr)
+    return false;
+
+  constexpr uint64_t MaxSequenceBytes = 256;
+  for (uint64_t Size = 2 * MinInstSize; Size <= MaxSequenceBytes;
+       Size += MinInstSize) {
+    const uint8_t *Bytes = Ctx.Elf.dataAtVAddr(*TargetVAddr, Size);
+    if (!Bytes)
+      return false;
+    std::vector<InternalDecodedInst> Decoded;
+    if (!decodeTextSection(Bytes, Size, Ctx.LS, Decoded) || Decoded.empty() ||
+        Decoded.back().Offset + Decoded.back().Size != Size)
+      continue;
+
+    const InternalDecodedInst &Back = Decoded.back();
+    uint64_t Resume = 0;
+    if (Back.Mnemonic != "s_branch" ||
+        !Ctx.LS.MIA->evaluateBranch(Back.Inst, Target + Back.Offset, Back.Size,
+                                    Resume))
+      continue;
+    const uint64_t Fallthrough = Branch.Offset + Branch.Size;
+    if (Resume < Fallthrough || Resume - Fallthrough > 4 * MinInstSize ||
+        (Resume - Fallthrough) % MinInstSize != 0 || Resume > Ctx.TextSize)
+      continue;
+    bool PaddingIsNop = true;
+    for (uint64_t Offset = Fallthrough; Offset < Resume; Offset += MinInstSize)
+      PaddingIsNop &= ArrayRef<uint8_t>(Ctx.Text + Offset, MinInstSize) ==
+                      ArrayRef<uint8_t>(Ctx.LS.SNopBytes);
+    if (!PaddingIsNop)
+      continue;
+
+    for (const InternalDecodedInst &DI : ArrayRef(Decoded).drop_back()) {
+      const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+      if (DI.Mnemonic == "<unknown>" ||
+          instructionTouchesRegister(DI, BaseMCReg, Ctx.LS) ||
+          Desc.mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+// Find a descriptor definition that unconditionally precedes the tensor in
+// the same straight-line basic block. Relocating that definition and appending
+// the mask is safe only when no entry edge can skip it and no intervening
+// instruction observes or changes the descriptor base.
+std::optional<LocalTensorMaskDefinition>
+findLocalTensorMaskDefinition(const PatchContext &Ctx, size_t TensorIdx,
+                              MCRegister BaseMCReg) {
+  if (!Ctx.LS.MIA || TensorIdx == 0 ||
+      isDirectControlFlowTarget(Ctx, Ctx.Decoded[TensorIdx].Offset) ||
+      functionHasIndirectControlFlow(Ctx, Ctx.Decoded[TensorIdx].Offset))
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Ctx.Decoded[TensorIdx].Offset);
+  if (!Range)
+    return std::nullopt;
+
+  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+  uint64_t NextOffset = Ctx.Decoded[TensorIdx].Offset;
+  for (size_t I = TensorIdx; I-- > 0;) {
+    const InternalDecodedInst &Candidate = Ctx.Decoded[I];
+    if (Candidate.Offset < Range->Begin ||
+        Candidate.Offset + Candidate.Size != NextOffset ||
+        Candidate.Mnemonic == "<unknown>" || Candidate.Mnemonic == "<replaced>")
+      return std::nullopt;
+
+    if (isTensorDescriptorMask(Candidate, BaseMCReg, MRI))
+      return LocalTensorMaskDefinition{I, true};
+    if (isRelocatedTensorMaskDefinition(Ctx, Candidate, BaseMCReg))
+      return LocalTensorMaskDefinition{I, true};
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(Candidate.Inst.getOpcode());
+    const bool IsMatchingReadFirstLane =
+        Candidate.Mnemonic == "v_readfirstlane_b32" && Desc.getNumDefs() == 1 &&
+        Candidate.Inst.getNumOperands() >= 2 &&
+        Candidate.Inst.getOperand(0).isReg() &&
+        Candidate.Inst.getOperand(0).getReg() == BaseMCReg.id();
+    if (IsMatchingReadFirstLane)
+      return LocalTensorMaskDefinition{I, false};
+
+    if (instructionTouchesRegister(Candidate, BaseMCReg, Ctx.LS) ||
+        isDirectControlFlowTarget(Ctx, Candidate.Offset))
+      return std::nullopt;
+    if (Desc.mayAffectControlFlow(Candidate.Inst, MRI) &&
+        !isTransparentShortTrampoline(Ctx, Candidate, BaseMCReg))
+      return std::nullopt;
+    NextOffset = Candidate.Offset;
+  }
+  return std::nullopt;
 }
 
 bool isSccReg(MCRegister Reg, const MCRegisterInfo &MRI) {
@@ -722,10 +1722,6 @@ void commitScratchVgpr(PatchContext &Ctx, const ScratchAlloc &Alloc) {
 // (no KD bump needed), so unlike VGPRs this needs no liveness. Same strategy
 // the E5M3 patch uses.
 //
-// TODO: the E5M3 patch open-codes this same scratch-SGPR reservation. Hoist
-// SgprScratchAlloc / tryAllocScratchSgpr / commitScratchSgpr into shared
-// infrastructure both patches call, rather than duplicating it.
-
 struct SgprScratchAlloc {
   unsigned Sgpr = 0;
   std::string KernelName;
@@ -763,12 +1759,1376 @@ void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
   Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, Alloc.ExtraSgprsNeeded);
 }
 
+// -- tensor descriptor must analysis ---------------------------------------
+
+std::optional<uint64_t> applyTensorSignedPcDelta(uint64_t CapturedPc,
+                                                 int64_t Delta) {
+  if (Delta >= 0) {
+    uint64_t Magnitude = static_cast<uint64_t>(Delta);
+    if (CapturedPc > std::numeric_limits<uint64_t>::max() - Magnitude)
+      return std::nullopt;
+    return CapturedPc + Magnitude;
+  }
+
+  uint64_t Magnitude = Delta == std::numeric_limits<int64_t>::min()
+                           ? uint64_t{1} << 63
+                           : static_cast<uint64_t>(-Delta);
+  if (CapturedPc < Magnitude)
+    return std::nullopt;
+  return CapturedPc - Magnitude;
+}
+
+std::optional<uint64_t>
+evaluateTensorDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                      const LLVMState &LS) {
+  uint64_t Target = 0;
+  if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
+    return Target;
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  if (DI.Inst.getOpcode() != LS.SCallI64Opcode || !Desc.isCall() ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isReg() ||
+      !DI.Inst.getOperand(0).getReg() || !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+
+  const uint64_t Encoded =
+      static_cast<uint64_t>(DI.Inst.getOperand(1).getImm()) & 0xffffu;
+  const int64_t DwordDelta = Encoded < 0x8000u
+                                 ? static_cast<int64_t>(Encoded)
+                                 : static_cast<int64_t>(Encoded) - 0x10000;
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      DI.Offset, DI.Size, "tensor direct control-flow PC base");
+  if (!PcBase)
+    return std::nullopt;
+  if (DwordDelta >= 0)
+    return checkedAddUint64(*PcBase,
+                            static_cast<uint64_t>(DwordDelta) * MinInstSize,
+                            "tensor direct control-flow target");
+  return checkedSubUint64(*PcBase,
+                          static_cast<uint64_t>(-DwordDelta) * MinInstSize,
+                          "tensor direct control-flow target");
+}
+
+std::optional<std::pair<MCRegister, int64_t>>
+getTensorHotswapAddSetPc(ArrayRef<InternalDecodedInst> Decoded,
+                         size_t SetPcIndex) {
+  if (SetPcIndex == 0 || SetPcIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Add = Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+  if (Add.Mnemonic != "s_add_nc_u64" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      Add.Offset > std::numeric_limits<uint64_t>::max() - Add.Size ||
+      Add.Offset + Add.Size != SetPc.Offset || Add.Inst.getNumOperands() != 3 ||
+      SetPc.Inst.getNumOperands() != 1 || !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() || !Add.Inst.getOperand(2).isImm() ||
+      !SetPc.Inst.getOperand(0).isReg())
+    return std::nullopt;
+
+  MCRegister Pair = Add.Inst.getOperand(0).getReg();
+  if (!Pair.isValid() || Add.Inst.getOperand(1).getReg() != Pair.id() ||
+      SetPc.Inst.getOperand(0).getReg() != Pair.id())
+    return std::nullopt;
+  return std::pair<MCRegister, int64_t>{Pair, Add.Inst.getOperand(2).getImm()};
+}
+
+std::optional<size_t>
+findTensorDecodedIndex(ArrayRef<InternalDecodedInst> Decoded, uint64_t Offset) {
+  auto It = llvm::lower_bound(Decoded, Offset,
+                              [](const InternalDecodedInst &DI,
+                                 uint64_t Value) { return DI.Offset < Value; });
+  if (It == Decoded.end() || It->Offset != Offset)
+    return std::nullopt;
+  return It - Decoded.begin();
+}
+
+std::optional<uint64_t>
+resolveTensorContiguousSetPc(ArrayRef<InternalDecodedInst> Decoded,
+                             size_t SetPcIndex,
+                             const DenseSet<uint64_t> &DirectTargets) {
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getTensorHotswapAddSetPc(Decoded, SetPcIndex);
+  if (!AddSet || SetPcIndex < 2)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[SetPcIndex - 2];
+  const InternalDecodedInst &Add = Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+  if (GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size ||
+      GetPc.Offset + GetPc.Size != Add.Offset ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id())
+    return std::nullopt;
+  if (SetPc.Offset > std::numeric_limits<uint64_t>::max() - SetPc.Size)
+    return std::nullopt;
+  const uint64_t SequenceEnd = SetPc.Offset + SetPc.Size;
+  if (llvm::any_of(DirectTargets, [&](uint64_t Target) {
+        return Target > GetPc.Offset && Target < SequenceEnd;
+      }))
+    return std::nullopt;
+  return applyTensorSignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+}
+
+std::optional<uint64_t>
+resolveTensorSetPcTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                         uint64_t SetPcOffset,
+                         const DenseSet<uint64_t> &DirectTargets) {
+  std::optional<size_t> Index = findTensorDecodedIndex(AllDecoded, SetPcOffset);
+  if (!Index)
+    return std::nullopt;
+  return resolveTensorContiguousSetPc(AllDecoded, *Index, DirectTargets);
+}
+
+struct TensorTrampolinePath {
+  uint64_t ResumeOffset = 0;
+  SmallVector<size_t, 16> Instructions;
+};
+
+std::optional<TensorTrampolinePath>
+findTensorTrampolinePath(ArrayRef<InternalDecodedInst> AllDecoded,
+                         uint64_t Target, const TensorAnalysisRange &Range,
+                         size_t ExternalBegin, const LLVMState &LS,
+                         const DenseSet<uint64_t> &DirectTargets) {
+  if (!LS.MIA)
+    return std::nullopt;
+
+  TensorTrampolinePath Result;
+  // The split-relay resolver can produce a destination that already lies in
+  // the candidate range.  Re-enter it directly: walking from that address as
+  // if it were external would incorrectly compress candidate instructions
+  // (including a tensor load) into the trampoline edge.
+  if (Target >= Range.Begin && Target < Range.End) {
+    Result.ResumeOffset = Target;
+    return Result;
+  }
+  size_t RemainingInstructions = AllDecoded.size();
+  DenseSet<uint64_t> VisitedOffsets;
+  auto SegmentHasInteriorEntry = [&](uint64_t Begin, uint64_t End) {
+    return llvm::any_of(
+               DirectTargets,
+               [&](uint64_t Entry) { return Entry > Begin && Entry < End; }) ||
+           llvm::any_of(Range.ForeignExternalEntries, [&](uint64_t Entry) {
+             return Entry > Begin && Entry < End;
+           });
+  };
+  while (RemainingInstructions != 0) {
+    if (llvm::is_contained(Range.ForeignExternalEntries, Target))
+      return std::nullopt;
+    std::optional<size_t> Start = findTensorDecodedIndex(AllDecoded, Target);
+    // Instructions in another original-.text function may have independent
+    // callable roots and predecessors carrying arbitrary descriptor state.
+    // Only candidate instructions (handled by the immediate resume above) or
+    // appended executable trampoline code can be candidate-owned here.
+    if (!Start || *Start < ExternalBegin)
+      return std::nullopt;
+
+    const uint64_t SegmentStart = Target;
+    uint64_t ExpectedOffset = Target;
+    bool FollowedHop = false;
+    for (size_t I = *Start; I < AllDecoded.size(); ++I) {
+      const InternalDecodedInst &DI = AllDecoded[I];
+      if (RemainingInstructions == 0)
+        return std::nullopt;
+      --RemainingInstructions;
+      if (!VisitedOffsets.insert(DI.Offset).second ||
+          DI.Offset != ExpectedOffset || DI.Size == 0 ||
+          DI.Offset > std::numeric_limits<uint64_t>::max() - DI.Size)
+        return std::nullopt;
+      ExpectedOffset = DI.Offset + DI.Size;
+      Result.Instructions.push_back(I);
+      if (DI.Mnemonic == "<unknown>")
+        return std::nullopt;
+
+      if (DI.Mnemonic == "s_set_pc_i64") {
+        if (I < 2 || AllDecoded[I - 2].Offset < SegmentStart)
+          return std::nullopt;
+        std::optional<uint64_t> Next =
+            resolveTensorContiguousSetPc(AllDecoded, I, DirectTargets);
+        if (!Next)
+          return std::nullopt;
+        if (*Next >= Range.Begin && *Next < Range.End) {
+          if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+            return std::nullopt;
+          Result.ResumeOffset = *Next;
+          return Result;
+        }
+        if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+          return std::nullopt;
+        Target = *Next;
+        FollowedHop = true;
+        break;
+      }
+
+      const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+      const bool IsCall = LS.MIA->isCall(DI.Inst);
+      const bool IsReturn = LS.MIA->isReturn(DI.Inst);
+      const bool IsBranch = LS.MIA->isBranch(DI.Inst);
+      if (IsCall || IsReturn || Desc.isTrap())
+        return std::nullopt;
+      if (IsBranch) {
+        uint64_t Next = 0;
+        if (!LS.MIA->isUnconditionalBranch(DI.Inst) ||
+            LS.MIA->isIndirectBranch(DI.Inst) ||
+            !LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Next))
+          return std::nullopt;
+        if (Next >= Range.Begin && Next < Range.End) {
+          if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+            return std::nullopt;
+          Result.ResumeOffset = Next;
+          return Result;
+        }
+        if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+          return std::nullopt;
+        Target = Next;
+        FollowedHop = true;
+        break;
+      }
+      if (Desc.isTerminator() || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+        return std::nullopt;
+    }
+    if (!FollowedHop)
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+std::optional<std::pair<uint64_t, SmallVector<size_t, 2>>>
+resolveTensorRelayTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                         const InternalDecodedInst &GetPc, uint64_t RelayOffset,
+                         const DenseSet<uint64_t> &DirectTargets) {
+  std::optional<size_t> AddIndex =
+      findTensorDecodedIndex(AllDecoded, RelayOffset);
+  if (!AddIndex || *AddIndex + 1 >= AllDecoded.size())
+    return std::nullopt;
+
+  const size_t SetPcIndex = *AddIndex + 1;
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getTensorHotswapAddSetPc(AllDecoded, SetPcIndex);
+  if (!AddSet || GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id() ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size)
+    return std::nullopt;
+  const InternalDecodedInst &SetPc = AllDecoded[SetPcIndex];
+  if (SetPc.Offset > std::numeric_limits<uint64_t>::max() - SetPc.Size)
+    return std::nullopt;
+  const uint64_t SequenceEnd = SetPc.Offset + SetPc.Size;
+  if (llvm::any_of(DirectTargets, [&](uint64_t Target) {
+        return Target > RelayOffset && Target < SequenceEnd;
+      }))
+    return std::nullopt;
+
+  std::optional<uint64_t> Target =
+      applyTensorSignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+  if (!Target)
+    return std::nullopt;
+  return std::pair<uint64_t, SmallVector<size_t, 2>>{
+      *Target, SmallVector<size_t, 2>{*AddIndex, SetPcIndex}};
+}
+
+std::optional<uint64_t> resolveTensorCarrySetPc(
+    ArrayRef<InternalDecodedInst> Decoded, size_t SetPcIndex,
+    const DenseSet<uint64_t> &DirectTargets, const LLVMState &LS) {
+  if (!LS.MRI || SetPcIndex < 3 || SetPcIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[SetPcIndex - 3];
+  const InternalDecodedInst &AddLo = Decoded[SetPcIndex - 2];
+  const InternalDecodedInst &AddHi = Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+  if (GetPc.Mnemonic != "s_get_pc_i64" || AddLo.Mnemonic != "s_add_u32" ||
+      AddHi.Mnemonic != "s_addc_u32" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || AddLo.Inst.getNumOperands() != 3 ||
+      AddHi.Inst.getNumOperands() != 3 || SetPc.Inst.getNumOperands() != 1 ||
+      !GetPc.Inst.getOperand(0).isReg() || !AddLo.Inst.getOperand(0).isReg() ||
+      !AddLo.Inst.getOperand(1).isReg() || !AddLo.Inst.getOperand(2).isImm() ||
+      !AddHi.Inst.getOperand(0).isReg() || !AddHi.Inst.getOperand(1).isReg() ||
+      !AddHi.Inst.getOperand(2).isImm() || !SetPc.Inst.getOperand(0).isReg())
+    return std::nullopt;
+
+  auto IsContiguous = [](const InternalDecodedInst &L,
+                         const InternalDecodedInst &R) {
+    return L.Offset <= std::numeric_limits<uint64_t>::max() - L.Size &&
+           L.Offset + L.Size == R.Offset;
+  };
+  if (!IsContiguous(GetPc, AddLo) || !IsContiguous(AddLo, AddHi) ||
+      !IsContiguous(AddHi, SetPc))
+    return std::nullopt;
+
+  MCRegister Pair = GetPc.Inst.getOperand(0).getReg();
+  MCRegister Lo = AddLo.Inst.getOperand(0).getReg();
+  MCRegister Hi = AddHi.Inst.getOperand(0).getReg();
+  if (!Pair.isValid() || !Lo.isValid() || !Hi.isValid() ||
+      SetPc.Inst.getOperand(0).getReg() != Pair.id() ||
+      AddLo.Inst.getOperand(1).getReg() != Lo.id() ||
+      AddHi.Inst.getOperand(1).getReg() != Hi.id())
+    return std::nullopt;
+  const unsigned LoSubReg = LS.MRI->getSubRegIndex(Pair, Lo);
+  const unsigned HiSubReg = LS.MRI->getSubRegIndex(Pair, Hi);
+  if (LoSubReg == 0 || HiSubReg == 0 || LoSubReg >= HiSubReg)
+    return std::nullopt;
+
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      SetPc.Offset, SetPc.Size, "tensor carry set-PC sequence end");
+  std::optional<uint64_t> CapturedPc = checkedAddUint64(
+      GetPc.Offset, GetPc.Size, "tensor carry set-PC captured PC");
+  if (!SequenceEnd || !CapturedPc ||
+      llvm::any_of(DirectTargets, [&](uint64_t Target) {
+        return Target > GetPc.Offset && Target < *SequenceEnd;
+      }))
+    return std::nullopt;
+
+  const uint64_t LoImm =
+      static_cast<uint32_t>(AddLo.Inst.getOperand(2).getImm());
+  const uint64_t HiImm =
+      static_cast<uint32_t>(AddHi.Inst.getOperand(2).getImm());
+  return *CapturedPc + (LoImm | (HiImm << 32));
+}
+
+struct TensorExternalCfgEdge {
+  size_t SourceIndex = 0;
+  uint64_t Target = 0;
+  std::optional<unsigned> DispatchStubIndex;
+};
+
+struct TensorExternalCfg {
+  bool Valid = false;
+  size_t ExternalBegin = 0;
+  std::vector<TensorExternalCfgEdge> Edges;
+  BitVector UnresolvedSources;
+};
+
+struct TensorPcSequence {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  bool RequiresRelaySource = false;
+  SmallVector<size_t, 2> RelaySources;
+};
+
+TensorExternalCfg buildTensorExternalCfg(
+    ArrayRef<InternalDecodedInst> Decoded,
+    ArrayRef<InternalDecodedInst> AllDecoded,
+    ArrayRef<TensorDispatchStub> DispatchStubs,
+    ArrayRef<uint64_t> VirtualExternalEntries,
+    ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges,
+    ArrayRef<uint64_t> OriginalCodeEntries, const LLVMState &LS,
+    const DenseSet<uint64_t> &DirectTargets) {
+  TensorExternalCfg Result;
+  Result.UnresolvedSources = BitVector(AllDecoded.size());
+  if (!LS.MIA || !LS.MCII || !LS.MRI || AllDecoded.size() < Decoded.size())
+    return Result;
+  for (size_t I = 0; I < Decoded.size(); ++I)
+    if (AllDecoded[I].Offset != Decoded[I].Offset ||
+        AllDecoded[I].Size != Decoded[I].Size)
+      return Result;
+  Result.ExternalBegin = Decoded.size();
+
+  for (uint64_t Root : VirtualExternalEntries) {
+    std::optional<size_t> RootIndex = findTensorDecodedIndex(AllDecoded, Root);
+    if (!RootIndex || *RootIndex < Result.ExternalBegin)
+      return Result;
+    if (llvm::any_of(DispatchStubs, [&](const TensorDispatchStub &Stub) {
+          return Root >= Stub.Begin && Root < Stub.End;
+        }))
+      return Result;
+  }
+
+  DenseMap<size_t, unsigned> DispatchTerminals;
+  for (unsigned StubIndex = 0; StubIndex < DispatchStubs.size(); ++StubIndex) {
+    const TensorDispatchStub &Stub = DispatchStubs[StubIndex];
+    std::optional<size_t> Terminal =
+        findTensorDecodedIndex(AllDecoded, Stub.Terminal);
+    if (!Terminal || *Terminal < Result.ExternalBegin ||
+        !DispatchTerminals.try_emplace(*Terminal, StubIndex).second)
+      return Result;
+  }
+
+  DenseMap<size_t, uint64_t> RelayTargets;
+  DenseMap<size_t, SmallVector<size_t, 2>> RelaySources;
+  DenseSet<size_t> ConflictingRelays;
+  for (size_t I = 1; I < AllDecoded.size(); ++I) {
+    const InternalDecodedInst &Branch = AllDecoded[I];
+    const InternalDecodedInst &GetPc = AllDecoded[I - 1];
+    if (Branch.Mnemonic != "s_branch" || GetPc.Mnemonic != "s_get_pc_i64" ||
+        GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size ||
+        GetPc.Offset + GetPc.Size != Branch.Offset)
+      continue;
+    std::optional<uint64_t> RelayOffset =
+        evaluateTensorDirectControlFlowTarget(Branch, LS);
+    if (!RelayOffset)
+      continue;
+    auto Relay = resolveTensorRelayTarget(AllDecoded, GetPc, *RelayOffset,
+                                          DirectTargets);
+    if (!Relay || Relay->second.empty())
+      continue;
+    const size_t Terminal = Relay->second.back();
+    auto [It, Inserted] = RelayTargets.try_emplace(Terminal, Relay->first);
+    if (!Inserted && It->second != Relay->first)
+      ConflictingRelays.insert(Terminal);
+    RelaySources[Terminal].push_back(I);
+  }
+  if (!ConflictingRelays.empty())
+    return Result;
+
+  std::vector<TensorPcSequence> PcSequences;
+  for (size_t I = 0; I < AllDecoded.size(); ++I) {
+    if (AllDecoded[I].Mnemonic != "s_set_pc_i64" ||
+        DispatchTerminals.contains(I))
+      continue;
+    std::optional<uint64_t> Target =
+        resolveTensorContiguousSetPc(AllDecoded, I, DirectTargets);
+    size_t BeginIndex = 0;
+    bool RequiresRelaySource = false;
+    if (Target) {
+      BeginIndex = I - 2;
+    } else {
+      Target = resolveTensorCarrySetPc(AllDecoded, I, DirectTargets, LS);
+      if (Target) {
+        BeginIndex = I - 3;
+      } else {
+        auto Relay = RelayTargets.find(I);
+        if (Relay == RelayTargets.end())
+          continue;
+        Target = Relay->second;
+        BeginIndex = I - 1;
+        RequiresRelaySource = true;
+      }
+    }
+    std::optional<uint64_t> End =
+        checkedAddUint64(AllDecoded[I].Offset, AllDecoded[I].Size,
+                         "tensor computed-PC sequence end");
+    if (!End || BeginIndex >= I || AllDecoded[BeginIndex].Offset >= *End)
+      return Result;
+    TensorPcSequence Sequence{AllDecoded[BeginIndex].Offset, *End,
+                              RequiresRelaySource};
+    if (RequiresRelaySource)
+      Sequence.RelaySources = RelaySources[I];
+    PcSequences.push_back(std::move(Sequence));
+  }
+  for (const auto &[Terminal, Sources] : RelaySources)
+    for (size_t Source : Sources) {
+      if (Source == 0 || Source >= AllDecoded.size())
+        return Result;
+      std::optional<uint64_t> End =
+          checkedAddUint64(AllDecoded[Source].Offset, AllDecoded[Source].Size,
+                           "tensor relay source sequence end");
+      if (!End)
+        return Result;
+      PcSequences.push_back({AllDecoded[Source - 1].Offset, *End, false, {}});
+    }
+
+  auto AddEdge = [&](size_t Source, uint64_t Target,
+                     std::optional<unsigned> DispatchStubIndex = std::nullopt) {
+    Result.Edges.push_back({Source, Target, DispatchStubIndex});
+  };
+  auto AddFallthrough = [&](size_t I) {
+    if (I + 1 >= AllDecoded.size() ||
+        AllDecoded[I].Offset >
+            std::numeric_limits<uint64_t>::max() - AllDecoded[I].Size ||
+        AllDecoded[I].Offset + AllDecoded[I].Size != AllDecoded[I + 1].Offset)
+      return false;
+    AddEdge(I, AllDecoded[I + 1].Offset);
+    return true;
+  };
+
+  for (size_t I = Result.ExternalBegin; I < AllDecoded.size(); ++I) {
+    const InternalDecodedInst &DI = AllDecoded[I];
+    auto Dispatch = DispatchTerminals.find(I);
+    if (Dispatch != DispatchTerminals.end()) {
+      AddEdge(I, DispatchStubs[Dispatch->second].Target, Dispatch->second);
+      continue;
+    }
+
+    if (DI.Mnemonic == "<unknown>") {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (StringRef(DI.Mnemonic).starts_with("s_rfe")) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      std::optional<uint64_t> Target =
+          resolveTensorContiguousSetPc(AllDecoded, I, DirectTargets);
+      if (!Target)
+        Target = resolveTensorCarrySetPc(AllDecoded, I, DirectTargets, LS);
+      if (!Target) {
+        auto Relay = RelayTargets.find(I);
+        if (Relay != RelayTargets.end() && !ConflictingRelays.contains(I))
+          Target = Relay->second;
+      }
+      if (Target)
+        AddEdge(I, *Target);
+      else
+        Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (DI.Mnemonic == "s_code_end" || DI.Mnemonic == "s_endpgm" ||
+        DI.Mnemonic == "s_endpgm_saved")
+      continue;
+
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsCall = LS.MIA->isCall(DI.Inst) || Desc.isCall();
+    const bool IsReturn = LS.MIA->isReturn(DI.Inst) || Desc.isReturn();
+    const bool IsBranch = LS.MIA->isBranch(DI.Inst) || Desc.isBranch();
+    if (IsReturn) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (IsBranch || IsCall) {
+      if (LS.MIA->isIndirectBranch(DI.Inst) || Desc.isIndirectBranch()) {
+        Result.UnresolvedSources.set(I);
+        continue;
+      }
+      std::optional<uint64_t> Target =
+          evaluateTensorDirectControlFlowTarget(DI, LS);
+      if (!Target) {
+        Result.UnresolvedSources.set(I);
+        continue;
+      }
+      AddEdge(I, *Target);
+      const bool IsConditional =
+          LS.MIA->isConditionalBranch(DI.Inst) || Desc.isConditionalBranch();
+      if ((IsCall || IsConditional) && !AddFallthrough(I))
+        Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (Desc.isTrap() || Desc.isTerminator()) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (!AddFallthrough(I))
+      Result.UnresolvedSources.set(I);
+  }
+
+  // A recognized get-PC/add/set-PC sequence has a statically known target
+  // only when execution enters through all of its prerequisites.  An edge or
+  // callable root into the middle can reuse an arbitrary pre-existing SGPR
+  // value and turn the nominally direct set-PC into an indirect transfer.
+  auto HasValidSequenceIngress = [&](std::optional<size_t> SourceIndex,
+                                     uint64_t Target) {
+    for (const TensorPcSequence &Sequence : PcSequences) {
+      if (Target < Sequence.Begin || Target >= Sequence.End)
+        continue;
+
+      if (SourceIndex) {
+        if (*SourceIndex >= AllDecoded.size())
+          return false;
+        const InternalDecodedInst &Source = AllDecoded[*SourceIndex];
+        const bool IsSequentialPrerequisite =
+            Source.Offset >= Sequence.Begin && Source.Offset < Sequence.End &&
+            Source.Offset <=
+                std::numeric_limits<uint64_t>::max() - Source.Size &&
+            Source.Offset + Source.Size == Target;
+        if (IsSequentialPrerequisite)
+          continue;
+        if (Target == Sequence.Begin &&
+            (!Sequence.RequiresRelaySource ||
+             llvm::is_contained(Sequence.RelaySources, *SourceIndex)))
+          continue;
+      } else if (Target == Sequence.Begin && !Sequence.RequiresRelaySource) {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  };
+
+  // Every resolved edge must land on an exact decoded instruction boundary.
+  // Otherwise the target is outside the analyzed graph (or in the middle of
+  // an instruction), so treating it as a closed direct edge would be unsound.
+  for (const TensorExternalCfgEdge &Edge : Result.Edges) {
+    if (Edge.SourceIndex >= AllDecoded.size() ||
+        !findTensorDecodedIndex(AllDecoded, Edge.Target) ||
+        !HasValidSequenceIngress(Edge.SourceIndex, Edge.Target))
+      return TensorExternalCfg{};
+  }
+  for (const auto &[Source, Target] : OriginalControlFlowEdges) {
+    std::optional<size_t> SourceIndex =
+        findTensorDecodedIndex(AllDecoded, Source);
+    if (!SourceIndex || *SourceIndex >= Result.ExternalBegin ||
+        !findTensorDecodedIndex(AllDecoded, Target) ||
+        !HasValidSequenceIngress(*SourceIndex, Target))
+      return TensorExternalCfg{};
+  }
+  for (uint64_t Root : OriginalCodeEntries) {
+    std::optional<size_t> RootIndex = findTensorDecodedIndex(AllDecoded, Root);
+    if (!RootIndex || *RootIndex >= Result.ExternalBegin ||
+        !HasValidSequenceIngress(std::nullopt, Root))
+      return TensorExternalCfg{};
+  }
+  for (uint64_t Root : VirtualExternalEntries)
+    if (!HasValidSequenceIngress(std::nullopt, Root))
+      return TensorExternalCfg{};
+
+  for (const TensorExternalCfgEdge &Edge : Result.Edges)
+    for (const TensorDispatchStub &Stub : DispatchStubs)
+      if (Edge.Target >= Stub.Begin && Edge.Target < Stub.End) {
+        const uint64_t Source = AllDecoded[Edge.SourceIndex].Offset;
+        if (Source < Stub.Begin || Source >= Stub.End)
+          return TensorExternalCfg{};
+      }
+  Result.Valid = true;
+  return Result;
+}
+
+std::optional<unsigned> getNumberedRegFactIndex(MCRegister Reg,
+                                                const MCRegisterInfo &MRI,
+                                                unsigned MaxSgprs,
+                                                unsigned MaxVgprs) {
+  const char *RawName = MRI.getName(Reg);
+  if (!RawName)
+    return std::nullopt;
+  StringRef Name(RawName);
+  if (Name.contains('_'))
+    return std::nullopt;
+
+  unsigned Index = 0;
+  if (Name.consume_front("SGPR")) {
+    if (Name.getAsInteger(10, Index) || Index >= MaxSgprs)
+      return std::nullopt;
+    return Index;
+  }
+  if (Name.consume_front("VGPR")) {
+    if (Name.getAsInteger(10, Index) || Index >= MaxVgprs)
+      return std::nullopt;
+    return MaxSgprs + Index;
+  }
+  return std::nullopt;
+}
+
+std::optional<unsigned> getTrue16ParentFactIndex(MCRegister Reg,
+                                                 const MCRegisterInfo &MRI,
+                                                 unsigned MaxSgprs,
+                                                 unsigned MaxVgprs) {
+  StringRef Name = MRI.getName(Reg);
+  const bool IsLowHalf = Name.ends_with("_LO16");
+  const bool IsHighHalf = Name.ends_with("_HI16");
+  if (!IsLowHalf && !IsHighHalf)
+    return std::nullopt;
+
+  unsigned Index = 0;
+  if (Name.consume_front("SGPR")) {
+    Name = Name.take_until([](char C) { return C == '_'; });
+    if (!Name.getAsInteger(10, Index) && Index < MaxSgprs)
+      return Index;
+    return std::nullopt;
+  }
+  if (Name.consume_front("VGPR")) {
+    Name = Name.take_until([](char C) { return C == '_'; });
+    if (!Name.getAsInteger(10, Index) && Index < MaxVgprs)
+      return MaxSgprs + Index;
+  }
+  return std::nullopt;
+}
+
+SmallVector<MCRegister, 4> getNumberedRegLeaves(MCRegister Reg,
+                                                const MCRegisterInfo &MRI,
+                                                unsigned MaxSgprs,
+                                                unsigned MaxVgprs) {
+  if (getNumberedRegFactIndex(Reg, MRI, MaxSgprs, MaxVgprs))
+    return {Reg};
+
+  SmallVector<MCRegister, 4> Leaves;
+  for (MCRegister Sub : getDirectSubRegs(Reg, MRI))
+    if (getNumberedRegFactIndex(Sub, MRI, MaxSgprs, MaxVgprs))
+      Leaves.push_back(Sub);
+  return Leaves;
+}
+
+bool operandLow16KnownZero(const MCOperand &Op, const BitVector &State,
+                           const MCRegisterInfo &MRI, unsigned MaxSgprs,
+                           unsigned MaxVgprs) {
+  if (Op.isImm())
+    return (static_cast<uint64_t>(Op.getImm()) & 0xffff) == 0;
+  if (!Op.isReg() || !Op.getReg())
+    return false;
+  std::optional<unsigned> Fact =
+      getNumberedRegFactIndex(MCRegister(Op.getReg()), MRI, MaxSgprs, MaxVgprs);
+  return Fact && State.test(*Fact);
+}
+
+void setRegLow16Fact(BitVector &State, MCRegister Reg, bool IsKnownZero,
+                     const MCRegisterInfo &MRI, unsigned MaxSgprs,
+                     unsigned MaxVgprs) {
+  if (std::optional<unsigned> Fact =
+          getNumberedRegFactIndex(Reg, MRI, MaxSgprs, MaxVgprs)) {
+    if (IsKnownZero)
+      State.set(*Fact);
+    else
+      State.reset(*Fact);
+    return;
+  }
+
+  // True16 defs do not enumerate their 32-bit parent as a direct subregister.
+  // Conservatively kill the parent's fact for either half. This includes
+  // partial SGPR defs: retaining an SGPR descriptor fact across an overlapping
+  // subregister write would make the tensor proof unsound.
+  if (std::optional<unsigned> Parent =
+          getTrue16ParentFactIndex(Reg, MRI, MaxSgprs, MaxVgprs)) {
+    State.reset(*Parent);
+    return;
+  }
+
+  for (MCRegister Sub : getDirectSubRegs(Reg, MRI))
+    setRegLow16Fact(State, Sub, IsKnownZero, MRI, MaxSgprs, MaxVgprs);
+}
+
+bool tensorInstructionDefinesExec(const MCInst &Inst, const MCInstrDesc &Desc,
+                                  const MCRegisterInfo &MRI) {
+  auto IsExec = [&](MCRegister Reg) {
+    StringRef Name = MRI.getName(Reg);
+    return Name == "EXEC" || Name == "EXEC_LO" || Name == "EXEC_HI";
+  };
+  const unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), Inst.getNumOperands());
+  for (unsigned I = 0; I < NumDefs; ++I)
+    if (Inst.getOperand(I).isReg() && Inst.getOperand(I).getReg() &&
+        IsExec(MCRegister(Inst.getOperand(I).getReg())))
+      return true;
+  return llvm::any_of(Desc.implicit_defs(),
+                      [&](MCPhysReg Reg) { return IsExec(MCRegister(Reg)); });
+}
+
+BitVector transferTensorDescriptorFacts(const InternalDecodedInst &DI,
+                                        const BitVector &Input,
+                                        const LLVMState &LS, unsigned MaxSgprs,
+                                        unsigned MaxVgprs) {
+  const MCInst &Inst = DI.Inst;
+  const MCInstrDesc &Desc = LS.MCII->get(Inst.getOpcode());
+  const MCRegisterInfo &MRI = *LS.MRI;
+  const unsigned ExecNonemptyFact = MaxSgprs + MaxVgprs;
+  BitVector EffectiveInput = Input;
+  if (tensorInstructionDefinesExec(Inst, Desc, MRI)) {
+    EffectiveInput.reset(MaxSgprs, MaxSgprs + MaxVgprs);
+    EffectiveInput.reset(ExecNonemptyFact);
+  }
+  BitVector Output = EffectiveInput;
+
+  const unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), Inst.getNumOperands());
+  for (unsigned I = 0; I < NumDefs; ++I) {
+    const MCOperand &Def = Inst.getOperand(I);
+    if (Def.isReg() && Def.getReg())
+      setRegLow16Fact(Output, MCRegister(Def.getReg()), false, MRI, MaxSgprs,
+                      MaxVgprs);
+  }
+  for (MCPhysReg Def : Desc.implicit_defs())
+    setRegLow16Fact(Output, MCRegister(Def), false, MRI, MaxSgprs, MaxVgprs);
+
+  auto CopyOne = [&](unsigned DefOp, unsigned SourceOp) {
+    if (DefOp >= Inst.getNumOperands() || SourceOp >= Inst.getNumOperands() ||
+        !Inst.getOperand(DefOp).isReg() || !Inst.getOperand(DefOp).getReg())
+      return;
+    MCRegister Dst = MCRegister(Inst.getOperand(DefOp).getReg());
+    std::optional<unsigned> DstFact =
+        getNumberedRegFactIndex(Dst, MRI, MaxSgprs, MaxVgprs);
+    const bool FullNumberedDestination = DstFact.has_value();
+    const bool VgprDestination = DstFact && *DstFact >= MaxSgprs;
+    bool Known = FullNumberedDestination &&
+                 (!VgprDestination || EffectiveInput.test(ExecNonemptyFact)) &&
+                 operandLow16KnownZero(Inst.getOperand(SourceOp),
+                                       EffectiveInput, MRI, MaxSgprs, MaxVgprs);
+    setRegLow16Fact(Output, Dst, Known, MRI, MaxSgprs, MaxVgprs);
+  };
+
+  if ((DI.Mnemonic == "s_mov_b32" || DI.Mnemonic == "v_mov_b32") &&
+      Inst.getNumOperands() == 2) {
+    CopyOne(0, 1);
+  } else if (DI.Mnemonic == "s_mov_b64" && Inst.getNumOperands() >= 2 &&
+             Inst.getOperand(0).isReg() && Inst.getOperand(0).getReg()) {
+    SmallVector<MCRegister, 4> Dst = getNumberedRegLeaves(
+        MCRegister(Inst.getOperand(0).getReg()), MRI, MaxSgprs, MaxVgprs);
+    if (Inst.getOperand(1).isReg() && Inst.getOperand(1).getReg()) {
+      SmallVector<MCRegister, 4> Src = getNumberedRegLeaves(
+          MCRegister(Inst.getOperand(1).getReg()), MRI, MaxSgprs, MaxVgprs);
+      if (Dst.size() == Src.size()) {
+        for (unsigned I = 0; I < Dst.size(); ++I) {
+          std::optional<unsigned> SourceFact =
+              getNumberedRegFactIndex(Src[I], MRI, MaxSgprs, MaxVgprs);
+          setRegLow16Fact(Output, Dst[I],
+                          SourceFact && EffectiveInput.test(*SourceFact), MRI,
+                          MaxSgprs, MaxVgprs);
+        }
+      }
+    }
+  } else if (DI.Mnemonic == "v_dual_mov_b32" && NumDefs == 2 &&
+             Inst.getNumOperands() == 4) {
+    CopyOne(0, 2);
+    CopyOne(1, 3);
+  } else if (DI.Mnemonic == "v_readfirstlane_b32") {
+    if (EffectiveInput.test(ExecNonemptyFact))
+      CopyOne(0, 1);
+  } else if (DI.Mnemonic == "s_pack_hh_b32_b16" && Inst.getNumOperands() >= 2 &&
+             Inst.getOperand(0).isReg() && Inst.getOperand(0).getReg() &&
+             Inst.getOperand(1).isImm() && Inst.getOperand(1).getImm() == 0) {
+    setRegLow16Fact(Output, MCRegister(Inst.getOperand(0).getReg()), true, MRI,
+                    MaxSgprs, MaxVgprs);
+  }
+
+  return Output;
+}
+
+static constexpr uint64_t TensorMaskDefTop =
+    std::numeric_limits<uint64_t>::max();
+static constexpr uint64_t TensorMaskDefUnknown = TensorMaskDefTop - 1;
+using TensorMaskDefState = SmallVector<uint64_t, 8>;
+
+TensorMaskDefState transferTensorMaskDefinitions(
+    const InternalDecodedInst &DI, const TensorMaskDefState &Input,
+    const DenseMap<unsigned, unsigned> &TrackedSgprs, const LLVMState &LS,
+    unsigned MaxSgprs, unsigned MaxVgprs) {
+  TensorMaskDefState Output = Input;
+  const MCInst &Inst = DI.Inst;
+  const MCInstrDesc &Desc = LS.MCII->get(Inst.getOpcode());
+  const MCRegisterInfo &MRI = *LS.MRI;
+
+  auto KillReg = [&](MCRegister Reg) {
+    if (std::optional<unsigned> Parent =
+            getTrue16ParentFactIndex(Reg, MRI, MaxSgprs, MaxVgprs)) {
+      auto Slot = TrackedSgprs.find(*Parent);
+      if (Slot != TrackedSgprs.end())
+        Output[Slot->second] = TensorMaskDefUnknown;
+      return;
+    }
+    for (MCRegister Leaf : getNumberedRegLeaves(Reg, MRI, MaxSgprs, MaxVgprs)) {
+      std::optional<unsigned> Fact =
+          getNumberedRegFactIndex(Leaf, MRI, MaxSgprs, MaxVgprs);
+      if (!Fact)
+        continue;
+      auto Slot = TrackedSgprs.find(*Fact);
+      if (Slot != TrackedSgprs.end()) {
+        Output[Slot->second] = TensorMaskDefUnknown;
+      }
+    }
+  };
+
+  const unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), Inst.getNumOperands());
+  for (unsigned I = 0; I < NumDefs; ++I) {
+    const MCOperand &Def = Inst.getOperand(I);
+    if (Def.isReg() && Def.getReg())
+      KillReg(MCRegister(Def.getReg()));
+  }
+  for (MCPhysReg Def : Desc.implicit_defs())
+    KillReg(MCRegister(Def));
+
+  if (DI.Mnemonic == "v_readfirstlane_b32" && Inst.getNumOperands() >= 1 &&
+      Inst.getOperand(0).isReg() && Inst.getOperand(0).getReg()) {
+    std::optional<unsigned> Fact = getNumberedRegFactIndex(
+        MCRegister(Inst.getOperand(0).getReg()), MRI, MaxSgprs, MaxVgprs);
+    if (Fact) {
+      auto Slot = TrackedSgprs.find(*Fact);
+      if (Slot != TrackedSgprs.end())
+        Output[Slot->second] = DI.Offset;
+    }
+  }
+  return Output;
+}
+
+void meetTensorMaskDefinitions(TensorMaskDefState &Accumulator,
+                               const TensorMaskDefState &Candidate) {
+  assert(Accumulator.size() == Candidate.size());
+  for (unsigned I = 0; I < Accumulator.size(); ++I) {
+    if (Accumulator[I] == TensorMaskDefTop)
+      Accumulator[I] = Candidate[I];
+    else if (Accumulator[I] != Candidate[I])
+      Accumulator[I] = TensorMaskDefUnknown;
+  }
+}
+
+struct TensorCfgPredecessor {
+  unsigned From = 0;
+  SmallVector<size_t, 16> ExternalInstructions;
+};
+
+void addTensorCfgEdge(
+    unsigned From, unsigned To,
+    std::vector<SmallVector<unsigned, 2>> &Successors,
+    std::vector<SmallVector<TensorCfgPredecessor, 2>> &Predecessors,
+    ArrayRef<size_t> ExternalInstructions = {}) {
+  if (!llvm::is_contained(Successors[From], To))
+    Successors[From].push_back(To);
+  if (llvm::any_of(Predecessors[To], [&](const TensorCfgPredecessor &Pred) {
+        return Pred.From == From &&
+               llvm::equal(Pred.ExternalInstructions, ExternalInstructions);
+      }))
+    return;
+  TensorCfgPredecessor Pred;
+  Pred.From = From;
+  Pred.ExternalInstructions.append(ExternalInstructions.begin(),
+                                   ExternalInstructions.end());
+  Predecessors[To].push_back(std::move(Pred));
+}
+
+void analyzeTensorDescriptorRange(ArrayRef<InternalDecodedInst> Decoded,
+                                  ArrayRef<InternalDecodedInst> AllDecoded,
+                                  const TensorExternalCfg &ExternalCfg,
+                                  const TensorAnalysisRange &Range,
+                                  const LLVMState &LS, unsigned MaxSgprs,
+                                  unsigned MaxVgprs,
+                                  const DenseSet<uint64_t> &DirectTargets,
+                                  TensorDescriptorMustAnalysis &Result,
+                                  BitVector &Seen) {
+  SmallVector<size_t> GlobalIndices;
+  auto First = llvm::lower_bound(
+      Decoded, Range.Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto Last = llvm::lower_bound(
+      Decoded, Range.End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  for (auto It = First; It != Last; ++It)
+    GlobalIndices.push_back(It - Decoded.begin());
+  if (GlobalIndices.empty() ||
+      Decoded[GlobalIndices.front()].Offset != Range.Begin ||
+      !llvm::any_of(GlobalIndices, [&](size_t I) {
+        return Decoded[I].Mnemonic == "tensor_load_to_lds";
+      }))
+    return;
+  uint64_t ExpectedOffset = Range.Begin;
+  for (size_t GlobalIdx : GlobalIndices) {
+    const InternalDecodedInst &DI = Decoded[GlobalIdx];
+    if (DI.Offset != ExpectedOffset || DI.Size == 0 ||
+        DI.Offset > std::numeric_limits<uint64_t>::max() - DI.Size)
+      return;
+    ExpectedOffset = DI.Offset + DI.Size;
+  }
+  if (ExpectedOffset != Range.End)
+    return;
+
+  const unsigned Count = GlobalIndices.size();
+  DenseMap<uint64_t, unsigned> OffsetToLocal;
+  for (unsigned I = 0; I < Count; ++I)
+    OffsetToLocal.try_emplace(Decoded[GlobalIndices[I]].Offset, I);
+
+  DenseMap<unsigned, unsigned> TrackedSgprs;
+  for (size_t GlobalIdx : GlobalIndices) {
+    if (Decoded[GlobalIdx].Mnemonic != "tensor_load_to_lds")
+      continue;
+    MCRegister Base = getDescriptorBaseSgpr(Decoded[GlobalIdx].Inst, *LS.MRI);
+    std::optional<unsigned> Fact =
+        getNumberedRegFactIndex(Base, *LS.MRI, MaxSgprs, MaxVgprs);
+    if (Fact && *Fact < MaxSgprs && !TrackedSgprs.contains(*Fact))
+      TrackedSgprs.try_emplace(*Fact, TrackedSgprs.size());
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  std::vector<SmallVector<TensorCfgPredecessor, 2>> Predecessors(Count);
+  BitVector UnknownSuccessors(Count);
+  BitVector ModeledExternalInstructions(AllDecoded.size());
+  auto RecordModeledExternal = [&](const TensorTrampolinePath &Path) {
+    for (size_t ExternalIdx : Path.Instructions)
+      if (ExternalIdx < ModeledExternalInstructions.size())
+        ModeledExternalInstructions.set(ExternalIdx);
+  };
+  SmallVector<unsigned> HotswapSetPcCandidates;
+  for (unsigned I = 0; I < Count; ++I) {
+    const InternalDecodedInst &DI = Decoded[GlobalIndices[I]];
+    const bool HasFallthrough = I + 1 < Count;
+    if (DI.Mnemonic == "<unknown>" || !LS.MIA) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsCall = LS.MIA->isCall(DI.Inst) || Desc.isCall();
+    const bool IsReturn = LS.MIA->isReturn(DI.Inst) || Desc.isReturn();
+    const bool IsBranch = LS.MIA->isBranch(DI.Inst) || Desc.isBranch();
+    if (StringRef(DI.Mnemonic).starts_with("s_rfe")) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (IsReturn)
+      continue;
+    if (IsCall) {
+      UnknownSuccessors.set(I);
+      if (!Desc.isTerminator() && HasFallthrough)
+        addTensorCfgEdge(I, I + 1, Successors, Predecessors);
+      continue;
+    }
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      HotswapSetPcCandidates.push_back(I);
+      continue;
+    }
+    if (Desc.isTrap()) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    if (IsBranch) {
+      const bool IsIndirect =
+          LS.MIA->isIndirectBranch(DI.Inst) || Desc.isIndirectBranch();
+      const bool IsConditional =
+          LS.MIA->isConditionalBranch(DI.Inst) || Desc.isConditionalBranch();
+      const bool IsUnconditional = LS.MIA->isUnconditionalBranch(DI.Inst) ||
+                                   Desc.isUnconditionalBranch();
+      bool TargetKnown = false;
+      if (!IsIndirect) {
+        uint64_t Target = 0;
+        if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+          TargetKnown = true;
+          if (Target >= Range.Begin && Target < Range.End) {
+            auto TargetIt = OffsetToLocal.find(Target);
+            if (TargetIt == OffsetToLocal.end()) {
+              UnknownSuccessors.set(I);
+              TargetKnown = false;
+            } else {
+              addTensorCfgEdge(I, TargetIt->second, Successors, Predecessors);
+            }
+          } else {
+            // An out-of-range destination is not an ordinary function exit:
+            // generated HotSwap bodies may re-enter this range. Only a fully
+            // decoded unconditional trampoline path can preserve facts.
+            TargetKnown = false;
+          }
+          if (!TargetKnown && IsUnconditional) {
+            std::optional<TensorTrampolinePath> Path = findTensorTrampolinePath(
+                AllDecoded, Target, Range, ExternalCfg.ExternalBegin, LS,
+                DirectTargets);
+            if (!Path && I != 0 && DI.Mnemonic == "s_branch" &&
+                !DirectTargets.contains(DI.Offset)) {
+              const InternalDecodedInst &GetPc = Decoded[GlobalIndices[I - 1]];
+              if (GetPc.Offset <=
+                      std::numeric_limits<uint64_t>::max() - GetPc.Size &&
+                  GetPc.Offset + GetPc.Size == DI.Offset &&
+                  GetPc.Mnemonic == "s_get_pc_i64") {
+                auto Relay = resolveTensorRelayTarget(AllDecoded, GetPc, Target,
+                                                      DirectTargets);
+                if (Relay) {
+                  Path = findTensorTrampolinePath(
+                      AllDecoded, Relay->first, Range,
+                      ExternalCfg.ExternalBegin, LS, DirectTargets);
+                  if (Path)
+                    Path->Instructions.insert(Path->Instructions.begin(),
+                                              Relay->second.begin(),
+                                              Relay->second.end());
+                }
+              }
+            }
+            if (Path) {
+              RecordModeledExternal(*Path);
+              auto ResumeIt = OffsetToLocal.find(Path->ResumeOffset);
+              if (ResumeIt == OffsetToLocal.end()) {
+                UnknownSuccessors.set(I);
+                TargetKnown = false;
+              } else {
+                addTensorCfgEdge(I, ResumeIt->second, Successors, Predecessors,
+                                 Path->Instructions);
+                TargetKnown = true;
+              }
+            }
+          }
+        }
+      }
+      if (!TargetKnown)
+        UnknownSuccessors.set(I);
+      if (IsConditional) {
+        if (HasFallthrough)
+          addTensorCfgEdge(I, I + 1, Successors, Predecessors);
+        else
+          UnknownSuccessors.set(I);
+      } else if (!IsUnconditional) {
+        UnknownSuccessors.set(I);
+      }
+      continue;
+    }
+
+    if (Desc.isTerminator())
+      continue;
+    if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (HasFallthrough)
+      addTensorCfgEdge(I, I + 1, Successors, Predecessors);
+    else
+      UnknownSuccessors.set(I);
+  }
+
+  for (unsigned I : HotswapSetPcCandidates) {
+    const InternalDecodedInst &SetPc = Decoded[GlobalIndices[I]];
+    std::optional<uint64_t> Target =
+        resolveTensorSetPcTarget(AllDecoded, SetPc.Offset, DirectTargets);
+    if (!Target) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (*Target >= Range.Begin && *Target < Range.End) {
+      auto TargetIt = OffsetToLocal.find(*Target);
+      if (TargetIt == OffsetToLocal.end())
+        UnknownSuccessors.set(I);
+      else
+        addTensorCfgEdge(I, TargetIt->second, Successors, Predecessors);
+      continue;
+    }
+
+    std::optional<TensorTrampolinePath> Path =
+        findTensorTrampolinePath(AllDecoded, *Target, Range,
+                                 ExternalCfg.ExternalBegin, LS, DirectTargets);
+    if (!Path) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    auto ResumeIt = OffsetToLocal.find(Path->ResumeOffset);
+    if (ResumeIt == OffsetToLocal.end()) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    RecordModeledExternal(*Path);
+    addTensorCfgEdge(I, ResumeIt->second, Successors, Predecessors,
+                     Path->Instructions);
+  }
+
+  // A modeled external subgraph is candidate-owned only if every decoded
+  // predecessor is candidate-owned too. Virtual KD dispatch is the sole
+  // sourceless entry and is admitted only through an exact validated stub.
+  auto OffsetTouchesModeledExternal = [&](uint64_t Offset) {
+    auto It = llvm::upper_bound(
+        AllDecoded, Offset, [](uint64_t Value, const InternalDecodedInst &DI) {
+          return Value < DI.Offset;
+        });
+    if (It == AllDecoded.begin())
+      return false;
+    --It;
+    const size_t Index = It - AllDecoded.begin();
+    return Index >= ExternalCfg.ExternalBegin &&
+           ModeledExternalInstructions.test(Index) &&
+           It->Offset <= std::numeric_limits<uint64_t>::max() - It->Size &&
+           Offset >= It->Offset && Offset < It->Offset + It->Size;
+  };
+  if (llvm::any_of(Range.ForeignExternalEntries, OffsetTouchesModeledExternal))
+    return;
+
+  auto CandidateDispatchStubContaining =
+      [&](uint64_t Offset) -> const TensorDispatchStub * {
+    auto It = llvm::find_if(Range.DispatchStubs, [&](const auto &Stub) {
+      return Stub.Target == Range.Begin && Offset >= Stub.Begin &&
+             Offset < Stub.End;
+    });
+    return It == Range.DispatchStubs.end() ? nullptr : &*It;
+  };
+  if (llvm::any_of(Range.VirtualExternalEntries, [&](uint64_t Root) {
+        return OffsetTouchesModeledExternal(Root) ||
+               CandidateDispatchStubContaining(Root) != nullptr;
+      }))
+    return;
+  if (ExternalCfg.UnresolvedSources.any())
+    return;
+
+  for (const TensorExternalCfgEdge &Edge : ExternalCfg.Edges) {
+    const bool SourceModeled =
+        ModeledExternalInstructions.test(Edge.SourceIndex);
+    const bool TargetsCandidate =
+        Edge.Target >= Range.Begin && Edge.Target < Range.End;
+    const bool IsCandidateDispatch =
+        Edge.DispatchStubIndex &&
+        *Edge.DispatchStubIndex < Range.DispatchStubs.size() &&
+        Range.DispatchStubs[*Edge.DispatchStubIndex].Target == Range.Begin &&
+        Edge.Target == Range.Begin;
+    if (TargetsCandidate && !SourceModeled && !IsCandidateDispatch)
+      return;
+    if (OffsetTouchesModeledExternal(Edge.Target) && !SourceModeled)
+      return;
+
+    if (const TensorDispatchStub *Stub =
+            CandidateDispatchStubContaining(Edge.Target)) {
+      const uint64_t Source = AllDecoded[Edge.SourceIndex].Offset;
+      if (Source < Stub->Begin || Source >= Stub->End)
+        return;
+    }
+  }
+
+  BitVector Reachable(Count);
+  SmallVector<unsigned> Worklist{0};
+  Reachable.set(0);
+  for (size_t Next = 0; Next < Worklist.size(); ++Next) {
+    unsigned I = Worklist[Next];
+    if (UnknownSuccessors.test(I))
+      return;
+    for (unsigned Succ : Successors[I])
+      if (!Reachable.test(Succ)) {
+        Reachable.set(Succ);
+        Worklist.push_back(Succ);
+      }
+  }
+
+  const unsigned FactCount = MaxSgprs + MaxVgprs + 1;
+  const unsigned ExecNonemptyFact = MaxSgprs + MaxVgprs;
+  BitVector Top(FactCount, true);
+  BitVector Bottom(FactCount);
+  BitVector EntryState = Bottom;
+  EntryState.set(ExecNonemptyFact);
+  std::vector<BitVector> MustIn(Count, Top);
+  std::vector<BitVector> MustOut(Count, Top);
+  MustIn[0] = EntryState;
+  MustOut[0] = transferTensorDescriptorFacts(
+      Decoded[GlobalIndices[0]], EntryState, LS, MaxSgprs, MaxVgprs);
+
+  TensorMaskDefState DefTop(TrackedSgprs.size(), TensorMaskDefTop);
+  TensorMaskDefState DefUnknown(TrackedSgprs.size(), TensorMaskDefUnknown);
+  std::vector<TensorMaskDefState> DefIn(Count, DefTop);
+  std::vector<TensorMaskDefState> DefOut(Count, DefTop);
+  DefIn[0] = DefUnknown;
+  DefOut[0] =
+      transferTensorMaskDefinitions(Decoded[GlobalIndices[0]], DefUnknown,
+                                    TrackedSgprs, LS, MaxSgprs, MaxVgprs);
+
+  bool Changed = true;
+  unsigned Iterations = 0;
+  const unsigned IterationLimit = std::max(Count + 1, FactCount + 1);
+  while (Changed && Iterations++ < IterationLimit) {
+    Changed = false;
+    for (unsigned I = 0; I < Count; ++I) {
+      if (!Reachable.test(I))
+        continue;
+      BitVector NewIn = I == 0 ? EntryState : Top;
+      TensorMaskDefState NewDefIn = I == 0 ? DefUnknown : DefTop;
+      bool SawPredecessor = I == 0;
+      // Node zero also has a virtual dispatch predecessor carrying EntryState.
+      // Meet real backedges with that seed instead of treating every loop to
+      // the kernel entry as a fresh dispatch with nonempty EXEC.
+      for (const TensorCfgPredecessor &Pred : Predecessors[I]) {
+        if (!Reachable.test(Pred.From))
+          continue;
+        SawPredecessor = true;
+        BitVector EdgeOut = MustOut[Pred.From];
+        TensorMaskDefState EdgeDefOut = DefOut[Pred.From];
+        for (size_t ExternalIdx : Pred.ExternalInstructions) {
+          EdgeOut = transferTensorDescriptorFacts(
+              AllDecoded[ExternalIdx], EdgeOut, LS, MaxSgprs, MaxVgprs);
+          EdgeDefOut = transferTensorMaskDefinitions(AllDecoded[ExternalIdx],
+                                                     EdgeDefOut, TrackedSgprs,
+                                                     LS, MaxSgprs, MaxVgprs);
+        }
+        NewIn &= EdgeOut;
+        meetTensorMaskDefinitions(NewDefIn, EdgeDefOut);
+      }
+      if (!SawPredecessor) {
+        NewIn.reset();
+        NewDefIn = DefUnknown;
+      }
+      BitVector NewOut = transferTensorDescriptorFacts(
+          Decoded[GlobalIndices[I]], NewIn, LS, MaxSgprs, MaxVgprs);
+      TensorMaskDefState NewDefOut =
+          transferTensorMaskDefinitions(Decoded[GlobalIndices[I]], NewDefIn,
+                                        TrackedSgprs, LS, MaxSgprs, MaxVgprs);
+      if (NewIn != MustIn[I] || NewOut != MustOut[I] || NewDefIn != DefIn[I] ||
+          NewDefOut != DefOut[I]) {
+        MustIn[I] = std::move(NewIn);
+        MustOut[I] = std::move(NewOut);
+        DefIn[I] = std::move(NewDefIn);
+        DefOut[I] = std::move(NewDefOut);
+        Changed = true;
+      }
+    }
+  }
+  if (Changed)
+    return;
+
+  for (unsigned I = 0; I < Count; ++I) {
+    const size_t GlobalIdx = GlobalIndices[I];
+    if (!Reachable.test(I) ||
+        Decoded[GlobalIdx].Mnemonic != "tensor_load_to_lds")
+      continue;
+    MCRegister Base = getDescriptorBaseSgpr(Decoded[GlobalIdx].Inst, *LS.MRI);
+    std::optional<unsigned> Fact =
+        getNumberedRegFactIndex(Base, *LS.MRI, MaxSgprs, MaxVgprs);
+    const bool KnownZero = Fact && MustIn[I].test(*Fact);
+    uint64_t MaskDef = TensorMaskDefUnknown;
+    if (Fact) {
+      auto Slot = TrackedSgprs.find(*Fact);
+      if (Slot != TrackedSgprs.end())
+        MaskDef = DefIn[I][Slot->second];
+    }
+    if (MaskDef < Range.Begin || MaskDef >= Range.End)
+      MaskDef = TensorMaskDefUnknown;
+    if (Seen.test(GlobalIdx)) {
+      if (!KnownZero)
+        Result.Low16KnownZero.reset(GlobalIdx);
+      if (Result.MaskDefinitionOffsets[GlobalIdx] != MaskDef)
+        Result.MaskDefinitionOffsets[GlobalIdx] = TensorMaskDefUnknown;
+    } else {
+      Seen.set(GlobalIdx);
+      if (KnownZero)
+        Result.Low16KnownZero.set(GlobalIdx);
+      Result.MaskDefinitionOffsets[GlobalIdx] = MaskDef;
+    }
+  }
+}
+
+TensorDescriptorMustAnalysis computeTensorDescriptorMustAnalysisImpl(
+    ArrayRef<InternalDecodedInst> Decoded,
+    ArrayRef<InternalDecodedInst> AllDecoded,
+    ArrayRef<TensorAnalysisRange> KernelRanges, const LLVMState &LS,
+    const DenseSet<uint64_t> &DirectTargets, unsigned MaxSgprs,
+    unsigned MaxVgprs) {
+  TensorDescriptorMustAnalysis Result{
+      BitVector(Decoded.size()),
+      std::vector<uint64_t>(Decoded.size(), TensorMaskDefUnknown)};
+  BitVector Seen(Decoded.size());
+  if (!LS.MCII || !LS.MRI || MaxSgprs == 0 || MaxVgprs == 0)
+    return Result;
+  if (KernelRanges.empty())
+    return Result;
+
+  ArrayRef<TensorDispatchStub> DispatchStubs =
+      KernelRanges.front().DispatchStubs;
+  auto SameDispatchStub = [](const TensorDispatchStub &L,
+                             const TensorDispatchStub &R) {
+    return L.Begin == R.Begin && L.End == R.End && L.Terminal == R.Terminal &&
+           L.Target == R.Target;
+  };
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return Range.DispatchStubs.size() != DispatchStubs.size() ||
+               !llvm::equal(Range.DispatchStubs, DispatchStubs,
+                            SameDispatchStub);
+      }))
+    return Result;
+  ArrayRef<uint64_t> VirtualExternalEntries =
+      KernelRanges.front().VirtualExternalEntries;
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return !llvm::equal(Range.VirtualExternalEntries,
+                            VirtualExternalEntries);
+      }))
+    return Result;
+  ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges =
+      KernelRanges.front().OriginalControlFlowEdges;
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return !llvm::equal(Range.OriginalControlFlowEdges,
+                            OriginalControlFlowEdges);
+      }))
+    return Result;
+  ArrayRef<uint64_t> OriginalCodeEntries =
+      KernelRanges.front().OriginalCodeEntries;
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return !llvm::equal(Range.OriginalCodeEntries, OriginalCodeEntries);
+      }))
+    return Result;
+  TensorExternalCfg ExternalCfg = buildTensorExternalCfg(
+      Decoded, AllDecoded, DispatchStubs, VirtualExternalEntries,
+      OriginalControlFlowEdges, OriginalCodeEntries, LS, DirectTargets);
+  if (!ExternalCfg.Valid)
+    return Result;
+  for (const TensorAnalysisRange &Range : KernelRanges)
+    analyzeTensorDescriptorRange(Decoded, AllDecoded, ExternalCfg, Range, LS,
+                                 MaxSgprs, MaxVgprs, DirectTargets, Result,
+                                 Seen);
+  return Result;
+}
+
 // -- patchTensorLoadToLdsA0 -------------------------------------------------
 //
-// Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
-// descriptor's base SGPR. Preserve the architectural SGPR value when it is live
-// after the tensor instruction: the descriptor is a source operand, so the
-// rewrite must not make its temporary normalization visible to later code.
+// Replace the canonical one-cycle scalar delay immediately before the tensor
+// load with s_pack_hh_b32_b16. Tensor loads are PC-sensitive on gfx1250 A0, so
+// they must remain at their linked address instead of executing in a sled or
+// appended trampoline. Reuse the exact canonical delay slot to clear the
+// descriptor's multicast bits without allocating a scratch register.
 
 bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -778,6 +3138,44 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   if (!BaseMCReg.isValid()) {
     log() << "hotswap: error: tensor_load_to_lds: could not extract descriptor "
              "base register\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  // The tensor instruction is PC-sensitive on gfx1250 A0. It must never be
+  // borrowed by generic far source-window expansion, even when its mask is
+  // placed at an earlier local descriptor definition.
+  protectNonClauseRelocationOffset(Ctx, DI.Offset);
+
+  if (Ctx.TensorDescriptorAnalysis &&
+      Idx < Ctx.TensorDescriptorAnalysis->Low16KnownZero.size() &&
+      Ctx.TensorDescriptorAnalysis->Low16KnownZero.test(Idx)) {
+    log() << "hotswap: tensor_load_to_lds: descriptor low16 already zero at 0x"
+          << utohexstr(DI.Offset) << "; tensor remains unchanged\n";
+    DI.Mnemonic = "<replaced>";
+    return false;
+  }
+
+  if (Ctx.TensorDescriptorAnalysis &&
+      Idx < Ctx.TensorDescriptorAnalysis->MaskDefinitionOffsets.size()) {
+    const uint64_t DefOffset =
+        Ctx.TensorDescriptorAnalysis->MaskDefinitionOffsets[Idx];
+    if (Ctx.TensorMaskedDefinitionOffsets.contains(DefOffset)) {
+      log() << "hotswap: tensor_load_to_lds: reusing masked descriptor "
+               "definition at 0x"
+            << utohexstr(DefOffset) << "; tensor remains at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      DI.Mnemonic = "<replaced>";
+      return false;
+    }
+  }
+
+  // Every A0 mask path executes before the PC-sensitive tensor instruction.
+  // A direct edge to the tensor or any unresolved indirect entry in its
+  // function can bypass that mask, including one already present in the input.
+  if (isDirectControlFlowTarget(Ctx, DI.Offset) ||
+      functionHasIndirectControlFlow(Ctx, DI.Offset)) {
+    log() << "hotswap: error: tensor_load_to_lds at 0x" << utohexstr(DI.Offset)
+          << " may be entered without executing its descriptor mask\n";
     return failRequiredPatch(Ctx);
   }
 
@@ -794,54 +3192,84 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     return failRequiredPatch(Ctx);
   }
 
-  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
-  const uint8_t *OrigInst = Ctx.Text + DI.Offset;
-
-  if (SgprLive) {
-    std::optional<SafeSgprScratchBlock> Scratch =
-        findSafeSgprScratchBlock(Ctx, DI.Offset, /*Count=*/1, /*Alignment=*/1,
-                                 "tensor_load_to_lds descriptor save");
-    if (!Scratch) {
-      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
-               "available\n";
-      return failRequiredPatch(Ctx);
+  std::optional<LocalTensorMaskDefinition> LocalDef =
+      findLocalTensorMaskDefinition(Ctx, Idx, BaseMCReg);
+  const bool ClaimedLocalDefinition = LocalDef && !LocalDef->AlreadyMasked &&
+                                      Ctx.ClaimedReplacementOffsets.contains(
+                                          Ctx.Decoded[LocalDef->Index].Offset);
+  if (ClaimedLocalDefinition) {
+    // The definition still executes in the atomic relocated stream, but its
+    // linked address is no longer an independent patch source. Prefer the
+    // reconstructed canonical delay slot immediately before the tensor.
+    log() << "hotswap: tensor_load_to_lds: descriptor definition at 0x"
+          << utohexstr(Ctx.Decoded[LocalDef->Index].Offset)
+          << " is relocated; using linked delay slot for the mask\n";
+  } else if (LocalDef) {
+    if (LocalDef->AlreadyMasked) {
+      protectNonClauseRelocationOffset(Ctx,
+                                       Ctx.Decoded[LocalDef->Index].Offset);
+      Ctx.TensorMaskedDefinitionOffsets.insert(
+          Ctx.Decoded[LocalDef->Index].Offset);
+      log() << "hotswap: tensor_load_to_lds: descriptor already masked at 0x"
+            << utohexstr(Ctx.Decoded[LocalDef->Index].Offset)
+            << "; tensor remains at 0x" << utohexstr(DI.Offset) << "\n";
+      DI.Mnemonic = "<replaced>";
+      return false;
     }
 
-    std::string ScratchName = "s" + std::to_string(Scratch->Base);
-    SmallVector<uint8_t> Save = assembleSingleInst(
-        "s_mov_b32 " + ScratchName + ", " + BaseSreg, Ctx.LS);
-    SmallVector<uint8_t> Restore = assembleSingleInst(
-        "s_mov_b32 " + BaseSreg + ", " + ScratchName, Ctx.LS);
-    if (Save.empty() || Restore.empty()) {
-      log() << "hotswap: error: tensor_load_to_lds: failed to assemble "
-               "descriptor save/restore through "
-            << ScratchName << "\n";
+    InternalDecodedInst &Def = Ctx.Decoded[LocalDef->Index];
+    if (Def.Offset > Ctx.TextSize || Def.Size > Ctx.TextSize - Def.Offset)
       return failRequiredPatch(Ctx);
-    }
-
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(Save.begin(), Save.end());
+    SmallVector<uint8_t> Replacement(Ctx.Text + Def.Offset,
+                                     Ctx.Text + Def.Offset + Def.Size);
     Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-    Replacement.append(Restore.begin(), Restore.end());
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+    if (!emitReplacementCode(Ctx, Def.Offset, Def.Size, Replacement))
       return failRequiredPatch(Ctx);
+    protectNonClauseRelocationOffset(Ctx, Def.Offset);
+    Ctx.TensorMaskedDefinitionOffsets.insert(Def.Offset);
 
-    if (!commitSafeSgprScratchBlock(Ctx, DI.Offset, *Scratch,
-                                    "tensor_load_to_lds descriptor save"))
-      return failRequiredPatch(Ctx);
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " live, save/restore via " << ScratchName << "\n";
-  } else {
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-      return failRequiredPatch(Ctx);
-
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " dead, no save/restore needed\n";
+    log() << "hotswap: tensor_load_to_lds: masked local descriptor definition "
+             "at 0x"
+          << utohexstr(Def.Offset) << "; tensor remains at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    Ctx.RequiredPatchApplied = true;
+    Def.Mnemonic = "<replaced>";
+    DI.Mnemonic = "<replaced>";
+    return true;
   }
+
+  SmallVector<uint8_t> DelayBytes =
+      assembleSingleInst("s_delay_alu instid0(SALU_CYCLE_1)", Ctx.LS);
+  if (DelayBytes.empty()) {
+    log() << "hotswap: tensor_load_to_lds delay assembly failed\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  if (Idx == 0) {
+    log() << "hotswap: error: tensor_load_to_lds at 0x" << utohexstr(DI.Offset)
+          << " has no preceding delay slot\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+  ArrayRef<uint8_t> PrevBytes(Ctx.Text + Prev.Offset, Prev.Size);
+  const bool ReconstructedDelay =
+      Ctx.ClaimedReplacementOffsets.contains(Prev.Offset);
+  if ((!ReconstructedDelay && Prev.Mnemonic != "s_delay_alu") ||
+      Prev.Offset + Prev.Size != DI.Offset ||
+      PrevBytes != ArrayRef<uint8_t>(DelayBytes) ||
+      Prev.Size != PackBytes.size()) {
+    log() << "hotswap: error: tensor_load_to_lds at 0x" << utohexstr(DI.Offset)
+          << " is not preceded by the canonical scalar delay\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  protectNonClauseRelocationOffset(Ctx, Prev.Offset);
+
+  std::memcpy(Ctx.Text + Prev.Offset, PackBytes.data(), PackBytes.size());
+  log() << "hotswap: tensor_load_to_lds: in-place descriptor mask at 0x"
+        << utohexstr(Prev.Offset) << "; tensor remains at 0x"
+        << utohexstr(DI.Offset) << "\n";
 
   Ctx.RequiredPatchApplied = true;
   DI.Mnemonic = "<replaced>";
@@ -1270,8 +3698,9 @@ SmallVector<std::string> buildAddtidStoreAsm(StringRef VTmpName,
 // Trampoline expansion for ds_load_addtid_b32 / ds_store_addtid_b32 on
 // A0. The replacement materialises the ADDTID address through the ALU
 // (so the full 32-bit M0 is used) and issues a regular ds_*_b32. GDS=1
-// is rejected: the rewrite stays a no-op so the original (broken on A0)
-// instruction is preserved and the failure is loud in the verbose log.
+// is rejected. Once an ADDTID mnemonic is recognized, every failure must be
+// fatal so the rewrite cannot report success with an A0-incompatible
+// instruction still present.
 
 bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -1286,14 +3715,14 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     log() << "hotswap: error: " << DI.Mnemonic << " with GDS=1 at 0x"
           << utohexstr(DI.Offset)
           << " is not supported; leaving original instruction in place\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   std::optional<uint16_t> OffsetOpt = getAddtidOffset(DI.Inst);
   if (!OffsetOpt) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": missing/non-immediate offset\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
   uint16_t Offset = *OffsetOpt;
 
@@ -1302,7 +3731,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       !DI.Inst.getOperand(AddtidOpReg).getReg()) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": missing register operand\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
@@ -1311,7 +3740,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   if (RegName.empty()) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": cannot resolve register name\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   bool IsLoad = isAddtidLoad(DI.Mnemonic);
@@ -1351,7 +3780,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       log() << " at 0x" << utohexstr(DI.Offset) << "\n";
       log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
             << utohexstr(DI.Offset) << ": no scratch VGPR available\n";
-      return false;
+      return failRequiredPatch(Ctx);
     }
 
     std::string TmpName = ("v" + Twine(StoreScratch->Vgpr)).str();
@@ -1372,11 +3801,11 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     log() << "hotswap: error: " << DI.Mnemonic
           << " trampoline assembly failed at 0x" << utohexstr(DI.Offset)
           << "\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Bytes))
-    return false;
+    return failRequiredPatch(Ctx);
 
   // Commit the scratch-VGPR reservation only after the patch is in place:
   // any earlier failure (assembly, sled/trampoline emission) leaves no
@@ -1400,11 +3829,152 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
 
 } // anonymous namespace
 
-std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
-                                                      StringRef FromMnem,
-                                                      StringRef ToMnem,
-                                                      const LLVMState &LS) {
-  return expandDs2AddrImpl(Inst, FromMnem, ToMnem, LS);
+TensorDescriptorMustAnalysis
+computeTensorDescriptorMustAnalysis(ArrayRef<InternalDecodedInst> Decoded,
+                                    ArrayRef<InternalDecodedInst> AllDecoded,
+                                    ArrayRef<TensorAnalysisRange> KernelRanges,
+                                    const LLVMState &LS,
+                                    const DenseSet<uint64_t> &DirectTargets,
+                                    unsigned MaxSgprs, unsigned MaxVgprs) {
+  return computeTensorDescriptorMustAnalysisImpl(
+      Decoded, AllDecoded, KernelRanges, LS, DirectTargets, MaxSgprs, MaxVgprs);
+}
+
+// Keep atomic relocation eligibility aligned with both precomputed whole-pass
+// ownership and the per-instruction dispatcher. Callers may copy an earlier
+// same-size correction from current text, but must not claim a site that owns
+// an independent rewrite. Conditional families mirror their dispatch gates so
+// valid no-op variants remain relocatable.
+bool requiresIndependentInstructionRewrite(const PatchContext &Ctx,
+                                           size_t Idx) {
+  if (Idx >= Ctx.Decoded.size())
+    return true;
+
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  StringRef Mnemonic(DI.Mnemonic);
+  if (Mnemonic == "<unknown>" || Mnemonic == "<replaced>")
+    return true;
+
+  if (hasSiteReplacementReservation(Ctx, DI.Offset))
+    return true;
+
+  if (Mnemonic == "tensor_load_to_lds")
+    return Ctx.Config.MaskPolicy != MaskWorkaroundPolicy::None;
+
+  if (!Ctx.Config.RunB0A0Patches)
+    return false;
+
+  if (!getDs2AddrReplacement(Mnemonic).empty()) {
+    const bool ProvenAligned =
+        Ctx.Ds2AddressProvenAligned.size() == Ctx.Decoded.size() &&
+        Ctx.Ds2AddressProvenAligned.test(Idx);
+    return !ProvenAligned;
+  }
+
+  if (isClusterLoad(Mnemonic)) {
+    // The off form is demoted in-place. The SGPR-relative form survives that
+    // pass and needs the trampoline mask only for the A0 policy.
+    bool HasSgprOperand = !Ctx.LS.MRI;
+    if (Ctx.LS.MRI)
+      for (const MCOperand &Operand : DI.Inst)
+        HasSgprOperand |= Operand.isReg() && Operand.getReg() &&
+                          StringRef(Ctx.LS.MRI->getName(Operand.getReg()))
+                              .starts_with("SGPR");
+    return !HasSgprOperand || Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0;
+  }
+
+  if (!getAddtidReplacement(Mnemonic).empty() ||
+      isWmmaSplitPatchCandidate(Mnemonic) ||
+      Mnemonic == "s_barrier_signal_isfirst" ||
+      Mnemonic == "v_wmma_scale16_f32_16x16x128_f8f6f4" ||
+      Mnemonic == "v_wmma_scale16_f32_32x16x128_f4")
+    return true;
+
+  // Mirror only the dispatcher's semantic CLAMP gate. Non-CLAMP FP8
+  // conversions are valid on A0 and may move with a protected window.
+  auto NeedsClampPatchAt = [&](unsigned OperandIndex) {
+    // A missing or non-immediate CLAMP field is malformed, not a proven no-op;
+    // retain ownership so the scratch pass can reject it explicitly.
+    return OperandIndex >= DI.Inst.getNumOperands() ||
+           !DI.Inst.getOperand(OperandIndex).isImm() ||
+           DI.Inst.getOperand(OperandIndex).getImm() != 0;
+  };
+  if (Mnemonic == "v_cvt_pk_fp8_f32")
+    return (DI.Size != 8 && DI.Size != 12) || NeedsClampPatchAt(5);
+  if (Mnemonic == "v_cvt_sr_fp8_f32")
+    return DI.Size != 8 || NeedsClampPatchAt(5);
+  if (Mnemonic.starts_with("v_cvt_f32_fp8")) {
+    if (DI.Size == 4)
+      return false;
+    return DI.Size != 8 || NeedsClampPatchAt(2);
+  }
+
+  return false;
+}
+
+void precomputeDs2AddressAlignment(PatchContext &Ctx) {
+  Ctx.Ds2AddressProvenAligned.resize(Ctx.Decoded.size());
+  Ctx.Ds2AddressProvenAligned.reset();
+  if (Ctx.HasUnknownArbitraryIndirectTarget)
+    return;
+
+  DenseMap<std::pair<size_t, unsigned>, SmallVector<size_t, 4>> CandidateUses;
+  for (size_t I = 0; I != Ctx.Decoded.size(); ++I) {
+    if (getDs2AddrReplacement(Ctx.Decoded[I].Mnemonic).empty())
+      continue;
+    if (computeDs2AddressProvenAligned(Ctx, I)) {
+      Ctx.Ds2AddressProvenAligned.set(I);
+      continue;
+    }
+
+    const InternalDecodedInst &DS = Ctx.Decoded[I];
+    StringRef Mnem(DS.Mnemonic);
+    if (Mnem != "ds_load_2addr_b32" && Mnem != "ds_load_2addr_b64" &&
+        Mnem != "ds_store_2addr_b32" && Mnem != "ds_store_2addr_b64")
+      continue;
+    if (DS.Inst.getNumOperands() == 0 ||
+        !DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).isImm() ||
+        DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).getImm() != 0)
+      continue;
+    std::optional<DsOperands> Ops =
+        extractDsOperands(DS.Inst, DS.Mnemonic, Ctx.LS);
+    if (!Ops)
+      continue;
+    const unsigned AddrIndex = Mnem.starts_with("ds_store_") ? 0 : 1;
+    if (Ops->Regs.size() <= AddrIndex)
+      continue;
+    MCRegister Address = Ops->Regs[AddrIndex];
+    const unsigned Alignment = Ops->IsB64 ? 8 : 4;
+    if (Ops->Off0 % Alignment != 0 || Ops->Off1 % Alignment != 0)
+      continue;
+    std::optional<ElfView::FunctionTextRange> Function =
+        Ctx.Elf.findFunctionTextRangeAtOffset(DS.Offset);
+    if (!Function ||
+        Ctx.IndirectControlFlowFunctions.contains(Function->Begin) ||
+        Ctx.CrossFunctionInteriorEntryFunctions.contains(Function->Begin) ||
+        !Ctx.DirectControlFlowTargets ||
+        Ctx.DirectControlFlowTargets->contains(DS.Offset))
+      continue;
+
+    for (size_t DefI = I; DefI-- > 0;) {
+      const InternalDecodedInst &Def = Ctx.Decoded[DefI];
+      if (Def.Offset < Function->Begin)
+        break;
+      if (!definesRegister(Def, Address, Ctx.LS))
+        continue;
+      if ((isAlignedConstantAddressDef(Def, Address, Alignment, Ctx, DefI,
+                                       /*RequireEqualMode=*/false) ||
+           isAlignedSgprCopyAddressDef(Def, Address, Alignment, Ctx, DefI)) &&
+          DefI < Ctx.VgprMsbDstBefore.size() && Ctx.VgprMsbDstBefore[DefI] >= 0)
+        CandidateUses[{DefI, Address.id()}].push_back(I);
+      break;
+    }
+  }
+
+  for (const auto &Entry : CandidateUses)
+    proveLongRangeDs2Alignment(Ctx, Entry.first.first,
+                               MCRegister(Entry.first.second), Entry.second,
+                               Ctx.Ds2AddressProvenAligned);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------
@@ -1423,12 +3993,15 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
-  // Per-rule sub-buckets under the "strat:trampoline" parent (recorded by the
-  // dispatcher in comgr-hotswap-b0a0.cpp); timed only at matching sites.
   if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty()) {
     HotswapProfile::Scope S =
         Ctx.Profile.time(HotswapMetric::TrampolineDs2Addr);
-    const uint32_t P = patchDs2Addr(Ctx, Idx) ? 1 : 0;
+    if (isDs2AddressProvenAligned(Ctx, Idx)) {
+      log() << "hotswap: ds_2addr: preserved proven-aligned " << Mnem
+            << " at 0x" << utohexstr(Ctx.Decoded[Idx].Offset) << "\n";
+      return 0;
+    }
+    const uint32_t P = patchDs2Addr(Ctx, Idx);
     S.addPatches(P);
     return P;
   }

--- a/amd/comgr/src/comgr-hotswap-patch-vop3px2-src2.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-vop3px2-src2.cpp
@@ -47,6 +47,7 @@ namespace {
 constexpr uint8_t Byte6ScaleSrc2Mask = 0xFC;
 constexpr uint8_t Byte7ScaleSrc2LoMask = 0x03;
 constexpr uint8_t Byte7ScaleSrc2HiBit = 0x04;
+constexpr uint32_t Vop3px2Size = 16;
 
 bool isVop3px2ScaleInst(StringRef Mnemonic) {
   return StringSwitch<bool>(Mnemonic)
@@ -82,8 +83,8 @@ bool patchScaleSrc2(uint8_t *InstBytes) {
 }
 
 // Must run before any pass that grows .text or invalidates
-// Ctx.Decoded[i].Offset. Currently safe after applyWmmaHazardPatch
-// because trampolines are deferred to the post-pass grow step.
+// Ctx.Decoded[i].Offset. Whole-pass requirements are discovered first but do
+// not mutate bytes; trampoline growth remains deferred to finalization.
 //
 // This only fires on the B0-to-A0 rewrite path (applyGfx1250B0toA0Rules).
 // A0-native binaries are compiled with an A0-targeted Clang that sets the
@@ -96,6 +97,21 @@ static uint32_t applyVop3px2Src2FixImpl(PatchContext &Ctx) {
     if (!isVop3px2ScaleInst(DI.Mnemonic))
       continue;
     ++Scanned;
+
+    if (DI.Size != Vop3px2Size || DI.Offset > Ctx.TextSize ||
+        DI.Size > Ctx.TextSize - DI.Offset) {
+      log() << "hotswap: error: VOP3PX2 SRC2 fix has invalid source at 0x"
+            << utohexstr(DI.Offset) << " (size " << DI.Size << ")\n";
+      Ctx.RequiredPatchFailed = true;
+      continue;
+    }
+
+    if (Ctx.ClaimedReplacementOffsets.contains(DI.Offset)) {
+      log() << "hotswap: error: VOP3PX2 SRC2 fix at 0x" << utohexstr(DI.Offset)
+            << " overlaps an atomic relocated source window\n";
+      Ctx.RequiredPatchFailed = true;
+      continue;
+    }
 
     if (patchScaleSrc2(Ctx.Text + DI.Offset)) {
       log() << "hotswap: VOP3PX2 SRC2 fix at 0x" << utohexstr(DI.Offset) << ": "

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
@@ -104,22 +104,24 @@ WmmaNopReq classifyWmmaNops(StringRef Mnemonic) {
   return {4, 4};
 }
 
+int updateWmmaHazardDeficit(DenseMap<size_t, int> &MaxDeficits,
+                            size_t ValuIndex, int Deficit) {
+  int &Maximum = MaxDeficits[ValuIndex];
+  Maximum = std::max(Maximum, Deficit);
+  return Maximum;
+}
+
 namespace {
 
-// Scan a decoded stream for WMMA/SWMMAC -> overlapping co-executable VALU
-// hazards, returning the nop deficits keyed by VALU index (into \p Stream).
-//
-// \p RequireAbsolute picks the nop budget. The original kernel stream (false)
-// already carries the compiler-inserted spacing, so only the extra deficit
-// beyond that matters; freshly emitted trampoline bodies (true) have no such
-// baseline, so the full required count is enforced.
-std::vector<WmmaHazard> scanCoexecHazards(ArrayRef<InternalDecodedInst> Stream,
-                                          const MCInstrInfo &MCII,
-                                          const MCRegisterInfo &MRI,
-                                          bool RequireAbsolute,
-                                          int *WmmaScannedOut = nullptr) {
-  std::vector<WmmaHazard> Hazards;
-  DenseSet<size_t> PatchedValuIndices;
+// Scan one decoded stream for WMMA/SWMMAC -> overlapping co-executable VALU
+// hazards. Original code uses its compiler-provided baseline as the scan gate;
+// freshly emitted trampoline bodies must satisfy the absolute target budget.
+// Multiple WMMAs may converge on one VALU, so retain the maximum deficit.
+static std::optional<std::vector<WmmaHazard>> scanCoexecHazards(
+    ArrayRef<InternalDecodedInst> Stream, const MCInstrInfo &MCII,
+    const MCRegisterInfo &MRI, bool RequireAbsolute,
+    int *WmmaScannedOut = nullptr) {
+  DenseMap<size_t, int> MaxDeficitByValu;
   int WmmaScanned = 0;
 
   for (size_t WmmaIdx = 0, E = Stream.size(); WmmaIdx < E; ++WmmaIdx) {
@@ -128,18 +130,22 @@ std::vector<WmmaHazard> scanCoexecHazards(ArrayRef<InternalDecodedInst> Stream,
       continue;
 
     ++WmmaScanned;
-    WmmaNopReq Req = classifyWmmaNops(WmmaDI.Mnemonic);
-    // Target is always the full required count. For the original stream, the
-    // compiler-inserted baseline only gates whether a scan is needed: if the
-    // requirement is no more than that baseline, the existing spacing suffices.
-    // Trampoline bodies have no baseline, so the full count is always enforced.
+    const WmmaNopReq Req = classifyWmmaNops(WmmaDI.Mnemonic);
     if (!RequireAbsolute && Req.A0Nops <= Req.B0Nops)
       continue;
-    int Target = Req.A0Nops;
+    const int Target = Req.A0Nops;
 
     int SafeSlots = 0;
     for (size_t ValuIdx = WmmaIdx + 1; ValuIdx < E; ++ValuIdx) {
       const InternalDecodedInst &Candidate = Stream[ValuIdx];
+      if (Candidate.Mnemonic == "<unknown>" ||
+          Candidate.Mnemonic == "<replaced>") {
+        log() << "hotswap: error: cannot prove WMMA co-exec spacing from 0x"
+              << utohexstr(WmmaDI.Offset) << " across instruction at 0x"
+              << utohexstr(Candidate.Offset) << " (" << Candidate.Mnemonic
+              << ")\n";
+        return std::nullopt;
+      }
 
       if (isVNop(Candidate)) {
         ++SafeSlots;
@@ -162,13 +168,16 @@ std::vector<WmmaHazard> scanCoexecHazards(ArrayRef<InternalDecodedInst> Stream,
           continue;
         }
 
-        if (SafeSlots < Target && PatchedValuIndices.insert(ValuIdx).second) {
-          Hazards.push_back({ValuIdx, Target - SafeSlots});
+        if (SafeSlots < Target) {
+          const int Deficit = Target - SafeSlots;
+          const int MaxDeficit =
+              updateWmmaHazardDeficit(MaxDeficitByValu, ValuIdx, Deficit);
           log() << "hotswap: WMMA co-exec hazard at 0x"
                 << utohexstr(WmmaDI.Offset) << ": " << WmmaDI.Mnemonic
                 << " needs " << Target << " v_nops, only " << SafeSlots
                 << " found before " << Candidate.Mnemonic << " at 0x"
-                << utohexstr(Candidate.Offset) << "\n";
+                << utohexstr(Candidate.Offset) << " (candidate max deficit "
+                << MaxDeficit << ")\n";
         }
         break;
       }
@@ -177,49 +186,64 @@ std::vector<WmmaHazard> scanCoexecHazards(ArrayRef<InternalDecodedInst> Stream,
     }
   }
 
+  std::vector<WmmaHazard> Hazards;
+  Hazards.reserve(MaxDeficitByValu.size());
+  for (size_t I = 0, E = Stream.size(); I != E; ++I)
+    if (auto It = MaxDeficitByValu.find(I); It != MaxDeficitByValu.end())
+      Hazards.push_back({I, It->second});
   if (WmmaScannedOut)
     *WmmaScannedOut = WmmaScanned;
   return Hazards;
 }
 
-std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
+static std::optional<std::vector<WmmaHazard>>
+findWmmaCoexecHazards(const PatchContext &Ctx) {
   int WmmaScanned = 0;
-  std::vector<WmmaHazard> Hazards =
-      scanCoexecHazards(Ctx.Decoded, *Ctx.LS.MCII, *Ctx.LS.MRI,
-                        /*RequireAbsolute=*/false, &WmmaScanned);
-  log() << "hotswap: WMMA co-exec validation: " << Hazards.size()
+  std::optional<std::vector<WmmaHazard>> Hazards = scanCoexecHazards(
+      Ctx.Decoded, *Ctx.LS.MCII, *Ctx.LS.MRI,
+      /*RequireAbsolute=*/false, &WmmaScanned);
+  if (!Hazards)
+    return std::nullopt;
+  log() << "hotswap: WMMA co-exec validation: " << Hazards->size()
         << " hazards (" << WmmaScanned << " WMMA instructions scanned)\n";
   return Hazards;
 }
 
-// Fail-closed safety net for trampoline bodies emitted by other passes (e.g.
-// the exact scale16 K-split): they contain their own WMMAs but were never in
-// Ctx.Decoded, so findWmmaCoexecHazards cannot see them, and they carry no
-// compiler-inserted spacing, so each is checked against the full required
-// count. A residual deficit means a pass shipped an unsafe WMMA/VALU ordering,
-// so we refuse the rewrite. Runs before branch fixup/coalescing, so each
-// T.Bytes is still {body, reserved-return-slot}; the reserved tail is trimmed
-// before decoding since its zero bytes are not real instructions.
-void validateTrampolineCoexec(PatchContext &Ctx) {
+// Emitted trampoline bodies were not present in Ctx.Decoded and carry no
+// compiler spacing baseline. Validate their absolute WMMA/VALU separation
+// before branch fixup and coalescing; malformed bodies fail the rewrite closed.
+static void validateTrampolineCoexec(PatchContext &Ctx) {
   const MCInstrInfo &MCII = *Ctx.LS.MCII;
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
 
   for (const Trampoline &T : Ctx.OutTrampolines) {
-    unsigned Reserve = T.Long ? SetPcReturnReserveBytes : MinInstSize;
+    const unsigned Reserve = T.Long ? SetPcReturnReserveBytes : MinInstSize;
     if (T.Bytes.size() <= Reserve)
       continue;
-    size_t BodySize = T.Bytes.size() - Reserve;
+    const size_t BodySize = T.Bytes.size() - Reserve;
 
     std::vector<InternalDecodedInst> Body;
-    if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body))
+    if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body)) {
+      log() << "hotswap: error: could not decode trampoline body for WMMA "
+               "co-exec validation at site 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      Ctx.RequiredPatchFailed = true;
       continue;
+    }
 
-    std::vector<WmmaHazard> TH =
-        scanCoexecHazards(Body, MCII, MRI, /*RequireAbsolute=*/true);
-    if (!TH.empty()) {
+    std::optional<std::vector<WmmaHazard>> Hazards = scanCoexecHazards(
+        Body, MCII, MRI, /*RequireAbsolute=*/true);
+    if (!Hazards) {
+      log() << "hotswap: error: indeterminate WMMA co-exec spacing in "
+               "trampoline for site 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      Ctx.RequiredPatchFailed = true;
+      continue;
+    }
+    if (!Hazards->empty()) {
       log() << "hotswap: error: WMMA co-exec hazard unmitigated in trampoline "
                "for site 0x"
-            << utohexstr(T.OriginalOffset) << " (" << TH.size()
+            << utohexstr(T.OriginalOffset) << " (" << Hazards->size()
             << " site(s)); failing closed\n";
       Ctx.RequiredPatchFailed = true;
     }
@@ -228,50 +252,111 @@ void validateTrampolineCoexec(PatchContext &Ctx) {
 
 } // anonymous namespace
 
+static bool precomputeWmmaHazardsImpl(PatchContext &Ctx) {
+  std::optional<std::vector<WmmaHazard>> Hazards =
+      findWmmaCoexecHazards(Ctx);
+  if (!Hazards) {
+    Ctx.RequiredPatchFailed = true;
+    return false;
+  }
+  for (const WmmaHazard &H : *Hazards) {
+    if (H.ValuIdx >= Ctx.Decoded.size() || H.Deficit <= 0) {
+      log() << "hotswap: error: invalid precomputed WMMA hazard candidate\n";
+      Ctx.RequiredPatchFailed = true;
+      return false;
+    }
+    const InternalDecodedInst &DI = Ctx.Decoded[H.ValuIdx];
+    SiteReplacementState &State = Ctx.SiteReplacements[DI.Offset];
+    if (State.Committed ||
+        (State.OriginalSize != 0 && State.OriginalSize != DI.Size)) {
+      log() << "hotswap: error: WMMA hazard candidate at 0x"
+            << utohexstr(DI.Offset)
+            << " conflicts with pre-existing replacement ownership\n";
+      Ctx.RequiredPatchFailed = true;
+      return false;
+    }
+    if (State.RequiredLeadingVNops == 0)
+      Ctx.WmmaHazardSites.push_back(DI.Offset);
+    State.OriginalSize = DI.Size;
+    State.RequiredLeadingVNops =
+        std::max(State.RequiredLeadingVNops, static_cast<unsigned>(H.Deficit));
+  }
+  return true;
+}
+
 static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
-  std::vector<WmmaHazard> Hazards = findWmmaCoexecHazards(Ctx);
-  if (Hazards.empty()) {
-    // Even with no original-stream hazards, other passes may have emitted
-    // WMMA-bearing trampolines that need their own separation validated.
-    validateTrampolineCoexec(Ctx);
+  for (uint64_t Offset : Ctx.WmmaHazardSites) {
+    auto StateIt = Ctx.SiteReplacements.find(Offset);
+    if (StateIt == Ctx.SiteReplacements.end() ||
+        StateIt->second.RequiredLeadingVNops == 0) {
+      log() << "hotswap: error: lost precomputed WMMA hazard state at 0x"
+            << utohexstr(Offset) << "\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+    if (StateIt->second.WmmaHazardComposed)
+      continue;
+    if (StateIt->second.Committed) {
+      log() << "hotswap: error: replacement at 0x" << utohexstr(Offset)
+            << " committed without its WMMA hazard requirement\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+
+    auto DI = llvm::lower_bound(
+        Ctx.Decoded, Offset,
+        [](const InternalDecodedInst &Inst, uint64_t CandidateOffset) {
+          return Inst.Offset < CandidateOffset;
+        });
+    if (DI == Ctx.Decoded.end() || DI->Offset != Offset ||
+        DI->Size != StateIt->second.OriginalSize || Offset > Ctx.TextSize ||
+        DI->Size > Ctx.TextSize - Offset) {
+      log() << "hotswap: error: WMMA hazard source at 0x"
+            << utohexstr(Offset) << " is not a valid current instruction\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+
+    // No per-instruction pass owned this site. Preserve the bytes after all
+    // same-size in-place corrections, then let the central emission helper
+    // prepend the precomputed v_nops and commit the single site owner.
+    SmallVector<uint8_t> Current(Ctx.Text + Offset,
+                                 Ctx.Text + Offset + DI->Size);
+    if (!emitReplacementCode(Ctx, Offset, DI->Size, Current)) {
+      log() << "hotswap: error: could not emit required WMMA hazard fix at 0x"
+            << utohexstr(Offset) << "\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+
+    StateIt = Ctx.SiteReplacements.find(Offset);
+    if (StateIt == Ctx.SiteReplacements.end() ||
+        !StateIt->second.WmmaHazardComposed) {
+      log() << "hotswap: error: WMMA hazard requirement at 0x"
+            << utohexstr(Offset) << " was not composed by emission\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+  }
+
+  if (Ctx.WmmaHazardsComposed != Ctx.WmmaHazardSites.size()) {
+    log() << "hotswap: error: composed " << Ctx.WmmaHazardsComposed << " of "
+          << Ctx.WmmaHazardSites.size()
+          << " precomputed WMMA hazard requirements\n";
+    Ctx.RequiredPatchFailed = true;
     return 0;
   }
 
-  uint32_t Patched = 0;
-  for (const WmmaHazard &H : Hazards) {
-    const InternalDecodedInst &ValuDI = Ctx.Decoded[H.ValuIdx];
-
-    uint64_t TrampolineTextOffset = Ctx.TextSize;
-    for (const Trampoline &T : Ctx.OutTrampolines)
-      TrampolineTextOffset += T.Bytes.size();
-
-    SmallVector<MCInst> Insts;
-    for (int I = 0; I < H.Deficit; ++I)
-      Insts.push_back(Ctx.LS.VNopInst);
-    Insts.push_back(ValuDI.Inst);
-
-    Trampoline T = buildTrampoline(Insts, ValuDI.Offset, ValuDI.Size,
-                                   TrampolineTextOffset, Ctx.LS);
-    if (T.Bytes.empty()) {
-      log() << "hotswap: error: WMMA hazard: buildTrampoline failed at 0x"
-            << utohexstr(ValuDI.Offset) << "\n";
-      continue;
-    }
-    Ctx.OutTrampolines.push_back(std::move(T));
-
-    log() << "hotswap: WMMA hazard fix at 0x" << utohexstr(ValuDI.Offset)
-          << ": inserted " << H.Deficit << " v_nop(s)\n";
-    ++Patched;
-  }
-
-  // Validate every emitted trampoline (including the ones just added above and
-  // any WMMA-bearing bodies from other passes) against the full required
-  // budget.
+  // Scale16 and other patch families can emit WMMA-bearing bodies that were
+  // absent from the immutable source stream. Enforce their full target spacing.
   validateTrampolineCoexec(Ctx);
-  return Patched;
+  if (Ctx.RequiredPatchFailed)
+    return 0;
+  return Ctx.WmmaHazardsComposed;
 }
 
 void registerWmmaHazardPatch(HotswapPatchVTable &VT) {
+  VT.precomputeWmmaHazards = &precomputeWmmaHazardsImpl;
   VT.applyWmmaHazardPatch = &applyWmmaHazardPatchImpl;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -315,11 +315,6 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   if (DI.Size != VOP3PXSize)
     return failClosed(Ctx, DI, "unexpected instruction size " + Twine(DI.Size));
 
-  // Skip offsets a prior pass/rewrite already claimed (idempotency).
-  for (const Trampoline &T : Ctx.OutTrampolines)
-    if (T.OriginalOffset == DI.Offset)
-      return 0;
-
   const uint8_t *Raw = Ctx.Text + DI.Offset;
 
   std::optional<unsigned> ScaleABase =

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -67,15 +67,29 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCSchedule.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstring>
+#include <limits>
 #include <optional>
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+
+bool hasDirectControlFlowTargetInWindowInterior(
+    const std::optional<DenseSet<uint64_t>> &Targets, uint64_t Begin,
+    uint64_t End) {
+  if (!Targets || Begin >= End)
+    return true;
+  return llvm::any_of(*Targets, [=](uint64_t Target) {
+    return Target > Begin && Target < End;
+  });
+}
+
 namespace {
 
 // -- Split family table ------------------------------------------------------
@@ -430,6 +444,53 @@ std::string formatVgprRange(int Base, int Count) {
   return formatv("v[{0}:{1}]", Base, Base + Count - 1).str();
 }
 
+// Recover the persistent VGPR-MSB mode from the immutable whole-function CFG
+// fixed point. Equal predecessor states, including loop backedges, retain an
+// exact mode; conflicting paths, opaque calls, and unknown MODE writes remain
+// unknown and fail closed.
+std::optional<unsigned> findActiveVgprMsbMode(const PatchContext &Ctx,
+                                              size_t Idx) {
+  if (Idx >= Ctx.VgprMsbModeBefore.size())
+    return std::nullopt;
+  // A mandatory A0-incompatible WMMA must still be rewritten in a block that
+  // a fully validated CFG proves unreachable. Its MODE is semantically
+  // unobservable, so use the ABI entry value. Unanalyzed functions and
+  // reachable paths with conflicting MODE values continue to fail closed.
+  if (Ctx.VgprMsbModeBefore[Idx] == VgprMsbUnreachable)
+    return 0;
+  if (Ctx.VgprMsbModeBefore[Idx] < 0)
+    return std::nullopt;
+  return static_cast<unsigned>(Ctx.VgprMsbModeBefore[Idx]);
+}
+
+enum class VgprMsbOperand : unsigned {
+  Src0 = 0,
+  Src1 = 2,
+  Src2 = 4,
+  Dst = 6,
+};
+
+unsigned getVgprMsbs(unsigned Mode, VgprMsbOperand Operand) {
+  return (Mode >> static_cast<unsigned>(Operand)) & 0x3;
+}
+
+void setVgprMsbs(unsigned &Mode, VgprMsbOperand Operand, unsigned Msbs) {
+  const unsigned Shift = static_cast<unsigned>(Operand);
+  Mode = (Mode & ~(0x3u << Shift)) | (Msbs << Shift);
+}
+
+bool advanceVgprMsbMode(int &Base, VgprMsbOperand Operand, unsigned OldMode,
+                        unsigned &NewMode) {
+  unsigned OldMsbs = getVgprMsbs(OldMode, Operand);
+  unsigned PhysicalBase = (OldMsbs << 8) + static_cast<unsigned>(Base);
+  unsigned NewMsbs = PhysicalBase >> 8;
+  if (NewMsbs > 3)
+    return false;
+  Base = static_cast<int>(PhysicalBase & 0xff);
+  setVgprMsbs(NewMode, Operand, NewMsbs);
+  return true;
+}
+
 // -- Operand validation -----------------------------------------------------
 
 bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
@@ -479,7 +540,9 @@ bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
 // second half, src2 = dst (the carry from the first half).
 std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
                                               const PrintedAsm &P,
-                                              const WmmaOps &R) {
+                                              const WmmaOps &R,
+                                              unsigned ActiveVgprMsbMode,
+                                              bool &UsesVgprMsbTransition) {
   assert(R.Dst.second > 0 && (R.Src2IsImm || R.Src2.second == R.Dst.second));
   assert(R.Src0.second > 0 && R.Src0.second % 2 == 0);
   assert(R.Src1.second > 0 && R.Src1.second % 2 == 0);
@@ -496,18 +559,44 @@ std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
     return {};
 
   std::vector<std::string> Out;
-  Out.reserve(2);
+  Out.reserve(5);
+  UsesVgprMsbTransition = false;
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}", Replacement, Dst,
                         formatVgprRange(R.Src0.first, AHalf),
                         formatVgprRange(R.Src1.first, BHalf), Src2Printed,
                         *ModFirst)
                     .str());
+
+  int Src0HiBase = R.Src0.first + AHalf;
+  int Src1HiBase = R.Src1.first + BHalf;
+  unsigned OldMode = ActiveVgprMsbMode;
+  unsigned NewMode = OldMode;
+  if (!advanceVgprMsbMode(Src0HiBase, VgprMsbOperand::Src0, OldMode, NewMode) ||
+      !advanceVgprMsbMode(Src1HiBase, VgprMsbOperand::Src1, OldMode, NewMode))
+    return {};
+
+  // The upper half uses dst as src2, so src2 must select the incoming
+  // destination bank even when neither source slice crossed v255.
+  setVgprMsbs(NewMode, VgprMsbOperand::Src2,
+              getVgprMsbs(OldMode, VgprMsbOperand::Dst));
+
+  if (NewMode != OldMode) {
+    UsesVgprMsbTransition = true;
+    // Immediate bits [15:8] record the previous mode. Restore the exact
+    // incoming mode before returning from the split trampoline.
+    unsigned SetUpperMode = NewMode | (OldMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", SetUpperMode).str());
+  }
+
   // Second half: src2 = dst (the carry).
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}", Replacement, Dst,
-                        formatVgprRange(R.Src0.first + AHalf, AHalf),
-                        formatVgprRange(R.Src1.first + BHalf, BHalf), Dst,
-                        *ModSecond)
+                        formatVgprRange(Src0HiBase, AHalf),
+                        formatVgprRange(Src1HiBase, BHalf), Dst, *ModSecond)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned RestoreMode = OldMode | (NewMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", RestoreMode).str());
+  }
   return Out;
 }
 
@@ -515,9 +604,9 @@ std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
 // src2 are split in half by M. The replacement uses the f8f6f4 WMMA with
 // both matrix format modifiers forced to MATRIX_FMT_FP4 so the data layout
 // matches the original f4 instruction.
-std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
-                                            const PrintedAsm &P,
-                                            const WmmaOps &R) {
+std::vector<std::string>
+buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
+                   unsigned ActiveVgprMsbMode, bool &UsesVgprMsbTransition) {
   assert(R.Dst.second > 0 && R.Dst.second % 2 == 0);
   assert(R.Src2IsImm || R.Src2.second == R.Dst.second);
   assert(R.Src0.second > 0 && R.Src0.second % 2 == 0);
@@ -526,12 +615,22 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
   int DstHalf = R.Dst.second / 2;
   int AHalf = R.Src0.second / 2;
   StringRef B = P.Operands[2]; // broadcast: same printer-canonical form
+  int DstHiBase = R.Dst.first + DstHalf;
+  int Src0HiBase = R.Src0.first + AHalf;
+  int Src2HiBase = R.Src2IsImm ? 0 : R.Src2.first + DstHalf;
+  unsigned OldMode = ActiveVgprMsbMode;
+  unsigned NewMode = OldMode;
+  if (!advanceVgprMsbMode(DstHiBase, VgprMsbOperand::Dst, OldMode, NewMode) ||
+      !advanceVgprMsbMode(Src0HiBase, VgprMsbOperand::Src0, OldMode, NewMode) ||
+      (!R.Src2IsImm &&
+       !advanceVgprMsbMode(Src2HiBase, VgprMsbOperand::Src2, OldMode, NewMode)))
+    return {};
+
   // src2 is preserved on both halves when imm; sliced when VGPR.
   std::string CLo = R.Src2IsImm ? P.Operands[3].str()
                                 : formatVgprRange(R.Src2.first, DstHalf);
-  std::string CHi = R.Src2IsImm
-                        ? P.Operands[3].str()
-                        : formatVgprRange(R.Src2.first + DstHalf, DstHalf);
+  std::string CHi =
+      R.Src2IsImm ? P.Operands[3].str() : formatVgprRange(Src2HiBase, DstHalf);
   // Matrix format modifiers are required by the f8f6f4 destination opcode
   // and not present on the f4 source opcode, so the splitter appends them
   // explicitly. Modifier suffix from the source is preserved on both halves
@@ -544,49 +643,449 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
     return {};
 
   std::vector<std::string> Out;
-  Out.reserve(2);
+  Out.reserve(4);
+  UsesVgprMsbTransition = NewMode != OldMode;
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first, DstHalf),
                         formatVgprRange(R.Src0.first, AHalf), B, CLo, FmtSuffix,
                         *Mod)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned SetUpperMode = NewMode | (OldMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", SetUpperMode).str());
+  }
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
-                        formatVgprRange(R.Dst.first + DstHalf, DstHalf),
-                        formatVgprRange(R.Src0.first + AHalf, AHalf), B, CHi,
-                        FmtSuffix, *Mod)
+                        formatVgprRange(DstHiBase, DstHalf),
+                        formatVgprRange(Src0HiBase, AHalf), B, CHi, FmtSuffix,
+                        *Mod)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned RestoreMode = OldMode | (NewMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", RestoreMode).str());
+  }
   return Out;
+}
+
+struct ProtectedWmmaSourceWindow {
+  uint64_t Offset = 0;
+  uint32_t Size = 0;
+  size_t DelayIndex = 0;
+  size_t LastMovedIndex = 0;
+  size_t SecondTargetIndex = 0;
+  unsigned FirstInstId = 0;
+  unsigned SecondInstId = 0;
+  bool RetainsSecondTarget = false;
+
+  bool demergesCombinedDelay() const { return SecondInstId != 0; }
+};
+
+struct CombinedDelayFields {
+  unsigned FirstInstId = 0;
+  unsigned Skip = 0;
+  unsigned SecondInstId = 0;
+};
+
+std::optional<CombinedDelayFields>
+decodeDelayFields(const InternalDecodedInst &Delay) {
+  if (Delay.Mnemonic != "s_delay_alu" || Delay.Inst.getNumOperands() != 1 ||
+      !Delay.Inst.getOperand(0).isImm())
+    return std::nullopt;
+
+  uint64_t Imm = static_cast<uint64_t>(Delay.Inst.getOperand(0).getImm());
+  if ((Imm & ~uint64_t{0x7FF}) != 0)
+    return std::nullopt;
+
+  CombinedDelayFields Fields{static_cast<unsigned>(Imm & 0xF),
+                             static_cast<unsigned>((Imm >> 4) & 0x7),
+                             static_cast<unsigned>((Imm >> 7) & 0xF)};
+  if (Fields.FirstInstId >= 12 || Fields.SecondInstId >= 12 ||
+      Fields.Skip > 5 || (Fields.SecondInstId == 0 && Fields.Skip != 0))
+    return std::nullopt;
+  return Fields;
+}
+
+std::optional<InternalDecodedInst>
+decodeCurrentWindowMember(const PatchContext &Ctx,
+                          const InternalDecodedInst &Original) {
+  if (Original.Mnemonic == "<unknown>" || Original.Mnemonic == "<replaced>" ||
+      Original.Offset > Ctx.TextSize ||
+      Original.Size > Ctx.TextSize - Original.Offset)
+    return std::nullopt;
+  std::vector<InternalDecodedInst> Current;
+  if (!decodeTextSection(Ctx.Text + Original.Offset, Original.Size, Ctx.LS,
+                         Current) ||
+      Current.size() != 1 || Current.front().Offset != 0 ||
+      Current.front().Size != Original.Size)
+    return std::nullopt;
+  Current.front().Offset = Original.Offset;
+  return std::move(Current.front());
+}
+
+namespace AmdgpuDelayTSFlags {
+static constexpr uint64_t TRANS = UINT64_C(1) << 16;
+static constexpr uint64_t IsWMMA = UINT64_C(1) << 59;
+static constexpr uint64_t IsSWMMAC = UINT64_C(1) << 63;
+} // namespace AmdgpuDelayTSFlags
+
+struct DelayPipelineResources {
+  bool HasValu = false;
+  bool HasTransValu = false;
+  bool HasXdl = false;
+};
+
+std::optional<DelayPipelineResources>
+getDelayPipelineResources(const InternalDecodedInst &DI,
+                          const PatchContext &Ctx) {
+  if (!Ctx.LS.STI || !Ctx.LS.MCII)
+    return std::nullopt;
+  const MCSchedModel &Model = Ctx.LS.STI->getSchedModel();
+  if (!Model.hasInstrSchedModel())
+    return std::nullopt;
+
+  unsigned SchedClass = Ctx.LS.MCII->get(DI.Inst.getOpcode()).getSchedClass();
+  for (unsigned Depth = 0; Depth != 8; ++Depth) {
+    if (SchedClass >= Model.NumSchedClasses)
+      return std::nullopt;
+    const MCSchedClassDesc *Desc = Model.getSchedClassDesc(SchedClass);
+    if (!Desc->isValid())
+      return std::nullopt;
+    if (!Desc->isVariant()) {
+      DelayPipelineResources Resources;
+      for (const MCWriteProcResEntry *
+               It = Ctx.LS.STI->getWriteProcResBegin(Desc),
+              *End = Ctx.LS.STI->getWriteProcResEnd(Desc);
+           It != End; ++It) {
+        unsigned ResourceIndex = It->ProcResourceIdx;
+        for (unsigned ResourceDepth = 0;
+             ResourceIndex != 0 &&
+             ResourceDepth != Model.getNumProcResourceKinds();
+             ++ResourceDepth) {
+          if (ResourceIndex >= Model.getNumProcResourceKinds())
+            return std::nullopt;
+          const MCProcResourceDesc *Resource =
+              Model.getProcResource(ResourceIndex);
+          StringRef Name = Resource->Name ? Resource->Name : "";
+          Resources.HasValu |= Name == "HWVALU";
+          Resources.HasTransValu |= Name == "HWTransVALU";
+          Resources.HasXdl |= Name == "HWXDL";
+          ResourceIndex = Resource->SuperIdx;
+        }
+      }
+      if (Desc->NumWriteProcResEntries == 0)
+        return std::nullopt;
+      return Resources;
+    }
+
+    unsigned Resolved = Ctx.LS.STI->resolveVariantSchedClass(
+        SchedClass, &DI.Inst, Ctx.LS.MCII.get(), Model.getProcessorID());
+    if (Resolved == 0 || Resolved == SchedClass)
+      return std::nullopt;
+    SchedClass = Resolved;
+  }
+  return std::nullopt;
+}
+
+// Match AMDGPUInsertDelayAlu's dependency class without duplicating an opcode
+// list. TRANS32 uses the transcendental pipeline without the ordinary VALU
+// pipeline, while gfx1250 XDL WMMA uses HWXDL. In particular, F64 DPMACC and
+// non-XDL WMMA must not advance the TRANS ordinal. An incomplete scheduling
+// model is unknown rather than silently selecting the wrong producer.
+std::optional<bool> isDelayTransInstruction(const InternalDecodedInst &DI,
+                                            const PatchContext &Ctx) {
+  uint64_t Flags = Ctx.LS.MCII->get(DI.Inst.getOpcode()).TSFlags;
+  const bool HasTransFlag = (Flags & AmdgpuDelayTSFlags::TRANS) != 0;
+  const bool IsWmmaLike =
+      (Flags & (AmdgpuDelayTSFlags::IsWMMA | AmdgpuDelayTSFlags::IsSWMMAC)) !=
+      0;
+  if (!HasTransFlag && !IsWmmaLike)
+    return false;
+
+  std::optional<DelayPipelineResources> Resources =
+      getDelayPipelineResources(DI, Ctx);
+  if (!Resources)
+    return std::nullopt;
+  if (IsWmmaLike)
+    return Resources->HasXdl;
+  if (!Resources->HasTransValu)
+    return std::nullopt;
+  return !Resources->HasValu;
+}
+
+bool isPcIndependentDelayWindowMember(const InternalDecodedInst &DI,
+                                      const PatchContext &Ctx) {
+  if (!Ctx.LS.MIA || DI.Mnemonic == "<unknown>" ||
+      DI.Mnemonic == "<replaced>" || DI.Mnemonic == "s_delay_alu" ||
+      DI.Mnemonic == "s_clause" || DI.Mnemonic == "s_set_vgpr_msb" ||
+      // Tensor DMA instructions are explicitly linked-PC-sensitive on A0.
+      DI.Mnemonic == "tensor_load_to_lds" ||
+      StringRef(DI.Mnemonic).contains("_pc_"))
+    return false;
+  const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+  return !Desc.isTerminator() && !Desc.isBranch() && !Desc.isCall() &&
+         !Desc.isReturn() &&
+         !Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI);
+}
+
+bool sourceRangeOverlapsQueuedReplacement(const PatchContext &Ctx,
+                                          uint64_t Begin, uint64_t End) {
+  for (const Trampoline &T : Ctx.OutTrampolines) {
+    std::optional<uint64_t> TEnd = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "queued replacement source end");
+    if (!TEnd || (Begin < *TEnd && T.OriginalOffset < End))
+      return true;
+  }
+  return false;
+}
+
+bool sourceRangeOverlapsTextSymbolExtent(const PatchContext &Ctx,
+                                         uint64_t Begin, uint64_t End) {
+  if (!Ctx.TextSymbolExtents)
+    return true;
+  auto It =
+      llvm::lower_bound(*Ctx.TextSymbolExtents, Begin,
+                        [](const ElfView::TextOffsetRange &Extent,
+                           uint64_t Offset) { return Extent.End <= Offset; });
+  return It != Ctx.TextSymbolExtents->end() && It->Begin < End;
+}
+
+// A delay-protected WMMA cannot be replaced at its linked address alone: the
+// surviving s_delay_alu would describe the source branch rather than the
+// replacement. Recover the unique owner from the encoded instruction span.
+// For a combined delay, move every position-independent member before the
+// second target, split the WMMA in that ordered stream, and use the last moved
+// dword for the reconstructed second delay. No instruction mnemonic or kernel
+// schedule determines the geometry.
+std::optional<ProtectedWmmaSourceWindow>
+findProtectedWmmaSourceWindow(const PatchContext &Ctx, size_t WmmaIndex) {
+  const InternalDecodedInst &Wmma = Ctx.Decoded[WmmaIndex];
+  auto Fail =
+      [&](StringRef Reason) -> std::optional<ProtectedWmmaSourceWindow> {
+    log() << "hotswap: error: WMMA split: protected site at 0x"
+          << utohexstr(Wmma.Offset) << " " << Reason << "\n";
+    return std::nullopt;
+  };
+
+  if (WmmaIndex == 0 || !Ctx.LS.MIA || !Ctx.DirectControlFlowTargets)
+    return Fail("has no supported preceding delay window");
+  if (Ctx.HasUnknownArbitraryIndirectTarget)
+    return Fail("cannot be relocated with an unresolved indirect entry");
+
+  constexpr size_t MaxClauseSpan = 64;
+  const size_t FirstPossibleOwner =
+      WmmaIndex > MaxClauseSpan ? WmmaIndex - MaxClauseSpan : 0;
+  size_t DelayIndex = 0;
+  unsigned DelayOwners = 0;
+  std::optional<CombinedDelayFields> Fields;
+  for (size_t I = FirstPossibleOwner; I != WmmaIndex; ++I) {
+    const InternalDecodedInst &Candidate = Ctx.Decoded[I];
+    const size_t Distance = WmmaIndex - I;
+    if (Candidate.Mnemonic == "s_delay_alu" &&
+        getDelayProtectedSpan(Candidate) >= Distance) {
+      ++DelayOwners;
+      std::optional<InternalDecodedInst> Current =
+          decodeCurrentWindowMember(Ctx, Candidate);
+      std::optional<CombinedDelayFields> CandidateFields =
+          Current ? decodeDelayFields(*Current) : std::nullopt;
+      if (!CandidateFields || getDelayProtectedSpan(*Current) < Distance)
+        continue;
+      DelayIndex = I;
+      Fields = *CandidateFields;
+      continue;
+    }
+    if (Candidate.Mnemonic == "s_clause" &&
+        Candidate.Inst.getNumOperands() == 1 &&
+        Candidate.Inst.getOperand(0).isImm()) {
+      const unsigned ClauseSpan =
+          (static_cast<unsigned>(Candidate.Inst.getOperand(0).getImm()) & 63u) +
+          1;
+      if (ClauseSpan >= Distance)
+        return Fail("overlaps another delay or hard clause");
+    }
+  }
+  if (DelayOwners != 1 || !Fields)
+    return Fail(DelayOwners > 1 ? "has ambiguous delay ownership"
+                                : "has no supported preceding delay window");
+
+  const InternalDecodedInst *Delay = &Ctx.Decoded[DelayIndex];
+  const unsigned Span = getDelayProtectedSpan(*Delay);
+  if (Span == 0 || Span > Ctx.Decoded.size() - DelayIndex - 1)
+    return Fail("has an invalid delay target layout");
+  const size_t SecondTargetIndex = DelayIndex + Span;
+  if (WmmaIndex > SecondTargetIndex)
+    return Fail("has an invalid delay target layout");
+
+  const bool DemergeCombinedDelay = Span > 1;
+  if (DemergeCombinedDelay &&
+      (Fields->FirstInstId == 0 || Fields->SecondInstId == 0 ||
+       Span != Fields->Skip + 1))
+    return Fail("has an unsupported combined dependency graph");
+  const bool RetainsSecondTarget =
+      DemergeCombinedDelay && WmmaIndex < SecondTargetIndex;
+  const size_t LastMovedIndex =
+      RetainsSecondTarget ? SecondTargetIndex - 1 : WmmaIndex;
+  if (RetainsSecondTarget && Ctx.Decoded[LastMovedIndex].Size != MinInstSize)
+    return Fail("has no dword slot for the reconstructed second delay");
+
+  // collectRelocationProtectedOffsets does not mark the directive itself.
+  // Therefore a protected Delay proves that an earlier clause or another
+  // delay overlaps this two-instruction window.
+  if (Ctx.RelocationProtectedOffsets.contains(Delay->Offset))
+    return Fail("overlaps another delay or hard clause");
+
+  std::optional<ElfView::FunctionTextRange> DelayFunction =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Delay->Offset);
+  std::optional<ElfView::FunctionTextRange> WmmaFunction =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Wmma.Offset);
+  if (!DelayFunction || !WmmaFunction ||
+      DelayFunction->Begin != WmmaFunction->Begin ||
+      DelayFunction->End != WmmaFunction->End)
+    return Fail("does not share a proven function with its delay");
+  if (Ctx.IndirectControlFlowFunctions.contains(WmmaFunction->Begin))
+    return Fail("is in a function with an ambiguous indirect entry");
+
+  std::optional<uint64_t> End =
+      RetainsSecondTarget
+          ? std::optional<uint64_t>(Ctx.Decoded[LastMovedIndex].Offset)
+          : checkedAddUint64(Wmma.Offset, Wmma.Size,
+                             "delay-protected WMMA window end");
+  if (!End || *End <= Delay->Offset ||
+      *End - Delay->Offset > std::numeric_limits<uint32_t>::max())
+    return Fail("has an invalid source-window extent");
+  std::optional<uint64_t> ClaimEnd = checkedAddUint64(
+      Ctx.Decoded[LastMovedIndex].Offset, Ctx.Decoded[LastMovedIndex].Size,
+      "delay-protected WMMA claimed-window end");
+  const uint64_t EntryCheckEnd =
+      RetainsSecondTarget ? Ctx.Decoded[SecondTargetIndex].Offset : *End;
+  if (!ClaimEnd ||
+      sourceRangeOverlapsQueuedReplacement(Ctx, Delay->Offset, *ClaimEnd))
+    return Fail("overlaps an existing replacement source");
+  if (sourceRangeOverlapsTextSymbolExtent(Ctx, Delay->Offset, *ClaimEnd))
+    return Fail("overlaps a sized non-callable text symbol");
+  if (hasDirectControlFlowTargetInWindowInterior(Ctx.DirectControlFlowTargets,
+                                                 Delay->Offset, EntryCheckEnd))
+    return Fail("has a direct entry into the source-window interior "
+                "(including symbol entries)");
+  if (Delay->Offset > Ctx.TextSize || EntryCheckEnd > Ctx.TextSize)
+    return Fail("has a source window outside .text");
+
+  uint64_t ExpectedOffset = Delay->Offset;
+  for (size_t I = DelayIndex; I <= SecondTargetIndex; ++I) {
+    const InternalDecodedInst &Original = Ctx.Decoded[I];
+    std::optional<InternalDecodedInst> Current =
+        decodeCurrentWindowMember(Ctx, Original);
+    std::optional<ElfView::FunctionTextRange> Function =
+        Ctx.Elf.findFunctionTextRangeAtOffset(Original.Offset);
+    if (!Current || !Function || Function->Begin != DelayFunction->Begin ||
+        Function->End != DelayFunction->End ||
+        Original.Offset != ExpectedOffset)
+      return Fail("has a non-contiguous current instruction window");
+    ExpectedOffset += Original.Size;
+
+    if (I == WmmaIndex && Current->Inst.getOpcode() != Wmma.Inst.getOpcode())
+      return Fail("has a modified WMMA source instruction");
+
+    if (I <= LastMovedIndex &&
+        Ctx.ClaimedReplacementOffsets.contains(Original.Offset))
+      return Fail("overlaps an existing atomic replacement window");
+    if (I != DelayIndex && I != WmmaIndex && I <= LastMovedIndex &&
+        !isPcIndependentDelayWindowMember(*Current, Ctx))
+      return Fail("has a non-relocatable instruction in its delay window");
+    if (I != DelayIndex && (Current->Mnemonic == "s_delay_alu" ||
+                            Current->Mnemonic == "s_clause" ||
+                            Current->Mnemonic == "s_set_vgpr_msb"))
+      return Fail("has an unsupported nested dependency graph");
+    // Every moved position is claimed after this atomic relocation. A later
+    // per-instruction patch there would be silently skipped by the outer
+    // dispatcher, so reject before mutating bytes. The retained second target
+    // is deliberately excluded: it remains at its linked address and can
+    // compose with the reconstructed delay (tensor masking relies on this).
+    if (I != DelayIndex && I != WmmaIndex && I <= LastMovedIndex &&
+        requiresIndependentInstructionRewrite(Ctx, I)) {
+      log() << "hotswap: error: WMMA split: delay-window member at 0x"
+            << utohexstr(Original.Offset)
+            << " requires a separate HotSwap patch\n";
+      return Fail("would suppress another required HotSwap patch");
+    }
+  }
+
+  return ProtectedWmmaSourceWindow{
+      Delay->Offset,
+      static_cast<uint32_t>(*End - Delay->Offset),
+      DelayIndex,
+      LastMovedIndex,
+      SecondTargetIndex,
+      DemergeCombinedDelay ? Fields->FirstInstId : 0,
+      DemergeCombinedDelay ? Fields->SecondInstId : 0,
+      RetainsSecondTarget};
+}
+
+std::optional<unsigned> remapSecondDelayDependency(
+    const PatchContext &Ctx, const ProtectedWmmaSourceWindow &Window,
+    size_t WmmaIndex, ArrayRef<uint8_t> WmmaReplacement) {
+  unsigned Dependency = Window.SecondInstId;
+  if (!Window.RetainsSecondTarget || Dependency < 5 || Dependency > 7)
+    return Dependency;
+
+  std::optional<InternalDecodedInst> Source =
+      decodeCurrentWindowMember(Ctx, Ctx.Decoded[WmmaIndex]);
+  std::optional<bool> SourceIsTrans =
+      Source ? isDelayTransInstruction(*Source, Ctx) : std::nullopt;
+  if (!SourceIsTrans || !*SourceIsTrans)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst> Split;
+  if (!decodeTextSection(WmmaReplacement.data(), WmmaReplacement.size(), Ctx.LS,
+                         Split))
+    return std::nullopt;
+  unsigned ReplacementTrans = 0;
+  for (const InternalDecodedInst &DI : Split) {
+    std::optional<bool> IsTrans = isDelayTransInstruction(DI, Ctx);
+    if (!IsTrans)
+      return std::nullopt;
+    ReplacementTrans += *IsTrans;
+  }
+  if (ReplacementTrans == 0)
+    return std::nullopt;
+
+  // Instid counts prior operations in its dependency class. Instructions
+  // after the source WMMA retain their ordinal. The original WMMA maps to the
+  // last TRANS in its replacement and therefore also retains its ordinal.
+  // Only a producer older than the source shifts by the net extra TRANS count.
+  unsigned LaterTrans = 0;
+  for (size_t I = WmmaIndex + 1; I <= Window.LastMovedIndex; ++I) {
+    std::optional<InternalDecodedInst> Current =
+        decodeCurrentWindowMember(Ctx, Ctx.Decoded[I]);
+    if (!Current)
+      return std::nullopt;
+    std::optional<bool> IsTrans = isDelayTransInstruction(*Current, Ctx);
+    if (!IsTrans)
+      return std::nullopt;
+    LaterTrans += *IsTrans;
+  }
+
+  unsigned Ordinal = Dependency - 4;
+  if (Ordinal <= LaterTrans + 1)
+    return Dependency;
+  const unsigned ExtraTrans = ReplacementTrans - 1;
+  if (ExtraTrans > 3 || Ordinal > 3 - ExtraTrans)
+    return std::nullopt;
+  return 4 + Ordinal + ExtraTrans;
 }
 
 } // anonymous namespace
 
-// Return-value semantics (current shared dispatcher API in b0a0.cpp):
-//   0  = either "this patch did not match the instruction" OR "matched
-//        but failed to apply" -- the dispatcher cannot distinguish the
-//        two and will fall through to the next patch class. For WMMA
-//        split mnemonics no other patch class will match, so a
-//        matched-but-failed case results in the rewriter returning
-//        SUCCESS at the API level with the original A0-incompatible
-//        opcode left in .text. The runtime will then fail to load (or
-//        worse, mis-execute) the kernel with no clear error attribution.
-//   N>0 = "matched, applied N patches" (this splitter only ever returns
-//        1 since it splits one source WMMA into one trampoline).
-//
-// chinmaydd flagged this on PR #2379 as a cross-cutting concern across
-// every patch in the hotswap subsystem: the shared `uint32_t (*)(
-// PatchContext&, size_t)` signature in b0a0.cpp's weak-stub dispatcher
-// has the same ambiguity for in-place patches (#2222), the WMMA hazard
-// patch (#2265), and any future patch. A proper fix is a separate
-// follow-up that changes the dispatcher's return type to an enum
-// (NoMatch / Patched / Failed) or threads a `bool *Aborted` through
-// PatchContext, with the dispatcher checking the failure flag and
-// short-circuiting the rewrite with AMD_COMGR_STATUS_ERROR rather than
-// silently leaving the original opcode in .text.
-//
-// For now: every "matched but failed" path below logs an error via
-// log() (so the failure is at least visible when AMD_COMGR_EMIT_VERBOSE_LOGS
-// is set) and returns 0. The early "did not match" path returns 0
-// without logging.
+bool isWmmaSplitPatchCandidate(StringRef Mnemonic) {
+  return lookupSplitRule(Mnemonic).has_value();
+}
+
+// The dispatcher uses zero for both "no match" and "failed". Once a split
+// rule matches, set RequiredPatchFailed on every failure so the original
+// A0-incompatible WMMA can never be returned as a successful rewrite.
+static uint32_t failWmmaSplit(PatchContext &Ctx) {
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
 
@@ -594,11 +1093,16 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!Match)
     return 0; // Did NOT match -- correct dispatcher fall-through.
 
-  // ----- All return-0 paths below are MATCHED-BUT-FAILED -----
-  // Until the dispatcher API is refactored to distinguish these cleanly,
-  // each of these is a silent miscompile risk for the runtime; the log()
-  // line is the only signal the user gets that a recognized opcode was
-  // left in .text.
+  // Snapshot the original relocation constraint before VGPR-MSB handling adds
+  // the split site to the set to protect its generated mode transitions.
+  const bool WasRelocationProtected =
+      Ctx.RelocationProtectedOffsets.contains(DI.Offset);
+  std::optional<ProtectedWmmaSourceWindow> ProtectedWindow;
+  if (WasRelocationProtected) {
+    ProtectedWindow = findProtectedWmmaSourceWindow(Ctx, Idx);
+    if (!ProtectedWindow)
+      return failWmmaSplit(Ctx);
+  }
 
   // Structural sanity check against the opcode side. Every WMMA variant this
   // patch handles has exactly one destination operand at the MCInstrDesc
@@ -609,7 +1113,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (MCID.getNumDefs() != 1) {
     log() << "hotswap: error: WMMA split: " << DI.Mnemonic << " has "
           << MCID.getNumDefs() << " defs, expected 1\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
   std::optional<WmmaOps> Ops =
@@ -617,11 +1121,11 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!Ops) {
     log() << "hotswap: error: WMMA split: could not extract operands from "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
   if (!validateSplitOperands(Match->Kind, *Ops, DI.Mnemonic))
-    return 0; // matched-but-failed (validateSplitOperands logs the reason)
+    return failWmmaSplit(Ctx);
 
   // Print the source instruction in canonical asm form. The printer is the
   // authoritative source for src2 inline-immediate formatting (FP inline
@@ -636,20 +1140,48 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!P) {
     log() << "hotswap: error: WMMA split: could not parse printed form of "
           << DI.Mnemonic << ": " << StringRef(PrintedBuf).trim() << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
+  }
+
+  bool UsesVgprMsbTransition = false;
+  bool NeedsKnownVgprMsbMode = Match->Kind == SplitKind::Split128to64FP8BF8;
+  if (Match->Kind == SplitKind::Split32x16to16x16F4) {
+    NeedsKnownVgprMsbMode =
+        Ops->Dst.first + Ops->Dst.second / 2 > 255 ||
+        Ops->Src0.first + Ops->Src0.second / 2 > 255 ||
+        (!Ops->Src2IsImm && Ops->Src2.first + Ops->Dst.second / 2 > 255);
+  }
+
+  unsigned ActiveVgprMsbMode = 0;
+  if (NeedsKnownVgprMsbMode) {
+    std::optional<unsigned> Mode = findActiveVgprMsbMode(Ctx, Idx);
+    if (!Mode) {
+      log() << "hotswap: error: WMMA split: cannot determine VGPR-MSB mode "
+               "for "
+            << DI.Mnemonic << " at offset 0x" << utohexstr(DI.Offset) << "\n";
+      return failWmmaSplit(Ctx);
+    }
+    ActiveVgprMsbMode = *Mode;
   }
 
   std::vector<std::string> AsmLines;
   switch (Match->Kind) {
   case SplitKind::Split128to64FP8BF8:
-    AsmLines = buildSplit128to64Asm(Match->Replacement, *P, *Ops);
+    AsmLines = buildSplit128to64Asm(Match->Replacement, *P, *Ops,
+                                    ActiveVgprMsbMode, UsesVgprMsbTransition);
     break;
   case SplitKind::Split32x16to16x16F4:
-    AsmLines = buildSplit32x16Asm(Match->Replacement, *P, *Ops);
+    AsmLines = buildSplit32x16Asm(Match->Replacement, *P, *Ops,
+                                  ActiveVgprMsbMode, UsesVgprMsbTransition);
     break;
   }
-  if (AsmLines.empty())
-    return 0; // matched-but-failed (build*Asm rejected an unsupported modifier)
+  if (AsmLines.empty()) {
+    log() << "hotswap: error: WMMA split: could not build replacement for "
+          << DI.Mnemonic << "\n";
+    return failWmmaSplit(Ctx);
+  }
+  if (UsesVgprMsbTransition)
+    protectNonClauseRelocationOffset(Ctx, DI.Offset);
 
   // Assemble the split sequence and defer trampoline emission to
   // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
@@ -659,16 +1191,101 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (Replacement.empty()) {
     log() << "hotswap: error: WMMA split: trampoline assembly failed for "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
-  }
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement)) {
-    log() << "hotswap: error: WMMA split: could not emit trampoline for "
-          << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
+  uint64_t SourceOffset = DI.Offset;
+  uint32_t SourceSize = DI.Size;
+  SmallVector<uint8_t> DeferredDelayBytes;
+  if (ProtectedWindow) {
+    const InternalDecodedInst &Delay = Ctx.Decoded[ProtectedWindow->DelayIndex];
+    SmallVector<uint8_t> WithDelay;
+    if (ProtectedWindow->demergesCombinedDelay()) {
+      std::optional<unsigned> SecondInstId =
+          remapSecondDelayDependency(Ctx, *ProtectedWindow, Idx, Replacement);
+      if (!SecondInstId) {
+        log() << "hotswap: error: WMMA split: combined s_delay_alu at 0x"
+              << utohexstr(Delay.Offset)
+              << " has an unrepresentable TRANS dependency after split\n";
+        return failWmmaSplit(Ctx);
+      }
+      SmallVector<uint8_t> FirstDelayBytes = assembleSingleInst(
+          "s_delay_alu " + std::to_string(ProtectedWindow->FirstInstId),
+          Ctx.LS);
+      DeferredDelayBytes = assembleSingleInst(
+          "s_delay_alu " + std::to_string(*SecondInstId), Ctx.LS);
+      if (FirstDelayBytes.size() != MinInstSize ||
+          DeferredDelayBytes.size() != MinInstSize) {
+        log() << "hotswap: error: WMMA split: could not demerge combined "
+                 "s_delay_alu at 0x"
+              << utohexstr(Delay.Offset) << "\n";
+        return failWmmaSplit(Ctx);
+      }
+
+      WithDelay.append(FirstDelayBytes.begin(), FirstDelayBytes.end());
+      for (size_t I = ProtectedWindow->DelayIndex + 1;
+           I <= ProtectedWindow->LastMovedIndex; ++I) {
+        if (!ProtectedWindow->RetainsSecondTarget &&
+            I == ProtectedWindow->SecondTargetIndex)
+          WithDelay.append(DeferredDelayBytes.begin(),
+                           DeferredDelayBytes.end());
+        if (I == Idx) {
+          WithDelay.append(Replacement.begin(), Replacement.end());
+          continue;
+        }
+        const InternalDecodedInst &Member = Ctx.Decoded[I];
+        WithDelay.append(Ctx.Text + Member.Offset,
+                         Ctx.Text + Member.Offset + Member.Size);
+      }
+    } else {
+      WithDelay.append(Ctx.Text + Delay.Offset,
+                       Ctx.Text + Delay.Offset + Delay.Size);
+      WithDelay.append(Replacement.begin(), Replacement.end());
+    }
+    Replacement = std::move(WithDelay);
+    SourceOffset = ProtectedWindow->Offset;
+    SourceSize = ProtectedWindow->Size;
+  }
+
+  if (ProtectedWindow && ProtectedWindow->RetainsSecondTarget &&
+      !canEmitShortTrampoline(Ctx, SourceOffset, SourceSize,
+                              Replacement.size())) {
+    log() << "hotswap: error: WMMA split: combined-delay demerge at 0x"
+          << utohexstr(SourceOffset) << " requires a short trampoline\n";
+    return failWmmaSplit(Ctx);
+  }
+
+  if (!emitToTrampoline(Ctx, SourceOffset, SourceSize, Replacement)) {
+    log() << "hotswap: error: WMMA split: could not emit trampoline for "
+          << DI.Mnemonic << "\n";
+    return failWmmaSplit(Ctx);
+  }
+
+  if (ProtectedWindow && ProtectedWindow->RetainsSecondTarget) {
+    const InternalDecodedInst &LastMoved =
+        Ctx.Decoded[ProtectedWindow->LastMovedIndex];
+    std::memcpy(Ctx.Text + LastMoved.Offset, DeferredDelayBytes.data(),
+                MinInstSize);
+  }
+  if (ProtectedWindow) {
+    for (size_t I = ProtectedWindow->DelayIndex;
+         I <= ProtectedWindow->LastMovedIndex; ++I) {
+      const uint64_t Offset = Ctx.Decoded[I].Offset;
+      Ctx.ClaimedReplacementOffsets.insert(Offset);
+      protectNonClauseRelocationOffset(Ctx, Offset);
+    }
+  }
+
+  Ctx.RequiredPatchApplied = true;
   log() << "hotswap: WMMA split: patched " << DI.Mnemonic << " at offset 0x"
-        << utohexstr(DI.Offset) << "\n";
+        << utohexstr(DI.Offset);
+  if (ProtectedWindow && ProtectedWindow->demergesCombinedDelay())
+    log() << " by demerging combined delay in source window at 0x"
+          << utohexstr(SourceOffset);
+  else if (ProtectedWindow)
+    log() << " with preceding delay in source window at 0x"
+          << utohexstr(SourceOffset);
+  log() << "\n";
   return 1;
 }
 

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -5,6 +5,12 @@ HotSwap is COMGR's AMDGPU code-object rewriting support. The public
 target ISA names, then returns a new executable code object with the applicable
 rewrite applied. The input code object is not modified.
 
+Input code objects must obey the AMDGPU callable-control-flow ABI. In
+particular, `s_swap_pc_i64` writing the standard link pair `s[30:31]` must be a
+call to a callable function entry represented by the code object. Using that
+ABI call form for an arbitrary interior transfer is unsupported and may produce
+invalid rewritten code.
+
 This directory contains COMGR's hotswap transpiler scaffolding, the raiser-based
 path for heavier cross-ISA transformations. The same-family stepping patches and
 entry trampolines are implemented in the surrounding COMGR source files and are
@@ -34,6 +40,18 @@ of returning the original unpatched code object.
 necessarily that the output bytes changed. If the source/target ISA pair and
 rewrite options select no enabled transformation, the output is a copy of the
 input.
+
+## Generated executable pools
+
+When a rewrite grows executable code, COMGR records the generated pool's
+layout and target stepping in an ELF note. A later rewrite accepts that pool
+only when its section, load segment, note, and target state agree; malformed,
+overlapping, unmarked, or target-mismatched pools fail closed.
+
+This note is a structural provenance and state certificate, not an
+authentication mechanism. HotSwap assumes its input comes from a trusted
+compiler or an earlier trusted HotSwap invocation; callers must not use the
+note to establish the integrity of an untrusted code object.
 
 ## Register accounting
 

--- a/amd/comgr/test-lit/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap-absolute-call.s
@@ -15,9 +15,10 @@
 
 // DISASM-LABEL: <test_absolute_call>:
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], 0x1010
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_nop 0
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-already-a0-incomplete.s
+++ b/amd/comgr/test-lit/hotswap-already-a0-incomplete.s
@@ -1,0 +1,69 @@
+// COM: An A0 tag on only some kernels is not a completion certificate. Missing
+// COM: revision metadata must take the normal analysis path, even if no rule
+// COM: ultimately matches this small object.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck %s
+// CHECK-NOT: every kernel already reports gfx1250 revision A0
+// CHECK: applied 0 instruction patches
+// CHECK: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl tagged
+.p2align 8
+.type tagged,@function
+tagged:
+  s_endpgm
+.size tagged, .-tagged
+
+.globl untagged
+.p2align 8
+.type untagged,@function
+untagged:
+  s_endpgm
+.size untagged, .-untagged
+
+.rodata
+.p2align 8
+.amdhsa_kernel tagged
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel untagged
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: tagged
+      .symbol: tagged.kd
+      .gfx1250_revision: A0
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: untagged
+      .symbol: untagged.kd
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-already-a0-malformed.s
+++ b/amd/comgr/test-lit/hotswap-already-a0-malformed.s
@@ -1,0 +1,45 @@
+// COM: A non-string revision cannot certify target state. Fail closed before
+// COM: interpreting the object as either an already-rewritten A0 object or a
+// COM: valid B0 input whose metadata can be retagged in place.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+// CHECK: .gfx1250_revision is not a string
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl malformed
+.p2align 8
+.type malformed,@function
+malformed:
+  s_endpgm
+.size malformed, .-malformed
+
+.rodata
+.p2align 8
+.amdhsa_kernel malformed
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: malformed
+      .symbol: malformed.kd
+      .gfx1250_revision: 0
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-already-a0-mixed.s
+++ b/amd/comgr/test-lit/hotswap-already-a0-mixed.s
@@ -1,0 +1,87 @@
+// COM: A single A0 tag is not an object-wide target-state certificate. Mixed
+// COM: kernel metadata must run the rewrite, retag every kernel, and only then
+// COM: permit a byte-identical repeated request.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=FIRST %s
+// FIRST-NOT: every kernel already reports gfx1250 revision A0
+// FIRST: applied 1 instruction patches
+// FIRST: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: ds_load_2addr_b64
+// RUN: %llvm-readelf --notes %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=METADATA %s
+// METADATA-NOT: .gfx1250_revision: B0
+// METADATA-COUNT-2: .gfx1250_revision: A0
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf 2>&1 | %FileCheck --check-prefix=SECOND %s
+// SECOND: every kernel already reports gfx1250 revision A0
+// SECOND: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl already_a0
+.p2align 8
+.type already_a0,@function
+already_a0:
+  s_endpgm
+.size already_a0, .-already_a0
+
+.globl still_b0
+.p2align 8
+.type still_b0,@function
+still_b0:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_endpgm
+  .rept 16
+    s_nop 0
+  .endr
+.size still_b0, .-still_b0
+
+.rodata
+.p2align 8
+.amdhsa_kernel already_a0
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel still_b0
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: already_a0
+      .symbol: already_a0.kd
+      .gfx1250_revision: A0
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: still_b0
+      .symbol: still_b0.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-already-a0-noop.s
+++ b/amd/comgr/test-lit/hotswap-already-a0-noop.s
@@ -1,0 +1,80 @@
+// COM: Uniform per-kernel A0 metadata is an object-wide target-state
+// COM: certificate. A repeated B0-to-A0 request must return the object
+// COM: unchanged, even when its instructions would match B0 rewrite rules if
+// COM: reinterpreted without that metadata.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: every kernel already reports gfx1250 revision A0
+// LOG-NOT: ds_2addr:
+// LOG: RESULT: SUCCESS
+// RUN: cmp %t.elf %t.out.elf
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM: ds_load_2addr_b64
+
+// COM: The target-state certificate suppresses only B0-to-A0 instruction
+// COM: patches. An independently requested entry trampoline still runs.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --entry-trampolines --output %t.entry.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=ENTRY %s
+// ENTRY: every kernel already reports gfx1250 revision A0
+// ENTRY: RESULT: SUCCESS
+// RUN: %llvm-readelf -s %t.entry.elf | %FileCheck --check-prefix=ENTRY-SYM %s
+// ENTRY-SYM-NOT: already_a0.stub
+// RUN: %llvm-objdump -d %t.entry.elf | \
+// RUN:   %FileCheck --check-prefix=ENTRY-DISASM %s
+// ENTRY-DISASM-LABEL: <already_a0>:
+// ENTRY-DISASM-NEXT: global_wb
+// ENTRY-DISASM-NEXT: v_nop
+// ENTRY-DISASM-NEXT: ds_load_2addr_b64
+
+// COM: Direct entry displacement is stepping-neutral. A later B0-to-A0 request
+// COM: takes the A0 metadata fast path and returns the object unchanged.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.entry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.entry.repeat.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=ENTRY-REPEAT %s
+// ENTRY-REPEAT: every kernel already reports gfx1250 revision A0
+// ENTRY-REPEAT: RESULT: SUCCESS
+// RUN: cmp %t.entry.elf %t.entry.repeat.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl already_a0
+.p2align 8
+.type already_a0,@function
+already_a0:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_endpgm
+.size already_a0, .-already_a0
+
+.rodata
+.p2align 8
+.amdhsa_kernel already_a0
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: already_a0
+      .symbol: already_a0.kd
+      .gfx1250_revision: A0
+      .sgpr_count: 2
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-already-a0-omitted-kernel.s
+++ b/amd/comgr/test-lit/hotswap-already-a0-omitted-kernel.s
@@ -1,0 +1,59 @@
+// COM: Uniform metadata entries are insufficient when metadata omits a real
+// COM: kernel descriptor. The target-state fast path requires complete name
+// COM: coverage of the descriptor set.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck %s
+// CHECK-NOT: every kernel already reports gfx1250 revision A0
+// CHECK: applied 0 instruction patches
+// CHECK: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl listed
+.p2align 8
+.type listed,@function
+listed:
+  s_endpgm
+.size listed, .-listed
+
+.globl omitted
+.p2align 8
+.type omitted,@function
+omitted:
+  s_endpgm
+.size omitted, .-omitted
+
+.rodata
+.p2align 8
+.amdhsa_kernel listed
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel omitted
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: listed
+      .symbol: listed.kd
+      .gfx1250_revision: A0
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-call-tail-gateway-packing.s
+++ b/amd/comgr/test-lit/hotswap-call-tail-gateway-packing.s
@@ -1,0 +1,162 @@
+// COM: Three 8-byte far sites can reach only one 24-byte, one 16-byte, and one
+// COM: 8-byte external gateway sled. The source-relative 12-byte call tails pack
+// COM: twice into the 24-byte sled and once into the 16-byte sled. A full
+// COM: get-PC/add/set-PC gateway could serve only two sites.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 3 SCC-neutral forward gateway(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d --mcpu=gfx1250 %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <call_tail_site0>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_nop 0
+// DISASM-LABEL: <call_tail_site1>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_nop 0
+// DISASM-LABEL: <call_tail_site2>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_nop 0
+// DISASM-LABEL: <gateway_24>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM-LABEL: <gateway_16>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl call_tail_site0
+.p2align 8
+.type call_tail_site0,@function
+call_tail_site0:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size call_tail_site0, .-call_tail_site0
+
+.rept 1021
+  s_mov_b32 s64, s65
+.endr
+
+.globl call_tail_site1
+.type call_tail_site1,@function
+call_tail_site1:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size call_tail_site1, .-call_tail_site1
+
+.rept 1021
+  s_mov_b32 s64, s65
+.endr
+
+.globl call_tail_site2
+.type call_tail_site2,@function
+call_tail_site2:
+  ds_load_2addr_stride64_b32 v[8:9], v10 offset0:1 offset1:3
+  s_endpgm
+.size call_tail_site2, .-call_tail_site2
+
+.rept 4093
+  s_mov_b32 s64, s65
+.endr
+
+.type gateway_24,@function
+gateway_24:
+  s_endpgm
+.size gateway_24, .-gateway_24
+.fill 24, 1, 0
+
+.rept 1017
+  s_mov_b32 s64, s65
+.endr
+
+.type gateway_16,@function
+gateway_16:
+  s_endpgm
+.size gateway_16, .-gateway_16
+.fill 16, 1, 0
+
+.rept 1019
+  s_mov_b32 s64, s65
+.endr
+
+.type gateway_8,@function
+gateway_8:
+  s_endpgm
+.size gateway_8, .-gateway_8
+.fill 8, 1, 0
+
+.rept 70000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel call_tail_site0
+  .amdhsa_next_free_vgpr 11
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel call_tail_site1
+  .amdhsa_next_free_vgpr 11
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel call_tail_site2
+  .amdhsa_next_free_vgpr 11
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: call_tail_site0
+      .symbol: call_tail_site0.kd
+      .sgpr_count: 66
+      .vgpr_count: 11
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: call_tail_site1
+      .symbol: call_tail_site1.kd
+      .sgpr_count: 66
+      .vgpr_count: 11
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: call_tail_site2
+      .symbol: call_tail_site2.kd
+      .sgpr_count: 66
+      .vgpr_count: 11
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-combined-delay-required-patch-ownership.s
+++ b/amd/comgr/test-lit/hotswap-combined-delay-required-patch-ownership.s
@@ -1,0 +1,83 @@
+// An atomic combined-delay relocation must not consume another instruction
+// that still needs a per-instruction HotSwap pass. Exercise both discovery
+// orders: DS2 before WMMA and WMMA before DS2. Both rewrites must fail before
+// installing a source branch, rather than marking the later site replaced or
+// claimed and silently skipping its required correction.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.ds2-first.elf
+// RUN: rm -f %t.ds2-first.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ds2-first.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.ds2-first.out.elf --expect-status ERROR \
+// RUN:   2>&1 | %FileCheck --check-prefix=DS2-FIRST %s
+// RUN: test ! -e %t.ds2-first.out.elf
+// DS2-FIRST: ds_2addr: combined-delay window member at 0x{{[0-9A-F]+}} requires a separate HotSwap patch
+// DS2-FIRST: ds_2addr: protected source at 0x{{[0-9A-F]+}} has no supported combined-delay window
+// DS2-FIRST: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.wmma-first.elf
+// RUN: rm -f %t.wmma-first.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.wmma-first.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.wmma-first.out.elf --expect-status ERROR \
+// RUN:   2>&1 | %FileCheck --check-prefix=WMMA-FIRST %s
+// RUN: test ! -e %t.wmma-first.out.elf
+// WMMA-FIRST: WMMA split: delay-window member at 0x{{[0-9A-F]+}} requires a separate HotSwap patch
+// WMMA-FIRST: WMMA split: protected site at 0x{{[0-9A-F]+}} would suppress another required HotSwap patch
+// WMMA-FIRST: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl combined_delay_required_patch_ownership
+.p2align 8
+.type combined_delay_required_patch_ownership,@function
+combined_delay_required_patch_ownership:
+#if CASE == 1
+  // DS2 is strictly between both delay targets. Its demerge used to relocate
+  // and mark the second-target WMMA replaced before the split pass saw it.
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+  s_nop 0
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 2
+  // WMMA is the first target and DS2 is an interior member. Its split used to
+  // claim the DS2's linked address, causing the outer dispatcher to skip it.
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_nop 0
+  s_nop 0
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Lcombined_delay_required_patch_ownership_end:
+.size combined_delay_required_patch_ownership, .Lcombined_delay_required_patch_ownership_end-combined_delay_required_patch_ownership
+
+.rodata
+.p2align 8
+.amdhsa_kernel combined_delay_required_patch_ownership
+  .amdhsa_next_free_vgpr 64
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: combined_delay_required_patch_ownership
+      .symbol: combined_delay_required_patch_ownership.kd
+      .sgpr_count: 2
+      .vgpr_count: 64
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-direct-call-return-proof.s
+++ b/amd/comgr/test-lit/hotswap-direct-call-return-proof.s
@@ -1,0 +1,223 @@
+// COM: A nonstandard SGPR pair is a return address only when an exact direct
+// COM: call supplies it on every path. Partial clobbers, alternate branch or
+// COM: materialized ingress, opaque control flow, and an unresolved ABI-link
+// COM: call turn the set-PC back into an arbitrary transfer.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=0 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.good.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.good.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.good.out.elf 2>&1 | %FileCheck --check-prefix=GOOD-API %s
+// GOOD-API: recognized proven direct-call return
+// GOOD-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.good.out.elf | %FileCheck --check-prefix=GOOD %s
+// RUN: hotswap-rewrite %t.good.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.good.out2.elf
+// RUN: cmp %t.good.out.elf %t.good.out2.elf
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.clobber.elf
+// RUN: hotswap-rewrite %t.clobber.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.clobber.out.elf | %FileCheck --check-prefix=BAD-API %s
+// RUN: %llvm-objdump -d %t.clobber.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.ingress.elf
+// RUN: hotswap-rewrite %t.ingress.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.ingress.out.elf | %FileCheck --check-prefix=BAD-API %s
+// RUN: %llvm-objdump -d %t.ingress.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.rfe.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.rfe.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.rfe.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=REJECT-API %s
+// RUN: %llvm-objdump -d %t.rfe.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.unknown.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.unknown.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.unknown.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=REJECT-API %s
+// RUN: %llvm-objdump -d %t.unknown.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.trap.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.trap.out.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=GOOD-API %s
+// RUN: %llvm-objdump -d %t.trap.out.elf | %FileCheck --check-prefix=GOOD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.materialized.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.materialized.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.materialized.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=REJECT-API %s
+// RUN: %llvm-objdump -d %t.materialized.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.global.elf
+// RUN: hotswap-rewrite %t.global.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.global.out.elf | %FileCheck --check-prefix=BAD-API %s
+// RUN: %llvm-objdump -d %t.global.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=8 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.weak.elf
+// RUN: hotswap-rewrite %t.weak.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.weak.out.elf | %FileCheck --check-prefix=BAD-API %s
+// RUN: %llvm-objdump -d %t.weak.out.elf | %FileCheck --check-prefix=BAD %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=9 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.standard-link.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.standard-link.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.standard-link.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=REJECT-API %s
+// RUN: %llvm-objdump -d %t.standard-link.out.elf \
+// RUN:   | %FileCheck --check-prefix=BAD %s
+
+// BAD-API: RESULT: SUCCESS
+// REJECT-API-NOT: recognized proven direct-call return
+// REJECT-API: RESULT: SUCCESS
+
+// GOOD-LABEL: <direct_return_observer>:
+// GOOD-NEXT: global_wb
+// GOOD-NEXT: v_nop
+// GOOD-NEXT: global_load_b32 v0
+// GOOD-NEXT: s_wait_loadcnt 0x0
+// GOOD-NEXT: s_nop 0
+// GOOD-NEXT: global_load_b32 v1
+
+// BAD-LABEL: <direct_return_observer>:
+// BAD-NEXT: global_wb
+// BAD-NEXT: v_nop
+// BAD-NEXT: global_load_b32 v0
+// BAD-NEXT: s_wait_loadcnt 0x0
+// BAD-NEXT: s_nop 0
+// BAD-NEXT: global_load_b32 v1
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl direct_return_caller
+.p2align 8
+.type direct_return_caller,@function
+direct_return_caller:
+  global_wb scope:SCOPE_CU
+  v_nop
+#if CASE == 2
+  s_cmp_eq_u32 s2, 0
+  s_cbranch_scc1 direct_return_helper
+#endif
+#if CASE == 3
+  s_rfe_i64 s[4:5]
+#endif
+#if CASE == 4
+  .long 0xffffffff
+#endif
+#if CASE == 5
+  s_trap 0
+#endif
+#if CASE == 6
+.Lmaterialized_getpc:
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], \
+      direct_return_helper-(.Lmaterialized_getpc+4)
+  s_set_pc_i64 s[4:5]
+#endif
+#if CASE == 9
+  s_swap_pc_i64 s[30:31], s[4:5]
+#endif
+  s_call_i64 s[0:1], direct_return_helper
+  s_endpgm
+.Ldirect_return_caller_end:
+.size direct_return_caller, .Ldirect_return_caller_end-direct_return_caller
+
+.local direct_return_helper
+.type direct_return_helper,@function
+direct_return_helper:
+#if CASE == 1
+  s_mov_b32 s0, 0
+#endif
+  s_set_pc_i64 s[0:1]
+.Ldirect_return_helper_end:
+.size direct_return_helper, .Ldirect_return_helper_end-direct_return_helper
+
+#if CASE == 7
+.globl direct_return_helper_external
+.type direct_return_helper_external,@function
+.set direct_return_helper_external, direct_return_helper
+.size direct_return_helper_external, \
+    .Ldirect_return_helper_end-direct_return_helper
+#elif CASE == 8
+.weak direct_return_helper_external
+.type direct_return_helper_external,@function
+.set direct_return_helper_external, direct_return_helper
+.size direct_return_helper_external, \
+    .Ldirect_return_helper_end-direct_return_helper
+#endif
+
+.globl direct_return_observer
+.p2align 8
+.type direct_return_observer,@function
+direct_return_observer:
+  global_wb scope:SCOPE_CU
+  v_nop
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0
+  s_clause 0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0
+  s_endpgm
+.Ldirect_return_observer_end:
+.size direct_return_observer, .Ldirect_return_observer_end-direct_return_observer
+
+.rodata
+.p2align 8
+.amdhsa_kernel direct_return_caller
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 3
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel direct_return_observer
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: direct_return_caller
+      .symbol: direct_return_caller.kd
+      .sgpr_count: 3
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: direct_return_observer
+      .symbol: direct_return_observer.kd
+      .sgpr_count: 0
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-alignment-order-independent.s
+++ b/amd/comgr/test-lit/hotswap-ds2-alignment-order-independent.s
@@ -1,0 +1,69 @@
+// COM: The later DS2 address is defined before an earlier DS2 that requires
+// COM: expansion. Alignment exemptions must be cached before patching: once
+// COM: the earlier instruction is relabelled <replaced>, it must not hide the
+// COM: aligned definition from the later site.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: hotswap: ds_2addr: preserved proven-aligned ds_load_2addr_b64 at 0x
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <order_independent_alignment>:
+// DISASM-NEXT: s_set_vgpr_msb 0x400
+// DISASM-NEXT: v_add_nc_u32_e64 v6, 0x100, 0
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: ds_load_2addr_b64 v[12:15], v6 offset1:1
+// DISASM-NEXT: s_endpgm
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl order_independent_alignment
+.type order_independent_alignment,@function
+order_independent_alignment:
+  s_set_vgpr_msb 0x400
+  v_add_nc_u32_e64 v6, 0x100, 0
+  ds_load_2addr_b64 v[8:11], v7 offset1:1
+  ds_load_2addr_b64 v[12:15], v6 offset1:1
+  s_endpgm
+
+// The first expansion exactly fills this compact 20-byte sled.
+.Lexact_20_byte_sled:
+.rept 5
+  s_nop 0
+.endr
+.size order_independent_alignment, .-order_independent_alignment
+
+.rodata
+.p2align 8
+.amdhsa_kernel order_independent_alignment
+  .amdhsa_next_free_vgpr 16
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: order_independent_alignment
+      .symbol: order_independent_alignment.kd
+      .sgpr_count: 2
+      .vgpr_count: 16
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-combined-delay-asymmetric-relay.s
+++ b/amd/comgr/test-lit/hotswap-ds2-combined-delay-asymmetric-relay.s
@@ -1,0 +1,90 @@
+// COM: Entry reaches the replacement body directly at the positive s_branch
+// COM: limit, while the larger return origin needs one independent gateway.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: DS2 gateway plan: used 0 entry gateway(s), 1 return gateway(s), and body sled at 0x20000 for site 0x0
+// API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x0
+// API-NOT: hotswap: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <combined_delay_asymmetric>:
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_asymmetric+0x20000>
+// DISASM: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: v_cndmask_b32_e64 v116, 0, v198, s12
+// DISASM: s_branch {{[0-9]+}}{{.*}}<combined_delay_asymmetric+0x18>
+// DISASM: v_cmp_eq_u32_e64 s12, 0, v6
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_asymmetric+0x10000>
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local combined_delay_asymmetric
+.type combined_delay_asymmetric,@function
+combined_delay_asymmetric:
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+  v_cndmask_b32_e64 v116, 0, v198, s12
+
+.rept (0x10000 - 0x24 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_branch .Lreturn_gateway_resume
+.Lreturn_gateway:
+  .zero 4
+.Lreturn_gateway_resume:
+
+.rept (0x20000 - 0x10004 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_set_pc_i64 s[30:31]
+.Lbody_sled:
+.rept 11
+  s_nop 0
+.endr
+.size combined_delay_asymmetric, .-combined_delay_asymmetric
+
+.globl metadata_anchor
+.type metadata_anchor,@function
+metadata_anchor:
+  s_endpgm
+.size metadata_anchor, .-metadata_anchor
+
+.rodata
+.p2align 8
+.amdhsa_kernel metadata_anchor
+  .amdhsa_next_free_vgpr 199
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: metadata_anchor
+      .symbol: metadata_anchor.kd
+      .sgpr_count: 106
+      .vgpr_count: 199
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-combined-delay-gateway-relay.s
+++ b/amd/comgr/test-lit/hotswap-ds2-combined-delay-gateway-relay.s
@@ -1,0 +1,158 @@
+// COM: A combined-delay DS2 prefix needs a contiguous relocation body, but the
+// COM: only sufficiently large owned NOP sled is just outside direct source
+// COM: reach. Relay both edges through a source-reachable, branch-only padding
+// COM: island and retain the final delay/consumer suffix at its source address.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: DS2 gateway plan: used 1 entry gateway(s), 1 return gateway(s), and body sled at 0x20040 for site 0x0
+// API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x0
+// API-NOT: hotswap: error:
+// API: hotswap: applied 1 instruction patches
+// API: RESULT: SUCCESS
+
+// RUN: %clang -x assembler-with-cpp -DSHORT_BODY -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.short.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.short.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SHORT %s
+// SHORT: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
+// SHORT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DSECOND_DS2 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.second.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.second.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.second.out.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=SECOND-API %s
+// SECOND-API-NOT: hotswap: error:
+// SECOND-API: hotswap: DS2 gateway plan: used 1 entry gateway(s), 1 return gateway(s), and body sled at 0x20044 for site 0x0
+// SECOND-API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x0 around protected site 0x8 with 2 DS2 rewrite(s)
+// SECOND-API: hotswap: applied 2 instruction patches
+// SECOND-API-NOT: hotswap: error:
+// SECOND-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.second.out.elf | \
+// RUN:   %FileCheck --check-prefix=SECOND-DISASM %s
+// SECOND-DISASM-LABEL: <combined_delay_gateway_relay>:
+// SECOND-DISASM-NOT: ds_load_2addr_b64
+// SECOND-DISASM: ds_load_b64 v[2:3], v52 offset:1224
+// SECOND-DISASM-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// SECOND-DISASM-NEXT: s_wait_dscnt 0x0
+// SECOND-DISASM-NEXT: ds_load_b64 v[6:7], v52 offset:1352
+// SECOND-DISASM-NEXT: ds_load_b64 v[8:9], v52 offset:1416
+// SECOND-DISASM-NEXT: s_wait_dscnt 0x0
+// SECOND-DISASM-NOT: ds_load_2addr_b64
+// RUN: hotswap-rewrite %t.second.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <combined_delay_gateway_relay>:
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_gateway_relay+0x10004>
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: v_cndmask_b32_e64 v116, 0, v198, s12
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: s_branch {{[0-9]+}}{{.*}}<combined_delay_gateway_relay+0x18>
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_gateway_relay+0x20040>
+// DISASM: s_delay_alu instid0(SALU_CYCLE_1)
+// DISASM-NEXT: s_or_b32 exec_lo, exec_lo, s12
+// DISASM-NEXT: ds_load_b64 v[2:3], v52 offset:1224
+// DISASM-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x1
+// DISASM-NEXT: v_cmp_eq_u32_e64 s12, 0, v6
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_gateway_relay+0x10000>
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: <metadata_anchor>:
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local combined_delay_gateway_relay
+.type combined_delay_gateway_relay,@function
+combined_delay_gateway_relay:
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+#ifdef SECOND_DS2
+  ds_load_2addr_b64 v[6:9], v52 offset0:169 offset1:177
+#else
+  s_wait_dscnt 1
+#endif
+  v_cmp_eq_u32_e64 s12, 0, v6
+  v_cndmask_b32_e64 v116, 0, v198, s12
+
+// The branch makes this zero-filled island unreachable by fallthrough. It is
+// eligible for gateways only, not for the replacement body.
+.rept (0x10000 - 0x24 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_branch .Lgateway_resume
+.Lgateway_padding:
+  .zero 8
+.Lgateway_resume:
+
+// Keep the body beyond direct source reach but within one short branch of the
+// gateway. The original window needs 11 NOP dwords; two DS2 rewrites need 15.
+.rept (0x20040 - 0x10008 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_set_pc_i64 s[30:31]
+.Lbody_sled:
+#ifdef SHORT_BODY
+.rept 10
+#elif defined(SECOND_DS2)
+.rept 15
+#else
+.rept 11
+#endif
+  s_nop 0
+.endr
+.size combined_delay_gateway_relay, .-combined_delay_gateway_relay
+
+.globl metadata_anchor
+.type metadata_anchor,@function
+metadata_anchor:
+  s_endpgm
+.size metadata_anchor, .-metadata_anchor
+
+.rodata
+.p2align 8
+.amdhsa_kernel metadata_anchor
+  .amdhsa_next_free_vgpr 199
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: metadata_anchor
+      .symbol: metadata_anchor.kd
+      .sgpr_count: 106
+      .vgpr_count: 199
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-combined-delay-multihop-relay.s
+++ b/amd/comgr/test-lit/hotswap-ds2-combined-delay-multihop-relay.s
@@ -1,0 +1,121 @@
+// COM: A validated DS2 relocation body can be more than one short-branch span
+// COM: from its source. Certified branch-only padding pairs form a symmetric
+// COM: entry/return chain without SGPR or VCC scratch.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: DS2 gateway plan: used 2 entry gateway(s), 2 return gateway(s), and body sled at 0x30080 for site 0x0
+// API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x0
+// API-NOT: hotswap: error:
+// API: RESULT: SUCCESS
+
+// RUN: %clang -x assembler-with-cpp -DONE_GATEWAY -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.one.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.one.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=ONE %s
+// ONE: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
+// ONE: RESULT: ERROR
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <combined_delay_multihop>:
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_multihop+0x10004>
+// DISASM: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: v_cndmask_b32_e64 v116, 0, v198, s12
+// DISASM: s_branch {{[0-9]+}}{{.*}}<combined_delay_multihop+0x18>
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_multihop+0x20044>
+// DISASM: s_branch {{.*}}<combined_delay_multihop+0x10000>
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_multihop+0x30080>
+// DISASM: s_delay_alu instid0(SALU_CYCLE_1)
+// DISASM-NEXT: s_or_b32 exec_lo, exec_lo, s12
+// DISASM-NEXT: ds_load_b64 v[2:3], v52 offset:1224
+// DISASM-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x1
+// DISASM-NEXT: v_cmp_eq_u32_e64 s12, 0, v6
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_multihop+0x20040>
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local combined_delay_multihop
+.type combined_delay_multihop,@function
+combined_delay_multihop:
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+  v_cndmask_b32_e64 v116, 0, v198, s12
+
+.rept (0x10000 - 0x24 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_branch .Lgateway_one_resume
+.Lgateway_one:
+  .zero 8
+.Lgateway_one_resume:
+
+.rept (0x20040 - 0x10008 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_branch .Lgateway_two_resume
+.Lgateway_two:
+#ifdef ONE_GATEWAY
+  .zero 4
+.Lgateway_two_resume:
+.rept (0x30080 - 0x20044 - 4) / 4
+#else
+  .zero 8
+.Lgateway_two_resume:
+.rept (0x30080 - 0x20048 - 4) / 4
+#endif
+  s_mov_b32 s0, s0
+.endr
+  s_set_pc_i64 s[30:31]
+.Lbody_sled:
+.rept 11
+  s_nop 0
+.endr
+.size combined_delay_multihop, .-combined_delay_multihop
+
+.globl metadata_anchor
+.type metadata_anchor,@function
+metadata_anchor:
+  s_endpgm
+.size metadata_anchor, .-metadata_anchor
+
+.rodata
+.p2align 8
+.amdhsa_kernel metadata_anchor
+  .amdhsa_next_free_vgpr 199
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: metadata_anchor
+      .symbol: metadata_anchor.kd
+      .sgpr_count: 106
+      .vgpr_count: 199
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-combined-delay-ownership.s
+++ b/amd/comgr/test-lit/hotswap-ds2-combined-delay-ownership.s
@@ -1,0 +1,137 @@
+// COM: Discover a DS2's combined-delay owner from encoded target geometry.
+// COM: Interior positions are supported at every legal skip distance, while
+// COM: either protected target and overlapping owners remain conservative.
+
+// RUN: %clang -x assembler-with-cpp -DMIN_SKIP -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.min.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.min.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.min.out.elf 2>&1 | %FileCheck --check-prefix=MIN %s
+// MIN-NOT: hotswap: error:
+// MIN: hotswap: ds_2addr: demerged combined s_delay_alu at 0x
+// MIN-NOT: hotswap: error:
+// MIN: RESULT: SUCCESS
+
+// The DS2 is four instructions after its owner, rather than at the formerly
+// assumed owner+2 position, and remains strictly between both targets.
+// RUN: %clang -x assembler-with-cpp -DDEEP_INTERIOR \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.deep.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.deep.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.deep.out.elf 2>&1 | %FileCheck --check-prefix=DEEP %s
+// DEEP-NOT: hotswap: error:
+// DEEP: hotswap: ds_2addr: demerged combined s_delay_alu at 0x
+// DEEP-NOT: hotswap: error:
+// DEEP: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.deep.out.elf | %FileCheck --check-prefix=DEEP-DISASM %s
+// DEEP-DISASM-LABEL: <combined_delay_ownership>:
+// DEEP-DISASM-NOT: ds_load_2addr_b64
+// DEEP-DISASM: s_delay_alu instid0(VALU_DEP_1)
+// DEEP-DISASM-NEXT: v_cmp_eq_u32_e64 s12, 0, v6
+// DEEP-DISASM: s_delay_alu instid0(SALU_CYCLE_1)
+// DEEP-DISASM: ds_load_b64 v[2:3], v52 offset:1224
+// DEEP-DISASM-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// DEEP-DISASM-NOT: ds_load_2addr_b64
+
+// RUN: %clang -x assembler-with-cpp -DFIRST_TARGET \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.first.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.first.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=FIRST %s
+// FIRST: hotswap: error: ds_2addr: protected source at 0x4 has no supported combined-delay window
+// FIRST: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DSECOND_TARGET \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.second.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.second.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SECOND %s
+// SECOND: hotswap: error: ds_2addr: protected source at 0x14 has no supported combined-delay window
+// SECOND: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DOVERLAPPING_OWNERS \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.overlap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.overlap.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=OVERLAP %s
+// OVERLAP: hotswap: error: ds_2addr: protected source at 0x10 has no supported
+// OVERLAP-SAME: combined-delay window
+// OVERLAP: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl combined_delay_ownership
+.p2align 8
+.type combined_delay_ownership,@function
+combined_delay_ownership:
+#if defined(MIN_SKIP)
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  v_cmp_eq_u32_e64 s12, 0, v6
+#elif defined(DEEP_INTERIOR)
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  s_wait_dscnt 0
+  s_nop 0
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+#elif defined(FIRST_TARGET)
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 0
+  s_nop 0
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+#elif defined(SECOND_TARGET)
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  s_wait_dscnt 0
+  s_nop 0
+  s_wait_dscnt 1
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+#elif defined(OVERLAPPING_OWNERS)
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_4) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  s_wait_dscnt 0
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+#endif
+  s_endpgm
+  .rept 48
+    s_nop 0
+  .endr
+.Lcombined_delay_ownership_end:
+.size combined_delay_ownership, .Lcombined_delay_ownership_end-combined_delay_ownership
+
+.rodata
+.p2align 8
+.amdhsa_kernel combined_delay_ownership
+  .amdhsa_next_free_vgpr 199
+  .amdhsa_next_free_sgpr 13
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: combined_delay_ownership
+      .symbol: combined_delay_ownership.kd
+      .sgpr_count: 13
+      .vgpr_count: 199
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-combined-delay-shared-sled.s
+++ b/amd/comgr/test-lit/hotswap-ds2-combined-delay-shared-sled.s
@@ -1,0 +1,85 @@
+// COM: The only certified storage has exactly two gateway dwords followed by
+// COM: the relocation body. Interval reservations let entry, return, and body
+// COM: share that sled without aliasing or advancing its cursor past capacity.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: DS2 gateway plan: used 1 entry gateway(s), 1 return gateway(s), and body sled at 0x20008 for site 0x0
+// API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x0
+// API-NOT: hotswap: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <combined_delay_shared_sled>:
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_shared_sled+0x20000>
+// DISASM: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: v_cndmask_b32_e64 v116, 0, v198, s12
+// DISASM: s_branch {{.*}}<combined_delay_shared_sled+0x20008>
+// DISASM-NEXT: s_branch {{[0-9]+}}{{.*}}<combined_delay_shared_sled+0x18>
+// DISASM-NEXT: s_delay_alu instid0(SALU_CYCLE_1)
+// DISASM: v_cmp_eq_u32_e64 s12, 0, v6
+// DISASM-NEXT: s_branch {{.*}}<combined_delay_shared_sled+0x20004>
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local combined_delay_shared_sled
+.type combined_delay_shared_sled,@function
+combined_delay_shared_sled:
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+  v_cndmask_b32_e64 v116, 0, v198, s12
+
+.rept (0x20000 - 0x24 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_set_pc_i64 s[30:31]
+.Lbody_sled:
+.rept 13
+  s_nop 0
+.endr
+.size combined_delay_shared_sled, .-combined_delay_shared_sled
+
+.globl metadata_anchor
+.type metadata_anchor,@function
+metadata_anchor:
+  s_endpgm
+.size metadata_anchor, .-metadata_anchor
+
+.rodata
+.p2align 8
+.amdhsa_kernel metadata_anchor
+  .amdhsa_next_free_vgpr 199
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: metadata_anchor
+      .symbol: metadata_anchor.kd
+      .sgpr_count: 106
+      .vgpr_count: 199
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-combined-delay-window.s
+++ b/amd/comgr/test-lit/hotswap-ds2-combined-delay-window.s
@@ -1,0 +1,190 @@
+// COM: Splitting a DS2 between the two targets of a combined s_delay_alu
+// COM: changes the encoded instskip geometry. Restore its packed dependencies
+// COM: as two standalone delays, keeping the final delay and its consumer as
+// COM: a contiguous suffix at the end of the original source window.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x
+// API-NOT: hotswap: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <combined_delay_ds2>:
+// DISASM-NEXT: s_branch
+
+// A four-byte final consumer uses an eight-byte retained suffix instead of the
+// twelve-byte suffix above. The same structural rule must accept both widths.
+// RUN: %clang -x assembler-with-cpp -DSHORT_CONSUMER -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.short.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.short.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.short.out.elf 2>&1 | %FileCheck --check-prefix=SHORT-API %s
+// SHORT-API-NOT: hotswap: error:
+// SHORT-API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x
+// SHORT-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.short.out.elf | %FileCheck --check-prefix=SHORT-DISASM %s
+// SHORT-DISASM-LABEL: <combined_delay_ds2>:
+// SHORT-DISASM-NEXT: s_branch
+// SHORT-DISASM: s_delay_alu instid0(VALU_DEP_1)
+// SHORT-DISASM-NEXT: v_min_i32_e32 v116, v116, v6
+// SHORT-DISASM-NOT: ds_load_2addr_b64
+// SHORT-DISASM: s_delay_alu instid0(SALU_CYCLE_1)
+// SHORT-DISASM-NEXT: s_or_b32 exec_lo, exec_lo, s12
+// SHORT-DISASM-NEXT: ds_load_b64 v[2:3], v52 offset:1224
+// SHORT-DISASM-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// SHORT-DISASM-NEXT: s_wait_dscnt 0x0
+// SHORT-DISASM-NEXT: s_wait_dscnt 0x1
+// SHORT-DISASM-NEXT: v_cmp_eq_u32_e64 s12, 0, v6
+// SHORT-DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: v_cndmask_b32_e64 v116, 0, v198, s12
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: s_delay_alu instid0(SALU_CYCLE_1)
+// DISASM-NEXT: s_or_b32 exec_lo, exec_lo, s12
+// DISASM-NEXT: ds_load_b64 v[2:3], v52 offset:1224
+// DISASM-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x1
+// DISASM-NEXT: v_cmp_eq_u32_e64 s12, 0, v6
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// A single combined delay can protect more than one required DS2 rewrite.
+// Relocate and rewrite the complete window atomically rather than allowing the
+// first replacement to suppress the second one.
+// RUN: %clang -x assembler-with-cpp -DMULTI_DS2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.multi.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.multi.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.multi.out.elf 2>&1 | %FileCheck --check-prefix=MULTI-API %s
+// MULTI-API-NOT: hotswap: error:
+// MULTI-API: hotswap: ds_2addr: demerged combined s_delay_alu at 0x{{[0-9A-F]+}} around protected site 0x{{[0-9A-F]+}} with 2 DS2 rewrite(s)
+// MULTI-API: hotswap: applied 2 instruction patches
+// MULTI-API-NOT: hotswap: error:
+// MULTI-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.multi.out.elf | \
+// RUN:   %FileCheck --check-prefix=MULTI-DISASM %s
+// MULTI-DISASM-LABEL: <combined_delay_ds2>:
+// MULTI-DISASM-NEXT: s_branch
+// MULTI-DISASM-NOT: ds_load_2addr_b32
+// MULTI-DISASM: s_delay_alu instid0(VALU_DEP_1)
+// MULTI-DISASM-NEXT: v_add_nc_u32_e32 v12, v4, v11
+// MULTI-DISASM: s_delay_alu instid0(VALU_DEP_1)
+// MULTI-DISASM-NEXT: v_add_nc_u32_e32 v10, v2, v10
+// MULTI-DISASM-NEXT: ds_load_b32 v2, v58 offset:52
+// MULTI-DISASM-NEXT: ds_load_b32 v3, v58 offset:56
+// MULTI-DISASM-NEXT: s_wait_dscnt 0x0
+// MULTI-DISASM-NEXT: ds_load_b32 v4, v58 offset:60
+// MULTI-DISASM-NEXT: ds_load_b32 v5, v58 offset:64
+// MULTI-DISASM-NEXT: s_wait_dscnt 0x0
+// MULTI-DISASM-NEXT: s_wait_dscnt 0x3
+// MULTI-DISASM-NEXT: v_add_nc_u32_e32 v11, v3, v10
+// MULTI-DISASM-NOT: ds_load_2addr_b32
+// RUN: hotswap-rewrite %t.multi.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=MULTI-IDEM %s
+// MULTI-IDEM: IDEMPOTENT: YES
+
+// RUN: %clang -x assembler-with-cpp -DMULTI_DS2 -DMIXED_DS2 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.mixed.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.mixed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.mixed.out.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=MULTI-API %s
+// RUN: %llvm-objdump -d %t.mixed.out.elf | \
+// RUN:   %FileCheck --check-prefix=MIXED-DISASM %s
+// MIXED-DISASM-LABEL: <combined_delay_ds2>:
+// MIXED-DISASM-NOT: ds_store_2addr_b32
+// MIXED-DISASM-NOT: ds_load_2addr_b32
+// MIXED-DISASM: ds_store_b32 v58, v2 offset:52
+// MIXED-DISASM-NEXT: ds_store_b32 v58, v3 offset:56
+// MIXED-DISASM-NEXT: s_wait_dscnt 0x0
+// MIXED-DISASM-NEXT: ds_load_b32 v4, v58 offset:60
+// MIXED-DISASM-NEXT: ds_load_b32 v5, v58 offset:64
+// MIXED-DISASM-NEXT: s_wait_dscnt 0x0
+// MIXED-DISASM-NOT: ds_store_2addr_b32
+// MIXED-DISASM-NOT: ds_load_2addr_b32
+// RUN: hotswap-rewrite %t.mixed.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=MULTI-IDEM %s
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl combined_delay_ds2
+.p2align 8
+.type combined_delay_ds2,@function
+combined_delay_ds2:
+#ifdef MULTI_DS2
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | instid1(VALU_DEP_1)
+  v_add_nc_u32_e32 v10, v2, v10
+#ifdef MIXED_DS2
+  ds_store_2addr_b32 v58, v2, v3 offset0:13 offset1:14
+#else
+  ds_load_2addr_b32 v[2:3], v58 offset0:13 offset1:14
+#endif
+  ds_load_2addr_b32 v[4:5], v58 offset0:15 offset1:16
+  s_wait_dscnt 3
+  v_add_nc_u32_e32 v11, v3, v10
+  v_add_nc_u32_e32 v12, v4, v11
+#else
+  s_delay_alu instid0(SALU_CYCLE_1) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  s_or_b32 exec_lo, exec_lo, s12
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_wait_dscnt 1
+  v_cmp_eq_u32_e64 s12, 0, v6
+#ifdef SHORT_CONSUMER
+  v_min_i32_e32 v116, v116, v6
+#else
+  v_cndmask_b32_e64 v116, 0, v198, s12
+#endif
+#endif
+  s_endpgm
+  .rept 32
+    s_nop 0
+  .endr
+.Lcombined_delay_ds2_end:
+.size combined_delay_ds2, .Lcombined_delay_ds2_end-combined_delay_ds2
+
+.rodata
+.p2align 8
+.amdhsa_kernel combined_delay_ds2
+  .amdhsa_next_free_vgpr 199
+  .amdhsa_next_free_sgpr 13
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: combined_delay_ds2
+      .symbol: combined_delay_ds2.kd
+      .sgpr_count: 13
+      .vgpr_count: 199
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-gateway-coalesced-pairs.s
+++ b/amd/comgr/test-lit/hotswap-ds2-gateway-coalesced-pairs.s
@@ -1,0 +1,100 @@
+// COM: Two adjacent far DS2 sites have no safe SGPR/VCC scratch. They must
+// COM: coalesce into one replacement body in an in-function tail NOP sled,
+// COM: using an unreachable zero-filled hole only for the entry/return branch
+// COM: gateway dwords.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: DS2 gateway plan: used 1 entry gateway(s), 1 return gateway(s), and body sled at 0x20020 for site 0x0
+// API-NEXT: hotswap: coalesced 2 adjacent ds_2addr rewrites at 0x0
+// API-NOT: hotswap: error:
+// API: hotswap: applied 2 instruction patches
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <ds2_gateway_coalesced_pair>:
+// DISASM-NEXT: s_branch {{.*}}<ds2_gateway_coalesced_pair+0x10004>
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: s_branch 49152
+// DISASM-NEXT: s_branch {{.*}}<ds2_gateway_coalesced_pair+0x20020>
+// DISASM: ds_load_b64 v[0:1], v4 offset:8
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: ds_load_b64 v[4:5], v8 offset:8
+// DISASM-NEXT: ds_load_b64 v[6:7], v8 offset:16
+// DISASM-NEXT: s_branch {{.*}}<ds2_gateway_coalesced_pair+0x10000>
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: <metadata_anchor>:
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local ds2_gateway_coalesced_pair
+.type ds2_gateway_coalesced_pair,@function
+ds2_gateway_coalesced_pair:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  ds_load_2addr_b64 v[4:7], v8 offset0:1 offset1:2
+
+// The zero-filled bridge is gateway-only even though it lies within the
+// oversized source function.
+.rept (0x10000 - 16 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_branch .Lgateway_resume
+.Lgateway_padding:
+  .zero 8
+.Lgateway_resume:
+
+.rept (0x20020 - 0x10008 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_set_pc_i64 s[30:31]
+.Lbody_sled:
+.rept 10
+  s_nop 0
+.endr
+.size ds2_gateway_coalesced_pair, .-ds2_gateway_coalesced_pair
+
+.globl metadata_anchor
+.type metadata_anchor,@function
+metadata_anchor:
+  s_endpgm
+.size metadata_anchor, .-metadata_anchor
+
+.rodata
+.p2align 8
+.amdhsa_kernel metadata_anchor
+  .amdhsa_next_free_vgpr 17
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: metadata_anchor
+      .symbol: metadata_anchor.kd
+      .sgpr_count: 106
+      .vgpr_count: 17
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-gateway-relay.s
+++ b/amd/comgr/test-lit/hotswap-ds2-gateway-relay.s
@@ -1,0 +1,97 @@
+// COM: A far DS2 site has no safe SGPR/VCC scratch. Its replacement body
+// COM: belongs in an in-function tail NOP sled. An unreachable zero-filled
+// COM: hole midway through the function is usable only for the two branch
+// COM: gateway dwords that relay between the source and body.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: hotswap: error:
+// API: hotswap: DS2 gateway plan: used 1 entry gateway(s), 1 return gateway(s), and body sled at 0x20020 for site 0x0
+// API-NOT: hotswap: error:
+// API: hotswap: applied 1 instruction patches
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <ds2_gateway_relay>:
+// DISASM-NEXT: s_branch {{.*}}<ds2_gateway_relay+0x10004>
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: s_branch 49152
+// DISASM-NEXT: s_branch {{.*}}<ds2_gateway_relay+0x20020>
+// DISASM: ds_load_b64 v[0:1], v4 offset:8
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:16
+// DISASM-NEXT: s_branch {{.*}}<ds2_gateway_relay+0x10000>
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM: <metadata_anchor>:
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: REWRITE: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.local ds2_gateway_relay
+.type ds2_gateway_relay,@function
+ds2_gateway_relay:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+
+// Put a two-dword zero-filled gateway halfway to the body. The branch around
+// it makes the hole unreachable by fallthrough, while its interior has no
+// callable entry or direct branch target.
+.rept (0x10000 - 8 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_branch .Lgateway_resume
+.Lgateway_padding:
+  .zero 8
+.Lgateway_resume:
+
+// The body starts just beyond direct source reach. It is a real NOP sled:
+// inside the source function, after a no-fallthrough instruction, and ending
+// exactly at the function boundary.
+.rept (0x20020 - 0x10008 - 4) / 4
+  s_mov_b32 s0, s0
+.endr
+  s_set_pc_i64 s[30:31]
+.Lbody_sled:
+.rept 5
+  s_nop 0
+.endr
+.size ds2_gateway_relay, .-ds2_gateway_relay
+
+.globl metadata_anchor
+.type metadata_anchor,@function
+metadata_anchor:
+  s_endpgm
+.size metadata_anchor, .-metadata_anchor
+
+.rodata
+.p2align 8
+.amdhsa_kernel metadata_anchor
+  .amdhsa_next_free_vgpr 17
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: metadata_anchor
+      .symbol: metadata_anchor.kd
+      .sgpr_count: 106
+      .vgpr_count: 17
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-global-post-function-body.s
+++ b/amd/comgr/test-lit/hotswap-ds2-global-post-function-body.s
@@ -1,0 +1,95 @@
+// COM: A strictly proven explicit-NOP run after first_kernel has one physical
+// COM: allocation cursor. The first DS2 rewrite consumes it as owner-local
+// COM: storage; the second kernel may consume the remaining bytes only through
+// COM: the certified DS2 relocation-body policy. The bodies must not overlap.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <first_kernel>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: ds_load_b32 v0
+// DISASM-NEXT: ds_load_b32 v1
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: ds_store_b32 v2, v0
+// DISASM-NEXT: ds_store_b32 v2, v1
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <second_kernel>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl first_kernel
+.p2align 8
+.type first_kernel,@function
+first_kernel:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0
+  s_endpgm
+.size first_kernel, .-first_kernel
+
+.globl second_kernel
+.p2align 8
+.type second_kernel,@function
+second_kernel:
+  ds_store_2addr_stride64_b32 v2, v0, v1 offset0:1 offset1:3
+  s_wait_dscnt 0
+  s_endpgm
+.size second_kernel, .-second_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: first_kernel
+      .symbol: first_kernel.kd
+      .sgpr_count: 1
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: second_kernel
+      .symbol: second_kernel.kd
+      .sgpr_count: 1
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-proven-aligned.s
+++ b/amd/comgr/test-lit/hotswap-ds2-proven-aligned.s
@@ -1,0 +1,349 @@
+// COM: A0 accepts an ordinary DS_READ2/DS_WRITE2 when the address is aligned.
+// COM: HotSwap may preserve that compact form only when must-dataflow proves
+// COM: VALU-dst and DS-src0 select the same VGPR bank and a same-block constant
+// COM: definition remains valid under unchanged MODE and EXEC.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <aligned_entry>:
+// DISASM: v_add_nc_u32_e64 v4, 0x4000, 0
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_restored_zero>:
+// DISASM: s_set_vgpr_msb 0x400
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_high_bank>:
+// DISASM: s_set_vgpr_msb 0x41
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_store>:
+// DISASM: ds_store_2addr_b64
+// DISASM-LABEL: <aligned_sgpr_mov>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_dual_slot0>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_dual_slot1>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_long_mul>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_immediate_mov>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_mask_loop>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_empty_bypass>:
+// DISASM: ds_load_2addr_b64
+// DISASM-LABEL: <aligned_standard_return>:
+// DISASM: ds_load_2addr_b64
+// DISASM: s_set_pc_i64 s[30:31]
+
+// DISASM-LABEL: <unequal_mode>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <mode_changed_after_def>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <exec_changed_after_def>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <unequal_merge>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <entry_after_def>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <address_redefined>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <misaligned_constant>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <misaligned_immediate_mov>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <stride_form>:
+// DISASM-NOT: ds_load_2addr_stride64_b64
+// DISASM-LABEL: <sgpr_redefined>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <sgpr_bypass>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <dual_other_slot_unaligned>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <pair_mask_clobber>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <preexisting_mask_restore>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <active_bypass>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <loop_address_redefined>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <call_clobber>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <long_mode_mismatch>:
+// DISASM-NOT: ds_load_2addr_b64
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro tail
+  s_endpgm
+  .rept 8
+    s_nop 0
+  .endr
+.endm
+
+.macro begin_func name
+  .globl \name
+  .p2align 8
+  .type \name,@function
+\name:
+.endm
+
+.macro end_func name
+  .size \name, .-\name
+.endm
+
+begin_func aligned_entry
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_entry
+
+begin_func aligned_restored_zero
+  s_set_vgpr_msb 0x400
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_restored_zero
+
+begin_func aligned_high_bank
+  s_set_vgpr_msb 0x41
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_high_bank
+
+begin_func aligned_store
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_store_2addr_b64 v4, v[0:1], v[2:3] offset0:1 offset1:2
+  tail
+end_func aligned_store
+
+begin_func aligned_sgpr_mov
+  s_mul_i32 s4, s4, 56
+  v_mov_b32 v4, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_sgpr_mov
+
+begin_func aligned_dual_slot0
+  s_mul_i32 s4, s4, 56
+  v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_dual_slot0
+
+begin_func aligned_dual_slot1
+  s_mul_i32 s5, s5, 56
+  v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+  ds_load_2addr_b64 v[0:3], v5 offset0:1 offset1:2
+  tail
+end_func aligned_dual_slot1
+
+begin_func aligned_long_mul
+  s_set_vgpr_msb 0x40
+  v_mul_lo_u32 v4, v0, 56
+  s_and_saveexec_b32 s4, s5
+  s_or_b32 exec_lo, exec_lo, s4
+  s_set_vgpr_msb 0x1
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_long_mul
+
+begin_func aligned_immediate_mov
+  v_mov_b32 v4, 0x43a8
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_immediate_mov
+
+begin_func aligned_mask_loop
+  s_mov_b32 s4, 0
+.Lmask_loop:
+  v_mul_lo_u32 v4, v0, 56
+  ds_load_b32 v1, v4 offset:36
+  s_wait_dscnt 0
+  v_cmp_ne_u32_e32 vcc_lo, 0, v1
+  s_or_b32 s4, vcc_lo, s4
+  s_and_not1_b32 exec_lo, exec_lo, s4
+  s_cbranch_execnz .Lmask_loop
+  s_or_b32 exec_lo, exec_lo, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_mask_loop
+
+begin_func aligned_empty_bypass
+  s_cbranch_scc1 .Lempty_candidate
+  s_mov_b32 exec_lo, 0
+  s_branch .Lempty_join
+.Lempty_candidate:
+  v_mul_lo_u32 v4, v0, 56
+.Lempty_join:
+  s_nop 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func aligned_empty_bypass
+
+begin_func aligned_standard_return
+  v_mul_lo_u32 v4, v0, 56
+  s_and_saveexec_b32 s4, s5
+  s_or_b32 exec_lo, exec_lo, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_set_pc_i64 s[30:31]
+end_func aligned_standard_return
+
+begin_func unequal_mode
+  s_set_vgpr_msb 0x40
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func unequal_mode
+
+begin_func mode_changed_after_def
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  s_set_vgpr_msb 0x41
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func mode_changed_after_def
+
+begin_func exec_changed_after_def
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  s_mov_b32 exec_lo, -1
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func exec_changed_after_def
+
+begin_func unequal_merge
+  s_cbranch_scc1 .Lunequal
+  s_set_vgpr_msb 0x41
+  s_branch .Lmerge
+.Lunequal:
+  s_set_vgpr_msb 0x40
+.Lmerge:
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func unequal_merge
+
+begin_func entry_after_def
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  s_cbranch_scc1 .Lentry
+  s_nop 0
+.Lentry:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func entry_after_def
+
+begin_func address_redefined
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  v_mov_b32 v4, v5
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func address_redefined
+
+begin_func misaligned_constant
+  v_add_nc_u32_e64 v4, 0x4001, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func misaligned_constant
+
+begin_func misaligned_immediate_mov
+  v_mov_b32 v4, 0x43a9
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func misaligned_immediate_mov
+
+begin_func stride_form
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func stride_form
+
+begin_func sgpr_redefined
+  s_mul_i32 s4, s4, 56
+  s_mov_b32 s4, s5
+  v_mov_b32 v4, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func sgpr_redefined
+
+begin_func sgpr_bypass
+  s_cbranch_scc1 .Lsgpr_copy
+  s_mul_i32 s4, s4, 56
+.Lsgpr_copy:
+  v_mov_b32 v4, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func sgpr_bypass
+
+begin_func dual_other_slot_unaligned
+  s_mul_i32 s4, s4, 56
+  v_dual_mov_b32 v4, s4 :: v_dual_mov_b32 v5, s5
+  ds_load_2addr_b64 v[0:3], v5 offset0:1 offset1:2
+  tail
+end_func dual_other_slot_unaligned
+
+begin_func pair_mask_clobber
+  v_mul_lo_u32 v4, v0, 56
+  s_mov_b32 s4, exec_lo
+  s_mov_b64 s[4:5], -1
+  s_mov_b32 exec_lo, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func pair_mask_clobber
+
+begin_func preexisting_mask_restore
+  s_mov_b32 s4, exec_lo
+  v_mul_lo_u32 v4, v0, 56
+  s_mov_b32 exec_lo, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func preexisting_mask_restore
+
+begin_func active_bypass
+  s_cbranch_scc1 .Lactive_candidate
+  s_nop 0
+  s_branch .Lactive_join
+.Lactive_candidate:
+  v_mul_lo_u32 v4, v0, 56
+.Lactive_join:
+  s_nop 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func active_bypass
+
+begin_func loop_address_redefined
+  s_branch .Laddress_candidate
+.Laddress_clobber:
+  v_mov_b32 v4, v5
+  s_branch .Laddress_use
+.Laddress_candidate:
+  v_mul_lo_u32 v4, v0, 56
+  s_cbranch_scc1 .Laddress_clobber
+.Laddress_use:
+  s_nop 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func loop_address_redefined
+
+begin_func call_clobber
+  v_mul_lo_u32 v4, v0, 56
+  s_call_i64 s[30:31], .Lcall_target
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+.Lcall_target:
+  s_set_pc_i64 s[30:31]
+end_func call_clobber
+
+begin_func long_mode_mismatch
+  s_set_vgpr_msb 0x40
+  v_mul_lo_u32 v4, v0, 56
+  s_and_saveexec_b32 s4, s5
+  s_or_b32 exec_lo, exec_lo, s4
+  s_set_vgpr_msb 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  tail
+end_func long_mode_mismatch

--- a/amd/comgr/test-lit/hotswap-ds2-source-tail-wait-coalesced.s
+++ b/amd/comgr/test-lit/hotswap-ds2-source-tail-wait-coalesced.s
@@ -1,0 +1,72 @@
+// COM: Two adjacent 8-byte DS2 instructions coalesce into one local sled. The
+// COM: combined replacements are 40 bytes; moving only the final four-byte
+// COM: drain to source+4 leaves 36 body bytes plus one four-byte branch-back,
+// COM: exactly filling this 40-byte sled. Preselection and emission must use
+// COM: the same compact-layout size.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: hotswap: coalesced 2 adjacent ds_2addr rewrites
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <coalesced_source_tail_wait>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: ds_store_b64 v2, v[0:1] offset:256
+// DISASM-NEXT: ds_store_b64 v2, v[4:5] offset:768
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: ds_store_b64 v8, v[6:7] offset:512
+// DISASM-NEXT: ds_store_b64 v8, v[10:11] offset:1024
+// DISASM-NEXT: s_branch {{.*}} <coalesced_source_tail_wait+0x4>
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl coalesced_source_tail_wait
+.type coalesced_source_tail_wait,@function
+coalesced_source_tail_wait:
+  ds_store_2addr_b64 v2, v[0:1], v[4:5] offset0:32 offset1:96
+  ds_store_2addr_b64 v8, v[6:7], v[10:11] offset0:64 offset1:128
+  s_endpgm
+
+.Lexact_40_byte_sled:
+.rept 10
+  s_nop 0
+.endr
+.size coalesced_source_tail_wait, .-coalesced_source_tail_wait
+
+.rodata
+.p2align 8
+.amdhsa_kernel coalesced_source_tail_wait
+  .amdhsa_next_free_vgpr 12
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: coalesced_source_tail_wait
+      .symbol: coalesced_source_tail_wait.kd
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-source-tail-wait.s
+++ b/amd/comgr/test-lit/hotswap-ds2-source-tail-wait.s
@@ -1,0 +1,87 @@
+// COM: An 8-byte DS2 source leaves one dword after its branch. Keep only the
+// COM: exact final s_wait_dscnt 0 from the split replacement in that dword, so
+// COM: the sled needs two 8-byte DS stores plus one 4-byte branch-back: exactly
+// COM: 20 bytes instead of 24. The sled returns to source+4, executes the wait,
+// COM: then falls through to the original continuation.
+
+// RUN: %clang -x assembler-with-cpp -DPROTECTED=0 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <source_tail_wait>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: ds_store_b64 v2, v[0:1] offset:256
+// DISASM-NEXT: ds_store_b64 v2, v[4:5] offset:768
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+// COM: A callable entry at source+4 is strictly inside every replacement
+// COM: window for the eight-byte DS2. It must reject the rewrite rather than
+// COM: silently becoming branch-tail padding in any fallback placement.
+// RUN: %clang -x assembler-with-cpp -DPROTECTED=1 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.protected.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.protected.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=PROTECTED %s
+// PROTECTED: replacement source [0x0, 0x8) contains protected interior entry 0x4
+// PROTECTED: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl source_tail_wait
+.type source_tail_wait,@function
+source_tail_wait:
+  ds_store_2addr_b64 v2, v[0:1], v[4:5] offset0:32 offset1:96
+#if PROTECTED
+.globl protected_interior
+.type protected_interior,@function
+.set protected_interior, source_tail_wait + 4
+#endif
+  s_endpgm
+
+// This is deliberately the exact compact-layout capacity. The legacy layout
+// needs 24 bytes and therefore cannot use it. Keep the sled inside the source
+// function so it is legitimate replacement-body storage.
+.Lexact_20_byte_sled:
+.rept 5
+  s_nop 0
+.endr
+.size source_tail_wait, .-source_tail_wait
+
+.rodata
+.p2align 8
+.amdhsa_kernel source_tail_wait
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: source_tail_wait
+      .symbol: source_tail_wait.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-ds2-unknown-indirect.s
+++ b/amd/comgr/test-lit/hotswap-ds2-unknown-indirect.s
@@ -1,0 +1,38 @@
+// COM: An unresolved indirect transfer may enter any instruction in the
+// COM: object. It therefore prevents the long-range proof from assuming that
+// COM: an aligned address definition actively dominates a later DS2 use.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <guarded_ds2>:
+// DISASM-NOT: ds_load_2addr_b64
+// DISASM-LABEL: <unknown_indirect>:
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl guarded_ds2
+.p2align 8
+.type guarded_ds2,@function
+guarded_ds2:
+  v_mul_lo_u32 v4, v0, 56
+  s_and_saveexec_b32 s4, s5
+  s_or_b32 exec_lo, exec_lo, s4
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_endpgm
+  .rept 8
+    s_nop 0
+  .endr
+.size guarded_ds2, .-guarded_ds2
+
+.globl unknown_indirect
+.p2align 8
+.type unknown_indirect,@function
+unknown_indirect:
+  s_set_pc_i64 s[8:9]
+.size unknown_indirect, .-unknown_indirect

--- a/amd/comgr/test-lit/hotswap-external-gateway-protected-entry.s
+++ b/amd/comgr/test-lit/hotswap-external-gateway-protected-entry.s
@@ -1,0 +1,190 @@
+// COM: Zero-filled external padding cannot donate a far-branch gateway when it
+// COM: contains any emitted symbol, a decoded direct target, or a
+// COM: kernel-descriptor entry. Only a temporary .L assembly anchor omitted
+// COM: from the final symbol table leaves the otherwise unreachable run usable.
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=0 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.control.elf
+// RUN: %llvm-readelf -s %t.control.elf \
+// RUN:   | %FileCheck --check-prefix=CONTROL-SYMS %s
+// CONTROL-SYMS: Symbol table
+// CONTROL-SYMS-NOT: protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.control.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.control.out.elf 2>&1 | %FileCheck --check-prefix=CONTROL %s
+// RUN: %llvm-objdump -d %t.control.out.elf \
+// RUN:   | %FileCheck --check-prefix=CONTROL-DISASM %s
+// CONTROL: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// CONTROL: RESULT: SUCCESS
+// CONTROL-DISASM: s_get_pc_i64
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.func.elf
+// RUN: %llvm-readelf -s %t.func.elf | %FileCheck --check-prefix=FUNC-SYM %s
+// FUNC-SYM: FUNC LOCAL DEFAULT {{.*}} protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.func.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// COM: STT_GNU_IFUNC and STT_AMDGPU_HSA_KERNEL both have value 10, so LLVM's
+// COM: AMDGPU readelf spelling for this symbol is target-specific.
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.ifunc.elf
+// RUN: %llvm-readelf -s %t.ifunc.elf | %FileCheck --check-prefix=IFUNC-SYM %s
+// IFUNC-SYM: AMDGPU_HSA_KERNEL LOCAL DEFAULT {{.*}} protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ifunc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.kd.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.kd.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=4 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.object.elf
+// RUN: %llvm-readelf -s %t.object.elf | %FileCheck --check-prefix=OBJECT-SYM %s
+// OBJECT-SYM: OBJECT LOCAL DEFAULT {{.*}} protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.object.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=5 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.global.elf
+// RUN: %llvm-readelf -s %t.global.elf | %FileCheck --check-prefix=GLOBAL-SYM %s
+// GLOBAL-SYM: NOTYPE GLOBAL DEFAULT {{.*}} protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.global.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=6 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.weak.elf
+// RUN: %llvm-readelf -s %t.weak.elf | %FileCheck --check-prefix=WEAK-SYM %s
+// WEAK-SYM: NOTYPE WEAK DEFAULT {{.*}} protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.weak.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=7 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.direct.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.direct.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DENTRY_KIND=8 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.local-notype.elf
+// RUN: %llvm-readelf -s %t.local-notype.elf \
+// RUN:   | %FileCheck --check-prefix=LOCAL-NOTYPE %s
+// LOCAL-NOTYPE: NOTYPE LOCAL DEFAULT {{.*}} protected_entry
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.local-notype.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+
+// CHECK: hotswap: error: no safe short-branch gateway for far site
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl gateway_kernel
+.p2align 8
+.type gateway_kernel,@function
+gateway_kernel:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0
+  s_endpgm
+.size gateway_kernel, .-gateway_kernel
+
+// Without entry protection this zero run is the only reachable gateway and
+// its first bytes, including protected_entry, are overwritten.
+#if ENTRY_KIND == 0 || ENTRY_KIND == 7
+#define PROTECTED_ENTRY .Lprotected_entry
+#else
+#define PROTECTED_ENTRY protected_entry
+#endif
+
+#if ENTRY_KIND == 7
+.local direct_source
+.type direct_source,@function
+direct_source:
+  s_branch PROTECTED_ENTRY
+.size direct_source, .-direct_source
+#endif
+
+#if ENTRY_KIND == 5
+.globl protected_entry
+#elif ENTRY_KIND == 6
+.weak protected_entry
+#elif ENTRY_KIND != 0 && ENTRY_KIND != 7
+.local protected_entry
+#endif
+#if ENTRY_KIND == 1
+.type protected_entry,@function
+#elif ENTRY_KIND == 2
+.type protected_entry,@gnu_indirect_function
+#elif ENTRY_KIND == 4
+.type protected_entry,@object
+#endif
+PROTECTED_ENTRY:
+  .zero 32
+#if ENTRY_KIND == 1 || ENTRY_KIND == 2 || ENTRY_KIND == 4
+.size protected_entry, .-protected_entry
+#endif
+
+// Push the appended trampoline pool beyond s_branch reach.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel gateway_kernel
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+#if ENTRY_KIND == 3
+.p2align 8
+.amdhsa_kernel protected_entry
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+#endif
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: gateway_kernel
+      .symbol: gateway_kernel.kd
+      .sgpr_count: 66
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+#if ENTRY_KIND == 3
+    - .name: protected_entry
+      .symbol: protected_entry.kd
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+#endif
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-external-gateway-protected-extent.s
+++ b/amd/comgr/test-lit/hotswap-external-gateway-protected-extent.s
@@ -1,0 +1,94 @@
+// COM: A sized non-callable .text symbol protects its entire half-open extent
+// COM: from use as donor storage, even when its point boundary precedes the
+// COM: zero-filled gateway. An extent ending exactly at the gateway does not
+// COM: overlap it.
+
+// RUN: %clang -x assembler-with-cpp -DEXTENT_KIND=0 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.object.elf
+// RUN: %llvm-readelf -s %t.object.elf \
+// RUN:   | %FileCheck --check-prefix=OBJECT-SYM %s
+// OBJECT-SYM: OBJECT LOCAL DEFAULT {{[0-9]+}} protected_extent
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.object.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=OVERLAP %s
+
+// RUN: %clang -x assembler-with-cpp -DEXTENT_KIND=1 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.notype.elf
+// RUN: %llvm-readelf -s %t.notype.elf \
+// RUN:   | %FileCheck --check-prefix=NOTYPE-SYM %s
+// NOTYPE-SYM: NOTYPE LOCAL DEFAULT {{[0-9]+}} protected_extent
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.notype.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=OVERLAP %s
+
+// RUN: %clang -x assembler-with-cpp -DEXTENT_KIND=2 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.half-open.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.half-open.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.half-open.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=HALF-OPEN %s
+
+// OVERLAP: hotswap: error: no safe short-branch gateway for far site
+// OVERLAP: RESULT: ERROR
+// HALF-OPEN: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// HALF-OPEN: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl gateway_kernel
+.p2align 8
+.type gateway_kernel,@function
+gateway_kernel:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0
+  s_endpgm
+.size gateway_kernel, .-gateway_kernel
+
+.local protected_extent
+#if EXTENT_KIND != 1
+.type protected_extent,@object
+#endif
+protected_extent:
+  s_endpgm
+#if EXTENT_KIND == 2
+.size protected_extent, .-protected_extent
+#endif
+  .zero 32
+#if EXTENT_KIND != 2
+.size protected_extent, .-protected_extent
+#endif
+
+// Push the appended trampoline pool beyond direct s_branch reach.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel gateway_kernel
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: gateway_kernel
+      .symbol: gateway_kernel.kd
+      .sgpr_count: 66
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-gateway-conflict-retry.s
+++ b/amd/comgr/test-lit/hotswap-gateway-conflict-retry.s
@@ -1,0 +1,106 @@
+// COM: Both far sites share one 16-byte sled. Exact 12-byte call-tail accounting
+// COM: leaves one dword for the earlier site's relay chain, avoiding the false
+// COM: dependency cycle caused by the former 20-byte forward reservation.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: gateway reservation solver: {{[0-9]+}} protected pass(es),
+// LOG-SAME: 0 conflict-directed retry/retries
+// LOG-NOT: gateway allocation dependency cycle
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl first_conflicting_site
+.p2align 8
+.type first_conflicting_site,@function
+first_conflicting_site:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size first_conflicting_site, .-first_conflicting_site
+
+.rept 24996
+  s_mov_b32 s64, s65
+.endr
+
+.type shared_gateway,@function
+shared_gateway:
+  s_endpgm
+.size shared_gateway, .-shared_gateway
+.fill 16, 1, 0
+
+.rept 12496
+  s_mov_b32 s64, s65
+.endr
+
+.globl second_conflicting_site
+.type second_conflicting_site,@function
+second_conflicting_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size second_conflicting_site, .-second_conflicting_site
+
+// This position makes the first trampoline reachable from final_relay while
+// the second, which follows it in the pool, is just out of branch range.
+.rept 9157
+  s_mov_b32 s64, s65
+.endr
+
+.type final_relay,@function
+final_relay:
+  s_endpgm
+.size final_relay, .-final_relay
+.fill 4, 1, 0
+
+.rept 31162
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_conflicting_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_conflicting_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: first_conflicting_site
+      .symbol: first_conflicting_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: second_conflicting_site
+      .symbol: second_conflicting_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-gateway-dynamic-last-slot.s
+++ b/amd/comgr/test-lit/hotswap-gateway-dynamic-last-slot.s
@@ -1,0 +1,125 @@
+// COM: The later site starts with two complete gateways. The earlier relay may
+// COM: consume four bytes from the first (2 -> 1), but when its next greedy hop
+// COM: would consume the second (1 -> 0), it must take an alternate relay.
+// COM: The later site can then use the one intact 20-byte gateway.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: gateway reservation solver:
+// LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl first_dynamic_site
+.p2align 8
+.type first_dynamic_site,@function
+first_dynamic_site:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size first_dynamic_site, .-first_dynamic_site
+
+.rept 24996
+  s_mov_b32 s64, s65
+.endr
+
+.type first_full_gateway,@function
+first_full_gateway:
+  s_endpgm
+.size first_full_gateway, .-first_full_gateway
+.fill 20, 1, 0
+
+.rept 12495
+  s_mov_b32 s64, s65
+.endr
+
+.globl later_dynamic_site
+.type later_dynamic_site,@function
+later_dynamic_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size later_dynamic_site, .-later_dynamic_site
+
+.rept 7496
+  s_mov_b32 s64, s65
+.endr
+
+.type alternate_relay,@function
+alternate_relay:
+  s_endpgm
+.size alternate_relay, .-alternate_relay
+.fill 4, 1, 0
+
+.rept 4998
+  s_mov_b32 s64, s65
+.endr
+
+.type second_full_gateway,@function
+second_full_gateway:
+  s_endpgm
+.size second_full_gateway, .-second_full_gateway
+.fill 20, 1, 0
+
+.rept 24994
+  s_mov_b32 s64, s65
+.endr
+
+.type final_relay,@function
+final_relay:
+  s_endpgm
+.size final_relay, .-final_relay
+.fill 4, 1, 0
+
+.rept 25000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_dynamic_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel later_dynamic_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: first_dynamic_site
+      .symbol: first_dynamic_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: later_dynamic_site
+      .symbol: later_dynamic_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-gateway-relay-backtrack.s
+++ b/amd/comgr/test-lit/hotswap-gateway-relay-backtrack.s
@@ -1,0 +1,115 @@
+// COM: The first site's farthest relay consumes one of the second site's two
+// COM: full gateway slots, then its only next hop would consume the last one.
+// COM: Backtrack to the nearer relay first; the later hop then leaves the
+// COM: second site's other full gateway intact.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: gateway reservation solver:
+// LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl relay_search_site
+.p2align 8
+.type relay_search_site,@function
+relay_search_site:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size relay_search_site, .-relay_search_site
+
+.rept 19996
+  s_mov_b32 s64, s65
+.endr
+
+.type nearer_relay,@function
+nearer_relay:
+  s_endpgm
+.size nearer_relay, .-nearer_relay
+.fill 4, 1, 0
+
+.rept 4998
+  s_mov_b32 s64, s65
+.endr
+
+.type farthest_gateway,@function
+farthest_gateway:
+  s_endpgm
+.size farthest_gateway, .-farthest_gateway
+.fill 20, 1, 0
+
+.rept 12495
+  s_mov_b32 s64, s65
+.endr
+
+.globl reserved_site
+.type reserved_site,@function
+reserved_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size reserved_site, .-reserved_site
+
+.rept 6085
+  s_mov_b32 s64, s65
+.endr
+
+.type later_gateway,@function
+later_gateway:
+  s_endpgm
+.size later_gateway, .-later_gateway
+.fill 20, 1, 0
+
+.rept 31411
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel relay_search_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel reserved_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: relay_search_site
+      .symbol: relay_search_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: reserved_site
+      .symbol: reserved_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-gateway-scarcity-before-relay.s
+++ b/amd/comgr/test-lit/hotswap-gateway-scarcity-before-relay.s
@@ -1,0 +1,124 @@
+// COM: Two far sites share one gateway sled. The earlier site can also use a
+// COM: separate 12-byte call-tail gateway, but its greedy relay route crosses
+// COM: the shared sled first. Process the later, one-slot site first; it takes
+// COM: the other relay route and leaves the earlier site its alternate gateway.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <abundant_site>:
+// DISASM-NEXT: s_call_i64
+// DISASM-LABEL: <scarce_site>:
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl abundant_site
+.p2align 8
+.type abundant_site,@function
+abundant_site:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size abundant_site, .-abundant_site
+
+// This call-tail gateway is reachable only from the earlier site.
+.type abundant_gateway,@function
+abundant_gateway:
+  s_endpgm
+.size abundant_gateway, .-abundant_gateway
+.fill 20, 1, 0
+
+// Put the shared gateway about 100 KB from the first source.
+.rept 24990
+  s_mov_b32 s64, s65
+.endr
+
+.type shared_gateway,@function
+shared_gateway:
+  s_endpgm
+.size shared_gateway, .-shared_gateway
+.fill 20, 1, 0
+
+// The second source is about 150 KB from the start. Its only gateway sled is
+// shared_gateway: abundant_gateway is out of short-branch range and the later
+// relay has only one dword.
+.rept 12495
+  s_mov_b32 s64, s65
+.endr
+
+.globl scarce_site
+.type scarce_site,@function
+scarce_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size scarce_site, .-scarce_site
+
+.rept 12497
+  s_mov_b32 s64, s65
+.endr
+
+.type relay_gateway,@function
+relay_gateway:
+  s_endpgm
+.size relay_gateway, .-relay_gateway
+.fill 4, 1, 0
+
+// Keep both appended trampolines far from their source sites. Before gateway
+// reservation, abundant_site relayed through shared_gateway and relay_gateway,
+// consuming the only full slot available to scarce_site.
+.rept 25000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel abundant_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel scarce_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: abundant_site
+      .symbol: abundant_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: scarce_site
+      .symbol: scarce_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-gateway-shared-sole-slot.s
+++ b/amd/comgr/test-lit/hotswap-gateway-shared-sole-slot.s
@@ -1,0 +1,133 @@
+// COM: Two far sites each have the same sole 20-byte gateway. The earlier
+// COM: site's greedy relay route would consume four bytes from that gateway
+// COM: even though it has a separate relay route. Protect the later unfinished
+// COM: owner, route the first site around the shared slot, then assign the
+// COM: intact gateway to the second site.
+
+// RUN: %clang -x assembler-with-cpp -DGATEWAY_BYTES=20 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// A 24-byte shared sled may donate one relay dword while preserving its one
+// complete 20-byte gateway slot. This pins the exact capacity boundary and
+// prevents reservation handling from excluding the whole sled.
+// RUN: %clang -x assembler-with-cpp -DGATEWAY_BYTES=24 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.24.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.24.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.24.out.elf 2>&1 | %FileCheck --check-prefix=CAPACITY %s
+// CAPACITY: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// CAPACITY: hotswap: assigned 1 forward s_branch island chain(s)
+// CAPACITY-NOT: no safe short-branch gateway
+// CAPACITY: RESULT: SUCCESS
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+#ifndef GATEWAY_BYTES
+#define GATEWAY_BYTES 20
+#endif
+.text
+.globl first_tied_site
+.p2align 8
+.type first_tied_site,@function
+first_tied_site:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size first_tied_site, .-first_tied_site
+
+.rept 19996
+  s_mov_b32 s64, s65
+.endr
+
+.type alternate_relay,@function
+alternate_relay:
+  s_endpgm
+.size alternate_relay, .-alternate_relay
+.fill 4, 1, 0
+
+.rept 4998
+  s_mov_b32 s64, s65
+.endr
+
+.type shared_sole_gateway,@function
+shared_sole_gateway:
+  s_endpgm
+.size shared_sole_gateway, .-shared_sole_gateway
+.fill GATEWAY_BYTES, 1, 0
+
+.rept (50000 - GATEWAY_BYTES) / 4
+  s_mov_b32 s64, s65
+.endr
+
+.globl second_tied_site
+.type second_tied_site,@function
+second_tied_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size second_tied_site, .-second_tied_site
+
+.rept 7496
+  s_mov_b32 s64, s65
+.endr
+
+.type final_relay,@function
+final_relay:
+  s_endpgm
+.size final_relay, .-final_relay
+.fill 4, 1, 0
+
+.rept 30000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_tied_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_tied_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: first_tied_site
+      .symbol: first_tied_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: second_tied_site
+      .symbol: second_tied_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-indirect-call-contract.s
+++ b/amd/comgr/test-lit/hotswap-indirect-call-contract.s
@@ -1,0 +1,106 @@
+// COM: An unresolved s_swap_pc_i64 that writes the ABI link pair is an opaque
+// COM: call to a callable entry. It does not make arbitrary code padding a
+// COM: possible target, so a separately proven far-branch gateway remains
+// COM: usable. Nonstandard swaps, arbitrary set-PC transfers, and a statically
+// COM: resolved standard-link call to a non-entry target still fail closed.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=0 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.standard.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.standard.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.standard.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=STANDARD %s
+// STANDARD: hotswap: recognized ABI standard-link indirect call
+// STANDARD: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// STANDARD: RESULT: SUCCESS
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.nonstandard.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nonstandard.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=POISON %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.setpc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.setpc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=POISON %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.nonentry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nonentry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NONENTRY %s
+
+// POISON: hotswap: incomplete control-flow targets disable NOP padding donation
+// POISON: hotswap: error: no safe short-branch gateway for far site
+// POISON: RESULT: ERROR
+// NONENTRY: materialized call to a non-entry target
+// NONENTRY: hotswap: incomplete control-flow targets disable NOP padding donation
+// NONENTRY: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl gateway_kernel
+.type gateway_kernel,@function
+gateway_kernel:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0
+  s_endpgm
+.size gateway_kernel, .-gateway_kernel
+
+// This is the sole source-side set-PC gateway for the far patch above.
+.rept 8
+  s_nop 0
+.endr
+
+.local indirect_caller
+.type indirect_caller,@function
+indirect_caller:
+#if CASE == 0
+  s_swap_pc_i64 s[30:31], s[2:3]
+#elif CASE == 1
+  s_swap_pc_i64 s[28:29], s[2:3]
+#elif CASE == 2
+  s_set_pc_i64 s[2:3]
+#elif CASE == 3
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], 12
+  s_swap_pc_i64 s[30:31], s[2:3]
+  s_endpgm
+.Lnonentry:
+#endif
+  s_endpgm
+.size indirect_caller, .-indirect_caller
+
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel gateway_kernel
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: gateway_kernel
+      .symbol: gateway_kernel.kd
+      .sgpr_count: 66
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-after-far-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-after-far-trampoline.s
@@ -1,0 +1,77 @@
+// COM: A required far trampoline makes the following original text CFG-dead
+// COM: after its source edge is installed. The blanket gfx1250 A0 clause
+// COM: workaround still removes hard clauses in that original text.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: coalesced 2 adjacent ds_2addr rewrites at 0x0
+// LOG: growWithTrampolines: appended 1 trampoline
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_clause_after_far_trampoline>:
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// COM: The coalesced source window moves the adjacent s_mov into the far
+// COM: replacement body and pads its linked slot before resuming at global_wb.
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM-NOT: s_add_pc_i64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_clause_after_far_trampoline
+.p2align 8
+.type test_clause_after_far_trampoline,@function
+test_clause_after_far_trampoline:
+  ds_store_2addr_b64 v6, v[0:1], v[36:37] offset0:2 offset1:3
+  ds_store_2addr_b64 v6, v[8:9], v[10:11] offset0:0 offset1:1
+  s_mov_b32 s20, s21
+  global_wb scope:SCOPE_CU
+  v_nop
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+  .rept 40000
+    s_mov_b32 s20, s21
+  .endr
+.Ltest_clause_after_far_trampoline_end:
+.size test_clause_after_far_trampoline, .Ltest_clause_after_far_trampoline_end-test_clause_after_far_trampoline
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_clause_after_far_trampoline
+  .amdhsa_next_free_vgpr 40
+  .amdhsa_next_free_sgpr 24
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_clause_after_far_trampoline
+      .symbol: test_clause_after_far_trampoline.kd
+      .sgpr_count: 24
+      .vgpr_count: 40
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-after-routed-chain.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-after-routed-chain.s
@@ -1,0 +1,74 @@
+// COM: Reconstruct a HotSwap-style routed tail-cave chain whose body performs
+// COM: no VMEM. The source branch reaches the clause through two external
+// COM: direct-branch hops. Its straight-line body exceeds 64 KiB, which is a
+// COM: legal size for a coalesced HotSwap body. The clause still contains the
+// COM: kernel's first VMEM and must be removed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_clause_after_routed_chain>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM: s_branch
+// DISASM-NEXT: s_mov_b32 s4, s5
+// DISASM: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_clause_after_routed_chain
+.p2align 8
+.type test_clause_after_routed_chain,@function
+test_clause_after_routed_chain:
+  s_branch .Lroute_forward
+.Lroute_resume:
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_clause_after_routed_chain_end:
+.size test_clause_after_routed_chain, .Ltest_clause_after_routed_chain_end-test_clause_after_routed_chain
+
+.Lroute_forward:
+  s_branch .Lroute_body
+.Lroute_body:
+  .rept 16385
+    s_mov_b32 s4, s5
+  .endr
+  s_branch .Lroute_resume
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_clause_after_routed_chain
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 8
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_clause_after_routed_chain
+      .symbol: test_clause_after_routed_chain.kd
+      .sgpr_count: 8
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-after-vmem-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-after-vmem-trampoline.s
@@ -1,0 +1,70 @@
+// COM: A VMEM operation moved to an external HotSwap trampoline still counts
+// COM: as prior VMEM after the trampoline returns. The blanket gfx1250 A0
+// COM: clause workaround nevertheless removes the following hard clause.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_clause_after_vmem_trampoline>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_loadcnt 0x0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[6:7], off
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], m0
+// DISASM-NEXT: s_pack_hh_b32_b16 m0, 0, m0
+// DISASM-NEXT: cluster_load_b32 v4, v1, s[2:3]
+// DISASM-NEXT: s_mov_b32 m0, [[SCRATCH]]
+// DISASM-NEXT: s_branch
+// DISASM-NOT: s_add_pc_i64
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_clause_after_vmem_trampoline
+.p2align 8
+.type test_clause_after_vmem_trampoline,@function
+test_clause_after_vmem_trampoline:
+  cluster_load_b32 v4, v1, s[2:3]
+  s_wait_loadcnt 0x0
+  s_clause 0x0
+  global_load_b32 v0, v[6:7], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_clause_after_vmem_trampoline_end:
+.size test_clause_after_vmem_trampoline, .Ltest_clause_after_vmem_trampoline_end-test_clause_after_vmem_trampoline
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_clause_after_vmem_trampoline
+  .amdhsa_next_free_vgpr 8
+  .amdhsa_next_free_sgpr 16
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_clause_after_vmem_trampoline
+      .symbol: test_clause_after_vmem_trampoline.kd
+      .sgpr_count: 16
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-delay-overlap.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-delay-overlap.s
@@ -1,0 +1,54 @@
+// COM: Removing an unsafe clause must not release a member that is also in an
+// COM: s_delay_alu dependency span. The cluster-load rewrite cannot relocate
+// COM: this protected member, so HotSwap must continue to fail closed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: inplace: initial-VMEM s_clause -> s_nop
+// LOG: hotswap: error: replacement source at 0x8 is relocation-protected
+// LOG: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_clause_delay_overlap
+.p2align 8
+.type test_clause_delay_overlap,@function
+test_clause_delay_overlap:
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_1) | instid1(VALU_DEP_1)
+  s_clause 0x0
+  cluster_load_b32 v4, v1, s[2:3]
+  s_wait_loadcnt 0x0
+  s_endpgm
+  .rept 24
+    s_nop 0
+  .endr
+.Ltest_clause_delay_overlap_end:
+.size test_clause_delay_overlap, .Ltest_clause_delay_overlap_end-test_clause_delay_overlap
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_clause_delay_overlap
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_clause_delay_overlap
+      .symbol: test_clause_delay_overlap.kd
+      .sgpr_count: 4
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-external-cfg.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-external-cfg.s
@@ -1,0 +1,116 @@
+// COM: Initial-VMEM analysis must model entries and exits that cross a kernel
+// COM: function boundary. A direct external entry can bypass the kernel's
+// COM: prior VMEM, while an unrecognized external branch is not proof that a
+// COM: textually later clause is unreachable.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <test_external_ingress>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1, v[4:5], off
+
+// DISASM-LABEL: <test_unresolved_external_branch>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.local external_ingress_source
+.p2align 8
+.type external_ingress_source,@function
+external_ingress_source:
+  s_branch .Ltest_external_ingress_clause
+.Lexternal_ingress_source_end:
+.size external_ingress_source, .Lexternal_ingress_source_end-external_ingress_source
+
+.globl test_external_ingress
+.p2align 8
+.type test_external_ingress,@function
+test_external_ingress:
+  global_wb scope:SCOPE_CU
+  v_nop
+  global_load_b32 v0, v[2:3], off
+.Ltest_external_ingress_clause:
+  s_clause 0x0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_external_ingress_end:
+.size test_external_ingress, .Ltest_external_ingress_end-test_external_ingress
+
+.globl test_unresolved_external_branch
+.p2align 8
+.type test_unresolved_external_branch,@function
+test_unresolved_external_branch:
+  s_branch external_exit
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_unresolved_external_branch_end:
+.size test_unresolved_external_branch, .Ltest_unresolved_external_branch_end-test_unresolved_external_branch
+
+.local external_exit
+.p2align 8
+.type external_exit,@function
+external_exit:
+  s_endpgm
+.Lexternal_exit_end:
+.size external_exit, .Lexternal_exit_end-external_exit
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_external_ingress
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_unresolved_external_branch
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_external_ingress
+      .symbol: test_external_ingress.kd
+      .sgpr_count: 0
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_unresolved_external_branch
+      .symbol: test_unresolved_external_branch.kd
+      .sgpr_count: 0
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-indirect-ingress.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-indirect-ingress.s
@@ -1,0 +1,98 @@
+// COM: A genuinely arbitrary set-PC in any function can enter another kernel
+// COM: after its prior VMEM. Initial-VMEM clause analysis must therefore fail
+// COM: closed across every descriptor-backed range.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+// DISASM-LABEL: <indirect_ingress_victim>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: global_load_b32 v0
+// DISASM-NEXT: s_wait_loadcnt 0x0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1
+
+// DISASM-LABEL: <arbitrary_ingress_source>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_set_pc_i64 s[8:9]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl indirect_ingress_victim
+.p2align 8
+.type indirect_ingress_victim,@function
+indirect_ingress_victim:
+  global_wb scope:SCOPE_CU
+  v_nop
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0
+  s_clause 0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0
+  s_endpgm
+.Lindirect_ingress_victim_end:
+.size indirect_ingress_victim, .Lindirect_ingress_victim_end-indirect_ingress_victim
+
+.globl arbitrary_ingress_source
+.p2align 8
+.type arbitrary_ingress_source,@function
+arbitrary_ingress_source:
+  global_wb scope:SCOPE_CU
+  v_nop
+  s_set_pc_i64 s[8:9]
+  global_load_b32 v2, v[6:7], off
+  s_wait_loadcnt 0
+  s_endpgm
+.Larbitrary_ingress_source_end:
+.size arbitrary_ingress_source, .Larbitrary_ingress_source_end-arbitrary_ingress_source
+
+.rodata
+.p2align 8
+.amdhsa_kernel indirect_ingress_victim
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel arbitrary_ingress_source
+  .amdhsa_next_free_vgpr 8
+  .amdhsa_next_free_sgpr 10
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: indirect_ingress_victim
+      .symbol: indirect_ingress_victim.kd
+      .sgpr_count: 0
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: arbitrary_ingress_source
+      .symbol: arbitrary_ingress_source.kd
+      .sgpr_count: 10
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-multi-descriptor-entry.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-multi-descriptor-entry.s
@@ -1,0 +1,86 @@
+// COM: Two descriptors may name different entries inside one sized STT_FUNC.
+// COM: The interior descriptor entry starts a fresh initial-VMEM path even
+// COM: though the outer entry executes VMEM first.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %llvm-readelf -s %t.elf | %FileCheck --check-prefix=SYMBOLS %s
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+// SYMBOLS-DAG: FUNC{{.*}}descriptor_range_owner
+// SYMBOLS-DAG: NOTYPE{{.*}}descriptor_range_interior
+
+// DISASM-LABEL: <descriptor_range_interior>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl descriptor_range_owner
+.p2align 8
+.type descriptor_range_owner,@function
+descriptor_range_owner:
+  global_wb scope:SCOPE_CU
+  v_nop
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0
+  s_endpgm
+
+.globl descriptor_range_interior
+.p2align 8
+.type descriptor_range_interior,@notype
+descriptor_range_interior:
+  s_clause 0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0
+  s_endpgm
+.Ldescriptor_range_end:
+.size descriptor_range_owner, .Ldescriptor_range_end-descriptor_range_owner
+
+.rodata
+.p2align 8
+.amdhsa_kernel descriptor_range_owner
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel descriptor_range_interior
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: descriptor_range_owner
+      .symbol: descriptor_range_owner.kd
+      .sgpr_count: 0
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: descriptor_range_interior
+      .symbol: descriptor_range_interior.kd
+      .sgpr_count: 0
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-opaque-ingress.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-opaque-ingress.s
@@ -1,0 +1,96 @@
+// COM: Opaque PC-valued control flow in any descriptor-backed function can
+// COM: enter any instruction, so it globally invalidates the prior-VMEM proof.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=0 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.rfe.elf
+// RUN: hotswap-rewrite %t.rfe.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.rfe.out.elf | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.rfe.out.elf | %FileCheck %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.unknown.elf
+// RUN: hotswap-rewrite %t.unknown.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.unknown.out.elf | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.unknown.out.elf | %FileCheck %s
+
+// API: RESULT: SUCCESS
+
+// CHECK-LABEL: <opaque_ingress_victim>:
+// CHECK-NEXT: global_wb
+// CHECK-NEXT: v_nop
+// CHECK-NEXT: global_load_b32 v0
+// CHECK-NEXT: s_wait_loadcnt 0x0
+// CHECK-NEXT: s_nop 0
+// CHECK-NEXT: global_load_b32 v1
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl opaque_ingress_source
+.p2align 8
+.type opaque_ingress_source,@function
+opaque_ingress_source:
+#if CASE == 0
+  s_rfe_i64 s[0:1]
+#elif CASE == 1
+  .long 0xffffffff
+#endif
+  s_endpgm
+.Lopaque_ingress_source_end:
+.size opaque_ingress_source, .Lopaque_ingress_source_end-opaque_ingress_source
+
+.globl opaque_ingress_victim
+.p2align 8
+.type opaque_ingress_victim,@function
+opaque_ingress_victim:
+  global_wb scope:SCOPE_CU
+  v_nop
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0
+  s_clause 0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0
+  s_endpgm
+.Lopaque_ingress_victim_end:
+.size opaque_ingress_victim, .Lopaque_ingress_victim_end-opaque_ingress_victim
+
+.rodata
+.p2align 8
+.amdhsa_kernel opaque_ingress_source
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel opaque_ingress_victim
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: opaque_ingress_source
+      .symbol: opaque_ingress_source.kd
+      .sgpr_count: 2
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: opaque_ingress_victim
+      .symbol: opaque_ingress_victim.kd
+      .sgpr_count: 0
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-release.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-release.s
@@ -1,0 +1,68 @@
+// COM: Removing an unsafe hard clause must also release its members from the
+// COM: clause's relocation protection. The SGPR-relative cluster load needs a
+// COM: relocating A0 mask rewrite, so retaining stale clause protection would
+// COM: make this otherwise valid object fail.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <test_clause_release>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+// DISASM: s_endpgm
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], m0
+// DISASM-NEXT: s_pack_hh_b32_b16 m0, 0, m0
+// DISASM-NEXT: cluster_load_b32 v4, v1, s[2:3]
+// DISASM-NEXT: s_mov_b32 m0, [[SCRATCH]]
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_clause_release
+.p2align 8
+.type test_clause_release,@function
+test_clause_release:
+  s_clause 0x0
+  cluster_load_b32 v4, v1, s[2:3]
+  s_wait_loadcnt 0x0
+  s_endpgm
+  .rept 24
+    s_nop 0
+  .endr
+.Ltest_clause_release_end:
+.size test_clause_release, .Ltest_clause_release_end-test_clause_release
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_clause_release
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_clause_release
+      .symbol: test_clause_release.kd
+      .sgpr_count: 4
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-standard-call-entry.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-standard-call-entry.s
@@ -1,0 +1,89 @@
+// COM: An unresolved ABI-link call may enter any callable STT_FUNC. When an
+// COM: interior callable lies inside an outer descriptor-owned range, it must
+// COM: be a fresh initial-VMEM root rather than inheriting the outer VMEM.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: recognized ABI standard-link indirect call
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <standard_call_interior>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl standard_call_outer
+.p2align 8
+.type standard_call_outer,@function
+standard_call_outer:
+  global_wb scope:SCOPE_CU
+  v_nop
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0
+  s_endpgm
+
+.local standard_call_interior
+.type standard_call_interior,@function
+standard_call_interior:
+  s_clause 0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0
+  s_set_pc_i64 s[30:31]
+.Lstandard_call_outer_end:
+.size standard_call_outer, .Lstandard_call_outer_end-standard_call_outer
+.size standard_call_interior, .Lstandard_call_outer_end-standard_call_interior
+
+.globl standard_call_source
+.p2align 8
+.type standard_call_source,@function
+standard_call_source:
+  global_wb scope:SCOPE_CU
+  v_nop
+  s_swap_pc_i64 s[30:31], s[2:3]
+  s_endpgm
+.Lstandard_call_source_end:
+.size standard_call_source, .Lstandard_call_source_end-standard_call_source
+
+.rodata
+.p2align 8
+.amdhsa_kernel standard_call_outer
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel standard_call_source
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: standard_call_outer
+      .symbol: standard_call_outer.kd
+      .sgpr_count: 32
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: standard_call_source
+      .symbol: standard_call_source.kd
+      .sgpr_count: 32
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-clause-uniform.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-uniform.s
@@ -1,0 +1,344 @@
+// COM: The gfx1250 A0 workaround removes every hard clause, including clauses
+// COM: whose members have a uniform cache scope and clauses reached only after
+// COM: prior VMEM. Verify that each clause becomes an equal-sized scalar NOP.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <test_uniform_clause>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: buffer_load_b128 v[0:3], v18, s[4:7], null offen th:TH_LOAD_LU
+// DISASM-NEXT: buffer_load_b128 v[4:7], v18, s[8:11], null offen th:TH_LOAD_LU
+
+// DISASM-NEXT: s_wait_loadcnt 0x0
+
+// COM: A second rewrite must retain the replacement NOP and be byte-identical.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_uniform_clause
+.p2align 8
+.type test_uniform_clause,@function
+test_uniform_clause:
+  global_wb scope:SCOPE_CU
+  v_nop
+  s_clause 0x1
+  buffer_load_b128 v[0:3], v18, s[4:7], null offen th:TH_LOAD_LU
+  buffer_load_b128 v[4:7], v18, s[8:11], null offen th:TH_LOAD_LU
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_uniform_clause_end:
+.size test_uniform_clause, .Ltest_uniform_clause_end-test_uniform_clause
+
+// DISASM-LABEL: <test_initial_vmem_clause>:
+// DISASM-NEXT: s_load_b64 s[0:1], s[0:1], 0x0 nv
+// DISASM-NEXT: s_wait_kmcnt 0x0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b128 v[0:3], v[8:9], off
+// DISASM-NEXT: global_load_b128 v[4:7], v[8:9], off offset:16
+// DISASM-NEXT: global_load_b128 v[10:13], v[8:9], off offset:32
+// DISASM-NEXT: global_load_b128 v[14:17], v[8:9], off offset:48
+
+.globl test_initial_vmem_clause
+.p2align 8
+.type test_initial_vmem_clause,@function
+test_initial_vmem_clause:
+  s_load_b64 s[0:1], s[0:1], 0x0 nv
+  s_wait_kmcnt 0x0
+  s_clause 0x3
+  global_load_b128 v[0:3], v[8:9], off
+  global_load_b128 v[4:7], v[8:9], off offset:16
+  global_load_b128 v[10:13], v[8:9], off offset:32
+  global_load_b128 v[14:17], v[8:9], off offset:48
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_initial_vmem_clause_end:
+.size test_initial_vmem_clause, .Ltest_initial_vmem_clause_end-test_initial_vmem_clause
+
+// COM: Match the exact two-load AITER activation pattern as well as the
+// COM: four-load quantization pattern above.
+// DISASM-LABEL: <test_initial_buffer_clause>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: buffer_load_b128 v[0:3], v18, s[4:7], null offen th:TH_LOAD_LU
+// DISASM-NEXT: buffer_load_b128 v[4:7], v18, s[8:11], null offen th:TH_LOAD_LU
+
+.globl test_initial_buffer_clause
+.p2align 8
+.type test_initial_buffer_clause,@function
+test_initial_buffer_clause:
+  s_clause 0x1
+  buffer_load_b128 v[0:3], v18, s[4:7], null offen th:TH_LOAD_LU
+  buffer_load_b128 v[4:7], v18, s[8:11], null offen th:TH_LOAD_LU
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_initial_buffer_clause_end:
+.size test_initial_buffer_clause, .Ltest_initial_buffer_clause_end-test_initial_buffer_clause
+
+// A textually earlier VMEM does not satisfy the entry requirement when a
+// branch can bypass it.
+// DISASM-LABEL: <test_bypassed_prior_vmem>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1, v[2:3], off
+
+.globl test_bypassed_prior_vmem
+.p2align 8
+.type test_bypassed_prior_vmem,@function
+test_bypassed_prior_vmem:
+  s_branch .Ltest_bypassed_prior_vmem_clause
+  global_load_b32 v0, v[2:3], off
+.Ltest_bypassed_prior_vmem_clause:
+  s_clause 0x0
+  global_load_b32 v1, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_bypassed_prior_vmem_end:
+.size test_bypassed_prior_vmem, .Ltest_bypassed_prior_vmem_end-test_bypassed_prior_vmem
+
+// Even when an exiting branch cannot bypass the prior VMEM, blanket clause
+// removal replaces the clause.
+// DISASM-LABEL: <test_exit_branch_prior_vmem>:
+// DISASM-NEXT: s_cmp_eq_u32 s0, 0
+// DISASM-NEXT: s_cbranch_scc1
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1, v[4:5], off
+
+.globl test_exit_branch_prior_vmem
+.p2align 8
+.type test_exit_branch_prior_vmem,@function
+test_exit_branch_prior_vmem:
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Ltest_exit_branch_prior_vmem_exit
+  global_load_b32 v0, v[2:3], off
+  s_clause 0x0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0x0
+.Ltest_exit_branch_prior_vmem_exit:
+  s_endpgm
+.Ltest_exit_branch_prior_vmem_end:
+.size test_exit_branch_prior_vmem, .Ltest_exit_branch_prior_vmem_end-test_exit_branch_prior_vmem
+
+// Both arms of this diamond execute a VMEM before reaching the join. Blanket
+// clause removal still replaces the clause.
+// DISASM-LABEL: <test_diamond_all_prior_vmem>:
+// DISASM-NEXT: s_cmp_eq_u32 s0, 0
+// DISASM-NEXT: s_cbranch_scc1
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: global_load_b32 v2, v[2:3], off
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1, v[4:5], off
+
+.globl test_diamond_all_prior_vmem
+.p2align 8
+.type test_diamond_all_prior_vmem,@function
+test_diamond_all_prior_vmem:
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Ltest_diamond_all_prior_vmem_right
+  global_load_b32 v0, v[2:3], off
+  s_branch .Ltest_diamond_all_prior_vmem_join
+.Ltest_diamond_all_prior_vmem_right:
+  global_load_b32 v2, v[2:3], off
+.Ltest_diamond_all_prior_vmem_join:
+  s_clause 0x0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_diamond_all_prior_vmem_end:
+.size test_diamond_all_prior_vmem, .Ltest_diamond_all_prior_vmem_end-test_diamond_all_prior_vmem
+
+// One arm of this diamond reaches the join without a VMEM. The clause can
+// therefore contain the first dynamically reached VMEM and must be removed.
+// DISASM-LABEL: <test_diamond_missing_prior_vmem>:
+// DISASM-NEXT: s_cmp_eq_u32 s0, 0
+// DISASM-NEXT: s_cbranch_scc1
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_mov_b32 s1, 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v1, v[4:5], off
+
+.globl test_diamond_missing_prior_vmem
+.p2align 8
+.type test_diamond_missing_prior_vmem,@function
+test_diamond_missing_prior_vmem:
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Ltest_diamond_missing_prior_vmem_right
+  global_load_b32 v0, v[2:3], off
+  s_branch .Ltest_diamond_missing_prior_vmem_join
+.Ltest_diamond_missing_prior_vmem_right:
+  s_mov_b32 s1, 0
+.Ltest_diamond_missing_prior_vmem_join:
+  s_clause 0x0
+  global_load_b32 v1, v[4:5], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_diamond_missing_prior_vmem_end:
+.size test_diamond_missing_prior_vmem, .Ltest_diamond_missing_prior_vmem_end-test_diamond_missing_prior_vmem
+
+// Kernel entry symbols may have st_size=0; the descriptor is authoritative.
+// DISASM-LABEL: <test_zero_size_initial_clause>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+.globl test_zero_size_initial_clause
+.p2align 8
+.type test_zero_size_initial_clause,@function
+test_zero_size_initial_clause:
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+
+// A call target may contain the first VMEM even though the ABI continuation
+// immediately exits. Model both the unknown call target and the fallthrough.
+// DISASM-LABEL: <test_call_first_vmem>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+
+.globl test_call_first_vmem
+.p2align 8
+.type test_call_first_vmem,@function
+test_call_first_vmem:
+  s_call_i64 s[0:1], .Ltest_call_first_vmem_callee
+  s_endpgm
+.Ltest_call_first_vmem_callee:
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_set_pc_i64 s[0:1]
+.Ltest_call_first_vmem_end:
+.size test_call_first_vmem, .Ltest_call_first_vmem_end-test_call_first_vmem
+
+// A resumable debug trap does not prove that subsequent instructions are
+// unreachable. The clause after it can still contain the first VMEM.
+// DISASM-LABEL: <test_resumable_trap_first_vmem>:
+// DISASM-NEXT: s_trap 3
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+
+.globl test_resumable_trap_first_vmem
+.p2align 8
+.type test_resumable_trap_first_vmem,@function
+test_resumable_trap_first_vmem:
+  s_trap 3
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_endpgm
+.Ltest_resumable_trap_first_vmem_end:
+.size test_resumable_trap_first_vmem, .Ltest_resumable_trap_first_vmem_end-test_resumable_trap_first_vmem
+
+// Functions without a kernel descriptor have no known entry fact. A helper
+// reached before its caller executes a VMEM must therefore be conservative.
+// DISASM-LABEL: <test_uncovered_helper_caller>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_endpgm
+// DISASM-LABEL: <test_uncovered_helper>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0, v[2:3], off
+
+.globl test_uncovered_helper_caller
+.p2align 8
+.type test_uncovered_helper_caller,@function
+test_uncovered_helper_caller:
+  s_call_i64 s[0:1], test_uncovered_helper
+  s_endpgm
+.Ltest_uncovered_helper_caller_end:
+.size test_uncovered_helper_caller, .Ltest_uncovered_helper_caller_end-test_uncovered_helper_caller
+
+.local test_uncovered_helper
+.p2align 8
+.type test_uncovered_helper,@function
+test_uncovered_helper:
+  s_clause 0x0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0x0
+  s_set_pc_i64 s[0:1]
+.Ltest_uncovered_helper_end:
+.size test_uncovered_helper, .Ltest_uncovered_helper_end-test_uncovered_helper
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_uniform_clause
+  .amdhsa_next_free_vgpr 19
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_initial_vmem_clause
+  .amdhsa_next_free_vgpr 18
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_initial_buffer_clause
+  .amdhsa_next_free_vgpr 19
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_bypassed_prior_vmem
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_exit_branch_prior_vmem
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_diamond_all_prior_vmem
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_diamond_missing_prior_vmem
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_zero_size_initial_clause
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_call_first_vmem
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_resumable_trap_first_vmem
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel test_uncovered_helper_caller
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-inplace-clause-visible-entry.s
+++ b/amd/comgr/test-lit/hotswap-inplace-clause-visible-entry.s
@@ -1,0 +1,67 @@
+// COM: A loader-visible function nested in a descriptor-owned range is an
+// COM: independent entry and cannot inherit the outer kernel's prior VMEM.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN:   -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --output %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck %s
+// RUN: hotswap-rewrite %t.out.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --output %t.out2.elf
+// RUN: cmp %t.out.elf %t.out2.elf
+
+// API: RESULT: SUCCESS
+// CHECK-LABEL: <visible_nested_entry>:
+// CHECK-NEXT: s_nop 0
+// CHECK-NEXT: global_load_b32 v0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl visible_entry_kernel
+.p2align 8
+.type visible_entry_kernel,@function
+visible_entry_kernel:
+  global_wb scope:SCOPE_CU
+  v_nop
+  s_branch .Lvisible_entry_done
+
+.globl visible_nested_entry
+.type visible_nested_entry,@function
+visible_nested_entry:
+  s_clause 0
+  global_load_b32 v0, v[2:3], off
+  s_wait_loadcnt 0
+  s_endpgm
+.Lvisible_nested_entry_end:
+.size visible_nested_entry, \
+    .Lvisible_nested_entry_end-visible_nested_entry
+
+.Lvisible_entry_done:
+  s_endpgm
+.Lvisible_entry_kernel_end:
+.size visible_entry_kernel, .Lvisible_entry_kernel_end-visible_entry_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel visible_entry_kernel
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: visible_entry_kernel
+      .symbol: visible_entry_kernel.kd
+      .sgpr_count: 0
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-fastpath.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-fastpath.s
@@ -42,11 +42,31 @@
 // NO-SYMS-NOT: .stub
 
 // COM: The per-kernel scratch pair s[8:9] sits above the kernel's 8 live SGPRs,
-// COM: so the descriptor SGPR reservation is bumped to cover it (8 -> 10),
-// COM: exactly like the MC path.
+// COM: so the metadata total is conservatively bumped to cover both the pair
+// COM: and a possible existing VCC reservation (8 -> 12), like the MC path.
 // RUN: %llvm-readelf --notes %t.fast.elf | %FileCheck --check-prefix=SGPR %s
 // SGPR: .name:           plain_kernel
-// SGPR: .sgpr_count:     10
+// SGPR: .sgpr_count:     12
+
+// COM: The fast byte template uses the same logical base 106 for VCC when the
+// COM: metadata total leaves no numbered pair, and bumps the total to 108.
+// RUN: sed 's/.sgpr_count: 8/.sgpr_count: 105/' %s > %t.vcc.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.vcc.s -o %t.vcc.elf
+// RUN: hotswap-rewrite %t.vcc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.vcc.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.vcc.out.elf | %FileCheck --check-prefix=VCC %s
+// RUN: %llvm-readelf --notes %t.vcc.out.elf \
+// RUN:   | %FileCheck --check-prefix=VCC-METADATA %s
+// VCC: s_get_pc_i64 vcc
+// VCC-NEXT: s_add_co_u32 vcc_lo
+// VCC-NEXT: s_add_co_ci_u32 vcc_hi
+// VCC-NEXT: s_set_pc_i64 vcc
+// VCC-METADATA: .name:           plain_kernel
+// VCC-METADATA: .sgpr_count:     108
 
 // COM: Byte-compare idempotency: a second pass recognizes the installed stub
 // COM: (and the in-place workaround) and is a no-op.

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -55,7 +55,7 @@
 // DISASM-NEXT: s_get_pc_i64
 
 // METADATA: .name:           entry_tramp_kernel
-// METADATA: .sgpr_count:     10
+// METADATA: .sgpr_count:     12
 
 // COM: The alignment fallback records each appended stub for debuggers.
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
@@ -70,15 +70,38 @@
 // API2: RESULT: SUCCESS
 // RUN: cmp %t.out.elf %t.out2.elf
 
-// COM: The alignment fallback needs a scratch SGPR pair for its appended stubs.
+// COM: .sgpr_count includes VCC. When no numbered scratch pair remains, the MC
+// COM: path uses VCC as its entry-only temporary and reserves the full total.
 // RUN: sed 's/.sgpr_count: 8/.sgpr_count: 105/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
 // RUN: hotswap-rewrite %t.highsgpr.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --entry-trampolines --output %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=VCC-SCRATCH %s
+// RUN: %llvm-readelf --notes %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=VCC-METADATA %s
+// VCC-SCRATCH: s_get_pc_i64 vcc
+// VCC-SCRATCH-NEXT: s_add_co_u32 vcc_lo
+// VCC-SCRATCH-NEXT: s_add_co_ci_u32 vcc_hi
+// VCC-SCRATCH-NEXT: s_set_pc_i64 vcc
+// VCC-METADATA: .name:           entry_tramp_kernel
+// VCC-METADATA: .sgpr_count:     108
+
+// COM: A total above the numbered SGPRs plus VCC is malformed and still fails
+// COM: closed without producing a partial rewrite.
+// RUN: sed 's/.sgpr_count: 8/.sgpr_count: 109/' %s > %t.badsgpr.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.badsgpr.s -o %t.badsgpr.elf
+// RUN: hotswap-rewrite %t.badsgpr.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --entry-trampolines --expect-status ERROR \
-// RUN:   | %FileCheck --check-prefix=NO-SCRATCH %s
-// NO-SCRATCH: RESULT: ERROR
+// RUN:   | %FileCheck --check-prefix=BAD-SGPR %s
+// BAD-SGPR: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
+++ b/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
@@ -18,12 +18,16 @@
 
 // DISASM-LABEL: <test_large_usage_cache>:
 // DISASM: s_get_pc_i64
+// DISASM: s_add_nc_u64
 // DISASM: s_set_pc_i64
 // DISASM: s_call_i64
 // DISASM: s_get_pc_i64
+// DISASM: s_add_nc_u64
 // DISASM: s_set_pc_i64
-// DISASM: tensor_load_to_lds
-// DISASM: tensor_load_to_lds
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+// DISASM: ds_load_b32 v4, v6 offset:256
+// DISASM-NEXT: ds_load_b32 v5, v6 offset:768
 
 // META: .name:           test_large_usage_cache
 // META: .sgpr_count:     38
@@ -39,7 +43,7 @@
 .p2align 8
 .type test_large_usage_cache,@function
 test_large_usage_cache:
-  tensor_load_to_lds s[0:3], s[4:11]
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
   s_mov_b32 s30, s30
   s_mov_b32 s30, s30
   s_mov_b32 s30, s30
@@ -47,7 +51,7 @@ test_large_usage_cache:
   s_mov_b32 s30, s30
   s_mov_b32 s30, s30
   s_call_i64 s[20:21], cache_helper
-  tensor_load_to_lds s[0:3], s[4:11]
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
   s_mov_b32 s31, s31
   s_mov_b32 s31, s31
   s_mov_b32 s31, s31
@@ -73,7 +77,7 @@ cache_helper:
 .rodata
 .p2align 8
 .amdhsa_kernel test_large_usage_cache
-  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_vgpr 7
   .amdhsa_next_free_sgpr 34
 .end_amdhsa_kernel
 
@@ -85,7 +89,7 @@ cache_helper:
     - .name: test_large_usage_cache
       .symbol: test_large_usage_cache.kd
       .sgpr_count: 34
-      .vgpr_count: 1
+      .vgpr_count: 7
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-materialized-tail-transfer-structural.s
+++ b/amd/comgr/test-lit/hotswap-materialized-tail-transfer-structural.s
@@ -1,0 +1,191 @@
+// COM: A compiler may schedule arbitrary straight-line instructions between a
+// COM: materialized PC-relative address and its terminal s_set_pc_i64. Prove
+// COM: this transfer structurally: one unchanged SGPR pair, an absolute delta,
+// COM: a contiguous control-flow-free gap with no pair access or interior
+// COM: entry, an owning-function tail transfer, and another function's entry
+// COM: as the destination. Do not recognize one mnemonic schedule, one SGPR
+// COM: pair, or a bounded instruction count.
+// COM:
+// COM: The far DS2 rewrite below depends on the sole donated gateway. Thus a
+// COM: positive RESULT: SUCCESS also proves that the transfer was recognized;
+// COM: an unknown indirect target globally disables the gateway and fails the
+// COM: rewrite. Negative cases pin every part of the structural certificate.
+
+// RUN: for CASE in 1 2 3; do \
+// RUN:   %clang -x assembler-with-cpp -DCASE=$CASE -target amdgcn-amd-amdhsa \
+// RUN:     -mcpu=gfx1250 -nostdlib %s -o %t.$CASE.elf && \
+// RUN:   env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.$CASE.elf \
+// RUN:     amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:     amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:     --output %t.$CASE.out.elf 2>&1 \
+// RUN:     | %FileCheck --check-prefix=POSITIVE %s || exit 1; \
+// RUN: done
+
+// RUN: for CASE in 4 5 6 7 8 9 10 11; do \
+// RUN:   %clang -x assembler-with-cpp -DCASE=$CASE -target amdgcn-amd-amdhsa \
+// RUN:     -mcpu=gfx1250 -nostdlib %s -o %t.$CASE.elf && \
+// RUN:   env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.$CASE.elf \
+// RUN:     amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:     amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:     --expect-status ERROR 2>&1 \
+// RUN:     | %FileCheck --check-prefix=NEGATIVE %s || exit 1; \
+// RUN: done
+
+// POSITIVE: hotswap: recognized materialized PC transfer
+// POSITIVE: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// POSITIVE: RESULT: SUCCESS
+
+// NEGATIVE-NOT: hotswap: recognized materialized PC transfer
+// NEGATIVE: hotswap: incomplete control-flow targets disable NOP padding donation
+// NEGATIVE: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl gateway_kernel
+.type gateway_kernel,@function
+gateway_kernel:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0
+  s_endpgm
+.size gateway_kernel, .-gateway_kernel
+
+// This is the sole source-side gateway for the far patch above.
+.rept 8
+  s_nop 0
+.endr
+
+.local materialized_source
+.type materialized_source,@function
+materialized_source:
+#if CASE == 7
+  // Entering the otherwise safe gap through a direct branch invalidates the
+  // sequence even though no control-flow instruction lies inside it.
+  s_cbranch_scc1 .Ldirect_gap_entry
+#endif
+
+.Lgetpc:
+#if CASE == 8
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], materialized_target-(.Lgetpc+4)
+#elif CASE == 9
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], s[8:9]
+#elif CASE == 1
+  s_get_pc_i64 s[0:1]
+  s_add_nc_u64 s[0:1], s[0:1], materialized_target-(.Lgetpc+4)
+#elif CASE == 3
+  s_get_pc_i64 s[6:7]
+  s_add_nc_u64 s[6:7], s[6:7], materialized_target-(.Lgetpc+4)
+#elif CASE == 11
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], \
+      .Lmaterialized_target_interior-(.Lgetpc+4)
+#else
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], materialized_target-(.Lgetpc+4)
+#endif
+
+#if CASE == 1
+  // More than the former bounded look-back, all independent of s[0:1].
+  .rept 10
+    s_mov_b32 s8, s9
+  .endr
+#elif CASE == 2
+  // A separated tail transfer may use any otherwise valid SGPR pair.
+  s_nop 0
+#elif CASE == 3
+  // Safe scheduling is not defined by a fixed mnemonic order.
+  s_mov_b32 s8, s9
+  v_mov_b32_e32 v0, v1
+  s_wait_dscnt 0
+  s_cmp_eq_u32 s10, s11
+  v_add_nc_u32_e32 v2, v3, v4
+  s_nop 0
+#elif CASE == 4
+  // An explicit access to either half of the target pair is unsafe.
+  s_mov_b32 s4, s8
+#elif CASE == 5
+  // The gap must be straight-line, even when the branch only skips a NOP.
+  s_cbranch_scc1 .Lcontrol_gap_target
+  s_nop 0
+.Lcontrol_gap_target:
+  s_nop 0
+#elif CASE == 6
+  // An emitted symbol is an addressable interior entry.
+  .local materialized_gap_symbol
+materialized_gap_symbol:
+  s_nop 0
+#elif CASE == 7
+  s_nop 0
+.Ldirect_gap_entry:
+  s_nop 0
+#elif CASE == 8
+  // The terminal transfer names a different pair from get-PC and add.
+  s_nop 0
+#elif CASE == 9
+  // A register delta is not a statically materialized destination.
+  s_nop 0
+#elif CASE == 10
+  s_nop 0
+#elif CASE == 11
+  s_nop 0
+#else
+  .error "CASE must select a test body"
+#endif
+
+#if CASE == 1
+  s_setpc_b64 s[0:1]
+#elif CASE == 3
+  s_setpc_b64 s[6:7]
+#elif CASE == 8
+  s_setpc_b64 s[6:7]
+#else
+  s_setpc_b64 s[4:5]
+#endif
+
+#if CASE == 10
+  // A tail transfer must end its owning function.
+  s_nop 0
+  s_endpgm
+#endif
+.size materialized_source, .-materialized_source
+
+.local materialized_target
+.type materialized_target,@function
+materialized_target:
+#if CASE == 11
+  s_nop 0
+.Lmaterialized_target_interior:
+#endif
+  s_endpgm
+.size materialized_target, .-materialized_target
+
+// Put the appended trampoline beyond direct s_branch reach without creating
+// another NOP donor.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel gateway_kernel
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: gateway_kernel
+      .symbol: gateway_kernel.kd
+      .sgpr_count: 66
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
@@ -1,5 +1,6 @@
-// COM: A NOP sled belongs to its containing kernel. The patchable DS
-// COM: instruction in second_kernel must not borrow first_kernel padding.
+// COM: A symbol in post-function NOP padding prevents that range from being
+// COM: certified as global relocation storage. The patchable DS instruction
+// COM: in second_kernel must not borrow the protected first-kernel padding.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -21,6 +22,9 @@
 // DISASM-NEXT: s_nop 0
 // DISASM-NEXT: s_nop 0
 // DISASM-NEXT: s_endpgm
+
+// DISASM-LABEL: <first_padding_entry>:
+// DISASM-NEXT: s_nop 0
 
 // DISASM-LABEL: <second_kernel>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
@@ -51,6 +55,8 @@ first_kernel:
 .Lfirst_kernel_end:
 .size first_kernel, .Lfirst_kernel_end-first_kernel
 
+.globl first_padding_entry
+first_padding_entry:
 .globl second_kernel
 .p2align 8
 .type second_kernel,@function

--- a/amd/comgr/test-lit/hotswap-nop-sled-protected-extent.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-protected-extent.s
@@ -1,0 +1,68 @@
+// COM: A sized OBJECT whose point starts before post-function NOP padding but
+// COM: whose extent covers that padding prevents it from donating replacement
+// COM: body storage. The later kernel must use the appended pool instead.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %llvm-readelf -s %t.elf | %FileCheck --check-prefix=SYMBOL %s
+// SYMBOL: OBJECT LOCAL DEFAULT {{[0-9]+}} protected_extent
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <protected_extent>:
+// DISASM-NEXT: {{[0-9a-f]+}}: 00 00 b0 bf 00 00 80 bf
+// DISASM-LABEL: <second_kernel>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
+// DISASM: s_endpgm
+// DISASM: ds_load_b32 v0
+// DISASM: ds_load_b32 v1
+// DISASM: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl first_kernel
+.p2align 8
+.type first_kernel,@function
+first_kernel:
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.local protected_extent
+.type protected_extent,@object
+protected_extent:
+  s_endpgm
+.Lfirst_kernel_end:
+.size first_kernel, .Lfirst_kernel_end-first_kernel
+
+.globl second_kernel
+.p2align 8
+.size protected_extent, .-protected_extent
+.type second_kernel,@function
+second_kernel:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.Lsecond_kernel_end:
+.size second_kernel, .Lsecond_kernel_end-second_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_kernel
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-owned-tail-gateway-collision.s
+++ b/amd/comgr/test-lit/hotswap-owned-tail-gateway-collision.s
@@ -1,0 +1,114 @@
+// COM: One function owns a 24-byte tail NOP sled. Its first DS2 replacement
+// COM: consumes 20 bytes, leaving exactly one dword. A second DS2 site needs a
+// COM: far trampoline whose forward edge uses that remaining dword as a branch
+// COM: island. Gateway allocation must continue from the shared sled cursor,
+// COM: not rediscover stale NOPs and overwrite the replacement body.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: recognized materialized PC transfer
+// LOG: hotswap: safe far return: used local NOP sled
+// LOG: hotswap: safe far return: reusing original site-dead s[104:105]
+// LOG: hotswap: assigned 1 forward s_branch island chain(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <owned_tail_kernel>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM: ds_store_b64 v22, v[10:11] offset:856
+// DISASM-NEXT: ds_store_b64 v22, v[18:19] offset:1080
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <callee>:
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl owned_tail_kernel
+.p2align 8
+.type owned_tail_kernel,@function
+owned_tail_kernel:
+  ds_store_2addr_b64 v22, v[10:11], v[18:19] offset0:107 offset1:135
+
+// One path reaches the materialized return without defining s[104:105], so
+// the first DS2 cannot claim that pair as site-dead scratch. The other path
+// reaches the far source, where the pair is defined before every exit.
+  s_cbranch_scc1 .Lmaterialized_exit
+  s_cbranch_scc1 .Lfar_resume
+.Lfar_source:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lfar_resume:
+  s_wait_dscnt 0
+  s_mov_b64 s[104:105], 0
+  .rept 15000
+    s_mov_b32 s64, s65
+  .endr
+
+.Lmaterialized_exit:
+  s_cmp_lg_u64 s[0:1], 0
+  s_cmp_lg_u64 s[2:3], 0
+  s_cmp_lg_u64 s[104:105], 0
+  s_cmp_lg_u64 s[30:31], 0
+  s_and_saveexec_b32 s0, vcc_lo
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], 44
+  ds_store_b64 v1, v[4:5]
+  s_swap_pc_i64 s[30:31], s[2:3]
+  s_setpc_b64 s[30:31]
+
+// The body and gateway are two roles sharing one allocation cursor. The
+// no-fallthrough return makes this a valid body-capable tail sled, and the
+// function range owns every byte.
+.Lowned_tail_sled:
+.rept 6
+  s_nop 0
+.endr
+.size owned_tail_kernel, .-owned_tail_kernel
+
+.local callee
+.type callee,@function
+callee:
+  s_setpc_b64 s[30:31]
+.size callee, .-callee
+
+// Keep the appended trampoline pool beyond direct s_branch reach. The owned
+// tail remains within source reach and can bridge the far source to the pool.
+.rept 25000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel owned_tail_kernel
+  .amdhsa_next_free_vgpr 24
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: owned_tail_kernel
+      .symbol: owned_tail_kernel.kd
+      .sgpr_count: 106
+      .vgpr_count: 24
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -24,9 +24,10 @@
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
 // DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3], 16
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], s[2:3]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_nop 0
 
 // COM: A second rewrite must preserve the resolved call and patched object.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-pc-materialized-cross-function-mode.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-cross-function-mode.s
@@ -1,0 +1,72 @@
+// COM: A proven arbitrary-link call into another function's interior bypasses
+// COM: that function's ABI entry and VGPR-MSB initialization. Do not use the
+// COM: entry-only MODE proof to exempt an aligned DS2 at the interior target.
+// COM: A call to the actual function entry remains eligible for the proof.
+
+// RUN: %clang -x assembler-with-cpp -DTARGET_INTERIOR=0 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.entry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.entry.out.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=LOG %s
+// RUN: %llvm-objdump -d %t.entry.out.elf | \
+// RUN:   %FileCheck --check-prefix=ENTRY %s
+
+// RUN: %clang -x assembler-with-cpp -DTARGET_INTERIOR=1 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.interior.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.interior.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.interior.out.elf 2>&1 | \
+// RUN:   %FileCheck --check-prefix=LOG %s
+// RUN: %llvm-objdump -d %t.interior.out.elf | \
+// RUN:   %FileCheck --check-prefix=INTERIOR %s
+// RUN: hotswap-rewrite %t.interior.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// LOG: hotswap: resolved PC-materialized call
+// LOG-NOT: hotswap: unresolved call target
+// LOG: RESULT: SUCCESS
+// ENTRY-LABEL: <materialized_cross_entry_target>:
+// ENTRY: ds_load_2addr_b64
+// ENTRY-LABEL: <materialized_cross_entry_caller>:
+// INTERIOR-LABEL: <materialized_cross_entry_target>:
+// INTERIOR-NOT: ds_load_2addr_b64
+// INTERIOR-LABEL: <materialized_cross_entry_caller>:
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.local materialized_cross_entry_target
+.p2align 8
+.type materialized_cross_entry_target,@function
+materialized_cross_entry_target:
+  s_set_vgpr_msb 0
+.Lmaterialized_cross_entry_interior:
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_endpgm
+  .rept 8
+    s_nop 0
+  .endr
+.Lmaterialized_cross_entry_target_end:
+.size materialized_cross_entry_target, .Lmaterialized_cross_entry_target_end-materialized_cross_entry_target
+
+.local materialized_cross_entry_caller
+.p2align 8
+.type materialized_cross_entry_caller,@function
+materialized_cross_entry_caller:
+  s_get_pc_i64 s[2:3]
+#if TARGET_INTERIOR
+  // Captured PC is caller+4; the aligned callee's interior is target+4.
+  s_add_nc_u64 s[2:3], s[2:3], -256
+#else
+  // Captured PC is caller+4; the aligned callee entry is target+0.
+  s_add_nc_u64 s[2:3], s[2:3], -260
+#endif
+  s_swap_pc_i64 s[0:1], s[2:3]
+  s_endpgm
+.Lmaterialized_cross_entry_caller_end:
+.size materialized_cross_entry_caller, .Lmaterialized_cross_entry_caller_end-materialized_cross_entry_caller

--- a/amd/comgr/test-lit/hotswap-relay-before-later-gateway.s
+++ b/amd/comgr/test-lit/hotswap-relay-before-later-gateway.s
@@ -1,0 +1,128 @@
+// COM: A relay-only site needs one dword from a 20-byte sled that is also the
+// COM: other site's sole full gateway. Do not globally allocate every full
+// COM: gateway: the one-slot site takes its independent relay route first,
+// COM: leaving the shared sled available to the relay-only chain.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG-NOT: SCC-neutral forward gateway
+// LOG: hotswap: assigned 2 forward s_branch island chain(s)
+// LOG-NOT: no safe short-branch gateway
+// LOG: RESULT: SUCCESS
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl relay_only_site
+.p2align 8
+.type relay_only_site,@function
+relay_only_site:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_endpgm
+.size relay_only_site, .-relay_only_site
+
+.rept 24996
+  s_mov_b32 s64, s65
+.endr
+
+.type first_relay,@function
+first_relay:
+  s_endpgm
+.size first_relay, .-first_relay
+.fill 4, 1, 0
+
+.rept 12499
+  s_mov_b32 s64, s65
+.endr
+
+.globl reservable_site
+.type reservable_site,@function
+reservable_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size reservable_site, .-reservable_site
+
+.rept 12496
+  s_mov_b32 s64, s65
+.endr
+
+// relay_only_site cannot reach this sled directly, so it initially has zero
+// full gateway candidates. It reaches the sled through first_relay instead.
+.type shared_full_gateway,@function
+shared_full_gateway:
+  s_endpgm
+.size shared_full_gateway, .-shared_full_gateway
+.fill 20, 1, 0
+
+.rept 19994
+  s_mov_b32 s64, s65
+.endr
+
+// reservable_site is processed first and uses this independent route instead
+// of allocating shared_full_gateway.
+.type reservable_relay,@function
+reservable_relay:
+  s_endpgm
+.size reservable_relay, .-reservable_relay
+.fill 4, 1, 0
+
+.rept 7498
+  s_mov_b32 s64, s65
+.endr
+
+.type relay_only_final,@function
+relay_only_final:
+  s_endpgm
+.size relay_only_final, .-relay_only_final
+.fill 4, 1, 0
+
+.rept 22500
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel relay_only_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdhsa_kernel reservable_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 66
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: relay_only_site
+      .symbol: relay_only_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: reservable_site
+      .symbol: reservable_site.kd
+      .sgpr_count: 66
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-sequential-b0-a0-pool.s
+++ b/amd/comgr/test-lit/hotswap-sequential-b0-a0-pool.s
@@ -1,0 +1,139 @@
+// COM: A target-state certificate must cover every executable byte in the
+// COM: object, including code emitted by an earlier HotSwap pass. A strict B0
+// COM: rewrite moves this PC-sensitive tensor instruction into an appended
+// COM: executable pool. A later B0-to-A0 pass must not ignore that pool and
+// COM: retag the kernel A0.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// COM: Control case: a normal object whose only executable code is `.text`
+// COM: remains eligible. Replacing the tensor with an unaligned DS2 also makes
+// COM: the successful A0 pass append a target-correct pool. Repeating that
+// COM: completed rewrite must use the A0 certificate before the structural
+// COM: outside-`.text` guard and return byte-identical output.
+// RUN: sed 's/tensor_load_to_lds s\[0:3\], s\[4:11\]/ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2/' %s > %t.control.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.control.s -o %t.control.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.control.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.control.a0.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CONTROL %s
+// CONTROL: growWithTrampolines: appended 1 trampoline
+// CONTROL: RESULT: SUCCESS
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.control.a0.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.control.repeat.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=REPEAT %s
+// REPEAT: every kernel already reports gfx1250 revision A0
+// REPEAT-NOT: executable code outside .text
+// REPEAT: RESULT: SUCCESS
+// RUN: cmp %t.control.a0.elf %t.control.repeat.elf
+
+// COM: The pool note, not optional per-kernel metadata, carries completion
+// COM: state for generated executable code. With metadata removed, a repeated
+// COM: B0-to-A0 request must still accept the A0 pool, apply no new patches,
+// COM: and return byte-identical output.
+// RUN: sed -e 's/tensor_load_to_lds s\[0:3\], s\[4:11\]/ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2/' \
+// RUN:   -e '/^\.amdgpu_metadata$/,/^\.end_amdgpu_metadata$/d' %s > %t.nometa.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.nometa.s -o %t.nometa.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.nometa.a0.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NOMETA-FIRST %s
+// NOMETA-FIRST: target-state 1 provenance
+// NOMETA-FIRST: RESULT: SUCCESS
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.a0.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.nometa.repeat.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=NOMETA-REPEAT %s
+// NOMETA-REPEAT: applied 0 instruction patches
+// NOMETA-REPEAT-NOT: incompatible executable code
+// NOMETA-REPEAT: RESULT: SUCCESS
+// RUN: cmp %t.nometa.a0.elf %t.nometa.repeat.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --strict-mode --output %t.b0.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=B0 %s
+// B0: growWithTrampolines: appended 1 trampoline
+// B0: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.b0.elf | %FileCheck --check-prefix=B0-DIS %s
+// B0-DIS-LABEL: <sequential_tensor>:
+// B0-DIS: s_branch
+// B0-DIS: Disassembly of section :
+// B0-DIS: tensor_load_to_lds
+
+// COM: Until HotSwap can retarget every executable section, the generalized
+// COM: safe behavior is to reject this composition rather than issue a false
+// COM: object-wide A0 certificate.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.b0.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=A0 %s
+// A0: was produced for an incompatible target stepping
+// A0: RESULT: ERROR
+
+// COM: Pool provenance is validated before the per-kernel A0 metadata fast
+// COM: path. A stale or forged A0 metadata tag must not certify a B0 pool.
+// RUN: sed 's/\.gfx1250_revision: B0/.gfx1250_revision: A0/' %s > %t.a0meta.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.a0meta.s -o %t.a0meta.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.a0meta.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --strict-mode --output %t.a0meta.b0pool.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=STALE-FIRST %s
+// STALE-FIRST: target-state 2 provenance
+// STALE-FIRST: RESULT: SUCCESS
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.a0meta.b0pool.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=STALE-A0 %s
+// STALE-A0-NOT: every kernel already reports gfx1250 revision A0
+// STALE-A0: was produced for an incompatible target stepping
+// STALE-A0: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl sequential_tensor
+.p2align 8
+.type sequential_tensor,@function
+sequential_tensor:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+.size sequential_tensor, .-sequential_tensor
+
+.rodata
+.p2align 8
+.amdhsa_kernel sequential_tensor
+  .amdhsa_next_free_vgpr 8
+  .amdhsa_next_free_sgpr 16
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: sequential_tensor
+      .symbol: sequential_tensor.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 16
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-site-dead-backward-expansion.s
+++ b/amd/comgr/test-lit/hotswap-site-dead-backward-expansion.s
@@ -1,0 +1,72 @@
+// COM: Backward source growth does not move the resume point. A site-dead
+// COM: scratch pair therefore remains safe when every prepended instruction
+// COM: does not read the pair's clobbered value. A pure definition may be
+// COM: copied because it reconstructs the original state. This provides the
+// COM: complete direct
+// COM: set-PC source window without requiring nearby gateway padding.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: reusing original site-dead s[62:63]
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <site_dead_backward_expansion>:
+// DISASM-NEXT: s_get_pc_i64 s[62:63]
+// DISASM-NEXT: s_add_nc_u64 s[62:63], s[62:63],
+// DISASM-NEXT: s_set_pc_i64 s[62:63]
+// DISASM: v_add3_u32 v18, v10, v18, v11
+// DISASM-NEXT: s_mov_b64 s[62:63], 0
+// DISASM-NEXT: ds_load_b64 v[8:9], v6 offset:944
+// DISASM-NEXT: ds_load_b64 v[6:7], v6 offset:880
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl site_dead_backward_expansion
+.p2align 8
+.type site_dead_backward_expansion,@function
+site_dead_backward_expansion:
+  v_add3_u32 v18, v10, v18, v11
+  s_mov_b64 s[62:63], 0
+  ds_load_2addr_b64 v[6:9], v6 offset0:110 offset1:118
+  s_mov_b64 s[62:63], 0
+  s_cmp_lg_u64 s[62:63], 0
+  s_endpgm
+.size site_dead_backward_expansion, .-site_dead_backward_expansion
+
+// Put the appended trampoline pool beyond short-branch reach without donating
+// any in-function NOP padding to the source.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel site_dead_backward_expansion
+  .amdhsa_next_free_vgpr 19
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: site_dead_backward_expansion
+      .symbol: site_dead_backward_expansion.kd
+      .sgpr_count: 106
+      .vgpr_count: 19
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-site-dead-backward-read.s
+++ b/amd/comgr/test-lit/hotswap-site-dead-backward-read.s
@@ -1,0 +1,66 @@
+// COM: Backward source growth must not move an instruction that reads the
+// COM: selected site-dead scratch pair. The forward set-PC edge has already
+// COM: clobbered that value before the copied instruction would execute.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: reusing original site-dead s[62:63]
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <site_dead_backward_read>:
+// DISASM: s_mov_b32 s13, s62
+// DISASM-NEXT: s_call_i64 s[62:63],
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl site_dead_backward_read
+.p2align 8
+.type site_dead_backward_read,@function
+site_dead_backward_read:
+  v_add3_u32 v18, v10, v18, v11
+  s_mov_b32 s13, s62
+  ds_load_2addr_b64 v[6:9], v6 offset0:110 offset1:118
+  s_mov_b64 s[62:63], 0
+  s_endpgm
+.size site_dead_backward_read, .-site_dead_backward_read
+
+// A nearby gateway lets the rewrite succeed after unsafe source growth is
+// rejected. Non-NOP filler keeps the appended body outside short-branch reach.
+.rept 8
+  s_nop 0
+.endr
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel site_dead_backward_read
+  .amdhsa_next_free_vgpr 19
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: site_dead_backward_read
+      .symbol: site_dead_backward_read.kd
+      .sgpr_count: 106
+      .vgpr_count: 19
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-site-dead-no-source-expansion.s
+++ b/amd/comgr/test-lit/hotswap-site-dead-no-source-expansion.s
@@ -1,0 +1,69 @@
+// COM: A site-dead SGPR pair is safe only at the original resume point. The
+// COM: far trampoline must not move the following pure definition into its
+// COM: source window, because the set-PC return would then overwrite it.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: reusing original site-dead s[62:63]
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <site_dead_no_source_expansion>:
+// DISASM-NEXT: s_call_i64 s[62:63],
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_mov_b64 s[62:63], 0
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl site_dead_no_source_expansion
+.p2align 8
+.type site_dead_no_source_expansion,@function
+site_dead_no_source_expansion:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_mov_b64 s[62:63], 0
+.rept 4
+  s_nop 0
+.endr
+  s_cmp_lg_u64 s[62:63], 0
+  s_endpgm
+.size site_dead_no_source_expansion, .-site_dead_no_source_expansion
+
+// Safe nearby gateway space followed by enough non-NOP code to put the
+// appended trampoline pool outside short-branch reach.
+.rept 8
+  s_nop 0
+.endr
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel site_dead_no_source_expansion
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: site_dead_no_source_expansion
+      .symbol: site_dead_no_source_expansion.kd
+      .sgpr_count: 106
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-site-dead-vcc.s
+++ b/amd/comgr/test-lit/hotswap-site-dead-vcc.s
@@ -1,0 +1,69 @@
+// COM: A far device-function patch may use VCC only when the original
+// COM: function already requires VCC and both halves are dead at the resume.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: safe far return: reusing site-dead vcc
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <site_dead_vcc>:
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM-NEXT: s_add_nc_u64 vcc, vcc,
+// DISASM-NEXT: s_set_pc_i64 vcc
+// DISASM-NEXT: s_set_pc_i64 s[30:31]
+// DISASM: s_mov_b32 vcc_lo, 0
+// DISASM: v_cmp_lt_u32_e32 vcc_lo
+// DISASM-NEXT: s_get_pc_i64 vcc
+// DISASM: s_set_pc_i64 vcc
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl site_dead_vcc
+.p2align 8
+.type site_dead_vcc,@function
+site_dead_vcc:
+  s_mov_b32 vcc_lo, 0
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  v_cmp_lt_u32_e32 vcc_lo, v0, v1
+  s_set_pc_i64 s[30:31]
+.size site_dead_vcc, .-site_dead_vcc
+
+// Safe gateway space outside the function, followed by non-NOP far filler.
+.rept 8
+  s_nop 0
+.endr
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel site_dead_vcc
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: site_dead_vcc
+      .symbol: site_dead_vcc.kd
+      .sgpr_count: 108
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-source-window-vgpr-msb-relocation.s
+++ b/amd/comgr/test-lit/hotswap-source-window-vgpr-msb-relocation.s
@@ -1,0 +1,130 @@
+// COM: Straight-line source growth may relocate a complete s_set_vgpr_msb
+// COM: instruction when doing so preserves its dynamic order. A known entry
+// COM: may become the new window start, but can never become its interior.
+
+// RUN: %clang -x assembler-with-cpp -DFORWARD \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN:   -nostdlib %s -o %t.forward.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.forward.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.forward.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=FORWARD-LOG %s
+// FORWARD-LOG-NOT: hotswap: error:
+// FORWARD-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.forward.out.elf \
+// RUN:   | %FileCheck --check-prefix=FORWARD %s
+// FORWARD-LABEL: <mode_setter_source_window>:
+// FORWARD-NEXT: s_set_vgpr_msb 1
+// FORWARD-NEXT: s_get_pc_i64
+// FORWARD-NEXT: s_add_nc_u64
+// FORWARD-NEXT: s_set_pc_i64
+// FORWARD: ds_load_b64 v[2:3], v52 offset:1224
+// FORWARD-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// FORWARD-NEXT: s_wait_dscnt 0x0
+// FORWARD-NEXT: s_set_vgpr_msb 0x100
+// FORWARD-NEXT: ds_load_b64 v[28:29], v87 offset:17328
+
+// RUN: %clang -x assembler-with-cpp -DBACKWARD \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN:   -nostdlib %s -o %t.backward.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.backward.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.backward.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=BACKWARD-LOG %s
+// BACKWARD-LOG-NOT: hotswap: error:
+// BACKWARD-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.backward.out.elf \
+// RUN:   | %FileCheck --check-prefix=BACKWARD %s
+// BACKWARD-LABEL: <mode_setter_source_window>:
+// BACKWARD-NEXT: s_set_vgpr_msb 1
+// BACKWARD-NEXT: s_get_pc_i64
+// BACKWARD-NEXT: s_add_nc_u64
+// BACKWARD-NEXT: s_set_pc_i64
+// BACKWARD: ds_load_b64 v[28:29], v87 offset:17328
+// BACKWARD-NEXT: s_set_vgpr_msb 0x100
+// BACKWARD-NEXT: ds_load_b64 v[2:3], v52 offset:1224
+// BACKWARD-NEXT: ds_load_b64 v[4:5], v52 offset:1288
+// BACKWARD-NEXT: s_wait_dscnt 0x0
+
+// RUN: %clang -x assembler-with-cpp -DTARGETED \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 \
+// RUN:   -nostdlib %s -o %t.targeted.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.targeted.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.targeted.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=TARGETED-LOG %s
+// TARGETED-LOG-NOT: hotswap: error:
+// TARGETED-LOG: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.targeted.out.elf \
+// RUN:   | %FileCheck --check-prefix=TARGETED %s
+// TARGETED: s_set_vgpr_msb 0x100
+// TARGETED: s_call_i64 s[10:11],
+
+// RUN: hotswap-rewrite %t.forward.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl mode_setter_source_window
+.p2align 8
+.type mode_setter_source_window,@function
+mode_setter_source_window:
+#if defined(FORWARD)
+  s_set_vgpr_msb 1
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+  s_set_vgpr_msb 0x100
+  ds_load_b64 v[28:29], v87 offset:17328
+#elif defined(BACKWARD)
+  s_set_vgpr_msb 1
+  ds_load_b64 v[28:29], v87 offset:17328
+  s_set_vgpr_msb 0x100
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+#elif defined(TARGETED)
+  s_branch mode_setter_site
+  s_mov_b32 s4, s5
+  s_set_vgpr_msb 0x100
+mode_setter_site:
+  ds_load_2addr_b64 v[2:5], v52 offset0:153 offset1:161
+#endif
+  s_endpgm
+.Lmode_setter_source_window_end:
+.size mode_setter_source_window, .Lmode_setter_source_window_end-mode_setter_source_window
+
+#ifdef TARGETED
+// The targeted patch site blocks backward growth because it would become an
+// interior entry. This certified external padding supplies a gateway instead.
+.rept 8
+  s_nop 0
+.endr
+#endif
+
+// Keep the appended trampoline pool beyond direct s_branch reach.
+.rept 40000
+  s_mov_b32 s8, s9
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel mode_setter_source_window
+  .amdhsa_next_free_vgpr 88
+  .amdhsa_next_free_sgpr 10
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: mode_setter_source_window
+      .symbol: mode_setter_source_window.kd
+      .sgpr_count: 10
+      .vgpr_count: 88
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-required-failure.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-required-failure.s
@@ -1,0 +1,55 @@
+// COM: A recognized ADDTID instruction is an A0-required rewrite. If its
+// COM: trampoline cannot be placed, fail closed without producing an output
+// COM: object instead of reporting success with the incompatible instruction.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_addtid_required_failure
+.p2align 8
+.type test_addtid_required_failure,@function
+test_addtid_required_failure:
+  s_cbranch_scc1 .Lresume
+  ds_load_addtid_b32 v0 offset:128
+.Lresume:
+  s_endpgm
+.Ltest_addtid_required_failure_end:
+.size test_addtid_required_failure, .Ltest_addtid_required_failure_end-test_addtid_required_failure
+
+// Non-NOP far filler leaves no local replacement sled or forward gateway.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_addtid_required_failure
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_addtid_required_failure
+      .symbol: test_addtid_required_failure.kd
+      .sgpr_count: 106
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -8,35 +8,21 @@
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// COM: Exercise the large-object planning path with verbose accounting. This
-// COM: fixture contains more than 250 KiB of text and requires a deterministic
-// COM: forward branch-island chain.
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.scale.elf 2>&1 | %FileCheck --check-prefix=SCALE %s
-// SCALE: hotswap: assigned 1 forward s_branch island chain(s)
-// SCALE: hotswap: applied 1 instruction patches
-// SCALE: hotswap: growWithTrampolines: appended 1 trampoline
-
-// RUN: hotswap-rewrite %t.scale.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent | %FileCheck --check-prefix=SCALE-IDEM %s
-// SCALE-IDEM: IDEMPOTENT: YES
-
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 
 // DISASM-LABEL: <test_branch_islands>:
-// DISASM-NEXT: s_delay_alu
 // DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
 // DISASM-LABEL: <gateway_0>:
 // DISASM-NEXT: s_endpgm
 // DISASM-NEXT: s_branch
 // DISASM-LABEL: <gateway_1>:
 // DISASM-NEXT: s_endpgm
 // DISASM-NEXT: s_branch
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+// DISASM-NEXT: s_wait_dscnt 0x0
 // DISASM-NEXT: s_get_pc_i64 s[14:15]
 // DISASM-NEXT: s_add_nc_u64 s[14:15], s[14:15],
 // DISASM-NEXT: s_set_pc_i64 s[14:15]
@@ -52,8 +38,7 @@
 .p2align 8
 .type test_branch_islands,@function
 test_branch_islands:
-  s_delay_alu instid0(SALU_CYCLE_1)
-  tensor_load_to_lds s[0:3], s[4:11]
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
   s_endpgm
 .size test_branch_islands, .-test_branch_islands
 
@@ -84,7 +69,7 @@ gateway_1:
 .rodata
 .p2align 8
 .amdhsa_kernel test_branch_islands
-  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
 
@@ -96,7 +81,7 @@ gateway_1:
     - .name: test_branch_islands
       .symbol: test_branch_islands.kd
       .sgpr_count: 14
-      .vgpr_count: 1
+      .vgpr_count: 3
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
@@ -1,7 +1,6 @@
 // COM: A far required DS2 rewrite has exactly one safe 16-byte external
-// COM: gateway. The gfx1250 SCC-neutral set-PC sequence encodes in 16 bytes
-// COM: for this forward displacement, so planning must use its MC-encoded
-// COM: size instead of requiring the 20-byte worst-case reservation.
+// COM: gateway. The source-relative call tail needs only a 12-byte
+// COM: add-nc/set-PC sequence, so it fits without a full get-PC prefix.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
@@ -17,11 +16,10 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
 
 // DISASM-LABEL: <compact_gateway>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64
 // DISASM-NEXT: s_nop
 // DISASM-LABEL: <gateway_barrier>:
 // DISASM-NEXT: s_endpgm
-// DISASM-NEXT: s_get_pc_i64 s[0:1]
 // DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 // DISASM: ds_load_b32 v0, v2 offset:256

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-far-sgpr.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-far-sgpr.s
@@ -1,0 +1,113 @@
+// COM: A far DS2 patch can live in an ordinary device function shared by
+// COM: multiple kernels. The set-PC return uses one globally unused SGPR pair
+// COM: and charges that pair to both possible callers.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <device_ds2>:
+// DISASM-NEXT: s_call_i64 s[66:67],
+// DISASM-LABEL: <kernel_b>:
+// DISASM: s_endpgm
+// DISASM-NEXT: s_add_nc_u64 s[66:67], s[66:67],
+// DISASM-NEXT: s_set_pc_i64 s[66:67]
+// DISASM: ds_load_b64 v[0:1], v4 offset:512
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:1024
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_get_pc_i64 s[66:67]
+// DISASM-NEXT: s_add_nc_u64 s[66:67], s[66:67],
+// DISASM-NEXT: s_set_pc_i64 s[66:67]
+
+// META: .name:           kernel_a
+// META: .sgpr_count:     70
+// META: .name:           kernel_b
+// META: .sgpr_count:     70
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.local device_ds2
+.type device_ds2,@function
+device_ds2:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_set_pc_i64 s[30:31]
+.Ldevice_ds2_end:
+.size device_ds2, .Ldevice_ds2_end-device_ds2
+
+.globl kernel_a
+.type kernel_a,@function
+kernel_a:
+  s_call_i64 s[30:31], device_ds2
+  s_endpgm
+.Lkernel_a_end:
+.size kernel_a, .Lkernel_a_end-kernel_a
+
+.globl kernel_b
+.type kernel_b,@function
+kernel_b:
+  s_call_i64 s[30:31], device_ds2
+  s_endpgm
+.Lkernel_b_end:
+.size kernel_b, .Lkernel_b_end-kernel_b
+
+// Safe gateway space outside every function range.
+.rept 8
+  s_nop 0
+.endr
+
+// Push the appended pool beyond s_branch reach without extending a function.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel kernel_a
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdhsa_kernel kernel_b
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: kernel_a
+      .symbol: kernel_a.kd
+      .sgpr_count: 48
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: kernel_b
+      .symbol: kernel_b.kd
+      .sgpr_count: 48
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -1,8 +1,6 @@
-// COM: A far patch can live in a zero-size ordinary device function shared by
-// COM: multiple kernels. The tensor descriptor save and set-PC return safely
-// COM: reuse one global scratch block, charged to both possible callers. The
-// COM: missing .size directive exercises zero-size function-range inference on
-// COM: the far path.
+// COM: A tensor load in an ordinary device function shared by multiple kernels
+// COM: is patched in place. The distant end of .text must not force the tensor
+// COM: into a trampoline or increase either caller's SGPR metadata.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
@@ -15,26 +13,15 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
 
 // DISASM-LABEL: <device_tensor>:
-// DISASM-NEXT: s_branch
-// DISASM-NEXT: s_nop
-// DISASM-NEXT: s_nop
-// DISASM-LABEL: <kernel_b>:
-// DISASM: s_endpgm
-// DISASM-NEXT: s_get_pc_i64 s[66:67]
-// DISASM-NEXT: s_add_nc_u64 s[66:67], s[66:67],
-// DISASM-NEXT: s_set_pc_i64 s[66:67]
-// DISASM: s_mov_b32 s66, s4
+// DISASM-NOT: s_branch
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_mov_b32 s4, s66
-// DISASM-NEXT: s_get_pc_i64 s[66:67]
-// DISASM-NEXT: s_add_nc_u64 s[66:67], s[66:67],
-// DISASM-NEXT: s_set_pc_i64 s[66:67]
+// DISASM-NEXT: s_set_pc_i64 s[30:31]
 
 // META: .name:           kernel_a
-// META: .sgpr_count:     70
+// META: .sgpr_count:     48
 // META: .name:           kernel_b
-// META: .sgpr_count:     70
+// META: .sgpr_count:     48
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -46,6 +33,7 @@
 .local device_tensor
 .type device_tensor,@function
 device_tensor:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_set_pc_i64 s[30:31]
 

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -7,10 +7,10 @@
 // COM: forwarding in another wave on the same SIMD, causing wrong results,
 // COM: hangs, or a GPU page fault.
 // COM:
-// COM: Fix: use the gfx12 SCC-neutral SGPR-backed set-PC sequence on both
-// COM: edges. Merge adjacent sites and bounded straight-line neighbors when
-// COM: they provide enough source bytes; otherwise short-branch through safe
-// COM: NOP padding.
+// COM: Fix: use the pre-Gen5 SGPR-backed set-PC sequence on both edges. Merge
+// COM: adjacent sites and bounded straight-line neighbors when they provide
+// COM: enough source bytes; otherwise call through safe NOP padding and use
+// COM: its link value for a compact add/set-PC tail.
 // COM: No path emits the broken instruction.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -27,7 +27,7 @@
 // COM: Case 1 (2-address load, RCCL's pattern).
 // DISASM-NOT: s_add_pc_i64
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 2 (adjacent sites coalesced into a set-PC forward gateway).
 // DISASM-LABEL: <test_ds2addr_far_adjacent>:
@@ -38,20 +38,20 @@
 // COM: Case 3 (an interior direct-branch target must prevent coalescing).
 // DISASM-LABEL: <test_ds2addr_far_branch_target>:
 // DISASM-NEXT: s_cbranch_scc1
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 4 (a direct-call target is also an interior entry point).
 // DISASM-LABEL: <test_ds2addr_far_call_target>:
 // DISASM-NEXT: s_call_i64
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 // DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // COM: Case 5 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64 s[2:3],
 
 // DISASM-NOT: ds_load_2addr
 // DISASM-NOT: ds_store_2addr

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
@@ -19,7 +19,7 @@
 // DISASM-LABEL: <test_multi_ds>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_wait_dscnt 0x0
 
 // COM: Idempotency

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -27,12 +27,13 @@
 // ENTRY-NEXT: global_wb
 // ENTRY-NEXT: v_nop
 // ENTRY-NEXT: s_branch
-// ENTRY-NEXT: s_nop 0
+// COM: The split replacement keeps its source-tail drain before the original
+// COM: downstream drain in the displaced layout.
+// ENTRY-NEXT: s_wait_dscnt 0x0
 // ENTRY-NEXT: s_wait_dscnt 0x0
 // ENTRY-NEXT: s_endpgm
 // ENTRY: ds_load_b32 v0, v2 offset:256
 // ENTRY-NEXT: ds_load_b32 v1, v2 offset:768
-// ENTRY-NEXT: s_wait_dscnt 0x0
 // ENTRY-NEXT: s_branch
 // ENTRY-NOT: s_get_pc_i64
 

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -34,7 +34,7 @@
 // DISASM-LABEL: <test_multi_ds_nostride64>:
 // DISASM-NOT: ds_load_2addr_b32
 // DISASM: s_branch
-// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_wait_dscnt 0x0
 // COM: Sled 1 (first DS2 site, vdst pair v[0:1]).
 // DISASM: ds_load_b32 v0, v4 offset:4

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -285,7 +285,7 @@ test_ds_xchg_b64_nostride64:
 // DISASM-NOT: ds_storexchg_2addr_rtn_b32
 // DISASM: s_branch
 // DISASM: s_branch
-// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_wait_dscnt 0x0
 // COM: Sled 1: load expansion.
 // DISASM: ds_load_b32 v0, v8 offset:4

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
@@ -20,10 +20,10 @@
 // DISASM-LABEL: <test_ds_nowait>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_endpgm
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
-// DISASM: s_wait_dscnt 0x0
 // DISASM: s_branch
 
 // COM: Idempotency

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
@@ -9,7 +9,7 @@
 // RUN:   | %FileCheck %s
 
 // CHECK: hotswap: error: ds_storexchg_2addr has cyclic destination/source overlap
-// CHECK-NOT: hotswap: error: ds_2addr expansion failed
+// CHECK: hotswap: error: ds_2addr expansion failed for: ds_storexchg_2addr_rtn_b64
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
@@ -1,8 +1,5 @@
 // COM: Splitting a compound DS instruction must preserve its read-before-write
 // COM: semantics when the address or data registers overlap a destination.
-// COM: This kernel deliberately has no nop sled, forcing the appended
-// COM: trampoline/growth path. Its cyclic exchange is the intentional no-op
-// COM: case: the original instruction must remain byte-stable.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
@@ -21,10 +21,10 @@
 // DISASM-LABEL: <test_ds_pipelined_single>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_wait_dscnt 0x1
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
-// DISASM: s_wait_dscnt 0x0
 // DISASM: s_branch
 
 // COM: Kernel 2 (two splits): each split lands its own s_wait_dscnt 0x0 drain;
@@ -32,14 +32,14 @@
 // DISASM-LABEL: <test_ds_pipelined_multi>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_branch
+// DISASM: s_wait_dscnt 0x0
 // DISASM: s_wait_dscnt 0x1
 // DISASM: ds_load_b32 v0
 // DISASM: ds_load_b32 v1
 // DISASM: s_wait_dscnt 0x0
 // DISASM: ds_load_b32 v2
 // DISASM: ds_load_b32 v3
-// DISASM: s_wait_dscnt 0x0
+// DISASM: s_branch
 
 // COM: Idempotency: a second rewrite produces identical bytes (the 2-addr
 // COM: forms are gone, so there is nothing left to split).

--- a/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
@@ -29,26 +29,27 @@
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=LOG %s
 // COM: Pin the message shape (mnemonic, both raw + scaled values, the
-// COM: 16-bit limit, and the required-rewrite failure closer) so a regression
-// COM: in the message format or the limit constant fails here, not in some
-// COM: downstream-symptoms test. The helper's specific message is the only
-// COM: diagnostic; patchDs2Addr does not add a second generic failure.
-// COM: RESULT: ERROR comes last because leaving the required A0 rewrite
-// COM: unapplied would be unsafe.
+// COM: 16-bit limit, and the "required A0 rewrite cannot continue"
+// COM: closer) so a regression in the message format or the limit
+// COM: constant fails here, not in some downstream-symptoms test. The
+// COM: generic "ds_2addr expansion failed" line is the patchDs2Addr-level
+// COM: error that follows naturally from the overflow guard returning
+// COM: an empty expansion; pin it too so a refactor that reroutes the
+// COM: error path is caught. RESULT: ERROR comes last because leaving the
+// COM: required A0 rewrite unpatched must fail the rewrite as a whole.
 // LOG:      hotswap: error: ds_load_2addr_stride64_b64 scaled offsets exceed
 // LOG-SAME: the single-address DS 16-bit field
 // LOG-SAME: off0=raw 128 * scale 512 = 65536
 // LOG-SAME: off1=raw 255 * scale 512 = 130560
 // LOG-SAME: max 65535
 // LOG-SAME: required A0 rewrite cannot continue
+// LOG:      hotswap: error: ds_2addr expansion failed for: ds_load_2addr_stride64_b64
 // LOG:      RESULT: ERROR
 
-// ---- Kernel 1: out-of-range -- patch must NOT fire --------------------------
+// ---- Kernel 1: out-of-range -- rewrite must fail ----------------------------
 // COM: Both per-operand indices scale past 0xFFFF (off0:128 -> 65536,
-// COM: off1:255 -> 130560). The trampoline must reject the patch and
-// COM: leave ds_load_2addr_stride64_b64 in the kernel verbatim. No
-// COM: s_branch is inserted, no replacement ds_load_b64 appears, the
-// COM: NOP sled is unused. The DISASM-NOT lines pin all three negatives.
+// COM: off1:255 -> 130560). The trampoline must reject the patch and fail
+// COM: the rewrite instead of emitting a silently truncated replacement.
 // DISASM-LABEL: <test_ds_load_b64_overflow>:
 // DISASM:       ds_load_2addr_stride64_b64 v[0:3], v4 offset0:128 offset1:255
 // DISASM-NEXT:  s_wait_dscnt 0x0

--- a/amd/comgr/test-lit/hotswap-trampoline-far-no-metadata.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-far-no-metadata.s
@@ -1,0 +1,44 @@
+// COM: A far patch whose scratch pair must be globally allocated fails closed
+// COM: when the code object has no metadata note to charge for that allocation.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+// CHECK: hotswap: error:
+// CHECK-SAME: metadata
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_far_no_metadata
+.p2align 8
+.type test_far_no_metadata,@function
+test_far_no_metadata:
+  s_cbranch_scc1 .Lresume
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lresume:
+  s_cmp_lg_u64 s[62:63], 0
+  s_cmp_lg_u64 s[60:61], 0
+  s_cmp_lg_u64 s[58:59], 0
+  s_cmp_lg_u64 s[56:57], 0
+  s_cmp_lg_u64 s[46:47], 0
+  s_cmp_lg_u64 s[44:45], 0
+  s_endpgm
+.Ltest_far_no_metadata_end:
+.size test_far_no_metadata, .Ltest_far_no_metadata_end-test_far_no_metadata
+
+// Safe gateway space outside the function, followed by non-NOP far filler.
+.rept 8
+  s_nop 0
+.endr
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_far_no_metadata
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-far-no-sgpr.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-far-no-sgpr.s
@@ -1,0 +1,53 @@
+// COM: A far patch must fail closed when every candidate pair is live at the
+// COM: resume point and no globally unused SGPR pair remains.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck %s
+// CHECK: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_far_no_sgpr
+.p2align 8
+.type test_far_no_sgpr,@function
+test_far_no_sgpr:
+  s_cbranch_scc1 .Lresume
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lresume:
+  // No numbered pair is defined before exit, and the original function does
+  // not use VCC. The rewrite therefore cannot introduce VCC as scratch.
+  s_endpgm
+.Ltest_far_no_sgpr_end:
+.size test_far_no_sgpr, .Ltest_far_no_sgpr_end-test_far_no_sgpr
+
+// Non-NOP far filler leaves no local replacement sled or forward gateway.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_far_no_sgpr
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_far_no_sgpr
+      .symbol: test_far_no_sgpr.kd
+      .sgpr_count: 106
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
@@ -1,8 +1,8 @@
 // COM: Production activation, quantization, and shared-expert objects exposed
-// COM: gateway fragments that can hold the 20-byte SCC-neutral gfx12 set-PC
-// COM: sequence but not the former 28-byte SCC save/restore sequence. Keep SCC
-// COM: live across this required DS2 rewrite and provide exactly one 20-byte
-// COM: gateway. The pool is beyond s_branch range and no island chain exists.
+// COM: gateway fragments that can hold the 12-byte source-relative call tail.
+// COM: Keep SCC live across this required DS2 rewrite and provide exactly one
+// COM: 20-byte gateway. The pool is beyond s_branch range and no island chain
+// COM: exists.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
@@ -18,11 +18,10 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
 
 // DISASM-LABEL: <fragmented_gateway>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_call_i64
 // DISASM-NEXT: s_nop
 // DISASM-LABEL: <gateway_barrier>:
 // DISASM-NEXT: s_endpgm
-// DISASM-NEXT: s_get_pc_i64 s[0:1]
 // DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 // DISASM: ds_load_b32 v0, v2 offset:256

--- a/amd/comgr/test-lit/hotswap-trampoline-layout-reserve.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-layout-reserve.s
@@ -1,0 +1,101 @@
+// COM: A far trampoline placed before a boundary-reachable site grows during
+// COM: source-window expansion and receives a pool branch island. Queue layout
+// COM: must reserve both before deciding that the later site can use short
+// COM: branches; otherwise final fixup sees a shifted trampoline and fails.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <first_far>:
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM-LABEL: <boundary_site>:
+// DISASM-NEXT: s_branch 32767
+// DISASM: ds_load_b32 v4, v6 offset:256
+// DISASM-NEXT: ds_load_b32 v5, v6 offset:768
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl first_far
+.type first_far,@function
+first_far:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_mov_b32 s0, s1
+  s_mov_b32 s2, s3
+  s_mov_b32 s4, s5
+  s_endpgm
+.size first_far, .-first_far
+
+// Keep the first site far from the pool without donating NOP padding.
+.rept 41640
+  s_mov_b32 s0, s1
+.endr
+
+.globl boundary_site
+.type boundary_site,@function
+boundary_site:
+  ds_load_2addr_stride64_b32 v[4:5], v6 offset0:1 offset1:3
+  s_endpgm
+.size boundary_site, .-boundary_site
+
+// A far classification has a legal short-hop set-PC gateway. Before the queue
+// reservation fix this site was misclassified as short, so the gateway was
+// never assigned and final branch fixup failed after the earlier pool growth.
+.rept 4
+  s_nop 0
+.endr
+
+  // Tuned so the later trampoline is at the short-branch boundary before the
+  // earlier far trampoline's final growth and island are accounted for.
+  .rept 31100
+    s_mov_b32 s0, s1
+  .endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel first_far
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 8
+.end_amdhsa_kernel
+
+.amdhsa_kernel boundary_site
+  .amdhsa_next_free_vgpr 7
+  .amdhsa_next_free_sgpr 8
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: first_far
+      .symbol: first_far.kd
+      .sgpr_count: 10
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: boundary_site
+      .symbol: boundary_site.kd
+      .sgpr_count: 10
+      .vgpr_count: 7
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,7 +1,7 @@
-// COM: A0 cannot execute s_add_pc_i64. Both edges use an SGPR-backed set-PC
-// COM: sequence. The 20-byte source window carries the forward sequence
-// COM: directly. A large non-NOP .rept filler (~160 KB) pushes the pool past
-// COM: s_branch's reach to force the far case.
+// COM: A tensor_load_to_lds must remain at its linked PC on gfx1250 A0. A
+// COM: large .rept filler (~160 KB) makes any appended pool unreachable by
+// COM: s_branch, but does not affect the in-place canonical-delay rewrite.
+// COM: The function intentionally has st_size == 0, matching Tensile objects.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -16,48 +16,19 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <test_far>:
-// DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_nc_u64 s[12:13], s[12:13],
-// DISASM-NEXT: s_set_pc_i64 s[12:13]
-// DISASM-NEXT: s_endpgm
-// DISASM-LABEL: <gateway_barrier>:
-// DISASM-NEXT: s_endpgm
-// DISASM: s_mov_b64 vcc, -1
+// DISASM-NEXT: s_mov_b64 vcc, -1
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_nc_u64 s[12:13], s[12:13],
-// DISASM-NEXT: s_set_pc_i64 s[12:13]
+// DISASM-NEXT: s_endpgm
 
 // METADATA: .name:           test_far
-// METADATA: .sgpr_count:     16
+// METADATA: .sgpr_count:     14
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
-
-// COM: A kernel with no aligned two-SGPR block fails closed instead of
-// COM: emitting the unsafe return or clobbering a live register.
-// RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
-// RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
-// RUN: hotswap-rewrite %t.full-sgpr.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
-// FAIL: RESULT: ERROR
-
-// COM: A metadata-less object also fails closed because scratch usage cannot
-// COM: be charged to its owning kernel.
-// RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.nometa.s -o %t.nometa.elf
-// RUN: hotswap-rewrite %t.nometa.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -66,21 +37,11 @@
 .type test_far,@function
 test_far:
   s_mov_b64 vcc, -1
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
-.size test_far, .-test_far
-
-// Provide external zero-filled alignment space after a separate
-// no-fallthrough function.
-.type gateway_barrier,@function
-gateway_barrier:
-  s_endpgm
-.size gateway_barrier, .-gateway_barrier
-.fill 32, 1, 0
-
-  // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
-  // s_branch's +-128 KB reach from the tensor_load above (forces the
-  // long-branch path).
+  // ~160 KB of non-NOP filler demonstrates that pool reachability is
+  // irrelevant to the tensor patch.
   .rept 40000
     s_mov_b32 s0, s1
   .endr

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-known.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-known.s
@@ -1,5 +1,7 @@
 // COM: Test HotSwap B0 tensor_load_to_lds masking when fixed .cluster_dims
-// COM: metadata proves the dispatch is non-cluster or size-one.
+// COM: metadata proves the dispatch is non-cluster or size-one. The known
+// COM: non-cluster case uses the in-place canonical-delay rewrite; a clustered
+// COM: dispatch retains the B0 conditional trampoline.
 
 // RUN: %llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1250 \
 // RUN:   --amdhsa-code-object-version=6 -filetype=obj %s -o %t.o
@@ -30,12 +32,11 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <test_tensor_b0_known_noncluster>:
-// DISASM: s_branch
-// DISASM: s_endpgm
 // DISASM-NOT: s_getreg_b32
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NOT: s_branch
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <test_tensor_b0_known_cluster>:
 // DISASM: s_branch
 // DISASM: s_endpgm
@@ -73,6 +74,7 @@
 .p2align 8
 .type test_tensor_b0_known_noncluster,@function
 test_tensor_b0_known_noncluster:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
   s_nop 0

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-cross-entry.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-cross-entry.s
@@ -1,0 +1,93 @@
+// The kernel-entry EXEC seed and descriptor facts are valid only for dispatch.
+// Reject non-dispatch ingress from another original-.text function, including
+// an interior branch, s_call_i64's operand-1 target, and materialized set-PC.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.branch-interior.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.branch-interior.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.call-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.call-entry.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.setpc-interior.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.setpc-interior.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.branch-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.branch-entry.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.indirect-call.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect-call.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.unknown-owned.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.unknown-owned.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.fallthrough-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.fallthrough-entry.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+
+// NEG-NOT: descriptor low16 already zero
+// NEG: hotswap: error: tensor_load_to_lds at 0x
+// NEG: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl tensor_external_ingress
+.type tensor_external_ingress,@function
+tensor_external_ingress:
+#if CASE == 1
+  s_branch .Ltensor
+#elif CASE == 2
+  s_call_i64 s[30:31], test_tensor_cross_entry
+#elif CASE == 3
+.Lgetpc:
+  s_get_pc_i64 s[0:1]
+  s_add_nc_u64 s[0:1], s[0:1], .Ltensor-(.Lgetpc+4)
+  s_set_pc_i64 s[0:1]
+#elif CASE == 4
+  s_branch test_tensor_cross_entry
+#elif CASE == 5
+  s_swap_pc_i64 s[30:31], s[0:1]
+#elif CASE == 6
+  .long 0xffffffff
+#elif CASE == 7
+  s_nop 0
+#else
+#error unsupported CASE
+#endif
+#if CASE != 7
+  s_endpgm
+#endif
+.Ltensor_external_ingress_end:
+.size tensor_external_ingress, .Ltensor_external_ingress_end-tensor_external_ingress
+
+.globl test_tensor_cross_entry
+#if CASE != 7
+.p2align 8
+#endif
+.type test_tensor_cross_entry,@function
+test_tensor_cross_entry:
+  v_mov_b32 v0, 0
+  v_readfirstlane_b32 s4, v0
+  s_cmp_eq_u32 s4, 0
+  s_nop 0
+.Ltensor:
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_tensor_cross_entry_end:
+.size test_tensor_cross_entry, .Ltest_tensor_cross_entry_end-test_tensor_cross_entry
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_cross_entry
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 32
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_cross_entry
+      .symbol: test_tensor_cross_entry.kd
+      .sgpr_count: 32
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-entry-reject.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-entry-reject.s
@@ -1,0 +1,49 @@
+// A descriptor mask placed before tensor_load_to_lds is insufficient when a
+// direct or unresolved indirect edge can enter at the PC-sensitive tensor and
+// bypass the mask. Exercise both the already-masked and canonical-delay paths.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.direct.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.direct.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=DIRECT %s
+// DIRECT: tensor_load_to_lds at 0x{{[0-9A-F]+}} may be entered without executing its descriptor mask
+// DIRECT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.indirect.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=INDIRECT %s
+// INDIRECT: tensor_load_to_lds at 0x{{[0-9A-F]+}} may be entered without executing its descriptor mask
+// INDIRECT: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_entry_reject
+.p2align 8
+.type test_tensor_entry_reject,@function
+test_tensor_entry_reject:
+#if CASE == 1
+  s_branch .Ltensor
+  s_pack_hh_b32_b16 s4, 0, s4
+#elif CASE == 2
+  s_set_pc_i64 s[0:1]
+  s_delay_alu instid0(SALU_CYCLE_1)
+#else
+  .error "CASE must select a test body"
+#endif
+.Ltensor:
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_tensor_entry_reject_end:
+.size test_tensor_entry_reject, .Ltest_tensor_entry_reject_end-test_tensor_entry_reject
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_entry_reject
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 28
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -1,8 +1,6 @@
-// COM: Test isSgprLiveAfter edge cases for tensor_load_to_lds patching.
-// COM: A branch instruction between the tensor_load and the next use of
-// COM: the descriptor SGPR forces the heuristic to conservatively assume
-// COM: the SGPR is live, producing save/restore even though the use may
-// COM: not execute on all paths.
+// COM: Test persistent tensor_load_to_lds descriptor normalization across a
+// COM: control-flow edge. The descriptor remains masked on either successor,
+// COM: so the in-place rewrite needs no liveness-dependent save/restore.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -14,18 +12,15 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load
-// COM: and s_mov (which reads s4). isSgprLiveAfter returns true at the
-// COM: branch, so save/restore is emitted conservatively.
+// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load and
+// COM: s_mov (which reads s4). The later read sees the normalized descriptor.
 // DISASM-LABEL: <test_tensor_branch_guard>:
-// DISASM: s_branch
-// DISASM: s_cbranch_scc1
-// DISASM: s_endpgm
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NOT: s_branch
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_cbranch_scc1
+// DISASM-NEXT: s_mov_b32 s0, s4
+// DISASM-NEXT: s_endpgm
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \
@@ -40,6 +35,7 @@
 .p2align 8
 .type test_tensor_branch_guard,@function
 test_tensor_branch_guard:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_cbranch_scc1 .Lskip
   s_mov_b32 s0, s4

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-local-def.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-local-def.s
@@ -1,0 +1,75 @@
+// COM: A gfx1250 A0 tensor descriptor can be formed well before the tensor
+// COM: load, leaving no disposable scalar delay immediately before the load.
+// COM: When a straight-line v_readfirstlane uniquely defines the descriptor
+// COM: base, relocate that definition with the multicast mask and leave the
+// COM: PC-sensitive tensor instruction at its linked address. The intervening
+// COM: K=128 WMMA and its single-instruction delay move as one source window,
+// COM: so the delay still immediately precedes the split sequence rather than
+// COM: incorrectly naming the source branch.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: WMMA co-exec validation: 0 hazards (1 WMMA instructions scanned)
+// API: hotswap: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} with preceding delay in source window
+// API: hotswap: tensor_load_to_lds: masked local descriptor definition at 0x
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_tensor_local_def>:
+// DISASM: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: tensor_load_to_lds s[24:27], s[4:11]
+// DISASM: v_readfirstlane_b32 s4, v40
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_local_def
+.p2align 8
+.type test_tensor_local_def,@function
+test_tensor_local_def:
+  v_readfirstlane_b32 s4, v40
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_tensor_local_def_end:
+.size test_tensor_local_def, .Ltest_tensor_local_def_end-test_tensor_local_def
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_local_def
+  .amdhsa_next_free_vgpr 41
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_local_def
+      .symbol: test_tensor_local_def.kd
+      .sgpr_count: 12
+      .vgpr_count: 28
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
@@ -1,7 +1,7 @@
 // COM: Test multi-site tensor_load_to_lds patching: multiple tensor_load
 // COM: instructions in a single kernel. Verifies:
-// COM:   - Each site is independently patched with its own s_pack_hh
-// COM:   - Idempotency guard correctly handles back-to-back patches
+// COM:   - Each site's canonical delay is independently replaced by s_pack_hh
+// COM:   - The idempotency guard recognizes every in-place pack
 // COM:   - DS + tensor coexistence in the same kernel
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -16,44 +16,35 @@
 
 // COM: Kernel 1: two tensor_load_to_lds with different descriptors
 // COM: (s[4:11] and s[16:23]). Both should be patched independently.
-// COM: The second tensor_load's predecessor after patching is the first's
-// COM: branch-back, not its own s_pack_hh — idempotency guard must not
-// COM: false-positive on it.
 // DISASM-LABEL: <test_tensor_multi_different>:
-// DISASM: s_branch
-// DISASM: s_branch
-// DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
+// DISASM-NOT: s_branch
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_pack_hh_b32_b16 s16, 0, s16
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[16:23]
+// DISASM-NEXT: s_endpgm
 
 // COM: Kernel 2: two tensor_load_to_lds sharing the same descriptor
-// COM: (s[4:11]). Both should still be patched — the idempotency guard
-// COM: checks the immediately preceding instruction, and after patching
-// COM: the first, the second's predecessor is an s_branch (not s_pack_hh).
+// COM: (s[4:11]). Both canonical delay slots should still be patched.
 // DISASM-LABEL: <test_tensor_multi_same>:
-// DISASM: s_branch
-// DISASM: s_branch
-// DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
+// DISASM-NOT: s_branch
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_endpgm
 
 // COM: Kernel 3: mixed DS 2-addr + tensor_load in the same kernel.
-// COM: Both patch types should coexist: DS expansion produces two
-// COM: single-address loads + wait bump, tensor produces s_pack_hh.
+// COM: Both patch types should coexist: DS expands through its trampoline and
+// COM: the tensor pass independently replaces its canonical delay in place.
 // DISASM-LABEL: <test_tensor_mixed_ds>:
 // DISASM-NOT: ds_load_2addr_stride64_b32
 // DISASM: s_branch
-// DISASM: s_wait_dscnt
-// DISASM: s_branch
-// DISASM: s_endpgm
+// DISASM: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_endpgm
 
 // COM: Idempotency
 // RUN: hotswap-rewrite %t.out.elf \
@@ -70,7 +61,9 @@
 .p2align 8
 .type test_tensor_multi_different,@function
 test_tensor_multi_different:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[16:23]
   s_endpgm
   s_nop 0
@@ -114,7 +107,9 @@ test_tensor_multi_different:
 .p2align 8
 .type test_tensor_multi_same,@function
 test_tensor_multi_same:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
   s_nop 0
@@ -160,6 +155,7 @@ test_tensor_multi_same:
 test_tensor_mixed_ds:
   ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
   s_wait_dscnt 0x0
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
   s_nop 0

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-must-cfg.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-must-cfg.s
@@ -1,0 +1,152 @@
+// Exercise the tensor descriptor low16 must analysis independently of the
+// canonical-delay and local-definition fallbacks. Positive cases prove the
+// descriptor on every path. Negative cases omit the delay and include an
+// intervening descriptor use so an unsound fact would incorrectly succeed.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.copy.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.copy.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.copy.out 2>&1 | %FileCheck --check-prefix=POS %s
+// RUN: hotswap-rewrite %t.copy.out amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.merge.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.merge.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.merge.out 2>&1 | %FileCheck --check-prefix=POS %s
+// RUN: hotswap-rewrite %t.merge.out amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.merge-clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.merge-clobber.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.loop-clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.loop-clobber.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.true16.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.true16.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.vopd.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.vopd.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.vopd.out 2>&1 | %FileCheck --check-prefix=POS %s
+// RUN: hotswap-rewrite %t.vopd.out amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.mixed-vopd.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.mixed-vopd.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=8 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.exec-zero.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.exec-zero.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=9 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.intervening-use.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.intervening-use.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=10 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.shared.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.shared.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.shared.out 2>&1 | %FileCheck --check-prefix=SHARED %s
+// RUN: hotswap-rewrite %t.shared.out amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// RUN: %clang -x assembler-with-cpp -DCASE=11 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.entry-loop.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.entry-loop.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=12 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.sgpr-overlap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.sgpr-overlap.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 | %FileCheck --check-prefix=NEG %s
+// RUN: %clang -x assembler-with-cpp -DCASE=13 -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.invariant-loop.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.invariant-loop.elf amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.invariant-loop.out 2>&1 | %FileCheck --check-prefix=POS %s
+// RUN: hotswap-rewrite %t.invariant-loop.out amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 --strict-mode --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// POS: descriptor low16 already zero at 0x
+// POS: RESULT: SUCCESS
+// NEG-NOT: descriptor low16 already zero
+// NEG: hotswap: error: tensor_load_to_lds at 0x
+// NEG: RESULT: ERROR
+// SHARED: masked local descriptor definition at 0x
+// SHARED: reusing masked descriptor definition at 0x
+// SHARED: RESULT: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_tensor_must_cfg
+.p2align 8
+.type test_tensor_must_cfg,@function
+test_tensor_must_cfg:
+#if CASE == 1
+  s_mov_b32 s20, 0
+  s_mov_b32 s4, s20
+#elif CASE == 2
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lzero_path
+  s_mov_b32 s4, 0
+  s_branch .Ltensor
+.Lzero_path:
+  s_mov_b32 s4, 0
+.Ltensor:
+#elif CASE == 3
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lunknown_path
+  s_mov_b32 s4, 0
+  s_branch .Ltensor
+.Lunknown_path:
+  s_mov_b32 s4, 1
+.Ltensor:
+#elif CASE == 4
+  s_mov_b32 s4, 0
+.Lloop:
+  s_mov_b32 s4, s20
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lloop
+#elif CASE == 5
+  v_mov_b32 v0, 0
+  v_add_f16 v0.l, v1.l, v2.l
+  v_readfirstlane_b32 s4, v0
+  s_cmp_eq_u32 s4, 0
+#elif CASE == 6
+  v_dual_mov_b32 v0, 0 :: v_dual_mov_b32 v1, 0
+  v_readfirstlane_b32 s4, v0
+#elif CASE == 7
+  v_dual_mov_b32 v0, 0 :: v_dual_add_nc_u32 v1, v2, v3
+  v_readfirstlane_b32 s4, v0
+  s_cmp_eq_u32 s4, 0
+#elif CASE == 8
+  s_mov_b64 exec, 0
+  v_mov_b32 v0, 0
+  v_readfirstlane_b32 s4, v0
+  s_mov_b64 exec, -1
+  s_cmp_eq_u32 s4, 0
+#elif CASE == 9
+  v_readfirstlane_b32 s4, v0
+  s_mov_b32 s20, s4
+#elif CASE == 10
+  v_readfirstlane_b32 s4, v0
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_nop 0
+#elif CASE == 11
+  v_mov_b32 v0, 0
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lentry_loop_done
+  s_mov_b64 exec, 0
+  s_branch test_tensor_must_cfg
+.Lentry_loop_done:
+  v_readfirstlane_b32 s4, v0
+  s_cmp_eq_u32 s4, 0
+#elif CASE == 12
+  v_mov_b32 v0, 0
+  v_readfirstlane_b32 s4, v0
+  s_mov_b64 s[4:5], s[20:21]
+  s_cmp_eq_u32 s4, 0
+#elif CASE == 13
+  s_mov_b32 s4, 0
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 test_tensor_must_cfg
+#else
+#error unsupported CASE
+#endif
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_tensor_must_cfg_end:
+.size test_tensor_must_cfg, .Ltest_tensor_must_cfg_end-test_tensor_must_cfg
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_tensor_must_cfg
+  .amdhsa_next_free_vgpr 8
+  .amdhsa_next_free_sgpr 28
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_must_cfg
+      .symbol: test_tensor_must_cfg.kd
+      .sgpr_count: 28
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
@@ -1,15 +1,27 @@
-// COM: Live tensor_load_to_lds descriptor SGPRs require save/restore around
-// COM: the A0 D# Group 1 mask clear. If the kernel consumes all addressable
-// COM: SGPRs, hotswap must fail instead of returning unsafe code.
+// COM: Replacing the canonical delay in place needs no scratch register. A
+// COM: kernel declaring all user-addressable SGPRs must therefore rewrite
+// COM: successfully without changing SGPR metadata.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefixes=LOG,API %s
-// LOG: hotswap: error: tensor_load_to_lds descriptor save: no aligned block of 1 safe SGPRs fits below s106
-// API: RESULT: ERROR
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
+
+// DISASM-LABEL: <test_tensor_no_scratch>:
+// DISASM-NOT: s_branch
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s0, s4
+// DISASM-NEXT: s_endpgm
+
+// METADATA: .name:           test_tensor_no_scratch
+// METADATA: .sgpr_count:     106
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -17,6 +29,7 @@
 .p2align 8
 .type test_tensor_no_scratch,@function
 test_tensor_no_scratch:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_mov_b32 s0, s4
   s_endpgm

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -1,95 +1,54 @@
-// COM: Test the true trampoline fallback path for tensor_load_to_lds
-// COM: when no NOP sled is available. Two variants:
-// COM:   dead SGPR - s_pack_hh + tensor_load appended via growWithTrampolines
-// COM:   live SGPR - save/pack/tensor/restore appended via growWithTrampolines
-// COM: Both force emitReplacementCode to use emitToTrampoline.
+// COM: tensor_load_to_lds is PC-sensitive on gfx1250 A0 and cannot fall back
+// COM: to a NOP sled or appended trampoline. Mutate the instruction immediately
+// COM: before the tensor between an ordinary s_nop and the canonical scalar
+// COM: delay. The former must reach the missing-delay diagnostic; the latter
+// COM: must rewrite in place at the same tensor PC.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang -x assembler-with-cpp -DCANONICAL_DELAY=0 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.bad.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.bad.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --strict-mode --output %t.out.elf \
-// RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: SUCCESS
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=BAD %s
+// BAD-NOT: may be entered without executing its descriptor mask
+// BAD: hotswap: error: tensor_load_to_lds at 0x4 is not preceded by the canonical scalar delay
+// BAD: RESULT: ERROR
 
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-
-// COM: Kernel 1 (dead SGPR, no in-function sled): original tensor_load
-// COM: replaced by s_branch forward. Inter-function alignment padding is not a
-// COM: borrowable sled, so trampoline bodies are appended after the original
-// COM: functions.
-// DISASM-LABEL: <test_tensor_trampoline>:
-// DISASM-NEXT: s_branch
-// DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_endpgm
-// DISASM-NOT: tensor_load_to_lds
-
-// COM: Kernel 2 (live SGPR, no in-function sled): the original tensor_load is
-// COM: replaced by s_branch forward to its appended trampoline body.
-// DISASM-LABEL: <test_tensor_trampoline_live>:
-// DISASM-NEXT: s_branch
-// DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_nop 0
-// DISASM-NEXT: s_mov_b32
-// DISASM-NEXT: s_endpgm
-// DISASM-NOT: tensor_load_to_lds
-
-// COM: Dead-SGPR trampoline body: s_pack_hh + tensor_load + branch-back,
-// COM: appended in the trampoline pool section (a fresh vaddr above .text), so
-// COM: objdump emits a section header between .text and the pool -- use DISASM
-// COM: (not DISASM-NEXT) to cross that boundary.
-// DISASM: s_pack_hh_b32_b16
-// DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_branch
-
-// COM: Live-SGPR trampoline body (for kernel 2): save + pack + tensor + restore
-// COM: followed by branch-back.
-// DISASM-NEXT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// RUN: %clang -x assembler-with-cpp -DCANONICAL_DELAY=1 \
+// RUN:   -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.good.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.good.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.good.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=GOOD %s
+// GOOD: tensor_load_to_lds: in-place descriptor mask at 0x0; tensor remains at 0x4
+// GOOD: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.good.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_tensor_no_delay>:
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
-// DISASM-NEXT: s_branch
-
-// COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --strict-mode --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_endpgm
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
-.globl test_tensor_trampoline
+.globl test_tensor_no_delay
 .p2align 8
-.type test_tensor_trampoline,@function
-test_tensor_trampoline:
+.type test_tensor_no_delay,@function
+test_tensor_no_delay:
+#if CANONICAL_DELAY
+  s_delay_alu instid0(SALU_CYCLE_1)
+#else
+  s_nop 0
+#endif
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
-.Ltest_tensor_trampoline_end:
-.size test_tensor_trampoline, .Ltest_tensor_trampoline_end-test_tensor_trampoline
-
-// ---- Kernel 2: live SGPR, no NOP sled (persistent mask trampoline) --------
-
-.globl test_tensor_trampoline_live
-.p2align 8
-.type test_tensor_trampoline_live,@function
-test_tensor_trampoline_live:
-  tensor_load_to_lds s[0:3], s[4:11]
-  s_mov_b32 s0, s4
-  s_endpgm
-.Ltest_tensor_trampoline_live_end:
-.size test_tensor_trampoline_live, .Ltest_tensor_trampoline_live_end-test_tensor_trampoline_live
+.Ltest_tensor_no_delay_end:
+.size test_tensor_no_delay, .Ltest_tensor_no_delay_end-test_tensor_no_delay
 
 .rodata
 .p2align 8
-.amdhsa_kernel test_tensor_trampoline
-  .amdhsa_next_free_vgpr 1
-  .amdhsa_next_free_sgpr 12
-.end_amdhsa_kernel
-
-.p2align 8
-.amdhsa_kernel test_tensor_trampoline_live
+.amdhsa_kernel test_tensor_no_delay
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
@@ -99,18 +58,8 @@ test_tensor_trampoline_live:
     - 3
     - 0
   amdhsa.kernels:
-    - .name: test_tensor_trampoline
-      .symbol: test_tensor_trampoline.kd
-      .sgpr_count: 12
-      .vgpr_count: 1
-      .kernarg_segment_size: 0
-      .group_segment_fixed_size: 0
-      .private_segment_fixed_size: 0
-      .kernarg_segment_align: 8
-      .wavefront_size: 64
-      .max_flat_workgroup_size: 256
-    - .name: test_tensor_trampoline_live
-      .symbol: test_tensor_trampoline_live.kd
+    - .name: test_tensor_no_delay
+      .symbol: test_tensor_no_delay.kd
       .sgpr_count: 12
       .vgpr_count: 1
       .kernarg_segment_size: 0

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,19 +1,17 @@
-// COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
-// COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
-// COM: the descriptor's base SGPR. Base operand variants via NOP sled:
-// COM:   dead SGPR - only s_pack_hh prepended (no save/restore)
-// COM:   live SGPR - s_mov save, s_pack_hh, tensor, s_mov restore
+// COM: Test the gfx1250 A0 tensor_load_to_lds multicast fix. The compiler's
+// COM: canonical one-cycle scalar delay immediately before each tensor load is
+// COM: replaced in place by s_pack_hh_b32_b16. The tensor instruction remains
+// COM: at its linked PC and no trampoline or scratch register is used.
 // COM:   alt descriptor - different SGPR range (s[16:23]) for pack target
-// COM:   SGPR redef - descriptor SGPR overwritten before use (dead path)
-// COM:   zero-size FUNC - live path when the function symbol has st_size == 0
+// COM:   SGPR redef - descriptor SGPR overwritten before its next use
+// COM:   zero-size FUNC - kernel lookup when the function has st_size == 0
 // COM:   four-group tensor - operand 1 is still D# Group 1 and patches s4
-// COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
-// COM: s_branch checks.
+// COM: Verifies per-kernel behavior with CHECK-LABEL blocks.
 // COM:
 // COM: Companion tests:
-// COM:   hotswap-trampoline-tensor-nosled.s     - trampoline fallback path
+// COM:   hotswap-trampoline-tensor-nosled.s     - missing-delay failure path
 // COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
-// COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
+// COM:   hotswap-trampoline-tensor-liveness.s   - control-flow edge case
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,7 +21,7 @@
 // RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API-NOT: kernel descriptor symbol '.kd' not found
-// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
+// API: hotswap: tensor_load_to_lds: in-place descriptor mask at 0x
 // API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
@@ -31,84 +29,59 @@
 
 // COM: --- Per-kernel checks ---
 
-// COM: Kernel 1 (dead SGPR): s_branch forward to sled, s_pack_hh and
-// COM: tensor_load_to_lds appear in sled area, s_branch back to original
-// COM: stream. No v_writelane/v_readlane since descriptor SGPR is dead
-// COM: (s_endpgm follows immediately).
+// COM: Kernel 1 (dead SGPR): the canonical delay becomes the descriptor mask.
 // DISASM-LABEL: <test_tensor_dead>:
-// DISASM-NOT: v_writelane_b32
-// DISASM-NOT: v_readlane_b32
-// DISASM: s_branch
-// DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
-// DISASM-NOT: v_writelane_b32
-// DISASM-NOT: v_readlane_b32
+// DISASM-NOT: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_endpgm
 
-// COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
-// COM: tensor/restore sequence in sled area with branch-back.
-// COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
-// COM: save/restore via a scratch SGPR is required.
+// COM: Kernel 2 (live SGPR): s4 is used after tensor_load_to_lds, and observes
+// COM: the persistently normalized descriptor. No scratch SGPR is required.
 // DISASM-LABEL: <test_tensor_live>:
-// DISASM: s_branch
-// DISASM: s_endpgm
-// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds
-// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
-// DISASM-NEXT: s_branch
+// DISASM-NOT: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s0, s4
+// DISASM-NEXT: s_endpgm
 
 // COM: Kernel 3 (alternate descriptor s[16:23]): verifies
 // COM: getDescriptorBaseSgpr correctly extracts s16 from a different
 // COM: SReg_256 range. s_pack_hh should target s16, not s4.
 // COM: SGPR is dead (s_endpgm follows).
 // DISASM-LABEL: <test_tensor_alt_descriptor>:
-// DISASM-NOT: v_writelane_b32
-// DISASM: s_branch
-// DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16 s16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
+// DISASM-NOT: s_branch
+// DISASM: s_pack_hh_b32_b16 s16, 0, s16
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[16:23]
+// DISASM-NEXT: s_endpgm
 
 // COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
 // COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
-// COM: isSgprLiveAfter sees a def-before-use and takes the dead path,
-// COM: so no save/restore is needed.
+// COM: The persistent mask remains safe when the descriptor is redefined.
 // DISASM-LABEL: <test_tensor_sgpr_redef>:
-// DISASM-NOT: v_writelane_b32
-// DISASM-NOT: v_readlane_b32
-// DISASM: s_branch
-// DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16
-// DISASM: tensor_load_to_lds
-// DISASM: s_branch
-// DISASM-NOT: v_writelane_b32
-// DISASM-NOT: v_readlane_b32
+// DISASM-NOT: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s4, 0
+// DISASM-NEXT: s_endpgm
 
 // COM: Kernel 5 (zero-size FUNC): real Tensile objects can omit `.size`,
 // COM: leaving the FUNC symbol with st_size == 0. Kernel lookup must still
-// COM: find its descriptor so scratch allocation succeeds. This kernel has no
-// COM: bounded local sled, so the replacement body is emitted in the appended
-// COM: trampoline pool and checked after Kernel 6.
+// COM: find its descriptor even though the rewrite itself is purely in place.
 // DISASM-LABEL: <test_tensor_zero_size>:
-// DISASM: s_branch
-// DISASM: s_mov_b32 s0, s4
-// DISASM-NEXT: s_endpgm
-// DISASM: s_mov_b32 [[ZERO_SCRATCH:s[0-9]+]], s4
-// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NOT: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_mov_b32 s4, [[ZERO_SCRATCH]]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_mov_b32 s0, s4
+// DISASM-NEXT: s_endpgm
 
 // COM: Kernel 6 (four-group tensor): operand 1 is D# Group 1, so the
 // COM: patch must clear s4 even though additional SGPR tuple operands follow.
 // DISASM-LABEL: <test_tensor_four_group>:
-// DISASM: s_branch
-// DISASM: s_endpgm
+// DISASM-NOT: s_branch
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_endpgm
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
 // RUN: hotswap-rewrite %t.out.elf \
@@ -125,6 +98,7 @@
 .p2align 8
 .type test_tensor_dead,@function
 test_tensor_dead:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
   s_nop 0
@@ -152,6 +126,7 @@ test_tensor_dead:
 .p2align 8
 .type test_tensor_live,@function
 test_tensor_live:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_mov_b32 s0, s4
   s_endpgm
@@ -180,6 +155,7 @@ test_tensor_live:
 .p2align 8
 .type test_tensor_alt_descriptor,@function
 test_tensor_alt_descriptor:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[16:23]
   s_endpgm
   s_nop 0
@@ -207,6 +183,7 @@ test_tensor_alt_descriptor:
 .p2align 8
 .type test_tensor_sgpr_redef,@function
 test_tensor_sgpr_redef:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_mov_b32 s4, 0
   s_endpgm
@@ -235,6 +212,7 @@ test_tensor_sgpr_redef:
 .p2align 8
 .type test_tensor_zero_size,@function
 test_tensor_zero_size:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11]
   s_mov_b32 s0, s4
   s_endpgm
@@ -262,6 +240,7 @@ test_tensor_zero_size:
 .p2align 8
 .type test_tensor_four_group,@function
 test_tensor_four_group:
+  s_delay_alu instid0(SALU_CYCLE_1)
   tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
   s_endpgm
   s_nop 0

--- a/amd/comgr/test-lit/hotswap-unowned-gateway-closure.s
+++ b/amd/comgr/test-lit/hotswap-unowned-gateway-closure.s
@@ -1,0 +1,98 @@
+// COM: A pass-one far rewrite may place an exact materialized call-tail gateway
+// COM: in certified NOP padding immediately after a sized function. The
+// COM: gateway has no function owner, but its unique direct-call ingress,
+// COM: terminal predecessor, exact instruction shape, and executable-pool
+// COM: destination make it as statically known as an ordinary direct transfer.
+// COM: Recognizing
+// COM: it on pass two preserves global control-flow completeness and the
+// COM: independent DS2 alignment proof.
+
+// RUN: %clang -x assembler-with-cpp -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.nometa.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.nometa.out.elf 2>&1 | %FileCheck --check-prefix=FIRST %s
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.nometa.out2.elf 2>&1 | %FileCheck --check-prefix=SECOND %s
+// RUN: cmp %t.nometa.out.elf %t.nometa.out2.elf
+
+// COM: A non-entry symbol inside the sequence invalidates the certificate.
+// RUN: llvm-objcopy --add-symbol=gateway_interior=.text:0x2c,local \
+// RUN:   %t.nometa.out.elf %t.interior-symbol.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.interior-symbol.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=INTERIOR %s
+
+// COM: An empty kernel array is also not a target-state certificate.
+// RUN: %clang -x assembler-with-cpp -DEMPTY_METADATA -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.empty.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.empty.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.empty.out.elf 2>&1 | %FileCheck --check-prefix=FIRST %s
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.empty.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.empty.out2.elf 2>&1 | %FileCheck --check-prefix=SECOND %s
+// RUN: cmp %t.empty.out.elf %t.empty.out2.elf
+
+// FIRST: ds_2addr: preserved proven-aligned ds_load_2addr_b64 at 0xC
+// FIRST: assigned 1 SCC-neutral forward gateway(s)
+// FIRST: RESULT: SUCCESS
+
+// SECOND-NOT: incomplete control-flow targets
+// SECOND: recognized materialized PC transfer [0x28, 0x34) -> 0x{{[0-9A-F]+}}
+// SECOND-NOT: incomplete control-flow targets
+// SECOND: ds_2addr: preserved proven-aligned ds_load_2addr_b64 at 0xC
+// SECOND: applied 0 instruction patches
+// SECOND: RESULT: SUCCESS
+
+// INTERIOR-NOT: recognized materialized PC transfer [0x28, 0x34)
+// INTERIOR: incomplete control-flow targets disable NOP padding donation
+// INTERIOR: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// This B0 DS2 is legal on A0 because v4 is proven 8-byte aligned. It is
+// intentionally retained on pass one and must remain proven on pass two.
+.local aligned_site
+.type aligned_site,@function
+aligned_site:
+  v_add_nc_u32_e64 v4, 0x4000, 0
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_endpgm
+.size aligned_site, .-aligned_site
+
+// This unproven DS2 forces an appended far trampoline. The definition after
+// the site proves s[2:3] dead at the resume point, avoiding kernel metadata.
+.local gateway_source
+.type gateway_source,@function
+gateway_source:
+  ds_load_2addr_b64 v[0:3], v4 offset0:1 offset1:2
+  s_mov_b64 s[2:3], 0
+  s_endpgm
+.size gateway_source, .-gateway_source
+
+// Exactly one 20-byte generated gateway reservation. Its 12-byte call tail is
+// unowned .text padding immediately after a sized, no-fallthrough function.
+.rept 5
+  s_nop 0
+.endr
+
+// Keep the appended trampoline more than one s_branch hop from the source and
+// leave no intermediate NOP islands.
+.rept 100000
+  s_mov_b32 s0, s1
+.endr
+
+#ifdef EMPTY_METADATA
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels: []
+.end_amdgpu_metadata
+#endif

--- a/amd/comgr/test-lit/hotswap-wmma-combined-delay-whole-pass-ownership.s
+++ b/amd/comgr/test-lit/hotswap-wmma-combined-delay-whole-pass-ownership.s
@@ -1,0 +1,147 @@
+// A per-instruction WMMA split can atomically relocate every instruction in a
+// combined-delay window before whole-function passes run. Those later passes
+// still analyze the immutable decoded stream, so they must honor ownership of
+// the linked addresses rather than queue a second replacement for bytes that
+// are reserved for the source branch. Exercise an overlapping co-exec VALU, an
+// overlapping VOP3PX2 scale instruction, and a disjoint co-exec VALU.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.hazard.elf
+// RUN: rm -f %t.hazard.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.hazard.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.hazard.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=HAZARD %s
+// RUN: test ! -e %t.hazard.out.elf
+// HAZARD: WMMA co-exec hazard at 0x{{[0-9A-F]+}}
+// HAZARD: WMMA co-exec validation: 1 hazards (2 WMMA instructions scanned)
+// HAZARD: WMMA split: delay-window member at 0x{{[0-9A-F]+}} requires a separate HotSwap patch
+// HAZARD: WMMA split: protected site at 0x{{[0-9A-F]+}} would suppress another required HotSwap patch
+// HAZARD: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.scale.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.scale.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.scale.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=SCALE %s
+// SCALE: VOP3PX2 SRC2 fix at 0x{{[0-9A-F]+}}: v_wmma_scale_f32_16x16x128_f8f6f4 scale_src2 -> VGPR0
+// SCALE: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay
+// SCALE: RESULT: SUCCESS
+
+// The source interval is one branch plus seven padding dwords. If the later
+// bit-field pass instead touched the stale VOP3PX2 address, one of these nops
+// would be corrupted. The scale instruction itself survives in the relocated
+// body after being corrected before the source window is copied.
+// RUN: %llvm-objdump -d %t.scale.out.elf \
+// RUN:   | %FileCheck --check-prefix=SCALE-DISASM %s
+// SCALE-DISASM-LABEL: <test_whole_pass_ownership>:
+// SCALE-DISASM-NEXT: s_branch
+// SCALE-DISASM-COUNT-7: s_nop 0
+// SCALE-DISASM-NEXT: s_delay_alu instid0(VALU_DEP_1)
+// SCALE-DISASM: v_wmma_scale_f32_16x16x128_f8f6f4
+// SCALE-DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// SCALE-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+
+// RUN: hotswap-rewrite %t.scale.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.disjoint.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.disjoint.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.disjoint.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=DISJOINT %s
+// DISJOINT: WMMA co-exec hazard at 0x{{[0-9A-F]+}}
+// DISJOINT: WMMA co-exec validation: 1 hazards (2 WMMA instructions scanned)
+// DISJOINT: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay
+// DISJOINT: WMMA co-exec requirement composed into replacement at 0x{{[0-9A-F]+}} (8 leading v_nop(s))
+// DISJOINT: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.disjoint.out.elf \
+// RUN:   | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_whole_pass_ownership>:
+// DISASM: v_wmma_i32_16x16x64_iu8
+// DISASM-NEXT: s_branch
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-COUNT-8: v_nop
+// DISASM-NEXT: v_add_f32{{(_e32)?}} v16, v0, v1
+
+// RUN: hotswap-rewrite %t.disjoint.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_whole_pass_ownership
+.p2align 8
+.type test_whole_pass_ownership,@function
+test_whole_pass_ownership:
+#if CASE == 1
+  // The integer WMMA's first overlapping VALU is also the first target of the
+  // combined delay owned by the later split. The whole-function hazard pass
+  // must not install another trampoline at its stale linked address.
+  v_wmma_i32_16x16x64_iu8 v[16:23], v[0:7], v[8:15], v[16:23]
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_add_f32 v16, v0, v1
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_nop 0
+  v_mov_b32 v61, v60
+#elif CASE == 2
+  // The VOP3PX2 field fix is in-place and same-size. It must run before the
+  // combined window is copied, so the corrected bytes move with the window
+  // and no later pass mutates the linked address reserved for its source edge.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  v_mov_b32 v63, v62
+  v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[8:23], v[24:35], v[40:47], v1, v2 matrix_a_fmt:MATRIX_FMT_BF8 matrix_b_fmt:MATRIX_FMT_FP6 matrix_a_scale:MATRIX_SCALE_ROW1 matrix_b_scale:MATRIX_SCALE_ROW1
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_nop 0
+  v_mov_b32 v61, v60
+#elif CASE == 3
+  // A hazard entirely after the claimed source window is independent and
+  // remains eligible for its own trampoline.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_mov_b32 v63, v62
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_nop 0
+  v_mov_b32 v61, v60
+  v_wmma_i32_16x16x64_iu8 v[16:23], v[0:7], v[8:15], v[16:23]
+  v_add_f32 v16, v0, v1
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Ltest_whole_pass_ownership_end:
+.size test_whole_pass_ownership, .Ltest_whole_pass_ownership_end-test_whole_pass_ownership
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_whole_pass_ownership
+  .amdhsa_next_free_vgpr 64
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_whole_pass_ownership
+      .symbol: test_whole_pass_ownership.kd
+      .sgpr_count: 2
+      .vgpr_count: 64
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-hazard-composition.s
+++ b/amd/comgr/test-lit/hotswap-wmma-hazard-composition.s
@@ -1,0 +1,132 @@
+// A WMMA co-execution requirement and an ordinary FP8 CLAMP correction can
+// target the same instruction. The central replacement owner must prepend the
+// required v_nops to the FP8 emulation body instead of queuing two competing
+// source rewrites. Exercise both appended-trampoline and owned-sled placement.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trampoline.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.trampoline.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.trampoline.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=API,PACK %s
+// RUN: %llvm-objdump -d %t.trampoline.out.elf \
+// RUN:   | %FileCheck --check-prefix=TRAMPOLINE %s
+// RUN: hotswap-rewrite %t.trampoline.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.sled.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.sled.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.sled.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=API,PACK %s
+// RUN: %llvm-objdump -d %t.sled.out.elf \
+// RUN:   | %FileCheck --check-prefix=SLED %s
+// RUN: hotswap-rewrite %t.sled.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// The unpack patch calls emitToTrampoline directly rather than the sled-aware
+// emitReplacementCode entry point. It must use the same single composition
+// transaction and must not prepend the requirement twice.
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.direct.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.direct.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.direct.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=API,UNPACK %s
+// RUN: %llvm-objdump -d %t.direct.out.elf \
+// RUN:   | %FileCheck --check-prefix=DIRECT %s
+// RUN: hotswap-rewrite %t.direct.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// API: WMMA co-exec hazard at 0x{{[0-9A-F]+}}: v_wmma_i32_16x16x64_iu8 needs 8 v_nops
+// API: WMMA co-exec validation: 1 hazards (1 WMMA instructions scanned)
+// API: WMMA co-exec requirement composed into replacement at 0x{{[0-9A-F]+}} (8 leading v_nop(s))
+// PACK: cvt_pk_fp8_f32: patched CLAMP=1 (E5M3) at offset 0x{{[0-9A-F]+}}
+// UNPACK: cvt_f32_fp8: patched CLAMP=1 (E5M3) at offset 0x{{[0-9A-F]+}}
+// API: applied 2 instruction patches
+// API: RESULT: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+// TRAMPOLINE-LABEL: <test_wmma_hazard_composition>:
+// TRAMPOLINE-NEXT: v_wmma_i32_16x16x64_iu8
+// TRAMPOLINE-NEXT: s_branch
+// TRAMPOLINE-NEXT: s_nop 0
+// TRAMPOLINE-NEXT: s_endpgm
+// TRAMPOLINE-COUNT-8: v_nop
+// TRAMPOLINE-NEXT: s_mov_b32
+// TRAMPOLINE-NEXT: v_and_b32{{.*}}0x7fffffff, v1
+
+// SLED-LABEL: <test_wmma_hazard_composition>:
+// SLED-NEXT: v_wmma_i32_16x16x64_iu8
+// SLED-NEXT: s_branch
+// SLED-NEXT: s_nop 0
+// SLED-NEXT: s_endpgm
+// SLED-COUNT-8: v_nop
+// SLED-NEXT: s_mov_b32
+// SLED-NEXT: v_and_b32{{.*}}0x7fffffff, v1
+
+// DIRECT-LABEL: <test_wmma_hazard_composition>:
+// DIRECT-NEXT: v_wmma_i32_16x16x64_iu8
+// DIRECT-NEXT: s_branch
+// DIRECT-NEXT: s_nop 0
+// DIRECT-NEXT: s_endpgm
+// DIRECT-COUNT-8: v_nop
+// DIRECT-NEXT: s_mov_b32
+// DIRECT-NEXT: v_and_b32{{.*}}0xff, v1
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_hazard_composition
+.p2align 8
+.type test_wmma_hazard_composition,@function
+test_wmma_hazard_composition:
+  v_wmma_i32_16x16x64_iu8 v[16:23], v[0:7], v[8:15], v[16:23]
+#if CASE == 3
+  v_cvt_f32_fp8 v16, v1 clamp
+#else
+  v_cvt_pk_fp8_f32 v16, v1, v2 clamp
+#endif
+  s_endpgm
+#if CASE == 2
+  .rept 96
+  s_nop 0
+  .endr
+#elif CASE != 1 && CASE != 3
+  .error "CASE must select a test body"
+#endif
+.Ltest_wmma_hazard_composition_end:
+.size test_wmma_hazard_composition, .Ltest_wmma_hazard_composition_end-test_wmma_hazard_composition
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_hazard_composition
+  .amdhsa_next_free_vgpr 24
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_hazard_composition
+      .symbol: test_wmma_hazard_composition.kd
+      .sgpr_count: 2
+      .vgpr_count: 24
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge-long-branch.s
@@ -1,0 +1,60 @@
+// Combined-delay demerge is limited to a short trampoline. A far source would
+// replace the delay window with generated set-PC control flow that tensor-mask
+// idempotence does not treat as a straight-line local definition. Fail before
+// mutating the predecessor or writing a partially rewritten output.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: rm -f %t.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: test ! -e %t.out.elf
+// API: WMMA split: combined-delay demerge at 0x{{[0-9A-F]+}} requires a short trampoline
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_demerge_far
+.p2align 8
+.type test_wmma_delay_demerge_far,@function
+test_wmma_delay_demerge_far:
+  v_readfirstlane_b32 s4, v40
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_wmma_delay_demerge_far_end:
+.size test_wmma_delay_demerge_far, .Ltest_wmma_delay_demerge_far_end-test_wmma_delay_demerge_far
+
+// Keep the trampoline pool beyond s_branch reach without extending the
+// function or creating another gateway sled.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_delay_demerge_far
+  .amdhsa_next_free_vgpr 41
+  .amdhsa_next_free_sgpr 28
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_delay_demerge_far
+      .symbol: test_wmma_delay_demerge_far.kd
+      .sgpr_count: 28
+      .vgpr_count: 41
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge.s
@@ -1,0 +1,79 @@
+// A combined delay can protect both a source-side v_readfirstlane and the
+// PC-sensitive tensor load after a K=128 WMMA. Splitting only the WMMA would
+// leave the original delay naming a source branch. Demerge the two dependency
+// IDs instead: relocate the first delay target, split WMMA, and barrier, then
+// execute the second single-target delay from the vacated barrier slot. The
+// tensor stays at its linked address.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: WMMA co-exec validation: 0 hazards (1 WMMA instructions scanned)
+// API: hotswap: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay in source window
+// API: hotswap: tensor_load_to_lds: masked local descriptor definition at 0x
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_delay_demerge>:
+// DISASM: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: tensor_load_to_lds s[24:27], s[4:11]
+// DISASM: v_readfirstlane_b32 s4, v40
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_delay_alu instid0(VALU_DEP_2)
+// DISASM-NEXT: v_readfirstlane_b32 s19, v3
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_barrier_wait 0xffff
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_demerge
+.p2align 8
+.type test_wmma_delay_demerge,@function
+test_wmma_delay_demerge:
+  v_readfirstlane_b32 s4, v40
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_wmma_delay_demerge_end:
+.size test_wmma_delay_demerge, .Ltest_wmma_delay_demerge_end-test_wmma_delay_demerge
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_delay_demerge
+  .amdhsa_next_free_vgpr 41
+  .amdhsa_next_free_sgpr 20
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_delay_demerge
+      .symbol: test_wmma_delay_demerge.kd
+      .sgpr_count: 20
+      .vgpr_count: 41
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-general.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-general.s
@@ -1,0 +1,237 @@
+// Exercise combined-delay repair from encoded dependency geometry rather than
+// one compiler schedule. The positive cases vary dependency classes, skip
+// spans, and intervening TRANS history. The negative cases require fail-closed
+// behavior when the adjusted TRANS ordinal is not encodable or a moved member
+// affects control flow.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.classes.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.classes.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.classes.out \
+// RUN:   2>&1 | %FileCheck --check-prefix=CLASSES-API %s
+// RUN: %llvm-objdump -d %t.classes.out \
+// RUN:   | %FileCheck --check-prefix=CLASSES-DISASM %s
+// CLASSES-API: WMMA split: patched {{.*}} by demerging combined delay
+// CLASSES-API: RESULT: SUCCESS
+// CLASSES-DISASM-LABEL: <test_wmma_delay_general>:
+// CLASSES-DISASM: s_delay_alu instid0(VALU_DEP_3)
+// CLASSES-DISASM-NEXT: v_mov_b32_e32 v60, v60
+// CLASSES-DISASM: s_delay_alu instid0(SALU_CYCLE_2)
+// CLASSES-DISASM-NEXT: s_mov_b32 s19, s19
+// CLASSES-DISASM-NEXT: s_nop 0
+// CLASSES-DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// CLASSES-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// CLASSES-DISASM-NEXT: s_barrier_wait 0xffff
+
+// With no later TRANS, old TRANS_DEP_2 names a producer older than the source
+// WMMA. One additional split TRANS shifts it to the last encodable ordinal.
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans-remap.elf
+// RUN: hotswap-rewrite %t.trans-remap.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.trans-remap.out | %FileCheck --check-prefix=TRANS2-API %s
+// RUN: %llvm-objdump -d %t.trans-remap.out \
+// RUN:   | %FileCheck --check-prefix=TRANS2-DISASM %s
+// TRANS2-API: RESULT: SUCCESS
+// TRANS2-DISASM-LABEL: <test_wmma_delay_general>:
+// TRANS2-DISASM: s_delay_alu instid0(TRANS32_DEP_3)
+// TRANS2-DISASM-NEXT: v_mov_b32_e32 v60, v60
+
+// A later TRANS makes the original WMMA the second prior TRANS; its semantic
+// producer maps to the last split half and therefore keeps DEP_2 unchanged.
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans-later.elf
+// RUN: hotswap-rewrite %t.trans-later.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.trans-later.out | %FileCheck --check-prefix=LATER-API %s
+// RUN: %llvm-objdump -d %t.trans-later.out \
+// RUN:   | %FileCheck --check-prefix=LATER-DISASM %s
+// LATER-API: RESULT: SUCCESS
+// LATER-DISASM-LABEL: <test_wmma_delay_general>:
+// LATER-DISASM: s_delay_alu instid0(TRANS32_DEP_2)
+// LATER-DISASM-NEXT: v_mov_b32_e32 v60, v60
+// LATER-DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// LATER-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// LATER-DISASM-NEXT: v_sin_f32_e32 v50, v51
+
+// TRANS_DEP_3 with no later TRANS would require unencodable DEP_4.
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans-overflow.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.trans-overflow.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=TRANS3 %s
+// TRANS3: has an unrepresentable TRANS dependency after split
+// TRANS3: RESULT: ERROR
+
+// A branch inside the protected interval cannot be moved into the trampoline.
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.control.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.control.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CONTROL %s
+// CONTROL: has a non-relocatable instruction in its delay window
+// CONTROL: RESULT: ERROR
+
+// The second dependency may be reconstructed in a generic dword slot. When
+// that slot contains the canonical scalar delay, tensor masking may consume it
+// even though the immutable instruction there was the moved predecessor.
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.tensor.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.tensor.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.tensor.out \
+// RUN:   2>&1 | %FileCheck --check-prefix=TENSOR-API %s
+// RUN: %llvm-objdump -d %t.tensor.out \
+// RUN:   | %FileCheck --check-prefix=TENSOR-DISASM %s
+// TENSOR-API: WMMA split: patched {{.*}} by demerging combined delay
+// TENSOR-API: tensor_load_to_lds: in-place descriptor mask
+// TENSOR-API: RESULT: SUCCESS
+// TENSOR-DISASM-LABEL: <test_wmma_delay_general>:
+// TENSOR-DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// TENSOR-DISASM-NEXT: tensor_load_to_lds s[24:27], s[4:11]
+
+// A non-callable symbol can own bytes even when its start lies before the
+// source head. Its extent, not only its address, blocks relocation.
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.extent.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.extent.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=EXTENT %s
+// EXTENT: overlaps a sized non-callable text symbol
+// EXTENT: RESULT: ERROR
+
+// If the WMMA is itself the second target, both reconstructed dependencies
+// move before the replacement and no TRANS ordinal adjustment is needed.
+// RUN: %clang -x assembler-with-cpp -DCASE=8 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.second-target.elf
+// RUN: hotswap-rewrite %t.second-target.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.second-target.out \
+// RUN:   | %FileCheck --check-prefix=SECOND-API %s
+// RUN: %llvm-objdump -d %t.second-target.out \
+// RUN:   | %FileCheck --check-prefix=SECOND-DISASM %s
+// SECOND-API: RESULT: SUCCESS
+// SECOND-DISASM-LABEL: <test_wmma_delay_general>:
+// SECOND-DISASM: s_delay_alu instid0(VALU_DEP_1)
+// SECOND-DISASM-NEXT: s_mov_b32 s19, s19
+// SECOND-DISASM-NEXT: s_nop 0
+// SECOND-DISASM-NEXT: s_delay_alu instid0(TRANS32_DEP_2)
+// SECOND-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// SECOND-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+
+// gfx1250 non-XDL WMMA uses the VALU pipeline and must not advance a TRANS
+// dependency ordinal. With no later TRANS, DEP_2 still shifts to DEP_3.
+// RUN: %clang -x assembler-with-cpp -DCASE=9 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.non-xdl.elf
+// RUN: hotswap-rewrite %t.non-xdl.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.non-xdl.out | %FileCheck --check-prefix=NON-XDL-API %s
+// RUN: %llvm-objdump -d %t.non-xdl.out \
+// RUN:   | %FileCheck --check-prefix=NON-XDL-DISASM %s
+// NON-XDL-API: RESULT: SUCCESS
+// NON-XDL-DISASM-LABEL: <test_wmma_delay_general>:
+// NON-XDL-DISASM: s_delay_alu instid0(TRANS32_DEP_3)
+// NON-XDL-DISASM-NEXT: s_barrier_wait 0xffff
+
+// F64 DPMACC may carry the TRANS TSFlag but AMDGPUInsertDelayAlu classifies it
+// as ordinary VALU. It likewise must not hide the required DEP_2 -> DEP_3
+// adjustment.
+// RUN: %clang -x assembler-with-cpp -DCASE=10 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.dpmacc.elf
+// RUN: hotswap-rewrite %t.dpmacc.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.dpmacc.out | %FileCheck --check-prefix=DPMACC-API %s
+// RUN: %llvm-objdump -d %t.dpmacc.out \
+// RUN:   | %FileCheck --check-prefix=DPMACC-DISASM %s
+// DPMACC-API: RESULT: SUCCESS
+// DPMACC-DISASM-LABEL: <test_wmma_delay_general>:
+// DPMACC-DISASM: s_delay_alu instid0(TRANS32_DEP_3)
+// DPMACC-DISASM-NEXT: s_barrier_wait 0xffff
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_general
+.p2align 8
+.type test_wmma_delay_general,@function
+test_wmma_delay_general:
+#if CASE == 1
+  s_delay_alu instid0(SALU_CYCLE_2) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+  s_mov_b32 s19, s19
+  s_nop 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 2
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 3
+  s_delay_alu instid0(FMA_ACCUM_CYCLE_1) | instskip(SKIP_3) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_sin_f32 v50, v51
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 4
+  s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(TRANS32_DEP_3)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 5
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(SALU_CYCLE_1)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_branch .Ltarget
+  s_barrier_wait 0xffff
+.Ltarget:
+  v_mov_b32 v60, v60
+#elif CASE == 6
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 7
+  .globl protected_text_object
+  .type protected_text_object,@object
+protected_text_object:
+  s_nop 0
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+.Lprotected_text_object_end:
+  .size protected_text_object, .Lprotected_text_object_end-protected_text_object
+#elif CASE == 8
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  s_nop 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 9
+  s_delay_alu instid0(FMA_ACCUM_CYCLE_1) | instskip(SKIP_3) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_wmma_f32_16x16x4_f32 v[40:47], v[48:49], v[50:51], v[40:47]
+  s_nop 0
+  s_barrier_wait 0xffff
+#elif CASE == 10
+  s_delay_alu instid0(FMA_ACCUM_CYCLE_1) | instskip(SKIP_3) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_rcp_f64 v[48:49], v[50:51]
+  s_nop 0
+  s_barrier_wait 0xffff
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Ltest_wmma_delay_general_end:
+.size test_wmma_delay_general, .Ltest_wmma_delay_general_end-test_wmma_delay_general

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-window-reject.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-window-reject.s
@@ -1,0 +1,176 @@
+// A protected WMMA is safe to split only when its immediately preceding
+// single-instruction delay can move with it as one unambiguous source window.
+// Assemble ten structural counterexamples from this file and require each to
+// fail closed.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.direct.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.direct.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=DIRECT %s
+// DIRECT: WMMA split: protected site at 0x{{[0-9A-F]+}} has a direct entry into the source-window interior
+// DIRECT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.overlap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.overlap.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=OVERLAP %s
+// OVERLAP: WMMA split: protected site at 0x{{[0-9A-F]+}} overlaps another delay or hard clause
+// OVERLAP: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.span.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.span.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SPAN %s
+// SPAN: WMMA split: protected site at 0x{{[0-9A-F]+}} has no supported preceding delay window
+// SPAN: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.indirect.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=INDIRECT %s
+// INDIRECT: WMMA split: protected site at 0x{{[0-9A-F]+}} cannot be relocated with an unresolved indirect entry
+// INDIRECT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.combined-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.combined-entry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=COMBINED-ENTRY %s
+// COMBINED-ENTRY: WMMA split: protected site at 0x{{[0-9A-F]+}} has a direct entry into the source-window interior
+// COMBINED-ENTRY: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.combined-def.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.combined-def.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=COMBINED-DEF %s
+// COMBINED-DEF: descriptor definition at 0x{{[0-9A-F]+}} is relocated; using linked delay slot for the mask
+// COMBINED-DEF: is not preceded by the canonical scalar delay
+// COMBINED-DEF: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.missing-first-id.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.missing-first-id.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=BAD-ID %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=8 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.missing-second-id.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.missing-second-id.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=BAD-ID %s
+// BAD-ID: WMMA split: protected site at 0x{{[0-9A-F]+}} {{(has no supported preceding delay window|has an unsupported combined dependency graph)}}
+// BAD-ID: RESULT: ERROR
+
+// COM: A successful WMMA demerge followed by a required tensor-mask failure
+// COM: must not write the partially mutated in-memory object to the output.
+// RUN: %clang -x assembler-with-cpp -DCASE=9 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.late-failure.elf
+// RUN: rm -f %t.late-failure.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.late-failure.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.late-failure.out.elf \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=LATE-FAIL %s
+// RUN: test ! -e %t.late-failure.out.elf
+// LATE-FAIL: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay
+// LATE-FAIL: tensor_load_to_lds at 0x{{[0-9A-F]+}} is not preceded by the canonical scalar delay
+// LATE-FAIL: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=10 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans32-dependency.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.trans32-dependency.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=TRANS32 %s
+// TRANS32: has an unrepresentable TRANS dependency after split
+// TRANS32: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_reject
+.p2align 8
+.type test_wmma_delay_reject,@function
+test_wmma_delay_reject:
+#if CASE == 1
+  // Target the first literal slot, not merely the WMMA instruction boundary.
+  // s_branch simm16=2 reaches PC+12 from this instruction at PC+0.
+  .long 0xBFA00002
+  s_delay_alu instid0(VALU_DEP_1)
+.Lwmma:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 2
+  s_delay_alu instid0(SALU_CYCLE_1)
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 3
+  // Reserved dependency ID 12 is malformed and retains the conservative
+  // maximum protection span, but cannot be reconstructed.
+  s_delay_alu 0xc
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_nop
+  v_nop
+  v_nop
+  v_nop
+  v_nop
+#elif CASE == 4
+  s_set_pc_i64 s[0:1]
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 5
+  // The predecessor is overwritten with the demerged tensor delay, so an
+  // independent edge to that slot must reject the complete transformation.
+  s_branch .Lcombined_barrier
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+.Lcombined_barrier:
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 6
+  // Tensor masking would otherwise try to patch this definition separately,
+  // overlapping the WMMA source window.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s4, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 7
+  // Both dependency IDs are required by the demerge proof.
+  s_delay_alu 0xb0
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 8
+  // A skip field without instid1 is malformed and retains the conservative
+  // six-instruction relocation protection.
+  s_delay_alu 0x32
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 9
+  // No straight-line definition of tensor base s4 exists. The WMMA demerge
+  // is valid, but the later required tensor mask must fail the whole rewrite.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 10
+  // With no later TRANS, splitting one WMMA into two would shift an older
+  // TRANS_DEP_3 producer to unencodable ordinal four.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(TRANS32_DEP_3)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Ltest_wmma_delay_reject_end:
+.size test_wmma_delay_reject, .Ltest_wmma_delay_reject_end-test_wmma_delay_reject

--- a/amd/comgr/test-lit/hotswap-wmma-split-indirect-entry-reject.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-indirect-entry-reject.s
@@ -1,0 +1,71 @@
+// Source relocation must fail closed for an unresolved set-PC transfer. A
+// tail set-PC is a return only when MC proves it or it uses the ABI link pair;
+// likewise, the rewriter's get-PC/add/set-PC exit shape is recognized only
+// when no direct edge enters its interior.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.tail-nonlink.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.tail-nonlink.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=TAIL %s
+// TAIL: source relocation disabled for function at 0x{{[0-9A-F]+}} by s_set_pc_i64 at 0x
+// TAIL: WMMA split: protected site at 0x{{[0-9A-F]+}} cannot be relocated with an unresolved indirect entry
+// TAIL: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.pc-relative-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.pc-relative-entry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=ALT %s
+// ALT: source relocation disabled for function at 0x{{[0-9A-F]+}} by s_set_pc_i64 at 0x
+// ALT: WMMA split: protected site at 0x{{[0-9A-F]+}} cannot be relocated with an unresolved indirect entry
+// ALT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.pc-relative-exit.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.pc-relative-exit.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.pc-relative-exit.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=KNOWN %s
+// KNOWN-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} with preceding delay in source window
+// KNOWN: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_indirect_entry_reject
+.p2align 8
+.type test_wmma_indirect_entry_reject,@function
+test_wmma_indirect_entry_reject:
+#if CASE == 1
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  // An arbitrary computed tail transfer is not an ABI return.
+  s_set_pc_i64 s[0:1]
+#elif CASE == 2
+  s_branch .Ladd
+  s_get_pc_i64 s[0:1]
+.Ladd:
+  s_add_nc_u64 s[0:1], s[0:1], 0x1000
+  s_set_pc_i64 s[0:1]
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+#elif CASE == 3
+  // The exact generated shape with a statically known exit and no interior
+  // entry is not an indirect destination ambiguity.
+  s_get_pc_i64 s[0:1]
+  s_add_nc_u64 s[0:1], s[0:1], 0x1000
+  s_set_pc_i64 s[0:1]
+  // Mandatory rewrites still patch CFG-unreachable instructions. Cover both
+  // an explicit dead MODE write and a second dead site with no local MODE.
+  s_set_vgpr_msb 0
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+#else
+  .error "CASE must select a test body"
+#endif
+.Ltest_wmma_indirect_entry_reject_end:
+.size test_wmma_indirect_entry_reject, .Ltest_wmma_indirect_entry_reject_end-test_wmma_indirect_entry_reject

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -1,6 +1,6 @@
 // COM: WMMA-split shares emitToTrampoline with the other patch families. A
-// COM: split site beyond s_branch's +-128 KB reach uses SGPR-backed set-PC
-// COM: sequences on both edges and never executes s_add_pc_i64. External NOP
+// COM: split site beyond s_branch's +-128 KB reach uses SGPR-backed PC
+// COM: transfers on both edges and never executes s_add_pc_i64. External NOP
 // COM: space supplies the forward gateway; non-NOP filler forces the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -17,9 +17,8 @@
 // COM: The site redirects through a safe gateway to two K=64 halves and
 // COM: returns through the SCC-neutral set-PC sequence.
 // DISASM-LABEL: <test_wsplit_far>:
-// DISASM-NEXT: s_branch
-// DISASM: s_get_pc_i64 s[0:1]
-// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
+// DISASM-NEXT: s_call_i64 s[0:1],
+// DISASM: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 // DISASM: v_wmma_f32_16x16x64_fp8_fp8
 // DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
@@ -1,0 +1,83 @@
+// Recover exact VGPR-MSB state through CFG joins instead of rejecting every
+// direct target. This covers a backedge loop, a nonzero fixed point, and a
+// non-MODE SETREG that must preserve the tracked fields.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-3: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_zero_loop>:
+// DISASM:       s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+// DISASM:       s_branch
+// DISASM:       s_cbranch_scc1
+// DISASM-LABEL: <test_wmma_nonzero_loop>:
+// DISASM:       s_set_vgpr_msb 0x60
+// DISASM:       s_branch
+// DISASM:       s_cbranch_scc1
+// DISASM-LABEL: <test_wmma_nonmode_setreg>:
+// DISASM:       s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_STATUS), 7
+// DISASM-NEXT:  s_branch
+// DISASM:       Disassembly of section :
+// DISASM:       v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+// DISASM-NEXT:  s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl test_wmma_zero_loop
+.p2align 8
+.type test_wmma_zero_loop,@function
+test_wmma_zero_loop:
+  // gfx1250's SETREG fixup writes VGPR-MSB fields from imm32[19:12], which
+  // are zero here even though the selected WAVE_MODE bit is set to one.
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+.Lzero_loop:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_cbranch_scc1 .Lzero_loop
+  s_endpgm
+.size test_wmma_zero_loop, .-test_wmma_zero_loop
+
+.globl test_wmma_nonzero_loop
+.p2align 8
+.type test_wmma_nonzero_loop,@function
+test_wmma_nonzero_loop:
+  s_set_vgpr_msb 0x60
+.Lnonzero_loop:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_cbranch_scc1 .Lnonzero_loop
+  s_endpgm
+.size test_wmma_nonzero_loop, .-test_wmma_nonzero_loop
+
+.globl test_wmma_nonmode_setreg
+.p2align 8
+.type test_wmma_nonmode_setreg,@function
+test_wmma_nonmode_setreg:
+  s_set_vgpr_msb 0x60
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_STATUS), 7
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_nonmode_setreg, .-test_wmma_nonmode_setreg

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
@@ -1,0 +1,27 @@
+// A merge that disagrees only in src1 must lose the complete VGPR-MSB mode.
+// This guards the four-field CFG lattice independently of the dst/src0 facts
+// used by DS2 alignment.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 | %FileCheck %s
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_src1_merge
+.p2align 8
+.type test_wmma_src1_merge,@function
+test_wmma_src1_merge:
+  s_cbranch_scc1 .Lzero
+  s_set_vgpr_msb 4
+  s_branch .Ljoin
+.Lzero:
+  s_set_vgpr_msb 0
+.Ljoin:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_src1_merge, .-test_wmma_src1_merge

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
@@ -1,0 +1,57 @@
+// A K-split's second half replaces src2 with dst. Even when neither source
+// slice crosses v255, the temporary src2 bank must therefore match the
+// incoming dst bank. Preserve and restore every other incoming mode field.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_k_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_branch
+// DISASM-LABEL: <test_wmma_k_vgpr_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[32:39], v[0:7], v[16:23], 0
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[32:39]{{.*}}, v[8:15], v[24:31], v[32:39]
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+// DISASM-NEXT: s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[32:39], v[0:7], v[16:23], v[40:47]
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[32:39]{{.*}}, v[8:15], v[24:31], v[32:39]
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_k_src2_role
+.p2align 8
+.type test_wmma_k_src2_role,@function
+test_wmma_k_src2_role:
+  // Incoming mode: dst=1, src2=2, src0=src1=0.
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_k_src2_role, .-test_wmma_k_src2_role
+
+.globl test_wmma_k_vgpr_src2_role
+.p2align 8
+.type test_wmma_k_vgpr_src2_role,@function
+test_wmma_k_vgpr_src2_role:
+  // The first half must read src2 from bank 2. The second half replaces that
+  // operand with dst and must therefore select bank 1 before restoring bank 2.
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[40:47]
+  s_endpgm
+.size test_wmma_k_vgpr_src2_role, .-test_wmma_k_vgpr_src2_role

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
@@ -1,0 +1,75 @@
+// A far crossing split needs a forward gateway. Source-window growth may move
+// the callable-entry VGPR-MSB setter only as the first copied instruction, so
+// every entry still establishes the original mode before either WMMA half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <test_wmma_vgpr_msb_far>:
+// DISASM-NEXT: s_call_i64 s[0:1],
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+// DISASM:      s_set_vgpr_msb 0
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[250:257], v[114:121], 0
+// DISASM-NEXT: s_set_vgpr_msb 1
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
+// DISASM-NEXT: s_set_vgpr_msb 0x100
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb_far
+.p2align 8
+.type test_wmma_vgpr_msb_far,@function
+test_wmma_vgpr_msb_far:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[162:169], v[250:265], v[114:129], 0
+  s_endpgm
+.Ltest_wmma_vgpr_msb_far_end:
+.size test_wmma_vgpr_msb_far, .Ltest_wmma_vgpr_msb_far_end-test_wmma_vgpr_msb_far
+
+// Safe external gateway space after the no-fallthrough terminator.
+.rept 8
+  s_nop 0
+.endr
+
+// Keep the appended pool beyond s_branch reach from the split site.
+.rept 40000
+  s_mov_b32 s3, s4
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_vgpr_msb_far
+  .amdhsa_next_free_vgpr 266
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_vgpr_msb_far
+      .symbol: test_wmma_vgpr_msb_far.kd
+      .sgpr_count: 0
+      .vgpr_count: 266
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
@@ -1,0 +1,57 @@
+// An M-split slices dst, src0, and VGPR src2 independently. Normalize every
+// upper-half base into its operand's mode field, keep broadcast src1 unchanged,
+// and restore the exact nonzero incoming mode after the upper half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-2: WMMA split: patched v_wmma_f32_32x16x128_f4
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_m_operand_roles>:
+// DISASM-NEXT:  s_set_vgpr_msb 9
+// DISASM-NEXT:  s_branch
+// DISASM-LABEL: <test_wmma_m_immediate_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 57
+// DISASM-NEXT:  s_branch
+// DISASM:      v_wmma_f32_16x16x128_f8f6f4 v[250:257], v[248:255], v[100:107], v[252:259]{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x95a
+// DISASM-NEXT: v_wmma_f32_16x16x128_f8f6f4 v[2:9]{{.*}}, v[0:7]{{.*}}, v[100:107]{{.*}}, v[4:11]{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x5a09
+// DISASM-NEXT: s_branch
+// DISASM:      v_wmma_f32_16x16x128_f8f6f4 v[250:257], v[248:255], v[100:107], 0{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x397a
+// DISASM-NEXT: v_wmma_f32_16x16x128_f8f6f4 v[2:9]{{.*}}, v[0:7]{{.*}}, v[100:107]{{.*}}, 0{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x7a39
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_m_operand_roles
+.p2align 8
+.type test_wmma_m_operand_roles,@function
+test_wmma_m_operand_roles:
+  // Incoming mode: src0=1, src1=2, src2=0, dst=0.
+  s_set_vgpr_msb 9
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], v[252:267]
+  s_endpgm
+.size test_wmma_m_operand_roles, .-test_wmma_m_operand_roles
+
+.globl test_wmma_m_immediate_src2_role
+.p2align 8
+.type test_wmma_m_immediate_src2_role,@function
+test_wmma_m_immediate_src2_role:
+  // Incoming mode: src0=1, src1=2, src2=3, dst=0. Immediate src2 does not
+  // consume its role, but the temporary mode must preserve it exactly.
+  s_set_vgpr_msb 0x39
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], 0
+  s_endpgm
+.size test_wmma_m_immediate_src2_role, .-test_wmma_m_immediate_src2_role

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
@@ -1,0 +1,35 @@
+// A direct call can enter the WMMA either with the function-entry mode or the
+// fallthrough can reach it after selecting a different destination bank. The
+// K-split sources do not cross v255, but the second half replaces immediate
+// src2 with dst and therefore still needs the ambiguous mode. Fail closed.
+// This also exercises s_call_i64's unusual target operand layout in the shared
+// direct-control-flow target index.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CHECK %s
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb_merge
+.p2align 8
+.type test_wmma_vgpr_msb_merge,@function
+test_wmma_vgpr_msb_merge:
+  s_call_i64 s[0:1], .Lwmma
+  s_set_vgpr_msb 0x40
+.Lwmma:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.Ltest_wmma_vgpr_msb_merge_end:
+.size test_wmma_vgpr_msb_merge, .Ltest_wmma_vgpr_msb_merge_end-test_wmma_vgpr_msb_merge
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_vgpr_msb_merge
+  .amdhsa_next_free_vgpr 266
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
@@ -1,0 +1,23 @@
+// A dynamic write to WAVE_MODE does not reveal the incoming VGPR-MSB fields.
+// Keep the required WMMA split fail-closed instead of assuming ABI entry mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_dynamic_mode
+.p2align 8
+.type test_wmma_dynamic_mode,@function
+test_wmma_dynamic_mode:
+  s_setreg_b32 hwreg(HW_REG_WAVE_MODE), s0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_dynamic_mode, .-test_wmma_dynamic_mode

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
@@ -1,0 +1,37 @@
+// On gfx1250, an immediate MODE write establishes all four VGPR-MSB fields.
+// Immediate bits [19:12] are rotated into s_set_vgpr_msb order; 0x81 becomes
+// mode 0x60 and must be restored around the split WMMA's upper half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_setreg_mode>:
+// DISASM:       s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 0x81000
+// DISASM:       s_branch
+// DISASM:       s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_setreg_mode
+.p2align 8
+.type test_wmma_setreg_mode,@function
+test_wmma_setreg_mode:
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 0x81000
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_setreg_mode, .-test_wmma_setreg_mode

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
@@ -1,0 +1,35 @@
+// Verify that a K-split whose upper source half crosses v255 changes the
+// gfx1250 VGPR-MSB mode around that half and restores the incoming mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_vgpr_msb>:
+// DISASM:      s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[250:257], v[114:121], 0
+// DISASM-NEXT: s_set_vgpr_msb 1
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
+// DISASM-NEXT: s_set_vgpr_msb 0x100
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb
+.p2align 8
+.type test_wmma_vgpr_msb,@function
+test_wmma_vgpr_msb:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[162:169], v[250:265], v[114:129], 0
+  s_endpgm
+.size test_wmma_vgpr_msb, .-test_wmma_vgpr_msb

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -19,6 +19,69 @@ static std::vector<uint8_t> makeText(size_t Size = 16) {
   return std::vector<uint8_t>(Size, 0);
 }
 
+static llvm::Expected<ElfView>
+createElfView(comgr_test::KernelDescriptorElf &Obj) {
+  return ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+}
+
+static bool relocateHeaderTable(std::vector<uint8_t> &Bytes,
+                                uint64_t OldOffset, uint16_t EntrySize,
+                                uint16_t OldCount, uint16_t NewCount,
+                                size_t MinimumEntrySize,
+                                uint64_t &NewOffset) {
+  if (NewCount < OldCount || EntrySize < MinimumEntrySize ||
+      OldOffset > Bytes.size())
+    return false;
+  const uint64_t OldSize = static_cast<uint64_t>(OldCount) * EntrySize;
+  if (OldSize > Bytes.size() - OldOffset)
+    return false;
+
+  std::vector<uint8_t> OldTable(
+      Bytes.begin() + static_cast<size_t>(OldOffset),
+      Bytes.begin() + static_cast<size_t>(OldOffset + OldSize));
+  NewOffset = comgr_test::alignTo8(Bytes.size());
+  const uint64_t NewSize = static_cast<uint64_t>(NewCount) * EntrySize;
+  if (NewOffset > std::numeric_limits<size_t>::max() - NewSize)
+    return false;
+  Bytes.resize(static_cast<size_t>(NewOffset + NewSize), 0);
+  std::memcpy(Bytes.data() + NewOffset, OldTable.data(), OldTable.size());
+  return true;
+}
+
+static bool setProgramHeaderCount(std::vector<uint8_t> &Bytes,
+                                  uint16_t NewCount) {
+  if (Bytes.size() < sizeof(llvm::ELF::Elf64_Ehdr))
+    return false;
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Bytes.data(), sizeof(Header));
+  uint64_t NewOffset = 0;
+  if (!relocateHeaderTable(Bytes, Header.e_phoff, Header.e_phentsize,
+                           Header.e_phnum, NewCount,
+                           sizeof(llvm::ELF::Elf64_Phdr), NewOffset))
+    return false;
+  Header.e_phoff = NewOffset;
+  Header.e_phnum = NewCount;
+  std::memcpy(Bytes.data(), &Header, sizeof(Header));
+  return true;
+}
+
+static bool setSectionHeaderCount(std::vector<uint8_t> &Bytes,
+                                  uint16_t NewCount) {
+  if (Bytes.size() < sizeof(llvm::ELF::Elf64_Ehdr))
+    return false;
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Bytes.data(), sizeof(Header));
+  uint64_t NewOffset = 0;
+  if (!relocateHeaderTable(Bytes, Header.e_shoff, Header.e_shentsize,
+                           Header.e_shnum, NewCount,
+                           sizeof(llvm::ELF::Elf64_Shdr), NewOffset))
+    return false;
+  Header.e_shoff = NewOffset;
+  Header.e_shnum = NewCount;
+  std::memcpy(Bytes.data(), &Header, sizeof(Header));
+  return true;
+}
+
 static unsigned readReservedSgprs(const std::vector<uint8_t> &Bytes,
                                   uint64_t KernelDescriptorOffset) {
   namespace hsa = llvm::amdhsa;
@@ -66,6 +129,26 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+TEST(ElfView, RejectsExtendedSymbolSectionIndices) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  llvm::ELF::Elf64_Shdr Symtab{};
+  std::memcpy(&Symtab,
+              Obj.Bytes.data() + Header.e_shoff + 4 * Header.e_shentsize,
+              sizeof(Symtab));
+  llvm::ELF::Elf64_Sym Kernel{};
+  const uint64_t KernelOffset = Symtab.sh_offset + sizeof(Kernel);
+  std::memcpy(&Kernel, Obj.Bytes.data() + KernelOffset, sizeof(Kernel));
+  Kernel.st_shndx = llvm::ELF::SHN_XINDEX;
+  std::memcpy(Obj.Bytes.data() + KernelOffset, &Kernel, sizeof(Kernel));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  EXPECT_FALSE((bool)View);
+  llvm::consumeError(View.takeError());
+}
+
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
 TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {
@@ -101,19 +184,75 @@ TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {
 
 // -- findNearestSled ----------------------------------------------------------
 
-TEST(FindNearestSled, SkipsSledsOutsideInstructionFunctionRange) {
+TEST(FindNearestSled, SkipsSledsOutsideSourceOwnerRange) {
   std::vector<NopSled> Sleds;
-  // {Start, End, WritePos, FunctionStart, FunctionEnd}
+  // {Start, End, WritePos, OwnerStart, OwnerEnd}
   Sleds.push_back({/*Start=*/0, /*End=*/32, /*WritePos=*/0,
-                   /*FunctionStart=*/0, /*FunctionEnd=*/32});
+                   /*OwnerStart=*/0, /*OwnerEnd=*/32});
   Sleds.push_back({/*Start=*/96, /*End=*/128, /*WritePos=*/96,
-                   /*FunctionStart=*/96, /*FunctionEnd=*/160});
+                   /*OwnerStart=*/96, /*OwnerEnd=*/160});
 
   NopSled *Sled = findNearestSled(Sleds, 108, 8);
   ASSERT_NE(Sled, nullptr);
   EXPECT_EQ(Sled->Start, 96u);
 
   EXPECT_EQ(findNearestSled(Sleds, 64, 8), nullptr);
+}
+
+TEST(FindNearestSled, UsesGatewayOnlyPaddingOnlyWhenRequested) {
+  std::vector<NopSled> Sleds;
+  Sleds.push_back({/*Start=*/0, /*End=*/32, /*WritePos=*/0,
+                   /*OwnerStart=*/0, /*OwnerEnd=*/128,
+                   /*GatewayOnly=*/true});
+  Sleds.push_back({/*Start=*/64, /*End=*/96, /*WritePos=*/64,
+                   /*OwnerStart=*/0, /*OwnerEnd=*/128});
+
+  EXPECT_EQ(findNearestSled(Sleds, 4, 8), &Sleds[1]);
+  EXPECT_EQ(findNearestSled(Sleds, 4, 8, NopSledUse::Gateway),
+            &Sleds[0]);
+}
+
+TEST(FindNearestSled, SeparatesSourceOwnerFromStorageCapacity) {
+  std::vector<NopSled> Sleds = {
+      {/*Start=*/64, /*End=*/96, /*WritePos=*/64,
+       /*OwnerStart=*/0, /*OwnerEnd=*/32}};
+
+  EXPECT_EQ(findNearestSled(Sleds, /*Offset=*/16, /*Needed=*/32), &Sleds[0]);
+  EXPECT_EQ(findNearestSled(Sleds, /*Offset=*/64, /*Needed=*/8), nullptr);
+}
+
+TEST(FindNearestSled, SharesPostFunctionPaddingAcrossCertifiedRoles) {
+  std::vector<NopSled> Sleds = {
+      {/*Start=*/64, /*End=*/96, /*WritePos=*/64,
+       /*OwnerStart=*/0, /*OwnerEnd=*/32, /*GatewayOnly=*/false,
+       /*GlobalGateway=*/true, /*GlobalBody=*/true}};
+
+  NopSled *Body =
+      findNearestSled(Sleds, /*Offset=*/16, /*Needed=*/20);
+  ASSERT_EQ(Body, &Sleds[0]);
+  Body->WritePos += 20;
+
+  EXPECT_EQ(findNearestSled(Sleds, /*Offset=*/128, /*Needed=*/8), nullptr);
+  EXPECT_EQ(findNearestSled(Sleds, /*Offset=*/128, /*Needed=*/8,
+                            NopSledUse::RelocationBody),
+            &Sleds[0]);
+  EXPECT_EQ(findNearestSled(Sleds, /*Offset=*/128, /*Needed=*/8,
+                            NopSledUse::Gateway),
+            &Sleds[0]);
+  EXPECT_EQ(Sleds[0].WritePos, 84u);
+}
+
+TEST(FindNearestSled, PrefersOwnerBodyBeforeGlobalRelocationBody) {
+  std::vector<NopSled> Sleds = {
+      {/*Start=*/40, /*End=*/72, /*WritePos=*/40,
+       /*OwnerStart=*/64, /*OwnerEnd=*/96, /*GatewayOnly=*/false,
+       /*GlobalGateway=*/true, /*GlobalBody=*/true},
+      {/*Start=*/200, /*End=*/232, /*WritePos=*/200,
+       /*OwnerStart=*/0, /*OwnerEnd=*/32}};
+
+  EXPECT_EQ(findNearestSled(Sleds, /*Offset=*/16, /*Needed=*/20,
+                            NopSledUse::RelocationBody),
+            &Sleds[1]);
 }
 
 // -- ElfView::getKernelStaticLdsSize ------------------------------------------
@@ -216,6 +355,7 @@ TEST(ElfView, GrowWithTrampolinesKeepsAllocSectionSymbols) {
 
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
@@ -229,7 +369,8 @@ TEST(ElfView, GrowWithTrampolinesKeepsAllocSectionSymbols) {
   Trampolines.push_back(T);
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Out =
-      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+      ViewOrErr->growWithTrampolines(
+          Trampolines, SNop, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Out, nullptr);
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
@@ -239,6 +380,460 @@ TEST(ElfView, GrowWithTrampolinesKeepsAllocSectionSymbols) {
   llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr);
+}
+
+TEST(ElfView, TrampolinePoolVAddrRejectsAlignmentOverflow) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  llvm::ELF::Elf64_Shdr Rodata{};
+  std::memcpy(&Rodata,
+              Obj.Bytes.data() + Header.e_shoff + 2 * Header.e_shentsize,
+              sizeof(Rodata));
+  ASSERT_NE(Rodata.sh_size, 0u);
+  Rodata.sh_addr = std::numeric_limits<uint64_t>::max() - Rodata.sh_size;
+  std::memcpy(Obj.Bytes.data() + Header.e_shoff + 2 * Header.e_shentsize,
+              &Rodata, sizeof(Rodata));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  EXPECT_FALSE(View->trampolinePoolVAddr().has_value());
+}
+
+TEST(ElfView, TrampolinePoolVAddrAccountsForLoadSegmentMemoryTail) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  ASSERT_EQ(Header.e_phnum, 1u);
+  llvm::ELF::Elf64_Phdr Load{};
+  std::memcpy(&Load, Obj.Bytes.data() + Header.e_phoff, sizeof(Load));
+  ASSERT_EQ(Load.p_type, llvm::ELF::PT_LOAD);
+  Load.p_memsz = 0x5001;
+  std::memcpy(Obj.Bytes.data() + Header.e_phoff, &Load, sizeof(Load));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  ASSERT_TRUE(View->trampolinePoolVAddr().has_value());
+  EXPECT_EQ(*View->trampolinePoolVAddr(), 0x7000u);
+}
+
+TEST(ElfView, TrampolinePoolVAddrRejectsLoadSegmentRangeOverflow) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  ASSERT_EQ(Header.e_phnum, 1u);
+  llvm::ELF::Elf64_Phdr Load{};
+  std::memcpy(&Load, Obj.Bytes.data() + Header.e_phoff, sizeof(Load));
+  ASSERT_EQ(Load.p_type, llvm::ELF::PT_LOAD);
+  Load.p_vaddr = std::numeric_limits<uint64_t>::max() - 7;
+  Load.p_memsz = 16;
+  std::memcpy(Obj.Bytes.data() + Header.e_phoff, &Load, sizeof(Load));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  EXPECT_FALSE(View->trampolinePoolVAddr().has_value());
+}
+
+TEST(ElfView, GrowWithTrampolinesAcceptsLargestDirectProgramHeaderCount) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  constexpr uint16_t InputCount = llvm::ELF::PN_XNUM - 2;
+  ASSERT_TRUE(setProgramHeaderCount(Obj.Bytes, InputCount));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  Trampoline T;
+  T.Bytes.assign(8, 0);
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      View->growWithTrampolines({T}, SNop,
+                                ExecutablePoolTargetState::Neutral);
+  ASSERT_NE(Out, nullptr);
+
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Out->getBufferStart(), sizeof(Header));
+  EXPECT_EQ(Header.e_phnum, llvm::ELF::PN_XNUM - 1);
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  EXPECT_TRUE(OutView->trampolinePoolVAddr().has_value());
+}
+
+TEST(ElfView, GrowWithTrampolinesRejectsProgramHeaderExtendedNumbering) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  constexpr uint16_t InputCount = llvm::ELF::PN_XNUM - 1;
+  ASSERT_TRUE(setProgramHeaderCount(Obj.Bytes, InputCount));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  Trampoline T;
+  T.Bytes.assign(8, 0);
+  const uint8_t SNop[4] = {};
+  EXPECT_EQ(View->growWithTrampolines(
+                {T}, SNop, ExecutablePoolTargetState::Neutral),
+            nullptr);
+}
+
+TEST(ElfView, GrowWithTrampolinesAcceptsLargestDirectSectionHeaderCount) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  constexpr uint16_t InputCount = llvm::ELF::SHN_LORESERVE - 3;
+  ASSERT_TRUE(setSectionHeaderCount(Obj.Bytes, InputCount));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  Trampoline T;
+  T.Bytes.assign(8, 0);
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      View->growWithTrampolines({T}, SNop,
+                                ExecutablePoolTargetState::Neutral);
+  ASSERT_NE(Out, nullptr);
+
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Out->getBufferStart(), sizeof(Header));
+  EXPECT_EQ(Header.e_shnum, llvm::ELF::SHN_LORESERVE - 1);
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  EXPECT_TRUE(OutView->trampolinePoolVAddr().has_value());
+}
+
+TEST(ElfView, GrowWithTrampolinesRejectsSectionHeaderExtendedNumbering) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  constexpr uint16_t InputCount = llvm::ELF::SHN_LORESERVE - 2;
+  ASSERT_TRUE(setSectionHeaderCount(Obj.Bytes, InputCount));
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  Trampoline T;
+  T.Bytes.assign(8, 0);
+  const uint8_t SNop[4] = {};
+  EXPECT_EQ(View->growWithTrampolines(
+                {T}, SNop, ExecutablePoolTargetState::Neutral),
+            nullptr);
+}
+
+TEST(ElfView, GrowWithTrampolinesDropsRelocatedPtPhdr) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.EmitPhdrSegment = true;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+  llvm::ELF::Elf64_Ehdr Before{};
+  std::memcpy(&Before, Obj.Bytes.data(), sizeof(Before));
+  ASSERT_GE(Before.e_phnum, 2u);
+  llvm::ELF::Elf64_Phdr OriginalPhdr{};
+  std::memcpy(&OriginalPhdr, Obj.Bytes.data() + Before.e_phoff,
+              sizeof(OriginalPhdr));
+  ASSERT_EQ(OriginalPhdr.p_type, llvm::ELF::PT_PHDR);
+
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  Trampoline T;
+  T.Bytes.assign(8, 0);
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out =
+      View->growWithTrampolines({T}, SNop,
+                                ExecutablePoolTargetState::Neutral);
+  ASSERT_NE(Out, nullptr);
+
+  llvm::ELF::Elf64_Ehdr After{};
+  std::memcpy(&After, Out->getBufferStart(), sizeof(After));
+  EXPECT_NE(After.e_phoff, Before.e_phoff);
+  EXPECT_EQ(After.e_phnum, Before.e_phnum + 1);
+  bool SawNull = false;
+  bool SawPhdr = false;
+  for (uint16_t I = 0; I != After.e_phnum; ++I) {
+    llvm::ELF::Elf64_Phdr Entry{};
+    std::memcpy(&Entry,
+                Out->getBufferStart() + After.e_phoff +
+                    static_cast<uint64_t>(I) * After.e_phentsize,
+                sizeof(Entry));
+    SawNull |= Entry.p_type == llvm::ELF::PT_NULL;
+    SawPhdr |= Entry.p_type == llvm::ELF::PT_PHDR;
+  }
+  EXPECT_TRUE(SawNull);
+  EXPECT_FALSE(SawPhdr);
+}
+
+TEST(ElfView, ExecutablePoolProvenanceIsTargetSpecificAndFailClosed) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+  llvm::Expected<ElfView> SourceView = createElfView(Obj);
+  ASSERT_TRUE((bool)SourceView) << llvm::toString(SourceView.takeError());
+  const uint64_t TextAddr = SourceView->textAddr();
+  const uint64_t TextOffset = SourceView->textOffset();
+  const uint8_t SNop[4] = {};
+  Trampoline T;
+  T.Bytes.assign(8, 0);
+  std::vector<Trampoline> Trampolines{T};
+
+  auto Grow = [&](ExecutablePoolTargetState State) {
+    llvm::Expected<ElfView> View = createElfView(Obj);
+    EXPECT_TRUE((bool)View);
+    if (!View) {
+      llvm::consumeError(View.takeError());
+      return std::unique_ptr<llvm::WritableMemoryBuffer>();
+    }
+    return View->growWithTrampolines(Trampolines, SNop, State);
+  };
+  auto ExpectCompatibility = [](llvm::WritableMemoryBuffer &Buffer,
+                                ExecutablePoolTargetState State,
+                                bool Expected) {
+    uint8_t *Data = reinterpret_cast<uint8_t *>(Buffer.getBufferStart());
+    llvm::Expected<ElfView> View =
+        ElfView::create(Data, Buffer.getBufferSize());
+    ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+    std::optional<bool> Compatible =
+        View->executableCodeOutsideTextIsCompatibleWith(State);
+    ASSERT_TRUE(Compatible.has_value());
+    EXPECT_EQ(*Compatible, Expected);
+  };
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Neutral =
+      Grow(ExecutablePoolTargetState::Neutral);
+  ASSERT_NE(Neutral, nullptr);
+  ExpectCompatibility(*Neutral, ExecutablePoolTargetState::A0, true);
+  ExpectCompatibility(*Neutral, ExecutablePoolTargetState::B0, true);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> A0 =
+      Grow(ExecutablePoolTargetState::A0);
+  ASSERT_NE(A0, nullptr);
+  ExpectCompatibility(*A0, ExecutablePoolTargetState::A0, true);
+  ExpectCompatibility(*A0, ExecutablePoolTargetState::B0, false);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> B0 =
+      Grow(ExecutablePoolTargetState::B0);
+  ASSERT_NE(B0, nullptr);
+  ExpectCompatibility(*B0, ExecutablePoolTargetState::B0, true);
+  ExpectCompatibility(*B0, ExecutablePoolTargetState::A0, false);
+  EXPECT_EQ(Grow(static_cast<ExecutablePoolTargetState>(99)), nullptr);
+
+  uint8_t *A0Data = reinterpret_cast<uint8_t *>(A0->getBufferStart());
+  llvm::Expected<ElfView> A0View = ElfView::create(A0Data, A0->getBufferSize());
+  ASSERT_TRUE((bool)A0View) << llvm::toString(A0View.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> TwoPools =
+      A0View->growWithTrampolines(Trampolines, SNop,
+                                  ExecutablePoolTargetState::A0);
+  ASSERT_NE(TwoPools, nullptr);
+  ExpectCompatibility(*TwoPools, ExecutablePoolTargetState::A0, true);
+
+  using ELFT = llvm::object::ELF64LE;
+  auto FindPoolNoteSection = [](llvm::WritableMemoryBuffer &Buffer)
+      -> std::optional<std::pair<unsigned, ELFT::Shdr>> {
+    const uint8_t *Data =
+        reinterpret_cast<const uint8_t *>(Buffer.getBufferStart());
+    llvm::Expected<llvm::object::ELFFile<ELFT>> File =
+        llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
+            reinterpret_cast<const char *>(Data), Buffer.getBufferSize()));
+    if (!File)
+      return std::nullopt;
+    llvm::Expected<ELFT::ShdrRange> Sections = File->sections();
+    if (!Sections)
+      return std::nullopt;
+    for (unsigned I = 0; I != Sections->size(); ++I)
+      if ((*Sections)[I].sh_type == llvm::ELF::SHT_NOTE &&
+          !((*Sections)[I].sh_flags & llvm::ELF::SHF_ALLOC))
+        return std::pair<unsigned, ELFT::Shdr>{I, (*Sections)[I]};
+    return std::nullopt;
+  };
+  auto CloneBuffer = [](llvm::WritableMemoryBuffer &Buffer) {
+    std::unique_ptr<llvm::WritableMemoryBuffer> Clone =
+        llvm::WritableMemoryBuffer::getNewMemBuffer(Buffer.getBufferSize());
+    if (Clone)
+      std::memcpy(Clone->getBufferStart(), Buffer.getBufferStart(),
+                  Buffer.getBufferSize());
+    return Clone;
+  };
+  auto FindPoolSection = [TextAddr](llvm::WritableMemoryBuffer &Buffer)
+      -> std::optional<std::pair<unsigned, ELFT::Shdr>> {
+    const uint8_t *Data =
+        reinterpret_cast<const uint8_t *>(Buffer.getBufferStart());
+    llvm::Expected<llvm::object::ELFFile<ELFT>> File =
+        llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
+            reinterpret_cast<const char *>(Data), Buffer.getBufferSize()));
+    if (!File)
+      return std::nullopt;
+    llvm::Expected<ELFT::ShdrRange> Sections = File->sections();
+    if (!Sections)
+      return std::nullopt;
+    for (unsigned I = 0; I != Sections->size(); ++I) {
+      const ELFT::Shdr &Shdr = (*Sections)[I];
+      if (Shdr.sh_type == llvm::ELF::SHT_PROGBITS &&
+          (Shdr.sh_flags & (llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR)) ==
+              (llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR) &&
+          Shdr.sh_addr != TextAddr)
+        return std::pair<unsigned, ELFT::Shdr>{I, Shdr};
+    }
+    return std::nullopt;
+  };
+  enum class Mutation {
+    UnsupportedVersion,
+    Unmarked,
+    DuplicateNote,
+    Align8Note,
+    MissingNameNul,
+    EnlargedTextLoad,
+    PoolFileAliasesText,
+    PoolVAddrOverlapsText,
+  };
+  auto Mutate = [&](llvm::WritableMemoryBuffer &Buffer, Mutation Kind) {
+    llvm::ELF::Elf64_Ehdr Header{};
+    std::memcpy(&Header, Buffer.getBufferStart(), sizeof(Header));
+    auto WriteShdr = [&](unsigned Index, const ELFT::Shdr &Shdr) {
+      std::memcpy(Buffer.getBufferStart() + Header.e_shoff +
+                      static_cast<uint64_t>(Index) * Header.e_shentsize,
+                  &Shdr, sizeof(Shdr));
+    };
+    auto RewritePhdr = [&](auto Predicate, auto Rewrite) {
+      for (unsigned I = 0; I != Header.e_phnum; ++I) {
+        llvm::ELF::Elf64_Phdr Phdr{};
+        char *PhdrData = Buffer.getBufferStart() + Header.e_phoff +
+                         static_cast<uint64_t>(I) * Header.e_phentsize;
+        std::memcpy(&Phdr, PhdrData, sizeof(Phdr));
+        if (!Predicate(Phdr))
+          continue;
+        Rewrite(Phdr);
+        std::memcpy(PhdrData, &Phdr, sizeof(Phdr));
+        return true;
+      }
+      return false;
+    };
+
+    std::optional<std::pair<unsigned, ELFT::Shdr>> Note =
+        FindPoolNoteSection(Buffer);
+    if (!Note)
+      return false;
+    if (Kind == Mutation::UnsupportedVersion) {
+      uint32_t Version = 2;
+      std::memcpy(Buffer.getBufferStart() + Note->second.sh_offset + 20,
+                  &Version, sizeof(Version));
+      return true;
+    }
+    if (Kind == Mutation::Unmarked) {
+      ELFT::Shdr Shdr = Note->second;
+      Shdr.sh_type = llvm::ELF::SHT_PROGBITS;
+      WriteShdr(Note->first, Shdr);
+      return true;
+    }
+    if (Kind == Mutation::DuplicateNote) {
+      for (unsigned I = 0; I != Header.e_shnum; ++I) {
+        ELFT::Shdr Shdr{};
+        std::memcpy(&Shdr,
+                    Buffer.getBufferStart() + Header.e_shoff +
+                        static_cast<uint64_t>(I) * Header.e_shentsize,
+                    sizeof(Shdr));
+        if (Shdr.sh_type == llvm::ELF::SHT_PROGBITS &&
+            !(Shdr.sh_flags & llvm::ELF::SHF_EXECINSTR)) {
+          WriteShdr(I, Note->second);
+          return true;
+        }
+      }
+      return false;
+    }
+    if (Kind == Mutation::Align8Note) {
+      ELFT::Shdr Shdr = Note->second;
+      Shdr.sh_addralign = 8;
+      WriteShdr(Note->first, Shdr);
+      return true;
+    }
+    if (Kind == Mutation::MissingNameNul) {
+      uint32_t NameSize = 6;
+      std::memcpy(Buffer.getBufferStart() + Note->second.sh_offset, &NameSize,
+                  sizeof(NameSize));
+      return true;
+    }
+    if (Kind == Mutation::EnlargedTextLoad)
+      return RewritePhdr(
+          [&](const llvm::ELF::Elf64_Phdr &Phdr) {
+            return Phdr.p_type == llvm::ELF::PT_LOAD &&
+                   Phdr.p_vaddr == TextAddr && Phdr.p_offset == TextOffset;
+          },
+          [](llvm::ELF::Elf64_Phdr &Phdr) {
+            ++Phdr.p_filesz;
+            ++Phdr.p_memsz;
+          });
+
+    std::optional<std::pair<unsigned, ELFT::Shdr>> Pool =
+        FindPoolSection(Buffer);
+    if (!Pool)
+      return false;
+    if (Kind == Mutation::PoolFileAliasesText) {
+      ELFT::Shdr Shdr = Pool->second;
+      Shdr.sh_offset = TextOffset;
+      WriteShdr(Pool->first, Shdr);
+      return RewritePhdr(
+          [&](const llvm::ELF::Elf64_Phdr &Phdr) {
+            return Phdr.p_type == llvm::ELF::PT_LOAD &&
+                   Phdr.p_vaddr == Pool->second.sh_addr &&
+                   Phdr.p_filesz == Pool->second.sh_size;
+          },
+          [&](llvm::ELF::Elf64_Phdr &Phdr) { Phdr.p_offset = TextOffset; });
+    }
+    ELFT::Shdr Shdr = Pool->second;
+    Shdr.sh_addr = TextAddr;
+    WriteShdr(Pool->first, Shdr);
+    bool Rewritten = RewritePhdr(
+        [&](const llvm::ELF::Elf64_Phdr &Phdr) {
+          return Phdr.p_type == llvm::ELF::PT_LOAD &&
+                 Phdr.p_vaddr == Pool->second.sh_addr &&
+                 Phdr.p_filesz == Pool->second.sh_size;
+        },
+        [&](llvm::ELF::Elf64_Phdr &Phdr) {
+          Phdr.p_vaddr = TextAddr;
+          Phdr.p_paddr = TextAddr;
+        });
+    // Nhdr (12) + padded "AMDGPU\0" (8) + version/state (8).
+    std::memcpy(Buffer.getBufferStart() + Note->second.sh_offset + 28,
+                &TextAddr, sizeof(TextAddr));
+    return Rewritten;
+  };
+
+  struct MutationCase {
+    const char *Name;
+    Mutation Kind;
+    bool IsMalformed;
+  };
+  const MutationCase Cases[] = {
+      {"unsupported version", Mutation::UnsupportedVersion, true},
+      {"unmarked pool", Mutation::Unmarked, false},
+      {"duplicate note", Mutation::DuplicateNote, true},
+      {"align-8 note", Mutation::Align8Note, true},
+      {"missing name NUL", Mutation::MissingNameNul, true},
+      {"enlarged text load", Mutation::EnlargedTextLoad, false},
+      {"pool file alias", Mutation::PoolFileAliasesText, false},
+      {"pool vaddr overlap", Mutation::PoolVAddrOverlapsText, false},
+  };
+  for (const MutationCase &Case : Cases) {
+    SCOPED_TRACE(Case.Name);
+    std::unique_ptr<llvm::WritableMemoryBuffer> Buffer = CloneBuffer(*A0);
+    ASSERT_NE(Buffer, nullptr);
+    ASSERT_TRUE(Mutate(*Buffer, Case.Kind));
+
+    uint8_t *Data = reinterpret_cast<uint8_t *>(Buffer->getBufferStart());
+    llvm::Expected<ElfView> View =
+        ElfView::create(Data, Buffer->getBufferSize());
+    ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+    std::optional<bool> Compatible =
+        View->executableCodeOutsideTextIsCompatibleWith(
+            ExecutablePoolTargetState::A0);
+    if (Case.IsMalformed) {
+      EXPECT_FALSE(Compatible.has_value());
+    } else {
+      ASSERT_TRUE(Compatible.has_value());
+      EXPECT_FALSE(*Compatible);
+    }
+  }
 }
 
 // gfx1250 "address of a global" idiom, as emitted for e.g. `x++` on a
@@ -301,6 +896,7 @@ TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
 
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
   // .text (at TextAddr) references the descriptor symbol in .rodata (at
   // RodataAddr), which sits after .text -- like a kernel referencing a global
   // in a post-.text data section.
@@ -322,7 +918,8 @@ TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
   std::vector<Trampoline> Trampolines{T};
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Out =
-      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+      ViewOrErr->growWithTrampolines(
+          Trampolines, SNop, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Out, nullptr);
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
@@ -388,7 +985,9 @@ DwarfRefElf makeDwarfRefElf(uint64_t TextAddr = 0x1000,
   constexpr uint32_t GNameOff = 1;
 
   constexpr unsigned ShNum = 7;
-  const uint64_t ShOff = sizeof(Elf64_Ehdr);
+  const uint64_t PhOff = sizeof(Elf64_Ehdr);
+  const uint64_t ShOff =
+      comgr_test::alignTo8(PhOff + sizeof(Elf64_Phdr));
   const uint64_t TextOff =
       comgr_test::alignTo8(ShOff + ShNum * sizeof(Elf64_Shdr));
   const uint64_t DataOff = comgr_test::alignTo8(TextOff + TextSize);
@@ -408,12 +1007,26 @@ DwarfRefElf makeDwarfRefElf(uint64_t TextAddr = 0x1000,
   Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
   Ehdr.e_type = ET_DYN;
   Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_phoff = PhOff;
+  Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  Ehdr.e_phnum = 1;
   Ehdr.e_shoff = ShOff;
   Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
   Ehdr.e_shentsize = sizeof(Elf64_Shdr);
   Ehdr.e_shnum = ShNum;
   Ehdr.e_shstrndx = 6;
   std::memcpy(B, &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr TextLoad{};
+  TextLoad.p_type = PT_LOAD;
+  TextLoad.p_flags = PF_R | PF_X;
+  TextLoad.p_offset = TextOff;
+  TextLoad.p_vaddr = TextAddr;
+  TextLoad.p_paddr = TextAddr;
+  TextLoad.p_filesz = TextSize;
+  TextLoad.p_memsz = TextSize;
+  TextLoad.p_align = 4;
+  std::memcpy(B + PhOff, &TextLoad, sizeof(TextLoad));
 
   std::memcpy(B + StrOff, Str, sizeof(Str));
   std::memcpy(B + ShStrOff, ShStr, sizeof(ShStr));
@@ -538,7 +1151,8 @@ TEST(ElfView, GrowWithTrampolinesKeepsDwarfConsistentWithSymbol) {
   std::vector<Trampoline> Trampolines{T};
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Out =
-      ViewOrErr->growWithTrampolines(Trampolines, SNop);
+      ViewOrErr->growWithTrampolines(
+          Trampolines, SNop, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Out, nullptr);
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
@@ -555,57 +1169,55 @@ TEST(ElfView, GrowWithTrampolinesKeepsDwarfConsistentWithSymbol) {
   EXPECT_EQ(DwarfAddr, SymbolVAddr);
 }
 
-// Covers: addKernelEntryTrampolineSymbols attaches a distinct, correctly
-// placed `<kernel>.stub` symbol for every appended entry-trampoline stub, so a
-// dispatch whose entry now points at a stub still resolves to a name.
-//
-// How: build a synthetic AMDGPU code object that has a .symtab, then grow .text
-// by two entry-stub-sized (KernelEntryStubStride) blocks with
-// growWithTrampolines -- mirroring the pass appending one stub per kernel.
-// Call addKernelEntryTrampolineSymbols with two fixups that use distinct kernel
-// names and the two stub offsets (0 and KernelEntryStubStride). Re-parse the
-// returned buffer with llvm::object::ELFFile and, for each fixup, assert a
-// "<name>.stub" symbol exists in .symtab that is (a) STT_FUNC, (b) defined in
-// the appended trampoline-pool section (st_shndx), (c) located at PoolVAddr +
-// StubTextOffset (where the dispatch entry now points), and (d) sized to
-// KernelEntryStubStride. Two fixups (rather than one) prove each stub gets its
-// own name at its own address, not a single shared or mis-placed entry.
-TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
+// Stub symbols must describe the same entry as the rewritten kernel descriptor
+// and the appended executable pool. Growing the non-allocating symbol tables
+// must not move or invalidate that pool's PT_LOAD mapping.
+TEST(ElfView, AddKernelEntryTrampolineSymbolMatchesDescriptorAndPool) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  llvm::Expected<ElfView> ViewOrErr = createElfView(Obj);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
-  ASSERT_TRUE(PoolVAddrOr.has_value());
-  const uint64_t PoolVAddr = *PoolVAddrOr;
+  std::optional<uint64_t> PoolVAddr = ViewOrErr->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddr.has_value());
 
-  // Grow .text by two entry-stub-sized blocks, mirroring the entry-trampoline
-  // pass appending one stub per kernel.
   Trampoline Stub;
-  Stub.Bytes.assign(2 * KernelEntryStubStride, 0xAA);
+  Stub.Bytes.assign(KernelEntryStubStride, 0xa5);
   std::vector<Trampoline> Growth{Stub};
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
-      ViewOrErr->growWithTrampolines(Growth, SNop);
+      ViewOrErr->growWithTrampolines(
+          Growth, SNop, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Grown, nullptr);
 
-  // One fixup per appended stub; the names need not match real kernels, since
-  // addKernelEntryTrampolineSymbols only attaches a symbol at each stub
-  // address.
   std::vector<KernelEntryTrampolineFixup> Fixups = {
-      {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10},
-      {"kernel_b", /*StubTextOffset=*/KernelEntryStubStride,
-       /*RequiredSgprs=*/12},
+      {"entry_kernel", /*StubTextOffset=*/0, /*RequiredSgprs=*/10,
+       /*InstPrefLines=*/0},
   };
-  std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
-      addKernelEntryTrampolineSymbols(*Grown, PoolVAddr, Fixups);
-  ASSERT_NE(WithSyms, nullptr);
+  uint8_t *GrownData =
+      reinterpret_cast<uint8_t *>(Grown->getBufferStart());
+  llvm::Expected<ElfView> GrownView =
+      ElfView::create(GrownData, Grown->getBufferSize());
+  ASSERT_TRUE((bool)GrownView) << llvm::toString(GrownView.takeError());
+  std::optional<uint64_t> KdVAddr =
+      GrownView->getKernelDescriptorVAddr("entry_kernel");
+  ASSERT_TRUE(KdVAddr.has_value());
+  ASSERT_GE(*PoolVAddr, *KdVAddr);
+  ASSERT_LE(*PoolVAddr - *KdVAddr,
+            static_cast<uint64_t>(std::numeric_limits<int64_t>::max()));
+  ASSERT_TRUE(GrownView->updateKernelDescriptorEntryOffset(
+      "entry_kernel", static_cast<int64_t>(*PoolVAddr - *KdVAddr)));
 
   using ELFT = llvm::object::ELF64LE;
+  llvm::ELF::Elf64_Ehdr GrownHeader{};
+  std::memcpy(&GrownHeader, Grown->getBufferStart(), sizeof(GrownHeader));
+  std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
+      addKernelEntryTrampolineSymbols(*Grown, *PoolVAddr, Fixups);
+  ASSERT_NE(WithSyms, nullptr);
+
   const uint8_t *Data =
       reinterpret_cast<const uint8_t *>(WithSyms->getBufferStart());
   llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
@@ -617,20 +1229,21 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   llvm::Expected<ELFT::ShdrRange> SecsOrErr = File.sections();
   ASSERT_TRUE((bool)SecsOrErr) << llvm::toString(SecsOrErr.takeError());
   const ELFT::Shdr *SymtabShdr = nullptr;
-  unsigned PoolIdx = 0;
-  {
-    unsigned I = 0;
-    for (const ELFT::Shdr &S : *SecsOrErr) {
-      if (S.sh_type == llvm::ELF::SHT_SYMTAB && !SymtabShdr)
-        SymtabShdr = &S;
-      if ((S.sh_flags & llvm::ELF::SHF_ALLOC) && S.sh_addr == PoolVAddr &&
-          PoolIdx == 0)
-        PoolIdx = I;
-      ++I;
+  std::optional<unsigned> PoolSectionIndex;
+  for (unsigned I = 0; I != SecsOrErr->size(); ++I) {
+    const ELFT::Shdr &S = (*SecsOrErr)[I];
+    if (S.sh_type == llvm::ELF::SHT_SYMTAB) {
+      SymtabShdr = &S;
+      continue;
     }
+    if (S.sh_type == llvm::ELF::SHT_PROGBITS &&
+        (S.sh_flags & (llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR)) ==
+            (llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR) &&
+        S.sh_addr == *PoolVAddr && S.sh_size >= KernelEntryStubStride)
+      PoolSectionIndex = I;
   }
   ASSERT_NE(SymtabShdr, nullptr);
-  ASSERT_NE(PoolIdx, 0u) << "trampoline-pool section not found at PoolVAddr";
+  ASSERT_TRUE(PoolSectionIndex.has_value());
   llvm::Expected<ELFT::SymRange> SymsOrErr = File.symbols(SymtabShdr);
   ASSERT_TRUE((bool)SymsOrErr) << llvm::toString(SymsOrErr.takeError());
   llvm::Expected<llvm::StringRef> StrTabOrErr =
@@ -646,133 +1259,95 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
     return nullptr;
   };
 
-  // Every appended stub must have a <kernel>.stub STT_FUNC symbol covering the
-  // stub, in the trampoline-pool section, at the stub's virtual address (where
-  // the dispatch entry now points).
-  for (const KernelEntryTrampolineFixup &F : Fixups) {
-    const ELFT::Sym *Sym = FindSym(F.KernelName + ".stub");
-    ASSERT_NE(Sym, nullptr) << "missing stub symbol for " << F.KernelName;
-    EXPECT_EQ(static_cast<unsigned>(Sym->getType()),
-              static_cast<unsigned>(llvm::ELF::STT_FUNC));
-    EXPECT_EQ(Sym->st_shndx, PoolIdx);
-    EXPECT_EQ(Sym->st_value, PoolVAddr + F.StubTextOffset);
-    EXPECT_EQ(Sym->st_size, KernelEntryStubStride);
-    // The symbol's [value, value + size) range must lie fully inside the
-    // section it claims (st_shndx), catching a symbol placed in the wrong
-    // section or past its bounds.
-    const ELFT::Shdr &StubSec = (*SecsOrErr)[Sym->st_shndx];
-    EXPECT_GE(Sym->st_value, StubSec.sh_addr);
-    EXPECT_LE(Sym->st_value + Sym->st_size, StubSec.sh_addr + StubSec.sh_size);
-  }
+  const ELFT::Sym *Sym = FindSym("entry_kernel.stub");
+  ASSERT_NE(Sym, nullptr);
+  EXPECT_EQ(static_cast<unsigned>(Sym->getType()),
+            static_cast<unsigned>(llvm::ELF::STT_FUNC));
+  EXPECT_EQ(Sym->st_shndx, *PoolSectionIndex);
+  EXPECT_EQ(Sym->st_value, *PoolVAddr);
+  EXPECT_EQ(Sym->st_size, KernelEntryStubStride);
+
+  uint8_t *WithSymsData =
+      reinterpret_cast<uint8_t *>(WithSyms->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(WithSymsData, WithSyms->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  llvm::ArrayRef<KernelDescriptorInfo> Descriptors =
+      OutView->kernelDescriptors();
+  ASSERT_EQ(Descriptors.size(), 1u);
+  ASSERT_GE(Descriptors.front().EntryOffset, 0);
+  const uint64_t DescriptorEntry =
+      Descriptors.front().VAddr +
+      static_cast<uint64_t>(Descriptors.front().EntryOffset);
+  EXPECT_EQ(Sym->st_value, DescriptorEntry);
+
+  llvm::ELF::Elf64_Ehdr OutputHeader{};
+  std::memcpy(&OutputHeader, Data, sizeof(OutputHeader));
+  EXPECT_EQ(OutputHeader.e_phoff, GrownHeader.e_phoff);
+  EXPECT_EQ(OutputHeader.e_phnum, GrownHeader.e_phnum);
+  EXPECT_EQ(OutputHeader.e_phentsize, GrownHeader.e_phentsize);
+  const uint64_t PhdrBytes =
+      static_cast<uint64_t>(OutputHeader.e_phnum) * OutputHeader.e_phentsize;
+  ASSERT_LE(OutputHeader.e_phoff, WithSyms->getBufferSize());
+  ASSERT_LE(PhdrBytes, WithSyms->getBufferSize() - OutputHeader.e_phoff);
+  ASSERT_LE(GrownHeader.e_phoff, Grown->getBufferSize());
+  ASSERT_LE(PhdrBytes, Grown->getBufferSize() - GrownHeader.e_phoff);
+  EXPECT_EQ(std::memcmp(Data + OutputHeader.e_phoff,
+                        Grown->getBufferStart() + GrownHeader.e_phoff,
+                        PhdrBytes),
+            0);
+
+  llvm::Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  ASSERT_TRUE((bool)PhdrsOrErr) << llvm::toString(PhdrsOrErr.takeError());
+  const ELFT::Phdr *PoolPhdr = nullptr;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr)
+    if (Phdr.p_type == llvm::ELF::PT_LOAD &&
+        (Phdr.p_flags & (llvm::ELF::PF_R | llvm::ELF::PF_X)) ==
+            (llvm::ELF::PF_R | llvm::ELF::PF_X) &&
+        Phdr.p_vaddr == *PoolVAddr &&
+        Phdr.p_filesz >= KernelEntryStubStride) {
+      PoolPhdr = &Phdr;
+      break;
+    }
+  ASSERT_NE(PoolPhdr, nullptr);
+  ASSERT_LE(PoolPhdr->p_offset, WithSyms->getBufferSize());
+  ASSERT_LE(KernelEntryStubStride,
+            WithSyms->getBufferSize() - PoolPhdr->p_offset);
+  EXPECT_EQ(std::memcmp(Data + PoolPhdr->p_offset, Stub.Bytes.data(),
+                        KernelEntryStubStride),
+            0);
 }
 
-// A zero-sized allocatable section can share the trampoline pool's base
-// address: trampolinePoolVAddr() still selects that address and
-// growWithTrampolines() appends the real pool after it. The stub symbol must
-// land in the real, non-empty pool section that spans PoolVAddr -- not the
-// empty section at the same address -- so its [value, value + size) range stays
-// inside its declared section. Guards the pool-section lookup against an exact
-// sh_addr == PoolVAddr scan that could select the empty section first.
+// A zero-sized allocatable section may share the trampoline pool's base.
+// Stub symbols must name the real executable pool section that fully contains
+// the stub, not the empty section at the same address.
 TEST(ElfView, AddKernelEntryTrampolineSymbolsSkipsZeroSizedSectionAtPoolVAddr) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";
-  Opts.ExtraAllocSectionAddr = 0x3000; // page-aligned, past .rodata
-
-  comgr_test::KernelDescriptorElf Obj =
-      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
-  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
-  ASSERT_TRUE(PoolVAddrOr.has_value());
-  const uint64_t PoolVAddr = *PoolVAddrOr;
-  // The zero-sized section shares the pool base -- the scenario under test.
-  ASSERT_EQ(PoolVAddr, 0x3000u);
-
-  Trampoline Stub;
-  Stub.Bytes.assign(KernelEntryStubStride, 0xAA);
-  std::vector<Trampoline> Growth{Stub};
-  const uint8_t SNop[4] = {};
-  std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
-      ViewOrErr->growWithTrampolines(Growth, SNop);
-  ASSERT_NE(Grown, nullptr);
-
-  std::vector<KernelEntryTrampolineFixup> Fixups = {
-      {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10}};
-  std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
-      addKernelEntryTrampolineSymbols(*Grown, PoolVAddr, Fixups);
-  ASSERT_NE(WithSyms, nullptr);
-
-  using ELFT = llvm::object::ELF64LE;
-  llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
-      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
-          reinterpret_cast<const char *>(WithSyms->getBufferStart()),
-          WithSyms->getBufferSize()));
-  ASSERT_TRUE((bool)FileOrErr) << llvm::toString(FileOrErr.takeError());
-  llvm::object::ELFFile<ELFT> &File = *FileOrErr;
-  llvm::Expected<ELFT::ShdrRange> SecsOrErr = File.sections();
-  ASSERT_TRUE((bool)SecsOrErr) << llvm::toString(SecsOrErr.takeError());
-  const ELFT::Shdr *Symtab = nullptr;
-  for (const ELFT::Shdr &S : *SecsOrErr)
-    if (S.sh_type == llvm::ELF::SHT_SYMTAB) {
-      Symtab = &S;
-      break;
-    }
-  ASSERT_NE(Symtab, nullptr);
-  llvm::Expected<ELFT::SymRange> Syms = File.symbols(Symtab);
-  ASSERT_TRUE((bool)Syms) << llvm::toString(Syms.takeError());
-  llvm::Expected<llvm::StringRef> Str = File.getStringTableForSymtab(*Symtab);
-  ASSERT_TRUE((bool)Str) << llvm::toString(Str.takeError());
-  const ELFT::Sym *StubSym = nullptr;
-  for (const ELFT::Sym &Sym : *Syms) {
-    llvm::Expected<llvm::StringRef> N = Sym.getName(*Str);
-    ASSERT_TRUE((bool)N) << llvm::toString(N.takeError());
-    if (*N == "kernel_a.stub") {
-      StubSym = &Sym;
-      break;
-    }
-  }
-  ASSERT_NE(StubSym, nullptr);
-
-  // The symbol must reference the real pool section (non-empty, spanning
-  // PoolVAddr), not the zero-sized section at the same address.
-  ASSERT_LT(StubSym->st_shndx, SecsOrErr->size());
-  const ELFT::Shdr &Sec = (*SecsOrErr)[StubSym->st_shndx];
-  EXPECT_NE(Sec.sh_size, 0u);
-  EXPECT_GE(StubSym->st_value, Sec.sh_addr);
-  EXPECT_LT(StubSym->st_value, Sec.sh_addr + Sec.sh_size);
-  EXPECT_EQ(StubSym->st_value, PoolVAddr);
-}
-
-TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
-  comgr_test::KernelDescriptorElfOptions Opts;
-  Opts.KernelName = "entry_kernel";
-  Opts.MetadataSgprCount = 8;
+  Opts.ExtraAllocSectionAddr = 0x3000;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
-  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
-  ASSERT_TRUE(PoolVAddrOr.has_value());
-  const uint64_t PoolVAddr = *PoolVAddrOr;
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  std::optional<uint64_t> PoolVAddr = View->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddr.has_value());
+  ASSERT_EQ(*PoolVAddr, 0x3000u);
 
   Trampoline Stub;
-  Stub.Bytes.assign(2 * KernelEntryStubStride, 0xAA);
+  Stub.Bytes.assign(KernelEntryStubStride, 0xaa);
   std::vector<Trampoline> Growth{Stub};
   const uint8_t SNop[4] = {};
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
-      ViewOrErr->growWithTrampolines(Growth, SNop);
+      View->growWithTrampolines(
+          Growth, SNop, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Grown, nullptr);
 
   std::vector<KernelEntryTrampolineFixup> Fixups = {
-      {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10},
-      {"kernel_b", /*StubTextOffset=*/KernelEntryStubStride,
-       /*RequiredSgprs=*/12},
-  };
+      {"entry_kernel", /*StubTextOffset=*/0, /*RequiredSgprs=*/10,
+       /*InstPrefLines=*/0}};
   std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
-      addKernelEntryTrampolineSymbols(*Grown, PoolVAddr, Fixups);
+      addKernelEntryTrampolineSymbols(*Grown, *PoolVAddr, Fixups);
   ASSERT_NE(WithSyms, nullptr);
 
   using ELFT = llvm::object::ELF64LE;
@@ -780,26 +1355,98 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
       llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
           WithSyms->getBufferStart(), WithSyms->getBufferSize()));
   ASSERT_TRUE((bool)FileOrErr) << llvm::toString(FileOrErr.takeError());
+  llvm::Expected<ELFT::ShdrRange> Sections = FileOrErr->sections();
+  ASSERT_TRUE((bool)Sections) << llvm::toString(Sections.takeError());
 
-  llvm::Expected<ELFT::PhdrRange> PhdrsOrErr = FileOrErr->program_headers();
-  ASSERT_TRUE((bool)PhdrsOrErr) << llvm::toString(PhdrsOrErr.takeError());
-  EXPECT_GE(PhdrsOrErr->size(), 2u);
+  const ELFT::Shdr *Symtab = nullptr;
+  for (const ELFT::Shdr &Section : *Sections)
+    if (Section.sh_type == llvm::ELF::SHT_SYMTAB) {
+      Symtab = &Section;
+      break;
+    }
+  ASSERT_NE(Symtab, nullptr);
+  llvm::Expected<ELFT::SymRange> Symbols = FileOrErr->symbols(Symtab);
+  ASSERT_TRUE((bool)Symbols) << llvm::toString(Symbols.takeError());
+  llvm::Expected<llvm::StringRef> Strings =
+      FileOrErr->getStringTableForSymtab(*Symtab);
+  ASSERT_TRUE((bool)Strings) << llvm::toString(Strings.takeError());
 
-  bool FoundPoolLoad = false;
-  for (const auto &Phdr : *PhdrsOrErr) {
-    EXPECT_LE(Phdr.p_offset, WithSyms->getBufferSize());
-    if (Phdr.p_type == llvm::ELF::PT_LOAD && (Phdr.p_flags & llvm::ELF::PF_X)) {
-      FoundPoolLoad = true;
-      EXPECT_GT(Phdr.p_filesz, 0u);
-      ASSERT_LE(Phdr.p_offset + Phdr.p_filesz, WithSyms->getBufferSize());
-      const uint8_t *PoolBytes =
-          reinterpret_cast<const uint8_t *>(WithSyms->getBufferStart()) +
-          Phdr.p_offset;
-      for (uint64_t I = 0; I < Phdr.p_filesz; ++I)
-        EXPECT_EQ(PoolBytes[I], 0xAA) << "pool content mismatch at byte " << I;
+  const ELFT::Sym *StubSym = nullptr;
+  for (const ELFT::Sym &Sym : *Symbols) {
+    llvm::Expected<llvm::StringRef> Name = Sym.getName(*Strings);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == "entry_kernel.stub") {
+      StubSym = &Sym;
+      break;
     }
   }
-  EXPECT_TRUE(FoundPoolLoad) << "no executable PT_LOAD segment found";
+  ASSERT_NE(StubSym, nullptr);
+  ASSERT_LT(StubSym->st_shndx, Sections->size());
+  const ELFT::Shdr &StubSection = (*Sections)[StubSym->st_shndx];
+  EXPECT_EQ(StubSym->st_value, *PoolVAddr);
+  EXPECT_NE(StubSection.sh_size, 0u);
+  EXPECT_EQ(StubSection.sh_type, llvm::ELF::SHT_PROGBITS);
+  EXPECT_EQ(StubSection.sh_flags &
+                (llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR),
+            llvm::ELF::SHF_ALLOC | llvm::ELF::SHF_EXECINSTR);
+  EXPECT_GE(StubSym->st_value, StubSection.sh_addr);
+  EXPECT_LE(StubSym->st_value + StubSym->st_size,
+            StubSection.sh_addr + StubSection.sh_size);
+}
+
+TEST(ElfView, AddKernelEntryTrampolineSymbolsRejectsLinkedShndxTable) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+  llvm::Expected<ElfView> View = createElfView(Obj);
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  std::optional<uint64_t> PoolVAddr = View->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddr.has_value());
+
+  Trampoline Stub;
+  Stub.Bytes.assign(KernelEntryStubStride, 0);
+  std::vector<Trampoline> Growth{Stub};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
+      View->growWithTrampolines(Growth, SNop,
+                                ExecutablePoolTargetState::Neutral);
+  ASSERT_NE(Grown, nullptr);
+
+  llvm::ELF::Elf64_Ehdr Header{};
+  std::memcpy(&Header, Grown->getBufferStart(), sizeof(Header));
+  std::optional<unsigned> SymtabIndex;
+  std::optional<unsigned> NoteIndex;
+  for (unsigned I = 0; I != Header.e_shnum; ++I) {
+    llvm::ELF::Elf64_Shdr Shdr{};
+    std::memcpy(&Shdr,
+                Grown->getBufferStart() + Header.e_shoff +
+                    static_cast<uint64_t>(I) * Header.e_shentsize,
+                sizeof(Shdr));
+    if (Shdr.sh_type == llvm::ELF::SHT_SYMTAB)
+      SymtabIndex = I;
+    else if (Shdr.sh_type == llvm::ELF::SHT_NOTE)
+      NoteIndex = I;
+  }
+  ASSERT_TRUE(SymtabIndex.has_value());
+  ASSERT_TRUE(NoteIndex.has_value());
+  llvm::ELF::Elf64_Shdr Shndx{};
+  std::memcpy(&Shndx,
+              Grown->getBufferStart() + Header.e_shoff +
+                  static_cast<uint64_t>(*NoteIndex) * Header.e_shentsize,
+              sizeof(Shndx));
+  Shndx.sh_type = llvm::ELF::SHT_SYMTAB_SHNDX;
+  Shndx.sh_link = *SymtabIndex;
+  std::memcpy(Grown->getBufferStart() + Header.e_shoff +
+                  static_cast<uint64_t>(*NoteIndex) * Header.e_shentsize,
+              &Shndx, sizeof(Shndx));
+
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"entry_kernel", /*StubTextOffset=*/0, /*RequiredSgprs=*/8,
+       /*InstPrefLines=*/0},
+  };
+  EXPECT_EQ(addKernelEntryTrampolineSymbols(*Grown, *PoolVAddr, Fixups),
+            nullptr);
 }
 
 TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
@@ -924,8 +1571,7 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  llvm::Expected<ElfView> ViewOrErr = createElfView(Obj);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
   const unsigned DescriptorSgprsBefore =
       readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset);
@@ -944,8 +1590,7 @@ TEST(ElfView, UpdateKernelMetadataSgprCountsKeepsPrimedCacheCoherent) {
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  llvm::Expected<ElfView> ViewOrErr = createElfView(Obj);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
 
@@ -999,8 +1644,7 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountMetadataOnlyRequiresMetadata) {
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  llvm::Expected<ElfView> ViewOrErr = createElfView(Obj);
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
   const unsigned DescriptorSgprsBefore =
       readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset);
@@ -1104,19 +1748,17 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsDescriptorLimitFirst) {
 
 // -- kernel-descriptor cache dedup --------------------------------------------
 
-// The descriptor cache dedups by (name, vaddr): the same kernel name can appear
-// at more than one descriptor vaddr, and a repeat of an already-seen
-// (name, vaddr) pair must be dropped regardless of ordering. This pins the
-// A@x, A@y, A@x case, which a "remember only the last vaddr per name" dedup
-// would mishandle by re-adding the trailing A@x.
-TEST(ElfView, KernelDescriptorCacheDedupsByNameAndVAddrAcrossOrdering) {
+// A kernel name is the key used by metadata and descriptor fixups, so it must
+// resolve to one location. Repeated identical symbols are harmless, but a
+// second location for the same name makes the cache incomplete and prevents a
+// rewrite from updating only one of the descriptors.
+TEST(ElfView, KernelDescriptorCacheRejectsAmbiguousNameAcrossOrdering) {
   comgr_test::MultiKernelDescriptorElfOptions Opts;
   Opts.TextAddr = 0x1000;
   Opts.TextSize = 0x400;
   Opts.RodataAddr = 0x2000;
-  // Distinct descriptor vaddrs for the two "A" instances, and a "B" in between,
-  // then a duplicate of the first A. Expect three unique descriptors:
-  // A@0x2000, B@0x2100, A@0x2200 -- the trailing A@0x2000 duplicate is dropped.
+  // Distinct descriptor locations for the two "A" instances, with a "B" in
+  // between and an identical repeat of the first A at the end.
   Opts.Kernels = {
       {"kern_a", 0x1000, 0x2000, /*EntryOffset=*/-0x1000},
       {"kern_b", 0x1100, 0x2100, /*EntryOffset=*/-0x1000},
@@ -1130,11 +1772,10 @@ TEST(ElfView, KernelDescriptorCacheDedupsByNameAndVAddrAcrossOrdering) {
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
   llvm::ArrayRef<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
-  ASSERT_EQ(KDs.size(), 3u);
+  EXPECT_FALSE(ViewOrErr->kernelDescriptorCacheIsComplete());
+  ASSERT_EQ(KDs.size(), 2u);
   EXPECT_EQ(KDs[0].KernelName, "kern_a");
   EXPECT_EQ(KDs[0].VAddr, 0x2000u);
   EXPECT_EQ(KDs[1].KernelName, "kern_b");
   EXPECT_EQ(KDs[1].VAddr, 0x2100u);
-  EXPECT_EQ(KDs[2].KernelName, "kern_a");
-  EXPECT_EQ(KDs[2].VAddr, 0x2200u);
 }

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -395,6 +395,94 @@ TEST(EncodeSBranch, FailsOnInvalidState) {
   EXPECT_TRUE(S.encodeSBranch(0, 8).empty());
 }
 
+// -- encodeSCallI64 ----------------------------------------------------------
+
+static uint64_t decodeSCallTarget(uint64_t From,
+                                  const InternalDecodedInst &Decoded) {
+  const uint64_t Encoded =
+      static_cast<uint64_t>(Decoded.Inst.getOperand(1).getImm()) & 0xFFFFu;
+  const int64_t DwordDelta = Encoded < 0x8000u
+                                 ? static_cast<int64_t>(Encoded)
+                                 : static_cast<int64_t>(Encoded) - 0x10000;
+  const uint64_t PcBase = From + MinInstSize;
+  return DwordDelta >= 0
+             ? PcBase + static_cast<uint64_t>(DwordDelta) * MinInstSize
+             : PcBase - static_cast<uint64_t>(-DwordDelta) * MinInstSize;
+}
+
+TEST(EncodeSCallI64, WritesNextPcAndPreservesScc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x20000;
+  constexpr uint64_t To = 0x1F000;
+  llvm::SmallVector<uint8_t> Out =
+      encodeSCallI64(S, From, To, /*SgprBase=*/12);
+  ASSERT_EQ(Out.size(), MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "s_call_i64");
+  EXPECT_EQ(Decoded[0].Inst.getOpcode(), S.SCallI64Opcode);
+  ASSERT_EQ(Decoded[0].Inst.getNumOperands(), 2u);
+  EXPECT_EQ(decodeSCallTarget(From, Decoded[0]), To);
+
+  // RDNA4 S_CALL_B64 writes PC+4 to its explicit SDST operand. Its ISA
+  // definition has no SCC operand, and LLVM's descriptor must agree.
+  const llvm::MCInstrDesc &Desc = S.MCII->get(Decoded[0].Inst.getOpcode());
+  EXPECT_TRUE(Desc.isCall());
+  EXPECT_EQ(Desc.getNumDefs(), 1u);
+  EXPECT_TRUE(Decoded[0].Inst.getOperand(0).isReg());
+  for (llvm::MCPhysReg Reg : Desc.implicit_defs())
+    EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
+}
+
+TEST(EncodeSCallI64, EnforcesSignedDwordRangeAndAlignment) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t ForwardFrom = 0x1000;
+  constexpr uint64_t ForwardLimit =
+      ForwardFrom + MinInstSize +
+      static_cast<uint64_t>(BranchOffsetMax) * MinInstSize;
+  EXPECT_EQ(encodeSCallI64(S, ForwardFrom, ForwardLimit, /*SgprBase=*/12)
+                .size(),
+            MinInstSize);
+  EXPECT_TRUE(encodeSCallI64(S, ForwardFrom, ForwardLimit + MinInstSize,
+                            /*SgprBase=*/12)
+                  .empty());
+
+  constexpr uint64_t BackwardFrom = 0x40000;
+  constexpr uint64_t BackwardLimit =
+      BackwardFrom + MinInstSize -
+      static_cast<uint64_t>(-BranchOffsetMin) * MinInstSize;
+  EXPECT_EQ(encodeSCallI64(S, BackwardFrom, BackwardLimit, /*SgprBase=*/12)
+                .size(),
+            MinInstSize);
+  EXPECT_TRUE(encodeSCallI64(S, BackwardFrom, BackwardLimit - MinInstSize,
+                            /*SgprBase=*/12)
+                  .empty());
+  EXPECT_TRUE(
+      encodeSCallI64(S, ForwardFrom, ForwardFrom + 5, /*SgprBase=*/12).empty());
+}
+
+TEST(EncodeSCallI64, SupportsVccScratchPair) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Out =
+      encodeSCallI64(S, 0x1000, 0x1100, Gfx1250MaxSgprs);
+  ASSERT_EQ(Out.size(), MinInstSize);
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_TRUE(Decoded[0].Inst.getOperand(0).isReg());
+  EXPECT_EQ(llvm::StringRef(
+                S.MRI->getName(Decoded[0].Inst.getOperand(0).getReg())),
+            "VCC");
+}
+
 // -- encodeSetPCLongBranch ---------------------------------------------------
 
 TEST(EncodeSetPCLongBranch, BackwardLandsOnTarget) {
@@ -403,13 +491,12 @@ TEST(EncodeSetPCLongBranch, BackwardLandsOnTarget) {
 
   const uint64_t From = 0x81000;
   const uint64_t To = 0x1004;
-  std::optional<llvm::SmallVector<uint8_t>> Out =
+  llvm::SmallVector<uint8_t> Out =
       encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
-  ASSERT_TRUE(Out);
-  EXPECT_EQ(Out->size(), SetPcReturnReserveBytes);
+  ASSERT_FALSE(Out.empty());
 
   std::vector<InternalDecodedInst> Dec;
-  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Dec));
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
   ASSERT_EQ(Dec.size(), 3u);
   EXPECT_EQ(Dec[0].Mnemonic, "s_get_pc_i64");
   EXPECT_EQ(Dec[1].Mnemonic, "s_add_nc_u64");
@@ -432,24 +519,133 @@ TEST(EncodeSetPCLongBranch, BackwardLandsOnTarget) {
   EXPECT_EQ(static_cast<uint32_t>(Delta >> 32), 0xFFFFFFFFu);
 }
 
+TEST(EncodeSetPCLongBranch, RejectsMisalignedScratchPair) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  EXPECT_TRUE(encodeSetPCLongBranch(S, 0, 0x1000, /*SgprBase=*/3).empty());
+}
+
+static InternalDecodedInst decodeDelay(llvm::StringRef Assembly) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Assembly, S);
+  std::vector<InternalDecodedInst> Decoded;
+  if (Bytes.empty() ||
+      !decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded) ||
+      Decoded.size() != 1)
+    return {};
+  return std::move(Decoded.front());
+}
+
+TEST(RelocationDelaySpan, ProtectsOnlyEncodedDependencySpan) {
+  InternalDecodedInst First = decodeDelay("s_delay_alu instid0(VALU_DEP_1)");
+  ASSERT_EQ(First.Mnemonic, "s_delay_alu");
+  EXPECT_EQ(getDelayProtectedSpan(First), 1u);
+
+  InternalDecodedInst Third =
+      decodeDelay("s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | "
+                  "instid1(SALU_CYCLE_1)");
+  ASSERT_EQ(Third.Mnemonic, "s_delay_alu");
+  EXPECT_EQ(getDelayProtectedSpan(Third), 3u);
+
+  InternalDecodedInst Sixth =
+      decodeDelay("s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_4) | "
+                  "instid1(SALU_CYCLE_1)");
+  ASSERT_EQ(Sixth.Mnemonic, "s_delay_alu");
+  EXPECT_EQ(getDelayProtectedSpan(Sixth), 6u);
+}
+
+TEST(RelocationDelaySpan, MalformedEncodingUsesConservativeMaximum) {
+  InternalDecodedInst Delay;
+  Delay.Mnemonic = "s_delay_alu";
+  EXPECT_EQ(getDelayProtectedSpan(Delay), 6u);
+
+  Delay.Inst.addOperand(llvm::MCOperand::createImm(12));
+  EXPECT_EQ(getDelayProtectedSpan(Delay), 6u);
+  Delay.Inst.getOperand(0).setImm(12u << 7);
+  EXPECT_EQ(getDelayProtectedSpan(Delay), 6u);
+  Delay.Inst.getOperand(0).setImm(6u << 4 | 1u << 7);
+  EXPECT_EQ(getDelayProtectedSpan(Delay), 6u);
+  Delay.Inst.getOperand(0).setImm(0x8001);
+  EXPECT_EQ(getDelayProtectedSpan(Delay), 6u);
+}
+
+TEST(WmmaSourceWindow, RejectsEveryInteriorEntryIncludingLiteralSlots) {
+  std::optional<llvm::DenseSet<uint64_t>> Targets;
+  Targets.emplace();
+  Targets->insert(0x100); // The replacement branch remains at the window head.
+  Targets->insert(0x114); // The return address is outside the open interval.
+  EXPECT_FALSE(
+      hasDirectControlFlowTargetInWindowInterior(Targets, 0x100, 0x114));
+
+  Targets->insert(0x108); // A literal slot in the original 16-byte WMMA.
+  EXPECT_TRUE(
+      hasDirectControlFlowTargetInWindowInterior(Targets, 0x100, 0x114));
+}
+
+TEST(WmmaSourceWindow, FailsClosedWithoutUsableTargetInformation) {
+  std::optional<llvm::DenseSet<uint64_t>> Targets;
+  EXPECT_TRUE(
+      hasDirectControlFlowTargetInWindowInterior(Targets, 0x100, 0x114));
+  Targets.emplace();
+  EXPECT_TRUE(
+      hasDirectControlFlowTargetInWindowInterior(Targets, 0x114, 0x100));
+}
+
+// -- encodeSetPCLongBranch geometry ------------------------------------------
+
+static uint64_t
+decodeSetPCLongBranchTarget(uint64_t From,
+                            llvm::ArrayRef<InternalDecodedInst> Decoded) {
+  const uint64_t PcBase = From + Decoded[0].Size;
+  const uint64_t Delta =
+      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
+  return PcBase + Delta;
+}
+
+TEST(EncodeSetPCLongBranch, BackwardLandsOnTargetWithoutDefiningScc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x81000;
+  constexpr uint64_t To = 0x1008;
+  llvm::SmallVector<uint8_t> Out =
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_FALSE(Out.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Decoded[1].Mnemonic, "s_add_nc_u64");
+  EXPECT_EQ(Decoded[2].Mnemonic, "s_set_pc_i64");
+  EXPECT_EQ(decodeSetPCLongBranchTarget(From, Decoded), To);
+
+  const llvm::MCRegister Pair = Decoded[0].Inst.getOperand(0).getReg();
+  EXPECT_EQ(Decoded[1].Inst.getOperand(0).getReg(), Pair);
+  EXPECT_EQ(Decoded[1].Inst.getOperand(1).getReg(), Pair);
+  EXPECT_EQ(Decoded[2].Inst.getOperand(0).getReg(), Pair);
+  for (const InternalDecodedInst &DI : Decoded) {
+    const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
+    for (llvm::MCPhysReg Reg : Desc.implicit_defs())
+      EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
+  }
+}
+
 TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
   constexpr uint64_t From = 0x1000;
   constexpr uint64_t To = 0x81000;
-  std::optional<llvm::SmallVector<uint8_t>> Out =
+  llvm::SmallVector<uint8_t> Out =
       encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
-  ASSERT_TRUE(Out);
-  EXPECT_EQ(Out->size(), 16u);
+  ASSERT_FALSE(Out.empty());
+  EXPECT_EQ(Out.size(), 16u);
 
   std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 3u);
-  ASSERT_TRUE(Decoded[1].Inst.getOperand(2).isImm());
-  uint64_t Delta =
-      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
-  EXPECT_EQ(From + MinInstSize + Delta, To);
+  EXPECT_EQ(decodeSetPCLongBranchTarget(From, Decoded), To);
 }
 
 TEST(EncodeSetPCLongBranch, InlineDisplacementUsesTwelveBytes) {
@@ -478,7 +674,7 @@ TEST(FindNearestSetPcGateway, FitsActualSixteenByteEncoding) {
 
   std::vector<NopSled> Gateways = {
       {/*Start=*/0x100, /*End=*/0x110, /*WritePos=*/0x100,
-       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+       /*OwnerStart=*/0, /*OwnerEnd=*/0x1000}};
   llvm::Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
       findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0,
                               /*TargetOffset=*/0x81000, /*SgprBase=*/12);
@@ -496,9 +692,9 @@ TEST(FindNearestSetPcGateway, SkipsNearerUndersizedCandidate) {
 
   std::vector<NopSled> Gateways = {
       {/*Start=*/0x80100, /*End=*/0x80110, /*WritePos=*/0x80100,
-       /*FunctionStart=*/0, /*FunctionEnd=*/0x100000},
+       /*OwnerStart=*/0, /*OwnerEnd=*/0x100000},
       {/*Start=*/0x80200, /*End=*/0x80214, /*WritePos=*/0x80200,
-       /*FunctionStart=*/0, /*FunctionEnd=*/0x100000}};
+       /*OwnerStart=*/0, /*OwnerEnd=*/0x100000}};
   llvm::Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
       findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0x80000,
                               /*TargetOffset=*/0x1004, /*SgprBase=*/12);
@@ -517,7 +713,7 @@ TEST(FindNearestSetPcGateway, DistinguishesNoFitFromEncodingFailure) {
 
   std::vector<NopSled> Gateways = {
       {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
-       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+       /*OwnerStart=*/0, /*OwnerEnd=*/0x1000}};
   llvm::Expected<std::optional<EncodedSetPcGateway>> NoFit =
       findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0,
                               /*TargetOffset=*/0x81000, /*SgprBase=*/12);
@@ -539,7 +735,7 @@ TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
 
   std::vector<NopSled> Gateways = {
       {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
-       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+       /*OwnerStart=*/0, /*OwnerEnd=*/0x1000}};
   llvm::Expected<uint64_t> NoSlots = countReachableSetPcGatewaySlots(
       Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x81000,
       /*SgprBase=*/12, /*MaxSlots=*/1);
@@ -558,15 +754,92 @@ TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
 TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
-  EXPECT_FALSE(encodeSetPCLongBranch(
-      S, std::numeric_limits<uint64_t>::max() - MinInstSize + 1, 0,
-      /*SgprBase=*/12));
+  EXPECT_TRUE(encodeSetPCLongBranch(
+                  S, std::numeric_limits<uint64_t>::max() - MinInstSize + 1, 0,
+                  /*SgprBase=*/12)
+                  .empty());
 }
 
-TEST(EncodeSetPCLongBranch, RejectsMisalignedScratchPair) {
+TEST(EncodeSetPCLongBranch, WideForwardDeltaUsesFullReservation) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
-  EXPECT_FALSE(encodeSetPCLongBranch(S, 0, 0x1000, /*SgprBase=*/3));
+
+  constexpr uint64_t From = 0x1000;
+  constexpr uint64_t To = 0x100002000ULL;
+  llvm::SmallVector<uint8_t> Out =
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_FALSE(Out.empty());
+  EXPECT_EQ(Out.size(), SetPcForwardSequenceBytes);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_EQ(decodeSetPCLongBranchTarget(From, Decoded), To);
+}
+
+TEST(EncodeSetPCLongBranch, CallTailSizeIsOwnerStableAtLiteralBoundaries) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t Source = 0x20000;
+  constexpr uint64_t CompactTarget = Source + 0x80000000ULL;
+  llvm::SmallVector<uint8_t> CompactAtSource =
+      encodeSetPCLongBranch(S, Source, CompactTarget, /*SgprBase=*/12);
+  llvm::SmallVector<uint8_t> WideAtEarlierSled =
+      encodeSetPCLongBranch(S, Source - MinInstSize, CompactTarget,
+                            /*SgprBase=*/12);
+  ASSERT_EQ(CompactAtSource.size(), 16u);
+  ASSERT_EQ(WideAtEarlierSled.size(), SetPcForwardSequenceBytes);
+  EXPECT_EQ(CompactAtSource.size() - MinInstSize, 12u);
+  EXPECT_EQ(encodeSCallI64(S, Source, Source - MinInstSize, /*SgprBase=*/12)
+                .size(),
+            MinInstSize);
+
+  constexpr uint64_t WideTarget = Source + 0x80000008ULL;
+  llvm::SmallVector<uint8_t> WideAtSource =
+      encodeSetPCLongBranch(S, Source, WideTarget, /*SgprBase=*/12);
+  llvm::SmallVector<uint8_t> CompactAtLaterSled =
+      encodeSetPCLongBranch(S, Source + 2 * MinInstSize, WideTarget,
+                            /*SgprBase=*/12);
+  ASSERT_EQ(WideAtSource.size(), SetPcForwardSequenceBytes);
+  ASSERT_EQ(CompactAtLaterSled.size(), 16u);
+  EXPECT_EQ(WideAtSource.size() - MinInstSize, 16u);
+  EXPECT_EQ(encodeSCallI64(S, Source, Source + 2 * MinInstSize,
+                          /*SgprBase=*/12)
+                .size(),
+            MinInstSize);
+
+  std::vector<InternalDecodedInst> Full;
+  ASSERT_TRUE(decodeTextSection(CompactAtSource.data(), CompactAtSource.size(),
+                                S, Full));
+  ASSERT_EQ(Full.size(), 3u);
+  EXPECT_EQ(Full[0].Inst.getOpcode(), S.SGetPcI64Opcode);
+  EXPECT_EQ(Full[0].Size, MinInstSize);
+  EXPECT_EQ(decodeSetPCLongBranchTarget(Source, Full), CompactTarget);
+
+  std::vector<InternalDecodedInst> Tail;
+  ASSERT_TRUE(decodeTextSection(CompactAtSource.data() + MinInstSize,
+                                CompactAtSource.size() - MinInstSize, S, Tail));
+  ASSERT_EQ(Tail.size(), 2u);
+  EXPECT_EQ(Tail[0].Inst.getOpcode(), S.SAddNcU64Opcode);
+  EXPECT_EQ(Tail[1].Inst.getOpcode(), S.SSetPcI64Opcode);
+  const unsigned Pair = Full[0].Inst.getOperand(0).getReg();
+  EXPECT_EQ(Tail[0].Inst.getOperand(0).getReg(), Pair);
+  EXPECT_EQ(Tail[0].Inst.getOperand(1).getReg(), Pair);
+  EXPECT_EQ(Tail[1].Inst.getOperand(0).getReg(), Pair);
+}
+
+TEST(EncodeSetPCLongBranch, RejectsUnalignedPairAndPcOverflow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  EXPECT_TRUE(encodeSetPCLongBranch(S, 0x1000, 0x2000,
+                                    /*SgprBase=*/13)
+                  .empty());
+  EXPECT_TRUE(encodeSetPCLongBranch(S, std::numeric_limits<uint64_t>::max() - 1,
+                                    0,
+                                    /*SgprBase=*/12)
+                  .empty());
 }
 
 // -- buildKernelEntryTrampolineFast ------------------------------------------
@@ -634,6 +907,64 @@ static uint64_t decodeFastStubTarget(const LLVMState &S, uint64_t StubVAddr,
   const uint32_t Carry = static_cast<uint32_t>(SumLo >> 32);
   const uint32_t ResHi = BaseHi + Hi + Carry;
   return (static_cast<uint64_t>(ResHi) << 32) | ResLo;
+}
+
+static llvm::SmallVector<uint8_t>
+getAppendedEntryStub(const std::vector<Trampoline> &Growth,
+                     const KernelEntryTrampolineFixup &Fixup) {
+  llvm::SmallVector<uint8_t> Flat;
+  for (const Trampoline &T : Growth)
+    Flat.append(T.Bytes.begin(), T.Bytes.end());
+  if (Fixup.StubTextOffset > Flat.size() ||
+      Flat.size() - Fixup.StubTextOffset < KernelEntryStubStride)
+    return {};
+  return llvm::SmallVector<uint8_t>(Flat.begin() + Fixup.StubTextOffset,
+                                    Flat.begin() + Fixup.StubTextOffset +
+                                        KernelEntryStubStride);
+}
+
+static void expectEntryStubUsesVcc(llvm::ArrayRef<uint8_t> Bytes,
+                                   const LLVMState &S) {
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_GE(Decoded.size(), 6u);
+  ASSERT_NE(S.MRI, nullptr);
+  ASSERT_TRUE(Decoded[2].Inst.getOperand(0).isReg());
+  ASSERT_TRUE(Decoded[3].Inst.getOperand(0).isReg());
+  ASSERT_TRUE(Decoded[4].Inst.getOperand(0).isReg());
+  ASSERT_TRUE(Decoded[5].Inst.getOperand(0).isReg());
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[2].Inst.getOperand(0).getReg())),
+      "VCC");
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[3].Inst.getOperand(0).getReg())),
+      "VCC_LO");
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[4].Inst.getOperand(0).getReg())),
+      "VCC_HI");
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[5].Inst.getOperand(0).getReg())),
+      "VCC");
+}
+
+static void expectEntryStubUsesTopNumberedPair(llvm::ArrayRef<uint8_t> Bytes,
+                                               const LLVMState &S) {
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_GE(Decoded.size(), 6u);
+  ASSERT_NE(S.MRI, nullptr);
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[2].Inst.getOperand(0).getReg())),
+      "SGPR104_SGPR105");
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[3].Inst.getOperand(0).getReg())),
+      "SGPR104");
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[4].Inst.getOperand(0).getReg())),
+      "SGPR105");
+  EXPECT_EQ(
+      llvm::StringRef(S.MRI->getName(Decoded[5].Inst.getOperand(0).getReg())),
+      "SGPR104_SGPR105");
 }
 
 TEST(BuildKernelEntryTrampolineFast, ForwardDeltaLandsOnEntry) {
@@ -747,11 +1078,24 @@ TEST(BuildKernelEntryTrampolineFast, PatchesScratchSgprRegisterFields) {
   EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
 }
 
-// A kernel whose live SGPR count leaves no aligned scratch pair below MaxSgprs
-// must decline cleanly (nullopt), never clobber a live SGPR or crash. This is
-// the correctness guarantee the per-kernel scratch allocation adds over a fixed
-// pair: MetadataSgprCount is set to the top of the addressable range.
-TEST(KernelEntryTrampolineFast, DeclinesWhenNoScratchPairFits) {
+TEST(BuildKernelEntryTrampolineFast, EncodesLogicalTopPairAsVcc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t StubVAddr = 0x180000;
+  constexpr uint64_t EntryVAddr = 0x100000;
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr,
+                                     /*ScratchSgpr=*/Gfx1250MaxNumberedSgprs);
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  expectEntryStubUsesVcc(Bytes, S);
+  EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
+}
+
+// .sgpr_count is a total that includes VCC. Counts 105 through 108 have no
+// unused numbered pair, but may use the entry-only VCC temporary and must
+// reserve the complete 108-SGPR metadata total.
+TEST(KernelEntryTrampolineFast, UsesVccForValidTopMetadataCounts) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
@@ -759,9 +1103,42 @@ TEST(KernelEntryTrampolineFast, DeclinesWhenNoScratchPairFits) {
   ASSERT_EQ(EndPgm.size(), MinInstSize);
   llvm::SmallVector<uint8_t> Text(EndPgm.begin(), EndPgm.end());
 
+  for (unsigned SgprCount : {105u, 106u, 107u, 108u}) {
+    SCOPED_TRACE(SgprCount);
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.MetadataSgprCount = SgprCount;
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(Text, Opts);
+    llvm::Expected<ElfView> View =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+    std::vector<Trampoline> Growth;
+    std::vector<KernelEntryTrampolineFixup> Fixups;
+    std::optional<uint32_t> Count = appendKernelEntryTrampolinesFast(
+        *View, "gfx1250", /*MaxSgprs=*/Gfx1250MaxNumberedSgprs, Growth, Fixups);
+    ASSERT_TRUE(Count.has_value());
+    EXPECT_EQ(*Count, 1u);
+    ASSERT_EQ(Fixups.size(), 1u);
+    EXPECT_EQ(Fixups[0].RequiredSgprs, Gfx1250MaxTotalSgprs);
+    EXPECT_FALSE(Fixups[0].SkipSgprReservation);
+    llvm::SmallVector<uint8_t> Stub = getAppendedEntryStub(Growth, Fixups[0]);
+    ASSERT_EQ(Stub.size(), KernelEntryStubStride);
+    expectEntryStubUsesVcc(Stub, S);
+  }
+}
+
+TEST(KernelEntryTrampolineFast,
+     TopNumberedPairConservativelyReservesPossibleVcc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+
   comgr_test::KernelDescriptorElfOptions Opts;
-  // 106 SGPRs used: no aligned pair fits below the 106-SGPR gfx1250 limit.
-  Opts.MetadataSgprCount = 106;
+  // A total of 104 may mean 102 numbered SGPRs plus VCC. The conservative
+  // allocation still selects s[104:105], then reserves VCC as well.
+  Opts.MetadataSgprCount = 104;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(Text, Opts);
   llvm::Expected<ElfView> View =
@@ -771,13 +1148,42 @@ TEST(KernelEntryTrampolineFast, DeclinesWhenNoScratchPairFits) {
   std::vector<Trampoline> Growth;
   std::vector<KernelEntryTrampolineFixup> Fixups;
   std::optional<uint32_t> Count = appendKernelEntryTrampolinesFast(
-      *View, "gfx1250", /*MaxSgprs=*/106, Growth, Fixups);
-  EXPECT_FALSE(Count.has_value());
+      *View, "gfx1250", /*MaxSgprs=*/Gfx1250MaxNumberedSgprs, Growth, Fixups);
+  ASSERT_TRUE(Count.has_value());
+  EXPECT_EQ(*Count, 1u);
+  ASSERT_EQ(Fixups.size(), 1u);
+  EXPECT_EQ(Fixups[0].RequiredSgprs, Gfx1250MaxTotalSgprs);
+  llvm::SmallVector<uint8_t> Stub = getAppendedEntryStub(Growth, Fixups[0]);
+  ASSERT_EQ(Stub.size(), KernelEntryStubStride);
+  expectEntryStubUsesTopNumberedPair(Stub, S);
 }
 
-// The complement of the decline case: a modest SGPR count leaves room, so the
-// fast path installs one trampoline and records the bumped scratch pair in the
-// fixup (SkipSgprReservation=false), exactly like the MC path.
+TEST(KernelEntryTrampolineFast, RejectsMalformedTotalSgprCount) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = Gfx1250MaxTotalSgprs + 1;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  EXPECT_FALSE(appendKernelEntryTrampolinesFast(
+                   *View, "gfx1250",
+                   /*MaxSgprs=*/Gfx1250MaxNumberedSgprs, Growth, Fixups)
+                   .has_value());
+  EXPECT_TRUE(Growth.empty());
+  EXPECT_TRUE(Fixups.empty());
+}
+
+// A modest SGPR count leaves a numbered pair, so the fast path installs one
+// trampoline and records the conservative metadata total in the fixup.
 TEST(KernelEntryTrampolineFast, AllocatesPerKernelScratchAndBumpsReservation) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -801,9 +1207,39 @@ TEST(KernelEntryTrampolineFast, AllocatesPerKernelScratchAndBumpsReservation) {
   ASSERT_TRUE(Count.has_value());
   EXPECT_EQ(*Count, 1u);
   ASSERT_EQ(Fixups.size(), 1u);
-  // Scratch pair is s[8:9]; the fixup records the top of the pair (base + 2).
-  EXPECT_EQ(Fixups[0].RequiredSgprs, 10u);
+  // Keep room for VCC because .sgpr_count does not separate special SGPRs.
+  EXPECT_EQ(Fixups[0].RequiredSgprs, 12u);
   EXPECT_FALSE(Fixups[0].SkipSgprReservation);
+}
+
+TEST(KernelEntryTrampoline, RejectsAmbiguousDescriptorNamesOnBothPaths) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.Kernels = {
+      {"kernel", 0x1000, 0x2000, /*EntryOffset=*/-0x1000},
+      {"kernel", 0x1100, 0x2100, /*EntryOffset=*/-0x1000},
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Bytes.data(), Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  ASSERT_FALSE(View->kernelDescriptorCacheIsComplete());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  EXPECT_FALSE(appendKernelEntryTrampolines(
+                   *View, S, /*MaxSgprs=*/106, Growth, Fixups)
+                   .has_value());
+  EXPECT_TRUE(Growth.empty());
+  EXPECT_TRUE(Fixups.empty());
+
+  EXPECT_FALSE(appendKernelEntryTrampolinesFast(
+                   *View, "gfx1250", /*MaxSgprs=*/106, Growth, Fixups)
+                   .has_value());
+  EXPECT_TRUE(Growth.empty());
+  EXPECT_TRUE(Fixups.empty());
 }
 
 TEST(IsSBranchReachable, CoversBoundariesAlignmentAndPcOverflow) {
@@ -1548,6 +1984,40 @@ TEST(FindNearestSled, HandlesLargeUnsignedOffsets) {
   EXPECT_EQ(Sled, &Sleds[1]);
 }
 
+TEST(GatewaySlotReachability, CursorCanCrossLowerReachBoundary) {
+  const uint64_t Source = MaxSledDistance + 0x1000;
+  const uint64_t Start = Source - MaxSledDistance;
+  NopSled Sled = {Start, Start + 24, Start, 0,
+                  std::numeric_limits<uint64_t>::max()};
+  Sled.GlobalGateway = true;
+
+  // The initial cursor is exactly out of range, but advancing one dword leaves
+  // a complete 20-byte gateway at a reachable address.
+  EXPECT_TRUE(canEverReachGatewaySlot(Sled, Source, /*Needed=*/20));
+  NopSled FourByteAdvance = Sled;
+  FourByteAdvance.WritePos += MinInstSize;
+  EXPECT_TRUE(canEverReachGatewaySlot(FourByteAdvance, Source, /*Needed=*/20));
+  NopSled TwentyByteAdvance = Sled;
+  TwentyByteAdvance.WritePos += 20;
+  EXPECT_FALSE(
+      canEverReachGatewaySlot(TwentyByteAdvance, Source, /*Needed=*/20));
+
+  Sled.End = Start + 20;
+  EXPECT_FALSE(canEverReachGatewaySlot(Sled, Source, /*Needed=*/20));
+}
+
+TEST(GatewaySlotReachability, CursorCannotMoveBackIntoUpperReachBoundary) {
+  const uint64_t Source = 0x1000;
+  NopSled Sled = {Source + MaxSledDistance - MinInstSize,
+                  Source + MaxSledDistance + 64, Source + MaxSledDistance, 0,
+                  std::numeric_limits<uint64_t>::max()};
+  Sled.GlobalGateway = true;
+
+  EXPECT_FALSE(canEverReachGatewaySlot(Sled, Source, /*Needed=*/20));
+  Sled.WritePos -= MinInstSize;
+  EXPECT_TRUE(canEverReachGatewaySlot(Sled, Source, /*Needed=*/20));
+}
+
 // -- assembleSingleInst / decodeTextSection round-trip ------------------------
 
 TEST(AssembleDecode, SNopRoundTrip) {
@@ -1563,7 +2033,6 @@ TEST(AssembleDecode, SNopRoundTrip) {
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 1u);
-  EXPECT_TRUE(Decoded[0].DecodeSucceeded);
   EXPECT_EQ(Decoded[0].Size, MinInstSize);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
 }
@@ -1784,6 +2253,425 @@ static bool appendSingleInstBytes(llvm::SmallVectorImpl<uint8_t> &Bytes,
   return true;
 }
 
+static std::vector<InternalDecodedInst>
+decodeInstSequence(llvm::ArrayRef<llvm::StringRef> Instructions,
+                   const LLVMState &S) {
+  llvm::SmallVector<uint8_t> Bytes;
+  for (llvm::StringRef Inst : Instructions)
+    if (!appendSingleInstBytes(Bytes, Inst, S))
+      return {};
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  return Decoded;
+}
+
+static void expectCachedSiteDeadMatchesOracle(
+    llvm::ArrayRef<llvm::StringRef> Instructions, size_t ResumeIndex,
+    const LLVMState &S) {
+  llvm::SmallVector<uint8_t> Text;
+  for (llvm::StringRef Inst : Instructions)
+    ASSERT_TRUE(appendSingleInstBytes(Text, Inst, S));
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 106;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(ViewOrErr->textData(), ViewOrErr->textSize(), S,
+                                Decoded));
+  ASSERT_EQ(Decoded.size(), Instructions.size());
+  ASSERT_GT(ResumeIndex, 0u);
+  ASSERT_LT(ResumeIndex, Decoded.size());
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config, Decoded, ViewOrErr->textData(),
+                   ViewOrErr->textSize(), 0, S, Trampolines, Sleds,
+                   *ViewOrErr, Liveness, KernelStats, ScratchPatches,
+                   ControlFlow, Prof};
+  precomputeSiteDeadSgprFacts(Ctx);
+
+  const InternalDecodedInst &Previous = Decoded[ResumeIndex - 1];
+  std::optional<llvm::BitVector> Cached = getSiteDeadNumberedSgprs(
+      Ctx, Previous.Offset, Previous.Size);
+  ASSERT_TRUE(Cached);
+  for (unsigned Pair = 0; Pair + 1 < Config.MaxSgprs; Pair += 2) {
+    bool CachedPair = Cached->test(Pair) && Cached->test(Pair + 1);
+    bool OraclePair = isSgprPairDeadFrom(
+        Decoded, ResumeIndex, Pair, S,
+        llvm::ArrayRef<uint8_t>(ViewOrErr->textData(), ViewOrErr->textSize()));
+    EXPECT_EQ(CachedPair, OraclePair) << "pair s[" << Pair << ':' << Pair + 1
+                                      << ']';
+  }
+}
+
+TEST(CollectTouchedNumberedSgprs, ChecksTheCompleteReplacement) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Clean;
+  ASSERT_TRUE(appendSingleInstBytes(Clean, "s_wait_dscnt 0", S));
+  ASSERT_TRUE(appendSingleInstBytes(Clean, "v_add_u32 v0, v1, v2", S));
+  std::optional<llvm::BitVector> CleanTouched =
+      collectTouchedNumberedSgprs(Clean, /*NumberedSgprLimit=*/106, S);
+  ASSERT_TRUE(CleanTouched);
+  EXPECT_FALSE(CleanTouched->test(62));
+  EXPECT_FALSE(CleanTouched->test(63));
+
+  llvm::SmallVector<uint8_t> TouchesPair = Clean;
+  ASSERT_TRUE(
+      appendSingleInstBytes(TouchesPair, "s_mov_b64 s[62:63], s[0:1]", S));
+  std::optional<llvm::BitVector> PairTouched =
+      collectTouchedNumberedSgprs(TouchesPair,
+                                  /*NumberedSgprLimit=*/106, S);
+  ASSERT_TRUE(PairTouched);
+  EXPECT_TRUE(PairTouched->test(0));
+  EXPECT_TRUE(PairTouched->test(1));
+  EXPECT_TRUE(PairTouched->test(62));
+  EXPECT_TRUE(PairTouched->test(63));
+}
+
+TEST(SgprPairDeadFrom, AcceptsDefsBeforeUsesOnEveryDirectPath) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_cselect_b32 s62, -1, 0", "s_branch 1",
+       "s_cselect_b32 s62, -1, 0", "s_cselect_b32 s63, -1, 0",
+       "s_cmp_lg_u64 s[62:63], 0", "s_endpgm"},
+      S);
+  ASSERT_EQ(Decoded.size(), 8u);
+  EXPECT_TRUE(isSgprPairDeadFrom(Decoded, /*ResumeIndex=*/1,
+                                 /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, RejectsUseBeforeDefOnOneDirectPath) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_cselect_b32 s62, -1, 0", "s_branch 1",
+       "s_cmp_lg_u32 s62, 0", "s_cselect_b32 s63, -1, 0", "s_endpgm"},
+      S);
+  ASSERT_EQ(Decoded.size(), 7u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Decoded, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, RejectsHiddenTiedUseBeforeDefinition) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_bitset0_b64 s[62:63], 1", "s_endpgm"}, S);
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Decoded, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, SwapPcCallFullyDefinesLinkPair) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded =
+      decodeInstSequence({"s_nop 0", "s_swap_pc_i64 s[30:31], s[2:3]",
+                          "s_cmp_lg_u64 s[30:31], 0", "s_endpgm"},
+                         S);
+  ASSERT_EQ(Decoded.size(), 4u);
+  EXPECT_TRUE(isSgprPairDeadFrom(Decoded, /*ResumeIndex=*/1,
+                                 /*SgprBase=*/30, S));
+}
+
+TEST(SgprPairDeadFrom, TracksTheTwoHalvesIndependently) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Safe = decodeInstSequence(
+      {"s_nop 0", "s_cselect_b32 s62, -1, 0", "s_cselect_b32 s63, -1, 0",
+       "s_cmp_lg_u64 s[62:63], 0", "s_endpgm"},
+      S);
+  ASSERT_EQ(Safe.size(), 5u);
+  EXPECT_TRUE(isSgprPairDeadFrom(Safe, /*ResumeIndex=*/1,
+                                 /*SgprBase=*/62, S));
+
+  std::vector<InternalDecodedInst> HighLive =
+      decodeInstSequence({"s_nop 0", "s_cselect_b32 s62, -1, 0",
+                          "s_cmp_lg_u32 s63, 0", "s_endpgm"},
+                         S);
+  ASSERT_EQ(HighLive.size(), 4u);
+  EXPECT_FALSE(isSgprPairDeadFrom(HighLive, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, ConvergesAcrossABackedge) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_cselect_b32 s62, -1, 0", "s_cbranch_scc0 -2",
+       "s_cselect_b32 s63, -1, 0", "s_cmp_lg_u64 s[62:63], 0", "s_endpgm"},
+      S);
+  ASSERT_EQ(Decoded.size(), 6u);
+  EXPECT_TRUE(isSgprPairDeadFrom(Decoded, /*ResumeIndex=*/1,
+                                 /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, RejectsUnboundedControlFlow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Indirect =
+      decodeInstSequence({"s_nop 0", "s_setpc_b64 s[40:41]", "s_endpgm"}, S);
+  ASSERT_EQ(Indirect.size(), 3u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Indirect, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+
+  std::vector<InternalDecodedInst> Outside =
+      decodeInstSequence({"s_nop 0", "s_branch 10", "s_endpgm"}, S);
+  ASSERT_EQ(Outside.size(), 3u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Outside, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, RejectsLivePairAtCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Live = decodeInstSequence(
+      {"s_nop 0", "s_call_i64 s[30:31], 0", "s_endpgm"}, S);
+  ASSERT_EQ(Live.size(), 3u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Live, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+
+  std::vector<InternalDecodedInst> Killed = decodeInstSequence(
+      {"s_nop 0", "s_mov_b64 s[62:63], 0", "s_call_i64 s[30:31], 0",
+       "s_endpgm"},
+      S);
+  ASSERT_EQ(Killed.size(), 4u);
+  EXPECT_TRUE(isSgprPairDeadFrom(Killed, /*ResumeIndex=*/1,
+                                 /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, RejectsLivePairAtFunctionExit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_set_pc_i64 s[30:31]"}, S);
+  ASSERT_EQ(Decoded.size(), 2u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Decoded, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+}
+
+TEST(SgprPairDeadFrom, RequiresDefinitionOnEveryExitPath) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Bypass = decodeInstSequence(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_mov_b64 s[62:63], 0",
+       "s_branch 1", "s_nop 0", "s_endpgm"},
+      S);
+  ASSERT_EQ(Bypass.size(), 6u);
+  EXPECT_FALSE(isSgprPairDeadFrom(Bypass, /*ResumeIndex=*/1,
+                                  /*SgprBase=*/62, S));
+
+  std::vector<InternalDecodedInst> BothDefined = decodeInstSequence(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_mov_b64 s[62:63], 0",
+       "s_branch 1", "s_mov_b64 s[62:63], 0", "s_endpgm"},
+      S);
+  ASSERT_EQ(BothDefined.size(), 6u);
+  EXPECT_TRUE(isSgprPairDeadFrom(BothDefined, /*ResumeIndex=*/1,
+                                 /*SgprBase=*/62, S));
+}
+
+TEST(VccPairDeadFrom, AcceptsWave32LowDefinitionAndStandardReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "v_cmp_lt_u32_e32 vcc_lo, v0, v1",
+       "s_and_b32 s0, s1, vcc_lo", "s_set_pc_i64 s[30:31]"},
+      S);
+  ASSERT_EQ(Decoded.size(), 4u);
+  // The implicit wave32 compare kills VCC_LO. VCC_HI is unused until the
+  // exact ABI return, where caller-clobbered VCC stops being observable.
+  EXPECT_TRUE(isVccPairDeadFrom(Decoded, /*ResumeIndex=*/1, S));
+}
+
+TEST(VccPairDeadFrom, RejectsUseBeforeDefinitionOnOnePath) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_cbranch_scc0 2",
+       "v_cmp_lt_u32_e32 vcc_lo, v0, v1", "s_branch 1",
+       "s_and_b32 s0, s1, vcc_lo", "s_set_pc_i64 s[30:31]"},
+      S);
+  ASSERT_EQ(Decoded.size(), 6u);
+  EXPECT_FALSE(isVccPairDeadFrom(Decoded, /*ResumeIndex=*/1, S));
+}
+
+TEST(VccPairDeadFrom, RejectsExplicitHighUseBeforeDefinition) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_cmp_lg_u32 vcc_hi, 0",
+       "v_cmp_lt_u32_e32 vcc_lo, v0, v1", "s_set_pc_i64 s[30:31]"},
+      S);
+  ASSERT_EQ(Decoded.size(), 4u);
+  EXPECT_FALSE(isVccPairDeadFrom(Decoded, /*ResumeIndex=*/1, S));
+}
+
+TEST(VccPairDeadFrom, RejectsImplicitPredicateUseBeforeDefinition) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_cbranch_vccz 1",
+       "v_cmp_lt_u32_e32 vcc_lo, v0, v1", "s_set_pc_i64 s[30:31]"},
+      S);
+  ASSERT_EQ(Decoded.size(), 4u);
+  EXPECT_FALSE(isVccPairDeadFrom(Decoded, /*ResumeIndex=*/1, S));
+}
+
+TEST(VccPairDeadFrom, RejectsUnknownIndirectTransfer) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_setpc_b64 s[40:41]"}, S);
+  ASSERT_EQ(Decoded.size(), 2u);
+  EXPECT_FALSE(isVccPairDeadFrom(Decoded, /*ResumeIndex=*/1, S));
+}
+
+TEST(VccPairDeadFrom, AcceptsStandardLinkCallBoundary) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  std::vector<InternalDecodedInst> Decoded = decodeInstSequence(
+      {"s_nop 0", "s_swap_pc_i64 s[30:31], s[2:3]"}, S);
+  ASSERT_EQ(Decoded.size(), 2u);
+  EXPECT_TRUE(isVccPairDeadFrom(Decoded, /*ResumeIndex=*/1, S));
+}
+
+TEST(SiteDeadSgprFacts, CachedMasksMatchPathOracle) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_cselect_b32 s62, -1, 0",
+       "s_branch 1", "s_cselect_b32 s62, -1, 0",
+       "s_cselect_b32 s63, -1, 0", "s_cmp_lg_u64 s[62:63], 0",
+       "s_endpgm"},
+      1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_cselect_b32 s62, -1, 0",
+       "s_branch 1", "s_cmp_lg_u32 s62, 0", "s_cselect_b32 s63, -1, 0",
+       "s_endpgm"},
+      1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_bitset0_b64 s[62:63], 1", "s_endpgm"}, 1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_swap_pc_i64 s[30:31], s[2:3]",
+       "s_cmp_lg_u64 s[30:31], 0", "s_endpgm"},
+      1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_cselect_b32 s62, -1, 0", "s_cbranch_scc0 -2",
+       "s_cselect_b32 s63, -1, 0", "s_cmp_lg_u64 s[62:63], 0",
+       "s_endpgm"},
+      1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_setpc_b64 s[40:41]", "s_endpgm"}, 1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_call_i64 s[30:31], 0", "s_endpgm"}, 1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_mov_b64 s[62:63], 0", "s_call_i64 s[30:31], 0",
+       "s_endpgm"},
+      1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_mov_b64 s[62:63], 0",
+       "s_branch 1", "s_nop 0", "s_endpgm"},
+      1, S);
+  expectCachedSiteDeadMatchesOracle(
+      {"s_nop 0", "s_cbranch_scc0 2", "s_mov_b64 s[62:63], 0",
+       "s_branch 1", "s_mov_b64 s[62:63], 0", "s_endpgm"},
+      1, S);
+}
+
+TEST(SiteDeadSgprFacts, ProofPoisonDoesNotInflateNumberedLimit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = {0xff, 0xff, 0xff, 0xff};
+  ASSERT_TRUE(appendSingleInstBytes(Text, "s_mov_b32 s5, 0", S));
+  ASSERT_TRUE(appendSingleInstBytes(Text, "s_endpgm", S));
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.EmitKernelDescriptorSymbol = false;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(ViewOrErr->textData(), ViewOrErr->textSize(), S,
+                                Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  ASSERT_EQ(Decoded[0].Mnemonic, "<unknown>");
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config, Decoded, ViewOrErr->textData(),
+                   ViewOrErr->textSize(), 0, S, Trampolines, Sleds,
+                   *ViewOrErr, Liveness, KernelStats, ScratchPatches,
+                   ControlFlow, Prof};
+  precomputeSiteDeadSgprFacts(Ctx);
+
+  auto It = Ctx.SiteDeadSgprFacts.find({0, ViewOrErr->textSize()});
+  ASSERT_NE(It, Ctx.SiteDeadSgprFacts.end());
+  EXPECT_EQ(It->second.NumberedLimit, 6u);
+}
+
+TEST(FindSafeSgprScratchBlock, RejectsUndecodedInstructions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = {0xff, 0xff, 0xff, 0xff};
+  ASSERT_TRUE(appendSingleInstBytes(Text, "s_endpgm", S));
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(ViewOrErr->textData(), ViewOrErr->textSize(), S,
+                                Decoded));
+  ASSERT_EQ(Decoded.size(), 2u);
+  ASSERT_EQ(Decoded[0].Mnemonic, "<unknown>");
+
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
+  PatchContext Ctx{Config, Decoded, ViewOrErr->textData(),
+                   ViewOrErr->textSize(), 0, S, Trampolines, Sleds,
+                   *ViewOrErr, Liveness, KernelStats, ScratchPatches,
+                   ControlFlow, Prof};
+
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/2,
+                                        /*Alignment=*/2, "unit test"));
+}
+
 TEST(CheckVgprOverlap, DetectsDirectOverlap) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1850,44 +2738,6 @@ TEST(BuildTrampoline, EmptyOnBadAsm) {
   EXPECT_TRUE(T.Bytes.empty());
 }
 
-// -- DS two-address expansion ------------------------------------------------
-
-TEST(ExpandDs2Addr, PreservesAddressNeededBySecondLoad) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(
-      "ds_load_2addr_b64 v[12:15], v12 offset0:0 offset1:1", S);
-  ASSERT_FALSE(Bytes.empty());
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 1u);
-
-  std::optional<std::vector<std::string>> Expanded =
-      expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic, "ds_load_b64", S);
-  ASSERT_TRUE(Expanded);
-  ASSERT_EQ(Expanded->size(), 2u);
-  EXPECT_EQ((*Expanded)[0], "ds_load_b64 v[14:15], v12 offset:8");
-  EXPECT_EQ((*Expanded)[1], "ds_load_b64 v[12:13], v12");
-}
-
-TEST(ExpandDs2Addr, RejectsCyclicExchangeDependency) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-
-  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(
-      "ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] "
-      "offset0:0 offset1:1",
-      S);
-  ASSERT_FALSE(Bytes.empty());
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 1u);
-
-  EXPECT_FALSE(expandDs2Addr(Decoded[0].Inst, Decoded[0].Mnemonic,
-                             "ds_storexchg_rtn_b64", S));
-}
-
 // -- buildKernelEntryTrampoline -----------------------------------------------
 
 TEST(BuildKernelEntryTrampoline, BuildsRecognizedPcRelativeStub) {
@@ -1929,6 +2779,23 @@ TEST(BuildKernelEntryTrampoline, BuildsRecognizedPcRelativeStub) {
       Decoded[4].Inst,
       (llvm::Twine("s_addc_u32 s9, s9, 0x") + llvm::utohexstr(Hi)).str(), S);
   expectInstMatchesAsm(Decoded[5].Inst, "s_set_pc_i64 s[8:9]", S);
+}
+
+TEST(BuildKernelEntryTrampoline, SpellsLogicalTopPairAsVcc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t StubVAddr = 0x200000;
+  constexpr uint64_t EntryVAddr = 0x10100;
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampoline(StubVAddr, EntryVAddr,
+                                 /*ScratchSgpr=*/Gfx1250MaxNumberedSgprs, S);
+
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  EXPECT_TRUE(isKernelEntryTrampoline(Bytes, S));
+  EXPECT_EQ(getKernelEntryTrampolineTargetVAddr(Bytes, StubVAddr, S),
+            EntryVAddr);
+  expectEntryStubUsesVcc(Bytes, S);
 }
 
 TEST(BuildKernelEntryTrampoline, PrefixPrefiltersNonStubBytes) {
@@ -2477,7 +3344,8 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
             ExpectedStubOffset + KernelEntryStubStride + ExpectedGuard);
 
   std::unique_ptr<llvm::WritableMemoryBuffer> Out =
-      ViewOrErr->growWithTrampolines(Growth, S.SNopBytes);
+      ViewOrErr->growWithTrampolines(
+          Growth, S.SNopBytes, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Out, nullptr);
 
   ASSERT_TRUE(
@@ -2503,7 +3371,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
                             hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE),
             KernelEntryStubInstPrefLines);
   EXPECT_NE(OutRsrc3 & hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_GLG_EN, 0u);
-  EXPECT_EQ(Fixups[0].RequiredSgprs, 10u);
+  EXPECT_EQ(Fixups[0].RequiredSgprs, 12u);
   uint32_t OutRsrc1 = 0;
   std::memcpy(&OutRsrc1,
               OutKd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
@@ -2764,7 +3632,8 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   ASSERT_TRUE(PoolVAddr.has_value());
 
   std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
-      View1->growWithTrampolines(Growth1, S.SNopBytes);
+      View1->growWithTrampolines(
+          Growth1, S.SNopBytes, ExecutablePoolTargetState::Neutral);
   ASSERT_NE(Grown, nullptr);
   ASSERT_TRUE(
       rewriteKernelEntryDescriptorOffsets(*Grown, *PoolVAddr, S.Cpu, Fixups1));
@@ -2923,15 +3792,74 @@ TEST(KernelEntryTrampoline, AppendReturnsZeroWhenNoDescriptorsExist) {
   EXPECT_TRUE(Fixups.empty());
 }
 
-TEST(KernelEntryTrampoline, AppendFailsWithoutSgprScratchPair) {
+TEST(KernelEntryTrampoline, UsesVccForValidTopMetadataCounts) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
   llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
   ASSERT_EQ(Text.size(), MinInstSize);
 
+  for (unsigned SgprCount : {105u, 106u, 107u, 108u}) {
+    SCOPED_TRACE(SgprCount);
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.MetadataSgprCount = SgprCount;
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(Text, Opts);
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+    std::vector<Trampoline> Growth;
+    std::vector<KernelEntryTrampolineFixup> Fixups;
+    std::optional<uint32_t> Count = appendKernelEntryTrampolines(
+        *ViewOrErr, S, /*MaxSgprs=*/Gfx1250MaxNumberedSgprs, Growth, Fixups);
+
+    ASSERT_TRUE(Count.has_value());
+    EXPECT_EQ(*Count, 1u);
+    ASSERT_EQ(Fixups.size(), 1u);
+    EXPECT_EQ(Fixups[0].RequiredSgprs, Gfx1250MaxTotalSgprs);
+    EXPECT_FALSE(Fixups[0].SkipSgprReservation);
+    llvm::SmallVector<uint8_t> Stub = getAppendedEntryStub(Growth, Fixups[0]);
+    ASSERT_EQ(Stub.size(), KernelEntryStubStride);
+    expectEntryStubUsesVcc(Stub, S);
+  }
+}
+
+TEST(KernelEntryTrampoline, TopNumberedPairConservativelyReservesPossibleVcc) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+
   comgr_test::KernelDescriptorElfOptions Opts;
-  Opts.MetadataSgprCount = 105;
+  Opts.MetadataSgprCount = 104;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  std::optional<uint32_t> Count = appendKernelEntryTrampolines(
+      *ViewOrErr, S, /*MaxSgprs=*/Gfx1250MaxNumberedSgprs, Growth, Fixups);
+  ASSERT_TRUE(Count.has_value());
+  EXPECT_EQ(*Count, 1u);
+  ASSERT_EQ(Fixups.size(), 1u);
+  EXPECT_EQ(Fixups[0].RequiredSgprs, Gfx1250MaxTotalSgprs);
+  llvm::SmallVector<uint8_t> Stub = getAppendedEntryStub(Growth, Fixups[0]);
+  ASSERT_EQ(Stub.size(), KernelEntryStubStride);
+  expectEntryStubUsesTopNumberedPair(Stub, S);
+}
+
+TEST(KernelEntryTrampoline, RejectsMalformedTotalSgprCountTransactionally) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = Gfx1250MaxTotalSgprs + 1;
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(Text, Opts);
   llvm::Expected<ElfView> ViewOrErr =
@@ -2943,10 +3871,10 @@ TEST(KernelEntryTrampoline, AppendFailsWithoutSgprScratchPair) {
   std::vector<Trampoline> Growth;
   Growth.push_back(Existing);
   std::vector<KernelEntryTrampolineFixup> Fixups;
-  std::optional<uint32_t> Count = appendKernelEntryTrampolines(
-      *ViewOrErr, S, /*MaxSgprs=*/106, Growth, Fixups);
-
-  EXPECT_FALSE(Count.has_value());
+  EXPECT_FALSE(appendKernelEntryTrampolines(
+                   *ViewOrErr, S,
+                   /*MaxSgprs=*/Gfx1250MaxNumberedSgprs, Growth, Fixups)
+                   .has_value());
   ASSERT_EQ(Growth.size(), 1u);
   EXPECT_EQ(llvm::ArrayRef<uint8_t>(Growth[0].Bytes),
             llvm::ArrayRef<uint8_t>(Existing.Bytes));
@@ -3069,6 +3997,16 @@ TEST(ClassifyWmmaNops, CoversKnownMnemonics) {
     EXPECT_EQ(Req.A0Nops, C.A0Nops) << C.Mnemonic.str();
     EXPECT_EQ(Req.B0Nops, C.B0Nops) << C.Mnemonic.str();
   }
+}
+
+TEST(WmmaHazardDeficit, KeepsStrongestRequirementPerCandidate) {
+  llvm::DenseMap<size_t, int> MaxDeficits;
+  EXPECT_EQ(updateWmmaHazardDeficit(MaxDeficits, 7, 3), 3);
+  EXPECT_EQ(updateWmmaHazardDeficit(MaxDeficits, 7, 8), 8);
+  EXPECT_EQ(updateWmmaHazardDeficit(MaxDeficits, 7, 2), 8);
+  EXPECT_EQ(updateWmmaHazardDeficit(MaxDeficits, 11, 4), 4);
+  EXPECT_EQ(MaxDeficits.lookup(7), 8);
+  EXPECT_EQ(MaxDeficits.lookup(11), 4);
 }
 
 // -- patchScaleSrc2 -----------------------------------------------------------
@@ -3351,6 +4289,548 @@ TEST(AddTid, StoreTrampolineThroughBuildTrampoline) {
                                       "s_branch"};
   expectDecodedMnemonics(Decoded, Expected);
   expectDecodedBodyMatchesAsm(Decoded, AsmLines, S);
+}
+
+// -- tensor external control-flow provenance --------------------------------
+
+static InternalDecodedInst decodeTensorTestInstruction(
+    llvm::ArrayRef<uint8_t> Bytes, uint64_t Offset, const LLVMState &S) {
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  EXPECT_EQ(Decoded.size(), 1u);
+  if (Decoded.empty())
+    return {};
+  Decoded.front().Offset = Offset;
+  return std::move(Decoded.front());
+}
+
+static InternalDecodedInst decodeTensorTestInstruction(
+    llvm::StringRef Assembly, uint64_t Offset, const LLVMState &S) {
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Assembly, S);
+  EXPECT_FALSE(Bytes.empty()) << Assembly.str();
+  return decodeTensorTestInstruction(Bytes, Offset, S);
+}
+
+static std::vector<InternalDecodedInst>
+decodeTensorTestBlock(llvm::ArrayRef<uint8_t> Bytes, uint64_t Offset,
+                      const LLVMState &S) {
+  std::vector<InternalDecodedInst> Decoded;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  for (InternalDecodedInst &DI : Decoded)
+    DI.Offset += Offset;
+  return Decoded;
+}
+
+static std::vector<InternalDecodedInst>
+buildTensorProvenanceBody(const LLVMState &S,
+                          std::optional<uint64_t> ExternalTarget =
+                              std::nullopt,
+                          bool SplitRelay = false) {
+  std::vector<InternalDecodedInst> Result;
+  uint64_t Offset = 0;
+  auto Add = [&](llvm::StringRef Assembly) {
+    InternalDecodedInst DI =
+        decodeTensorTestInstruction(Assembly, Offset, S);
+    Offset += DI.Size;
+    Result.push_back(std::move(DI));
+  };
+  Add("v_mov_b32 v0, 0");
+  Add("v_readfirstlane_b32 s4, v0");
+  if (SplitRelay)
+    Add("s_get_pc_i64 s[0:1]");
+  if (ExternalTarget) {
+    llvm::SmallVector<uint8_t> Branch = S.encodeSBranch(Offset, *ExternalTarget);
+    InternalDecodedInst DI =
+        decodeTensorTestInstruction(Branch, Offset, S);
+    Offset += DI.Size;
+    Result.push_back(std::move(DI));
+  }
+  Add("tensor_load_to_lds s[24:27], s[4:11]");
+  Add("s_endpgm");
+  return Result;
+}
+
+static TensorDescriptorMustAnalysis runTensorProvenanceAnalysis(
+    llvm::ArrayRef<InternalDecodedInst> Body,
+    llvm::ArrayRef<InternalDecodedInst> External,
+    llvm::ArrayRef<TensorDispatchStub> DispatchStubs,
+    llvm::ArrayRef<uint64_t> DirectTargetOffsets,
+    llvm::ArrayRef<uint64_t> ForeignExternalEntries, const LLVMState &S,
+    llvm::ArrayRef<uint64_t> VirtualExternalEntries = {},
+    llvm::ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges = {},
+    llvm::ArrayRef<uint64_t> OriginalCodeEntries = {},
+    std::optional<uint64_t> RangeEnd = std::nullopt) {
+  std::vector<InternalDecodedInst> All(Body.begin(), Body.end());
+  All.insert(All.end(), External.begin(), External.end());
+  llvm::sort(All, [](const InternalDecodedInst &L,
+                     const InternalDecodedInst &R) {
+    return L.Offset < R.Offset;
+  });
+  const InternalDecodedInst &Last = Body.back();
+  TensorAnalysisRange Range{0, RangeEnd.value_or(Last.Offset + Last.Size)};
+  Range.ForeignExternalEntries.assign(ForeignExternalEntries.begin(),
+                                      ForeignExternalEntries.end());
+  Range.VirtualExternalEntries.assign(VirtualExternalEntries.begin(),
+                                      VirtualExternalEntries.end());
+  Range.OriginalControlFlowEdges.assign(OriginalControlFlowEdges.begin(),
+                                        OriginalControlFlowEdges.end());
+  Range.OriginalCodeEntries.assign(OriginalCodeEntries.begin(),
+                                   OriginalCodeEntries.end());
+  Range.DispatchStubs.assign(DispatchStubs.begin(), DispatchStubs.end());
+  llvm::DenseSet<uint64_t> DirectTargets;
+  for (uint64_t Target : DirectTargetOffsets)
+    DirectTargets.insert(Target);
+  return computeTensorDescriptorMustAnalysis(
+      Body, All, llvm::ArrayRef<TensorAnalysisRange>(Range), S, DirectTargets,
+      /*MaxSgprs=*/106, /*MaxVgprs=*/1024);
+}
+
+static size_t tensorInstructionIndex(
+    llvm::ArrayRef<InternalDecodedInst> Body) {
+  auto It = llvm::find_if(Body, [](const InternalDecodedInst &DI) {
+    return DI.Mnemonic == "tensor_load_to_lds";
+  });
+  EXPECT_NE(It, Body.end());
+  return It == Body.end() ? 0 : It - Body.begin();
+}
+
+class TensorExternalProvenance : public ::testing::Test {
+protected:
+  void SetUp() override { ASSERT_TRUE(S.Valid); }
+
+  void expectExternalInstructionRejected(llvm::StringRef Assembly) {
+    SCOPED_TRACE(Assembly.str());
+    std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+    std::vector<InternalDecodedInst> External{
+        decodeTensorTestInstruction(Assembly, 0x1000, S)};
+    TensorDescriptorMustAnalysis Analysis =
+        runTensorProvenanceAnalysis(Body, External, {}, {}, {}, S);
+    EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+  }
+
+  LLVMState S = initLLVM(makeGfx1250Ident());
+};
+
+TEST_F(TensorExternalProvenance, ExactDispatchStubIsOnlyEntryException) {
+  std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+  TensorDescriptorMustAnalysis Basic =
+      runTensorProvenanceAnalysis(Body, {}, {}, {}, {}, S);
+  ASSERT_TRUE(Basic.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  constexpr uint64_t StubBegin = 0x1000;
+  llvm::SmallVector<uint8_t> StubBytes =
+      buildKernelEntryTrampoline(StubBegin, 0, /*ScratchSgpr=*/32, S);
+  ASSERT_EQ(StubBytes.size(), KernelEntryStubStride);
+  std::optional<KernelEntryTrampolineInfo> Info =
+      getKernelEntryTrampolineInfo(StubBytes, StubBegin, S);
+  ASSERT_TRUE(Info);
+  std::vector<InternalDecodedInst> Stub;
+  ASSERT_TRUE(decodeTextSection(StubBytes.data(), StubBytes.size(), S, Stub));
+  for (InternalDecodedInst &DI : Stub)
+    DI.Offset += StubBegin;
+  TensorDispatchStub Dispatch{StubBegin, StubBegin + KernelEntryStubStride,
+                              Info->TerminalVAddr, 0};
+
+  TensorDescriptorMustAnalysis Analysis = runTensorProvenanceAnalysis(
+      Body, Stub, llvm::ArrayRef<TensorDispatchStub>(Dispatch), {}, {}, S);
+  EXPECT_TRUE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  constexpr uint64_t ForeignSource = 0x1200;
+  const uint64_t StubInterior = Stub[2].Offset;
+  TensorDescriptorMustAnalysis InteriorRoot = runTensorProvenanceAnalysis(
+      Body, Stub, llvm::ArrayRef<TensorDispatchStub>(Dispatch), {}, {}, S,
+      {StubInterior});
+  EXPECT_FALSE(
+      InteriorRoot.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  std::vector<InternalDecodedInst> BeginIngress = Stub;
+  BeginIngress.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(ForeignSource, StubBegin), ForeignSource, S));
+  TensorDescriptorMustAnalysis ForeignBegin = runTensorProvenanceAnalysis(
+      Body, BeginIngress, llvm::ArrayRef<TensorDispatchStub>(Dispatch),
+      {StubBegin}, {}, S);
+  EXPECT_FALSE(
+      ForeignBegin.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  Stub.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(ForeignSource, StubInterior), ForeignSource, S));
+  TensorDescriptorMustAnalysis ForeignIngress = runTensorProvenanceAnalysis(
+      Body, Stub, llvm::ArrayRef<TensorDispatchStub>(Dispatch), {StubInterior},
+      {}, S);
+  EXPECT_FALSE(
+      ForeignIngress.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  StubBytes.back() ^= 1;
+  EXPECT_FALSE(getKernelEntryTrampolineInfo(StubBytes, StubBegin, S));
+}
+
+TEST_F(TensorExternalProvenance, NonDispatchCarryReturnToEntryRejected) {
+  std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+  constexpr uint64_t ExternalBegin = 0x1000;
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampoline(ExternalBegin, 0, /*ScratchSgpr=*/32, S);
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  std::vector<InternalDecodedInst> External;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, External));
+  for (InternalDecodedInst &DI : External)
+    DI.Offset += ExternalBegin;
+
+  TensorDescriptorMustAnalysis Analysis =
+      runTensorProvenanceAnalysis(Body, External, {}, {}, {}, S);
+  EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, UnresolvedExternalIndirectRejected) {
+  expectExternalInstructionRejected("s_set_pc_i64 s[0:1]");
+}
+
+TEST_F(TensorExternalProvenance, ForeignAppendedPredecessorRejected) {
+  constexpr uint64_t PathBegin = 0x100;
+  constexpr uint64_t ForeignBegin = 0x200;
+  std::vector<InternalDecodedInst> Body =
+      buildTensorProvenanceBody(S, PathBegin);
+  const uint64_t Resume = Body[tensorInstructionIndex(Body)].Offset;
+  std::vector<InternalDecodedInst> Path{
+      decodeTensorTestInstruction(S.encodeSBranch(PathBegin, Resume),
+                                  PathBegin, S)};
+  TensorDescriptorMustAnalysis Positive = runTensorProvenanceAnalysis(
+      Body, Path, {}, {PathBegin, Resume}, {}, S);
+  EXPECT_TRUE(Positive.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  Path.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(ForeignBegin, PathBegin), ForeignBegin, S));
+  TensorDescriptorMustAnalysis Negative = runTensorProvenanceAnalysis(
+      Body, Path, {}, {PathBegin, Resume}, {}, S);
+  EXPECT_FALSE(Negative.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, VirtualKernelRootIntoModeledPathRejected) {
+  constexpr uint64_t PathBegin = 0x100;
+  std::vector<InternalDecodedInst> Body =
+      buildTensorProvenanceBody(S, PathBegin);
+  const uint64_t Resume = Body[tensorInstructionIndex(Body)].Offset;
+  std::vector<InternalDecodedInst> Path{
+      decodeTensorTestInstruction(S.encodeSBranch(PathBegin, Resume),
+                                  PathBegin, S)};
+  TensorDescriptorMustAnalysis Analysis = runTensorProvenanceAnalysis(
+      Body, Path, {}, {PathBegin, Resume}, {}, S, {PathBegin});
+  EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, ForeignRelayTailEntryRejected) {
+  constexpr uint64_t RelayBegin = 0x100;
+  constexpr uint64_t PathBegin = 0x120;
+  std::vector<InternalDecodedInst> Body =
+      buildTensorProvenanceBody(S, RelayBegin, /*SplitRelay=*/true);
+  const size_t GetPcIndex = 2;
+  const uint64_t GetPcOffset = Body[GetPcIndex].Offset;
+  const uint64_t Resume = Body[tensorInstructionIndex(Body)].Offset;
+
+  llvm::SmallVector<uint8_t> LongBranch = encodeSetPCLongBranch(
+      S, GetPcOffset, PathBegin, /*SgprBase=*/0);
+  std::vector<InternalDecodedInst> LongDecoded;
+  ASSERT_TRUE(decodeTextSection(LongBranch.data(), LongBranch.size(), S,
+                                LongDecoded));
+  ASSERT_EQ(LongDecoded.size(), 3u);
+  std::vector<InternalDecodedInst> External;
+  LongDecoded[1].Offset = RelayBegin;
+  LongDecoded[2].Offset = RelayBegin + LongDecoded[1].Size;
+  External.push_back(LongDecoded[1]);
+  External.push_back(LongDecoded[2]);
+  External.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(PathBegin, Resume), PathBegin, S));
+
+  TensorDescriptorMustAnalysis Positive = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayBegin, Resume}, {}, S);
+  EXPECT_TRUE(Positive.Low16KnownZero.test(tensorInstructionIndex(Body)));
+  TensorDescriptorMustAnalysis Negative = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayBegin, Resume}, {RelayBegin}, S);
+  EXPECT_FALSE(Negative.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  const uint64_t RelayBranch = Body[GetPcIndex + 1].Offset;
+  const std::pair<uint64_t, uint64_t> ExactRelayEdge{RelayBranch, RelayBegin};
+  TensorDescriptorMustAnalysis ExactRelay = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayBegin, Resume}, {}, S, {}, {ExactRelayEdge});
+  EXPECT_TRUE(ExactRelay.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  const std::pair<uint64_t, uint64_t> WrongRelayEdge{Body.front().Offset,
+                                                     RelayBegin};
+  TensorDescriptorMustAnalysis WrongRelay = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayBegin, Resume}, {}, S, {}, {WrongRelayEdge});
+  EXPECT_FALSE(WrongRelay.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  TensorDescriptorMustAnalysis RelayBranchRoot = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayBegin, Resume}, {}, S, {}, {}, {RelayBranch});
+  EXPECT_FALSE(
+      RelayBranchRoot.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  TensorDescriptorMustAnalysis RelayTailRoot = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayBegin, Resume}, {}, S, {RelayBegin});
+  EXPECT_FALSE(
+      RelayTailRoot.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, SplitRelayDirectReentryKeepsTensorPredecessor) {
+  constexpr uint64_t RelayBegin = 0x100;
+  std::vector<InternalDecodedInst> Body;
+  uint64_t Offset = 0;
+  auto Add = [&](llvm::StringRef Assembly) {
+    const size_t Index = Body.size();
+    InternalDecodedInst DI = decodeTensorTestInstruction(Assembly, Offset, S);
+    Offset += DI.Size;
+    Body.push_back(std::move(DI));
+    return Index;
+  };
+
+  const size_t ConditionalIndex = Add("s_cbranch_scc1 0");
+  Add("v_mov_b32 v0, 0");
+  Add("v_readfirstlane_b32 s4, v0");
+  const size_t NormalBranchIndex = Add("s_branch 0");
+  const uint64_t RelayGetPc = Offset;
+  Add("s_get_pc_i64 s[0:1]");
+  const size_t RelayBranchIndex = Add("s_branch 0");
+  const uint64_t TensorOffset = Offset;
+  Add("tensor_load_to_lds s[24:27], s[4:11]");
+  const size_t PostTensorBranchIndex = Add("s_branch 0");
+  Add("s_nop 0");
+  const uint64_t JoinOffset = Offset;
+  Add("s_endpgm");
+
+  const InternalDecodedInst &Conditional = Body[ConditionalIndex];
+  ASSERT_EQ((RelayGetPc - Conditional.Offset - Conditional.Size) %
+                MinInstSize,
+            0u);
+  const uint64_t ConditionalDelta =
+      (RelayGetPc - Conditional.Offset - Conditional.Size) / MinInstSize;
+  Body[ConditionalIndex] = decodeTensorTestInstruction(
+      "s_cbranch_scc1 " + std::to_string(ConditionalDelta),
+      Conditional.Offset, S);
+  Body[NormalBranchIndex] = decodeTensorTestInstruction(
+      S.encodeSBranch(Body[NormalBranchIndex].Offset, TensorOffset),
+      Body[NormalBranchIndex].Offset, S);
+  Body[RelayBranchIndex] = decodeTensorTestInstruction(
+      S.encodeSBranch(Body[RelayBranchIndex].Offset, RelayBegin),
+      Body[RelayBranchIndex].Offset, S);
+  Body[PostTensorBranchIndex] = decodeTensorTestInstruction(
+      S.encodeSBranch(Body[PostTensorBranchIndex].Offset, JoinOffset),
+      Body[PostTensorBranchIndex].Offset, S);
+
+  llvm::SmallVector<uint8_t> LongBranch = encodeSetPCLongBranch(
+      S, RelayGetPc, TensorOffset, /*SgprBase=*/0);
+  std::vector<InternalDecodedInst> LongDecoded =
+      decodeTensorTestBlock(LongBranch, 0, S);
+  ASSERT_EQ(LongDecoded.size(), 3u);
+  LongDecoded[1].Offset = RelayBegin;
+  LongDecoded[2].Offset = RelayBegin + LongDecoded[1].Size;
+  std::vector<InternalDecodedInst> External{LongDecoded[1], LongDecoded[2]};
+
+  const std::pair<uint64_t, uint64_t> RelayEdge{
+      Body[RelayBranchIndex].Offset, RelayBegin};
+  TensorDescriptorMustAnalysis Analysis = runTensorProvenanceAnalysis(
+      Body, External, {}, {RelayGetPc, RelayBegin, TensorOffset, JoinOffset},
+      {}, S, {}, {RelayEdge}, {0});
+  EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, CallableOriginalHelperPathRejected) {
+  constexpr uint64_t HelperBegin = 0x80;
+  constexpr uint64_t ExternalBegin = 0x100;
+  std::vector<InternalDecodedInst> Body;
+  uint64_t Offset = 0;
+  auto Add = [&](llvm::StringRef Assembly) {
+    const size_t Index = Body.size();
+    InternalDecodedInst DI = decodeTensorTestInstruction(Assembly, Offset, S);
+    Offset += DI.Size;
+    Body.push_back(std::move(DI));
+    return Index;
+  };
+
+  Add("v_mov_b32 v0, 0");
+  Add("v_readfirstlane_b32 s4, v0");
+  const size_t ConditionalIndex = Add("s_cbranch_scc1 0");
+  const size_t HelperBranchIndex = Add("s_branch 0");
+  const uint64_t TensorOffset = Offset;
+  Add("tensor_load_to_lds s[24:27], s[4:11]");
+  Add("s_endpgm");
+  const uint64_t CandidateEnd = Offset;
+
+  const uint64_t ConditionalOffset = Body[ConditionalIndex].Offset;
+  const uint64_t ConditionalSize = Body[ConditionalIndex].Size;
+  ASSERT_GT(TensorOffset, ConditionalOffset + ConditionalSize);
+  ASSERT_EQ((TensorOffset - ConditionalOffset - ConditionalSize) % MinInstSize,
+            0u);
+  const uint64_t ConditionalDelta =
+      (TensorOffset - ConditionalOffset - ConditionalSize) / MinInstSize;
+  Body[ConditionalIndex] = decodeTensorTestInstruction(
+      "s_cbranch_scc1 " + std::to_string(ConditionalDelta),
+      ConditionalOffset, S);
+  Body[HelperBranchIndex] = decodeTensorTestInstruction(
+      S.encodeSBranch(Body[HelperBranchIndex].Offset, HelperBegin),
+      Body[HelperBranchIndex].Offset, S);
+  Body.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(HelperBegin, ExternalBegin), HelperBegin, S));
+
+  llvm::SmallVector<uint8_t> ExternalBytes = encodeSetPCLongBranch(
+      S, ExternalBegin, TensorOffset, /*SgprBase=*/0);
+  std::vector<InternalDecodedInst> External =
+      decodeTensorTestBlock(ExternalBytes, ExternalBegin, S);
+  ASSERT_EQ(External.size(), 3u);
+
+  const std::pair<uint64_t, uint64_t> HelperEdge{HelperBegin, ExternalBegin};
+  TensorDescriptorMustAnalysis Analysis = runTensorProvenanceAnalysis(
+      Body, External, {}, {HelperBegin, ExternalBegin, TensorOffset}, {}, S,
+      {}, {HelperEdge}, {0, HelperBegin}, CandidateEnd);
+  EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, ComputedPcInteriorIngressRejected) {
+  constexpr uint64_t SequenceBegin = 0x100;
+  std::vector<InternalDecodedInst> Body =
+      buildTensorProvenanceBody(S, SequenceBegin);
+  const uint64_t Resume = Body[tensorInstructionIndex(Body)].Offset;
+  llvm::SmallVector<uint8_t> SequenceBytes =
+      encodeSetPCLongBranch(S, SequenceBegin, Resume, /*SgprBase=*/0);
+  ASSERT_FALSE(SequenceBytes.empty());
+  std::vector<InternalDecodedInst> External =
+      decodeTensorTestBlock(SequenceBytes, SequenceBegin, S);
+  ASSERT_EQ(External.size(), 3u);
+
+  TensorDescriptorMustAnalysis Positive = runTensorProvenanceAnalysis(
+      Body, External, {}, {SequenceBegin, Resume}, {}, S);
+  EXPECT_TRUE(Positive.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  constexpr uint64_t ForeignSource = 0x200;
+  const uint64_t AddInterior = External[1].Offset;
+  External.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(ForeignSource, AddInterior), ForeignSource, S));
+  TensorDescriptorMustAnalysis ForeignEdge = runTensorProvenanceAnalysis(
+      Body, External, {}, {SequenceBegin, Resume}, {}, S);
+  EXPECT_FALSE(
+      ForeignEdge.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  External.pop_back();
+  TensorDescriptorMustAnalysis VirtualRoot = runTensorProvenanceAnalysis(
+      Body, External, {}, {SequenceBegin, Resume}, {}, S, {AddInterior});
+  EXPECT_FALSE(
+      VirtualRoot.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, OriginalCodeRootMustEnterComputedPcPrefix) {
+  llvm::SmallVector<uint8_t> Probe =
+      encodeSetPCLongBranch(S, 0, 0, /*SgprBase=*/0);
+  ASSERT_FALSE(Probe.empty());
+  const uint64_t Resume = Probe.size();
+  llvm::SmallVector<uint8_t> SequenceBytes =
+      encodeSetPCLongBranch(S, 0, Resume, /*SgprBase=*/0);
+  ASSERT_EQ(SequenceBytes.size(), Resume);
+  std::vector<InternalDecodedInst> Body =
+      decodeTensorTestBlock(SequenceBytes, 0, S);
+  ASSERT_EQ(Body.size(), 3u);
+  uint64_t Offset = Resume;
+  auto Add = [&](llvm::StringRef Assembly) {
+    InternalDecodedInst DI = decodeTensorTestInstruction(Assembly, Offset, S);
+    Offset += DI.Size;
+    Body.push_back(std::move(DI));
+  };
+  Add("v_mov_b32 v0, 0");
+  Add("v_readfirstlane_b32 s4, v0");
+  Add("tensor_load_to_lds s[24:27], s[4:11]");
+  Add("s_endpgm");
+
+  TensorDescriptorMustAnalysis PrefixRoot = runTensorProvenanceAnalysis(
+      Body, {}, {}, {Resume}, {}, S, {}, {}, {0});
+  EXPECT_TRUE(PrefixRoot.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  const uint64_t AddInterior = Body[1].Offset;
+  TensorDescriptorMustAnalysis InteriorRoot = runTensorProvenanceAnalysis(
+      Body, {}, {}, {Resume}, {}, S, {}, {}, {AddInterior});
+  EXPECT_FALSE(
+      InteriorRoot.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, ExternalTargetMustBeDecodedBoundary) {
+  std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+  constexpr uint64_t Source = 0x100;
+  constexpr uint64_t MissingTarget = 0x200;
+  std::vector<InternalDecodedInst> External{decodeTensorTestInstruction(
+      S.encodeSBranch(Source, MissingTarget), Source, S)};
+  TensorDescriptorMustAnalysis Missing =
+      runTensorProvenanceAnalysis(Body, External, {}, {}, {}, S);
+  EXPECT_FALSE(Missing.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  InternalDecodedInst Literal = decodeTensorTestInstruction(
+      "s_mov_b32 s0, 0x12345678", MissingTarget, S);
+  ASSERT_GT(Literal.Size, MinInstSize);
+  External.push_back(Literal);
+  External.push_back(decodeTensorTestInstruction(
+      "s_endpgm", MissingTarget + Literal.Size, S));
+  External.front() = decodeTensorTestInstruction(
+      S.encodeSBranch(Source, MissingTarget + MinInstSize), Source, S);
+  TensorDescriptorMustAnalysis Interior =
+      runTensorProvenanceAnalysis(Body, External, {}, {}, {}, S);
+  EXPECT_FALSE(Interior.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, OutOfRangeFallthroughRejected) {
+  std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+  const uint64_t LastOffset = Body.back().Offset;
+  Body.back() = decodeTensorTestInstruction("s_nop 0", LastOffset, S);
+  TensorDescriptorMustAnalysis Analysis =
+      runTensorProvenanceAnalysis(Body, {}, {}, {}, {}, S);
+  EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, ExternalBoundaryFallthroughRejected) {
+  expectExternalInstructionRejected("s_nop 0");
+}
+
+TEST_F(TensorExternalProvenance, ExternalTrapRejected) {
+  expectExternalInstructionRejected("s_trap 0");
+}
+
+TEST_F(TensorExternalProvenance, ExternalRfeRejected) {
+  expectExternalInstructionRejected("s_rfe_i64 s[0:1]");
+}
+
+TEST_F(TensorExternalProvenance, CandidateRfeRejected) {
+  std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+  Body.back() =
+      decodeTensorTestInstruction("s_rfe_i64 s[0:1]", Body.back().Offset, S);
+  TensorDescriptorMustAnalysis Analysis =
+      runTensorProvenanceAnalysis(Body, {}, {}, {}, {}, S);
+  EXPECT_FALSE(Analysis.Low16KnownZero.test(tensorInstructionIndex(Body)));
+}
+
+TEST_F(TensorExternalProvenance, ForeignIngressIntoAnyDispatchStubRejected) {
+  std::vector<InternalDecodedInst> Body = buildTensorProvenanceBody(S);
+  constexpr uint64_t StubBegin = 0x1000;
+  constexpr uint64_t UnrelatedTarget = 0x300;
+  llvm::SmallVector<uint8_t> StubBytes = buildKernelEntryTrampoline(
+      StubBegin, UnrelatedTarget, /*ScratchSgpr=*/32, S);
+  ASSERT_EQ(StubBytes.size(), KernelEntryStubStride);
+  std::optional<KernelEntryTrampolineInfo> Info =
+      getKernelEntryTrampolineInfo(StubBytes, StubBegin, S);
+  ASSERT_TRUE(Info);
+  std::vector<InternalDecodedInst> Stub;
+  ASSERT_TRUE(decodeTextSection(StubBytes.data(), StubBytes.size(), S, Stub));
+  for (InternalDecodedInst &DI : Stub)
+    DI.Offset += StubBegin;
+  Stub.push_back(
+      decodeTensorTestInstruction("s_endpgm", UnrelatedTarget, S));
+  TensorDispatchStub Dispatch{StubBegin, StubBegin + KernelEntryStubStride,
+                              Info->TerminalVAddr, UnrelatedTarget};
+  TensorDescriptorMustAnalysis Positive = runTensorProvenanceAnalysis(
+      Body, Stub, llvm::ArrayRef<TensorDispatchStub>(Dispatch), {}, {}, S);
+  EXPECT_TRUE(Positive.Low16KnownZero.test(tensorInstructionIndex(Body)));
+
+  constexpr uint64_t ForeignSource = 0x1200;
+  const uint64_t StubInterior = Stub[2].Offset;
+  Stub.push_back(decodeTensorTestInstruction(
+      S.encodeSBranch(ForeignSource, StubInterior), ForeignSource, S));
+  TensorDescriptorMustAnalysis Negative = runTensorProvenanceAnalysis(
+      Body, Stub, llvm::ArrayRef<TensorDispatchStub>(Dispatch), {StubInterior},
+      {}, S);
+  EXPECT_FALSE(Negative.Low16KnownZero.test(tensorInstructionIndex(Body)));
 }
 
 // -- decodeTextSection instruction-decode cache -------------------------------

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -79,6 +79,9 @@ struct KernelDescriptorElfOptions {
   // When non-empty, emit these kernel metadata entries instead of the single
   // entry described by MetadataKernelName / MetadataSgprCount.
   std::vector<MetadataKernel> MetadataKernels;
+  // Emit a real PT_PHDR entry before PT_LOAD, with both the ELF and program
+  // header tables covered by the load segment.
+  bool EmitPhdrSegment = false;
   bool MetadataOmitVgprCount = false;
   bool MetadataVgprCountAsString = false;
   // When set, emit an extra zero-sized SHF_ALLOC section (".pad") at this
@@ -225,10 +228,15 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
       alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
   const uint64_t NoteOff =
       HasMetadataNote ? alignTo4(ShStrTabOff + sizeof(ShStrTab)) : 0;
-  const uint64_t PhOff =
-      HasMetadataNote ? alignTo8(NoteOff + MetadataNote.size()) : 0;
-  const uint64_t ContentEnd = HasMetadataNote ? PhOff + sizeof(Elf64_Phdr)
-                                              : ShStrTabOff + sizeof(ShStrTab);
+  const bool HasTextLoad = Options.ElfType != ET_REL;
+  const uint16_t PhNum = static_cast<uint16_t>(Options.EmitPhdrSegment) +
+                         static_cast<uint16_t>(HasTextLoad) +
+                         static_cast<uint16_t>(HasMetadataNote);
+  const uint64_t BeforePhdrs = HasMetadataNote ? NoteOff + MetadataNote.size()
+                                               : ShStrTabOff + sizeof(ShStrTab);
+  const uint64_t PhOff = PhNum ? alignTo8(BeforePhdrs) : 0;
+  const uint64_t ContentEnd =
+      PhNum ? PhOff + PhNum * sizeof(Elf64_Phdr) : BeforePhdrs;
   const uint64_t BufSize = alignTo8(ContentEnd + 64);
 
   KernelDescriptorElf Result;
@@ -253,10 +261,10 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   Ehdr.e_type = Options.ElfType;
   Ehdr.e_version = EV_CURRENT;
   Ehdr.e_shoff = ShOff;
-  if (HasMetadataNote) {
+  if (PhNum) {
     Ehdr.e_phoff = PhOff;
     Ehdr.e_phentsize = sizeof(Elf64_Phdr);
-    Ehdr.e_phnum = 1;
+    Ehdr.e_phnum = PhNum;
   }
   Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
   Ehdr.e_shentsize = sizeof(Elf64_Shdr);
@@ -323,6 +331,45 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
     std::memcpy(Buf + ShOff + 6 * sizeof(Elf64_Shdr), &PadSh, sizeof(PadSh));
   }
 
+  uint64_t PhdrOff = PhOff;
+  if (Options.EmitPhdrSegment) {
+    assert(HasTextLoad && Options.TextAddr >= TextOffset);
+    const uint64_t LoadVAddr = Options.TextAddr - TextOffset;
+    Elf64_Phdr HeaderPhdr{};
+    HeaderPhdr.p_type = PT_PHDR;
+    HeaderPhdr.p_flags = PF_R;
+    HeaderPhdr.p_offset = PhOff;
+    HeaderPhdr.p_vaddr = LoadVAddr + PhOff;
+    HeaderPhdr.p_paddr = HeaderPhdr.p_vaddr;
+    HeaderPhdr.p_filesz = PhNum * sizeof(Elf64_Phdr);
+    HeaderPhdr.p_memsz = HeaderPhdr.p_filesz;
+    HeaderPhdr.p_align = alignof(Elf64_Phdr);
+    std::memcpy(Buf + PhdrOff, &HeaderPhdr, sizeof(HeaderPhdr));
+    PhdrOff += sizeof(Elf64_Phdr);
+  }
+
+  if (HasTextLoad) {
+    Elf64_Phdr TextPhdr{};
+    TextPhdr.p_type = PT_LOAD;
+    TextPhdr.p_flags = PF_R | PF_X;
+    if (Options.EmitPhdrSegment) {
+      TextPhdr.p_offset = 0;
+      TextPhdr.p_vaddr = Options.TextAddr - TextOffset;
+      TextPhdr.p_paddr = TextPhdr.p_vaddr;
+      TextPhdr.p_filesz = ContentEnd;
+      TextPhdr.p_memsz = ContentEnd;
+    } else {
+      TextPhdr.p_offset = TextOffset;
+      TextPhdr.p_vaddr = Options.TextAddr;
+      TextPhdr.p_paddr = Options.TextAddr;
+      TextPhdr.p_filesz = Text.size();
+      TextPhdr.p_memsz = Text.size();
+    }
+    TextPhdr.p_align = 4;
+    std::memcpy(Buf + PhdrOff, &TextPhdr, sizeof(TextPhdr));
+    PhdrOff += sizeof(Elf64_Phdr);
+  }
+
   if (HasMetadataNote) {
     Elf64_Phdr NotePhdr{};
     NotePhdr.p_type = PT_NOTE;
@@ -330,7 +377,7 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
     NotePhdr.p_filesz = MetadataNote.size();
     NotePhdr.p_memsz = MetadataNote.size();
     NotePhdr.p_align = 4;
-    std::memcpy(Buf + PhOff, &NotePhdr, sizeof(NotePhdr));
+    std::memcpy(Buf + PhdrOff, &NotePhdr, sizeof(NotePhdr));
   }
 
   std::memcpy(


### PR DESCRIPTION
Also see https://github.com/jammm/hotswap_repros/blob/main/docs/PR_3387_MAPPING.md
## Summary

This PR adds the remaining cross-pass correctness machinery needed when several
required transformations interact in one large, multi-function code object:

- Transactional ownership across semantic passes
- Site-specific SGPR-pair and VCC dataflow proofs
- Conservative modeling of callable, indirect, and opaque control-flow ingress
- Atomic DS2 and WMMA combined-delay handling
- Must-dataflow proofs for PC-sensitive tensor descriptor repair
- CFG-wide VGPR-MSB state for required WMMA splits
- Entry-aware hard-clause validation
- Structural state for generated executable pools and repeated rewriting

A required transformation now succeeds only when its placement, source-window
ownership, control-flow assumptions, encoding, ELF growth, and metadata update
can all be established. Otherwise the complete rewrite fails without returning
a partially transformed code object.

These gaps were exposed by gfx1250 code objects captured while running
DeepSeek V4 Pro through the open-source ATOM/AITER stack. The captures were
reduced to focused COMGR tests and standalone reproducers. The implementation
is general to gfx1250 HotSwap and contains no model-specific paths.

- Base: PR #3374 head
  `fae9307759fd7961e479747fd4822d889c925399`
- Head: `3d900e5b002d`
- Branch: `users/jam/hotswap-zero-failures-amd-staging-v2`

## Issues Observed In The Open-Source Workload

### Far-return placement and scratch liveness

Large AITER mHC and activation objects contained required sites outside
short-branch range. Some sites had no contiguous source window large enough for
a far-return sequence, while candidate original SGPR pairs or VCC were live on
only some outgoing paths. Large RCCL code objects additionally exposed
fragmented gateway space, protected callable extents, and order-sensitive relay
allocation.

This PR proves a candidate pair dead from the exact resume point across all
modeled successors before reusing it. VCC is subject to the same proof.
Fallback SGPR allocation remains resource-accounted. Gateway, relay, branch
island, and source-window placement respect descriptors, symbols, relocations,
callable entries, materialized PC transfers, and generated-code ownership.

The implementation preserves PR #3374's SCC-neutral
`s_get_pc_i64` / `s_add_nc_u64` / `s_set_pc_i64` routing and does not generate
`s_add_pc_i64`.

### DS2 combined-delay ownership

Generated A8W8, top-k, activation, and RCCL objects contained multiple required
DS2 rewrites protected by one combined `s_delay_alu`. Applying or relocating
one member independently could consume another member's delay, source window,
or only reachable gateway.

This PR plans all required DS2 members owned by one delay window as one
transaction. Address and destination dependencies, split ordering, alignment,
required `s_wait_dscnt 0` placement, source windows, and gateway routes are
validated together. Unsupported tuples, offsets, ownership graphs, or routes
fail the complete rewrite.

### PC-sensitive tensor descriptor repair

Grouped-MoE captures contained `tensor_load_to_lds` sites without the canonical
adjacent scalar-delay slot. Other sites had no spare SGPR for the earlier
save-and-restore approach. Relocating the tensor instruction is not valid
because its linked PC participates in its behavior.

This PR keeps the tensor instruction at its original address. It accepts one
of three proofs:

- The descriptor low bits are already masked
- A canonical adjacent scalar-delay slot can hold the mask
- A local descriptor definition must reach the tensor on every modeled entry
  path and can be masked in place

Descriptor entries, visible callable symbols, direct calls and returns,
materialized PC transfers, opaque control flow, and arbitrary indirect ingress
participate in the proof. A bypassing or unresolved entry disables the proof
and causes the required rewrite to fail closed.

Two retained no-scratch captures still reach a later tensor site whose
descriptor placement cannot be proven. They are intentional fail-closed
negative cases: the API returns an error and produces no output object.

### WMMA VGPR-MSB, delays, and hazards

A captured K=128 A8W8 object required a WMMA split after a loop header. The
earlier straight-line recovery rejected it with:

```text
WMMA split: cannot determine VGPR-MSB mode for
v_wmma_f32_16x16x128_fp8_fp8 at offset 0x5D8
```

A captured logits object also combined the required split with a protected
dependency window, a barrier, a PC-sensitive tensor load, and WMMA hazards.
Moving only the WMMA would leave the original delay describing the wrong
instruction sequence.

This PR computes all four VGPR-MSB fields as a forward CFG fixed point across
branches, loops, joins, and SETREG updates. A split is emitted only when the
complete incoming mode is exact. The upper K=64 operation is encoded under the
required mode and the incoming mode is restored afterward.

Supported combined-delay windows are demerged atomically. WMMA semantic
replacement, reconstructed delays, and RAW, WAR, and WAW hazard repair share
one ownership plan. Conflicting reachable state, unresolved ingress, interior
entries, overlapping dependency windows, or unsupported ownership fail closed.

### Hard-clause entry paths

A sparse-prefill object associated with a DeepSeek V4 Pro runtime fault
contained an entry-path `s_clause` before any compatible VMEM operation. Other
objects showed that deleting every clause is also incorrect.

This PR validates clause family, membership, scope, and transformed members,
then uses a must-analysis over every modeled entry path. Malformed,
mixed-family, transformed-member, and initial-VMEM clauses are removed. A
uniform same-family clause is preserved only when every modeled path has
already executed a compatible VMEM operation.

### Cross-pass transactions and repeated rewriting

PR #3374 already records a required-site failure. This PR extends that state
through every semantic pass and adds prepare/commit ownership for shared source
instructions, delay windows, scratch reservations, gateways, and metadata.

The complete appended layout is reserved before final branch fixups. ELF growth
validates executable load coverage, header relocation, symbols, protected
extents, kernel descriptors, and resource metadata before committing.

Generated executable pools carry a non-allocating structural note describing
their layout and target stepping. A later invocation accepts a pool only when
the note, section, executable segment, layout, and target state agree.
Malformed, incomplete, overlapping, unmarked, or target-mismatched state fails
closed. A supported B0-to-A0 output is byte-identical when rewritten to A0
again.

## Callable-Control-Flow ABI

HotSwap requires input code objects to follow the AMDGPU
callable-control-flow ABI.

In particular, an `s_swap_pc_i64` that writes the standard link pair
`s[30:31]` must be a call to a callable function entry represented by the code
object. This is an input precondition, not an inference made from MC's generic
instruction classification.

If the target entry or link behavior cannot be resolved from the represented
control-flow information, HotSwap treats the ingress and link state as
unknown. It does not use that transfer as an optimistic call boundary for
liveness, relocation, clause, or must-definition proofs. A required rewrite
that depends on such a proof fails closed.

Generated provenance notes describe structural layout and rewrite state. They
do not authenticate untrusted input. HotSwap assumes input from a trusted
compiler or an earlier trusted HotSwap invocation.

## Validation

Fresh host validation from the PR #3374-based source and COMGR build:

| Check | Result |
| --- | ---: |
| COMGR runtime and HotSwap rewrite targets | Passed |
| `HotswapMCTests` | 98/98 passed |
| `HotswapElfTests` | 38/38 passed |
| HotSwap-filtered COMGR LIT | 145/145 passed |
| Full COMGR LIT | 175 passed, 1 unsupported, 2 non-HotSwap SDK-version failures |

The two full-suite failures are `device-lib-linking.cl`, whose device-library
expectation differs from the installed SDK, and
`spirv-tests/unbundle-compressed.hip`, whose expected payload magic differs
from that SDK's compressed bundle output. All HotSwap-filtered tests pass.

Focused host coverage includes:

- Required-patch failure propagation and source ownership
- Site-dead SGPR-pair and VCC proofs
- Protected entries, extents, gateways, relays, and branch islands
- DS2 multi-site and combined-delay transactions
- Tensor must-definition and external-ingress rejection
- VGPR-MSB CFG state, SETREG handling, WMMA delays, and hazards
- Clause must-analysis across callable and indirect entries
- ELF growth, pool provenance, atomic metadata updates, and idempotence

The exact-object validation set includes the captured mHC, activation, logits,
A8W8, mxscale, tensor no-delay, sparse-prefill, and RCCL objects. Supported
objects must complete a first rewrite, pass ELF and disassembly checks, and
produce a byte-identical second rewrite. The two retained tensor negative
objects must return an error without producing output.

Direct device reproducers and RCCL controls are run in separate fresh processes
with HotSwap enabled and disabled. Acceptance is based on process status, exact
output comparisons where available, rewrite diagnostics, runtime library maps,
and absence of GPU fault signatures.

## Evidence Boundaries

- The sparse-prefill and mxscale captures retain exact mappings to runtime
  faults, but object-to-fault provenance alone does not prove HotSwap causality.
- The mHC object is combined integration coverage rather than a dedicated
  reproducer for every transform it contains.
- The captured hipBLASLt Cijk object is a negative isolation control; no unique
  HotSwap fix is attributed to it.
- Generic ATOM/AITER launchers map to this PR only through the transforms
  reported by their COMGR rewrite logs.
- Expected fail-closed inputs are not counted as successful rewrite cases.

## Scope

- This PR changes COMGR's gfx1250 same-family HotSwap implementation,
  documentation, and tests.
- PR #3374's fail-safe, far-routing, and large-object foundations remain the
  base of this work.
- Runtime-form HotSwap ISA target parsing is already present below PR #3374 and
  is not introduced here.
- The `TargetParser.h` include change selects the header available in the
  installed LLVM SDK and does not change rewrite semantics.
- This PR does not modify ATOM, AITER, Triton, ROCr, RCCL, or model source.
