### PR TITLE
[comgr][hotswap] Add opt-in HOTSWAP_PROFILE rewrite profiler with fixes

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -103,6 +103,7 @@ set(SOURCES
   src/comgr-env.cpp
   src/comgr-hotswap.cpp
   src/comgr-hotswap-b0a0.cpp
+  src/comgr-hotswap-profile.cpp
   src/comgr-hotswap-entry-trampoline.cpp
   src/comgr-hotswap-entry-trampoline-fast.cpp
   src/comgr-hotswap-occupancy.cpp

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -136,13 +136,6 @@ set(SOURCES
 option(COMGR_ENABLE_HOTSWAP_TRANSPILE
   "Build the hotswap-transpiler-backed amd_comgr_hotswap_transpile entry point" OFF)
 
-# HotSwap profiling instrumentation, opt-in. When ON, compiles the HotSwap
-# profiling helpers (timing + decode-repetition stats) into amd_comgr; they
-# remain gated at runtime by the HOTSWAP_PROFILE env var. When OFF (default),
-# the profiling code is compiled out entirely via no-op stubs.
-option(ENABLE_HOTSWAP_PROFILE
-  "Compile in HotSwap profiling instrumentation (runtime-gated by HOTSWAP_PROFILE)" OFF)
-
 # Add Windows resource file for version info
 if(WIN32)
   # Allow users to override the DLL name via -DCOMGR_DLL_NAME
@@ -229,10 +222,6 @@ target_include_directories(amd_comgr
 # link edge"), not here.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   target_compile_definitions(amd_comgr PRIVATE COMGR_ENABLE_HOTSWAP_TRANSPILE=1)
-endif()
-
-if(ENABLE_HOTSWAP_PROFILE)
-  target_compile_definitions(amd_comgr PRIVATE ENABLE_HOTSWAP_PROFILE)
 endif()
 
 message("")

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -136,6 +136,13 @@ set(SOURCES
 option(COMGR_ENABLE_HOTSWAP_TRANSPILE
   "Build the hotswap-transpiler-backed amd_comgr_hotswap_transpile entry point" OFF)
 
+# HotSwap profiling instrumentation, opt-in. When ON, compiles the HotSwap
+# profiling helpers (timing + decode-repetition stats) into amd_comgr; they
+# remain gated at runtime by the HOTSWAP_PROFILE env var. When OFF (default),
+# the profiling code is compiled out entirely via no-op stubs.
+option(ENABLE_HOTSWAP_PROFILE
+  "Compile in HotSwap profiling instrumentation (runtime-gated by HOTSWAP_PROFILE)" OFF)
+
 # Add Windows resource file for version info
 if(WIN32)
   # Allow users to override the DLL name via -DCOMGR_DLL_NAME
@@ -222,6 +229,10 @@ target_include_directories(amd_comgr
 # link edge"), not here.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   target_compile_definitions(amd_comgr PRIVATE COMGR_ENABLE_HOTSWAP_TRANSPILE=1)
+endif()
+
+if(ENABLE_HOTSWAP_PROFILE)
+  target_compile_definitions(amd_comgr PRIVATE ENABLE_HOTSWAP_PROFILE)
 endif()
 
 message("")

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -778,18 +778,22 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   }
 
   if (Far) {
-    if (InstSize < MinInstSize) {
-      // Count-only row: the "calls" column is the number of declined far sites.
+    // Every decline of a valid far site increments jump:declined_far (a
+    // count-only row) so the metric reflects all placement failures, including
+    // resource pressure, not just the size guard.
+    auto declineFar = [&](const Twine &Reason) {
       Ctx.Profile.count(HotswapMetric::JumpDeclined);
       log() << "hotswap: far trampoline site 0x" << utohexstr(InstOffset)
-            << " declined: " << InstSize << " B, smaller than " << MinInstSize
-            << " B forward branch\n";
+            << " declined: " << Reason << "\n";
       return false;
-    }
+    };
+    if (InstSize < MinInstSize)
+      return declineFar(Twine(InstSize) + " B, smaller than " +
+                        Twine(MinInstSize) + " B forward branch");
     std::optional<SafeSgprScratchBlock> Scratch =
         reserveSafeFarReturn(Ctx, InstOffset);
     if (!Scratch)
-      return false;
+      return declineFar("no safe SGPR triple for set-PC return");
     T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
     T.Long = true;
     T.UsesSetPCBack = true;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -47,9 +47,10 @@ using namespace llvm;
 namespace COMGR {
 namespace hotswap {
 
-// HotSwap rewrite profiling (opt-in via HOTSWAP_PROFILE) lives in
+// HotSwap rewrite profiling (compiled in via ENABLE_HOTSWAP_PROFILE, reported
+// at runtime through Comgr TimeStatistics / AMD_COMGR_TIME_STATISTICS) lives in
 // comgr-hotswap-internal.h so the sibling comgr-hotswap-patch-*.cpp TUs can
-// record per-rule timings into the same process-wide accumulator.
+// record per-rule timings into the same per-rewrite session.
 
 // -- GFX1250 B0-to-A0 constants -----------------------------------------------
 //

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2690,10 +2690,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   if (RunInstructionPatches) {
     std::vector<InternalDecodedInst> Decoded;
     uint64_t DecodeT0 = Prof ? profNowNs() : 0;
-    bool Decoded_ok = decodeTextSection(Text, Elf.textSize(), LS, Decoded);
+    bool DecodedOk = decodeTextSection(Text, Elf.textSize(), LS, Decoded);
     if (Prof)
       Profile.add(HotswapMetric::Decode, profNowNs() - DecodeT0, 0);
-    if (!Decoded_ok) {
+    if (!DecodedOk) {
       log() << "hotswap: error: retargetCodeObject: decodeTextSection "
             << "failed on .text (" << Elf.textSize() << " bytes).\n";
       return AMD_COMGR_STATUS_ERROR;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -47,10 +47,8 @@ using namespace llvm;
 namespace COMGR {
 namespace hotswap {
 
-// HotSwap rewrite profiling (always compiled, reported at runtime through Comgr
-// TimeStatistics / AMD_COMGR_TIME_STATISTICS) lives in
-// comgr-hotswap-internal.h so the sibling comgr-hotswap-patch-*.cpp TUs can
-// record per-rule timings into the same per-rewrite session.
+// HotSwap rewrite profiling lives in comgr-hotswap-internal.h so the sibling
+// comgr-hotswap-patch-*.cpp TUs can record into the same per-rewrite session.
 
 // -- GFX1250 B0-to-A0 constants -----------------------------------------------
 //
@@ -404,8 +402,7 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
     std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
 
   Sled.WritePos += Replacement.size() + MinInstSize;
-  // Count-only row: patch placed in-line via a nearby NOP sled with a short
-  // s_branch to/from it (no appended trampoline needed).
+  // Count-only row: patch placed in-line via a nearby NOP sled, no trampoline.
   Ctx.Profile.count(HotswapMetric::JumpNopSled);
   return true;
 }
@@ -2221,11 +2218,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   // against on these and we must not invoke the patch passes for them.
   constexpr StringLiteral UnknownMnemonic = "<unknown>";
   using PerInstPatchFn = uint32_t (*)(PatchContext &, size_t);
-  // One per-instruction pass: its dispatch function, the profiler bucket it
-  // reports under, and the locally-summed time/patches. Summing lives on the
-  // pass (not in a parallel array) so there is no index drift, and it is
-  // flushed once to the session after the loop -- no locking on the hot path,
-  // and the parent row's "calls" stays one per code object.
+  // A pass plus its metric; time/patches are summed locally and flushed once
+  // after the loop (see HotswapProfile::add).
   struct TimedPass {
     PerInstPatchFn Fn;
     HotswapMetric Metric;
@@ -2615,14 +2609,11 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_SUCCESS;
   }
 
-  // One profiling session per code object. The whole rewrite is timed via RAII
-  // (phase:rewrite_total records on every return path); the session merges into
-  // the process-wide aggregator once, when it goes out of scope. Prof gates the
-  // manual per-phase clock reads so the disabled path never touches the clock.
+  // One profiling session per code object, merged into TimeStatistics when it
+  // goes out of scope. Prof gates the manual per-phase clock reads.
   HotswapProfile Profile(hotswapProfilingEnabled());
   const bool Prof = Profile.enabled();
-  // RAII: records phase:rewrite_total on every return path. maybe_unused since
-  // the stub Scope (profiling compiled out) has no observable use.
+  // RAII guard: records phase:rewrite_total on every return path.
   [[maybe_unused]] HotswapProfile::Scope TotalScope =
       Profile.time(HotswapMetric::RewriteTotal);
 

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -37,12 +37,19 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
+#include <cstdio>
 #include <limits>
+#include <mutex>
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+
+// HotSwap rewrite profiling (opt-in via HOTSWAP_PROFILE) lives in
+// comgr-hotswap-internal.h so the sibling comgr-hotswap-patch-*.cpp TUs can
+// record per-rule timings into the same process-wide accumulator.
 
 // -- GFX1250 B0-to-A0 constants -----------------------------------------------
 //
@@ -396,6 +403,9 @@ truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
     std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
 
   Sled.WritePos += Replacement.size() + MinInstSize;
+  // Count-only row: patch placed in-line via a nearby NOP sled with a short
+  // s_branch to/from it (no appended trampoline needed).
+  Ctx.Profile.count(HotswapMetric::JumpNopSled);
   return true;
 }
 
@@ -771,6 +781,8 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
 
   if (Far) {
     if (InstSize < MinInstSize) {
+      // Count-only row: the "calls" column is the number of declined far sites.
+      Ctx.Profile.count(HotswapMetric::JumpDeclined);
       log() << "hotswap: far trampoline site 0x" << utohexstr(InstOffset)
             << " declined: " << InstSize << " B, smaller than " << MinInstSize
             << " B forward branch\n";
@@ -784,11 +796,13 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     T.Long = true;
     T.UsesSetPCBack = true;
     T.LongBranchSgprBase = Scratch->Base;
+    Ctx.Profile.count(HotswapMetric::JumpLong);
     Ctx.OutTrampolines.emplace_back(std::move(T));
     Ctx.QueuedTrampolineBytes = *QueuedBytes;
     return true;
   }
   {
+    Ctx.Profile.count(HotswapMetric::JumpShort);
     // Reserve the short branch-back slot; fixupTrampolineBranches fills it in.
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
   }
@@ -2136,9 +2150,14 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     std::vector<InternalDecodedInst> &Decoded, uint8_t *Text, uint64_t TextSize,
     const LLVMState &LS, std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
     std::vector<ScratchPatchInfo> &OutScratchPatches,
-    const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
+    const RewriteConfig &Config, bool &OutRequiredPatchApplied,
+    HotswapProfile &Profile) {
   uint32_t Patched = 0;
+
+  HotswapProfile::Scope SledScope = Profile.time(HotswapMetric::NopSledScan);
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
+  SledScope.finish();
+
   std::optional<DeclaredTextEntryInfo> DeclaredEntries =
       collectDeclaredTextEntries(Elf);
   if (!DeclaredEntries)
@@ -2159,9 +2178,14 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     truncateNopSledsAtDirectTargets(Sleds, ControlFlow->Targets);
   }
 
+  HotswapProfile::Scope CfgScope = Profile.time(HotswapMetric::CfgBuild);
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
+  CfgScope.finish();
+
+  HotswapProfile::Scope LiveScope = Profile.time(HotswapMetric::Liveness);
   LivenessInfo Liveness =
       computeLiveness(Decoded, Cfg, *LS.MCII, *LS.MRI, Config.MaxVgprs);
+  LiveScope.finish();
 
   if (!Liveness.Converged) {
     log() << "hotswap: error: liveness analysis did not converge, using "
@@ -2185,9 +2209,9 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   if (!PoolBaseOffset)
     return std::nullopt;
   PatchContext Ctx{
-      Config,      Decoded,           Text,        TextSize, *PoolBaseOffset,
-      LS,          OutTrampolines,    Sleds,       Elf,      Liveness,
-      KernelStats, OutScratchPatches, *ControlFlow};
+      Config,      Decoded,           Text,         TextSize, *PoolBaseOffset,
+      LS,          OutTrampolines,    Sleds,        Elf,      Liveness,
+      KernelStats, OutScratchPatches, *ControlFlow, Profile};
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
 
@@ -2196,24 +2220,42 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   // against on these and we must not invoke the patch passes for them.
   constexpr StringLiteral UnknownMnemonic = "<unknown>";
   using PerInstPatchFn = uint32_t (*)(PatchContext &, size_t);
-  SmallVector<PerInstPatchFn, 5> PerInstPasses;
+  // One per-instruction pass: its dispatch function, the profiler bucket it
+  // reports under, and the locally-summed time/patches. Summing lives on the
+  // pass (not in a parallel array) so there is no index drift, and it is
+  // flushed once to the session after the loop -- no locking on the hot path,
+  // and the parent row's "calls" stays one per code object.
+  struct TimedPass {
+    PerInstPatchFn Fn;
+    HotswapMetric Metric;
+    uint64_t Nanos = 0;
+    uint64_t Patches = 0;
+  };
+  SmallVector<TimedPass, 5> Passes;
   if (Config.RunB0A0Patches) {
-    PerInstPasses.push_back(VT.applyInPlacePatches);
-    PerInstPasses.push_back(VT.applyTrampolinePatches);
-    PerInstPasses.push_back(VT.applyWmmaSplitPatches);
-    PerInstPasses.push_back(VT.applyScratchPatches);
-    PerInstPasses.push_back(VT.applyWmmaScale16Patches);
+    Passes.push_back({VT.applyInPlacePatches, HotswapMetric::InPlace});
+    Passes.push_back({VT.applyTrampolinePatches, HotswapMetric::Trampoline});
+    Passes.push_back({VT.applyWmmaSplitPatches, HotswapMetric::WmmaSplit});
+    Passes.push_back({VT.applyScratchPatches, HotswapMetric::ScratchFp8});
+    Passes.push_back({VT.applyWmmaScale16Patches, HotswapMetric::WmmaScale16});
   } else {
-    PerInstPasses.push_back(VT.applyTrampolinePatches);
+    Passes.push_back({VT.applyTrampolinePatches, HotswapMetric::Trampoline});
   }
+
+  const bool Prof = Ctx.Profile.enabled();
 
   for (size_t Idx = 0, E = Decoded.size(); Idx < E; ++Idx) {
     const InternalDecodedInst &DI = Decoded[Idx];
     if (DI.Mnemonic == UnknownMnemonic)
       continue;
 
-    for (PerInstPatchFn Fn : PerInstPasses) {
-      std::optional<uint32_t> P = runPerInstPass(Fn, Ctx, Idx);
+    for (TimedPass &Pass : Passes) {
+      const uint64_t T0 = Prof ? profNowNs() : 0;
+      std::optional<uint32_t> P = runPerInstPass(Pass.Fn, Ctx, Idx);
+      if (Prof) {
+        Pass.Nanos += profNowNs() - T0;
+        Pass.Patches += P.value_or(0);
+      }
       if (!P)
         return std::nullopt;
       if (*P == 0)
@@ -2222,6 +2264,10 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       break;
     }
   }
+
+  if (Prof)
+    for (const TimedPass &Pass : Passes)
+      Ctx.Profile.add(Pass.Metric, Pass.Nanos, Pass.Patches);
 
   // Whole-kernel passes below run after per-instruction patches. Earlier
   // passes may have modified Text bytes, but the Decoded stream still holds
@@ -2234,10 +2280,22 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   //    treat a branch as WMMA/VALU/VOP3PX2.
   // If a future patch family changes instruction boundaries, the Decoded
   // stream must be rebuilt before these passes run.
-  if (Config.RunB0A0Patches && VT.applyWmmaHazardPatch)
-    Patched += VT.applyWmmaHazardPatch(Ctx);
-  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix)
-    Patched += VT.applyVop3px2Src2Fix(Ctx);
+  if (Config.RunB0A0Patches && VT.applyWmmaHazardPatch) {
+    HotswapProfile::Scope HazardScope =
+        Ctx.Profile.time(HotswapMetric::WmmaHazard);
+    const uint32_t P = VT.applyWmmaHazardPatch(Ctx);
+    HazardScope.addPatches(P);
+    HazardScope.finish();
+    Patched += P;
+  }
+  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix) {
+    HotswapProfile::Scope Vop3Scope =
+        Ctx.Profile.time(HotswapMetric::Vop3px2Src2);
+    const uint32_t P = VT.applyVop3px2Src2Fix(Ctx);
+    Vop3Scope.addPatches(P);
+    Vop3Scope.finish();
+    Patched += P;
+  }
 
   if (!OutTrampolines.empty()) {
     if (!ControlFlow->HasUnresolvedTargets) {
@@ -2556,11 +2614,26 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_SUCCESS;
   }
 
+  // One profiling session per code object. The whole rewrite is timed via RAII
+  // (phase:rewrite_total records on every return path); the session merges into
+  // the process-wide aggregator once, when it goes out of scope. Prof gates the
+  // manual per-phase clock reads so the disabled path never touches the clock.
+  HotswapProfile Profile(hotswapProfilingEnabled());
+  const bool Prof = Profile.enabled();
+  // RAII: records phase:rewrite_total on every return path. maybe_unused since
+  // the stub Scope (profiling compiled out) has no observable use.
+  [[maybe_unused]] HotswapProfile::Scope TotalScope =
+      Profile.time(HotswapMetric::RewriteTotal);
+
   // Take a working copy so the input is preserved and we have a mutable
   // buffer to parse / patch.
+  uint64_t InputCopyT0 = Prof ? profNowNs() : 0;
   std::vector<uint8_t> Buf(static_cast<const uint8_t *>(ElfData),
                            static_cast<const uint8_t *>(ElfData) + ElfSize);
+  if (Prof)
+    Profile.add(HotswapMetric::InputCopy, profNowNs() - InputCopyT0, 0);
 
+  uint64_t ParseT0 = Prof ? profNowNs() : 0;
   Expected<ElfView> ViewOrErr = ElfView::create(Buf.data(), Buf.size());
   if (!ViewOrErr) {
     log() << "hotswap: error: retargetCodeObject: input is not a "
@@ -2573,6 +2646,8 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
   ElfView &Elf = *ViewOrErr;
+  if (Prof)
+    Profile.add(HotswapMetric::ElfParse, profNowNs() - ParseT0, 0);
 
   // The CPU name and s_nop padding bytes are the only rewrite state the fast
   // path needs; both are also carried by LLVMState on the MC path. Holding them
@@ -2600,7 +2675,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     log() << "hotswap: entry trampolines: B0->B0 fast path (no MC/.text "
              "disassembly)\n";
   } else {
+    uint64_t InitT0 = Prof ? profNowNs() : 0;
     LS = initLLVM(TargetIdent);
+    if (Prof)
+      Profile.add(HotswapMetric::InitLLVM, profNowNs() - InitT0, 0);
     if (!LS.Valid) {
       log() << "hotswap: error: retargetCodeObject: initLLVM failed "
             << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
@@ -2619,15 +2697,22 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   bool RequiredPatchApplied = false;
   if (RunInstructionPatches) {
     std::vector<InternalDecodedInst> Decoded;
-    if (!decodeTextSection(Text, Elf.textSize(), LS, Decoded)) {
+    uint64_t DecodeT0 = Prof ? profNowNs() : 0;
+    bool Decoded_ok = decodeTextSection(Text, Elf.textSize(), LS, Decoded);
+    if (Prof)
+      Profile.add(HotswapMetric::Decode, profNowNs() - DecodeT0, 0);
+    if (!Decoded_ok) {
       log() << "hotswap: error: retargetCodeObject: decodeTextSection "
             << "failed on .text (" << Elf.textSize() << " bytes).\n";
       return AMD_COMGR_STATUS_ERROR;
     }
 
+    uint64_t DispatchT0 = Prof ? profNowNs() : 0;
     std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
         Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
-        Config, RequiredPatchApplied);
+        Config, RequiredPatchApplied, Profile);
+    if (Prof)
+      Profile.add(HotswapMetric::B0A0Dispatch, profNowNs() - DispatchT0, 0);
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;
@@ -2644,6 +2729,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_ERROR;
 
   std::unique_ptr<WritableMemoryBuffer> Result;
+  uint64_t PoolT0 = Prof ? profNowNs() : 0;
   std::vector<Trampoline> Growth = Deferred;
   // The appended pool's fresh virtual address is the single reference point for
   // all trampoline branch/stub targets (growWithTrampolines places it there).
@@ -2660,8 +2746,14 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   if (!PoolBaseOffsetOr)
     return AMD_COMGR_STATUS_ERROR;
   const uint64_t PoolBaseOffset = *PoolBaseOffsetOr;
+  if (Prof)
+    Profile.add(HotswapMetric::PoolSetup, profNowNs() - PoolT0, 0);
   if (!Deferred.empty()) {
-    if (!fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS)) {
+    uint64_t FixupT0 = Prof ? profNowNs() : 0;
+    bool FixupOk = fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS);
+    if (Prof)
+      Profile.add(HotswapMetric::FixupTrampolines, profNowNs() - FixupT0, 0);
+    if (!FixupOk) {
       if (RequiredPatchApplied) {
         log() << "hotswap: error: required patch trampoline branch fixup "
                  "failed; refusing to return the original unsafe code "
@@ -2695,12 +2787,16 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
   if (Options.RunEntryTrampolines) {
+    uint64_t EntryT0 = Prof ? profNowNs() : 0;
     std::optional<uint32_t> EntryCount =
         UseFastAppend
             ? appendKernelEntryTrampolinesFast(Elf, TargetCpu, Config.MaxSgprs,
                                                Growth, EntryFixups)
             : appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs, Growth,
                                            EntryFixups);
+    if (Prof)
+      Profile.add(HotswapMetric::EntryTrampolines, profNowNs() - EntryT0,
+                  EntryCount.value_or(0));
     if (!EntryCount)
       return AMD_COMGR_STATUS_ERROR;
     Count += *EntryCount;
@@ -2708,12 +2804,20 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     log() << "hotswap: kernel-entry trampolines disabled for this rewrite\n";
   }
 
-  if (!Deferred.empty() &&
-      !appendDeferredTrampolinePrefetchGuard(Elf, LS, Growth))
-    return AMD_COMGR_STATUS_ERROR;
+  if (!Deferred.empty()) {
+    uint64_t GuardT0 = Prof ? profNowNs() : 0;
+    bool GuardOk = appendDeferredTrampolinePrefetchGuard(Elf, LS, Growth);
+    if (Prof)
+      Profile.add(HotswapMetric::PrefetchGuard, profNowNs() - GuardT0, 0);
+    if (!GuardOk)
+      return AMD_COMGR_STATUS_ERROR;
+  }
 
   if (!Growth.empty()) {
+    uint64_t GrowT0 = Prof ? profNowNs() : 0;
     Result = Elf.growWithTrampolines(Growth, SNopBytes);
+    if (Prof)
+      Profile.add(HotswapMetric::GrowElf, profNowNs() - GrowT0, 0);
     if (!Result) {
       log() << "hotswap: error: retargetCodeObject: "
             << "ElfView::growWithTrampolines returned null with "
@@ -2730,9 +2834,17 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       }
       GrowthTotal += T.Bytes.size();
     }
+    uint64_t DbgT0 = Prof ? profNowNs() : 0;
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr, TargetCpu,
-                                             EntryFixups))
+    if (Prof)
+      Profile.add(HotswapMetric::DebugSections, profNowNs() - DbgT0, 0);
+
+    uint64_t KdT0 = Prof ? profNowNs() : 0;
+    bool KdOk = rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr,
+                                                    TargetCpu, EntryFixups);
+    if (Prof)
+      Profile.add(HotswapMetric::KdRewrite, profNowNs() - KdT0, 0);
+    if (!KdOk)
       return AMD_COMGR_STATUS_ERROR;
 
     // Give each appended entry stub a `<kernel>.stub` symbol so a dispatch
@@ -2749,21 +2861,31 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     const bool AddStubSymbols =
         !UseFastAppend || env::shouldAddEntryTrampolineSymbols();
     if (!EntryFixups.empty() && AddStubSymbols) {
+      uint64_t SymT0 = Prof ? profNowNs() : 0;
       std::unique_ptr<WritableMemoryBuffer> WithSyms =
           addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),
                                           Elf.textAddr(), Elf.textSize(),
                                           EntryFixups);
+      if (Prof)
+        Profile.add(HotswapMetric::SymbolInsert, profNowNs() - SymT0, 0);
       if (WithSyms)
         Result = std::move(WithSyms);
     }
   } else {
+    uint64_t OutCopyT0 = Prof ? profNowNs() : 0;
     Result = copyOutputBuffer(Buf.data(), ElfSize, "patched");
+    if (Prof)
+      Profile.add(HotswapMetric::OutputCopy, profNowNs() - OutCopyT0, 0);
     if (!Result)
       return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
   }
 
-  if (!ScratchPatches.empty())
+  if (!ScratchPatches.empty()) {
+    uint64_t VerifyT0 = Prof ? profNowNs() : 0;
     runScratchVerification(*Result, LS, ScratchPatches, Config.MaxVgprs);
+    if (Prof)
+      Profile.add(HotswapMetric::ScratchVerify, profNowNs() - VerifyT0, 0);
+  }
 
   Out = std::move(Result);
   return AMD_COMGR_STATUS_SUCCESS;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -47,8 +47,8 @@ using namespace llvm;
 namespace COMGR {
 namespace hotswap {
 
-// HotSwap rewrite profiling (compiled in via ENABLE_HOTSWAP_PROFILE, reported
-// at runtime through Comgr TimeStatistics / AMD_COMGR_TIME_STATISTICS) lives in
+// HotSwap rewrite profiling (always compiled, reported at runtime through Comgr
+// TimeStatistics / AMD_COMGR_TIME_STATISTICS) lives in
 // comgr-hotswap-internal.h so the sibling comgr-hotswap-patch-*.cpp TUs can
 // record per-rule timings into the same per-rewrite session.
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -24,9 +24,16 @@
 #include "comgr-env.h"
 #include "comgr.h"
 
+#include <algorithm>
+#include <array>
+#include <chrono>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <utility>
@@ -95,6 +102,362 @@ inline std::optional<uint64_t> checkedSubUint64(uint64_t LHS, uint64_t RHS,
   }
   return LHS - RHS;
 }
+
+// -- HotSwap rewrite profiling -----------------------------------------------
+//
+// Two-level gate:
+//   1. Compile time -- the whole facility is compiled in only when the build
+//      defines ENABLE_HOTSWAP_PROFILE (e.g. cmake -DENABLE_HOTSWAP_PROFILE=ON,
+//      which passes -DENABLE_HOTSWAP_PROFILE to the compiler). In a normal
+//      build every type below collapses to the no-op stubs in the #else branch,
+//      so there is no code, no static state, and no per-call overhead.
+//   2. Run time  -- when compiled in, it stays dormant until HOTSWAP_PROFILE is
+//      set (and not "0"). A disabled session never reads the clock.
+//
+// Design (see review on ROCm/llvm-project#3364): a single retargetCodeObject
+// call is single-threaded internally, but many calls run concurrently on
+// different threads. So each call owns a stack-local HotswapProfile whose
+// counters live in a fixed-size array indexed by HotswapMetric -- the hot path
+// records with no lock and no string lookup. When the rewrite finishes, the
+// session merges its array once into the process-wide HotswapAggregator (the
+// only lock, taken once per code object), which prints the table at exit.
+//
+// Row families:
+//   phase:*  coarse pipeline stages in retargetCodeObject. The timed stages
+//            plus phase:unaccounted partition phase:rewrite_total.
+//   strat:*  the B0-to-A0 patch strategies, with per-rule children indented
+//            under their parent (e.g. strat:trampoline -> ds_2addr).
+//   jump:*   trampoline placement outcomes; the "calls" column is the count.
+
+/// Identity of a profiled bucket. Used as an array index so the hot path
+/// records without hashing a string. The enumerator order MUST match the
+/// hotswapMetricInfo table below.
+enum class HotswapMetric : uint8_t {
+  // phase:* rows. The entries flagged PartitionsTotal in hotswapMetricInfo sum,
+  // together with Unaccounted, to RewriteTotal. Declared in pipeline order.
+  RewriteTotal,
+  InputCopy,
+  ElfParse,
+  InitLLVM,
+  Decode,
+  B0A0Dispatch,
+  PoolSetup,
+  FixupTrampolines,
+  EntryTrampolines,
+  PrefetchGuard,
+  GrowElf,
+  DebugSections,
+  KdRewrite,
+  SymbolInsert,
+  ScratchVerify,
+  OutputCopy,
+  Unaccounted,
+  // dispatch-internal sub-phases (shown indented under B0A0Dispatch)
+  NopSledScan,
+  CfgBuild,
+  Liveness,
+  // strat:* parents
+  InPlace,
+  Trampoline,
+  WmmaSplit,
+  ScratchFp8,
+  WmmaScale16,
+  WmmaHazard,
+  Vop3px2Src2,
+  // strat:inplace children (s_clause is handled identically on A0/B0 upstream,
+  // so it is no longer an in-place rewrite and has no bucket)
+  InPlaceClusterLoad,
+  InPlaceBarrierSignal,
+  // strat:trampoline children
+  TrampolineDs2Addr,
+  TrampolineTensorTdm,
+  TrampolineAddtid,
+  TrampolineClusterLoad,
+  // jump:* outcomes (count-only rows)
+  JumpNopSled,
+  JumpShort,
+  JumpLong,
+  JumpDeclined,
+  Count
+};
+
+inline constexpr size_t HotswapMetricCount =
+    static_cast<size_t>(HotswapMetric::Count);
+
+#ifdef ENABLE_HOTSWAP_PROFILE
+
+inline uint64_t profNowNs() {
+  return std::chrono::duration_cast<std::chrono::nanoseconds>(
+             std::chrono::steady_clock::now().time_since_epoch())
+      .count();
+}
+
+struct HotswapSample {
+  uint64_t Nanos = 0;
+  uint64_t Calls = 0;
+  uint64_t Patches = 0;
+  uint64_t MinNanos = std::numeric_limits<uint64_t>::max();
+  uint64_t MaxNanos = 0;
+};
+
+/// Static per-metric display info: label, parent (Count == top-level row), and
+/// whether the row partitions phase:rewrite_total. Indexed by HotswapMetric;
+/// the array order MUST match the enumerator order.
+struct HotswapMetricInfo {
+  const char *Label;
+  HotswapMetric Parent;
+  bool PartitionsTotal;
+};
+
+inline constexpr HotswapMetricInfo hotswapMetricInfo[HotswapMetricCount] = {
+    {"phase:rewrite_total", HotswapMetric::Count, false},
+    {"phase:input_copy", HotswapMetric::Count, true},
+    {"phase:elf_parse", HotswapMetric::Count, true},
+    {"phase:initLLVM", HotswapMetric::Count, true},
+    {"phase:decode", HotswapMetric::Count, true},
+    {"phase:b0a0_dispatch", HotswapMetric::Count, true},
+    {"phase:pool_setup", HotswapMetric::Count, true},
+    {"phase:fixup_trampolines", HotswapMetric::Count, true},
+    {"phase:entry_trampolines", HotswapMetric::Count, true},
+    {"phase:prefetch_guard", HotswapMetric::Count, true},
+    {"phase:grow_elf", HotswapMetric::Count, true},
+    {"phase:debug_sections", HotswapMetric::Count, true},
+    {"phase:kd_rewrite", HotswapMetric::Count, true},
+    {"phase:symbol_insert", HotswapMetric::Count, true},
+    {"phase:scratch_verify", HotswapMetric::Count, true},
+    {"phase:output_copy", HotswapMetric::Count, true},
+    {"phase:unaccounted", HotswapMetric::Count, false},
+    {"nop_sled_scan", HotswapMetric::B0A0Dispatch, false},
+    {"cfg_build", HotswapMetric::B0A0Dispatch, false},
+    {"liveness", HotswapMetric::B0A0Dispatch, false},
+    {"strat:inplace", HotswapMetric::Count, false},
+    {"strat:trampoline", HotswapMetric::Count, false},
+    {"strat:wmma_split", HotswapMetric::Count, false},
+    {"strat:scratch_fp8", HotswapMetric::Count, false},
+    {"strat:wmma_scale16", HotswapMetric::Count, false},
+    {"strat:wmma_hazard", HotswapMetric::Count, false},
+    {"strat:vop3px2_src2", HotswapMetric::Count, false},
+    {"cluster_load", HotswapMetric::InPlace, false},
+    {"s_barrier_signal_isfirst", HotswapMetric::InPlace, false},
+    {"ds_2addr", HotswapMetric::Trampoline, false},
+    {"tensor_tdm", HotswapMetric::Trampoline, false},
+    {"addtid", HotswapMetric::Trampoline, false},
+    {"cluster_load", HotswapMetric::Trampoline, false},
+    {"jump:nop_sled", HotswapMetric::Count, false},
+    {"jump:short_s_branch", HotswapMetric::Count, false},
+    {"jump:far_set_pc_back", HotswapMetric::Count, false},
+    {"jump:declined_far", HotswapMetric::Count, false},
+};
+
+/// Process-wide accumulator. Each per-rewrite HotswapProfile merges its array
+/// here once, under a single lock. Meyers singleton; prints the table at exit.
+class HotswapAggregator {
+public:
+  static HotswapAggregator &get() {
+    static HotswapAggregator Instance;
+    return Instance;
+  }
+
+  bool enabled() const { return Enabled; }
+
+  void merge(const std::array<HotswapSample, HotswapMetricCount> &Samples) {
+    std::scoped_lock Lock(Mtx);
+    for (size_t I = 0; I < HotswapMetricCount; ++I) {
+      HotswapSample &T = Totals[I];
+      const HotswapSample &S = Samples[I];
+      T.Nanos += S.Nanos;
+      T.Calls += S.Calls;
+      T.Patches += S.Patches;
+      T.MinNanos = std::min(T.MinNanos, S.MinNanos);
+      T.MaxNanos = std::max(T.MaxNanos, S.MaxNanos);
+    }
+    HaveData = true;
+  }
+
+  ~HotswapAggregator() { dump(); }
+
+private:
+  HotswapAggregator() {
+    const char *V = getenv("HOTSWAP_PROFILE");
+    Enabled = V && V[0] != '\0' && llvm::StringRef(V) != "0";
+  }
+
+  bool hasData(HotswapMetric M) const {
+    const HotswapSample &S = Totals[static_cast<size_t>(M)];
+    return S.Calls != 0 || S.Nanos != 0 || S.Patches != 0;
+  }
+
+  void printRow(llvm::StringRef Label, unsigned Indent,
+                const HotswapSample &S) const {
+    std::string L = std::string(Indent * 2, ' ') + Label.str();
+    const double TotalUs = S.Nanos / 1000.0;
+    const double AvgUs = S.Calls ? TotalUs / S.Calls : 0.0;
+    const double MinUs = S.MinNanos == std::numeric_limits<uint64_t>::max()
+                             ? 0.0
+                             : S.MinNanos / 1000.0;
+    const double MaxUs = S.MaxNanos / 1000.0;
+    fprintf(stderr, "%-28s %8llu %12.1f %11.3f %11.3f %11.3f %9llu\n",
+            L.c_str(), static_cast<unsigned long long>(S.Calls), TotalUs, AvgUs,
+            MinUs, MaxUs, static_cast<unsigned long long>(S.Patches));
+  }
+
+  void dump() {
+    if (!Enabled || !HaveData)
+      return;
+
+    // phase:unaccounted = rewrite_total - sum(partitioning phases), so the
+    // timed phases plus this residual add up to the whole rewrite.
+    uint64_t PhaseSum = 0;
+    for (size_t I = 0; I < HotswapMetricCount; ++I)
+      if (hotswapMetricInfo[I].PartitionsTotal)
+        PhaseSum += Totals[I].Nanos;
+    HotswapSample &Total =
+        Totals[static_cast<size_t>(HotswapMetric::RewriteTotal)];
+    HotswapSample &Unacc =
+        Totals[static_cast<size_t>(HotswapMetric::Unaccounted)];
+    Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
+    Unacc.Calls = Total.Calls;
+
+    fprintf(stderr,
+            "\n=== HotSwap COMGR rewrite profile (HOTSWAP_PROFILE) ===\n");
+    fprintf(stderr, "%-28s %8s %12s %11s %11s %11s %9s\n", "name", "calls",
+            "total_us", "avg_us", "min_us", "max_us", "patches");
+    // Top-level rows in enum order, each followed by its children indented one
+    // level. Children carry a non-Count parent and are skipped by the outer
+    // loop.
+    for (size_t I = 0; I < HotswapMetricCount; ++I) {
+      const HotswapMetricInfo &Info = hotswapMetricInfo[I];
+      if (Info.Parent != HotswapMetric::Count)
+        continue;
+      const HotswapMetric M = static_cast<HotswapMetric>(I);
+      if (!hasData(M) && M != HotswapMetric::Unaccounted)
+        continue;
+      printRow(Info.Label, 0, Totals[I]);
+      for (size_t J = 0; J < HotswapMetricCount; ++J) {
+        if (hotswapMetricInfo[J].Parent != M)
+          continue;
+        if (!hasData(static_cast<HotswapMetric>(J)))
+          continue;
+        printRow(hotswapMetricInfo[J].Label, 1, Totals[J]);
+      }
+    }
+    fprintf(stderr, "======================================================\n");
+  }
+
+  bool Enabled = false;
+  bool HaveData = false;
+  std::mutex Mtx;
+  std::array<HotswapSample, HotswapMetricCount> Totals{};
+};
+
+/// True when profiling is compiled in and armed at runtime (HOTSWAP_PROFILE).
+inline bool hotswapProfilingEnabled() {
+  return HotswapAggregator::get().enabled();
+}
+
+/// Per-rewrite profiling session. Lives on the retargetCodeObject stack and is
+/// referenced from PatchContext so deep patch sites record into its lock-free
+/// local array. Merges once into the aggregator on destruction.
+class HotswapProfile {
+public:
+  explicit HotswapProfile(bool Enabled) : Enabled(Enabled) {}
+  HotswapProfile(const HotswapProfile &) = delete;
+  HotswapProfile &operator=(const HotswapProfile &) = delete;
+  ~HotswapProfile() {
+    if (Enabled)
+      HotswapAggregator::get().merge(Samples);
+  }
+
+  bool enabled() const { return Enabled; }
+
+  /// RAII timer. Records the elapsed ns (plus any patches) under Metric on
+  /// finish() or destruction. A disabled session hands out an inert scope with
+  /// a null back-pointer, so the clock is never read on the disabled path.
+  class Scope {
+  public:
+    Scope(HotswapProfile *Profile, HotswapMetric Metric)
+        : Profile(Profile), Metric(Metric), StartNs(Profile ? profNowNs() : 0) {
+    }
+    Scope(const Scope &) = delete;
+    Scope &operator=(const Scope &) = delete;
+    ~Scope() { finish(); }
+    void addPatches(uint64_t P) { Patches += P; }
+    void finish() {
+      if (!Profile)
+        return;
+      Profile->add(Metric, profNowNs() - StartNs, Patches);
+      Profile = nullptr;
+    }
+
+  private:
+    HotswapProfile *Profile;
+    HotswapMetric Metric;
+    uint64_t StartNs;
+    uint64_t Patches = 0;
+  };
+
+  Scope time(HotswapMetric Metric) {
+    return Scope(Enabled ? this : nullptr, Metric);
+  }
+
+  /// Count-only record (e.g. jump outcomes): one call, no wall time.
+  void count(HotswapMetric Metric, uint64_t N = 1) {
+    if (Enabled)
+      Samples[static_cast<size_t>(Metric)].Calls += N;
+  }
+
+  /// Accumulate a pre-measured interval as one call. Used by the
+  /// per-instruction pass loop, which sums locally across the stream and
+  /// flushes one row per rewrite (so a strat:* parent's "calls" stays one per
+  /// code object).
+  void add(HotswapMetric Metric, uint64_t Nanos, uint64_t Patches) {
+    if (!Enabled)
+      return;
+    HotswapSample &S = Samples[static_cast<size_t>(Metric)];
+    S.Nanos += Nanos;
+    S.Calls += 1;
+    S.Patches += Patches;
+    S.MinNanos = std::min(S.MinNanos, Nanos);
+    S.MaxNanos = std::max(S.MaxNanos, Nanos);
+  }
+
+  /// Read-only view of the per-metric samples. Exposed for unit testing the
+  /// session accumulation; production code reports through the aggregator.
+  const HotswapSample &sample(HotswapMetric Metric) const {
+    return Samples[static_cast<size_t>(Metric)];
+  }
+
+private:
+  bool Enabled;
+  std::array<HotswapSample, HotswapMetricCount> Samples{};
+};
+
+#else // !ENABLE_HOTSWAP_PROFILE
+
+// Profiling compiled out. These no-op shims keep every hotswap-*.cpp call site
+// valid at zero cost: the session is never enabled, so the timing / record
+// calls are dead-code eliminated. No static state, no atexit dump, no work.
+
+inline uint64_t profNowNs() { return 0; }
+inline bool hotswapProfilingEnabled() { return false; }
+
+class HotswapProfile {
+public:
+  class Scope {
+  public:
+    void addPatches(uint64_t) {}
+    void finish() {}
+  };
+  explicit HotswapProfile(bool = false) {}
+  HotswapProfile(const HotswapProfile &) = delete;
+  HotswapProfile &operator=(const HotswapProfile &) = delete;
+  bool enabled() const { return false; }
+  Scope time(HotswapMetric) { return Scope{}; }
+  void count(HotswapMetric, uint64_t = 1) {}
+  void add(HotswapMetric, uint64_t, uint64_t) {}
+};
+
+#endif // ENABLE_HOTSWAP_PROFILE
 
 // -- Trampoline and NOP sled --------------------------------------------------
 
@@ -873,6 +1236,9 @@ struct PatchContext {
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
   const DirectControlFlowInfo &DirectControlFlow;
+  // Per-rewrite profiling session (no-op stub unless ENABLE_HOTSWAP_PROFILE).
+  // Deep patch sites record into its lock-free local array.
+  HotswapProfile &Profile;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -106,14 +106,11 @@ inline std::optional<uint64_t> checkedSubUint64(uint64_t LHS, uint64_t RHS,
 
 // -- HotSwap rewrite profiling -----------------------------------------------
 //
-// Two-level gate:
-//   1. Compile time -- the instrumentation is compiled in only when the build
-//      defines ENABLE_HOTSWAP_PROFILE (e.g. cmake -DENABLE_HOTSWAP_PROFILE=ON).
-//      In a normal build every type below collapses to the no-op stubs in the
-//      #else branch, so there is no code and no per-call overhead.
-//   2. Run time  -- when compiled in, it reports only when Comgr time
-//      statistics are enabled (AMD_COMGR_TIME_STATISTICS); a disabled session
-//      never reads the clock.
+// Opt-in at run time only: it reports when Comgr time statistics are enabled
+// (AMD_COMGR_TIME_STATISTICS). A disabled session is a single branch per hook
+// and never reads the clock or takes a lock -- the same "only a branch when
+// disabled" cost as the rest of Comgr's TimeStatistics, so no compile-time gate
+// is needed.
 //
 // Design (see review on ROCm/llvm-project#3364 and #3388): a single
 // retargetCodeObject call is single-threaded internally, but many calls run
@@ -187,8 +184,6 @@ enum class HotswapMetric : uint8_t {
 
 inline constexpr size_t HotswapMetricCount =
     static_cast<size_t>(HotswapMetric::Count);
-
-#ifdef ENABLE_HOTSWAP_PROFILE
 
 inline uint64_t profNowNs() {
   return std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -346,6 +341,10 @@ private:
         Samples[static_cast<size_t>(HotswapMetric::Unaccounted)];
     Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
     Unacc.Calls = Total.Calls;
+    // This rewrite contributes one unaccounted sample, so set min == max == its
+    // residual; otherwise the record loop below would emit min/max of 0 for a
+    // nonzero row and skew the merged min/max across rewrites.
+    Unacc.MinNanos = Unacc.MaxNanos = Unacc.Nanos;
 
     const double UnitsPerNs = env::getGranularityUnitsPerSecond() / 1.0e9;
     // Build names first (SmallVector inline storage keeps them stable), then
@@ -390,33 +389,6 @@ private:
   bool Enabled;
   std::array<HotswapSample, HotswapMetricCount> Samples{};
 };
-
-#else // !ENABLE_HOTSWAP_PROFILE
-
-// Profiling compiled out. These no-op shims keep every hotswap-*.cpp call site
-// valid at zero cost: the session is never enabled, so the timing / record
-// calls are dead-code eliminated. No static state, no atexit dump, no work.
-
-inline uint64_t profNowNs() { return 0; }
-inline bool hotswapProfilingEnabled() { return false; }
-
-class HotswapProfile {
-public:
-  class Scope {
-  public:
-    void addPatches(uint64_t) {}
-    void finish() {}
-  };
-  explicit HotswapProfile(bool = false) {}
-  HotswapProfile(const HotswapProfile &) = delete;
-  HotswapProfile &operator=(const HotswapProfile &) = delete;
-  bool enabled() const { return false; }
-  Scope time(HotswapMetric) { return Scope{}; }
-  void count(HotswapMetric, uint64_t = 1) {}
-  void add(HotswapMetric, uint64_t, uint64_t) {}
-};
-
-#endif // ENABLE_HOTSWAP_PROFILE
 
 // -- Trampoline and NOP sled --------------------------------------------------
 
@@ -1195,8 +1167,8 @@ struct PatchContext {
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
   const DirectControlFlowInfo &DirectControlFlow;
-  // Per-rewrite profiling session (no-op stub unless ENABLE_HOTSWAP_PROFILE).
-  // Deep patch sites record into its lock-free local array.
+  // Per-rewrite profiling session (inert unless AMD_COMGR_TIME_STATISTICS is
+  // set). Deep patch sites record into its lock-free local array.
   HotswapProfile &Profile;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -106,29 +106,17 @@ inline std::optional<uint64_t> checkedSubUint64(uint64_t LHS, uint64_t RHS,
 
 // -- HotSwap rewrite profiling -----------------------------------------------
 //
-// Opt-in at run time only: it reports when Comgr time statistics are enabled
-// (AMD_COMGR_TIME_STATISTICS). A disabled session is a single branch per hook
-// and never reads the clock or takes a lock -- the same "only a branch when
-// disabled" cost as the rest of Comgr's TimeStatistics, so no compile-time gate
-// is needed.
+// Opt-in via AMD_COMGR_TIME_STATISTICS. When disabled each hook is a single
+// branch -- no clock read, no lock -- so no compile-time gate is needed.
 //
-// Design (see review on ROCm/llvm-project#3364 and #3388): a single
-// retargetCodeObject call is single-threaded internally, but many calls run
-// concurrently on different threads. So each call owns a stack-local
-// HotswapProfile whose counters live in a fixed-size array indexed by
-// HotswapMetric -- the hot path records with no lock and no string lookup. When
-// the rewrite finishes, the session merges its array once (the only lock, taken
-// once per code object) into Comgr's built-in profiler, TimeStatistics, which
-// dumps the aggregated stats at process exit. We reuse TimeStatistics rather
-// than a bespoke aggregator (per review feedback); the only addition there is a
-// mutex + a batch-merge entry point + a few extra columns.
+// retargetCodeObject is single-threaded per call but runs concurrently across
+// threads, so each call owns a stack-local HotswapProfile that records into a
+// fixed array indexed by HotswapMetric (no lock, no string lookup on the hot
+// path) and merges once into Comgr's TimeStatistics when the rewrite finishes.
 //
-// Row families (names carry one level of parent/child hierarchy via '/'):
-//   phase:*  coarse pipeline stages in retargetCodeObject. The timed stages
-//            plus phase:unaccounted partition phase:rewrite_total.
-//   strat:*  the B0-to-A0 patch strategies, with per-rule children
-//            (e.g. strat:trampoline/ds_2addr).
-//   jump:*   trampoline placement outcomes; the "calls" column is the count.
+// Row names encode one parent/child level via '/': phase:* pipeline stages
+// (timed stages + phase:unaccounted partition phase:rewrite_total), strat:*
+// patch strategies with per-rule children, and jump:* placement outcomes.
 
 /// Identity of a profiled bucket. Used as an array index so the hot path
 /// records without hashing a string. The enumerator order MUST match the
@@ -248,9 +236,7 @@ inline constexpr HotswapMetricInfo hotswapMetricInfo[HotswapMetricCount] = {
     {"jump:declined_far", HotswapMetric::Count, false},
 };
 
-/// True when the hotswap profiler is compiled in and Comgr time statistics are
-/// enabled at runtime (AMD_COMGR_TIME_STATISTICS). Hotswap timings are reported
-/// through Comgr's built-in profiler (TimeStatistics), not a bespoke sink.
+/// True when hotswap timings should be recorded (AMD_COMGR_TIME_STATISTICS).
 inline bool hotswapProfilingEnabled() { return env::needTimeStatistics(); }
 
 /// Per-rewrite profiling session. Lives on the retargetCodeObject stack and is
@@ -304,10 +290,8 @@ public:
       Samples[static_cast<size_t>(Metric)].Calls += N;
   }
 
-  /// Accumulate a pre-measured interval as one call. Used by the
-  /// per-instruction pass loop, which sums locally across the stream and
-  /// flushes one row per rewrite (so a strat:* parent's "calls" stays one per
-  /// code object).
+  /// Accumulate a pre-measured interval as one call. The pass loop sums locally
+  /// and calls this once per rewrite, so a strat:* parent's "calls" stays one.
   void add(HotswapMetric Metric, uint64_t Nanos, uint64_t Patches) {
     if (!Enabled)
       return;
@@ -341,9 +325,8 @@ private:
         Samples[static_cast<size_t>(HotswapMetric::Unaccounted)];
     Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
     Unacc.Calls = Total.Calls;
-    // This rewrite contributes one unaccounted sample, so set min == max == its
-    // residual; otherwise the record loop below would emit min/max of 0 for a
-    // nonzero row and skew the merged min/max across rewrites.
+    // One unaccounted sample per rewrite: min == max == residual so the merged
+    // min/max across rewrites stays correct.
     Unacc.MinNanos = Unacc.MaxNanos = Unacc.Nanos;
 
     const double UnitsPerNs = env::getGranularityUnitsPerSecond() / 1.0e9;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -287,12 +287,18 @@ public:
   /// session accumulation; production code reports through TimeStatistics.
   const HotswapSample &sample(HotswapMetric Metric) const;
 
+  /// Derive phase:unaccounted and convert each recorded sample into a
+  /// TimeStatistics::PerfStatRecord (ns -> configured unit, one-level
+  /// parent/child row name, e.g. "strat:trampoline/ds_2addr"). Row-name storage
+  /// is appended to \p Names, which must outlive the returned records (each
+  /// Name is a StringRef into it). flush() merges the result; unit tests
+  /// inspect it. Defined in comgr-hotswap-profile.cpp.
+  llvm::SmallVector<COMGR::TimeStatistics::PerfStatRecord, HotswapMetricCount>
+  buildRecords(llvm::SmallVectorImpl<std::string> &Names);
+
 private:
-  /// Fold this rewrite's samples into Comgr TimeStatistics in one batch: derive
-  /// phase:unaccounted, convert ns to the configured granularity unit, encode
-  /// the one-level parent/child hierarchy in each row name (e.g.
-  /// "strat:trampoline/ds_2addr"), and merge under a single lock. Defined in
-  /// comgr-hotswap-profile.cpp.
+  /// Merge this rewrite's samples into Comgr TimeStatistics in one batch under
+  /// a single lock (see buildRecords). Defined in comgr-hotswap-profile.cpp.
   void flush();
 
   bool Enabled;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -224,12 +224,12 @@ inline constexpr HotswapMetricInfo hotswapMetricInfo[HotswapMetricCount] = {
     {"strat:wmma_scale16", HotswapMetric::Count, false},
     {"strat:wmma_hazard", HotswapMetric::Count, false},
     {"strat:vop3px2_src2", HotswapMetric::Count, false},
-    {"cluster_load", HotswapMetric::InPlace, false},
+    {"cluster_load_swap", HotswapMetric::InPlace, false},
     {"s_barrier_signal_isfirst", HotswapMetric::InPlace, false},
     {"ds_2addr", HotswapMetric::Trampoline, false},
     {"tensor_tdm", HotswapMetric::Trampoline, false},
     {"addtid", HotswapMetric::Trampoline, false},
-    {"cluster_load", HotswapMetric::Trampoline, false},
+    {"cluster_load_mask", HotswapMetric::Trampoline, false},
     {"jump:nop_sled", HotswapMetric::Count, false},
     {"jump:short_s_branch", HotswapMetric::Count, false},
     {"jump:far_set_pc_back", HotswapMetric::Count, false},
@@ -280,7 +280,7 @@ public:
     uint64_t Patches = 0;
   };
 
-  Scope time(HotswapMetric Metric) {
+  [[nodiscard]] Scope time(HotswapMetric Metric) {
     return Scope(Enabled ? this : nullptr, Metric);
   }
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -23,6 +23,7 @@
 #include "amd_comgr.h"
 #include "comgr-env.h"
 #include "comgr.h"
+#include "time-stat/ts-interface.h"
 
 #include <algorithm>
 #include <array>
@@ -106,27 +107,30 @@ inline std::optional<uint64_t> checkedSubUint64(uint64_t LHS, uint64_t RHS,
 // -- HotSwap rewrite profiling -----------------------------------------------
 //
 // Two-level gate:
-//   1. Compile time -- the whole facility is compiled in only when the build
-//      defines ENABLE_HOTSWAP_PROFILE (e.g. cmake -DENABLE_HOTSWAP_PROFILE=ON,
-//      which passes -DENABLE_HOTSWAP_PROFILE to the compiler). In a normal
-//      build every type below collapses to the no-op stubs in the #else branch,
-//      so there is no code, no static state, and no per-call overhead.
-//   2. Run time  -- when compiled in, it stays dormant until HOTSWAP_PROFILE is
-//      set (and not "0"). A disabled session never reads the clock.
+//   1. Compile time -- the instrumentation is compiled in only when the build
+//      defines ENABLE_HOTSWAP_PROFILE (e.g. cmake -DENABLE_HOTSWAP_PROFILE=ON).
+//      In a normal build every type below collapses to the no-op stubs in the
+//      #else branch, so there is no code and no per-call overhead.
+//   2. Run time  -- when compiled in, it reports only when Comgr time
+//      statistics are enabled (AMD_COMGR_TIME_STATISTICS); a disabled session
+//      never reads the clock.
 //
-// Design (see review on ROCm/llvm-project#3364): a single retargetCodeObject
-// call is single-threaded internally, but many calls run concurrently on
-// different threads. So each call owns a stack-local HotswapProfile whose
-// counters live in a fixed-size array indexed by HotswapMetric -- the hot path
-// records with no lock and no string lookup. When the rewrite finishes, the
-// session merges its array once into the process-wide HotswapAggregator (the
-// only lock, taken once per code object), which prints the table at exit.
+// Design (see review on ROCm/llvm-project#3364 and #3388): a single
+// retargetCodeObject call is single-threaded internally, but many calls run
+// concurrently on different threads. So each call owns a stack-local
+// HotswapProfile whose counters live in a fixed-size array indexed by
+// HotswapMetric -- the hot path records with no lock and no string lookup. When
+// the rewrite finishes, the session merges its array once (the only lock, taken
+// once per code object) into Comgr's built-in profiler, TimeStatistics, which
+// dumps the aggregated stats at process exit. We reuse TimeStatistics rather
+// than a bespoke aggregator (per review feedback); the only addition there is a
+// mutex + a batch-merge entry point + a few extra columns.
 //
-// Row families:
+// Row families (names carry one level of parent/child hierarchy via '/'):
 //   phase:*  coarse pipeline stages in retargetCodeObject. The timed stages
 //            plus phase:unaccounted partition phase:rewrite_total.
-//   strat:*  the B0-to-A0 patch strategies, with per-rule children indented
-//            under their parent (e.g. strat:trampoline -> ds_2addr).
+//   strat:*  the B0-to-A0 patch strategies, with per-rule children
+//            (e.g. strat:trampoline/ds_2addr).
 //   jump:*   trampoline placement outcomes; the "calls" column is the count.
 
 /// Identity of a profiled bucket. Used as an array index so the hot path
@@ -249,115 +253,14 @@ inline constexpr HotswapMetricInfo hotswapMetricInfo[HotswapMetricCount] = {
     {"jump:declined_far", HotswapMetric::Count, false},
 };
 
-/// Process-wide accumulator. Each per-rewrite HotswapProfile merges its array
-/// here once, under a single lock. Meyers singleton; prints the table at exit.
-class HotswapAggregator {
-public:
-  static HotswapAggregator &get() {
-    static HotswapAggregator Instance;
-    return Instance;
-  }
-
-  bool enabled() const { return Enabled; }
-
-  void merge(const std::array<HotswapSample, HotswapMetricCount> &Samples) {
-    std::scoped_lock Lock(Mtx);
-    for (size_t I = 0; I < HotswapMetricCount; ++I) {
-      HotswapSample &T = Totals[I];
-      const HotswapSample &S = Samples[I];
-      T.Nanos += S.Nanos;
-      T.Calls += S.Calls;
-      T.Patches += S.Patches;
-      T.MinNanos = std::min(T.MinNanos, S.MinNanos);
-      T.MaxNanos = std::max(T.MaxNanos, S.MaxNanos);
-    }
-    HaveData = true;
-  }
-
-  ~HotswapAggregator() { dump(); }
-
-private:
-  HotswapAggregator() {
-    const char *V = getenv("HOTSWAP_PROFILE");
-    Enabled = V && V[0] != '\0' && llvm::StringRef(V) != "0";
-  }
-
-  bool hasData(HotswapMetric M) const {
-    const HotswapSample &S = Totals[static_cast<size_t>(M)];
-    return S.Calls != 0 || S.Nanos != 0 || S.Patches != 0;
-  }
-
-  void printRow(llvm::StringRef Label, unsigned Indent,
-                const HotswapSample &S) const {
-    std::string L = std::string(Indent * 2, ' ') + Label.str();
-    const double TotalUs = S.Nanos / 1000.0;
-    const double AvgUs = S.Calls ? TotalUs / S.Calls : 0.0;
-    const double MinUs = S.MinNanos == std::numeric_limits<uint64_t>::max()
-                             ? 0.0
-                             : S.MinNanos / 1000.0;
-    const double MaxUs = S.MaxNanos / 1000.0;
-    fprintf(stderr, "%-28s %8llu %12.1f %11.3f %11.3f %11.3f %9llu\n",
-            L.c_str(), static_cast<unsigned long long>(S.Calls), TotalUs, AvgUs,
-            MinUs, MaxUs, static_cast<unsigned long long>(S.Patches));
-  }
-
-  void dump() {
-    if (!Enabled || !HaveData)
-      return;
-
-    // phase:unaccounted = rewrite_total - sum(partitioning phases), so the
-    // timed phases plus this residual add up to the whole rewrite.
-    uint64_t PhaseSum = 0;
-    for (size_t I = 0; I < HotswapMetricCount; ++I)
-      if (hotswapMetricInfo[I].PartitionsTotal)
-        PhaseSum += Totals[I].Nanos;
-    HotswapSample &Total =
-        Totals[static_cast<size_t>(HotswapMetric::RewriteTotal)];
-    HotswapSample &Unacc =
-        Totals[static_cast<size_t>(HotswapMetric::Unaccounted)];
-    Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
-    Unacc.Calls = Total.Calls;
-
-    fprintf(stderr,
-            "\n=== HotSwap COMGR rewrite profile (HOTSWAP_PROFILE) ===\n");
-    fprintf(stderr, "%-28s %8s %12s %11s %11s %11s %9s\n", "name", "calls",
-            "total_us", "avg_us", "min_us", "max_us", "patches");
-    // Top-level rows in enum order, each followed by its children indented one
-    // level. Children carry a non-Count parent and are skipped by the outer
-    // loop.
-    for (size_t I = 0; I < HotswapMetricCount; ++I) {
-      const HotswapMetricInfo &Info = hotswapMetricInfo[I];
-      if (Info.Parent != HotswapMetric::Count)
-        continue;
-      const HotswapMetric M = static_cast<HotswapMetric>(I);
-      if (!hasData(M) && M != HotswapMetric::Unaccounted)
-        continue;
-      printRow(Info.Label, 0, Totals[I]);
-      for (size_t J = 0; J < HotswapMetricCount; ++J) {
-        if (hotswapMetricInfo[J].Parent != M)
-          continue;
-        if (!hasData(static_cast<HotswapMetric>(J)))
-          continue;
-        printRow(hotswapMetricInfo[J].Label, 1, Totals[J]);
-      }
-    }
-    fprintf(stderr, "======================================================\n");
-  }
-
-  bool Enabled = false;
-  bool HaveData = false;
-  std::mutex Mtx;
-  std::array<HotswapSample, HotswapMetricCount> Totals{};
-};
-
-/// True when profiling is compiled in and armed at runtime (HOTSWAP_PROFILE).
-inline bool hotswapProfilingEnabled() {
-  return HotswapAggregator::get().enabled();
-}
+/// True when the hotswap profiler is compiled in and Comgr time statistics are
+/// enabled at runtime (AMD_COMGR_TIME_STATISTICS). Hotswap timings are reported
+/// through Comgr's built-in profiler (TimeStatistics), not a bespoke sink.
+inline bool hotswapProfilingEnabled() { return env::needTimeStatistics(); }
 
 /// Per-rewrite profiling session. Lives on the retargetCodeObject stack and is
 /// referenced from PatchContext so deep patch sites record into its lock-free
-/// local array. Merges once into the aggregator on destruction.
+/// local array. Merges once into Comgr TimeStatistics on destruction.
 class HotswapProfile {
 public:
   explicit HotswapProfile(bool Enabled) : Enabled(Enabled) {}
@@ -365,7 +268,7 @@ public:
   HotswapProfile &operator=(const HotswapProfile &) = delete;
   ~HotswapProfile() {
     if (Enabled)
-      HotswapAggregator::get().merge(Samples);
+      flush();
   }
 
   bool enabled() const { return Enabled; }
@@ -422,12 +325,68 @@ public:
   }
 
   /// Read-only view of the per-metric samples. Exposed for unit testing the
-  /// session accumulation; production code reports through the aggregator.
+  /// session accumulation; production code reports through TimeStatistics.
   const HotswapSample &sample(HotswapMetric Metric) const {
     return Samples[static_cast<size_t>(Metric)];
   }
 
 private:
+  /// Fold this rewrite's samples into Comgr TimeStatistics in one batch: derive
+  /// phase:unaccounted, convert ns to the configured granularity unit, encode
+  /// the one-level parent/child hierarchy in each row name (e.g.
+  /// "strat:trampoline/ds_2addr"), and merge under a single lock.
+  void flush() {
+    uint64_t PhaseSum = 0;
+    for (size_t I = 0; I < HotswapMetricCount; ++I)
+      if (hotswapMetricInfo[I].PartitionsTotal)
+        PhaseSum += Samples[I].Nanos;
+    HotswapSample &Total =
+        Samples[static_cast<size_t>(HotswapMetric::RewriteTotal)];
+    HotswapSample &Unacc =
+        Samples[static_cast<size_t>(HotswapMetric::Unaccounted)];
+    Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
+    Unacc.Calls = Total.Calls;
+
+    const double UnitsPerNs = env::getGranularityUnitsPerSecond() / 1.0e9;
+    // Build names first (SmallVector inline storage keeps them stable), then
+    // point the records' StringRefs at them.
+    llvm::SmallVector<std::string, HotswapMetricCount> Names;
+    llvm::SmallVector<size_t, HotswapMetricCount> Rows;
+    for (size_t I = 0; I < HotswapMetricCount; ++I) {
+      const HotswapSample &S = Samples[I];
+      const HotswapMetric M = static_cast<HotswapMetric>(I);
+      if (!S.Calls && !S.Nanos && !S.Patches && M != HotswapMetric::Unaccounted)
+        continue;
+      const HotswapMetricInfo &Info = hotswapMetricInfo[I];
+      if (Info.Parent != HotswapMetric::Count)
+        Names.push_back(
+            std::string(
+                hotswapMetricInfo[static_cast<size_t>(Info.Parent)].Label) +
+            "/" + Info.Label);
+      else
+        Names.push_back(std::string(Info.Label));
+      Rows.push_back(I);
+    }
+
+    llvm::SmallVector<COMGR::TimeStatistics::PerfStatRecord, HotswapMetricCount>
+        Records;
+    Records.reserve(Rows.size());
+    for (size_t K = 0; K < Rows.size(); ++K) {
+      const HotswapSample &S = Samples[Rows[K]];
+      COMGR::TimeStatistics::PerfStatRecord R;
+      R.Name = Names[K];
+      R.TimeTaken = static_cast<double>(S.Nanos) * UnitsPerNs;
+      R.Calls = S.Calls;
+      R.Patches = S.Patches;
+      R.MinTime = S.MinNanos == std::numeric_limits<uint64_t>::max()
+                      ? 0.0
+                      : static_cast<double>(S.MinNanos) * UnitsPerNs;
+      R.MaxTime = static_cast<double>(S.MaxNanos) * UnitsPerNs;
+      Records.push_back(R);
+    }
+    COMGR::TimeStatistics::mergeStats(Records);
+  }
+
   bool Enabled;
   std::array<HotswapSample, HotswapMetricCount> Samples{};
 };

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -14,6 +14,7 @@
 ///   comgr-hotswap-llvm.cpp      LLVM MC infrastructure (disasm/asm/encode)
 ///   comgr-hotswap-b0a0.cpp      GFX1250 B0-to-A0 policy + public API
 ///   comgr-hotswap-occupancy.cpp VGPR/workgroup capacity policy
+///   comgr-hotswap-profile.cpp   HotSwap rewrite profiler (out-of-line bodies)
 ///
 //===----------------------------------------------------------------------===//
 
@@ -259,19 +260,12 @@ public:
   /// a null back-pointer, so the clock is never read on the disabled path.
   class Scope {
   public:
-    Scope(HotswapProfile *Profile, HotswapMetric Metric)
-        : Profile(Profile), Metric(Metric), StartNs(Profile ? profNowNs() : 0) {
-    }
+    Scope(HotswapProfile *Profile, HotswapMetric Metric);
     Scope(const Scope &) = delete;
     Scope &operator=(const Scope &) = delete;
     ~Scope() { finish(); }
     void addPatches(uint64_t P) { Patches += P; }
-    void finish() {
-      if (!Profile)
-        return;
-      Profile->add(Metric, profNowNs() - StartNs, Patches);
-      Profile = nullptr;
-    }
+    void finish();
 
   private:
     HotswapProfile *Profile;
@@ -280,94 +274,26 @@ public:
     uint64_t Patches = 0;
   };
 
-  [[nodiscard]] Scope time(HotswapMetric Metric) {
-    return Scope(Enabled ? this : nullptr, Metric);
-  }
+  [[nodiscard]] Scope time(HotswapMetric Metric);
 
   /// Count-only record (e.g. jump outcomes): one call, no wall time.
-  void count(HotswapMetric Metric, uint64_t N = 1) {
-    if (Enabled)
-      Samples[static_cast<size_t>(Metric)].Calls += N;
-  }
+  void count(HotswapMetric Metric, uint64_t N = 1);
 
   /// Accumulate a pre-measured interval as one call. The pass loop sums locally
   /// and calls this once per rewrite, so a strat:* parent's "calls" stays one.
-  void add(HotswapMetric Metric, uint64_t Nanos, uint64_t Patches) {
-    if (!Enabled)
-      return;
-    HotswapSample &S = Samples[static_cast<size_t>(Metric)];
-    S.Nanos += Nanos;
-    S.Calls += 1;
-    S.Patches += Patches;
-    S.MinNanos = std::min(S.MinNanos, Nanos);
-    S.MaxNanos = std::max(S.MaxNanos, Nanos);
-  }
+  void add(HotswapMetric Metric, uint64_t Nanos, uint64_t Patches);
 
   /// Read-only view of the per-metric samples. Exposed for unit testing the
   /// session accumulation; production code reports through TimeStatistics.
-  const HotswapSample &sample(HotswapMetric Metric) const {
-    return Samples[static_cast<size_t>(Metric)];
-  }
+  const HotswapSample &sample(HotswapMetric Metric) const;
 
 private:
   /// Fold this rewrite's samples into Comgr TimeStatistics in one batch: derive
   /// phase:unaccounted, convert ns to the configured granularity unit, encode
   /// the one-level parent/child hierarchy in each row name (e.g.
-  /// "strat:trampoline/ds_2addr"), and merge under a single lock.
-  void flush() {
-    uint64_t PhaseSum = 0;
-    for (size_t I = 0; I < HotswapMetricCount; ++I)
-      if (hotswapMetricInfo[I].PartitionsTotal)
-        PhaseSum += Samples[I].Nanos;
-    HotswapSample &Total =
-        Samples[static_cast<size_t>(HotswapMetric::RewriteTotal)];
-    HotswapSample &Unacc =
-        Samples[static_cast<size_t>(HotswapMetric::Unaccounted)];
-    Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
-    Unacc.Calls = Total.Calls;
-    // One unaccounted sample per rewrite: min == max == residual so the merged
-    // min/max across rewrites stays correct.
-    Unacc.MinNanos = Unacc.MaxNanos = Unacc.Nanos;
-
-    const double UnitsPerNs = env::getGranularityUnitsPerSecond() / 1.0e9;
-    // Build names first (SmallVector inline storage keeps them stable), then
-    // point the records' StringRefs at them.
-    llvm::SmallVector<std::string, HotswapMetricCount> Names;
-    llvm::SmallVector<size_t, HotswapMetricCount> Rows;
-    for (size_t I = 0; I < HotswapMetricCount; ++I) {
-      const HotswapSample &S = Samples[I];
-      const HotswapMetric M = static_cast<HotswapMetric>(I);
-      if (!S.Calls && !S.Nanos && !S.Patches && M != HotswapMetric::Unaccounted)
-        continue;
-      const HotswapMetricInfo &Info = hotswapMetricInfo[I];
-      if (Info.Parent != HotswapMetric::Count)
-        Names.push_back(
-            std::string(
-                hotswapMetricInfo[static_cast<size_t>(Info.Parent)].Label) +
-            "/" + Info.Label);
-      else
-        Names.push_back(std::string(Info.Label));
-      Rows.push_back(I);
-    }
-
-    llvm::SmallVector<COMGR::TimeStatistics::PerfStatRecord, HotswapMetricCount>
-        Records;
-    Records.reserve(Rows.size());
-    for (size_t K = 0; K < Rows.size(); ++K) {
-      const HotswapSample &S = Samples[Rows[K]];
-      COMGR::TimeStatistics::PerfStatRecord R;
-      R.Name = Names[K];
-      R.TimeTaken = static_cast<double>(S.Nanos) * UnitsPerNs;
-      R.Calls = S.Calls;
-      R.Patches = S.Patches;
-      R.MinTime = S.MinNanos == std::numeric_limits<uint64_t>::max()
-                      ? 0.0
-                      : static_cast<double>(S.MinNanos) * UnitsPerNs;
-      R.MaxTime = static_cast<double>(S.MaxNanos) * UnitsPerNs;
-      Records.push_back(R);
-    }
-    COMGR::TimeStatistics::mergeStats(Records);
-  }
+  /// "strat:trampoline/ds_2addr"), and merge under a single lock. Defined in
+  /// comgr-hotswap-profile.cpp.
+  void flush();
 
   bool Enabled;
   std::array<HotswapSample, HotswapMetricCount> Samples{};

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -119,6 +119,8 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   StringRef ReplacementAsm = getClusterLoadReplacementAsm(Mnemonic);
   if (!ReplacementAsm.empty()) {
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::InPlaceClusterLoad);
     // The replacement templates above are all the saddr=off encoding form
     // (global address in a 64-bit VGPR pair). The SGPR-relative (_SADDR)
     // cluster_load shares the mnemonic but has a different operand layout, so
@@ -136,6 +138,7 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
       if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
         log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
               << " at 0x" << utohexstr(DI.Offset) << "\n";
+        S.addPatches(1);
         return 1;
       }
     }
@@ -167,11 +170,14 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
   // and falls through to the dispatcher's "no match" return below.
   // The AMDGPU backend never emits the _M0 form for compute kernels.
   if (Mnemonic == "s_barrier_signal_isfirst") {
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::InPlaceBarrierSignal);
     std::optional<unsigned> NewOpcode =
         resolveOpcode("s_barrier_signal -1", Ctx.LS);
     if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
       log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
+      S.addPatches(1);
       return 1;
     }
   }

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -1423,21 +1423,50 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
-  if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty())
-    return patchDs2Addr(Ctx, Idx) ? 1 : 0;
-
-  if (Mnem == "tensor_load_to_lds") {
-    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0)
-      return patchTensorLoadToLdsA0(Ctx, Idx) ? 1 : 0;
-    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::B0)
-      return patchTensorLoadToLdsB0(Ctx, Idx) ? 1 : 0;
+  // Per-rule sub-buckets nested under the "strat:trampoline" parent total
+  // (which the dispatcher in comgr-hotswap-b0a0.cpp records). Timed only at
+  // matching sites into the per-rewrite session, so there is no locking on the
+  // hot path and no cost scanning non-matching instructions.
+  if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty()) {
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::TrampolineDs2Addr);
+    const uint32_t P = patchDs2Addr(Ctx, Idx) ? 1 : 0;
+    S.addPatches(P);
+    return P;
   }
 
-  if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0 && isClusterLoad(Mnem))
-    return patchClusterLoadMaskA0(Ctx, Idx) ? 1 : 0;
+  if (Mnem == "tensor_load_to_lds") {
+    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0) {
+      HotswapProfile::Scope S =
+          Ctx.Profile.time(HotswapMetric::TrampolineTensorTdm);
+      const uint32_t P = patchTensorLoadToLdsA0(Ctx, Idx) ? 1 : 0;
+      S.addPatches(P);
+      return P;
+    }
+    if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::B0) {
+      HotswapProfile::Scope S =
+          Ctx.Profile.time(HotswapMetric::TrampolineTensorTdm);
+      const uint32_t P = patchTensorLoadToLdsB0(Ctx, Idx) ? 1 : 0;
+      S.addPatches(P);
+      return P;
+    }
+  }
 
-  if (Ctx.Config.RunB0A0Patches && !getAddtidReplacement(Mnem).empty())
-    return patchDsAddtid(Ctx, Idx) ? 1 : 0;
+  if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0 &&
+      isClusterLoad(Mnem)) {
+    HotswapProfile::Scope S =
+        Ctx.Profile.time(HotswapMetric::TrampolineClusterLoad);
+    const uint32_t P = patchClusterLoadMaskA0(Ctx, Idx) ? 1 : 0;
+    S.addPatches(P);
+    return P;
+  }
+
+  if (Ctx.Config.RunB0A0Patches && !getAddtidReplacement(Mnem).empty()) {
+    HotswapProfile::Scope S = Ctx.Profile.time(HotswapMetric::TrampolineAddtid);
+    const uint32_t P = patchDsAddtid(Ctx, Idx) ? 1 : 0;
+    S.addPatches(P);
+    return P;
+  }
 
   return 0;
 }

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -1423,10 +1423,8 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
-  // Per-rule sub-buckets nested under the "strat:trampoline" parent total
-  // (which the dispatcher in comgr-hotswap-b0a0.cpp records). Timed only at
-  // matching sites into the per-rewrite session, so there is no locking on the
-  // hot path and no cost scanning non-matching instructions.
+  // Per-rule sub-buckets under the "strat:trampoline" parent (recorded by the
+  // dispatcher in comgr-hotswap-b0a0.cpp); timed only at matching sites.
   if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty()) {
     HotswapProfile::Scope S =
         Ctx.Profile.time(HotswapMetric::TrampolineDs2Addr);

--- a/amd/comgr/src/comgr-hotswap-profile.cpp
+++ b/amd/comgr/src/comgr-hotswap-profile.cpp
@@ -7,11 +7,8 @@
 ///
 /// \file
 /// Out-of-line definitions for the HotSwap rewrite profiler declared in
-/// comgr-hotswap-internal.h. The header is included by every
-/// comgr-hotswap-*.cpp translation unit, so keeping the merge/flush logic here
-/// (rather than inline) avoids recompiling it everywhere. Behavior and gating
-/// (AMD_COMGR_TIME_STATISTICS) are documented on the declarations in the
-/// header.
+/// comgr-hotswap-internal.h, kept here rather than inline so the merge/flush
+/// logic is not recompiled in every TU that includes the header.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -55,7 +52,8 @@ const HotswapSample &HotswapProfile::sample(HotswapMetric Metric) const {
   return Samples[static_cast<size_t>(Metric)];
 }
 
-void HotswapProfile::flush() {
+llvm::SmallVector<COMGR::TimeStatistics::PerfStatRecord, HotswapMetricCount>
+HotswapProfile::buildRecords(llvm::SmallVectorImpl<std::string> &Names) {
   uint64_t PhaseSum = 0;
   for (size_t I = 0; I < HotswapMetricCount; ++I)
     if (hotswapMetricInfo[I].PartitionsTotal)
@@ -71,9 +69,9 @@ void HotswapProfile::flush() {
   Unacc.MinNanos = Unacc.MaxNanos = Unacc.Nanos;
 
   const double UnitsPerNs = env::getGranularityUnitsPerSecond() / 1.0e9;
-  // Build names first (SmallVector inline storage keeps them stable), then
-  // point the records' StringRefs at them.
-  llvm::SmallVector<std::string, HotswapMetricCount> Names;
+  // Append row names to the caller's storage (keeps them stable), then point
+  // the records' StringRefs at them.
+  const size_t NameBase = Names.size();
   llvm::SmallVector<size_t, HotswapMetricCount> Rows;
   for (size_t I = 0; I < HotswapMetricCount; ++I) {
     const HotswapSample &S = Samples[I];
@@ -97,7 +95,7 @@ void HotswapProfile::flush() {
   for (size_t K = 0; K < Rows.size(); ++K) {
     const HotswapSample &S = Samples[Rows[K]];
     COMGR::TimeStatistics::PerfStatRecord R;
-    R.Name = Names[K];
+    R.Name = Names[NameBase + K];
     R.TimeTaken = static_cast<double>(S.Nanos) * UnitsPerNs;
     R.Calls = S.Calls;
     R.Patches = S.Patches;
@@ -107,7 +105,12 @@ void HotswapProfile::flush() {
     R.MaxTime = static_cast<double>(S.MaxNanos) * UnitsPerNs;
     Records.push_back(R);
   }
-  COMGR::TimeStatistics::mergeStats(Records);
+  return Records;
+}
+
+void HotswapProfile::flush() {
+  llvm::SmallVector<std::string, HotswapMetricCount> Names;
+  COMGR::TimeStatistics::mergeStats(buildRecords(Names));
 }
 
 } // namespace hotswap

--- a/amd/comgr/src/comgr-hotswap-profile.cpp
+++ b/amd/comgr/src/comgr-hotswap-profile.cpp
@@ -1,0 +1,114 @@
+//===- comgr-hotswap-profile.cpp - HotSwap rewrite profiler --------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Out-of-line definitions for the HotSwap rewrite profiler declared in
+/// comgr-hotswap-internal.h. The header is included by every
+/// comgr-hotswap-*.cpp translation unit, so keeping the merge/flush logic here
+/// (rather than inline) avoids recompiling it everywhere. Behavior and gating
+/// (AMD_COMGR_TIME_STATISTICS) are documented on the declarations in the
+/// header.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+namespace COMGR {
+namespace hotswap {
+
+HotswapProfile::Scope::Scope(HotswapProfile *Profile, HotswapMetric Metric)
+    : Profile(Profile), Metric(Metric), StartNs(Profile ? profNowNs() : 0) {}
+
+void HotswapProfile::Scope::finish() {
+  if (!Profile)
+    return;
+  Profile->add(Metric, profNowNs() - StartNs, Patches);
+  Profile = nullptr;
+}
+
+HotswapProfile::Scope HotswapProfile::time(HotswapMetric Metric) {
+  return Scope(Enabled ? this : nullptr, Metric);
+}
+
+void HotswapProfile::count(HotswapMetric Metric, uint64_t N) {
+  if (Enabled)
+    Samples[static_cast<size_t>(Metric)].Calls += N;
+}
+
+void HotswapProfile::add(HotswapMetric Metric, uint64_t Nanos,
+                         uint64_t Patches) {
+  if (!Enabled)
+    return;
+  HotswapSample &S = Samples[static_cast<size_t>(Metric)];
+  S.Nanos += Nanos;
+  S.Calls += 1;
+  S.Patches += Patches;
+  S.MinNanos = std::min(S.MinNanos, Nanos);
+  S.MaxNanos = std::max(S.MaxNanos, Nanos);
+}
+
+const HotswapSample &HotswapProfile::sample(HotswapMetric Metric) const {
+  return Samples[static_cast<size_t>(Metric)];
+}
+
+void HotswapProfile::flush() {
+  uint64_t PhaseSum = 0;
+  for (size_t I = 0; I < HotswapMetricCount; ++I)
+    if (hotswapMetricInfo[I].PartitionsTotal)
+      PhaseSum += Samples[I].Nanos;
+  HotswapSample &Total =
+      Samples[static_cast<size_t>(HotswapMetric::RewriteTotal)];
+  HotswapSample &Unacc =
+      Samples[static_cast<size_t>(HotswapMetric::Unaccounted)];
+  Unacc.Nanos = Total.Nanos > PhaseSum ? Total.Nanos - PhaseSum : 0;
+  Unacc.Calls = Total.Calls;
+  // One unaccounted sample per rewrite: min == max == residual so the merged
+  // min/max across rewrites stays correct.
+  Unacc.MinNanos = Unacc.MaxNanos = Unacc.Nanos;
+
+  const double UnitsPerNs = env::getGranularityUnitsPerSecond() / 1.0e9;
+  // Build names first (SmallVector inline storage keeps them stable), then
+  // point the records' StringRefs at them.
+  llvm::SmallVector<std::string, HotswapMetricCount> Names;
+  llvm::SmallVector<size_t, HotswapMetricCount> Rows;
+  for (size_t I = 0; I < HotswapMetricCount; ++I) {
+    const HotswapSample &S = Samples[I];
+    const HotswapMetric M = static_cast<HotswapMetric>(I);
+    if (!S.Calls && !S.Nanos && !S.Patches && M != HotswapMetric::Unaccounted)
+      continue;
+    const HotswapMetricInfo &Info = hotswapMetricInfo[I];
+    if (Info.Parent != HotswapMetric::Count)
+      Names.push_back(
+          std::string(
+              hotswapMetricInfo[static_cast<size_t>(Info.Parent)].Label) +
+          "/" + Info.Label);
+    else
+      Names.push_back(std::string(Info.Label));
+    Rows.push_back(I);
+  }
+
+  llvm::SmallVector<COMGR::TimeStatistics::PerfStatRecord, HotswapMetricCount>
+      Records;
+  Records.reserve(Rows.size());
+  for (size_t K = 0; K < Rows.size(); ++K) {
+    const HotswapSample &S = Samples[Rows[K]];
+    COMGR::TimeStatistics::PerfStatRecord R;
+    R.Name = Names[K];
+    R.TimeTaken = static_cast<double>(S.Nanos) * UnitsPerNs;
+    R.Calls = S.Calls;
+    R.Patches = S.Patches;
+    R.MinTime = S.MinNanos == std::numeric_limits<uint64_t>::max()
+                    ? 0.0
+                    : static_cast<double>(S.MinNanos) * UnitsPerNs;
+    R.MaxTime = static_cast<double>(S.MaxNanos) * UnitsPerNs;
+    Records.push_back(R);
+  }
+  COMGR::TimeStatistics::mergeStats(Records);
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -15,6 +15,7 @@
 #include <functional>
 #include <iostream>
 #include <memory>
+#include <mutex>
 #include <stdlib.h>
 #include <system_error>
 
@@ -62,23 +63,27 @@ void getLogFile(std::string &PerfLog) {
 }
 
 bool InitTimeStatistics(std::string LogFile) {
-  if (!PS) {
-    if (!env::needTimeStatistics()) {
-      return false;
-    }
+  // Thread-safe lazy init: concurrent Comgr calls (e.g. concurrent hotswap
+  // rewrites merging their stats) can reach this simultaneously. call_once
+  // guarantees PS is created and the atexit dump registered exactly once,
+  // instead of the previous unguarded `if (!PS)` check racing on both.
+  static std::once_flag InitFlag;
+  std::call_once(InitFlag, [&LogFile]() {
+    if (!env::needTimeStatistics())
+      return;
 
-    if (LogFile == "") {
+    if (LogFile == "")
       getLogFile(LogFile);
-    }
 
-    PS = std::make_unique<PerfStats>();
-    if (!PS || !PS->Init(LogFile)) {
+    std::unique_ptr<PerfStats> Stats = std::make_unique<PerfStats>();
+    if (!Stats->Init(LogFile)) {
       std::cerr << "TimeStatistics failed to initialize\n";
-      return false;
+      return;
     }
+    PS = std::move(Stats);
     std::atexit(&dump);
-  }
-  return true;
+  });
+  return PS != nullptr;
 }
 
 void ProfilePoint::finish() {

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -103,6 +103,15 @@ ProfilePoint::~ProfilePoint() {
   }
 }
 
+void mergeStats(llvm::ArrayRef<PerfStatRecord> Records) {
+  // Lazily stand up the sink (and the atexit dump) exactly as ProfilePoint
+  // does; a no-op when AMD_COMGR_TIME_STATISTICS is unset.
+  if (!InitTimeStatistics(""))
+    return;
+  if (PS)
+    PS->mergeStats(Records);
+}
+
 // Timer implementation
 #if defined _WIN64 || defined _WIN32
 class PerfTimerWindows : public PerfTimerImpl {

--- a/amd/comgr/src/time-stat/time-stat.cpp
+++ b/amd/comgr/src/time-stat/time-stat.cpp
@@ -63,10 +63,8 @@ void getLogFile(std::string &PerfLog) {
 }
 
 bool InitTimeStatistics(std::string LogFile) {
-  // Thread-safe lazy init: concurrent Comgr calls (e.g. concurrent hotswap
-  // rewrites merging their stats) can reach this simultaneously. call_once
-  // guarantees PS is created and the atexit dump registered exactly once,
-  // instead of the previous unguarded `if (!PS)` check racing on both.
+  // Thread-safe lazy init: call_once creates PS and registers the atexit dump
+  // exactly once, even if concurrent Comgr calls reach here simultaneously.
   static std::once_flag InitFlag;
   std::call_once(InitFlag, [&LogFile]() {
     if (!env::needTimeStatistics())

--- a/amd/comgr/src/time-stat/time-stat.h
+++ b/amd/comgr/src/time-stat/time-stat.h
@@ -76,9 +76,8 @@ public:
     D.MaxTime = std::max(D.MaxTime, TimeTaken);
   }
 
-  // Fold many pre-aggregated rows in under a single lock (one acquisition per
-  // caller, not per row) so hot-path producers can accumulate lock-free and
-  // merge once.
+  // Fold many pre-aggregated rows in under a single lock so hot-path producers
+  // can accumulate lock-free and merge once.
   void mergeStats(llvm::ArrayRef<PerfStatRecord> Records) {
     std::scoped_lock Lock(Mtx);
     for (const PerfStatRecord &R : Records) {

--- a/amd/comgr/src/time-stat/time-stat.h
+++ b/amd/comgr/src/time-stat/time-stat.h
@@ -12,11 +12,16 @@
 #include "perf-timer.h"
 #include "ts-interface.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "amd_comgr.h"
 #include <algorithm>
+#include <functional>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <mutex>
 
 namespace COMGR {
@@ -110,6 +115,13 @@ public:
                             static_cast<unsigned long long>(D.Patches))
             << " " << Unit << "\n";
     }
+  }
+
+  // Snapshot an aggregated row by name for unit tests; returns a zeroed
+  // ProfileData when the row is absent. Locks like the other accessors.
+  ProfileData lookupForTest(llvm::StringRef Name) {
+    std::scoped_lock Lock(Mtx);
+    return ProfileDataMap.lookup(Name);
   }
 };
 

--- a/amd/comgr/src/time-stat/time-stat.h
+++ b/amd/comgr/src/time-stat/time-stat.h
@@ -10,17 +10,26 @@
 #define AMD_COMGR_TIME_STAT_H
 
 #include "perf-timer.h"
+#include "ts-interface.h"
 #include "llvm/ADT/StringMap.h"
 
 #include "amd_comgr.h"
+#include <algorithm>
 #include <iostream>
+#include <limits>
+#include <mutex>
 
 namespace COMGR {
 namespace TimeStatistics {
 
 struct ProfileData {
-  double TimeTaken;
-  int Counter;
+  double TimeTaken = 0.0;
+  int Counter = 0;
+  // Extra columns produced by batch-merged callers (mergeStats). Defaulted so
+  // ProfilePoint-based callers, which only record wall time, are unaffected.
+  uint64_t Patches = 0;
+  double MinTime = std::numeric_limits<double>::max();
+  double MaxTime = 0.0;
 };
 
 class PerfStats {
@@ -29,6 +38,9 @@ class PerfStats {
       pLog;
   PerfTimer PT;
 
+  // Guards ProfileDataMap so AddToStats / mergeStats / dumpPerfStats are safe
+  // under concurrent Comgr calls (e.g. concurrent hotswap rewrites).
+  std::mutex Mtx;
   llvm::StringMap<ProfileData> ProfileDataMap;
 
 public:
@@ -56,16 +68,48 @@ public:
   double getCurrentTime() { return PT.getCurrentTime(); }
 
   void AddToStats(llvm::StringRef Name, double TimeTaken) {
-    ProfileDataMap[Name].TimeTaken += TimeTaken;
-    ProfileDataMap[Name].Counter++;
+    std::scoped_lock Lock(Mtx);
+    ProfileData &D = ProfileDataMap[Name];
+    D.TimeTaken += TimeTaken;
+    D.Counter++;
+    D.MinTime = std::min(D.MinTime, TimeTaken);
+    D.MaxTime = std::max(D.MaxTime, TimeTaken);
+  }
+
+  // Fold many pre-aggregated rows in under a single lock (one acquisition per
+  // caller, not per row) so hot-path producers can accumulate lock-free and
+  // merge once.
+  void mergeStats(llvm::ArrayRef<PerfStatRecord> Records) {
+    std::scoped_lock Lock(Mtx);
+    for (const PerfStatRecord &R : Records) {
+      ProfileData &D = ProfileDataMap[R.Name];
+      D.TimeTaken += R.TimeTaken;
+      D.Counter += static_cast<int>(R.Calls);
+      D.Patches += R.Patches;
+      if (R.Calls) {
+        D.MinTime = std::min(D.MinTime, R.MinTime);
+        D.MaxTime = std::max(D.MaxTime, R.MaxTime);
+      }
+    }
   }
 
   void dumpPerfStats() {
+    std::scoped_lock Lock(Mtx);
+    llvm::StringRef Unit = env::getTimeStatisticsGranularity();
     for (const auto &Item : ProfileDataMap) {
+      const ProfileData &D = Item.getValue();
+      const double MinT =
+          D.MinTime == std::numeric_limits<double>::max() ? 0.0 : D.MinTime;
+      // Keep the granularity unit last so existing consumers that anchor on it
+      // (e.g. the time-statistics.cl "grep 'ms$'" check) still match; the extra
+      // columns are inserted before it.
       *pLog << llvm::format("%-50s", Item.getKey().str().c_str())
-            << llvm::format("%6d", Item.getValue().Counter) << " calls "
-            << llvm::format("%10.4f", Item.getValue().TimeTaken) << " "
-            << env::getTimeStatisticsGranularity() << "\n";
+            << llvm::format("%6d", D.Counter) << " calls "
+            << llvm::format("%10.4f", D.TimeTaken)
+            << llvm::format("  min %10.4f  max %10.4f  patches %6llu", MinT,
+                            D.MaxTime,
+                            static_cast<unsigned long long>(D.Patches))
+            << " " << Unit << "\n";
     }
   }
 };

--- a/amd/comgr/src/time-stat/ts-interface.h
+++ b/amd/comgr/src/time-stat/ts-interface.h
@@ -30,9 +30,8 @@ private:
   bool isFinished = false;
 };
 
-// A pre-aggregated statistics row produced elsewhere (e.g. a lock-free
-// per-caller session) and folded into the shared PerfStats in one shot. Lets a
-// producer accumulate locally on a hot path and pay the global lock only once.
+// A pre-aggregated statistics row folded into the shared PerfStats in one shot,
+// so a producer can accumulate locally and pay the global lock only once.
 struct PerfStatRecord {
   llvm::StringRef Name;
   double TimeTaken = 0.0; // already in the configured granularity units

--- a/amd/comgr/src/time-stat/ts-interface.h
+++ b/amd/comgr/src/time-stat/ts-interface.h
@@ -9,7 +9,11 @@
 #ifndef AMD_COMGR_TS_INTERFACE_H
 #define AMD_COMGR_TS_INTERFACE_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
+
+#include "amd_comgr.h" // for amd_comgr_action_kind_t
+#include <cstdint>
 // External interface
 
 namespace COMGR {
@@ -26,9 +30,26 @@ private:
   bool isFinished = false;
 };
 
+// A pre-aggregated statistics row produced elsewhere (e.g. a lock-free
+// per-caller session) and folded into the shared PerfStats in one shot. Lets a
+// producer accumulate locally on a hot path and pay the global lock only once.
+struct PerfStatRecord {
+  llvm::StringRef Name;
+  double TimeTaken = 0.0; // already in the configured granularity units
+  uint64_t Calls = 0;
+  uint64_t Patches = 0;
+  double MinTime = 0.0;
+  double MaxTime = 0.0;
+};
+
 bool InitTimeStatistics(std::string LogFile);
 void StartAction(amd_comgr_action_kind_t);
 void EndAction();
+
+/// Thread-safe batch merge of \p Records into the process-wide PerfStats under
+/// a single lock. Lazily initializes the sink; a no-op when time statistics are
+/// not enabled (AMD_COMGR_TIME_STATISTICS unset).
+void mergeStats(llvm::ArrayRef<PerfStatRecord> Records);
 
 } // namespace TimeStatistics
 } // namespace COMGR

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -145,6 +145,38 @@ target_include_directories(HotswapMCTests PRIVATE
 
 comgr_configure_test_target(HotswapMCTests)
 
+# -- HotswapProfileTests ------------------------------------------------------
+#
+# The profiler (comgr-hotswap-internal.h) is header-only and compiled out by
+# default. The library links it with a PRIVATE ENABLE_HOTSWAP_PROFILE, which
+# does not reach the unit test binaries above (they recompile the sources
+# separately). This dedicated target defines the macro so the enabled branch is
+# actually built and exercised, covering runtime-off and runtime-on sessions.
+
+add_executable(HotswapProfileTests
+  HotswapProfileTest.cpp
+  # COMGR::env::shouldEmitVerboseLogs() is referenced by the inline
+  # COMGR::hotswap::log() helper pulled in via comgr-hotswap-internal.h.
+  ../src/comgr-env.cpp)
+
+llvm_map_components_to_libnames(COMGR_TEST_UNIT_PROFILE_LIBS
+  BinaryFormat Object Support TargetParser)
+
+target_compile_definitions(HotswapProfileTests PRIVATE ENABLE_HOTSWAP_PROFILE)
+
+target_link_libraries(HotswapProfileTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  ${COMGR_TEST_UNIT_PROFILE_LIBS}
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(HotswapProfileTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>)
+
+comgr_configure_test_target(HotswapProfileTests)
+
 # -- RaiserScaffoldingTests ---------------------------------------------------
 #
 # Pins the bare-bones raiser scaffolding contract (`hotswap/raiser.hpp`):
@@ -230,9 +262,10 @@ comgr_configure_test_target(LoggerTests)
 add_custom_target(test-unit
   COMMAND $<TARGET_FILE:HotswapElfTests>
   COMMAND $<TARGET_FILE:HotswapMCTests>
+  COMMAND $<TARGET_FILE:HotswapProfileTests>
   COMMAND $<TARGET_FILE:RaiserScaffoldingTests>
   COMMAND $<TARGET_FILE:DemangleSymbolNameTest>
   COMMAND $<TARGET_FILE:LoggerTests>)
-add_dependencies(test-unit HotswapElfTests HotswapMCTests
+add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
   RaiserScaffoldingTests DemangleSymbolNameTest LoggerTests)
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -151,13 +151,16 @@ comgr_configure_test_target(HotswapMCTests)
 # default. The library links it with a PRIVATE ENABLE_HOTSWAP_PROFILE, which
 # does not reach the unit test binaries above (they recompile the sources
 # separately). This dedicated target defines the macro so the enabled branch is
-# actually built and exercised, covering runtime-off and runtime-on sessions.
+# actually built and exercised, covering disabled and enabled sessions.
 
 add_executable(HotswapProfileTests
   HotswapProfileTest.cpp
-  # COMGR::env::shouldEmitVerboseLogs() is referenced by the inline
-  # COMGR::hotswap::log() helper pulled in via comgr-hotswap-internal.h.
-  ../src/comgr-env.cpp)
+  # COMGR::env::* is referenced by the inline COMGR::hotswap::log() helper and by
+  # the profiler gating, both pulled in via comgr-hotswap-internal.h.
+  ../src/comgr-env.cpp
+  # HotswapProfile::flush() merges into Comgr TimeStatistics, so the enabled
+  # build needs TimeStatistics::mergeStats().
+  ../src/time-stat/time-stat.cpp)
 
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_PROFILE_LIBS
   BinaryFormat Object Support TargetParser)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -116,7 +116,10 @@ add_executable(HotswapMCTests
   ../src/comgr-hotswap-patch-wmma-hazard.cpp
   ../src/comgr-hotswap-patch-wmma-scale16.cpp
   ../src/comgr-hotswap-patch-wmma-split.cpp
-  ../src/comgr-env.cpp)
+  ../src/comgr-env.cpp
+  # HotswapProfile::flush() (always compiled now) merges into Comgr
+  # TimeStatistics, so this target needs TimeStatistics::mergeStats().
+  ../src/time-stat/time-stat.cpp)
 
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_MC_LIBS
   BinaryFormat
@@ -147,11 +150,10 @@ comgr_configure_test_target(HotswapMCTests)
 
 # -- HotswapProfileTests ------------------------------------------------------
 #
-# The profiler (comgr-hotswap-internal.h) is header-only and compiled out by
-# default. The library links it with a PRIVATE ENABLE_HOTSWAP_PROFILE, which
-# does not reach the unit test binaries above (they recompile the sources
-# separately). This dedicated target defines the macro so the enabled branch is
-# actually built and exercised, covering disabled and enabled sessions.
+# The profiler (comgr-hotswap-internal.h) is header-only and always compiled;
+# it is gated only at run time by AMD_COMGR_TIME_STATISTICS. This dedicated
+# target exercises the HotswapProfile session logic directly (accumulation and
+# flush) for both disabled and enabled sessions.
 
 add_executable(HotswapProfileTests
   HotswapProfileTest.cpp
@@ -164,8 +166,6 @@ add_executable(HotswapProfileTests
 
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_PROFILE_LIBS
   BinaryFormat Object Support TargetParser)
-
-target_compile_definitions(HotswapProfileTests PRIVATE ENABLE_HOTSWAP_PROFILE)
 
 target_link_libraries(HotswapProfileTests PRIVATE
   ${COMGR_GTEST_LIBS}

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -117,8 +117,9 @@ add_executable(HotswapMCTests
   ../src/comgr-hotswap-patch-wmma-scale16.cpp
   ../src/comgr-hotswap-patch-wmma-split.cpp
   ../src/comgr-env.cpp
-  # HotswapProfile::flush() (always compiled now) merges into Comgr
-  # TimeStatistics, so this target needs TimeStatistics::mergeStats().
+  # HotswapProfile bodies are out-of-line in comgr-hotswap-profile.cpp; its
+  # flush() merges into Comgr TimeStatistics (time-stat.cpp / mergeStats()).
+  ../src/comgr-hotswap-profile.cpp
   ../src/time-stat/time-stat.cpp)
 
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_MC_LIBS
@@ -150,18 +151,20 @@ comgr_configure_test_target(HotswapMCTests)
 
 # -- HotswapProfileTests ------------------------------------------------------
 #
-# The profiler (comgr-hotswap-internal.h) is header-only and always compiled;
-# it is gated only at run time by AMD_COMGR_TIME_STATISTICS. This dedicated
-# target exercises the HotswapProfile session logic directly (accumulation and
-# flush) for both disabled and enabled sessions.
+# The profiler is declared in comgr-hotswap-internal.h with out-of-line bodies
+# in comgr-hotswap-profile.cpp; it is gated only at run time by
+# AMD_COMGR_TIME_STATISTICS. This dedicated target exercises the HotswapProfile
+# session logic directly (accumulation and flush) for both disabled and enabled
+# sessions.
 
 add_executable(HotswapProfileTests
   HotswapProfileTest.cpp
   # COMGR::env::* is referenced by the inline COMGR::hotswap::log() helper and by
   # the profiler gating, both pulled in via comgr-hotswap-internal.h.
   ../src/comgr-env.cpp
-  # HotswapProfile::flush() merges into Comgr TimeStatistics, so the enabled
-  # build needs TimeStatistics::mergeStats().
+  # HotswapProfile bodies are out-of-line in comgr-hotswap-profile.cpp; its
+  # flush() merges into Comgr TimeStatistics (time-stat.cpp / mergeStats()).
+  ../src/comgr-hotswap-profile.cpp
   ../src/time-stat/time-stat.cpp)
 
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_PROFILE_LIBS

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1119,6 +1119,7 @@ TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
   DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
   PatchContext Ctx{Config,
                    Decoded,
                    View.textData(),
@@ -1131,7 +1132,8 @@ TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
                    Liveness,
                    KernelStats,
                    ScratchPatches,
-                   ControlFlow};
+                   ControlFlow,
+                   Prof};
 
   EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
                                         /*Alignment=*/1, "unit test"));
@@ -1204,6 +1206,7 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
   DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
   PatchContext Ctx{Config,
                    Decoded,
                    View.textData(),
@@ -1216,7 +1219,8 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
                    Liveness,
                    KernelStats,
                    ScratchPatches,
-                   ControlFlow};
+                   ControlFlow,
+                   Prof};
 
   const SafeSgprScratchBlock Block{/*Base=*/4, /*Count=*/1};
   EXPECT_FALSE(

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1164,6 +1164,7 @@ TEST(SafeSgprScratchBlock, RejectsAlignmentOverflow) {
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
   DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
   PatchContext Ctx{Config,
                    Decoded,
                    View.textData(),
@@ -1176,7 +1177,8 @@ TEST(SafeSgprScratchBlock, RejectsAlignmentOverflow) {
                    Liveness,
                    KernelStats,
                    ScratchPatches,
-                   ControlFlow};
+                   ControlFlow,
+                   Prof};
 
   EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
                                         /*Alignment=*/2, "unit test"));

--- a/amd/comgr/test-unit/HotswapOccupancyTest.cpp
+++ b/amd/comgr/test-unit/HotswapOccupancyTest.cpp
@@ -90,6 +90,7 @@ TEST(HotswapOccupancy, RejectsPatchOutsideKnownKernelWithZeroReportedGrowth) {
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
   DirectControlFlowInfo ControlFlow;
+  HotswapProfile Prof(/*Enabled=*/false);
   PatchContext Ctx{Config,
                    Decoded,
                    ViewOrErr->textData(),
@@ -102,7 +103,8 @@ TEST(HotswapOccupancy, RejectsPatchOutsideKnownKernelWithZeroReportedGrowth) {
                    Liveness,
                    KernelStats,
                    ScratchPatches,
-                   ControlFlow};
+                   ControlFlow,
+                   Prof};
 
   EXPECT_EQ(checkKernelVgprBump(Ctx, /*KernelName=*/{}, /*ExtraVgprs=*/0,
                                 PatchRequirement::Optional),

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -6,11 +6,12 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Unit tests for the opt-in HotSwap rewrite profiler (comgr-hotswap-internal.h).
-/// This translation unit is compiled with ENABLE_HOTSWAP_PROFILE defined so the
-/// enabled branch (which the default library build compiles out) is exercised,
-/// covering both runtime-off and runtime-on sessions. See review on
-/// ROCm/llvm-project#3364, comment about the enabled branch being untested.
+/// Unit tests for the opt-in HotSwap rewrite profiler
+/// (comgr-hotswap-internal.h). This translation unit is compiled with
+/// ENABLE_HOTSWAP_PROFILE defined so the enabled branch (which the default
+/// library build compiles out) is exercised, covering both runtime-off and
+/// runtime-on sessions. See review on ROCm/llvm-project#3364, comment about the
+/// enabled branch being untested.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -113,8 +114,8 @@ TEST(HotswapProfile, DisabledScopeRecordsNothing) {
 }
 
 // The static label/parent/partition table must stay in lockstep with the enum:
-// every row has a label, every child points at a valid top-level parent, and the
-// phases that partition rewrite_total exist while total/unaccounted do not.
+// every row has a label, every child points at a valid top-level parent, and
+// the phases that partition rewrite_total exist while total/unaccounted do not.
 TEST(HotswapProfile, MetricInfoTableWellFormed) {
   size_t PartitionCount = 0;
   for (size_t I = 0; I < HotswapMetricCount; ++I) {

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -20,14 +20,12 @@
 
 using namespace COMGR::hotswap;
 
-// Runtime gate: with AMD_COMGR_TIME_STATISTICS unset, the session must report
-// disabled so no hot-path clock read happens.
+// Runtime gate: with AMD_COMGR_TIME_STATISTICS unset, the session is disabled.
 TEST(HotswapProfile, ProfilingDisabledByDefault) {
   EXPECT_FALSE(hotswapProfilingEnabled());
 }
 
-// A disabled session is fully inert: every hook is a no-op and nothing lands in
-// the local samples (runtime-off mode).
+// A disabled session is inert: every hook is a no-op, nothing lands in samples.
 TEST(HotswapProfile, DisabledSessionRecordsNothing) {
   HotswapProfile Profile(/*Enabled=*/false);
   EXPECT_FALSE(Profile.enabled());
@@ -85,8 +83,7 @@ TEST(HotswapProfile, ScopeRecordsOnceOnDestruction) {
   EXPECT_EQ(S.Patches, 1u);
 }
 
-// finish() is idempotent: an explicit finish() followed by destruction records
-// a single call, not two.
+// finish() is idempotent: explicit finish() then destruction records one call.
 TEST(HotswapProfile, ScopeFinishIsIdempotent) {
   HotswapProfile Profile(/*Enabled=*/true);
   {
@@ -110,9 +107,7 @@ TEST(HotswapProfile, DisabledScopeRecordsNothing) {
   EXPECT_EQ(Profile.sample(HotswapMetric::Trampoline).Calls, 0u);
 }
 
-// The static label/parent/partition table must stay in lockstep with the enum:
-// every row has a label, every child points at a valid top-level parent, and
-// the phases that partition rewrite_total exist while total/unaccounted do not.
+// The label/parent/partition table must stay in lockstep with the enum.
 TEST(HotswapProfile, MetricInfoTableWellFormed) {
   size_t PartitionCount = 0;
   for (size_t I = 0; I < HotswapMetricCount; ++I) {

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -28,11 +28,6 @@
 
 using namespace COMGR::hotswap;
 
-// Runtime gate: with AMD_COMGR_TIME_STATISTICS unset, the session is disabled.
-TEST(HotswapProfile, ProfilingDisabledByDefault) {
-  EXPECT_FALSE(hotswapProfilingEnabled());
-}
-
 // A disabled session is inert: every hook is a no-op, nothing lands in samples.
 TEST(HotswapProfile, DisabledSessionRecordsNothing) {
   HotswapProfile Profile(/*Enabled=*/false);
@@ -192,7 +187,7 @@ TEST(TimeStatisticsMerge, ConcurrentMergeStatsIsRaceFree) {
   constexpr unsigned NumThreads = 8;
   constexpr unsigned MergesPerThread = 2000;
 
-  auto Worker = [&Stats]() {
+  auto Worker = [&Stats, MergesPerThread]() {
     for (unsigned I = 0; I < MergesPerThread; ++I) {
       COMGR::TimeStatistics::PerfStatRecord R;
       R.Name = "row";

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -15,8 +15,16 @@
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
+#include "time-stat/time-stat.h"
 
 #include "gtest/gtest.h"
+
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+
+#include <string>
+#include <thread>
+#include <vector>
 
 using namespace COMGR::hotswap;
 
@@ -133,4 +141,81 @@ TEST(HotswapProfile, MetricInfoTableWellFormed) {
   EXPECT_STREQ(
       hotswapMetricInfo[static_cast<size_t>(HotswapMetric::RewriteTotal)].Label,
       "phase:rewrite_total");
+}
+
+// flush()/buildRecords() derives phase:unaccounted = rewrite_total - sum of the
+// partitioned phases, converts each sample's ns to the configured granularity
+// unit, and encodes parent/child row names. Inspect the records against known
+// samples (flush() merges this same set into TimeStatistics).
+TEST(HotswapProfile, FlushDerivesUnaccountedAndConvertsUnits) {
+  HotswapProfile Profile(/*Enabled=*/true);
+  Profile.add(HotswapMetric::RewriteTotal, 10000, 0);
+  Profile.add(HotswapMetric::Decode, 3000, 0);
+  Profile.add(HotswapMetric::GrowElf, 2000, 0);
+  // A strat child: exercises the parent/child row name and confirms a
+  // non-partitioned row does not change the unaccounted residual.
+  Profile.add(HotswapMetric::TrampolineDs2Addr, 1000, 4);
+
+  llvm::SmallVector<std::string, HotswapMetricCount> Names;
+  llvm::SmallVector<COMGR::TimeStatistics::PerfStatRecord, HotswapMetricCount>
+      Records = Profile.buildRecords(Names);
+
+  // buildRecords() writes the derived residual back into the samples:
+  // 10000 - (3000 + 2000) = 5000. The strat child (1000) does not partition.
+  EXPECT_EQ(Profile.sample(HotswapMetric::Unaccounted).Nanos, 5000u);
+
+  llvm::StringMap<COMGR::TimeStatistics::PerfStatRecord> ByName;
+  for (const COMGR::TimeStatistics::PerfStatRecord &R : Records)
+    ByName[R.Name] = R;
+
+  const double UnitsPerNs = COMGR::env::getGranularityUnitsPerSecond() / 1.0e9;
+  ASSERT_TRUE(ByName.count("phase:rewrite_total"));
+  EXPECT_DOUBLE_EQ(ByName["phase:rewrite_total"].TimeTaken,
+                   10000.0 * UnitsPerNs);
+  EXPECT_DOUBLE_EQ(ByName["phase:decode"].TimeTaken, 3000.0 * UnitsPerNs);
+  EXPECT_DOUBLE_EQ(ByName["phase:grow_elf"].TimeTaken, 2000.0 * UnitsPerNs);
+
+  ASSERT_TRUE(ByName.count("phase:unaccounted"));
+  EXPECT_DOUBLE_EQ(ByName["phase:unaccounted"].TimeTaken, 5000.0 * UnitsPerNs);
+
+  // Child rows carry the "parent/child" name and their patch counts.
+  ASSERT_TRUE(ByName.count("strat:trampoline/ds_2addr"));
+  EXPECT_EQ(ByName["strat:trampoline/ds_2addr"].Patches, 4u);
+}
+
+// PerfStats::mergeStats is the profiler's concurrency premise: many concurrent
+// rewrites fold their local records into one shared, mutex-guarded map. Hammer
+// it from several threads and confirm every record is accounted for (and that
+// the shared map access is race-free under ASAN/TSAN).
+TEST(TimeStatisticsMerge, ConcurrentMergeStatsIsRaceFree) {
+  COMGR::TimeStatistics::PerfStats Stats;
+  constexpr unsigned NumThreads = 8;
+  constexpr unsigned MergesPerThread = 2000;
+
+  auto Worker = [&Stats]() {
+    for (unsigned I = 0; I < MergesPerThread; ++I) {
+      COMGR::TimeStatistics::PerfStatRecord R;
+      R.Name = "row";
+      R.TimeTaken = 1.0;
+      R.Calls = 1;
+      R.Patches = 2;
+      R.MinTime = 1.0;
+      R.MaxTime = 1.0;
+      Stats.mergeStats(R);
+    }
+  };
+
+  std::vector<std::thread> Threads;
+  for (unsigned T = 0; T < NumThreads; ++T)
+    Threads.emplace_back(Worker);
+  for (std::thread &T : Threads)
+    T.join();
+
+  const COMGR::TimeStatistics::ProfileData D = Stats.lookupForTest("row");
+  const unsigned Total = NumThreads * MergesPerThread;
+  EXPECT_EQ(D.Counter, static_cast<int>(Total));
+  EXPECT_EQ(D.Patches, static_cast<uint64_t>(Total) * 2);
+  EXPECT_DOUBLE_EQ(D.TimeTaken, static_cast<double>(Total));
+  EXPECT_DOUBLE_EQ(D.MinTime, 1.0);
+  EXPECT_DOUBLE_EQ(D.MaxTime, 1.0);
 }

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -7,11 +7,10 @@
 ///
 /// \file
 /// Unit tests for the opt-in HotSwap rewrite profiler
-/// (comgr-hotswap-internal.h). This translation unit is compiled with
-/// ENABLE_HOTSWAP_PROFILE defined so the enabled branch (which the default
-/// library build compiles out) is exercised, covering both disabled and enabled
-/// per-rewrite sessions. See review on ROCm/llvm-project#3364 and #3388,
-/// comment about the enabled branch being untested.
+/// (comgr-hotswap-internal.h). The profiler is always compiled and gated only
+/// at run time (AMD_COMGR_TIME_STATISTICS), so these tests exercise both the
+/// disabled and enabled per-rewrite sessions directly. See review on
+/// ROCm/llvm-project#3364 and #3388.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -21,10 +20,8 @@
 
 using namespace COMGR::hotswap;
 
-#ifdef ENABLE_HOTSWAP_PROFILE
-
-// Runtime gate: with the facility compiled in but AMD_COMGR_TIME_STATISTICS
-// unset, the session must report disabled so no hot-path clock read happens.
+// Runtime gate: with AMD_COMGR_TIME_STATISTICS unset, the session must report
+// disabled so no hot-path clock read happens.
 TEST(HotswapProfile, ProfilingDisabledByDefault) {
   EXPECT_FALSE(hotswapProfilingEnabled());
 }
@@ -142,10 +139,3 @@ TEST(HotswapProfile, MetricInfoTableWellFormed) {
       hotswapMetricInfo[static_cast<size_t>(HotswapMetric::RewriteTotal)].Label,
       "phase:rewrite_total");
 }
-
-#else // !ENABLE_HOTSWAP_PROFILE
-
-// Guards against the target accidentally dropping the compile definition.
-TEST(HotswapProfile, CompiledOut) { SUCCEED(); }
-
-#endif // ENABLE_HOTSWAP_PROFILE

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -1,0 +1,150 @@
+//===- HotswapProfileTest.cpp - Unit tests for HotSwap profiling ----------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Unit tests for the opt-in HotSwap rewrite profiler (comgr-hotswap-internal.h).
+/// This translation unit is compiled with ENABLE_HOTSWAP_PROFILE defined so the
+/// enabled branch (which the default library build compiles out) is exercised,
+/// covering both runtime-off and runtime-on sessions. See review on
+/// ROCm/llvm-project#3364, comment about the enabled branch being untested.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "gtest/gtest.h"
+
+using namespace COMGR::hotswap;
+
+#ifdef ENABLE_HOTSWAP_PROFILE
+
+// Runtime gate: with the facility compiled in but HOTSWAP_PROFILE unset, the
+// process-wide session must report disabled so no hot-path clock read happens.
+TEST(HotswapProfile, ProfilingDisabledByDefault) {
+  EXPECT_FALSE(hotswapProfilingEnabled());
+}
+
+// A disabled session is fully inert: every hook is a no-op and nothing lands in
+// the local samples (runtime-off mode).
+TEST(HotswapProfile, DisabledSessionRecordsNothing) {
+  HotswapProfile Profile(/*Enabled=*/false);
+  EXPECT_FALSE(Profile.enabled());
+
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::Decode);
+    S.addPatches(7);
+  }
+  Profile.count(HotswapMetric::JumpShort, 4);
+  Profile.add(HotswapMetric::Trampoline, 1000, 2);
+
+  EXPECT_EQ(Profile.sample(HotswapMetric::Decode).Calls, 0u);
+  EXPECT_EQ(Profile.sample(HotswapMetric::JumpShort).Calls, 0u);
+  EXPECT_EQ(Profile.sample(HotswapMetric::Trampoline).Calls, 0u);
+  EXPECT_EQ(Profile.sample(HotswapMetric::Trampoline).Nanos, 0u);
+}
+
+// add() folds a pre-measured interval as one call, tracking totals and min/max.
+TEST(HotswapProfile, EnabledSessionAddAccumulates) {
+  HotswapProfile Profile(/*Enabled=*/true);
+  EXPECT_TRUE(Profile.enabled());
+
+  Profile.add(HotswapMetric::Decode, 500, 2);
+  Profile.add(HotswapMetric::Decode, 1500, 3);
+
+  const HotswapSample &S = Profile.sample(HotswapMetric::Decode);
+  EXPECT_EQ(S.Calls, 2u);
+  EXPECT_EQ(S.Nanos, 2000u);
+  EXPECT_EQ(S.Patches, 5u);
+  EXPECT_EQ(S.MinNanos, 500u);
+  EXPECT_EQ(S.MaxNanos, 1500u);
+}
+
+// count() bumps only the call count (jump-outcome rows carry no wall time).
+TEST(HotswapProfile, CountOnlyRecordsCalls) {
+  HotswapProfile Profile(/*Enabled=*/true);
+  Profile.count(HotswapMetric::JumpShort);
+  Profile.count(HotswapMetric::JumpShort, 2);
+
+  const HotswapSample &S = Profile.sample(HotswapMetric::JumpShort);
+  EXPECT_EQ(S.Calls, 3u);
+  EXPECT_EQ(S.Nanos, 0u);
+  EXPECT_EQ(S.Patches, 0u);
+}
+
+// The RAII Scope records exactly one call (with its patches) on destruction.
+TEST(HotswapProfile, ScopeRecordsOnceOnDestruction) {
+  HotswapProfile Profile(/*Enabled=*/true);
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::TrampolineDs2Addr);
+    S.addPatches(1);
+  }
+  const HotswapSample &S = Profile.sample(HotswapMetric::TrampolineDs2Addr);
+  EXPECT_EQ(S.Calls, 1u);
+  EXPECT_EQ(S.Patches, 1u);
+}
+
+// finish() is idempotent: an explicit finish() followed by destruction records
+// a single call, not two.
+TEST(HotswapProfile, ScopeFinishIsIdempotent) {
+  HotswapProfile Profile(/*Enabled=*/true);
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::WmmaSplit);
+    S.addPatches(2);
+    S.finish();
+    S.finish();
+  }
+  const HotswapSample &S = Profile.sample(HotswapMetric::WmmaSplit);
+  EXPECT_EQ(S.Calls, 1u);
+  EXPECT_EQ(S.Patches, 2u);
+}
+
+// A Scope from a disabled session never records, even when patches are added.
+TEST(HotswapProfile, DisabledScopeRecordsNothing) {
+  HotswapProfile Profile(/*Enabled=*/false);
+  {
+    HotswapProfile::Scope S = Profile.time(HotswapMetric::Trampoline);
+    S.addPatches(9);
+  }
+  EXPECT_EQ(Profile.sample(HotswapMetric::Trampoline).Calls, 0u);
+}
+
+// The static label/parent/partition table must stay in lockstep with the enum:
+// every row has a label, every child points at a valid top-level parent, and the
+// phases that partition rewrite_total exist while total/unaccounted do not.
+TEST(HotswapProfile, MetricInfoTableWellFormed) {
+  size_t PartitionCount = 0;
+  for (size_t I = 0; I < HotswapMetricCount; ++I) {
+    const HotswapMetricInfo &Info = hotswapMetricInfo[I];
+    ASSERT_NE(Info.Label, nullptr);
+    EXPECT_NE(Info.Label[0], '\0');
+    if (Info.Parent != HotswapMetric::Count) {
+      // A child's parent must itself be a top-level row.
+      const size_t ParentIdx = static_cast<size_t>(Info.Parent);
+      ASSERT_LT(ParentIdx, HotswapMetricCount);
+      EXPECT_EQ(hotswapMetricInfo[ParentIdx].Parent, HotswapMetric::Count);
+    }
+    if (Info.PartitionsTotal)
+      ++PartitionCount;
+  }
+  EXPECT_GT(PartitionCount, 0u);
+  EXPECT_FALSE(
+      hotswapMetricInfo[static_cast<size_t>(HotswapMetric::RewriteTotal)]
+          .PartitionsTotal);
+  EXPECT_FALSE(
+      hotswapMetricInfo[static_cast<size_t>(HotswapMetric::Unaccounted)]
+          .PartitionsTotal);
+  EXPECT_STREQ(
+      hotswapMetricInfo[static_cast<size_t>(HotswapMetric::RewriteTotal)].Label,
+      "phase:rewrite_total");
+}
+
+#else // !ENABLE_HOTSWAP_PROFILE
+
+// Guards against the target accidentally dropping the compile definition.
+TEST(HotswapProfile, CompiledOut) { SUCCEED(); }
+
+#endif // ENABLE_HOTSWAP_PROFILE

--- a/amd/comgr/test-unit/HotswapProfileTest.cpp
+++ b/amd/comgr/test-unit/HotswapProfileTest.cpp
@@ -9,9 +9,9 @@
 /// Unit tests for the opt-in HotSwap rewrite profiler
 /// (comgr-hotswap-internal.h). This translation unit is compiled with
 /// ENABLE_HOTSWAP_PROFILE defined so the enabled branch (which the default
-/// library build compiles out) is exercised, covering both runtime-off and
-/// runtime-on sessions. See review on ROCm/llvm-project#3364, comment about the
-/// enabled branch being untested.
+/// library build compiles out) is exercised, covering both disabled and enabled
+/// per-rewrite sessions. See review on ROCm/llvm-project#3364 and #3388,
+/// comment about the enabled branch being untested.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -23,8 +23,8 @@ using namespace COMGR::hotswap;
 
 #ifdef ENABLE_HOTSWAP_PROFILE
 
-// Runtime gate: with the facility compiled in but HOTSWAP_PROFILE unset, the
-// process-wide session must report disabled so no hot-path clock read happens.
+// Runtime gate: with the facility compiled in but AMD_COMGR_TIME_STATISTICS
+// unset, the session must report disabled so no hot-path clock read happens.
 TEST(HotswapProfile, ProfilingDisabledByDefault) {
   EXPECT_FALSE(hotswapProfilingEnabled());
 }


### PR DESCRIPTION
Introduces an opt-in profiler for the gfx1250 B0→A0 HotSwap rewrite. Every code object COMGR rewrites at load time goes through a pipeline (parse → decode → apply patch strategies → grow ELF), and until now that cost was a black box. This makes it measurable so we can see where time goes and drive timing/perf optimization.

This PR supersedes #3364: it keeps the same feature but reworks the implementation to address the review feedback there (thread-safety, hot-path locking, attribution accuracy, partitioning, and test coverage).