### PR TITLE
[comgr][hotswap] B0->B0 fast path + descriptor-rewrite perf (amd-staging companion)

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -104,6 +104,7 @@ set(SOURCES
   src/comgr-hotswap.cpp
   src/comgr-hotswap-b0a0.cpp
   src/comgr-hotswap-entry-trampoline.cpp
+  src/comgr-hotswap-entry-trampoline-fast.cpp
   src/comgr-hotswap-patch-trampoline.cpp
   src/comgr-hotswap-elf.cpp
   src/comgr-hotswap-llvm.cpp

--- a/amd/comgr/src/comgr-env.cpp
+++ b/amd/comgr/src/comgr-env.cpp
@@ -41,6 +41,13 @@ bool shouldSaveLLVMTemps() {
   return SaveTemps && StringRef(SaveTemps) != "0";
 }
 
+bool shouldAddEntryTrampolineSymbols() {
+  // Opt-in (exactly "1"): the B0->B0 fast path skips the debug-only stub
+  // symbols by default on the load-time-critical path.
+  static char *AddSyms = COMGR_GETENV("AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS");
+  return AddSyms && StringRef(AddSyms) == "1";
+}
+
 std::optional<bool> shouldUseVFS() {
   if (shouldSaveTemps())
     return false;

--- a/amd/comgr/src/comgr-env.h
+++ b/amd/comgr/src/comgr-env.h
@@ -33,6 +33,11 @@ LogLevel resolveLogLevel();
 /// Return whether the environment requests temps be saved.
 bool shouldSaveTemps();
 bool shouldSaveLLVMTemps();
+
+/// True when AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS is exactly "1": add the
+/// debug-only `<kernel>.stub` symbols the B0->B0 fast path skips by default.
+bool shouldAddEntryTrampolineSymbols();
+
 std::optional<bool> shouldUseVFS();
 
 /// If the environment requests logs be redirected, return the string identifier

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1976,11 +1976,30 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   }
   ElfView &Elf = *ViewOrErr;
 
-  LLVMState LS = initLLVM(TargetIdent);
-  if (!LS.Valid) {
-    log() << "hotswap: error: retargetCodeObject: initLLVM failed "
-          << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
-    return AMD_COMGR_STATUS_ERROR;
+  // B0->B0 entry-only fast path: no instruction patches means no .text decode,
+  // so skip the whole LLVM MC layer and emit entry stubs from a pre-encoded
+  // byte template. Gated to gfx1250: the template bytes and the HWSD workaround
+  // are gfx1250-specific; other gfx125x and A0 take the MC path.
+  const bool UseFastAppend = Options.RunEntryTrampolines &&
+                             !RunInstructionPatches &&
+                             TargetIdent.Processor == "gfx1250";
+
+  LLVMState LS;
+  if (UseFastAppend) {
+    // Only LS.SNopBytes and LS.Cpu are read on the fast tail; populate them
+    // without paying for the full MC stack.
+    LS.Cpu = TargetIdent.Processor;
+    static constexpr uint8_t SNop[4] = {0x00, 0x00, 0x80, 0xbf};
+    LS.SNopBytes.assign(SNop, SNop + sizeof(SNop));
+    log() << "hotswap: entry trampolines: B0->B0 fast path (no MC/.text "
+             "disassembly)\n";
+  } else {
+    LS = initLLVM(TargetIdent);
+    if (!LS.Valid) {
+      log() << "hotswap: error: retargetCodeObject: initLLVM failed "
+            << "for CPU '" << TargetIdent.Processor << "'; aborting rewrite.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
   }
 
   RewriteConfig Config = makeGfx1250B0A0Config();
@@ -2070,8 +2089,11 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
   if (Options.RunEntryTrampolines) {
-    std::optional<uint32_t> EntryCount = appendKernelEntryTrampolines(
-        Elf, LS, Config.MaxSgprs, Growth, EntryFixups);
+    std::optional<uint32_t> EntryCount =
+        UseFastAppend
+            ? appendKernelEntryTrampolinesFast(Elf, LS.Cpu, Growth, EntryFixups)
+            : appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs, Growth,
+                                           EntryFixups);
     if (!EntryCount)
       return AMD_COMGR_STATUS_ERROR;
     Count += *EntryCount;
@@ -2111,7 +2133,17 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     // `info dispatches`). This grows only the non-alloc .symtab/.strtab and
     // returns a new buffer; failure is non-fatal (the rewritten code object is
     // still correct, just missing the debug-only symbol).
-    if (!EntryFixups.empty()) {
+    //
+    // FAST PATH: this .symtab/.strtab rebuild + full buffer copy scales with
+    // kernel count and is pure overhead for a load-time-critical path (the ROCr
+    // loader trampoline adds no such symbols). The symbols are only a debugging
+    // aid, so the fast path skips them by default. Set
+    // AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 to re-enable (e.g. for rocgdb).
+    const bool AddStubSymbols = !UseFastAppend || []() {
+      const char *E = std::getenv("AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS");
+      return E && E[0] == '1' && E[1] == '\0';
+    }();
+    if (!EntryFixups.empty() && AddStubSymbols) {
       std::unique_ptr<WritableMemoryBuffer> WithSyms =
           addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),
                                           Elf.textAddr(), Elf.textSize(),

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1976,21 +1976,29 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   }
   ElfView &Elf = *ViewOrErr;
 
+  // The CPU name and s_nop padding bytes are the only rewrite state the fast
+  // path needs; both are also carried by LLVMState on the MC path. Holding them
+  // as standalone locals lets the shared tail work off them regardless of which
+  // path ran, so the fast path never builds an LLVMState.
+  const StringRef TargetCpu = TargetIdent.Processor;
+  static constexpr uint8_t SNop[4] = {0x00, 0x00, 0x80, 0xbf};
+  SmallVector<uint8_t, 4> SNopBytes(SNop, SNop + sizeof(SNop));
+
   // B0->B0 entry-only fast path: no instruction patches means no .text decode,
   // so skip the whole LLVM MC layer and emit entry stubs from a pre-encoded
-  // byte template. Gated to gfx1250: the template bytes and the HWSD workaround
-  // are gfx1250-specific; other gfx125x and A0 take the MC path.
+  // byte template. UseB0B0EntryFastPath is decided by the caller from the
+  // source/target stepping; the template bytes and the HWSD workaround are
+  // gfx1250-specific, which that flag already accounts for.
   const bool UseFastAppend = Options.RunEntryTrampolines &&
                              !RunInstructionPatches &&
-                             TargetIdent.Processor == "gfx1250";
+                             Options.UseB0B0EntryFastPath;
 
+  // The MC layer (disassembler, encoder, register info) is only initialized on
+  // the non-fast path. The fast path leaves LS default-constructed and unused:
+  // it works entirely off TargetCpu / SNopBytes above, and every LS access
+  // below is guarded by a condition that is false on the fast path.
   LLVMState LS;
   if (UseFastAppend) {
-    // Only LS.SNopBytes and LS.Cpu are read on the fast tail; populate them
-    // without paying for the full MC stack.
-    LS.Cpu = TargetIdent.Processor;
-    static constexpr uint8_t SNop[4] = {0x00, 0x00, 0x80, 0xbf};
-    LS.SNopBytes.assign(SNop, SNop + sizeof(SNop));
     log() << "hotswap: entry trampolines: B0->B0 fast path (no MC/.text "
              "disassembly)\n";
   } else {
@@ -2090,10 +2098,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
   if (Options.RunEntryTrampolines) {
     std::optional<uint32_t> EntryCount =
-        UseFastAppend
-            ? appendKernelEntryTrampolinesFast(Elf, LS.Cpu, Growth, EntryFixups)
-            : appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs, Growth,
-                                           EntryFixups);
+        UseFastAppend ? appendKernelEntryTrampolinesFast(Elf, TargetCpu, Growth,
+                                                         EntryFixups)
+                      : appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs,
+                                                     Growth, EntryFixups);
     if (!EntryCount)
       return AMD_COMGR_STATUS_ERROR;
     Count += *EntryCount;
@@ -2106,7 +2114,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_ERROR;
 
   if (!Growth.empty()) {
-    Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);
+    Result = Elf.growWithTrampolines(Growth, SNopBytes);
     if (!Result) {
       log() << "hotswap: error: retargetCodeObject: "
             << "ElfView::growWithTrampolines returned null with "
@@ -2124,7 +2132,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
       GrowthTotal += T.Bytes.size();
     }
     patchDebugSections(*Result, Deferred, Elf, GrowthTotal);
-    if (!rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr, LS.Cpu,
+    if (!rewriteKernelEntryDescriptorOffsets(*Result, PoolVAddr, TargetCpu,
                                              EntryFixups))
       return AMD_COMGR_STATUS_ERROR;
 

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -27,6 +27,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "comgr-env.h"
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/DenseSet.h"
@@ -2147,10 +2148,8 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     // loader trampoline adds no such symbols). The symbols are only a debugging
     // aid, so the fast path skips them by default. Set
     // AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 to re-enable (e.g. for rocgdb).
-    const bool AddStubSymbols = !UseFastAppend || []() {
-      const char *E = std::getenv("AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS");
-      return E && E[0] == '1' && E[1] == '\0';
-    }();
+    const bool AddStubSymbols =
+        !UseFastAppend || env::shouldAddEntryTrampolineSymbols();
     if (!EntryFixups.empty() && AddStubSymbols) {
       std::unique_ptr<WritableMemoryBuffer> WithSyms =
           addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2098,8 +2098,8 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   std::vector<KernelEntryTrampolineFixup> EntryFixups;
   if (Options.RunEntryTrampolines) {
     std::optional<uint32_t> EntryCount =
-        UseFastAppend ? appendKernelEntryTrampolinesFast(Elf, TargetCpu, Growth,
-                                                         EntryFixups)
+        UseFastAppend ? appendKernelEntryTrampolinesFast(
+                            Elf, TargetCpu, Config.MaxSgprs, Growth, EntryFixups)
                       : appendKernelEntryTrampolines(Elf, LS, Config.MaxSgprs,
                                                      Growth, EntryFixups);
     if (!EntryCount)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -597,6 +597,7 @@ void ElfView::initializeKernelDescriptorCache() const {
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
   StringMap<uint64_t> FileOffsets;
+  StringMap<uint64_t> SeenVAddr;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -650,19 +651,30 @@ void ElfView::initializeKernelDescriptorCache() const {
               offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
           sizeof(EntryOffset));
 
-      std::string KernelName = NameOrErr->drop_back(3).str();
-      const bool Seen = std::any_of(
-          Result.begin(), Result.end(), [&](const KernelDescriptorInfo &Info) {
-            return Info.KernelName == KernelName && Info.VAddr == Sym.st_value;
-          });
-      if (!Seen)
+      StringRef KernelNameRef = NameOrErr->drop_back(3);
+      std::string KernelName = KernelNameRef.str();
+      // Dedup by (name, vaddr) via a map; a per-symbol O(n) scan made cache
+      // init O(n^2).
+      StringMap<uint64_t>::const_iterator SeenIt =
+          SeenVAddr.find(KernelNameRef);
+      const bool Seen =
+          SeenIt != SeenVAddr.end() && SeenIt->second == Sym.st_value;
+      if (!Seen) {
+        SeenVAddr[KernelNameRef] = Sym.st_value;
         Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
-      FileOffsets.try_emplace(NameOrErr->drop_back(3), *FileOffset);
+      }
+      FileOffsets.try_emplace(KernelNameRef, *FileOffset);
     }
   }
 
   KernelDescriptorFileOffsetCache = std::move(FileOffsets);
   KernelDescriptorCache = std::move(Result);
+
+  // Name -> vaddr map so getKernelDescriptorVAddr() is O(1) per call instead of
+  // a linear scan (O(n^2) over ~1000 per-fixup lookups).
+  KernelDescriptorVAddrCache.clear();
+  for (const KernelDescriptorInfo &Info : *KernelDescriptorCache)
+    KernelDescriptorVAddrCache.try_emplace(Info.KernelName, Info.VAddr);
 }
 
 uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
@@ -681,11 +693,12 @@ ArrayRef<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
 
 std::optional<uint64_t>
 ElfView::getKernelDescriptorVAddr(StringRef KernelName) const {
-  for (const KernelDescriptorInfo &Info : kernelDescriptors()) {
-    if (Info.KernelName == KernelName)
-      return Info.VAddr;
-  }
-  return std::nullopt;
+  initializeKernelDescriptorCache();
+  StringMap<uint64_t>::const_iterator It =
+      KernelDescriptorVAddrCache.find(KernelName);
+  if (It == KernelDescriptorVAddrCache.end())
+    return std::nullopt;
+  return It->second;
 }
 
 bool ElfView::updateKernelDescriptorEntryOffset(StringRef KernelName,

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -668,7 +668,11 @@ void ElfView::initializeKernelDescriptorCache() const {
   KernelDescriptorCache = std::move(Result);
 
   // Name -> vaddr map so getKernelDescriptorVAddr() is O(1) per call instead of
-  // a linear scan (O(n^2) over ~1000 per-fixup lookups).
+  // a linear scan (O(n^2) over ~1000 per-fixup lookups). When a name has more
+  // than one descriptor (the dedup set tracks (name, vaddr) pairs), try_emplace
+  // keeps the first in symtab order -- the same descriptor the prior linear
+  // scan returned, so the single-value lookup is unchanged. The multi-vaddr set
+  // matters only for enumeration/dedup, not this name->vaddr resolution.
   KernelDescriptorVAddrCache.clear();
   for (const KernelDescriptorInfo &Info : *KernelDescriptorCache)
     KernelDescriptorVAddrCache.try_emplace(Info.KernelName, Info.VAddr);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -16,6 +16,7 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
@@ -597,7 +598,7 @@ void ElfView::initializeKernelDescriptorCache() const {
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
   StringMap<uint64_t> FileOffsets;
-  StringMap<uint64_t> SeenVAddr;
+  StringMap<DenseSet<uint64_t>> SeenVAddr;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -653,16 +654,12 @@ void ElfView::initializeKernelDescriptorCache() const {
 
       StringRef KernelNameRef = NameOrErr->drop_back(3);
       std::string KernelName = KernelNameRef.str();
-      // Dedup by (name, vaddr) via a map; a per-symbol O(n) scan made cache
-      // init O(n^2).
-      StringMap<uint64_t>::const_iterator SeenIt =
-          SeenVAddr.find(KernelNameRef);
-      const bool Seen =
-          SeenIt != SeenVAddr.end() && SeenIt->second == Sym.st_value;
-      if (!Seen) {
-        SeenVAddr[KernelNameRef] = Sym.st_value;
+      // Dedup by (name, vaddr): a kernel name can legitimately map to more than
+      // one vaddr, so track the full vaddr set per name rather than only the
+      // last one. (The previous per-symbol linear scan over Result made cache
+      // init O(n^2).)
+      if (SeenVAddr[KernelNameRef].insert(Sym.st_value).second)
         Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
-      }
       FileOffsets.try_emplace(KernelNameRef, *FileOffset);
     }
   }

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
@@ -112,8 +112,12 @@ entryHasWorkaroundPrefixFast(const ElfView &Elf,
   if (!Entry)
     return std::nullopt;
   const uint8_t *EntryBytes = Elf.dataAtVAddr(*Entry, FastEntryPrefixBytes);
-  if (!EntryBytes)
+  if (!EntryBytes) {
+    log() << "hotswap: fast: kernel '" << KD.KernelName << "' entry vaddr 0x"
+          << Twine::utohexstr(*Entry)
+          << " is not backed by readable data; assuming no workaround prefix.\n";
     return false;
+  }
   return std::memcmp(EntryBytes, EntryPrefix, FastEntryPrefixBytes) == 0;
 }
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
@@ -6,13 +6,14 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// B0-on-B0 kernel-entry trampoline FAST PATH. Mirrors the ROCr loader
-/// trampoline: no LLVM MC layer (no initLLVM, no assembler, no disassembler).
-/// The stub is emitted from a pre-encoded gfx1250 byte template with only the
-/// two PC-relative delta immediates patched in, using a fixed s[100:101]
-/// scratch pair (so no per-kernel SGPR read and no descriptor SGPR-reservation
-/// update). Idempotency and the compile-time-workaround skip are decided by raw
-/// byte comparison rather than decoding.
+/// B0-on-B0 kernel-entry trampoline FAST PATH. No LLVM MC layer (no initLLVM,
+/// no assembler, no disassembler): the stub is emitted from a pre-encoded
+/// gfx1250 byte template with the two PC-relative delta immediates and the
+/// per-kernel scratch SGPR register fields patched in. Like the MC path, the
+/// scratch pair is allocated above each kernel's SGPR count (never a live kernel
+/// input, including preloaded kernargs) and the descriptor's SGPR reservation is
+/// bumped accordingly. Idempotency and the compile-time-workaround skip are
+/// decided by raw byte comparison rather than decoding.
 ///
 /// This path is selected automatically for pure B0->B0 entry-only rewrites
 /// (no B0->A0 instruction patches, no mask workaround). The MC-based path in
@@ -36,11 +37,14 @@ using namespace llvm;
 namespace COMGR {
 namespace hotswap {
 
-// Pre-encoded gfx1250 stub template (fixed s[100:101]). Ground-truth encodings
-// from llvm-mc -mcpu=gfx1250 (little-endian). The body is 40 bytes and is
-// padded to KernelEntryStubStride (256) with s_code_end. s_get_pc_i64 loads the
-// address of the instruction after it (s_add, at StubVAddr +
-// FastEntryPcBaseOffset), which is the base for the PC-relative delta.
+// Pre-encoded gfx1250 stub template. Ground-truth encodings from
+// llvm-mc -mcpu=gfx1250 (little-endian). The body is 40 bytes and is padded to
+// KernelEntryStubStride (256) with s_code_end. s_get_pc_i64 loads the address
+// of the instruction after it (s_add, at StubVAddr + FastEntryPcBaseOffset),
+// which is the base for the PC-relative delta. The template is spelled with
+// s[100:101]; buildKernelEntryTrampolineFast rewrites the six SGPR register-
+// field bytes per kernel to the allocated scratch pair (see the FastEntry*Offset
+// encoding table in comgr-hotswap-internal.h).
 // clang-format off
 static constexpr uint8_t StubTemplate[FastEntryStubBodyBytes] = {
     0x7c, 0x00, 0x0b, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // global_wb
@@ -62,10 +66,24 @@ static constexpr uint8_t EntryPrefix[FastEntryPrefixBytes] = {
 // clang-format on
 
 SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
-                                                    uint64_t EntryVAddr) {
+                                                    uint64_t EntryVAddr,
+                                                    unsigned ScratchSgpr) {
   SmallVector<uint8_t> Bytes;
   Bytes.resize(KernelEntryStubStride);
   std::memcpy(Bytes.data(), StubTemplate, FastEntryStubBodyBytes);
+
+  // Patch the scratch SGPR pair s[N:N+1] into the register fields. The template
+  // is spelled with s[100:101]; only the six field bytes change with N (see the
+  // FastEntry*Offset encoding table in comgr-hotswap-internal.h). ScratchSgpr is
+  // an even base <= 104 (guaranteed by the aligned-pair allocation in
+  // appendKernelEntryTrampolinesFast).
+  const uint8_t N = static_cast<uint8_t>(ScratchSgpr);
+  Bytes[FastEntryGetPcSdstOffset] = 0x80 | N;
+  Bytes[FastEntryAddLoSrc0Offset] = N;
+  Bytes[FastEntryAddLoSdstOffset] = N;
+  Bytes[FastEntryAddHiSrc0Offset] = N + 1;
+  Bytes[FastEntryAddHiSdstOffset] = N + 1;
+  Bytes[FastEntrySetPcSrcOffset] = N;
 
   // Materialize EntryVAddr relative to the s_get_pc base. Two's complement, so
   // back-jumps are handled.
@@ -99,6 +117,39 @@ entryHasWorkaroundPrefixFast(const ElfView &Elf,
   return std::memcmp(EntryBytes, EntryPrefix, FastEntryPrefixBytes) == 0;
 }
 
+// Allocate an aligned scratch SGPR pair s[N:N+1] just above the kernel's live
+// SGPR count, exactly like the MC path's allocateEntryStubScratchSgprs. This is
+// the correctness guarantee over a fixed s[100:101]: N is above every live
+// input (system/user SGPRs and preloaded kernargs), so the stub never clobbers
+// one. Declines (returns nullopt) if no aligned pair fits below MaxSgprs.
+static std::optional<unsigned>
+allocateEntryStubScratchSgprsFast(const ElfView &Elf,
+                                  const KernelDescriptorInfo &KD,
+                                  unsigned MaxSgprs) {
+  constexpr unsigned ScratchSgprs = 2;
+  std::optional<unsigned> SgprCount = Elf.getKernelSgprCount(KD.KernelName);
+  if (!SgprCount) {
+    log() << "hotswap: error: fast entry trampoline: failed to read SGPR count "
+          << "for '" << KD.KernelName << "'.\n";
+    return std::nullopt;
+  }
+  if (*SgprCount > MaxSgprs) {
+    log() << "hotswap: error: fast entry trampoline: kernel '" << KD.KernelName
+          << "' uses " << *SgprCount << " SGPRs, above max " << MaxSgprs
+          << ".\n";
+    return std::nullopt;
+  }
+
+  unsigned ScratchBase = (*SgprCount + 1) & ~1u;
+  if (ScratchBase > MaxSgprs || MaxSgprs - ScratchBase < ScratchSgprs) {
+    log() << "hotswap: error: fast entry trampoline: kernel '" << KD.KernelName
+          << "' uses " << *SgprCount << " SGPRs; no aligned scratch pair fits "
+          << "below max " << MaxSgprs << ".\n";
+    return std::nullopt;
+  }
+  return ScratchBase;
+}
+
 static bool appendPaddingFast(std::vector<Trampoline> &Out, uint64_t PadBytes) {
   if (PadBytes == 0)
     return true;
@@ -116,7 +167,8 @@ static bool appendPaddingFast(std::vector<Trampoline> &Out, uint64_t PadBytes) {
 }
 
 std::optional<uint32_t> appendKernelEntryTrampolinesFast(
-    const ElfView &Elf, StringRef TargetCpu, std::vector<Trampoline> &Growth,
+    const ElfView &Elf, StringRef TargetCpu, unsigned MaxSgprs,
+    std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups) {
   ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
   if (Descriptors.empty())
@@ -180,30 +232,32 @@ std::optional<uint32_t> appendKernelEntryTrampolinesFast(
 
   for (const WorkItem &Item : Work) {
     const KernelDescriptorInfo &KD = Item.KD;
-    std::optional<uint64_t> StubVAddr = checkedAddUint64(
-        PoolVAddr, AppendOffset,
-        (Twine("fast entry trampoline vaddr for '") + KD.KernelName + "'")
-            .str());
+    std::optional<uint64_t> StubVAddr =
+        checkedAddUint64(PoolVAddr, AppendOffset, "fast entry trampoline vaddr");
     if (!StubVAddr)
+      return std::nullopt;
+    std::optional<unsigned> ScratchSgpr =
+        allocateEntryStubScratchSgprsFast(Elf, KD, MaxSgprs);
+    if (!ScratchSgpr)
       return std::nullopt;
     std::optional<uint64_t> Entry = entryVAddr(KD);
     if (!Entry)
       return std::nullopt;
 
     Trampoline T;
-    T.Bytes = buildKernelEntryTrampolineFast(*StubVAddr, *Entry);
+    T.Bytes = buildKernelEntryTrampolineFast(*StubVAddr, *Entry, *ScratchSgpr);
     LocalGrowth.push_back(std::move(T));
 
-    // Fixed s[100:101]: no per-kernel SGPR read, and SkipSgprReservation tells
-    // the descriptor rewrite to leave the logical SGPR count unchanged.
-    LocalFixups.push_back({KD.KernelName, AppendOffset, /*RequiredSgprs=*/0,
+    // Per-kernel scratch pair s[*ScratchSgpr:*ScratchSgpr+1]: bump the
+    // descriptor SGPR reservation (SkipSgprReservation=false) so the shared
+    // rewriteKernelEntryDescriptorOffsets records the pair, exactly like the MC
+    // path.
+    LocalFixups.push_back({KD.KernelName, AppendOffset, *ScratchSgpr + 2,
                            Item.StubInstPrefLines,
-                           /*SkipSgprReservation=*/true});
+                           /*SkipSgprReservation=*/false});
 
     std::optional<uint64_t> NewAppendOffset = checkedAddUint64(
-        AppendOffset, KernelEntryStubStride,
-        (Twine("fast entry append offset after '") + KD.KernelName + "'")
-            .str());
+        AppendOffset, KernelEntryStubStride, "fast entry append offset");
     if (!NewAppendOffset)
       return std::nullopt;
     AppendOffset = *NewAppendOffset;
@@ -234,7 +288,7 @@ std::optional<uint32_t> appendKernelEntryTrampolinesFast(
 
   log() << "hotswap: fast: installed " << LocalFixups.size()
         << " kernel-entry trampoline" << (LocalFixups.size() == 1 ? "" : "s")
-        << " (no-disasm, fixed s[100:101]) with " << GuardBytes
+        << " (no-disasm, per-kernel scratch SGPR) with " << GuardBytes
         << " prefetch guard bytes\n";
   return static_cast<uint32_t>(LocalFixups.size());
 }

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline-fast.cpp
@@ -1,0 +1,243 @@
+//===- comgr-hotswap-entry-trampoline-fast.cpp - B0->B0 fast path ---------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// B0-on-B0 kernel-entry trampoline FAST PATH. Mirrors the ROCr loader
+/// trampoline: no LLVM MC layer (no initLLVM, no assembler, no disassembler).
+/// The stub is emitted from a pre-encoded gfx1250 byte template with only the
+/// two PC-relative delta immediates patched in, using a fixed s[100:101]
+/// scratch pair (so no per-kernel SGPR read and no descriptor SGPR-reservation
+/// update). Idempotency and the compile-time-workaround skip are decided by raw
+/// byte comparison rather than decoding.
+///
+/// This path is selected automatically for pure B0->B0 entry-only rewrites
+/// (no B0->A0 instruction patches, no mask workaround). The MC-based path in
+/// comgr-hotswap-entry-trampoline.cpp handles A0 and any rewrite that needs
+/// instruction patches.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/Support/Endian.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+// Pre-encoded gfx1250 stub template (fixed s[100:101]). Ground-truth encodings
+// from llvm-mc -mcpu=gfx1250 (little-endian). The body is 40 bytes and is
+// padded to KernelEntryStubStride (256) with s_code_end. s_get_pc_i64 loads the
+// address of the instruction after it (s_add, at StubVAddr +
+// FastEntryPcBaseOffset), which is the base for the PC-relative delta.
+// clang-format off
+static constexpr uint8_t StubTemplate[FastEntryStubBodyBytes] = {
+    0x7c, 0x00, 0x0b, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // global_wb
+    0x00, 0x00, 0x00, 0x7e,                                                 // v_nop
+    0x00, 0x47, 0xe4, 0xbe,                                                 // s_get_pc_i64 s[100:101]
+    0x64, 0xff, 0x64, 0x80, 0x00, 0x00, 0x00, 0x00,                         // s_add_co_u32 s100,s100,imm32 (imm@24)
+    0x65, 0xff, 0x65, 0x82, 0x00, 0x00, 0x00, 0x00,                         // s_add_co_ci_u32 s101,s101,imm32 (imm@32)
+    0x64, 0x48, 0x80, 0xbe,                                                 // s_set_pc_i64 s[100:101]
+};
+
+static constexpr uint8_t SCodeEnd[4] = {0x00, 0x00, 0x9f, 0xbf};
+static constexpr uint8_t SNop[4] = {0x00, 0x00, 0x80, 0xbf};
+
+// global_wb; v_nop prefix (16 bytes), for raw idempotency / workaround detection.
+static constexpr uint8_t EntryPrefix[FastEntryPrefixBytes] = {
+    0x7c, 0x00, 0x0b, 0xee, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x7e,
+};
+// clang-format on
+
+SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
+                                                    uint64_t EntryVAddr) {
+  SmallVector<uint8_t> Bytes;
+  Bytes.resize(KernelEntryStubStride);
+  std::memcpy(Bytes.data(), StubTemplate, FastEntryStubBodyBytes);
+
+  // Materialize EntryVAddr relative to the s_get_pc base. Two's complement, so
+  // back-jumps are handled.
+  const uint64_t PcBase = StubVAddr + FastEntryPcBaseOffset;
+  const uint64_t Delta = EntryVAddr - PcBase;
+  llvm::support::endian::write32le(Bytes.data() + FastEntryDeltaLoOffset,
+                                   static_cast<uint32_t>(Delta));
+  llvm::support::endian::write32le(Bytes.data() + FastEntryDeltaHiOffset,
+                                   static_cast<uint32_t>(Delta >> 32));
+
+  // Pad to stride with s_code_end (prefetch-safe; never executed).
+  for (uint64_t Off = FastEntryStubBodyBytes; Off < KernelEntryStubStride;
+       Off += sizeof(SCodeEnd))
+    std::memcpy(Bytes.data() + Off, SCodeEnd, sizeof(SCodeEnd));
+  return Bytes;
+}
+
+// Raw byte check: does the descriptor's current entry already begin with
+// global_wb; v_nop (either a hotswap fast stub already installed, or the
+// compile-time unclaused-VMEM workaround prologue)? Both mean "do not add a
+// trampoline".
+static std::optional<bool>
+entryHasWorkaroundPrefixFast(const ElfView &Elf,
+                             const KernelDescriptorInfo &KD) {
+  std::optional<uint64_t> Entry = entryVAddr(KD);
+  if (!Entry)
+    return std::nullopt;
+  const uint8_t *EntryBytes = Elf.dataAtVAddr(*Entry, FastEntryPrefixBytes);
+  if (!EntryBytes)
+    return false;
+  return std::memcmp(EntryBytes, EntryPrefix, FastEntryPrefixBytes) == 0;
+}
+
+static bool appendPaddingFast(std::vector<Trampoline> &Out, uint64_t PadBytes) {
+  if (PadBytes == 0)
+    return true;
+  if (PadBytes % sizeof(SNop) != 0) {
+    log() << "hotswap: error: fast entry-stub padding " << PadBytes
+          << " is not a multiple of s_nop size.\n";
+    return false;
+  }
+  Trampoline Pad;
+  Pad.Bytes.reserve(PadBytes);
+  while (static_cast<uint64_t>(Pad.Bytes.size()) < PadBytes)
+    Pad.Bytes.append(SNop, SNop + sizeof(SNop));
+  Out.push_back(std::move(Pad));
+  return true;
+}
+
+std::optional<uint32_t> appendKernelEntryTrampolinesFast(
+    const ElfView &Elf, StringRef TargetCpu, std::vector<Trampoline> &Growth,
+    std::vector<KernelEntryTrampolineFixup> &OutFixups) {
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  if (Descriptors.empty())
+    return 0;
+
+  struct WorkItem {
+    KernelDescriptorInfo KD;
+    uint32_t StubInstPrefLines = 0;
+  };
+  std::vector<WorkItem> Work;
+  uint32_t MaxStubInstPrefLines = 0;
+
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    // Skip if the entry already carries the workaround (already-installed fast
+    // stub, or a compile-time global_wb; v_nop prologue). Raw byte check.
+    std::optional<bool> HasPrefix = entryHasWorkaroundPrefixFast(Elf, KD);
+    if (!HasPrefix)
+      return std::nullopt;
+    if (*HasPrefix) {
+      log() << "hotswap: fast: kernel '" << KD.KernelName
+            << "' entry already has global_wb; v_nop; skipping trampoline\n";
+      continue;
+    }
+    std::optional<uint32_t> OriginalInstPrefLines =
+        Elf.getKernelDescriptorInstPrefSize(KD.KernelName, TargetCpu);
+    if (!OriginalInstPrefLines)
+      return std::nullopt;
+    uint32_t StubInstPrefLines =
+        std::min(*OriginalInstPrefLines, KernelEntryStubInstPrefLines);
+    MaxStubInstPrefLines = std::max(MaxStubInstPrefLines, StubInstPrefLines);
+    Work.push_back({KD, StubInstPrefLines});
+  }
+  if (Work.empty())
+    return 0;
+
+  uint64_t AppendOffset = 0;
+  for (const Trampoline &T : Growth)
+    AppendOffset += T.Bytes.size();
+
+  std::optional<uint64_t> PoolVAddrOr = Elf.trampolinePoolVAddr();
+  if (!PoolVAddrOr)
+    return std::nullopt;
+  const uint64_t PoolVAddr = *PoolVAddrOr;
+
+  std::optional<uint64_t> StubPoolBaseVAddr =
+      checkedAddUint64(PoolVAddr, AppendOffset, "fast entry stub-pool base");
+  if (!StubPoolBaseVAddr)
+    return std::nullopt;
+  std::optional<uint64_t> AlignedBase =
+      checkedAlignTo(*StubPoolBaseVAddr, KernelEntryStubStride,
+                     "fast entry trampoline aligned stub-pool base");
+  if (!AlignedBase)
+    return std::nullopt;
+  const uint64_t StubStart = *AlignedBase - PoolVAddr;
+
+  std::vector<Trampoline> LocalGrowth;
+  std::vector<KernelEntryTrampolineFixup> LocalFixups;
+  if (!appendPaddingFast(LocalGrowth, StubStart - AppendOffset))
+    return std::nullopt;
+  AppendOffset = StubStart;
+
+  for (const WorkItem &Item : Work) {
+    const KernelDescriptorInfo &KD = Item.KD;
+    std::optional<uint64_t> StubVAddr = checkedAddUint64(
+        PoolVAddr, AppendOffset,
+        (Twine("fast entry trampoline vaddr for '") + KD.KernelName + "'")
+            .str());
+    if (!StubVAddr)
+      return std::nullopt;
+    std::optional<uint64_t> Entry = entryVAddr(KD);
+    if (!Entry)
+      return std::nullopt;
+
+    Trampoline T;
+    T.Bytes = buildKernelEntryTrampolineFast(*StubVAddr, *Entry);
+    LocalGrowth.push_back(std::move(T));
+
+    // Fixed s[100:101]: no per-kernel SGPR read, and SkipSgprReservation tells
+    // the descriptor rewrite to leave the logical SGPR count unchanged.
+    LocalFixups.push_back({KD.KernelName, AppendOffset, /*RequiredSgprs=*/0,
+                           Item.StubInstPrefLines,
+                           /*SkipSgprReservation=*/true});
+
+    std::optional<uint64_t> NewAppendOffset = checkedAddUint64(
+        AppendOffset, KernelEntryStubStride,
+        (Twine("fast entry append offset after '") + KD.KernelName + "'")
+            .str());
+    if (!NewAppendOffset)
+      return std::nullopt;
+    AppendOffset = *NewAppendOffset;
+  }
+
+  // Prefetch guard sized like the MC path (shared helper).
+  const uint64_t GuardBytes =
+      computeKernelEntryPrefetchGuardBytes(MaxStubInstPrefLines);
+  if (GuardBytes != 0) {
+    Trampoline Guard;
+    Guard.Bytes.reserve(GuardBytes);
+    for (uint64_t Off = 0; Off < GuardBytes; Off += sizeof(SCodeEnd))
+      Guard.Bytes.append(SCodeEnd, SCodeEnd + sizeof(SCodeEnd));
+    LocalGrowth.push_back(std::move(Guard));
+  }
+
+  if (LocalFixups.empty())
+    return 0;
+  if (LocalFixups.size() > std::numeric_limits<uint32_t>::max()) {
+    log() << "hotswap: error: fast kernel-entry trampoline count "
+          << LocalFixups.size() << " exceeds uint32_t.\n";
+    return std::nullopt;
+  }
+
+  for (Trampoline &T : LocalGrowth)
+    Growth.push_back(std::move(T));
+  OutFixups.insert(OutFixups.end(), LocalFixups.begin(), LocalFixups.end());
+
+  log() << "hotswap: fast: installed " << LocalFixups.size()
+        << " kernel-entry trampoline" << (LocalFixups.size() == 1 ? "" : "s")
+        << " (no-disasm, fixed s[100:101]) with " << GuardBytes
+        << " prefetch guard bytes\n";
+  return static_cast<uint32_t>(LocalFixups.size());
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -16,6 +16,7 @@
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/Twine.h"
 
 #include <algorithm>
@@ -644,6 +645,9 @@ bool rewriteKernelEntryDescriptorOffsets(
 
   bool Ok = true;
   ElfView &OutElf = *ViewOrErr;
+  // Collect SGPR bumps and apply them in one batched metadata rewrite after the
+  // loop; a per-fixup update reparses/reserializes the whole note (O(n^2)).
+  StringMap<unsigned> SgprBumps;
   for (const KernelEntryTrampolineFixup &Fixup : Fixups) {
     std::optional<uint64_t> KdVAddr =
         OutElf.getKernelDescriptorVAddr(Fixup.KernelName);
@@ -671,17 +675,16 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    // The fast path leaves the logical SGPR reservation unchanged (fixed
-    // s[100:101]), so skip the descriptor SGPR-count update entirely.
-    bool UpdatedSgprs = Fixup.SkipSgprReservation
-                            ? true
-                            : OutElf.updateKernelDescriptorSgprCount(
-                                  Fixup.KernelName, Fixup.RequiredSgprs,
-                                  /*UpdateDescriptor=*/false);
+    if (!Fixup.SkipSgprReservation && Fixup.RequiredSgprs != 0)
+      SgprBumps[Fixup.KernelName] =
+          std::max(SgprBumps.lookup(Fixup.KernelName), Fixup.RequiredSgprs);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
-    Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;
+    Ok = UpdatedEntry && UpdatedInstPref && Ok;
   }
+
+  if (!SgprBumps.empty())
+    Ok = OutElf.updateKernelMetadataSgprCounts(SgprBumps) && Ok;
   return Ok;
 }
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -675,9 +675,10 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    if (!Fixup.SkipSgprReservation && Fixup.RequiredSgprs != 0)
-      SgprBumps[Fixup.KernelName] =
-          std::max(SgprBumps.lookup(Fixup.KernelName), Fixup.RequiredSgprs);
+    if (!Fixup.SkipSgprReservation && Fixup.RequiredSgprs != 0) {
+      unsigned &Bump = SgprBumps[Fixup.KernelName];
+      Bump = std::max(Bump, Fixup.RequiredSgprs);
+    }
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -279,8 +279,8 @@ bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
          std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
 }
 
-static std::optional<uint64_t>
-checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
+std::optional<uint64_t> checkedAlignTo(uint64_t Value, uint64_t Alignment,
+                                       StringRef Context) {
   if (Alignment == 0)
     return Value;
 
@@ -290,7 +290,7 @@ checkedAlignTo(uint64_t Value, uint64_t Alignment, StringRef Context) {
   return checkedAddUint64(Value, Alignment - Remainder, Context);
 }
 
-static std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
+std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   if (KD.EntryOffset >= 0)
     return checkedAddUint64(
         KD.VAddr, static_cast<uint64_t>(KD.EntryOffset),
@@ -671,9 +671,13 @@ bool rewriteKernelEntryDescriptorOffsets(
     }
     bool UpdatedEntry =
         OutElf.updateKernelDescriptorEntryOffset(Fixup.KernelName, *NewOffset);
-    bool UpdatedSgprs = OutElf.updateKernelDescriptorSgprCount(
-        Fixup.KernelName, Fixup.RequiredSgprs,
-        /*UpdateDescriptor=*/false);
+    // The fast path leaves the logical SGPR reservation unchanged (fixed
+    // s[100:101]), so skip the descriptor SGPR-count update entirely.
+    bool UpdatedSgprs = Fixup.SkipSgprReservation
+                            ? true
+                            : OutElf.updateKernelDescriptorSgprCount(
+                                  Fixup.KernelName, Fixup.RequiredSgprs,
+                                  /*UpdateDescriptor=*/false);
     bool UpdatedInstPref = OutElf.updateKernelDescriptorInstPrefSize(
         Fixup.KernelName, TargetCpu, Fixup.InstPrefLines);
     Ok = UpdatedEntry && UpdatedSgprs && UpdatedInstPref && Ok;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -448,6 +448,7 @@ private:
   mutable std::optional<std::vector<KernelDescriptorInfo>>
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
+  mutable llvm::StringMap<uint64_t> KernelDescriptorVAddrCache;
   mutable KernelSgprCacheState SgprCacheState =
       KernelSgprCacheState::Uninitialized;
   mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -132,6 +132,15 @@ static_assert(KernelEntryStubStride % KernelEntryInstPrefUnitBytes == 0,
 static constexpr uint32_t KernelEntryStubInstPrefLines =
     KernelEntryStubStride / KernelEntryInstPrefUnitBytes;
 
+// B0->B0 fast-path stub layout (see comgr-hotswap-entry-trampoline-fast.cpp).
+// Pre-encoded gfx1250 stub, fixed s[100:101]; only the two PC-relative deltas
+// are patched per kernel. All offsets are into the 256-byte stub.
+static constexpr uint64_t FastEntryStubBodyBytes = 40; // body: to s_set_pc_i64
+static constexpr uint64_t FastEntryPrefixBytes = 16;   // global_wb + v_nop
+static constexpr uint64_t FastEntryPcBaseOffset = 20;  // s_add (after s_get_pc)
+static constexpr uint64_t FastEntryDeltaLoOffset = 24; // s_add_co_u32 imm32
+static constexpr uint64_t FastEntryDeltaHiOffset = 32; // s_add_co_ci_u32 imm32
+
 struct KernelDescriptorInfo {
   std::string KernelName;
   uint64_t VAddr = 0;
@@ -932,6 +941,11 @@ struct KernelEntryTrampolineFixup {
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
   uint32_t InstPrefLines = 0;
+  // The fast path uses a fixed s[100:101] scratch pair that is never a live
+  // kernel input, so the logical SGPR reservation is unchanged and the
+  // descriptor SGPR-count update is skipped. The MC path allocates a per-kernel
+  // pair and leaves this false.
+  bool SkipSgprReservation = false;
 };
 
 /// Build a 256-byte, entry-aligned HotSwap kernel-entry stub at
@@ -973,6 +987,28 @@ bool rewriteKernelEntryDescriptorOffsets(
     llvm::WritableMemoryBuffer &OutBuf, uint64_t PoolVAddr,
     llvm::StringRef TargetCpu,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+
+/// Resolve the virtual address of a kernel descriptor's entry point. Shared by
+/// the MC and fast entry-trampoline paths.
+std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD);
+
+/// Round Value up to a multiple of Alignment, reporting overflow against
+/// Context. Shared by the MC and fast entry-trampoline paths.
+std::optional<uint64_t> checkedAlignTo(uint64_t Value, uint64_t Alignment,
+                                       llvm::StringRef Context);
+
+/// B0->B0 FAST PATH (comgr-hotswap-entry-trampoline-fast.cpp): emit entry stubs
+/// from a pre-encoded gfx1250 byte template with fixed s[100:101] and no LLVM
+/// MC layer. Same append/fixup contract as appendKernelEntryTrampolines, but no
+/// per-kernel SGPR read and RequiredSgprs is left 0 (descriptor SGPR
+/// reservation unchanged). Selected automatically for pure B0->B0 entry-only
+/// rewrites.
+llvm::SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
+                                                          uint64_t EntryVAddr);
+std::optional<uint32_t> appendKernelEntryTrampolinesFast(
+    const ElfView &Elf, llvm::StringRef TargetCpu,
+    std::vector<Trampoline> &Growth,
+    std::vector<KernelEntryTrampolineFixup> &OutFixups);
 
 /// Add a `<kernel_name>.stub` STT_FUNC symbol to the code object's `.symtab`
 /// for each appended kernel-entry stub, so tools that resolve a dispatch's

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1033,6 +1033,12 @@ struct Gfx1250RewriteOptions {
   bool RunB0A0Patches = true;
   bool RunEntryTrampolines = false;
   MaskWorkaroundPolicy MaskPolicy = MaskWorkaroundPolicy::None;
+  // Source and target are both gfx1250 B0. Only then may the entry-trampoline
+  // rewrite take the no-MC fast path; the source/target stepping needed to
+  // decide this is known to the caller but not recoverable from TargetIdent
+  // alone. A0->A0 and A0->B0 also run without instruction patches, so this must
+  // be set explicitly rather than inferred inside retargetCodeObject.
+  bool UseB0B0EntryFastPath = false;
 };
 
 /// Run the selected GFX1250 hotswap rewrite passes on \p ElfData / \p ElfSize.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -133,13 +133,28 @@ static constexpr uint32_t KernelEntryStubInstPrefLines =
     KernelEntryStubStride / KernelEntryInstPrefUnitBytes;
 
 // B0->B0 fast-path stub layout (see comgr-hotswap-entry-trampoline-fast.cpp).
-// Pre-encoded gfx1250 stub, fixed s[100:101]; only the two PC-relative deltas
-// are patched per kernel. All offsets are into the 256-byte stub.
+// Pre-encoded gfx1250 stub; the two PC-relative delta immediates and the
+// per-kernel scratch SGPR register fields are patched per kernel. All offsets
+// are into the 256-byte stub.
 static constexpr uint64_t FastEntryStubBodyBytes = 40; // body: to s_set_pc_i64
 static constexpr uint64_t FastEntryPrefixBytes = 16;   // global_wb + v_nop
 static constexpr uint64_t FastEntryPcBaseOffset = 20;  // s_add (after s_get_pc)
 static constexpr uint64_t FastEntryDeltaLoOffset = 24; // s_add_co_u32 imm32
 static constexpr uint64_t FastEntryDeltaHiOffset = 32; // s_add_co_ci_u32 imm32
+
+// SGPR register-field byte offsets within the stub body. The scratch pair is
+// s[N:N+1] with N = ScratchBase (even). Verified by llvm-mc round-trip on
+// gfx1250 (see the encoding table in comgr-hotswap-entry-trampoline-fast.cpp):
+//   s_get_pc_i64 sdst         : byte = 0x80 | N
+//   s_add_co_u32 src0/sdst    : byte = N
+//   s_add_co_ci_u32 src0/sdst : byte = N + 1
+//   s_set_pc_i64 src          : byte = N
+static constexpr uint64_t FastEntryGetPcSdstOffset = 18;
+static constexpr uint64_t FastEntryAddLoSrc0Offset = 20;
+static constexpr uint64_t FastEntryAddLoSdstOffset = 22;
+static constexpr uint64_t FastEntryAddHiSrc0Offset = 28;
+static constexpr uint64_t FastEntryAddHiSdstOffset = 30;
+static constexpr uint64_t FastEntrySetPcSrcOffset = 36;
 
 struct KernelDescriptorInfo {
   std::string KernelName;
@@ -941,10 +956,10 @@ struct KernelEntryTrampolineFixup {
   uint64_t StubTextOffset = 0;
   unsigned RequiredSgprs = 0;
   uint32_t InstPrefLines = 0;
-  // The fast path uses a fixed s[100:101] scratch pair that is never a live
-  // kernel input, so the logical SGPR reservation is unchanged and the
-  // descriptor SGPR-count update is skipped. The MC path allocates a per-kernel
-  // pair and leaves this false.
+  // Both the MC path and the fast path allocate a per-kernel scratch pair above
+  // the kernel's live SGPR count and bump the descriptor SGPR reservation, so
+  // this is normally false. It stays reserved for a caller that installs a stub
+  // using a pair already counted in the reservation (no bump needed).
   bool SkipSgprReservation = false;
 };
 
@@ -998,15 +1013,17 @@ std::optional<uint64_t> checkedAlignTo(uint64_t Value, uint64_t Alignment,
                                        llvm::StringRef Context);
 
 /// B0->B0 FAST PATH (comgr-hotswap-entry-trampoline-fast.cpp): emit entry stubs
-/// from a pre-encoded gfx1250 byte template with fixed s[100:101] and no LLVM
-/// MC layer. Same append/fixup contract as appendKernelEntryTrampolines, but no
-/// per-kernel SGPR read and RequiredSgprs is left 0 (descriptor SGPR
-/// reservation unchanged). Selected automatically for pure B0->B0 entry-only
-/// rewrites.
+/// from a pre-encoded gfx1250 byte template with no LLVM MC layer. Same
+/// append/fixup contract as appendKernelEntryTrampolines: the scratch pair is
+/// allocated per kernel above its live SGPR count and \p ScratchSgpr is patched
+/// into the stub's SGPR register fields, so the descriptor SGPR reservation is
+/// bumped exactly like the MC path. Selected automatically for pure B0->B0
+/// entry-only rewrites.
 llvm::SmallVector<uint8_t> buildKernelEntryTrampolineFast(uint64_t StubVAddr,
-                                                          uint64_t EntryVAddr);
+                                                          uint64_t EntryVAddr,
+                                                          unsigned ScratchSgpr);
 std::optional<uint32_t> appendKernelEntryTrampolinesFast(
-    const ElfView &Elf, llvm::StringRef TargetCpu,
+    const ElfView &Elf, llvm::StringRef TargetCpu, unsigned MaxSgprs,
     std::vector<Trampoline> &Growth,
     std::vector<KernelEntryTrampolineFixup> &OutFixups);
 

--- a/amd/comgr/src/comgr-hotswap.cpp
+++ b/amd/comgr/src/comgr-hotswap.cpp
@@ -230,6 +230,13 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
   Options.RunEntryTrampolines = RunEntryTrampolines;
   Options.MaskPolicy =
       getMaskWorkaroundPolicy(TargetIdent, StrictMode, Options.RunB0A0Patches);
+  // Fast entry-trampoline path is B0->B0 only. Match the stepping defaults used
+  // by shouldRunB0A0Patches: an unspecified source is treated as B0, but the
+  // target must explicitly be B0 (unspecified defaults to A0), so the fast path
+  // fails closed to the MC path when the target stepping is unknown.
+  Options.UseB0B0EntryFastPath = TargetIdent.Ident.Processor == "gfx1250" &&
+                                 SourceIdent.IsB0.value_or(true) &&
+                                 TargetIdent.IsB0.value_or(false);
 
   std::unique_ptr<llvm::MemoryBuffer> OutBuffer;
   amd_comgr_status_t Status = hotswap::retargetCodeObject(

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-fastpath.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-fastpath.s
@@ -1,0 +1,128 @@
+// COM: On a pure B0-to-B0 entry-only rewrite HotSwap takes the no-MC fast path:
+// COM: it emits each entry stub from a pre-encoded template with a fixed
+// COM: s[100:101] scratch pair, leaves the descriptor SGPR reservation
+// COM: unchanged, and adds no debug-only .stub symbols. A prologue that already
+// COM: carries the workaround is skipped.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.fast.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.fast.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The redirect is through the descriptor, so the kernel body is not
+// COM: rewritten in place.
+// DISASM-LABEL: <plain_kernel>:
+// DISASM-NEXT: s_setreg_imm32_b32
+// DISASM-NEXT: s_endpgm
+
+// COM: A prologue that already has global_wb; v_nop keeps its in-place
+// COM: workaround and gets no redirect stub.
+// DISASM-LABEL: <precompiled_wa_kernel>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_endpgm
+
+// COM: The appended stub uses the fixed s[100:101] pair, not a per-kernel pair
+// COM: like the MC path (which would emit s[8:9] here).
+// DISASM: s_get_pc_i64 s[100:101]
+// DISASM-NEXT: s_add_co_u32 s100
+// DISASM-NEXT: s_add_co_ci_u32 s101
+// DISASM-NEXT: s_set_pc_i64 s[100:101]
+
+// COM: The fast path adds no .stub symbols by default (the loader adds none;
+// COM: they are only a debugging aid).
+// RUN: %llvm-readelf -s %t.fast.elf | %FileCheck --check-prefix=NO-SYMS %s
+// NO-SYMS-NOT: .stub
+
+// COM: Fixed s[100:101] is never a live kernel input, so the logical SGPR
+// COM: reservation is left unchanged (the MC path would bump it).
+// RUN: %llvm-readelf --notes %t.fast.elf | %FileCheck --check-prefix=SGPR %s
+// SGPR: .name:           plain_kernel
+// SGPR: .sgpr_count:     8
+
+// COM: Byte-compare idempotency: a second pass recognizes the installed stub
+// COM: (and the in-place workaround) and is a no-op.
+// RUN: hotswap-rewrite %t.fast.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.fast2.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: cmp %t.fast.elf %t.fast2.elf
+
+// COM: AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 re-enables the .stub symbols on
+// COM: the fast path (e.g. for rocgdb).
+// RUN: env AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.syms.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-readelf -s %t.syms.elf | %FileCheck --check-prefix=SYMS %s
+// SYMS: plain_kernel.stub
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+// No workaround: expect a fast-path redirect stub.
+.globl plain_kernel
+.p2align 8
+.type plain_kernel,@function
+plain_kernel:
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  s_endpgm
+.Lplain_kernel_end:
+.size plain_kernel, .Lplain_kernel_end-plain_kernel
+
+// Prologue already carries the workaround: expect no stub.
+.globl precompiled_wa_kernel
+.p2align 8
+.type precompiled_wa_kernel,@function
+precompiled_wa_kernel:
+  global_wb
+  v_nop
+  s_endpgm
+.Lprecompiled_wa_kernel_end:
+.size precompiled_wa_kernel, .Lprecompiled_wa_kernel_end-precompiled_wa_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel plain_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel precompiled_wa_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: plain_kernel
+      .symbol: plain_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: precompiled_wa_kernel
+      .symbol: precompiled_wa_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -104,6 +104,7 @@ add_executable(HotswapMCTests
   HotswapMCTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
+  ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp
   ../src/comgr-hotswap-llvm.cpp
   ../src/comgr-hotswap-patch-f32-to-e5m3.cpp

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -908,3 +908,40 @@ TEST(ElfView, UpdateKernelDescriptorSgprCountRejectsDescriptorLimitFirst) {
   EXPECT_EQ(*MetadataSgprs, 200u);
   EXPECT_EQ(readReservedSgprs(Obj.Bytes, Obj.KernelDescriptorOffset), 8u);
 }
+
+// -- kernel-descriptor cache dedup --------------------------------------------
+
+// The descriptor cache dedups by (name, vaddr): the same kernel name can appear
+// at more than one descriptor vaddr, and a repeat of an already-seen
+// (name, vaddr) pair must be dropped regardless of ordering. This pins the
+// A@x, A@y, A@x case, which a "remember only the last vaddr per name" dedup
+// would mishandle by re-adding the trailing A@x.
+TEST(ElfView, KernelDescriptorCacheDedupsByNameAndVAddrAcrossOrdering) {
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.TextAddr = 0x1000;
+  Opts.TextSize = 0x400;
+  Opts.RodataAddr = 0x2000;
+  // Distinct descriptor vaddrs for the two "A" instances, and a "B" in between,
+  // then a duplicate of the first A. Expect three unique descriptors:
+  // A@0x2000, B@0x2100, A@0x2200 -- the trailing A@0x2000 duplicate is dropped.
+  Opts.Kernels = {
+      {"kern_a", 0x1000, 0x2000, /*EntryOffset=*/-0x1000},
+      {"kern_b", 0x1100, 0x2100, /*EntryOffset=*/-0x1000},
+      {"kern_a", 0x1200, 0x2200, /*EntryOffset=*/-0x1000},
+      {"kern_a", 0x1000, 0x2000, /*EntryOffset=*/-0x1000}, // dup of first
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Bytes.data(), Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 3u);
+  EXPECT_EQ(KDs[0].KernelName, "kern_a");
+  EXPECT_EQ(KDs[0].VAddr, 0x2000u);
+  EXPECT_EQ(KDs[1].KernelName, "kern_b");
+  EXPECT_EQ(KDs[1].VAddr, 0x2100u);
+  EXPECT_EQ(KDs[2].KernelName, "kern_a");
+  EXPECT_EQ(KDs[2].VAddr, 0x2200u);
+}

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1158,6 +1158,81 @@ TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(StubVAddr - *KdVAddr));
 }
 
+// rewriteKernelEntryDescriptorOffsets aggregates per-kernel SGPR bumps into a
+// single batched metadata update. Drive it with a fixup list covering the
+// aggregation cases: a kernel appearing twice (take the max), a kernel that
+// skips the reservation, and a kernel with a zero requirement. Only the
+// max-aggregated kernel's metadata SGPR count should be raised.
+TEST(RewriteKernelEntryDescriptorOffsets, AggregatesSgprBumpsMaxSkipZero) {
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.Kernels = {
+      {"k_max", 0x1000, 0x2000, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+      {"k_skip", 0x1100, 0x2100, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+      {"k_zero", 0x1200, 0x2200, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Buf =
+      llvm::WritableMemoryBuffer::getNewUninitMemBuffer(Bytes.size());
+  ASSERT_NE(Buf, nullptr);
+  std::memcpy(Buf->getBufferStart(), Bytes.data(), Bytes.size());
+
+  // Two fixups name k_max with different RequiredSgprs -> aggregate to the max
+  // (12). k_skip sets SkipSgprReservation, k_zero has RequiredSgprs == 0; both
+  // must leave the metadata count untouched.
+  const uint64_t PoolVAddr = 0x4000;
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"k_max", /*StubTextOffset=*/0, /*RequiredSgprs=*/10, /*InstPrefLines=*/0,
+       /*SkipSgprReservation=*/false},
+      {"k_max", /*StubTextOffset=*/KernelEntryStubStride, /*RequiredSgprs=*/12,
+       /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+      {"k_skip", /*StubTextOffset=*/2 * KernelEntryStubStride,
+       /*RequiredSgprs=*/20, /*InstPrefLines=*/0, /*SkipSgprReservation=*/true},
+      {"k_zero", /*StubTextOffset=*/3 * KernelEntryStubStride,
+       /*RequiredSgprs=*/0, /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+  };
+
+  ASSERT_TRUE(
+      rewriteKernelEntryDescriptorOffsets(*Buf, PoolVAddr, "gfx1250", Fixups));
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Buf->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Buf->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  EXPECT_EQ(OutView->getKernelSgprCount("k_max"), 12u);
+  EXPECT_EQ(OutView->getKernelSgprCount("k_skip"), 8u);
+  EXPECT_EQ(OutView->getKernelSgprCount("k_zero"), 8u);
+}
+
+// A fixup naming a kernel with no descriptor must fail the whole rewrite, even
+// when another fixup in the batch is valid.
+TEST(RewriteKernelEntryDescriptorOffsets, PropagatesMissingDescriptorFailure) {
+  comgr_test::MultiKernelDescriptorElfOptions Opts;
+  Opts.Kernels = {
+      {"present", 0x1000, 0x2000, /*EntryOffset=*/-0x1000,
+       /*ComputePgmRsrc3=*/0, /*EmitMetadata=*/true, /*MetadataSgprCount=*/8},
+  };
+  std::vector<uint8_t> Bytes = comgr_test::makeMultiKernelDescriptorElf(Opts);
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Buf =
+      llvm::WritableMemoryBuffer::getNewUninitMemBuffer(Bytes.size());
+  ASSERT_NE(Buf, nullptr);
+  std::memcpy(Buf->getBufferStart(), Bytes.data(), Bytes.size());
+
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"present", /*StubTextOffset=*/0, /*RequiredSgprs=*/10,
+       /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+      {"absent", /*StubTextOffset=*/KernelEntryStubStride, /*RequiredSgprs=*/10,
+       /*InstPrefLines=*/0, /*SkipSgprReservation=*/false},
+  };
+
+  EXPECT_FALSE(rewriteKernelEntryDescriptorOffsets(*Buf, /*PoolVAddr=*/0x4000,
+                                                   "gfx1250", Fixups));
+}
+
 // Count symbols named \p Name in the .symtab of the ELF held in \p Buf.
 // Returns ~0u if the ELF or its symbol table cannot be parsed, so a mis-parse
 // surfaces as a failed expectation rather than a silent zero.

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -261,17 +261,18 @@ TEST(EncodeSetPCLongBranch, RejectsMisalignedScratchPair) {
 // -- buildKernelEntryTrampolineFast ------------------------------------------
 //
 // The fast path emits its entry stub from a pre-encoded byte template, patching
-// only the two PC-relative delta immediates. These tests disassemble the
-// emitted bytes and confirm (a) the stub keeps the fixed s[100:101] scratch
-// pair the template hard-codes, and (b) the runtime PC arithmetic --
-// s_get_pc_i64 then the two-word add-with-carry -- lands exactly on the
-// original entry. Checking the decoded immediates rather than the raw template
-// guards against a bad PC-base offset or a wrong delta word, which the
-// disassembly-mnemonic lit test cannot catch.
+// the two PC-relative delta immediates and the scratch SGPR register fields.
+// These tests disassemble the emitted bytes and confirm (a) the stub names one
+// consistent scratch pair across all six SGPR fields, and (b) the runtime PC
+// arithmetic -- s_get_pc_i64 then the two-word add-with-carry -- lands exactly
+// on the original entry. They pass ScratchSgpr=100 so the decoded bytes match
+// the historical fixed-pair layout. Checking the decoded immediates rather than
+// the raw template guards against a bad PC-base offset or a wrong delta word,
+// which the disassembly-mnemonic lit test cannot catch.
 
 // Disassemble a fast stub and reconstruct the entry vaddr it jumps to,
 // modelling the on-hardware two's-complement add-with-carry across the
-// s[100:101] pair. Also asserts the fixed structure (fixed scratch pair,
+// scratch pair. Also asserts the structure (one consistent scratch pair,
 // expected opcodes).
 static uint64_t decodeFastStubTarget(const LLVMState &S, uint64_t StubVAddr,
                                      llvm::ArrayRef<uint8_t> Bytes) {
@@ -330,7 +331,7 @@ TEST(BuildKernelEntryTrampolineFast, ForwardDeltaLandsOnEntry) {
   const uint64_t StubVAddr = 0x100000;
   const uint64_t EntryVAddr = 0x180000; // forward
   llvm::SmallVector<uint8_t> Bytes =
-      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr);
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr, /*ScratchSgpr=*/100);
   ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
   EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
 }
@@ -341,7 +342,7 @@ TEST(BuildKernelEntryTrampolineFast, BackwardDeltaLandsOnEntry) {
   const uint64_t StubVAddr = 0x180000;
   const uint64_t EntryVAddr = 0x100000; // backward: negative delta
   llvm::SmallVector<uint8_t> Bytes =
-      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr);
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr, /*ScratchSgpr=*/100);
   ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
   EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
 }
@@ -354,9 +355,93 @@ TEST(BuildKernelEntryTrampolineFast, CarryProducingDeltaLandsOnEntry) {
   const uint64_t StubVAddr = 0xFFFFF000;
   const uint64_t EntryVAddr = 0x1'0002'0000; // crosses the 4 GiB boundary
   llvm::SmallVector<uint8_t> Bytes =
-      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr);
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr, /*ScratchSgpr=*/100);
   ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
   EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
+}
+
+// The stub's six SGPR register fields must encode whatever scratch pair the
+// allocator picked -- not the s[100:101] the template is spelled with. Build
+// with an even base other than 100 and confirm the decoded pair matches, and
+// that the delta still lands on the entry (the field patch must not disturb the
+// delta words).
+TEST(BuildKernelEntryTrampolineFast, PatchesScratchSgprRegisterFields) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  const uint64_t StubVAddr = 0x100000;
+  const uint64_t EntryVAddr = 0x140000;
+  const unsigned ScratchSgpr = 8; // aligned pair s[8:9]
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr, ScratchSgpr);
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+
+  std::vector<InternalDecodedInst> Dec;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Dec));
+  ASSERT_GE(Dec.size(), 6u);
+  const llvm::MCInst &GetPc = Dec[2].Inst;
+  ASSERT_TRUE(GetPc.getOperand(0).isReg());
+  // s_get_pc names the low SGPR of the pair; s[8:9] decodes as SGPR8.
+  EXPECT_EQ(GetPc.getOperand(0).getReg(), Dec[5].Inst.getOperand(0).getReg());
+  EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
+}
+
+// A kernel whose live SGPR count leaves no aligned scratch pair below MaxSgprs
+// must decline cleanly (nullopt), never clobber a live SGPR or crash. This is
+// the correctness guarantee the per-kernel scratch allocation adds over a fixed
+// pair: MetadataSgprCount is set to the top of the addressable range.
+TEST(KernelEntryTrampolineFast, DeclinesWhenNoScratchPairFits) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> EndPgm = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(EndPgm.size(), MinInstSize);
+  llvm::SmallVector<uint8_t> Text(EndPgm.begin(), EndPgm.end());
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  // 106 SGPRs used: no aligned pair fits below the 106-SGPR gfx1250 limit.
+  Opts.MetadataSgprCount = 106;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  std::optional<uint32_t> Count = appendKernelEntryTrampolinesFast(
+      *View, "gfx1250", /*MaxSgprs=*/106, Growth, Fixups);
+  EXPECT_FALSE(Count.has_value());
+}
+
+// The complement of the decline case: a modest SGPR count leaves room, so the
+// fast path installs one trampoline and records the bumped scratch pair in the
+// fixup (SkipSgprReservation=false), exactly like the MC path.
+TEST(KernelEntryTrampolineFast, AllocatesPerKernelScratchAndBumpsReservation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> EndPgm = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(EndPgm.size(), MinInstSize);
+  llvm::SmallVector<uint8_t> Text(EndPgm.begin(), EndPgm.end());
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8; // scratch pair lands at s[8:9]
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(Text, Opts);
+  llvm::Expected<ElfView> View =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+
+  std::vector<Trampoline> Growth;
+  std::vector<KernelEntryTrampolineFixup> Fixups;
+  std::optional<uint32_t> Count = appendKernelEntryTrampolinesFast(
+      *View, "gfx1250", /*MaxSgprs=*/106, Growth, Fixups);
+  ASSERT_TRUE(Count.has_value());
+  EXPECT_EQ(*Count, 1u);
+  ASSERT_EQ(Fixups.size(), 1u);
+  // Scratch pair is s[8:9]; the fixup records the top of the pair (base + 2).
+  EXPECT_EQ(Fixups[0].RequiredSgprs, 10u);
+  EXPECT_FALSE(Fixups[0].SkipSgprReservation);
 }
 
 TEST(IsSBranchReachable, CoversBoundariesAlignmentAndPcOverflow) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -258,6 +258,107 @@ TEST(EncodeSetPCLongBranch, RejectsMisalignedScratchPair) {
   EXPECT_FALSE(encodeSetPCLongBranch(S, 0, 0x1000, /*SgprBase=*/3));
 }
 
+// -- buildKernelEntryTrampolineFast ------------------------------------------
+//
+// The fast path emits its entry stub from a pre-encoded byte template, patching
+// only the two PC-relative delta immediates. These tests disassemble the
+// emitted bytes and confirm (a) the stub keeps the fixed s[100:101] scratch
+// pair the template hard-codes, and (b) the runtime PC arithmetic --
+// s_get_pc_i64 then the two-word add-with-carry -- lands exactly on the
+// original entry. Checking the decoded immediates rather than the raw template
+// guards against a bad PC-base offset or a wrong delta word, which the
+// disassembly-mnemonic lit test cannot catch.
+
+// Disassemble a fast stub and reconstruct the entry vaddr it jumps to,
+// modelling the on-hardware two's-complement add-with-carry across the
+// s[100:101] pair. Also asserts the fixed structure (fixed scratch pair,
+// expected opcodes).
+static uint64_t decodeFastStubTarget(const LLVMState &S, uint64_t StubVAddr,
+                                     llvm::ArrayRef<uint8_t> Bytes) {
+  std::vector<InternalDecodedInst> Dec;
+  EXPECT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Dec));
+  EXPECT_GE(Dec.size(), 6u);
+
+  // Body layout: global_wb, v_nop, s_get_pc_i64, s_add_co_u32 (delta lo),
+  // s_add_co_ci_u32 (delta hi), s_set_pc_i64.
+  EXPECT_EQ(Dec[0].Inst.getOpcode(), S.GlobalWbOpcode);
+  EXPECT_EQ(Dec[1].Inst.getOpcode(), S.VNopInst.getOpcode());
+  EXPECT_EQ(Dec[2].Inst.getOpcode(), S.SGetPcI64Opcode);
+  EXPECT_EQ(Dec[3].Inst.getOpcode(), S.SAddU32Opcode);
+  EXPECT_EQ(Dec[4].Inst.getOpcode(), S.SAddcU32Opcode);
+  EXPECT_EQ(Dec[5].Inst.getOpcode(), S.SSetPcI64Opcode);
+  const llvm::MCInst &GetPc = Dec[2].Inst;
+  const llvm::MCInst &AddLo = Dec[3].Inst;
+  const llvm::MCInst &AddHi = Dec[4].Inst;
+  const llvm::MCInst &SetPc = Dec[5].Inst;
+
+  // s_get_pc, s_set_pc, and both add destinations must all name the same fixed
+  // scratch pair the template hard-codes (s[100:101]).
+  EXPECT_TRUE(GetPc.getOperand(0).isReg() && SetPc.getOperand(0).isReg() &&
+              AddLo.getOperand(0).isReg() && AddHi.getOperand(0).isReg());
+  const llvm::MCRegister Pair = GetPc.getOperand(0).getReg();
+  EXPECT_EQ(SetPc.getOperand(0).getReg(), Pair);
+  EXPECT_EQ(AddLo.getOperand(0).getReg(), AddLo.getOperand(1).getReg());
+  EXPECT_EQ(AddHi.getOperand(0).getReg(), AddHi.getOperand(1).getReg());
+
+  // The 32-bit literal is the trailing dword of each 8-byte add. Read it from
+  // the disassembler-reported instruction span rather than the decoded operand:
+  // the AMDGPU disassembler models s_add_co_ci_u32's literal as an expr, so
+  // getImm() on it is unreliable, while s_add_co_u32's is a plain imm.
+  EXPECT_EQ(Dec[3].Size, 8u);
+  EXPECT_EQ(Dec[4].Size, 8u);
+  const uint32_t Lo = readDword(Bytes.data() + Dec[3].Offset + Dec[3].Size - 4);
+  const uint32_t Hi = readDword(Bytes.data() + Dec[4].Offset + Dec[4].Size - 4);
+
+  // PC base is the address of the instruction after s_get_pc_i64.
+  const uint64_t PcBase = StubVAddr + Dec[2].Offset + Dec[2].Size;
+
+  // Model the hardware add-with-carry across the 64-bit pair rather than a
+  // plain 64-bit add, so a delta that carries out of the low word is exercised.
+  const uint32_t BaseLo = static_cast<uint32_t>(PcBase);
+  const uint32_t BaseHi = static_cast<uint32_t>(PcBase >> 32);
+  const uint64_t SumLo = static_cast<uint64_t>(BaseLo) + Lo;
+  const uint32_t ResLo = static_cast<uint32_t>(SumLo);
+  const uint32_t Carry = static_cast<uint32_t>(SumLo >> 32);
+  const uint32_t ResHi = BaseHi + Hi + Carry;
+  return (static_cast<uint64_t>(ResHi) << 32) | ResLo;
+}
+
+TEST(BuildKernelEntryTrampolineFast, ForwardDeltaLandsOnEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  const uint64_t StubVAddr = 0x100000;
+  const uint64_t EntryVAddr = 0x180000; // forward
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr);
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
+}
+
+TEST(BuildKernelEntryTrampolineFast, BackwardDeltaLandsOnEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  const uint64_t StubVAddr = 0x180000;
+  const uint64_t EntryVAddr = 0x100000; // backward: negative delta
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr);
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
+}
+
+TEST(BuildKernelEntryTrampolineFast, CarryProducingDeltaLandsOnEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  // Pc base low word is near the top of 32 bits, and the entry is far enough
+  // above that the low-word add overflows and must carry into the high word.
+  const uint64_t StubVAddr = 0xFFFFF000;
+  const uint64_t EntryVAddr = 0x1'0002'0000; // crosses the 4 GiB boundary
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampolineFast(StubVAddr, EntryVAddr);
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  EXPECT_EQ(decodeFastStubTarget(S, StubVAddr, Bytes), EntryVAddr);
+}
+
 TEST(IsSBranchReachable, CoversBoundariesAlignmentAndPcOverflow) {
   constexpr uint64_t PositiveLimit =
       static_cast<uint64_t>(BranchOffsetMax + 1) * MinInstSize;

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -15,6 +15,7 @@
 #include "llvm/Support/AMDHSAKernelDescriptor.h"
 #include "llvm/Support/MathExtras.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -323,6 +324,220 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   }
 
   return Result;
+}
+
+// Options for an ELF carrying several kernel descriptors, for tests that need
+// more than one kernel (descriptor-cache dedup ordering, batched SGPR updates).
+// Kept separate from makeKernelDescriptorElf so the single-kernel fixture used
+// by most tests is untouched.
+struct MultiKernelDescriptorElfOptions {
+  struct Kernel {
+    std::string Name;
+    // STT_FUNC entry symbol value; must lie within [TextAddr,
+    // TextAddr+TextSize).
+    uint64_t EntryVAddr = 0;
+    // STT_OBJECT `<name>.kd` symbol value; must be >= RodataAddr. The dedup
+    // path keys on (name, KdVAddr), so repeat a (Name, KdVAddr) pair to emit a
+    // duplicate symbol and vary KdVAddr to emit a distinct descriptor.
+    uint64_t KdVAddr = 0;
+    int64_t EntryOffset = 0; // kernel_code_entry_byte_offset in the descriptor
+    uint32_t ComputePgmRsrc3 = 0;
+    // When true, add an amdhsa.kernels metadata entry (with SgprCount) for this
+    // kernel. Leave false to model a descriptor that has no metadata entry.
+    bool EmitMetadata = false;
+    unsigned MetadataSgprCount = 0;
+  };
+
+  uint16_t ElfType = llvm::ELF::ET_DYN;
+  uint64_t TextAddr = 0x1000;
+  uint64_t TextSize = 0x400;
+  uint64_t RodataAddr = 0x2000;
+  std::vector<Kernel> Kernels;
+};
+
+inline std::vector<uint8_t>
+makeMultiKernelMetadataBlob(const MultiKernelDescriptorElfOptions &Options) {
+  KernelDescriptorElfOptions MetaOpts;
+  for (const MultiKernelDescriptorElfOptions::Kernel &K : Options.Kernels)
+    if (K.EmitMetadata)
+      MetaOpts.MetadataKernels.push_back({K.Name, K.MetadataSgprCount});
+  if (MetaOpts.MetadataKernels.empty())
+    return {};
+  std::string Blob = makeAmdgpuMetadataBlob(MetaOpts);
+  return makeAmdgpuMetadataNote(Blob);
+}
+
+inline std::vector<uint8_t>
+makeMultiKernelDescriptorElf(const MultiKernelDescriptorElfOptions &Options) {
+  using namespace llvm::ELF;
+  namespace hsa = llvm::amdhsa;
+
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t TextOffset = 0x240;
+  static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
+  static constexpr char ShStrTab[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
+
+  const size_t NumKernels = Options.Kernels.size();
+  assert(NumKernels > 0 && "multi-kernel ELF needs at least one kernel");
+
+  // .rodata must span the highest descriptor block. Each KdVAddr must sit at or
+  // above RodataAddr; distinct KdVAddrs get distinct blocks, duplicates reuse.
+  uint64_t RodataSpan = KdBytes;
+  for (const MultiKernelDescriptorElfOptions::Kernel &K : Options.Kernels) {
+    assert(K.KdVAddr >= Options.RodataAddr && "kd vaddr below .rodata");
+    assert(K.EntryVAddr >= Options.TextAddr &&
+           K.EntryVAddr < Options.TextAddr + Options.TextSize &&
+           "entry vaddr outside .text");
+    RodataSpan = std::max(RodataSpan, K.KdVAddr - Options.RodataAddr + KdBytes);
+  }
+
+  // String table: null byte, then per kernel "<name>\0" and "<name>.kd\0".
+  // Duplicates are emitted verbatim so repeated symbols stay independent.
+  std::string StrTab;
+  StrTab.push_back('\0');
+  std::vector<uint32_t> FuncNameOff(NumKernels), KdNameOff(NumKernels);
+  for (size_t I = 0; I < NumKernels; ++I) {
+    FuncNameOff[I] = static_cast<uint32_t>(StrTab.size());
+    StrTab += Options.Kernels[I].Name;
+    StrTab.push_back('\0');
+    KdNameOff[I] = static_cast<uint32_t>(StrTab.size());
+    StrTab += Options.Kernels[I].Name;
+    StrTab += ".kd";
+    StrTab.push_back('\0');
+  }
+
+  std::vector<uint8_t> MetadataNote = makeMultiKernelMetadataBlob(Options);
+  const bool HasMetadataNote = !MetadataNote.empty();
+
+  // Symbols: null [0], then per kernel a STT_FUNC entry and STT_OBJECT .kd.
+  const uint64_t SymCount = 1 + 2 * NumKernels;
+
+  const uint64_t RodataOff = alignTo8(TextOffset + Options.TextSize);
+  const uint64_t StrTabOff = alignTo8(RodataOff + RodataSpan);
+  const uint64_t SymTabOff = alignTo8(StrTabOff + StrTab.size());
+  const uint64_t ShStrTabOff =
+      alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t NoteOff =
+      HasMetadataNote ? alignTo4(ShStrTabOff + sizeof(ShStrTab)) : 0;
+  const uint64_t PhOff =
+      HasMetadataNote ? alignTo8(NoteOff + MetadataNote.size()) : 0;
+  const uint64_t ContentEnd = HasMetadataNote ? PhOff + sizeof(Elf64_Phdr)
+                                              : ShStrTabOff + sizeof(ShStrTab);
+  const uint64_t BufSize = alignTo8(ContentEnd + 64);
+
+  std::vector<uint8_t> Bytes(BufSize, 0);
+  uint8_t *Buf = Bytes.data();
+  std::memcpy(Buf + StrTabOff, StrTab.data(), StrTab.size());
+  std::memcpy(Buf + ShStrTabOff, ShStrTab, sizeof(ShStrTab));
+  if (HasMetadataNote)
+    std::memcpy(Buf + NoteOff, MetadataNote.data(), MetadataNote.size());
+
+  Elf64_Ehdr Ehdr = makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = Options.ElfType;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_shoff = ShOff;
+  if (HasMetadataNote) {
+    Ehdr.e_phoff = PhOff;
+    Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+    Ehdr.e_phnum = 1;
+  }
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = 6;
+  Ehdr.e_shstrndx = 5;
+  std::memcpy(Buf, &Ehdr, sizeof(Ehdr));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = 1;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_offset = TextOffset;
+  TextSh.sh_addr = Options.TextAddr;
+  TextSh.sh_size = Options.TextSize;
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf + ShOff + 1 * sizeof(Elf64_Shdr), &TextSh, sizeof(TextSh));
+
+  Elf64_Shdr RodataSh{};
+  RodataSh.sh_name = 7;
+  RodataSh.sh_type = SHT_PROGBITS;
+  RodataSh.sh_flags = SHF_ALLOC;
+  RodataSh.sh_offset = RodataOff;
+  RodataSh.sh_addr = Options.RodataAddr;
+  RodataSh.sh_size = RodataSpan;
+  RodataSh.sh_addralign = 8;
+  std::memcpy(Buf + ShOff + 2 * sizeof(Elf64_Shdr), &RodataSh,
+              sizeof(RodataSh));
+
+  Elf64_Shdr StrtabSh{};
+  StrtabSh.sh_name = 15;
+  StrtabSh.sh_type = SHT_STRTAB;
+  StrtabSh.sh_offset = StrTabOff;
+  StrtabSh.sh_size = StrTab.size();
+  std::memcpy(Buf + ShOff + 3 * sizeof(Elf64_Shdr), &StrtabSh,
+              sizeof(StrtabSh));
+
+  Elf64_Shdr SymtabSh{};
+  SymtabSh.sh_name = 23;
+  SymtabSh.sh_type = SHT_SYMTAB;
+  SymtabSh.sh_offset = SymTabOff;
+  SymtabSh.sh_size = SymCount * sizeof(Elf64_Sym);
+  SymtabSh.sh_link = 3; // .strtab section index
+  SymtabSh.sh_info = 1; // one past the last local symbol (only sym[0] is local)
+  SymtabSh.sh_entsize = sizeof(Elf64_Sym);
+  std::memcpy(Buf + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
+              sizeof(SymtabSh));
+
+  Elf64_Shdr ShstrSh{};
+  ShstrSh.sh_name = 31;
+  ShstrSh.sh_type = SHT_STRTAB;
+  ShstrSh.sh_offset = ShStrTabOff;
+  ShstrSh.sh_size = sizeof(ShStrTab);
+  std::memcpy(Buf + ShOff + 5 * sizeof(Elf64_Shdr), &ShstrSh, sizeof(ShstrSh));
+
+  if (HasMetadataNote) {
+    Elf64_Phdr NotePhdr{};
+    NotePhdr.p_type = PT_NOTE;
+    NotePhdr.p_offset = NoteOff;
+    NotePhdr.p_filesz = MetadataNote.size();
+    NotePhdr.p_memsz = MetadataNote.size();
+    NotePhdr.p_align = 4;
+    std::memcpy(Buf + PhOff, &NotePhdr, sizeof(NotePhdr));
+  }
+
+  // Descriptor blocks and symbols, one pair per kernel entry.
+  for (size_t I = 0; I < NumKernels; ++I) {
+    const MultiKernelDescriptorElfOptions::Kernel &K = Options.Kernels[I];
+    const uint64_t KdBlockOff = RodataOff + (K.KdVAddr - Options.RodataAddr);
+    std::memcpy(
+        Buf + KdBlockOff +
+            offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
+        &K.EntryOffset, sizeof(K.EntryOffset));
+    std::memcpy(Buf + KdBlockOff +
+                    offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc3),
+                &K.ComputePgmRsrc3, sizeof(K.ComputePgmRsrc3));
+
+    Elf64_Sym FuncSym{};
+    FuncSym.st_name = FuncNameOff[I];
+    FuncSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+    FuncSym.st_shndx = 1;
+    FuncSym.st_value = K.EntryVAddr;
+    FuncSym.st_size = 0x40;
+    std::memcpy(Buf + SymTabOff + (1 + 2 * I) * sizeof(Elf64_Sym), &FuncSym,
+                sizeof(FuncSym));
+
+    Elf64_Sym KdSym{};
+    KdSym.st_name = KdNameOff[I];
+    KdSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+    KdSym.st_shndx = 2;
+    KdSym.st_value = K.KdVAddr;
+    KdSym.st_size = KdBytes;
+    std::memcpy(Buf + SymTabOff + (2 + 2 * I) * sizeof(Elf64_Sym), &KdSym,
+                sizeof(KdSym));
+  }
+
+  return Bytes;
 }
 
 } // namespace comgr_test


### PR DESCRIPTION
## Purpose

Single direct-to-amd-staging companion for the whole fast-path + perf stack, so the full amd-staging CI evaluates it early. We are time-crunched to land today and CI is slow, so this runs the whole stack through CI now rather than waiting on separate cycles per PR.

This branch carries the stack as distinct commits (review the focused diffs in #3361 and #3382):

#3361 (B0->B0 entry-trampoline fast path):
- 08eb395 add B0-to-B0 entry-trampoline fast path
- 3e87dfb unit-test the B0->B0 fast-path entry stub
- d702a11 gate entry-trampoline fast path to B0->B0 only

#3382 (kernel-descriptor rewrite perf):
- d05450c speed up kernel-descriptor rewrites for large objects
- 1bbeb52 fix descriptor dedup to key on (name, vaddr) and add tests

This PR is for CI and is the one intended to merge to amd-staging, since merging it lands both.

Merge this without squash to keep the #3361 and #3382 commits distinct.

## Merge prerequisites (must land in amd-staging first)

- [x] #3346 make gfx1250 semantic rewrites fail-safe (merged)
- [ ] #3347 eliminate add-pc from far hotswap trampolines
- [ ] #3348 scale hotswap rewrites for large code objects

Until #3347 and #3348 land, this PR shows the cumulative diff of the whole stack. Once they merge and this branch is rebased onto the new amd-staging tip, the diff condenses to exactly the five commits above. That is when the true diff is shown and this can merge.