### PR TITLE
amd-staging: Fix missing CLANG_TEST_DEPS on amdllvm

### DIFF
--- a/clang/test/CMakeLists.txt
+++ b/clang/test/CMakeLists.txt
@@ -113,6 +113,12 @@ list(APPEND CLANG_TEST_DEPS
   hmaptool
   )
 
+if(CLANG_ENABLE_AMDCLANG)
+  list(APPEND CLANG_TEST_DEPS
+    amdllvm
+    )
+endif()
+
 if(CLANG_ENABLE_CIR)
   list(APPEND CLANG_TEST_DEPS
     cir-opt


### PR DESCRIPTION
Fixes Driver/amdllvm_version.c in ninja check-clang-driver


