### PR TITLE
[Comgr] Force --offload-new-driver in unbundle-compressed spirv test

### DIFF
--- a/amd/comgr/test-lit/spirv-tests/unbundle-compressed.hip
+++ b/amd/comgr/test-lit/spirv-tests/unbundle-compressed.hip
@@ -1,8 +1,10 @@
 // REQUIRES: comgr-has-spirv-translator
 // COM: Build a compressed bitcode bundle for amdgcnspirv.
+// COM: --offload-new-driver: SPIR-V bundling needs the new driver (old-driver
+// COM: default lines bundle raw bitcode and fail the SPV check).
 // RUN: %clang -c -x hip --offload-arch=amdgcnspirv \
 // RUN:    -nogpulib -nogpuinc -emit-llvm \
-// RUN:    --gpu-bundle-output --offload-device-only \
+// RUN:    --gpu-bundle-output --offload-device-only --offload-new-driver \
 // RUN:    --offload-compress \
 // RUN:    %s -o %t.compressed-bundle.bc
 


### PR DESCRIPTION
## Summary

`spirv-tests/unbundle-compressed.hip` asserts that the `amdgcnspirv` entry
inside a `--gpu-bundle-output` bundle is translated SPIR-V (magic
`0x07230203`). That only holds under the **new** offloading driver.

Compiler lines that default HIP to the **old** driver — the weekly/SMP
integration branches carrying `[HIP] use old hip driver by default` — bundle
raw LLVM IR bitcode instead (`BC\xc0\xde`), so the `SPV:` FileCheck fails. This
surfaced on a TheRock SMP compiler bump; amd-staging never saw it because it
defaults to the new driver.

Pin `--offload-new-driver` on the compile so the test exercises the path it
depends on regardless of the ambient default. `Args.hasFlag(OPT_offload_new_driver, ...)`
honors the explicit flag on both driver defaults, so this is a no-op on
amd-staging and a fix on the old-driver lines.

Test originally added in #2545.
