### PR TITLE
[comgr][hotswap] Cache instruction decode results no flag

### DIFF
--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -482,6 +482,9 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Size = It->second.Size;
       DI.Inst = It->second.Inst;
       DI.Mnemonic = It->second.Mnemonic;
+      // Only successful decodes are ever stored (see the store guard below), so
+      // a hit is by construction a successful decode.
+      DI.DecodeSucceeded = true;
       Pos += DI.Size;
       Decoded.emplace_back(std::move(DI));
       continue;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -38,6 +38,18 @@ namespace hotswap {
 static constexpr StringLiteral UnknownMnemonic("<unknown>");
 
 namespace {
+/// Whether the per-call instruction decode cache is enabled (HOTSWAP_DECODE_CACHE
+/// set and not "0"). Evaluated once per process.
+bool isDecodeCacheEnabled() {
+  static const bool Enabled = [] {
+    const char *V = getenv("HOTSWAP_DECODE_CACHE");
+    return V && V[0] != '\0' && StringRef(V) != "0";
+  }();
+  return Enabled;
+}
+} // namespace
+
+namespace {
 // The amdgcn Target is the same for every AMDGPU subtarget (the per-CPU /
 // per-feature differences live in MCSubtargetInfo), so a fixed triple is fine
 // for the one-time TargetRegistry lookup below. The per-call ISA-specific
@@ -448,9 +460,39 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
                        std::vector<InternalDecodedInst> &Decoded) {
   Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
   uint64_t Pos = 0;
+  // Per-call instruction decode cache (opt-in via HOTSWAP_DECODE_CACHE). Decode
+  // is a pure function of the instruction bytes, so byte-identical instructions
+  // (~87% of .text, almost all intra-object) reuse the first decode instead of
+  // re-running the MCDisassembler decision walk. Position-specific data lives in
+  // DI.Offset (set per occurrence), never in the cached MCInst, so reuse is
+  // safe. Keyed on the up-to-8-byte instruction window: a shared key implies
+  // identical decode; an over-specific key only costs a (correct) miss.
+  const bool Cache = isDecodeCacheEnabled();
+  struct DecodeCacheEntry {
+    MCInst Inst;
+    uint32_t Size;
+    std::string Mnemonic;
+  };
+  DenseMap<uint64_t, DecodeCacheEntry> LocalCache;
   while (Pos < TextSize) {
     InternalDecodedInst DI;
     DI.Offset = Pos;
+
+    uint64_t Key = 0;
+    unsigned KeyN = static_cast<unsigned>(std::min<uint64_t>(8, TextSize - Pos));
+    memcpy(&Key, Text + Pos, KeyN);
+
+    if (Cache) {
+      DenseMap<uint64_t, DecodeCacheEntry>::iterator It = LocalCache.find(Key);
+      if (It != LocalCache.end()) {
+        DI.Size = It->second.Size;
+        DI.Inst = It->second.Inst;
+        DI.Mnemonic = It->second.Mnemonic;
+        Pos += DI.Size;
+        Decoded.emplace_back(std::move(DI));
+        continue;
+      }
+    }
 
     ArrayRef<uint8_t> Bytes(Text + Pos, TextSize - Pos);
     uint64_t InstSize = 0;
@@ -476,6 +518,11 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
         DI.Mnemonic = UnknownMnemonic.str();
       }
     }
+    // Only cache clean 4/8-byte decodes whose key fully covers the instruction
+    // (KeyN >= Size); a truncated tail key could alias a shorter instruction.
+    if (Cache && Status != MCDisassembler::Fail && DI.Size <= KeyN)
+      LocalCache.try_emplace(Key,
+                             DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic});
     Pos += DI.Size;
     Decoded.emplace_back(std::move(DI));
   }

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -459,9 +459,9 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
   // before 64/32-bit ones), clamped to the bytes remaining in .text. Keying on
   // fewer bytes than the decoder reads is unsafe: two positions sharing a short
   // prefix but differing in later bytes can decode differently, so a short key
-  // could return a stale decode. Using a StringMap keyed on the raw window makes
-  // the available length part of the key, so a truncated tail window (e.g. 4
-  // bytes left) cannot alias a full-length window with the same prefix.
+  // could return a stale decode. Using a StringMap keyed on the raw window
+  // makes the available length part of the key, so a truncated tail window
+  // (e.g. 4 bytes left) cannot alias a full-length window with the same prefix.
   const unsigned MaxInstLen = S.MAI->getMaxInstLength(S.STI.get());
   struct DecodeCacheEntry {
     MCInst Inst;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -448,20 +448,13 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
                        std::vector<InternalDecodedInst> &Decoded) {
   Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
   uint64_t Pos = 0;
-  // Per-call instruction decode cache. Decode is a pure function of the
-  // instruction bytes, so byte-identical instructions (~87% of .text, almost
-  // all intra-object) reuse the first decode instead of re-running the
-  // MCDisassembler decision walk. Position-specific data lives in DI.Offset
-  // (set per occurrence), never in the cached MCInst, so reuse is safe.
-  //
-  // The key is the full window the disassembler may inspect: up to
-  // getMaxInstLength() bytes (16 on gfx1250, which tries 128/96-bit decodes
-  // before 64/32-bit ones), clamped to the bytes remaining in .text. Keying on
-  // fewer bytes than the decoder reads is unsafe: two positions sharing a short
-  // prefix but differing in later bytes can decode differently, so a short key
-  // could return a stale decode. Using a StringMap keyed on the raw window
-  // makes the available length part of the key, so a truncated tail window
-  // (e.g. 4 bytes left) cannot alias a full-length window with the same prefix.
+  // Per-call decode cache: byte-identical instructions reuse the first decode
+  // instead of re-running the disassembler; DI.Offset is set per occurrence, so
+  // reuse is safe. The key is the full window the disassembler may inspect (up
+  // to getMaxInstLength() bytes, clamped to what remains in .text); keying on
+  // fewer bytes is unsafe because two positions sharing a short prefix can
+  // decode differently. A StringMap keys on the raw window, so its length is
+  // part of the key and a truncated tail cannot alias a longer instruction.
   const unsigned MaxInstLen = S.MAI->getMaxInstLength(S.STI.get());
   struct DecodeCacheEntry {
     MCInst Inst;
@@ -482,8 +475,7 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Size = It->second.Size;
       DI.Inst = It->second.Inst;
       DI.Mnemonic = It->second.Mnemonic;
-      // Only successful decodes are ever stored (see the store guard below), so
-      // a hit is by construction a successful decode.
+      // Only successful decodes are stored, so a hit is always a success.
       DI.DecodeSucceeded = true;
       Pos += DI.Size;
       Decoded.emplace_back(std::move(DI));
@@ -514,11 +506,8 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
         DI.Mnemonic = UnknownMnemonic.str();
       }
     }
-    // Only cache successful decodes whose key window fully covers the decoded
-    // instruction (KeyN >= Size). This holds whenever getMaxInstLength() is an
-    // upper bound on the real instruction size, but the guard keeps the cache
-    // correct even if that bound is ever under-reported: a key shorter than the
-    // instruction could alias a different decode, so such entries are skipped.
+    // Cache only successful decodes whose key window covers the instruction
+    // (Size <= KeyN); a shorter key could alias a different decode.
     if (Status != MCDisassembler::Fail && DI.Size <= KeyN)
       LocalCache.try_emplace(Key,
                              DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic});

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -38,18 +38,6 @@ namespace hotswap {
 static constexpr StringLiteral UnknownMnemonic("<unknown>");
 
 namespace {
-/// Whether the per-call instruction decode cache is enabled (HOTSWAP_DECODE_CACHE
-/// set and not "0"). Evaluated once per process.
-bool isDecodeCacheEnabled() {
-  static const bool Enabled = [] {
-    const char *V = getenv("HOTSWAP_DECODE_CACHE");
-    return V && V[0] != '\0' && StringRef(V) != "0";
-  }();
-  return Enabled;
-}
-} // namespace
-
-namespace {
 // The amdgcn Target is the same for every AMDGPU subtarget (the per-CPU /
 // per-feature differences live in MCSubtargetInfo), so a fixed triple is fine
 // for the one-time TargetRegistry lookup below. The per-call ISA-specific
@@ -460,38 +448,43 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
                        std::vector<InternalDecodedInst> &Decoded) {
   Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
   uint64_t Pos = 0;
-  // Per-call instruction decode cache (opt-in via HOTSWAP_DECODE_CACHE). Decode
-  // is a pure function of the instruction bytes, so byte-identical instructions
-  // (~87% of .text, almost all intra-object) reuse the first decode instead of
-  // re-running the MCDisassembler decision walk. Position-specific data lives in
-  // DI.Offset (set per occurrence), never in the cached MCInst, so reuse is
-  // safe. Keyed on the up-to-8-byte instruction window: a shared key implies
-  // identical decode; an over-specific key only costs a (correct) miss.
-  const bool Cache = isDecodeCacheEnabled();
+  // Per-call instruction decode cache. Decode is a pure function of the
+  // instruction bytes, so byte-identical instructions (~87% of .text, almost
+  // all intra-object) reuse the first decode instead of re-running the
+  // MCDisassembler decision walk. Position-specific data lives in DI.Offset
+  // (set per occurrence), never in the cached MCInst, so reuse is safe.
+  //
+  // The key is the full window the disassembler may inspect: up to
+  // getMaxInstLength() bytes (16 on gfx1250, which tries 128/96-bit decodes
+  // before 64/32-bit ones), clamped to the bytes remaining in .text. Keying on
+  // fewer bytes than the decoder reads is unsafe: two positions sharing a short
+  // prefix but differing in later bytes can decode differently, so a short key
+  // could return a stale decode. Using a StringMap keyed on the raw window makes
+  // the available length part of the key, so a truncated tail window (e.g. 4
+  // bytes left) cannot alias a full-length window with the same prefix.
+  const unsigned MaxInstLen = S.MAI->getMaxInstLength(S.STI.get());
   struct DecodeCacheEntry {
     MCInst Inst;
     uint32_t Size;
     std::string Mnemonic;
   };
-  DenseMap<uint64_t, DecodeCacheEntry> LocalCache;
+  StringMap<DecodeCacheEntry> LocalCache;
   while (Pos < TextSize) {
     InternalDecodedInst DI;
     DI.Offset = Pos;
 
-    uint64_t Key = 0;
-    unsigned KeyN = static_cast<unsigned>(std::min<uint64_t>(8, TextSize - Pos));
-    memcpy(&Key, Text + Pos, KeyN);
+    unsigned KeyN =
+        static_cast<unsigned>(std::min<uint64_t>(MaxInstLen, TextSize - Pos));
+    StringRef Key(reinterpret_cast<const char *>(Text + Pos), KeyN);
 
-    if (Cache) {
-      DenseMap<uint64_t, DecodeCacheEntry>::iterator It = LocalCache.find(Key);
-      if (It != LocalCache.end()) {
-        DI.Size = It->second.Size;
-        DI.Inst = It->second.Inst;
-        DI.Mnemonic = It->second.Mnemonic;
-        Pos += DI.Size;
-        Decoded.emplace_back(std::move(DI));
-        continue;
-      }
+    StringMap<DecodeCacheEntry>::iterator It = LocalCache.find(Key);
+    if (It != LocalCache.end() && It->second.Size <= (TextSize - Pos)) {
+      DI.Size = It->second.Size;
+      DI.Inst = It->second.Inst;
+      DI.Mnemonic = It->second.Mnemonic;
+      Pos += DI.Size;
+      Decoded.emplace_back(std::move(DI));
+      continue;
     }
 
     ArrayRef<uint8_t> Bytes(Text + Pos, TextSize - Pos);
@@ -518,9 +511,12 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
         DI.Mnemonic = UnknownMnemonic.str();
       }
     }
-    // Only cache clean 4/8-byte decodes whose key fully covers the instruction
-    // (KeyN >= Size); a truncated tail key could alias a shorter instruction.
-    if (Cache && Status != MCDisassembler::Fail && DI.Size <= KeyN)
+    // Only cache successful decodes whose key window fully covers the decoded
+    // instruction (KeyN >= Size). This holds whenever getMaxInstLength() is an
+    // upper bound on the real instruction size, but the guard keeps the cache
+    // correct even if that bound is ever under-reported: a key shorter than the
+    // instruction could alias a different decode, so such entries are skipped.
+    if (Status != MCDisassembler::Fail && DI.Size <= KeyN)
       LocalCache.try_emplace(Key,
                              DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic});
     Pos += DI.Size;

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -9,8 +9,8 @@
 /// \file
 /// Tests for the hotswap MC/LLVM infrastructure in comgr-hotswap-llvm.cpp:
 /// initLLVM construction, LLVMState::encodeSBranch, assembleSingleInst /
-/// decodeTextSection round-trip, applyMnemonicSwap, applyByteReplace, and
-/// checkVgprOverlap.
+/// decodeTextSection round-trip, the decodeTextSection instruction-decode
+/// cache, applyMnemonicSwap, applyByteReplace, and checkVgprOverlap.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -1564,4 +1564,132 @@ TEST(AddTid, StoreTrampolineThroughBuildTrampoline) {
                                       "s_branch"};
   expectDecodedMnemonics(Decoded, Expected);
   expectDecodedBodyMatchesAsm(Decoded, AsmLines, S);
+}
+
+// -- decodeTextSection instruction-decode cache -------------------------------
+//
+// decodeTextSection caches decode results keyed on the up-to-getMaxInstLength()
+// byte window at each position, so byte-identical instructions reuse the first
+// decode instead of re-running the disassembler. The cache is unconditional (no
+// opt-in flag), so every decodeTextSection call above already exercises the
+// store path; these tests target the reuse and edge behaviour flagged in
+// review: repeated instructions must reuse decodes without corrupting the
+// per-occurrence Offset, distinct instructions of different sizes must not
+// alias one another, and a truncated final window (fewer than
+// getMaxInstLength() bytes left) must decode correctly rather than returning a
+// stale, oversized hit from an earlier full-length window.
+
+// Append the assembled bytes of each asm line in \p Lines to \p Text. Aborts
+// the test via appendSingleInstBytes if any line fails to assemble.
+static void appendInstStream(llvm::SmallVectorImpl<uint8_t> &Text,
+                             llvm::ArrayRef<const char *> Lines,
+                             const LLVMState &S) {
+  for (const char *Line : Lines)
+    ASSERT_TRUE(appendSingleInstBytes(Text, Line, S));
+}
+
+TEST(DecodeCache, RepeatedInstructionsReuseDecodeWithPerOccurrenceOffset) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // With a full getMaxInstLength() window of identical s_nops, the interior
+  // positions share one key: the first stores, the rest hit. Use enough nops
+  // that several positions still have a full (untruncated) window and hit.
+  constexpr unsigned Count = 8;
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I < Count; ++I)
+    ASSERT_TRUE(appendSingleInstBytes(Text, "s_nop 0", S));
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), Count);
+
+  const llvm::MCInst Ref = assembleOne("s_nop 0", S);
+  uint64_t ExpectedOffset = 0;
+  for (const InternalDecodedInst &DI : Decoded) {
+    EXPECT_EQ(DI.Mnemonic, "s_nop");
+    EXPECT_EQ(DI.Size, MinInstSize);
+    // Offset is set per occurrence and must never come from the cached entry.
+    EXPECT_EQ(DI.Offset, ExpectedOffset);
+    expectSameOperands(DI.Inst, Ref, "repeated s_nop");
+    ExpectedOffset += DI.Size;
+  }
+}
+
+TEST(DecodeCache, InterleavedDistinctSizesUseCorrectEntries) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Mix 4-, 8- and 12-byte instructions, repeating some so both the store and
+  // the hit path run, and interleave them so a wrong key would return the
+  // wrong (differently sized) decode.
+  const char *Seq[] = {
+      "s_nop 0",                                           // 4 bytes
+      "v_cvt_pk_fp8_f32 v4, 1.0, 0.5 clamp",               // 8 bytes
+      "s_nop 0",                                           // 4 bytes (repeat)
+      "v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp", // 12 bytes
+      "v_cvt_pk_fp8_f32 v4, 1.0, 0.5 clamp",               // 8 bytes (repeat)
+      "s_nop 0",                                           // 4 bytes (repeat)
+  };
+  const uint32_t ExpectedSizes[] = {MinInstSize,     2 * MinInstSize,
+                                    MinInstSize,     3 * MinInstSize,
+                                    2 * MinInstSize, MinInstSize};
+
+  llvm::SmallVector<uint8_t> Text;
+  appendInstStream(Text, Seq, S);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), std::size(Seq));
+
+  uint64_t ExpectedOffset = 0;
+  for (size_t I = 0; I < std::size(Seq); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    EXPECT_EQ(DI.Size, ExpectedSizes[I]) << "inst " << I;
+    EXPECT_EQ(DI.Offset, ExpectedOffset) << "inst " << I;
+    expectSameOperands(DI.Inst, assembleOne(Seq[I], S), Seq[I]);
+    ExpectedOffset += DI.Size;
+  }
+  EXPECT_EQ(ExpectedOffset, Text.size());
+}
+
+TEST(DecodeCache, TruncatedFinalWindowDecodesWithoutStaleHit) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // gfx1250 inspects up to a 16-byte window, so the final 4-byte s_nop below is
+  // keyed on a truncated window. If truncated-tail keys aliased earlier
+  // full-length keys, the last instruction could reuse an oversized decode and
+  // over-run the buffer; instead it must decode as a clean 4-byte s_nop, and
+  // the decoded sizes must sum to exactly the buffer length.
+  const unsigned MaxInstLen = S.MAI->getMaxInstLength(S.STI.get());
+  ASSERT_GT(MaxInstLen, static_cast<unsigned>(MinInstSize))
+      << "test assumes a multi-dword max instruction window";
+
+  const char *Seq[] = {
+      "v_cvt_pk_fp8_f32 v4, 0x477f0000, 0x477f0000 clamp", // 12 bytes
+      "s_nop 0",                                           // 4 bytes
+      "s_nop 0",                                           // final, truncated
+  };
+  // The final s_nop leaves only MinInstSize bytes, which is a truncated window
+  // (guaranteed by the MaxInstLen > MinInstSize assertion above).
+  llvm::SmallVector<uint8_t> Text;
+  appendInstStream(Text, Seq, S);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Text.data(), Text.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), std::size(Seq));
+
+  uint64_t Consumed = 0;
+  for (size_t I = 0; I < std::size(Seq); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    EXPECT_EQ(DI.Offset, Consumed) << "inst " << I;
+    expectSameOperands(DI.Inst, assembleOne(Seq[I], S), Seq[I]);
+    Consumed += DI.Size;
+  }
+  const InternalDecodedInst &Last = Decoded.back();
+  EXPECT_EQ(Last.Mnemonic, "s_nop");
+  EXPECT_EQ(Last.Size, MinInstSize);
+  // No over-run: the stream is consumed exactly, tail hit or miss.
+  EXPECT_EQ(Consumed, Text.size());
 }

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1592,9 +1592,7 @@ TEST(DecodeCache, RepeatedInstructionsReuseDecodeWithPerOccurrenceOffset) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  // With a full getMaxInstLength() window of identical s_nops, the interior
-  // positions share one key: the first stores, the rest hit. Use enough nops
-  // that several positions still have a full (untruncated) window and hit.
+  // A run of identical s_nops so interior positions hit the cache.
   constexpr unsigned Count = 8;
   llvm::SmallVector<uint8_t> Text;
   for (unsigned I = 0; I < Count; ++I)
@@ -1609,8 +1607,7 @@ TEST(DecodeCache, RepeatedInstructionsReuseDecodeWithPerOccurrenceOffset) {
   for (const InternalDecodedInst &DI : Decoded) {
     EXPECT_EQ(DI.Mnemonic, "s_nop");
     EXPECT_EQ(DI.Size, MinInstSize);
-    // Cache hits (all but the first here) must still report a successful
-    // decode; downstream passes gate on DecodeSucceeded.
+    // Cache hits must still report a successful decode.
     EXPECT_TRUE(DI.DecodeSucceeded);
     // Offset is set per occurrence and must never come from the cached entry.
     EXPECT_EQ(DI.Offset, ExpectedOffset);
@@ -1623,9 +1620,8 @@ TEST(DecodeCache, InterleavedDistinctSizesUseCorrectEntries) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  // Mix 4-, 8- and 12-byte instructions, repeating some so both the store and
-  // the hit path run, and interleave them so a wrong key would return the
-  // wrong (differently sized) decode.
+  // Mix 4/8/12-byte instructions, repeating some, so a wrong key would return
+  // a differently sized decode.
   const char *Seq[] = {
       "s_nop 0",                                           // 4 bytes
       "v_cvt_pk_fp8_f32 v4, 1.0, 0.5 clamp",               // 8 bytes
@@ -1660,11 +1656,8 @@ TEST(DecodeCache, TruncatedFinalWindowDecodesWithoutStaleHit) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  // gfx1250 inspects up to a 16-byte window, so the final 4-byte s_nop below is
-  // keyed on a truncated window. If truncated-tail keys aliased earlier
-  // full-length keys, the last instruction could reuse an oversized decode and
-  // over-run the buffer; instead it must decode as a clean 4-byte s_nop, and
-  // the decoded sizes must sum to exactly the buffer length.
+  // The final s_nop is keyed on a truncated (< getMaxInstLength()) window; it
+  // must decode cleanly rather than aliasing a longer cached entry.
   const unsigned MaxInstLen = S.MAI->getMaxInstLength(S.STI.get());
   ASSERT_GT(MaxInstLen, static_cast<unsigned>(MinInstSize))
       << "test assumes a multi-dword max instruction window";
@@ -1674,8 +1667,6 @@ TEST(DecodeCache, TruncatedFinalWindowDecodesWithoutStaleHit) {
       "s_nop 0",                                           // 4 bytes
       "s_nop 0",                                           // final, truncated
   };
-  // The final s_nop leaves only MinInstSize bytes, which is a truncated window
-  // (guaranteed by the MaxInstLen > MinInstSize assertion above).
   llvm::SmallVector<uint8_t> Text;
   appendInstStream(Text, Seq, S);
 
@@ -1693,6 +1684,6 @@ TEST(DecodeCache, TruncatedFinalWindowDecodesWithoutStaleHit) {
   const InternalDecodedInst &Last = Decoded.back();
   EXPECT_EQ(Last.Mnemonic, "s_nop");
   EXPECT_EQ(Last.Size, MinInstSize);
-  // No over-run: the stream is consumed exactly, tail hit or miss.
+  // Stream consumed exactly (no over-run).
   EXPECT_EQ(Consumed, Text.size());
 }

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1609,6 +1609,9 @@ TEST(DecodeCache, RepeatedInstructionsReuseDecodeWithPerOccurrenceOffset) {
   for (const InternalDecodedInst &DI : Decoded) {
     EXPECT_EQ(DI.Mnemonic, "s_nop");
     EXPECT_EQ(DI.Size, MinInstSize);
+    // Cache hits (all but the first here) must still report a successful
+    // decode; downstream passes gate on DecodeSucceeded.
+    EXPECT_TRUE(DI.DecodeSucceeded);
     // Offset is set per occurrence and must never come from the cached entry.
     EXPECT_EQ(DI.Offset, ExpectedOffset);
     expectSameOperands(DI.Inst, Ref, "repeated s_nop");


### PR DESCRIPTION
## Summary
Cache MC instruction decode results during the gfx1250 B0->A0 rewrite so byte-identical instructions reuse the first decode instead of re-running the MCDisassembler decision walk. Decode is a pure function of the instruction bytes, and position-specific data lives in `DI.Offset` (set per occurrence), never in the cached `MCInst`, so reuse is safe.
This is a pure load-time optimization with no functional or profiling changes.

This PR supersedes https://github.com/ROCm/llvm-project/pull/3367: it keeps the same feature but reworks the implementation to address the review feedback there
