### PR TITLE
[comgr][hotswap] Preserve unresolved call targets

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -264,10 +264,16 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 // -- NOP sled scanning --------------------------------------------------------
 
 static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
+                                 uint64_t End, uint64_t FunctionStart,
+                                 uint64_t FunctionEnd) {
+  if (End - Start >= MinNopSledSize)
+    Sleds.push_back({Start, End, Start, FunctionStart, FunctionEnd});
+}
+
+static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
                                  uint64_t End,
                                  const ElfView::FunctionTextRange &Range) {
-  if (End - Start >= MinNopSledSize)
-    Sleds.push_back({Start, End, Start, Range.Begin, Range.End});
+  appendNopSledIfLarge(Sleds, Start, End, Range.Begin, Range.End);
 }
 
 /// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
@@ -315,6 +321,34 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
   if (HasActiveRange)
     appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
   return Sleds;
+}
+
+/// A direct branch/call target into a NOP run makes that offset and every
+/// following byte in the run reachable by fallthrough, so only the prefix
+/// before the first target remains available as scratch padding.
+static void
+truncateNopSledsAtDirectTargets(std::vector<NopSled> &Sleds,
+                                const DenseSet<uint64_t> &DirectBranchTargets) {
+  if (DirectBranchTargets.empty() || Sleds.empty())
+    return;
+
+  std::vector<NopSled> Filtered;
+  Filtered.reserve(Sleds.size());
+  uint64_t Truncated = 0;
+  for (const NopSled &Sled : Sleds) {
+    uint64_t End = Sled.End;
+    for (uint64_t Target : DirectBranchTargets)
+      if (Target >= Sled.Start && Target < End)
+        End = Target;
+    if (End != Sled.End)
+      ++Truncated;
+    appendNopSledIfLarge(Filtered, Sled.Start, End, Sled.FunctionStart,
+                         Sled.FunctionEnd);
+  }
+  if (Truncated != 0)
+    log() << "hotswap: protected " << Truncated
+          << " NOP sled(s) containing direct branch/call target(s)\n";
+  Sleds = std::move(Filtered);
 }
 
 // -- Sled-or-trampoline code emission -----------------------------------------
@@ -859,9 +893,8 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
       continue;
     // Existing indirect branches are handled by
     // collectIndirectControlFlowFunctions(), which protects their containing
-    // function from source relocation. This PR's additional unresolved case
-    // is a call, such as register-target s_swap_pc_i64, that MC does not mark
-    // as an indirect branch.
+    // function from source relocation. Calls without a statically resolvable
+    // target are handled below.
     if (LS.MIA->isIndirectBranch(DI.Inst))
       continue;
 
@@ -875,7 +908,6 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
       if (!LS.MIA->isCall(DI.Inst))
         continue;
       if (DI.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
-          DI.Inst.getNumOperands() == 0 ||
           !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
               << " (" << DI.Mnemonic << ")\n";
@@ -1593,7 +1625,7 @@ assignLongBranchGateways(PatchContext &Ctx,
   // a later small or clause/delay-constrained source window.
   bool PoolBaseFar = !isSBranchReachable(InstOffset, Ctx.PoolBaseOffset) ||
                      !isSBranchReachable(*PoolReturnFrom, *ReturnTo);
-  if (!PoolBaseFar) {
+  if (!PoolBaseFar && !Ctx.DirectControlFlow.HasUnresolvedTargets) {
     // findNearestSled enforces sled headroom. emitToNopSled still validates
     // exact branch reachability because branch-back distance includes the
     // replacement size, not just the original instruction offset.
@@ -1643,6 +1675,18 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
   uint32_t Patched = 0;
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
+  std::optional<DirectControlFlowInfo> ControlFlow =
+      collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize());
+  if (!ControlFlow)
+    return std::nullopt;
+  if (ControlFlow->HasUnresolvedTargets) {
+    log() << "hotswap: unresolved control-flow target disables NOP-sled "
+             "emission, trampoline coalescing, source relocation, and .text "
+             "gateways\n";
+    Sleds.clear();
+  } else {
+    truncateNopSledsAtDirectTargets(Sleds, ControlFlow->Targets);
+  }
 
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
   LivenessInfo Liveness =
@@ -1669,10 +1713,10 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       *PoolVAddr, Elf.textAddr(), "trampoline pool base offset");
   if (!PoolBaseOffset)
     return std::nullopt;
-  PatchContext Ctx{Config,         Decoded,         Text,
-                   TextSize,       *PoolBaseOffset, LS,
-                   OutTrampolines, Sleds,           Elf,
-                   Liveness,       KernelStats,     OutScratchPatches};
+  PatchContext Ctx{
+      Config,      Decoded,           Text,        TextSize, *PoolBaseOffset,
+      LS,          OutTrampolines,    Sleds,       Elf,      Liveness,
+      KernelStats, OutScratchPatches, *ControlFlow};
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
 
@@ -1725,17 +1769,10 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     Patched += VT.applyVop3px2Src2Fix(Ctx);
 
   if (!OutTrampolines.empty()) {
-    std::optional<DirectControlFlowInfo> ControlFlow =
-        collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize());
-    if (!ControlFlow)
-      return std::nullopt;
     if (!ControlFlow->HasUnresolvedTargets) {
       mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
       expandStraightLineTrampolines(Ctx, ControlFlow->Targets);
       mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
-    } else {
-      log() << "hotswap: unresolved control-flow target disables trampoline "
-               "coalescing, source relocation, and .text gateways\n";
     }
     appendPoolBranchIslands(OutTrampolines);
     if (!assignLongBranchGateways(Ctx, ControlFlow->Targets,

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -842,7 +842,7 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
-static std::optional<DenseSet<uint64_t>>
+std::optional<DenseSet<uint64_t>>
 collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
                            const LLVMState &LS) {
   if (!LS.MIA) {
@@ -856,11 +856,13 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
       continue;
-    bool HasImmediate = false;
-    for (const MCOperand &Op : DI.Inst)
-      HasImmediate |= Op.isImm();
-    if (!LS.MIA->isCall(DI.Inst) && !HasImmediate)
+
+    bool HasPcRelativeOperand = false;
+    for (const MCOperandInfo &Op : LS.MCII->get(DI.Inst.getOpcode()).operands())
+      HasPcRelativeOperand |= Op.OperandType == MCOI::OPERAND_PCREL;
+    if (!HasPcRelativeOperand)
       continue;
+
     std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
     if (!Target) {
       log() << "hotswap: MC analysis could not evaluate direct control-flow "

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -842,26 +842,57 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
-std::optional<DenseSet<uint64_t>>
+std::optional<DirectControlFlowInfo>
 collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
-                           const LLVMState &LS) {
+                           const LLVMState &LS, uint64_t TextAddr,
+                           uint64_t TextSize) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
     return std::nullopt;
   }
 
-  DenseSet<uint64_t> Targets;
+  DirectControlFlowInfo Info;
   for (const InternalDecodedInst &DI : Decoded) {
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
-        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    // Existing indirect branches are handled by
+    // collectIndirectControlFlowFunctions(), which protects their containing
+    // function from source relocation. This PR's additional unresolved case
+    // is a call, such as register-target s_swap_pc_i64, that MC does not mark
+    // as an indirect branch.
+    if (LS.MIA->isIndirectBranch(DI.Inst))
       continue;
 
     bool HasPcRelativeOperand = false;
     for (const MCOperandInfo &Op : LS.MCII->get(DI.Inst.getOpcode()).operands())
       HasPcRelativeOperand |= Op.OperandType == MCOI::OPERAND_PCREL;
-    if (!HasPcRelativeOperand)
+    if (!HasPcRelativeOperand) {
+      // Preserve the established handling for non-call indirect transfers
+      // such as s_set_pc_i64. collectIndirectControlFlowFunctions() prevents
+      // source relocation in their containing function.
+      if (!LS.MIA->isCall(DI.Inst))
+        continue;
+      if (DI.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+          DI.Inst.getNumOperands() == 0 ||
+          !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+        log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
+              << " (" << DI.Mnemonic << ")\n";
+        Info.HasUnresolvedTargets = true;
+        continue;
+      }
+
+      std::optional<uint64_t> TextEnd =
+          checkedAddUint64(TextAddr, TextSize, "direct target text end");
+      if (!TextEnd)
+        return std::nullopt;
+      uint64_t Target = static_cast<uint64_t>(
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+      if (Target >= TextAddr && Target < *TextEnd)
+        Info.Targets.insert(Target - TextAddr);
       continue;
+    }
 
     std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
     if (!Target) {
@@ -871,9 +902,9 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
             << "; adjacent far trampolines will not be coalesced\n";
       return std::nullopt;
     }
-    Targets.insert(*Target);
+    Info.Targets.insert(*Target);
   }
-  return Targets;
+  return Info;
 }
 
 /// Coalesce runs of adjacent far patch sites when the same SGPR scratch block
@@ -1349,12 +1380,16 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
 
 static bool
 assignLongBranchGateways(PatchContext &Ctx,
-                         const DenseSet<uint64_t> &DirectBranchTargets) {
-  std::vector<NopSled> Gateways = buildExternalGatewaySleds(
-      Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
-      DirectBranchTargets);
-  for (const NopSled &Sled : Ctx.NopSleds)
-    Gateways.push_back(Sled);
+                         const DenseSet<uint64_t> &DirectBranchTargets,
+                         bool AllowTextGateways) {
+  std::vector<NopSled> Gateways;
+  if (AllowTextGateways) {
+    Gateways = buildExternalGatewaySleds(
+        Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+        DirectBranchTargets);
+    for (const NopSled &Sled : Ctx.NopSleds)
+      Gateways.push_back(Sled);
+  }
 
   DenseMap<uint64_t, size_t> PoolIslandOwners;
   uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
@@ -1690,15 +1725,21 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     Patched += VT.applyVop3px2Src2Fix(Ctx);
 
   if (!OutTrampolines.empty()) {
-    std::optional<DenseSet<uint64_t>> DirectBranchTargets =
-        collectDirectBranchTargets(Decoded, LS);
-    if (!DirectBranchTargets)
+    std::optional<DirectControlFlowInfo> ControlFlow =
+        collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize());
+    if (!ControlFlow)
       return std::nullopt;
-    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
-    expandStraightLineTrampolines(Ctx, *DirectBranchTargets);
-    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
+    if (!ControlFlow->HasUnresolvedTargets) {
+      mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
+      expandStraightLineTrampolines(Ctx, ControlFlow->Targets);
+      mergeAdjacentLongTrampolines(OutTrampolines, ControlFlow->Targets);
+    } else {
+      log() << "hotswap: unresolved control-flow target disables trampoline "
+               "coalescing, source relocation, and .text gateways\n";
+    }
     appendPoolBranchIslands(OutTrampolines);
-    if (!assignLongBranchGateways(Ctx, *DirectBranchTargets))
+    if (!assignLongBranchGateways(Ctx, ControlFlow->Targets,
+                                  !ControlFlow->HasUnresolvedTargets))
       return std::nullopt;
   }
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -763,6 +763,11 @@ struct SafeSgprUsageSummary {
   unsigned HighWatermark = 0;
 };
 
+struct DirectControlFlowInfo {
+  llvm::DenseSet<uint64_t> Targets;
+  bool HasUnresolvedTargets = false;
+};
+
 /// Mutable per-run context threaded through all patch passes. Bundles the
 /// input config, decoded instruction stream, raw .text bytes, MC state,
 /// output streams (trampolines / scratch info), and the shared ELF view +
@@ -784,6 +789,7 @@ struct PatchContext {
   const LivenessInfo &Liveness;
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
+  const DirectControlFlowInfo &DirectControlFlow;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;
@@ -849,11 +855,6 @@ bool isSBranchReachable(uint64_t From, uint64_t To);
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
-
-struct DirectControlFlowInfo {
-  llvm::DenseSet<uint64_t> Targets;
-  bool HasUnresolvedTargets = false;
-};
 
 /// Collect branch and call targets used to protect interior entry points from
 /// trampoline coalescing. Absolute addresses in TextAddr .. TextAddr +

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -850,12 +850,20 @@ std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
 
-/// Collect statically known branch and call targets used to protect interior
-/// entry points from trampoline coalescing. Register-target control flow has
-/// no statically known destination and must leave the returned set unchanged.
-std::optional<llvm::DenseSet<uint64_t>>
+struct DirectControlFlowInfo {
+  llvm::DenseSet<uint64_t> Targets;
+  bool HasUnresolvedTargets = false;
+};
+
+/// Collect branch and call targets used to protect interior entry points from
+/// trampoline coalescing. Absolute addresses in TextAddr .. TextAddr +
+/// TextSize are converted to text-relative offsets. Register-target control
+/// flow sets HasUnresolvedTargets so callers can disable transformations that
+/// consume possible destinations.
+std::optional<DirectControlFlowInfo>
 collectDirectBranchTargets(llvm::ArrayRef<InternalDecodedInst> Decoded,
-                           const LLVMState &LS);
+                           const LLVMState &LS, uint64_t TextAddr,
+                           uint64_t TextSize);
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -34,6 +34,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -848,6 +849,13 @@ bool isSBranchReachable(uint64_t From, uint64_t To);
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
+
+/// Collect statically known branch and call targets used to protect interior
+/// entry points from trampoline coalescing. Register-target control flow has
+/// no statically known destination and must leave the returned set unchanged.
+std::optional<llvm::DenseSet<uint64_t>>
+collectDirectBranchTargets(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                           const LLVMState &LS);
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/test-lit/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap-absolute-call.s
@@ -1,0 +1,69 @@
+// COM: s_swap_pc_i64 also accepts an absolute immediate target. Translate an
+// COM: address inside .text to a text-relative direct target so the second of
+// COM: two adjacent far patch sites retains an independently callable entry.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wl,--section-start=.text=0x1000 %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <test_absolute_call>:
+// DISASM-NEXT: s_swap_pc_i64 s[0:1], 0x1010
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_absolute_call
+.p2align 8
+.type test_absolute_call,@function
+test_absolute_call:
+  s_swap_pc_i64 s[0:1], 0x1010
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Labsolute_target:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_absolute_call_end:
+.size test_absolute_call, .Ltest_absolute_call_end-test_absolute_call
+
+// Two separate long sites need two 28-byte SCC-preserving gateways. This
+// padding follows s_endpgm and lies outside the function, so it is safe.
+.fill 64, 1, 0
+
+// Push the appended trampoline pool beyond s_branch's signed 16-bit dword
+// range and force direct-target-aware far-site handling.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_absolute_call
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_absolute_call
+      .symbol: test_absolute_call.kd
+      .sgpr_count: 2
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-indirect-call-far.s
+++ b/amd/comgr/test-lit/hotswap-indirect-call-far.s
@@ -11,7 +11,8 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=LOG,API %s
-// LOG: hotswap: unresolved control-flow target disables trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
 // LOG: hotswap: error: no safe short-branch gateway for far site
 // API: RESULT: ERROR
 
@@ -32,8 +33,7 @@ test_indirect_call_far:
   ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
   s_wait_dscnt 0x0
   s_endpgm
-.Ltest_indirect_call_far_end:
-.size test_indirect_call_far, .Ltest_indirect_call_far_end-test_indirect_call_far
+.size test_indirect_call_far, .-test_indirect_call_far
 
 // Ordinarily this external zero-filled space can host long-branch gateways.
 // An unresolved target could also land here, so the conservative path cannot

--- a/amd/comgr/test-lit/hotswap-indirect-call-far.s
+++ b/amd/comgr/test-lit/hotswap-indirect-call-far.s
@@ -1,0 +1,71 @@
+// COM: An unresolved register call may target any original text instruction.
+// COM: In particular, it can target the second of two adjacent far patch sites.
+// COM: The rewriter must not coalesce those sites or consume original .text
+// COM: gateway space. This object has no safe target-independent route to the
+// COM: far trampoline pool, so it must fail closed instead of returning a
+// COM: successful object whose register call lands on rewritten padding.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: unresolved control-flow target disables trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_indirect_call_far
+.p2align 8
+.type test_indirect_call_far,@function
+test_indirect_call_far:
+  // s_get_pc_i64 returns the address of the following instruction. The add
+  // therefore makes s[2:3] point at the second DS instruction below.
+  s_get_pc_i64 s[2:3]
+  s_add_co_u32 s2, s2, 20
+  s_add_co_ci_u32 s3, s3, 0
+  s_swap_pc_i64 s[0:1], s[2:3]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lindirect_target:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_indirect_call_far_end:
+.size test_indirect_call_far, .Ltest_indirect_call_far_end-test_indirect_call_far
+
+// Ordinarily this external zero-filled space can host long-branch gateways.
+// An unresolved target could also land here, so the conservative path cannot
+// consume it.
+.fill 64, 1, 0
+
+// Push the appended trampoline pool beyond s_branch's signed 16-bit dword
+// range so success would require coalescing, relocation, or a .text gateway.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_indirect_call_far
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_indirect_call_far
+      .symbol: test_indirect_call_far.kd
+      .sgpr_count: 4
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-indirect-call.s
+++ b/amd/comgr/test-lit/hotswap-indirect-call.s
@@ -1,0 +1,56 @@
+// COM: HSV-010 regression: a production PyTorch/AITER object contains the
+// COM: register-target call `s_swap_pc_i64 s[30:31], s[0:1]`. The target is
+// COM: not statically known, so direct-target collection must ignore it rather
+// COM: than aborting an otherwise valid rewrite.
+// COM:
+// COM: Keep a real DS two-address patch in this reduced object so the rewrite
+// COM: creates a trampoline and exercises the production failure path.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// DISASM-LABEL: <test_indirect_call>:
+// DISASM: s_swap_pc_i64 s[30:31], s[0:1]
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: ds_load_b32 v0
+// DISASM-NEXT: ds_load_b32 v1
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_indirect_call
+.p2align 8
+.type test_indirect_call,@function
+test_indirect_call:
+  s_swap_pc_i64 s[30:31], s[0:1]
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_indirect_call_end:
+.size test_indirect_call, .Ltest_indirect_call_end-test_indirect_call
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_indirect_call
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 32
+  .amdhsa_inst_pref_size 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-trampoline-direct-target-sled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-direct-target-sled.s
@@ -1,0 +1,85 @@
+// COM: A direct branch target into a NOP run makes the run executable program
+// COM: text, not scratch padding. collectDirectBranchTargets must therefore
+// COM: run before patch emission so emitReplacementCode cannot place a
+// COM: relocated replacement at the branch target.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The direct branch still lands on NOP padding. The DS2 replacement is
+// COM: emitted later in the appended trampoline pool, not at .Ldirect_target.
+// DISASM-LABEL: <test_direct_target_sled>:
+// DISASM-NOT: ds_load_2addr_stride64_b32
+// DISASM: s_cbranch_scc1
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM: ds_load_b32 v0
+// DISASM-NEXT: ds_load_b32 v1
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_direct_target_sled
+.p2align 8
+.type test_direct_target_sled,@function
+test_direct_target_sled:
+  s_cbranch_scc1 .Ldirect_target
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ldirect_target:
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_endpgm
+.Ltest_direct_target_sled_end:
+.size test_direct_target_sled, .Ltest_direct_target_sled_end-test_direct_target_sled
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_direct_target_sled
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_inst_pref_size 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_direct_target_sled
+      .symbol: test_direct_target_sled.kd
+      .sgpr_count: 1
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+      .uses_dynamic_stack: false
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -312,6 +312,7 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
   ASSERT_EQ(Decoded.size(), 1u);
   ASSERT_TRUE(S.MIA->isCall(Decoded[0].Inst));
+  ASSERT_FALSE(S.MIA->isIndirectBranch(Decoded[0].Inst));
   for (const llvm::MCOperand &Op : Decoded[0].Inst)
     ASSERT_FALSE(Op.isImm());
 
@@ -323,7 +324,30 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
-TEST(CollectDirectBranchTargets, CollectsImmediateAbsoluteTargetCall) {
+TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_set_pc_i64 s[8:9]", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_TRUE(S.MIA->isBranch(Decoded[0].Inst));
+  EXPECT_FALSE(S.MIA->isIndirectBranch(Decoded[0].Inst));
+  EXPECT_FALSE(S.MIA->isCall(Decoded[0].Inst));
+  EXPECT_TRUE(S.MIA->mayAffectControlFlow(Decoded[0].Inst, *S.MRI));
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
@@ -343,6 +367,20 @@ TEST(CollectDirectBranchTargets, CollectsImmediateAbsoluteTargetCall) {
   ASSERT_EQ(Info->Targets.size(), 1u);
   EXPECT_TRUE(Info->Targets.contains(0x10));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+
+  std::optional<DirectControlFlowInfo> OutsideInfo =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
+                                 /*TextSize=*/0x40);
+  ASSERT_TRUE(OutsideInfo);
+  EXPECT_TRUE(OutsideInfo->Targets.empty());
+  EXPECT_FALSE(OutsideInfo->HasUnresolvedTargets);
+
+  std::optional<DirectControlFlowInfo> OverflowInfo =
+      collectDirectBranchTargets(
+          Decoded, S,
+          /*TextAddr=*/std::numeric_limits<uint64_t>::max() - 0x10,
+          /*TextSize=*/0x20);
+  EXPECT_FALSE(OverflowInfo);
 }
 
 TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
@@ -389,6 +427,7 @@ TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
   LivenessInfo Liveness;
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
   PatchContext Ctx{Config,
                    Decoded,
                    View.textData(),
@@ -400,7 +439,8 @@ TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
                    View,
                    Liveness,
                    KernelStats,
-                   ScratchPatches};
+                   ScratchPatches,
+                   ControlFlow};
 
   EXPECT_FALSE(findSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, /*Count=*/1,
                                         /*Alignment=*/1, "unit test"));
@@ -429,6 +469,7 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
   LivenessInfo Liveness;
   llvm::StringMap<KernelPatchStats> KernelStats;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  DirectControlFlowInfo ControlFlow;
   PatchContext Ctx{Config,
                    Decoded,
                    View.textData(),
@@ -440,7 +481,8 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
                    View,
                    Liveness,
                    KernelStats,
-                   ScratchPatches};
+                   ScratchPatches,
+                   ControlFlow};
 
   const SafeSgprScratchBlock Block{/*Base=*/4, /*Count=*/1};
   EXPECT_FALSE(

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -301,7 +301,7 @@ TEST(EvaluateDirectControlFlowTarget, EvaluatesGfx1250CallOperandFallback) {
             0x200u + Decoded[0].Size + 2 * MinInstSize);
 }
 
-TEST(CollectDirectBranchTargets, IgnoresRegisterTargetCall) {
+TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
@@ -315,17 +315,19 @@ TEST(CollectDirectBranchTargets, IgnoresRegisterTargetCall) {
   for (const llvm::MCOperand &Op : Decoded[0].Inst)
     ASSERT_FALSE(Op.isImm());
 
-  std::optional<llvm::DenseSet<uint64_t>> Targets =
-      collectDirectBranchTargets(Decoded, S);
-  ASSERT_TRUE(Targets);
-  EXPECT_TRUE(Targets->empty());
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
-TEST(CollectDirectBranchTargets, IgnoresImmediateAbsoluteTargetCall) {
+TEST(CollectDirectBranchTargets, CollectsImmediateAbsoluteTargetCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_swap_pc_i64 s[30:31], 10", S);
+      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -334,10 +336,13 @@ TEST(CollectDirectBranchTargets, IgnoresImmediateAbsoluteTargetCall) {
   ASSERT_TRUE(S.MIA->isCall(Decoded[0].Inst));
   ASSERT_TRUE(Decoded[0].Inst.getOperand(1).isImm());
 
-  std::optional<llvm::DenseSet<uint64_t>> Targets =
-      collectDirectBranchTargets(Decoded, S);
-  ASSERT_TRUE(Targets);
-  EXPECT_TRUE(Targets->empty());
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x200,
+                                 /*TextSize=*/0x40);
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(0x10));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
 TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
@@ -352,11 +357,14 @@ TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
   ASSERT_EQ(Decoded.size(), 1u);
   Decoded[0].Offset = 0x200;
 
-  std::optional<llvm::DenseSet<uint64_t>> Targets =
-      collectDirectBranchTargets(Decoded, S);
-  ASSERT_TRUE(Targets);
-  ASSERT_EQ(Targets->size(), 1u);
-  EXPECT_TRUE(Targets->contains(0x200u + Decoded[0].Size + 2 * MinInstSize));
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000);
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(
+      Info->Targets.contains(0x200u + Decoded[0].Size + 2 * MinInstSize));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -301,6 +301,64 @@ TEST(EvaluateDirectControlFlowTarget, EvaluatesGfx1250CallOperandFallback) {
             0x200u + Decoded[0].Size + 2 * MinInstSize);
 }
 
+TEST(CollectDirectBranchTargets, IgnoresRegisterTargetCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_swap_pc_i64 s[30:31], s[0:1]", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_TRUE(S.MIA->isCall(Decoded[0].Inst));
+  for (const llvm::MCOperand &Op : Decoded[0].Inst)
+    ASSERT_FALSE(Op.isImm());
+
+  std::optional<llvm::DenseSet<uint64_t>> Targets =
+      collectDirectBranchTargets(Decoded, S);
+  ASSERT_TRUE(Targets);
+  EXPECT_TRUE(Targets->empty());
+}
+
+TEST(CollectDirectBranchTargets, IgnoresImmediateAbsoluteTargetCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_swap_pc_i64 s[30:31], 10", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_TRUE(S.MIA->isCall(Decoded[0].Inst));
+  ASSERT_TRUE(Decoded[0].Inst.getOperand(1).isImm());
+
+  std::optional<llvm::DenseSet<uint64_t>> Targets =
+      collectDirectBranchTargets(Decoded, S);
+  ASSERT_TRUE(Targets);
+  EXPECT_TRUE(Targets->empty());
+}
+
+TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  Decoded[0].Offset = 0x200;
+
+  std::optional<llvm::DenseSet<uint64_t>> Targets =
+      collectDirectBranchTargets(Decoded, S);
+  ASSERT_TRUE(Targets);
+  ASSERT_EQ(Targets->size(), 1u);
+  EXPECT_TRUE(Targets->contains(0x200u + Decoded[0].Size + 2 * MinInstSize));
+}
+
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);


### PR DESCRIPTION
## Summary

- distinguish PC-relative calls, absolute-immediate calls, and unresolved register-target calls using MC operand descriptors
- protect absolute call destinations inside .text from trampoline coalescing
- collect direct targets before patch emission so NOP-sled relocation cannot overwrite a known branch/call destination
- preserve unresolved destinations by disabling NOP-sled emission, coalescing, source relocation, and original .text gateways
- fail closed when no target-independent route to a far trampoline exists
- add focused unit coverage and near, absolute-target, and far fail-closed LIT regressions

## Root cause and safety

AMDGPU TableGen marks S_SWAPPC_B64 as a call, while its SSrc_b64 source may be a register or immediate. It is not marked as an indirect branch. See [SOP1_64 operands](https://github.com/ROCm/llvm-project/blob/f80590e0dc9712eadbb7838f47dce2ef7c564a23/llvm/lib/Target/AMDGPU/SOPInstructions.td#L119-L122) and [S_SWAPPC_B64 classification](https://github.com/ROCm/llvm-project/blob/f80590e0dc9712eadbb7838f47dce2ef7c564a23/llvm/lib/Target/AMDGPU/SOPInstructions.td#L335-L338).

The previous collector sent every call through PC-relative target evaluation. A register-target s_swap_pc_i64 could not be evaluated and aborted the rewrite. Simply skipping that call was unsafe because its unknown target could be an instruction consumed by trampoline coalescing or source relocation.

The collector now records absolute immediate targets that fall inside .text and marks register-target calls unresolved. It runs before patch emission, so NOP sleds can be truncated before the first known direct target and unresolved destinations can disable NOP-sled emission entirely. When any destination is unresolved, the rewriter retains the original text layout and uses only target-independent pool islands. If no safe branch route exists, rewriting returns an error instead of producing an object with a stale call destination.

## Production scope

At the current head, the captured 1,615,504-byte Shared Expert HSACO (SHA-256 `4c4bd45992ad7ce9fe0878804b45362fa7e54cfda42733e72e02182a6d9778fc`) is expected to fail closed in this PR alone. Its register-target calls at `0x12EE30` and `0x14676C` remain unresolved, so target-unproven NOP sleds and original-`.text` gateways are unavailable; rewriting stops at far site `0x248F4` instead of emitting an object that could overwrite an indirect destination.

[#3414](https://github.com/ROCm/llvm-project/pull/3414) adds the function-scoped dataflow proof that resolves those compiler-emitted calls. [#3418](https://github.com/ROCm/llvm-project/pull/3418) then supplies the smaller SCC-neutral far-transfer sequence needed for the remaining fragmented gateway windows. Full successful production rewriting and GPU execution are claims of that complete stack, not of #3412 by itself.

## Validation

- 2026-07-16 production fail-closed replay on `mi400` at `44387058031b5e5a92603f81ce5ce31fab997e3e`: the exact Shared Expert HSACO reports the two unresolved calls and rejects far site `0x248F4`; no output object is emitted
- 2026-07-16 focused follow-up on `mi400` at `44387058031b5e5a92603f81ce5ce31fab997e3e`: rebuilt `HotswapMCTests` in the clean #3412 validation tree; 66/66 passed, including `CollectDirectBranchTargets.IgnoresSetPcWithoutTreatingItAsCall`
- 2026-07-16 clean #3412 build on `mi400` at `3ee3228e4d77ab5ce55ee1a629138ee8480fd4e4`: built `amd_comgr`, `hotswap-rewrite`, `HotswapMCTests`, and `HotswapElfTests`; `HotswapMCTests` 65/65 passed; `HotswapElfTests` 25/25 passed; HotSwap LIT 78/78 passed, including the new `hotswap-trampoline-direct-target-sled.s` regression
- clang-format and full-diff whitespace, ASCII, no-auto, and 80-column audits pass
- Release check-comgr on MI300X: all 144 unit tests pass; LIT reports 98 passed, 11 unsupported, and 1 expected failure; CTest passes 31/31
- Clang 18 AddressSanitizer check-comgr on MI300X: the same unit, LIT, and CTest results pass
- ASAN used ASAN_OPTIONS=use_sigaltstack=0 because the host runtime otherwise fails internally while unmapping thread alternate signal stacks; memory and leak detection remain enabled

Tracking and production artifact: [HSV-010](https://amd.atlassian.net/wiki/spaces/MLSE/pages/1800642493)
