### PR TITLE
[comgr][hotswap] Resolve PC-materialized call targets

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -945,49 +945,12 @@ collectDeclaredTextEntries(const ElfView &Elf) {
   return Entries;
 }
 
-static bool hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
-                                     const LLVMState &LS, uint64_t TextAddr,
-                                     ArrayRef<uint64_t> DeclaredEntries,
-                                     uint64_t SequenceStart,
-                                     uint64_t SequenceEnd) {
-  for (uint64_t Entry : DeclaredEntries)
-    if (Entry > SequenceStart && Entry <= SequenceEnd)
-      return true;
-
-  for (const InternalDecodedInst &DI : Decoded) {
-    // Without bounding an indirect target, it may enter at any instruction in
-    // the materialization. Keep the call unresolved rather than relying on
-    // the indirect transfer's containing function alone.
-    if (DI.DecodeSucceeded && !LS.MIA->isReturn(DI.Inst) &&
-        (LS.MIA->isIndirectBranch(DI.Inst) ||
-         DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
-         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
-      return true;
-    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
-        LS.MIA->isReturn(DI.Inst))
-      continue;
-
-    std::optional<uint64_t> RelativeTarget;
-    bool HasPcRelativeOperand = false;
-    for (const MCOperandInfo &Operand :
-         LS.MCII->get(DI.Inst.getOpcode()).operands())
-      HasPcRelativeOperand |= Operand.OperandType == MCOI::OPERAND_PCREL;
-    if (HasPcRelativeOperand) {
-      RelativeTarget = evaluateDirectControlFlowTarget(DI, LS);
-    } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
-               DI.Inst.getNumOperands() != 0 &&
-               DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
-      uint64_t AbsoluteTarget = static_cast<uint64_t>(
-          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
-      if (AbsoluteTarget >= TextAddr)
-        RelativeTarget = AbsoluteTarget - TextAddr;
-    }
-    if (RelativeTarget && *RelativeTarget > SequenceStart &&
-        *RelativeTarget <= SequenceEnd)
-      return true;
-  }
-  return false;
-}
+struct PcMaterializedCallInfo {
+  uint64_t Target = 0;
+  uint64_t SequenceStart = 0;
+  uint64_t SequenceEnd = 0;
+  MCRegister ReturnRegister;
+};
 
 /// Resolve the compiler-emitted PC materialization used by the production
 /// reproducer:
@@ -1002,14 +965,13 @@ static bool hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
 /// by llvm/test/MC/AMDGPU/gfx1250_asm_salu_lit64.s. Stop at the first
 /// overlapping definition or control-flow boundary, so any variation remains
 /// unresolved and follows the existing fail-closed policy.
-static std::optional<uint64_t>
-resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
-                                size_t CallIndex, const LLVMState &LS,
-                                uint64_t TextAddr,
-                                ArrayRef<uint64_t> DeclaredEntries) {
+static std::optional<PcMaterializedCallInfo>
+matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
+                        const LLVMState &LS, uint64_t TextAddr) {
   const InternalDecodedInst &Call = Decoded[CallIndex];
   if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
-      Call.Inst.getNumOperands() == 0)
+      Call.Inst.getNumOperands() < 2 || !Call.Inst.getOperand(0).isReg() ||
+      !Call.Inst.getOperand(0).getReg())
     return std::nullopt;
   const MCOperand &TargetOperand =
       Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
@@ -1062,28 +1024,302 @@ resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
         *GetPcAddress, Candidate.Size, "PC-materialized call PC value");
     if (!PcValue)
       return std::nullopt;
-    if (hasKnownControlFlowEntry(Decoded, LS, TextAddr, DeclaredEntries,
-                                 Candidate.Offset, Call.Offset))
-      return std::nullopt;
-
     // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
     // immediate to uint64_t and adding it reproduces both positive and
     // negative literals, including INT64_MIN, without signed overflow.
-    return *PcValue + static_cast<uint64_t>(AddImmediate);
+    return PcMaterializedCallInfo{
+        *PcValue + static_cast<uint64_t>(AddImmediate), Candidate.Offset,
+        Call.Offset, MCRegister(Call.Inst.getOperand(0).getReg())};
   }
   return std::nullopt;
+}
+
+struct KnownCallSite {
+  size_t InstIndex = 0;
+  uint64_t Target = 0;
+  uint64_t Continuation = 0;
+  MCRegister ReturnRegister;
+};
+
+struct BoundedSetPcReturn {
+  size_t InstIndex = 0;
+  SmallVector<uint64_t, 2> Targets;
+};
+
+static bool hasPcRelativeOperand(const InternalDecodedInst &DI,
+                                 const LLVMState &LS) {
+  for (const MCOperandInfo &Operand :
+       LS.MCII->get(DI.Inst.getOpcode()).operands())
+    if (Operand.OperandType == MCOI::OPERAND_PCREL)
+      return true;
+  return false;
+}
+
+static std::optional<MCRegister>
+getCallReturnRegister(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (!DI.DecodeSucceeded || !LS.MIA->isCall(DI.Inst) ||
+      DI.Inst.getNumOperands() == 0 || !DI.Inst.getOperand(0).isReg() ||
+      !DI.Inst.getOperand(0).getReg())
+    return std::nullopt;
+  return MCRegister(DI.Inst.getOperand(0).getReg());
+}
+
+static std::optional<uint64_t>
+getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
+                    uint64_t TextAddr, uint64_t TextEnd) {
+  if (!DI.DecodeSucceeded ||
+      (!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+      LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst))
+    return std::nullopt;
+
+  if (hasPcRelativeOperand(DI, LS))
+    return evaluateDirectControlFlowTarget(DI, LS);
+
+  if (DI.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+      DI.Inst.getNumOperands() == 0 ||
+      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+    return std::nullopt;
+  uint64_t AbsoluteTarget = static_cast<uint64_t>(
+      DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+  if (AbsoluteTarget < TextAddr || AbsoluteTarget >= TextEnd)
+    return std::nullopt;
+  return AbsoluteTarget - TextAddr;
+}
+
+static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls) {
+  SmallVector<KnownCallSite, 4> Calls;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
+    if (!ReturnRegister)
+      continue;
+
+    std::optional<uint64_t> Target;
+    if (MaterializedCalls[I]) {
+      uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
+      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+        Target = AbsoluteTarget - TextAddr;
+    } else {
+      Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+    }
+    if (!Target)
+      continue;
+
+    std::optional<uint64_t> Continuation =
+        checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
+    if (!Continuation)
+      return std::nullopt;
+    Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+  }
+  return Calls;
+}
+
+static std::optional<SmallVector<BoundedSetPcReturn, 2>>
+collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
+                           const LLVMState &LS, uint64_t TextAddr,
+                           uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
+                           ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+                           ArrayRef<KnownCallSite> Calls) {
+  SmallVector<BoundedSetPcReturn, 2> Returns;
+  for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex) {
+    const InternalDecodedInst &Return = Decoded[ReturnIndex];
+    // AMDGPUMCInstLower lowers S_SETPC_B64_return to S_SETPC_B64, so the
+    // decoded instruction no longer carries MIA::isReturn identity. Recover
+    // only the bounded local-function form from its call/link dataflow.
+    if (!Return.DecodeSucceeded ||
+        Return.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        Return.Inst.getNumOperands() != 1 ||
+        !Return.Inst.getOperand(0).isReg() ||
+        !Return.Inst.getOperand(0).getReg())
+      continue;
+    MCRegister ReturnRegister(Return.Inst.getOperand(0).getReg());
+
+    bool IsBounded = false;
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+      if (Range.Begin < TextAddr || Range.Begin >= TextEnd ||
+          Range.End <= Range.Begin || Range.End > TextEnd ||
+          (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL))
+        continue;
+      uint64_t FunctionBegin = Range.Begin - TextAddr;
+      uint64_t FunctionEnd = Range.End - TextAddr;
+      if (Return.Offset < FunctionBegin || Return.Offset >= FunctionEnd)
+        continue;
+
+      bool Safe = true;
+      for (uint64_t Entry : DeclaredEntries)
+        if (Entry > FunctionBegin && Entry < FunctionEnd) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: declared entry at 0x"
+                << utohexstr(Entry) << " bypasses the function entry\n";
+          Safe = false;
+          break;
+        }
+      if (!Safe)
+        continue;
+
+      // The link pair must retain the value written by the incoming call
+      // throughout the function. This includes blocks laid out after the
+      // return that may branch back into its epilogue.
+      for (const InternalDecodedInst &DI : Decoded) {
+        if (DI.Offset < FunctionBegin || DI.Offset >= FunctionEnd)
+          continue;
+        if (!DI.DecodeSucceeded ||
+            definesOverlappingRegister(DI, LS, ReturnRegister)) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: link register is "
+                   "unprovable at 0x"
+                << utohexstr(DI.Offset) << "\n";
+          Safe = false;
+          break;
+        }
+      }
+      if (!Safe)
+        continue;
+
+      SmallVector<uint64_t, 2> Targets;
+      for (const KnownCallSite &Call : Calls) {
+        if (Call.Target != FunctionBegin)
+          continue;
+        if (Call.ReturnRegister != ReturnRegister) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: call at 0x"
+                << utohexstr(Decoded[Call.InstIndex].Offset)
+                << " uses a different link register\n";
+          Safe = false;
+          break;
+        }
+        Targets.push_back(Call.Continuation);
+      }
+      if (!Safe || Targets.empty())
+        continue;
+
+      // A branch from outside the function would bypass the call link
+      // definition. Direct calls to the function entry are allowed only when
+      // they were collected above with this exact return register.
+      for (size_t SourceIndex = 0; SourceIndex != Decoded.size();
+           ++SourceIndex) {
+        const InternalDecodedInst &Source = Decoded[SourceIndex];
+        std::optional<uint64_t> Target =
+            getDirectTextTarget(Source, LS, TextAddr, TextEnd);
+        if (!Target || *Target < FunctionBegin || *Target >= FunctionEnd ||
+            (Source.Offset >= FunctionBegin && Source.Offset < FunctionEnd))
+          continue;
+
+        bool IsKnownEntryCall = false;
+        if (LS.MIA->isCall(Source.Inst) && *Target == FunctionBegin)
+          for (const KnownCallSite &Call : Calls)
+            IsKnownEntryCall |= Call.InstIndex == SourceIndex &&
+                                Call.ReturnRegister == ReturnRegister;
+        if (!IsKnownEntryCall) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: control flow at 0x"
+                << utohexstr(Source.Offset) << " enters at 0x"
+                << utohexstr(*Target) << "\n";
+          Safe = false;
+          break;
+        }
+      }
+      if (!Safe)
+        continue;
+
+      llvm::sort(Targets);
+      Targets.erase(std::unique(Targets.begin(), Targets.end()), Targets.end());
+      Returns.push_back({ReturnIndex, std::move(Targets)});
+      IsBounded = true;
+      break;
+    }
+    if (!IsBounded)
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+            << " remains an unbounded indirect transfer\n";
+  }
+  return Returns;
+}
+
+static const BoundedSetPcReturn *
+findBoundedSetPcReturn(ArrayRef<BoundedSetPcReturn> Returns, size_t InstIndex) {
+  for (const BoundedSetPcReturn &Return : Returns)
+    if (Return.InstIndex == InstIndex)
+      return &Return;
+  return nullptr;
+}
+
+static bool
+hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
+                         const LLVMState &LS, uint64_t TextAddr,
+                         uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
+                         ArrayRef<BoundedSetPcReturn> BoundedReturns,
+                         uint64_t SequenceStart, uint64_t SequenceEnd) {
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry > SequenceStart && Entry <= SequenceEnd)
+      return true;
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      const BoundedSetPcReturn *Return =
+          findBoundedSetPcReturn(BoundedReturns, I);
+      if (!Return)
+        return true;
+      for (uint64_t Target : Return->Targets)
+        if (Target > SequenceStart && Target <= SequenceEnd)
+          return true;
+      continue;
+    }
+
+    // Without bounding an indirect target, it may enter at any instruction in
+    // the materialization. Keep the call unresolved rather than relying on
+    // the indirect transfer's containing function alone.
+    if (DI.DecodeSucceeded && !LS.MIA->isReturn(DI.Inst) &&
+        (LS.MIA->isIndirectBranch(DI.Inst) ||
+         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
+      return true;
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+
+    std::optional<uint64_t> RelativeTarget =
+        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+    if (RelativeTarget && *RelativeTarget > SequenceStart &&
+        *RelativeTarget <= SequenceEnd)
+      return true;
+  }
+  return false;
 }
 
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-    uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries) {
+    uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
     return std::nullopt;
   }
+
+  std::optional<uint64_t> TextEnd =
+      checkedAddUint64(TextAddr, TextSize, "direct target text end");
+  if (!TextEnd)
+    return std::nullopt;
+
+  SmallVector<std::optional<PcMaterializedCallInfo>, 16> MaterializedCalls(
+      Decoded.size());
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+
+  std::optional<SmallVector<KnownCallSite, 4>> Calls =
+      collectKnownCallSites(Decoded, LS, TextAddr, *TextEnd, MaterializedCalls);
+  if (!Calls)
+    return std::nullopt;
+  std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
+      collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
+                                 DeclaredEntries, FunctionRanges, *Calls);
+  if (!BoundedReturns)
+    return std::nullopt;
 
   DirectControlFlowInfo Info;
   for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
@@ -1113,9 +1349,13 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
         Target = static_cast<uint64_t>(
             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
-      } else {
-        Target = resolvePcMaterializedCallTarget(Decoded, InstIndex, LS,
-                                                 TextAddr, DeclaredEntries);
+      } else if (MaterializedCalls[InstIndex] &&
+                 !hasKnownControlFlowEntry(
+                     Decoded, LS, TextAddr, *TextEnd, DeclaredEntries,
+                     *BoundedReturns,
+                     MaterializedCalls[InstIndex]->SequenceStart,
+                     MaterializedCalls[InstIndex]->SequenceEnd)) {
+        Target = MaterializedCalls[InstIndex]->Target;
       }
       if (!Target) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
@@ -1124,10 +1364,6 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
         continue;
       }
 
-      std::optional<uint64_t> TextEnd =
-          checkedAddUint64(TextAddr, TextSize, "direct target text end");
-      if (!TextEnd)
-        return std::nullopt;
       if (*Target >= TextAddr && *Target < *TextEnd) {
         uint64_t RelativeTarget = *Target - TextAddr;
         Info.Targets.insert(RelativeTarget);
@@ -1892,9 +2128,11 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       collectDeclaredTextEntries(Elf);
   if (!DeclaredEntries)
     return std::nullopt;
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Elf.functionTextRanges();
   std::optional<DirectControlFlowInfo> ControlFlow =
       collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize(),
-                                 *DeclaredEntries);
+                                 *DeclaredEntries, FunctionRanges);
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -911,17 +911,26 @@ static bool isControlFlowBoundary(const InternalDecodedInst &DI,
          LS.MIA->isBarrier(DI.Inst);
 }
 
-static std::optional<SmallVector<uint64_t, 16>>
+struct DeclaredTextEntryInfo {
+  SmallVector<uint64_t, 16> Entries;
+  SmallVector<uint64_t, 16> ExternalEntries;
+};
+
+static std::optional<DeclaredTextEntryInfo>
 collectDeclaredTextEntries(const ElfView &Elf) {
   std::optional<uint64_t> TextEnd =
       checkedAddUint64(Elf.textAddr(), Elf.textSize(), "declared text end");
   if (!TextEnd)
     return std::nullopt;
 
-  SmallVector<uint64_t, 16> Entries;
+  DeclaredTextEntryInfo Info;
   for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges())
-    if (Range.Begin >= Elf.textAddr() && Range.Begin < *TextEnd)
-      Entries.push_back(Range.Begin - Elf.textAddr());
+    if (Range.Begin >= Elf.textAddr() && Range.Begin < *TextEnd) {
+      uint64_t Entry = Range.Begin - Elf.textAddr();
+      Info.Entries.push_back(Entry);
+      if (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL)
+        Info.ExternalEntries.push_back(Entry);
+    }
 
   for (const KernelDescriptorInfo &Descriptor : Elf.kernelDescriptors()) {
     std::optional<uint64_t> EntryAddress;
@@ -939,10 +948,13 @@ collectDeclaredTextEntries(const ElfView &Elf) {
     }
     if (!EntryAddress)
       return std::nullopt;
-    if (*EntryAddress >= Elf.textAddr() && *EntryAddress < *TextEnd)
-      Entries.push_back(*EntryAddress - Elf.textAddr());
+    if (*EntryAddress >= Elf.textAddr() && *EntryAddress < *TextEnd) {
+      uint64_t Entry = *EntryAddress - Elf.textAddr();
+      Info.Entries.push_back(Entry);
+      Info.ExternalEntries.push_back(Entry);
+    }
   }
-  return Entries;
+  return Info;
 }
 
 struct PcMaterializedCallInfo {
@@ -1117,12 +1129,101 @@ static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
   return Calls;
 }
 
+static bool hasUnprovenFallthroughEntry(ArrayRef<InternalDecodedInst> Decoded,
+                                        const LLVMState &LS, uint64_t TextAddr,
+                                        uint64_t TextEnd,
+                                        uint64_t FunctionBegin,
+                                        uint64_t ReturnOffset,
+                                        ArrayRef<uint64_t> DeclaredEntries,
+                                        ArrayRef<KnownCallSite> Calls) {
+  if (FunctionBegin == 0)
+    return false;
+
+  size_t BeginIndex = 0;
+  while (BeginIndex != Decoded.size() &&
+         Decoded[BeginIndex].Offset < FunctionBegin)
+    ++BeginIndex;
+  if (BeginIndex == Decoded.size() ||
+      Decoded[BeginIndex].Offset != FunctionBegin) {
+    log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+          << " is not a bounded return: function entry at 0x"
+          << utohexstr(FunctionBegin) << " is not an instruction boundary\n";
+    return true;
+  }
+
+  uint64_t ChainBegin = FunctionBegin;
+  size_t PredecessorIndex = BeginIndex;
+  while (PredecessorIndex != 0) {
+    const InternalDecodedInst &Predecessor = Decoded[PredecessorIndex - 1];
+    std::optional<uint64_t> PredecessorEnd = checkedAddUint64(
+        Predecessor.Offset, Predecessor.Size, "fallthrough predecessor end");
+    if (!PredecessorEnd || *PredecessorEnd != ChainBegin ||
+        !Predecessor.DecodeSucceeded) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: fallthrough into function entry "
+               "at 0x"
+            << utohexstr(FunctionBegin) << " is unprovable\n";
+      return true;
+    }
+    if (LS.MIA->isBarrier(Predecessor.Inst))
+      break;
+    ChainBegin = Predecessor.Offset;
+    --PredecessorIndex;
+  }
+
+  if (ChainBegin == FunctionBegin)
+    return false;
+
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry >= ChainBegin && Entry < FunctionBegin) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: declared entry at 0x"
+            << utohexstr(Entry) << " falls through to function entry 0x"
+            << utohexstr(FunctionBegin) << "\n";
+      return true;
+    }
+
+  for (const KnownCallSite &Call : Calls) {
+    uint64_t Source = Decoded[Call.InstIndex].Offset;
+    if (Source >= ChainBegin && Source < FunctionBegin)
+      continue;
+    if ((Call.Target >= ChainBegin && Call.Target < FunctionBegin) ||
+        (Call.Continuation >= ChainBegin &&
+         Call.Continuation < FunctionBegin)) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: call at 0x" << utohexstr(Source)
+            << " enters the fallthrough chain at 0x"
+            << utohexstr(Call.Target >= ChainBegin &&
+                                 Call.Target < FunctionBegin
+                             ? Call.Target
+                             : Call.Continuation)
+            << "\n";
+      return true;
+    }
+  }
+
+  for (const InternalDecodedInst &Source : Decoded) {
+    std::optional<uint64_t> Target =
+        getDirectTextTarget(Source, LS, TextAddr, TextEnd);
+    if (!Target || *Target < ChainBegin || *Target >= FunctionBegin ||
+        (Source.Offset >= ChainBegin && Source.Offset < FunctionBegin))
+      continue;
+    log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+          << " is not a bounded return: control flow at 0x"
+          << utohexstr(Source.Offset) << " enters the fallthrough chain at 0x"
+          << utohexstr(*Target) << "\n";
+    return true;
+  }
+  return false;
+}
+
 static std::optional<SmallVector<BoundedSetPcReturn, 2>>
 collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
                            const LLVMState &LS, uint64_t TextAddr,
                            uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                            ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-                           ArrayRef<KnownCallSite> Calls) {
+                           ArrayRef<KnownCallSite> Calls,
+                           ArrayRef<uint64_t> ExternalEntries) {
   SmallVector<BoundedSetPcReturn, 2> Returns;
   for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex) {
     const InternalDecodedInst &Return = Decoded[ReturnIndex];
@@ -1149,6 +1250,33 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
 
       bool Safe = true;
+      for (uint64_t Entry : ExternalEntries)
+        if (Entry >= FunctionBegin && Entry < FunctionEnd) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: externally reachable entry at "
+                   "0x"
+                << utohexstr(Entry) << " overlaps the local function\n";
+          Safe = false;
+          break;
+        }
+      if (!Safe)
+        continue;
+
+      for (const ElfView::FunctionTextRange &Alias : FunctionRanges) {
+        if (Return.Offset + TextAddr < Alias.Begin ||
+            Return.Offset + TextAddr >= Alias.End || Alias.Begin == Range.Begin)
+          continue;
+        log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+              << " is not a bounded return: overlapping function entry at "
+                 "0x"
+              << utohexstr(Alias.Begin - TextAddr)
+              << " makes entry provenance ambiguous\n";
+        Safe = false;
+        break;
+      }
+      if (!Safe)
+        continue;
+
       for (uint64_t Entry : DeclaredEntries)
         if (Entry > FunctionBegin && Entry < FunctionEnd) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
@@ -1158,6 +1286,11 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
           break;
         }
       if (!Safe)
+        continue;
+
+      if (hasUnprovenFallthroughEntry(Decoded, LS, TextAddr, TextEnd,
+                                      FunctionBegin, Return.Offset,
+                                      DeclaredEntries, Calls))
         continue;
 
       // The link pair must retain the value written by the incoming call
@@ -1181,8 +1314,17 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
 
       SmallVector<uint64_t, 2> Targets;
       for (const KnownCallSite &Call : Calls) {
-        if (Call.Target != FunctionBegin)
+        if (Call.Target < FunctionBegin || Call.Target >= FunctionEnd)
           continue;
+        if (Call.Target != FunctionBegin) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: call at 0x"
+                << utohexstr(Decoded[Call.InstIndex].Offset)
+                << " enters the function interior at 0x"
+                << utohexstr(Call.Target) << "\n";
+          Safe = false;
+          break;
+        }
         if (Call.ReturnRegister != ReturnRegister) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
                 << " is not a bounded return: call at 0x"
@@ -1294,7 +1436,8 @@ hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
-    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<uint64_t> ExternalEntries) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -1317,7 +1460,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     return std::nullopt;
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
       collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, FunctionRanges, *Calls);
+                                 DeclaredEntries, FunctionRanges, *Calls,
+                                 ExternalEntries);
   if (!BoundedReturns)
     return std::nullopt;
 
@@ -2124,15 +2268,15 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
   uint32_t Patched = 0;
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
-  std::optional<SmallVector<uint64_t, 16>> DeclaredEntries =
+  std::optional<DeclaredTextEntryInfo> DeclaredEntries =
       collectDeclaredTextEntries(Elf);
   if (!DeclaredEntries)
     return std::nullopt;
   std::vector<ElfView::FunctionTextRange> FunctionRanges =
       Elf.functionTextRanges();
-  std::optional<DirectControlFlowInfo> ControlFlow =
-      collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize(),
-                                 *DeclaredEntries, FunctionRanges);
+  std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
+      Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
+      FunctionRanges, DeclaredEntries->ExternalEntries);
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -911,11 +911,58 @@ static bool isControlFlowBoundary(const InternalDecodedInst &DI,
          LS.MIA->isBarrier(DI.Inst);
 }
 
+static std::optional<SmallVector<uint64_t, 16>>
+collectDeclaredTextEntries(const ElfView &Elf) {
+  std::optional<uint64_t> TextEnd =
+      checkedAddUint64(Elf.textAddr(), Elf.textSize(), "declared text end");
+  if (!TextEnd)
+    return std::nullopt;
+
+  SmallVector<uint64_t, 16> Entries;
+  for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges())
+    if (Range.Begin >= Elf.textAddr() && Range.Begin < *TextEnd)
+      Entries.push_back(Range.Begin - Elf.textAddr());
+
+  for (const KernelDescriptorInfo &Descriptor : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> EntryAddress;
+    if (Descriptor.EntryOffset >= 0) {
+      EntryAddress = checkedAddUint64(
+          Descriptor.VAddr, static_cast<uint64_t>(Descriptor.EntryOffset),
+          "kernel descriptor entry address");
+    } else {
+      uint64_t Magnitude =
+          Descriptor.EntryOffset == std::numeric_limits<int64_t>::min()
+              ? uint64_t{1} << 63
+              : static_cast<uint64_t>(-Descriptor.EntryOffset);
+      EntryAddress = checkedSubUint64(Descriptor.VAddr, Magnitude,
+                                      "kernel descriptor entry address");
+    }
+    if (!EntryAddress)
+      return std::nullopt;
+    if (*EntryAddress >= Elf.textAddr() && *EntryAddress < *TextEnd)
+      Entries.push_back(*EntryAddress - Elf.textAddr());
+  }
+  return Entries;
+}
+
 static bool hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
                                      const LLVMState &LS, uint64_t TextAddr,
+                                     ArrayRef<uint64_t> DeclaredEntries,
                                      uint64_t SequenceStart,
                                      uint64_t SequenceEnd) {
+  for (uint64_t Entry : DeclaredEntries)
+    if (Entry > SequenceStart && Entry <= SequenceEnd)
+      return true;
+
   for (const InternalDecodedInst &DI : Decoded) {
+    // Without bounding an indirect target, it may enter at any instruction in
+    // the materialization. Keep the call unresolved rather than relying on
+    // the indirect transfer's containing function alone.
+    if (DI.DecodeSucceeded && !LS.MIA->isReturn(DI.Inst) &&
+        (LS.MIA->isIndirectBranch(DI.Inst) ||
+         DI.Inst.getOpcode() == LS.SSetPcI64Opcode ||
+         DI.Inst.getOpcode() == LS.SAddPcI64Opcode))
+      return true;
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isReturn(DI.Inst))
       continue;
@@ -958,9 +1005,10 @@ static bool hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
 static std::optional<uint64_t>
 resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
                                 size_t CallIndex, const LLVMState &LS,
-                                uint64_t TextAddr) {
+                                uint64_t TextAddr,
+                                ArrayRef<uint64_t> DeclaredEntries) {
   const InternalDecodedInst &Call = Decoded[CallIndex];
-  if (Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+  if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
       Call.Inst.getNumOperands() == 0)
     return std::nullopt;
   const MCOperand &TargetOperand =
@@ -974,7 +1022,7 @@ resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
   for (size_t I = CallIndex; I != 0;) {
     --I;
     const InternalDecodedInst &Candidate = Decoded[I];
-    if (isControlFlowBoundary(Candidate, LS))
+    if (!Candidate.DecodeSucceeded || isControlFlowBoundary(Candidate, LS))
       return std::nullopt;
     if (!definesOverlappingRegister(Candidate, LS, TargetRegister))
       continue;
@@ -996,7 +1044,7 @@ resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
   for (size_t I = *AddIndex; I != 0;) {
     --I;
     const InternalDecodedInst &Candidate = Decoded[I];
-    if (isControlFlowBoundary(Candidate, LS))
+    if (!Candidate.DecodeSucceeded || isControlFlowBoundary(Candidate, LS))
       return std::nullopt;
     if (!definesOverlappingRegister(Candidate, LS, TargetRegister))
       continue;
@@ -1014,8 +1062,8 @@ resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
         *GetPcAddress, Candidate.Size, "PC-materialized call PC value");
     if (!PcValue)
       return std::nullopt;
-    if (hasKnownControlFlowEntry(Decoded, LS, TextAddr, Candidate.Offset,
-                                 Call.Offset))
+    if (hasKnownControlFlowEntry(Decoded, LS, TextAddr, DeclaredEntries,
+                                 Candidate.Offset, Call.Offset))
       return std::nullopt;
 
     // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
@@ -1028,10 +1076,9 @@ resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
 
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
-std::optional<DirectControlFlowInfo>
-collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
-                           const LLVMState &LS, uint64_t TextAddr,
-                           uint64_t TextSize) {
+std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -1067,8 +1114,8 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
         Target = static_cast<uint64_t>(
             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
       } else {
-        Target =
-            resolvePcMaterializedCallTarget(Decoded, InstIndex, LS, TextAddr);
+        Target = resolvePcMaterializedCallTarget(Decoded, InstIndex, LS,
+                                                 TextAddr, DeclaredEntries);
       }
       if (!Target) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
@@ -1841,8 +1888,13 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
   uint32_t Patched = 0;
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
+  std::optional<SmallVector<uint64_t, 16>> DeclaredEntries =
+      collectDeclaredTextEntries(Elf);
+  if (!DeclaredEntries)
+    return std::nullopt;
   std::optional<DirectControlFlowInfo> ControlFlow =
-      collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize());
+      collectDirectBranchTargets(Decoded, LS, Elf.textAddr(), Elf.textSize(),
+                                 *DeclaredEntries);
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -875,6 +875,157 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                           "direct control-flow target");
 }
 
+static bool definesOverlappingRegister(const InternalDecodedInst &DI,
+                                       const LLVMState &LS,
+                                       MCRegister Register) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  if (Desc.variadicOpsAreDefs()) {
+    unsigned VariadicBegin =
+        std::min(Desc.getNumOperands(), DI.Inst.getNumOperands());
+    for (unsigned I = VariadicBegin; I != DI.Inst.getNumOperands(); ++I) {
+      const MCOperand &Operand = DI.Inst.getOperand(I);
+      if (Operand.isReg() && Operand.getReg() &&
+          LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+        return true;
+    }
+  }
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    if (LS.MRI->regsOverlap(MCRegister(ImplicitDef), Register))
+      return true;
+  return false;
+}
+
+static bool isControlFlowBoundary(const InternalDecodedInst &DI,
+                                  const LLVMState &LS) {
+  return DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+         DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+         LS.MIA->isBranch(DI.Inst) || LS.MIA->isCall(DI.Inst) ||
+         LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
+         LS.MIA->isBarrier(DI.Inst);
+}
+
+static bool hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
+                                     const LLVMState &LS, uint64_t TextAddr,
+                                     uint64_t SequenceStart,
+                                     uint64_t SequenceEnd) {
+  for (const InternalDecodedInst &DI : Decoded) {
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+
+    std::optional<uint64_t> RelativeTarget;
+    bool HasPcRelativeOperand = false;
+    for (const MCOperandInfo &Operand :
+         LS.MCII->get(DI.Inst.getOpcode()).operands())
+      HasPcRelativeOperand |= Operand.OperandType == MCOI::OPERAND_PCREL;
+    if (HasPcRelativeOperand) {
+      RelativeTarget = evaluateDirectControlFlowTarget(DI, LS);
+    } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+               DI.Inst.getNumOperands() != 0 &&
+               DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+      uint64_t AbsoluteTarget = static_cast<uint64_t>(
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+      if (AbsoluteTarget >= TextAddr)
+        RelativeTarget = AbsoluteTarget - TextAddr;
+    }
+    if (RelativeTarget && *RelativeTarget > SequenceStart &&
+        *RelativeTarget <= SequenceEnd)
+      return true;
+  }
+  return false;
+}
+
+/// Resolve the compiler-emitted PC materialization used by the production
+/// reproducer:
+///
+///   s_get_pc_i64 Target
+///   ...                         // no Target definition or control flow
+///   s_add_nc_u64 Target, Target, Immediate
+///   ...                         // no Target definition or control flow
+///   s_swap_pc_i64 Return, Target
+///
+/// The opcode and operand layout are defined by SOPInstructions.td and pinned
+/// by llvm/test/MC/AMDGPU/gfx1250_asm_salu_lit64.s. Stop at the first
+/// overlapping definition or control-flow boundary, so any variation remains
+/// unresolved and follows the existing fail-closed policy.
+static std::optional<uint64_t>
+resolvePcMaterializedCallTarget(ArrayRef<InternalDecodedInst> Decoded,
+                                size_t CallIndex, const LLVMState &LS,
+                                uint64_t TextAddr) {
+  const InternalDecodedInst &Call = Decoded[CallIndex];
+  if (Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+      Call.Inst.getNumOperands() == 0)
+    return std::nullopt;
+  const MCOperand &TargetOperand =
+      Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
+  if (!TargetOperand.isReg() || !TargetOperand.getReg())
+    return std::nullopt;
+  MCRegister TargetRegister(TargetOperand.getReg());
+
+  std::optional<size_t> AddIndex;
+  int64_t AddImmediate = 0;
+  for (size_t I = CallIndex; I != 0;) {
+    --I;
+    const InternalDecodedInst &Candidate = Decoded[I];
+    if (isControlFlowBoundary(Candidate, LS))
+      return std::nullopt;
+    if (!definesOverlappingRegister(Candidate, LS, TargetRegister))
+      continue;
+    if (Candidate.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+        Candidate.Inst.getNumOperands() != 3 ||
+        !Candidate.Inst.getOperand(0).isReg() ||
+        Candidate.Inst.getOperand(0).getReg() != TargetRegister ||
+        !Candidate.Inst.getOperand(1).isReg() ||
+        Candidate.Inst.getOperand(1).getReg() != TargetRegister ||
+        !Candidate.Inst.getOperand(2).isImm())
+      return std::nullopt;
+    AddIndex = I;
+    AddImmediate = Candidate.Inst.getOperand(2).getImm();
+    break;
+  }
+  if (!AddIndex)
+    return std::nullopt;
+
+  for (size_t I = *AddIndex; I != 0;) {
+    --I;
+    const InternalDecodedInst &Candidate = Decoded[I];
+    if (isControlFlowBoundary(Candidate, LS))
+      return std::nullopt;
+    if (!definesOverlappingRegister(Candidate, LS, TargetRegister))
+      continue;
+    if (Candidate.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+        Candidate.Inst.getNumOperands() != 1 ||
+        !Candidate.Inst.getOperand(0).isReg() ||
+        Candidate.Inst.getOperand(0).getReg() != TargetRegister)
+      return std::nullopt;
+
+    std::optional<uint64_t> GetPcAddress = checkedAddUint64(
+        TextAddr, Candidate.Offset, "PC-materialized call instruction");
+    if (!GetPcAddress)
+      return std::nullopt;
+    std::optional<uint64_t> PcValue = checkedAddUint64(
+        *GetPcAddress, Candidate.Size, "PC-materialized call PC value");
+    if (!PcValue)
+      return std::nullopt;
+    if (hasKnownControlFlowEntry(Decoded, LS, TextAddr, Candidate.Offset,
+                                 Call.Offset))
+      return std::nullopt;
+
+    // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
+    // immediate to uint64_t and adding it reproduces both positive and
+    // negative literals, including INT64_MIN, without signed overflow.
+    return *PcValue + static_cast<uint64_t>(AddImmediate);
+  }
+  return std::nullopt;
+}
+
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
 std::optional<DirectControlFlowInfo>
@@ -888,7 +1039,8 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
   }
 
   DirectControlFlowInfo Info;
-  for (const InternalDecodedInst &DI : Decoded) {
+  for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
+    const InternalDecodedInst &DI = Decoded[InstIndex];
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isReturn(DI.Inst))
       continue;
@@ -908,8 +1060,17 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
       // source relocation in their containing function.
       if (!LS.MIA->isCall(DI.Inst))
         continue;
-      if (DI.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
-          !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+      std::optional<uint64_t> Target;
+      if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+          DI.Inst.getNumOperands() != 0 &&
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+        Target = static_cast<uint64_t>(
+            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+      } else {
+        Target =
+            resolvePcMaterializedCallTarget(Decoded, InstIndex, LS, TextAddr);
+      }
+      if (!Target) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
               << " (" << DI.Mnemonic << ")\n";
         Info.HasUnresolvedTargets = true;
@@ -920,10 +1081,14 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
           checkedAddUint64(TextAddr, TextSize, "direct target text end");
       if (!TextEnd)
         return std::nullopt;
-      uint64_t Target = static_cast<uint64_t>(
-          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
-      if (Target >= TextAddr && Target < *TextEnd)
-        Info.Targets.insert(Target - TextAddr);
+      if (*Target >= TextAddr && *Target < *TextEnd) {
+        uint64_t RelativeTarget = *Target - TextAddr;
+        Info.Targets.insert(RelativeTarget);
+        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
+          log() << "hotswap: resolved PC-materialized call at 0x"
+                << utohexstr(DI.Offset) << " to .text+0x"
+                << utohexstr(RelativeTarget) << "\n";
+      }
       continue;
     }
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -888,16 +888,21 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 /// register calls are resolved when their target value has one provable
 /// straight-line definition and no direct, indirect, or declared entry can
 /// bypass that definition. Canonical local-function returns are bounded to
-/// the continuations of calls that preserve the same link register. \p
-/// DeclaredEntries contains text-relative function and kernel entry offsets;
-/// \p FunctionRanges supplies the symbol ranges used for the return proof.
-/// Other register-target control flow sets HasUnresolvedTargets so callers can
-/// disable transformations that consume possible destinations.
+/// the continuations of calls that preserve the same link register, provided
+/// no interior call, overlapping external alias, or reachable fallthrough can
+/// enter the function without that link definition. \p DeclaredEntries
+/// contains text-relative function and kernel entry offsets; \p FunctionRanges
+/// supplies the symbol ranges used for the return proof; \p ExternalEntries
+/// identifies externally reachable symbol and kernel entries, including
+/// aliases at a local function's start. Other register-target control flow
+/// sets HasUnresolvedTargets so callers can disable transformations that
+/// consume possible destinations.
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize,
     llvm::ArrayRef<uint64_t> DeclaredEntries,
-    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {});
+    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
+    llvm::ArrayRef<uint64_t> ExternalEntries = {});
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -550,6 +550,7 @@ struct LLVMState {
   /// matching disassembled mnemonic strings.
   unsigned GlobalWbOpcode = 0;
   unsigned SGetPcI64Opcode = 0;
+  unsigned SAddNcU64Opcode = 0;
   unsigned SAddU32Opcode = 0;
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
@@ -883,9 +884,11 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 
 /// Collect branch and call targets used to protect interior entry points from
 /// trampoline coalescing. Absolute addresses in TextAddr .. TextAddr +
-/// TextSize are converted to text-relative offsets. Register-target control
-/// flow sets HasUnresolvedTargets so callers can disable transformations that
-/// consume possible destinations.
+/// TextSize are converted to text-relative offsets. Canonical PC-materialized
+/// register calls are resolved when their target value has one provable
+/// straight-line definition. Other register-target control flow sets
+/// HasUnresolvedTargets so callers can disable transformations that consume
+/// possible destinations.
 std::optional<DirectControlFlowInfo>
 collectDirectBranchTargets(llvm::ArrayRef<InternalDecodedInst> Decoded,
                            const LLVMState &LS, uint64_t TextAddr,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -886,13 +886,16 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 /// trampoline coalescing. Absolute addresses in TextAddr .. TextAddr +
 /// TextSize are converted to text-relative offsets. Canonical PC-materialized
 /// register calls are resolved when their target value has one provable
-/// straight-line definition. Other register-target control flow sets
+/// straight-line definition and no direct, indirect, or declared entry can
+/// bypass that definition. \p DeclaredEntries contains text-relative function
+/// and kernel entry offsets. Other register-target control flow sets
 /// HasUnresolvedTargets so callers can disable transformations that consume
 /// possible destinations.
 std::optional<DirectControlFlowInfo>
 collectDirectBranchTargets(llvm::ArrayRef<InternalDecodedInst> Decoded,
                            const LLVMState &LS, uint64_t TextAddr,
-                           uint64_t TextSize);
+                           uint64_t TextSize,
+                           llvm::ArrayRef<uint64_t> DeclaredEntries);
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -887,15 +887,17 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 /// TextSize are converted to text-relative offsets. Canonical PC-materialized
 /// register calls are resolved when their target value has one provable
 /// straight-line definition and no direct, indirect, or declared entry can
-/// bypass that definition. \p DeclaredEntries contains text-relative function
-/// and kernel entry offsets. Other register-target control flow sets
-/// HasUnresolvedTargets so callers can disable transformations that consume
-/// possible destinations.
-std::optional<DirectControlFlowInfo>
-collectDirectBranchTargets(llvm::ArrayRef<InternalDecodedInst> Decoded,
-                           const LLVMState &LS, uint64_t TextAddr,
-                           uint64_t TextSize,
-                           llvm::ArrayRef<uint64_t> DeclaredEntries);
+/// bypass that definition. Canonical local-function returns are bounded to
+/// the continuations of calls that preserve the same link register. \p
+/// DeclaredEntries contains text-relative function and kernel entry offsets;
+/// \p FunctionRanges supplies the symbol ranges used for the return proof.
+/// Other register-target control flow sets HasUnresolvedTargets so callers can
+/// disable transformations that consume possible destinations.
+std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextSize,
+    llvm::ArrayRef<uint64_t> DeclaredEntries,
+    llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {});
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -331,6 +331,9 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_get_pc_i64 s[0:1]", "s_get_pc_i64", S,
                                      S.SGetPcI64Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_nc_u64 s[0:1], s[0:1], 0",
+                                     "s_add_nc_u64", S, S.SAddNcU64Opcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_add_u32 s0, s0, 0", "s_add_u32", S,
                                      S.SAddU32Opcode))
     return S;

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call-declared-entry.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call-declared-entry.s
@@ -1,0 +1,74 @@
+// COM: A declared function entry inside a PC-materialized call sequence can
+// COM: bypass s_get_pc_i64 even when no direct branch targets that instruction.
+// COM: The register call must remain unresolved, which disables every rewrite
+// COM: that could consume an unknown original .text destination.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: unresolved call target at 0x8 (s_swap_pc_i64)
+// LOG: hotswap: unresolved control-flow target disables trampoline
+// LOG-SAME: coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_pc_materialized_declared_entry
+.p2align 8
+.type test_pc_materialized_declared_entry,@function
+test_pc_materialized_declared_entry:
+  s_get_pc_i64 s[2:3]
+
+// This symbol is an independent semantic entry. Entering here leaves s[2:3]
+// caller-defined, so the apparent linear target calculation is not a proof.
+.globl alternate_pc_materialization_entry
+.type alternate_pc_materialization_entry,@function
+alternate_pc_materialization_entry:
+  s_add_nc_u64 s[2:3], s[2:3], 16
+  s_swap_pc_i64 s[0:1], s[2:3]
+.Lalternate_pc_materialization_entry_end:
+.size alternate_pc_materialization_entry, .Lalternate_pc_materialization_entry_end-alternate_pc_materialization_entry
+
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_pc_materialized_declared_entry_end:
+.size test_pc_materialized_declared_entry, .Ltest_pc_materialized_declared_entry_end-test_pc_materialized_declared_entry
+
+// This space would be usable for gateways only if every control-flow target
+// were known.
+.fill 64, 1, 0
+
+// Keep the trampoline pool outside the signed s_branch range.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_pc_materialized_declared_entry
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_pc_materialized_declared_entry
+      .symbol: test_pc_materialized_declared_entry.kd
+      .sgpr_count: 4
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call-declared-entry.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call-declared-entry.s
@@ -10,8 +10,8 @@
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=LOG,API %s
 // LOG: hotswap: unresolved call target at 0x8 (s_swap_pc_i64)
-// LOG: hotswap: unresolved control-flow target disables trampoline
-// LOG-SAME: coalescing, source relocation, and .text gateways
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
 // LOG: hotswap: error: no safe short-branch gateway for far site
 // API: RESULT: ERROR
 

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call-external-alias.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call-external-alias.s
@@ -1,0 +1,88 @@
+// COM: A local return helper is not call-only when a GLOBAL PROTECTED kernel
+// COM: alias and kernel descriptor expose the same entry. Kernel dispatch
+// COM: does not define the helper's link pair, so the rewrite must fail closed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: s_set_pc_i64 at 0x4 is not a bounded return: externally reachable entry at 0x0 overlaps the local function
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.type local_return_helper,@function
+.globl aliased_return_kernel
+.protected aliased_return_kernel
+.type aliased_return_kernel,@function
+local_return_helper:
+aliased_return_kernel:
+  s_nop 0
+  s_set_pc_i64 s[0:1]
+.Laliased_return_end:
+.size local_return_helper, .Laliased_return_end-local_return_helper
+.size aliased_return_kernel, .Laliased_return_end-aliased_return_kernel
+
+.globl test_pc_materialized_external_alias
+.p2align 8
+.type test_pc_materialized_external_alias,@function
+test_pc_materialized_external_alias:
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], -260
+  s_swap_pc_i64 s[0:1], s[4:5]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_pc_materialized_external_alias_end:
+.size test_pc_materialized_external_alias, .Ltest_pc_materialized_external_alias_end-test_pc_materialized_external_alias
+
+.fill 64, 1, 0
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel aliased_return_kernel
+  .amdhsa_next_free_vgpr 0
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+.p2align 8
+.amdhsa_kernel test_pc_materialized_external_alias
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 6
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: aliased_return_kernel
+      .symbol: aliased_return_kernel.kd
+      .sgpr_count: 2
+      .vgpr_count: 0
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_pc_materialized_external_alias
+      .symbol: test_pc_materialized_external_alias.kd
+      .sgpr_count: 6
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call-fallthrough-entry.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call-fallthrough-entry.s
@@ -1,0 +1,92 @@
+// COM: A declared kernel immediately before a local return helper can reach
+// COM: the helper by fallthrough without defining its link pair. The return
+// COM: cannot be bounded even when its explicit caller is canonical.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: s_set_pc_i64 at 0x8 is not a bounded return: declared entry at 0x0 falls through to function entry 0x4
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl fallthrough_kernel
+.protected fallthrough_kernel
+.type fallthrough_kernel,@function
+fallthrough_kernel:
+  s_nop 0
+.Lfallthrough_kernel_end:
+.size fallthrough_kernel, .Lfallthrough_kernel_end-fallthrough_kernel
+
+.type local_return_helper,@function
+local_return_helper:
+  s_nop 0
+  s_set_pc_i64 s[0:1]
+.Llocal_return_helper_end:
+.size local_return_helper, .Llocal_return_helper_end-local_return_helper
+
+.globl test_pc_materialized_fallthrough_entry
+.p2align 8
+.type test_pc_materialized_fallthrough_entry,@function
+test_pc_materialized_fallthrough_entry:
+  // Captured PC is .text+0x104 and the helper begins at .text+0x4.
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], -256
+  s_swap_pc_i64 s[0:1], s[4:5]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_pc_materialized_fallthrough_entry_end:
+.size test_pc_materialized_fallthrough_entry, .Ltest_pc_materialized_fallthrough_entry_end-test_pc_materialized_fallthrough_entry
+
+.fill 64, 1, 0
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel fallthrough_kernel
+  .amdhsa_next_free_vgpr 0
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+.p2align 8
+.amdhsa_kernel test_pc_materialized_fallthrough_entry
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 6
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: fallthrough_kernel
+      .symbol: fallthrough_kernel.kd
+      .sgpr_count: 0
+      .vgpr_count: 0
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: test_pc_materialized_fallthrough_entry
+      .symbol: test_pc_materialized_fallthrough_entry.kd
+      .sgpr_count: 6
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call-interior-entry.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call-interior-entry.s
@@ -1,0 +1,78 @@
+// COM: Every known call entering a local return function must participate in
+// COM: the link-register proof. A register-materialized call into the
+// COM: function interior bypasses the entry and must keep the rewrite
+// COM: fail-closed, even when another canonical call targets the entry.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: s_set_pc_i64 at 0x4 is not a bounded return: call at 0x{{[0-9A-F]+}} enters the function interior at 0x4
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.type local_return_helper,@function
+local_return_helper:
+  s_nop 0
+.Llocal_return_epilogue:
+  s_set_pc_i64 s[0:1]
+.Llocal_return_helper_end:
+.size local_return_helper, .Llocal_return_helper_end-local_return_helper
+
+.globl test_pc_materialized_interior_entry
+.p2align 8
+.type test_pc_materialized_interior_entry,@function
+test_pc_materialized_interior_entry:
+  // Canonical entry call: captured PC is .text+0x104.
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], -260
+  s_swap_pc_i64 s[0:1], s[4:5]
+
+  // Interior call: captured PC is .text+0x118 and the target is .text+0x4.
+  // It also uses a different link pair from the helper return.
+  s_get_pc_i64 s[6:7]
+  s_add_nc_u64 s[6:7], s[6:7], -276
+  s_swap_pc_i64 s[2:3], s[6:7]
+
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_pc_materialized_interior_entry_end:
+.size test_pc_materialized_interior_entry, .Ltest_pc_materialized_interior_entry_end-test_pc_materialized_interior_entry
+
+.fill 64, 1, 0
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_pc_materialized_interior_entry
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 8
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_pc_materialized_interior_entry
+      .symbol: test_pc_materialized_interior_entry.kd
+      .sgpr_count: 8
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -1,0 +1,85 @@
+// COM: A canonical compiler-emitted register call materializes its target as
+// COM: s_get_pc_i64 plus s_add_nc_u64. Prove that target from the decoded MC
+// COM: operands instead of treating the call as globally unresolved. The
+// COM: target is the second adjacent far patch site, which must remain an
+// COM: independently callable entry while safe external gateways remain
+// COM: available for both patches.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: resolved PC-materialized call at 0x8 to .text+0x14
+// LOG-NOT: hotswap: unresolved call target
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_pc_materialized_call>:
+// DISASM-NEXT: s_get_pc_i64 s[2:3]
+// DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3], 16
+// DISASM-NEXT: s_swap_pc_i64 s[0:1], s[2:3]
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_branch
+
+// COM: A second rewrite must preserve the resolved call and patched object.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_pc_materialized_call
+.p2align 8
+.type test_pc_materialized_call,@function
+test_pc_materialized_call:
+  // The captured PC is .text+4; adding 16 selects .text+20, the second DS
+  // instruction below.
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], 16
+  s_swap_pc_i64 s[0:1], s[2:3]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lpc_materialized_target:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_pc_materialized_call_end:
+.size test_pc_materialized_call, .Ltest_pc_materialized_call_end-test_pc_materialized_call
+
+// Each far site needs its own 28-byte SCC-preserving gateway. This padding
+// follows s_endpgm and lies outside the function, so it is safe.
+.fill 64, 1, 0
+
+// Push the appended trampoline pool beyond s_branch's signed 16-bit dword
+// range and force direct-target-aware far-site handling.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_pc_materialized_call
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 4
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_pc_materialized_call
+      .symbol: test_pc_materialized_call.kd
+      .sgpr_count: 4
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -11,12 +11,16 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=LOG,API %s
-// LOG: hotswap: resolved PC-materialized call at 0x8 to .text+0x14
+// LOG: hotswap: resolved PC-materialized call at 0x{{[0-9A-F]+}} to .text+0x0
+// LOG: hotswap: resolved PC-materialized call at 0x{{[0-9A-F]+}} to .text+0x{{[1-9A-F][0-9A-F]*}}
 // LOG-NOT: hotswap: unresolved call target
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-LABEL: <test_pc_materialized_call>:
+// DISASM-NEXT: s_get_pc_i64 s[4:5]
+// DISASM-NEXT: s_add_nc_u64 s[4:5], s[4:5], 0xfffffffffffffefc
+// DISASM-NEXT: s_swap_pc_i64 s[0:1], s[4:5]
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
 // DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3], 16
 // DISASM-NEXT: s_swap_pc_i64 s[0:1], s[2:3]
@@ -33,12 +37,32 @@
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
+
+// This is the production return shape. MC lowering turns the compiler return
+// pseudo into plain s_set_pc_i64, so the rewriter must prove its destination
+// from the incoming call's link register rather than rely on MIA::isReturn.
+.type local_return_helper,@function
+local_return_helper:
+  s_nop 0
+.Llocal_return_epilogue:
+  s_set_pc_i64 s[0:1]
+  // The production helper has later blocks that branch back into its return
+  // epilogue. They remain safe because the whole local function preserves the
+  // link pair.
+  s_branch .Llocal_return_epilogue
+.Llocal_return_helper_end:
+.size local_return_helper, .Llocal_return_helper_end-local_return_helper
+
 .globl test_pc_materialized_call
 .p2align 8
 .type test_pc_materialized_call,@function
 test_pc_materialized_call:
-  // The captured PC is .text+4; adding 16 selects .text+20, the second DS
-  // instruction below.
+  // The helper starts at .text+0. This instruction captures .text+0x104.
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], -260
+  s_swap_pc_i64 s[0:1], s[4:5]
+
+  // Adding 16 to the captured PC selects the second DS instruction below.
   s_get_pc_i64 s[2:3]
   s_add_nc_u64 s[2:3], s[2:3], 16
   s_swap_pc_i64 s[0:1], s[2:3]

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -556,7 +556,7 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
 
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                 /*TextSize=*/0x1000);
+                                 /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnresolvedTargets);
@@ -579,7 +579,7 @@ TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
 
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                 /*TextSize=*/0x1000);
+                                 /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_FALSE(Info->HasUnresolvedTargets);
@@ -606,7 +606,8 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   // 0x1a000 + 0x12edcc + 4 - 0x12edd0 = 0x1a000.
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x1A000,
-                                 /*TextSize=*/0x150000);
+                                 /*TextSize=*/0x150000,
+                                 /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   ASSERT_EQ(Info->Targets.size(), 1u);
   EXPECT_TRUE(Info->Targets.contains(0));
@@ -630,7 +631,7 @@ TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
 
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                 /*TextSize=*/0x1000);
+                                 /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnresolvedTargets);
@@ -655,9 +656,85 @@ TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoMaterialization) {
   // apparent linear definition chain does not prove the register value.
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                 /*TextSize=*/0x1000);
+                                 /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.contains(8));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsDeclaredEntryIntoMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], 4\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{Decoded[1].Offset};
+
+  // A function or kernel entry at the add can bypass s_get_pc_i64, even when
+  // no direct branch in .text exposes that alternate path.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsUndecodedMaterializationSlot) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], 8\n"
+                         "v_mov_b32 v0, v1\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+  Decoded[2].DecodeSucceeded = false;
+  Decoded[2].Inst = llvm::MCInst();
+  Decoded[2].Mnemonic = "<unknown>";
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsUnboundedIndirectEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_set_pc_i64 s[4:5]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], 4\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+  ASSERT_EQ(Decoded[0].Inst.getOpcode(), S.SSetPcI64Opcode);
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
@@ -676,7 +753,7 @@ TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
 
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x200,
-                                 /*TextSize=*/0x40);
+                                 /*TextSize=*/0x40, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   ASSERT_EQ(Info->Targets.size(), 1u);
   EXPECT_TRUE(Info->Targets.contains(0x10));
@@ -684,7 +761,7 @@ TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
 
   std::optional<DirectControlFlowInfo> OutsideInfo =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
-                                 /*TextSize=*/0x40);
+                                 /*TextSize=*/0x40, /*DeclaredEntries=*/{});
   ASSERT_TRUE(OutsideInfo);
   EXPECT_TRUE(OutsideInfo->Targets.empty());
   EXPECT_FALSE(OutsideInfo->HasUnresolvedTargets);
@@ -693,7 +770,7 @@ TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
       collectDirectBranchTargets(
           Decoded, S,
           /*TextAddr=*/std::numeric_limits<uint64_t>::max() - 0x10,
-          /*TextSize=*/0x20);
+          /*TextSize=*/0x20, /*DeclaredEntries=*/{});
   EXPECT_FALSE(OverflowInfo);
 }
 
@@ -711,7 +788,7 @@ TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
 
   std::optional<DirectControlFlowInfo> Info =
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
-                                 /*TextSize=*/0x1000);
+                                 /*TextSize=*/0x1000, /*DeclaredEntries=*/{});
   ASSERT_TRUE(Info);
   ASSERT_EQ(Info->Targets.size(), 1u);
   EXPECT_TRUE(

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -834,6 +834,133 @@ TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoReturnFunction) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets,
+     RejectsInteriorPcMaterializedCallIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_get_pc_i64 s[4:5]\n"
+                         "s_add_nc_u64 s[4:5], s[4:5], -12\n"
+                         "s_swap_pc_i64 s[30:31], s[4:5]\n"
+                         "s_get_pc_i64 s[6:7]\n"
+                         "s_add_nc_u64 s[6:7], s[6:7], -20\n"
+                         "s_swap_pc_i64 s[2:3], s[6:7]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Decoded[2].Offset}};
+
+  // The first call enters the helper normally, but the second enters at its
+  // s_set_pc_i64 with a different link pair. Every known call into the range
+  // participates in the return proof, including register-materialized calls.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsExternalAliasAtLocalFunctionEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Decoded[2].Offset}};
+
+  // A global function or kernel alias at the local helper's start can enter
+  // without a call-defined link pair, even though it is not an interior entry.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges, ExternalEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsFallthroughIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_nop 0\n"
+                         "s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[1].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[1].Offset, Decoded[3].Offset}};
+
+  // The declared entry at zero reaches the local helper by fallthrough and
+  // does not define s[30:31], so the helper's return cannot be bounded.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, AllowsUnreachablePaddingBeforeReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_branch -1\n"
+                         "s_nop 0\n"
+                         "s_nop 0\n"
+                         "s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[3].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[3].Offset, Decoded[5].Offset}};
+
+  // The nops before the helper are unreachable because their backward
+  // fallthrough chain terminates at an unconditional branch. This mirrors the
+  // padding before the production HSACO's second helper.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -738,6 +738,102 @@ TEST(CollectDirectBranchTargets, RejectsUnboundedIndirectEntry) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_branch -2\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -16\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 6u);
+  ASSERT_EQ(Decoded[1].Inst.getOpcode(), S.SSetPcI64Opcode);
+  ASSERT_EQ(Decoded[3].Inst.getOpcode(), S.SGetPcI64Opcode);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Decoded[3].Offset}};
+
+  // The helper preserves the link pair from its entry through s_set_pc_i64.
+  // The block laid out after the return can branch back into the epilogue,
+  // matching the production CFG, but it preserves the pair as well. The
+  // materialized call is therefore the return's sole possible source.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 2u);
+  EXPECT_TRUE(Info->Targets.contains(0));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_mov_b32 s31, 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 5u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Decoded[2].Offset}};
+
+  // A partial link-pair definition makes the return target arbitrary, so the
+  // PC-materialized call must remain unresolved.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_branch -2\n"
+                         "s_branch -2\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -20\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Decoded[3].Offset}};
+
+  // The branch at the function end enters a block laid out after the return,
+  // which can branch back to the epilogue without a call-defined link pair.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -91,6 +91,7 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_LT(S.SDelayAluOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SEndPgmOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SEndPgmSavedOpcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SAddNcU64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SAddPcI64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SCallI64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SSwapPcI64Opcode, S.MCII->getNumOpcodes());
@@ -582,6 +583,82 @@ TEST(CollectDirectBranchTargets, IgnoresSetPcWithoutTreatingItAsCall) {
   ASSERT_TRUE(Info);
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], 0xffffffffffed1230\n"
+                         "v_mov_b32 v0, v1\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+  for (InternalDecodedInst &DI : Decoded)
+    DI.Offset += 0x12EDCC;
+
+  // This is the exact address calculation from the production reproducer:
+  // 0x1a000 + 0x12edcc + 4 - 0x12edd0 = 0x1a000.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x1A000,
+                                 /*TextSize=*/0x150000);
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(0));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -4\n"
+                         "s_mov_b32 s0, 0\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.empty());
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_branch 1\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], 4\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 4u);
+
+  // The branch enters at the add without executing s_get_pc_i64, so the
+  // apparent linear definition chain does not prove the register value.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(8));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
 TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {


### PR DESCRIPTION
#3412 has merged into `amd-staging` as squash commit
`7a0c8a67881b612b5a72edf162bc1660d339e7d8`. This PR is rebased directly on
that commit and contains only its four resolver and safety-hardening commits.
The current head is `49eefd84b29bd4b3da8c5b8a857a2e6311761680`.

## Summary

- recognize the compiler-emitted `s_get_pc_i64` -> `s_add_nc_u64` ->
  `s_swap_pc_i64` register-call form through decoded MC opcodes and operands
- scan backward to the first overlapping target-register definitions and
  reject any clobber, unexpected instruction shape, undecoded slot, or
  intervening control-flow boundary
- reject the proof when a direct target, ELF function symbol, or current
  kernel-descriptor entry can bypass `s_get_pc_i64`
- recover canonical local-function returns after MC lowering turns the
  compiler return pseudo into plain `s_set_pc_i64`
- check every known call whose target is in the local function range; reject
  interior entries and calls at the entry that use a different link pair
- preserve entry provenance separately from entry offsets; global/weak
  function symbols and kernel descriptors are externally reachable, including
  aliases exactly at a local function start
- reject overlapping function ranges that make the return entry ambiguous
- prove that fallthrough into the local entry is unreachable by walking the
  contiguous predecessor chain back to an MC control-flow barrier and rejecting
  declared, direct, or register-materialized incoming edges into that chain
- keep every other `s_set_pc_i64`, `s_add_pc_i64`, or MC-classified indirect
  branch unresolved, preserving #3412 fail-closed behavior
- add a resolved in-text destination to the protected target set only after all
  call, alias, link-register, and fallthrough checks pass

The opcode identities and control-flow properties come from MC APIs; no opcode
number or instruction encoding is hardcoded. The return proof remains
function-scoped because the production helpers contain blocks laid out after
`s_set_pc_i64` that branch back into the epilogue. Unreachable padding before a
helper remains accepted when its backward fallthrough chain terminates at an
unconditional control-flow barrier.

## Tests

Post-#3412-merge clean RelWithDebInfo validation at current head
`49eefd84b29b`:

- `HotswapMCTests`: 88/88 passed
- `HotswapElfTests`: 26/26 passed
- HotSwap LIT: 84/84 passed
- `git range-diff` shows all four commits patch-identical to the validated
  pre-restack commits
- `git diff --check` and clang-format pass

The pre-restack implementation was also validated with all COMGR unit suites,
the unfiltered COMGR LIT suite, and a GCC AddressSanitizer build. Those runs had
no test or sanitizer failure; the pre-existing `unpackage-test.hip` XPASS was
unchanged.

The direct-target coverage includes the exact production displacement,
partial-SGPR clobbers, alternate entries, bounded returns, interior
PC-materialized calls, external aliases, reachable fallthrough, and the
production unreachable-padding shape. Independent ELF-level regressions cover
an interior call with a mismatched link pair, a local/GLOBAL PROTECTED kernel
alias plus descriptor, and a kernel that falls through into the local helper.

## Production validation

Replayed current head `49eefd84b29b` against the captured 1,615,504-byte Shared
Expert HSACO (`sha256
4c4bd45992ad7ce9fe0878804b45362fa7e54cfda42733e72e02182a6d9778fc`).

- the call at `0x12EE30` resolves to `.text+0x0`
- the call at `0x14676C` resolves to `.text+0x3980`; its 14 preceding padding
  nops are proven unreachable because the chain ends at an unconditional branch
- offline rewriting advances past the former `0x248F4 (0 candidates)` failure
  and reaches the independent `0xD9504 (22 candidates)` gateway-placement
  limitation
- the expected result for this PR alone is `ERROR` at `0xD9504`; #3418 supplies
  the smaller SCC-neutral transfer that fits the remaining gateway capacity

Before the restack, the patch-identical resolver was also exercised on physical
GPU 2 of `mi400`: the Shared Expert chain passed 100 iterations with HotSwap
enabled and with `HSA_HOTSWAP_DISABLE=1`, with bit-identical activation,
quantization, and scale hashes. Both runs reported max absolute error
`0.02978134`, quant sum `37553.437500`, and scale sum `19.024853`.

The remaining `0xD9504` placement failure is outside this PR's call-target
analysis. Runtime fallback remains safe and the workload completes; full
rewrite success for the captured HSACO is validated in #3418.
