### PR TITLE
[comgr][hotswap] add B0-to-B0 entry-trampoline fast path (amd-staging companion)

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -104,6 +104,7 @@ set(SOURCES
   src/comgr-hotswap.cpp
   src/comgr-hotswap-b0a0.cpp
   src/comgr-hotswap-entry-trampoline.cpp
+  src/comgr-hotswap-entry-trampoline-fast.cpp
   src/comgr-hotswap-patch-trampoline.cpp
   src/comgr-hotswap-elf.cpp
   src/comgr-hotswap-llvm.cpp

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -29,8 +29,10 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
 #include <cassert>
@@ -361,88 +363,85 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
   return true;
 }
 
-// s_add_pc_i64 long branch from \p FromOffset to \p TargetOffset (.text
-// offsets). It adds a signed literal to the next instruction's PC, so the
-// offset is TargetOffset - (FromOffset + size); size is 8 (forward, 32-bit
-// literal) or 12 (backward, 64-bit literal), resolved by trying each. Encoded
-// via the MC assembler. Returns empty on failure.
-//
-// Precondition: callers only long-branch *far* sites, so the target is far
-// enough that s_add_pc_i64 always needs a real (>= 32-bit) literal. A tiny
-// offset would instead assemble to the 4-byte inline-constant form, match
-// neither candidate size, and yield empty. That is asserted here (assert
-// liberally); the empty return is kept as a release-build safety net so a
-// stray near target degrades to the unpatched-object fallback rather than
-// crashing the loader.
-SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                                      uint64_t TargetOffset) {
-  [[maybe_unused]] const int64_t Distance =
-      static_cast<int64_t>(TargetOffset) - static_cast<int64_t>(FromOffset);
-  [[maybe_unused]] const int64_t MinLongDistance = LongBranchMaxBytes;
-  assert((Distance > MinLongDistance || Distance < -MinLongDistance) &&
-         "encodeLongBranch: target is not a far site; the long-branch path is "
-         "only valid for offsets beyond an s_add_pc_i64 instruction's reach");
-
-  for (uint32_t Size : {LongBranchFwdBytes, LongBranchMaxBytes}) {
-    int64_t Off = static_cast<int64_t>(TargetOffset) -
-                  static_cast<int64_t>(FromOffset + Size);
-    SmallVector<uint8_t> Bytes =
-        assembleSingleInst("s_add_pc_i64 " + std::to_string(Off), LS);
-    if (Bytes.size() == Size)
-      return Bytes;
+std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
+                                                          uint64_t FromOffset,
+                                                          uint64_t TargetOffset,
+                                                          unsigned SgprBase) {
+  if ((SgprBase & 1u) != 0 ||
+      SgprBase > std::numeric_limits<unsigned>::max() - 2) {
+    log() << "hotswap: error: set-PC long branch requires an aligned "
+             "three-SGPR block, got s"
+          << SgprBase << "\n";
+    return std::nullopt;
   }
-  return {};
+
+  const std::string Lo = "s" + std::to_string(SgprBase);
+  const std::string Hi = "s" + std::to_string(SgprBase + 1);
+  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
+                           std::to_string(SgprBase + 1) + "]";
+  const std::string SccSave = "s" + std::to_string(SgprBase + 2);
+
+  // Per the AMDGPU ISA, s_get_pc_i64 captures the address immediately after
+  // itself. EncodeSetPCLongBranch.ForwardLandsOnTarget pins this PC base.
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      FromOffset, 2 * MinInstSize, "set-PC long branch PC base");
+  if (!PcBase)
+    return std::nullopt;
+  uint64_t Delta = TargetOffset - *PcBase;
+  uint32_t LoDelta = static_cast<uint32_t>(Delta);
+  uint32_t HiDelta = static_cast<uint32_t>(Delta >> 32);
+
+  SmallVector<std::string, 6> AsmLines;
+  AsmLines.push_back("s_cselect_b32 " + SccSave + ", 1, 0");
+  AsmLines.push_back("s_get_pc_i64 " + Pair);
+  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
+                     utohexstr(LoDelta));
+  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
+                     utohexstr(HiDelta));
+  AsmLines.push_back("s_cmp_lg_u32 " + SccSave + ", 0");
+  AsmLines.push_back("s_set_pc_i64 " + Pair);
+  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
+  if (Bytes.empty()) {
+    log() << "hotswap: error: failed to assemble set-PC long branch via "
+          << Pair << "\n";
+    return std::nullopt;
+  }
+  return Bytes;
 }
 
-std::optional<SmallVector<uint8_t>>
-encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                           uint64_t TargetOffset, unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0 ||
-      SgprBase == std::numeric_limits<unsigned>::max()) {
-    log() << "hotswap: error: SCC-neutral long branch requires an aligned "
+static std::optional<SmallVector<uint8_t>>
+encodeSetPCLongBranchClobberSCC(const LLVMState &LS, uint64_t FromOffset,
+                                uint64_t TargetOffset, unsigned SgprBase) {
+  if ((SgprBase & 1u) != 0) {
+    log() << "hotswap: error: SCC-dead set-PC branch requires an aligned "
              "SGPR pair, got s"
           << SgprBase << "\n";
     return std::nullopt;
   }
 
+  const std::string Lo = "s" + std::to_string(SgprBase);
+  const std::string Hi = "s" + std::to_string(SgprBase + 1);
   const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
                            std::to_string(SgprBase + 1) + "]";
-  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
-  if (GetPc.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_get_pc_i64 for "
-          << Pair << "\n";
-    return std::nullopt;
-  }
-
   std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, GetPc.size(), "SCC-neutral long branch PC base");
+      FromOffset, MinInstSize, "SCC-dead set-PC branch PC base");
   if (!PcBase)
     return std::nullopt;
+  uint64_t Delta = TargetOffset - *PcBase;
 
-  // Unsigned subtraction intentionally materializes the two's-complement
-  // delta for backward branches.
-  const uint64_t Delta = TargetOffset - *PcBase;
-  SmallVector<uint8_t> Add = assembleSingleInst(
-      "s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" + utohexstr(Delta), LS);
-  if (Add.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_add_nc_u64 for "
+  SmallVector<std::string, 4> AsmLines;
+  AsmLines.push_back("s_get_pc_i64 " + Pair);
+  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
+                     utohexstr(static_cast<uint32_t>(Delta)));
+  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
+                     utohexstr(static_cast<uint32_t>(Delta >> 32)));
+  AsmLines.push_back("s_set_pc_i64 " + Pair);
+  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
+  if (Bytes.empty()) {
+    log() << "hotswap: error: failed to assemble SCC-dead set-PC branch via "
           << Pair << "\n";
     return std::nullopt;
   }
-  SmallVector<uint8_t> SetPc = assembleSingleInst("s_set_pc_i64 " + Pair, LS);
-  if (SetPc.empty()) {
-    log() << "hotswap: error: SCC-neutral long branch failed to assemble "
-             "s_set_pc_i64 for "
-          << Pair << "\n";
-    return std::nullopt;
-  }
-
-  SmallVector<uint8_t> Bytes;
-  Bytes.append(GetPc.begin(), GetPc.end());
-  Bytes.append(Add.begin(), Add.end());
-  Bytes.append(SetPc.begin(), SetPc.end());
   return Bytes;
 }
 
@@ -653,100 +652,95 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
   return true;
 }
 
-static std::optional<SmallVector<uint8_t>>
-buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
-                   uint64_t BackStart) {
+static std::optional<SafeSgprScratchBlock>
+reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
+      Ctx, InstOffset, /*Count=*/3, /*Alignment=*/2, "safe far return");
   if (!Scratch)
-    return std::nullopt;
-
-  std::optional<uint64_t> ReturnTo =
-      checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
-  if (!ReturnTo)
-    return std::nullopt;
-  std::optional<SmallVector<uint8_t>> Bytes =
-      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, Scratch->Base);
-  if (!Bytes)
     return std::nullopt;
   if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
     return std::nullopt;
+  return Scratch;
+}
 
-  const std::string Pair = "s[" + std::to_string(Scratch->Base) + ":" +
-                           std::to_string(Scratch->Base + 1) + "]";
-  log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
-        << Pair << "\n";
-  return std::move(*Bytes);
+bool isSBranchReachable(uint64_t From, uint64_t To) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(From, MinInstSize, "short branch PC base");
+  if (!PcBase)
+    return false;
+  uint64_t Delta = To >= *PcBase ? To - *PcBase : *PcBase - To;
+  if (Delta % MinInstSize != 0)
+    return false;
+  uint64_t MaxDelta =
+      To >= *PcBase ? static_cast<uint64_t>(BranchOffsetMax) * MinInstSize
+                    : static_cast<uint64_t>(-BranchOffsetMin) * MinInstSize;
+  return Delta <= MaxDelta;
 }
 
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses s_add_pc_i64 on the forward edge. Required rewrites return through an
-/// SGPR pair with an SCC-neutral get-PC/add/set-PC sequence; optional rewrites
-/// decline. The 8-byte forward branch overwrites the site in place, so a
-/// smaller site declines rather than clobbering the next instruction.
+/// uses an SCC-preserving get-PC/add/set-PC sequence on the backward edge.
+/// Adjacent far sites are coalesced after patching to reduce gateway pressure.
+/// Every far source edge then uses a short branch to nearby safe NOP padding;
+/// that gateway uses the pre-Gen5 SGPR-backed set-PC sequence. No source or
+/// return edge executes gfx1250's broken s_add_pc_i64 instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement,
-                                    bool AllowSafeFarReturn) {
+                                    ArrayRef<uint8_t> Replacement) {
   // This trampoline lands at the appended pool base and after every trampoline
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
   // final pool offset (relative to .text) is known exactly now.
   uint64_t PoolStart = Ctx.PoolBaseOffset;
-  for (const Trampoline &Prev : Ctx.OutTrampolines)
-    PoolStart += Prev.Bytes.size();
+  for (const Trampoline &Prev : Ctx.OutTrampolines) {
+    std::optional<uint64_t> NextPoolStart = checkedAddUint64(
+        PoolStart, Prev.Bytes.size(), "trampoline pool layout");
+    if (!NextPoolStart)
+      return false;
+    PoolStart = *NextPoolStart;
+  }
 
   // An s_branch encodes To - From as a signed simm16 dword field, in range iff
   // (To - From - MinInstSize) / MinInstSize fits [BranchOffsetMin,
   // BranchOffsetMax] (see LLVMState::encodeSBranch). Test both edges with the
   // short branch-back slot; the branch-back (pool tail -> site) is the farther
   // of the two. Go long only when a short branch cannot reach.
-  auto WithinSBranch = [](uint64_t From, uint64_t To) {
-    int64_t Dword = (static_cast<int64_t>(To) - static_cast<int64_t>(From) -
-                     static_cast<int64_t>(MinInstSize)) /
-                    static_cast<int64_t>(MinInstSize);
-    return Dword >= BranchOffsetMin && Dword <= BranchOffsetMax;
-  };
-  const uint64_t ShortBackFrom = PoolStart + Replacement.size();
-  const bool Far = !(WithinSBranch(InstOffset, PoolStart) &&
-                     WithinSBranch(ShortBackFrom, InstOffset + InstSize));
+  std::optional<uint64_t> ShortBackFrom = checkedAddUint64(
+      PoolStart, Replacement.size(), "short trampoline return slot");
+  std::optional<uint64_t> ReturnTo =
+      checkedAddUint64(InstOffset, InstSize, "trampoline return target");
+  if (!ShortBackFrom || !ReturnTo)
+    return false;
+  const bool Far = !(isSBranchReachable(InstOffset, PoolStart) &&
+                     isSBranchReachable(*ShortBackFrom, *ReturnTo));
 
   Trampoline T;
   T.OriginalOffset = InstOffset;
   T.OriginalSize = InstSize;
   T.Bytes.insert(T.Bytes.end(), Replacement.begin(), Replacement.end());
+  if (std::optional<ElfView::FunctionTextRange> Range =
+          Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset)) {
+    T.HasFunctionRange = true;
+    T.FunctionStart = Range->Begin;
+    T.FunctionEnd = Range->End;
+  }
 
   if (Far) {
-    // HSV-009: the far pool's backward s_add_pc_i64 branch corrupts wave state
-    // on gfx1250 A0 (forward is fine). Optional transformations decline the
-    // site; required transformations use the SGPR-backed safe return below.
-    if (!AllowSafeFarReturn) {
-      log() << "hotswap: far trampoline at 0x" << utohexstr(InstOffset)
-            << " declined (backward s_add_pc_i64 unreliable on gfx1250 A0, "
-            << "HSV-009); site left unpatched\n";
-      return false;
-    }
-    if (InstSize < LongBranchFwdBytes) {
-      log() << "hotswap: error: safe far trampoline site 0x"
-            << utohexstr(InstOffset) << " is " << InstSize
-            << " B, smaller than " << LongBranchFwdBytes
+    if (InstSize < MinInstSize) {
+      log() << "hotswap: far trampoline site 0x" << utohexstr(InstOffset)
+            << " declined: " << InstSize << " B, smaller than " << MinInstSize
             << " B forward branch\n";
       return false;
     }
-
-    std::optional<uint64_t> BackStart = checkedAddUint64(
-        PoolStart, Replacement.size(), "safe far return start offset");
-    if (!BackStart)
+    std::optional<SafeSgprScratchBlock> Scratch =
+        reserveSafeFarReturn(Ctx, InstOffset);
+    if (!Scratch)
       return false;
-    std::optional<SmallVector<uint8_t>> Back =
-        buildSafeFarReturn(Ctx, InstOffset, InstSize, *BackStart);
-    if (!Back)
-      return false;
-    T.Bytes.append(Back->begin(), Back->end());
+    T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
     T.Long = true;
-    T.PreEncodedBack = true;
+    T.UsesSetPCBack = true;
+    T.LongBranchSgprBase = Scratch->Base;
     Ctx.OutTrampolines.emplace_back(std::move(T));
     return true;
   }
@@ -758,27 +752,773 @@ buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
   return true;
 }
 
+std::optional<uint64_t>
+evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                const LLVMState &LS) {
+  uint64_t Target = 0;
+  if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
+    return Target;
+
+  // TODO(https://github.com/ROCm/llvm-project/issues/3351): Remove this
+  // fallback when AMDGPUMCInstrAnalysis::evaluateBranch locates the descriptor
+  // operand marked MCOI::OPERAND_PCREL. Its current operand-zero restriction
+  // is in llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp.
+  // GFX1250 s_call_i64 instead has its destination SGPR pair in slot zero and
+  // its simm16 dword displacement in slot one; the operand layout and width
+  // are pinned by llvm/test/MC/AMDGPU/gfx1250_asm_sopk.s.
+  if (DI.Inst.getOpcode() != LS.SCallI64Opcode ||
+      DI.Inst.getNumOperands() == 0 ||
+      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+    return std::nullopt;
+
+  uint64_t Encoded =
+      static_cast<uint64_t>(
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
+      0xFFFFu;
+  int64_t DwordDelta = SignExtend64<16>(Encoded);
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      DI.Offset, DI.Size, "direct control-flow target PC base");
+  if (!PcBase)
+    return std::nullopt;
+  if (DwordDelta >= 0)
+    return checkedAddUint64(*PcBase,
+                            static_cast<uint64_t>(DwordDelta) * MinInstSize,
+                            "direct control-flow target");
+  return checkedSubUint64(*PcBase,
+                          static_cast<uint64_t>(-DwordDelta) * MinInstSize,
+                          "direct control-flow target");
+}
+
+/// Collect statically known direct branch and call destinations so an interior
+/// entry point is never swallowed by coalescing.
+static std::optional<DenseSet<uint64_t>>
+collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
+                           const LLVMState &LS) {
+  if (!LS.MIA) {
+    log() << "hotswap: MC branch analysis is unavailable; adjacent far "
+             "trampolines will not be coalesced\n";
+    return std::nullopt;
+  }
+
+  DenseSet<uint64_t> Targets;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Op : DI.Inst)
+      HasImmediate |= Op.isImm();
+    if (!LS.MIA->isCall(DI.Inst) && !HasImmediate)
+      continue;
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (!Target) {
+      log() << "hotswap: MC analysis could not evaluate direct control-flow "
+               "instruction at 0x"
+            << utohexstr(DI.Offset)
+            << "; adjacent far trampolines will not be coalesced\n";
+      return std::nullopt;
+    }
+    Targets.insert(*Target);
+  }
+  return Targets;
+}
+
+/// Coalesce runs of adjacent far patch sites when the same SGPR scratch block
+/// is safe at every site. Removing each interior return reservation preserves
+/// replacement order and reduces the number of required forward gateways.
+/// This deliberately never steals an unpatched neighboring instruction.
+static void
+mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
+                             const DenseSet<uint64_t> &DirectBranchTargets) {
+  std::vector<Trampoline> Merged;
+  Merged.reserve(Trampolines.size());
+  uint64_t MergeCount = 0;
+
+  for (Trampoline &T : Trampolines) {
+    bool Adjacent = false;
+    if (!Merged.empty()) {
+      Trampoline &Prev = Merged.back();
+      std::optional<uint64_t> PrevEnd = checkedAddUint64(
+          Prev.OriginalOffset, Prev.OriginalSize, "adjacent trampoline end");
+      Adjacent = PrevEnd && *PrevEnd == T.OriginalOffset && Prev.Long &&
+                 T.Long && Prev.UsesSetPCBack && T.UsesSetPCBack &&
+                 Prev.LongBranchSgprBase == T.LongBranchSgprBase &&
+                 Prev.HasFunctionRange && T.HasFunctionRange &&
+                 Prev.FunctionStart == T.FunctionStart &&
+                 Prev.FunctionEnd == T.FunctionEnd &&
+                 !DirectBranchTargets.contains(T.OriginalOffset) &&
+                 Prev.Bytes.size() >= SetPcReturnReserveBytes &&
+                 T.Bytes.size() >= SetPcReturnReserveBytes;
+    }
+
+    if (!Adjacent) {
+      Merged.emplace_back(std::move(T));
+      continue;
+    }
+
+    Trampoline &Prev = Merged.back();
+    if (T.OriginalSize >
+        std::numeric_limits<uint32_t>::max() - Prev.OriginalSize) {
+      Merged.emplace_back(std::move(T));
+      continue;
+    }
+    Prev.Bytes.resize(Prev.Bytes.size() - SetPcReturnReserveBytes);
+    Prev.Bytes.append(T.Bytes.begin(), T.Bytes.end());
+    Prev.OriginalSize += T.OriginalSize;
+    ++MergeCount;
+  }
+
+  Trampolines = std::move(Merged);
+  if (MergeCount != 0)
+    log() << "hotswap: coalesced " << MergeCount
+          << " adjacent far trampoline edge(s)\n";
+}
+
+static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
+  for (Trampoline &T : Trampolines) {
+    if (!T.Long)
+      continue;
+    T.Bytes.append(PoolBranchIslandBytes, uint8_t{0});
+    T.HasPoolBranchIsland = true;
+  }
+}
+
+static bool isEndProgram(const InternalDecodedInst &DI, const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  return Opcode == LS.SEndPgmOpcode || Opcode == LS.SEndPgmSavedOpcode;
+}
+
+static bool isPcSensitive(const InternalDecodedInst &DI, const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  return Opcode == LS.SAddPcI64Opcode || Opcode == LS.SGetPcI64Opcode ||
+         Opcode == LS.SSetPcI64Opcode || Opcode == LS.SSwapPcI64Opcode ||
+         Opcode == LS.SPrefetchInstPcRelOpcode ||
+         Opcode == LS.SPrefetchDataPcRelOpcode;
+}
+
+static bool isSafeStraightLineRelocation(const InternalDecodedInst &DI,
+                                         const LLVMState &LS,
+                                         const DenseSet<uint64_t> &Protected) {
+  if (!LS.MIA || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+    return false;
+  unsigned Opcode = DI.Inst.getOpcode();
+  return DI.DecodeSucceeded && !Protected.contains(DI.Offset) &&
+         Opcode != LS.SClauseOpcode && Opcode != LS.SDelayAluOpcode &&
+         !isPcSensitive(DI, LS);
+}
+
+/// Decode the bytes currently present at an original instruction site. Earlier
+/// rewrite passes may have changed Ctx.Text after Ctx.Decoded was populated, so
+/// relocation decisions must not classify the stale MCInst and then copy a
+/// different instruction. A size change is conservatively non-relocatable.
+static std::optional<InternalDecodedInst>
+decodeCurrentInstruction(const PatchContext &Ctx,
+                         const InternalDecodedInst &Original) {
+  if (Original.Offset > Ctx.TextSize ||
+      Original.Size > Ctx.TextSize - Original.Offset)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst> Current;
+  if (!decodeTextSection(Ctx.Text + Original.Offset, Original.Size, Ctx.LS,
+                         Current) ||
+      Current.size() != 1 || Current[0].Size != Original.Size)
+    return std::nullopt;
+  Current[0].Offset = Original.Offset;
+  return std::move(Current[0]);
+}
+
+/// Instructions covered by a hard clause or a delay directive must remain in
+/// place relative to that directive. Mark the complete encoded clause and the
+/// maximum six-instruction forward span addressable by s_delay_alu.
+static DenseSet<uint64_t>
+collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
+                                  const LLVMState &LS) {
+  DenseSet<uint64_t> Protected;
+  unsigned ClauseRemaining = 0;
+  unsigned DelayRemaining = 0;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (ClauseRemaining != 0) {
+      Protected.insert(DI.Offset);
+      --ClauseRemaining;
+    }
+    if (DelayRemaining != 0) {
+      Protected.insert(DI.Offset);
+      --DelayRemaining;
+    }
+
+    if (DI.Inst.getOpcode() == LS.SClauseOpcode &&
+        DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isImm())
+      ClauseRemaining =
+          (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 63u) + 1;
+    else if (DI.Inst.getOpcode() == LS.SDelayAluOpcode)
+      DelayRemaining = 6;
+  }
+  return Protected;
+}
+
+/// Relocating an instruction changes its address. In a function containing a
+/// register-based PC transfer, MC cannot prove that the instruction is not an
+/// indirect destination, so leave the complete function in place.
+static DenseSet<uint64_t>
+collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
+                                    const LLVMState &LS, const ElfView &Elf) {
+  DenseSet<uint64_t> Functions;
+  if (!LS.MIA)
+    return Functions;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
+      continue;
+    if (!LS.MIA->isIndirectBranch(DI.Inst) &&
+        !(LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+          isPcSensitive(DI, LS)))
+      continue;
+    std::optional<ElfView::FunctionTextRange> Range =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    if (Range && Functions.insert(Range->Begin).second)
+      log() << "hotswap: source relocation disabled for function at 0x"
+            << utohexstr(Range->Begin) << " by " << DI.Mnemonic << " at 0x"
+            << utohexstr(DI.Offset) << "\n";
+  }
+  return Functions;
+}
+
+/// Grow undersized far-site windows only through proven straight-line code.
+/// Patched neighbors are merged; ordinary instructions are copied verbatim
+/// into the trampoline body and retain their original order. This is bounded
+/// to the 28 bytes required by the accepted pre-Gen5 forward sequence.
+static void
+expandStraightLineTrampolines(PatchContext &Ctx,
+                              const DenseSet<uint64_t> &DirectBranchTargets) {
+  DenseMap<uint64_t, size_t> DecodedAt;
+  for (size_t I = 0; I != Ctx.Decoded.size(); ++I)
+    DecodedAt[Ctx.Decoded[I].Offset] = I;
+  DenseSet<uint64_t> Protected =
+      collectRelocationProtectedOffsets(Ctx.Decoded, Ctx.LS);
+  DenseSet<uint64_t> IndirectControlFlowFunctions =
+      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    if (Ctx.OutTrampolines[I].HasFunctionRange &&
+        IndirectControlFlowFunctions.contains(
+            Ctx.OutTrampolines[I].FunctionStart))
+      continue;
+    while (Ctx.OutTrampolines[I].Long &&
+           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+      Trampoline &T = Ctx.OutTrampolines[I];
+      std::optional<uint64_t> End = checkedAddUint64(
+          T.OriginalOffset, T.OriginalSize, "straight-line expansion end");
+      if (!End || DirectBranchTargets.contains(*End))
+        break;
+
+      if (I + 1 < Ctx.OutTrampolines.size() &&
+          Ctx.OutTrampolines[I + 1].OriginalOffset == *End) {
+        Trampoline &Next = Ctx.OutTrampolines[I + 1];
+        if (!Next.Long || !Next.UsesSetPCBack ||
+            Next.LongBranchSgprBase != T.LongBranchSgprBase ||
+            !T.HasFunctionRange || !Next.HasFunctionRange ||
+            T.FunctionStart != Next.FunctionStart ||
+            T.FunctionEnd != Next.FunctionEnd ||
+            Next.Bytes.size() < SetPcReturnReserveBytes)
+          break;
+        T.Bytes.resize(T.Bytes.size() - SetPcReturnReserveBytes);
+        T.Bytes.append(Next.Bytes.begin(), Next.Bytes.end());
+        T.OriginalSize += Next.OriginalSize;
+        Ctx.OutTrampolines.erase(Ctx.OutTrampolines.begin() + I + 1);
+        continue;
+      }
+
+      DenseMap<uint64_t, size_t>::const_iterator It = DecodedAt.find(*End);
+      if (It == DecodedAt.end())
+        break;
+      const InternalDecodedInst &Original = Ctx.Decoded[It->second];
+      std::optional<InternalDecodedInst> Current =
+          decodeCurrentInstruction(Ctx, Original);
+      if (!Current)
+        break;
+      const InternalDecodedInst &DI = *Current;
+      std::optional<ElfView::FunctionTextRange> Range =
+          Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
+      if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
+          Range->End != T.FunctionEnd ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected) ||
+          T.Bytes.size() < SetPcReturnReserveBytes)
+        break;
+
+      T.Bytes.insert(T.Bytes.end() - SetPcReturnReserveBytes,
+                     Ctx.Text + DI.Offset, Ctx.Text + DI.Offset + DI.Size);
+      T.OriginalSize += DI.Size;
+    }
+
+    while (Ctx.OutTrampolines[I].Long &&
+           Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
+      Trampoline &T = Ctx.OutTrampolines[I];
+      if (DirectBranchTargets.contains(T.OriginalOffset))
+        break;
+      DenseMap<uint64_t, size_t>::const_iterator It =
+          DecodedAt.find(T.OriginalOffset);
+      if (It == DecodedAt.end() || It->second == 0)
+        break;
+      const InternalDecodedInst &Original = Ctx.Decoded[It->second - 1];
+      std::optional<InternalDecodedInst> Current =
+          decodeCurrentInstruction(Ctx, Original);
+      if (!Current)
+        break;
+      const InternalDecodedInst &DI = *Current;
+      if (DI.Offset + DI.Size != T.OriginalOffset ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected))
+        break;
+      if (I != 0) {
+        const Trampoline &Previous = Ctx.OutTrampolines[I - 1];
+        if (Previous.OriginalOffset + Previous.OriginalSize > DI.Offset)
+          break;
+      }
+      std::optional<ElfView::FunctionTextRange> Range =
+          Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
+      if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
+          Range->End != T.FunctionEnd)
+        break;
+      T.Bytes.insert(T.Bytes.begin(), Ctx.Text + DI.Offset,
+                     Ctx.Text + DI.Offset + DI.Size);
+      T.OriginalOffset = DI.Offset;
+      T.OriginalSize += DI.Size;
+    }
+  }
+}
+
+static bool hasNoFallthrough(const InternalDecodedInst &DI,
+                             const LLVMState &LS) {
+  return isEndProgram(DI, LS) ||
+         (LS.MIA &&
+          (LS.MIA->isUnconditionalBranch(DI.Inst) ||
+           LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+           LS.MIA->isBarrier(DI.Inst)));
+}
+
+static void appendGatewaySled(std::vector<NopSled> &Sleds, uint64_t Start,
+                              uint64_t End, uint64_t TextSize, bool Safe,
+                              bool HasTarget) {
+  if (Safe && !HasTarget && End - Start >= MinInstSize)
+    Sleds.push_back({Start, End, Start, 0, TextSize});
+}
+
+/// Find zero-filled alignment holes, including holes covered by an oversized
+/// function symbol, and s_nop padding outside every function. Such padding is
+/// a safe branch gateway only when it follows a no-fallthrough instruction and
+/// contains no direct branch/call target. In-function s_nop runs are added from
+/// Ctx.NopSleds separately.
+static std::vector<NopSled>
+buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
+                          const LLVMState &LS, const ElfView &Elf,
+                          ArrayRef<uint8_t> Text,
+                          const DenseSet<uint64_t> &DirectBranchTargets) {
+  std::vector<NopSled> Sleds;
+  const InternalDecodedInst *Previous = nullptr;
+  bool Active = false;
+  bool Safe = false;
+  bool HasTarget = false;
+  uint64_t Start = 0;
+  uint64_t End = 0;
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    bool ZeroPadding =
+        DI.Offset <= Text.size() && DI.Size <= Text.size() - DI.Offset;
+    if (ZeroPadding)
+      for (uint8_t Byte : Text.slice(DI.Offset, DI.Size))
+        ZeroPadding &= Byte == 0;
+    bool IsExternalNop = DI.Inst.getOpcode() == LS.SNopOpcode &&
+                         !Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    bool GatewayPadding = ZeroPadding || IsExternalNop;
+    if (!GatewayPadding || (Active && DI.Offset != End)) {
+      if (Active)
+        appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
+      Active = false;
+    }
+    if (!GatewayPadding) {
+      Previous = &DI;
+      continue;
+    }
+    if (!Active) {
+      Active = true;
+      Start = DI.Offset;
+      Safe = Previous && hasNoFallthrough(*Previous, LS);
+      HasTarget = false;
+    }
+    HasTarget |= DirectBranchTargets.contains(DI.Offset);
+    End = DI.Offset + DI.Size;
+  }
+  if (Active)
+    appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
+  return Sleds;
+}
+
+enum class SccScanResult {
+  Unresolved,
+  Used,
+  Defined,
+};
+
+static SccScanResult scanSccInstruction(const InternalDecodedInst &DI,
+                                        const LLVMState &LS, MCRegister SCC) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  if (Desc.hasImplicitUseOfPhysReg(SCC))
+    return SccScanResult::Used;
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = DefCount; I != DI.Inst.getNumOperands(); ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
+      return SccScanResult::Used;
+  }
+
+  if (Desc.hasImplicitDefOfPhysReg(SCC, LS.MRI.get()))
+    return SccScanResult::Defined;
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
+      return SccScanResult::Defined;
+  }
+  return SccScanResult::Unresolved;
+}
+
+/// Prove that clobbering SCC on the forward edge cannot affect the replacement
+/// body or its continuation. Stop conservatively at unresolved control flow.
+static bool isIncomingSccDead(const PatchContext &Ctx, const Trampoline &T) {
+  MCRegister SCC = Ctx.LS.SCCRegister;
+  uint64_t TrailingBytes = SetPcReturnReserveBytes +
+                           (T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0);
+  if (!SCC || T.Bytes.size() < TrailingBytes)
+    return false;
+
+  uint64_t BodySize = T.Bytes.size() - TrailingBytes;
+  std::vector<InternalDecodedInst> Body;
+  if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body))
+    return false;
+  for (const InternalDecodedInst &DI : Body) {
+    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
+    if (Result == SccScanResult::Used)
+      return false;
+    if (Result == SccScanResult::Defined)
+      return true;
+    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+      return false;
+  }
+
+  std::optional<uint64_t> End = checkedAddUint64(
+      T.OriginalOffset, T.OriginalSize, "SCC-dead continuation start");
+  if (!End)
+    return false;
+  for (const InternalDecodedInst &DI : Ctx.Decoded) {
+    if (DI.Offset < *End)
+      continue;
+    if (T.HasFunctionRange && DI.Offset >= T.FunctionEnd)
+      break;
+    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
+    if (Result == SccScanResult::Used)
+      return false;
+    if (Result == SccScanResult::Defined)
+      return true;
+    if (isEndProgram(DI, Ctx.LS))
+      return true;
+    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+      return false;
+  }
+  return true;
+}
+
+static uint64_t countReachableGatewaySlots(ArrayRef<NopSled> Gateways,
+                                           uint64_t Offset, uint64_t Needed) {
+  uint64_t Slots = 0;
+  for (const NopSled &Sled : Gateways) {
+    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+      continue;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
+      continue;
+    uint64_t Distance = Sled.WritePos > Offset ? Sled.WritePos - Offset
+                                               : Offset - Sled.WritePos;
+    if (Distance >= MaxSledDistance)
+      continue;
+    Slots += (UsableEnd - Sled.WritePos) / Needed;
+  }
+  return Slots;
+}
+
+static std::optional<SmallVector<uint64_t, 4>>
+allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
+                             uint64_t FromOffset, uint64_t TargetOffset) {
+  struct Allocation {
+    size_t SledIndex = 0;
+    uint64_t PreviousWritePos = 0;
+  };
+  SmallVector<Allocation, 4> Allocations;
+  SmallVector<uint64_t, 4> Islands;
+  DenseSet<size_t> UsedSleds;
+  uint64_t Current = FromOffset;
+
+  while (!isSBranchReachable(Current, TargetOffset)) {
+    size_t BestIndex = Gateways.size();
+    uint64_t BestOffset = 0;
+    for (size_t I = 0; I != Gateways.size(); ++I) {
+      NopSled &Sled = Gateways[I];
+      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
+          FromOffset >= Sled.FunctionEnd)
+        continue;
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
+          Sled.WritePos > UsableEnd ||
+          MinInstSize > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(Current, Sled.WritePos))
+        continue;
+      if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset) {
+        BestIndex = I;
+        BestOffset = Sled.WritePos;
+      }
+    }
+
+    if (BestIndex == Gateways.size()) {
+      for (size_t I = Allocations.size(); I != 0; --I) {
+        const Allocation &A = Allocations[I - 1];
+        Gateways[A.SledIndex].WritePos = A.PreviousWritePos;
+      }
+      return std::nullopt;
+    }
+
+    NopSled &Best = Gateways[BestIndex];
+    Allocations.push_back({BestIndex, Best.WritePos});
+    Islands.push_back(Best.WritePos);
+    Current = Best.WritePos;
+    Best.WritePos += MinInstSize;
+    UsedSleds.insert(BestIndex);
+  }
+  return Islands;
+}
+
+static bool
+assignLongBranchGateways(PatchContext &Ctx,
+                         const DenseSet<uint64_t> &DirectBranchTargets) {
+  std::vector<NopSled> Gateways = buildExternalGatewaySleds(
+      Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+      DirectBranchTargets);
+  for (const NopSled &Sled : Ctx.NopSleds)
+    Gateways.push_back(Sled);
+
+  DenseMap<uint64_t, size_t> PoolIslandOwners;
+  uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    std::optional<uint64_t> Next = checkedAddUint64(
+        IslandLayoutOffset, T.Bytes.size(), "pool branch-island layout");
+    if (!Next)
+      return false;
+    if (T.HasPoolBranchIsland) {
+      T.PoolBranchIslandOffset = *Next - PoolBranchIslandBytes;
+      PoolIslandOwners[T.PoolBranchIslandOffset] = I;
+      Gateways.push_back({T.PoolBranchIslandOffset,
+                          T.PoolBranchIslandOffset + PoolBranchIslandBytes,
+                          T.PoolBranchIslandOffset, 0,
+                          std::numeric_limits<uint64_t>::max()});
+    }
+    IslandLayoutOffset = *Next;
+  }
+
+  struct PendingGateway {
+    size_t TrampolineIndex = 0;
+    uint64_t TargetOffset = 0;
+    bool IncomingSccDead = false;
+    uint64_t NeededBytes = 0;
+    uint64_t InitialCandidateSlots = 0;
+  };
+  std::vector<PendingGateway> Pending;
+  uint64_t TrampOffset = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t TP = TrampOffset;
+    std::optional<uint64_t> Next = checkedAddUint64(
+        TrampOffset, T.Bytes.size(), "gateway trampoline layout");
+    if (!Next)
+      return false;
+    TrampOffset = *Next;
+    if (!T.Long)
+      continue;
+
+    if (isSBranchReachable(T.OriginalOffset, TP)) {
+      T.UsesShortBranchForward = true;
+      continue;
+    }
+    bool IncomingSccDead = isIncomingSccDead(Ctx, T);
+    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+        Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
+    if (Direct && Direct->size() <= T.OriginalSize) {
+      T.UsesDirectSetPCForward = true;
+      T.DirectSetPCForwardBytes = std::move(*Direct);
+      continue;
+    }
+    if (IncomingSccDead) {
+      Direct = encodeSetPCLongBranchClobberSCC(Ctx.LS, T.OriginalOffset, TP,
+                                               T.LongBranchSgprBase);
+      if (Direct && Direct->size() <= T.OriginalSize) {
+        T.UsesDirectSetPCForward = true;
+        T.DirectSetPCForwardBytes = std::move(*Direct);
+        continue;
+      }
+    }
+
+    uint64_t Needed =
+        IncomingSccDead ? SetPcMinGatewayBytes : SetPcForwardSequenceBytes;
+    Pending.push_back(
+        {I, TP, IncomingSccDead, Needed,
+         countReachableGatewaySlots(Gateways, T.OriginalOffset, Needed)});
+  }
+
+  std::vector<PendingGateway> StillPending;
+  StillPending.reserve(Pending.size());
+  uint64_t BranchIslandChains = 0;
+  for (const PendingGateway &P : Pending) {
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    std::optional<SmallVector<uint64_t, 4>> Islands =
+        allocateForwardBranchIslands(Gateways, T.OriginalOffset,
+                                     P.TargetOffset);
+    if (!Islands || Islands->empty()) {
+      StillPending.push_back(P);
+      continue;
+    }
+    T.ForwardBranchIslands = std::move(*Islands);
+    T.ForwardBranchTargetOffset = P.TargetOffset;
+    ++BranchIslandChains;
+  }
+  Pending = std::move(StillPending);
+
+  // Allocate SCC-preserving gateways first. They need more contiguous bytes
+  // and have fewer placement options; SCC-dead gateways can fill the remaining
+  // 20-byte fragments afterward.
+  std::stable_sort(Pending.begin(), Pending.end(),
+                   [](const PendingGateway &LHS, const PendingGateway &RHS) {
+                     if (LHS.NeededBytes != RHS.NeededBytes)
+                       return LHS.NeededBytes > RHS.NeededBytes;
+                     return LHS.InitialCandidateSlots <
+                            RHS.InitialCandidateSlots;
+                   });
+
+  uint64_t PreservingGateways = 0;
+  uint64_t SccDeadGateways = 0;
+  for (const PendingGateway &P : Pending) {
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    NopSled *Sled = findNearestSled(Gateways, T.OriginalOffset, P.NeededBytes);
+    if (!Sled ||
+        Ctx.LS.encodeSBranch(T.OriginalOffset, Sled->WritePos).empty()) {
+      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
+            << " initial candidate slot(s))\n";
+      return false;
+    }
+    std::optional<SmallVector<uint8_t>> Gateway =
+        P.IncomingSccDead
+            ? encodeSetPCLongBranchClobberSCC(
+                  Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase)
+            : encodeSetPCLongBranch(Ctx.LS, Sled->WritePos, P.TargetOffset,
+                                    T.LongBranchSgprBase);
+    if (!Gateway || Gateway->size() > P.NeededBytes) {
+      log() << "hotswap: error: failed to encode far-site gateway at 0x"
+            << utohexstr(Sled->WritePos) << "\n";
+      return false;
+    }
+    T.HasForwardGateway = true;
+    T.ForwardGatewayOffset = Sled->WritePos;
+    T.ForwardGatewayBytes = std::move(*Gateway);
+    Sled->WritePos += T.ForwardGatewayBytes.size();
+    if (P.IncomingSccDead)
+      ++SccDeadGateways;
+    else
+      ++PreservingGateways;
+  }
+  if (!Pending.empty())
+    log() << "hotswap: assigned " << PreservingGateways
+          << " SCC-preserving and " << SccDeadGateways
+          << " SCC-dead forward gateway(s)\n";
+  if (BranchIslandChains != 0)
+    log() << "hotswap: assigned " << BranchIslandChains
+          << " forward s_branch island chain(s)\n";
+
+  for (Trampoline &T : Ctx.OutTrampolines) {
+    if (T.HasForwardGateway) {
+      if (T.ForwardGatewayOffset > Ctx.TextSize ||
+          T.ForwardGatewayBytes.size() >
+              Ctx.TextSize - T.ForwardGatewayOffset) {
+        log() << "hotswap: error: forward gateway at 0x"
+              << utohexstr(T.ForwardGatewayOffset) << " extends past .text.\n";
+        return false;
+      }
+      std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
+                  T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
+    }
+    for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
+      uint64_t From = T.ForwardBranchIslands[I];
+      uint64_t To = I + 1 == T.ForwardBranchIslands.size()
+                        ? T.ForwardBranchTargetOffset
+                        : T.ForwardBranchIslands[I + 1];
+      SmallVector<uint8_t> Branch = Ctx.LS.encodeSBranch(From, To);
+      if (Branch.size() != MinInstSize) {
+        log() << "hotswap: error: failed to encode forward branch island at "
+                 "0x"
+              << utohexstr(From) << "\n";
+        return false;
+      }
+      DenseMap<uint64_t, size_t>::const_iterator Owner =
+          PoolIslandOwners.find(From);
+      if (Owner != PoolIslandOwners.end()) {
+        Trampoline &OwnerT = Ctx.OutTrampolines[Owner->second];
+        std::memcpy(OwnerT.Bytes.data() + OwnerT.Bytes.size() -
+                        PoolBranchIslandBytes,
+                    Branch.data(), Branch.size());
+      } else {
+        if (From > Ctx.TextSize || Branch.size() > Ctx.TextSize - From) {
+          log() << "hotswap: error: forward branch island at 0x"
+                << utohexstr(From) << " is outside .text and trampoline pool\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + From, Branch.data(), Branch.size());
+      }
+    }
+  }
+  return true;
+}
+
 /// Emit \p Replacement for the instruction at [\p InstOffset,
 /// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
 /// reachable sled with sufficient headroom exists; otherwise falls back to a
 /// deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement,
-                                       bool AllowSafeFarReturn) {
-  // findNearestSled enforces sled headroom. emitToNopSled still validates
-  // exact branch reachability because branch-back distance includes the
-  // replacement size, not just the original instruction offset.
-  uint64_t Needed = Replacement.size() + MinInstSize;
-  if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
-    if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
-      return true;
-    log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
-          << utohexstr(Sled->WritePos)
-          << " is not branch-reachable after assembly; using trampoline.\n";
+                                       ArrayRef<uint8_t> Replacement) {
+  std::optional<uint64_t> ReturnTo = checkedAddUint64(
+      InstOffset, InstSize, "replacement trampoline return target");
+  std::optional<uint64_t> PoolReturnFrom =
+      checkedAddUint64(Ctx.PoolBaseOffset, Replacement.size(),
+                       "replacement trampoline return slot");
+  if (!ReturnTo || !PoolReturnFrom)
+    return false;
+
+  // When the pool base is already out of short-branch reach, defer every site
+  // to the global trampoline pass. That pass can coalesce adjacent patches
+  // before allocating gateways; consuming NOP padding greedily here can strand
+  // a later small or clause/delay-constrained source window.
+  bool PoolBaseFar = !isSBranchReachable(InstOffset, Ctx.PoolBaseOffset) ||
+                     !isSBranchReachable(*PoolReturnFrom, *ReturnTo);
+  if (!PoolBaseFar) {
+    // findNearestSled enforces sled headroom. emitToNopSled still validates
+    // exact branch reachability because branch-back distance includes the
+    // replacement size, not just the original instruction offset.
+    uint64_t Needed = Replacement.size() + MinInstSize;
+    if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
+      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
+        return true;
+      log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
+            << utohexstr(Sled->WritePos)
+            << " is not branch-reachable after assembly; using trampoline.\n";
+    }
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement,
-                          AllowSafeFarReturn);
+  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -896,6 +1636,19 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix)
     Patched += VT.applyVop3px2Src2Fix(Ctx);
 
+  if (!OutTrampolines.empty()) {
+    std::optional<DenseSet<uint64_t>> DirectBranchTargets =
+        collectDirectBranchTargets(Decoded, LS);
+    if (!DirectBranchTargets)
+      return std::nullopt;
+    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
+    expandStraightLineTrampolines(Ctx, *DirectBranchTargets);
+    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
+    appendPoolBranchIslands(OutTrampolines);
+    if (!assignLongBranchGateways(Ctx, *DirectBranchTargets))
+      return std::nullopt;
+  }
+
   for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
     const KernelPatchStats &Stats = KV.second;
@@ -964,37 +1717,73 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
   uint64_t TrampOffset = PoolBaseOffset;
   for (Trampoline &T : Trampolines) {
     uint64_t TP = TrampOffset;
-    TrampOffset += T.Bytes.size();
+    std::optional<uint64_t> NextTrampOffset = checkedAddUint64(
+        TrampOffset, T.Bytes.size(), "trampoline fixup layout");
+    if (!NextTrampOffset)
+      return false;
+    TrampOffset = *NextTrampOffset;
 
-    // Required far patches carry an SCC-neutral s_get_pc_i64/s_add_nc_u64/
-    // s_set_pc_i64 return assembled when the trampoline is queued. Other long
-    // returns are never queued on gfx1250 A0 because backward s_add_pc_i64 is
-    // unsafe.
-    if (!T.PreEncodedBack) {
-      const uint32_t BackReserve = T.Long ? LongBranchMaxBytes : MinInstSize;
-      const uint64_t BackSlot = TP + T.Bytes.size() - BackReserve;
-      const uint64_t ReturnTo = T.OriginalOffset + T.OriginalSize;
+    if (T.Long && !T.UsesSetPCBack) {
+      log() << "hotswap: error: far trampoline lacks safe set-PC return at 0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    const uint32_t BackReserve =
+        T.UsesSetPCBack ? SetPcReturnReserveBytes : MinInstSize;
+    const uint32_t TrailingIsland =
+        T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0;
+    if (T.Bytes.size() < BackReserve + TrailingIsland) {
+      log() << "hotswap: error: trampoline return reservation is truncated at "
+               "0x"
+            << utohexstr(T.OriginalOffset) << "\n";
+      return false;
+    }
+    const uint64_t BackSlot = TrampOffset - TrailingIsland - BackReserve;
+    const size_t BackOffset = T.Bytes.size() - TrailingIsland - BackReserve;
+    std::optional<uint64_t> ReturnTo = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "trampoline return target");
+    if (!ReturnTo)
+      return false;
 
-      SmallVector<uint8_t> BrBack =
-          T.Long ? encodeLongBranch(LS, BackSlot, ReturnTo)
-                 : LS.encodeSBranch(BackSlot, ReturnTo);
-      if (BrBack.empty() || BrBack.size() > BackReserve) {
-        log() << "hotswap: error: trampoline branch-back encoding failed at "
-                 "0x"
-              << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+    std::optional<SmallVector<uint8_t>> BrBack;
+    if (T.UsesSetPCBack) {
+      BrBack =
+          encodeSetPCLongBranch(LS, BackSlot, *ReturnTo, T.LongBranchSgprBase);
+    } else {
+      SmallVector<uint8_t> ShortBranch = LS.encodeSBranch(BackSlot, *ReturnTo);
+      if (!ShortBranch.empty())
+        BrBack = std::move(ShortBranch);
+    }
+    if (!BrBack || BrBack->size() > BackReserve) {
+      log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
+            << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
+      return false;
+    }
+    std::memcpy(T.Bytes.data() + BackOffset, BrBack->data(), BrBack->size());
+    for (uint32_t I = BrBack->size(); I + MinInstSize <= BackReserve;
+         I += MinInstSize)
+      std::memcpy(T.Bytes.data() + BackOffset + I, LS.SNopBytes.data(),
+                  MinInstSize);
+
+    SmallVector<uint8_t> BrFwd;
+    if (T.Long) {
+      if (T.UsesShortBranchForward) {
+        BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
+      } else if (!T.ForwardBranchIslands.empty()) {
+        BrFwd =
+            LS.encodeSBranch(T.OriginalOffset, T.ForwardBranchIslands.front());
+      } else if (T.UsesDirectSetPCForward) {
+        BrFwd = T.DirectSetPCForwardBytes;
+      } else if (T.HasForwardGateway) {
+        BrFwd = LS.encodeSBranch(T.OriginalOffset, T.ForwardGatewayOffset);
+      } else {
+        log() << "hotswap: error: far trampoline has no forward gateway at 0x"
+              << utohexstr(T.OriginalOffset) << "\n";
         return false;
       }
-      std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve, BrBack.data(),
-                  BrBack.size());
-      for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
-           I += MinInstSize)
-        std::memcpy(T.Bytes.data() + T.Bytes.size() - BackReserve + I,
-                    LS.SNopBytes.data(), MinInstSize);
+    } else {
+      BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
     }
-
-    SmallVector<uint8_t> BrFwd =
-        T.Long ? encodeLongBranch(LS, T.OriginalOffset, TP)
-               : LS.encodeSBranch(T.OriginalOffset, TP);
     if (BrFwd.empty() || BrFwd.size() > T.OriginalSize) {
       log() << "hotswap: error: trampoline branch-fwd encoding failed at 0x"
             << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -107,7 +107,7 @@ static bool appendCodeEndGuard(std::vector<Trampoline> &Growth,
 
 static std::optional<uint32_t>
 getMaxOriginalKernelInstPrefSize(const ElfView &Elf, const LLVMState &LS) {
-  std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   uint32_t MaxOriginalInstPrefLines = 0;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     std::optional<uint32_t> OriginalInstPrefLines =
@@ -503,10 +503,47 @@ static bool instructionUsesVcc(const LLVMState &LS,
   return false;
 }
 
+static SafeSgprUsageSummary
+summarizeSafeSgprUsage(PatchContext &Ctx,
+                       ArrayRef<InternalDecodedInst> Instructions,
+                       StringRef Context) {
+  SafeSgprUsageSummary Summary;
+  for (const InternalDecodedInst &DI : Instructions) {
+    Summary.UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
+    Summary.HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
+    for (const MCOperand &Op : DI.Inst) {
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
+                                           Ctx.Config.MaxSgprs,
+                                           Summary.HighWatermark, Context)) {
+        Summary.Valid = false;
+        return Summary;
+      }
+    }
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs,
+                                           Summary.HighWatermark, Context)) {
+        Summary.Valid = false;
+        return Summary;
+      }
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs,
+                                           Summary.HighWatermark, Context)) {
+        Summary.Valid = false;
+        return Summary;
+      }
+  }
+  return Summary;
+}
+
 std::optional<SafeSgprScratchBlock>
-findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
-                         unsigned Count, unsigned Alignment,
-                         StringRef Context) {
+findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
+                         unsigned Alignment, StringRef Context) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
     log() << "hotswap: error: " << Context
           << ": invalid global SGPR block request (count=" << Count
@@ -519,45 +556,50 @@ findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
   std::string Owner =
       Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
   bool ScanWholeObject = Owner.empty() || !FunctionRange;
+  SafeSgprUsageSummary *Usage = nullptr;
   if (!ScanWholeObject) {
-    for (const InternalDecodedInst &DI : Ctx.Decoded) {
-      if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
-        continue;
-      if (Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst)) {
-        ScanWholeObject = true;
-        break;
-      }
+    using FunctionKey = std::pair<uint64_t, uint64_t>;
+    FunctionKey Key{FunctionRange->Begin, FunctionRange->End};
+    DenseMap<FunctionKey, SafeSgprUsageSummary>::iterator Cached =
+        Ctx.FunctionSgprUsage.find(Key);
+    if (Cached == Ctx.FunctionSgprUsage.end()) {
+      std::vector<InternalDecodedInst>::const_iterator Begin = std::lower_bound(
+          Ctx.Decoded.cbegin(), Ctx.Decoded.cend(), FunctionRange->Begin,
+          [](const InternalDecodedInst &DI, uint64_t Offset) {
+            return DI.Offset < Offset;
+          });
+      std::vector<InternalDecodedInst>::const_iterator End =
+          std::lower_bound(Begin, Ctx.Decoded.cend(), FunctionRange->End,
+                           [](const InternalDecodedInst &DI, uint64_t Offset) {
+                             return DI.Offset < Offset;
+                           });
+      size_t BeginIndex = Begin - Ctx.Decoded.cbegin();
+      size_t InstructionCount = End - Begin;
+      SafeSgprUsageSummary Summary =
+          summarizeSafeSgprUsage(Ctx,
+                                 ArrayRef<InternalDecodedInst>(Ctx.Decoded)
+                                     .slice(BeginIndex, InstructionCount),
+                                 Context);
+      Cached = Ctx.FunctionSgprUsage.try_emplace(Key, Summary).first;
     }
+    Usage = &Cached->second;
+    ScanWholeObject = Usage->HasCall;
   }
 
-  bool UsesVcc = false;
-  unsigned HighWatermark = 0;
-  for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (!ScanWholeObject &&
-        (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End))
-      continue;
-    UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
-    for (const MCOperand &Op : DI.Inst) {
-      if (!Op.isReg() || !Op.getReg())
-        continue;
-      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
-                                           Ctx.Config.MaxSgprs, HighWatermark,
-                                           Context))
-        return std::nullopt;
-    }
-
-    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
-    for (MCPhysReg Reg : Desc.implicit_uses())
-      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
-                                           Ctx.Config.MaxSgprs, HighWatermark,
-                                           Context))
-        return std::nullopt;
-    for (MCPhysReg Reg : Desc.implicit_defs())
-      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
-                                           Ctx.Config.MaxSgprs, HighWatermark,
-                                           Context))
-        return std::nullopt;
+  if (ScanWholeObject) {
+    if (!Ctx.WholeObjectSgprUsage)
+      Ctx.WholeObjectSgprUsage = summarizeSafeSgprUsage(
+          Ctx, ArrayRef<InternalDecodedInst>(Ctx.Decoded), Context);
+    Usage = &*Ctx.WholeObjectSgprUsage;
   }
+  if (!Usage || !Usage->Valid) {
+    log() << "hotswap: error: " << Context
+          << ": cached SGPR usage analysis failed\n";
+    return std::nullopt;
+  }
+
+  bool UsesVcc = Usage->UsesVcc;
+  unsigned HighWatermark = Usage->HighWatermark;
 
   constexpr unsigned VccSgprs = 2;
   if (!Owner.empty()) {
@@ -608,7 +650,7 @@ findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
 bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 StringRef Context) {
-  std::vector<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
+  ArrayRef<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
   if (Descriptors.empty()) {
     log() << "hotswap: error: " << Context
           << ": code object has no kernel descriptors to charge for scratch "
@@ -692,14 +734,10 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   // already queued -- later ones are appended behind it and cannot shift it,
   // and fixupTrampolineBranches walks the same list in the same order -- so its
   // final pool offset (relative to .text) is known exactly now.
-  uint64_t PoolStart = Ctx.PoolBaseOffset;
-  for (const Trampoline &Prev : Ctx.OutTrampolines) {
-    std::optional<uint64_t> NextPoolStart = checkedAddUint64(
-        PoolStart, Prev.Bytes.size(), "trampoline pool layout");
-    if (!NextPoolStart)
-      return false;
-    PoolStart = *NextPoolStart;
-  }
+  std::optional<uint64_t> PoolStart = checkedAddUint64(
+      Ctx.PoolBaseOffset, Ctx.QueuedTrampolineBytes, "trampoline pool layout");
+  if (!PoolStart)
+    return false;
 
   // An s_branch encodes To - From as a signed simm16 dword field, in range iff
   // (To - From - MinInstSize) / MinInstSize fits [BranchOffsetMin,
@@ -707,13 +745,24 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   // short branch-back slot; the branch-back (pool tail -> site) is the farther
   // of the two. Go long only when a short branch cannot reach.
   std::optional<uint64_t> ShortBackFrom = checkedAddUint64(
-      PoolStart, Replacement.size(), "short trampoline return slot");
+      *PoolStart, Replacement.size(), "short trampoline return slot");
   std::optional<uint64_t> ReturnTo =
       checkedAddUint64(InstOffset, InstSize, "trampoline return target");
   if (!ShortBackFrom || !ReturnTo)
     return false;
-  const bool Far = !(isSBranchReachable(InstOffset, PoolStart) &&
+  const bool Far = !(isSBranchReachable(InstOffset, *PoolStart) &&
                      isSBranchReachable(*ShortBackFrom, *ReturnTo));
+
+  uint64_t ReturnReserve = Far ? SetPcReturnReserveBytes : MinInstSize;
+  std::optional<uint64_t> TrampolineSize = checkedAddUint64(
+      Replacement.size(), ReturnReserve, "queued trampoline size");
+  if (!TrampolineSize)
+    return false;
+  std::optional<uint64_t> QueuedBytes =
+      checkedAddUint64(Ctx.QueuedTrampolineBytes, *TrampolineSize,
+                       "queued trampoline byte count");
+  if (!QueuedBytes)
+    return false;
 
   Trampoline T;
   T.OriginalOffset = InstOffset;
@@ -742,6 +791,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     T.UsesSetPCBack = true;
     T.LongBranchSgprBase = Scratch->Base;
     Ctx.OutTrampolines.emplace_back(std::move(T));
+    Ctx.QueuedTrampolineBytes = *QueuedBytes;
     return true;
   }
   {
@@ -749,6 +799,7 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
     T.Bytes.insert(T.Bytes.end(), MinInstSize, uint8_t{0});
   }
   Ctx.OutTrampolines.emplace_back(std::move(T));
+  Ctx.QueuedTrampolineBytes = *QueuedBytes;
   return true;
 }
 
@@ -1649,7 +1700,13 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       return std::nullopt;
   }
 
-  for (const llvm::StringMapEntry<KernelPatchStats> &KV : KernelStats) {
+  struct ResourceCounts {
+    unsigned Vgprs;
+    unsigned Sgprs;
+  };
+  StringMap<ResourceCounts> CountsBefore;
+  StringMap<unsigned> RequiredSgprCounts;
+  for (const StringMapEntry<KernelPatchStats> &KV : KernelStats) {
     StringRef KName = KV.first();
     const KernelPatchStats &Stats = KV.second;
     if (KName.empty())
@@ -1657,6 +1714,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     std::optional<unsigned> VgprsBefore =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
     std::optional<unsigned> SgprsBefore = Elf.getKernelSgprCount(KName);
+    CountsBefore.try_emplace(KName, ResourceCounts{VgprsBefore.value_or(0),
+                                                   SgprsBefore.value_or(0)});
     if (Stats.ExtraVgprs > 0)
       Elf.updateKernelDescriptor(KName, Stats.ExtraVgprs,
                                  Config.VgprGranuleSize);
@@ -1673,20 +1732,33 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
         return std::nullopt;
       }
       unsigned RequiredSgprs = *SgprsBefore + Stats.ExtraSgprs;
-      if (!Elf.updateKernelDescriptorSgprCount(KName, RequiredSgprs,
-                                               /*UpdateDescriptor=*/false)) {
-        log() << "hotswap: error: failed to update SGPR count for kernel "
-              << KName << "\n";
-        return std::nullopt;
-      }
+      RequiredSgprCounts.try_emplace(KName, RequiredSgprs);
+    }
+  }
+
+  if (!Elf.updateKernelMetadataSgprCounts(RequiredSgprCounts)) {
+    log() << "hotswap: error: failed to update kernel SGPR metadata\n";
+    return std::nullopt;
+  }
+
+  for (const StringMapEntry<KernelPatchStats> &KV : KernelStats) {
+    StringRef KName = KV.first();
+    const KernelPatchStats &Stats = KV.second;
+    if (KName.empty())
+      continue;
+    StringMap<ResourceCounts>::const_iterator Before = CountsBefore.find(KName);
+    if (Before == CountsBefore.end()) {
+      log() << "hotswap: error: missing cached resource counts for kernel "
+            << KName << "\n";
+      return std::nullopt;
     }
     std::optional<unsigned> VgprsAfter =
         Elf.getKernelVgprCount(KName, Config.VgprGranuleSize);
     std::optional<unsigned> SgprsAfter = Elf.getKernelSgprCount(KName);
     log() << "hotswap: liveness: kernel " << KName
-          << ": vgprs_before=" << VgprsBefore.value_or(0)
+          << ": vgprs_before=" << Before->second.Vgprs
           << ", vgprs_after=" << VgprsAfter.value_or(0)
-          << ", sgprs_before=" << SgprsBefore.value_or(0)
+          << ", sgprs_before=" << Before->second.Sgprs
           << ", sgprs_after=" << SgprsAfter.value_or(0)
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -446,6 +446,44 @@ encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
   return Bytes;
 }
 
+static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
+                                                 MCRegister Reg) {
+  // TODO(https://github.com/ROCm/llvm-project/issues/3350): Replace this
+  // register-name fallback with a public AMDGPU MC hardware-index helper.
+  if (!Reg.isValid())
+    return std::nullopt;
+  StringRef Name(MRI.getName(Reg));
+  if (!Name.consume_front("SGPR") || Name.empty() || Name.contains('_'))
+    return std::nullopt;
+  unsigned Index = 0;
+  if (Name.getAsInteger(10, Index))
+    return std::nullopt;
+  return Index;
+}
+
+static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
+                                            MCRegister Reg, unsigned MaxSgprs,
+                                            unsigned &HighWatermark,
+                                            StringRef Context) {
+  SmallVector<MCRegister, 8> Candidates;
+  Candidates.push_back(Reg);
+  for (MCPhysReg Sub : MRI.subregs(Reg))
+    Candidates.push_back(MCRegister(Sub));
+
+  for (MCRegister Candidate : Candidates) {
+    std::optional<unsigned> Index = numberedSgprIndex(MRI, Candidate);
+    if (!Index)
+      continue;
+    if (*Index >= MaxSgprs) {
+      log() << "hotswap: error: " << Context << ": numbered SGPR s" << *Index
+            << " exceeds the addressable limit s" << (MaxSgprs - 1) << "\n";
+      return false;
+    }
+    HighWatermark = std::max(HighWatermark, *Index + 1);
+  }
+  return true;
+}
+
 static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
   return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
 }
@@ -466,94 +504,176 @@ static bool instructionUsesVcc(const LLVMState &LS,
   return false;
 }
 
-static std::optional<SmallVector<uint8_t>>
-buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
-                   uint64_t BackStart) {
-  std::string KernelName =
-      Ctx.Elf.findKernelAtAddress(InstOffset + Ctx.Elf.textAddr());
-  if (KernelName.empty()) {
-    log() << "hotswap: error: safe far return: no kernel owns site 0x"
-          << utohexstr(InstOffset) << "\n";
+std::optional<SafeSgprScratchBlock>
+findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
+                         unsigned Count, unsigned Alignment,
+                         StringRef Context) {
+  if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
+    log() << "hotswap: error: " << Context
+          << ": invalid global SGPR block request (count=" << Count
+          << ", alignment=" << Alignment << ")\n";
     return std::nullopt;
   }
 
-  std::optional<unsigned> TotalSgprCount =
-      Ctx.Elf.getKernelSgprCount(KernelName);
-  if (!TotalSgprCount) {
-    log() << "hotswap: error: safe far return: invalid SGPR count for kernel "
-          << KernelName << "\n";
-    return std::nullopt;
-  }
-
-  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs adds two
-  // implicit SGPRs when VCC is used. They are not part of the numbered s0-s105
-  // register space. Inspect the owning function so scratch allocation starts
-  // above numbered SGPRs rather than above the metadata total. If VCC is only
-  // used by a callee, retaining the total as the allocation base is
-  // conservative; the call flag below keeps two implicit slots in the updated
-  // metadata.
-  bool UsesVcc = false;
-  bool HasCall = false;
   std::optional<ElfView::FunctionTextRange> FunctionRange =
-      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
-  if (!FunctionRange) {
-    log() << "hotswap: error: safe far return: no function owns site 0x"
-          << utohexstr(InstOffset) << "\n";
-    return std::nullopt;
+      Ctx.Elf.findFunctionTextRangeAtOffset(TextOffset);
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  bool ScanWholeObject = Owner.empty() || !FunctionRange;
+  if (!ScanWholeObject) {
+    for (const InternalDecodedInst &DI : Ctx.Decoded) {
+      if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+        continue;
+      if (Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst)) {
+        ScanWholeObject = true;
+        break;
+      }
+    }
   }
 
+  bool UsesVcc = false;
+  unsigned HighWatermark = 0;
   for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End)
+    if (!ScanWholeObject &&
+        (DI.Offset < FunctionRange->Begin || DI.Offset >= FunctionRange->End))
       continue;
     UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
-    HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
+    for (const MCOperand &Op : DI.Inst) {
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           Context))
+        return std::nullopt;
+    }
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           Context))
+        return std::nullopt;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           Context))
+        return std::nullopt;
   }
 
   constexpr unsigned VccSgprs = 2;
-  if (UsesVcc && *TotalSgprCount < VccSgprs) {
-    log() << "hotswap: error: safe far return: VCC-using kernel " << KernelName
-          << " has invalid SGPR count " << *TotalSgprCount << "\n";
-    return std::nullopt;
-  }
-  unsigned NumberedSgprCount = *TotalSgprCount - (UsesVcc ? VccSgprs : 0);
-  if (NumberedSgprCount > Ctx.Config.MaxSgprs) {
-    log() << "hotswap: error: safe far return: numbered SGPR count for kernel "
-          << KernelName << " exceeds " << Ctx.Config.MaxSgprs << "\n";
-    return std::nullopt;
+  if (!Owner.empty()) {
+    std::optional<unsigned> Declared = Ctx.Elf.getKernelSgprCount(Owner);
+    if (!Declared) {
+      log() << "hotswap: error: " << Context
+            << ": failed to read SGPR count for kernel " << Owner << "\n";
+      return std::nullopt;
+    }
+    if (UsesVcc && *Declared < VccSgprs) {
+      log() << "hotswap: error: " << Context << ": VCC-using kernel " << Owner
+            << " has invalid SGPR count " << *Declared << "\n";
+      return std::nullopt;
+    }
+    unsigned DeclaredNumbered = *Declared - (UsesVcc ? VccSgprs : 0);
+    HighWatermark = std::max(HighWatermark, DeclaredNumbered);
+  } else {
+    // A device function can be reached from kernels with different declared
+    // register footprints. Without a complete call graph, keep the block above
+    // every declaration and charge every kernel in the commit step.
+    for (const KernelDescriptorInfo &KD : Ctx.Elf.kernelDescriptors()) {
+      std::optional<unsigned> Declared =
+          Ctx.Elf.getKernelSgprCount(KD.KernelName);
+      if (!Declared) {
+        log() << "hotswap: error: " << Context
+              << ": failed to read SGPR count for kernel " << KD.KernelName
+              << "\n";
+        return std::nullopt;
+      }
+      HighWatermark = std::max(HighWatermark, *Declared);
+    }
   }
 
-  // s_get_pc_i64/s_set_pc_i64 require an aligned pair. Allocate it above the
-  // kernel's declared registers so no live program register is repurposed.
-  // s_add_nc_u64 adjusts the captured PC without reading or writing SCC.
-  unsigned ScratchPair = (NumberedSgprCount + 1) & ~1u;
-  if (ScratchPair + 1 >= Ctx.Config.MaxSgprs) {
-    log() << "hotswap: error: safe far return: kernel " << KernelName
-          << " has no aligned SGPR pair below s" << Ctx.Config.MaxSgprs << "\n";
+  if (HighWatermark > std::numeric_limits<unsigned>::max() - (Alignment - 1)) {
+    log() << "hotswap: error: " << Context
+          << ": SGPR alignment calculation overflows unsigned\n";
     return std::nullopt;
   }
+  unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
+  if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
+    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
+          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    return std::nullopt;
+  }
+  return SafeSgprScratchBlock{Base, Count};
+}
+
+bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
+                                const SafeSgprScratchBlock &Block,
+                                StringRef Context) {
+  std::vector<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
+  if (Descriptors.empty()) {
+    log() << "hotswap: error: " << Context
+          << ": code object has no kernel descriptors to charge for scratch "
+             "SGPRs\n";
+    return false;
+  }
+
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
+  bool ChargedOwner = false;
+
+  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs returns
+  // two non-numbered VCC SGPRs on GFX1250. Always include them in the metadata
+  // requirement. This may conservatively overstate a kernel that does not use
+  // VCC, but never mistakes VCC for numbered s0-s105 registers.
+  constexpr unsigned VccSgprs = 2;
+  unsigned RequiredSgprs = Block.Base + Block.Count + VccSgprs;
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    if (!Owner.empty() && KD.KernelName != Owner)
+      continue;
+    ChargedOwner = true;
+
+    std::optional<unsigned> Current = Ctx.Elf.getKernelSgprCount(KD.KernelName);
+    if (!Current) {
+      log() << "hotswap: error: " << Context
+            << ": failed to read SGPR count for kernel " << KD.KernelName
+            << "\n";
+      return false;
+    }
+    if (*Current >= RequiredSgprs)
+      continue;
+    KernelPatchStats &Stats = Ctx.KernelStats[KD.KernelName];
+    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, RequiredSgprs - *Current);
+  }
+
+  if (!ChargedOwner) {
+    log() << "hotswap: error: " << Context << ": kernel '" << Owner
+          << "' has no descriptor\n";
+    return false;
+  }
+  return true;
+}
+
+static std::optional<SmallVector<uint8_t>>
+buildSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                   uint64_t BackStart) {
+  std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
+      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
+  if (!Scratch)
+    return std::nullopt;
 
   std::optional<uint64_t> ReturnTo =
       checkedAddUint64(InstOffset, InstSize, "safe far return target offset");
   if (!ReturnTo)
     return std::nullopt;
   std::optional<SmallVector<uint8_t>> Bytes =
-      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, ScratchPair);
+      encodeSccNeutralLongBranch(Ctx.LS, BackStart, *ReturnTo, Scratch->Base);
   if (!Bytes)
     return std::nullopt;
-
-  unsigned RequiredNumberedSgprs = ScratchPair + 2;
-  unsigned PreservedImplicitSgprs = (UsesVcc || HasCall) ? VccSgprs : 0;
-  unsigned RequiredSgprs = RequiredNumberedSgprs + PreservedImplicitSgprs;
-  if (RequiredSgprs < *TotalSgprCount) {
-    log() << "hotswap: error: safe far return: SGPR accounting underflow for "
-          << KernelName << "\n";
+  if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
     return std::nullopt;
-  }
-  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-  Stats.ExtraSgprs =
-      std::max(Stats.ExtraSgprs, RequiredSgprs - *TotalSgprCount);
-  const std::string Pair = "s[" + std::to_string(ScratchPair) + ":" +
-                           std::to_string(ScratchPair + 1) + "]";
+
+  const std::string Pair = "s[" + std::to_string(Scratch->Base) + ":" +
+                           std::to_string(Scratch->Base + 1) + "]";
   log() << "hotswap: safe far return at 0x" << utohexstr(InstOffset) << " via "
         << Pair << "\n";
   return std::move(*Bytes);
@@ -1029,6 +1149,13 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   } else {
     log() << "hotswap: instruction patches disabled for this rewrite\n";
   }
+
+  // gfx1250 revision is recorded per kernel in the AMDGPU metadata note.
+  // Running a B0 object on A0 requires retagging that metadata even when no
+  // machine instruction needed rewriting. Native A0 code generation preserves
+  // s_clause and emits the same instructions as B0 for valid clauses.
+  if (Options.RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
+    return AMD_COMGR_STATUS_ERROR;
 
   std::unique_ptr<WritableMemoryBuffer> Result;
   std::vector<Trampoline> Growth = Deferred;

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1976,11 +1976,30 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   }
   ElfView &Elf = *ViewOrErr;
 
-  LLVMState LS = initLLVM(TargetIdent);
-  if (!LS.Valid) {
-    log() << "hotswap: error: retargetCodeObject: initLLVM failed "
-          << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
-    return AMD_COMGR_STATUS_ERROR;
+  // B0->B0 entry-only fast path: no instruction patches means no .text decode,
+  // so skip the whole LLVM MC layer and emit entry stubs from a pre-encoded
+  // byte template. Gated to gfx1250: the template bytes and the HWSD workaround
+  // are gfx1250-specific; other gfx125x and A0 take the MC path.
+  const bool UseFastAppend = Options.RunEntryTrampolines &&
+                             !RunInstructionPatches &&
+                             TargetIdent.Processor == "gfx1250";
+
+  LLVMState LS;
+  if (UseFastAppend) {
+    // Only LS.SNopBytes and LS.Cpu are read on the fast tail; populate them
+    // without paying for the full MC stack.
+    LS.Cpu = TargetIdent.Processor;
+    static constexpr uint8_t SNop[4] = {0x00, 0x00, 0x80, 0xbf};
+    LS.SNopBytes.assign(SNop, SNop + sizeof(SNop));
+    log() << "hotswap: entry trampolines: B0->B0 fast path (no MC/.text "
+             "disassembly)\n";
+  } else {
+    LS = initLLVM(TargetIdent);
+    if (!LS.Valid) {
+      log() << "hotswap: error: retargetCodeObject: initLLVM failed "
+            << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
   }
 
   RewriteConfig Config = makeGfx1250B0A0Config();
@@ -2070,8 +2089,11 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
   if (Options.RunEntryTrampolines) {
-    std::optional<uint32_t> EntryCount = appendKernelEntryTrampolines(
-        Elf, LS, Config.MaxSgprs, Growth, EntryFixups);
+    std::optional<uint32_t> EntryCount =
+        UseFastAppend
+            ? appendKernelEntryTrampolinesFast(Elf, LS.Cpu, Growth, EntryFixups)
+            : appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs, Growth,
+                                           EntryFixups);
     if (!EntryCount)
       return AMD_COMGR_STATUS_ERROR;
     Count += *EntryCount;
@@ -2111,7 +2133,17 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     // `info dispatches`). This grows only the non-alloc .symtab/.strtab and
     // returns a new buffer; failure is non-fatal (the rewritten code object is
     // still correct, just missing the debug-only symbol).
-    if (!EntryFixups.empty()) {
+    //
+    // FAST PATH: this .symtab/.strtab rebuild + full buffer copy scales with
+    // kernel count and is pure overhead for a load-time-critical path (the ROCr
+    // loader trampoline adds no such symbols). The symbols are only a debugging
+    // aid, so the fast path skips them by default. Set
+    // AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 to re-enable (e.g. for rocgdb).
+    const bool AddStubSymbols = !UseFastAppend || []() {
+      const char *E = std::getenv("AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS");
+      return E && E[0] == '1' && E[1] == '\0';
+    }();
+    if (!EntryFixups.empty() && AddStubSymbols) {
       std::unique_ptr<WritableMemoryBuffer> WithSyms =
           addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),
                                           Elf.textAddr(), Elf.textSize(),

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -15,6 +15,7 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
@@ -118,17 +119,22 @@ readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
   return readUnsignedMetadataNode(SgprNode, KernelName, ".sgpr_count", Context);
 }
 
-static MetadataSgprUpdateStatus
-updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
-                              StringRef KernelName, unsigned RequiredSgprs) {
+using MetadataNoteMutator = function_ref<std::optional<bool>(
+    msgpack::Document &, msgpack::MapDocNode &)>;
+
+/// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
+/// write changed notes back in place after checking that their encoded size and
+/// destination remain valid. Returns false after logging a specific failure.
+static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
+                                 StringRef Context, MetadataNoteMutator Mutator,
+                                 bool &SawMetadataNote) {
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   if (!PhdrsOrErr) {
-    log() << "hotswap: error: updateKernelMetadataSgprCount: failed to read "
-          << "program headers: " << toString(PhdrsOrErr.takeError()) << "\n";
-    return MetadataSgprUpdateStatus::Error;
+    log() << "hotswap: error: " << Context << ": failed to read program "
+          << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return false;
   }
 
-  bool SawMetadataNote = false;
   for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
     if (Phdr.p_type != ELF::PT_NOTE)
       continue;
@@ -142,93 +148,116 @@ updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
 
       ArrayRef<uint8_t> Desc = Note.getDesc(4);
       if (Desc.empty()) {
-        log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU "
-              << "metadata note has an empty descriptor.\n";
-        return MetadataSgprUpdateStatus::Error;
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata note has an empty descriptor.\n";
+        return false;
       }
 
       StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
       msgpack::Document Doc;
       if (!Doc.readFromBlob(Blob, false)) {
-        log() << "hotswap: error: updateKernelMetadataSgprCount: failed to "
-              << "parse AMDGPU metadata note.\n";
-        return MetadataSgprUpdateStatus::Error;
+        log() << "hotswap: error: " << Context
+              << ": failed to parse AMDGPU metadata note.\n";
+        return false;
       }
 
       msgpack::DocNode Root = Doc.getRoot();
       if (!Root.isMap()) {
-        log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU "
-              << "metadata root is not a map.\n";
-        return MetadataSgprUpdateStatus::Error;
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata root is not a map.\n";
+        return false;
       }
 
-      msgpack::MapDocNode &RootMap = Root.getMap();
-      msgpack::DocNode::MapTy::iterator KernelsIt =
-          RootMap.find("amdhsa.kernels");
-      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+      std::optional<bool> Changed = Mutator(Doc, Root.getMap());
+      if (!Changed)
+        return false;
+      if (!*Changed)
         continue;
 
-      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
-      for (msgpack::DocNode &KNode : KernelArray) {
-        if (!KNode.isMap())
-          continue;
-
-        msgpack::MapDocNode &KMap = KNode.getMap();
-        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
-        if (NameIt == KMap.end() || !NameIt->second.isString() ||
-            NameIt->second.getString() != KernelName)
-          continue;
-
-        msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
-        if (SgprIt == KMap.end()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
-                << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-
-        std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
-            SgprIt->second, KernelName, "updateKernelMetadataSgprCount");
-        if (!CurrentSgprs)
-          return MetadataSgprUpdateStatus::Error;
-        if (RequiredSgprs <= *CurrentSgprs)
-          return MetadataSgprUpdateStatus::Found;
-
-        SgprIt->second = static_cast<uint64_t>(RequiredSgprs);
-        std::string NewBlob;
-        Doc.writeToBlob(NewBlob);
-        if (NewBlob.size() != Blob.size()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: updating "
-                << ".sgpr_count for '" << KernelName << "' changes metadata "
-                << "note size from " << Blob.size() << " to " << NewBlob.size()
-                << " bytes; in-place rewrite cannot preserve ELF layout.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-
-        const uint8_t *DescBegin = Desc.data();
-        if (DescBegin < File.base() || DescBegin >= File.end()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
-                << "descriptor pointer is outside the ELF buffer.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-        size_t DescOffset = DescBegin - File.base();
-        if (Desc.size() > File.getBufSize() ||
-            DescOffset > File.getBufSize() - Desc.size()) {
-          log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
-                << "descriptor extends past the ELF buffer.\n";
-          return MetadataSgprUpdateStatus::Error;
-        }
-
-        std::memcpy(Elf + DescOffset, NewBlob.data(), NewBlob.size());
-        return MetadataSgprUpdateStatus::Found;
+      std::string NewBlob;
+      Doc.writeToBlob(NewBlob);
+      if (NewBlob.size() != Blob.size()) {
+        log() << "hotswap: error: " << Context
+              << ": updating AMDGPU metadata changes note size from "
+              << Blob.size() << " to " << NewBlob.size()
+              << " bytes; in-place rewrite cannot preserve ELF layout.\n";
+        return false;
       }
+
+      const uint8_t *DescBegin = Desc.data();
+      if (DescBegin < File.base() || DescBegin >= File.end()) {
+        log() << "hotswap: error: " << Context
+              << ": metadata descriptor pointer is outside the ELF buffer.\n";
+        return false;
+      }
+      size_t DescOffset = DescBegin - File.base();
+      if (Desc.size() > File.getBufSize() ||
+          DescOffset > File.getBufSize() - Desc.size()) {
+        log() << "hotswap: error: " << Context
+              << ": metadata descriptor extends past the ELF buffer.\n";
+        return false;
+      }
+      std::memcpy(Elf + DescOffset, NewBlob.data(), NewBlob.size());
     }
 
     if (Err) {
-      log() << "hotswap: error: updateKernelMetadataSgprCount: failed to "
-            << "iterate AMDGPU notes: " << toString(std::move(Err)) << "\n";
-      return MetadataSgprUpdateStatus::Error;
+      log() << "hotswap: error: " << Context
+            << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
+            << "\n";
+      return false;
     }
   }
+  return true;
+}
+
+static MetadataSgprUpdateStatus
+updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
+                              StringRef KernelName, unsigned RequiredSgprs) {
+  bool SawMetadataNote = false;
+  bool Found = false;
+  bool Rewritten = rewriteMetadataNotes(
+      Elf, File, "updateKernelMetadataSgprCount",
+      [&](msgpack::Document &,
+          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
+        msgpack::DocNode::MapTy::iterator KernelsIt =
+            RootMap.find("amdhsa.kernels");
+        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+          return false;
+
+        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+          if (!KNode.isMap())
+            continue;
+          msgpack::MapDocNode &KMap = KNode.getMap();
+          msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
+          if (NameIt == KMap.end() || !NameIt->second.isString() ||
+              NameIt->second.getString() != KernelName)
+            continue;
+
+          Found = true;
+          msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
+          if (SgprIt == KMap.end()) {
+            log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
+                  << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
+            return std::nullopt;
+          }
+
+          std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
+              SgprIt->second, KernelName, "updateKernelMetadataSgprCount");
+          if (!CurrentSgprs)
+            return std::nullopt;
+          if (RequiredSgprs <= *CurrentSgprs)
+            return false;
+
+          SgprIt->second = static_cast<uint64_t>(RequiredSgprs);
+          return true;
+        }
+        return false;
+      },
+      SawMetadataNote);
+  if (!Rewritten)
+    return MetadataSgprUpdateStatus::Error;
+  if (Found)
+    return MetadataSgprUpdateStatus::Found;
 
   if (SawMetadataNote) {
     log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU metadata "
@@ -236,6 +265,41 @@ updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
     return MetadataSgprUpdateStatus::Error;
   }
   return MetadataSgprUpdateStatus::NotFound;
+}
+
+bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
+  bool SawMetadataNote = false;
+  return rewriteMetadataNotes(
+      data(), File, "updateGfx1250RevisionMetadata",
+      [&](msgpack::Document &Doc,
+          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
+        msgpack::DocNode::MapTy::iterator KernelsIt =
+            RootMap.find("amdhsa.kernels");
+        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+          return false;
+
+        bool Changed = false;
+        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+          if (!KNode.isMap())
+            continue;
+          msgpack::MapDocNode &KMap = KNode.getMap();
+          msgpack::DocNode::MapTy::iterator RevisionIt =
+              KMap.find(".gfx1250_revision");
+          if (RevisionIt == KMap.end())
+            continue;
+          if (!RevisionIt->second.isString()) {
+            log() << "hotswap: error: updateGfx1250RevisionMetadata: "
+                  << ".gfx1250_revision is not a string.\n";
+            return std::nullopt;
+          }
+          if (RevisionIt->second.getString() == Revision)
+            continue;
+          RevisionIt->second = Doc.getNode(Revision, /*Copy=*/true);
+          Changed = true;
+        }
+        return Changed;
+      },
+      SawMetadataNote);
 }
 
 // -- applyByteReplace ---------------------------------------------------------
@@ -461,34 +525,18 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
 
 std::optional<ElfView::FunctionTextRange>
 ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
-  for (const ELFT::Shdr &SymShdr : Sections) {
-    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
-        SymShdr.sh_type != ELF::SHT_DYNSYM)
+  std::optional<FunctionTextRange> Best;
+  for (const FunctionTextRange &Range : functionTextRanges()) {
+    if (Range.Begin < textAddr() || Range.End < textAddr())
       continue;
-
-    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
-    if (!SymsOrErr) {
-      consumeError(SymsOrErr.takeError());
+    uint64_t Begin = Range.Begin - textAddr();
+    uint64_t End = Range.End - textAddr();
+    if (TextOffset < Begin || TextOffset >= End)
       continue;
-    }
-
-    for (const ELFT::Sym &Sym : *SymsOrErr) {
-      if (Sym.getType() != ELF::STT_FUNC && Sym.getType() != ELF::STT_GNU_IFUNC)
-        continue;
-      if (Sym.st_shndx != TextSectionIndex || Sym.st_size == 0)
-        continue;
-      if (Sym.st_value < textAddr())
-        continue;
-
-      uint64_t Start = Sym.st_value - textAddr();
-      if (Sym.st_size > std::numeric_limits<uint64_t>::max() - Start)
-        continue;
-      uint64_t End = Start + Sym.st_size;
-      if (TextOffset >= Start && TextOffset < End)
-        return ElfView::FunctionTextRange{Start, End};
-    }
+    if (!Best || Begin > Best->Begin)
+      Best = FunctionTextRange{Begin, End};
   }
-  return std::nullopt;
+  return Best;
 }
 
 // -- ElfView::findKernelDescriptor --------------------------------------------
@@ -1190,8 +1238,7 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
   SmallVector<uint8_t> StrBlob, SymBlob;
   for (const KernelEntryTrampolineFixup &F : Fixups) {
     std::string Name = F.KernelName + ".stub";
-    uint32_t NameOff =
-        static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
+    uint32_t NameOff = static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
     StrBlob.append(Name.begin(), Name.end());
     StrBlob.push_back(0);
 

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -8,8 +8,9 @@
 ///
 /// \file
 /// Implementation of hotswap::ElfView and the free-function ELF helpers.
-/// Parses are delegated to llvm::object::ELFFile; there is no hand-rolled
-/// section/symbol cache.
+/// Parses are delegated to llvm::object::ELFFile. ElfView caches immutable
+/// symbol ranges and metadata-derived SGPR counts for the duration of one
+/// rewrite so large code objects do not repeatedly parse the same ELF data.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -121,12 +122,20 @@ readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
 
 using MetadataNoteMutator = function_ref<std::optional<bool>(
     msgpack::Document &, msgpack::MapDocNode &)>;
+using MetadataNoteValidator = function_ref<bool(bool)>;
+
+struct PendingMetadataWrite {
+  size_t Offset = 0;
+  std::string Blob;
+};
 
 /// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
-/// write changed notes back in place after checking that their encoded size and
-/// destination remain valid. Returns false after logging a specific failure.
+/// defer changed writes until \p Validator accepts the complete traversal.
+/// This keeps multi-note updates atomic while sharing the parsing, encoded-size
+/// and destination validation for every metadata mutation.
 static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
                                  StringRef Context, MetadataNoteMutator Mutator,
+                                 MetadataNoteValidator Validator,
                                  bool &SawMetadataNote) {
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   if (!PhdrsOrErr) {
@@ -134,7 +143,7 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
           << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
     return false;
   }
-
+  std::vector<PendingMetadataWrite> PendingWrites;
   for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
     if (Phdr.p_type != ELF::PT_NOTE)
       continue;
@@ -197,7 +206,7 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
               << ": metadata descriptor extends past the ELF buffer.\n";
         return false;
       }
-      std::memcpy(Elf + DescOffset, NewBlob.data(), NewBlob.size());
+      PendingWrites.push_back({DescOffset, std::move(NewBlob)});
     }
 
     if (Err) {
@@ -207,16 +216,24 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
       return false;
     }
   }
+
+  if (!Validator(SawMetadataNote))
+    return false;
+  for (const PendingMetadataWrite &Write : PendingWrites)
+    std::memcpy(Elf + Write.Offset, Write.Blob.data(), Write.Blob.size());
   return true;
 }
 
 static MetadataSgprUpdateStatus
-updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
-                              StringRef KernelName, unsigned RequiredSgprs) {
+rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
+                                const StringMap<unsigned> &RequiredSgprs) {
+  if (RequiredSgprs.empty())
+    return MetadataSgprUpdateStatus::Found;
+
   bool SawMetadataNote = false;
-  bool Found = false;
+  StringMap<bool> Found;
   bool Rewritten = rewriteMetadataNotes(
-      Elf, File, "updateKernelMetadataSgprCount",
+      Elf, File, "updateKernelMetadataSgprCounts",
       [&](msgpack::Document &,
           msgpack::MapDocNode &RootMap) -> std::optional<bool> {
         msgpack::DocNode::MapTy::iterator KernelsIt =
@@ -224,47 +241,59 @@ updateKernelMetadataSgprCount(uint8_t *Elf, const ELFFileT &File,
         if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
           return false;
 
+        bool Changed = false;
         for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
           if (!KNode.isMap())
             continue;
           msgpack::MapDocNode &KMap = KNode.getMap();
           msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
-          if (NameIt == KMap.end() || !NameIt->second.isString() ||
-              NameIt->second.getString() != KernelName)
+          if (NameIt == KMap.end() || !NameIt->second.isString())
             continue;
 
-          Found = true;
+          StringRef KernelName = NameIt->second.getString();
+          StringMap<unsigned>::const_iterator Required =
+              RequiredSgprs.find(KernelName);
+          if (Required == RequiredSgprs.end() || Found.contains(KernelName))
+            continue;
+
           msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
           if (SgprIt == KMap.end()) {
-            log() << "hotswap: error: updateKernelMetadataSgprCount: metadata "
+            log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
                   << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
             return std::nullopt;
           }
 
           std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
-              SgprIt->second, KernelName, "updateKernelMetadataSgprCount");
+              SgprIt->second, KernelName, "updateKernelMetadataSgprCounts");
           if (!CurrentSgprs)
             return std::nullopt;
-          if (RequiredSgprs <= *CurrentSgprs)
-            return false;
+          Found.try_emplace(KernelName, true);
+          if (Required->second <= *CurrentSgprs)
+            continue;
 
-          SgprIt->second = static_cast<uint64_t>(RequiredSgprs);
-          return true;
+          SgprIt->second = static_cast<uint64_t>(Required->second);
+          Changed = true;
         }
-        return false;
+        return Changed;
+      },
+      [&](bool SawMetadata) {
+        if (!SawMetadata)
+          return true;
+        for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+          if (Found.contains(Required.first()))
+            continue;
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+                   "metadata has no entry for kernel '"
+                << Required.first() << "'.\n";
+          return false;
+        }
+        return true;
       },
       SawMetadataNote);
   if (!Rewritten)
     return MetadataSgprUpdateStatus::Error;
-  if (Found)
-    return MetadataSgprUpdateStatus::Found;
-
-  if (SawMetadataNote) {
-    log() << "hotswap: error: updateKernelMetadataSgprCount: AMDGPU metadata "
-          << "has no entry for kernel '" << KernelName << "'.\n";
-    return MetadataSgprUpdateStatus::Error;
-  }
-  return MetadataSgprUpdateStatus::NotFound;
+  return SawMetadataNote ? MetadataSgprUpdateStatus::Found
+                         : MetadataSgprUpdateStatus::NotFound;
 }
 
 bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
@@ -299,7 +328,7 @@ bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
         }
         return Changed;
       },
-      SawMetadataNote);
+      [](bool) { return true; }, SawMetadataNote);
 }
 
 // -- applyByteReplace ---------------------------------------------------------
@@ -404,14 +433,18 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
 
 // -- ElfView::functionTextRanges ---------------------------------------------
 
-std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
+ArrayRef<ElfView::FunctionTextRange> ElfView::cachedFunctionTextRanges() const {
+  if (FunctionRangeCache)
+    return *FunctionRangeCache;
+
   std::vector<FunctionTextRange> Ranges;
   uint64_t TextBegin = textAddr();
   uint64_t TextSizeValue = textSize();
   if (TextSizeValue > std::numeric_limits<uint64_t>::max() - TextBegin) {
     log() << "hotswap: error: function text range scan: .text virtual "
           << "address range overflows uint64_t.\n";
-    return Ranges;
+    FunctionRangeCache.emplace();
+    return *FunctionRangeCache;
   }
   uint64_t TextEnd = TextBegin + TextSizeValue;
 
@@ -464,32 +497,57 @@ std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
     }
   }
 
-  return Ranges;
+  llvm::stable_sort(
+      Ranges, [](const FunctionTextRange &LHS, const FunctionTextRange &RHS) {
+        return LHS.Begin < RHS.Begin;
+      });
+  FunctionRangeCache = std::move(Ranges);
+  return *FunctionRangeCache;
+}
+
+std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
+  ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
+  return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
 }
 
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
+const ElfView::FunctionTextRange *
+ElfView::findFunctionTextRangeAtAddress(uint64_t TextAddress) const {
+  ArrayRef<FunctionTextRange> Ranges = cachedFunctionTextRanges();
+  ArrayRef<FunctionTextRange>::const_iterator GroupEnd =
+      std::upper_bound(Ranges.begin(), Ranges.end(), TextAddress,
+                       [](uint64_t Address, const FunctionTextRange &Range) {
+                         return Address < Range.Begin;
+                       });
+
+  // Prefer the covering range with the greatest start address, matching the
+  // previous full scan. Preserve the stable symbol-table order for duplicate
+  // starts so aliases resolve exactly as before.
+  while (GroupEnd != Ranges.begin()) {
+    ArrayRef<FunctionTextRange>::const_iterator GroupBegin = GroupEnd - 1;
+    uint64_t Begin = GroupBegin->Begin;
+    while (GroupBegin != Ranges.begin() && (GroupBegin - 1)->Begin == Begin)
+      --GroupBegin;
+    for (ArrayRef<FunctionTextRange>::const_iterator It = GroupBegin;
+         It != GroupEnd; ++It)
+      if (TextAddress < It->End)
+        return &*It;
+    GroupEnd = GroupBegin;
+  }
+  return nullptr;
+}
+
 std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
-  bool Found = false;
-  uint64_t BestValue = 0;
-  std::string BestName;
-
-  std::vector<FunctionTextRange> Ranges = functionTextRanges();
-  for (const FunctionTextRange &Range : Ranges) {
-    if (TextAddress < Range.Begin || TextAddress >= Range.End)
-      continue;
-
-    const ELFT::Sym &Sym = *Range.Symbol;
-    if (Found && Sym.st_value <= BestValue)
-      continue;
-
+  const FunctionTextRange *Range = findFunctionTextRangeAtAddress(TextAddress);
+  if (Range) {
+    const ELFT::Sym &Sym = *Range->Symbol;
     Expected<StringRef> StrTabOrErr =
-        File.getStringTableForSymtab(*Range.Symtab, Sections);
+        File.getStringTableForSymtab(*Range->Symtab, Sections);
     if (!StrTabOrErr) {
       consumeError(StrTabOrErr.takeError());
-      continue;
+      return "";
     }
-
     Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
     if (!NameOrErr) {
       log() << "hotswap: error: findKernelAtAddress: function symbol "
@@ -498,12 +556,7 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
             << "\n";
       return "";
     }
-    Found = true;
-    BestValue = Sym.st_value;
-    BestName = NameOrErr->str();
-  }
-
-  if (Found) {
+    std::string BestName = NameOrErr->str();
     // Confirm the selected symbol is actually a kernel: every kernel carries a
     // "<name>.kd" descriptor symbol, whereas a plain device function does not.
     // This is the same descriptor lookup getKernelVgprCount performs, so a real
@@ -525,74 +578,25 @@ std::string ElfView::findKernelAtAddress(uint64_t TextAddress) const {
 
 std::optional<ElfView::FunctionTextRange>
 ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
-  std::optional<FunctionTextRange> Best;
-  for (const FunctionTextRange &Range : functionTextRanges()) {
-    if (Range.Begin < textAddr() || Range.End < textAddr())
-      continue;
-    uint64_t Begin = Range.Begin - textAddr();
-    uint64_t End = Range.End - textAddr();
-    if (TextOffset < Begin || TextOffset >= End)
-      continue;
-    if (!Best || Begin > Best->Begin)
-      Best = FunctionTextRange{Begin, End};
-  }
-  return Best;
-}
-
-// -- ElfView::findKernelDescriptor --------------------------------------------
-
-uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
-  std::string KdName = (KernelName + ".kd").str();
-  for (const ELFT::Shdr &SymShdr : Sections) {
-    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
-        SymShdr.sh_type != ELF::SHT_DYNSYM)
-      continue;
-
-    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
-    if (!SymsOrErr) {
-      consumeError(SymsOrErr.takeError());
-      continue;
-    }
-    Expected<StringRef> StrTabOrErr =
-        File.getStringTableForSymtab(SymShdr, Sections);
-    if (!StrTabOrErr) {
-      consumeError(StrTabOrErr.takeError());
-      continue;
-    }
-
-    for (const ELFT::Sym &Sym : *SymsOrErr) {
-      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
-      if (!NameOrErr) {
-        consumeError(NameOrErr.takeError());
-        continue;
-      }
-      if (*NameOrErr != KdName)
-        continue;
-      unsigned Shndx = Sym.st_shndx;
-      Expected<const ELFT::Shdr *> HostShdrOrErr = File.getSection(Shndx);
-      if (!HostShdrOrErr) {
-        consumeError(HostShdrOrErr.takeError());
-        continue;
-      }
-      const ELFT::Shdr &HostShdr = **HostShdrOrErr;
-      std::optional<uint64_t> FileOffset = checkedSectionFileOffset(
-          HostShdr, Sym.st_value, KdSize, size(),
-          (Twine("findKernelDescriptor: descriptor symbol '") + *NameOrErr +
-           "'")
-              .str());
-      if (!FileOffset)
-        continue;
-      return data() + *FileOffset;
-    }
-  }
-  return nullptr;
+  if (TextOffset >= textSize() ||
+      TextOffset > std::numeric_limits<uint64_t>::max() - textAddr())
+    return std::nullopt;
+  const FunctionTextRange *Range =
+      findFunctionTextRangeAtAddress(textAddr() + TextOffset);
+  if (!Range || Range->Begin < textAddr() || Range->End < textAddr())
+    return std::nullopt;
+  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr()};
 }
 
 // -- ElfView::kernelDescriptors -----------------------------------------------
 
-std::vector<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
+void ElfView::initializeKernelDescriptorCache() const {
+  if (KernelDescriptorCache)
+    return;
+
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
+  StringMap<uint64_t> FileOffsets;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -653,10 +657,26 @@ std::vector<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
           });
       if (!Seen)
         Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
+      FileOffsets.try_emplace(NameOrErr->drop_back(3), *FileOffset);
     }
   }
 
-  return Result;
+  KernelDescriptorFileOffsetCache = std::move(FileOffsets);
+  KernelDescriptorCache = std::move(Result);
+}
+
+uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
+  initializeKernelDescriptorCache();
+  StringMap<uint64_t>::const_iterator It =
+      KernelDescriptorFileOffsetCache.find(KernelName);
+  if (It == KernelDescriptorFileOffsetCache.end())
+    return nullptr;
+  return data() + It->second;
+}
+
+ArrayRef<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
+  initializeKernelDescriptorCache();
+  return *KernelDescriptorCache;
 }
 
 std::optional<uint64_t>
@@ -680,6 +700,12 @@ bool ElfView::updateKernelDescriptorEntryOffset(StringRef KernelName,
   std::memcpy(
       Kd + offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
       &NewEntryOffset, sizeof(NewEntryOffset));
+  for (KernelDescriptorInfo &Info : *KernelDescriptorCache) {
+    if (Info.KernelName != KernelName)
+      continue;
+    Info.EntryOffset = NewEntryOffset;
+    break;
+  }
   return true;
 }
 
@@ -728,8 +754,10 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
     }
   }
 
+  StringMap<unsigned> RequiredSgprCounts;
+  RequiredSgprCounts.try_emplace(KernelName, RequiredSgprs);
   MetadataSgprUpdateStatus MetadataStatus =
-      updateKernelMetadataSgprCount(data(), File, KernelName, RequiredSgprs);
+      rewriteKernelMetadataSgprCounts(data(), File, RequiredSgprCounts);
   if (MetadataStatus == MetadataSgprUpdateStatus::Error)
     return false;
   if (!UpdateDescriptor &&
@@ -743,6 +771,16 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
   // On pre-gfx10 targets, NotFound is allowed for minimal code objects without
   // AMDGPU metadata because the descriptor remains the canonical count.
 
+  if (SgprCacheState == KernelSgprCacheState::Metadata &&
+      MetadataStatus == MetadataSgprUpdateStatus::Found) {
+    StringMap<std::optional<unsigned>>::iterator Cached =
+        KernelSgprCountCache.find(KernelName);
+    if (Cached == KernelSgprCountCache.end())
+      KernelSgprCountCache.try_emplace(KernelName, RequiredSgprs);
+    else if (!Cached->second || RequiredSgprs > *Cached->second)
+      Cached->second = RequiredSgprs;
+  }
+
   if (!RequiredGranulated)
     return true;
 
@@ -750,6 +788,33 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
                   *RequiredGranulated);
   std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               &Rsrc1, sizeof(Rsrc1));
+  if (SgprCacheState == KernelSgprCacheState::NoMetadata)
+    KernelSgprCountCache.erase(KernelName);
+  return true;
+}
+
+bool ElfView::updateKernelMetadataSgprCounts(
+    const StringMap<unsigned> &RequiredSgprs) {
+  MetadataSgprUpdateStatus MetadataStatus =
+      rewriteKernelMetadataSgprCounts(data(), File, RequiredSgprs);
+  if (MetadataStatus == MetadataSgprUpdateStatus::Error)
+    return false;
+  if (MetadataStatus == MetadataSgprUpdateStatus::NotFound) {
+    log() << "hotswap: error: updateKernelMetadataSgprCounts: code object "
+             "has no AMDGPU metadata note.\n";
+    return false;
+  }
+
+  if (SgprCacheState == KernelSgprCacheState::Metadata) {
+    for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+      StringMap<std::optional<unsigned>>::iterator Cached =
+          KernelSgprCountCache.find(Required.first());
+      if (Cached == KernelSgprCountCache.end())
+        KernelSgprCountCache.try_emplace(Required.first(), Required.second);
+      else if (!Cached->second || Required.second > *Cached->second)
+        Cached->second = Required.second;
+    }
+  }
   return true;
 }
 
@@ -889,9 +954,13 @@ ElfView::getKernelStaticLdsSize(StringRef KernelName) const {
 // preferred source. Falls back to the KD field when no metadata note is
 // present (e.g. minimal test ELFs assembled with -nostdlib).
 
-std::optional<unsigned>
-ElfView::getKernelSgprCount(StringRef KernelName) const {
-  // --- Try msgpack metadata note first. ---
+void ElfView::initializeKernelSgprCountCache() const {
+  if (SgprCacheState != KernelSgprCacheState::Uninitialized)
+    return;
+
+  // Default to Error so every malformed-note early return leaves an explicit
+  // terminal cache state instead of reparsing the same large blob.
+  SgprCacheState = KernelSgprCacheState::Error;
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   bool SawMetadataNote = false;
   if (PhdrsOrErr) {
@@ -907,25 +976,25 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
 
         ArrayRef<uint8_t> Desc = Note.getDesc(4);
         if (Desc.empty()) {
-          log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata note "
+          log() << "hotswap: error: SGPR cache: AMDGPU metadata note "
                 << "has an empty descriptor.\n";
-          return std::nullopt;
+          return;
         }
 
         StringRef Blob(reinterpret_cast<const char *>(Desc.data()),
                        Desc.size());
         msgpack::Document Doc;
         if (!Doc.readFromBlob(Blob, false)) {
-          log() << "hotswap: error: getKernelSgprCount: failed to parse "
+          log() << "hotswap: error: SGPR cache: failed to parse "
                 << "AMDGPU metadata note.\n";
-          return std::nullopt;
+          return;
         }
 
         msgpack::DocNode Root = Doc.getRoot();
         if (!Root.isMap()) {
-          log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata root "
+          log() << "hotswap: error: SGPR cache: AMDGPU metadata root "
                 << "is not a map.\n";
-          return std::nullopt;
+          return;
         }
         msgpack::MapDocNode &RootMap = Root.getMap();
         msgpack::DocNode::MapTy::iterator KernelsIt =
@@ -940,36 +1009,60 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
           msgpack::MapDocNode &KMap = KNode.getMap();
           msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
           if (NameIt == KMap.end() || !NameIt->second.isString() ||
-              NameIt->second.getString() != KernelName)
+              KernelSgprCountCache.find(NameIt->second.getString()) !=
+                  KernelSgprCountCache.end())
             continue;
 
           msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
           if (SgprIt == KMap.end()) {
-            log() << "hotswap: error: getKernelSgprCount: metadata for kernel '"
-                  << KernelName << "' has no .sgpr_count.\n";
-            return std::nullopt;
+            KernelSgprCountCache.try_emplace(NameIt->second.getString(),
+                                             std::nullopt);
+            continue;
           }
-          return readSgprCountMetadataNode(SgprIt->second, KernelName,
-                                           "getKernelSgprCount");
+          StringRef Name = NameIt->second.getString();
+          KernelSgprCountCache.try_emplace(
+              Name,
+              readSgprCountMetadataNode(SgprIt->second, Name, "SGPR cache"));
         }
       }
       if (Err) {
-        log() << "hotswap: error: getKernelSgprCount: failed to iterate "
+        log() << "hotswap: error: SGPR cache: failed to iterate "
               << "AMDGPU notes: " << toString(std::move(Err)) << "\n";
-        return std::nullopt;
+        return;
       }
     }
   } else {
-    log() << "hotswap: error: getKernelSgprCount: failed to read program "
+    log() << "hotswap: error: SGPR cache: failed to read program "
           << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
-    return std::nullopt;
+    return;
   }
 
-  if (SawMetadataNote) {
+  SgprCacheState = SawMetadataNote ? KernelSgprCacheState::Metadata
+                                   : KernelSgprCacheState::NoMetadata;
+}
+
+std::optional<unsigned>
+ElfView::getKernelSgprCount(StringRef KernelName) const {
+  initializeKernelSgprCountCache();
+  if (SgprCacheState == KernelSgprCacheState::Error)
+    return std::nullopt;
+
+  StringMap<std::optional<unsigned>>::const_iterator Cached =
+      KernelSgprCountCache.find(KernelName);
+  if (SgprCacheState == KernelSgprCacheState::Metadata) {
+    if (Cached != KernelSgprCountCache.end()) {
+      if (!Cached->second)
+        log() << "hotswap: error: getKernelSgprCount: metadata for kernel '"
+              << KernelName << "' has no valid .sgpr_count.\n";
+      return Cached->second;
+    }
     log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata has no "
           << ".sgpr_count entry for kernel '" << KernelName << "'.\n";
     return std::nullopt;
   }
+
+  if (Cached != KernelSgprCountCache.end())
+    return Cached->second;
 
   // --- Fallback: read the KD field. ---
   // The LLVM assembler populates GRANULATED_WAVEFRONT_SGPR_COUNT even on
@@ -977,8 +1070,10 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
   // ROCm-compiled code objects that lack a metadata note.
   namespace hsa = amdhsa;
   uint8_t *Kd = const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
-  if (!Kd)
+  if (!Kd) {
+    KernelSgprCountCache.try_emplace(KernelName, std::nullopt);
     return std::nullopt;
+  }
   uint32_t Rsrc1;
   std::memcpy(&Rsrc1,
               Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
@@ -992,7 +1087,9 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
           << KernelName << "' exceeds unsigned.\n";
     return std::nullopt;
   }
-  return static_cast<unsigned>(SgprCount);
+  std::optional<unsigned> Result = static_cast<unsigned>(SgprCount);
+  KernelSgprCountCache.try_emplace(KernelName, Result);
+  return Result;
 }
 
 // -- ElfView::getKernelClusterDims --------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
@@ -1,0 +1,243 @@
+//===- comgr-hotswap-entry-trampoline-fast.cpp - B0->B0 fast path ---------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// B0-on-B0 kernel-entry trampoline FAST PATH. Mirrors the ROCr loader
+/// trampoline: no LLVM MC layer (no initLLVM, no assembler, no disassembler).
+/// The stub is emitted from a pre-encoded gfx1250 byte template with only the
+/// two PC-relative delta immediates patched in, using a fixed s[100:101]
+/// scratch pair (so no per-kernel SGPR read and no descriptor SGPR-reservation
+/// update). Idempotency and the compile-time-workaround skip are decided by raw
+/// byte comparison rather than decoding.
+///
+/// This path is selected automatically for pure B0->B0 entry-only rewrites
+/// (no B0->A0 instruction patches, no mask workaround). The MC-based path in
+/// comgr-hotswap-entry-trampoline.cpp handles A0 and any rewrite that needs
+/// instruction patches.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Endian.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+// Pre-encoded gfx1250 stub template (fixed s[100:101]). Ground-truth encodings
+// from llvm-mc -mcpu=gfx1250 (little-endian). The body is 40 bytes and is
+// padded to KernelEntryStubStride (256) with s_code_end. s_get_pc_i64 loads the
+// address of the instruction after it (s_add, at StubVAddr +
+// FastEntryPcBaseOffset), which is the base for the PC-relative delta.
+// clang-format off
+static constexpr uint8_t StubTemplate[FastEntryStubBodyBytes] = {
+    0x7c, 0x00, 0x0b, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // global_wb
+    0x00, 0x00, 0x00, 0x7e,                                                 // v_nop
+    0x00, 0x47, 0xe4, 0xbe,                                                 // s_get_pc_i64 s[100:101]
+    0x64, 0xff, 0x64, 0x80, 0x00, 0x00, 0x00, 0x00,                         // s_add_co_u32 s100,s100,imm32 (imm@24)
+    0x65, 0xff, 0x65, 0x82, 0x00, 0x00, 0x00, 0x00,                         // s_add_co_ci_u32 s101,s101,imm32 (imm@32)
+    0x64, 0x48, 0x80, 0xbe,                                                 // s_set_pc_i64 s[100:101]
+};
+
+static constexpr uint8_t SCodeEnd[4] = {0x00, 0x00, 0x9f, 0xbf};
+static constexpr uint8_t SNop[4] = {0x00, 0x00, 0x80, 0xbf};
+
+// global_wb; v_nop prefix (16 bytes), for raw idempotency / workaround detection.
+static constexpr uint8_t EntryPrefix[FastEntryPrefixBytes] = {
+    0x7c, 0x00, 0x0b, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x7e,
+};
+// clang-format on
+
+SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
+                                                    uint64_t EntryVAddr) {
+  SmallVector<uint8_t> Bytes;
+  Bytes.resize(KernelEntryStubStride);
+  std::memcpy(Bytes.data(), StubTemplate, FastEntryStubBodyBytes);
+
+  // Materialize EntryVAddr relative to the s_get_pc base. Two's complement, so
+  // back-jumps are handled.
+  const uint64_t PcBase = StubVAddr + FastEntryPcBaseOffset;
+  const uint64_t Delta = EntryVAddr - PcBase;
+  llvm::support::endian::write32le(Bytes.data() + FastEntryDeltaLoOffset,
+                                   static_cast<uint32_t>(Delta));
+  llvm::support::endian::write32le(Bytes.data() + FastEntryDeltaHiOffset,
+                                   static_cast<uint32_t>(Delta >> 32));
+
+  // Pad to stride with s_code_end (prefetch-safe; never executed).
+  for (uint64_t Off = FastEntryStubBodyBytes; Off < KernelEntryStubStride;
+       Off += sizeof(SCodeEnd))
+    std::memcpy(Bytes.data() + Off, SCodeEnd, sizeof(SCodeEnd));
+  return Bytes;
+}
+
+// Raw byte check: does the descriptor's current entry already begin with
+// global_wb; v_nop (either a hotswap fast stub already installed, or the
+// compile-time unclaused-VMEM workaround prologue)? Both mean "do not add a
+// trampoline".
+static std::optional<bool>
+entryHasWorkaroundPrefixFast(const ElfView &Elf,
+                             const KernelDescriptorInfo &KD) {
+  std::optional<uint64_t> Entry = entryVAddr(KD);
+  if (!Entry)
+    return std::nullopt;
+  const uint8_t *EntryBytes = Elf.dataAtVAddr(*Entry, FastEntryPrefixBytes);
+  if (!EntryBytes)
+    return false;
+  return std::memcmp(EntryBytes, EntryPrefix, FastEntryPrefixBytes) == 0;
+}
+
+static bool appendPaddingFast(std::vector<Trampoline> &Out, uint64_t PadBytes) {
+  if (PadBytes == 0)
+    return true;
+  if (PadBytes % sizeof(SNop) != 0) {
+    log() << "hotswap: error: fast entry-stub padding " << PadBytes
+          << " is not a multiple of s_nop size.\n";
+    return false;
+  }
+  Trampoline Pad;
+  Pad.Bytes.reserve(PadBytes);
+  while (static_cast<uint64_t>(Pad.Bytes.size()) < PadBytes)
+    Pad.Bytes.append(SNop, SNop + sizeof(SNop));
+  Out.push_back(std::move(Pad));
+  return true;
+}
+
+std::optional<uint32_t> appendKernelEntryTrampolinesFast(
+    const ElfView &Elf, StringRef TargetCpu, std::vector<Trampoline> &Growth,
+    std::vector<KernelEntryTrampolineFixup> &OutFixups) {
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  if (Descriptors.empty())
+    return 0;
+
+  struct WorkItem {
+    KernelDescriptorInfo KD;
+    uint32_t StubInstPrefLines = 0;
+  };
+  std::vector<WorkItem> Work;
+  uint32_t MaxStubInstPrefLines = 0;
+
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    // Skip if the entry already carries the workaround (already-installed fast
+    // stub, or a compile-time global_wb; v_nop prologue). Raw byte check.
+    std::optional<bool> HasPrefix = entryHasWorkaroundPrefixFast(Elf, KD);
+    if (!HasPrefix)
+      return std::nullopt;
+    if (*HasPrefix) {
+      log() << "hotswap: fast: kernel '" << KD.KernelName
+            << "' entry already has global_wb; v_nop; skipping trampoline\n";
+      continue;
+    }
+    std::optional<uint32_t> OriginalInstPrefLines =
+        Elf.getKernelDescriptorInstPrefSize(KD.KernelName, TargetCpu);
+    if (!OriginalInstPrefLines)
+      return std::nullopt;
+    uint32_t StubInstPrefLines =
+        std::min(*OriginalInstPrefLines, KernelEntryStubInstPrefLines);
+    MaxStubInstPrefLines = std::max(MaxStubInstPrefLines, StubInstPrefLines);
+    Work.push_back({KD, StubInstPrefLines});
+  }
+  if (Work.empty())
+    return 0;
+
+  uint64_t AppendOffset = 0;
+  for (const Trampoline &T : Growth)
+    AppendOffset += T.Bytes.size();
+
+  std::optional<uint64_t> PoolVAddrOr = Elf.trampolinePoolVAddr();
+  if (!PoolVAddrOr)
+    return std::nullopt;
+  const uint64_t PoolVAddr = *PoolVAddrOr;
+
+  std::optional<uint64_t> StubPoolBaseVAddr =
+      checkedAddUint64(PoolVAddr, AppendOffset, "fast entry stub-pool base");
+  if (!StubPoolBaseVAddr)
+    return std::nullopt;
+  std::optional<uint64_t> AlignedBase =
+      checkedAlignTo(*StubPoolBaseVAddr, KernelEntryStubStride,
+                     "fast entry trampoline aligned stub-pool base");
+  if (!AlignedBase)
+    return std::nullopt;
+  const uint64_t StubStart = *AlignedBase - PoolVAddr;
+
+  std::vector<Trampoline> LocalGrowth;
+  std::vector<KernelEntryTrampolineFixup> LocalFixups;
+  if (!appendPaddingFast(LocalGrowth, StubStart - AppendOffset))
+    return std::nullopt;
+  AppendOffset = StubStart;
+
+  for (const WorkItem &Item : Work) {
+    const KernelDescriptorInfo &KD = Item.KD;
+    std::optional<uint64_t> StubVAddr = checkedAddUint64(
+        PoolVAddr, AppendOffset,
+        (Twine("fast entry trampoline vaddr for '") + KD.KernelName + "'")
+            .str());
+    if (!StubVAddr)
+      return std::nullopt;
+    std::optional<uint64_t> Entry = entryVAddr(KD);
+    if (!Entry)
+      return std::nullopt;
+
+    Trampoline T;
+    T.Bytes = buildKernelEntryTrampolineFast(*StubVAddr, *Entry);
+    LocalGrowth.push_back(std::move(T));
+
+    // Fixed s[100:101]: no per-kernel SGPR read, and SkipSgprReservation tells
+    // the descriptor rewrite to leave the logical SGPR count unchanged.
+    LocalFixups.push_back({KD.KernelName, AppendOffset, /*RequiredSgprs=*/0,
+                           Item.StubInstPrefLines,
+                           /*SkipSgprReservation=*/true});
+
+    std::optional<uint64_t> NewAppendOffset = checkedAddUint64(
+        AppendOffset, KernelEntryStubStride,
+        (Twine("fast entry append offset after '") + KD.KernelName + "'")
+            .str());
+    if (!NewAppendOffset)
+      return std::nullopt;
+    AppendOffset = *NewAppendOffset;
+  }
+
+  // Prefetch guard sized like the MC path (shared helper).
+  const uint64_t GuardBytes =
+      computeKernelEntryPrefetchGuardBytes(MaxStubInstPrefLines);
+  if (GuardBytes != 0) {
+    Trampoline Guard;
+    Guard.Bytes.reserve(GuardBytes);
+    for (uint64_t Off = 0; Off < GuardBytes; Off += sizeof(SCodeEnd))
+      Guard.Bytes.append(SCodeEnd, SCodeEnd + sizeof(SCodeEnd));
+    LocalGrowth.push_back(std::move(Guard));
+  }
+
+  if (LocalFixups.empty())
+    return 0;
+  if (LocalFixups.size() > std::numeric_limits<uint32_t>::max()) {
+    log() << "hotswap: error: fast kernel-entry trampoline count "
+          << LocalFixups.size() << " exceeds uint32_t.\n";
+    return std::nullopt;
+  }
+
+  for (Trampoline &T : LocalGrowth)
+    Growth.push_back(std::move(T));
+  OutFixups.insert(OutFixups.end(), LocalFixups.begin(), LocalFixups.end());
+
+  log() << "hotswap: fast: installed " << LocalFixups.size()
+        << " kernel-entry trampoline" << (LocalFixups.size() == 1 ? "" : "s")
+        << " (no-disasm, fixed s[100:101]) with " << GuardBytes
+        << " prefetch guard bytes\n";
+  return static_cast<uint32_t>(LocalFixups.size());
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -484,7 +484,7 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
     const ElfView &Elf, const LLVMState &LS, unsigned MaxSgprs,
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups) {
-  std::vector<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   if (Descriptors.empty())
     return 0;
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -279,8 +279,8 @@ bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
          std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
 }
 
-static std::optional<uint64_t>
-checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
+std::optional<uint64_t> checkedAlignTo(uint64_t Value, uint64_t Alignment,
+                                       StringRef Context) {
   if (Alignment == 0)
     return Value;
 
@@ -290,7 +290,7 @@ checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
   return checkedAddUint64(Value, Alignment - Remainder, Context);
 }
 
-static std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
+std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   if (KD.EntryOffset >= 0)
     return checkedAddUint64(
         KD.VAddr, static_cast<uint64_t>(KD.EntryOffset),
@@ -308,11 +308,9 @@ static std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   return KD.VAddr - Magnitude;
 }
 
-static std::optional<bool>
-descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
-                                  const KernelDescriptorInfo &KD,
-                                  const LLVMState &LS,
-                                  ArrayRef<uint8_t> EntryStubPrefix) {
+static std::optional<bool> descriptorAlreadyTargetsEntryStub(
+    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS,
+    ArrayRef<uint8_t> EntryStubPrefix) {
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
@@ -337,8 +335,8 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
     return false;
 
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(Candidate, LS,
-                             Decoded, "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+                             "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;
@@ -671,9 +669,13 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
-        Fixup.KernelName, Fixup.RequiredSgprs,
-        /*UpdateDescriptor=*/false);
+    // The fast path leaves the logical SGPR reservation unchanged (fixed
+    // s[100:101]), so skip the descriptor SGPR-count update entirely.
+    bool UpdatedSgprs = Fixup.SkipSgprReservation
+                            ? true
+                            : OutElf.updateKernelDescriptorSgprCount(
+                                  Fixup.KernelName, Fixup.RequiredSgprs,
+                                  /*UpdateDescriptor=*/false);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -28,6 +28,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "llvm/ADT/ArrayRef.h"
@@ -292,8 +293,9 @@ public:
   uint8_t *findKernelDescriptor(llvm::StringRef KernelName);
 
   /// Enumerate kernel descriptor symbols named "<kernel>.kd" and read their
-  /// current kernel_code_entry_byte_offset values.
-  std::vector<KernelDescriptorInfo> kernelDescriptors() const;
+  /// current kernel_code_entry_byte_offset values. The returned range remains
+  /// valid until this ElfView is destroyed.
+  llvm::ArrayRef<KernelDescriptorInfo> kernelDescriptors() const;
 
   /// Return the virtual address of the kernel descriptor symbol for
   /// \p KernelName, or std::nullopt when the descriptor is not present.
@@ -310,6 +312,11 @@ public:
   bool updateKernelDescriptorSgprCount(llvm::StringRef KernelName,
                                        unsigned RequiredSgprs,
                                        bool UpdateDescriptor = true);
+
+  /// Update metadata SGPR counts for every named kernel in one parse and
+  /// serialization pass. All requested kernels must be present.
+  bool updateKernelMetadataSgprCounts(
+      const llvm::StringMap<unsigned> &RequiredSgprs);
 
   /// Retag every gfx1250 kernel in the AMDGPU metadata note with \p Revision.
   /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
@@ -391,15 +398,35 @@ public:
                       llvm::ArrayRef<uint8_t> SNopBytes) const;
 
 private:
+  enum class KernelSgprCacheState {
+    Uninitialized,
+    Metadata,
+    NoMetadata,
+    Error,
+  };
+
   ElfView(ELFFileT File, ELFT::ShdrRange Sections,
           const ELFT::Shdr *TextSection, unsigned TextSectionIndex)
       : File(std::move(File)), Sections(Sections), TextSection(TextSection),
         TextSectionIndex(TextSectionIndex) {}
 
+  llvm::ArrayRef<FunctionTextRange> cachedFunctionTextRanges() const;
+  const FunctionTextRange *
+  findFunctionTextRangeAtAddress(uint64_t TextAddress) const;
+  void initializeKernelDescriptorCache() const;
+  void initializeKernelSgprCountCache() const;
+
   ELFFileT File;
   ELFT::ShdrRange Sections;
   const ELFT::Shdr *TextSection;
   unsigned TextSectionIndex;
+  mutable std::optional<std::vector<FunctionTextRange>> FunctionRangeCache;
+  mutable std::optional<std::vector<KernelDescriptorInfo>>
+      KernelDescriptorCache;
+  mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
+  mutable KernelSgprCacheState SgprCacheState =
+      KernelSgprCacheState::Uninitialized;
+  mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;
 };
 
 // -- Free-function ELF helpers (no ELF state required) ------------------------
@@ -728,6 +755,13 @@ struct KernelPatchStats {
   unsigned ScratchAboveKd = 0;
 };
 
+struct SafeSgprUsageSummary {
+  bool Valid = true;
+  bool UsesVcc = false;
+  bool HasCall = false;
+  unsigned HighWatermark = 0;
+};
+
 /// Mutable per-run context threaded through all patch passes. Bundles the
 /// input config, decoded instruction stream, raw .text bytes, MC state,
 /// output streams (trampolines / scratch info), and the shared ELF view +
@@ -753,6 +787,16 @@ struct PatchContext {
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;
   bool RequiredPatchApplied = false;
+  // Sum of the bytes already queued in OutTrampolines. Keeping this in the
+  // per-rewrite context makes each new pool-position calculation constant
+  // time even for code objects with many thousands of patch sites.
+  uint64_t QueuedTrampolineBytes = 0;
+  // Safe far-return scratch allocation can be queried at many patch sites in
+  // one function. Cache the immutable decoded SGPR usage summaries so each
+  // function, and the whole-object fallback, is scanned at most once.
+  std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
+      FunctionSgprUsage{0};
 };
 
 /// A block of numbered SGPRs that is not referenced in the function being
@@ -766,9 +810,8 @@ struct SafeSgprScratchBlock {
 /// Find an aligned block of unused numbered SGPRs for \p TextOffset. Returns
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
-findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
-                         unsigned Count, unsigned Alignment,
-                         llvm::StringRef Context);
+findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
+                         unsigned Alignment, llvm::StringRef Context);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -295,6 +295,11 @@ public:
                                        unsigned RequiredSgprs,
                                        bool UpdateDescriptor = true);
 
+  /// Retag every gfx1250 kernel in the AMDGPU metadata note with \p Revision.
+  /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
+  /// size, so this preserves the ELF layout.
+  bool updateGfx1250RevisionMetadata(llvm::StringRef Revision);
+
   /// Read COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
   std::optional<uint32_t>
   getKernelDescriptorInstPrefSize(llvm::StringRef KernelName,
@@ -716,6 +721,29 @@ struct PatchContext {
   bool RequiredPatchApplied = false;
 };
 
+/// A block of numbered SGPRs that is not referenced in the function being
+/// patched, or anywhere in the code object when the site may be reached by a
+/// call whose register requirements cannot be bounded locally.
+struct SafeSgprScratchBlock {
+  unsigned Base = 0;
+  unsigned Count = 0;
+};
+
+/// Find an aligned block of unused numbered SGPRs for \p TextOffset. Returns
+/// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
+std::optional<SafeSgprScratchBlock>
+findSafeSgprScratchBlock(const PatchContext &Ctx, uint64_t TextOffset,
+                         unsigned Count, unsigned Alignment,
+                         llvm::StringRef Context);
+
+/// Charge a previously selected global block to the kernel owning \p
+/// TextOffset. If the site is in an ordinary device function, conservatively
+/// charge every kernel descriptor because the ELF does not carry a complete
+/// call graph.
+bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
+                                const SafeSgprScratchBlock &Block,
+                                llvm::StringRef Context);
+
 // -- Trampoline emission helpers (defined in comgr-hotswap-b0a0.cpp) ----------
 
 [[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
@@ -880,8 +908,9 @@ bool rewriteKernelEntryDescriptorOffsets(
 /// virtual addresses, program headers, or relocations change; `.dynsym` (used
 /// by the loader) is left untouched.
 std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex, uint64_t TextAddr,
-    uint64_t OldTextSize, llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex,
+    uint64_t TextAddr, uint64_t OldTextSize,
+    llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -99,13 +99,27 @@ struct Trampoline {
   uint64_t OriginalOffset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
-  // When set, both edges use an s_add_pc_i64 long branch instead of s_branch
-  // (reaches anywhere, no scratch reg, no SCC). Set when the appended pool is
-  // beyond s_branch's +-128 KB reach; widens the reserved branch-back slot.
+  // When set, the pool is beyond s_branch reach. The source site branches to a
+  // nearby NOP gateway, which uses the scratch-backed pre-Gen5 set-PC sequence
+  // to reach the pool without executing s_add_pc_i64.
   bool Long = false;
-  // The branch-back is already present at the end of Bytes. Used by required
-  // far patches whose backward edge cannot use s_add_pc_i64 on gfx1250 A0.
-  bool PreEncodedBack = false;
+  bool UsesSetPCBack = false;
+  unsigned LongBranchSgprBase = 0;
+  bool HasPoolBranchIsland = false;
+  uint64_t PoolBranchIslandOffset = 0;
+  bool UsesShortBranchForward = false;
+  bool UsesDirectSetPCForward = false;
+  llvm::SmallVector<uint8_t> DirectSetPCForwardBytes;
+  llvm::SmallVector<uint64_t, 4> ForwardBranchIslands;
+  uint64_t ForwardBranchTargetOffset = 0;
+  bool HasForwardGateway = false;
+  uint64_t ForwardGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> ForwardGatewayBytes;
+  // A far-site run may only be coalesced within one known function. Unknown
+  // ranges stay unmerged because adjacent symbols are independent entries.
+  bool HasFunctionRange = false;
+  uint64_t FunctionStart = 0;
+  uint64_t FunctionEnd = 0;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -168,13 +182,15 @@ static constexpr uint64_t MinNopSledSize = 8;
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
 
-// s_add_pc_i64 long-branch encoded sizes: 8 bytes for a forward (32-bit
-// literal) offset, 12 for a backward (64-bit literal) one. The back slot
-// reserves the max; unused tail bytes are s_nop-padded. emitToTrampoline picks
-// the long path only when a short s_branch cannot reach the site's exact pool
-// offset on either edge (computed from the already-queued trampolines).
-static constexpr uint32_t LongBranchFwdBytes = 8;
-static constexpr uint32_t LongBranchMaxBytes = 12;
+// Fixed reservation for the SCC-preserving set-PC return. The assembled
+// sequence is 28 bytes for a same-object forward or backward delta.
+static constexpr uint32_t SetPcReturnReserveBytes = 28;
+
+// A gateway needs at least 20 bytes when incoming SCC is proven dead. Live SCC
+// uses the 28-byte preserving sequence.
+static constexpr uint32_t SetPcMinGatewayBytes = 20;
+static constexpr uint32_t SetPcForwardSequenceBytes = 28;
+static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
 // LLVMState::encodeSBranch to reject out-of-range branches before handing
@@ -485,6 +501,23 @@ struct LLVMState {
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
 
+  /// MC identities used by far-trampoline relocation analysis. Each opcode is
+  /// resolved once through the asm parser so policy code never compares
+  /// disassembled mnemonic strings.
+  unsigned SClauseOpcode = 0;
+  unsigned SDelayAluOpcode = 0;
+  unsigned SEndPgmOpcode = 0;
+  unsigned SEndPgmSavedOpcode = 0;
+  unsigned SAddPcI64Opcode = 0;
+  unsigned SCallI64Opcode = 0;
+  unsigned SSwapPcI64Opcode = 0;
+  unsigned SPrefetchInstPcRelOpcode = 0;
+  unsigned SPrefetchDataPcRelOpcode = 0;
+
+  /// SCC, recovered from the implicit definition on a parsed scalar compare.
+  /// This avoids scanning target register names in policy code.
+  llvm::MCRegister SCCRegister;
+
   bool Valid = false;
 
   /// Encode a relative `s_branch` from \p FromOffset to \p ToOffset and
@@ -506,6 +539,7 @@ struct InternalDecodedInst {
   uint32_t Size = 0;
   llvm::MCInst Inst;
   std::string Mnemonic;
+  bool DecodeSucceeded = false;
 };
 
 // -- Function declarations (LLVM MC layer) ------------------------------------
@@ -751,28 +785,30 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                  llvm::ArrayRef<uint8_t> Replacement);
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement,
-                                    bool AllowSafeFarReturn = false);
+                                    llvm::ArrayRef<uint8_t> Replacement);
 
-// Encode an s_add_pc_i64 PC-relative long branch from \p FromOffset to
-// \p TargetOffset (.text byte offsets). Exposed for unit testing the offset
-// math / encoding. Returns empty on failure.
-llvm::SmallVector<uint8_t> encodeLongBranch(const LLVMState &LS,
-                                            uint64_t FromOffset,
-                                            uint64_t TargetOffset);
-
-// Encode an SCC-neutral PC-relative long branch through an aligned SGPR pair.
-// s_get_pc_i64 captures the next instruction's PC, s_add_nc_u64 applies the
-// two's-complement delta without reading or writing SCC, and s_set_pc_i64
-// transfers control. Exposed for unit testing the offset math and register
-// constraints. Returns std::nullopt after logging the specific failure.
+/// Encode an SCC-preserving indirect long branch using three numbered SGPRs:
+/// an aligned PC pair at \p SgprBase and an SCC-save temporary at Base + 2.
+/// The displacement is materialized as two 32-bit literals; no
+/// s_add_pc_i64 or 64-bit literal is emitted.
 std::optional<llvm::SmallVector<uint8_t>>
-encodeSccNeutralLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                           uint64_t TargetOffset, unsigned SgprBase);
+encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
+                      uint64_t TargetOffset, unsigned SgprBase);
+
+/// Return whether an s_branch at \p From can encode \p To, including the
+/// instruction-relative PC base, alignment, signed range, and overflow checks.
+bool isSBranchReachable(uint64_t From, uint64_t To);
+
+/// Evaluate a statically direct branch or call target from its decoded MCInst.
+/// Uses MCInstrAnalysis where supported and the documented gfx1250 s_call_i64
+/// operand fallback otherwise.
+std::optional<uint64_t>
+evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                const LLVMState &LS);
+
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement,
-                                       bool AllowSafeFarReturn = false);
+                                       llvm::ArrayRef<uint8_t> Replacement);
 
 /// Expand one decoded gfx1250 DS two-address instruction into the ordered
 /// single-address instruction sequence used by the trampoline patch. Exposed

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -132,6 +132,19 @@ static_assert(KernelEntryStubStride % KernelEntryInstPrefUnitBytes == 0,
 static constexpr uint32_t KernelEntryStubInstPrefLines =
     KernelEntryStubStride / KernelEntryInstPrefUnitBytes;
 
+// -- B0->B0 fast-path stub layout (see
+// comgr-hotswap-entry-trampoline-fast.cpp). Pre-encoded gfx1250 stub with fixed
+// s[100:101]; only the two PC-relative delta immediates are patched per kernel.
+// Offsets are into the 256-byte stub.
+static constexpr uint64_t FastEntryStubBodyBytes = 40; // through s_set_pc_i64
+static constexpr uint64_t FastEntryPrefixBytes =
+    16; // global_wb (12) + v_nop (4)
+static constexpr uint64_t FastEntryPcBaseOffset =
+    20; // addr of s_add (after s_get_pc)
+static constexpr uint64_t FastEntryDeltaLoOffset = 24; // imm32 in s_add_co_u32
+static constexpr uint64_t FastEntryDeltaHiOffset =
+    32; // imm32 in s_add_co_ci_u32
+
 struct KernelDescriptorInfo {
   std::string KernelName;
   uint64_t VAddr = 0;
@@ -932,6 +945,11 @@ struct KernelEntryTrampolineFixup {
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
   uint32_t InstPrefLines = 0;
+  // The fast path uses a fixed s[100:101] scratch pair that is never a live
+  // kernel input, so the logical SGPR reservation is unchanged and the
+  // descriptor SGPR-count update is skipped. The MC path allocates a per-kernel
+  // pair and leaves this false.
+  bool SkipSgprReservation = false;
 };
 
 /// Build a 256-byte, entry-aligned HotSwap kernel-entry stub at
@@ -973,6 +991,28 @@ bool rewriteKernelEntryDescriptorOffsets(
     llvm::WritableMemoryBuffer &OutBuf, uint64_t PoolVAddr,
     llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+
+/// Resolve the virtual address of a kernel descriptor's entry point. Shared by
+/// the MC and fast entry-trampoline paths.
+std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD);
+
+/// Round Value up to a multiple of Alignment, reporting overflow against
+/// Context. Shared by the MC and fast entry-trampoline paths.
+std::optional<uint64_t> checkedAlignTo(uint64_t Value, uint64_t Alignment,
+                                       llvm::StringRef Context);
+
+/// B0->B0 FAST PATH (comgr-hotswap-entry-trampoline-fast.cpp): emit entry stubs
+/// from a pre-encoded gfx1250 byte template with fixed s[100:101] and no LLVM
+/// MC layer. Same append/fixup contract as appendKernelEntryTrampolines, but no
+/// per-kernel SGPR read and RequiredSgprs is left 0 (descriptor SGPR
+/// reservation unchanged). Selected automatically for pure B0->B0 entry-only
+/// rewrites.
+llvm::SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
+                                                          uint64_t EntryVAddr);
+std::optional<uint32_t> appendKernelEntryTrampolinesFast(
+    const ElfView &Elf, llvm::StringRef TargetCpu,
+    std::vector<Trampoline> &Growth,
+    std::vector<KernelEntryTrampolineFixup> &OutFixups);
 
 /// Add a `<kernel_name>.stub` STT_FUNC symbol to the code object's `.symtab`
 /// for each appended kernel-entry stub, so tools that resolve a dispatch's

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -340,6 +340,60 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_set_pc_i64 s[0:1]", "s_set_pc_i64", S,
                                      S.SSetPcI64Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_clause 0", "s_clause", S,
+                                     S.SClauseOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_delay_alu instid0(VALU_DEP_1)",
+                                     "s_delay_alu", S, S.SDelayAluOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_endpgm", "s_endpgm", S,
+                                     S.SEndPgmOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_endpgm_saved", "s_endpgm_saved", S,
+                                     S.SEndPgmSavedOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_pc_i64 0", "s_add_pc_i64", S,
+                                     S.SAddPcI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[0:1], 0", "s_call_i64", S,
+                                     S.SCallI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[0:1], s[2:3]",
+                                     "s_swap_pc_i64", S, S.SSwapPcI64Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_prefetch_inst_pc_rel 100, s10, 7",
+                                     "s_prefetch_inst_pc_rel", S,
+                                     S.SPrefetchInstPcRelOpcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_prefetch_data_pc_rel 100, s10, 7",
+                                     "s_prefetch_data_pc_rel", S,
+                                     S.SPrefetchDataPcRelOpcode))
+    return S;
+
+  SmallVector<MCInst, 2> SccDefInsts =
+      parseAsmToMCInsts("s_cmp_eq_u32 s0, s0", S);
+  if (SccDefInsts.size() != 1) {
+    log() << "hotswap: error: initLLVM: failed to parse an SCC-defining "
+             "scalar compare for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
+  const MCInstrDesc &SccDefDesc = S.MCII->get(SccDefInsts.front().getOpcode());
+  for (MCPhysReg Reg : SccDefDesc.implicit_defs()) {
+    if (S.SCCRegister.isValid()) {
+      log() << "hotswap: error: initLLVM: scalar compare has multiple "
+               "implicit definitions for CPU '"
+            << S.Cpu << "'.\n";
+      return S;
+    }
+    S.SCCRegister = MCRegister(Reg);
+  }
+  if (!S.SCCRegister.isValid()) {
+    log() << "hotswap: error: initLLVM: scalar compare has no implicit SCC "
+             "definition for CPU '"
+          << S.Cpu << "'.\n";
+    return S;
+  }
 
   S.Valid = true;
   return S;
@@ -407,6 +461,7 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Size = MinInstSize;
       DI.Mnemonic = UnknownMnemonic.str();
     } else {
+      DI.DecodeSucceeded = true;
       DI.Size = static_cast<uint32_t>(InstSize);
       // MCInstPrinter::getMnemonic returns a pointer into the generated AsmStrs
       // table. Storage is process-lifetime static; the trailing whitespace

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -11,8 +11,6 @@
 ///
 ///   - cluster_load             -> global_load    (opcode swap via MCInst +
 ///                                                 MCCodeEmitter)
-///   - s_clause                 -> s_nop          (byte-level overwrite via
-///                                                 applyByteReplace)
 ///   - s_barrier_signal_isfirst -> s_barrier_signal
 ///                                                (opcode swap; same operand
 ///                                                 layout, drops SCC write)
@@ -140,17 +138,6 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
               << " at 0x" << utohexstr(DI.Offset) << "\n";
         return 1;
       }
-    }
-  }
-
-  if (Mnemonic == "s_clause") {
-    RewriteRule Rule;
-    Rule.ReplaceBytes.assign(Ctx.LS.SNopBytes.begin(), Ctx.LS.SNopBytes.end());
-    if (applyByteReplace(Rule, DI.Offset, DI.Size, Ctx.Text, Ctx.TextSize,
-                         Ctx.LS)) {
-      log() << "hotswap: inplace: s_clause -> s_nop at 0x"
-            << utohexstr(DI.Offset) << "\n";
-      return 1;
     }
   }
 

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -442,8 +442,7 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   }
 
   SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                           /*AllowSafeFarReturn=*/true))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
     return failRequiredPatch(Ctx);
 
   DI.Mnemonic = "<replaced>";
@@ -825,8 +824,7 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     Replacement.append(PackBytes.begin(), PackBytes.end());
     Replacement.append(OrigInst, OrigInst + DI.Size);
     Replacement.append(Restore.begin(), Restore.end());
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                             /*AllowSafeFarReturn=*/true))
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
       return failRequiredPatch(Ctx);
 
     if (!commitSafeSgprScratchBlock(Ctx, DI.Offset, *Scratch,
@@ -838,8 +836,7 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     SmallVector<uint8_t> Replacement;
     Replacement.append(PackBytes.begin(), PackBytes.end());
     Replacement.append(OrigInst, OrigInst + DI.Size);
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                             /*AllowSafeFarReturn=*/true))
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
       return failRequiredPatch(Ctx);
 
     log() << "hotswap: tensor_load_to_lds: " << BaseSreg

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -222,7 +222,7 @@ extractDsOperands(const MCInst &Inst, StringRef FromMnem, const LLVMState &LS) {
           << RawOff0 << " * scale " << Scale << " = " << Scaled0
           << ", off1=raw " << RawOff1 << " * scale " << Scale << " = "
           << Scaled1 << ", max " << Ds1AddrOffsetMax
-          << "); leaving original instruction in place\n";
+          << "); required A0 rewrite cannot continue\n";
     return std::nullopt;
   }
   Ops.Off0 = static_cast<uint32_t>(Scaled0);
@@ -282,12 +282,9 @@ std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
   // natural order is already safe.)
   SmallVector<MCRegister, 4> DstSubs = getDirectSubRegs(Ops.Regs[0], *Ops.MRI);
   const unsigned FirstHalfWidth = Ops.IsB64 ? 2 : 1;
-  bool AddrOverlapsFirst =
-      DstSubs.size() >= FirstHalfWidth &&
-      llvm::any_of(ArrayRef(DstSubs).take_front(FirstHalfWidth),
-                   [&](MCRegister Reg) {
-                     return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]);
-                   });
+  bool AddrOverlapsFirst = llvm::any_of(
+      ArrayRef(DstSubs).take_front(FirstHalfWidth),
+      [&](MCRegister Reg) { return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]); });
   if (AddrOverlapsFirst)
     return std::vector<std::string>{std::move(Second), std::move(First)};
   return std::vector<std::string>{std::move(First), std::move(Second)};
@@ -367,8 +364,9 @@ std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
       registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
       registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
   if (FirstClobbersSecond && SecondClobbersFirst) {
-    log() << "hotswap: ds_storexchg_2addr has cyclic destination/source "
-             "overlap; leaving original instruction in place\n";
+    log() << "hotswap: error: ds_storexchg_2addr has cyclic "
+             "destination/source overlap and cannot be split without scratch "
+             "VGPRs\n";
     return std::nullopt;
   }
   if (FirstClobbersSecond)
@@ -420,7 +418,7 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   std::optional<std::vector<std::string>> Expanded =
       expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
   if (!Expanded)
-    return false;
+    return failRequiredPatch(Ctx);
 
   std::string Combined;
   for (const std::string &Line : *Expanded)
@@ -440,12 +438,13 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-    return false;
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                           /*AllowSafeFarReturn=*/true))
+    return failRequiredPatch(Ctx);
 
   DI.Mnemonic = "<replaced>";
   return true;
@@ -768,9 +767,9 @@ void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
 // -- patchTensorLoadToLdsA0 -------------------------------------------------
 //
 // Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
-// descriptor's base SGPR. The A0 routing bits must remain clear for every
-// subsequent use of the descriptor, so normalize it persistently instead of
-// restoring the invalid B0 value after each tensor load.
+// descriptor's base SGPR. Preserve the architectural SGPR value when it is live
+// after the tensor instruction: the descriptor is a source operand, so the
+// rewrite must not make its temporary normalization visible to later code.
 
 bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -796,18 +795,56 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     return failRequiredPatch(Ctx);
   }
 
+  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
   const uint8_t *OrigInst = Ctx.Text + DI.Offset;
-  SmallVector<uint8_t> Replacement;
-  Replacement.append(PackBytes.begin(), PackBytes.end());
-  Replacement.append(OrigInst, OrigInst + DI.Size);
 
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
-                           /*AllowSafeFarReturn=*/true))
-    return failRequiredPatch(Ctx);
+  if (SgprLive) {
+    std::optional<SafeSgprScratchBlock> Scratch =
+        findSafeSgprScratchBlock(Ctx, DI.Offset, /*Count=*/1, /*Alignment=*/1,
+                                 "tensor_load_to_lds descriptor save");
+    if (!Scratch) {
+      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
+               "available\n";
+      return failRequiredPatch(Ctx);
+    }
 
-  log() << "hotswap: tensor_load_to_lds: persistently cleared multicast bits "
-           "in "
-        << BaseSreg << "\n";
+    std::string ScratchName = "s" + std::to_string(Scratch->Base);
+    SmallVector<uint8_t> Save = assembleSingleInst(
+        "s_mov_b32 " + ScratchName + ", " + BaseSreg, Ctx.LS);
+    SmallVector<uint8_t> Restore = assembleSingleInst(
+        "s_mov_b32 " + BaseSreg + ", " + ScratchName, Ctx.LS);
+    if (Save.empty() || Restore.empty()) {
+      log() << "hotswap: error: tensor_load_to_lds: failed to assemble "
+               "descriptor save/restore through "
+            << ScratchName << "\n";
+      return failRequiredPatch(Ctx);
+    }
+
+    SmallVector<uint8_t> Replacement;
+    Replacement.append(Save.begin(), Save.end());
+    Replacement.append(PackBytes.begin(), PackBytes.end());
+    Replacement.append(OrigInst, OrigInst + DI.Size);
+    Replacement.append(Restore.begin(), Restore.end());
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                             /*AllowSafeFarReturn=*/true))
+      return failRequiredPatch(Ctx);
+
+    if (!commitSafeSgprScratchBlock(Ctx, DI.Offset, *Scratch,
+                                    "tensor_load_to_lds descriptor save"))
+      return failRequiredPatch(Ctx);
+    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
+          << " live, save/restore via " << ScratchName << "\n";
+  } else {
+    SmallVector<uint8_t> Replacement;
+    Replacement.append(PackBytes.begin(), PackBytes.end());
+    Replacement.append(OrigInst, OrigInst + DI.Size);
+    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                             /*AllowSafeFarReturn=*/true))
+      return failRequiredPatch(Ctx);
+
+    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
+          << " dead, no save/restore needed\n";
+  }
 
   Ctx.RequiredPatchApplied = true;
   DI.Mnemonic = "<replaced>";

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -160,13 +160,13 @@ struct VOP3PWmmaLayout {
 // HasMatrixReuse=1 profile).
 constexpr VOP3PWmmaLayout LayoutK128Fp8Bf8 = {
     /*NumOperands=*/7, /*VDst=*/0, /*Src0=*/1, /*Src1=*/2,
-    /*Src2Mods=*/3, /*Src2=*/4};
+    /*Src2Mods=*/3,    /*Src2=*/4};
 
 // 32x16x128 f4: vdst, src0, src1, src2_modifiers, src2 (5 operands; no
 // matrix_*_reuse -- HasMatrixReuse=0 on the F4 profile).
 constexpr VOP3PWmmaLayout Layout32x16F4 = {
     /*NumOperands=*/5, /*VDst=*/0, /*Src0=*/1, /*Src1=*/2,
-    /*Src2Mods=*/3, /*Src2=*/4};
+    /*Src2Mods=*/3,    /*Src2=*/4};
 
 const VOP3PWmmaLayout &layoutFor(SplitKind Kind) {
   switch (Kind) {
@@ -182,8 +182,8 @@ const VOP3PWmmaLayout &layoutFor(SplitKind Kind) {
 
 constexpr unsigned VgprRegIdxMask = 0x3ff;
 
-const MCRegisterClass *
-findSmallestEnclosingClass(MCRegister Reg, const MCRegisterInfo &MRI) {
+const MCRegisterClass *findSmallestEnclosingClass(MCRegister Reg,
+                                                  const MCRegisterInfo &MRI) {
   thread_local const MCRegisterInfo *CachedMRI = nullptr;
   thread_local DenseMap<unsigned, const MCRegisterClass *> Cache;
 
@@ -236,8 +236,8 @@ struct WmmaOps {
 };
 
 std::optional<WmmaOps> extractWmmaOps(const MCInst &Inst,
-                                      const MCRegisterInfo &MRI,
-                                      SplitKind Kind, StringRef Mnemonic) {
+                                      const MCRegisterInfo &MRI, SplitKind Kind,
+                                      StringRef Mnemonic) {
   WmmaOps R;
   const VOP3PWmmaLayout &L = layoutFor(Kind);
 
@@ -285,7 +285,7 @@ std::optional<WmmaOps> extractWmmaOps(const MCInst &Inst,
 
 struct PrintedAsm {
   StringRef Mnemonic;
-  StringRef Operands[4]; // vdst, src0, src1, src2 (printer-canonical form)
+  StringRef Operands[4];    // vdst, src0, src1, src2 (printer-canonical form)
   StringRef ModifierSuffix; // includes leading space if non-empty
 };
 
@@ -392,16 +392,15 @@ std::optional<std::string> transformModifierSuffix(StringRef Suffix,
   std::string Out;
   for (StringRef T : tokenizeModifiers(Suffix)) {
     if (!isKnownSplitterModifier(T)) {
-      log() << "hotswap: error: WMMA split: unsupported modifier token \""
-            << T << "\" -- splitter modifier set must be updated\n";
+      log() << "hotswap: error: WMMA split: unsupported modifier token \"" << T
+            << "\" -- splitter modifier set must be updated\n";
       return std::nullopt;
     }
     if (T == "matrix_a_reuse" || T == "matrix_b_reuse")
       continue;
     std::array<StringRef, 3> Bits;
-    if (KSplitSecondHalf &&
-        (parsePackedModifier(T, "neg_lo", Bits) ||
-         parsePackedModifier(T, "neg_hi", Bits))) {
+    if (KSplitSecondHalf && (parsePackedModifier(T, "neg_lo", Bits) ||
+                             parsePackedModifier(T, "neg_hi", Bits))) {
       // Clear the src2 bit (third element of the [X,Y,Z] tuple). If the
       // remaining bits are all zero, drop the modifier entirely (matches
       // the printer's behavior of omitting an all-zero packed modifier).
@@ -548,8 +547,8 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
   Out.reserve(2);
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first, DstHalf),
-                        formatVgprRange(R.Src0.first, AHalf), B, CLo,
-                        FmtSuffix, *Mod)
+                        formatVgprRange(R.Src0.first, AHalf), B, CLo, FmtSuffix,
+                        *Mod)
                     .str());
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first + DstHalf, DstHalf),
@@ -653,8 +652,8 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
     return 0; // matched-but-failed (build*Asm rejected an unsupported modifier)
 
   // Assemble the split sequence and defer trampoline emission to
-  // emitToTrampoline, which picks a short s_branch or an s_add_pc_i64 long
-  // branch based on the site's distance from the appended pool.
+  // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
+  // gateway based on the site's distance from the appended pool.
   SmallVector<uint8_t> Replacement =
       assembleSingleInst(joinAsmLines(AsmLines), Ctx.LS);
   if (Replacement.empty()) {

--- a/amd/comgr/test-lit/hotswap-inplace-mixed.s
+++ b/amd/comgr/test-lit/hotswap-inplace-mixed.s
@@ -1,5 +1,5 @@
-// COM: Test HotSwap in-place patches: cluster_load -> global_load and
-// COM: s_clause -> s_nop replacements on a kernel containing both.
+// COM: Test HotSwap in-place cluster_load -> global_load patches and verify
+// COM: that valid s_clause instructions are preserved.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -10,24 +10,27 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=METADATA %s
 
 // COM: cluster_load mnemonics should be gone, replaced by global_load
 // DISASM-NOT: cluster_load_b32
 // DISASM-NOT: cluster_load_b128
 
-// COM: s_clause should be gone, replaced by s_nop
-// DISASM-NOT: s_clause
-
 // COM: Replacement global_load instructions should be present
 // DISASM-DAG: global_load_b32 v0
 // DISASM-DAG: global_load_b128 v[4:7]
 
-// COM: The s_nop replacement for s_clause
-// DISASM-DAG: s_nop
+// COM: Native A0 code generation preserves valid clauses.
+// DISASM: s_clause 0x1
 
 // COM: Original global_load instructions should still be there
 // DISASM-DAG: global_load_b32 v10
 // DISASM-DAG: global_load_b32 v11
+
+// COM: Every rewritten gfx1250 kernel must be labeled for A0.
+// METADATA-NOT: .gfx1250_revision: B0
+// METADATA: .gfx1250_revision: A0
 
 // COM: Idempotency: rewriting the patched output again should produce
 // COM: identical bytes.
@@ -62,3 +65,21 @@ test_inplace_kernel:
   .amdhsa_next_free_vgpr 12
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_inplace_kernel
+      .symbol: test_inplace_kernel.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 2
+      .vgpr_count: 12
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-noop.s
+++ b/amd/comgr/test-lit/hotswap-inplace-noop.s
@@ -1,5 +1,5 @@
-// COM: Test HotSwap passthrough: kernel with no cluster_load or s_clause
-// COM: should pass through unchanged.
+// COM: A kernel requiring no instruction rewrite still needs its gfx1250
+// COM: revision metadata retagged from B0 to A0.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -10,6 +10,8 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=METADATA %s
 
 // COM: Strict mode is accepted even when no strict rewrite matches.
 // RUN: hotswap-rewrite %t.elf \
@@ -23,6 +25,9 @@
 // DISASM-NOT: s_clause
 // DISASM: global_load_b32 v0
 // DISASM: s_endpgm
+
+// METADATA-NOT: .gfx1250_revision: B0
+// METADATA: .gfx1250_revision: A0
 
 // COM: Idempotency: output should be identical on second rewrite.
 // RUN: hotswap-rewrite %t.out.elf \
@@ -50,3 +55,21 @@ test_noop_kernel:
   .amdhsa_next_free_vgpr 4
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_noop_kernel
+      .symbol: test_noop_kernel.kd
+      .gfx1250_revision: B0
+      .sgpr_count: 2
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-fastpath.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-fastpath.s
@@ -1,0 +1,128 @@
+// COM: On a pure B0-to-B0 entry-only rewrite HotSwap takes the no-MC fast path:
+// COM: it emits each entry stub from a pre-encoded template with a fixed
+// COM: s[100:101] scratch pair, leaves the descriptor SGPR reservation
+// COM: unchanged, and adds no debug-only .stub symbols. A prologue that already
+// COM: carries the workaround is skipped.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.fast.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.fast.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The redirect is through the descriptor, so the kernel body is not
+// COM: rewritten in place.
+// DISASM-LABEL: <plain_kernel>:
+// DISASM-NEXT: s_setreg_imm32_b32
+// DISASM-NEXT: s_endpgm
+
+// COM: A prologue that already has global_wb; v_nop keeps its in-place
+// COM: workaround and gets no redirect stub.
+// DISASM-LABEL: <precompiled_wa_kernel>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_endpgm
+
+// COM: The appended stub uses the fixed s[100:101] pair, not a per-kernel pair
+// COM: like the MC path (which would emit s[8:9] here).
+// DISASM: s_get_pc_i64 s[100:101]
+// DISASM-NEXT: s_add_co_u32 s100
+// DISASM-NEXT: s_add_co_ci_u32 s101
+// DISASM-NEXT: s_set_pc_i64 s[100:101]
+
+// COM: The fast path adds no .stub symbols by default (the loader adds none;
+// COM: they are only a debugging aid).
+// RUN: %llvm-readelf -s %t.fast.elf | %FileCheck --check-prefix=NO-SYMS %s
+// NO-SYMS-NOT: .stub
+
+// COM: Fixed s[100:101] is never a live kernel input, so the logical SGPR
+// COM: reservation is left unchanged (the MC path would bump it).
+// RUN: %llvm-readelf --notes %t.fast.elf | %FileCheck --check-prefix=SGPR %s
+// SGPR: .name:           plain_kernel
+// SGPR: .sgpr_count:     8
+
+// COM: Byte-compare idempotency: a second pass recognizes the installed stub
+// COM: (and the in-place workaround) and is a no-op.
+// RUN: hotswap-rewrite %t.fast.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.fast2.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: cmp %t.fast.elf %t.fast2.elf
+
+// COM: AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 re-enables the .stub symbols on
+// COM: the fast path (e.g. for rocgdb).
+// RUN: env AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.syms.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-readelf -s %t.syms.elf | %FileCheck --check-prefix=SYMS %s
+// SYMS: plain_kernel.stub
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+// No workaround: expect a fast-path redirect stub.
+.globl plain_kernel
+.p2align 8
+.type plain_kernel,@function
+plain_kernel:
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  s_endpgm
+.Lplain_kernel_end:
+.size plain_kernel, .Lplain_kernel_end-plain_kernel
+
+// Prologue already carries the workaround: expect no stub.
+.globl precompiled_wa_kernel
+.p2align 8
+.type precompiled_wa_kernel,@function
+precompiled_wa_kernel:
+  global_wb
+  v_nop
+  s_endpgm
+.Lprecompiled_wa_kernel_end:
+.size precompiled_wa_kernel, .Lprecompiled_wa_kernel_end-precompiled_wa_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel plain_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel precompiled_wa_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: plain_kernel
+      .symbol: plain_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: precompiled_wa_kernel
+      .symbol: precompiled_wa_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
+++ b/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
@@ -1,0 +1,95 @@
+// COM: Exercise the large-object SGPR-usage caches with two patch sites in a
+// COM: function containing a direct call. The first site builds the per-function
+// COM: summary, the call promotes it to the whole-object summary, and the
+// COM: second site reuses both cached results. Non-NOP straight-line windows
+// COM: let each far site carry its set-PC sequence without a gateway.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: applied 2 instruction patches
+// LOG: hotswap: growWithTrampolines: appended 2 trampolines
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <test_large_usage_cache>:
+// DISASM: s_cselect_b32
+// DISASM: s_set_pc_i64
+// DISASM: s_call_i64
+// DISASM: s_cselect_b32
+// DISASM: s_set_pc_i64
+// DISASM: tensor_load_to_lds
+// DISASM: tensor_load_to_lds
+
+// META: .name:           test_large_usage_cache
+// META: .sgpr_count:     39
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_large_usage_cache
+.p2align 8
+.type test_large_usage_cache,@function
+test_large_usage_cache:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_mov_b32 s30, s30
+  s_call_i64 s[20:21], cache_helper
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_mov_b32 s31, s31
+  s_endpgm
+.Ltest_large_usage_cache_end:
+.size test_large_usage_cache, .Ltest_large_usage_cache_end-test_large_usage_cache
+
+.type cache_helper,@function
+cache_helper:
+  s_set_pc_i64 s[20:21]
+.Lcache_helper_end:
+.size cache_helper, .Lcache_helper_end-cache_helper
+
+// Keep the appended pool beyond short-branch reach without supplying NOP
+// padding that could bypass the straight-line expansion path above.
+.rept 70000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_large_usage_cache
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 34
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_large_usage_cache
+      .symbol: test_large_usage_cache.kd
+      .sgpr_count: 34
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -1,0 +1,94 @@
+// COM: A far source and trampoline can be connected entirely with short
+// COM: branches through safe alignment holes. Each hop preserves SCC and the
+// COM: trampoline return uses the accepted SGPR-backed set-PC sequence.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+
+// DISASM-LABEL: <test_branch_islands>:
+// DISASM-NEXT: s_delay_alu
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_0>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_1>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_branch
+// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_cselect_b32 s16, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[14:15]
+// DISASM-NEXT: s_add_co_u32 s14, s14,
+// DISASM-NEXT: s_add_co_ci_u32 s15, s15,
+// DISASM-NEXT: s_cmp_lg_u32 s16, 0
+// DISASM-NEXT: s_set_pc_i64 s[14:15]
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_branch_islands
+.p2align 8
+.type test_branch_islands,@function
+test_branch_islands:
+  s_delay_alu instid0(SALU_CYCLE_1)
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_endpgm
+.size test_branch_islands, .-test_branch_islands
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.type gateway_0,@function
+gateway_0:
+  s_endpgm
+.size gateway_0, .-gateway_0
+.fill 4, 1, 0
+
+.rept 25000
+  s_mov_b32 s0, s1
+.endr
+
+.type gateway_1,@function
+gateway_1:
+  s_endpgm
+.size gateway_1, .-gateway_1
+.fill 4, 1, 0
+
+.rept 15000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_branch_islands
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_branch_islands
+      .symbol: test_branch_islands.kd
+      .sgpr_count: 14
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -8,6 +8,21 @@
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
+// COM: Exercise the large-object planning path with verbose accounting. This
+// COM: fixture contains more than 250 KiB of text and requires a deterministic
+// COM: forward branch-island chain.
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.scale.elf 2>&1 | %FileCheck --check-prefix=SCALE %s
+// SCALE: hotswap: assigned 1 forward s_branch island chain(s)
+// SCALE: hotswap: applied 1 instruction patches
+// SCALE: hotswap: growWithTrampolines: appended 1 trampoline
+
+// RUN: hotswap-rewrite %t.scale.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=SCALE-IDEM %s
+// SCALE-IDEM: IDEMPOTENT: YES
+
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -1,0 +1,123 @@
+// COM: A far patch can live in an ordinary device function shared by multiple
+// COM: kernels. The tensor descriptor save and set-PC return safely reuse one
+// COM: global scratch block, charged to both possible callers.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <device_tensor>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-NEXT: s_nop
+// DISASM-LABEL: <kernel_b>:
+// DISASM: s_endpgm
+// DISASM-NEXT: s_cselect_b32 s68, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[66:67]
+// DISASM-NEXT: s_add_co_u32 s66, s66,
+// DISASM-NEXT: s_add_co_ci_u32 s67, s67,
+// DISASM-NEXT: s_cmp_lg_u32 s68, 0
+// DISASM-NEXT: s_set_pc_i64 s[66:67]
+// DISASM: s_mov_b32 s66, s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s4, s66
+// DISASM-NEXT: s_cselect_b32 s68, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[66:67]
+// DISASM-NEXT: s_add_co_u32 s66, s66,
+// DISASM-NEXT: s_add_co_ci_u32 s67, s67,
+// DISASM-NEXT: s_cmp_lg_u32 s68, 0
+// DISASM-NEXT: s_set_pc_i64 s[66:67]
+
+// META: .name:           kernel_a
+// META: .sgpr_count:     71
+// META: .name:           kernel_b
+// META: .sgpr_count:     71
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.local device_tensor
+.type device_tensor,@function
+device_tensor:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_set_pc_i64 s[30:31]
+.Ldevice_tensor_end:
+.size device_tensor, .Ldevice_tensor_end-device_tensor
+
+.globl kernel_a
+.type kernel_a,@function
+kernel_a:
+  s_call_i64 s[30:31], device_tensor
+  s_endpgm
+.Lkernel_a_end:
+.size kernel_a, .Lkernel_a_end-kernel_a
+
+.globl kernel_b
+.type kernel_b,@function
+kernel_b:
+  s_call_i64 s[30:31], device_tensor
+  s_endpgm
+.Lkernel_b_end:
+.size kernel_b, .Lkernel_b_end-kernel_b
+
+// Safe external gateway space: it follows a no-fallthrough instruction and is
+// outside every function range, so it cannot be executed by fallthrough.
+.rept 8
+  s_nop 0
+.endr
+
+// Push the appended trampoline pool beyond s_branch reach without extending
+// any function symbol range.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel kernel_a
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdhsa_kernel kernel_b
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 48
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: kernel_a
+      .symbol: kernel_a.kd
+      .sgpr_count: 48
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: kernel_b
+      .symbol: kernel_b.kd
+      .sgpr_count: 48
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -3,12 +3,14 @@
 // COM: device functions (e.g. runTreeUpDown) contain ds_*_2addr sites that sit
 // COM: far (> s_branch's +-128 KB reach) from the appended trampoline pool in
 // COM: the ~225 MB fatbin. Taking the far path emitted an s_add_pc_i64 long
-// COM: branch whose BACKWARD branch-back corrupts wave state on gfx1250 A0,
-// COM: producing a GPU memory fault in ncclDevKernel_Generic_4 (0/10 runs).
+// COM: branch. On affected gfx1250 parts, even one execution can corrupt SGPR
+// COM: forwarding in another wave on the same SIMD, causing wrong results,
+// COM: hangs, or a GPU page fault.
 // COM:
-// COM: Required DS2 rewrites use the safe SCC-neutral scratch-SGPR return. The
-// COM: two kernels below force the far path for a 2-address load and store and
-// COM: verify both are split instead of returning unsafe B0 instructions.
+// COM: Fix: use the pre-Gen5 SGPR-backed set-PC sequence on both edges. Merge
+// COM: adjacent sites and bounded straight-line neighbors when they provide
+// COM: enough source bytes; otherwise short-branch through safe NOP padding.
+// COM: No path emits the broken instruction.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -22,32 +24,74 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // COM: Case 1 (2-address load, RCCL's pattern).
+// DISASM-NOT: s_add_pc_i64
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: s_add_pc_i64
+// DISASM-NEXT: s_branch
 
-// COM: Case 2 (2-address store).
+// COM: Case 2 (adjacent sites coalesced into a set-PC forward gateway).
+// DISASM-LABEL: <test_ds2addr_far_adjacent>:
+// DISASM-NEXT: s_cselect_b32 s4, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2, s2,
+// DISASM-NEXT: s_add_co_ci_u32 s3, s3, 0
+// DISASM-NEXT: s_cmp_lg_u32 s4, 0
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
+
+// COM: Case 3 (an interior direct-branch target must prevent coalescing).
+// DISASM-LABEL: <test_ds2addr_far_branch_target>:
+// DISASM-NEXT: s_cbranch_scc1
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+
+// COM: Case 4 (a direct-call target is also an interior entry point).
+// DISASM-LABEL: <test_ds2addr_far_call_target>:
+// DISASM-NEXT: s_call_i64
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+
+// COM: Case 5 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: s_add_pc_i64
+// DISASM-NEXT: s_branch
 
 // DISASM-NOT: ds_load_2addr
 // DISASM-NOT: ds_store_2addr
-// DISASM: ds_load_b64 v[0:1], v4 offset:512
-// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:1024
-// DISASM: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM: ds_load_b64 v[8:9], v12 offset:2560
+// DISASM-NEXT: ds_load_b64 v[10:11], v12 offset:3072
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: ds_load_b64 v[12:13], v16 offset:3584
+// DISASM-NEXT: ds_load_b64 v[14:15], v16 offset:4096
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_cselect_b32 s4, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2, s2,
+// DISASM-NEXT: s_add_co_ci_u32 s3, s3,
+// DISASM-NEXT: s_cmp_lg_u32 s4, 0
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 // DISASM: ds_store_b32 v2, v0 offset:256
 // DISASM-NEXT: ds_store_b32 v2, v1 offset:768
-// DISASM: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_cselect_b32 s4, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_co_u32 s2, s2,
+// DISASM-NEXT: s_add_co_ci_u32 s3, s3,
+// DISASM-NEXT: s_cmp_lg_u32 s4, 0
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 
 // METADATA: .name:           test_ds2addr_far_load
-// METADATA: .sgpr_count:     6
+// METADATA: .sgpr_count:     7
 // METADATA: .name:           test_ds2addr_far_store
-// METADATA: .sgpr_count:     6
+// METADATA: .sgpr_count:     7
+// METADATA: .name:           test_ds2addr_far_adjacent
+// METADATA: .sgpr_count:     7
+// METADATA: .name:           test_ds2addr_far_branch_target
+// METADATA: .sgpr_count:     7
+// METADATA: .name:           test_ds2addr_far_call_target
+// METADATA: .sgpr_count:     7
 
-// COM: Idempotency: rewriting the split output again is a no-op.
+// COM: Idempotency: rewriting the patched output again is a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
@@ -66,6 +110,45 @@ test_ds2addr_far_load:
 .Ltest_ds2addr_far_load_end:
 .size test_ds2addr_far_load, .Ltest_ds2addr_far_load_end-test_ds2addr_far_load
 
+.globl test_ds2addr_far_adjacent
+.p2align 8
+.type test_ds2addr_far_adjacent,@function
+test_ds2addr_far_adjacent:
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  ds_load_2addr_stride64_b64 v[8:11], v12 offset0:5 offset1:6
+  ds_load_2addr_stride64_b64 v[12:15], v16 offset0:7 offset1:8
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_adjacent_end:
+.size test_ds2addr_far_adjacent, .Ltest_ds2addr_far_adjacent_end-test_ds2addr_far_adjacent
+
+.globl test_ds2addr_far_branch_target
+.p2align 8
+.type test_ds2addr_far_branch_target,@function
+test_ds2addr_far_branch_target:
+  s_cbranch_scc1 .Lsecond_ds2addr
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lsecond_ds2addr:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_branch_target_end:
+.size test_ds2addr_far_branch_target, .Ltest_ds2addr_far_branch_target_end-test_ds2addr_far_branch_target
+
+.globl test_ds2addr_far_call_target
+.p2align 8
+.type test_ds2addr_far_call_target,@function
+test_ds2addr_far_call_target:
+  s_call_i64 s[0:1], .Lcalled_ds2addr
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lcalled_ds2addr:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_ds2addr_far_call_target_end:
+.size test_ds2addr_far_call_target, .Ltest_ds2addr_far_call_target_end-test_ds2addr_far_call_target
+
 .globl test_ds2addr_far_store
 .p2align 8
 .type test_ds2addr_far_store,@function
@@ -75,7 +158,7 @@ test_ds2addr_far_store:
   s_endpgm
   // ~160 KB of non-NOP filler (forms no usable sled) so the appended trampoline
   // pool is beyond s_branch's +-128 KB reach from both kernels above, forcing
-  // the far (long-branch) path -- which is declined on gfx1250 A0.
+  // the far (long-branch) path.
   .rept 40000
     s_mov_b32 s0, s1
   .endr
@@ -92,6 +175,21 @@ test_ds2addr_far_store:
 .amdhsa_kernel test_ds2addr_far_store
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_adjacent
+  .amdhsa_next_free_vgpr 17
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_branch_target
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_ds2addr_far_call_target
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel
 
 .amdgpu_metadata
@@ -113,6 +211,36 @@ test_ds2addr_far_store:
       .symbol: test_ds2addr_far_store.kd
       .sgpr_count: 1
       .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_adjacent
+      .symbol: test_ds2addr_far_adjacent.kd
+      .sgpr_count: 1
+      .vgpr_count: 17
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_branch_target
+      .symbol: test_ds2addr_far_branch_target.kd
+      .sgpr_count: 1
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_call_target
+      .symbol: test_ds2addr_far_call_target.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -6,13 +6,9 @@
 // COM: branch whose BACKWARD branch-back corrupts wave state on gfx1250 A0,
 // COM: producing a GPU memory fault in ncclDevKernel_Generic_4 (0/10 runs).
 // COM:
-// COM: Fix: decline far ds_*_2addr sites (leave the original instruction) until
-// COM: a scratch-register long branch-back lands. The two kernels below force
-// COM: the far path for a 2-addr LOAD and STORE and assert the decline: the
-// COM: original ds_*_2addr stays, and neither an s_add_pc_i64 redirect nor the
-// COM: single-address split (ds_load_b64 / ds_store_b32) is emitted. The near
-// COM: (sled / short-s_branch) ds_*_2addr path is still exercised and split by
-// COM: hotswap-trampoline-ds.s; only the far path changes here.
+// COM: Required DS2 rewrites use the safe SCC-neutral scratch-SGPR return. The
+// COM: two kernels below force the far path for a 2-address load and store and
+// COM: verify both are split instead of returning unsafe B0 instructions.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,21 +19,35 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
-// COM: Case 1 (2-addr LOAD, RCCL's pattern): declined -- original op stays, no
-// COM: forward long branch, no single-address split.
+// COM: Case 1 (2-address load, RCCL's pattern).
 // DISASM-LABEL: <test_ds2addr_far_load>:
-// DISASM-NEXT: ds_load_2addr_stride64_b64
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: ds_load_b64
+// DISASM-NEXT: s_add_pc_i64
 
-// COM: Case 2 (2-addr STORE): declined the same way.
+// COM: Case 2 (2-address store).
 // DISASM-LABEL: <test_ds2addr_far_store>:
-// DISASM-NEXT: ds_store_2addr_stride64_b32
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: ds_store_b32
+// DISASM-NEXT: s_add_pc_i64
 
-// COM: Idempotency: rewriting the declined output again is a no-op.
+// DISASM-NOT: ds_load_2addr
+// DISASM-NOT: ds_store_2addr
+// DISASM: ds_load_b64 v[0:1], v4 offset:512
+// DISASM-NEXT: ds_load_b64 v[2:3], v4 offset:1024
+// DISASM: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
+// DISASM: ds_store_b32 v2, v0 offset:256
+// DISASM-NEXT: ds_store_b32 v2, v1 offset:768
+// DISASM: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_nc_u64 s[2:3]
+// DISASM-NEXT: s_set_pc_i64 s[2:3]
+
+// METADATA: .name:           test_ds2addr_far_load
+// METADATA: .sgpr_count:     6
+// METADATA: .name:           test_ds2addr_far_store
+// METADATA: .sgpr_count:     6
+
+// COM: Idempotency: rewriting the split output again is a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
@@ -83,3 +93,30 @@ test_ds2addr_far_store:
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 1
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_ds2addr_far_load
+      .symbol: test_ds2addr_far_load.kd
+      .sgpr_count: 1
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_ds2addr_far_store
+      .symbol: test_ds2addr_far_store.kd
+      .sgpr_count: 1
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap-cyclic.s
@@ -1,0 +1,32 @@
+// COM: A cyclic destination/source dependency cannot be split into two
+// COM: sequential exchanges without scratch VGPRs. Returning the original B0
+// COM: DS2 instruction in an A0 object would be unsafe, so rewriting must fail.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+
+// CHECK: hotswap: error: ds_storexchg_2addr has cyclic destination/source overlap
+// CHECK-NOT: hotswap: error: ds_2addr expansion failed
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_ds_overlap_cyclic
+.p2align 8
+.type test_ds_overlap_cyclic,@function
+test_ds_overlap_cyclic:
+  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  s_wait_dscnt 0
+  s_endpgm
+.Ltest_ds_overlap_cyclic_end:
+.size test_ds_overlap_cyclic, .Ltest_ds_overlap_cyclic_end-test_ds_overlap_cyclic
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_ds_overlap_cyclic
+  .amdhsa_next_free_vgpr 25
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-overlap.s
@@ -17,9 +17,6 @@
 
 // DISASM-LABEL: <test_ds_overlap>:
 
-// COM: A cyclic exchange dependency has no safe ordering and is declined.
-// DISASM: ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset1:1
-
 // COM: Address overlaps the first b64 destination half: issue half 1 first.
 // DISASM:      ds_load_b64 v[14:15], v12 offset:8
 // DISASM-NEXT: ds_load_b64 v[12:13], v12
@@ -36,6 +33,21 @@
 // DISASM:      ds_storexchg_rtn_b64 v[10:11], v8, v[14:15] offset:8
 // DISASM-NEXT: ds_storexchg_rtn_b64 v[8:9], v8, v[12:13]
 
+// COM: A data1 dependency also reverses a b32 exchange.
+// DISASM:      ds_storexchg_rtn_b32 v31, v40, v30 offset:4
+// DISASM-NEXT: ds_storexchg_rtn_b32 v30, v40, v41
+
+// COM: A data0 dependency on destination half 1 keeps the natural order.
+// DISASM:      ds_storexchg_rtn_b32 v32, v40, v33
+// DISASM-NEXT: ds_storexchg_rtn_b32 v33, v40, v41 offset:4
+
+// COM: Stride64 loads and exchanges use the same dependency ordering while
+// COM: scaling offset1 by 64 elements.
+// DISASM:      ds_load_b64 v[44:45], v42 offset:512
+// DISASM-NEXT: ds_load_b64 v[42:43], v42
+// DISASM:      ds_storexchg_rtn_b64 v[48:49], v46, v[52:53] offset:512
+// DISASM-NEXT: ds_storexchg_rtn_b64 v[46:47], v46, v[50:51]
+
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
 .globl test_ds_overlap
@@ -46,7 +58,10 @@ test_ds_overlap:
   ds_load_2addr_b32 v[4:5], v4 offset0:1 offset1:2
   ds_load_2addr_b64 v[16:19], v18 offset0:0 offset1:1
   ds_storexchg_2addr_rtn_b64 v[8:11], v8, v[12:13], v[14:15] offset0:0 offset1:1
-  ds_storexchg_2addr_rtn_b64 v[20:23], v24, v[22:23], v[20:21] offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b32 v[30:31], v40, v41, v30 offset0:0 offset1:1
+  ds_storexchg_2addr_rtn_b32 v[32:33], v40, v33, v41 offset0:0 offset1:1
+  ds_load_2addr_stride64_b64 v[42:45], v42 offset0:0 offset1:1
+  ds_storexchg_2addr_stride64_rtn_b64 v[46:49], v46, v[50:51], v[52:53] offset0:0 offset1:1
   s_wait_dscnt 0x0
   s_endpgm
 .Ltest_ds_overlap_end:
@@ -55,6 +70,6 @@ test_ds_overlap:
 .rodata
 .p2align 8
 .amdhsa_kernel test_ds_overlap
-  .amdhsa_next_free_vgpr 25
+  .amdhsa_next_free_vgpr 54
   .amdhsa_next_free_sgpr 2
 .end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds2-offset-overflow.s
@@ -8,9 +8,9 @@
 // COM:   raw 128 * 512 = 65536  -- one past the limit
 // COM:   raw 255 * 512 = 130560 -- worst case
 // COM:
-// COM: When that happens the patch is not representable, so the trampoline
-// COM: must leave the original (broken-on-A0) instruction in place rather
-// COM: than emit a silently-truncated single-address replacement.
+// COM: When that happens the patch is not representable. Returning the
+// COM: original broken-on-A0 instruction would be unsafe, so the rewrite must
+// COM: fail rather than emit a silently truncated replacement.
 // COM:
 // COM: Coverage:
 // COM:   test_ds_load_b64_overflow : raw 128/255 -> scaled 65536/130560
@@ -26,25 +26,22 @@
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
 // RUN:   hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=LOG %s
 // COM: Pin the message shape (mnemonic, both raw + scaled values, the
-// COM: 16-bit limit, and the "leaving original instruction in place"
-// COM: closer) so a regression in the message format or the limit
-// COM: constant fails here, not in some downstream-symptoms test. The
-// COM: helper's specific message is the only diagnostic; patchDs2Addr does
-// COM: not mislabel this intentional safe decline with a second generic
-// COM: failure. RESULT: SUCCESS comes last because the rewrite as a whole
-// COM: succeeds (the in-range kernel is patched).
+// COM: 16-bit limit, and the required-rewrite failure closer) so a regression
+// COM: in the message format or the limit constant fails here, not in some
+// COM: downstream-symptoms test. The helper's specific message is the only
+// COM: diagnostic; patchDs2Addr does not add a second generic failure.
+// COM: RESULT: ERROR comes last because leaving the required A0 rewrite
+// COM: unapplied would be unsafe.
 // LOG:      hotswap: error: ds_load_2addr_stride64_b64 scaled offsets exceed
 // LOG-SAME: the single-address DS 16-bit field
 // LOG-SAME: off0=raw 128 * scale 512 = 65536
 // LOG-SAME: off1=raw 255 * scale 512 = 130560
 // LOG-SAME: max 65535
-// LOG-SAME: leaving original instruction in place
-// LOG:      RESULT: SUCCESS
-
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// LOG-SAME: required A0 rewrite cannot continue
+// LOG:      RESULT: ERROR
 
 // ---- Kernel 1: out-of-range -- patch must NOT fire --------------------------
 // COM: Both per-operand indices scale past 0xFFFF (off0:128 -> 65536,
@@ -132,12 +129,8 @@ test_ds_load_b64_inrange:
 // COM: the in-range kernel the body now uses plain ds_load_b64, which
 // COM: the dispatcher does not recognise, so it is also untouched. Net:
 // COM: byte-identical output between passes.
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
-// RUN:   hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --check-idempotent \
-// RUN:   | %FileCheck --check-prefix=IDEM %s
-// IDEM: IDEMPOTENT: YES
+// COM: No output is produced after a required-patch failure, so idempotency is
+// COM: intentionally not checked for the rejected object.
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -6,6 +6,8 @@
 // COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
 // COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
 // COM: pushes the pool past s_branch's reach to force the far case.
+// COM: The function intentionally has st_size == 0, matching Tensile objects
+// COM: that omit .size and exercising zero-size function-range recovery.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -49,7 +51,7 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=NO-PAIR %s
-// NO-PAIR: hotswap: error: safe far return: kernel test_far has no aligned SGPR pair below s106
+// NO-PAIR: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
 // NO-PAIR: RESULT: ERROR
 
 // COM: gfx10+ cannot represent an increased SGPR count in the kernel
@@ -83,7 +85,7 @@ test_far:
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:
-.size test_far, .Ltest_far_end-test_far
+// Deliberately no .size.
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,13 +1,8 @@
-// COM: HSV-009 / PLAT-205406: on gfx1250 A0 a backward s_add_pc_i64 corrupts
-// COM: wave state. Required far tensor patches use a forward s_add_pc_i64 and
-// COM: an SCC-neutral s_get_pc_i64/s_add_nc_u64/s_set_pc_i64 return instead.
-// COM:
-// COM: Optional far trampoline rewrites are still allowed to decline;
-// COM: hotswap-trampoline-ds-long-branch.s covers that behavior.
-// COM: A large .rept filler (~160 KB, non-NOP so it forms no usable sled)
+// COM: A0 cannot execute s_add_pc_i64. Both edges use an SGPR-backed set-PC
+// COM: sequence; the short source slot reaches that sequence through safe
+// COM: external zero-filled gateway space. A large non-NOP .rept filler
+// COM: (~160 KB)
 // COM: pushes the pool past s_branch's reach to force the far case.
-// COM: The function intentionally has st_size == 0, matching Tensile objects
-// COM: that omit .size and exercising zero-size function-range recovery.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -17,22 +12,30 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <test_far>:
-// DISASM-NEXT: s_mov_b64 vcc, -1
-// DISASM-NEXT: s_add_pc_i64
-// DISASM-NOT: s_add_pc_i64
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
 // DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_nc_u64 s[12:13]
+// DISASM-NEXT: s_add_co_u32 s12, s12,
+// DISASM-NEXT: s_add_co_ci_u32 s13, s13,
 // DISASM-NEXT: s_set_pc_i64 s[12:13]
-// DISASM-NOT: s_add_pc_i64
+// DISASM: s_mov_b64 vcc, -1
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_cselect_b32 s14, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[12:13]
+// DISASM-NEXT: s_add_co_u32 s12, s12,
+// DISASM-NEXT: s_add_co_ci_u32 s13, s13,
+// DISASM-NEXT: s_cmp_lg_u32 s14, 0
+// DISASM-NEXT: s_set_pc_i64 s[12:13]
 
 // METADATA: .name:           test_far
-// METADATA: .sgpr_count:     16
+// METADATA: .sgpr_count:     17
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -40,34 +43,26 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: The far return still needs an aligned SGPR pair. Exhausting all 106
-// COM: numbered SGPRs must fail instead of clobbering a program register.
+// COM: A kernel with no aligned three-SGPR block fails closed instead of
+// COM: emitting the unsafe return or clobbering a live register.
 // RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
 // RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \
-// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.no-pair.s
+// RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
-// RUN:   %t.no-pair.s -o %t.no-pair.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.no-pair.elf \
+// RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
+// RUN: hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefix=NO-PAIR %s
-// NO-PAIR: hotswap: error: safe far return: no aligned block of 2 safe SGPRs fits below s106
-// NO-PAIR: RESULT: ERROR
+// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
+// FAIL: RESULT: ERROR
 
-// COM: gfx10+ cannot represent an increased SGPR count in the kernel
-// COM: descriptor because that field is reserved. A metadata-less object must
-// COM: therefore fail rather than emit an under-declared far-return scratch
-// COM: allocation or write the reserved descriptor field.
+// COM: A metadata-less object also fails closed because scratch usage cannot
+// COM: be charged to its owning kernel.
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.nometa.s -o %t.nometa.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.nometa.elf \
+// RUN: hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
-// RUN:   | %FileCheck --check-prefix=NO-METADATA %s
-// NO-METADATA: hotswap: error: updateKernelDescriptorSgprCount: kernel 'test_far' requires
-// NO-METADATA: descriptor SGPR-count field is reserved
-// NO-METADATA: RESULT: ERROR
+// RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -78,6 +73,16 @@ test_far:
   s_mov_b64 vcc, -1
   tensor_load_to_lds s[0:3], s[4:11]
   s_endpgm
+.size test_far, .-test_far
+
+// Provide external zero-filled alignment space after a separate
+// no-fallthrough function.
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 32, 1, 0
+
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the tensor_load above (forces the
   // long-branch path).
@@ -85,7 +90,6 @@ test_far:
     s_mov_b32 s0, s1
   .endr
 .Ltest_far_end:
-// Deliberately no .size.
 
 .rodata
 .p2align 8

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -1,6 +1,8 @@
-// COM: Test persistent tensor_load_to_lds descriptor normalization across a
-// COM: control-flow edge. The descriptor remains masked on either successor,
-// COM: so the rewrite needs no liveness-dependent save/restore sequence.
+// COM: Test isSgprLiveAfter edge cases for tensor_load_to_lds patching.
+// COM: A branch instruction between the tensor_load and the next use of
+// COM: the descriptor SGPR forces the heuristic to conservatively assume
+// COM: the SGPR is live, producing save/restore even though the use may
+// COM: not execute on all paths.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -12,14 +14,17 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
-// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load and
-// COM: s_mov (which reads s4). The later read sees the normalized descriptor.
+// COM: Kernel 1 (branch guard): s_cbranch_scc1 sits between tensor_load
+// COM: and s_mov (which reads s4). isSgprLiveAfter returns true at the
+// COM: branch, so save/restore is emitted conservatively.
 // DISASM-LABEL: <test_tensor_branch_guard>:
 // DISASM: s_branch
 // DISASM: s_cbranch_scc1
 // DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
@@ -65,3 +70,20 @@ test_tensor_branch_guard:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_branch_guard
+      .symbol: test_tensor_branch_guard.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
@@ -213,3 +213,40 @@ test_tensor_mixed_ds:
   .amdhsa_next_free_vgpr 3
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_multi_different
+      .symbol: test_tensor_multi_different.kd
+      .sgpr_count: 24
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_multi_same
+      .symbol: test_tensor_multi_same.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_mixed_ds
+      .symbol: test_tensor_mixed_ds.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-noscratch.s
@@ -1,26 +1,15 @@
-// COM: A0 descriptor multicast bits stay clear after normalization. Even a
-// COM: kernel declaring all user-addressable SGPRs therefore needs no scratch
-// COM: register and must rewrite successfully without changing SGPR metadata.
+// COM: Live tensor_load_to_lds descriptor SGPRs require save/restore around
+// COM: the A0 D# Group 1 mask clear. If the kernel consumes all addressable
+// COM: SGPRs, hotswap must fail instead of returning unsafe code.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.out.elf \
-// RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: SUCCESS
-
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
-
-// DISASM-LABEL: <test_tensor_no_scratch>:
-// DISASM: s_branch
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_branch
-
-// METADATA: .name:           test_tensor_no_scratch
-// METADATA: .sgpr_count:     106
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: error: tensor_load_to_lds descriptor save: no aligned block of 1 safe SGPRs fits below s106
+// API: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -1,7 +1,7 @@
 // COM: Test the true trampoline fallback path for tensor_load_to_lds
-// COM: when no NOP sled is available. Both live and dead descriptor variants
-// COM: append the persistent s_pack_hh + tensor_load normalization via
-// COM: growWithTrampolines.
+// COM: when no NOP sled is available. Two variants:
+// COM:   dead SGPR - s_pack_hh + tensor_load appended via growWithTrampolines
+// COM:   live SGPR - save/pack/tensor/restore appended via growWithTrampolines
 // COM: Both force emitReplacementCode to use emitToTrampoline.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -43,10 +43,12 @@
 // DISASM-NEXT: tensor_load_to_lds
 // DISASM-NEXT: s_branch
 
-// COM: Live-SGPR trampoline body (for kernel 2): the same persistent mask and
-// COM: tensor sequence followed by branch-back.
+// COM: Live-SGPR trampoline body (for kernel 2): save + pack + tensor + restore
+// COM: followed by branch-back.
+// DISASM-NEXT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
@@ -91,3 +93,30 @@ test_tensor_trampoline_live:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 12
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_trampoline
+      .symbol: test_tensor_trampoline.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_trampoline_live
+      .symbol: test_tensor_trampoline_live.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -1,11 +1,11 @@
 // COM: Test HotSwap trampoline patch: tensor_load_to_lds multicast fix.
 // COM: Prepends s_pack_hh_b32_b16 to clear multicast routing bits in
-// COM: the descriptor's base SGPR. The multicast bits remain clear after
-// COM: normalization, so live and dead descriptors use the same pack/tensor
-// COM: sequence without save/restore.
+// COM: the descriptor's base SGPR. Base operand variants via NOP sled:
+// COM:   dead SGPR - only s_pack_hh prepended (no save/restore)
+// COM:   live SGPR - s_mov save, s_pack_hh, tensor, s_mov restore
 // COM:   alt descriptor - different SGPR range (s[16:23]) for pack target
-// COM:   SGPR redef - descriptor SGPR overwritten before its next use
-// COM:   zero-size FUNC - kernel lookup when the function has st_size == 0
+// COM:   SGPR redef - descriptor SGPR overwritten before use (dead path)
+// COM:   zero-size FUNC - live path when the function symbol has st_size == 0
 // COM:   four-group tensor - operand 1 is still D# Group 1 and patches s4
 // COM: Verifies per-kernel behavior with CHECK-LABEL blocks and explicit
 // COM: s_branch checks.
@@ -13,7 +13,7 @@
 // COM: Companion tests:
 // COM:   hotswap-trampoline-tensor-nosled.s     - trampoline fallback path
 // COM:   hotswap-trampoline-tensor-multi.s      - multi-site stacking
-// COM:   hotswap-trampoline-tensor-liveness.s   - control-flow edge case
+// COM:   hotswap-trampoline-tensor-liveness.s   - isSgprLiveAfter edge cases
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -23,7 +23,7 @@
 // RUN:   2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s
 // API-NOT: kernel descriptor symbol '.kd' not found
-// API: hotswap: tensor_load_to_lds: persistently cleared multicast bits in s4
+// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
 // API-NOT: kernel descriptor symbol '.kd' not found
 // API: RESULT: SUCCESS
 
@@ -46,13 +46,17 @@
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
 
-// COM: Kernel 2 (live SGPR): s4 is used after tensor_load_to_lds, and observes
-// COM: the persistently normalized descriptor. No scratch SGPR is required.
+// COM: Kernel 2 (live SGPR): s_branch forward to sled, then save/pack/
+// COM: tensor/restore sequence in sled area with branch-back.
+// COM: s4 is used after tensor_load_to_lds (s_mov reads it), so
+// COM: save/restore via a scratch SGPR is required.
 // DISASM-LABEL: <test_tensor_live>:
 // DISASM: s_branch
 // DISASM: s_endpgm
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds
+// DISASM-NEXT: s_mov_b32 s4, [[SCRATCH]]
 // DISASM-NEXT: s_branch
 
 // COM: Kernel 3 (alternate descriptor s[16:23]): verifies
@@ -69,7 +73,8 @@
 
 // COM: Kernel 4 (SGPR redefined before use): s4 is overwritten by
 // COM: s_mov_b32 s4, 0 immediately after tensor_load, then s_endpgm.
-// COM: The persistent mask remains safe when the descriptor is redefined.
+// COM: isSgprLiveAfter sees a def-before-use and takes the dead path,
+// COM: so no save/restore is needed.
 // DISASM-LABEL: <test_tensor_sgpr_redef>:
 // DISASM-NOT: v_writelane_b32
 // DISASM-NOT: v_readlane_b32
@@ -83,13 +88,18 @@
 
 // COM: Kernel 5 (zero-size FUNC): real Tensile objects can omit `.size`,
 // COM: leaving the FUNC symbol with st_size == 0. Kernel lookup must still
-// COM: find its descriptor. This kernel has no
+// COM: find its descriptor so scratch allocation succeeds. This kernel has no
 // COM: bounded local sled, so the replacement body is emitted in the appended
 // COM: trampoline pool and checked after Kernel 6.
 // DISASM-LABEL: <test_tensor_zero_size>:
 // DISASM: s_branch
 // DISASM: s_mov_b32 s0, s4
 // DISASM-NEXT: s_endpgm
+// DISASM: s_mov_b32 [[ZERO_SCRATCH:s[0-9]+]], s4
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// DISASM-NEXT: s_mov_b32 s4, [[ZERO_SCRATCH]]
+// DISASM-NEXT: s_branch
 
 // COM: Kernel 6 (four-group tensor): operand 1 is D# Group 1, so the
 // COM: patch must clear s4 even though additional SGPR tuple operands follow.
@@ -98,10 +108,6 @@
 // DISASM: s_endpgm
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
-// DISASM-NEXT: s_branch
-
-// DISASM: s_pack_hh_b32_b16 s4, 0, s4
-// DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
@@ -313,3 +319,70 @@ test_tensor_four_group:
   .amdhsa_next_free_vgpr 1
   .amdhsa_next_free_sgpr 20
 .end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_tensor_dead
+      .symbol: test_tensor_dead.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_live
+      .symbol: test_tensor_live.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_alt_descriptor
+      .symbol: test_tensor_alt_descriptor.kd
+      .sgpr_count: 24
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_sgpr_redef
+      .symbol: test_tensor_sgpr_redef.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_zero_size
+      .symbol: test_tensor_zero_size.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_tensor_four_group
+      .symbol: test_tensor_four_group.kd
+      .sgpr_count: 20
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -1,10 +1,7 @@
-// COM: HSV-009 / PLAT-205406: WMMA-split shares emitToTrampoline with the other
-// COM: patch families, so a split site beyond s_branch's +-128 KB reach of the
-// COM: appended pool takes the far path -- which on gfx1250 A0 is DECLINED
-// COM: (left unpatched) because the backward s_add_pc_i64 branch-back corrupts
-// COM: wave state at runtime. The original v_wmma_f32_16x16x128_fp8_fp8 stays at
-// COM: the site; it is neither split into two K=64 halves nor redirected. A
-// COM: large .rept filler (~160 KB, non-NOP) forces the far case.
+// COM: WMMA-split shares emitToTrampoline with the other patch families. A
+// COM: split site beyond s_branch's +-128 KB reach uses SGPR-backed set-PC
+// COM: sequences on both edges and never executes s_add_pc_i64. External NOP
+// COM: space supplies the forward gateway; non-NOP filler forces the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -14,15 +11,25 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
 
-// COM: Declined: the site keeps its original K=128 WMMA (it is NOT overwritten
-// COM: with an s_add_pc_i64 forward branch), and no split halves
-// COM: (v_wmma_f32_16x16x64_fp8_fp8) or long-branch redirect are emitted.
+// COM: The site redirects through a safe gateway to two K=64 halves and
+// COM: returns through the SCC-preserving set-PC sequence.
 // DISASM-LABEL: <test_wsplit_far>:
-// DISASM-NEXT: v_wmma_f32_16x16x128_fp8_fp8
-// DISASM-NOT: s_add_pc_i64
-// DISASM-NOT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_branch
+// DISASM: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_co_u32 s0, s0,
+// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_cselect_b32 s2, 1, 0
+// DISASM-NEXT: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_co_u32 s0, s0,
+// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
+// DISASM-NEXT: s_cmp_lg_u32 s2, 0
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
 
 // COM: Idempotency: rewriting the output again must be a no-op.
 // RUN: hotswap-rewrite %t.out.elf \
@@ -39,9 +46,39 @@
 test_wsplit_far:
   v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[32:39]
   s_endpgm
+.size test_wsplit_far, .-test_wsplit_far
+
+// Safe external gateway space after the kernel's no-fallthrough terminator.
+.rept 8
+  s_nop 0
+.endr
+
   // ~160 KB of non-NOP filler so the appended trampoline pool is beyond
   // s_branch's +-128 KB reach from the WMMA above (forces the long-branch path).
   .rept 40000
     s_mov_b32 s0, s1
   .endr
-.size test_wsplit_far, .-test_wsplit_far
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wsplit_far
+  .amdhsa_next_free_vgpr 40
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wsplit_far
+      .symbol: test_wsplit_far.kd
+      .sgpr_count: 0
+      .vgpr_count: 40
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -640,6 +640,28 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
 }
 
+TEST(ElfView, UpdateGfx1250RevisionMetadataRetagsKernelInPlace) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8;
+  Opts.MetadataGfx1250Revision = "B0";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::StringRef Before(reinterpret_cast<const char *>(Obj.Bytes.data()),
+                         Obj.Bytes.size());
+  EXPECT_NE(Before.find("B0"), llvm::StringRef::npos);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ASSERT_TRUE(ViewOrErr->updateGfx1250RevisionMetadata("A0"));
+
+  llvm::StringRef After(reinterpret_cast<const char *>(Obj.Bytes.data()),
+                        Obj.Bytes.size());
+  EXPECT_EQ(After.find("B0"), llvm::StringRef::npos);
+  EXPECT_NE(After.find("A0"), llvm::StringRef::npos);
+}
+
 TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -138,7 +138,7 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
   llvm::Expected<ElfView> ViewOrErr =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  std::vector<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   EXPECT_EQ(KDs[0].KernelName, "entry_kernel");
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr);
@@ -156,9 +156,14 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
           offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
       sizeof(ReadBack));
   EXPECT_EQ(ReadBack, NewOff);
+  ASSERT_EQ(ViewOrErr->kernelDescriptors().size(), 1u);
+  EXPECT_EQ(ViewOrErr->kernelDescriptors()[0].EntryOffset, NewOff);
 
+  // Prime the descriptor fallback cache before changing the encoded count.
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
   ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
   EXPECT_GE(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 10u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 16u);
 }
 
 TEST(ElfView, KernelDescriptorsSkipsKdWhenFileOffsetOverflows) {
@@ -207,7 +212,7 @@ TEST(ElfView, GrowWithTrampolinesKeepsAllocSectionSymbols) {
   llvm::Expected<ElfView> OutView =
       ElfView::create(OutData, Out->getBufferSize());
   ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
-  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   EXPECT_EQ(KDs[0].VAddr, Obj.RodataAddr);
 }
@@ -306,7 +311,7 @@ TEST(ElfView, GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol) {
   const uint64_t IsaResolved =
       decodeReferencedVAddr(OutView->textData(), OutView->textAddr());
   // ...vs. the address the symbol table now reports for the same global.
-  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   const uint64_t SymbolVAddr = KDs[0].VAddr;
 
@@ -632,6 +637,8 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountUpdatesMetadataAndDescriptor) {
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
+  // Prime the metadata cache before the in-place update.
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
   ASSERT_TRUE(ViewOrErr->updateKernelDescriptorSgprCount("entry_kernel", 10));
   std::optional<unsigned> MetadataSgprs =
       ViewOrErr->getKernelSgprCount("entry_kernel");
@@ -680,6 +687,62 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 10u);
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset),
             DescriptorSgprsBefore);
+}
+
+TEST(ElfView, UpdateKernelMetadataSgprCountsKeepsPrimedCacheCoherent) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 8u);
+
+  llvm::StringMap<unsigned> RequiredSgprs;
+  RequiredSgprs.try_emplace("entry_kernel", 10u);
+  ASSERT_TRUE(ViewOrErr->updateKernelMetadataSgprCounts(RequiredSgprs));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 10u);
+}
+
+TEST(ElfView, UpdateKernelMetadataSgprCountsBatchesMixedRequirements) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataKernels = {{"needs_update", 8}, {"already_enough", 16}};
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::StringMap<unsigned> RequiredSgprs;
+  RequiredSgprs.try_emplace("needs_update", 10u);
+  RequiredSgprs.try_emplace("already_enough", 12u);
+  ASSERT_TRUE(ViewOrErr->updateKernelMetadataSgprCounts(RequiredSgprs));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("needs_update"), 10u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("already_enough"), 16u);
+}
+
+TEST(ElfView, UpdateKernelMetadataSgprCountsRejectsAbsentKernelAtomically) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataKernels = {{"needs_update", 8}, {"already_enough", 16}};
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::StringMap<unsigned> RequiredSgprs;
+  RequiredSgprs.try_emplace("needs_update", 10u);
+  RequiredSgprs.try_emplace("already_enough", 12u);
+  RequiredSgprs.try_emplace("absent_kernel", 4u);
+  EXPECT_FALSE(ViewOrErr->updateKernelMetadataSgprCounts(RequiredSgprs));
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("needs_update"), 8u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("already_enough"), 16u);
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("absent_kernel"), std::nullopt);
 }
 
 TEST(ElfView, UpdateKernelDescriptorSgprCountMetadataOnlyRequiresMetadata) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -87,6 +87,16 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_NE(S.Target, nullptr);
   ASSERT_NE(S.MCII, nullptr);
   EXPECT_LT(S.SBranchOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SClauseOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SDelayAluOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SEndPgmOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SEndPgmSavedOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SAddPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SCallI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SSwapPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SPrefetchInstPcRelOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SPrefetchDataPcRelOpcode, S.MCII->getNumOpcodes());
+  EXPECT_TRUE(S.SCCRegister.isValid());
   EXPECT_EQ(S.SNopBytes.size(), MinInstSize);
 }
 
@@ -182,130 +192,113 @@ TEST(EncodeSBranch, FailsOnInvalidState) {
   EXPECT_TRUE(S.encodeSBranch(0, 8).empty());
 }
 
-// -- encodeLongBranch (s_add_pc_i64) -----------------------------------------
-//
-// The long branch reaches anywhere via s_add_pc_i64, which adds a signed
-// literal to the PC of the next instruction: landing PC == From + size + imm.
-// A positive (forward) offset fits a 32-bit literal (8 bytes); a negative
-// (backward) offset needs a 64-bit literal (12 bytes). These verify the offset
-// math and encoding structurally rather than pinning exact bytes.
+// -- encodeSetPCLongBranch ---------------------------------------------------
 
-// Read the signed literal that follows the 4-byte opcode dword.
-static int64_t longBranchLiteral(llvm::ArrayRef<uint8_t> Out) {
-  if (Out.size() == LongBranchFwdBytes)
-    return static_cast<int32_t>(readDword(Out.data() + MinInstSize));
-  int64_t V = 0;
-  std::memcpy(&V, Out.data() + MinInstSize, sizeof(V));
-  return V;
-}
-
-TEST(EncodeLongBranch, ForwardLandsOnTarget) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // ~512 KB forward -- well beyond s_branch's +-128 KB reach.
-  const uint64_t From = 0x1000, To = 0x81000;
-  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_EQ(Out.size(), LongBranchFwdBytes);
-  EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
-
-  std::vector<InternalDecodedInst> Dec;
-  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
-  ASSERT_EQ(Dec.size(), 1u);
-  EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
-}
-
-TEST(EncodeLongBranch, BackwardUsesWideLiteralAndLandsOnTarget) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // Backward jump (trampoline tail -> earlier return point).
-  const uint64_t From = 0x81000, To = 0x1004;
-  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_EQ(Out.size(), LongBranchMaxBytes);
-  EXPECT_EQ(static_cast<int64_t>(From) + static_cast<int64_t>(Out.size()) +
-                longBranchLiteral(Out),
-            static_cast<int64_t>(To));
-
-  std::vector<InternalDecodedInst> Dec;
-  ASSERT_TRUE(decodeTextSection(Out.data(), Out.size(), S, Dec));
-  ASSERT_EQ(Dec.size(), 1u);
-  EXPECT_EQ(Dec[0].Mnemonic, "s_add_pc_i64");
-}
-
-TEST(EncodeLongBranch, ReachesBeyondSBranchRange) {
-  LLVMState S = initLLVM(makeGfx1250Ident());
-  ASSERT_TRUE(S.Valid);
-  // 4 MB: s_branch rejects it, the long branch encodes it.
-  const uint64_t From = 0, To = 0x400000;
-  EXPECT_TRUE(S.encodeSBranch(From, To).empty());
-  llvm::SmallVector<uint8_t> Out = encodeLongBranch(S, From, To);
-  ASSERT_FALSE(Out.empty());
-  EXPECT_EQ(From + Out.size() + longBranchLiteral(Out), To);
-}
-
-// -- encodeSccNeutralLongBranch ----------------------------------------------
-
-static uint64_t
-decodeSccNeutralLongBranchTarget(uint64_t From,
-                                 llvm::ArrayRef<InternalDecodedInst> Decoded) {
-  const uint64_t PcBase = From + Decoded[0].Size;
-  const uint64_t Delta =
-      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
-  return PcBase + Delta;
-}
-
-TEST(EncodeSccNeutralLongBranch, BackwardLandsOnTargetWithoutDefiningScc) {
+TEST(EncodeSetPCLongBranch, UsesSccPreservingSequenceWithoutAddPc) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  constexpr uint64_t From = 0x81000;
-  constexpr uint64_t To = 0x1008;
+  const uint64_t From = 0x81000;
+  const uint64_t To = 0x1004;
   std::optional<llvm::SmallVector<uint8_t>> Out =
-      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
   ASSERT_TRUE(Out);
 
-  std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_EQ(Decoded[0].Mnemonic, "s_get_pc_i64");
-  EXPECT_EQ(Decoded[1].Mnemonic, "s_add_nc_u64");
-  EXPECT_EQ(Decoded[2].Mnemonic, "s_set_pc_i64");
-  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+  std::vector<InternalDecodedInst> Dec;
+  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Dec));
+  ASSERT_EQ(Dec.size(), 6u);
+  EXPECT_EQ(Dec[0].Mnemonic, "s_cselect_b32");
+  EXPECT_EQ(Dec[1].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Dec[2].Mnemonic, "s_add_co_u32");
+  EXPECT_EQ(Dec[3].Mnemonic, "s_add_co_ci_u32");
+  EXPECT_EQ(Dec[4].Mnemonic, "s_cmp_lg_u32");
+  EXPECT_EQ(Dec[5].Mnemonic, "s_set_pc_i64");
+  for (const InternalDecodedInst &DI : Dec)
+    EXPECT_NE(DI.Mnemonic, "s_add_pc_i64");
 
-  const llvm::MCRegister Pair = Decoded[0].Inst.getOperand(0).getReg();
-  EXPECT_EQ(Decoded[1].Inst.getOperand(0).getReg(), Pair);
-  EXPECT_EQ(Decoded[1].Inst.getOperand(1).getReg(), Pair);
-  EXPECT_EQ(Decoded[2].Inst.getOperand(0).getReg(), Pair);
-  for (const InternalDecodedInst &DI : Decoded) {
-    const llvm::MCInstrDesc &Desc = S.MCII->get(DI.Inst.getOpcode());
-    for (llvm::MCPhysReg Reg : Desc.implicit_defs())
-      EXPECT_NE(llvm::StringRef(S.MRI->getName(Reg)), "SCC");
-  }
+  // s_get_pc_i64 is the second dword and captures From + 8. The two add
+  // immediates materialize this exact two's-complement displacement.
+  uint64_t Delta = To - (From + 2 * MinInstSize);
+  EXPECT_EQ(static_cast<uint32_t>(Delta), 0xFFF7FFFCu);
+  EXPECT_EQ(static_cast<uint32_t>(Delta >> 32), 0xFFFFFFFFu);
 }
 
-TEST(EncodeSccNeutralLongBranch, ForwardLandsOnTarget) {
+TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
   constexpr uint64_t From = 0x1000;
   constexpr uint64_t To = 0x81000;
   std::optional<llvm::SmallVector<uint8_t>> Out =
-      encodeSccNeutralLongBranch(S, From, To, /*SgprBase=*/12);
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
   ASSERT_TRUE(Out);
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 3u);
-  EXPECT_EQ(decodeSccNeutralLongBranchTarget(From, Decoded), To);
+  ASSERT_EQ(Decoded.size(), 6u);
+  ASSERT_TRUE(Decoded[2].Inst.getOperand(2).isImm());
+  ASSERT_TRUE(Decoded[3].Inst.getOperand(2).isImm());
+  uint64_t Lo = static_cast<uint32_t>(Decoded[2].Inst.getOperand(2).getImm());
+  uint64_t Hi = static_cast<uint32_t>(Decoded[3].Inst.getOperand(2).getImm());
+  uint64_t Delta = Lo | (Hi << 32);
+  EXPECT_EQ(From + 2 * MinInstSize + Delta, To);
 }
 
-TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
+TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
+  EXPECT_FALSE(encodeSetPCLongBranch(
+      S, std::numeric_limits<uint64_t>::max() - MinInstSize, 0,
+      /*SgprBase=*/12));
+}
 
-  EXPECT_FALSE(encodeSccNeutralLongBranch(S, 0x1000, 0x2000,
-                                          /*SgprBase=*/13));
-  EXPECT_FALSE(encodeSccNeutralLongBranch(
-      S, std::numeric_limits<uint64_t>::max() - 1, 0, /*SgprBase=*/12));
+TEST(EncodeSetPCLongBranch, RejectsMisalignedScratchPair) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  EXPECT_FALSE(encodeSetPCLongBranch(S, 0, 0x1000, /*SgprBase=*/3));
+}
+
+TEST(IsSBranchReachable, CoversBoundariesAlignmentAndPcOverflow) {
+  constexpr uint64_t PositiveLimit =
+      static_cast<uint64_t>(BranchOffsetMax + 1) * MinInstSize;
+  EXPECT_TRUE(isSBranchReachable(/*From=*/0, PositiveLimit));
+  EXPECT_FALSE(isSBranchReachable(/*From=*/0, PositiveLimit + MinInstSize));
+  EXPECT_FALSE(isSBranchReachable(/*From=*/0, /*To=*/7));
+
+  constexpr uint64_t NegativeFrom =
+      static_cast<uint64_t>(-(BranchOffsetMin + 1)) * MinInstSize;
+  EXPECT_TRUE(isSBranchReachable(NegativeFrom, /*To=*/0));
+  EXPECT_FALSE(isSBranchReachable(NegativeFrom + MinInstSize, /*To=*/0));
+  EXPECT_FALSE(isSBranchReachable(std::numeric_limits<uint64_t>::max() - 1,
+                                  /*To=*/0));
+}
+
+TEST(EvaluateDirectControlFlowTarget, EvaluatesImmediateBranch) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst("s_branch 1", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  Decoded[0].Offset = 0x100;
+  EXPECT_EQ(evaluateDirectControlFlowTarget(Decoded[0], S), 0x108u);
+}
+
+TEST(EvaluateDirectControlFlowTarget, EvaluatesGfx1250CallOperandFallback) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[0:1], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  Decoded[0].Offset = 0x200;
+  EXPECT_EQ(evaluateDirectControlFlowTarget(Decoded[0], S),
+            0x200u + Decoded[0].Size + 2 * MinInstSize);
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
@@ -389,8 +382,7 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
 }
 
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
-  std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
-                                {100, 128, 100, 100, 128}};
+  std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64}, {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),
             nullptr);
 }
@@ -424,6 +416,7 @@ TEST(AssembleDecode, SNopRoundTrip) {
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_TRUE(Decoded[0].DecodeSucceeded);
   EXPECT_EQ(Decoded[0].Size, MinInstSize);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
 }
@@ -800,10 +793,9 @@ TEST(BuildKernelEntryTrampoline, PrefixPrefiltersHipblasltSmokeEntryBytes) {
   // idempotency path should reject this by raw prefix before classifying it as
   // a possible appended entry stub.
   const uint8_t EntryBytes[] = {
-      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00,
-      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00,
-      0xff, 0x02, 0x3f, 0x8b, 0xff, 0xff, 0xff, 0x3f,
-      0x02, 0x9e, 0x40, 0x85, 0x03, 0x00, 0xc1, 0xbe,
+      0x1a, 0x08, 0x80, 0xb9, 0x02, 0x00, 0x00, 0x00, 0x1a, 0x08, 0x80,
+      0xb9, 0x02, 0x00, 0x00, 0x00, 0xff, 0x02, 0x3f, 0x8b, 0xff, 0xff,
+      0xff, 0x3f, 0x02, 0x9e, 0x40, 0x85, 0x03, 0x00, 0xc1, 0xbe,
   };
 
   llvm::SmallVector<uint8_t> Candidate;
@@ -813,8 +805,8 @@ TEST(BuildKernelEntryTrampoline, PrefixPrefiltersHipblasltSmokeEntryBytes) {
   ASSERT_EQ(Candidate.size(), KernelEntryStubStride);
 
   std::vector<InternalDecodedInst> Decoded;
-  ASSERT_TRUE(decodeTextSection(Candidate.data(), sizeof(EntryBytes), S,
-                                Decoded));
+  ASSERT_TRUE(
+      decodeTextSection(Candidate.data(), sizeof(EntryBytes), S, Decoded));
   ASSERT_GE(Decoded.size(), 5u);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_setreg_imm32_b32");
   EXPECT_EQ(Decoded[1].Mnemonic, "s_setreg_imm32_b32");
@@ -987,9 +979,9 @@ static unsigned countSymtabSymbolsNamed(llvm::WritableMemoryBuffer &Buf,
                                         llvm::StringRef Name) {
   using ELFT = llvm::object::ELF64LE;
   llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
-      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
-          reinterpret_cast<const char *>(Buf.getBufferStart()),
-          Buf.getBufferSize()));
+      llvm::object::ELFFile<ELFT>::create(
+          llvm::StringRef(reinterpret_cast<const char *>(Buf.getBufferStart()),
+                          Buf.getBufferSize()));
   if (!FileOrErr) {
     llvm::consumeError(FileOrErr.takeError());
     return ~0u;

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -308,6 +308,86 @@ TEST(EncodeSccNeutralLongBranch, RejectsUnalignedPairAndPcOverflow) {
       S, std::numeric_limits<uint64_t>::max() - 1, 0, /*SgprBase=*/12));
 }
 
+TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_mov_b32 s4, s0", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(View.textData(), View.textSize(), S, Decoded));
+  RewriteConfig Config;
+  Config.MaxSgprs = 4;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches};
+
+  EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
+                                        /*Alignment=*/1, "unit test"));
+}
+
+TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+
+  comgr_test::KernelDescriptorElfOptions Options;
+  Options.EmitKernelDescriptorSymbol = false;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Options);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  std::vector<InternalDecodedInst> Decoded;
+  RewriteConfig Config;
+  Config.MaxSgprs = 106;
+  std::vector<Trampoline> Trampolines;
+  std::vector<NopSled> Sleds;
+  LivenessInfo Liveness;
+  llvm::StringMap<KernelPatchStats> KernelStats;
+  std::vector<ScratchPatchInfo> ScratchPatches;
+  PatchContext Ctx{Config,
+                   Decoded,
+                   View.textData(),
+                   View.textSize(),
+                   /*PoolBaseOffset=*/0,
+                   S,
+                   Trampolines,
+                   Sleds,
+                   View,
+                   Liveness,
+                   KernelStats,
+                   ScratchPatches};
+
+  const SafeSgprScratchBlock Block{/*Base=*/4, /*Count=*/1};
+  EXPECT_FALSE(
+      commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Block, "unit test"));
+}
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64},
                                 {100, 128, 100, 100, 128}};

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -964,7 +964,7 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(OutRsrc1, Rsrc1Before);
   EXPECT_EQ(OutView->getKernelSgprCount("kernel"), Fixups[0].RequiredSgprs);
 
-  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
   ASSERT_EQ(KDs.size(), 1u);
   std::optional<uint64_t> KdVAddr = OutView->getKernelDescriptorVAddr("kernel");
   ASSERT_TRUE(KdVAddr.has_value());

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -63,6 +63,7 @@ struct KernelDescriptorElfOptions {
   uint32_t ComputePgmRsrc3 = 0;
   std::optional<std::string> MetadataKernelName;
   std::optional<unsigned> MetadataSgprCount;
+  std::optional<std::string> MetadataGfx1250Revision;
   bool MetadataOmitSgprCount = false;
   bool MetadataSgprCountAsString = false;
 };
@@ -92,6 +93,9 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
       Kernel[".sgpr_count"] =
           static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
   }
+  if (Options.MetadataGfx1250Revision)
+    Kernel[".gfx1250_revision"] =
+        Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
   Kernels.push_back(Kernel);
   Root["amdhsa.kernels"] = Kernels;
 
@@ -157,9 +161,9 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   StrTab += ".kd";
   StrTab.push_back('\0');
 
-  const bool HasMetadataNote = Options.MetadataSgprCount ||
-                               Options.MetadataOmitSgprCount ||
-                               Options.MetadataSgprCountAsString;
+  const bool HasMetadataNote =
+      Options.MetadataSgprCount || Options.MetadataGfx1250Revision ||
+      Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString;
   std::vector<uint8_t> MetadataNote;
   if (HasMetadataNote) {
     std::string MetadataBlob = makeAmdgpuMetadataBlob(Options);

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -49,6 +49,11 @@ inline uint64_t alignTo4(uint64_t V) { return llvm::alignTo(V, 4); }
 inline uint64_t alignTo8(uint64_t V) { return llvm::alignTo(V, 8); }
 
 struct KernelDescriptorElfOptions {
+  struct MetadataKernel {
+    std::string Name;
+    unsigned SgprCount = 0;
+  };
+
   uint16_t ElfType = llvm::ELF::ET_DYN;
   std::string KernelName = "kernel";
   uint64_t TextAddr = 0x1000;
@@ -66,6 +71,9 @@ struct KernelDescriptorElfOptions {
   std::optional<std::string> MetadataGfx1250Revision;
   bool MetadataOmitSgprCount = false;
   bool MetadataSgprCountAsString = false;
+  // When non-empty, emit these kernel metadata entries instead of the single
+  // entry described by MetadataKernelName / MetadataSgprCount.
+  std::vector<MetadataKernel> MetadataKernels;
 };
 
 struct KernelDescriptorElf {
@@ -80,23 +88,32 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
   llvm::msgpack::Document Doc;
   llvm::msgpack::MapDocNode Root = Doc.getRoot().getMap(/*Convert=*/true);
   llvm::msgpack::ArrayDocNode Kernels = Doc.getArrayNode();
-  llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
-
-  const std::string &MetadataKernelName = Options.MetadataKernelName
-                                              ? *Options.MetadataKernelName
-                                              : Options.KernelName;
-  Kernel[".name"] = Doc.getNode(MetadataKernelName, /*Copy=*/true);
-  if (!Options.MetadataOmitSgprCount) {
-    if (Options.MetadataSgprCountAsString)
-      Kernel[".sgpr_count"] = Doc.getNode("not-an-integer", /*Copy=*/true);
-    else
-      Kernel[".sgpr_count"] =
-          static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
+  if (!Options.MetadataKernels.empty()) {
+    for (const KernelDescriptorElfOptions::MetadataKernel &Spec :
+         Options.MetadataKernels) {
+      llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
+      Kernel[".name"] = Doc.getNode(Spec.Name, /*Copy=*/true);
+      Kernel[".sgpr_count"] = static_cast<uint64_t>(Spec.SgprCount);
+      Kernels.push_back(Kernel);
+    }
+  } else {
+    llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
+    const std::string &MetadataKernelName = Options.MetadataKernelName
+                                                ? *Options.MetadataKernelName
+                                                : Options.KernelName;
+    Kernel[".name"] = Doc.getNode(MetadataKernelName, /*Copy=*/true);
+    if (!Options.MetadataOmitSgprCount) {
+      if (Options.MetadataSgprCountAsString)
+        Kernel[".sgpr_count"] = Doc.getNode("not-an-integer", /*Copy=*/true);
+      else
+        Kernel[".sgpr_count"] =
+            static_cast<uint64_t>(Options.MetadataSgprCount.value_or(0));
+    }
+    if (Options.MetadataGfx1250Revision)
+      Kernel[".gfx1250_revision"] =
+          Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
+    Kernels.push_back(Kernel);
   }
-  if (Options.MetadataGfx1250Revision)
-    Kernel[".gfx1250_revision"] =
-        Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
-  Kernels.push_back(Kernel);
   Root["amdhsa.kernels"] = Kernels;
 
   std::string Blob;
@@ -163,7 +180,8 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
 
   const bool HasMetadataNote =
       Options.MetadataSgprCount || Options.MetadataGfx1250Revision ||
-      Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString;
+      Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString ||
+      !Options.MetadataKernels.empty();
   std::vector<uint8_t> MetadataNote;
   if (HasMetadataNote) {
     std::string MetadataBlob = makeAmdgpuMetadataBlob(Options);


### PR DESCRIPTION
## Purpose

Direct-to-`amd-staging` companion for #3361, so the full `amd-staging` CI
workflows evaluate the cumulative stack early. **Review the fast path in #3361**
(its base is #3348, so its diff is only the fast-path change). This PR is not for
review — it exists for CI and is the one that will merge to `amd-staging`.

## Merge prerequisites (MUST land in `amd-staging` first)

- [x] #3346 — make gfx1250 semantic rewrites fail-safe (merged)
- [ ] #3347 — eliminate add-pc from far hotswap trampolines
- [ ] #3348 — scale hotswap rewrites for large code objects

Until #3347 and #3348 land, this PR shows the **cumulative** diff of the whole
stack. Once they merge (and this branch is rebased onto the new `amd-staging`
tip), the diff condenses to exactly the #3361 fast-path change — that is when the
true diff is shown and this can merge. To be closed if #3361 lands via its own path.
