### PR TITLE
comgr: gfx1250 hotswap WMMA VGPR-MSB split (fail-closed) review

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2821,9 +2821,9 @@ findSiteDeadOriginalPair(PatchContext &Ctx, uint64_t InstOffset,
         !ReplacementTouched->test(Pair + 1) && SiteDead->test(Pair) &&
         SiteDead->test(Pair + 1)) {
 #ifndef NDEBUG
-      assert(isSgprPairDeadFrom(
-          Continuation->first, Continuation->second, Pair, Ctx.LS,
-          ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize)));
+      assert(isSgprPairDeadFrom(Continuation->first, Continuation->second, Pair,
+                                Ctx.LS,
+                                ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize)));
 #endif
       log() << "hotswap: safe far return: reusing original site-dead s[" << Pair
             << ':' << Pair + 1 << "] after 0x" << utohexstr(InstOffset)

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2823,7 +2823,7 @@ findSiteDeadOriginalPair(PatchContext &Ctx, uint64_t InstOffset,
 #ifndef NDEBUG
       assert(isSgprPairDeadFrom(
           Continuation->first, Continuation->second, Pair, Ctx.LS,
-          ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize))));
+          ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize)));
 #endif
       log() << "hotswap: safe far return: reusing original site-dead s[" << Pair
             << ':' << Pair + 1 << "] after 0x" << utohexstr(InstOffset)

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -32,7 +32,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Endian.h"
 
 #include <algorithm>
 #include <cassert>
@@ -59,6 +59,338 @@ static constexpr unsigned Gfx1250MaxVgprs = 1024;
 // GFX12 wave32: 106 user-addressable SGPRs (s0-s105); s106-s107 are VCC.
 static constexpr unsigned Gfx1250MaxSgprs = 106;
 static constexpr unsigned Gfx1250VgprGranuleSize = 16;
+
+struct OriginalIngressInfo {
+  DenseSet<uint64_t> CrossRangeEntryFunctions;
+  std::vector<std::pair<uint64_t, uint64_t>> ExternalEntries;
+  std::vector<std::pair<uint64_t, uint64_t>> ControlFlowEdges;
+};
+
+static std::optional<uint64_t>
+kernelEntryVAddr(const KernelDescriptorInfo &KD) {
+  if (KD.EntryOffset >= 0)
+    return checkedAddUint64(KD.VAddr, static_cast<uint64_t>(KD.EntryOffset),
+                            "kernel entry address");
+
+  const uint64_t Magnitude =
+      KD.EntryOffset == std::numeric_limits<int64_t>::min()
+          ? uint64_t{1} << 63
+          : static_cast<uint64_t>(-KD.EntryOffset);
+  if (KD.VAddr < Magnitude)
+    return std::nullopt;
+  return KD.VAddr - Magnitude;
+}
+
+static std::optional<DenseSet<uint64_t>>
+collectResolvedKernelEntryOffsets(ElfView &Elf, const LLVMState &LS) {
+  if (!Elf.kernelDescriptorCacheIsComplete())
+    return std::nullopt;
+
+  std::optional<uint64_t> TextEnd =
+      checkedAddUint64(Elf.textAddr(), Elf.textSize(), "kernel entry text end");
+  if (!TextEnd)
+    return std::nullopt;
+
+  DenseSet<uint64_t> Result;
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> Entry = kernelEntryVAddr(KD);
+    if (!Entry)
+      return std::nullopt;
+    if (*Entry >= Elf.textAddr() && *Entry < *TextEnd) {
+      Result.insert(*Entry - Elf.textAddr());
+      continue;
+    }
+
+    const uint8_t *Stub = Elf.dataAtVAddr(*Entry, KernelEntryStubStride);
+    if (!Stub)
+      return std::nullopt;
+    std::optional<uint64_t> OriginalEntry = getKernelEntryTrampolineTargetVAddr(
+        ArrayRef<uint8_t>(Stub, KernelEntryStubStride), *Entry, LS);
+    if (!OriginalEntry || *OriginalEntry < Elf.textAddr() ||
+        *OriginalEntry >= *TextEnd)
+      return std::nullopt;
+    Result.insert(*OriginalEntry - Elf.textAddr());
+  }
+  return Result;
+}
+
+static bool
+isExternallyVisibleCallable(const ElfView::FunctionTextRange &Range) {
+  if (!Range.Symbol || Range.Symbol->getBinding() == ELF::STB_LOCAL)
+    return false;
+  const unsigned Visibility = Range.Symbol->getVisibility();
+  return Visibility == ELF::STV_DEFAULT || Visibility == ELF::STV_PROTECTED;
+}
+
+static std::vector<KernelTextRange> collectKernelTextRanges(
+    ElfView &Elf, const LLVMState &LS,
+    ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges,
+    bool HasUnknownArbitraryIndirectTarget,
+    bool HasUnresolvedStandardLinkCall) {
+  std::optional<DenseSet<uint64_t>> EntryOffsets =
+      collectResolvedKernelEntryOffsets(Elf, LS);
+  if (!EntryOffsets)
+    return {};
+
+  std::vector<KernelTextRange> Result;
+  for (uint64_t Entry : *EntryOffsets) {
+    std::optional<ElfView::FunctionTextRange> Owner =
+        Elf.findFunctionTextRangeAtOffset(Entry);
+    if (!Owner || Owner->End <= Owner->Begin)
+      continue;
+    auto Existing = llvm::find_if(Result, [&](const KernelTextRange &Range) {
+      return Range.Begin == Owner->Begin && Range.End == Owner->End;
+    });
+    if (Existing == Result.end()) {
+      Result.push_back(
+          {Owner->Begin, Owner->End, {}, HasUnknownArbitraryIndirectTarget});
+      Existing = std::prev(Result.end());
+    }
+    if (!llvm::is_contained(Existing->Entries, Entry))
+      Existing->Entries.push_back(Entry);
+  }
+
+  for (KernelTextRange &Candidate : Result) {
+    for (const auto &[Source, Target] : OriginalControlFlowEdges) {
+      if (Target < Candidate.Begin || Target >= Candidate.End ||
+          (Source >= Candidate.Begin && Source < Candidate.End))
+        continue;
+      if (!llvm::is_contained(Candidate.Entries, Target))
+        Candidate.Entries.push_back(Target);
+    }
+    for (const ElfView::FunctionTextRange &Callable :
+         Elf.functionTextRanges()) {
+      if (Callable.Begin < Elf.textAddr() ||
+          (!HasUnresolvedStandardLinkCall &&
+           !isExternallyVisibleCallable(Callable)))
+        continue;
+      const uint64_t Entry = Callable.Begin - Elf.textAddr();
+      if (Entry >= Candidate.Begin && Entry < Candidate.End &&
+          !llvm::is_contained(Candidate.Entries, Entry))
+        Candidate.Entries.push_back(Entry);
+    }
+    llvm::sort(Candidate.Entries);
+  }
+  return Result;
+}
+
+static std::vector<TensorAnalysisRange> collectTensorAnalysisRanges(
+    ElfView &Elf, const LLVMState &LS, const DenseSet<uint64_t> &CodeEntries,
+    const DenseSet<uint64_t> &IndirectControlFlowFunctions,
+    const DenseSet<uint64_t> &CrossRangeEntryFunctions,
+    ArrayRef<std::pair<uint64_t, uint64_t>> ExternalEntries,
+    ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges,
+    bool HasUnknownArbitraryIndirectTarget) {
+  if (HasUnknownArbitraryIndirectTarget)
+    return {};
+
+  DenseSet<uint64_t> EntryVAddrs;
+  std::vector<TensorDispatchStub> DispatchStubs;
+  std::vector<uint64_t> VirtualExternalEntries;
+  std::optional<uint64_t> TextEnd = checkedAddUint64(
+      Elf.textAddr(), Elf.textSize(), "tensor analysis .text end");
+  if (!TextEnd)
+    return {};
+
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> Entry = kernelEntryVAddr(KD);
+    if (!Entry)
+      return {};
+    if (*Entry >= Elf.textAddr() && *Entry < *TextEnd) {
+      EntryVAddrs.insert(*Entry);
+      continue;
+    }
+    if (*Entry < Elf.textAddr())
+      return {};
+    const uint64_t EntryOffset = *Entry - Elf.textAddr();
+
+    const uint8_t *Stub = Elf.dataAtVAddr(*Entry, KernelEntryStubStride);
+    if (!Stub) {
+      if (!llvm::is_contained(VirtualExternalEntries, EntryOffset))
+        VirtualExternalEntries.push_back(EntryOffset);
+      continue;
+    }
+    std::optional<KernelEntryTrampolineInfo> Info =
+        getKernelEntryTrampolineInfo(
+            ArrayRef<uint8_t>(Stub, KernelEntryStubStride), *Entry, LS);
+    if (!Info) {
+      if (!llvm::is_contained(VirtualExternalEntries, EntryOffset))
+        VirtualExternalEntries.push_back(EntryOffset);
+      continue;
+    }
+    if (Info->TargetVAddr < Elf.textAddr())
+      return {};
+
+    std::optional<uint64_t> StubOffset = checkedSubUint64(
+        *Entry, Elf.textAddr(), "tensor kernel-entry stub offset");
+    if (!StubOffset)
+      return {};
+    std::optional<uint64_t> StubEnd = checkedAddUint64(
+        *StubOffset, KernelEntryStubStride, "tensor kernel-entry stub end");
+    std::optional<uint64_t> TerminalOffset =
+        checkedSubUint64(Info->TerminalVAddr, Elf.textAddr(),
+                         "tensor kernel-entry terminal offset");
+    if (!StubEnd || !TerminalOffset || *TerminalOffset < *StubOffset ||
+        *TerminalOffset >= *StubEnd)
+      return {};
+    const uint64_t TargetOffset = Info->TargetVAddr - Elf.textAddr();
+    if (Info->TargetVAddr < *TextEnd)
+      EntryVAddrs.insert(Info->TargetVAddr);
+    TensorDispatchStub Dispatch{*StubOffset, *StubEnd, *TerminalOffset,
+                                TargetOffset};
+    auto Existing = llvm::find_if(DispatchStubs, [&](const auto &Other) {
+      return Other.Begin == Dispatch.Begin;
+    });
+    if (Existing == DispatchStubs.end()) {
+      DispatchStubs.push_back(Dispatch);
+    } else if (Existing->End != Dispatch.End ||
+               Existing->Terminal != Dispatch.Terminal ||
+               Existing->Target != Dispatch.Target) {
+      return {};
+    }
+  }
+
+  llvm::sort(DispatchStubs,
+             [](const TensorDispatchStub &L, const TensorDispatchStub &R) {
+               return L.Begin < R.Begin;
+             });
+  for (size_t I = 1; I < DispatchStubs.size(); ++I)
+    if (DispatchStubs[I - 1].End > DispatchStubs[I].Begin)
+      return {};
+  if (llvm::any_of(ExternalEntries, [&](const auto &Edge) {
+        return llvm::any_of(DispatchStubs, [&](const auto &Stub) {
+          return Edge.second >= Stub.Begin && Edge.second < Stub.End;
+        });
+      }))
+    return {};
+
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Elf.functionTextRanges();
+  std::vector<uint64_t> OriginalCodeEntries(CodeEntries.begin(),
+                                            CodeEntries.end());
+  llvm::sort(OriginalCodeEntries);
+  std::vector<TensorAnalysisRange> Result;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
+    if (!EntryVAddrs.contains(Range.Begin) || Range.Begin < Elf.textAddr() ||
+        Range.End <= Range.Begin || Range.End < Elf.textAddr())
+      continue;
+    TensorAnalysisRange Candidate{Range.Begin - Elf.textAddr(),
+                                  Range.End - Elf.textAddr()};
+    Candidate.VirtualExternalEntries = VirtualExternalEntries;
+    Candidate.OriginalControlFlowEdges.assign(OriginalControlFlowEdges.begin(),
+                                              OriginalControlFlowEdges.end());
+    Candidate.OriginalCodeEntries = OriginalCodeEntries;
+    Candidate.DispatchStubs = DispatchStubs;
+    if (IndirectControlFlowFunctions.contains(Candidate.Begin))
+      continue;
+    if (llvm::any_of(CodeEntries, [&](uint64_t Entry) {
+          return Entry > Candidate.Begin && Entry < Candidate.End;
+        }))
+      continue;
+    if (llvm::any_of(EntryVAddrs, [&](uint64_t Entry) {
+          return Entry > Range.Begin && Entry < Range.End;
+        }))
+      continue;
+    if (CrossRangeEntryFunctions.contains(Candidate.Begin))
+      continue;
+    if (llvm::any_of(
+            FunctionRanges, [&](const ElfView::FunctionTextRange &Other) {
+              if (Other.Begin == Range.Begin && Other.End == Range.End)
+                return false;
+              return Other.Begin < Range.End && Range.Begin < Other.End;
+            }))
+      continue;
+    if (!llvm::any_of(Result, [&](const TensorAnalysisRange &Existing) {
+          return Existing.Begin == Candidate.Begin &&
+                 Existing.End == Candidate.End;
+        })) {
+      for (const auto &[Source, Target] : ExternalEntries)
+        if (Source < Candidate.Begin || Source >= Candidate.End)
+          if (!llvm::is_contained(Candidate.ForeignExternalEntries, Target))
+            Candidate.ForeignExternalEntries.push_back(Target);
+      Result.push_back(Candidate);
+    }
+  }
+  return Result;
+}
+
+/// Decode all executable sections into one .text-relative instruction view.
+/// The original .text stream remains the only mutable input; appended HotSwap
+/// pools are included only for conservative control-flow analyses.
+static bool
+buildHotswapAnalysisDecoded(const ElfView &Elf, const LLVMState &LS,
+                            ArrayRef<InternalDecodedInst> TextDecoded,
+                            std::vector<InternalDecodedInst> &Out) {
+  Out.assign(TextDecoded.begin(), TextDecoded.end());
+  std::optional<uint64_t> TextEnd = checkedAddUint64(
+      Elf.textAddr(), Elf.textSize(), "HotSwap analysis .text end");
+  if (!TextEnd)
+    return false;
+
+  for (const ElfView::ELFT::Shdr &Shdr : Elf.sections()) {
+    if (&Shdr == Elf.textSection() || !(Shdr.sh_flags & ELF::SHF_EXECINSTR) ||
+        Shdr.sh_type == ELF::SHT_NOBITS || Shdr.sh_size == 0)
+      continue;
+    std::optional<uint64_t> SectionEnd = checkedAddUint64(
+        Shdr.sh_addr, Shdr.sh_size, "HotSwap analysis executable section end");
+    if (!SectionEnd)
+      return false;
+    if (Shdr.sh_addr < *TextEnd) {
+      if (*SectionEnd > Elf.textAddr()) {
+        log() << "hotswap: error: executable analysis section at "
+                 "vaddr 0x"
+              << utohexstr(Shdr.sh_addr) << " overlaps .text\n";
+        return false;
+      }
+      // Sections entirely below .text cannot be represented in the unsigned
+      // .text-relative analysis view. Any path to them remains unknown and
+      // therefore fails the range proof closed.
+      continue;
+    }
+    if (Shdr.sh_offset > Elf.size() ||
+        Shdr.sh_size > Elf.size() - Shdr.sh_offset)
+      return false;
+
+    std::vector<InternalDecodedInst> SectionDecoded;
+    if (!decodeTextSection(Elf.data() + Shdr.sh_offset, Shdr.sh_size, LS,
+                           SectionDecoded)) {
+      log() << "hotswap: error: failed to decode executable analysis "
+               "section at vaddr 0x"
+            << utohexstr(Shdr.sh_addr) << "\n";
+      return false;
+    }
+
+    const uint64_t Base = Shdr.sh_addr - Elf.textAddr();
+    for (InternalDecodedInst &DI : SectionDecoded) {
+      std::optional<uint64_t> Rebased = checkedAddUint64(
+          Base, DI.Offset, "HotSwap analysis instruction offset");
+      if (!Rebased)
+        return false;
+      DI.Offset = *Rebased;
+      Out.push_back(std::move(DI));
+    }
+  }
+
+  llvm::sort(Out,
+             [](const InternalDecodedInst &L, const InternalDecodedInst &R) {
+               return L.Offset < R.Offset;
+             });
+  if (!Out.empty() && Out.front().Size == 0)
+    return false;
+  for (size_t I = 1; I < Out.size(); ++I) {
+    if (Out[I].Size == 0)
+      return false;
+    std::optional<uint64_t> PreviousEnd = checkedAddUint64(
+        Out[I - 1].Offset, Out[I - 1].Size, "HotSwap analysis instruction end");
+    if (!PreviousEnd || *PreviousEnd > Out[I].Offset) {
+      log() << "hotswap: error: overlapping executable analysis "
+               "instruction at 0x"
+            << utohexstr(Out[I].Offset) << "\n";
+      return false;
+    }
+  }
+  return true;
+}
 
 /// Build the default RewriteConfig used for the GFX1250 B0-to-A0 rewrite:
 /// fills in the identity source / target ISA (both gfx1250) and the
@@ -265,59 +597,264 @@ LLVM_ATTRIBUTE_WEAK void patchDebugFrame(uint8_t *, size_t, uint64_t, uint64_t,
 
 static void appendNopSledIfLarge(std::vector<NopSled> &Sleds, uint64_t Start,
                                  uint64_t End,
-                                 const ElfView::FunctionTextRange &Range) {
+                                 const ElfView::FunctionTextRange &Range,
+                                 bool GlobalPostFunction = false) {
   if (End - Start >= MinNopSledSize)
-    Sleds.push_back({Start, End, Start, Range.Begin, Range.End});
+    Sleds.push_back({Start, End, Start, Range.Begin, Range.End,
+                     /*GatewayOnly=*/false,
+                     /*GlobalGateway=*/GlobalPostFunction,
+                     /*GlobalBody=*/GlobalPostFunction});
+}
+
+static bool hasNoFallthrough(const InternalDecodedInst &DI,
+                             const LLVMState &LS);
+
+static bool overlapsTextSymbolExtent(ArrayRef<ElfView::TextOffsetRange> Extents,
+                                     const InternalDecodedInst &DI) {
+  auto It =
+      llvm::lower_bound(Extents, DI.Offset,
+                        [](const ElfView::TextOffsetRange &Extent,
+                           uint64_t Offset) { return Extent.End <= Offset; });
+  return It != Extents.end() &&
+         (It->Begin <= DI.Offset || It->Begin - DI.Offset < DI.Size);
 }
 
 /// Scan \p Decoded for runs of consecutive `s_nop` instructions at least
 /// MinNopSledSize bytes long and return the resulting NopSled list. Each sled
-/// records its owning function range so emitReplacementCode can only borrow
-/// padding from the same kernel as the instruction being patched. NOPs outside
-/// any sized function symbol are ignored.
+/// records its owner range so ordinary replacement bodies use source-owned
+/// padding. A strictly proven explicit-NOP run immediately after a sized
+/// function remains owned by that function and is also globally usable for
+/// branch gateways and explicitly opted-in PC-independent relocation bodies.
 static std::vector<NopSled>
 buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
-                const ElfView &Elf) {
+                const ElfView &Elf,
+                const DenseSet<uint64_t> &DirectBranchTargets,
+                const DenseSet<uint64_t> &IndirectControlFlowFunctions,
+                ArrayRef<uint64_t> TextSymbolOffsets,
+                ArrayRef<ElfView::TextOffsetRange> TextSymbolExtents) {
+  enum class Ownership { None, InFunction, PostFunction };
   std::vector<NopSled> Sleds;
-  bool HasActiveRange = false;
+  Ownership ActiveOwnership = Ownership::None;
+  bool ActiveSafe = false;
+  bool ActiveHasTarget = false;
   ElfView::FunctionTextRange ActiveRange;
   uint64_t Start = 0;
   uint64_t End = 0;
 
-  for (const InternalDecodedInst &DI : Decoded) {
+  SmallVector<uint64_t, 16> SortedDirectTargets(DirectBranchTargets.begin(),
+                                                DirectBranchTargets.end());
+  llvm::sort(SortedDirectTargets);
+
+  auto HasOffsetInInstruction = [](ArrayRef<uint64_t> Offsets,
+                                   const InternalDecodedInst &DI) {
+    auto It = llvm::lower_bound(Offsets, DI.Offset);
+    return It != Offsets.end() && *It - DI.Offset < DI.Size;
+  };
+
+  auto Flush = [&] {
+    if (ActiveOwnership != Ownership::None && ActiveSafe && !ActiveHasTarget &&
+        (ActiveOwnership == Ownership::PostFunction || End == ActiveRange.End))
+      appendNopSledIfLarge(Sleds, Start, End, ActiveRange,
+                           /*GlobalPostFunction=*/ActiveOwnership ==
+                               Ownership::PostFunction);
+    ActiveOwnership = Ownership::None;
+  };
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
     if (DI.Inst.getOpcode() != LS.SNopOpcode) {
-      if (HasActiveRange)
-        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
-      HasActiveRange = false;
+      Flush();
       continue;
     }
 
     std::optional<ElfView::FunctionTextRange> Range =
         Elf.findFunctionTextRangeAtOffset(DI.Offset);
-    if (!Range || DI.Size > Range->End - DI.Offset) {
-      if (HasActiveRange)
-        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
-      HasActiveRange = false;
+    const bool InFunction =
+        Range && DI.Offset < Range->End && DI.Size <= Range->End - DI.Offset;
+    const bool HasSymbol = HasOffsetInInstruction(TextSymbolOffsets, DI);
+    const bool HasSymbolExtent =
+        overlapsTextSymbolExtent(TextSymbolExtents, DI);
+    const bool HasDirectTarget =
+        HasOffsetInInstruction(SortedDirectTargets, DI);
+    const bool HasProtectedEntry =
+        HasSymbol || HasSymbolExtent || HasDirectTarget;
+
+    if (ActiveOwnership == Ownership::InFunction && InFunction &&
+        ActiveRange.Begin == Range->Begin && ActiveRange.End == Range->End &&
+        DI.Offset == End) {
+      // Donor storage may not overwrite any symbol boundary. Exact-start
+      // aliases are permitted only for the original replacement source in
+      // emitReplacementCode, never for independently discovered storage.
+      ActiveHasTarget |= HasProtectedEntry;
+      End = DI.Offset + DI.Size;
       continue;
     }
-
-    if (!HasActiveRange || ActiveRange.Begin != Range->Begin ||
-        ActiveRange.End != Range->End || DI.Offset != End) {
-      if (HasActiveRange)
-        appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
-      ActiveRange = *Range;
-      HasActiveRange = true;
-      Start = DI.Offset;
+    if (ActiveOwnership == Ownership::PostFunction && !InFunction &&
+        DI.Offset == End) {
+      ActiveHasTarget |= HasProtectedEntry;
+      End = DI.Offset + DI.Size;
+      continue;
     }
+    Flush();
+
+    if (InFunction) {
+      ActiveRange = *Range;
+      ActiveOwnership = Ownership::InFunction;
+      Start = DI.Offset;
+      ActiveSafe = I != 0 &&
+                   Decoded[I - 1].Offset + Decoded[I - 1].Size == DI.Offset &&
+                   hasNoFallthrough(Decoded[I - 1], LS) &&
+                   !IndirectControlFlowFunctions.contains(Range->Begin);
+      ActiveHasTarget = false;
+    } else if (I != 0 &&
+               Decoded[I - 1].Offset + Decoded[I - 1].Size == DI.Offset) {
+      std::optional<ElfView::FunctionTextRange> PreviousRange =
+          Elf.findFunctionTextRangeAtOffset(Decoded[I - 1].Offset);
+      if (!PreviousRange || !PreviousRange->Symbol ||
+          PreviousRange->Symbol->st_size == 0 ||
+          PreviousRange->End != DI.Offset ||
+          IndirectControlFlowFunctions.contains(PreviousRange->Begin) ||
+          !hasNoFallthrough(Decoded[I - 1], LS))
+        continue;
+      ActiveRange = *PreviousRange;
+      ActiveOwnership = Ownership::PostFunction;
+      Start = DI.Offset;
+      ActiveSafe = true;
+      ActiveHasTarget = false;
+    } else {
+      continue;
+    }
+    ActiveHasTarget |= HasProtectedEntry;
     End = DI.Offset + DI.Size;
   }
 
-  if (HasActiveRange)
-    appendNopSledIfLarge(Sleds, Start, End, ActiveRange);
+  Flush();
   return Sleds;
 }
 
 // -- Sled-or-trampoline code emission -----------------------------------------
+
+struct NopSledEmissionLayout {
+  size_t BodySize = 0;
+  size_t SourceTailOffset = 0;
+  size_t SourceTailSize = 0;
+
+  uint64_t sledBytes() const { return BodySize + MinInstSize; }
+};
+
+static bool isDs2SourceMnemonic(StringRef Mnemonic) {
+  return Mnemonic == "ds_load_2addr_b32" || Mnemonic == "ds_load_2addr_b64" ||
+         Mnemonic == "ds_load_2addr_stride64_b32" ||
+         Mnemonic == "ds_load_2addr_stride64_b64" ||
+         Mnemonic == "ds_store_2addr_b32" || Mnemonic == "ds_store_2addr_b64" ||
+         Mnemonic == "ds_store_2addr_stride64_b32" ||
+         Mnemonic == "ds_store_2addr_stride64_b64" ||
+         Mnemonic == "ds_storexchg_2addr_rtn_b32" ||
+         Mnemonic == "ds_storexchg_2addr_rtn_b64" ||
+         Mnemonic == "ds_storexchg_2addr_stride64_rtn_b32" ||
+         Mnemonic == "ds_storexchg_2addr_stride64_rtn_b64";
+}
+
+/// Keep a structurally validated replacement suffix in the bytes after the
+/// source branch. An ordinary DS2 keeps its final DS-counter drain. A validated
+/// combined-delay window keeps the reconstructed standalone delay together
+/// with the instruction it protects. In both cases the relocated prefix
+/// branches back to the retained suffix and execution falls through the padded
+/// remainder of the original window.
+static NopSledEmissionLayout
+getNopSledEmissionLayout(const PatchContext &Ctx, uint64_t InstOffset,
+                         uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+                         ReplacementPlacement Placement) {
+  NopSledEmissionLayout Layout{Replacement.size(), 0, 0};
+  if (Placement == ReplacementPlacement::Default ||
+      InstSize < 2 * MinInstSize || Replacement.size() < MinInstSize ||
+      Ctx.HasUnknownArbitraryIndirectTarget || !Ctx.DirectControlFlowTargets)
+    return Layout;
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  std::optional<uint64_t> InstEnd =
+      checkedAddUint64(InstOffset, InstSize, "NOP sled source-tail end");
+  if (!Function || !InstEnd || *InstEnd > Function->End)
+    return Layout;
+  for (uint64_t Offset = InstOffset + MinInstSize; Offset < *InstEnd;
+       Offset += MinInstSize)
+    if (Ctx.DirectControlFlowTargets->contains(Offset))
+      return Layout;
+
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), Ctx.LS,
+                         Decoded) ||
+      Decoded.empty())
+    return Layout;
+  if (Placement == ReplacementPlacement::Ds2SourceTail) {
+    auto Source =
+        llvm::lower_bound(Ctx.Decoded, InstOffset,
+                          [](const InternalDecodedInst &DI, uint64_t Offset) {
+                            return DI.Offset < Offset;
+                          });
+    uint64_t ExpectedSourceOffset = InstOffset;
+    while (ExpectedSourceOffset < *InstEnd) {
+      if (Source == Ctx.Decoded.end() ||
+          Source->Offset != ExpectedSourceOffset ||
+          !isDs2SourceMnemonic(Source->Mnemonic))
+        return Layout;
+      ExpectedSourceOffset += Source->Size;
+      ++Source;
+    }
+    if (ExpectedSourceOffset != *InstEnd)
+      return Layout;
+    for (uint64_t Offset = InstOffset + MinInstSize; Offset < *InstEnd;
+         Offset += MinInstSize)
+      if (Ctx.RelocationProtectedOffsets.contains(Offset))
+        return Layout;
+
+    const InternalDecodedInst &Wait = Decoded.back();
+    if (Wait.Offset + Wait.Size != Replacement.size() ||
+        Wait.Size != MinInstSize || Wait.Mnemonic != "s_wait_dscnt" ||
+        Wait.Inst.getNumOperands() != 1 || !Wait.Inst.getOperand(0).isImm() ||
+        Wait.Inst.getOperand(0).getImm() != 0 ||
+        Replacement.size() == MinInstSize)
+      return Layout;
+    Layout.SourceTailOffset = MinInstSize;
+    Layout.SourceTailSize = MinInstSize;
+    Layout.BodySize -= MinInstSize;
+    return Layout;
+  }
+
+  if (Placement != ReplacementPlacement::ProtectedCombinedDelay ||
+      Decoded.size() < 2)
+    return Layout;
+  const InternalDecodedInst &Delay = Decoded[Decoded.size() - 2];
+  const InternalDecodedInst &Protected = Decoded.back();
+  if (Delay.Mnemonic != "s_delay_alu" || Delay.Size != MinInstSize ||
+      getDelayProtectedSpan(Delay) != 1 ||
+      Delay.Offset + Delay.Size != Protected.Offset ||
+      Protected.Offset + Protected.Size != Replacement.size() ||
+      Protected.Mnemonic == "<unknown>" || Protected.Mnemonic == "<replaced>" ||
+      Protected.Mnemonic == "s_delay_alu" || Protected.Mnemonic == "s_clause" ||
+      Protected.Mnemonic == "s_set_vgpr_msb" ||
+      StringRef(Protected.Mnemonic).contains("_pc_") ||
+      (Ctx.LS.MIA &&
+       Ctx.LS.MIA->mayAffectControlFlow(Protected.Inst, *Ctx.LS.MRI)))
+    return Layout;
+  const uint64_t TailSize = Delay.Size + Protected.Size;
+  if (TailSize > std::numeric_limits<uint32_t>::max() ||
+      TailSize >= Replacement.size() || TailSize > InstSize - MinInstSize)
+    return Layout;
+  Layout.SourceTailSize = static_cast<uint32_t>(TailSize);
+  Layout.SourceTailOffset = InstSize - TailSize;
+  Layout.BodySize -= TailSize;
+  return Layout;
+}
+
+uint64_t getNopSledBytesNeeded(const PatchContext &Ctx, uint64_t InstOffset,
+                               uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+                               ReplacementPlacement Placement) {
+  return getNopSledEmissionLayout(Ctx, InstOffset, InstSize, Replacement,
+                                  Placement)
+      .sledBytes();
+}
 
 /// Emit the replacement code for the instruction at [\p InstOffset,
 /// \p InstOffset + \p InstSize) into a nearby NOP sled: writes \p Replacement
@@ -327,17 +864,46 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
 /// bytes. Advances \c Sled.WritePos by the amount consumed. Returns false if
 /// either branch encoding fails. Branches are encoded before any bytes are
 /// written so a failure leaves \c Ctx.Text and \c Sled.WritePos unchanged.
-[[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
-                                 uint64_t InstOffset, uint32_t InstSize,
-                                 ArrayRef<uint8_t> Replacement) {
+[[nodiscard]] static bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
+                                        uint64_t InstOffset, uint32_t InstSize,
+                                        ArrayRef<uint8_t> Replacement,
+                                        ReplacementPlacement Placement) {
+  const bool AllowGlobalBody = Placement != ReplacementPlacement::Default;
+  if (Sled.GatewayOnly) {
+    log() << "hotswap: error: emitToNopSled: gateway-only padding cannot "
+             "hold a replacement body\n";
+    return false;
+  }
+  if (!Sled.canHoldBodyFrom(InstOffset, AllowGlobalBody)) {
+    log() << "hotswap: error: emitToNopSled: source does not own replacement "
+             "body storage\n";
+    return false;
+  }
   const LLVMState &LS = Ctx.LS;
-  SmallVector<uint8_t> BrBack = LS.encodeSBranch(
-      Sled.WritePos + Replacement.size(), InstOffset + InstSize);
+  const NopSledEmissionLayout Layout = getNopSledEmissionLayout(
+      Ctx, InstOffset, InstSize, Replacement, Placement);
+  const uint64_t UsableEnd = Sled.End;
+  if (Sled.WritePos < Sled.Start || Sled.WritePos > UsableEnd ||
+      UsableEnd > Ctx.TextSize || Layout.BodySize > UsableEnd - Sled.WritePos ||
+      MinInstSize > UsableEnd - Sled.WritePos - Layout.BodySize) {
+    log() << "hotswap: error: emitToNopSled: replacement exceeds owned sled "
+             "capacity\n";
+    return false;
+  }
+  if (InstOffset > Ctx.TextSize || InstSize > Ctx.TextSize - InstOffset) {
+    log() << "hotswap: error: emitToNopSled: replacement site is outside "
+             ".text\n";
+    return false;
+  }
+  const uint64_t ResumeOffset = Layout.SourceTailSize != 0
+                                    ? InstOffset + Layout.SourceTailOffset
+                                    : InstOffset + InstSize;
+  SmallVector<uint8_t> BrBack =
+      LS.encodeSBranch(Sled.WritePos + Layout.BodySize, ResumeOffset);
   if (BrBack.empty()) {
     log() << "hotswap: error: emitToNopSled: encodeSBranch for branch-back "
-          << "at sled offset 0x"
-          << utohexstr(Sled.WritePos + Replacement.size()) << " -> 0x"
-          << utohexstr(InstOffset + InstSize) << " failed.\n";
+          << "at sled offset 0x" << utohexstr(Sled.WritePos + Layout.BodySize)
+          << " -> 0x" << utohexstr(ResumeOffset) << " failed.\n";
     return false;
   }
 
@@ -349,106 +915,550 @@ buildNopSledMap(ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     return false;
   }
 
-  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Replacement.size());
-  std::memcpy(Ctx.Text + Sled.WritePos + Replacement.size(), BrBack.data(),
+  std::memcpy(Ctx.Text + Sled.WritePos, Replacement.data(), Layout.BodySize);
+  std::memcpy(Ctx.Text + Sled.WritePos + Layout.BodySize, BrBack.data(),
               BrBack.size());
   std::memcpy(Ctx.Text + InstOffset, BrFwd.data(), BrFwd.size());
 
-  // Pad the tail of the replaced instruction slot with cached s_nop bytes
-  // (pre-encoded in LLVMState at initLLVM() time).
+  // Pad every unused source dword with the cached s_nop encoding. The retained
+  // suffix, when present, is copied after this loop and therefore remains
+  // contiguous even when it sits at the end of a larger source window.
   for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
     std::memcpy(Ctx.Text + InstOffset + I, LS.SNopBytes.data(), MinInstSize);
+  if (Layout.SourceTailSize != 0)
+    std::memcpy(Ctx.Text + InstOffset + Layout.SourceTailOffset,
+                Replacement.data() + Layout.BodySize, Layout.SourceTailSize);
 
-  Sled.WritePos += Replacement.size() + MinInstSize;
+  Sled.WritePos += Layout.sledBytes();
   return true;
 }
 
-std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
-                                                          uint64_t FromOffset,
-                                                          uint64_t TargetOffset,
-                                                          unsigned SgprBase) {
+static bool isSBranchReachable(uint64_t From, uint64_t To);
+
+/// Place a validated, PC-independent DS2 replacement body through independently
+/// routed short-branch entry and return paths. Gateway reservations are exact
+/// instruction intervals, so non-overlapping roles may share certified padding
+/// and either route may use zero or several hops. A validated suffix remains in
+/// the source window. Every edge is encoded before bytes or cursors change.
+static bool emitDs2ThroughNopSledGateways(PatchContext &Ctx,
+                                          uint64_t InstOffset,
+                                          uint32_t InstSize,
+                                          ArrayRef<uint8_t> Replacement,
+                                          ReplacementPlacement Placement) {
+  if (Placement != ReplacementPlacement::Ds2SourceTail &&
+      Placement != ReplacementPlacement::ProtectedCombinedDelay)
+    return false;
+  const bool AllowDs2SourceTailWait =
+      Placement == ReplacementPlacement::Ds2SourceTail;
+  const NopSledEmissionLayout Layout = getNopSledEmissionLayout(
+      Ctx, InstOffset, InstSize, Replacement, Placement);
+  constexpr uint64_t DsInstSize = 2 * MinInstSize;
+  if (Layout.BodySize > std::numeric_limits<uint64_t>::max() - MinInstSize)
+    return false;
+  const uint64_t BodyBytes = Layout.sledBytes();
+  const uint64_t ResumeOffset = Layout.SourceTailSize != 0
+                                    ? InstOffset + Layout.SourceTailOffset
+                                    : InstOffset + InstSize;
+  if (!Ctx.LS.MIA || Ctx.RelocationProtectedOffsets.contains(InstOffset) ||
+      InstOffset > Ctx.TextSize || InstSize > Ctx.TextSize - InstOffset ||
+      InstSize < MinInstSize || InstSize % MinInstSize != 0 ||
+      Replacement.size() != Layout.BodySize + Layout.SourceTailSize)
+    return false;
+
+  const size_t ValidatedSize =
+      AllowDs2SourceTailWait ? Layout.BodySize : Replacement.size();
+  std::vector<InternalDecodedInst> Body;
+  if (!decodeTextSection(Replacement.data(), ValidatedSize, Ctx.LS, Body))
+    return false;
+
+  if (AllowDs2SourceTailWait) {
+    const uint64_t SourceCount = InstSize / DsInstSize;
+    if (InstSize % DsInstSize != 0 || SourceCount == 0 ||
+        Layout.SourceTailSize != MinInstSize ||
+        Layout.BodySize !=
+            SourceCount * 2 * DsInstSize + (SourceCount - 1) * MinInstSize)
+      return false;
+
+    size_t BodyIndex = 0;
+    uint64_t ExpectedOffset = 0;
+    for (uint64_t Source = 0; Source != SourceCount; ++Source) {
+      for (unsigned Half = 0; Half != 2; ++Half) {
+        if (BodyIndex >= Body.size())
+          return false;
+        const InternalDecodedInst &Single = Body[BodyIndex++];
+        if (Single.Offset != ExpectedOffset || Single.Size != DsInstSize ||
+            !StringRef(Single.Mnemonic).starts_with("ds_") ||
+            isDs2SourceMnemonic(Single.Mnemonic))
+          return false;
+        ExpectedOffset += DsInstSize;
+      }
+      if (Source + 1 == SourceCount)
+        continue;
+      if (BodyIndex >= Body.size())
+        return false;
+      const InternalDecodedInst &Wait = Body[BodyIndex++];
+      if (Wait.Offset != ExpectedOffset || Wait.Size != MinInstSize ||
+          Wait.Mnemonic != "s_wait_dscnt" || Wait.Inst.getNumOperands() != 1 ||
+          !Wait.Inst.getOperand(0).isImm() ||
+          Wait.Inst.getOperand(0).getImm() != 0)
+        return false;
+      ExpectedOffset += MinInstSize;
+    }
+    if (BodyIndex != Body.size() || ExpectedOffset != Layout.BodySize)
+      return false;
+  } else {
+    // The only whole-window caller is the validated combined-delay DS2
+    // demerge. Keep the relay defensive: its reconstructed body must remain
+    // straight-line and position-independent, and both standalone delays must
+    // protect only their immediately following instruction.
+    unsigned DelayCount = 0;
+    unsigned SplitDsCount = 0;
+    for (const InternalDecodedInst &DI : Body) {
+      if (DI.Mnemonic == "<unknown>" || DI.Mnemonic == "<replaced>" ||
+          DI.Mnemonic == "s_clause" || DI.Mnemonic == "s_set_vgpr_msb" ||
+          StringRef(DI.Mnemonic).contains("_pc_") ||
+          (Ctx.LS.MIA &&
+           Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)))
+        return false;
+      if (DI.Mnemonic == "s_delay_alu") {
+        if (getDelayProtectedSpan(DI) != 1)
+          return false;
+        ++DelayCount;
+      }
+      if (StringRef(DI.Mnemonic).starts_with("ds_") &&
+          !isDs2SourceMnemonic(DI.Mnemonic))
+        ++SplitDsCount;
+    }
+    if (DelayCount != 2 || SplitDsCount < 2)
+      return false;
+  }
+
+  struct ByteInterval {
+    uint64_t Begin = 0;
+    uint64_t End = 0;
+  };
+  struct GatewaySlot {
+    size_t Sled = 0;
+    uint64_t Offset = 0;
+  };
+  struct GatewayPlan {
+    size_t BodySled = 0;
+    uint64_t BodyOffset = 0;
+    SmallVector<GatewaySlot, 4> EntryPath;
+    SmallVector<GatewaySlot, 4> ReturnPath;
+    uint64_t CursorBytes = 0;
+    uint64_t MaxEdgeDistance = 0;
+  };
+
+  auto Distance = [](uint64_t A, uint64_t B) { return A > B ? A - B : B - A; };
+  auto Overlaps = [](ByteInterval A, ByteInterval B) {
+    return A.Begin < B.End && B.Begin < A.End;
+  };
+  auto IsReserved = [&](ByteInterval Candidate,
+                        ArrayRef<ByteInterval> Reserved) {
+    return llvm::any_of(Reserved, [&](ByteInterval Existing) {
+      return Overlaps(Candidate, Existing);
+    });
+  };
+  auto BetterPlan = [](const GatewayPlan &A, const GatewayPlan &B) {
+    const size_t AGateways = A.EntryPath.size() + A.ReturnPath.size();
+    const size_t BGateways = B.EntryPath.size() + B.ReturnPath.size();
+    if (AGateways != BGateways)
+      return AGateways < BGateways;
+    if (A.CursorBytes != B.CursorBytes)
+      return A.CursorBytes < B.CursorBytes;
+    if (A.MaxEdgeDistance != B.MaxEdgeDistance)
+      return A.MaxEdgeDistance < B.MaxEdgeDistance;
+    return A.BodyOffset < B.BodyOffset;
+  };
+
+  // A placement has two independent gateway roles, entry and return, so expose
+  // two leading branch slots from each certified sled. Moving the body past
+  // zero, one, or two prefix slots also permits those disjoint roles and the
+  // body to share one allocation cursor.
+  constexpr unsigned MaxGatewaySlotsPerSled = 2;
+  constexpr unsigned MaxNextAlternatives = 16;
+  constexpr unsigned MaxCompletedPaths = 64;
+  constexpr unsigned MaxSearchStates = 32768;
+  std::optional<GatewayPlan> Best;
+
+  auto MinimumGatewayCount = [&](uint64_t From, uint64_t To) {
+    if (isSBranchReachable(From, To))
+      return uint64_t{0};
+    const uint64_t DistanceBytes = Distance(From, To);
+    const uint64_t EdgeSpan =
+        To > From ? (static_cast<uint64_t>(BranchOffsetMax) + 1) * MinInstSize
+                  : static_cast<uint64_t>(-BranchOffsetMin) * MinInstSize -
+                        MinInstSize;
+    const uint64_t Edges =
+        DistanceBytes / EdgeSpan + (DistanceBytes % EdgeSpan != 0);
+    return Edges - 1;
+  };
+  auto BodyGatewayLowerBound = [&](size_t BI) {
+    const uint64_t BodyOffset = Ctx.NopSleds[BI].WritePos;
+    return MinimumGatewayCount(InstOffset, BodyOffset) +
+           MinimumGatewayCount(BodyOffset + Layout.BodySize, ResumeOffset);
+  };
+
+  SmallVector<size_t, 32> BodyOrder;
+  for (size_t BI = 0; BI != Ctx.NopSleds.size(); ++BI) {
+    const NopSled &BodySled = Ctx.NopSleds[BI];
+    if (BodySled.GatewayOnly ||
+        !BodySled.canHoldBodyFrom(InstOffset, /*AllowGlobalBody=*/true) ||
+        BodySled.End > Ctx.TextSize || BodySled.WritePos < BodySled.Start ||
+        BodySled.WritePos > BodySled.End ||
+        BodyBytes > BodySled.End - BodySled.WritePos)
+      continue;
+    BodyOrder.push_back(BI);
+  }
+  llvm::sort(BodyOrder, [&](size_t A, size_t B) {
+    const uint64_t ALowerBound = BodyGatewayLowerBound(A);
+    const uint64_t BLowerBound = BodyGatewayLowerBound(B);
+    if (ALowerBound != BLowerBound)
+      return ALowerBound < BLowerBound;
+    const uint64_t AOffset = Ctx.NopSleds[A].WritePos;
+    const uint64_t BOffset = Ctx.NopSleds[B].WritePos;
+    const uint64_t ADistance =
+        std::max(Distance(InstOffset, AOffset),
+                 Distance(AOffset + Layout.BodySize, ResumeOffset));
+    const uint64_t BDistance =
+        std::max(Distance(InstOffset, BOffset),
+                 Distance(BOffset + Layout.BodySize, ResumeOffset));
+    return std::tie(ADistance, AOffset, A) < std::tie(BDistance, BOffset, B);
+  });
+
+  bool FoundResourceOptimalPlan = false;
+  for (size_t BI : BodyOrder) {
+    const NopSled &BodySled = Ctx.NopSleds[BI];
+    for (unsigned PrefixSlots = 0; PrefixSlots <= MaxGatewaySlotsPerSled;
+         ++PrefixSlots) {
+      const uint64_t PrefixBytes = PrefixSlots * MinInstSize;
+      if (PrefixBytes > BodySled.End - BodySled.WritePos ||
+          BodyBytes > BodySled.End - BodySled.WritePos - PrefixBytes)
+        continue;
+      const uint64_t BodyOffset = BodySled.WritePos + PrefixBytes;
+      const uint64_t BodyEnd = BodyOffset + BodyBytes;
+      const uint64_t BodyReturn = BodyOffset + Layout.BodySize;
+      const ByteInterval BodyInterval{BodyOffset, BodyEnd};
+      const ByteInterval SourceInterval{InstOffset, InstOffset + InstSize};
+      if (Overlaps(BodyInterval, SourceInterval))
+        continue;
+
+      SmallVector<GatewaySlot, 32> Slots;
+      for (size_t SI = 0; SI != Ctx.NopSleds.size(); ++SI) {
+        const NopSled &Sled = Ctx.NopSleds[SI];
+        if (!Sled.canGatewayFrom(InstOffset) || Sled.End > Ctx.TextSize ||
+            Sled.WritePos < Sled.Start || Sled.WritePos > Sled.End)
+          continue;
+
+        auto AppendSlots = [&](uint64_t Start, unsigned Count) {
+          for (unsigned I = 0; I != Count; ++I) {
+            if (Start > Sled.End || MinInstSize > Sled.End - Start)
+              break;
+            ByteInterval SlotInterval{Start, Start + MinInstSize};
+            if (!Overlaps(SlotInterval, BodyInterval) &&
+                !Overlaps(SlotInterval, SourceInterval))
+              Slots.push_back({SI, Start});
+            Start += MinInstSize;
+          }
+        };
+
+        if (SI == BI) {
+          AppendSlots(Sled.WritePos, PrefixSlots);
+          AppendSlots(BodyEnd, MaxGatewaySlotsPerSled);
+        } else {
+          AppendSlots(Sled.WritePos, MaxGatewaySlotsPerSled);
+        }
+      }
+      llvm::sort(Slots, [](const GatewaySlot &A, const GatewaySlot &B) {
+        return std::tie(A.Offset, A.Sled) < std::tie(B.Offset, B.Sled);
+      });
+
+      SmallVector<ByteInterval, 4> PermanentReservations{BodyInterval,
+                                                         SourceInterval};
+      // Enumerate a bounded set of progressively closer routes. Backtracking
+      // over several next-hop choices avoids the old nearest-island greediness;
+      // running the joint search in both path orders avoids privileging entry
+      // over return when the two routes contend for the same interval.
+      auto SearchPath = [&](uint64_t Start, uint64_t Target,
+                            ArrayRef<ByteInterval> Reservations,
+                            unsigned &StatesRemaining, auto &&OnComplete) {
+        SmallVector<size_t, 8> Path;
+        unsigned CompletedPaths = 0;
+        auto Visit = [&](auto &&Self, uint64_t Current) -> bool {
+          if (StatesRemaining == 0 || CompletedPaths >= MaxCompletedPaths)
+            return false;
+          --StatesRemaining;
+
+          if (isSBranchReachable(Current, Target)) {
+            ++CompletedPaths;
+            if (OnComplete(ArrayRef<size_t>(Path)))
+              return true;
+          }
+
+          SmallVector<size_t, MaxNextAlternatives> Next;
+          const uint64_t CurrentDistance = Distance(Current, Target);
+          for (size_t I = 0; I != Slots.size(); ++I) {
+            const GatewaySlot &Slot = Slots[I];
+            const ByteInterval SlotInterval{Slot.Offset,
+                                            Slot.Offset + MinInstSize};
+            if (Distance(Slot.Offset, Target) >= CurrentDistance ||
+                !isSBranchReachable(Current, Slot.Offset) ||
+                IsReserved(SlotInterval, Reservations))
+              continue;
+            bool ConflictsWithPath = llvm::any_of(Path, [&](size_t PI) {
+              const GatewaySlot &Used = Slots[PI];
+              return Overlaps(SlotInterval,
+                              {Used.Offset, Used.Offset + MinInstSize});
+            });
+            if (!ConflictsWithPath)
+              Next.push_back(I);
+          }
+          llvm::sort(Next, [&](size_t A, size_t B) {
+            const uint64_t ADistance = Distance(Slots[A].Offset, Target);
+            const uint64_t BDistance = Distance(Slots[B].Offset, Target);
+            return std::tie(ADistance, Slots[A].Offset, Slots[A].Sled) <
+                   std::tie(BDistance, Slots[B].Offset, Slots[B].Sled);
+          });
+          if (Next.size() > MaxNextAlternatives)
+            Next.resize(MaxNextAlternatives);
+          for (size_t I : Next) {
+            Path.push_back(I);
+            if (Self(Self, Slots[I].Offset))
+              return true;
+            Path.pop_back();
+          }
+          return false;
+        };
+        return Visit(Visit, Start);
+      };
+
+      SmallVector<size_t, 8> EntryIndices;
+      SmallVector<size_t, 8> ReturnIndices;
+      auto FindJointPaths = [&](bool EntryFirst) {
+        unsigned StatesRemaining = MaxSearchStates;
+        if (EntryFirst) {
+          return SearchPath(
+              InstOffset, BodyOffset, PermanentReservations, StatesRemaining,
+              [&](ArrayRef<size_t> Entry) {
+                SmallVector<ByteInterval, 12> Reserved(
+                    PermanentReservations.begin(), PermanentReservations.end());
+                for (size_t I : Entry)
+                  Reserved.push_back(
+                      {Slots[I].Offset, Slots[I].Offset + MinInstSize});
+                return SearchPath(
+                    BodyReturn, ResumeOffset, Reserved, StatesRemaining,
+                    [&](ArrayRef<size_t> Return) {
+                      EntryIndices.assign(Entry.begin(), Entry.end());
+                      ReturnIndices.assign(Return.begin(), Return.end());
+                      return true;
+                    });
+              });
+        }
+        return SearchPath(
+            BodyReturn, ResumeOffset, PermanentReservations, StatesRemaining,
+            [&](ArrayRef<size_t> Return) {
+              SmallVector<ByteInterval, 12> Reserved(
+                  PermanentReservations.begin(), PermanentReservations.end());
+              for (size_t I : Return)
+                Reserved.push_back(
+                    {Slots[I].Offset, Slots[I].Offset + MinInstSize});
+              return SearchPath(
+                  InstOffset, BodyOffset, Reserved, StatesRemaining,
+                  [&](ArrayRef<size_t> Entry) {
+                    EntryIndices.assign(Entry.begin(), Entry.end());
+                    ReturnIndices.assign(Return.begin(), Return.end());
+                    return true;
+                  });
+            });
+      };
+      if (!FindJointPaths(/*EntryFirst=*/true) &&
+          !FindJointPaths(/*EntryFirst=*/false))
+        continue;
+
+      GatewayPlan Plan;
+      Plan.BodySled = BI;
+      Plan.BodyOffset = BodyOffset;
+      for (size_t I : EntryIndices)
+        Plan.EntryPath.push_back(Slots[I]);
+      for (size_t I : ReturnIndices)
+        Plan.ReturnPath.push_back(Slots[I]);
+
+      SmallVector<uint64_t, 32> CommittedPositions(Ctx.NopSleds.size());
+      for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+        CommittedPositions[I] = Ctx.NopSleds[I].WritePos;
+      CommittedPositions[BI] = BodyEnd;
+      for (const GatewaySlot &Slot : Plan.EntryPath)
+        CommittedPositions[Slot.Sled] =
+            std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+      for (const GatewaySlot &Slot : Plan.ReturnPath)
+        CommittedPositions[Slot.Sled] =
+            std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+      for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+        Plan.CursorBytes += CommittedPositions[I] - Ctx.NopSleds[I].WritePos;
+
+      auto RecordEdgeDistance = [&](uint64_t From, uint64_t To) {
+        Plan.MaxEdgeDistance =
+            std::max(Plan.MaxEdgeDistance, Distance(From, To));
+      };
+      uint64_t From = InstOffset;
+      for (const GatewaySlot &Slot : Plan.EntryPath) {
+        RecordEdgeDistance(From, Slot.Offset);
+        From = Slot.Offset;
+      }
+      RecordEdgeDistance(From, BodyOffset);
+      From = BodyReturn;
+      for (const GatewaySlot &Slot : Plan.ReturnPath) {
+        RecordEdgeDistance(From, Slot.Offset);
+        From = Slot.Offset;
+      }
+      RecordEdgeDistance(From, ResumeOffset);
+
+      const size_t GatewayCount =
+          Plan.EntryPath.size() + Plan.ReturnPath.size();
+      const uint64_t GatewayLowerBound =
+          MinimumGatewayCount(InstOffset, BodyOffset) +
+          MinimumGatewayCount(BodyReturn, ResumeOffset);
+      const uint64_t CursorLowerBound =
+          BodyBytes + GatewayCount * static_cast<uint64_t>(MinInstSize);
+      const bool PlanIsResourceOptimal = GatewayCount == GatewayLowerBound &&
+                                         Plan.CursorBytes == CursorLowerBound;
+      if (!Best || BetterPlan(Plan, *Best))
+        Best = std::move(Plan);
+      // Every body byte and gateway instruction occupies a disjoint interval,
+      // so this is an absolute lower bound on aggregate cursor advancement.
+      // Do not stop merely because the route uses the fewest gateways: a plan
+      // with the same gateway count can still strand later rewrites by skipping
+      // otherwise reusable bytes at one or more allocation cursors.
+      if (PlanIsResourceOptimal) {
+        FoundResourceOptimalPlan = true;
+        break;
+      }
+    }
+    // If no cursor-perfect route exists for this body sled, compare all of its
+    // bounded prefix layouts but do not scan every sled with the same gateway
+    // lower bound. That preserves large-object scaling while avoiding the
+    // first-prefix cursor bias; later required patches still fail closed if the
+    // selected valid route leaves insufficient storage.
+    if (!FoundResourceOptimalPlan && Best) {
+      const size_t BestGatewayCount =
+          Best->EntryPath.size() + Best->ReturnPath.size();
+      FoundResourceOptimalPlan = BestGatewayCount == BodyGatewayLowerBound(BI);
+    }
+    if (FoundResourceOptimalPlan)
+      break;
+  }
+  if (!Best)
+    return false;
+
+  struct EncodedBranch {
+    uint64_t Offset = 0;
+    SmallVector<uint8_t, MinInstSize> Bytes;
+  };
+  SmallVector<EncodedBranch, 12> Branches;
+  auto EncodeEdge = [&](uint64_t From, uint64_t To) {
+    SmallVector<uint8_t> Bytes = Ctx.LS.encodeSBranch(From, To);
+    if (Bytes.size() != MinInstSize)
+      return false;
+    Branches.push_back({From, {Bytes.begin(), Bytes.end()}});
+    return true;
+  };
+
+  uint64_t From = InstOffset;
+  for (const GatewaySlot &Slot : Best->EntryPath) {
+    if (!EncodeEdge(From, Slot.Offset))
+      return false;
+    From = Slot.Offset;
+  }
+  if (!EncodeEdge(From, Best->BodyOffset))
+    return false;
+  From = Best->BodyOffset + Layout.BodySize;
+  for (const GatewaySlot &Slot : Best->ReturnPath) {
+    if (!EncodeEdge(From, Slot.Offset))
+      return false;
+    From = Slot.Offset;
+  }
+  if (!EncodeEdge(From, ResumeOffset))
+    return false;
+
+  // Branch encoding and interval planning are complete. From this point no
+  // operation can fail, so bytes and then all participating cursors commit as
+  // one placement transaction.
+  std::memcpy(Ctx.Text + Best->BodyOffset, Replacement.data(), Layout.BodySize);
+  for (const EncodedBranch &Branch :
+       ArrayRef<EncodedBranch>(Branches).drop_front())
+    std::memcpy(Ctx.Text + Branch.Offset, Branch.Bytes.data(), MinInstSize);
+  for (uint32_t I = MinInstSize; I < InstSize; I += MinInstSize)
+    std::memcpy(Ctx.Text + InstOffset + I, Ctx.LS.SNopBytes.data(),
+                MinInstSize);
+  if (Layout.SourceTailSize != 0)
+    std::memcpy(Ctx.Text + InstOffset + Layout.SourceTailOffset,
+                Replacement.data() + Layout.BodySize, Layout.SourceTailSize);
+  // The source edge is the first encoded branch. Write it after source padding
+  // and suffix retention so no source-window copy can overwrite it.
+  std::memcpy(Ctx.Text + InstOffset, Branches.front().Bytes.data(),
+              MinInstSize);
+
+  SmallVector<uint64_t, 32> CommittedPositions(Ctx.NopSleds.size());
+  for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+    CommittedPositions[I] = Ctx.NopSleds[I].WritePos;
+  CommittedPositions[Best->BodySled] = Best->BodyOffset + BodyBytes;
+  for (const GatewaySlot &Slot : Best->EntryPath)
+    CommittedPositions[Slot.Sled] =
+        std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+  for (const GatewaySlot &Slot : Best->ReturnPath)
+    CommittedPositions[Slot.Sled] =
+        std::max(CommittedPositions[Slot.Sled], Slot.Offset + MinInstSize);
+  for (size_t I = 0; I != Ctx.NopSleds.size(); ++I)
+    Ctx.NopSleds[I].WritePos = CommittedPositions[I];
+
+  log() << "hotswap: DS2 gateway plan: used " << Best->EntryPath.size()
+        << " entry gateway(s), " << Best->ReturnPath.size()
+        << " return gateway(s), and body sled at 0x"
+        << utohexstr(Best->BodyOffset) << " for site 0x"
+        << utohexstr(InstOffset) << "\n";
+  return true;
+}
+
+SmallVector<uint8_t> encodeSetPCLongBranch(const LLVMState &LS,
+                                           uint64_t FromOffset,
+                                           uint64_t TargetOffset,
+                                           unsigned SgprBase) {
   if ((SgprBase & 1u) != 0 ||
       SgprBase > std::numeric_limits<unsigned>::max() - 2) {
     log() << "hotswap: error: set-PC long branch requires an aligned "
-             "three-SGPR block, got s"
-          << SgprBase << "\n";
-    return std::nullopt;
-  }
-
-  const std::string Lo = "s" + std::to_string(SgprBase);
-  const std::string Hi = "s" + std::to_string(SgprBase + 1);
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
-  const std::string SccSave = "s" + std::to_string(SgprBase + 2);
-
-  // Per the AMDGPU ISA, s_get_pc_i64 captures the address immediately after
-  // itself. EncodeSetPCLongBranch.ForwardLandsOnTarget pins this PC base.
-  std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, 2 * MinInstSize, "set-PC long branch PC base");
-  if (!PcBase)
-    return std::nullopt;
-  uint64_t Delta = TargetOffset - *PcBase;
-  uint32_t LoDelta = static_cast<uint32_t>(Delta);
-  uint32_t HiDelta = static_cast<uint32_t>(Delta >> 32);
-
-  SmallVector<std::string, 6> AsmLines;
-  AsmLines.push_back("s_cselect_b32 " + SccSave + ", 1, 0");
-  AsmLines.push_back("s_get_pc_i64 " + Pair);
-  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
-                     utohexstr(LoDelta));
-  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
-                     utohexstr(HiDelta));
-  AsmLines.push_back("s_cmp_lg_u32 " + SccSave + ", 0");
-  AsmLines.push_back("s_set_pc_i64 " + Pair);
-  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
-  if (Bytes.empty()) {
-    log() << "hotswap: error: failed to assemble set-PC long branch via "
-          << Pair << "\n";
-    return std::nullopt;
-  }
-  return Bytes;
-}
-
-static std::optional<SmallVector<uint8_t>>
-encodeSetPCLongBranchClobberSCC(const LLVMState &LS, uint64_t FromOffset,
-                                uint64_t TargetOffset, unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0) {
-    log() << "hotswap: error: SCC-dead set-PC branch requires an aligned "
              "SGPR pair, got s"
           << SgprBase << "\n";
-    return std::nullopt;
+    return {};
   }
 
-  const std::string Lo = "s" + std::to_string(SgprBase);
-  const std::string Hi = "s" + std::to_string(SgprBase + 1);
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
-  std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, MinInstSize, "SCC-dead set-PC branch PC base");
-  if (!PcBase)
-    return std::nullopt;
-  uint64_t Delta = TargetOffset - *PcBase;
+  const std::string Pair = SgprBase == Gfx1250MaxSgprs
+                               ? "vcc"
+                               : "s[" + std::to_string(SgprBase) + ":" +
+                                     std::to_string(SgprBase + 1) + "]";
+  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
+  if (GetPc.empty())
+    return {};
 
-  SmallVector<std::string, 4> AsmLines;
-  AsmLines.push_back("s_get_pc_i64 " + Pair);
-  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
-                     utohexstr(static_cast<uint32_t>(Delta)));
-  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
-                     utohexstr(static_cast<uint32_t>(Delta >> 32)));
-  AsmLines.push_back("s_set_pc_i64 " + Pair);
-  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
-  if (Bytes.empty()) {
-    log() << "hotswap: error: failed to assemble SCC-dead set-PC branch via "
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, GetPc.size(), "set-PC long branch PC base");
+  if (!PcBase)
+    return {};
+  uint64_t Delta = TargetOffset - *PcBase;
+  std::string Asm = "s_get_pc_i64 " + Pair + "\n" + "s_add_nc_u64 " + Pair +
+                    ", " + Pair + ", 0x" + utohexstr(Delta) + "\n" +
+                    "s_set_pc_i64 " + Pair + "\n";
+  SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, LS);
+  if (Bytes.empty() || Bytes.size() > SetPcReturnReserveBytes) {
+    log() << "hotswap: error: failed to assemble SCC-neutral set-PC branch via "
           << Pair << "\n";
-    return std::nullopt;
+    return {};
   }
   return Bytes;
 }
 
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
                                                  MCRegister Reg) {
-  // TODO(https://github.com/ROCm/llvm-project/issues/3350): Replace this
-  // register-name fallback with a public AMDGPU MC hardware-index helper.
   if (!Reg.isValid())
     return std::nullopt;
   StringRef Name(MRI.getName(Reg));
@@ -484,7 +1494,10 @@ static bool updateNumberedSgprHighWatermark(const MCRegisterInfo &MRI,
 }
 
 static bool isVccRegister(const LLVMState &LS, MCRegister Reg) {
-  return Reg.isValid() && StringRef(LS.MRI->getName(Reg)).starts_with("VCC");
+  if (!LS.MRI || !Reg.isValid())
+    return false;
+  StringRef Name(LS.MRI->getName(Reg));
+  return Name.starts_with("VCC") || Name.starts_with("SRC_VCCZ");
 }
 
 static bool instructionUsesVcc(const LLVMState &LS,
@@ -503,12 +1516,1340 @@ static bool instructionUsesVcc(const LLVMState &LS,
   return false;
 }
 
+static uint8_t registerPairMask(const MCRegisterInfo &MRI,
+                                ArrayRef<MCRegister> PairRegs, MCRegister Reg) {
+  uint8_t Mask = 0;
+  for (unsigned Half = 0; Half < PairRegs.size(); ++Half)
+    if (Reg.isValid() && MRI.regsOverlap(Reg.id(), PairRegs[Half].id()))
+      Mask |= uint8_t{1} << Half;
+  return Mask;
+}
+
+struct RegisterPairAccess {
+  uint8_t Uses = 0;
+  uint8_t Defs = 0;
+};
+
+/// Classify one decoded instruction's semantic accesses to a physical register
+/// pair. Decoded MC operands do not always retain tied read-modify-write
+/// inputs, so recover those uses from the descriptor and fail closed when an
+/// omitted register operand cannot be accounted for.
+static std::optional<RegisterPairAccess>
+getRegisterPairAccess(const LLVMState &LS, const InternalDecodedInst &DI,
+                      ArrayRef<MCRegister> PairRegs,
+                      bool PairIsAbiVcc = false) {
+  if (!LS.MCII || !LS.MRI || PairRegs.size() != 2 || !PairRegs[0].isValid() ||
+      !PairRegs[1].isValid() || DI.Mnemonic == "<unknown>")
+    return std::nullopt;
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  auto PairMask = [&](MCRegister Reg, bool IsImplicit = false) {
+    // GFX1250 is wave32. MC descriptors spell the implicit predicate as the
+    // composite VCC register even though only VCC_LO participates.
+    if (PairIsAbiVcc && IsImplicit && Reg.isValid() &&
+        StringRef(LS.MRI->getName(Reg)) == "VCC")
+      return uint8_t{1};
+    if (PairIsAbiVcc && Reg.isValid() &&
+        StringRef(LS.MRI->getName(Reg)).starts_with("SRC_VCCZ"))
+      return uint8_t{1};
+    return registerPairMask(*LS.MRI, PairRegs, Reg);
+  };
+
+  RegisterPairAccess Access;
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned OpIdx = 0; OpIdx < DI.Inst.getNumOperands(); ++OpIdx) {
+    const MCOperand &Op = DI.Inst.getOperand(OpIdx);
+    if (!Op.isReg() || !Op.getReg())
+      continue;
+    uint8_t Mask = PairMask(MCRegister(Op.getReg()));
+    if (OpIdx < NumDefs)
+      Access.Defs |= Mask;
+    else
+      Access.Uses |= Mask;
+  }
+
+  for (unsigned OpIdx = NumDefs; OpIdx < Desc.getNumOperands(); ++OpIdx) {
+    int TiedTo = Desc.getOperandConstraint(OpIdx, MCOI::TIED_TO);
+    if (TiedTo < 0)
+      continue;
+    if (static_cast<unsigned>(TiedTo) >= NumDefs ||
+        static_cast<unsigned>(TiedTo) >= DI.Inst.getNumOperands())
+      return std::nullopt;
+    const MCOperand &Def = DI.Inst.getOperand(TiedTo);
+    if (!Def.isReg() || !Def.getReg())
+      return std::nullopt;
+    Access.Uses |= PairMask(MCRegister(Def.getReg()));
+  }
+
+  // Some AMDGPU disassembly forms omit a tied input even when the MC
+  // descriptor still declares it. Match such operands to an explicit
+  // definition by register class; an unaccounted operand is not safe to infer.
+  for (unsigned OpIdx = DI.Inst.getNumOperands(); OpIdx < Desc.getNumOperands();
+       ++OpIdx) {
+    const MCOperandInfo &Missing = Desc.operands()[OpIdx];
+    if (Missing.RegClass < 0)
+      continue;
+    bool MatchedDefinition = false;
+    for (unsigned DefIdx = 0; DefIdx < NumDefs; ++DefIdx) {
+      if (Desc.operands()[DefIdx].RegClass != Missing.RegClass)
+        continue;
+      const MCOperand &Def = DI.Inst.getOperand(DefIdx);
+      if (!Def.isReg() || !Def.getReg())
+        return std::nullopt;
+      Access.Uses |= PairMask(MCRegister(Def.getReg()));
+      MatchedDefinition = true;
+    }
+    if (!MatchedDefinition)
+      return std::nullopt;
+  }
+
+  for (MCPhysReg Reg : Desc.implicit_uses())
+    Access.Uses |= PairMask(MCRegister(Reg), /*IsImplicit=*/true);
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    Access.Defs |= PairMask(MCRegister(Reg), /*IsImplicit=*/true);
+  return Access;
+}
+
+static std::optional<uint64_t>
+evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                const LLVMState &LS);
+
+static bool isStandardLinkCall(const InternalDecodedInst &DI,
+                               const LLVMState &LS);
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS);
+
+std::optional<int64_t> getAbsoluteOperandValue(const MCOperand &Operand,
+                                               const InternalDecodedInst &DI,
+                                               ArrayRef<uint8_t> Text) {
+  if (Operand.isImm())
+    return Operand.getImm();
+  if (!Operand.isExpr() ||
+      (DI.Size != 2 * MinInstSize && DI.Size != 3 * MinInstSize))
+    return std::nullopt;
+
+  std::optional<uint64_t> End =
+      checkedAddUint64(DI.Offset, DI.Size, "literal instruction end");
+  if (!End || *End > Text.size())
+    return std::nullopt;
+  // AMDGPU's binary decoder represents trailing literal dwords as an MCExpr
+  // whose storage is not guaranteed to outlive getInstruction(). Read the
+  // encoded literal32 or literal64 instead of dereferencing that transient
+  // expression. The callers only accept scalar add opcodes whose base
+  // encoding is one dword.
+  if (DI.Size == 2 * MinInstSize)
+    return static_cast<int64_t>(
+        support::endian::read32le(Text.data() + *End - MinInstSize));
+  return static_cast<int64_t>(
+      support::endian::read64le(Text.data() + *End - 2 * MinInstSize));
+}
+
+static std::optional<uint64_t> evaluateMaterializedSetPcTarget(
+    ArrayRef<InternalDecodedInst> Function, unsigned SetPcIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, bool AllowOutsideText = false) {
+  if (SetPcIndex < 3 || !LS.MRI)
+    return std::nullopt;
+  const InternalDecodedInst &GetPc = Function[SetPcIndex - 3];
+  const InternalDecodedInst &AddLo = Function[SetPcIndex - 2];
+  const InternalDecodedInst &AddHi = Function[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Function[SetPcIndex];
+  if (GetPc.Offset + GetPc.Size != AddLo.Offset ||
+      AddLo.Offset + AddLo.Size != AddHi.Offset ||
+      AddHi.Offset + AddHi.Size != SetPc.Offset ||
+      GetPc.Mnemonic != "s_get_pc_i64" || AddLo.Mnemonic != "s_add_co_u32" ||
+      AddHi.Mnemonic != "s_add_co_ci_u32" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || SetPc.Inst.getNumOperands() != 1 ||
+      !GetPc.Inst.getOperand(0).isReg() || !SetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != SetPc.Inst.getOperand(0).getReg() ||
+      AddLo.Inst.getNumOperands() != 3 || AddHi.Inst.getNumOperands() != 3 ||
+      !AddLo.Inst.getOperand(0).isReg() || !AddLo.Inst.getOperand(1).isReg() ||
+      !AddHi.Inst.getOperand(0).isReg() || !AddHi.Inst.getOperand(1).isReg() ||
+      AddLo.Inst.getOperand(0).getReg() != AddLo.Inst.getOperand(1).getReg() ||
+      AddHi.Inst.getOperand(0).getReg() != AddHi.Inst.getOperand(1).getReg())
+    return std::nullopt;
+
+  std::optional<int64_t> LoValue =
+      getAbsoluteOperandValue(AddLo.Inst.getOperand(2), AddLo, Text);
+  std::optional<int64_t> HiValue =
+      getAbsoluteOperandValue(AddHi.Inst.getOperand(2), AddHi, Text);
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      SetPc.Offset, SetPc.Size, "materialized set-PC sequence end");
+  if (!LoValue || !HiValue || !SequenceEnd)
+    return std::nullopt;
+  for (uint64_t DirectTarget : DirectTargets)
+    if (DirectTarget > GetPc.Offset && DirectTarget < *SequenceEnd)
+      return std::nullopt;
+
+  MCRegister Pair(GetPc.Inst.getOperand(0).getReg());
+  std::optional<unsigned> Lo =
+      numberedSgprIndex(*LS.MRI, MCRegister(AddLo.Inst.getOperand(0).getReg()));
+  std::optional<unsigned> Hi =
+      numberedSgprIndex(*LS.MRI, MCRegister(AddHi.Inst.getOperand(0).getReg()));
+  if (!Lo || !Hi || *Hi != *Lo + 1 ||
+      !LS.MRI->regsOverlap(Pair.id(), AddLo.Inst.getOperand(0).getReg()) ||
+      !LS.MRI->regsOverlap(Pair.id(), AddHi.Inst.getOperand(0).getReg()))
+    return std::nullopt;
+
+  uint64_t Delta =
+      static_cast<uint32_t>(*LoValue) |
+      (static_cast<uint64_t>(static_cast<uint32_t>(*HiValue)) << 32);
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(GetPc.Offset, GetPc.Size, "materialized set-PC PC base");
+  if (!PcBase)
+    return std::nullopt;
+  uint64_t Target = *PcBase + Delta;
+
+  if (Target >= Text.size())
+    return AllowOutsideText ? std::optional<uint64_t>(Target) : std::nullopt;
+
+  // Only model a transfer to a decoded instruction boundary owned by this
+  // function. The unsigned addition above intentionally has ISA wraparound
+  // semantics; the range check rejects a wrapped target outside the function.
+  if (Function.empty() || Target < Function.front().Offset)
+    return std::nullopt;
+  std::optional<uint64_t> FunctionEnd =
+      checkedAddUint64(Function.back().Offset, Function.back().Size,
+                       "materialized set-PC function end");
+  if (!FunctionEnd || Target >= *FunctionEnd)
+    return std::nullopt;
+  ArrayRef<InternalDecodedInst>::iterator TargetIt = llvm::lower_bound(
+      Function, Target, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  if (TargetIt == Function.end() || TargetIt->Offset != Target)
+    return std::nullopt;
+  return Target;
+}
+
+static bool isDecodedInstructionBoundary(ArrayRef<InternalDecodedInst> Decoded,
+                                         uint64_t Target) {
+  ArrayRef<InternalDecodedInst>::iterator It = llvm::lower_bound(
+      Decoded, Target, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  return It != Decoded.end() && It->Offset == Target;
+}
+
+struct SgprPairHalves {
+  std::array<MCRegister, 2> Regs;
+  bool IsVcc = false;
+};
+
+static std::optional<SgprPairHalves> getSgprPairHalves(const LLVMState &LS,
+                                                       MCRegister Pair) {
+  if (!LS.MRI || !Pair.isValid())
+    return std::nullopt;
+
+  if (StringRef(LS.MRI->getName(Pair)) == "VCC") {
+    std::array<MCRegister, 2> Regs;
+    for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+      StringRef Name(LS.MRI->getName(Reg));
+      if (Name == "VCC_LO")
+        Regs[0] = MCRegister(Reg);
+      else if (Name == "VCC_HI")
+        Regs[1] = MCRegister(Reg);
+    }
+    if (!Regs[0].isValid() || !Regs[1].isValid())
+      return std::nullopt;
+    return SgprPairHalves{Regs, /*IsVcc=*/true};
+  }
+
+  SmallVector<std::pair<unsigned, MCRegister>, 2> Halves;
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    MCRegister Candidate(Reg);
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, Candidate);
+    if (Index && LS.MRI->regsOverlap(Pair.id(), Candidate.id()))
+      Halves.emplace_back(*Index, Candidate);
+  }
+  llvm::sort(Halves, llvm::less_first());
+  Halves.erase(llvm::unique(Halves,
+                            [](const auto &Lhs, const auto &Rhs) {
+                              return Lhs.first == Rhs.first;
+                            }),
+               Halves.end());
+  if (Halves.size() != 2 || Halves[1].first != Halves[0].first + 1)
+    return std::nullopt;
+  return SgprPairHalves{{Halves[0].second, Halves[1].second},
+                        /*IsVcc=*/false};
+}
+
+static bool hasOffsetInside(ArrayRef<uint64_t> SortedOffsets, uint64_t Begin,
+                            uint64_t End) {
+  auto It = llvm::upper_bound(SortedOffsets, Begin);
+  return It != SortedOffsets.end() && *It < End;
+}
+
+static bool overlapsTextSymbolExtent(ArrayRef<ElfView::TextOffsetRange> Extents,
+                                     uint64_t Begin, uint64_t End) {
+  auto It =
+      llvm::lower_bound(Extents, Begin,
+                        [](const ElfView::TextOffsetRange &Extent,
+                           uint64_t Offset) { return Extent.End <= Offset; });
+  return It != Extents.end() && It->Begin < End;
+}
+
+/// Recognize a compiler-emitted get-PC/add-nc/straight-line/set-or-swap-PC
+/// transfer. The exact register and layout checks make the computed
+/// destination as trustworthy as a direct branch target; malformed
+/// near-matches fail closed.
+static std::optional<MaterializedPcTransfer> evaluateMaterializedAddNcTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  if (!LS.MCII || !LS.MIA || !LS.MRI || TransferIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Transfer = Decoded[TransferIndex];
+  const bool IsSetPc = Transfer.Inst.getOpcode() == LS.SSetPcI64Opcode;
+  const bool IsSwapPc = Transfer.Inst.getOpcode() == LS.SSwapPcI64Opcode;
+  if (!IsSetPc && !IsSwapPc)
+    return std::nullopt;
+
+  MCRegister TargetPair;
+  if (IsSetPc) {
+    if (Transfer.Inst.getNumOperands() != 1 ||
+        !Transfer.Inst.getOperand(0).isReg())
+      return std::nullopt;
+    TargetPair = MCRegister(Transfer.Inst.getOperand(0).getReg());
+  } else {
+    if (Transfer.Inst.getNumOperands() != 2 ||
+        !Transfer.Inst.getOperand(0).isReg() ||
+        !Transfer.Inst.getOperand(1).isReg() ||
+        StringRef(LS.MRI->getName(Transfer.Inst.getOperand(0).getReg())) !=
+            "SGPR30_SGPR31")
+      return std::nullopt;
+    TargetPair = MCRegister(Transfer.Inst.getOperand(1).getReg());
+    if (LS.MRI->regsOverlap(Transfer.Inst.getOperand(0).getReg(),
+                            TargetPair.id()))
+      return std::nullopt;
+  }
+
+  std::optional<SgprPairHalves> PairRegs = getSgprPairHalves(LS, TargetPair);
+  if (!PairRegs)
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> TransferOwner =
+      Elf.findFunctionTextRangeAtOffset(Transfer.Offset);
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      Transfer.Offset, Transfer.Size, "materialized PC transfer end");
+  if (!SequenceEnd || (TransferOwner && *SequenceEnd > TransferOwner->End))
+    return std::nullopt;
+
+  size_t AddIndex = TransferIndex;
+  uint64_t NextOffset = Transfer.Offset;
+  for (size_t I = TransferIndex; I-- > 0;) {
+    const InternalDecodedInst &Candidate = Decoded[I];
+    std::optional<uint64_t> CandidateEnd = checkedAddUint64(
+        Candidate.Offset, Candidate.Size, "materialized transfer member end");
+    if (!CandidateEnd || *CandidateEnd != NextOffset ||
+        (TransferOwner && Candidate.Offset < TransferOwner->Begin))
+      return std::nullopt;
+
+    if (Candidate.Inst.getOpcode() == LS.SAddNcU64Opcode &&
+        Candidate.Inst.getNumOperands() == 3 &&
+        Candidate.Inst.getOperand(0).isReg() &&
+        Candidate.Inst.getOperand(1).isReg() &&
+        Candidate.Inst.getOperand(0).getReg() == TargetPair.id() &&
+        Candidate.Inst.getOperand(1).getReg() == TargetPair.id()) {
+      AddIndex = I;
+      break;
+    }
+
+    // An unowned sequence is accepted only for the exact gateway form below;
+    // never search arbitrary section contents for a matching definition.
+    if (!TransferOwner)
+      return std::nullopt;
+
+    const MCInstrDesc &Desc = LS.MCII->get(Candidate.Inst.getOpcode());
+    std::optional<RegisterPairAccess> Access =
+        getRegisterPairAccess(LS, Candidate, PairRegs->Regs, PairRegs->IsVcc);
+    if (!Access || Candidate.Mnemonic == "<unknown>" ||
+        Candidate.Mnemonic == "<replaced>" || Access->Uses != 0 ||
+        Access->Defs != 0 || Desc.mayAffectControlFlow(Candidate.Inst, *LS.MRI))
+      return std::nullopt;
+    NextOffset = Candidate.Offset;
+  }
+  if (AddIndex == TransferIndex || AddIndex == 0)
+    return std::nullopt;
+
+  const bool DelayOnly = AddIndex + 2 == TransferIndex &&
+                         Decoded[AddIndex + 1].Mnemonic == "s_delay_alu";
+  const bool RequiresTailEntry =
+      IsSetPc && AddIndex + 1 != TransferIndex && !DelayOnly;
+
+  const size_t GetPcIndex = AddIndex - 1;
+  const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
+  const InternalDecodedInst &Add = Decoded[AddIndex];
+  if (GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      GetPc.Offset + GetPc.Size != Add.Offset ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != TargetPair.id() ||
+      Add.Inst.getNumOperands() != 3 || !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() ||
+      Add.Inst.getOperand(0).getReg() != TargetPair.id() ||
+      Add.Inst.getOperand(1).getReg() != TargetPair.id())
+    return std::nullopt;
+
+  std::optional<int64_t> Delta =
+      getAbsoluteOperandValue(Add.Inst.getOperand(2), Add, Text);
+  if (!Delta)
+    return std::nullopt;
+  for (uint64_t DirectTarget : DirectTargets)
+    if (DirectTarget > GetPc.Offset && DirectTarget < *SequenceEnd)
+      return std::nullopt;
+  if ((TextSymbolOffsets &&
+       hasOffsetInside(*TextSymbolOffsets, GetPc.Offset, *SequenceEnd)) ||
+      (TextSymbolExtents &&
+       overlapsTextSymbolExtent(*TextSymbolExtents, GetPc.Offset,
+                                *SequenceEnd)))
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Owner =
+      Elf.findFunctionTextRangeAtOffset(GetPc.Offset);
+
+  uint64_t Target = GetPc.Offset + GetPc.Size + static_cast<uint64_t>(*Delta);
+  if ((Target > GetPc.Offset && Target < *SequenceEnd) ||
+      (Target < Text.size() && !isDecodedInstructionBoundary(Decoded, Target)))
+    return std::nullopt;
+
+  const bool HasCommonOwner = Owner && TransferOwner &&
+                              Owner->Begin == TransferOwner->Begin &&
+                              Owner->End == TransferOwner->End;
+  bool IsCertifiedExternalGateway = false;
+  if (IsSetPc && !Owner && !TransferOwner && AddIndex + 1 == TransferIndex &&
+      DirectTargets.contains(GetPc.Offset) && GetPcIndex != 0 &&
+      TextSymbolOffsets) {
+    const InternalDecodedInst &Previous = Decoded[GetPcIndex - 1];
+    const bool PreviousDoesNotFallThrough =
+        Previous.Offset + Previous.Size == GetPc.Offset &&
+        (hasNoFallthrough(Previous, LS) ||
+         Previous.Inst.getOpcode() == LS.SSetPcI64Opcode);
+    auto InteriorSymbol = llvm::upper_bound(*TextSymbolOffsets, GetPc.Offset);
+    const bool HasNoInteriorSymbol =
+        InteriorSymbol == TextSymbolOffsets->end() ||
+        *InteriorSymbol >= *SequenceEnd;
+    std::optional<uint64_t> TargetVAddr = checkedAddUint64(
+        Elf.textAddr(), Target, "materialized gateway target vaddr");
+    IsCertifiedExternalGateway =
+        PreviousDoesNotFallThrough && HasNoInteriorSymbol &&
+        Target >= Text.size() && TargetVAddr &&
+        (Target & (MinInstSize - 1)) == 0 &&
+        Elf.isExecutableVAddrRange(*TargetVAddr, MinInstSize);
+  }
+  if (!HasCommonOwner && !IsCertifiedExternalGateway)
+    return std::nullopt;
+
+  if (Target < Text.size()) {
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(Target);
+    if (!HasCommonOwner || !TargetOwner)
+      return std::nullopt;
+    if (RequiresTailEntry &&
+        (*SequenceEnd != Owner->End || TargetOwner->Begin != Target ||
+         TargetOwner->Begin == Owner->Begin))
+      return std::nullopt;
+    if (!RequiresTailEntry && TargetOwner->Begin != Owner->Begin &&
+        TargetOwner->Begin != Target)
+      return std::nullopt;
+  } else if (!IsCertifiedExternalGateway && RequiresTailEntry) {
+    return std::nullopt;
+  }
+
+  return MaterializedPcTransfer{GetPc.Offset, *SequenceEnd, Target};
+}
+
+/// Recognize the older scalar 64-bit-add lowering:
+///   s_get_pc_i64 pair
+///   s_add_co_u32 lo, lo, delta_lo
+///   s_add_co_ci_u32 hi, hi, delta_hi
+///   s_set_pc_i64 pair
+/// The low add's SCC carry is consumed immediately by the high add. Exact
+/// pair, adjacency, target-boundary, and interior-entry checks keep this as
+/// precise as a decoded direct branch.
+static std::optional<MaterializedPcTransfer> evaluateMaterializedCarryTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf) {
+  if (TransferIndex < 3 || TransferIndex >= Decoded.size())
+    return std::nullopt;
+  std::optional<uint64_t> Target = evaluateMaterializedSetPcTarget(
+      Decoded, TransferIndex, DirectTargets, Text, LS,
+      /*AllowOutsideText=*/true);
+  if (!Target)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[TransferIndex - 3];
+  const InternalDecodedInst &SetPc = Decoded[TransferIndex];
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      SetPc.Offset, SetPc.Size, "materialized carry transfer end");
+  std::optional<ElfView::FunctionTextRange> Owner =
+      Elf.findFunctionTextRangeAtOffset(GetPc.Offset);
+  std::optional<ElfView::FunctionTextRange> TransferOwner =
+      Elf.findFunctionTextRangeAtOffset(SetPc.Offset);
+  if (!SequenceEnd || !Owner || !TransferOwner ||
+      Owner->Begin != TransferOwner->Begin ||
+      Owner->End != TransferOwner->End ||
+      (*Target > GetPc.Offset && *Target < *SequenceEnd))
+    return std::nullopt;
+  if (*Target < Text.size()) {
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(*Target);
+    if (!TargetOwner ||
+        (TargetOwner->Begin != Owner->Begin && TargetOwner->Begin != *Target))
+      return std::nullopt;
+  }
+  return MaterializedPcTransfer{GetPc.Offset, *SequenceEnd, *Target};
+}
+
+std::optional<MaterializedPcTransfer> evaluateMaterializedPcTransfer(
+    ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  if (std::optional<MaterializedPcTransfer> Transfer =
+          evaluateMaterializedAddNcTransfer(
+              Decoded, TransferIndex, DirectTargets, Text, LS, Elf,
+              TextSymbolOffsets, TextSymbolExtents))
+    return Transfer;
+  return evaluateMaterializedCarryTransfer(Decoded, TransferIndex,
+                                           DirectTargets, Text, LS, Elf);
+}
+
+static OriginalIngressInfo collectOriginalIngress(
+    ArrayRef<InternalDecodedInst> Decoded,
+    const DenseSet<uint64_t> &DirectTargets, ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  OriginalIngressInfo Result;
+  auto Record = [&](uint64_t Source, uint64_t Target) {
+    Result.ControlFlowEdges.emplace_back(Source, Target);
+    if (Target >= Text.size()) {
+      Result.ExternalEntries.emplace_back(Source, Target);
+      return;
+    }
+    std::optional<ElfView::FunctionTextRange> SourceOwner =
+        Elf.findFunctionTextRangeAtOffset(Source);
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(Target);
+    if (TargetOwner &&
+        (!SourceOwner || SourceOwner->Begin != TargetOwner->Begin ||
+         SourceOwner->End != TargetOwner->End))
+      Result.CrossRangeEntryFunctions.insert(TargetOwner->Begin);
+  };
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if ((LS.MIA->isBranch(DI.Inst) || LS.MIA->isCall(DI.Inst)) &&
+        !LS.MIA->isIndirectBranch(DI.Inst) && !LS.MIA->isReturn(DI.Inst))
+      if (std::optional<uint64_t> Target =
+              evaluateDirectControlFlowTarget(DI, LS))
+        Record(DI.Offset, *Target);
+
+    // A call or ordinary fallthrough immediately into another function's
+    // entry is not kernel dispatch and therefore cannot carry the nonempty
+    // EXEC seed used by the tensor proof.
+    if (!hasNoFallthrough(DI, LS) &&
+        Elf.findFunctionTextRangeAtOffset(DI.Offset)) {
+      std::optional<uint64_t> Next = checkedAddUint64(
+          DI.Offset, DI.Size, "tensor cross-range fallthrough");
+      if (Next)
+        Record(DI.Offset, *Next);
+    }
+  }
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            evaluateMaterializedPcTransfer(Decoded, I, DirectTargets, Text, LS,
+                                           Elf, TextSymbolOffsets,
+                                           TextSymbolExtents))
+      Record(Transfer->Begin, Transfer->Target);
+  return Result;
+}
+
+std::optional<BitVector> collectTouchedNumberedSgprs(ArrayRef<uint8_t> Bytes,
+                                                     unsigned NumberedSgprLimit,
+                                                     const LLVMState &LS) {
+  if (!LS.MCII || !LS.MRI || NumberedSgprLimit == 0) {
+    log() << "hotswap: error: cannot collect replacement SGPR usage with "
+             "invalid LLVM state or register limit\n";
+    return std::nullopt;
+  }
+
+  SmallVector<MCRegister> NumberedSgprs(NumberedSgprLimit);
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, MCRegister(Reg));
+    if (Index && *Index < NumberedSgprLimit)
+      NumberedSgprs[*Index] = MCRegister(Reg);
+  }
+  if (!llvm::all_of(NumberedSgprs,
+                    [](MCRegister Reg) { return Reg.isValid(); })) {
+    log() << "hotswap: error: cannot map every numbered SGPR while checking "
+             "replacement usage\n";
+    return std::nullopt;
+  }
+
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Bytes.data(), Bytes.size(), LS, Decoded)) {
+    log() << "hotswap: error: cannot decode replacement while checking SGPR "
+             "usage\n";
+    return std::nullopt;
+  }
+
+  BitVector Touched(NumberedSgprLimit);
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Mnemonic == "<unknown>") {
+      log() << "hotswap: error: unknown replacement instruction prevents "
+               "SGPR usage proof\n";
+      return std::nullopt;
+    }
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    SmallVector<MCRegister, 16> Regs;
+    for (const MCOperand &Op : DI.Inst)
+      if (Op.isReg() && Op.getReg())
+        Regs.push_back(MCRegister(Op.getReg()));
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      Regs.push_back(MCRegister(Reg));
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      Regs.push_back(MCRegister(Reg));
+
+    for (MCRegister Reg : Regs)
+      for (unsigned I = 0; I < NumberedSgprLimit; ++I)
+        if (Reg.isValid() &&
+            LS.MRI->regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+          Touched.set(I);
+  }
+  return Touched;
+}
+
+static bool isRegisterPairDeadFrom(ArrayRef<InternalDecodedInst> Function,
+                                   size_t ResumeIndex,
+                                   ArrayRef<MCRegister> PairRegs,
+                                   ArrayRef<uint8_t> Text, const LLVMState &LS,
+                                   bool PairIsAbiVcc = false) {
+  if (!LS.MCII || !LS.MRI || !LS.MIA || PairRegs.size() != 2 ||
+      !PairRegs[0].isValid() || !PairRegs[1].isValid() ||
+      ResumeIndex >= Function.size())
+    return false;
+
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  for (unsigned I = 0; I < Function.size(); ++I)
+    OffsetToIndex.try_emplace(Function[I].Offset, I);
+  DenseSet<uint64_t> DirectTargets;
+  DenseSet<uint64_t> NoTargets;
+  for (unsigned I = 3; I < Function.size(); ++I) {
+    std::optional<uint64_t> Target =
+        evaluateMaterializedSetPcTarget(Function, I, NoTargets, Text, LS);
+    if (!Target)
+      continue;
+    // Entering after getpc would use a stale address, so a replacement may
+    // not resume in the middle of a sequence that this proof recognizes.
+    if (ResumeIndex > I - 3 && ResumeIndex <= I)
+      return false;
+    DirectTargets.insert(*Target);
+  }
+  for (const InternalDecodedInst &DI : Function) {
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Operand : DI.Inst)
+      HasImmediate |= Operand.isImm();
+    // Register-target control flow such as s_swap_pc_i64 and s_set_pc_i64
+    // has no direct target. Exact materialized set-PC sequences were handled
+    // above; other indirect transfers make the path proof fail when reached.
+    if (!HasImmediate)
+      continue;
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (!Target) {
+      log() << "hotswap: site-dead pair proof cannot resolve direct "
+               "control flow at 0x"
+            << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+      return false;
+    }
+    DirectTargets.insert(*Target);
+  }
+
+  SmallVector<std::pair<unsigned, uint8_t>, 32> Worklist;
+  std::vector<uint8_t> Seen(Function.size() * 4);
+  Worklist.emplace_back(ResumeIndex, uint8_t{3});
+  for (size_t Next = 0; Next < Worklist.size(); ++Next) {
+    unsigned I = Worklist[Next].first;
+    uint8_t LiveMask = Worklist[Next].second;
+    if (I >= Function.size())
+      return false;
+    uint8_t &WasSeen = Seen[I * 4 + LiveMask];
+    if (WasSeen)
+      continue;
+    WasSeen = 1;
+
+    const InternalDecodedInst &DI = Function[I];
+    if (DI.Mnemonic == "<unknown>") {
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof reached unknown instruction at 0x"
+              << utohexstr(DI.Offset) << "\n";
+      return false;
+    }
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsKnownNonControlFlow =
+        DI.Mnemonic == "s_set_vgpr_msb" ||
+        (DI.Mnemonic == "s_set_pc_i64" && DI.Inst.getNumOperands() == 1 &&
+         DI.Inst.getOperand(0).isImm());
+    std::optional<RegisterPairAccess> Access =
+        getRegisterPairAccess(LS, DI, PairRegs, PairIsAbiVcc);
+    if (!Access)
+      return false;
+
+    if (Access->Uses & LiveMask) {
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof found use-before-def at 0x"
+              << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+      return false;
+    }
+    LiveMask &= ~Access->Defs;
+    if (!LiveMask)
+      continue;
+    if (PairIsAbiVcc && isStandardLinkReturn(DI, LS))
+      continue;
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      std::optional<uint64_t> Materialized =
+          evaluateMaterializedSetPcTarget(Function, I, DirectTargets, Text, LS);
+      if (Materialized) {
+        DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+            OffsetToIndex.find(*Materialized);
+        if (TargetIt == OffsetToIndex.end()) {
+          if (PairIsAbiVcc)
+            log() << "hotswap: VCC lifetime proof reached outside materialized "
+                     "target at 0x"
+                  << utohexstr(DI.Offset) << "\n";
+          return false;
+        }
+        Worklist.emplace_back(TargetIt->second, LiveMask);
+        continue;
+      }
+    }
+
+    if (LS.MIA->isCall(DI.Inst)) {
+      if (PairIsAbiVcc && (evaluateDirectControlFlowTarget(DI, LS) ||
+                           isStandardLinkCall(DI, LS)))
+        continue;
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof reached unresolved call at 0x"
+              << utohexstr(DI.Offset) << "\n";
+      // MC classifies every s_swap_pc_i64 as a call, including hand-written
+      // register transfers whose target and ABI provenance are unknowable.
+      // Without a proven cross-function entry set, no call is a safe lifetime
+      // boundary for this post-link proof.
+      return false;
+    }
+
+    if (DI.Mnemonic == "s_endpgm" || LS.MIA->isReturn(DI.Inst)) {
+      if (PairIsAbiVcc)
+        continue;
+      return false;
+    }
+
+    if (!IsKnownNonControlFlow && LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (LS.MIA->isIndirectBranch(DI.Inst) ||
+          !LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        if (PairIsAbiVcc)
+          log() << "hotswap: VCC lifetime proof reached unresolved branch at 0x"
+                << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+        return false;
+      }
+      DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+          OffsetToIndex.find(Target);
+      if (TargetIt == OffsetToIndex.end()) {
+        if (PairIsAbiVcc)
+          log() << "hotswap: VCC lifetime proof reached outside branch target "
+                   "at 0x"
+                << utohexstr(DI.Offset) << "\n";
+        return false;
+      }
+      Worklist.emplace_back(TargetIt->second, LiveMask);
+      if (LS.MIA->isConditionalBranch(DI.Inst)) {
+        if (I + 1 >= Function.size())
+          return false;
+        Worklist.emplace_back(I + 1, LiveMask);
+      } else if (!LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        return false;
+      }
+      continue;
+    }
+
+    if ((!IsKnownNonControlFlow &&
+         (Desc.isTerminator() ||
+          LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))) ||
+        I + 1 >= Function.size()) {
+      if (PairIsAbiVcc)
+        log() << "hotswap: VCC lifetime proof reached opaque control flow at 0x"
+              << utohexstr(DI.Offset) << " (" << DI.Mnemonic << ")\n";
+      return false;
+    }
+    Worklist.emplace_back(I + 1, LiveMask);
+  }
+  return true;
+}
+
+static std::optional<std::array<MCRegister, 2>>
+findNumberedSgprPair(const LLVMState &LS, unsigned SgprBase) {
+  if (!LS.MRI || (SgprBase & 1u) != 0 ||
+      SgprBase == std::numeric_limits<unsigned>::max())
+    return std::nullopt;
+
+  std::array<MCRegister, 2> PairRegs;
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    std::optional<unsigned> Index = numberedSgprIndex(*LS.MRI, MCRegister(Reg));
+    if (Index && *Index >= SgprBase && *Index <= SgprBase + 1)
+      PairRegs[*Index - SgprBase] = MCRegister(Reg);
+  }
+  if (!PairRegs[0].isValid() || !PairRegs[1].isValid())
+    return std::nullopt;
+  return PairRegs;
+}
+
+bool isSgprPairDeadFrom(ArrayRef<InternalDecodedInst> Function,
+                        size_t ResumeIndex, unsigned SgprBase,
+                        const LLVMState &LS, ArrayRef<uint8_t> Text) {
+  std::optional<std::array<MCRegister, 2>> PairRegs =
+      findNumberedSgprPair(LS, SgprBase);
+  if (!PairRegs)
+    return false;
+  return isRegisterPairDeadFrom(Function, ResumeIndex, *PairRegs, Text, LS);
+}
+
+using NumberedSgprMask = std::array<uint64_t, 2>;
+
+static NumberedSgprMask allNumberedSgprs(unsigned Limit) {
+  NumberedSgprMask Result{};
+  for (unsigned I = 0; I < Limit; ++I)
+    Result[I / 64] |= uint64_t{1} << (I % 64);
+  return Result;
+}
+
+static void addOverlappingNumberedSgprs(NumberedSgprMask &Mask, MCRegister Reg,
+                                        ArrayRef<MCRegister> NumberedSgprs,
+                                        const MCRegisterInfo &MRI) {
+  if (!Reg.isValid())
+    return;
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I)
+    if (MRI.regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+      Mask[I / 64] |= uint64_t{1} << (I % 64);
+}
+
+static bool masksEqual(const NumberedSgprMask &A, const NumberedSgprMask &B) {
+  return A[0] == B[0] && A[1] == B[1];
+}
+
+static std::optional<SiteDeadSgprFunctionFacts>
+computeSiteDeadSgprFunctionFacts(PatchContext &Ctx,
+                                 const ElfView::FunctionTextRange &Range) {
+  if (!Ctx.LS.MCII || !Ctx.LS.MRI || !Ctx.LS.MIA || Ctx.Config.MaxSgprs == 0 ||
+      Ctx.Config.MaxSgprs > 128)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst>::const_iterator First =
+      llvm::lower_bound(Ctx.Decoded, Range.Begin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  std::vector<InternalDecodedInst>::const_iterator After =
+      llvm::lower_bound(Ctx.Decoded, Range.End,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  if (First == After)
+    return std::nullopt;
+  ArrayRef<InternalDecodedInst> Function(&*First,
+                                         static_cast<size_t>(After - First));
+  const unsigned Count = Function.size();
+
+  SmallVector<MCRegister, 128> NumberedSgprs(Ctx.Config.MaxSgprs);
+  for (unsigned Reg = 1, End = Ctx.LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    std::optional<unsigned> Index =
+        numberedSgprIndex(*Ctx.LS.MRI, MCRegister(Reg));
+    if (Index && *Index < NumberedSgprs.size())
+      NumberedSgprs[*Index] = MCRegister(Reg);
+  }
+  if (!llvm::all_of(NumberedSgprs,
+                    [](MCRegister Reg) { return Reg.isValid(); }))
+    return std::nullopt;
+
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  for (unsigned I = 0; I != Count; ++I)
+    OffsetToIndex.try_emplace(Function[I].Offset, I);
+
+  DenseSet<uint64_t> DirectTargets;
+  DenseSet<uint64_t> NoTargets;
+  BitVector ForbiddenResume(Count);
+  for (unsigned I = 3; I < Count; ++I)
+    if (std::optional<uint64_t> Target = evaluateMaterializedSetPcTarget(
+            Function, I, NoTargets, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+            Ctx.LS)) {
+      DirectTargets.insert(*Target);
+      // A resume inside get-PC/add/set-PC is invalid even when a direct target
+      // into that sequence prevents recognizing it as a CFG edge below.
+      ForbiddenResume.set(I - 2, I + 1);
+    }
+  for (const InternalDecodedInst &DI : Function) {
+    if ((!Ctx.LS.MIA->isBranch(DI.Inst) && !Ctx.LS.MIA->isCall(DI.Inst)) ||
+        Ctx.LS.MIA->isIndirectBranch(DI.Inst) || Ctx.LS.MIA->isReturn(DI.Inst))
+      continue;
+    bool HasImmediate = false;
+    for (const MCOperand &Operand : DI.Inst)
+      HasImmediate |= Operand.isImm();
+    if (!HasImmediate)
+      continue;
+    if (std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, Ctx.LS))
+      DirectTargets.insert(*Target);
+  }
+
+  DenseMap<unsigned, unsigned> MaterializedSuccessor;
+  for (unsigned I = 3; I < Count; ++I) {
+    std::optional<uint64_t> Target = evaluateMaterializedSetPcTarget(
+        Function, I, DirectTargets, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
+        Ctx.LS);
+    if (!Target)
+      continue;
+    DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+        OffsetToIndex.find(*Target);
+    if (TargetIt == OffsetToIndex.end())
+      continue;
+    MaterializedSuccessor.try_emplace(I, TargetIt->second);
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  std::vector<SmallVector<unsigned, 2>> Predecessors(Count);
+  for (unsigned I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = Function[I];
+    DenseMap<unsigned, unsigned>::const_iterator Materialized =
+        MaterializedSuccessor.find(I);
+    if (Materialized != MaterializedSuccessor.end()) {
+      Successors[I].push_back(Materialized->second);
+    } else if (DI.Mnemonic == "<unknown>" || Ctx.LS.MIA->isCall(DI.Inst) ||
+               DI.Mnemonic == "s_endpgm" || Ctx.LS.MIA->isReturn(DI.Inst)) {
+      // Calls and exits are fail-closed lifetime boundaries.
+    } else if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (!Ctx.LS.MIA->isIndirectBranch(DI.Inst) &&
+          Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        DenseMap<uint64_t, unsigned>::const_iterator TargetIt =
+            OffsetToIndex.find(Target);
+        if (TargetIt != OffsetToIndex.end()) {
+          Successors[I].push_back(TargetIt->second);
+          if (Ctx.LS.MIA->isConditionalBranch(DI.Inst) && I + 1 < Count)
+            Successors[I].push_back(I + 1);
+          else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+            Successors[I].clear();
+        }
+      }
+    } else {
+      const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+      if (!Desc.isTerminator() &&
+          !Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI) &&
+          I + 1 < Count)
+        Successors[I].push_back(I + 1);
+    }
+    for (unsigned Succ : Successors[I])
+      Predecessors[Succ].push_back(I);
+  }
+
+  NumberedSgprMask All = allNumberedSgprs(Ctx.Config.MaxSgprs);
+  std::vector<NumberedSgprMask> Defs(Count);
+  std::vector<NumberedSgprMask> Uses(Count);
+  for (unsigned I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = Function[I];
+    if (DI.Mnemonic == "<unknown>") {
+      Uses[I] = All;
+      continue;
+    }
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    unsigned NumDefs =
+        std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+    for (unsigned OpIdx = 0; OpIdx < DI.Inst.getNumOperands(); ++OpIdx) {
+      const MCOperand &Op = DI.Inst.getOperand(OpIdx);
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      addOverlappingNumberedSgprs(OpIdx < NumDefs ? Defs[I] : Uses[I],
+                                  MCRegister(Op.getReg()), NumberedSgprs,
+                                  *Ctx.LS.MRI);
+    }
+
+    bool Malformed = false;
+    for (unsigned OpIdx = NumDefs; OpIdx < Desc.getNumOperands(); ++OpIdx) {
+      int TiedTo = Desc.getOperandConstraint(OpIdx, MCOI::TIED_TO);
+      if (TiedTo < 0)
+        continue;
+      if (static_cast<unsigned>(TiedTo) >= NumDefs ||
+          static_cast<unsigned>(TiedTo) >= DI.Inst.getNumOperands()) {
+        Malformed = true;
+        break;
+      }
+      const MCOperand &Def = DI.Inst.getOperand(TiedTo);
+      if (!Def.isReg() || !Def.getReg()) {
+        Malformed = true;
+        break;
+      }
+      addOverlappingNumberedSgprs(Uses[I], MCRegister(Def.getReg()),
+                                  NumberedSgprs, *Ctx.LS.MRI);
+    }
+    for (unsigned OpIdx = DI.Inst.getNumOperands();
+         !Malformed && OpIdx < Desc.getNumOperands(); ++OpIdx) {
+      const MCOperandInfo &Missing = Desc.operands()[OpIdx];
+      if (Missing.RegClass < 0)
+        continue;
+      bool MatchedDefinition = false;
+      for (unsigned DefIdx = 0; DefIdx < NumDefs; ++DefIdx) {
+        if (Desc.operands()[DefIdx].RegClass != Missing.RegClass)
+          continue;
+        const MCOperand &Def = DI.Inst.getOperand(DefIdx);
+        if (!Def.isReg() || !Def.getReg()) {
+          Malformed = true;
+          break;
+        }
+        addOverlappingNumberedSgprs(Uses[I], MCRegister(Def.getReg()),
+                                    NumberedSgprs, *Ctx.LS.MRI);
+        MatchedDefinition = true;
+      }
+      if (!MatchedDefinition)
+        Malformed = true;
+    }
+    if (Malformed) {
+      Uses[I] = All;
+      continue;
+    }
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      addOverlappingNumberedSgprs(Uses[I], MCRegister(Reg), NumberedSgprs,
+                                  *Ctx.LS.MRI);
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      addOverlappingNumberedSgprs(Defs[I], MCRegister(Reg), NumberedSgprs,
+                                  *Ctx.LS.MRI);
+  }
+
+  std::vector<NumberedSgprMask> SafeBefore(Count, All);
+  SmallVector<unsigned, 128> Worklist;
+  BitVector Queued(Count, true);
+  for (unsigned I = 0; I != Count; ++I)
+    Worklist.push_back(I);
+  while (!Worklist.empty()) {
+    unsigned I = Worklist.pop_back_val();
+    Queued.reset(I);
+    NumberedSgprMask SafeOut{};
+    if (!Successors[I].empty()) {
+      SafeOut = All;
+      for (unsigned Succ : Successors[I]) {
+        SafeOut[0] &= SafeBefore[Succ][0];
+        SafeOut[1] &= SafeBefore[Succ][1];
+      }
+    }
+    NumberedSgprMask New{(SafeOut[0] | Defs[I][0]) & ~Uses[I][0],
+                         (SafeOut[1] | Defs[I][1]) & ~Uses[I][1]};
+    New[0] &= All[0];
+    New[1] &= All[1];
+    if (masksEqual(New, SafeBefore[I]))
+      continue;
+    SafeBefore[I] = New;
+    for (unsigned Pred : Predecessors[I])
+      if (!Queued.test(Pred)) {
+        Queued.set(Pred);
+        Worklist.push_back(Pred);
+      }
+  }
+
+  SiteDeadSgprFunctionFacts Facts;
+  Facts.Begin = Range.Begin;
+  Facts.End = Range.End;
+  Facts.GlobalFirst = First - Ctx.Decoded.cbegin();
+  unsigned HighWatermark = 0;
+  for (const InternalDecodedInst &DI : Function) {
+    for (const MCOperand &Op : DI.Inst) {
+      if (!Op.isReg() || !Op.getReg())
+        continue;
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Op.getReg()),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           "site-dead SGPR analysis"))
+        return std::nullopt;
+    }
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           "site-dead SGPR analysis"))
+        return std::nullopt;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (!updateNumberedSgprHighWatermark(*Ctx.LS.MRI, MCRegister(Reg),
+                                           Ctx.Config.MaxSgprs, HighWatermark,
+                                           "site-dead SGPR analysis"))
+        return std::nullopt;
+  }
+  Facts.NumberedLimit = HighWatermark;
+  std::string Owner =
+      Ctx.Elf.findKernelAtAddress(Range.Begin + Ctx.Elf.textAddr());
+  if (!Owner.empty()) {
+    std::optional<unsigned> Declared = Ctx.Elf.getKernelSgprCount(Owner);
+    if (!Declared || *Declared < 2)
+      return std::nullopt;
+    // The descriptor count may include VCC. Subtracting it unconditionally
+    // gives a conservative numbered-register limit.
+    Facts.NumberedLimit = std::max(
+        Facts.NumberedLimit, std::min(*Declared - 2, Ctx.Config.MaxSgprs));
+  }
+  Facts.SafeBefore = std::move(SafeBefore);
+  Facts.ForbiddenResume = std::move(ForbiddenResume);
+  return Facts;
+}
+
+void precomputeSiteDeadSgprFacts(PatchContext &Ctx) {
+  const uint64_t TextAddr = Ctx.Elf.textAddr();
+  for (const ElfView::FunctionTextRange &Absolute :
+       Ctx.Elf.functionTextRanges()) {
+    if (Absolute.Begin < TextAddr || Absolute.End <= Absolute.Begin)
+      continue;
+    uint64_t Begin = Absolute.Begin - TextAddr;
+    uint64_t End = std::min(Absolute.End - TextAddr, Ctx.TextSize);
+    if (Begin >= End)
+      continue;
+    std::pair<uint64_t, uint64_t> Key{Begin, End};
+    if (Ctx.SiteDeadSgprFacts.find(Key) != Ctx.SiteDeadSgprFacts.end())
+      continue;
+    ElfView::FunctionTextRange Relative{Begin, End, Absolute.Symbol,
+                                        Absolute.Symtab};
+    std::optional<SiteDeadSgprFunctionFacts> Facts =
+        computeSiteDeadSgprFunctionFacts(Ctx, Relative);
+    if (Facts)
+      Ctx.SiteDeadSgprFacts.try_emplace(Key, std::move(*Facts));
+  }
+}
+
+std::optional<BitVector> getSiteDeadNumberedSgprs(PatchContext &Ctx,
+                                                  uint64_t InstOffset,
+                                                  uint32_t InstSize) {
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!Range)
+    return std::nullopt;
+  using FunctionKey = std::pair<uint64_t, uint64_t>;
+  FunctionKey Key{Range->Begin, Range->End};
+  auto It = Ctx.SiteDeadSgprFacts.find(Key);
+  // Facts are deliberately computed from the immutable decoded stream before
+  // any instruction is relabeled as replaced.
+  if (It == Ctx.SiteDeadSgprFacts.end())
+    return std::nullopt;
+
+  std::optional<uint64_t> ResumeOffset =
+      checkedAddUint64(InstOffset, InstSize, "site-dead SGPR resume offset");
+  if (!ResumeOffset)
+    return std::nullopt;
+  const SiteDeadSgprFunctionFacts &Facts = It->second;
+  std::vector<InternalDecodedInst>::const_iterator First =
+      Ctx.Decoded.cbegin() + Facts.GlobalFirst;
+  std::vector<InternalDecodedInst>::const_iterator After =
+      First + Facts.SafeBefore.size();
+  std::vector<InternalDecodedInst>::const_iterator Resume =
+      std::lower_bound(First, After, *ResumeOffset,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (Resume == After || Resume->Offset != *ResumeOffset)
+    return std::nullopt;
+  size_t ResumeIndex = Resume - First;
+  BitVector Result(Ctx.Config.MaxSgprs);
+  if (Facts.ForbiddenResume.test(ResumeIndex))
+    return Result;
+  const NumberedSgprMask &Mask = Facts.SafeBefore[ResumeIndex];
+  for (unsigned I = 0; I != Ctx.Config.MaxSgprs; ++I)
+    if (Mask[I / 64] & (uint64_t{1} << (I % 64)))
+      Result.set(I);
+  return Result;
+}
+
+static std::optional<std::pair<ArrayRef<InternalDecodedInst>, size_t>>
+findFunctionContinuation(const PatchContext &Ctx, uint64_t InstOffset,
+                         uint32_t InstSize) {
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst>::const_iterator FunctionFirst =
+      llvm::lower_bound(Ctx.Decoded, FunctionRange->Begin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  std::vector<InternalDecodedInst>::const_iterator FunctionAfter =
+      llvm::lower_bound(Ctx.Decoded, FunctionRange->End,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  if (FunctionFirst == FunctionAfter)
+    return std::nullopt;
+
+  std::optional<uint64_t> ResumeOffset =
+      checkedAddUint64(InstOffset, InstSize, "site-dead pair resume offset");
+  if (!ResumeOffset)
+    return std::nullopt;
+  std::vector<InternalDecodedInst>::const_iterator Resume =
+      std::lower_bound(FunctionFirst, FunctionAfter, *ResumeOffset,
+                       [](const InternalDecodedInst &DI, uint64_t Offset) {
+                         return DI.Offset < Offset;
+                       });
+  if (Resume == FunctionAfter || Resume->Offset != *ResumeOffset)
+    return std::nullopt;
+
+  ArrayRef<InternalDecodedInst> Function(
+      &*FunctionFirst, static_cast<size_t>(FunctionAfter - FunctionFirst));
+  return std::pair{Function, static_cast<size_t>(Resume - FunctionFirst)};
+}
+
+static std::optional<std::array<MCRegister, 2>>
+findVccLoHiPair(const LLVMState &LS) {
+  if (!LS.MRI)
+    return std::nullopt;
+  std::array<MCRegister, 2> Pair;
+  for (unsigned Reg = 1, End = LS.MRI->getNumRegs(); Reg < End; ++Reg) {
+    StringRef Name(LS.MRI->getName(Reg));
+    if (Name == "VCC_LO")
+      Pair[0] = MCRegister(Reg);
+    else if (Name == "VCC_HI")
+      Pair[1] = MCRegister(Reg);
+  }
+  if (!Pair[0].isValid() || !Pair[1].isValid())
+    return std::nullopt;
+  return Pair;
+}
+
+bool isVccPairDeadFrom(ArrayRef<InternalDecodedInst> Function,
+                       size_t ResumeIndex, const LLVMState &LS,
+                       ArrayRef<uint8_t> Text) {
+  std::optional<std::array<MCRegister, 2>> Pair = findVccLoHiPair(LS);
+  return Pair && isRegisterPairDeadFrom(Function, ResumeIndex, *Pair, Text, LS,
+                                        /*PairIsAbiVcc=*/true);
+}
+
+static std::optional<bool> replacementTouchesVcc(ArrayRef<uint8_t> Replacement,
+                                                 const LLVMState &LS) {
+  if (!LS.MCII || !LS.MRI)
+    return std::nullopt;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), LS, Decoded))
+    return std::nullopt;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Mnemonic == "<unknown>")
+      return std::nullopt;
+    for (const MCOperand &Op : DI.Inst)
+      if (Op.isReg() && Op.getReg() &&
+          isVccRegister(LS, MCRegister(Op.getReg())))
+        return true;
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    for (MCPhysReg Reg : Desc.implicit_uses())
+      if (isVccRegister(LS, MCRegister(Reg)))
+        return true;
+    for (MCPhysReg Reg : Desc.implicit_defs())
+      if (isVccRegister(LS, MCRegister(Reg)))
+        return true;
+  }
+  return false;
+}
+
+static bool isVccPairDeadAfter(PatchContext &Ctx, uint64_t InstOffset,
+                               uint32_t InstSize) {
+  std::optional<std::pair<ArrayRef<InternalDecodedInst>, size_t>> Continuation =
+      findFunctionContinuation(Ctx, InstOffset, InstSize);
+  if (!Continuation ||
+      !llvm::any_of(Continuation->first, [&](const InternalDecodedInst &DI) {
+        return instructionUsesVcc(Ctx.LS, DI);
+      }))
+    return false;
+
+  // Using VCC for the trampoline must not introduce a new special-register
+  // allocation. An original VCC reference in the owning function ensures the
+  // compiler already propagated the VCC resource requirement to its callers.
+  return isVccPairDeadFrom(Continuation->first, Continuation->second, Ctx.LS,
+                           ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize));
+}
+
+static bool findSiteDeadVccPair(PatchContext &Ctx, uint64_t InstOffset,
+                                uint32_t InstSize,
+                                ArrayRef<uint8_t> Replacement) {
+  std::optional<bool> ReplacementTouches =
+      replacementTouchesVcc(Replacement, Ctx.LS);
+  if (!ReplacementTouches || *ReplacementTouches ||
+      !isVccPairDeadAfter(Ctx, InstOffset, InstSize))
+    return false;
+  log() << "hotswap: safe far return: reusing site-dead vcc after 0x"
+        << utohexstr(InstOffset) << "\n";
+  return true;
+}
+
+static std::optional<unsigned>
+findSiteDeadOriginalPair(PatchContext &Ctx, uint64_t InstOffset,
+                         uint32_t InstSize, ArrayRef<uint8_t> Replacement) {
+  std::optional<std::pair<ArrayRef<InternalDecodedInst>, size_t>> Continuation =
+      findFunctionContinuation(Ctx, InstOffset, InstSize);
+  if (!Continuation)
+    return std::nullopt;
+
+  std::optional<BitVector> ReplacementTouched =
+      collectTouchedNumberedSgprs(Replacement, Ctx.Config.MaxSgprs, Ctx.LS);
+  if (!ReplacementTouched)
+    return std::nullopt;
+  std::optional<BitVector> SiteDead =
+      getSiteDeadNumberedSgprs(Ctx, InstOffset, InstSize);
+  if (!SiteDead)
+    return std::nullopt;
+  std::optional<ElfView::FunctionTextRange> FunctionRange =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!FunctionRange)
+    return std::nullopt;
+  auto Facts = Ctx.SiteDeadSgprFacts.find(
+      std::pair{FunctionRange->Begin, FunctionRange->End});
+  if (Facts == Ctx.SiteDeadSgprFacts.end())
+    return std::nullopt;
+  unsigned NumberedLimit = Facts->second.NumberedLimit;
+
+  if (NumberedLimit < 2)
+    return std::nullopt;
+
+  unsigned Pair = (NumberedLimit - 2) & ~1u;
+  for (;;) {
+    if (!ReplacementTouched->test(Pair) &&
+        !ReplacementTouched->test(Pair + 1) && SiteDead->test(Pair) &&
+        SiteDead->test(Pair + 1)) {
+#ifndef NDEBUG
+      assert(isSgprPairDeadFrom(
+          Continuation->first, Continuation->second, Pair, Ctx.LS,
+          ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize))));
+#endif
+      log() << "hotswap: safe far return: reusing original site-dead s[" << Pair
+            << ':' << Pair + 1 << "] after 0x" << utohexstr(InstOffset)
+            << " (defined before every exit)\n";
+      return Pair;
+    }
+    if (Pair < 2)
+      break;
+    Pair -= 2;
+  }
+  return std::nullopt;
+}
+
 static SafeSgprUsageSummary
 summarizeSafeSgprUsage(PatchContext &Ctx,
                        ArrayRef<InternalDecodedInst> Instructions,
                        StringRef Context) {
   SafeSgprUsageSummary Summary;
   for (const InternalDecodedInst &DI : Instructions) {
+    if (DI.Mnemonic == "<unknown>") {
+      log() << "hotswap: error: " << Context
+            << ": undecoded instruction prevents SGPR usage proof at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      Summary.Valid = false;
+      return Summary;
+    }
     Summary.UsesVcc |= instructionUsesVcc(Ctx.LS, DI);
     Summary.HasCall |= Ctx.LS.MIA && Ctx.LS.MIA->isCall(DI.Inst);
     for (const MCOperand &Op : DI.Inst) {
@@ -543,11 +2884,13 @@ summarizeSafeSgprUsage(PatchContext &Ctx,
 
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, StringRef Context) {
+                         unsigned Alignment, StringRef Context,
+                         bool DiagnoseFailure) {
   if (Count == 0 || Alignment == 0 || (Alignment & (Alignment - 1)) != 0) {
-    log() << "hotswap: error: " << Context
-          << ": invalid global SGPR block request (count=" << Count
-          << ", alignment=" << Alignment << ")\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context
+            << ": invalid global SGPR block request (count=" << Count
+            << ", alignment=" << Alignment << ")\n";
     return std::nullopt;
   }
 
@@ -593,8 +2936,9 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
     Usage = &*Ctx.WholeObjectSgprUsage;
   }
   if (!Usage || !Usage->Valid) {
-    log() << "hotswap: error: " << Context
-          << ": cached SGPR usage analysis failed\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context
+            << ": cached SGPR usage analysis failed\n";
     return std::nullopt;
   }
 
@@ -605,13 +2949,15 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   if (!Owner.empty()) {
     std::optional<unsigned> Declared = Ctx.Elf.getKernelSgprCount(Owner);
     if (!Declared) {
-      log() << "hotswap: error: " << Context
-            << ": failed to read SGPR count for kernel " << Owner << "\n";
+      if (DiagnoseFailure)
+        log() << "hotswap: error: " << Context
+              << ": failed to read SGPR count for kernel " << Owner << "\n";
       return std::nullopt;
     }
     if (UsesVcc && *Declared < VccSgprs) {
-      log() << "hotswap: error: " << Context << ": VCC-using kernel " << Owner
-            << " has invalid SGPR count " << *Declared << "\n";
+      if (DiagnoseFailure)
+        log() << "hotswap: error: " << Context << ": VCC-using kernel " << Owner
+              << " has invalid SGPR count " << *Declared << "\n";
       return std::nullopt;
     }
     unsigned DeclaredNumbered = *Declared - (UsesVcc ? VccSgprs : 0);
@@ -620,13 +2966,20 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
     // A device function can be reached from kernels with different declared
     // register footprints. Without a complete call graph, keep the block above
     // every declaration and charge every kernel in the commit step.
+    if (!Ctx.Elf.kernelDescriptorCacheIsComplete()) {
+      if (DiagnoseFailure)
+        log() << "hotswap: error: " << Context
+              << ": kernel descriptor set is incomplete or ambiguous\n";
+      return std::nullopt;
+    }
     for (const KernelDescriptorInfo &KD : Ctx.Elf.kernelDescriptors()) {
       std::optional<unsigned> Declared =
           Ctx.Elf.getKernelSgprCount(KD.KernelName);
       if (!Declared) {
-        log() << "hotswap: error: " << Context
-              << ": failed to read SGPR count for kernel " << KD.KernelName
-              << "\n";
+        if (DiagnoseFailure)
+          log() << "hotswap: error: " << Context
+                << ": failed to read SGPR count for kernel " << KD.KernelName
+                << "\n";
         return std::nullopt;
       }
       HighWatermark = std::max(HighWatermark, *Declared);
@@ -634,14 +2987,17 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
   }
 
   if (HighWatermark > std::numeric_limits<unsigned>::max() - (Alignment - 1)) {
-    log() << "hotswap: error: " << Context
-          << ": SGPR alignment calculation overflows unsigned\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context
+            << ": SGPR alignment calculation overflows unsigned\n";
     return std::nullopt;
   }
   unsigned Base = (HighWatermark + Alignment - 1) & ~(Alignment - 1);
   if (Base > Ctx.Config.MaxSgprs || Count > Ctx.Config.MaxSgprs - Base) {
-    log() << "hotswap: error: " << Context << ": no aligned block of " << Count
-          << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs << "\n";
+    if (DiagnoseFailure)
+      log() << "hotswap: error: " << Context << ": no aligned block of "
+            << Count << " safe SGPRs fits below s" << Ctx.Config.MaxSgprs
+            << "\n";
     return std::nullopt;
   }
   return SafeSgprScratchBlock{Base, Count};
@@ -650,6 +3006,11 @@ findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
 bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 StringRef Context) {
+  if (!Ctx.Elf.kernelDescriptorCacheIsComplete()) {
+    log() << "hotswap: error: " << Context
+          << ": kernel descriptor set is incomplete or ambiguous\n";
+    return false;
+  }
   ArrayRef<KernelDescriptorInfo> Descriptors = Ctx.Elf.kernelDescriptors();
   if (Descriptors.empty()) {
     log() << "hotswap: error: " << Context
@@ -662,12 +3023,13 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
       Ctx.Elf.findKernelAtAddress(TextOffset + Ctx.Elf.textAddr());
   bool ChargedOwner = false;
 
-  // llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.cpp::getNumExtraSGPRs returns
-  // two non-numbered VCC SGPRs on GFX1250. Always include them in the metadata
-  // requirement. This may conservatively overstate a kernel that does not use
-  // VCC, but never mistakes VCC for numbered s0-s105 registers.
+  // GFX1250 has two non-numbered VCC SGPRs (GCNSubtarget::getNumExtraSGPRs).
+  // Always include them in the metadata requirement. This may conservatively
+  // overstate a kernel that does not use VCC, but never mistakes VCC for
+  // numbered s0-s105 registers.
   constexpr unsigned VccSgprs = 2;
   unsigned RequiredSgprs = Block.Base + Block.Count + VccSgprs;
+  SmallVector<std::pair<StringRef, unsigned>, 4> PendingCharges;
   for (const KernelDescriptorInfo &KD : Descriptors) {
     if (!Owner.empty() && KD.KernelName != Owner)
       continue;
@@ -680,10 +3042,8 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
             << "\n";
       return false;
     }
-    if (*Current >= RequiredSgprs)
-      continue;
-    KernelPatchStats &Stats = Ctx.KernelStats[KD.KernelName];
-    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, RequiredSgprs - *Current);
+    if (*Current < RequiredSgprs)
+      PendingCharges.emplace_back(KD.KernelName, RequiredSgprs - *Current);
   }
 
   if (!ChargedOwner) {
@@ -691,13 +3051,29 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
           << "' has no descriptor\n";
     return false;
   }
+  for (const auto &[KernelName, ExtraSgprs] : PendingCharges) {
+    KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+    Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, ExtraSgprs);
+  }
   return true;
 }
 
 static std::optional<SafeSgprScratchBlock>
-reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
-  std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/3, /*Alignment=*/2, "safe far return");
+reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                     ArrayRef<uint8_t> Replacement,
+                     bool DiagnoseFailure = true) {
+  if (std::optional<unsigned> ReusedPair =
+          findSiteDeadOriginalPair(Ctx, InstOffset, InstSize, Replacement))
+    return SafeSgprScratchBlock{*ReusedPair, 2,
+                                /*IsSiteProven=*/true};
+
+  if (findSiteDeadVccPair(Ctx, InstOffset, InstSize, Replacement))
+    return SafeSgprScratchBlock{Gfx1250MaxSgprs, 2,
+                                /*IsSiteProven=*/true};
+
+  std::optional<SafeSgprScratchBlock> Scratch =
+      findSafeSgprScratchBlock(Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2,
+                               "safe far return", DiagnoseFailure);
   if (!Scratch)
     return std::nullopt;
   if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
@@ -705,7 +3081,7 @@ reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
   return Scratch;
 }
 
-bool isSBranchReachable(uint64_t From, uint64_t To) {
+static bool isSBranchReachable(uint64_t From, uint64_t To) {
   std::optional<uint64_t> PcBase =
       checkedAddUint64(From, MinInstSize, "short branch PC base");
   if (!PcBase)
@@ -719,6 +3095,22 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   return Delta <= MaxDelta;
 }
 
+bool canEmitShortTrampoline(const PatchContext &Ctx, uint64_t InstOffset,
+                            uint32_t InstSize, uint64_t ReplacementSize) {
+  std::optional<uint64_t> PoolStart =
+      checkedAddUint64(Ctx.PoolBaseOffset, Ctx.QueuedTrampolineBytes,
+                       "short trampoline pool position");
+  std::optional<uint64_t> PoolReturn =
+      PoolStart ? checkedAddUint64(*PoolStart, ReplacementSize,
+                                   "short trampoline return position")
+                : std::nullopt;
+  std::optional<uint64_t> ReturnTo = checkedAddUint64(
+      InstOffset, InstSize, "short trampoline source return target");
+  return PoolStart && PoolReturn && ReturnTo &&
+         isSBranchReachable(InstOffset, *PoolStart) &&
+         isSBranchReachable(*PoolReturn, *ReturnTo);
+}
+
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
@@ -727,13 +3119,17 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
 /// Every far source edge then uses a short branch to nearby safe NOP padding;
 /// that gateway uses the pre-Gen5 SGPR-backed set-PC sequence. No source or
 /// return edge executes gfx1250's broken s_add_pc_i64 instruction.
-[[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
-                                    uint32_t InstSize,
-                                    ArrayRef<uint8_t> Replacement) {
-  // This trampoline lands at the appended pool base and after every trampoline
-  // already queued -- later ones are appended behind it and cannot shift it,
-  // and fixupTrampolineBranches walks the same list in the same order -- so its
-  // final pool offset (relative to .text) is known exactly now.
+static bool emitToTrampolineRaw(PatchContext &Ctx, uint64_t InstOffset,
+                                uint32_t InstSize,
+                                ArrayRef<uint8_t> Replacement,
+                                ReplacementPlacement Placement,
+                                bool DiagnoseFailure) {
+  const bool AllowGlobalBody = Placement != ReplacementPlacement::Default;
+  // This trampoline lands at the appended pool base after every trampoline
+  // already queued. QueuedTrampolineBytes is a conservative upper bound: far
+  // entries reserve the island appended during final layout and enough room
+  // for straight-line source-window growth. The actual pool position can only
+  // be earlier, which can only improve both branch directions.
   std::optional<uint64_t> PoolStart = checkedAddUint64(
       Ctx.PoolBaseOffset, Ctx.QueuedTrampolineBytes, "trampoline pool layout");
   if (!PoolStart)
@@ -750,17 +3146,42 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
       checkedAddUint64(InstOffset, InstSize, "trampoline return target");
   if (!ShortBackFrom || !ReturnTo)
     return false;
-  const bool Far = !(isSBranchReachable(InstOffset, *PoolStart) &&
-                     isSBranchReachable(*ShortBackFrom, *ReturnTo));
+  const bool Far =
+      !canEmitShortTrampoline(Ctx, InstOffset, InstSize, Replacement.size());
 
   uint64_t ReturnReserve = Far ? SetPcReturnReserveBytes : MinInstSize;
   std::optional<uint64_t> TrampolineSize = checkedAddUint64(
       Replacement.size(), ReturnReserve, "queued trampoline size");
   if (!TrampolineSize)
     return false;
-  std::optional<uint64_t> QueuedBytes =
-      checkedAddUint64(Ctx.QueuedTrampolineBytes, *TrampolineSize,
-                       "queued trampoline byte count");
+  uint64_t LayoutReserve = *TrampolineSize;
+  if (Far) {
+    std::optional<uint64_t> WithIsland =
+        checkedAddUint64(LayoutReserve, PoolBranchIslandBytes,
+                         "queued trampoline branch-island reserve");
+    if (!WithIsland)
+      return false;
+    LayoutReserve = *WithIsland;
+
+    // Expansion stops as soon as the source window reaches the set-PC forward
+    // sequence size. Instruction sizes are dword multiples, so the last copied
+    // instruction starts no later than one dword below that threshold.
+    if (InstSize < SetPcForwardSequenceBytes) {
+      std::optional<uint64_t> MaxExpandedSize = checkedAddUint64(
+          SetPcForwardSequenceBytes - MinInstSize, Ctx.MaxDecodedInstSize,
+          "queued trampoline source-growth bound");
+      if (!MaxExpandedSize || *MaxExpandedSize < InstSize)
+        return false;
+      std::optional<uint64_t> WithGrowth =
+          checkedAddUint64(LayoutReserve, *MaxExpandedSize - InstSize,
+                           "queued trampoline source-growth reserve");
+      if (!WithGrowth)
+        return false;
+      LayoutReserve = *WithGrowth;
+    }
+  }
+  std::optional<uint64_t> QueuedBytes = checkedAddUint64(
+      Ctx.QueuedTrampolineBytes, LayoutReserve, "queued trampoline byte count");
   if (!QueuedBytes)
     return false;
 
@@ -782,14 +3203,37 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
             << " B forward branch\n";
       return false;
     }
-    std::optional<SafeSgprScratchBlock> Scratch =
-        reserveSafeFarReturn(Ctx, InstOffset);
-    if (!Scratch)
+    std::optional<SafeSgprScratchBlock> Scratch = reserveSafeFarReturn(
+        Ctx, InstOffset, InstSize, Replacement, /*DiagnoseFailure=*/false);
+    if (!Scratch) {
+      uint64_t Needed = getNopSledBytesNeeded(Ctx, InstOffset, InstSize,
+                                              Replacement, Placement);
+      NopSledUse SledUse =
+          AllowGlobalBody ? NopSledUse::RelocationBody : NopSledUse::OwnerBody;
+      if (NopSled *Sled =
+              findNearestSled(Ctx.NopSleds, InstOffset, Needed, SledUse)) {
+        if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement,
+                          Placement)) {
+          log() << "hotswap: safe far return: used local NOP sled at 0x"
+                << utohexstr(Sled->WritePos - Needed) << " for site 0x"
+                << utohexstr(InstOffset) << "\n";
+          return true;
+        }
+      }
+      if (AllowGlobalBody &&
+          emitDs2ThroughNopSledGateways(Ctx, InstOffset, InstSize, Replacement,
+                                        Placement))
+        return true;
+      if (DiagnoseFailure)
+        (void)reserveSafeFarReturn(Ctx, InstOffset, InstSize, Replacement,
+                                   /*DiagnoseFailure=*/true);
       return false;
+    }
     T.Bytes.insert(T.Bytes.end(), SetPcReturnReserveBytes, uint8_t{0});
     T.Long = true;
     T.UsesSetPCBack = true;
     T.LongBranchSgprBase = Scratch->Base;
+    T.LongBranchScratchIsSiteProven = Scratch->IsSiteProven;
     Ctx.OutTrampolines.emplace_back(std::move(T));
     Ctx.QueuedTrampolineBytes = *QueuedBytes;
     return true;
@@ -803,30 +3247,175 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
   return true;
 }
 
-std::optional<uint64_t>
+struct PreparedSiteReplacement {
+  SmallVector<uint8_t> Bytes;
+  bool ComposesWmmaHazard = false;
+};
+
+static std::optional<PreparedSiteReplacement>
+prepareSiteReplacement(const PatchContext &Ctx, uint64_t InstOffset,
+                       uint32_t InstSize, ArrayRef<uint8_t> Replacement,
+                       bool DiagnoseFailure) {
+  std::optional<uint64_t> InstEnd = checkedAddUint64(
+      InstOffset, InstSize, "site replacement source interval");
+  if (!InstEnd)
+    return std::nullopt;
+
+  auto IsActive = [](const SiteReplacementState &State) {
+    return State.Committed || State.RequiredLeadingVNops != 0;
+  };
+  auto DiagnoseOverlap = [&](uint64_t Offset,
+                             const SiteReplacementState &State) {
+    std::optional<uint64_t> End = checkedAddUint64(
+        Offset, State.OriginalSize, "owned replacement source interval");
+    if (!End)
+      return false;
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source [0x" << utohexstr(InstOffset)
+            << ", 0x" << utohexstr(*InstEnd) << ") overlaps reserved source [0x"
+            << utohexstr(Offset) << ", 0x" << utohexstr(*End) << ")\n";
+    return true;
+  };
+
+  // Replacement intervals are inserted only after a successful emission or
+  // by whole-pass precomputation, and central ownership keeps them disjoint.
+  // An ordered map therefore needs only the predecessor plus entries whose
+  // starts fall inside the requested interval, instead of scanning every
+  // patched instruction in a large code object.
+  auto It = Ctx.SiteReplacements.lower_bound(InstOffset);
+  if (It != Ctx.SiteReplacements.begin()) {
+    auto Prev = std::prev(It);
+    if (IsActive(Prev->second)) {
+      std::optional<uint64_t> PrevEnd =
+          checkedAddUint64(Prev->first, Prev->second.OriginalSize,
+                           "owned replacement source interval");
+      if (!PrevEnd)
+        return std::nullopt;
+      if (*PrevEnd > InstOffset) {
+        DiagnoseOverlap(Prev->first, Prev->second);
+        return std::nullopt;
+      }
+    }
+  }
+
+  const SiteReplacementState *Exact = nullptr;
+  if (It != Ctx.SiteReplacements.end() && It->first == InstOffset) {
+    Exact = &It->second;
+    ++It;
+  }
+  for (; It != Ctx.SiteReplacements.end() && It->first < *InstEnd; ++It) {
+    if (!IsActive(It->second))
+      continue;
+    DiagnoseOverlap(It->first, It->second);
+    return std::nullopt;
+  }
+
+  if (Exact && Exact->Committed) {
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source at 0x"
+            << utohexstr(InstOffset) << " already has a committed owner\n";
+    return std::nullopt;
+  }
+  if (Exact && Exact->OriginalSize != InstSize) {
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source at 0x"
+            << utohexstr(InstOffset) << " has reserved size "
+            << Exact->OriginalSize << " but owner requested " << InstSize
+            << " bytes\n";
+    return std::nullopt;
+  }
+
+  PreparedSiteReplacement Prepared;
+  const unsigned VNops = Exact ? Exact->RequiredLeadingVNops : 0;
+  if (VNops != 0) {
+    SmallVector<uint8_t> VNopBytes = assembleSingleInst("v_nop", Ctx.LS);
+    if (VNopBytes.size() != MinInstSize) {
+      if (DiagnoseFailure)
+        log() << "hotswap: error: could not encode v_nop requirement for "
+                 "replacement source at 0x"
+              << utohexstr(InstOffset) << "\n";
+      return std::nullopt;
+    }
+    for (unsigned I = 0; I != VNops; ++I)
+      Prepared.Bytes.append(VNopBytes.begin(), VNopBytes.end());
+    Prepared.ComposesWmmaHazard = true;
+  }
+  Prepared.Bytes.append(Replacement.begin(), Replacement.end());
+  return Prepared;
+}
+
+static bool commitSiteReplacement(PatchContext &Ctx, uint64_t InstOffset,
+                                  uint32_t InstSize,
+                                  const PreparedSiteReplacement &Prepared) {
+  SiteReplacementState &State = Ctx.SiteReplacements[InstOffset];
+  if (State.Committed ||
+      (State.OriginalSize != 0 && State.OriginalSize != InstSize) ||
+      (Prepared.ComposesWmmaHazard && State.RequiredLeadingVNops == 0) ||
+      (!Prepared.ComposesWmmaHazard && State.RequiredLeadingVNops != 0)) {
+    log() << "hotswap: error: replacement ownership changed while committing "
+             "source at 0x"
+          << utohexstr(InstOffset) << "\n";
+    Ctx.RequiredPatchFailed = true;
+    return false;
+  }
+
+  State.OriginalSize = InstSize;
+  State.Committed = true;
+  if (Prepared.ComposesWmmaHazard) {
+    State.WmmaHazardComposed = true;
+    ++Ctx.WmmaHazardsComposed;
+    log() << "hotswap: WMMA co-exec requirement composed into replacement at "
+             "0x"
+          << utohexstr(InstOffset) << " (" << State.RequiredLeadingVNops
+          << " leading v_nop(s))\n";
+  }
+  Ctx.RequiredPatchApplied = true;
+  return true;
+}
+
+bool hasSiteReplacementReservation(const PatchContext &Ctx, uint64_t Offset) {
+  auto It = Ctx.SiteReplacements.find(Offset);
+  return It != Ctx.SiteReplacements.end() &&
+         (It->second.Committed || It->second.RequiredLeadingVNops != 0);
+}
+
+[[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
+                                    uint32_t InstSize,
+                                    ArrayRef<uint8_t> Replacement,
+                                    ReplacementPlacement Placement,
+                                    bool DiagnoseFailure) {
+  std::optional<PreparedSiteReplacement> Prepared = prepareSiteReplacement(
+      Ctx, InstOffset, InstSize, Replacement, DiagnoseFailure);
+  if (!Prepared)
+    return false;
+  if (!emitToTrampolineRaw(Ctx, InstOffset, InstSize, Prepared->Bytes,
+                           Placement, DiagnoseFailure))
+    return false;
+  return commitSiteReplacement(Ctx, InstOffset, InstSize, *Prepared);
+}
+
+static std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS) {
   uint64_t Target = 0;
   if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
     return Target;
 
-  // TODO(https://github.com/ROCm/llvm-project/issues/3351): Remove this
-  // fallback when AMDGPUMCInstrAnalysis::evaluateBranch locates the descriptor
-  // operand marked MCOI::OPERAND_PCREL. Its current operand-zero restriction
-  // is in llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.cpp.
-  // GFX1250 s_call_i64 instead has its destination SGPR pair in slot zero and
-  // its simm16 dword displacement in slot one; the operand layout and width
-  // are pinned by llvm/test/MC/AMDGPU/gfx1250_asm_sopk.s.
-  if (DI.Inst.getOpcode() != LS.SCallI64Opcode ||
-      DI.Inst.getNumOperands() == 0 ||
-      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+  // AMDGPUMCInstrAnalysis currently only accepts a PC-relative operand in
+  // slot zero. GFX1250 s_call_i64 instead has its destination SGPR pair in
+  // slot zero and its simm16 dword displacement in slot one. Keep this narrow
+  // workaround private to hotswap.
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  if (DI.Inst.getOpcode() != LS.SCallI64Opcode || !Desc.isCall() ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isReg() ||
+      !DI.Inst.getOperand(0).getReg() || !DI.Inst.getOperand(1).isImm())
     return std::nullopt;
 
   uint64_t Encoded =
-      static_cast<uint64_t>(
-          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
-      0xFFFFu;
-  int64_t DwordDelta = SignExtend64<16>(Encoded);
+      static_cast<uint64_t>(DI.Inst.getOperand(1).getImm()) & 0xFFFFu;
+  int64_t DwordDelta = Encoded < 0x8000u
+                           ? static_cast<int64_t>(Encoded)
+                           : static_cast<int64_t>(Encoded) - 0x10000;
   std::optional<uint64_t> PcBase = checkedAddUint64(
       DI.Offset, DI.Size, "direct control-flow target PC base");
   if (!PcBase)
@@ -842,35 +3431,81 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
 
 /// Collect statically known direct branch and call destinations so an interior
 /// entry point is never swallowed by coalescing.
-static std::optional<DenseSet<uint64_t>>
-collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
-                           const LLVMState &LS) {
+static std::optional<DenseSet<uint64_t>> collectDirectBranchTargets(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    ArrayRef<uint8_t> Text, const ElfView &Elf,
+    const DenseSet<uint64_t> &CodeEntries, ArrayRef<uint64_t> TextSymbolOffsets,
+    ArrayRef<ElfView::TextOffsetRange> TextSymbolExtents) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
     return std::nullopt;
   }
 
-  DenseSet<uint64_t> Targets;
+  // Keep actual control-flow and callable entries distinct from ordinary ELF
+  // symbols. Donor discovery separately rejects every emitted symbol in its
+  // storage. Text symbols are folded into the source-window protection set
+  // below, where an exact-start alias remains valid but an interior entry does
+  // not.
+  DenseSet<uint64_t> Targets = CodeEntries;
+  DenseSet<uint64_t> DecodedBoundaries;
+  for (const InternalDecodedInst &DI : Decoded)
+    DecodedBoundaries.insert(DI.Offset);
   for (const InternalDecodedInst &DI : Decoded) {
+    if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "call continuation control-flow target");
+      if (!Continuation || *Continuation >= Text.size() ||
+          !DecodedBoundaries.contains(*Continuation)) {
+        log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
+              << " has no exact in-text continuation; source relocation and "
+                 "donated sleds are disabled\n";
+        return std::nullopt;
+      }
+      Targets.insert(*Continuation);
+    }
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
       continue;
     bool HasImmediate = false;
     for (const MCOperand &Op : DI.Inst)
       HasImmediate |= Op.isImm();
-    if (!LS.MIA->isCall(DI.Inst) && !HasImmediate)
+    // Register-target control flow has no statically known interior target.
+    // collectIndirectControlFlowFunctions separately makes its containing
+    // function ineligible for source relocation and local sled donation.
+    if (!HasImmediate)
       continue;
     std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
     if (!Target) {
       log() << "hotswap: MC analysis could not evaluate direct control-flow "
                "instruction at 0x"
             << utohexstr(DI.Offset)
-            << "; adjacent far trampolines will not be coalesced\n";
+            << "; source relocation and donated sleds are disabled\n";
       return std::nullopt;
     }
     Targets.insert(*Target);
   }
+
+  // Gather materialized transfers against the immediate-target set, then
+  // revalidate every candidate against the union. This prevents two computed
+  // transfers from entering one another after the get-PC and turning a
+  // nominally constant destination back into an arbitrary one.
+  SmallVector<MaterializedPcTransfer> Candidates;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            evaluateMaterializedPcTransfer(Decoded, I, Targets, Text, LS, Elf,
+                                           TextSymbolOffsets,
+                                           TextSymbolExtents))
+      Candidates.push_back(*Transfer);
+
+  DenseSet<uint64_t> CombinedTargets = Targets;
+  for (const MaterializedPcTransfer &Transfer : Candidates)
+    CombinedTargets.insert(Transfer.Target);
+
+  // Preserve every nominal destination as a protected entry even when a
+  // source later fails revalidation. The final indirect-flow pass sees this
+  // over-approximation and marks any mutually-entered sequence arbitrary.
+  Targets = std::move(CombinedTargets);
   return Targets;
 }
 
@@ -880,7 +3515,8 @@ collectDirectBranchTargets(ArrayRef<InternalDecodedInst> Decoded,
 /// This deliberately never steals an unpatched neighboring instruction.
 static void
 mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
-                             const DenseSet<uint64_t> &DirectBranchTargets) {
+                             const DenseSet<uint64_t> &DirectBranchTargets,
+                             const DenseSet<uint64_t> &IncompleteFunctions) {
   std::vector<Trampoline> Merged;
   Merged.reserve(Trampolines.size());
   uint64_t MergeCount = 0;
@@ -894,9 +3530,12 @@ mergeAdjacentLongTrampolines(std::vector<Trampoline> &Trampolines,
       Adjacent = PrevEnd && *PrevEnd == T.OriginalOffset && Prev.Long &&
                  T.Long && Prev.UsesSetPCBack && T.UsesSetPCBack &&
                  Prev.LongBranchSgprBase == T.LongBranchSgprBase &&
+                 Prev.LongBranchScratchIsSiteProven ==
+                     T.LongBranchScratchIsSiteProven &&
                  Prev.HasFunctionRange && T.HasFunctionRange &&
                  Prev.FunctionStart == T.FunctionStart &&
                  Prev.FunctionEnd == T.FunctionEnd &&
+                 !IncompleteFunctions.contains(T.FunctionStart) &&
                  !DirectBranchTargets.contains(T.OriginalOffset) &&
                  Prev.Bytes.size() >= SetPcReturnReserveBytes &&
                  T.Bytes.size() >= SetPcReturnReserveBytes;
@@ -934,99 +3573,477 @@ static void appendPoolBranchIslands(std::vector<Trampoline> &Trampolines) {
   }
 }
 
-static bool isEndProgram(const InternalDecodedInst &DI, const LLVMState &LS) {
-  unsigned Opcode = DI.Inst.getOpcode();
-  return Opcode == LS.SEndPgmOpcode || Opcode == LS.SEndPgmSavedOpcode;
-}
-
-static bool isPcSensitive(const InternalDecodedInst &DI, const LLVMState &LS) {
-  unsigned Opcode = DI.Inst.getOpcode();
-  return Opcode == LS.SAddPcI64Opcode || Opcode == LS.SGetPcI64Opcode ||
-         Opcode == LS.SSetPcI64Opcode || Opcode == LS.SSwapPcI64Opcode ||
-         Opcode == LS.SPrefetchInstPcRelOpcode ||
-         Opcode == LS.SPrefetchDataPcRelOpcode;
-}
-
 static bool isSafeStraightLineRelocation(const InternalDecodedInst &DI,
                                          const LLVMState &LS,
                                          const DenseSet<uint64_t> &Protected) {
   if (!LS.MIA || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
     return false;
-  unsigned Opcode = DI.Inst.getOpcode();
-  return DI.DecodeSucceeded && !Protected.contains(DI.Offset) &&
-         Opcode != LS.SClauseOpcode && Opcode != LS.SDelayAluOpcode &&
-         !isPcSensitive(DI, LS);
+  return !Protected.contains(DI.Offset) && DI.Mnemonic != "<unknown>" &&
+         DI.Mnemonic != "<replaced>" && DI.Mnemonic != "s_clause" &&
+         DI.Mnemonic != "s_delay_alu" &&
+         !StringRef(DI.Mnemonic).contains("_pc_");
 }
 
-/// Decode the bytes currently present at an original instruction site. Earlier
-/// rewrite passes may have changed Ctx.Text after Ctx.Decoded was populated, so
-/// relocation decisions must not classify the stale MCInst and then copy a
-/// different instruction. A size change is conservatively non-relocatable.
+/// Re-decode the bytes that source growth would actually copy. Per-instruction
+/// patching runs before source-window expansion, so the original Decoded entry
+/// may no longer describe this interval. Requiring one same-size current
+/// instruction prevents relocation of a newly installed branch or a
+/// multi-instruction replacement under stale dataflow semantics.
 static std::optional<InternalDecodedInst>
-decodeCurrentInstruction(const PatchContext &Ctx,
-                         const InternalDecodedInst &Original) {
+decodeCurrentRelocationCandidate(const PatchContext &Ctx,
+                                 const InternalDecodedInst &Original) {
   if (Original.Offset > Ctx.TextSize ||
       Original.Size > Ctx.TextSize - Original.Offset)
     return std::nullopt;
-
   std::vector<InternalDecodedInst> Current;
   if (!decodeTextSection(Ctx.Text + Original.Offset, Original.Size, Ctx.LS,
                          Current) ||
-      Current.size() != 1 || Current[0].Size != Original.Size)
+      Current.size() != 1 || Current.front().Offset != 0 ||
+      Current.front().Size != Original.Size)
     return std::nullopt;
-  Current[0].Offset = Original.Offset;
-  return std::move(Current[0]);
+  Current.front().Offset = Original.Offset;
+  return std::move(Current.front());
+}
+
+/// Return the number of following instructions whose relative positions are
+/// significant to an s_delay_alu encoding. Instid0 names the immediately
+/// following instruction. Instid1 names the instruction selected by instskip,
+/// so every instruction through that target must stay in place. Malformed or
+/// undecodable immediates retain the conservative six-instruction bound.
+unsigned getDelayProtectedSpan(const InternalDecodedInst &DI) {
+  if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+    return 6;
+
+  uint64_t Imm = static_cast<uint64_t>(DI.Inst.getOperand(0).getImm());
+  if ((Imm & ~uint64_t{0x7FF}) != 0)
+    return 6;
+
+  unsigned InstId0 = Imm & 0xF;
+  unsigned Skip = (Imm >> 4) & 0x7;
+  unsigned InstId1 = (Imm >> 7) & 0xF;
+  if (InstId0 >= 12 || InstId1 >= 12 || Skip > 5 || (InstId1 == 0 && Skip != 0))
+    return 6;
+
+  unsigned Span = InstId0 != 0 ? 1 : 0;
+  if (InstId1 != 0)
+    Span = std::max(Span, Skip + 1);
+  return Span;
 }
 
 /// Instructions covered by a hard clause or a delay directive must remain in
 /// place relative to that directive. Mark the complete encoded clause and the
-/// maximum six-instruction forward span addressable by s_delay_alu.
-static DenseSet<uint64_t>
+/// exact s_delay_alu span when its immediate is well formed.
+static void
 collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
-                                  const LLVMState &LS) {
-  DenseSet<uint64_t> Protected;
-  unsigned ClauseRemaining = 0;
+                                  PatchContext &Ctx) {
   unsigned DelayRemaining = 0;
 
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (ClauseRemaining != 0) {
-      Protected.insert(DI.Offset);
-      --ClauseRemaining;
-    }
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
     if (DelayRemaining != 0) {
-      Protected.insert(DI.Offset);
+      protectNonClauseRelocationOffset(Ctx, DI.Offset);
       --DelayRemaining;
     }
 
-    if (DI.Inst.getOpcode() == LS.SClauseOpcode &&
-        DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isImm())
-      ClauseRemaining =
+    if (DI.Mnemonic == "s_clause" && DI.Inst.getNumOperands() == 1 &&
+        DI.Inst.getOperand(0).isImm()) {
+      const unsigned MemberCount =
           (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 63u) + 1;
-    else if (DI.Inst.getOpcode() == LS.SDelayAluOpcode)
-      DelayRemaining = 6;
+      const size_t Available =
+          std::min<size_t>(MemberCount, Decoded.size() - I - 1);
+      for (size_t Member = I + 1, End = I + 1 + Available; Member != End;
+           ++Member) {
+        const uint64_t Offset = Decoded[Member].Offset;
+        ++Ctx.ClauseRelocationProtectionCounts[Offset];
+        Ctx.RelocationProtectedOffsets.insert(Offset);
+      }
+    } else if (DI.Mnemonic == "s_delay_alu") {
+      DelayRemaining = std::max(DelayRemaining, getDelayProtectedSpan(DI));
+    }
   }
-  return Protected;
+}
+
+/// Under the public HotSwap API's callable-control-flow precondition, this is
+/// an ABI call and its register target is a callable function entry. This is a
+/// control-flow geometry fact only: all liveness and value analyses continue
+/// to treat the instruction as an opaque call boundary.
+static bool isStandardLinkCall(const InternalDecodedInst &DI,
+                               const LLVMState &LS) {
+  return DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+         DI.Inst.getNumOperands() == 2 && DI.Inst.getOperand(0).isReg() &&
+         DI.Inst.getOperand(0).getReg() &&
+         StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+             "SGPR30_SGPR31";
+}
+
+static std::optional<std::pair<unsigned, SgprPairHalves>>
+getNumberedSgprPair(const LLVMState &LS, const MCOperand &Operand) {
+  if (!Operand.isReg() || !Operand.getReg())
+    return std::nullopt;
+  std::optional<SgprPairHalves> Halves =
+      getSgprPairHalves(LS, MCRegister(Operand.getReg()));
+  if (!Halves || Halves->IsVcc)
+    return std::nullopt;
+  std::optional<unsigned> Lo = numberedSgprIndex(*LS.MRI, Halves->Regs[0]);
+  std::optional<unsigned> Hi = numberedSgprIndex(*LS.MRI, Halves->Regs[1]);
+  if (!Lo || !Hi || *Hi != *Lo + 1)
+    return std::nullopt;
+  return std::make_pair(*Lo, *Halves);
+}
+
+static bool hasUnresolvedStandardLinkCall(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const ElfView &Elf, const DenseSet<uint64_t> &DirectControlFlowTargets,
+    ArrayRef<uint8_t> Text, std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents) {
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    if (!isStandardLinkCall(Decoded[I], LS))
+      continue;
+    if (!evaluateMaterializedPcTransfer(Decoded, I, DirectControlFlowTargets,
+                                        Text, LS, Elf, TextSymbolOffsets,
+                                        TextSymbolExtents))
+      return true;
+  }
+  return false;
+}
+
+/// Prove nonstandard s_set_pc_i64 returns only when every modeled ingress
+/// carries the exact link written by an in-text s_call_i64 using the same
+/// physical SGPR pair. Any alternate entry, clobber, or unmodeled indirect
+/// transfer invalidates the proof globally.
+static DenseSet<uint64_t> collectProvenDirectCallReturns(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS, ElfView &Elf,
+    const DenseSet<uint64_t> &DirectControlFlowTargets, ArrayRef<uint8_t> Text,
+    std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents,
+    bool HasUnresolvedStandardLinkCall) {
+  DenseSet<uint64_t> Proven;
+  if (!LS.MIA || !LS.MCII || !LS.MRI || Decoded.empty())
+    return Proven;
+
+  // AMDGPU's instruction metadata does not classify RFE as a branch or a
+  // terminator. It can nevertheless resume at an arbitrary PC with arbitrary
+  // SGPR contents. An undecodable word may hide the same behavior, so no
+  // nonstandard link-pair proof survives either condition.
+  if (llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+        return DI.Mnemonic == "<unknown>" ||
+               StringRef(DI.Mnemonic).starts_with("s_rfe");
+      }))
+    return Proven;
+
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  OffsetToIndex.reserve(Decoded.size());
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    if (Decoded[I].Size == 0 ||
+        !OffsetToIndex.try_emplace(Decoded[I].Offset, I).second)
+      return {};
+  }
+
+  std::vector<std::optional<MaterializedPcTransfer>> Materialized(
+      Decoded.size());
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    Materialized[I] = evaluateMaterializedPcTransfer(
+        Decoded, I, DirectControlFlowTargets, Text, LS, Elf, TextSymbolOffsets,
+        TextSymbolExtents);
+
+  std::vector<std::optional<unsigned>> ReturnPairs(Decoded.size());
+  SmallVector<std::pair<unsigned, SgprPairHalves>, 4> Pairs;
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        isStandardLinkReturn(DI, LS) || Materialized[I] ||
+        DI.Inst.getNumOperands() != 1)
+      continue;
+    std::optional<std::pair<unsigned, SgprPairHalves>> Pair =
+        getNumberedSgprPair(LS, DI.Inst.getOperand(0));
+    if (!Pair)
+      continue;
+    ReturnPairs[I] = Pair->first;
+    if (!llvm::any_of(Pairs, [&](const auto &Existing) {
+          return Existing.first == Pair->first;
+        }))
+      Pairs.push_back(*Pair);
+  }
+  if (Pairs.empty())
+    return Proven;
+
+  std::optional<DenseSet<uint64_t>> DescriptorEntries =
+      collectResolvedKernelEntryOffsets(Elf, LS);
+  if (!DescriptorEntries)
+    return Proven;
+  SmallVector<unsigned, 8> DescriptorEntryIndices;
+  for (uint64_t Entry : *DescriptorEntries) {
+    auto It = OffsetToIndex.find(Entry);
+    if (It == OffsetToIndex.end())
+      return {};
+    DescriptorEntryIndices.push_back(It->second);
+  }
+
+  SmallVector<unsigned, 16> CallableEntryIndices;
+  for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges()) {
+    if (Range.Begin < Elf.textAddr() ||
+        (!HasUnresolvedStandardLinkCall && !isExternallyVisibleCallable(Range)))
+      continue;
+    const uint64_t Entry = Range.Begin - Elf.textAddr();
+    if (Entry >= Text.size())
+      continue;
+    auto It = OffsetToIndex.find(Entry);
+    if (It == OffsetToIndex.end())
+      return {};
+    if (!llvm::is_contained(CallableEntryIndices, It->second))
+      CallableEntryIndices.push_back(It->second);
+  }
+
+  struct CallIngress {
+    unsigned TargetIndex = 0;
+    std::optional<unsigned> ExactLinkPair;
+  };
+  SmallVector<unsigned, 16> CallContinuationIndices;
+  SmallVector<CallIngress, 16> CallIngresses;
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!LS.MIA->isCall(DI.Inst))
+      continue;
+
+    std::optional<uint64_t> Continuation = checkedAddUint64(
+        DI.Offset, DI.Size, "direct-call return proof continuation");
+    if (!Continuation || *Continuation >= Text.size())
+      return {};
+    auto ContinuationIt = OffsetToIndex.find(*Continuation);
+    if (ContinuationIt == OffsetToIndex.end())
+      return {};
+    if (!llvm::is_contained(CallContinuationIndices, ContinuationIt->second))
+      CallContinuationIndices.push_back(ContinuationIt->second);
+
+    std::optional<uint64_t> Target;
+    std::optional<unsigned> ExactPair;
+    if (DI.Inst.getOpcode() == LS.SCallI64Opcode) {
+      Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target)
+        return {};
+      if (DI.Inst.getNumOperands() == 2)
+        if (std::optional<std::pair<unsigned, SgprPairHalves>> Pair =
+                getNumberedSgprPair(LS, DI.Inst.getOperand(0)))
+          ExactPair = Pair->first;
+    } else if (Materialized[I]) {
+      Target = Materialized[I]->Target;
+    } else if (!LS.MIA->isIndirectBranch(DI.Inst)) {
+      Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target)
+        return {};
+    }
+    if (!Target || *Target >= Text.size())
+      continue;
+    auto TargetIt = OffsetToIndex.find(*Target);
+    if (TargetIt == OffsetToIndex.end())
+      return {};
+    CallIngresses.push_back({TargetIt->second, ExactPair});
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Decoded.size());
+  auto AddFallthrough = [&](unsigned I) {
+    std::optional<uint64_t> Next =
+        checkedAddUint64(Decoded[I].Offset, Decoded[I].Size,
+                         "direct-call return proof fallthrough");
+    if (!Next || *Next >= Text.size() || I + 1 >= Decoded.size() ||
+        Decoded[I + 1].Offset != *Next)
+      return false;
+    Successors[I].push_back(I + 1);
+    return true;
+  };
+  auto AddTarget = [&](unsigned I, uint64_t Target) {
+    if (Target >= Text.size())
+      return true;
+    auto It = OffsetToIndex.find(Target);
+    if (It == OffsetToIndex.end())
+      return false;
+    Successors[I].push_back(It->second);
+    return true;
+  };
+
+  for (unsigned I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    if (LS.MIA->isCall(DI.Inst) || DI.Mnemonic == "s_code_end" ||
+        DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (Materialized[I]) {
+      if (!AddTarget(I, Materialized[I]->Target))
+        return {};
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode)
+      continue;
+    if (LS.MIA->isBranch(DI.Inst)) {
+      if (LS.MIA->isIndirectBranch(DI.Inst))
+        continue;
+      std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+      if (!Target || !AddTarget(I, *Target))
+        return {};
+      if (LS.MIA->isConditionalBranch(DI.Inst)) {
+        if (!AddFallthrough(I))
+          return {};
+      } else if (!LS.MIA->isUnconditionalBranch(DI.Inst)) {
+        return {};
+      }
+      continue;
+    }
+    if (StringRef(DI.Mnemonic).starts_with("s_trap") || Desc.isTrap()) {
+      if (!AddFallthrough(I))
+        return {};
+      continue;
+    }
+    if (Desc.isTerminator() || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+      return {};
+    if (!AddFallthrough(I))
+      return {};
+  }
+
+  constexpr uint8_t ExactDirectCallLink = 1;
+  constexpr uint8_t UnknownLink = 2;
+  for (const auto &[PairBase, PairHalves] : Pairs) {
+    SmallVector<uint8_t> In(Decoded.size(), 0);
+    SmallVector<unsigned, 64> Worklist;
+    auto Merge = [&](unsigned Index, uint8_t State) {
+      const uint8_t Merged = In[Index] | State;
+      if (Merged == In[Index])
+        return;
+      In[Index] = Merged;
+      Worklist.push_back(Index);
+    };
+
+    for (unsigned Entry : DescriptorEntryIndices)
+      Merge(Entry, UnknownLink);
+    for (unsigned Entry : CallableEntryIndices)
+      Merge(Entry, UnknownLink);
+    for (unsigned Continuation : CallContinuationIndices)
+      Merge(Continuation, UnknownLink);
+    for (const CallIngress &Ingress : CallIngresses)
+      Merge(Ingress.TargetIndex,
+            Ingress.ExactLinkPair && *Ingress.ExactLinkPair == PairBase
+                ? ExactDirectCallLink
+                : UnknownLink);
+
+    for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+      const unsigned I = Worklist[Next];
+      const InternalDecodedInst &DI = Decoded[I];
+      if (ReturnPairs[I] && *ReturnPairs[I] == PairBase) {
+        if (In[I] == ExactDirectCallLink)
+          Proven.insert(DI.Offset);
+        else
+          Proven.erase(DI.Offset);
+        continue;
+      }
+
+      uint8_t Out = In[I];
+      const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+      if (DI.Mnemonic == "<unknown>" ||
+          StringRef(DI.Mnemonic).starts_with("s_trap") || Desc.isTrap()) {
+        Out = UnknownLink;
+      } else if (Out != 0) {
+        std::optional<RegisterPairAccess> Access = getRegisterPairAccess(
+            LS, DI, PairHalves.Regs, /*PairIsAbiVcc=*/false);
+        if (!Access || Access->Defs != 0)
+          Out = UnknownLink;
+      }
+      for (unsigned Succ : Successors[I])
+        Merge(Succ, Out);
+    }
+  }
+
+  // A genuinely arbitrary transfer can enter any instruction with an unknown
+  // link value, invalidating every otherwise-local direct-return proof.
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved")
+      continue;
+    const bool HasOpaqueControlFlow =
+        DI.Mnemonic == "<unknown>" ||
+        StringRef(DI.Mnemonic).starts_with("s_rfe");
+    if (!HasOpaqueControlFlow && !LS.MIA->isIndirectBranch(DI.Inst) &&
+        !(LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
+          StringRef(DI.Mnemonic).contains("_pc_")))
+      continue;
+    if (isStandardLinkReturn(DI, LS) || Materialized[I] ||
+        isStandardLinkCall(DI, LS) || Proven.contains(DI.Offset))
+      continue;
+    return {};
+  }
+  return Proven;
 }
 
 /// Relocating an instruction changes its address. In a function containing a
 /// register-based PC transfer, MC cannot prove that the instruction is not an
 /// indirect destination, so leave the complete function in place.
-static DenseSet<uint64_t>
-collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
-                                    const LLVMState &LS, const ElfView &Elf) {
+static DenseSet<uint64_t> collectIndirectControlFlowFunctions(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const ElfView &Elf, const DenseSet<uint64_t> &DirectControlFlowTargets,
+    ArrayRef<uint8_t> Text, std::optional<ArrayRef<uint64_t>> TextSymbolOffsets,
+    std::optional<ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents,
+    const DenseSet<uint64_t> &ProvenDirectCallReturns,
+    bool &HasUnknownArbitraryIndirectTarget) {
   DenseSet<uint64_t> Functions;
+  HasUnknownArbitraryIndirectTarget = false;
   if (!LS.MIA)
     return Functions;
 
-  for (const InternalDecodedInst &DI : Decoded) {
-    if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved")
       continue;
-    if (!LS.MIA->isIndirectBranch(DI.Inst) &&
+    const bool HasOpaqueControlFlow =
+        DI.Mnemonic == "<unknown>" ||
+        StringRef(DI.Mnemonic).starts_with("s_rfe");
+    if (!HasOpaqueControlFlow && !LS.MIA->isIndirectBranch(DI.Inst) &&
         !(LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI) &&
-          isPcSensitive(DI, LS)))
+          StringRef(DI.Mnemonic).contains("_pc_")))
       continue;
     std::optional<ElfView::FunctionTextRange> Range =
         Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    const bool IsSetPc = DI.Inst.getOpcode() == LS.SSetPcI64Opcode;
+    const bool UsesStandardLinkPair =
+        IsSetPc && DI.Inst.getNumOperands() == 1 &&
+        DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg() &&
+        StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+            "SGPR30_SGPR31";
+    // A standard-link return can leave from any basic block, but cannot name
+    // arbitrary code padding.
+    if (IsSetPc && UsesStandardLinkPair)
+      continue;
+    if (IsSetPc && ProvenDirectCallReturns.contains(DI.Offset)) {
+      log() << "hotswap: recognized proven direct-call return at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      continue;
+    }
+    if (std::optional<MaterializedPcTransfer> Transfer =
+            evaluateMaterializedPcTransfer(Decoded, I, DirectControlFlowTargets,
+                                           Text, LS, Elf, TextSymbolOffsets,
+                                           TextSymbolExtents)) {
+      if (LS.MIA->isCall(DI.Inst)) {
+        std::optional<ElfView::FunctionTextRange> TargetRange =
+            Elf.findFunctionTextRangeAtOffset(Transfer->Target);
+        if (!TargetRange || Transfer->Target != TargetRange->Begin) {
+          HasUnknownArbitraryIndirectTarget = true;
+          if (Range && Functions.insert(Range->Begin).second)
+            log() << "hotswap: source relocation disabled for function at 0x"
+                  << utohexstr(Range->Begin)
+                  << " by materialized call to a non-entry target at 0x"
+                  << utohexstr(DI.Offset) << "\n";
+          continue;
+        }
+      }
+      log() << "hotswap: recognized materialized PC transfer [0x"
+            << utohexstr(Transfer->Begin) << ", 0x" << utohexstr(Transfer->End)
+            << ") -> 0x" << utohexstr(Transfer->Target) << "\n";
+      continue;
+    }
+    if (isStandardLinkCall(DI, LS)) {
+      log() << "hotswap: recognized ABI standard-link indirect call at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      continue;
+    }
+    HasUnknownArbitraryIndirectTarget = true;
     if (Range && Functions.insert(Range->Begin).second)
       log() << "hotswap: source relocation disabled for function at 0x"
             << utohexstr(Range->Begin) << " by " << DI.Mnemonic << " at 0x"
@@ -1035,24 +4052,489 @@ collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
   return Functions;
 }
 
+struct VgprMsbState {
+  int8_t Dst = VgprMsbUnreachable;
+  int8_t Src0 = VgprMsbUnreachable;
+  int8_t Src1 = VgprMsbUnreachable;
+  int8_t Src2 = VgprMsbUnreachable;
+};
+
+static VgprMsbState vgprMsbStateFromMode(unsigned Mode) {
+  Mode &= 0xff;
+  return {static_cast<int8_t>((Mode >> 6) & 0x3),
+          static_cast<int8_t>(Mode & 0x3),
+          static_cast<int8_t>((Mode >> 2) & 0x3),
+          static_cast<int8_t>((Mode >> 4) & 0x3)};
+}
+
+static VgprMsbState unknownVgprMsbState() {
+  return {VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown};
+}
+
+static int16_t exactVgprMsbMode(VgprMsbState State) {
+  if (State.Dst < 0 || State.Src0 < 0 || State.Src1 < 0 || State.Src2 < 0)
+    return VgprMsbUnknown;
+  return static_cast<int16_t>(State.Src0 | (State.Src1 << 2) |
+                              (State.Src2 << 4) | (State.Dst << 6));
+}
+
+// COMGR intentionally does not depend on AMDGPU's backend-private
+// AMDGPUBaseInfo.h. Mirror the gfx1250 SETREG-to-VGPR-MSB conversion here:
+// the simm16 low six bits select HW_REG_WAVE_MODE (ID 1), and gfx1250's
+// setreg-vgpr-msb-fixup makes an immediate MODE write load all four two-bit
+// fields from immediate bits [19:12], rotated into s_set_vgpr_msb order.
+static std::optional<unsigned>
+decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI) {
+  if (DI.Mnemonic != "s_setreg_imm32_b32" || DI.Inst.getNumOperands() != 2 ||
+      !DI.Inst.getOperand(0).isImm() || !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+  constexpr unsigned ModeHwregId = 1;
+  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
+  if ((Simm16 & 0x3f) != ModeHwregId)
+    return std::nullopt;
+  unsigned Raw =
+      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> 12) & 0xff;
+  return ((Raw >> 2) | (Raw << 6)) & 0xff;
+}
+
+static std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI) {
+  if (!StringRef(DI.Mnemonic).starts_with("s_setreg") ||
+      DI.Inst.getNumOperands() == 0 ||
+      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+    return std::nullopt;
+  return static_cast<unsigned>(
+             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
+         0x3f;
+}
+
+static bool instructionDefinesNamedRegister(const InternalDecodedInst &DI,
+                                            StringRef Name,
+                                            const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() &&
+        StringRef(LS.MRI->getName(Op.getReg())) == Name)
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Reg) {
+    return StringRef(LS.MRI->getName(Reg)) == Name;
+  });
+}
+
+static std::optional<unsigned>
+getExactVgprMsbModeWritten(const InternalDecodedInst &DI) {
+  if (DI.Mnemonic == "s_set_vgpr_msb") {
+    if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+      return std::nullopt;
+    return static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 0xff;
+  }
+  return decodeSetregImmVgprMsbMode(DI);
+}
+
+static VgprMsbState transferVgprMsbState(VgprMsbState In,
+                                         const InternalDecodedInst &DI,
+                                         const LLVMState &LS) {
+  if (In.Dst == VgprMsbUnreachable)
+    return In;
+  if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(DI))
+    return vgprMsbStateFromMode(*Mode);
+  if (DI.Mnemonic == "s_set_vgpr_msb")
+    return unknownVgprMsbState();
+  if (StringRef(DI.Mnemonic).starts_with("s_setreg")) {
+    std::optional<unsigned> HwregId = getSetregHwregId(DI);
+    if (!HwregId)
+      return unknownVgprMsbState();
+    constexpr unsigned ModeHwregId = 1;
+    if (*HwregId != ModeHwregId)
+      return In;
+    return unknownVgprMsbState();
+  }
+  if (DI.Mnemonic == "<unknown>" ||
+      instructionDefinesNamedRegister(DI, "MODE", LS) ||
+      (LS.MIA && LS.MIA->isCall(DI.Inst)))
+    return unknownVgprMsbState();
+  return In;
+}
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS) {
+  return DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+         DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isReg() &&
+         DI.Inst.getOperand(0).getReg() &&
+         StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+             "SGPR30_SGPR31";
+}
+
+static int8_t mergeVgprMsbValue(int8_t Old, int8_t Incoming) {
+  if (Old == VgprMsbUnreachable)
+    return Incoming;
+  if (Incoming == VgprMsbUnreachable || Old == Incoming)
+    return Old;
+  return VgprMsbUnknown;
+}
+
+static VgprMsbState mergeVgprMsbState(VgprMsbState Old, VgprMsbState Incoming) {
+  return {mergeVgprMsbValue(Old.Dst, Incoming.Dst),
+          mergeVgprMsbValue(Old.Src0, Incoming.Src0),
+          mergeVgprMsbValue(Old.Src1, Incoming.Src1),
+          mergeVgprMsbValue(Old.Src2, Incoming.Src2)};
+}
+
+static void clearNumberedSgprAliases(BitVector &Aligned, MCRegister Reg,
+                                     const MCRegisterInfo &MRI) {
+  auto Clear = [&](MCRegister Candidate) {
+    if (std::optional<unsigned> Index = numberedSgprIndex(MRI, Candidate))
+      if (*Index < Aligned.size())
+        Aligned.reset(*Index);
+  };
+  Clear(Reg);
+  for (MCPhysReg Sub : MRI.subregs(Reg))
+    Clear(MCRegister(Sub));
+  for (MCPhysReg Super : MRI.superregs(Reg))
+    Clear(MCRegister(Super));
+}
+
+/// Track numbered SGPR values that are known to be divisible by eight. Calls
+/// lose every fact because post-link code has no IPRA regmask; ordinary defs
+/// kill aliases, and an exact s_mul_i32 by an aligned immediate regenerates
+/// the destination fact independently of its other operand.
+static BitVector transferSgprAlignment(BitVector In,
+                                       const InternalDecodedInst &DI,
+                                       ArrayRef<uint8_t> Text,
+                                       const LLVMState &LS) {
+  if (DI.Mnemonic == "<unknown>" || LS.MIA->isCall(DI.Inst)) {
+    In.reset();
+    return In;
+  }
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg())
+      clearNumberedSgprAliases(In, MCRegister(Op.getReg()), *LS.MRI);
+  }
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    clearNumberedSgprAliases(In, MCRegister(Reg), *LS.MRI);
+
+  if (DI.Mnemonic != "s_mul_i32" || NumDefs != 1 ||
+      !DI.Inst.getOperand(0).isReg())
+    return In;
+  std::optional<unsigned> Dst =
+      numberedSgprIndex(*LS.MRI, MCRegister(DI.Inst.getOperand(0).getReg()));
+  if (!Dst || *Dst >= In.size())
+    return In;
+  for (unsigned I = NumDefs; I != DI.Inst.getNumOperands(); ++I) {
+    std::optional<int64_t> Value =
+        getAbsoluteOperandValue(DI.Inst.getOperand(I), DI, Text);
+    if (Value && (static_cast<uint32_t>(*Value) & 7u) == 0) {
+      In.set(*Dst);
+      break;
+    }
+  }
+  return In;
+}
+
+static bool isAlignedSgprSource(const MCOperand &Op, const BitVector &Aligned,
+                                const MCRegisterInfo &MRI) {
+  if (!Op.isReg() || !Op.getReg())
+    return false;
+  std::optional<unsigned> Index =
+      numberedSgprIndex(MRI, MCRegister(Op.getReg()));
+  return Index && *Index < Aligned.size() && Aligned.test(*Index);
+}
+
+static void recordAlignedVgprCopies(const InternalDecodedInst &DI,
+                                    size_t GlobalIndex,
+                                    const BitVector &Aligned,
+                                    const LLVMState &LS, BitVector &Def0,
+                                    BitVector &Def1) {
+  Def0.reset(GlobalIndex);
+  Def1.reset(GlobalIndex);
+  if (DI.Mnemonic == "v_mov_b32") {
+    if (DI.Inst.getNumOperands() == 2 &&
+        isAlignedSgprSource(DI.Inst.getOperand(1), Aligned, *LS.MRI))
+      Def0.set(GlobalIndex);
+    return;
+  }
+  if (DI.Mnemonic != "v_dual_mov_b32" || DI.Inst.getNumOperands() != 4)
+    return;
+  if (isAlignedSgprSource(DI.Inst.getOperand(2), Aligned, *LS.MRI))
+    Def0.set(GlobalIndex);
+  if (isAlignedSgprSource(DI.Inst.getOperand(3), Aligned, *LS.MRI))
+    Def1.set(GlobalIndex);
+}
+
+/// Recover the persistent VGPR bank selectors on every path. The complete
+/// four-field state feeds WMMA splitting, while the independently merged
+/// dst/src0 fields also prove the equality needed by DS address rewrites.
+/// Unknown MODE definitions and calls lose the affected proof, and functions
+/// with arbitrary indirect entries are rejected.
+static BitVector computeVgprMsbDstSrc0Equality(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    const ElfView &Elf, const DenseSet<uint64_t> &DirectControlFlowTargets,
+    const DenseSet<uint64_t> &CodeEntries,
+    const DenseSet<uint64_t> &IndirectControlFlowFunctions,
+    ArrayRef<uint8_t> Text, BitVector &VgprDef0AlignedTo8,
+    BitVector &VgprDef1AlignedTo8, std::vector<int8_t> &VgprMsbDstBefore,
+    std::vector<int8_t> &VgprMsbSrc0Before,
+    std::vector<int16_t> &VgprMsbModeBefore,
+    DenseSet<uint64_t> &CrossFunctionInteriorEntryFunctions) {
+  BitVector ProvenEqual(Decoded.size());
+  VgprDef0AlignedTo8 = BitVector(Decoded.size());
+  VgprDef1AlignedTo8 = BitVector(Decoded.size());
+  VgprMsbDstBefore.assign(Decoded.size(), VgprMsbUnknown);
+  VgprMsbSrc0Before.assign(Decoded.size(), VgprMsbUnknown);
+  VgprMsbModeBefore.assign(Decoded.size(), VgprMsbUnanalyzed);
+  if (!LS.MIA || !LS.MCII || !LS.MRI)
+    return ProvenEqual;
+
+  DenseSet<uint64_t> CrossFunctionInteriorEntries;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+        LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isReturn(DI.Inst))
+      continue;
+    std::optional<uint64_t> Target = evaluateDirectControlFlowTarget(DI, LS);
+    if (!Target || *Target >= Text.size())
+      continue;
+    std::optional<ElfView::FunctionTextRange> SourceOwner =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(*Target);
+    if (TargetOwner && *Target != TargetOwner->Begin &&
+        (!SourceOwner || SourceOwner->Begin != TargetOwner->Begin ||
+         SourceOwner->End != TargetOwner->End))
+      CrossFunctionInteriorEntries.insert(TargetOwner->Begin);
+  }
+  CrossFunctionInteriorEntryFunctions = CrossFunctionInteriorEntries;
+
+  DenseSet<std::pair<uint64_t, uint64_t>> SeenRanges;
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Elf.functionTextRanges();
+  for (size_t RangeIndex = 0; RangeIndex != FunctionRanges.size();
+       ++RangeIndex) {
+    const ElfView::FunctionTextRange &VirtualRange = FunctionRanges[RangeIndex];
+    if (VirtualRange.Begin < Elf.textAddr() ||
+        VirtualRange.End < VirtualRange.Begin ||
+        VirtualRange.End > Elf.textAddr() + Text.size())
+      continue;
+    uint64_t Begin = VirtualRange.Begin - Elf.textAddr();
+    uint64_t End = VirtualRange.End - Elf.textAddr();
+    if (Begin >= End || !SeenRanges.insert({Begin, End}).second ||
+        IndirectControlFlowFunctions.contains(Begin) ||
+        CrossFunctionInteriorEntries.contains(Begin))
+      continue;
+
+    // An outer symbol must not donate facts to instructions owned by a nested
+    // function symbol. The ranges are sorted by start address, so the first
+    // later distinct start is sufficient to detect an overlap.
+    size_t NextRange = RangeIndex + 1;
+    while (NextRange != FunctionRanges.size() &&
+           FunctionRanges[NextRange].Begin == VirtualRange.Begin)
+      ++NextRange;
+    if (NextRange != FunctionRanges.size() &&
+        FunctionRanges[NextRange].Begin < VirtualRange.End)
+      continue;
+
+    // Ignore an overlapping/alias range unless ElfView would select it as the
+    // owner of its first instruction. This keeps the CFG and the later patch
+    // site's function identity consistent.
+    std::optional<ElfView::FunctionTextRange> Owner =
+        Elf.findFunctionTextRangeAtOffset(Begin);
+    if (!Owner || Owner->Begin != Begin || Owner->End != End)
+      continue;
+
+    auto First = llvm::lower_bound(
+        Decoded, Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    auto After = llvm::lower_bound(
+        Decoded, End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (First == After || First->Offset != Begin)
+      continue;
+
+    const size_t GlobalFirst = static_cast<size_t>(First - Decoded.begin());
+    const size_t Count = static_cast<size_t>(After - First);
+    DenseMap<uint64_t, unsigned> OffsetToLocalIndex;
+    OffsetToLocalIndex.reserve(Count);
+    bool Valid = true;
+    for (unsigned I = 0; I != Count; ++I) {
+      OffsetToLocalIndex.try_emplace(First[I].Offset, I);
+      if (First[I].Mnemonic == "<unknown>")
+        Valid = false;
+    }
+    if (!Valid)
+      continue;
+
+    std::vector<SmallVector<unsigned, 2>> Successors(Count);
+    BitVector CallableEntries(Count);
+    auto AddTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+      if (Target < Begin || Target >= End)
+        return true;
+      auto It = OffsetToLocalIndex.find(Target);
+      if (It == OffsetToLocalIndex.end())
+        return false;
+      Out.push_back(It->second);
+      return true;
+    };
+    auto AddFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+      if (I + 1 < Count)
+        Out.push_back(I + 1);
+    };
+
+    for (unsigned I = 0; I != Count && Valid; ++I) {
+      const InternalDecodedInst &DI = First[I];
+      SmallVectorImpl<unsigned> &Out = Successors[I];
+      if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+          LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, LS))
+        continue;
+      if (LS.MIA->isCall(DI.Inst)) {
+        if (!LS.MIA->isIndirectBranch(DI.Inst))
+          if (std::optional<uint64_t> Target =
+                  evaluateDirectControlFlowTarget(DI, LS))
+            if (*Target >= Begin && *Target < End)
+              if (auto It = OffsetToLocalIndex.find(*Target);
+                  It != OffsetToLocalIndex.end())
+                CallableEntries.set(It->second);
+        AddFallthrough(Out, I);
+        continue;
+      }
+      if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target;
+        std::optional<MaterializedPcTransfer> Materialized =
+            evaluateMaterializedPcTransfer(Decoded, GlobalFirst + I,
+                                           DirectControlFlowTargets, Text, LS,
+                                           Elf);
+        if (Materialized) {
+          Target = Materialized->Target;
+        } else if (LS.MIA->isIndirectBranch(DI.Inst)) {
+          Valid = false;
+          break;
+        } else {
+          Target = evaluateDirectControlFlowTarget(DI, LS);
+          if (!Target) {
+            Valid = false;
+            break;
+          }
+        }
+        Valid &= AddTarget(Out, *Target);
+        if (LS.MIA->isConditionalBranch(DI.Inst))
+          AddFallthrough(Out, I);
+        else if (!Materialized && !LS.MIA->isUnconditionalBranch(DI.Inst) &&
+                 !LS.MIA->isIndirectBranch(DI.Inst))
+          Valid = false;
+        continue;
+      }
+      if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+        Valid = false;
+        break;
+      }
+      AddFallthrough(Out, I);
+    }
+    if (!Valid)
+      continue;
+
+    // A validated function CFG distinguishes dead instructions from sites we
+    // could not analyze at all. Mandatory rewrites may use that distinction to
+    // transform semantically unreachable instructions without treating an
+    // ambiguous reachable MODE value as the ABI default.
+    for (size_t I = 0; I != Count; ++I)
+      VgprMsbModeBefore[GlobalFirst + I] = VgprMsbUnreachable;
+
+    std::vector<VgprMsbState> In(Count);
+    std::vector<BitVector> AlignedIn(Count, BitVector(Gfx1250MaxSgprs));
+    BitVector AlignmentReachable(Count);
+    SmallVector<unsigned, 64> Worklist;
+    // LLVM's gfx1250 VGPR-lowering ABI explicitly requires all four MSB fields
+    // to be zero on function entry. Calls still transfer to Unknown above
+    // because this object-level proof does not inspect the callee's return.
+    auto SeedAbiEntry = [&](unsigned I) {
+      VgprMsbState Seed = vgprMsbStateFromMode(0);
+      In[I] = mergeVgprMsbState(In[I], Seed);
+      AlignmentReachable.set(I);
+      Worklist.push_back(I);
+    };
+    SeedAbiEntry(0);
+    for (uint64_t Entry : CodeEntries)
+      if (Entry >= Begin && Entry < End)
+        if (auto It = OffsetToLocalIndex.find(Entry);
+            It != OffsetToLocalIndex.end() && It->second != 0)
+          SeedAbiEntry(It->second);
+    for (int I = CallableEntries.find_first(); I >= 0;
+         I = CallableEntries.find_next(I))
+      if (I != 0)
+        SeedAbiEntry(static_cast<unsigned>(I));
+    for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+      unsigned I = Worklist[Next];
+      size_t GlobalI = GlobalFirst + I;
+      VgprMsbDstBefore[GlobalI] = In[I].Dst;
+      VgprMsbSrc0Before[GlobalI] = In[I].Src0;
+      VgprMsbModeBefore[GlobalI] = exactVgprMsbMode(In[I]);
+      if (In[I].Dst >= 0 && In[I].Dst == In[I].Src0)
+        ProvenEqual.set(GlobalI);
+      else
+        ProvenEqual.reset(GlobalI);
+      recordAlignedVgprCopies(Decoded[GlobalI], GlobalI, AlignedIn[I], LS,
+                              VgprDef0AlignedTo8, VgprDef1AlignedTo8);
+      VgprMsbState Out = transferVgprMsbState(In[I], Decoded[GlobalI], LS);
+      BitVector AlignedOut =
+          transferSgprAlignment(AlignedIn[I], Decoded[GlobalI], Text, LS);
+      for (unsigned Succ : Successors[I]) {
+        VgprMsbState Merged = mergeVgprMsbState(In[Succ], Out);
+        bool Changed =
+            Merged.Dst != In[Succ].Dst || Merged.Src0 != In[Succ].Src0 ||
+            Merged.Src1 != In[Succ].Src1 || Merged.Src2 != In[Succ].Src2;
+        if (Changed)
+          In[Succ] = Merged;
+        if (!AlignmentReachable.test(Succ)) {
+          AlignedIn[Succ] = AlignedOut;
+          AlignmentReachable.set(Succ);
+          Changed = true;
+        } else {
+          BitVector AlignedMerged = AlignedIn[Succ];
+          AlignedMerged &= AlignedOut;
+          if (AlignedMerged != AlignedIn[Succ]) {
+            AlignedIn[Succ] = std::move(AlignedMerged);
+            Changed = true;
+          }
+        }
+        if (Changed)
+          Worklist.push_back(Succ);
+      }
+    }
+  }
+  return ProvenEqual;
+}
+
 /// Grow undersized far-site windows only through proven straight-line code.
 /// Patched neighbors are merged; ordinary instructions are copied verbatim
-/// into the trampoline body and retain their original order. This is bounded
-/// to the 28 bytes required by the accepted pre-Gen5 forward sequence.
+/// into the trampoline body and retain their original order. Growth is bounded
+/// by the space required for the selected SCC-neutral set-PC sequence.
 static void
 expandStraightLineTrampolines(PatchContext &Ctx,
                               const DenseSet<uint64_t> &DirectBranchTargets) {
   DenseMap<uint64_t, size_t> DecodedAt;
   for (size_t I = 0; I != Ctx.Decoded.size(); ++I)
     DecodedAt[Ctx.Decoded[I].Offset] = I;
-  DenseSet<uint64_t> Protected =
-      collectRelocationProtectedOffsets(Ctx.Decoded, Ctx.LS);
-  DenseSet<uint64_t> IndirectControlFlowFunctions =
-      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+
+  SmallVector<uint64_t, 16> SortedDirectTargets(DirectBranchTargets.begin(),
+                                                DirectBranchTargets.end());
+  llvm::sort(SortedDirectTargets);
+  auto HasTargetInRange = [&](uint64_t Begin, uint64_t End, bool IncludeBegin) {
+    auto It = llvm::lower_bound(SortedDirectTargets, Begin);
+    if (!IncludeBegin && It != SortedDirectTargets.end() && *It == Begin)
+      ++It;
+    return It != SortedDirectTargets.end() && *It < End;
+  };
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     if (Ctx.OutTrampolines[I].HasFunctionRange &&
-        IndirectControlFlowFunctions.contains(
+        Ctx.IndirectControlFlowFunctions.contains(
             Ctx.OutTrampolines[I].FunctionStart))
       continue;
     while (Ctx.OutTrampolines[I].Long &&
@@ -1068,6 +4550,8 @@ expandStraightLineTrampolines(PatchContext &Ctx,
         Trampoline &Next = Ctx.OutTrampolines[I + 1];
         if (!Next.Long || !Next.UsesSetPCBack ||
             Next.LongBranchSgprBase != T.LongBranchSgprBase ||
+            Next.LongBranchScratchIsSiteProven !=
+                T.LongBranchScratchIsSiteProven ||
             !T.HasFunctionRange || !Next.HasFunctionRange ||
             T.FunctionStart != Next.FunctionStart ||
             T.FunctionEnd != Next.FunctionEnd ||
@@ -1083,19 +4567,56 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       DenseMap<uint64_t, size_t>::const_iterator It = DecodedAt.find(*End);
       if (It == DecodedAt.end())
         break;
-      const InternalDecodedInst &Original = Ctx.Decoded[It->second];
-      std::optional<InternalDecodedInst> Current =
-          decodeCurrentInstruction(Ctx, Original);
-      if (!Current)
+      const InternalDecodedInst &OriginalDI = Ctx.Decoded[It->second];
+      std::optional<InternalDecodedInst> CurrentDI =
+          decodeCurrentRelocationCandidate(Ctx, OriginalDI);
+      if (!CurrentDI)
         break;
-      const InternalDecodedInst &DI = *Current;
+      const InternalDecodedInst &DI = *CurrentDI;
       std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
           Range->End != T.FunctionEnd ||
-          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected) ||
+          hasSiteReplacementReservation(Ctx, DI.Offset) ||
+          HasTargetInRange(DI.Offset, DI.Offset + DI.Size,
+                           /*IncludeBegin=*/true) ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS,
+                                        Ctx.RelocationProtectedOffsets) ||
+          DI.Offset > Ctx.TextSize || DI.Size > Ctx.TextSize - DI.Offset ||
           T.Bytes.size() < SetPcReturnReserveBytes)
         break;
+
+      if (T.LongBranchScratchIsSiteProven) {
+        // The original proof is tied to the old resume offset. Re-prove the
+        // chosen pair after every prospective moved instruction. The forward
+        // set-PC edge executes before the moved instruction, so also reject a
+        // semantic read of that pair. A pure definition is safe only when the
+        // new resume-point proof shows that its value is dead.
+        unsigned Pair = T.LongBranchSgprBase;
+        if (Pair == Gfx1250MaxSgprs) {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findVccLoHiPair(Ctx.LS);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs,
+                                               /*PairIsAbiVcc=*/true)
+                       : std::nullopt;
+          if (!Access || Access->Uses ||
+              !isVccPairDeadAfter(Ctx, DI.Offset, DI.Size))
+            break;
+        } else {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findNumberedSgprPair(Ctx.LS, Pair);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs)
+                       : std::nullopt;
+          std::optional<BitVector> SiteDead =
+              getSiteDeadNumberedSgprs(Ctx, DI.Offset, DI.Size);
+          if (!Access || Access->Uses || !SiteDead ||
+              Pair + 1 >= SiteDead->size() || !SiteDead->test(Pair) ||
+              !SiteDead->test(Pair + 1))
+            break;
+        }
+      }
 
       T.Bytes.insert(T.Bytes.end() - SetPcReturnReserveBytes,
                      Ctx.Text + DI.Offset, Ctx.Text + DI.Offset + DI.Size);
@@ -1105,20 +4626,29 @@ expandStraightLineTrampolines(PatchContext &Ctx,
     while (Ctx.OutTrampolines[I].Long &&
            Ctx.OutTrampolines[I].OriginalSize < SetPcForwardSequenceBytes) {
       Trampoline &T = Ctx.OutTrampolines[I];
+      // A target at the current window start may remain there, but prepending
+      // another instruction would turn it into an interior entry. The selected
+      // predecessor may itself be a target because it becomes the new start.
       if (DirectBranchTargets.contains(T.OriginalOffset))
         break;
       DenseMap<uint64_t, size_t>::const_iterator It =
           DecodedAt.find(T.OriginalOffset);
       if (It == DecodedAt.end() || It->second == 0)
         break;
-      const InternalDecodedInst &Original = Ctx.Decoded[It->second - 1];
-      std::optional<InternalDecodedInst> Current =
-          decodeCurrentInstruction(Ctx, Original);
-      if (!Current)
+      const InternalDecodedInst &OriginalDI = Ctx.Decoded[It->second - 1];
+      if (OriginalDI.Offset + OriginalDI.Size != T.OriginalOffset)
         break;
-      const InternalDecodedInst &DI = *Current;
+      std::optional<InternalDecodedInst> CurrentDI =
+          decodeCurrentRelocationCandidate(Ctx, OriginalDI);
+      if (!CurrentDI)
+        break;
+      const InternalDecodedInst &DI = *CurrentDI;
       if (DI.Offset + DI.Size != T.OriginalOffset ||
-          !isSafeStraightLineRelocation(DI, Ctx.LS, Protected))
+          hasSiteReplacementReservation(Ctx, DI.Offset) ||
+          HasTargetInRange(DI.Offset, DI.Offset + DI.Size,
+                           /*IncludeBegin=*/false) ||
+          !isSafeStraightLineRelocation(DI, Ctx.LS,
+                                        Ctx.RelocationProtectedOffsets))
         break;
       if (I != 0) {
         const Trampoline &Previous = Ctx.OutTrampolines[I - 1];
@@ -1128,8 +4658,36 @@ expandStraightLineTrampolines(PatchContext &Ctx,
       std::optional<ElfView::FunctionTextRange> Range =
           Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
       if (!Range || !T.HasFunctionRange || Range->Begin != T.FunctionStart ||
-          Range->End != T.FunctionEnd)
+          Range->End != T.FunctionEnd || DI.Offset > Ctx.TextSize ||
+          DI.Size > Ctx.TextSize - DI.Offset)
         break;
+
+      if (T.LongBranchScratchIsSiteProven) {
+        // Growing backward leaves the resume point unchanged, so the original
+        // dead-after-resume proof remains valid. The new forward set-PC edge
+        // clobbers the pair before the prepended instruction executes, so the
+        // instruction may define the pair but must not read its old value.
+        unsigned Pair = T.LongBranchSgprBase;
+        if (Pair == Gfx1250MaxSgprs) {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findVccLoHiPair(Ctx.LS);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs,
+                                               /*PairIsAbiVcc=*/true)
+                       : std::nullopt;
+          if (!Access || Access->Uses)
+            break;
+        } else {
+          std::optional<std::array<MCRegister, 2>> PairRegs =
+              findNumberedSgprPair(Ctx.LS, Pair);
+          std::optional<RegisterPairAccess> Access =
+              PairRegs ? getRegisterPairAccess(Ctx.LS, DI, *PairRegs)
+                       : std::nullopt;
+          if (!Access || Access->Uses)
+            break;
+        }
+      }
+
       T.Bytes.insert(T.Bytes.begin(), Ctx.Text + DI.Offset,
                      Ctx.Text + DI.Offset + DI.Size);
       T.OriginalOffset = DI.Offset;
@@ -1140,39 +4698,105 @@ expandStraightLineTrampolines(PatchContext &Ctx,
 
 static bool hasNoFallthrough(const InternalDecodedInst &DI,
                              const LLVMState &LS) {
-  return isEndProgram(DI, LS) ||
-         (LS.MIA &&
-          (LS.MIA->isUnconditionalBranch(DI.Inst) ||
-           LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst) ||
-           LS.MIA->isBarrier(DI.Inst)));
+  if (DI.Mnemonic == "s_code_end" || DI.Mnemonic == "s_endpgm" ||
+      DI.Mnemonic == "s_endpgm_saved")
+    return true;
+  if (!LS.MIA || LS.MIA->isCall(DI.Inst))
+    return false;
+  if (LS.MIA->isUnconditionalBranch(DI.Inst) &&
+      !LS.MIA->isIndirectBranch(DI.Inst))
+    return true;
+  return DI.Inst.getOpcode() == LS.SSetPcI64Opcode;
 }
 
 static void appendGatewaySled(std::vector<NopSled> &Sleds, uint64_t Start,
                               uint64_t End, uint64_t TextSize, bool Safe,
                               bool HasTarget) {
   if (Safe && !HasTarget && End - Start >= MinInstSize)
-    Sleds.push_back({Start, End, Start, 0, TextSize});
+    Sleds.push_back({Start, End, Start, 0, TextSize,
+                     /*GatewayOnly=*/true});
+}
+
+static std::optional<DenseSet<uint64_t>>
+collectCodeObjectEntryOffsets(const ElfView &Elf, uint64_t TextSize) {
+  if (!Elf.kernelDescriptorCacheIsComplete()) {
+    log() << "hotswap: incomplete kernel descriptor set prevents complete "
+             "code-entry discovery\n";
+    return std::nullopt;
+  }
+
+  DenseSet<uint64_t> Entries;
+  const uint64_t TextAddr = Elf.textAddr();
+
+  // A zero-filled function body is indistinguishable from alignment padding
+  // to the decoder. Preserve every callable symbol entry, including aliases
+  // and zero-sized functions, independently of whether direct control flow in
+  // this object names it.
+  for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges()) {
+    if (Range.Begin >= TextAddr && Range.Begin - TextAddr < TextSize)
+      Entries.insert(Range.Begin - TextAddr);
+  }
+
+  // Kernel descriptors may name an entry that has no STT_FUNC symbol. The
+  // signed entry offset is relative to the descriptor address.
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    uint64_t Entry = 0;
+    if (KD.EntryOffset >= 0) {
+      uint64_t Delta = static_cast<uint64_t>(KD.EntryOffset);
+      if (Delta > std::numeric_limits<uint64_t>::max() - KD.VAddr)
+        continue;
+      Entry = KD.VAddr + Delta;
+    } else {
+      uint64_t Magnitude =
+          KD.EntryOffset == std::numeric_limits<int64_t>::min()
+              ? static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1
+              : static_cast<uint64_t>(-KD.EntryOffset);
+      if (Magnitude > KD.VAddr)
+        continue;
+      Entry = KD.VAddr - Magnitude;
+    }
+    if (Entry >= TextAddr && Entry - TextAddr < TextSize)
+      Entries.insert(Entry - TextAddr);
+  }
+  return Entries;
 }
 
 /// Find zero-filled alignment holes, including holes covered by an oversized
 /// function symbol, and s_nop padding outside every function. Such padding is
 /// a safe branch gateway only when it follows a no-fallthrough instruction and
-/// contains no direct branch/call target. In-function s_nop runs are added from
-/// Ctx.NopSleds separately.
+/// contains no known control-flow target or callable entry. Body-owned
+/// s_nop runs are excluded so one physical range never has two allocation
+/// cursors.
 static std::vector<NopSled>
 buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
                           const LLVMState &LS, const ElfView &Elf,
                           ArrayRef<uint8_t> Text,
-                          const DenseSet<uint64_t> &DirectBranchTargets) {
+                          const DenseSet<uint64_t> &DirectBranchTargets,
+                          ArrayRef<uint64_t> TextSymbolOffsets,
+                          ArrayRef<ElfView::TextOffsetRange> TextSymbolExtents,
+                          ArrayRef<NopSled> OwnedSleds) {
   std::vector<NopSled> Sleds;
+  SmallVector<uint64_t, 16> ProtectedEntries(DirectBranchTargets.begin(),
+                                             DirectBranchTargets.end());
+  llvm::sort(ProtectedEntries);
+  ProtectedEntries.erase(
+      std::unique(ProtectedEntries.begin(), ProtectedEntries.end()),
+      ProtectedEntries.end());
+
   const InternalDecodedInst *Previous = nullptr;
   bool Active = false;
   bool Safe = false;
   bool HasTarget = false;
   uint64_t Start = 0;
   uint64_t End = 0;
-
+  size_t OwnedIndex = 0;
   for (const InternalDecodedInst &DI : Decoded) {
+    while (OwnedIndex != OwnedSleds.size() &&
+           OwnedSleds[OwnedIndex].End <= DI.Offset)
+      ++OwnedIndex;
+    const bool BodyOwned = OwnedIndex != OwnedSleds.size() &&
+                           OwnedSleds[OwnedIndex].Start <= DI.Offset &&
+                           DI.Offset < OwnedSleds[OwnedIndex].End;
     bool ZeroPadding =
         DI.Offset <= Text.size() && DI.Size <= Text.size() - DI.Offset;
     if (ZeroPadding)
@@ -1180,7 +4804,7 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
         ZeroPadding &= Byte == 0;
     bool IsExternalNop = DI.Inst.getOpcode() == LS.SNopOpcode &&
                          !Elf.findFunctionTextRangeAtOffset(DI.Offset);
-    bool GatewayPadding = ZeroPadding || IsExternalNop;
+    bool GatewayPadding = !BodyOwned && (ZeroPadding || IsExternalNop);
     if (!GatewayPadding || (Active && DI.Offset != End)) {
       if (Active)
         appendGatewaySled(Sleds, Start, End, Text.size(), Safe, HasTarget);
@@ -1196,7 +4820,18 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
       Safe = Previous && hasNoFallthrough(*Previous, LS);
       HasTarget = false;
     }
-    HasTarget |= DirectBranchTargets.contains(DI.Offset);
+    auto Entry = llvm::lower_bound(ProtectedEntries, DI.Offset);
+    const bool HasHardEntry =
+        Entry != ProtectedEntries.end() && *Entry - DI.Offset < DI.Size;
+    auto Symbol = llvm::lower_bound(TextSymbolOffsets, DI.Offset);
+    const bool HasSymbol =
+        Symbol != TextSymbolOffsets.end() && *Symbol - DI.Offset < DI.Size;
+    const bool HasSymbolExtent =
+        overlapsTextSymbolExtent(TextSymbolExtents, DI);
+    // External gateways are donor storage, so even an exact-start symbol
+    // blocks the range. Only an original replacement source may preserve such
+    // an alias while changing the bytes at that same address.
+    HasTarget |= HasHardEntry || HasSymbol || HasSymbolExtent;
     End = DI.Offset + DI.Size;
   }
   if (Active)
@@ -1204,86 +4839,13 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
-enum class SccScanResult {
-  Unresolved,
-  Used,
-  Defined,
-};
-
-static SccScanResult scanSccInstruction(const InternalDecodedInst &DI,
-                                        const LLVMState &LS, MCRegister SCC) {
-  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
-  if (Desc.hasImplicitUseOfPhysReg(SCC))
-    return SccScanResult::Used;
-  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
-  for (unsigned I = DefCount; I != DI.Inst.getNumOperands(); ++I) {
-    const MCOperand &Op = DI.Inst.getOperand(I);
-    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
-      return SccScanResult::Used;
-  }
-
-  if (Desc.hasImplicitDefOfPhysReg(SCC, LS.MRI.get()))
-    return SccScanResult::Defined;
-  for (unsigned I = 0; I != DefCount; ++I) {
-    const MCOperand &Op = DI.Inst.getOperand(I);
-    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
-      return SccScanResult::Defined;
-  }
-  return SccScanResult::Unresolved;
-}
-
-/// Prove that clobbering SCC on the forward edge cannot affect the replacement
-/// body or its continuation. Stop conservatively at unresolved control flow.
-static bool isIncomingSccDead(const PatchContext &Ctx, const Trampoline &T) {
-  MCRegister SCC = Ctx.LS.SCCRegister;
-  uint64_t TrailingBytes = SetPcReturnReserveBytes +
-                           (T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0);
-  if (!SCC || T.Bytes.size() < TrailingBytes)
-    return false;
-
-  uint64_t BodySize = T.Bytes.size() - TrailingBytes;
-  std::vector<InternalDecodedInst> Body;
-  if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body))
-    return false;
-  for (const InternalDecodedInst &DI : Body) {
-    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
-    if (Result == SccScanResult::Used)
-      return false;
-    if (Result == SccScanResult::Defined)
-      return true;
-    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
-      return false;
-  }
-
-  std::optional<uint64_t> End = checkedAddUint64(
-      T.OriginalOffset, T.OriginalSize, "SCC-dead continuation start");
-  if (!End)
-    return false;
-  for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (DI.Offset < *End)
-      continue;
-    if (T.HasFunctionRange && DI.Offset >= T.FunctionEnd)
-      break;
-    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
-    if (Result == SccScanResult::Used)
-      return false;
-    if (Result == SccScanResult::Defined)
-      return true;
-    if (isEndProgram(DI, Ctx.LS))
-      return true;
-    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
-      return false;
-  }
-  return true;
-}
-
 static uint64_t countReachableGatewaySlots(ArrayRef<NopSled> Gateways,
                                            uint64_t Offset, uint64_t Needed) {
   uint64_t Slots = 0;
   for (const NopSled &Sled : Gateways) {
-    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+    if (!Sled.canGatewayFrom(Offset))
       continue;
-    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    uint64_t UsableEnd = Sled.End;
     if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
       continue;
     uint64_t Distance = Sled.WritePos > Offset ? Sled.WritePos - Offset
@@ -1312,10 +4874,9 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
     uint64_t BestOffset = 0;
     for (size_t I = 0; I != Gateways.size(); ++I) {
       NopSled &Sled = Gateways[I];
-      if (UsedSleds.contains(I) || FromOffset < Sled.FunctionStart ||
-          FromOffset >= Sled.FunctionEnd)
+      if (UsedSleds.contains(I) || !Sled.canGatewayFrom(FromOffset))
         continue;
-      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      uint64_t UsableEnd = Sled.End;
       if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
           Sled.WritePos > UsableEnd ||
           MinInstSize > UsableEnd - Sled.WritePos ||
@@ -1345,14 +4906,11 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   return Islands;
 }
 
-static bool
-assignLongBranchGateways(PatchContext &Ctx,
-                         const DenseSet<uint64_t> &DirectBranchTargets) {
-  std::vector<NopSled> Gateways = buildExternalGatewaySleds(
-      Ctx.Decoded, Ctx.LS, Ctx.Elf, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize),
-      DirectBranchTargets);
-  for (const NopSled &Sled : Ctx.NopSleds)
-    Gateways.push_back(Sled);
+static bool assignLongBranchGateways(PatchContext &Ctx) {
+  // This is a snapshot of the one padding map built before any rewrite. It
+  // preserves every allocation already made by direct sled emission and never
+  // reinterprets the stale decoded stream after Ctx.Text has been modified.
+  std::vector<NopSled> Gateways = Ctx.NopSleds;
 
   DenseMap<uint64_t, size_t> PoolIslandOwners;
   uint64_t IslandLayoutOffset = Ctx.PoolBaseOffset;
@@ -1368,7 +4926,8 @@ assignLongBranchGateways(PatchContext &Ctx,
       Gateways.push_back({T.PoolBranchIslandOffset,
                           T.PoolBranchIslandOffset + PoolBranchIslandBytes,
                           T.PoolBranchIslandOffset, 0,
-                          std::numeric_limits<uint64_t>::max()});
+                          std::numeric_limits<uint64_t>::max(),
+                          /*GatewayOnly=*/true});
     }
     IslandLayoutOffset = *Next;
   }
@@ -1376,7 +4935,6 @@ assignLongBranchGateways(PatchContext &Ctx,
   struct PendingGateway {
     size_t TrampolineIndex = 0;
     uint64_t TargetOffset = 0;
-    bool IncomingSccDead = false;
     uint64_t NeededBytes = 0;
     uint64_t InitialCandidateSlots = 0;
   };
@@ -1397,28 +4955,16 @@ assignLongBranchGateways(PatchContext &Ctx,
       T.UsesShortBranchForward = true;
       continue;
     }
-    bool IncomingSccDead = isIncomingSccDead(Ctx, T);
-    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+    SmallVector<uint8_t> Direct = encodeSetPCLongBranch(
         Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
-    if (Direct && Direct->size() <= T.OriginalSize) {
+    if (!Direct.empty() && Direct.size() <= T.OriginalSize) {
       T.UsesDirectSetPCForward = true;
-      T.DirectSetPCForwardBytes = std::move(*Direct);
+      T.DirectSetPCForwardBytes = std::move(Direct);
       continue;
     }
-    if (IncomingSccDead) {
-      Direct = encodeSetPCLongBranchClobberSCC(Ctx.LS, T.OriginalOffset, TP,
-                                               T.LongBranchSgprBase);
-      if (Direct && Direct->size() <= T.OriginalSize) {
-        T.UsesDirectSetPCForward = true;
-        T.DirectSetPCForwardBytes = std::move(*Direct);
-        continue;
-      }
-    }
-
-    uint64_t Needed =
-        IncomingSccDead ? SetPcMinGatewayBytes : SetPcForwardSequenceBytes;
+    uint64_t Needed = SetPcForwardSequenceBytes;
     Pending.push_back(
-        {I, TP, IncomingSccDead, Needed,
+        {I, TP, Needed,
          countReachableGatewaySlots(Gateways, T.OriginalOffset, Needed)});
   }
 
@@ -1440,9 +4986,6 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
   Pending = std::move(StillPending);
 
-  // Allocate SCC-preserving gateways first. They need more contiguous bytes
-  // and have fewer placement options; SCC-dead gateways can fill the remaining
-  // 20-byte fragments afterward.
   std::stable_sort(Pending.begin(), Pending.end(),
                    [](const PendingGateway &LHS, const PendingGateway &RHS) {
                      if (LHS.NeededBytes != RHS.NeededBytes)
@@ -1451,11 +4994,11 @@ assignLongBranchGateways(PatchContext &Ctx,
                             RHS.InitialCandidateSlots;
                    });
 
-  uint64_t PreservingGateways = 0;
-  uint64_t SccDeadGateways = 0;
+  uint64_t AssignedGateways = 0;
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    NopSled *Sled = findNearestSled(Gateways, T.OriginalOffset, P.NeededBytes);
+    NopSled *Sled = findNearestSled(Gateways, T.OriginalOffset, P.NeededBytes,
+                                    NopSledUse::Gateway);
     if (!Sled ||
         Ctx.LS.encodeSBranch(T.OriginalOffset, Sled->WritePos).empty()) {
       log() << "hotswap: error: no safe short-branch gateway for far site 0x"
@@ -1463,46 +5006,30 @@ assignLongBranchGateways(PatchContext &Ctx,
             << " initial candidate slot(s))\n";
       return false;
     }
-    std::optional<SmallVector<uint8_t>> Gateway =
-        P.IncomingSccDead
-            ? encodeSetPCLongBranchClobberSCC(
-                  Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase)
-            : encodeSetPCLongBranch(Ctx.LS, Sled->WritePos, P.TargetOffset,
-                                    T.LongBranchSgprBase);
-    if (!Gateway || Gateway->size() > P.NeededBytes) {
+    SmallVector<uint8_t> Gateway = encodeSetPCLongBranch(
+        Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase);
+    if (Gateway.empty() || Gateway.size() > P.NeededBytes) {
       log() << "hotswap: error: failed to encode far-site gateway at 0x"
             << utohexstr(Sled->WritePos) << "\n";
       return false;
     }
     T.HasForwardGateway = true;
     T.ForwardGatewayOffset = Sled->WritePos;
-    T.ForwardGatewayBytes = std::move(*Gateway);
+    T.ForwardGatewayBytes = std::move(Gateway);
     Sled->WritePos += T.ForwardGatewayBytes.size();
-    if (P.IncomingSccDead)
-      ++SccDeadGateways;
-    else
-      ++PreservingGateways;
+    ++AssignedGateways;
   }
   if (!Pending.empty())
-    log() << "hotswap: assigned " << PreservingGateways
-          << " SCC-preserving and " << SccDeadGateways
-          << " SCC-dead forward gateway(s)\n";
+    log() << "hotswap: assigned " << AssignedGateways
+          << " SCC-neutral forward gateway(s)\n";
   if (BranchIslandChains != 0)
     log() << "hotswap: assigned " << BranchIslandChains
           << " forward s_branch island chain(s)\n";
 
   for (Trampoline &T : Ctx.OutTrampolines) {
-    if (T.HasForwardGateway) {
-      if (T.ForwardGatewayOffset > Ctx.TextSize ||
-          T.ForwardGatewayBytes.size() >
-              Ctx.TextSize - T.ForwardGatewayOffset) {
-        log() << "hotswap: error: forward gateway at 0x"
-              << utohexstr(T.ForwardGatewayOffset) << " extends past .text.\n";
-        return false;
-      }
+    if (T.HasForwardGateway)
       std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
                   T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
-    }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
       uint64_t From = T.ForwardBranchIslands[I];
       uint64_t To = I + 1 == T.ForwardBranchIslands.size()
@@ -1539,9 +5066,19 @@ assignLongBranchGateways(PatchContext &Ctx,
 /// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
 /// reachable sled with sufficient headroom exists; otherwise falls back to a
 /// deferred trampoline.
-[[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
-                                       uint32_t InstSize,
-                                       ArrayRef<uint8_t> Replacement) {
+static bool emitReplacementCodeRaw(PatchContext &Ctx, uint64_t InstOffset,
+                                   uint32_t InstSize,
+                                   ArrayRef<uint8_t> Replacement,
+                                   ReplacementPlacement Placement,
+                                   bool DiagnoseFailure) {
+  const bool AllowGlobalBody = Placement != ReplacementPlacement::Default;
+  if (Ctx.RelocationProtectedOffsets.contains(InstOffset)) {
+    if (DiagnoseFailure)
+      log() << "hotswap: error: replacement source at 0x"
+            << utohexstr(InstOffset) << " is relocation-protected\n";
+    return false;
+  }
+
   std::optional<uint64_t> ReturnTo = checkedAddUint64(
       InstOffset, InstSize, "replacement trampoline return target");
   std::optional<uint64_t> PoolReturnFrom =
@@ -1549,6 +5086,23 @@ assignLongBranchGateways(PatchContext &Ctx,
                        "replacement trampoline return slot");
   if (!ReturnTo || !PoolReturnFrom)
     return false;
+
+  // The address at the start remains a valid alias for the replacement or
+  // redirect, and the end is outside the rewritten half-open interval. Any
+  // entry strictly inside would instead land in a moved instruction, branch
+  // tail, or padding, so every patch family must reject the complete window.
+  if (Ctx.DirectControlFlowTargets && *ReturnTo > InstOffset) {
+    uint64_t Offset = InstOffset;
+    while (++Offset < *ReturnTo)
+      if (Ctx.DirectControlFlowTargets->contains(Offset)) {
+        if (DiagnoseFailure)
+          log() << "hotswap: error: replacement source [0x"
+                << utohexstr(InstOffset) << ", 0x" << utohexstr(*ReturnTo)
+                << ") contains protected interior entry 0x" << utohexstr(Offset)
+                << "\n";
+        return false;
+      }
+  }
 
   // When the pool base is already out of short-branch reach, defer every site
   // to the global trampoline pass. That pass can coalesce adjacent patches
@@ -1560,16 +5114,37 @@ assignLongBranchGateways(PatchContext &Ctx,
     // findNearestSled enforces sled headroom. emitToNopSled still validates
     // exact branch reachability because branch-back distance includes the
     // replacement size, not just the original instruction offset.
-    uint64_t Needed = Replacement.size() + MinInstSize;
-    if (NopSled *Sled = findNearestSled(Ctx.NopSleds, InstOffset, Needed)) {
-      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement))
+    uint64_t Needed = getNopSledBytesNeeded(Ctx, InstOffset, InstSize,
+                                            Replacement, Placement);
+    NopSledUse SledUse =
+        AllowGlobalBody ? NopSledUse::RelocationBody : NopSledUse::OwnerBody;
+    if (NopSled *Sled =
+            findNearestSled(Ctx.NopSleds, InstOffset, Needed, SledUse)) {
+      if (emitToNopSled(Ctx, *Sled, InstOffset, InstSize, Replacement,
+                        Placement))
         return true;
       log() << "hotswap: emitReplacementCode: NOP sled at offset 0x"
             << utohexstr(Sled->WritePos)
             << " is not branch-reachable after assembly; using trampoline.\n";
     }
   }
-  return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+  return emitToTrampolineRaw(Ctx, InstOffset, InstSize, Replacement, Placement,
+                             DiagnoseFailure);
+}
+
+[[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
+                                       uint32_t InstSize,
+                                       ArrayRef<uint8_t> Replacement,
+                                       ReplacementPlacement Placement,
+                                       bool DiagnoseFailure) {
+  std::optional<PreparedSiteReplacement> Prepared = prepareSiteReplacement(
+      Ctx, InstOffset, InstSize, Replacement, DiagnoseFailure);
+  if (!Prepared)
+    return false;
+  if (!emitReplacementCodeRaw(Ctx, InstOffset, InstSize, Prepared->Bytes,
+                              Placement, DiagnoseFailure))
+    return false;
+  return commitSiteReplacement(Ctx, InstOffset, InstSize, *Prepared);
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -1605,7 +5180,67 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     std::vector<ScratchPatchInfo> &OutScratchPatches,
     const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
   uint32_t Patched = 0;
-  std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
+  std::optional<DenseSet<uint64_t>> CodeEntries =
+      collectCodeObjectEntryOffsets(Elf, TextSize);
+  std::optional<std::vector<uint64_t>> TextSymbolOffsets =
+      Elf.textSymbolOffsets();
+  std::optional<std::vector<ElfView::TextOffsetRange>> TextSymbolExtents =
+      Elf.textSymbolExtents();
+  std::optional<DenseSet<uint64_t>> DirectControlFlowTargets;
+  if (CodeEntries && TextSymbolOffsets && TextSymbolExtents)
+    DirectControlFlowTargets = collectDirectBranchTargets(
+        Decoded, LS, ArrayRef<uint8_t>(Text, TextSize), Elf, *CodeEntries,
+        *TextSymbolOffsets, *TextSymbolExtents);
+  DenseSet<uint64_t> EmptyTargets;
+  const DenseSet<uint64_t> &KnownDirectTargets =
+      DirectControlFlowTargets ? *DirectControlFlowTargets : EmptyTargets;
+  const std::optional<ArrayRef<uint64_t>> OptionalTextSymbolOffsets =
+      TextSymbolOffsets ? std::optional<ArrayRef<uint64_t>>(*TextSymbolOffsets)
+                        : std::nullopt;
+  const std::optional<ArrayRef<ElfView::TextOffsetRange>>
+      OptionalTextSymbolExtents =
+          TextSymbolExtents ? std::optional<ArrayRef<ElfView::TextOffsetRange>>(
+                                  *TextSymbolExtents)
+                            : std::nullopt;
+  const ArrayRef<uint8_t> TextBytes(Text, TextSize);
+  const bool HasUnresolvedStandardLinkCall =
+      DirectControlFlowTargets
+          ? hasUnresolvedStandardLinkCall(Decoded, LS, Elf, KnownDirectTargets,
+                                          TextBytes, OptionalTextSymbolOffsets,
+                                          OptionalTextSymbolExtents)
+          : llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+              return isStandardLinkCall(DI, LS);
+            });
+  DenseSet<uint64_t> ProvenDirectCallReturns;
+  if (DirectControlFlowTargets && TextSymbolOffsets && TextSymbolExtents)
+    ProvenDirectCallReturns = collectProvenDirectCallReturns(
+        Decoded, LS, Elf, KnownDirectTargets, TextBytes,
+        OptionalTextSymbolOffsets, OptionalTextSymbolExtents,
+        HasUnresolvedStandardLinkCall);
+  bool HasUnknownArbitraryIndirectTarget = false;
+  DenseSet<uint64_t> IndirectControlFlowFunctions =
+      collectIndirectControlFlowFunctions(
+          Decoded, LS, Elf, KnownDirectTargets, TextBytes,
+          OptionalTextSymbolOffsets, OptionalTextSymbolExtents,
+          ProvenDirectCallReturns, HasUnknownArbitraryIndirectTarget);
+  if (!DirectControlFlowTargets)
+    for (const ElfView::FunctionTextRange &Range : Elf.functionTextRanges())
+      if (Range.Begin >= Elf.textAddr())
+        IndirectControlFlowFunctions.insert(Range.Begin - Elf.textAddr());
+  std::vector<NopSled> Sleds;
+  if (DirectControlFlowTargets && TextSymbolOffsets && TextSymbolExtents &&
+      !HasUnknownArbitraryIndirectTarget) {
+    Sleds = buildNopSledMap(Decoded, LS, Elf, KnownDirectTargets,
+                            IndirectControlFlowFunctions, *TextSymbolOffsets,
+                            *TextSymbolExtents);
+    std::vector<NopSled> ExternalSleds = buildExternalGatewaySleds(
+        Decoded, LS, Elf, ArrayRef<uint8_t>(Text, TextSize), KnownDirectTargets,
+        *TextSymbolOffsets, *TextSymbolExtents, Sleds);
+    Sleds.insert(Sleds.end(), ExternalSleds.begin(), ExternalSleds.end());
+  } else {
+    log() << "hotswap: incomplete control-flow targets disable NOP padding "
+             "donation\n";
+  }
 
   CFG Cfg = buildCfg(Decoded, *LS.MCII);
   LivenessInfo Liveness =
@@ -1622,6 +5257,64 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     }
   }
 
+  TensorDescriptorMustAnalysis TensorDescriptorAnalysis;
+  InitialVmemMustAnalysis InitialVmemAnalysis;
+  const bool HasClause =
+      Config.RunB0A0Patches &&
+      llvm::any_of(Decoded, [](const InternalDecodedInst &DI) {
+        return DI.Mnemonic == "s_clause";
+      });
+  const bool HasTensorLoad =
+      llvm::any_of(Decoded, [](const InternalDecodedInst &DI) {
+        return DI.Mnemonic == "tensor_load_to_lds";
+      });
+  std::vector<InternalDecodedInst> HotswapAnalysisDecoded;
+  if ((HasClause || HasTensorLoad) &&
+      !buildHotswapAnalysisDecoded(Elf, LS, Decoded, HotswapAnalysisDecoded))
+    return std::nullopt;
+  OriginalIngressInfo OriginalIngress;
+  if (HasClause || HasTensorLoad)
+    OriginalIngress = collectOriginalIngress(
+        Decoded, KnownDirectTargets, ArrayRef<uint8_t>(Text, TextSize), LS, Elf,
+        TextSymbolOffsets
+            ? std::optional<ArrayRef<uint64_t>>(*TextSymbolOffsets)
+            : std::nullopt,
+        TextSymbolExtents ? std::optional<ArrayRef<ElfView::TextOffsetRange>>(
+                                *TextSymbolExtents)
+                          : std::nullopt);
+  if (HasClause) {
+    std::vector<KernelTextRange> KernelRanges = collectKernelTextRanges(
+        Elf, LS, OriginalIngress.ControlFlowEdges,
+        HasUnknownArbitraryIndirectTarget, HasUnresolvedStandardLinkCall);
+    InitialVmemAnalysis = computeInitialVmemMustAnalysis(
+        Decoded, HotswapAnalysisDecoded, KernelRanges, LS);
+  }
+  if (HasTensorLoad) {
+    const bool TensorHasUnknownOwnedInstruction =
+        llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+          return DI.Mnemonic == "<unknown>" &&
+                 Elf.findFunctionTextRangeAtOffset(DI.Offset).has_value();
+        });
+    const bool TensorHasTrapOrRfe =
+        llvm::any_of(Decoded, [&](const InternalDecodedInst &DI) {
+          return StringRef(DI.Mnemonic).starts_with("s_rfe") ||
+                 StringRef(DI.Mnemonic).starts_with("s_trap") ||
+                 (LS.MCII && LS.MCII->get(DI.Inst.getOpcode()).isTrap());
+        });
+    std::vector<TensorAnalysisRange> TensorRanges;
+    if (CodeEntries && DirectControlFlowTargets)
+      TensorRanges = collectTensorAnalysisRanges(
+          Elf, LS, *CodeEntries, IndirectControlFlowFunctions,
+          OriginalIngress.CrossRangeEntryFunctions,
+          OriginalIngress.ExternalEntries, OriginalIngress.ControlFlowEdges,
+          HasUnknownArbitraryIndirectTarget ||
+              TensorHasUnknownOwnedInstruction ||
+              HasUnresolvedStandardLinkCall || TensorHasTrapOrRfe);
+    TensorDescriptorAnalysis = computeTensorDescriptorMustAnalysis(
+        Decoded, HotswapAnalysisDecoded, TensorRanges, LS, KnownDirectTargets,
+        Config.MaxSgprs, Config.MaxVgprs);
+  }
+
   StringMap<KernelPatchStats> KernelStats;
   // Pool base as a .text-relative offset for trampoline branch math. The pool
   // is always >= textAddr(); checkedSubUint64 guards a malformed object.
@@ -1636,8 +5329,50 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
                    TextSize,       *PoolBaseOffset, LS,
                    OutTrampolines, Sleds,           Elf,
                    Liveness,       KernelStats,     OutScratchPatches};
+  Ctx.InitialVmemAnalysis = &InitialVmemAnalysis;
+  Ctx.TensorDescriptorAnalysis = &TensorDescriptorAnalysis;
+  for (const InternalDecodedInst &DI : Decoded)
+    Ctx.MaxDecodedInstSize = std::max(Ctx.MaxDecodedInstSize, DI.Size);
+  Ctx.DirectControlFlowTargets = DirectControlFlowTargets;
+  if (TextSymbolExtents)
+    Ctx.TextSymbolExtents = *TextSymbolExtents;
+  Ctx.IndirectControlFlowFunctions = std::move(IndirectControlFlowFunctions);
+  Ctx.HasUnknownArbitraryIndirectTarget = HasUnknownArbitraryIndirectTarget;
+  if (Ctx.DirectControlFlowTargets && !Ctx.HasUnknownArbitraryIndirectTarget)
+    Ctx.VgprMsbDstSrc0EqualBefore = computeVgprMsbDstSrc0Equality(
+        Decoded, LS, Elf, *DirectControlFlowTargets, *CodeEntries,
+        Ctx.IndirectControlFlowFunctions, ArrayRef<uint8_t>(Text, TextSize),
+        Ctx.VgprDef0AlignedTo8, Ctx.VgprDef1AlignedTo8, Ctx.VgprMsbDstBefore,
+        Ctx.VgprMsbSrc0Before, Ctx.VgprMsbModeBefore,
+        Ctx.CrossFunctionInteriorEntryFunctions);
+  collectRelocationProtectedOffsets(Decoded, Ctx);
+
+  // Patch placement needs a conservative entry-boundary set, not just the
+  // edges used to build the CFG. Keep ordinary symbols out of control-flow
+  // analysis, then include them here so moving a source window can never
+  // swallow an addressable interior boundary.
+  if (Ctx.DirectControlFlowTargets && TextSymbolOffsets)
+    Ctx.DirectControlFlowTargets->insert(TextSymbolOffsets->begin(),
+                                         TextSymbolOffsets->end());
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
+  // Whole-function requirements must be discovered from the immutable stream
+  // before any same-size or relocating pass mutates the source bytes. Their
+  // reserved sites then participate in every atomic-window ownership check.
+  if (Config.RunB0A0Patches && VT.precomputeWmmaHazards &&
+      !VT.precomputeWmmaHazards(Ctx))
+    return std::nullopt;
+
+  precomputeDs2AddressAlignment(Ctx);
+  precomputeSiteDeadSgprFacts(Ctx);
+
+  // VOP3PX2 is a same-size bit-field correction. Apply it before any atomic
+  // source-window relocation so those windows copy already-correct current
+  // bytes rather than forcing a later overlapping rewrite.
+  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix)
+    Patched += VT.applyVop3px2Src2Fix(Ctx);
+  if (Ctx.RequiredPatchFailed)
+    return std::nullopt;
 
   // Skip undecoded slots produced by the decoder for bytes it could not
   // classify as a valid instruction; the dispatcher has nothing to match
@@ -1657,7 +5392,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
 
   for (size_t Idx = 0, E = Decoded.size(); Idx < E; ++Idx) {
     const InternalDecodedInst &DI = Decoded[Idx];
-    if (DI.Mnemonic == UnknownMnemonic)
+    if (DI.Mnemonic == UnknownMnemonic ||
+        Ctx.ClaimedReplacementOffsets.contains(DI.Offset))
       continue;
 
     for (PerInstPatchFn Fn : PerInstPasses) {
@@ -1671,32 +5407,32 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     }
   }
 
-  // Whole-kernel passes below run after per-instruction patches. Earlier
-  // passes may have modified Text bytes, but the Decoded stream still holds
-  // the original MCInst/Mnemonic/Offset entries. This is safe because:
-  //  - In-place patches only change opcodes within the same encoding size,
-  //    preserving instruction boundaries and offsets.
-  //  - Trampoline patches replace the original instruction with a branch
-  //    (same size), so the Decoded entry's Offset still points at the
-  //    branch site; the WMMA classifier and VOP3PX2 mnemonic match won't
-  //    treat a branch as WMMA/VALU/VOP3PX2.
-  // If a future patch family changes instruction boundaries, the Decoded
-  // stream must be rebuilt before these passes run.
+  // Finalize requirements that no ordinary per-instruction owner composed.
+  // The hazard pass copies current post-in-place bytes for those sites; it
+  // never rebuilds a replacement from stale MCInst state.
   if (Config.RunB0A0Patches && VT.applyWmmaHazardPatch)
     Patched += VT.applyWmmaHazardPatch(Ctx);
-  if (Config.RunB0A0Patches && VT.applyVop3px2Src2Fix)
-    Patched += VT.applyVop3px2Src2Fix(Ctx);
+  if (Ctx.RequiredPatchFailed)
+    return std::nullopt;
 
   if (!OutTrampolines.empty()) {
-    std::optional<DenseSet<uint64_t>> DirectBranchTargets =
-        collectDirectBranchTargets(Decoded, LS);
-    if (!DirectBranchTargets)
+    if (!Ctx.DirectControlFlowTargets)
       return std::nullopt;
-    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
-    expandStraightLineTrampolines(Ctx, *DirectBranchTargets);
-    mergeAdjacentLongTrampolines(OutTrampolines, *DirectBranchTargets);
+    // Whole-function passes append after the per-instruction walk and can
+    // therefore add an earlier site at the end of this vector. Neighbor-based
+    // coalescing and source growth require address order, independent of which
+    // patch family discovered each site.
+    llvm::stable_sort(OutTrampolines,
+                      [](const Trampoline &LHS, const Trampoline &RHS) {
+                        return LHS.OriginalOffset < RHS.OriginalOffset;
+                      });
+    mergeAdjacentLongTrampolines(OutTrampolines, *Ctx.DirectControlFlowTargets,
+                                 Ctx.IndirectControlFlowFunctions);
+    expandStraightLineTrampolines(Ctx, *Ctx.DirectControlFlowTargets);
+    mergeAdjacentLongTrampolines(OutTrampolines, *Ctx.DirectControlFlowTargets,
+                                 Ctx.IndirectControlFlowFunctions);
     appendPoolBranchIslands(OutTrampolines);
-    if (!assignLongBranchGateways(Ctx, *DirectBranchTargets))
+    if (!assignLongBranchGateways(Ctx))
       return std::nullopt;
   }
 
@@ -1817,22 +5553,17 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
     if (!ReturnTo)
       return false;
 
-    std::optional<SmallVector<uint8_t>> BrBack;
-    if (T.UsesSetPCBack) {
-      BrBack =
-          encodeSetPCLongBranch(LS, BackSlot, *ReturnTo, T.LongBranchSgprBase);
-    } else {
-      SmallVector<uint8_t> ShortBranch = LS.encodeSBranch(BackSlot, *ReturnTo);
-      if (!ShortBranch.empty())
-        BrBack = std::move(ShortBranch);
-    }
-    if (!BrBack || BrBack->size() > BackReserve) {
+    SmallVector<uint8_t> BrBack =
+        T.UsesSetPCBack ? encodeSetPCLongBranch(LS, BackSlot, *ReturnTo,
+                                                T.LongBranchSgprBase)
+                        : LS.encodeSBranch(BackSlot, *ReturnTo);
+    if (BrBack.empty() || BrBack.size() > BackReserve) {
       log() << "hotswap: error: trampoline branch-back encoding failed at 0x"
             << utohexstr(T.OriginalOffset) << (T.Long ? " (long)\n" : "\n");
       return false;
     }
-    std::memcpy(T.Bytes.data() + BackOffset, BrBack->data(), BrBack->size());
-    for (uint32_t I = BrBack->size(); I + MinInstSize <= BackReserve;
+    std::memcpy(T.Bytes.data() + BackOffset, BrBack.data(), BrBack.size());
+    for (uint32_t I = BrBack.size(); I + MinInstSize <= BackReserve;
          I += MinInstSize)
       std::memcpy(T.Bytes.data() + BackOffset + I, LS.SNopBytes.data(),
                   MinInstSize);
@@ -1924,9 +5655,8 @@ copyOutputBuffer(const void *Data, size_t Size, StringRef CopyKind) {
   std::unique_ptr<WritableMemoryBuffer> Result =
       WritableMemoryBuffer::getNewUninitMemBuffer(Size);
   if (!Result) {
-    log() << "hotswap: error: retargetCodeObject: "
-          << "getNewUninitMemBuffer(" << Size
-          << ") failed (out of memory) for the " << CopyKind
+    log() << "hotswap: error: retargetCodeObject: " << "getNewUninitMemBuffer("
+          << Size << ") failed (out of memory) for the " << CopyKind
           << " output copy.\n";
     return nullptr;
   }
@@ -1946,10 +5676,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   // initializer binds every register*Patch slot on first access, so no
   // explicit install step is needed here.
 
-  const bool RunInstructionPatches =
+  const bool RequestedInstructionPatches =
       Options.RunB0A0Patches ||
       Options.MaskPolicy != MaskWorkaroundPolicy::None;
-  if (!RunInstructionPatches && !Options.RunEntryTrampolines) {
+  if (!RequestedInstructionPatches && !Options.RunEntryTrampolines) {
     std::unique_ptr<WritableMemoryBuffer> Result =
         copyOutputBuffer(ElfData, ElfSize, "no-op");
     if (!Result)
@@ -1976,6 +5706,52 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   }
   ElfView &Elf = *ViewOrErr;
 
+  // Validate every executable region covered by the requested B0-to-A0
+  // operation before metadata can short-circuit instruction rewriting. The
+  // metadata certificate must not allow an incompatible or forged external
+  // pool to bypass structural provenance checks.
+  if (Options.RunB0A0Patches) {
+    std::optional<bool> CompatibleExternalCode =
+        Elf.executableCodeOutsideTextIsCompatibleWith(
+            ExecutablePoolTargetState::A0);
+    if (!CompatibleExternalCode)
+      return AMD_COMGR_STATUS_ERROR;
+    if (!*CompatibleExternalCode) {
+      log() << "hotswap: error: B0-to-A0 rewrite found unprovenanced or "
+               "target-incompatible executable code outside .text; refusing "
+               "to issue an incomplete A0 target-state certificate\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+  }
+
+  bool RunB0A0Patches = Options.RunB0A0Patches;
+  MaskWorkaroundPolicy MaskPolicy = Options.MaskPolicy;
+  if (RunB0A0Patches) {
+    std::optional<bool> AlreadyA0 = Elf.allKernelsHaveGfx1250Revision("A0");
+    if (!AlreadyA0)
+      return AMD_COMGR_STATUS_ERROR;
+    if (*AlreadyA0) {
+      // The metadata retag is committed only on a successfully returned
+      // rewrite. It is therefore an object-wide target-state certificate, not
+      // a heuristic derived from instruction patterns in transformed code.
+      log() << "hotswap: every kernel already reports gfx1250 revision A0; "
+               "skipping B0-to-A0 instruction rewrites\n";
+      RunB0A0Patches = false;
+      if (MaskPolicy == MaskWorkaroundPolicy::A0)
+        MaskPolicy = MaskWorkaroundPolicy::None;
+    }
+  }
+  const bool RunInstructionPatches =
+      RunB0A0Patches || MaskPolicy != MaskWorkaroundPolicy::None;
+  if (!RunInstructionPatches && !Options.RunEntryTrampolines) {
+    std::unique_ptr<WritableMemoryBuffer> Result =
+        copyOutputBuffer(ElfData, ElfSize, "already-targeted");
+    if (!Result)
+      return AMD_COMGR_STATUS_ERROR_OUT_OF_RESOURCES;
+    Out = std::move(Result);
+    return AMD_COMGR_STATUS_SUCCESS;
+  }
+
   LLVMState LS = initLLVM(TargetIdent);
   if (!LS.Valid) {
     log() << "hotswap: error: retargetCodeObject: initLLVM failed "
@@ -1984,8 +5760,8 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   }
 
   RewriteConfig Config = makeGfx1250B0A0Config();
-  Config.RunB0A0Patches = Options.RunB0A0Patches;
-  Config.MaskPolicy = Options.MaskPolicy;
+  Config.RunB0A0Patches = RunB0A0Patches;
+  Config.MaskPolicy = MaskPolicy;
 
   uint8_t *Text = Elf.textData();
   uint64_t Count = 0;
@@ -2015,7 +5791,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   // Running a B0 object on A0 requires retagging that metadata even when no
   // machine instruction needed rewriting. Native A0 code generation preserves
   // s_clause and emits the same instructions as B0 for valid clauses.
-  if (Options.RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
+  if (RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
     return AMD_COMGR_STATUS_ERROR;
 
   std::unique_ptr<WritableMemoryBuffer> Result;
@@ -2084,7 +5860,24 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     return AMD_COMGR_STATUS_ERROR;
 
   if (!Growth.empty()) {
-    Result = Elf.growWithTrampolines(Growth, LS.SNopBytes);
+    ExecutablePoolTargetState PoolTargetState =
+        ExecutablePoolTargetState::Neutral;
+    if (!Deferred.empty()) {
+      if (RunB0A0Patches || MaskPolicy == MaskWorkaroundPolicy::A0)
+        PoolTargetState = ExecutablePoolTargetState::A0;
+      else if (MaskPolicy == MaskWorkaroundPolicy::B0)
+        PoolTargetState = ExecutablePoolTargetState::B0;
+      if (PoolTargetState == ExecutablePoolTargetState::Neutral) {
+        log() << "hotswap: error: stepping-dependent deferred trampolines "
+                 "require an explicit A0 or B0 executable-pool target state.\n";
+        return AMD_COMGR_STATUS_ERROR;
+      }
+    } else if (EntryFixups.empty()) {
+      log() << "hotswap: error: a stepping-neutral executable pool must be "
+               "proven to contain kernel-entry stubs.\n";
+      return AMD_COMGR_STATUS_ERROR;
+    }
+    Result = Elf.growWithTrampolines(Growth, LS.SNopBytes, PoolTargetState);
     if (!Result) {
       log() << "hotswap: error: retargetCodeObject: "
             << "ElfView::growWithTrampolines returned null with "
@@ -2113,9 +5906,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     // still correct, just missing the debug-only symbol).
     if (!EntryFixups.empty()) {
       std::unique_ptr<WritableMemoryBuffer> WithSyms =
-          addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),
-                                          Elf.textAddr(), Elf.textSize(),
-                                          EntryFixups);
+          addKernelEntryTrampolineSymbols(*Result, PoolVAddr, EntryFixups);
       if (WithSyms)
         Result = std::move(WithSyms);
     }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -16,10 +16,10 @@
 
 #include "comgr-hotswap-internal.h"
 
-#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/Support/Endian.h"
 
 #include <algorithm>
 #include <limits>
@@ -51,6 +51,51 @@ static constexpr unsigned SgprEncodingGranule = 8;
 // Page alignment for the appended trampoline pool's virtual address and file
 // offset, so its PT_LOAD segment maps consistently.
 static constexpr uint64_t TrampolinePoolAlign = 4096;
+
+// Standard ELF note identifying one executable pool produced by HotSwap. The
+// description is a fixed little-endian schema:
+//   u32 version, u32 target state, u64 pool vaddr, u64 pool size.
+// The section carrying the note is deliberately non-allocating; loaders need
+// not map provenance that is consumed only by a later rewrite.
+static constexpr StringLiteral HotswapPoolNoteName = "AMDGPU";
+static constexpr uint32_t HotswapPoolNoteType = 0x48535750; // "HSWP"
+static constexpr uint32_t HotswapPoolNoteVersion = 1;
+static constexpr uint32_t HotswapPoolNoteDescSize = 24;
+
+static std::optional<uint64_t> checkedAlignToUint64(uint64_t Value,
+                                                    uint64_t Alignment,
+                                                    StringRef Context) {
+  if (Alignment == 0) {
+    log() << "hotswap: error: " << Context << " has zero alignment.\n";
+    return std::nullopt;
+  }
+  const uint64_t Remainder = Value % Alignment;
+  if (Remainder == 0)
+    return Value;
+  return checkedAddUint64(Value, Alignment - Remainder, Context);
+}
+
+static SmallVector<uint8_t, 48>
+buildHotswapPoolNote(uint64_t PoolVAddr, uint64_t PoolSize,
+                     ExecutablePoolTargetState TargetState) {
+  const uint32_t NameSize = HotswapPoolNoteName.size() + 1;
+  const uint32_t NameStorageSize = alignTo(NameSize, uint32_t{4});
+  SmallVector<uint8_t, 48> Bytes(12 + NameStorageSize +
+                                    HotswapPoolNoteDescSize,
+                                0);
+  support::endian::write32le(Bytes.data(), NameSize);
+  support::endian::write32le(Bytes.data() + 4, HotswapPoolNoteDescSize);
+  support::endian::write32le(Bytes.data() + 8, HotswapPoolNoteType);
+  std::memcpy(Bytes.data() + 12, HotswapPoolNoteName.data(),
+              HotswapPoolNoteName.size());
+  uint8_t *Desc = Bytes.data() + 12 + NameStorageSize;
+  support::endian::write32le(Desc, HotswapPoolNoteVersion);
+  support::endian::write32le(Desc + 4,
+                             static_cast<uint32_t>(TargetState));
+  support::endian::write64le(Desc + 8, PoolVAddr);
+  support::endian::write64le(Desc + 16, PoolSize);
+  return Bytes;
+}
 
 enum class MetadataSgprUpdateStatus {
   NotFound,
@@ -120,30 +165,27 @@ readSgprCountMetadataNode(const msgpack::DocNode &SgprNode,
   return readUnsignedMetadataNode(SgprNode, KernelName, ".sgpr_count", Context);
 }
 
-using MetadataNoteMutator = function_ref<std::optional<bool>(
-    msgpack::Document &, msgpack::MapDocNode &)>;
-using MetadataNoteValidator = function_ref<bool(bool)>;
+static MetadataSgprUpdateStatus
+rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
+                                const StringMap<unsigned> &RequiredSgprs) {
+  if (RequiredSgprs.empty())
+    return MetadataSgprUpdateStatus::Found;
 
-struct PendingMetadataWrite {
-  size_t Offset = 0;
-  std::string Blob;
-};
+  struct PendingWrite {
+    size_t Offset;
+    std::string Blob;
+  };
 
-/// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
-/// defer changed writes until \p Validator accepts the complete traversal.
-/// This keeps multi-note updates atomic while sharing the parsing, encoded-size
-/// and destination validation for every metadata mutation.
-static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
-                                 StringRef Context, MetadataNoteMutator Mutator,
-                                 MetadataNoteValidator Validator,
-                                 bool &SawMetadataNote) {
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   if (!PhdrsOrErr) {
-    log() << "hotswap: error: " << Context << ": failed to read program "
-          << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
-    return false;
+    log() << "hotswap: error: updateKernelMetadataSgprCounts: failed to read "
+          << "program headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return MetadataSgprUpdateStatus::Error;
   }
-  std::vector<PendingMetadataWrite> PendingWrites;
+
+  bool SawMetadataNote = false;
+  StringMap<bool> Found;
+  std::vector<PendingWrite> PendingWrites;
   for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
     if (Phdr.p_type != ELF::PT_NOTE)
       continue;
@@ -157,37 +199,197 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
 
       ArrayRef<uint8_t> Desc = Note.getDesc(4);
       if (Desc.empty()) {
-        log() << "hotswap: error: " << Context
-              << ": AMDGPU metadata note has an empty descriptor.\n";
+        log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+              << "metadata note has an empty descriptor.\n";
+        return MetadataSgprUpdateStatus::Error;
+      }
+
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false)) {
+        log() << "hotswap: error: updateKernelMetadataSgprCounts: failed to "
+              << "parse AMDGPU metadata note.\n";
+        return MetadataSgprUpdateStatus::Error;
+      }
+
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap()) {
+        log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+              << "metadata root is not a map.\n";
+        return MetadataSgprUpdateStatus::Error;
+      }
+
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+        continue;
+
+      bool Modified = false;
+      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
+      for (msgpack::DocNode &KNode : KernelArray) {
+        if (!KNode.isMap())
+          continue;
+
+        msgpack::MapDocNode &KMap = KNode.getMap();
+        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
+        if (NameIt == KMap.end() || !NameIt->second.isString())
+          continue;
+        StringRef KernelName = NameIt->second.getString();
+        StringMap<unsigned>::const_iterator Required =
+            RequiredSgprs.find(KernelName);
+        if (Required == RequiredSgprs.end() || Found.contains(KernelName))
+          continue;
+
+        msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
+        if (SgprIt == KMap.end()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
+                << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+
+        std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
+            SgprIt->second, KernelName, "updateKernelMetadataSgprCounts");
+        if (!CurrentSgprs)
+          return MetadataSgprUpdateStatus::Error;
+        Found.try_emplace(KernelName, true);
+        if (Required->second <= *CurrentSgprs)
+          continue;
+
+        SgprIt->second = static_cast<uint64_t>(Required->second);
+        Modified = true;
+      }
+
+      if (Modified) {
+        std::string NewBlob;
+        Doc.writeToBlob(NewBlob);
+        if (NewBlob.size() != Blob.size()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: updating "
+                   ".sgpr_count changes metadata note size from "
+                << Blob.size() << " to " << NewBlob.size()
+                << " bytes; in-place rewrite cannot preserve ELF layout.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+
+        const uint8_t *DescBegin = Desc.data();
+        if (DescBegin < File.base() || DescBegin >= File.end()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
+                << "descriptor pointer is outside the ELF buffer.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+        size_t DescOffset = DescBegin - File.base();
+        if (Desc.size() > File.getBufSize() ||
+            DescOffset > File.getBufSize() - Desc.size()) {
+          log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
+                << "descriptor extends past the ELF buffer.\n";
+          return MetadataSgprUpdateStatus::Error;
+        }
+        PendingWrites.push_back({DescOffset, std::move(NewBlob)});
+      }
+
+      if (Found.size() == RequiredSgprs.size())
+        break;
+    }
+
+    if (Err) {
+      log() << "hotswap: error: updateKernelMetadataSgprCounts: failed to "
+            << "iterate AMDGPU notes: " << toString(std::move(Err)) << "\n";
+      return MetadataSgprUpdateStatus::Error;
+    }
+    if (Found.size() == RequiredSgprs.size())
+      break;
+  }
+
+  if (SawMetadataNote) {
+    for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
+      if (Found.contains(Required.first()))
+        continue;
+      log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
+               "metadata has no entry for kernel '"
+            << Required.first() << "'.\n";
+      return MetadataSgprUpdateStatus::Error;
+    }
+    for (const PendingWrite &Write : PendingWrites)
+      std::memcpy(Elf + Write.Offset, Write.Blob.data(), Write.Blob.size());
+    return MetadataSgprUpdateStatus::Found;
+  }
+  return MetadataSgprUpdateStatus::NotFound;
+}
+
+bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: updateGfx1250RevisionMetadata: failed to read "
+          << "program headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+    return false;
+  }
+
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
+
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        continue;
+
+      ArrayRef<uint8_t> Desc = Note.getDesc(4);
+      if (Desc.empty()) {
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: AMDGPU "
+              << "metadata note has an empty descriptor.\n";
         return false;
       }
 
       StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
       msgpack::Document Doc;
       if (!Doc.readFromBlob(Blob, false)) {
-        log() << "hotswap: error: " << Context
-              << ": failed to parse AMDGPU metadata note.\n";
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: failed to "
+              << "parse AMDGPU metadata note.\n";
         return false;
       }
 
       msgpack::DocNode Root = Doc.getRoot();
       if (!Root.isMap()) {
-        log() << "hotswap: error: " << Context
-              << ": AMDGPU metadata root is not a map.\n";
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: AMDGPU "
+              << "metadata root is not a map.\n";
         return false;
       }
 
-      std::optional<bool> Changed = Mutator(Doc, Root.getMap());
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+        continue;
+
+      bool Changed = false;
+      for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+        if (!KNode.isMap())
+          continue;
+        msgpack::MapDocNode &KMap = KNode.getMap();
+        msgpack::DocNode::MapTy::iterator RevisionIt =
+            KMap.find(".gfx1250_revision");
+        if (RevisionIt == KMap.end())
+          continue;
+        if (!RevisionIt->second.isString()) {
+          log() << "hotswap: error: updateGfx1250RevisionMetadata: "
+                << ".gfx1250_revision is not a string.\n";
+          return false;
+        }
+        if (RevisionIt->second.getString() == Revision)
+          continue;
+        RevisionIt->second = Doc.getNode(Revision, /*Copy=*/true);
+        Changed = true;
+      }
+
       if (!Changed)
-        return false;
-      if (!*Changed)
         continue;
 
       std::string NewBlob;
       Doc.writeToBlob(NewBlob);
       if (NewBlob.size() != Blob.size()) {
-        log() << "hotswap: error: " << Context
-              << ": updating AMDGPU metadata changes note size from "
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: updating "
+              << ".gfx1250_revision changes metadata note size from "
               << Blob.size() << " to " << NewBlob.size()
               << " bytes; in-place rewrite cannot preserve ELF layout.\n";
         return false;
@@ -195,140 +397,135 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
 
       const uint8_t *DescBegin = Desc.data();
       if (DescBegin < File.base() || DescBegin >= File.end()) {
-        log() << "hotswap: error: " << Context
-              << ": metadata descriptor pointer is outside the ELF buffer.\n";
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: metadata "
+              << "descriptor pointer is outside the ELF buffer.\n";
         return false;
       }
       size_t DescOffset = DescBegin - File.base();
       if (Desc.size() > File.getBufSize() ||
           DescOffset > File.getBufSize() - Desc.size()) {
-        log() << "hotswap: error: " << Context
-              << ": metadata descriptor extends past the ELF buffer.\n";
+        log() << "hotswap: error: updateGfx1250RevisionMetadata: metadata "
+              << "descriptor extends past the ELF buffer.\n";
         return false;
       }
-      PendingWrites.push_back({DescOffset, std::move(NewBlob)});
+      std::memcpy(data() + DescOffset, NewBlob.data(), NewBlob.size());
     }
 
     if (Err) {
-      log() << "hotswap: error: " << Context
-            << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
-            << "\n";
+      log() << "hotswap: error: updateGfx1250RevisionMetadata: failed to "
+            << "iterate AMDGPU notes: " << toString(std::move(Err)) << "\n";
       return false;
     }
   }
-
-  if (!Validator(SawMetadataNote))
-    return false;
-  for (const PendingMetadataWrite &Write : PendingWrites)
-    std::memcpy(Elf + Write.Offset, Write.Blob.data(), Write.Blob.size());
   return true;
 }
 
-static MetadataSgprUpdateStatus
-rewriteKernelMetadataSgprCounts(uint8_t *Elf, const ELFFileT &File,
-                                const StringMap<unsigned> &RequiredSgprs) {
-  if (RequiredSgprs.empty())
-    return MetadataSgprUpdateStatus::Found;
+std::optional<bool>
+ElfView::allKernelsHaveGfx1250Revision(StringRef Revision) const {
+  if (!kernelDescriptorCacheIsComplete())
+    return false;
 
-  bool SawMetadataNote = false;
-  StringMap<bool> Found;
-  bool Rewritten = rewriteMetadataNotes(
-      Elf, File, "updateKernelMetadataSgprCounts",
-      [&](msgpack::Document &,
-          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
-        msgpack::DocNode::MapTy::iterator KernelsIt =
-            RootMap.find("amdhsa.kernels");
-        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
-          return false;
+  StringMap<bool> DescriptorSeen;
+  for (const KernelDescriptorInfo &Descriptor : kernelDescriptors())
+    DescriptorSeen.try_emplace(Descriptor.KernelName, false);
+  if (DescriptorSeen.empty())
+    return false;
 
-        bool Changed = false;
-        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
-          if (!KNode.isMap())
-            continue;
-          msgpack::MapDocNode &KMap = KNode.getMap();
-          msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
-          if (NameIt == KMap.end() || !NameIt->second.isString())
-            continue;
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: allKernelsHaveGfx1250Revision: failed to read "
+             "program headers: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
 
-          StringRef KernelName = NameIt->second.getString();
-          StringMap<unsigned>::const_iterator Required =
-              RequiredSgprs.find(KernelName);
-          if (Required == RequiredSgprs.end() || Found.contains(KernelName))
-            continue;
+  bool FoundKernel = false;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_NOTE)
+      continue;
 
-          msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
-          if (SgprIt == KMap.end()) {
-            log() << "hotswap: error: updateKernelMetadataSgprCounts: metadata "
-                  << "for kernel '" << KernelName << "' has no .sgpr_count.\n";
-            return std::nullopt;
-          }
+    Error Err = Error::success();
+    for (ELFT::Note Note : File.notes(Phdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        continue;
 
-          std::optional<unsigned> CurrentSgprs = readSgprCountMetadataNode(
-              SgprIt->second, KernelName, "updateKernelMetadataSgprCounts");
-          if (!CurrentSgprs)
-            return std::nullopt;
-          Found.try_emplace(KernelName, true);
-          if (Required->second <= *CurrentSgprs)
-            continue;
+      ArrayRef<uint8_t> Desc = Note.getDesc(4);
+      if (Desc.empty()) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: AMDGPU "
+                 "metadata note has an empty descriptor.\n";
+        return std::nullopt;
+      }
 
-          SgprIt->second = static_cast<uint64_t>(Required->second);
-          Changed = true;
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false)) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: failed to "
+                 "parse AMDGPU metadata note.\n";
+        return std::nullopt;
+      }
+
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap()) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: AMDGPU "
+                 "metadata root is not a map.\n";
+        return std::nullopt;
+      }
+
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator KernelsIt =
+          RootMap.find("amdhsa.kernels");
+      if (KernelsIt == RootMap.end())
+        continue;
+      if (!KernelsIt->second.isArray()) {
+        log() << "hotswap: error: allKernelsHaveGfx1250Revision: "
+                 "amdhsa.kernels is not an array.\n";
+        return std::nullopt;
+      }
+
+      for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
+        if (!KNode.isMap()) {
+          log() << "hotswap: error: allKernelsHaveGfx1250Revision: kernel "
+                   "metadata entry is not a map.\n";
+          return std::nullopt;
         }
-        return Changed;
-      },
-      [&](bool SawMetadata) {
-        if (!SawMetadata)
-          return true;
-        for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
-          if (Found.contains(Required.first()))
-            continue;
-          log() << "hotswap: error: updateKernelMetadataSgprCounts: AMDGPU "
-                   "metadata has no entry for kernel '"
-                << Required.first() << "'.\n";
-          return false;
+        msgpack::MapDocNode &KMap = KNode.getMap();
+        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
+        if (NameIt == KMap.end() || !NameIt->second.isString()) {
+          log() << "hotswap: error: allKernelsHaveGfx1250Revision: kernel "
+                   "metadata has no string .name.\n";
+          return std::nullopt;
         }
-        return true;
-      },
-      SawMetadataNote);
-  if (!Rewritten)
-    return MetadataSgprUpdateStatus::Error;
-  return SawMetadataNote ? MetadataSgprUpdateStatus::Found
-                         : MetadataSgprUpdateStatus::NotFound;
-}
-
-bool ElfView::updateGfx1250RevisionMetadata(StringRef Revision) {
-  bool SawMetadataNote = false;
-  return rewriteMetadataNotes(
-      data(), File, "updateGfx1250RevisionMetadata",
-      [&](msgpack::Document &Doc,
-          msgpack::MapDocNode &RootMap) -> std::optional<bool> {
-        msgpack::DocNode::MapTy::iterator KernelsIt =
-            RootMap.find("amdhsa.kernels");
-        if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
+        StringMap<bool>::iterator DescriptorIt =
+            DescriptorSeen.find(NameIt->second.getString());
+        if (DescriptorIt == DescriptorSeen.end())
           return false;
+        DescriptorIt->second = true;
 
-        bool Changed = false;
-        for (msgpack::DocNode &KNode : KernelsIt->second.getArray()) {
-          if (!KNode.isMap())
-            continue;
-          msgpack::MapDocNode &KMap = KNode.getMap();
-          msgpack::DocNode::MapTy::iterator RevisionIt =
-              KMap.find(".gfx1250_revision");
-          if (RevisionIt == KMap.end())
-            continue;
-          if (!RevisionIt->second.isString()) {
-            log() << "hotswap: error: updateGfx1250RevisionMetadata: "
-                  << ".gfx1250_revision is not a string.\n";
-            return std::nullopt;
-          }
-          if (RevisionIt->second.getString() == Revision)
-            continue;
-          RevisionIt->second = Doc.getNode(Revision, /*Copy=*/true);
-          Changed = true;
+        msgpack::DocNode::MapTy::iterator RevisionIt =
+            KMap.find(".gfx1250_revision");
+        if (RevisionIt == KMap.end())
+          return false;
+        if (!RevisionIt->second.isString()) {
+          log() << "hotswap: error: allKernelsHaveGfx1250Revision: "
+                   ".gfx1250_revision is not a string.\n";
+          return std::nullopt;
         }
-        return Changed;
-      },
-      [](bool) { return true; }, SawMetadataNote);
+        FoundKernel = true;
+        if (RevisionIt->second.getString() != Revision)
+          return false;
+      }
+    }
+    if (Err) {
+      log() << "hotswap: error: allKernelsHaveGfx1250Revision: failed to "
+               "iterate AMDGPU notes: "
+            << toString(std::move(Err)) << "\n";
+      return std::nullopt;
+    }
+  }
+  return FoundKernel &&
+         llvm::all_of(DescriptorSeen,
+                      [](const auto &Entry) { return Entry.getValue(); });
 }
 
 // -- applyByteReplace ---------------------------------------------------------
@@ -370,20 +567,35 @@ bool applyByteReplace(const RewriteRule &Rule, uint64_t InstOffset,
 // -- findNearestSled ----------------------------------------------------------
 
 NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
-                         uint64_t Needed) {
+                         uint64_t Needed, NopSledUse Use) {
   NopSled *Best = nullptr;
   uint64_t BestDist = std::numeric_limits<uint64_t>::max();
+  bool BestOwned = false;
   for (NopSled &Sled : Sleds) {
-    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+    if (Sled.GatewayOnly && Use != NopSledUse::Gateway)
       continue;
-    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-    if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
+    const bool Eligible =
+        Use == NopSledUse::Gateway
+            ? Sled.canGatewayFrom(Offset)
+            : Sled.canHoldBodyFrom(
+                  Offset, Use == NopSledUse::RelocationBody);
+    if (!Eligible)
+      continue;
+    if (Sled.WritePos > Sled.End || Needed > Sled.End - Sled.WritePos)
       continue;
     uint64_t Dist = Sled.WritePos > Offset ? Sled.WritePos - Offset
                                            : Offset - Sled.WritePos;
-    if (Dist < MaxSledDistance && Dist < BestDist) {
+    const bool Owned = Sled.ownsSource(Offset);
+    const bool PreferOwned = Use == NopSledUse::RelocationBody;
+    const bool Better =
+        !Best ||
+        (PreferOwned ? (Owned && !BestOwned) ||
+                           (Owned == BestOwned && Dist < BestDist)
+                     : Dist < BestDist);
+    if (Dist < MaxSledDistance && Better) {
       Best = &Sled;
       BestDist = Dist;
+      BestOwned = Owned;
     }
   }
   return Best;
@@ -408,6 +620,25 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
     return SectionsOrErr.takeError();
   ELFT::ShdrRange Sections = *SectionsOrErr;
 
+  // HotSwap rewrites reason about symbol ownership by section index. Silently
+  // treating SHN_XINDEX as a reserved/non-.text index would omit protected
+  // entries and extents. Extended symbol indices are uncommon in code objects;
+  // reject them until every symbol-table mutation preserves the associated
+  // SHT_SYMTAB_SHNDX table.
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (Shdr.sh_type != ELF::SHT_SYMTAB && Shdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&Shdr);
+    if (!SymsOrErr)
+      return SymsOrErr.takeError();
+    if (llvm::any_of(*SymsOrErr, [](const ELFT::Sym &Sym) {
+          return Sym.st_shndx == ELF::SHN_XINDEX;
+        }))
+      return createStringError(
+          object::object_error::parse_failed,
+          "HotSwap does not support SHN_XINDEX symbol section indices");
+  }
+
   const ELFT::Shdr *Text = nullptr;
   unsigned TextIdx = 0;
   unsigned Idx = 0;
@@ -418,7 +649,8 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
       ++Idx;
       continue;
     }
-    if (*NameOrErr == ".text" && Shdr.sh_offset + Shdr.sh_size <= Size) {
+    if (*NameOrErr == ".text" && Shdr.sh_offset <= Size &&
+        Shdr.sh_size <= Size - Shdr.sh_offset) {
       Text = &Shdr;
       TextIdx = Idx;
       break;
@@ -510,6 +742,83 @@ std::vector<ElfView::FunctionTextRange> ElfView::functionTextRanges() const {
   return std::vector<FunctionTextRange>(Ranges.begin(), Ranges.end());
 }
 
+std::optional<std::vector<uint64_t>> ElfView::textSymbolOffsets() const {
+  const uint64_t TextBegin = textAddr();
+  if (textSize() > std::numeric_limits<uint64_t>::max() - TextBegin) {
+    log() << "hotswap: error: .text symbol scan address range overflows\n";
+    return std::nullopt;
+  }
+  const uint64_t TextEnd = TextBegin + textSize();
+  std::vector<uint64_t> Offsets;
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      log() << "hotswap: error: failed to enumerate .text symbols: "
+            << toString(SymsOrErr.takeError()) << "\n";
+      return std::nullopt;
+    }
+    for (const ELFT::Sym &Sym : *SymsOrErr)
+      if (Sym.st_shndx == TextSectionIndex && Sym.st_value >= TextBegin &&
+          Sym.st_value < TextEnd)
+        Offsets.push_back(Sym.st_value - TextBegin);
+  }
+  llvm::sort(Offsets);
+  Offsets.erase(std::unique(Offsets.begin(), Offsets.end()), Offsets.end());
+  return Offsets;
+}
+
+std::optional<std::vector<ElfView::TextOffsetRange>>
+ElfView::textSymbolExtents() const {
+  const uint64_t TextBegin = textAddr();
+  if (textSize() > std::numeric_limits<uint64_t>::max() - TextBegin) {
+    log() << "hotswap: error: .text symbol extent scan address range "
+             "overflows\n";
+    return std::nullopt;
+  }
+  const uint64_t TextEnd = TextBegin + textSize();
+  std::vector<TextOffsetRange> Extents;
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      log() << "hotswap: error: failed to enumerate .text symbol extents: "
+            << toString(SymsOrErr.takeError()) << "\n";
+      return std::nullopt;
+    }
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.st_shndx != TextSectionIndex || Sym.st_size == 0 ||
+          Sym.getType() == ELF::STT_FUNC || Sym.getType() == ELF::STT_GNU_IFUNC)
+        continue;
+      if (Sym.st_size > std::numeric_limits<uint64_t>::max() - Sym.st_value) {
+        log() << "hotswap: error: .text symbol extent overflows\n";
+        return std::nullopt;
+      }
+      const uint64_t SymbolEnd = Sym.st_value + Sym.st_size;
+      const uint64_t Begin = std::max<uint64_t>(Sym.st_value, TextBegin);
+      const uint64_t End = std::min<uint64_t>(SymbolEnd, TextEnd);
+      if (Begin < End)
+        Extents.push_back({Begin - TextBegin, End - TextBegin});
+    }
+  }
+  llvm::sort(
+      Extents, [](const TextOffsetRange &LHS, const TextOffsetRange &RHS) {
+        return std::tie(LHS.Begin, LHS.End) < std::tie(RHS.Begin, RHS.End);
+      });
+  std::vector<TextOffsetRange> Coalesced;
+  for (const TextOffsetRange &Extent : Extents) {
+    if (Coalesced.empty() || Extent.Begin > Coalesced.back().End)
+      Coalesced.push_back(Extent);
+    else
+      Coalesced.back().End = std::max(Coalesced.back().End, Extent.End);
+  }
+  return Coalesced;
+}
+
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
 const ElfView::FunctionTextRange *
@@ -585,7 +894,8 @@ ElfView::findFunctionTextRangeAtOffset(uint64_t TextOffset) const {
       findFunctionTextRangeAtAddress(textAddr() + TextOffset);
   if (!Range || Range->Begin < textAddr() || Range->End < textAddr())
     return std::nullopt;
-  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr()};
+  return FunctionTextRange{Range->Begin - textAddr(), Range->End - textAddr(),
+                           Range->Symbol, Range->Symtab};
 }
 
 // -- ElfView::kernelDescriptors -----------------------------------------------
@@ -597,6 +907,7 @@ void ElfView::initializeKernelDescriptorCache() const {
   namespace hsa = amdhsa;
   std::vector<KernelDescriptorInfo> Result;
   StringMap<uint64_t> FileOffsets;
+  bool Complete = true;
 
   for (const ELFT::Shdr &SymShdr : Sections) {
     if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
@@ -607,6 +918,7 @@ void ElfView::initializeKernelDescriptorCache() const {
     if (!SymsOrErr) {
       log() << "hotswap: error: kernelDescriptors: failed to read symbols: "
             << toString(SymsOrErr.takeError()) << "\n";
+      Complete = false;
       continue;
     }
     Expected<StringRef> StrTabOrErr =
@@ -614,6 +926,7 @@ void ElfView::initializeKernelDescriptorCache() const {
     if (!StrTabOrErr) {
       log() << "hotswap: error: kernelDescriptors: failed to read symbol "
             << "string table: " << toString(StrTabOrErr.takeError()) << "\n";
+      Complete = false;
       continue;
     }
 
@@ -622,6 +935,7 @@ void ElfView::initializeKernelDescriptorCache() const {
       if (!NameOrErr) {
         log() << "hotswap: error: kernelDescriptors: failed to read symbol "
               << "name: " << toString(NameOrErr.takeError()) << "\n";
+        Complete = false;
         continue;
       }
       if (!NameOrErr->ends_with(".kd"))
@@ -633,6 +947,7 @@ void ElfView::initializeKernelDescriptorCache() const {
         log() << "hotswap: error: kernelDescriptors: descriptor symbol '"
               << *NameOrErr << "' has unreadable section index " << Sym.st_shndx
               << ": " << toString(HostShdrOrErr.takeError()) << "\n";
+        Complete = false;
         continue;
       }
       const ELFT::Shdr &HostShdr = **HostShdrOrErr;
@@ -640,8 +955,10 @@ void ElfView::initializeKernelDescriptorCache() const {
           HostShdr, Sym.st_value, KdSize, size(),
           (Twine("kernelDescriptors: descriptor symbol '") + *NameOrErr + "'")
               .str());
-      if (!FileOffset)
+      if (!FileOffset) {
+        Complete = false;
         continue;
+      }
 
       int64_t EntryOffset = 0;
       std::memcpy(
@@ -651,17 +968,24 @@ void ElfView::initializeKernelDescriptorCache() const {
           sizeof(EntryOffset));
 
       std::string KernelName = NameOrErr->drop_back(3).str();
-      const bool Seen = std::any_of(
-          Result.begin(), Result.end(), [&](const KernelDescriptorInfo &Info) {
-            return Info.KernelName == KernelName && Info.VAddr == Sym.st_value;
+      auto Existing =
+          llvm::find_if(Result, [&](const KernelDescriptorInfo &Info) {
+            return Info.KernelName == KernelName;
           });
-      if (!Seen)
-        Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
-      FileOffsets.try_emplace(NameOrErr->drop_back(3), *FileOffset);
+      if (Existing == Result.end()) {
+        Result.push_back({KernelName, Sym.st_value, *FileOffset, EntryOffset});
+        FileOffsets.try_emplace(KernelName, *FileOffset);
+      } else if (Existing->VAddr != Sym.st_value ||
+                 Existing->FileOffset != *FileOffset) {
+        log() << "hotswap: error: kernelDescriptors: descriptor name '"
+              << KernelName << "' resolves to multiple locations\n";
+        Complete = false;
+      }
     }
   }
 
   KernelDescriptorFileOffsetCache = std::move(FileOffsets);
+  KernelDescriptorCacheComplete = Complete;
   KernelDescriptorCache = std::move(Result);
 }
 
@@ -677,6 +1001,11 @@ uint8_t *ElfView::findKernelDescriptor(StringRef KernelName) {
 ArrayRef<KernelDescriptorInfo> ElfView::kernelDescriptors() const {
   initializeKernelDescriptorCache();
   return *KernelDescriptorCache;
+}
+
+bool ElfView::kernelDescriptorCacheIsComplete() const {
+  initializeKernelDescriptorCache();
+  return KernelDescriptorCacheComplete;
 }
 
 std::optional<uint64_t>
@@ -1249,6 +1578,344 @@ const uint8_t *ElfView::dataAtVAddr(uint64_t VAddr, uint64_t Len) const {
   return nullptr;
 }
 
+bool ElfView::isExecutableVAddrRange(uint64_t VAddr, uint64_t Len) const {
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    consumeError(PhdrsOrErr.takeError());
+    return false;
+  }
+
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD || !(Phdr.p_flags & ELF::PF_X) ||
+        VAddr < Phdr.p_vaddr)
+      continue;
+    uint64_t Offset = VAddr - Phdr.p_vaddr;
+    if (Offset <= Phdr.p_filesz && Len <= Phdr.p_filesz - Offset &&
+        Phdr.p_offset <= size() && Offset <= size() - Phdr.p_offset &&
+        Len <= size() - Phdr.p_offset - Offset)
+      return true;
+  }
+  return false;
+}
+
+std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
+    ExecutablePoolTargetState TargetState) const {
+  struct ExecutableRegion {
+    uint64_t VAddr;
+    uint64_t Size;
+    uint64_t FileOffset;
+  };
+  struct PoolProvenance {
+    uint64_t VAddr;
+    uint64_t Size;
+    ExecutablePoolTargetState State;
+  };
+
+  if (TargetState != ExecutablePoolTargetState::A0 &&
+      TargetState != ExecutablePoolTargetState::B0) {
+    log() << "hotswap: error: executable pool compatibility requires an "
+             "explicit A0 or B0 target state.\n";
+    return std::nullopt;
+  }
+
+  const uint64_t FileSize = size();
+  if (textOffset() > FileSize || textSize() > FileSize - textOffset()) {
+    log() << "hotswap: error: .text extends past the end of the ELF buffer.\n";
+    return std::nullopt;
+  }
+  if (textSize() > std::numeric_limits<uint64_t>::max() - textAddr()) {
+    log() << "hotswap: error: .text virtual-address range overflows.\n";
+    return std::nullopt;
+  }
+  const uint64_t TextAddrEnd = textAddr() + textSize();
+  const uint64_t TextFileEnd = textOffset() + textSize();
+  if (TextSectionIndex >= Sections.size()) {
+    log() << "hotswap: error: cached .text section index is out of range.\n";
+    return std::nullopt;
+  }
+  const ELFT::Shdr &TextShdr = Sections[TextSectionIndex];
+  if (TextShdr.sh_type != ELF::SHT_PROGBITS ||
+      !(TextShdr.sh_flags & ELF::SHF_ALLOC) ||
+      !(TextShdr.sh_flags & ELF::SHF_EXECINSTR) ||
+      (TextShdr.sh_flags & ELF::SHF_WRITE)) {
+    log() << "hotswap: error: .text is not a non-writable allocatable "
+             "SHT_PROGBITS executable section.\n";
+    return std::nullopt;
+  }
+
+  SmallVector<ExecutableRegion, 4> ExternalSections;
+  SmallVector<ExecutableRegion, 4> ExternalSegments;
+
+  unsigned SectionIndex = 0;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    const bool IsFileBackedExecutable =
+        (Shdr.sh_flags & ELF::SHF_EXECINSTR) &&
+        Shdr.sh_type != ELF::SHT_NOBITS && Shdr.sh_size != 0;
+    if (!IsFileBackedExecutable) {
+      ++SectionIndex;
+      continue;
+    }
+    if (Shdr.sh_offset > FileSize ||
+        Shdr.sh_size > FileSize - Shdr.sh_offset) {
+      log() << "hotswap: error: executable section " << SectionIndex
+            << " extends past the end of the ELF buffer.\n";
+      return std::nullopt;
+    }
+    if (Shdr.sh_size > std::numeric_limits<uint64_t>::max() - Shdr.sh_addr) {
+      log() << "hotswap: error: executable section " << SectionIndex
+            << " virtual-address range overflows.\n";
+      return std::nullopt;
+    }
+    if (SectionIndex != TextSectionIndex) {
+      if (Shdr.sh_type != ELF::SHT_PROGBITS ||
+          !(Shdr.sh_flags & ELF::SHF_ALLOC) ||
+          (Shdr.sh_flags & ELF::SHF_WRITE)) {
+        log() << "hotswap: error: external executable section " << SectionIndex
+              << " is not a non-writable allocatable SHT_PROGBITS pool.\n";
+        return false;
+      }
+      ExternalSections.push_back(
+          {Shdr.sh_addr, Shdr.sh_size, Shdr.sh_offset});
+    }
+    ++SectionIndex;
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: failed to enumerate program headers while "
+             "checking executable coverage: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+  unsigned TextSegmentCount = 0;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD || !(Phdr.p_flags & ELF::PF_X))
+      continue;
+    if (Phdr.p_offset > FileSize ||
+        Phdr.p_filesz > FileSize - Phdr.p_offset) {
+      log() << "hotswap: error: executable PT_LOAD extends past the end of "
+               "the ELF buffer.\n";
+      return std::nullopt;
+    }
+    if (Phdr.p_filesz == 0)
+      continue;
+    if (Phdr.p_filesz != Phdr.p_memsz ||
+        Phdr.p_filesz > std::numeric_limits<uint64_t>::max() - Phdr.p_vaddr) {
+      log() << "hotswap: error: executable PT_LOAD has unequal file/memory "
+               "sizes or an invalid virtual-address range.\n";
+      return std::nullopt;
+    }
+    const uint64_t SegmentAddrEnd = Phdr.p_vaddr + Phdr.p_filesz;
+    const uint64_t SegmentFileEnd = Phdr.p_offset + Phdr.p_filesz;
+    const bool ContainsText =
+        Phdr.p_vaddr <= textAddr() && TextAddrEnd <= SegmentAddrEnd &&
+        Phdr.p_offset <= textOffset() && TextFileEnd <= SegmentFileEnd &&
+        textAddr() - Phdr.p_vaddr == textOffset() - Phdr.p_offset;
+    if (!(Phdr.p_flags & ELF::PF_R) || (Phdr.p_flags & ELF::PF_W)) {
+      log() << "hotswap: error: executable PT_LOAD is not read-only "
+               "executable.\n";
+      return false;
+    }
+    if (ContainsText) {
+      if (Phdr.p_vaddr != textAddr() || Phdr.p_offset != textOffset() ||
+          Phdr.p_filesz != textSize()) {
+        log() << "hotswap: error: executable PT_LOAD containing .text also "
+                 "covers bytes outside the rewritten section.\n";
+        return false;
+      }
+      ++TextSegmentCount;
+      continue;
+    }
+    ExternalSegments.push_back(
+        {Phdr.p_vaddr, Phdr.p_filesz, Phdr.p_offset});
+  }
+  if (TextSegmentCount != 1) {
+    log() << "hotswap: error: .text must have exactly one exact RX PT_LOAD "
+             "mapping; found "
+          << TextSegmentCount << ".\n";
+    return false;
+  }
+
+  auto RangesOverlap = [](uint64_t AStart, uint64_t ASize,
+                          uint64_t BStart, uint64_t BSize) {
+    // All range ends were checked above before regions were collected.
+    return ASize != 0 && BSize != 0 && AStart < BStart + BSize &&
+           BStart < AStart + ASize;
+  };
+  auto ValidateDisjointExecutableRegions =
+      [&](ArrayRef<ExecutableRegion> Regions, StringRef Kind) {
+        for (size_t I = 0; I != Regions.size(); ++I) {
+          const ExecutableRegion &Region = Regions[I];
+          if (RangesOverlap(Region.VAddr, Region.Size, textAddr(), textSize()) ||
+              RangesOverlap(Region.FileOffset, Region.Size, textOffset(),
+                            textSize())) {
+            log() << "hotswap: error: external executable " << Kind << " " << I
+                  << " overlaps or aliases .text.\n";
+            return false;
+          }
+          for (size_t J = 0; J != I; ++J) {
+            const ExecutableRegion &Other = Regions[J];
+            if (RangesOverlap(Region.VAddr, Region.Size, Other.VAddr,
+                              Other.Size) ||
+                RangesOverlap(Region.FileOffset, Region.Size,
+                              Other.FileOffset, Other.Size)) {
+              log() << "hotswap: error: external executable " << Kind << " "
+                    << I << " overlaps or aliases " << Kind << " " << J
+                    << ".\n";
+              return false;
+            }
+          }
+        }
+        return true;
+      };
+  if (!ValidateDisjointExecutableRegions(ExternalSections, "section") ||
+      !ValidateDisjointExecutableRegions(ExternalSegments, "PT_LOAD"))
+    return false;
+
+  SmallVector<PoolProvenance, 4> Provenance;
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (Shdr.sh_type != ELF::SHT_NOTE)
+      continue;
+    if (Shdr.sh_offset > FileSize ||
+        Shdr.sh_size > FileSize - Shdr.sh_offset) {
+      log() << "hotswap: error: SHT_NOTE section extends past the end of the "
+               "ELF buffer.\n";
+      return std::nullopt;
+    }
+    if (Shdr.sh_addralign != 0 && Shdr.sh_addralign != 1 &&
+        Shdr.sh_addralign != 4 && Shdr.sh_addralign != 8) {
+      log() << "hotswap: error: SHT_NOTE section has unsupported alignment "
+            << Shdr.sh_addralign << ".\n";
+      return std::nullopt;
+    }
+    const uint64_t RecordAlign = std::max<uint64_t>(Shdr.sh_addralign, 4);
+
+    ArrayRef<uint8_t> NoteBytes(data() + Shdr.sh_offset,
+                                static_cast<size_t>(Shdr.sh_size));
+    uint64_t Cursor = 0;
+    while (Cursor != NoteBytes.size()) {
+      if (Cursor > NoteBytes.size() || NoteBytes.size() - Cursor < 12) {
+        log() << "hotswap: error: malformed SHT_NOTE record header.\n";
+        return std::nullopt;
+      }
+      const uint8_t *Header = NoteBytes.data() + Cursor;
+      const uint32_t NameSize = support::endian::read32le(Header);
+      const uint32_t DescSize = support::endian::read32le(Header + 4);
+      const uint32_t Type = support::endian::read32le(Header + 8);
+      const uint64_t NameStorageSize =
+          alignTo(uint64_t{NameSize}, RecordAlign);
+      const uint64_t DescStorageSize =
+          alignTo(uint64_t{DescSize}, RecordAlign);
+      const uint64_t BytesAfterHeader = NoteBytes.size() - Cursor - 12;
+      if (NameStorageSize > BytesAfterHeader ||
+          DescStorageSize > BytesAfterHeader - NameStorageSize) {
+        log() << "hotswap: error: malformed SHT_NOTE record payload.\n";
+        return std::nullopt;
+      }
+      const uint64_t NameOffset = Cursor + 12;
+      const uint64_t DescOffset = NameOffset + NameStorageSize;
+      const uint64_t RecordEnd = DescOffset + DescStorageSize;
+      ArrayRef<uint8_t> NameBytes =
+          NoteBytes.slice(static_cast<size_t>(NameOffset), NameSize);
+      const bool HasHotswapVendorSpelling =
+          NameBytes.size() >= HotswapPoolNoteName.size() &&
+          std::memcmp(NameBytes.data(), HotswapPoolNoteName.data(),
+                      HotswapPoolNoteName.size()) == 0;
+
+      if (Type == HotswapPoolNoteType && HasHotswapVendorSpelling) {
+        const bool HasExactTerminatedName =
+            NameBytes.size() == HotswapPoolNoteName.size() + 1 &&
+            NameBytes.back() == 0;
+        if (!HasExactTerminatedName || Shdr.sh_addralign != 4 ||
+            Shdr.sh_entsize != 0 ||
+            (Shdr.sh_flags & (ELF::SHF_ALLOC | ELF::SHF_EXECINSTR)) ||
+            Cursor != 0 || RecordEnd != NoteBytes.size()) {
+          log() << "hotswap: error: HotSwap pool provenance does not use the "
+                   "canonical non-allocating ELF-note layout.\n";
+          return std::nullopt;
+        }
+        if (DescSize != HotswapPoolNoteDescSize) {
+          log() << "hotswap: error: HotSwap pool provenance has descriptor "
+                   "size "
+                << DescSize << ", expected " << HotswapPoolNoteDescSize
+                << ".\n";
+          return std::nullopt;
+        }
+        const uint8_t *Desc = NoteBytes.data() + DescOffset;
+        const uint32_t Version = support::endian::read32le(Desc);
+        const uint32_t RawState = support::endian::read32le(Desc + 4);
+        const uint64_t VAddr = support::endian::read64le(Desc + 8);
+        const uint64_t RegionSize = support::endian::read64le(Desc + 16);
+        if (Version != HotswapPoolNoteVersion ||
+            RawState >
+                static_cast<uint32_t>(ExecutablePoolTargetState::B0) ||
+            RegionSize == 0 ||
+            RegionSize > std::numeric_limits<uint64_t>::max() - VAddr) {
+          log() << "hotswap: error: malformed or unsupported HotSwap pool "
+                   "provenance.\n";
+          return std::nullopt;
+        }
+        if (llvm::any_of(Provenance, [&](const PoolProvenance &Existing) {
+              return Existing.VAddr == VAddr && Existing.Size == RegionSize;
+            })) {
+          log() << "hotswap: error: duplicate HotSwap pool provenance for "
+                   "vaddr 0x"
+                << utohexstr(VAddr) << ".\n";
+          return std::nullopt;
+        }
+        Provenance.push_back(
+            {VAddr, RegionSize,
+             static_cast<ExecutablePoolTargetState>(RawState)});
+      }
+      Cursor = RecordEnd;
+    }
+  }
+
+  if (Provenance.size() != ExternalSections.size() ||
+      Provenance.size() != ExternalSegments.size()) {
+    log() << "hotswap: error: external executable pool section/segment/note "
+             "counts do not match.\n";
+    return false;
+  }
+
+  for (const PoolProvenance &Pool : Provenance) {
+    const ExecutableRegion *Section = nullptr;
+    const ExecutableRegion *Segment = nullptr;
+    unsigned SectionMatches = 0;
+    unsigned SegmentMatches = 0;
+    for (const ExecutableRegion &Region : ExternalSections)
+      if (Region.VAddr == Pool.VAddr && Region.Size == Pool.Size) {
+        Section = &Region;
+        ++SectionMatches;
+      }
+    for (const ExecutableRegion &Region : ExternalSegments)
+      if (Region.VAddr == Pool.VAddr && Region.Size == Pool.Size) {
+        Segment = &Region;
+        ++SegmentMatches;
+      }
+    if (SectionMatches != 1 || SegmentMatches != 1) {
+      log() << "hotswap: error: HotSwap pool provenance at vaddr 0x"
+            << utohexstr(Pool.VAddr)
+            << " does not have one exact RX section/PT_LOAD mapping.\n";
+      return false;
+    }
+    if (Section->FileOffset != Segment->FileOffset) {
+      log() << "hotswap: error: HotSwap pool section/PT_LOAD at vaddr 0x"
+            << utohexstr(Pool.VAddr)
+            << " refer to different file bytes.\n";
+      return false;
+    }
+    if (Pool.State != ExecutablePoolTargetState::Neutral &&
+        Pool.State != TargetState) {
+      log() << "hotswap: error: executable HotSwap pool at vaddr 0x"
+            << utohexstr(Pool.VAddr)
+            << " was produced for an incompatible target stepping.\n";
+      return false;
+    }
+  }
+  return true;
+}
+
 // -- ElfView::trampolinePoolVAddr ---------------------------------------------
 
 std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
@@ -1264,14 +1931,35 @@ std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
       return std::nullopt;
     MaxAllocEnd = std::max(MaxAllocEnd, *End);
   }
-  return alignTo(MaxAllocEnd, TrampolinePoolAlign);
+
+  // A PT_LOAD may reserve a zero-fill tail that is not represented by any
+  // section (p_memsz > p_filesz), or may cover mapped bytes without a section
+  // header at all. The appended pool must be above those ranges as well.
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr) {
+    log() << "hotswap: error: failed to enumerate load segments for pool "
+             "vaddr: "
+          << toString(PhdrsOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD)
+      continue;
+    std::optional<uint64_t> End = checkedAddUint64(
+        Phdr.p_vaddr, Phdr.p_memsz, "load segment end for pool vaddr");
+    if (!End)
+      return std::nullopt;
+    MaxAllocEnd = std::max(MaxAllocEnd, *End);
+  }
+  return checkedAlignToUint64(MaxAllocEnd, TrampolinePoolAlign,
+                              "trampoline pool virtual address");
 }
 
 // -- addKernelEntryTrampolineSymbols ------------------------------------------
 
 std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    WritableMemoryBuffer &In, unsigned TextSectionIndex, uint64_t TextAddr,
-    uint64_t OldTextSize, ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+    WritableMemoryBuffer &In, uint64_t PoolVAddr,
+    ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return nullptr;
 
@@ -1282,7 +1970,8 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
       ELFFileT::create(StringRef(reinterpret_cast<const char *>(Data), Size));
   if (!FileOrErr) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: failed to parse "
-          << "grown ELF: " << toString(FileOrErr.takeError()) << "\n";
+             "grown ELF: "
+          << toString(FileOrErr.takeError()) << "\n";
     return nullptr;
   }
   ELFFileT File = std::move(*FileOrErr);
@@ -1293,8 +1982,6 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
   }
   ELFT::ShdrRange Secs = *SecsOrErr;
 
-  // Locate .symtab and its linked string table. Scan from the end, since the
-  // symbol table sits near the end of the section list in these code objects.
   const ELFT::Shdr *SymShdr = nullptr;
   unsigned SymIdx = 0;
   for (unsigned I = Secs.size(); I-- > 0;)
@@ -1305,159 +1992,197 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     }
   if (!SymShdr) {
     log() << "hotswap: addKernelEntryTrampolineSymbols: no .symtab present; "
-          << "skipping stub symbols.\n";
+             "skipping stub symbols.\n";
+    return nullptr;
+  }
+  for (const ELFT::Shdr &Shdr : Secs) {
+    if (Shdr.sh_type != ELF::SHT_SYMTAB_SHNDX || Shdr.sh_link != SymIdx)
+      continue;
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: cannot append "
+             "symbols while a linked SHT_SYMTAB_SHNDX table is present.\n";
     return nullptr;
   }
   const unsigned StrIdx = SymShdr->sh_link;
   if (StrIdx == 0 || StrIdx >= Secs.size()) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: .symtab has an "
-          << "invalid sh_link (" << StrIdx << ").\n";
+             "invalid sh_link ("
+          << StrIdx << ").\n";
     return nullptr;
   }
   if (SymShdr->sh_entsize != sizeof(ELF::Elf64_Sym)) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: unexpected "
-          << ".symtab entry size " << SymShdr->sh_entsize << ".\n";
+             ".symtab entry size "
+          << SymShdr->sh_entsize << ".\n";
     return nullptr;
   }
   const ELFT::Shdr &StrShdr = Secs[StrIdx];
-
-  const uint64_t SymOff = SymShdr->sh_offset;
-  const uint64_t SymEnd = SymOff + SymShdr->sh_size;
-  const uint64_t StrOff = StrShdr.sh_offset;
-  const uint64_t StrEnd = StrOff + StrShdr.sh_size;
-  if (SymEnd > Size || StrEnd > Size || SymEnd < SymOff || StrEnd < StrOff) {
-    log() << "hotswap: error: addKernelEntryTrampolineSymbols: symbol/string "
-          << "table extends past the ELF buffer.\n";
+  if (StrShdr.sh_type != ELF::SHT_STRTAB) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: .symtab links "
+             "to a non-string-table section.\n";
+    return nullptr;
+  }
+  if ((SymShdr->sh_flags | StrShdr.sh_flags) & ELF::SHF_ALLOC) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: refusing to "
+             "relocate an allocatable symbol or string table.\n";
     return nullptr;
   }
 
-  // Build the appended string names and symbol entries.
+  const uint64_t SymOff = SymShdr->sh_offset;
+  const uint64_t StrOff = StrShdr.sh_offset;
+  std::optional<uint64_t> SymEnd = checkedAddUint64(
+      SymOff, SymShdr->sh_size, "kernel-entry stub input .symtab end");
+  std::optional<uint64_t> StrEnd = checkedAddUint64(
+      StrOff, StrShdr.sh_size, "kernel-entry stub input .strtab end");
+  if (!SymEnd || !StrEnd || *SymEnd > Size || *StrEnd > Size) {
+    log() << "hotswap: error: addKernelEntryTrampolineSymbols: symbol/string "
+             "table extends past the ELF buffer.\n";
+    return nullptr;
+  }
+
   SmallVector<uint8_t> StrBlob, SymBlob;
   for (const KernelEntryTrampolineFixup &F : Fixups) {
-    std::string Name = F.KernelName + ".stub";
-    uint32_t NameOff = static_cast<uint32_t>(StrShdr.sh_size + StrBlob.size());
-    StrBlob.append(Name.begin(), Name.end());
-    StrBlob.push_back(0);
-
-    std::optional<uint64_t> StubOff = checkedAddUint64(
-        OldTextSize, F.StubTextOffset, "stub symbol .text offset");
-    if (!StubOff)
-      return nullptr;
-    std::optional<uint64_t> StubVAddr =
-        checkedAddUint64(TextAddr, *StubOff, "stub symbol vaddr");
+    std::optional<uint64_t> StubVAddr = checkedAddUint64(
+        PoolVAddr, F.StubTextOffset, "kernel-entry stub symbol vaddr");
     if (!StubVAddr)
       return nullptr;
 
+    std::optional<unsigned> StubSectionIndex;
+    for (unsigned I = 0; I != Secs.size(); ++I) {
+      const ELFT::Shdr &Section = Secs[I];
+      if (Section.sh_type != ELF::SHT_PROGBITS ||
+          (Section.sh_flags & (ELF::SHF_ALLOC | ELF::SHF_EXECINSTR)) !=
+              (ELF::SHF_ALLOC | ELF::SHF_EXECINSTR) ||
+          *StubVAddr < Section.sh_addr)
+        continue;
+
+      const uint64_t SectionOffset = *StubVAddr - Section.sh_addr;
+      if (SectionOffset > Section.sh_size ||
+          KernelEntryStubStride > Section.sh_size - SectionOffset)
+        continue;
+      std::optional<uint64_t> StubFileOffset = checkedAddUint64(
+          Section.sh_offset, SectionOffset,
+          "kernel-entry stub symbol file offset");
+      if (!StubFileOffset || *StubFileOffset > Size ||
+          KernelEntryStubStride > Size - *StubFileOffset)
+        continue;
+
+      if (StubSectionIndex) {
+        log() << "hotswap: error: addKernelEntryTrampolineSymbols: stub for '"
+              << F.KernelName
+              << "' is covered by multiple executable sections.\n";
+        return nullptr;
+      }
+      StubSectionIndex = I;
+    }
+    if (!StubSectionIndex) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: stub for '"
+            << F.KernelName
+            << "' is not fully contained in a file-backed executable "
+               "section.\n";
+      return nullptr;
+    }
+    if (*StubSectionIndex >= ELF::SHN_LORESERVE) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: executable "
+               "stub section index requires unsupported SHN_XINDEX.\n";
+      return nullptr;
+    }
+
+    std::string Name = F.KernelName + ".stub";
+    std::optional<uint64_t> NameOff = checkedAddUint64(
+        StrShdr.sh_size, StrBlob.size(), "kernel-entry stub symbol name offset");
+    if (!NameOff || *NameOff > std::numeric_limits<uint32_t>::max()) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: string-table "
+               "offset exceeds Elf64_Sym::st_name.\n";
+      return nullptr;
+    }
+    StrBlob.append(Name.begin(), Name.end());
+    StrBlob.push_back(0);
+
     ELF::Elf64_Sym Sym{};
-    Sym.st_name = NameOff;
+    Sym.st_name = static_cast<uint32_t>(*NameOff);
     Sym.st_info = (ELF::STB_GLOBAL << 4) | ELF::STT_FUNC;
     Sym.st_other = ELF::STV_DEFAULT;
-    Sym.st_shndx = static_cast<uint16_t>(TextSectionIndex);
+    Sym.st_shndx = static_cast<uint16_t>(*StubSectionIndex);
     Sym.st_value = *StubVAddr;
     Sym.st_size = KernelEntryStubStride;
     const uint8_t *P = reinterpret_cast<const uint8_t *>(&Sym);
     SymBlob.append(P, P + sizeof(Sym));
   }
-  // The section header table must stay 8-byte aligned (LLVM's ELF reader
-  // rejects a misaligned table). SymBlob is a multiple of 8 (24-byte entries),
-  // so pad the string blob up to a multiple of 8 with unreferenced NULs.
-  StrBlob.append((8 - (StrBlob.size() % 8)) % 8, 0);
 
-  const uint64_t SymDelta = SymBlob.size();
-  const uint64_t StrDelta = StrBlob.size();
-  const size_t NewSize = Size + SymDelta + StrDelta;
+  std::optional<uint64_t> NewStrSize = checkedAddUint64(
+      StrShdr.sh_size, StrBlob.size(), "relocated stub .strtab size");
+  std::optional<uint64_t> NewSymSize = checkedAddUint64(
+      SymShdr->sh_size, SymBlob.size(), "relocated stub .symtab size");
+  if (!NewStrSize || !NewSymSize)
+    return nullptr;
+
+  auto SectionAlignment = [](uint64_t Alignment, uint64_t Minimum,
+                             StringRef Name) -> std::optional<uint64_t> {
+    Alignment = std::max(Alignment, Minimum);
+    if (!isPowerOf2_64(Alignment)) {
+      log() << "hotswap: error: addKernelEntryTrampolineSymbols: " << Name
+            << " alignment " << Alignment << " is not a power of two.\n";
+      return std::nullopt;
+    }
+    return Alignment;
+  };
+  std::optional<uint64_t> StrAlign =
+      SectionAlignment(StrShdr.sh_addralign, 1, ".strtab");
+  std::optional<uint64_t> SymAlign = SectionAlignment(
+      SymShdr->sh_addralign, alignof(ELF::Elf64_Sym), ".symtab");
+  if (!StrAlign || !SymAlign)
+    return nullptr;
+
+  // Relocate these non-allocating tables after the complete grown ELF. This
+  // leaves the executable pool, e_phoff, and every PT_LOAD p_offset unchanged.
+  std::optional<uint64_t> NewStrOff = checkedAlignToUint64(
+      Size, *StrAlign, "relocated kernel-entry stub .strtab offset");
+  if (!NewStrOff)
+    return nullptr;
+  std::optional<uint64_t> AfterStr = checkedAddUint64(
+      *NewStrOff, *NewStrSize, "relocated kernel-entry stub .strtab end");
+  if (!AfterStr)
+    return nullptr;
+  std::optional<uint64_t> NewSymOff = checkedAlignToUint64(
+      *AfterStr, *SymAlign, "relocated kernel-entry stub .symtab offset");
+  if (!NewSymOff)
+    return nullptr;
+  std::optional<uint64_t> NewSizeOr = checkedAddUint64(
+      *NewSymOff, *NewSymSize, "kernel-entry stub symbol ELF size");
+  if (!NewSizeOr || *NewSizeOr > std::numeric_limits<size_t>::max())
+    return nullptr;
+  const size_t NewSize = static_cast<size_t>(*NewSizeOr);
 
   std::unique_ptr<WritableMemoryBuffer> Out =
-      WritableMemoryBuffer::getNewUninitMemBuffer(NewSize);
+      WritableMemoryBuffer::getNewMemBuffer(NewSize);
   if (!Out) {
     log() << "hotswap: error: addKernelEntryTrampolineSymbols: allocation of "
           << NewSize << " bytes failed.\n";
     return nullptr;
   }
   uint8_t *O = reinterpret_cast<uint8_t *>(Out->getBufferStart());
-
-  // Insert the new symbol entries right after the existing .symtab contents and
-  // the new strings right after the existing .strtab contents. Both insertion
-  // points are expressed in original-file coordinates; copying in ascending
-  // order keeps the arithmetic order-independent (either table may come first).
-  struct Insertion {
-    uint64_t Pos;
-    const SmallVector<uint8_t> *Bytes;
-  };
-  Insertion A{SymEnd, &SymBlob}, B{StrEnd, &StrBlob};
-  if (A.Pos > B.Pos)
-    std::swap(A, B);
-
-  size_t OutPos = 0, InPos = 0;
-  auto CopyThrough = [&](uint64_t Upto) {
-    std::memcpy(O + OutPos, Data + InPos, Upto - InPos);
-    OutPos += Upto - InPos;
-    InPos = Upto;
-  };
-  CopyThrough(A.Pos);
-  std::memcpy(O + OutPos, A.Bytes->data(), A.Bytes->size());
-  OutPos += A.Bytes->size();
-  CopyThrough(B.Pos);
-  std::memcpy(O + OutPos, B.Bytes->data(), B.Bytes->size());
-  OutPos += B.Bytes->size();
-  std::memcpy(O + OutPos, Data + InPos, Size - InPos);
-
-  // Anything at or beyond an insertion point shifts by that insertion's size.
-  auto Shift = [&](uint64_t X) -> uint64_t {
-    return X + (X >= SymEnd ? SymDelta : 0) + (X >= StrEnd ? StrDelta : 0);
-  };
+  std::memcpy(O, Data, Size);
+  std::memcpy(O + *NewStrOff, Data + StrOff, StrShdr.sh_size);
+  std::memcpy(O + *NewStrOff + StrShdr.sh_size, StrBlob.data(), StrBlob.size());
+  std::memcpy(O + *NewSymOff, Data + SymOff, SymShdr->sh_size);
+  std::memcpy(O + *NewSymOff + SymShdr->sh_size, SymBlob.data(), SymBlob.size());
 
   uint64_t Shoff;
   uint16_t Shentsize, Shnum;
   std::memcpy(&Shoff, O + offsetof(Ehdr, e_shoff), sizeof(Shoff));
   std::memcpy(&Shentsize, O + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
   std::memcpy(&Shnum, O + offsetof(Ehdr, e_shnum), sizeof(Shnum));
-
-  uint64_t Phoff;
-  uint16_t Phentsize, Phnum;
-  std::memcpy(&Phoff, O + offsetof(Ehdr, e_phoff), sizeof(Phoff));
-  std::memcpy(&Phentsize, O + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
-  std::memcpy(&Phnum, O + offsetof(Ehdr, e_phnum), sizeof(Phnum));
-
-  uint64_t NewShoff = Shift(Shoff);
-  std::memcpy(O + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
-  uint64_t NewPhoff = Shift(Phoff);
-  std::memcpy(O + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
-
-  if (Shentsize < sizeof(Shdr))
+  if (Shentsize < sizeof(Shdr) || Shoff > Size ||
+      static_cast<uint64_t>(Shnum) * Shentsize > Size - Shoff)
     return nullptr;
 
-  for (uint16_t I = 0; I < Shnum; ++I) {
-    uint64_t P = NewShoff + static_cast<uint64_t>(I) * Shentsize;
-    if (P + sizeof(Shdr) > NewSize)
-      break;
-    uint8_t *Sh = O + P;
-    uint64_t ShOffset;
-    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
-    uint64_t NewOff = Shift(ShOffset);
-    std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOff, sizeof(NewOff));
-
-    if (I == SymIdx || I == StrIdx) {
-      uint64_t ShSize;
-      std::memcpy(&ShSize, Sh + offsetof(Shdr, sh_size), sizeof(ShSize));
-      ShSize += (I == SymIdx) ? SymDelta : StrDelta;
-      std::memcpy(Sh + offsetof(Shdr, sh_size), &ShSize, sizeof(ShSize));
-    }
-  }
-
-  if (Phentsize >= sizeof(Phdr)) {
-    for (uint16_t I = 0; I < Phnum; ++I) {
-      uint64_t P = NewPhoff + static_cast<uint64_t>(I) * Phentsize;
-      if (P + sizeof(Phdr) > NewSize)
-        break;
-      uint8_t *Ph = O + P;
-      uint64_t POffset;
-      std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
-      uint64_t NewPOffset = Shift(POffset);
-      std::memcpy(Ph + offsetof(Phdr, p_offset), &NewPOffset,
-                  sizeof(NewPOffset));
-    }
-  }
+  auto RelocateSection = [&](unsigned Index, uint64_t Offset, uint64_t Size) {
+    uint8_t *Sh = O + Shoff + static_cast<uint64_t>(Index) * Shentsize;
+    std::memcpy(Sh + offsetof(Shdr, sh_offset), &Offset, sizeof(Offset));
+    std::memcpy(Sh + offsetof(Shdr, sh_size), &Size, sizeof(Size));
+  };
+  RelocateSection(StrIdx, *NewStrOff, *NewStrSize);
+  RelocateSection(SymIdx, *NewSymOff, *NewSymSize);
 
   log() << "hotswap: added " << Fixups.size()
         << " kernel-entry stub symbol(s) to .symtab\n";
@@ -1468,7 +2193,8 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
 
 std::unique_ptr<WritableMemoryBuffer>
 ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
-                             ArrayRef<uint8_t> SNopBytes) const {
+                             ArrayRef<uint8_t> SNopBytes,
+                             ExecutablePoolTargetState TargetState) const {
   // SNopBytes is unused in the append-at-end model: nothing between .text and
   // the following sections moves, so there is no in-image gap to pad. It is
   // retained in the signature for callers and for a future in-place variant.
@@ -1476,6 +2202,13 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
 
   const size_t InputSize = size();
   const uint8_t *Input = data();
+
+  if (static_cast<uint32_t>(TargetState) >
+      static_cast<uint32_t>(ExecutablePoolTargetState::B0)) {
+    log() << "hotswap: error: growWithTrampolines: invalid executable pool "
+             "target state.\n";
+    return nullptr;
+  }
 
   if (InputSize < sizeof(Ehdr)) {
     log() << "hotswap: error: growWithTrampolines: input (" << InputSize
@@ -1516,15 +2249,19 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
     return nullptr;
   }
   const uint64_t PoolVAddr = *PoolVAddrOr;
-  const uint64_t PoolFileOff =
-      alignTo(static_cast<uint64_t>(InputSize), TrampolinePoolAlign);
+  std::optional<uint64_t> PoolFileOffOr = checkedAlignToUint64(
+      static_cast<uint64_t>(InputSize), TrampolinePoolAlign,
+      "trampoline pool file offset");
+  if (!PoolFileOffOr)
+    return nullptr;
+  const uint64_t PoolFileOff = *PoolFileOffOr;
 
-  // Copy the program-header and section-header tables to the end of the file,
-  // each with one new entry for the pool (a PT_LOAD segment so the loader maps
-  // it, and an SHF_ALLOC|SHF_EXECINSTR section so objdump/tools and a
-  // subsequent rewrite can see it), then repoint e_phoff / e_shoff. Those
-  // tables are metadata addressed via the ELF header, so relocating them moves
-  // nothing a baked literal can reference.
+  // Copy the program-header and section-header tables to the end of the file.
+  // Add a PT_LOAD and SHF_ALLOC|SHF_EXECINSTR section for the pool, plus a
+  // non-allocating SHT_NOTE that records its exact range and target state for a
+  // subsequent rewrite. Then repoint e_phoff / e_shoff. Those tables and the
+  // note are metadata addressed through the ELF header, so relocating them
+  // moves nothing a baked literal can reference.
   uint64_t Phoff, Shoff;
   uint16_t Phentsize, Phnum, Shentsize, Shnum;
   std::memcpy(&Phoff, Input + offsetof(Ehdr, e_phoff), sizeof(Phoff));
@@ -1544,44 +2281,72 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
       Shnum > 0 && Shoff != 0 && Shentsize >= sizeof(Shdr) &&
       Shoff <= InputSize &&
       static_cast<uint64_t>(Shnum) * Shentsize <= InputSize - Shoff;
+  if (!HasPhdrs || !HasShdrs) {
+    log() << "hotswap: error: growWithTrampolines: cannot record executable "
+             "pool provenance without valid program- and section-header "
+             "tables.\n";
+    return nullptr;
+  }
 
   std::optional<uint64_t> PoolEnd =
       checkedAddUint64(PoolFileOff, TrampTotal, "trampoline pool file end");
-  if (!PoolEnd)
+  std::optional<uint64_t> PoolVAddrEnd = checkedAddUint64(
+      PoolVAddr, TrampTotal, "trampoline pool virtual-address end");
+  if (!PoolEnd || !PoolVAddrEnd)
+    return nullptr;
+  SmallVector<uint8_t, 48> PoolNote =
+      buildHotswapPoolNote(PoolVAddr, TrampTotal, TargetState);
+  std::optional<uint64_t> PoolNoteFileOffOr = checkedAlignToUint64(
+      *PoolEnd, uint64_t{4}, "trampoline pool provenance note offset");
+  if (!PoolNoteFileOffOr)
+    return nullptr;
+  const uint64_t PoolNoteFileOff = *PoolNoteFileOffOr;
+  std::optional<uint64_t> PoolNoteEnd = checkedAddUint64(
+      PoolNoteFileOff, PoolNote.size(), "trampoline pool provenance note end");
+  if (!PoolNoteEnd)
     return nullptr;
 
-  // Lay out the relocated tables after the pool: [pool][phdrs][shdrs].
-  uint64_t Cursor = *PoolEnd;
-  const uint64_t NewPhnum = HasPhdrs ? static_cast<uint64_t>(Phnum) + 1 : Phnum;
-  const uint64_t NewShnum = HasShdrs ? static_cast<uint64_t>(Shnum) + 1 : Shnum;
-  uint64_t NewPhoff = Phoff;
-  uint64_t NewShoff = Shoff;
-  if (HasPhdrs) {
-    if (static_cast<uint64_t>(Phnum) >= std::numeric_limits<uint16_t>::max()) {
-      log() << "hotswap: error: growWithTrampolines: program-header count "
-            << Phnum << " leaves no room to append a PT_LOAD.\n";
-      return nullptr;
-    }
-    NewPhoff = alignTo(Cursor, static_cast<uint64_t>(alignof(Phdr)));
-    std::optional<uint64_t> End = checkedAddUint64(
-        NewPhoff, NewPhnum * Phentsize, "relocated phdr table end");
-    if (!End)
-      return nullptr;
-    Cursor = *End;
+  // Lay out metadata after the pool: [pool][note][phdrs][shdrs].
+  uint64_t Cursor = *PoolNoteEnd;
+  const uint64_t NewPhnum = static_cast<uint64_t>(Phnum) + 1;
+  const uint64_t NewShnum = static_cast<uint64_t>(Shnum) + 2;
+  if (NewPhnum >= ELF::PN_XNUM) {
+    log() << "hotswap: error: growWithTrampolines: program-header count "
+          << NewPhnum
+          << " after appending a PT_LOAD requires unsupported extended "
+             "numbering.\n";
+    return nullptr;
   }
-  if (HasShdrs) {
-    if (static_cast<uint64_t>(Shnum) >= std::numeric_limits<uint16_t>::max()) {
-      log() << "hotswap: error: growWithTrampolines: section-header count "
-            << Shnum << " leaves no room to append the pool section.\n";
-      return nullptr;
-    }
-    NewShoff = alignTo(Cursor, static_cast<uint64_t>(alignof(Shdr)));
-    std::optional<uint64_t> End = checkedAddUint64(
-        NewShoff, NewShnum * Shentsize, "relocated shdr table end");
-    if (!End)
-      return nullptr;
-    Cursor = *End;
+  std::optional<uint64_t> NewPhoffOr = checkedAlignToUint64(
+      Cursor, static_cast<uint64_t>(alignof(Phdr)),
+      "relocated phdr table offset");
+  if (!NewPhoffOr)
+    return nullptr;
+  const uint64_t NewPhoff = *NewPhoffOr;
+  std::optional<uint64_t> PhdrEnd = checkedAddUint64(
+      NewPhoff, NewPhnum * Phentsize, "relocated phdr table end");
+  if (!PhdrEnd)
+    return nullptr;
+  Cursor = *PhdrEnd;
+
+  if (NewShnum >= ELF::SHN_LORESERVE) {
+    log() << "hotswap: error: growWithTrampolines: section-header count "
+          << NewShnum
+          << " after appending the pool and provenance sections requires "
+             "unsupported extended numbering.\n";
+    return nullptr;
   }
+  std::optional<uint64_t> NewShoffOr = checkedAlignToUint64(
+      Cursor, static_cast<uint64_t>(alignof(Shdr)),
+      "relocated shdr table offset");
+  if (!NewShoffOr)
+    return nullptr;
+  const uint64_t NewShoff = *NewShoffOr;
+  std::optional<uint64_t> ShdrEnd = checkedAddUint64(
+      NewShoff, NewShnum * Shentsize, "relocated shdr table end");
+  if (!ShdrEnd)
+    return nullptr;
+  Cursor = *ShdrEnd;
   if (Cursor > std::numeric_limits<size_t>::max()) {
     log()
         << "hotswap: error: growWithTrampolines: grown size exceeds size_t.\n";
@@ -1609,51 +2374,72 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
     std::memcpy(Out + Pos, T.Bytes.data(), T.Bytes.size());
     Pos += T.Bytes.size();
   }
-  // 3. Relocated program-header table + appended PT_LOAD for the pool.
-  if (HasPhdrs) {
-    std::memcpy(Out + NewPhoff, Input + Phoff,
-                static_cast<size_t>(Phnum) * Phentsize);
-    Phdr PoolPhdr{};
-    PoolPhdr.p_type = ELF::PT_LOAD;
-    PoolPhdr.p_flags = ELF::PF_R | ELF::PF_X;
-    PoolPhdr.p_offset = PoolFileOff;
-    PoolPhdr.p_vaddr = PoolVAddr;
-    PoolPhdr.p_paddr = PoolVAddr;
-    PoolPhdr.p_filesz = TrampTotal;
-    PoolPhdr.p_memsz = TrampTotal;
-    PoolPhdr.p_align = TrampolinePoolAlign;
-    std::memcpy(Out + NewPhoff + static_cast<uint64_t>(Phnum) * Phentsize,
-                &PoolPhdr, sizeof(PoolPhdr));
-    std::memcpy(Out + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
-    uint16_t NewPhnum16 = static_cast<uint16_t>(NewPhnum);
-    std::memcpy(Out + offsetof(Ehdr, e_phnum), &NewPhnum16, sizeof(NewPhnum16));
+  // 3. Non-allocating standard ELF note describing the executable pool.
+  std::memcpy(Out + PoolNoteFileOff, PoolNote.data(), PoolNote.size());
+  // 4. Relocated program-header table + appended PT_LOAD for the pool.
+  std::memcpy(Out + NewPhoff, Input + Phoff,
+              static_cast<size_t>(Phnum) * Phentsize);
+  // PT_PHDR promises that the program-header table is part of the process
+  // image at the address recorded in that entry. The relocated table is
+  // metadata after the pool and is deliberately not mapped by a PT_LOAD, so an
+  // inherited PT_PHDR would describe the obsolete table. PT_PHDR is optional;
+  // remove the stale promise while preserving the remaining table slots.
+  for (uint16_t I = 0; I != Phnum; ++I) {
+    uint8_t *Entry = Out + NewPhoff + static_cast<uint64_t>(I) * Phentsize;
+    Phdr Existing{};
+    std::memcpy(&Existing, Entry, sizeof(Existing));
+    if (Existing.p_type != ELF::PT_PHDR)
+      continue;
+    Phdr Null{};
+    std::memcpy(Entry, &Null, sizeof(Null));
   }
-  // 4. Relocated section-header table + appended pool section. The section has
-  // an empty name (sh_name == 0): the loader ignores section headers and tools
-  // still disassemble it by flags, so no .shstrtab surgery is needed.
-  if (HasShdrs) {
-    std::memcpy(Out + NewShoff, Input + Shoff,
-                static_cast<size_t>(Shnum) * Shentsize);
-    Shdr PoolShdr{};
-    PoolShdr.sh_name = 0;
-    PoolShdr.sh_type = ELF::SHT_PROGBITS;
-    PoolShdr.sh_flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
-    PoolShdr.sh_addr = PoolVAddr;
-    PoolShdr.sh_offset = PoolFileOff;
-    PoolShdr.sh_size = TrampTotal;
-    PoolShdr.sh_addralign = TrampolinePoolAlign;
-    std::memcpy(Out + NewShoff + static_cast<uint64_t>(Shnum) * Shentsize,
-                &PoolShdr, sizeof(PoolShdr));
-    std::memcpy(Out + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
-    uint16_t NewShnum16 = static_cast<uint16_t>(NewShnum);
-    std::memcpy(Out + offsetof(Ehdr, e_shnum), &NewShnum16, sizeof(NewShnum16));
-  }
+  Phdr PoolPhdr{};
+  PoolPhdr.p_type = ELF::PT_LOAD;
+  PoolPhdr.p_flags = ELF::PF_R | ELF::PF_X;
+  PoolPhdr.p_offset = PoolFileOff;
+  PoolPhdr.p_vaddr = PoolVAddr;
+  PoolPhdr.p_paddr = PoolVAddr;
+  PoolPhdr.p_filesz = TrampTotal;
+  PoolPhdr.p_memsz = TrampTotal;
+  PoolPhdr.p_align = TrampolinePoolAlign;
+  std::memcpy(Out + NewPhoff + static_cast<uint64_t>(Phnum) * Phentsize,
+              &PoolPhdr, sizeof(PoolPhdr));
+  std::memcpy(Out + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
+  uint16_t NewPhnum16 = static_cast<uint16_t>(NewPhnum);
+  std::memcpy(Out + offsetof(Ehdr, e_phnum), &NewPhnum16, sizeof(NewPhnum16));
+  // 5. Relocated section-header table + appended pool and provenance sections.
+  // Both have empty names (sh_name == 0), avoiding .shstrtab surgery.
+  std::memcpy(Out + NewShoff, Input + Shoff,
+              static_cast<size_t>(Shnum) * Shentsize);
+  Shdr PoolShdr{};
+  PoolShdr.sh_name = 0;
+  PoolShdr.sh_type = ELF::SHT_PROGBITS;
+  PoolShdr.sh_flags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
+  PoolShdr.sh_addr = PoolVAddr;
+  PoolShdr.sh_offset = PoolFileOff;
+  PoolShdr.sh_size = TrampTotal;
+  PoolShdr.sh_addralign = TrampolinePoolAlign;
+  std::memcpy(Out + NewShoff + static_cast<uint64_t>(Shnum) * Shentsize,
+              &PoolShdr, sizeof(PoolShdr));
+  Shdr NoteShdr{};
+  NoteShdr.sh_name = 0;
+  NoteShdr.sh_type = ELF::SHT_NOTE;
+  NoteShdr.sh_offset = PoolNoteFileOff;
+  NoteShdr.sh_size = PoolNote.size();
+  NoteShdr.sh_addralign = 4;
+  std::memcpy(Out + NewShoff +
+                  (static_cast<uint64_t>(Shnum) + 1) * Shentsize,
+              &NoteShdr, sizeof(NoteShdr));
+  std::memcpy(Out + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+  uint16_t NewShnum16 = static_cast<uint16_t>(NewShnum);
+  std::memcpy(Out + offsetof(Ehdr, e_shnum), &NewShnum16, sizeof(NewShnum16));
 
   log() << "hotswap: growWithTrampolines: appended " << Trampolines.size()
         << (Trampolines.size() == 1 ? " trampoline (" : " trampolines (")
         << TrampTotal << " bytes) at vaddr 0x" << utohexstr(PoolVAddr)
         << " (file 0x" << utohexstr(PoolFileOff) << "); grew ELF from "
-        << InputSize << " to " << NewSize << " bytes.\n";
+        << InputSize << " to " << NewSize << " bytes with target-state "
+        << static_cast<uint32_t>(TargetState) << " provenance.\n";
   return Buf;
 }
 

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -62,9 +62,8 @@ static constexpr uint32_t HotswapPoolNoteType = 0x48535750; // "HSWP"
 static constexpr uint32_t HotswapPoolNoteVersion = 1;
 static constexpr uint32_t HotswapPoolNoteDescSize = 24;
 
-static std::optional<uint64_t> checkedAlignToUint64(uint64_t Value,
-                                                    uint64_t Alignment,
-                                                    StringRef Context) {
+static std::optional<uint64_t>
+checkedAlignToUint64(uint64_t Value, uint64_t Alignment, StringRef Context) {
   if (Alignment == 0) {
     log() << "hotswap: error: " << Context << " has zero alignment.\n";
     return std::nullopt;
@@ -80,9 +79,8 @@ buildHotswapPoolNote(uint64_t PoolVAddr, uint64_t PoolSize,
                      ExecutablePoolTargetState TargetState) {
   const uint32_t NameSize = HotswapPoolNoteName.size() + 1;
   const uint32_t NameStorageSize = alignTo(NameSize, uint32_t{4});
-  SmallVector<uint8_t, 48> Bytes(12 + NameStorageSize +
-                                    HotswapPoolNoteDescSize,
-                                0);
+  SmallVector<uint8_t, 48> Bytes(12 + NameStorageSize + HotswapPoolNoteDescSize,
+                                 0);
   support::endian::write32le(Bytes.data(), NameSize);
   support::endian::write32le(Bytes.data() + 4, HotswapPoolNoteDescSize);
   support::endian::write32le(Bytes.data() + 8, HotswapPoolNoteType);
@@ -90,8 +88,7 @@ buildHotswapPoolNote(uint64_t PoolVAddr, uint64_t PoolSize,
               HotswapPoolNoteName.size());
   uint8_t *Desc = Bytes.data() + 12 + NameStorageSize;
   support::endian::write32le(Desc, HotswapPoolNoteVersion);
-  support::endian::write32le(Desc + 4,
-                             static_cast<uint32_t>(TargetState));
+  support::endian::write32le(Desc + 4, static_cast<uint32_t>(TargetState));
   support::endian::write64le(Desc + 8, PoolVAddr);
   support::endian::write64le(Desc + 16, PoolSize);
   return Bytes;
@@ -523,9 +520,9 @@ ElfView::allKernelsHaveGfx1250Revision(StringRef Revision) const {
       return std::nullopt;
     }
   }
-  return FoundKernel &&
-         llvm::all_of(DescriptorSeen,
-                      [](const auto &Entry) { return Entry.getValue(); });
+  return FoundKernel && llvm::all_of(DescriptorSeen, [](const auto &Entry) {
+           return Entry.getValue();
+         });
 }
 
 // -- applyByteReplace ---------------------------------------------------------
@@ -577,8 +574,7 @@ NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
     const bool Eligible =
         Use == NopSledUse::Gateway
             ? Sled.canGatewayFrom(Offset)
-            : Sled.canHoldBodyFrom(
-                  Offset, Use == NopSledUse::RelocationBody);
+            : Sled.canHoldBodyFrom(Offset, Use == NopSledUse::RelocationBody);
     if (!Eligible)
       continue;
     if (Sled.WritePos > Sled.End || Needed > Sled.End - Sled.WritePos)
@@ -588,10 +584,9 @@ NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
     const bool Owned = Sled.ownsSource(Offset);
     const bool PreferOwned = Use == NopSledUse::RelocationBody;
     const bool Better =
-        !Best ||
-        (PreferOwned ? (Owned && !BestOwned) ||
-                           (Owned == BestOwned && Dist < BestDist)
-                     : Dist < BestDist);
+        !Best || (PreferOwned ? (Owned && !BestOwned) ||
+                                    (Owned == BestOwned && Dist < BestDist)
+                              : Dist < BestDist);
     if (Dist < MaxSledDistance && Better) {
       Best = &Sled;
       BestDist = Dist;
@@ -1648,15 +1643,14 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
 
   unsigned SectionIndex = 0;
   for (const ELFT::Shdr &Shdr : Sections) {
-    const bool IsFileBackedExecutable =
-        (Shdr.sh_flags & ELF::SHF_EXECINSTR) &&
-        Shdr.sh_type != ELF::SHT_NOBITS && Shdr.sh_size != 0;
+    const bool IsFileBackedExecutable = (Shdr.sh_flags & ELF::SHF_EXECINSTR) &&
+                                        Shdr.sh_type != ELF::SHT_NOBITS &&
+                                        Shdr.sh_size != 0;
     if (!IsFileBackedExecutable) {
       ++SectionIndex;
       continue;
     }
-    if (Shdr.sh_offset > FileSize ||
-        Shdr.sh_size > FileSize - Shdr.sh_offset) {
+    if (Shdr.sh_offset > FileSize || Shdr.sh_size > FileSize - Shdr.sh_offset) {
       log() << "hotswap: error: executable section " << SectionIndex
             << " extends past the end of the ELF buffer.\n";
       return std::nullopt;
@@ -1674,8 +1668,7 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
               << " is not a non-writable allocatable SHT_PROGBITS pool.\n";
         return false;
       }
-      ExternalSections.push_back(
-          {Shdr.sh_addr, Shdr.sh_size, Shdr.sh_offset});
+      ExternalSections.push_back({Shdr.sh_addr, Shdr.sh_size, Shdr.sh_offset});
     }
     ++SectionIndex;
   }
@@ -1691,8 +1684,7 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
   for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
     if (Phdr.p_type != ELF::PT_LOAD || !(Phdr.p_flags & ELF::PF_X))
       continue;
-    if (Phdr.p_offset > FileSize ||
-        Phdr.p_filesz > FileSize - Phdr.p_offset) {
+    if (Phdr.p_offset > FileSize || Phdr.p_filesz > FileSize - Phdr.p_offset) {
       log() << "hotswap: error: executable PT_LOAD extends past the end of "
                "the ELF buffer.\n";
       return std::nullopt;
@@ -1726,8 +1718,7 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
       ++TextSegmentCount;
       continue;
     }
-    ExternalSegments.push_back(
-        {Phdr.p_vaddr, Phdr.p_filesz, Phdr.p_offset});
+    ExternalSegments.push_back({Phdr.p_vaddr, Phdr.p_filesz, Phdr.p_offset});
   }
   if (TextSegmentCount != 1) {
     log() << "hotswap: error: .text must have exactly one exact RX PT_LOAD "
@@ -1736,8 +1727,8 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
     return false;
   }
 
-  auto RangesOverlap = [](uint64_t AStart, uint64_t ASize,
-                          uint64_t BStart, uint64_t BSize) {
+  auto RangesOverlap = [](uint64_t AStart, uint64_t ASize, uint64_t BStart,
+                          uint64_t BSize) {
     // All range ends were checked above before regions were collected.
     return ASize != 0 && BSize != 0 && AStart < BStart + BSize &&
            BStart < AStart + ASize;
@@ -1746,7 +1737,8 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
       [&](ArrayRef<ExecutableRegion> Regions, StringRef Kind) {
         for (size_t I = 0; I != Regions.size(); ++I) {
           const ExecutableRegion &Region = Regions[I];
-          if (RangesOverlap(Region.VAddr, Region.Size, textAddr(), textSize()) ||
+          if (RangesOverlap(Region.VAddr, Region.Size, textAddr(),
+                            textSize()) ||
               RangesOverlap(Region.FileOffset, Region.Size, textOffset(),
                             textSize())) {
             log() << "hotswap: error: external executable " << Kind << " " << I
@@ -1757,8 +1749,8 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
             const ExecutableRegion &Other = Regions[J];
             if (RangesOverlap(Region.VAddr, Region.Size, Other.VAddr,
                               Other.Size) ||
-                RangesOverlap(Region.FileOffset, Region.Size,
-                              Other.FileOffset, Other.Size)) {
+                RangesOverlap(Region.FileOffset, Region.Size, Other.FileOffset,
+                              Other.Size)) {
               log() << "hotswap: error: external executable " << Kind << " "
                     << I << " overlaps or aliases " << Kind << " " << J
                     << ".\n";
@@ -1776,8 +1768,7 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
   for (const ELFT::Shdr &Shdr : Sections) {
     if (Shdr.sh_type != ELF::SHT_NOTE)
       continue;
-    if (Shdr.sh_offset > FileSize ||
-        Shdr.sh_size > FileSize - Shdr.sh_offset) {
+    if (Shdr.sh_offset > FileSize || Shdr.sh_size > FileSize - Shdr.sh_offset) {
       log() << "hotswap: error: SHT_NOTE section extends past the end of the "
                "ELF buffer.\n";
       return std::nullopt;
@@ -1802,10 +1793,8 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
       const uint32_t NameSize = support::endian::read32le(Header);
       const uint32_t DescSize = support::endian::read32le(Header + 4);
       const uint32_t Type = support::endian::read32le(Header + 8);
-      const uint64_t NameStorageSize =
-          alignTo(uint64_t{NameSize}, RecordAlign);
-      const uint64_t DescStorageSize =
-          alignTo(uint64_t{DescSize}, RecordAlign);
+      const uint64_t NameStorageSize = alignTo(uint64_t{NameSize}, RecordAlign);
+      const uint64_t DescStorageSize = alignTo(uint64_t{DescSize}, RecordAlign);
       const uint64_t BytesAfterHeader = NoteBytes.size() - Cursor - 12;
       if (NameStorageSize > BytesAfterHeader ||
           DescStorageSize > BytesAfterHeader - NameStorageSize) {
@@ -1847,8 +1836,7 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
         const uint64_t VAddr = support::endian::read64le(Desc + 8);
         const uint64_t RegionSize = support::endian::read64le(Desc + 16);
         if (Version != HotswapPoolNoteVersion ||
-            RawState >
-                static_cast<uint32_t>(ExecutablePoolTargetState::B0) ||
+            RawState > static_cast<uint32_t>(ExecutablePoolTargetState::B0) ||
             RegionSize == 0 ||
             RegionSize > std::numeric_limits<uint64_t>::max() - VAddr) {
           log() << "hotswap: error: malformed or unsupported HotSwap pool "
@@ -1901,8 +1889,7 @@ std::optional<bool> ElfView::executableCodeOutsideTextIsCompatibleWith(
     }
     if (Section->FileOffset != Segment->FileOffset) {
       log() << "hotswap: error: HotSwap pool section/PT_LOAD at vaddr 0x"
-            << utohexstr(Pool.VAddr)
-            << " refer to different file bytes.\n";
+            << utohexstr(Pool.VAddr) << " refer to different file bytes.\n";
       return false;
     }
     if (Pool.State != ExecutablePoolTargetState::Neutral &&
@@ -1957,9 +1944,9 @@ std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
 
 // -- addKernelEntryTrampolineSymbols ------------------------------------------
 
-std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    WritableMemoryBuffer &In, uint64_t PoolVAddr,
-    ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+std::unique_ptr<WritableMemoryBuffer>
+addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
+                                ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return nullptr;
 
@@ -2059,9 +2046,9 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
       if (SectionOffset > Section.sh_size ||
           KernelEntryStubStride > Section.sh_size - SectionOffset)
         continue;
-      std::optional<uint64_t> StubFileOffset = checkedAddUint64(
-          Section.sh_offset, SectionOffset,
-          "kernel-entry stub symbol file offset");
+      std::optional<uint64_t> StubFileOffset =
+          checkedAddUint64(Section.sh_offset, SectionOffset,
+                           "kernel-entry stub symbol file offset");
       if (!StubFileOffset || *StubFileOffset > Size ||
           KernelEntryStubStride > Size - *StubFileOffset)
         continue;
@@ -2088,8 +2075,9 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     }
 
     std::string Name = F.KernelName + ".stub";
-    std::optional<uint64_t> NameOff = checkedAddUint64(
-        StrShdr.sh_size, StrBlob.size(), "kernel-entry stub symbol name offset");
+    std::optional<uint64_t> NameOff =
+        checkedAddUint64(StrShdr.sh_size, StrBlob.size(),
+                         "kernel-entry stub symbol name offset");
     if (!NameOff || *NameOff > std::numeric_limits<uint32_t>::max()) {
       log() << "hotswap: error: addKernelEntryTrampolineSymbols: string-table "
                "offset exceeds Elf64_Sym::st_name.\n";
@@ -2165,7 +2153,8 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
   std::memcpy(O + *NewStrOff, Data + StrOff, StrShdr.sh_size);
   std::memcpy(O + *NewStrOff + StrShdr.sh_size, StrBlob.data(), StrBlob.size());
   std::memcpy(O + *NewSymOff, Data + SymOff, SymShdr->sh_size);
-  std::memcpy(O + *NewSymOff + SymShdr->sh_size, SymBlob.data(), SymBlob.size());
+  std::memcpy(O + *NewSymOff + SymShdr->sh_size, SymBlob.data(),
+              SymBlob.size());
 
   uint64_t Shoff;
   uint16_t Shentsize, Shnum;
@@ -2249,9 +2238,9 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
     return nullptr;
   }
   const uint64_t PoolVAddr = *PoolVAddrOr;
-  std::optional<uint64_t> PoolFileOffOr = checkedAlignToUint64(
-      static_cast<uint64_t>(InputSize), TrampolinePoolAlign,
-      "trampoline pool file offset");
+  std::optional<uint64_t> PoolFileOffOr =
+      checkedAlignToUint64(static_cast<uint64_t>(InputSize),
+                           TrampolinePoolAlign, "trampoline pool file offset");
   if (!PoolFileOffOr)
     return nullptr;
   const uint64_t PoolFileOff = *PoolFileOffOr;
@@ -2317,9 +2306,9 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
              "numbering.\n";
     return nullptr;
   }
-  std::optional<uint64_t> NewPhoffOr = checkedAlignToUint64(
-      Cursor, static_cast<uint64_t>(alignof(Phdr)),
-      "relocated phdr table offset");
+  std::optional<uint64_t> NewPhoffOr =
+      checkedAlignToUint64(Cursor, static_cast<uint64_t>(alignof(Phdr)),
+                           "relocated phdr table offset");
   if (!NewPhoffOr)
     return nullptr;
   const uint64_t NewPhoff = *NewPhoffOr;
@@ -2336,9 +2325,9 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
              "unsupported extended numbering.\n";
     return nullptr;
   }
-  std::optional<uint64_t> NewShoffOr = checkedAlignToUint64(
-      Cursor, static_cast<uint64_t>(alignof(Shdr)),
-      "relocated shdr table offset");
+  std::optional<uint64_t> NewShoffOr =
+      checkedAlignToUint64(Cursor, static_cast<uint64_t>(alignof(Shdr)),
+                           "relocated shdr table offset");
   if (!NewShoffOr)
     return nullptr;
   const uint64_t NewShoff = *NewShoffOr;
@@ -2427,8 +2416,7 @@ ElfView::growWithTrampolines(ArrayRef<Trampoline> Trampolines,
   NoteShdr.sh_offset = PoolNoteFileOff;
   NoteShdr.sh_size = PoolNote.size();
   NoteShdr.sh_addralign = 4;
-  std::memcpy(Out + NewShoff +
-                  (static_cast<uint64_t>(Shnum) + 1) * Shentsize,
+  std::memcpy(Out + NewShoff + (static_cast<uint64_t>(Shnum) + 1) * Shentsize,
               &NoteShdr, sizeof(NoteShdr));
   std::memcpy(Out + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
   uint16_t NewShnum16 = static_cast<uint16_t>(NewShnum);

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -262,8 +262,8 @@ static bool hasExactEntryStubPadding(ArrayRef<uint8_t> Bytes,
                                      ArrayRef<InternalDecodedInst> Decoded,
                                      const LLVMState &LS) {
   if (Decoded.size() < 6 ||
-      Decoded[5].Offset > std::numeric_limits<uint64_t>::max() -
-                              Decoded[5].Size)
+      Decoded[5].Offset >
+          std::numeric_limits<uint64_t>::max() - Decoded[5].Size)
     return false;
   const uint64_t BodyEnd = Decoded[5].Offset + Decoded[5].Size;
   SmallVector<uint8_t> CodeEnd = getCodeEndBytes(LS);
@@ -303,8 +303,7 @@ getKernelEntryTrampolineInfo(ArrayRef<uint8_t> Bytes, uint64_t StubVAddr,
 }
 
 std::optional<uint64_t>
-getKernelEntryTrampolineTargetVAddr(ArrayRef<uint8_t> Bytes,
-                                    uint64_t StubVAddr,
+getKernelEntryTrampolineTargetVAddr(ArrayRef<uint8_t> Bytes, uint64_t StubVAddr,
                                     const LLVMState &LS) {
   std::optional<KernelEntryTrampolineInfo> Info =
       getKernelEntryTrampolineInfo(Bytes, StubVAddr, LS);

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -258,13 +258,59 @@ decodeEntryStubTargetVAddr(ArrayRef<InternalDecodedInst> Decoded,
   return *PcBase + Delta;
 }
 
-bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
-  if (!hasKernelEntryTrampolinePrefix(Bytes, LS))
+static bool hasExactEntryStubPadding(ArrayRef<uint8_t> Bytes,
+                                     ArrayRef<InternalDecodedInst> Decoded,
+                                     const LLVMState &LS) {
+  if (Decoded.size() < 6 ||
+      Decoded[5].Offset > std::numeric_limits<uint64_t>::max() -
+                              Decoded[5].Size)
     return false;
+  const uint64_t BodyEnd = Decoded[5].Offset + Decoded[5].Size;
+  SmallVector<uint8_t> CodeEnd = getCodeEndBytes(LS);
+  if (CodeEnd.empty() || BodyEnd > KernelEntryStubStride ||
+      (KernelEntryStubStride - BodyEnd) % CodeEnd.size() != 0)
+    return false;
+  for (uint64_t Offset = BodyEnd; Offset < KernelEntryStubStride;
+       Offset += CodeEnd.size())
+    if (!Bytes.slice(Offset, CodeEnd.size()).equals(CodeEnd))
+      return false;
+  return true;
+}
+
+bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
+  return getKernelEntryTrampolineInfo(Bytes, 0, LS).has_value();
+}
+
+std::optional<KernelEntryTrampolineInfo>
+getKernelEntryTrampolineInfo(ArrayRef<uint8_t> Bytes, uint64_t StubVAddr,
+                             const LLVMState &LS) {
+  if (!hasKernelEntryTrampolinePrefix(Bytes, LS))
+    return std::nullopt;
 
   std::vector<InternalDecodedInst> Decoded;
-  return decodeKernelEntryStub(Bytes, LS, Decoded, "isKernelEntryTrampoline") &&
-         hasEntryStubOperandShape(Decoded, LS);
+  if (!decodeKernelEntryStub(Bytes, LS, Decoded,
+                             "kernel entry target matcher") ||
+      !hasEntryStubOperandShape(Decoded, LS) ||
+      !hasExactEntryStubPadding(Bytes, Decoded, LS))
+    return std::nullopt;
+  std::optional<uint64_t> Target =
+      decodeEntryStubTargetVAddr(Decoded, StubVAddr);
+  std::optional<uint64_t> Terminal = checkedAddUint64(
+      StubVAddr, Decoded[5].Offset, "kernel entry terminal address");
+  if (!Target || !Terminal)
+    return std::nullopt;
+  return KernelEntryTrampolineInfo{*Target, *Terminal};
+}
+
+std::optional<uint64_t>
+getKernelEntryTrampolineTargetVAddr(ArrayRef<uint8_t> Bytes,
+                                    uint64_t StubVAddr,
+                                    const LLVMState &LS) {
+  std::optional<KernelEntryTrampolineInfo> Info =
+      getKernelEntryTrampolineInfo(Bytes, StubVAddr, LS);
+  if (!Info)
+    return std::nullopt;
+  return Info->TargetVAddr;
 }
 
 bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -23,8 +23,10 @@
 #include "comgr-env.h"
 #include "comgr.h"
 
+#include <array>
 #include <cstdint>
 #include <cstring>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -34,6 +36,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -60,6 +63,10 @@
 
 namespace COMGR {
 namespace hotswap {
+
+inline constexpr int8_t VgprMsbUnanalyzed = -3;
+inline constexpr int8_t VgprMsbUnreachable = -2;
+inline constexpr int8_t VgprMsbUnknown = -1;
 
 // -- Logging ------------------------------------------------------------------
 //
@@ -106,6 +113,10 @@ struct Trampoline {
   bool Long = false;
   bool UsesSetPCBack = false;
   unsigned LongBranchSgprBase = 0;
+  // The scratch pair was proven dead only at the original resume point.
+  // Backward source growth is safe only across instructions that do not touch
+  // the pair; forward growth must re-prove it at the moved resume point.
+  bool LongBranchScratchIsSiteProven = false;
   bool HasPoolBranchIsland = false;
   uint64_t PoolBranchIslandOffset = 0;
   bool UsesShortBranchForward = false;
@@ -135,6 +146,7 @@ static constexpr uint32_t KernelEntryStubInstPrefLines =
 struct KernelDescriptorInfo {
   std::string KernelName;
   uint64_t VAddr = 0;
+  uint64_t FileOffset = 0;
   int64_t EntryOffset = 0;
 };
 
@@ -144,18 +156,60 @@ struct KernelClusterDims {
   unsigned Z = 0;
 };
 
+enum class NopSledUse {
+  OwnerBody,
+  RelocationBody,
+  Gateway,
+};
+
+enum class ReplacementPlacement {
+  Default,
+  Ds2SourceTail,
+  ProtectedCombinedDelay,
+};
+
 struct NopSled {
   uint64_t Start = 0;
   uint64_t End = 0;
   uint64_t WritePos = 0;
-  uint64_t FunctionStart = 0;
-  uint64_t FunctionEnd = 0;
+  uint64_t OwnerStart = 0;
+  uint64_t OwnerEnd = 0;
+  // This storage may contain branch gateways only, never a replacement body.
+  // It covers certified external padding and appended-pool branch islands.
+  bool GatewayOnly = false;
+  // Explicit NOP padding immediately after a proven no-fallthrough function
+  // boundary remains body-owned by that function, but any function may use
+  // the same allocation cursor for branch-only gateway instructions.
+  bool GlobalGateway = false;
+  // Strictly proven post-function NOP padding may also hold straight-line,
+  // PC-independent relocation bodies when the patch pass explicitly opts in.
+  bool GlobalBody = false;
+
+  bool ownsSource(uint64_t Offset) const {
+    return OwnerStart <= Offset && Offset < OwnerEnd;
+  }
+
+  bool canGatewayFrom(uint64_t Offset) const {
+    return GlobalGateway || ownsSource(Offset);
+  }
+
+  bool canHoldBodyFrom(uint64_t Offset, bool AllowGlobalBody) const {
+    return ownsSource(Offset) || (AllowGlobalBody && GlobalBody);
+  }
 };
 
 enum class MaskWorkaroundPolicy {
   None,
   A0,
   B0,
+};
+
+/// Target dependence of an executable pool emitted by HotSwap. Neutral pools
+/// contain only stepping-independent code such as kernel-entry stubs.
+enum class ExecutablePoolTargetState : uint32_t {
+  Neutral = 0,
+  A0 = 1,
+  B0 = 2,
 };
 
 // -- Rewrite rule -------------------------------------------------------------
@@ -183,14 +237,10 @@ static constexpr uint64_t MinNopSledSize = 8;
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
 
-// Fixed reservation for the SCC-preserving set-PC return. The assembled
-// sequence is 28 bytes for a same-object forward or backward delta.
-static constexpr uint32_t SetPcReturnReserveBytes = 28;
-
-// A gateway needs at least 20 bytes when incoming SCC is proven dead. Live SCC
-// uses the 28-byte preserving sequence.
-static constexpr uint32_t SetPcMinGatewayBytes = 20;
-static constexpr uint32_t SetPcForwardSequenceBytes = 28;
+// Fixed reservation for the SCC-neutral set-PC sequence. The gfx1250
+// s_add_nc_u64 form is 20 bytes for a same-object forward or backward delta.
+static constexpr uint32_t SetPcReturnReserveBytes = 20;
+static constexpr uint32_t SetPcForwardSequenceBytes = 20;
 static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
@@ -227,6 +277,11 @@ public:
     uint64_t End = 0;
     const ELFT::Sym *Symbol = nullptr;
     const ELFT::Shdr *Symtab = nullptr;
+  };
+
+  struct TextOffsetRange {
+    uint64_t Begin = 0;
+    uint64_t End = 0;
   };
 
   /// Parse \p Data / \p Size into an ElfView. Fails if the bytes are not a
@@ -273,6 +328,15 @@ public:
   /// Zero-size symbols extend to the next function symbol or `.text` end.
   std::vector<FunctionTextRange> functionTextRanges() const;
 
+  /// Return every defined symbol offset in `.text`, irrespective of symbol
+  /// type. A missing value means symbol-table discovery was incomplete.
+  std::optional<std::vector<uint64_t>> textSymbolOffsets() const;
+
+  /// Return sorted, coalesced half-open extents for sized, non-callable
+  /// symbols defined in `.text`. Extents are clipped to `.text`; a missing
+  /// value means discovery was incomplete or an extent overflowed.
+  std::optional<std::vector<TextOffsetRange>> textSymbolExtents() const;
+
   /// Find the kernel function symbol whose range includes \p TextAddress.
   /// Returns "" if no matching function symbol exists.
   std::string findKernelAtAddress(uint64_t TextAddress) const;
@@ -288,6 +352,19 @@ public:
   /// section covers the range or it falls outside the buffer.
   const uint8_t *dataAtVAddr(uint64_t VAddr, uint64_t Len) const;
 
+  /// Return true when the complete virtual-address range is backed by bytes
+  /// in an executable PT_LOAD segment. Segment validation is still required
+  /// even when the range also has an executable section header.
+  bool isExecutableVAddrRange(uint64_t VAddr, uint64_t Len) const;
+
+  /// Return true when every file-backed executable region outside the `.text`
+  /// section analyzed by the instruction rewriter has valid HotSwap provenance
+  /// and is either stepping-neutral or built for \p TargetState. Unmarked,
+  /// stale, conflicting, or malformed provenance fails closed; structurally
+  /// malformed ELF data returns std::nullopt.
+  std::optional<bool> executableCodeOutsideTextIsCompatibleWith(
+      ExecutablePoolTargetState TargetState) const;
+
   /// Pointer to the kernel_descriptor for \p KernelName inside the buffer,
   /// or nullptr if not found.
   uint8_t *findKernelDescriptor(llvm::StringRef KernelName);
@@ -296,6 +373,10 @@ public:
   /// current kernel_code_entry_byte_offset values. The returned range remains
   /// valid until this ElfView is destroyed.
   llvm::ArrayRef<KernelDescriptorInfo> kernelDescriptors() const;
+
+  /// True only when every descriptor symbol was parsed and duplicate names
+  /// resolved to the same descriptor location.
+  bool kernelDescriptorCacheIsComplete() const;
 
   /// Return the virtual address of the kernel descriptor symbol for
   /// \p KernelName, or std::nullopt when the descriptor is not present.
@@ -322,6 +403,12 @@ public:
   /// The revision strings used by gfx1250 ("A0" and "B0") have equal encoded
   /// size, so this preserves the ELF layout.
   bool updateGfx1250RevisionMetadata(llvm::StringRef Revision);
+
+  /// Return true only when metadata contains at least one kernel and every
+  /// kernel explicitly records \p Revision. Missing revision keys return
+  /// false; malformed metadata returns std::nullopt.
+  std::optional<bool>
+  allKernelsHaveGfx1250Revision(llvm::StringRef Revision) const;
 
   /// Read COMPUTE_PGM_RSRC3.INST_PREF_SIZE for \p KernelName.
   std::optional<uint32_t>
@@ -378,11 +465,13 @@ public:
                               unsigned VgprGranuleSize);
 
   /// Virtual address at which growWithTrampolines appends the trampoline pool:
-  /// the first page-aligned address above every existing allocatable section.
+  /// the first page-aligned address above every existing allocatable section
+  /// and PT_LOAD memory range.
   /// Callers that pre-compute branch/stub targets (B0-to-A0 trampolines,
   /// kernel-entry stubs) must resolve pool positions against this value so the
   /// baked branches land on the pool's final location. Single source of truth
-  /// shared with growWithTrampolines. std::nullopt on sh_addr+sh_size overflow.
+  /// shared with growWithTrampolines. std::nullopt on section or segment range
+  /// overflow.
   std::optional<uint64_t> trampolinePoolVAddr() const;
 
   /// Grow the ELF by appending the trampoline pool at a fresh virtual address
@@ -395,7 +484,8 @@ public:
   /// AMDGPU code object, which carries no relocations to fix up.
   std::unique_ptr<llvm::WritableMemoryBuffer>
   growWithTrampolines(llvm::ArrayRef<Trampoline> Trampolines,
-                      llvm::ArrayRef<uint8_t> SNopBytes) const;
+                      llvm::ArrayRef<uint8_t> SNopBytes,
+                      ExecutablePoolTargetState TargetState) const;
 
 private:
   enum class KernelSgprCacheState {
@@ -424,6 +514,7 @@ private:
   mutable std::optional<std::vector<KernelDescriptorInfo>>
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
+  mutable bool KernelDescriptorCacheComplete = false;
   mutable KernelSgprCacheState SgprCacheState =
       KernelSgprCacheState::Uninitialized;
   mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;
@@ -442,9 +533,13 @@ struct LLVMState;
                                     const LLVMState &LS);
 
 /// Find the nearest NOP sled to \p Offset with at least \p Needed bytes of
-/// free space. Returns nullptr if none found within MaxSledDistance.
+/// free space. \p Use controls whether selection is restricted to owner-local
+/// bodies, allows certified relocation bodies in post-function padding, or
+/// allows branch-only gateways. Returns nullptr if none is found within
+/// MaxSledDistance.
 NopSled *findNearestSled(std::vector<NopSled> &Sleds, uint64_t Offset,
-                         uint64_t Needed);
+                         uint64_t Needed,
+                         NopSledUse Use = NopSledUse::OwnerBody);
 
 // -- RewriteConfig ------------------------------------------------------------
 //
@@ -526,24 +621,10 @@ struct LLVMState {
   unsigned SGetPcI64Opcode = 0;
   unsigned SAddU32Opcode = 0;
   unsigned SAddcU32Opcode = 0;
+  unsigned SAddNcU64Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
-
-  /// MC identities used by far-trampoline relocation analysis. Each opcode is
-  /// resolved once through the asm parser so policy code never compares
-  /// disassembled mnemonic strings.
-  unsigned SClauseOpcode = 0;
-  unsigned SDelayAluOpcode = 0;
-  unsigned SEndPgmOpcode = 0;
-  unsigned SEndPgmSavedOpcode = 0;
-  unsigned SAddPcI64Opcode = 0;
-  unsigned SCallI64Opcode = 0;
   unsigned SSwapPcI64Opcode = 0;
-  unsigned SPrefetchInstPcRelOpcode = 0;
-  unsigned SPrefetchDataPcRelOpcode = 0;
-
-  /// SCC, recovered from the implicit definition on a parsed scalar compare.
-  /// This avoids scanning target register names in policy code.
-  llvm::MCRegister SCCRegister;
+  unsigned SCallI64Opcode = 0;
 
   bool Valid = false;
 
@@ -566,7 +647,6 @@ struct InternalDecodedInst {
   uint32_t Size = 0;
   llvm::MCInst Inst;
   std::string Mnemonic;
-  bool DecodeSucceeded = false;
 };
 
 // -- Function declarations (LLVM MC layer) ------------------------------------
@@ -630,6 +710,12 @@ struct WmmaNopReq {
 /// Classify the A0/B0 v_nop requirement for a WMMA/SWMMAC mnemonic.
 WmmaNopReq classifyWmmaNops(llvm::StringRef Mnemonic);
 
+/// Record a WMMA spacing deficit for a candidate VALU and return the maximum
+/// requirement seen for that candidate. Multiple WMMA scans must compose the
+/// strongest requirement rather than letting discovery order weaken it.
+int updateWmmaHazardDeficit(llvm::DenseMap<size_t, int> &MaxDeficits,
+                            size_t ValuIndex, int Deficit);
+
 /// Patch the VOP3PX2 scale_src2 field (bits [58:50]) to VGPR0 encoding
 /// (0x100) in a 16-byte instruction buffer. Returns true if the field
 /// was modified (false if already set to the target value).
@@ -664,6 +750,26 @@ struct CFG {
   std::vector<BasicBlock> Blocks;
   llvm::DenseMap<uint64_t, unsigned> OffsetToBlock;
 };
+
+struct MaterializedPcTransfer {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  uint64_t Target = 0;
+};
+
+std::optional<int64_t> getAbsoluteOperandValue(const llvm::MCOperand &Operand,
+                                               const InternalDecodedInst &DI,
+                                               llvm::ArrayRef<uint8_t> Text);
+
+std::optional<MaterializedPcTransfer> evaluateMaterializedPcTransfer(
+    llvm::ArrayRef<InternalDecodedInst> Decoded, size_t TransferIndex,
+    const llvm::DenseSet<uint64_t> &DirectTargets, llvm::ArrayRef<uint8_t> Text,
+    const LLVMState &LS, const ElfView &Elf,
+    std::optional<llvm::ArrayRef<uint64_t>> TextSymbolOffsets = std::nullopt,
+    std::optional<llvm::ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents =
+        std::nullopt);
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS);
 
 /// Dataflow-liveness result for a kernel's VGPR set. \c LiveBefore[i] and
 /// \c LiveAfter[i] are the live-in / live-out bitvectors for Decoded[i].
@@ -743,6 +849,17 @@ struct ScratchPatchInfo {
   llvm::BitVector ScratchRegs;
 };
 
+/// Transactional ownership and composition state for one replacement source.
+/// A whole-function requirement may reserve a site before its ordinary
+/// per-instruction owner is known. The first successful emission commits that
+/// owner and composes every pending requirement into the same body.
+struct SiteReplacementState {
+  uint32_t OriginalSize = 0;
+  unsigned RequiredLeadingVNops = 0;
+  bool Committed = false;
+  bool WmmaHazardComposed = false;
+};
+
 // -- Patch types --------------------------------------------------------------
 
 /// Per-kernel counters accumulated by the patch passes. Reported via log()
@@ -761,6 +878,91 @@ struct SafeSgprUsageSummary {
   bool HasCall = false;
   unsigned HighWatermark = 0;
 };
+
+struct SiteDeadSgprFunctionFacts {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  size_t GlobalFirst = 0;
+  unsigned NumberedLimit = 0;
+  std::vector<std::array<uint64_t, 2>> SafeBefore;
+  llvm::BitVector ForbiddenResume;
+};
+
+struct KernelTextRange {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  std::vector<uint64_t> Entries;
+  bool HasArbitraryIndirectIngress = false;
+};
+
+/// Forward must-analysis used by the gfx1250 initial-VMEM workaround. The
+/// bitvectors are indexed like the mutable .text decode. DescriptorCovered
+/// distinguishes dead code in a known kernel from helpers whose entry
+/// semantics cannot be proven.
+struct InitialVmemMustAnalysis {
+  llvm::BitVector DescriptorCovered;
+  llvm::BitVector Reachable;
+  llvm::BitVector MustHavePriorVmem;
+};
+
+InitialVmemMustAnalysis
+computeInitialVmemMustAnalysis(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                               llvm::ArrayRef<InternalDecodedInst> AllDecoded,
+                               llvm::ArrayRef<KernelTextRange> KernelRanges,
+                               const LLVMState &LS);
+
+/// Forward must-analysis for the low 16 bits of tensor group descriptors.
+/// A set bit means every modeled path to the tensor instruction provides a
+/// group-1 base register whose low half is zero. MaskDefinitionOffsets records
+/// the single reaching v_readfirstlane definition when every path agrees, so
+/// one persistent mask can be shared by later tensor operations.
+struct TensorDescriptorMustAnalysis {
+  llvm::BitVector Low16KnownZero;
+  std::vector<uint64_t> MaskDefinitionOffsets;
+};
+
+/// Exact, byte-validated kernel-entry stub metadata. Offsets are relative to
+/// .text, including stubs in appended executable sections. The descriptor's
+/// virtual dispatch edge enters Begin; Terminal is the stub's only decoded
+/// transfer and resolves to Target.
+struct TensorDispatchStub {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  uint64_t Terminal = 0;
+  uint64_t Target = 0;
+};
+
+struct TensorAnalysisRange {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  // Original-.text control transfers from outside this range that target an
+  // appended executable segment. A generated path rooted in this range may
+  // not share one of these segment entries: the foreign path would carry an
+  // unmodeled descriptor and EXEC state to the same re-entry tail.
+  std::vector<uint64_t> ForeignExternalEntries;
+  // Hardware dispatch roots from kernel descriptors that do not name an exact
+  // validated HotSwap entry stub. They have no decoded predecessor edge and
+  // therefore may not enter a candidate-owned external subgraph.
+  std::vector<uint64_t> VirtualExternalEntries;
+  // Complete set of resolved original-.text control-flow and fallthrough
+  // edges. Source provenance distinguishes exact split-relay entry from an
+  // arbitrary join into its address-materialization tail.
+  std::vector<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges;
+  // Callable and kernel roots in original .text. A root may enter a computed
+  // PC sequence only at a self-initializing get-PC prefix.
+  std::vector<uint64_t> OriginalCodeEntries;
+  // Complete immutable set of validated dispatch stubs in this code object.
+  // The range analysis uses it both to admit its own virtual dispatch edge
+  // and to classify carry-form set-PC terminals belonging to other kernels.
+  std::vector<TensorDispatchStub> DispatchStubs;
+};
+
+TensorDescriptorMustAnalysis computeTensorDescriptorMustAnalysis(
+    llvm::ArrayRef<InternalDecodedInst> Decoded,
+    llvm::ArrayRef<InternalDecodedInst> AllDecoded,
+    llvm::ArrayRef<TensorAnalysisRange> KernelRanges, const LLVMState &LS,
+    const llvm::DenseSet<uint64_t> &DirectControlFlowTargets, unsigned MaxSgprs,
+    unsigned MaxVgprs);
 
 /// Mutable per-run context threaded through all patch passes. Bundles the
 /// input config, decoded instruction stream, raw .text bytes, MC state,
@@ -783,21 +985,104 @@ struct PatchContext {
   const LivenessInfo &Liveness;
   llvm::StringMap<KernelPatchStats> &KernelStats;
   std::vector<ScratchPatchInfo> &OutScratchPatches;
+  const InitialVmemMustAnalysis *InitialVmemAnalysis = nullptr;
+  const TensorDescriptorMustAnalysis *TensorDescriptorAnalysis = nullptr;
+  // Indexed once from the original instruction stream. CFG analyses use these
+  // sets to model predecessor merges and indirect entries without rescanning
+  // the complete code object for every patch site.
+  std::optional<llvm::DenseSet<uint64_t>> DirectControlFlowTargets;
+  // Sized, non-callable .text data/object extents. Moving any overlapping
+  // byte would violate symbol ownership even when the symbol starts before a
+  // candidate instruction window.
+  std::optional<llvm::ArrayRef<ElfView::TextOffsetRange>> TextSymbolExtents;
+  llvm::DenseSet<uint64_t> IndirectControlFlowFunctions;
+  llvm::DenseSet<uint64_t> CrossFunctionInteriorEntryFunctions;
+  bool HasUnknownArbitraryIndirectTarget = false;
+  // True before an instruction only when forward must-dataflow proves that
+  // MODE selects the same physical VGPR bank for VALU destinations and DS
+  // address operands on every reachable path.
+  llvm::BitVector VgprMsbDstSrc0EqualBefore;
+  // Exact persistent bank selectors before each instruction, or -1 when a
+  // path merge, call, or unknown MODE definition prevents recovery. Long
+  // range DS2 proofs compare a VALU definition's dst selector with the later
+  // DS address operand's src0 selector.
+  std::vector<int8_t> VgprMsbDstBefore;
+  std::vector<int8_t> VgprMsbSrc0Before;
+  // Exact packed src0/src1/src2/dst VGPR-MSB mode before each instruction.
+  // Negative sentinels distinguish unanalyzed functions, CFG-unreachable
+  // instructions, and reachable paths with an unknown field. WMMA splitting
+  // uses the complete mode while DS2 alignment can still consume the
+  // independently merged dst/src0 facts.
+  std::vector<int16_t> VgprMsbModeBefore;
+  // Set at a VALU copy when its corresponding destination is known to receive
+  // an 8-byte-aligned numbered SGPR value on every path. The two vectors keep
+  // the slots of v_dual_mov_b32 independent.
+  llvm::BitVector VgprDef0AlignedTo8;
+  llvm::BitVector VgprDef1AlignedTo8;
+  // DS2 alignment exemptions are decided from the immutable decoded stream
+  // before any earlier patch relabels an instruction as <replaced>.
+  llvm::BitVector Ds2AddressProvenAligned;
+  // Source-window expansion must not split clause/delay geometry or move a
+  // patch site whose replacement has explicitly position-sensitive state.
+  llvm::DenseSet<uint64_t> RelocationProtectedOffsets;
+  // Keep the source of relocation protection so removing an unsafe clause
+  // releases only that clause's members. Counts preserve overlapping or
+  // malformed clause ranges; delay and dynamically added protections remain
+  // independent and must survive clause removal.
+  llvm::DenseMap<uint64_t, unsigned> ClauseRelocationProtectionCounts{0};
+  llvm::DenseSet<uint64_t> NonClauseRelocationProtectedOffsets;
+  // Instructions whose execution was moved into a larger atomic replacement
+  // window. Keep their immutable MC description available to analyses that
+  // reason about the relocated instruction order, but prevent later patch
+  // families from emitting a second replacement at the stale linked address.
+  llvm::DenseSet<uint64_t> ClaimedReplacementOffsets;
+  // Descriptor definitions already extended by this pass with the persistent
+  // A0 low-half mask. A must-analysis may reuse one for a later tensor site,
+  // but may not use the reaching-definition fact to authorize a fresh move.
+  llvm::DenseSet<uint64_t> TensorMaskedDefinitionOffsets;
+  // Single source of truth for exact replacement ownership and pending
+  // whole-function composition requirements. This also covers NOP-sled
+  // placements, which do not appear in OutTrampolines.
+  std::map<uint64_t, SiteReplacementState> SiteReplacements;
+  llvm::SmallVector<uint64_t, 16> WmmaHazardSites;
+  uint32_t WmmaHazardsComposed = 0;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;
   bool RequiredPatchApplied = false;
-  // Sum of the bytes already queued in OutTrampolines. Keeping this in the
-  // per-rewrite context makes each new pool-position calculation constant
-  // time even for code objects with many thousands of patch sites.
+  // Conservative upper bound for the final bytes occupied by trampolines
+  // already queued in OutTrampolines. Far entries also reserve their eventual
+  // pool-island slot and bounded straight-line growth, so a later short-branch
+  // decision cannot be invalidated when the final pool is laid out.
   uint64_t QueuedTrampolineBytes = 0;
+  // Largest instruction in the immutable decoded stream. Source-window growth
+  // stops after crossing SetPcForwardSequenceBytes, so this bounds its final
+  // overshoot without assuming an ISA-wide maximum encoding size.
+  uint32_t MaxDecodedInstSize = 0;
   // Safe far-return scratch allocation can be queried at many patch sites in
   // one function. Cache the immutable decoded SGPR usage summaries so each
   // function, and the whole-object fallback, is scanned at most once.
   std::optional<SafeSgprUsageSummary> WholeObjectSgprUsage;
   llvm::DenseMap<std::pair<uint64_t, uint64_t>, SafeSgprUsageSummary>
       FunctionSgprUsage{0};
+  llvm::DenseMap<std::pair<uint64_t, uint64_t>, SiteDeadSgprFunctionFacts>
+      SiteDeadSgprFacts{0};
 };
+
+inline void protectNonClauseRelocationOffset(PatchContext &Ctx,
+                                             uint64_t Offset) {
+  Ctx.NonClauseRelocationProtectedOffsets.insert(Offset);
+  Ctx.RelocationProtectedOffsets.insert(Offset);
+}
+
+/// Return whether \p Mnemonic is one of the A0-incompatible WMMA forms owned
+/// by the split patch.
+bool isWmmaSplitPatchCandidate(llvm::StringRef Mnemonic);
+
+/// Return whether the instruction at \p Idx owns a precomputed whole-pass
+/// requirement or still needs an independent configured HotSwap rewrite.
+/// Atomic source-window relocation uses this to avoid claiming its source.
+bool requiresIndependentInstructionRewrite(const PatchContext &Ctx, size_t Idx);
 
 /// A block of numbered SGPRs that is not referenced in the function being
 /// patched, or anywhere in the code object when the site may be reached by a
@@ -805,13 +1090,15 @@ struct PatchContext {
 struct SafeSgprScratchBlock {
   unsigned Base = 0;
   unsigned Count = 0;
+  bool IsSiteProven = false;
 };
 
 /// Find an aligned block of unused numbered SGPRs for \p TextOffset. Returns
 /// nullopt after logging when no block fits below RewriteConfig::MaxSgprs.
 std::optional<SafeSgprScratchBlock>
 findSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset, unsigned Count,
-                         unsigned Alignment, llvm::StringRef Context);
+                         unsigned Alignment, llvm::StringRef Context,
+                         bool DiagnoseFailure = true);
 
 /// Charge a previously selected global block to the kernel owning \p
 /// TextOffset. If the site is in an ordinary device function, conservatively
@@ -821,46 +1108,86 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                 const SafeSgprScratchBlock &Block,
                                 llvm::StringRef Context);
 
+/// Decode \p Bytes and return every numbered SGPR touched by an explicit or
+/// implicit operand. Returns nullopt after logging if the sequence cannot be
+/// decoded completely.
+std::optional<llvm::BitVector>
+collectTouchedNumberedSgprs(llvm::ArrayRef<uint8_t> Bytes,
+                            unsigned NumberedSgprLimit, const LLVMState &LS);
+
+/// Return true when both halves of the aligned numbered SGPR pair beginning at
+/// \p SgprBase are defined before any reachable use from \p ResumeIndex. A call
+/// reached while either half remains live fails closed because its outgoing
+/// argument registers are not explicit in the machine instruction.
+bool isSgprPairDeadFrom(llvm::ArrayRef<InternalDecodedInst> Function,
+                        size_t ResumeIndex, unsigned SgprBase,
+                        const LLVMState &LS, llvm::ArrayRef<uint8_t> Text = {});
+
+/// Return true when both VCC halves are dead from \p ResumeIndex. On gfx1250
+/// wave32, implicit composite VCC operands affect VCC_LO; explicit VCC and
+/// VCC_HI operands retain their full register semantics. Proven ABI calls and
+/// returns terminate the caller-clobbered VCC lifetime.
+bool isVccPairDeadFrom(llvm::ArrayRef<InternalDecodedInst> Function,
+                       size_t ResumeIndex, const LLVMState &LS,
+                       llvm::ArrayRef<uint8_t> Text = {});
+
+/// Return the numbered SGPRs that every path from the original resume point
+/// defines before a use, call, or exit. Facts are cached per function.
+std::optional<llvm::BitVector> getSiteDeadNumberedSgprs(PatchContext &Ctx,
+                                                        uint64_t InstOffset,
+                                                        uint32_t InstSize);
+
+/// Build immutable site-dead facts before any patch relabels Decoded entries.
+void precomputeSiteDeadSgprFacts(PatchContext &Ctx);
+
 // -- Trampoline emission helpers (defined in comgr-hotswap-b0a0.cpp) ----------
 
-[[nodiscard]] bool emitToNopSled(PatchContext &Ctx, NopSled &Sled,
-                                 uint64_t InstOffset, uint32_t InstSize,
-                                 llvm::ArrayRef<uint8_t> Replacement);
-[[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
-                                    uint32_t InstSize,
-                                    llvm::ArrayRef<uint8_t> Replacement);
+uint64_t getNopSledBytesNeeded(
+    const PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+    llvm::ArrayRef<uint8_t> Replacement,
+    ReplacementPlacement Placement = ReplacementPlacement::Default);
 
-/// Encode an SCC-preserving indirect long branch using three numbered SGPRs:
-/// an aligned PC pair at \p SgprBase and an SCC-save temporary at Base + 2.
-/// The displacement is materialized as two 32-bit literals; no
-/// s_add_pc_i64 or 64-bit literal is emitted.
-std::optional<llvm::SmallVector<uint8_t>>
-encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
-                      uint64_t TargetOffset, unsigned SgprBase);
+[[nodiscard]] bool
+emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+                 llvm::ArrayRef<uint8_t> Replacement,
+                 ReplacementPlacement Placement = ReplacementPlacement::Default,
+                 bool DiagnoseFailure = true);
 
-/// Return whether an s_branch at \p From can encode \p To, including the
-/// instruction-relative PC base, alignment, signed range, and overflow checks.
-bool isSBranchReachable(uint64_t From, uint64_t To);
+/// Return the encoded s_delay_alu dependency span, or the conservative ISA
+/// maximum when the immediate cannot be interpreted safely.
+unsigned getDelayProtectedSpan(const InternalDecodedInst &DI);
 
-/// Evaluate a statically direct branch or call target from its decoded MCInst.
-/// Uses MCInstrAnalysis where supported and the documented gfx1250 s_call_i64
-/// operand fallback otherwise.
-std::optional<uint64_t>
-evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
-                                const LLVMState &LS);
+/// Return true when direct-control-flow information is unavailable, the
+/// half-open window is malformed, or a direct edge enters after \p Begin and
+/// before \p End. An edge to Begin is allowed because the replacement branch
+/// remains there; an edge to any later instruction or literal slot is not.
+bool hasDirectControlFlowTargetInWindowInterior(
+    const std::optional<llvm::DenseSet<uint64_t>> &Targets, uint64_t Begin,
+    uint64_t End);
 
-[[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
-                                       uint32_t InstSize,
-                                       llvm::ArrayRef<uint8_t> Replacement);
+/// Return true when both edges of a replacement at \p InstOffset can use
+/// s_branch with the trampoline's current queued pool position.
+bool canEmitShortTrampoline(const PatchContext &Ctx, uint64_t InstOffset,
+                            uint32_t InstSize, uint64_t ReplacementSize);
 
-/// Expand one decoded gfx1250 DS two-address instruction into the ordered
-/// single-address instruction sequence used by the trampoline patch. Exposed
-/// from the internal interface so unit tests can verify read-before-write
-/// dependency handling without constructing a complete ELF rewrite. Returns
-/// std::nullopt after logging a malformed or unsafe expansion.
-[[nodiscard]] std::optional<std::vector<std::string>>
-expandDs2Addr(const llvm::MCInst &Inst, llvm::StringRef FromMnem,
-              llvm::StringRef ToMnem, const LLVMState &LS);
+/// Encode an SCC-neutral indirect long branch using the aligned numbered SGPR
+/// pair at \p SgprBase. The displacement is applied with s_add_nc_u64; no
+/// s_add_pc_i64 is emitted and no third SGPR is needed to save SCC.
+llvm::SmallVector<uint8_t> encodeSetPCLongBranch(const LLVMState &LS,
+                                                 uint64_t FromOffset,
+                                                 uint64_t TargetOffset,
+                                                 unsigned SgprBase);
+
+[[nodiscard]] bool emitReplacementCode(
+    PatchContext &Ctx, uint64_t InstOffset, uint32_t InstSize,
+    llvm::ArrayRef<uint8_t> Replacement,
+    ReplacementPlacement Placement = ReplacementPlacement::Default,
+    bool DiagnoseFailure = true);
+
+/// Whether p Offset is reserved by a pending requirement or already owns a
+/// committed replacement. Relocation windows may not move such a site, while
+/// its exact per-instruction owner may still emit through the shared helpers.
+bool hasSiteReplacementReservation(const PatchContext &Ctx, uint64_t Offset);
 
 // -- Patch dispatch vtable ----------------------------------------------------
 //
@@ -894,6 +1221,7 @@ struct HotswapPatchVTable {
 
   // Whole-kernel passes: called once per kernel after the per-instruction
   // loop completes.
+  bool (*precomputeWmmaHazards)(PatchContext &) = nullptr;
   uint32_t (*applyWmmaHazardPatch)(PatchContext &) = nullptr;
   uint32_t (*applyVop3px2Src2Fix)(PatchContext &) = nullptr;
 };
@@ -925,6 +1253,9 @@ HotswapPatchVTable &getHotswapPatchVTable();
 #include "comgr-hotswap-patches.def"
 #undef HOTSWAP_PATCH
 
+/// Cache every DS2 alignment exemption before the patch loop mutates Decoded.
+void precomputeDs2AddressAlignment(PatchContext &Ctx);
+
 // -- Function declarations (kernel-entry trampoline pass) ---------------------
 
 struct KernelEntryTrampolineFixup {
@@ -946,6 +1277,26 @@ llvm::SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
 /// buildKernelEntryTrampoline, used to keep the rewrite idempotent.
 bool isKernelEntryTrampoline(llvm::ArrayRef<uint8_t> Bytes,
                              const LLVMState &LS);
+
+struct KernelEntryTrampolineInfo {
+  uint64_t TargetVAddr = 0;
+  uint64_t TerminalVAddr = 0;
+};
+
+/// Return the resolved target and terminal instruction address of an exact
+/// HotSwap entry stub. Besides validating the generated instruction shape,
+/// this requires the remainder of the fixed-size stub to contain only the
+/// exact generated s_code_end padding.
+std::optional<KernelEntryTrampolineInfo>
+getKernelEntryTrampolineInfo(llvm::ArrayRef<uint8_t> Bytes, uint64_t StubVAddr,
+                             const LLVMState &LS);
+
+/// Return the original kernel entry encoded by a structurally valid HotSwap
+/// entry stub at \p StubVAddr. Returns std::nullopt for a non-stub or malformed
+/// candidate.
+std::optional<uint64_t>
+getKernelEntryTrampolineTargetVAddr(llvm::ArrayRef<uint8_t> Bytes,
+                                    uint64_t StubVAddr, const LLVMState &LS);
 
 /// Cheap raw-byte prefilter for the entry stubs produced by
 /// buildKernelEntryTrampoline. This is intentionally weaker than
@@ -983,12 +1334,11 @@ bool rewriteKernelEntryDescriptorOffsets(
 /// problem) -- callers treat nullptr as "keep the existing buffer", since the
 /// symbol is a debugging aid and its absence is not a correctness failure.
 ///
-/// Only the trailing non-alloc `.symtab` / `.strtab` sections grow, so no
-/// virtual addresses, program headers, or relocations change; `.dynsym` (used
-/// by the loader) is left untouched.
+/// The non-allocating `.symtab` / `.strtab` copies are relocated after the
+/// existing ELF bytes, so the executable pool and all program-header mappings
+/// remain unchanged; `.dynsym` (used by the loader) is left untouched.
 std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex,
-    uint64_t TextAddr, uint64_t OldTextSize,
+    llvm::WritableMemoryBuffer &In, uint64_t PoolVAddr,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -710,12 +710,6 @@ struct WmmaNopReq {
 /// Classify the A0/B0 v_nop requirement for a WMMA/SWMMAC mnemonic.
 WmmaNopReq classifyWmmaNops(llvm::StringRef Mnemonic);
 
-/// Record a WMMA spacing deficit for a candidate VALU and return the maximum
-/// requirement seen for that candidate. Multiple WMMA scans must compose the
-/// strongest requirement rather than letting discovery order weaken it.
-int updateWmmaHazardDeficit(llvm::DenseMap<size_t, int> &MaxDeficits,
-                            size_t ValuIndex, int Deficit);
-
 /// Patch the VOP3PX2 scale_src2 field (bits [58:50]) to VGPR0 encoding
 /// (0x100) in a 16-byte instruction buffer. Returns true if the field
 /// was modified (false if already set to the target value).

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -346,8 +346,8 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[30:31], s[0:1]",
                                      "s_swap_pc_i64", S, S.SSwapPcI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[30:31], 0", "s_call_i64",
-                                     S, S.SCallI64Opcode))
+  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[30:31], 0", "s_call_i64", S,
+                                     S.SCallI64Opcode))
     return S;
 
   S.Valid = true;

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -337,63 +337,18 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_addc_u32 s1, s1, 0", "s_addc_u32", S,
                                      S.SAddcU32Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_nc_u64 s[0:1], s[0:1], 0",
+                                     "s_add_nc_u64", S, S.SAddNcU64Opcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_set_pc_i64 s[0:1]", "s_set_pc_i64", S,
                                      S.SSetPcI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_clause 0", "s_clause", S,
-                                     S.SClauseOpcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_delay_alu instid0(VALU_DEP_1)",
-                                     "s_delay_alu", S, S.SDelayAluOpcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_endpgm", "s_endpgm", S,
-                                     S.SEndPgmOpcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_endpgm_saved", "s_endpgm_saved", S,
-                                     S.SEndPgmSavedOpcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_add_pc_i64 0", "s_add_pc_i64", S,
-                                     S.SAddPcI64Opcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[0:1], 0", "s_call_i64", S,
-                                     S.SCallI64Opcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[0:1], s[2:3]",
+  if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[30:31], s[0:1]",
                                      "s_swap_pc_i64", S, S.SSwapPcI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_prefetch_inst_pc_rel 100, s10, 7",
-                                     "s_prefetch_inst_pc_rel", S,
-                                     S.SPrefetchInstPcRelOpcode))
+  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[30:31], 0", "s_call_i64",
+                                     S, S.SCallI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_prefetch_data_pc_rel 100, s10, 7",
-                                     "s_prefetch_data_pc_rel", S,
-                                     S.SPrefetchDataPcRelOpcode))
-    return S;
-
-  SmallVector<MCInst, 2> SccDefInsts =
-      parseAsmToMCInsts("s_cmp_eq_u32 s0, s0", S);
-  if (SccDefInsts.size() != 1) {
-    log() << "hotswap: error: initLLVM: failed to parse an SCC-defining "
-             "scalar compare for CPU '"
-          << S.Cpu << "'.\n";
-    return S;
-  }
-  const MCInstrDesc &SccDefDesc = S.MCII->get(SccDefInsts.front().getOpcode());
-  for (MCPhysReg Reg : SccDefDesc.implicit_defs()) {
-    if (S.SCCRegister.isValid()) {
-      log() << "hotswap: error: initLLVM: scalar compare has multiple "
-               "implicit definitions for CPU '"
-            << S.Cpu << "'.\n";
-      return S;
-    }
-    S.SCCRegister = MCRegister(Reg);
-  }
-  if (!S.SCCRegister.isValid()) {
-    log() << "hotswap: error: initLLVM: scalar compare has no implicit SCC "
-             "definition for CPU '"
-          << S.Cpu << "'.\n";
-    return S;
-  }
 
   S.Valid = true;
   return S;
@@ -461,7 +416,6 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       DI.Size = MinInstSize;
       DI.Mnemonic = UnknownMnemonic.str();
     } else {
-      DI.DecodeSucceeded = true;
       DI.Size = static_cast<uint32_t>(InstSize);
       // MCInstPrinter::getMnemonic returns a pointer into the generated AsmStrs
       // table. Storage is process-lifetime static; the trailing whitespace

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -11,6 +11,7 @@
 ///
 ///   - cluster_load             -> global_load    (opcode swap via MCInst +
 ///                                                 MCCodeEmitter)
+///   - unsafe s_clause          -> s_nop          (byte-level overwrite)
 ///   - s_barrier_signal_isfirst -> s_barrier_signal
 ///                                                (opcode swap; same operand
 ///                                                 layout, drops SCC write)
@@ -21,18 +22,30 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/MC/MCCodeEmitter.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
 namespace {
+
+uint32_t failRequiredInPlacePatch(PatchContext &Ctx, StringRef Mnemonic,
+                                  uint64_t Offset) {
+  log() << "hotswap: error: required in-place patch for " << Mnemonic
+        << " failed at 0x" << utohexstr(Offset) << "\n";
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
 
 /// Map a B0-only cluster_load mnemonic to the assembly string of its
 /// A0-compatible global_load equivalent (with a dummy operand to resolve
@@ -111,7 +124,653 @@ bool swapOpcode(InternalDecodedInst &DI, uint8_t *Text, const LLVMState &LS,
   return true;
 }
 
+enum class ClauseScope { CU, SE, Device, System };
+enum class ClauseFamily { VMEM, Flat, SMEM };
+
+std::optional<ClauseFamily> getClauseFamily(StringRef Mnemonic) {
+  if (Mnemonic.starts_with("buffer_") || Mnemonic.starts_with("tbuffer_") ||
+      Mnemonic.starts_with("global_") || Mnemonic.starts_with("scratch_") ||
+      Mnemonic.starts_with("image_") || Mnemonic.starts_with("cluster_") ||
+      Mnemonic.starts_with("tensor_"))
+    return ClauseFamily::VMEM;
+  if (Mnemonic.starts_with("flat_"))
+    return ClauseFamily::Flat;
+  if (Mnemonic.starts_with("s_load") || Mnemonic.starts_with("s_buffer_load"))
+    return ClauseFamily::SMEM;
+  return std::nullopt;
+}
+
+std::optional<ClauseFamily> getClauseFamily(const InternalDecodedInst &DI,
+                                            const LLVMState &LS) {
+  // Some GLOBAL_WB encodings do not have a stable printed mnemonic, but they
+  // are unclaused VMEM operations and therefore establish the entry workaround.
+  if (DI.Inst.getOpcode() == LS.GlobalWbOpcode)
+    return ClauseFamily::VMEM;
+  return getClauseFamily(DI.Mnemonic);
+}
+
+std::optional<ClauseScope> getClauseScope(const MCInst &Inst,
+                                          const LLVMState &LS) {
+  if (!LS.MCIP)
+    return std::nullopt;
+
+  SmallString<256> PrintedBuf;
+  raw_svector_ostream OS(PrintedBuf);
+  LS.MCIP->printInst(&Inst, /*Address=*/0, /*Annot=*/"", *LS.STI, OS);
+  StringRef Printed(PrintedBuf);
+  constexpr StringLiteral ScopePrefix("scope:");
+  size_t ScopePos = Printed.find(ScopePrefix);
+  if (ScopePos == StringRef::npos)
+    return ClauseScope::CU;
+
+  StringRef Scope = Printed.drop_front(ScopePos + ScopePrefix.size());
+  Scope = Scope.take_while([](char C) { return llvm::isAlnum(C) || C == '_'; });
+  return StringSwitch<std::optional<ClauseScope>>(Scope)
+      .Case("SCOPE_CU", ClauseScope::CU)
+      .Case("SCOPE_SE", ClauseScope::SE)
+      .Case("SCOPE_DEV", ClauseScope::Device)
+      .Case("SCOPE_SYS", ClauseScope::System)
+      .Default(std::nullopt);
+}
+
+/// Retain a hard clause only when its complete encoded membership is known,
+/// all non-NOP members are memory operations from one instruction family and
+/// cache scope, and no member needs a relocating rewrite.
+bool clauseHasUniformScope(const PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &Clause = Ctx.Decoded[Idx];
+  if (Clause.Inst.getNumOperands() == 0 || !Clause.Inst.getOperand(0).isImm())
+    return false;
+
+  const uint64_t MemberCount =
+      (static_cast<uint64_t>(Clause.Inst.getOperand(0).getImm()) & 63) + 1;
+  if (MemberCount > 63 || MemberCount > Ctx.Decoded.size() - Idx - 1)
+    return false;
+
+  std::optional<ClauseScope> Scope;
+  std::optional<ClauseFamily> Family;
+  bool SawMemory = false;
+  for (size_t I = Idx + 1; I <= Idx + MemberCount; ++I) {
+    const InternalDecodedInst &Member = Ctx.Decoded[I];
+    if (Member.Inst.getOpcode() == Ctx.LS.SNopOpcode)
+      continue;
+
+    if (requiresIndependentInstructionRewrite(Ctx, I)) {
+      const StringRef Mnemonic(Member.Mnemonic);
+      const bool WillBeRewrittenInPlace =
+          !getClusterLoadReplacementAsm(Mnemonic).empty() &&
+          !usesSgprBaseAddress(Member.Inst, *Ctx.LS.MRI);
+      if (!WillBeRewrittenInPlace)
+        return false;
+    }
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(Member.Inst.getOpcode());
+    if (!Desc.mayLoad() && !Desc.mayStore())
+      return false;
+
+    std::optional<ClauseFamily> MemberFamily = getClauseFamily(Member, Ctx.LS);
+    if (!MemberFamily || (Family && *Family != *MemberFamily))
+      return false;
+    Family = MemberFamily;
+
+    std::optional<ClauseScope> MemberScope =
+        getClauseScope(Member.Inst, Ctx.LS);
+    if (!MemberScope || (Scope && *Scope != *MemberScope))
+      return false;
+    Scope = MemberScope;
+    SawMemory = true;
+  }
+  return SawMemory;
+}
+
+bool clauseContainsVmem(ArrayRef<InternalDecodedInst> Decoded, size_t Idx,
+                        const LLVMState &LS) {
+  const InternalDecodedInst &Clause = Decoded[Idx];
+  if (Clause.Inst.getNumOperands() == 0 || !Clause.Inst.getOperand(0).isImm())
+    return false;
+
+  const uint64_t MemberCount =
+      (static_cast<uint64_t>(Clause.Inst.getOperand(0).getImm()) & 63) + 1;
+  if (MemberCount > 63 || MemberCount > Decoded.size() - Idx - 1)
+    return false;
+
+  for (size_t I = Idx + 1; I <= Idx + MemberCount; ++I) {
+    std::optional<ClauseFamily> Family = getClauseFamily(Decoded[I], LS);
+    if (Family == ClauseFamily::VMEM || Family == ClauseFamily::Flat)
+      return true;
+  }
+  return false;
+}
+
+bool isVmemOrFlat(const InternalDecodedInst &DI, const LLVMState &LS) {
+  std::optional<ClauseFamily> Family = getClauseFamily(DI, LS);
+  return Family == ClauseFamily::VMEM || Family == ClauseFamily::Flat;
+}
+
+void addCfgEdge(unsigned From, unsigned To,
+                std::vector<SmallVector<unsigned, 2>> &Successors,
+                std::vector<SmallVector<unsigned, 2>> &Predecessors) {
+  if (llvm::is_contained(Successors[From], To))
+    return;
+  Successors[From].push_back(To);
+  Predecessors[To].push_back(From);
+}
+
+std::optional<uint64_t> applySignedPcDelta(uint64_t CapturedPc, int64_t Delta) {
+  if (Delta >= 0)
+    return checkedAddUint64(CapturedPc, static_cast<uint64_t>(Delta),
+                            "HotSwap set-PC target");
+  const uint64_t Magnitude = Delta == std::numeric_limits<int64_t>::min()
+                                 ? uint64_t{1} << 63
+                                 : static_cast<uint64_t>(-Delta);
+  if (CapturedPc < Magnitude)
+    return std::nullopt;
+  return CapturedPc - Magnitude;
+}
+
+std::optional<std::pair<MCRegister, int64_t>>
+getHotswapAddSetPc(ArrayRef<InternalDecodedInst> Decoded,
+                   size_t SetPcGlobalIndex) {
+  if (SetPcGlobalIndex == 0 || SetPcGlobalIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Add = Decoded[SetPcGlobalIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcGlobalIndex];
+  if (Add.Mnemonic != "s_add_nc_u64" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      Add.Offset > std::numeric_limits<uint64_t>::max() - Add.Size ||
+      Add.Offset + Add.Size != SetPc.Offset || Add.Inst.getNumOperands() != 3 ||
+      SetPc.Inst.getNumOperands() != 1 || !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() || !Add.Inst.getOperand(2).isImm() ||
+      !SetPc.Inst.getOperand(0).isReg())
+    return std::nullopt;
+
+  MCRegister Pair = Add.Inst.getOperand(0).getReg();
+  if (!Pair.isValid() || Add.Inst.getOperand(1).getReg() != Pair.id() ||
+      SetPc.Inst.getOperand(0).getReg() != Pair.id())
+    return std::nullopt;
+  return std::pair<MCRegister, int64_t>{Pair, Add.Inst.getOperand(2).getImm()};
+}
+
+std::optional<uint64_t>
+resolveContiguousHotswapSetPcTarget(ArrayRef<InternalDecodedInst> Decoded,
+                                    size_t SetPcGlobalIndex) {
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getHotswapAddSetPc(Decoded, SetPcGlobalIndex);
+  if (!AddSet || SetPcGlobalIndex < 2)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[SetPcGlobalIndex - 2];
+  const InternalDecodedInst &Add = Decoded[SetPcGlobalIndex - 1];
+  if (GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size ||
+      GetPc.Offset + GetPc.Size != Add.Offset ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id())
+    return std::nullopt;
+  return applySignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+}
+
+std::optional<size_t>
+findDecodedIndexAtOffset(ArrayRef<InternalDecodedInst> Decoded,
+                         uint64_t Offset) {
+  auto It = llvm::lower_bound(Decoded, Offset,
+                              [](const InternalDecodedInst &DI,
+                                 uint64_t Value) { return DI.Offset < Value; });
+  if (It == Decoded.end() || It->Offset != Offset)
+    return std::nullopt;
+  return It - Decoded.begin();
+}
+
+std::optional<uint64_t>
+resolveHotswapSetPcTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                          uint64_t SetPcOffset) {
+  std::optional<size_t> Index =
+      findDecodedIndexAtOffset(AllDecoded, SetPcOffset);
+  if (!Index)
+    return std::nullopt;
+  return resolveContiguousHotswapSetPcTarget(AllDecoded, *Index);
+}
+
+/// Resolve a get-PC/s_branch relay whose add/set-PC pair is in another
+/// executable section. The displacement still uses the PC captured at source.
+std::optional<uint64_t>
+resolveHotswapRelayTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                          const InternalDecodedInst &GetPc,
+                          uint64_t RelayOffset) {
+  std::optional<size_t> AddIndex =
+      findDecodedIndexAtOffset(AllDecoded, RelayOffset);
+  if (!AddIndex || *AddIndex + 1 >= AllDecoded.size())
+    return std::nullopt;
+  const size_t SetPcIndex = *AddIndex + 1;
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getHotswapAddSetPc(AllDecoded, SetPcIndex);
+  if (!AddSet || GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id() ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size)
+    return std::nullopt;
+  return applySignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+}
+
+struct HotswapTrampolineResume {
+  uint64_t Offset = 0;
+  bool HasVmem = false;
+};
+
+std::optional<HotswapTrampolineResume>
+findHotswapTrampolineResume(ArrayRef<InternalDecodedInst> Decoded,
+                            uint64_t Target, const KernelTextRange &Range,
+                            const LLVMState &LS) {
+  if (!LS.MIA)
+    return std::nullopt;
+
+  size_t RemainingInstructions = Decoded.size();
+  bool HasVmem = false;
+  DenseSet<uint64_t> VisitedOffsets;
+  while (RemainingInstructions != 0) {
+    auto It = llvm::lower_bound(
+        Decoded, Target, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (It == Decoded.end() || It->Offset != Target)
+      return std::nullopt;
+
+    uint64_t ExpectedOffset = Target;
+    bool FollowedHop = false;
+    for (; It != Decoded.end(); ++It) {
+      if (RemainingInstructions == 0)
+        return std::nullopt;
+      --RemainingInstructions;
+      if (!VisitedOffsets.insert(It->Offset).second ||
+          It->Offset != ExpectedOffset || It->Size == 0 ||
+          It->Offset > std::numeric_limits<uint64_t>::max() - It->Size)
+        return std::nullopt;
+      ExpectedOffset = It->Offset + It->Size;
+      const size_t GlobalIndex = It - Decoded.begin();
+      if (It->Mnemonic == "<unknown>")
+        return std::nullopt;
+      HasVmem |= isVmemOrFlat(*It, LS);
+
+      if (It->Mnemonic == "s_set_pc_i64") {
+        std::optional<uint64_t> Next =
+            resolveContiguousHotswapSetPcTarget(Decoded, GlobalIndex);
+        if (!Next)
+          return std::nullopt;
+        if (*Next >= Range.Begin && *Next < Range.End)
+          return HotswapTrampolineResume{*Next, HasVmem};
+        Target = *Next;
+        FollowedHop = true;
+        break;
+      }
+
+      const MCInstrDesc &Desc = LS.MCII->get(It->Inst.getOpcode());
+      const bool IsCall = LS.MIA->isCall(It->Inst);
+      const bool IsReturn = LS.MIA->isReturn(It->Inst);
+      const bool IsBranch = LS.MIA->isBranch(It->Inst);
+      if (IsCall || IsReturn || Desc.isTrap())
+        return std::nullopt;
+      if (IsBranch) {
+        uint64_t Next = 0;
+        if (!LS.MIA->isUnconditionalBranch(It->Inst) ||
+            LS.MIA->isIndirectBranch(It->Inst) ||
+            !LS.MIA->evaluateBranch(It->Inst, It->Offset, It->Size, Next))
+          return std::nullopt;
+        if (Next >= Range.Begin && Next < Range.End)
+          return HotswapTrampolineResume{Next, HasVmem};
+        Target = Next;
+        FollowedHop = true;
+        break;
+      }
+      if (Desc.isTerminator() ||
+          LS.MIA->mayAffectControlFlow(It->Inst, *LS.MRI))
+        return std::nullopt;
+    }
+    if (!FollowedHop)
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+/// Analyze one descriptor-backed kernel range. Unknown control flow is modeled
+/// as reaching every instruction in the range, so a prior-VMEM fact is retained
+/// only when every modeled path proves it.
+void analyzeKernelRange(ArrayRef<InternalDecodedInst> Decoded,
+                        ArrayRef<InternalDecodedInst> AllDecoded,
+                        const KernelTextRange &Range, const LLVMState &LS,
+                        InitialVmemMustAnalysis &Result) {
+  SmallVector<size_t> GlobalIndices;
+  auto First = llvm::lower_bound(
+      Decoded, Range.Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto Last = llvm::lower_bound(
+      Decoded, Range.End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  for (auto It = First; It != Last; ++It)
+    GlobalIndices.push_back(It - Decoded.begin());
+  if (GlobalIndices.empty())
+    return;
+
+  for (size_t GlobalIdx : GlobalIndices)
+    Result.DescriptorCovered.set(GlobalIdx);
+
+  auto MergeConservativeRange = [&] {
+    for (size_t GlobalIdx : GlobalIndices) {
+      Result.Reachable.set(GlobalIdx);
+      Result.MustHavePriorVmem.reset(GlobalIdx);
+    }
+  };
+  if (Decoded[GlobalIndices.front()].Offset != Range.Begin ||
+      Range.HasArbitraryIndirectIngress) {
+    MergeConservativeRange();
+    return;
+  }
+
+  const unsigned Count = GlobalIndices.size();
+  DenseMap<uint64_t, unsigned> OffsetToLocal;
+  for (unsigned I = 0; I < Count; ++I)
+    OffsetToLocal.try_emplace(Decoded[GlobalIndices[I]].Offset, I);
+
+  BitVector EntryNodes(Count);
+  for (uint64_t Entry : Range.Entries) {
+    auto It = OffsetToLocal.find(Entry);
+    if (It == OffsetToLocal.end()) {
+      MergeConservativeRange();
+      return;
+    }
+    EntryNodes.set(It->second);
+  }
+  if (EntryNodes.none()) {
+    MergeConservativeRange();
+    return;
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  std::vector<SmallVector<unsigned, 2>> Predecessors(Count);
+  BitVector UnknownSuccessors(Count);
+  BitVector IsVmem(Count);
+  SmallVector<unsigned> HotswapSetPcCandidates;
+
+  for (unsigned I = 0; I < Count; ++I) {
+    const InternalDecodedInst &DI = Decoded[GlobalIndices[I]];
+    if (isVmemOrFlat(DI, LS))
+      IsVmem.set(I);
+
+    const bool HasFallthrough = I + 1 < Count;
+    if (DI.Mnemonic == "<unknown>") {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsCall = LS.MIA ? LS.MIA->isCall(DI.Inst) : Desc.isCall();
+    const bool IsReturn = LS.MIA ? LS.MIA->isReturn(DI.Inst) : Desc.isReturn();
+    const bool IsBranch = LS.MIA ? LS.MIA->isBranch(DI.Inst) : Desc.isBranch();
+    if (IsReturn)
+      continue;
+
+    // A debug trap can resume at the following instruction.
+    if (Desc.isTrap()) {
+      if (HasFallthrough)
+        addCfgEdge(I, I + 1, Successors, Predecessors);
+      continue;
+    }
+
+    if (IsCall) {
+      if (!Desc.isTerminator() && HasFallthrough)
+        addCfgEdge(I, I + 1, Successors, Predecessors);
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      HotswapSetPcCandidates.push_back(I);
+      continue;
+    }
+
+    if (IsBranch) {
+      const bool IsIndirect =
+          LS.MIA ? LS.MIA->isIndirectBranch(DI.Inst) : Desc.isIndirectBranch();
+      const bool IsConditional = LS.MIA ? LS.MIA->isConditionalBranch(DI.Inst)
+                                        : Desc.isConditionalBranch();
+      const bool IsUnconditional = LS.MIA
+                                       ? LS.MIA->isUnconditionalBranch(DI.Inst)
+                                       : Desc.isUnconditionalBranch();
+
+      bool TargetKnown = false;
+      if (!IsIndirect && LS.MIA) {
+        uint64_t Target = 0;
+        if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+          TargetKnown = true;
+          if (Target >= Range.Begin && Target < Range.End) {
+            auto TargetIt = OffsetToLocal.find(Target);
+            if (TargetIt == OffsetToLocal.end()) {
+              UnknownSuccessors.set(I);
+              TargetKnown = false;
+            } else {
+              addCfgEdge(I, TargetIt->second, Successors, Predecessors);
+            }
+          } else if (IsUnconditional) {
+            std::optional<HotswapTrampolineResume> Resume =
+                findHotswapTrampolineResume(AllDecoded, Target, Range, LS);
+            if (!Resume && I != 0 && DI.Mnemonic == "s_branch") {
+              const InternalDecodedInst &GetPc = Decoded[GlobalIndices[I - 1]];
+              if (GetPc.Offset <=
+                      std::numeric_limits<uint64_t>::max() - GetPc.Size &&
+                  GetPc.Offset + GetPc.Size == DI.Offset &&
+                  GetPc.Mnemonic == "s_get_pc_i64") {
+                std::optional<uint64_t> PoolTarget =
+                    resolveHotswapRelayTarget(AllDecoded, GetPc, Target);
+                if (PoolTarget)
+                  Resume = findHotswapTrampolineResume(AllDecoded, *PoolTarget,
+                                                       Range, LS);
+              }
+            }
+            if (Resume) {
+              auto ResumeIt = OffsetToLocal.find(Resume->Offset);
+              if (ResumeIt == OffsetToLocal.end()) {
+                UnknownSuccessors.set(I);
+                TargetKnown = false;
+              } else {
+                addCfgEdge(I, ResumeIt->second, Successors, Predecessors);
+                if (Resume->HasVmem)
+                  IsVmem.set(I);
+              }
+            } else {
+              UnknownSuccessors.set(I);
+              TargetKnown = false;
+            }
+          }
+        }
+      }
+      if (!TargetKnown)
+        UnknownSuccessors.set(I);
+
+      if (IsConditional && HasFallthrough)
+        addCfgEdge(I, I + 1, Successors, Predecessors);
+      else if (!IsConditional && !IsUnconditional)
+        UnknownSuccessors.set(I);
+      continue;
+    }
+
+    if (Desc.isTerminator())
+      continue;
+    if (LS.MIA && LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (HasFallthrough)
+      addCfgEdge(I, I + 1, Successors, Predecessors);
+  }
+
+  for (unsigned I : HotswapSetPcCandidates) {
+    const InternalDecodedInst &SetPc = Decoded[GlobalIndices[I]];
+    std::optional<uint64_t> Target =
+        resolveHotswapSetPcTarget(AllDecoded, SetPc.Offset);
+    if (!Target) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (*Target >= Range.Begin && *Target < Range.End) {
+      auto TargetIt = OffsetToLocal.find(*Target);
+      if (TargetIt == OffsetToLocal.end())
+        UnknownSuccessors.set(I);
+      else
+        addCfgEdge(I, TargetIt->second, Successors, Predecessors);
+      continue;
+    }
+
+    std::optional<HotswapTrampolineResume> Resume =
+        findHotswapTrampolineResume(AllDecoded, *Target, Range, LS);
+    if (!Resume) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    auto ResumeIt = OffsetToLocal.find(Resume->Offset);
+    if (ResumeIt == OffsetToLocal.end()) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    addCfgEdge(I, ResumeIt->second, Successors, Predecessors);
+    if (Resume->HasVmem)
+      IsVmem.set(I);
+  }
+
+  BitVector Reachable(Count);
+  SmallVector<unsigned> Worklist;
+  for (int Entry = EntryNodes.find_first(); Entry != -1;
+       Entry = EntryNodes.find_next(Entry)) {
+    Reachable.set(Entry);
+    Worklist.push_back(Entry);
+  }
+  for (size_t Next = 0; Next < Worklist.size(); ++Next) {
+    const unsigned I = Worklist[Next];
+    if (UnknownSuccessors.test(I)) {
+      Reachable.set();
+      break;
+    }
+    for (unsigned Target : Successors[I]) {
+      if (!Reachable.test(Target)) {
+        Reachable.set(Target);
+        Worklist.push_back(Target);
+      }
+    }
+  }
+
+  SmallVector<uint8_t> MustIn(Count, 1);
+  SmallVector<uint8_t> MustOut(Count, 1);
+  for (int Entry = EntryNodes.find_first(); Entry != -1;
+       Entry = EntryNodes.find_next(Entry)) {
+    MustIn[Entry] = 0;
+    MustOut[Entry] = IsVmem.test(Entry);
+  }
+
+  bool Changed = true;
+  while (Changed) {
+    Changed = false;
+    bool HasReachableUnknown = false;
+    bool UnknownMustOut = true;
+    for (int Pred = UnknownSuccessors.find_first(); Pred != -1;
+         Pred = UnknownSuccessors.find_next(Pred)) {
+      if (!Reachable.test(Pred))
+        continue;
+      HasReachableUnknown = true;
+      UnknownMustOut &= MustOut[Pred] != 0;
+    }
+
+    for (unsigned I = 0; I < Count; ++I) {
+      if (!Reachable.test(I))
+        continue;
+      bool NewIn = !EntryNodes.test(I);
+      bool SawPredecessor = EntryNodes.test(I);
+      if (!EntryNodes.test(I)) {
+        for (unsigned Pred : Predecessors[I]) {
+          if (!Reachable.test(Pred))
+            continue;
+          SawPredecessor = true;
+          NewIn &= MustOut[Pred] != 0;
+        }
+        if (HasReachableUnknown) {
+          SawPredecessor = true;
+          NewIn &= UnknownMustOut;
+        }
+        if (!SawPredecessor)
+          NewIn = false;
+      }
+      const bool NewOut = NewIn || IsVmem.test(I);
+      if (MustIn[I] != NewIn || MustOut[I] != NewOut) {
+        MustIn[I] = NewIn;
+        MustOut[I] = NewOut;
+        Changed = true;
+      }
+    }
+  }
+
+  for (unsigned I = 0; I < Count; ++I) {
+    if (!Reachable.test(I))
+      continue;
+    const size_t GlobalIdx = GlobalIndices[I];
+    if (Result.Reachable.test(GlobalIdx)) {
+      if (!MustIn[I])
+        Result.MustHavePriorVmem.reset(GlobalIdx);
+    } else {
+      Result.Reachable.set(GlobalIdx);
+      if (MustIn[I])
+        Result.MustHavePriorVmem.set(GlobalIdx);
+      else
+        Result.MustHavePriorVmem.reset(GlobalIdx);
+    }
+  }
+}
+
+bool isInitialVmemClause(const PatchContext &Ctx, size_t Idx) {
+  if (!clauseContainsVmem(Ctx.Decoded, Idx, Ctx.LS))
+    return false;
+  if (!Ctx.InitialVmemAnalysis ||
+      Idx >= Ctx.InitialVmemAnalysis->DescriptorCovered.size() ||
+      !Ctx.InitialVmemAnalysis->DescriptorCovered.test(Idx))
+    return true;
+  if (!Ctx.InitialVmemAnalysis->Reachable.test(Idx))
+    return false;
+  return !Ctx.InitialVmemAnalysis->MustHavePriorVmem.test(Idx);
+}
+
+void releaseClauseMemberRelocationProtection(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &Clause = Ctx.Decoded[Idx];
+  if (Clause.Inst.getNumOperands() == 0 || !Clause.Inst.getOperand(0).isImm())
+    return;
+
+  const size_t MemberCount =
+      (static_cast<uint64_t>(Clause.Inst.getOperand(0).getImm()) & 63) + 1;
+  const size_t Available = std::min(MemberCount, Ctx.Decoded.size() - Idx - 1);
+  const size_t End = Idx + 1 + Available;
+  for (size_t I = Idx + 1; I != End; ++I) {
+    const uint64_t Offset = Ctx.Decoded[I].Offset;
+    auto It = Ctx.ClauseRelocationProtectionCounts.find(Offset);
+    if (It == Ctx.ClauseRelocationProtectionCounts.end())
+      continue;
+    if (--It->second != 0)
+      continue;
+    Ctx.ClauseRelocationProtectionCounts.erase(It);
+    if (!Ctx.NonClauseRelocationProtectedOffsets.contains(Offset))
+      Ctx.RelocationProtectedOffsets.erase(Offset);
+  }
+}
+
 } // anonymous namespace
+
+InitialVmemMustAnalysis
+computeInitialVmemMustAnalysis(ArrayRef<InternalDecodedInst> Decoded,
+                               ArrayRef<InternalDecodedInst> AllDecoded,
+                               ArrayRef<KernelTextRange> KernelRanges,
+                               const LLVMState &LS) {
+  InitialVmemMustAnalysis Result{BitVector(Decoded.size()),
+                                 BitVector(Decoded.size()),
+                                 BitVector(Decoded.size())};
+  for (const KernelTextRange &Range : KernelRanges)
+    analyzeKernelRange(Decoded, AllDecoded, Range, LS, Result);
+  return Result;
+}
 
 static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -136,9 +795,30 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
       if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
         log() << "hotswap: inplace: " << Mnemonic << " -> opcode " << *NewOpcode
               << " at 0x" << utohexstr(DI.Offset) << "\n";
+        Ctx.RequiredPatchApplied = true;
         return 1;
       }
+      return failRequiredInPlacePatch(Ctx, Mnemonic, DI.Offset);
     }
+  }
+
+  if (Mnemonic == "s_clause") {
+    const bool InitialVmemClause = isInitialVmemClause(Ctx, Idx);
+    if (!InitialVmemClause && clauseHasUniformScope(Ctx, Idx))
+      return 0;
+
+    RewriteRule Rule;
+    Rule.ReplaceBytes.assign(Ctx.LS.SNopBytes.begin(), Ctx.LS.SNopBytes.end());
+    if (applyByteReplace(Rule, DI.Offset, DI.Size, Ctx.Text, Ctx.TextSize,
+                         Ctx.LS)) {
+      releaseClauseMemberRelocationProtection(Ctx, Idx);
+      log() << "hotswap: inplace: "
+            << (InitialVmemClause ? "initial-VMEM" : "mixed/unsupported-scope")
+            << " s_clause -> s_nop at 0x" << utohexstr(DI.Offset) << "\n";
+      Ctx.RequiredPatchApplied = true;
+      return 1;
+    }
+    return failRequiredInPlacePatch(Ctx, Mnemonic, DI.Offset);
   }
 
   // s_barrier_signal_isfirst -> s_barrier_signal: on A0, the isfirst
@@ -172,8 +852,10 @@ static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
     if (NewOpcode && swapOpcode(DI, Ctx.Text, Ctx.LS, *NewOpcode)) {
       log() << "hotswap: inplace: s_barrier_signal_isfirst -> opcode "
             << *NewOpcode << " at 0x" << utohexstr(DI.Offset) << "\n";
+      Ctx.RequiredPatchApplied = true;
       return 1;
     }
+    return failRequiredInPlacePatch(Ctx, Mnemonic, DI.Offset);
   }
 
   return 0;

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -47,6 +47,7 @@ using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+
 namespace {
 
 bool failRequiredPatch(PatchContext &Ctx) {
@@ -233,46 +234,34 @@ extractDsOperands(const MCInst &Inst, StringRef FromMnem, const LLVMState &LS) {
 
 // Split a compound destination register into two formatted destination strings.
 // b32: VReg_64 -> ("v0", "v1"); b64: VReg_128 -> ("v[0:1]", "v[2:3]")
-std::optional<std::pair<std::string, std::string>>
+std::pair<std::string, std::string>
 splitDstPair(MCRegister CompoundReg, bool IsB64, const MCRegisterInfo &MRI) {
   SmallVector<MCRegister, 4> Subs = getDirectSubRegs(CompoundReg, MRI);
   if (IsB64) {
-    if (Subs.size() < 4) {
-      log() << "hotswap: error: DS b64 destination " << MRI.getName(CompoundReg)
-            << " has " << Subs.size()
-            << " direct subregisters; expected at least 4\n";
-      return std::nullopt;
-    }
-    return std::pair<std::string, std::string>{
-        fmtRegPair(MRI, Subs[0], Subs[1]), fmtRegPair(MRI, Subs[2], Subs[3])};
+    if (Subs.size() < 4)
+      return {};
+    return {fmtRegPair(MRI, Subs[0], Subs[1]),
+            fmtRegPair(MRI, Subs[2], Subs[3])};
   }
-  if (Subs.size() < 2) {
-    log() << "hotswap: error: DS b32 destination " << MRI.getName(CompoundReg)
-          << " has " << Subs.size()
-          << " direct subregisters; expected at least 2\n";
-    return std::nullopt;
-  }
-  return std::pair<std::string, std::string>{toAsmRegName(MRI, Subs[0]),
-                                             toAsmRegName(MRI, Subs[1])};
+  if (Subs.size() < 2)
+    return {};
+  return {toAsmRegName(MRI, Subs[0]), toAsmRegName(MRI, Subs[1])};
 }
 
 // Expand a DS 2-address load into two single-address loads (dst, addr).
-std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
-                                                          StringRef ToMnem) {
-  if (Ops.Regs.size() < 2) {
-    log() << "hotswap: error: " << ToMnem << " expansion found "
-          << Ops.Regs.size() << " register operands; expected at least 2\n";
-    return std::nullopt;
-  }
-  std::optional<std::pair<std::string, std::string>> Dst =
+std::vector<std::string> expandDs2AddrLoad(const DsOperands &Ops,
+                                           StringRef ToMnem) {
+  if (Ops.Regs.size() < 2)
+    return {};
+  std::pair<std::string, std::string> Dst =
       splitDstPair(Ops.Regs[0], Ops.IsB64, *Ops.MRI);
-  if (!Dst)
-    return std::nullopt;
+  if (Dst.first.empty())
+    return {};
   std::string Addr = toAsmRegName(*Ops.MRI, Ops.Regs[1]);
   std::string First =
-      ToMnem.str() + " " + Dst->first + ", " + Addr + fmtOffset(Ops.Off0);
+      ToMnem.str() + " " + Dst.first + ", " + Addr + fmtOffset(Ops.Off0);
   std::string Second =
-      ToMnem.str() + " " + Dst->second + ", " + Addr + fmtOffset(Ops.Off1);
+      ToMnem.str() + " " + Dst.second + ", " + Addr + fmtOffset(Ops.Off1);
 
   // A compound DS load reads its address once before writing either half of
   // the destination. After splitting, the first single-address load must not
@@ -286,71 +275,57 @@ std::optional<std::vector<std::string>> expandDs2AddrLoad(const DsOperands &Ops,
       ArrayRef(DstSubs).take_front(FirstHalfWidth),
       [&](MCRegister Reg) { return Ops.MRI->regsOverlap(Reg, Ops.Regs[1]); });
   if (AddrOverlapsFirst)
-    return std::vector<std::string>{std::move(Second), std::move(First)};
-  return std::vector<std::string>{std::move(First), std::move(Second)};
+    return {std::move(Second), std::move(First)};
+  return {std::move(First), std::move(Second)};
 }
 
 // Expand a DS 2-address store into two single-address stores (addr, data).
-std::optional<std::vector<std::string>>
-expandDs2AddrStore(const DsOperands &Ops, StringRef ToMnem) {
-  if (Ops.Regs.size() < 3) {
-    log() << "hotswap: error: " << ToMnem << " expansion found "
-          << Ops.Regs.size() << " register operands; expected at least 3\n";
-    return std::nullopt;
-  }
+std::vector<std::string> expandDs2AddrStore(const DsOperands &Ops,
+                                            StringRef ToMnem) {
+  if (Ops.Regs.size() < 3)
+    return {};
   const MCRegisterInfo &MRI = *Ops.MRI;
   std::string Addr = toAsmRegName(MRI, Ops.Regs[0]);
   std::string Data0 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[1])
                                 : toAsmRegName(MRI, Ops.Regs[1]);
   std::string Data1 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[2])
                                 : toAsmRegName(MRI, Ops.Regs[2]);
-  return std::vector<std::string>{
+  return {
       ToMnem.str() + " " + Addr + ", " + Data0 + fmtOffset(Ops.Off0),
       ToMnem.str() + " " + Addr + ", " + Data1 + fmtOffset(Ops.Off1),
   };
 }
 
-bool registerSliceOverlaps(ArrayRef<MCRegister> Registers, unsigned Begin,
-                           unsigned Count, MCRegister Reg,
-                           const MCRegisterInfo &MRI) {
-  return llvm::any_of(Registers.slice(Begin, Count), [&](MCRegister DstReg) {
+// Expand a DS 2-address exchange into two single-address exchanges
+// (dst, addr, data).
+bool halfOverlaps(ArrayRef<MCRegister> DstSubs, unsigned Begin, unsigned Width,
+                  MCRegister Reg, const MCRegisterInfo &MRI) {
+  return llvm::any_of(DstSubs.slice(Begin, Width), [&](MCRegister DstReg) {
     return MRI.regsOverlap(DstReg, Reg);
   });
 }
 
-// Expand a DS 2-address exchange into two single-address exchanges
-// (dst, addr, data).
-std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
-                                                          StringRef ToMnem) {
-  if (Ops.Regs.size() < 4) {
-    log() << "hotswap: error: " << ToMnem << " expansion found "
-          << Ops.Regs.size() << " register operands; expected at least 4\n";
-    return std::nullopt;
-  }
+std::vector<std::string> expandDs2AddrXchg(const DsOperands &Ops,
+                                           StringRef ToMnem) {
+  if (Ops.Regs.size() < 4)
+    return {};
   const MCRegisterInfo &MRI = *Ops.MRI;
-  std::optional<std::pair<std::string, std::string>> Dst =
+  std::pair<std::string, std::string> Dst =
       splitDstPair(Ops.Regs[0], Ops.IsB64, MRI);
-  if (!Dst)
-    return std::nullopt;
+  if (Dst.first.empty())
+    return {};
   std::string Addr = toAsmRegName(MRI, Ops.Regs[1]);
   std::string Data0 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[2])
                                 : toAsmRegName(MRI, Ops.Regs[2]);
   std::string Data1 = Ops.IsB64 ? fmtRegOperand(MRI, Ops.Regs[3])
                                 : toAsmRegName(MRI, Ops.Regs[3]);
-  std::string First = ToMnem.str() + " " + Dst->first + ", " + Addr + ", " +
+  std::string First = ToMnem.str() + " " + Dst.first + ", " + Addr + ", " +
                       Data0 + fmtOffset(Ops.Off0);
-  std::string Second = ToMnem.str() + " " + Dst->second + ", " + Addr + ", " +
+  std::string Second = ToMnem.str() + " " + Dst.second + ", " + Addr + ", " +
                        Data1 + fmtOffset(Ops.Off1);
 
   SmallVector<MCRegister, 4> DstSubs = getDirectSubRegs(Ops.Regs[0], MRI);
   const unsigned HalfWidth = Ops.IsB64 ? 2 : 1;
-  if (DstSubs.size() < 2 * HalfWidth) {
-    log() << "hotswap: error: " << ToMnem << " destination "
-          << MRI.getName(Ops.Regs[0]) << " has " << DstSubs.size()
-          << " direct subregisters; expected at least " << 2 * HalfWidth
-          << "\n";
-    return std::nullopt;
-  }
 
   // Op0 writes the first destination half and op1 still needs addr + data1;
   // op1 writes the second half and op0 still needs addr + data0. Pick the safe
@@ -358,20 +333,20 @@ std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
   // neither ordering preserves the compound instruction's read-before-write
   // semantics without a scratch VGPR, so decline the rewrite.
   const bool FirstClobbersSecond =
-      registerSliceOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[1], MRI) ||
-      registerSliceOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[3], MRI);
+      halfOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[1], MRI) ||
+      halfOverlaps(DstSubs, 0, HalfWidth, Ops.Regs[3], MRI);
   const bool SecondClobbersFirst =
-      registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
-      registerSliceOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
+      halfOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[1], MRI) ||
+      halfOverlaps(DstSubs, HalfWidth, HalfWidth, Ops.Regs[2], MRI);
   if (FirstClobbersSecond && SecondClobbersFirst) {
     log() << "hotswap: error: ds_storexchg_2addr has cyclic "
              "destination/source overlap and cannot be split without scratch "
              "VGPRs\n";
-    return std::nullopt;
+    return {};
   }
   if (FirstClobbersSecond)
-    return std::vector<std::string>{std::move(Second), std::move(First)};
-  return std::vector<std::string>{std::move(First), std::move(Second)};
+    return {std::move(Second), std::move(First)};
+  return {std::move(First), std::move(Second)};
 }
 
 // -- expandDs2Addr ----------------------------------------------------------
@@ -379,13 +354,11 @@ std::optional<std::vector<std::string>> expandDs2AddrXchg(const DsOperands &Ops,
 // Top-level expansion: extracts operands from the decoded MCInst, computes
 // scaled offsets, then dispatches to the appropriate layout-specific helper.
 
-std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
-                                                          StringRef FromMnem,
-                                                          StringRef ToMnem,
-                                                          const LLVMState &LS) {
+std::vector<std::string> expandDs2Addr(const MCInst &Inst, StringRef FromMnem,
+                                       StringRef ToMnem, const LLVMState &LS) {
   std::optional<DsOperands> Ops = extractDsOperands(Inst, FromMnem, LS);
   if (!Ops)
-    return std::nullopt;
+    return {};
 
   // Use the trailing underscore so the three prefixes are disjoint
   // ("ds_load_", "ds_store_", "ds_storexchg_"); without it "ds_store" is a
@@ -398,7 +371,563 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
     return expandDs2AddrStore(*Ops, ToMnem);
 
   log() << "hotswap: error: unrecognized DS mnemonic: " << FromMnem << "\n";
-  return std::nullopt;
+  return {};
+}
+
+bool definesRegister(const InternalDecodedInst &DI, MCRegister Reg,
+                     const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() && LS.MRI->regsOverlap(Op.getReg(), Reg.id()))
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Implicit) {
+    return LS.MRI->regsOverlap(Implicit, Reg.id());
+  });
+}
+
+bool definesModeOrExec(const InternalDecodedInst &DI, const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  auto IsModeOrExec = [&](MCRegister Reg) {
+    StringRef Name = LS.MRI->getName(Reg.id());
+    return Name == "MODE" || Name == "EXEC" || Name == "EXEC_LO" ||
+           Name == "EXEC_HI";
+  };
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() && IsModeOrExec(MCRegister(Op.getReg())))
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Implicit) {
+    return IsModeOrExec(MCRegister(Implicit));
+  });
+}
+
+bool isAlignedConstantAddressDef(const InternalDecodedInst &DI,
+                                 MCRegister Address, unsigned Alignment,
+                                 const PatchContext &Ctx, size_t Idx,
+                                 bool RequireEqualMode = true) {
+  if (RequireEqualMode && (Idx >= Ctx.VgprMsbDstSrc0EqualBefore.size() ||
+                           !Ctx.VgprMsbDstSrc0EqualBefore.test(Idx)))
+    return false;
+  if (DI.Mnemonic == "v_add_nc_u32" && DI.Inst.getNumOperands() == 4) {
+    const MCOperand &Dst = DI.Inst.getOperand(0);
+    const MCOperand &Src0 = DI.Inst.getOperand(1);
+    const MCOperand &Src1 = DI.Inst.getOperand(2);
+    const MCOperand &Modifiers = DI.Inst.getOperand(3);
+    if (!Dst.isReg() || Dst.getReg() != Address.id() || !Src0.isImm() ||
+        !Src1.isImm() || !Modifiers.isImm() || Modifiers.getImm() != 0)
+      return false;
+    uint32_t Value = static_cast<uint32_t>(Src0.getImm()) +
+                     static_cast<uint32_t>(Src1.getImm());
+    return Alignment != 0 && Value % Alignment == 0;
+  }
+
+  if (DI.Mnemonic == "v_mov_b32" && DI.Inst.getNumOperands() == 2) {
+    const MCOperand &Dst = DI.Inst.getOperand(0);
+    if (!Dst.isReg() || Dst.getReg() != Address.id() || Alignment == 0)
+      return false;
+    std::optional<int64_t> Value = getAbsoluteOperandValue(
+        DI.Inst.getOperand(1), DI, ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize));
+    return Value && static_cast<uint32_t>(*Value) % Alignment == 0;
+  }
+
+  if (DI.Mnemonic == "v_mul_lo_u32" &&
+      (DI.Inst.getNumOperands() == 3 || DI.Inst.getNumOperands() == 4)) {
+    const MCOperand &Dst = DI.Inst.getOperand(0);
+    const MCOperand &Src0 = DI.Inst.getOperand(1);
+    const MCOperand &Src1 = DI.Inst.getOperand(2);
+    if (!Dst.isReg() || Dst.getReg() != Address.id() || Alignment == 0 ||
+        (DI.Inst.getNumOperands() == 4 &&
+         (!DI.Inst.getOperand(3).isImm() ||
+          DI.Inst.getOperand(3).getImm() != 0)))
+      return false;
+    return (Src0.isImm() &&
+            static_cast<uint32_t>(Src0.getImm()) % Alignment == 0) ||
+           (Src1.isImm() &&
+            static_cast<uint32_t>(Src1.getImm()) % Alignment == 0);
+  }
+
+  if (DI.Mnemonic != "v_dual_mov_b32" || DI.Inst.getNumOperands() != 4)
+    return false;
+  for (unsigned Def = 0; Def != 2; ++Def) {
+    const MCOperand &Dst = DI.Inst.getOperand(Def);
+    const MCOperand &Src = DI.Inst.getOperand(Def + 2);
+    if (!Dst.isReg() || Dst.getReg() != Address.id())
+      continue;
+    return Alignment != 0 && Src.isImm() &&
+           static_cast<uint32_t>(Src.getImm()) % Alignment == 0;
+  }
+  return false;
+}
+
+static bool isAlignedSgprCopyAddressDef(const InternalDecodedInst &DI,
+                                        MCRegister Address, unsigned Alignment,
+                                        const PatchContext &Ctx, size_t Idx) {
+  if (Alignment == 0 || Alignment > 8 ||
+      Idx >= Ctx.VgprMsbDstSrc0EqualBefore.size() ||
+      !Ctx.VgprMsbDstSrc0EqualBefore.test(Idx) ||
+      Idx >= Ctx.VgprDef0AlignedTo8.size() ||
+      Idx >= Ctx.VgprDef1AlignedTo8.size())
+    return false;
+
+  if (DI.Mnemonic == "v_mov_b32")
+    return DI.Inst.getNumOperands() == 2 && DI.Inst.getOperand(0).isReg() &&
+           DI.Inst.getOperand(0).getReg() == Address.id() &&
+           Ctx.VgprDef0AlignedTo8.test(Idx);
+
+  if (DI.Mnemonic != "v_dual_mov_b32" || DI.Inst.getNumOperands() != 4)
+    return false;
+  for (unsigned Def = 0; Def != 2; ++Def) {
+    const MCOperand &Dst = DI.Inst.getOperand(Def);
+    if (Dst.isReg() && Dst.getReg() == Address.id())
+      return (Def == 0 ? Ctx.VgprDef0AlignedTo8 : Ctx.VgprDef1AlignedTo8)
+          .test(Idx);
+  }
+  return false;
+}
+
+static bool isAlignedAddressDef(const InternalDecodedInst &DI,
+                                MCRegister Address, unsigned Alignment,
+                                const PatchContext &Ctx, size_t Idx) {
+  return isAlignedConstantAddressDef(DI, Address, Alignment, Ctx, Idx) ||
+         isAlignedSgprCopyAddressDef(DI, Address, Alignment, Ctx, Idx);
+}
+
+/// A0 only needs the DS2 split when the effective address may be unaligned.
+/// Preserve the compact original instruction when a same-block constant or a
+/// proven aligned SGPR copy defines the address. Equality of MODE's destination
+/// and src0 bank selectors is a must-dataflow fact; unchanged MODE and EXEC
+/// then guarantee that the VALU definition and DS address name the same
+/// physical VGPRs for the same active lanes.
+bool computeDs2AddressProvenAligned(PatchContext &Ctx, size_t Idx) {
+  if (Ctx.HasUnknownArbitraryIndirectTarget || !Ctx.DirectControlFlowTargets ||
+      Idx >= Ctx.VgprMsbDstSrc0EqualBefore.size())
+    return false;
+  const InternalDecodedInst &DS = Ctx.Decoded[Idx];
+  StringRef Mnem = DS.Mnemonic;
+  if (Mnem != "ds_load_2addr_b32" && Mnem != "ds_load_2addr_b64" &&
+      Mnem != "ds_store_2addr_b32" && Mnem != "ds_store_2addr_b64")
+    return false;
+  if (DS.Inst.getNumOperands() == 0 ||
+      !DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).isImm() ||
+      DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).getImm() != 0)
+    return false; // GDS and malformed operand layouts are never exempt.
+
+  std::optional<DsOperands> Ops =
+      extractDsOperands(DS.Inst, DS.Mnemonic, Ctx.LS);
+  if (!Ops)
+    return false;
+  unsigned AddrIndex = StringRef(DS.Mnemonic).starts_with("ds_store_") ? 0 : 1;
+  if (Ops->Regs.size() <= AddrIndex)
+    return false;
+  MCRegister Address = Ops->Regs[AddrIndex];
+  unsigned Alignment = Ops->IsB64 ? 8 : 4;
+  if (Ops->Off0 % Alignment != 0 || Ops->Off1 % Alignment != 0)
+    return false;
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(DS.Offset);
+  if (!Function || Ctx.IndirectControlFlowFunctions.contains(Function->Begin) ||
+      Ctx.DirectControlFlowTargets->contains(DS.Offset))
+    return false;
+
+  for (size_t I = Idx; I-- > 0;) {
+    const InternalDecodedInst &DI = Ctx.Decoded[I];
+    if (DI.Offset < Function->Begin)
+      break;
+    if (Ctx.DirectControlFlowTargets->contains(DI.Offset) ||
+        definesModeOrExec(DI, Ctx.LS) ||
+        StringRef(DI.Mnemonic).starts_with("s_setreg") ||
+        DI.Mnemonic == "<unknown>" || DI.Mnemonic == "<replaced>" ||
+        (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)))
+      break;
+    if (definesRegister(DI, Address, Ctx.LS))
+      return isAlignedAddressDef(DI, Address, Alignment, Ctx, I);
+  }
+  return false;
+}
+
+bool isDs2AddressProvenAligned(PatchContext &Ctx, size_t Idx) {
+  if (Ctx.Ds2AddressProvenAligned.size() == Ctx.Decoded.size())
+    return Ctx.Ds2AddressProvenAligned.test(Idx);
+  return computeDs2AddressProvenAligned(Ctx, Idx);
+}
+
+struct Ds2FlowEdge {
+  unsigned Successor = 0;
+  bool IsBranchTarget = false;
+};
+
+struct Ds2FunctionFlow {
+  size_t GlobalFirst = 0;
+  std::vector<SmallVector<Ds2FlowEdge, 2>> Successors;
+  bool Valid = false;
+};
+
+static Ds2FunctionFlow
+buildDs2FunctionFlow(PatchContext &Ctx,
+                     const ElfView::FunctionTextRange &Function) {
+  Ds2FunctionFlow Flow;
+  auto First =
+      llvm::lower_bound(Ctx.Decoded, Function.Begin,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  auto After =
+      llvm::lower_bound(Ctx.Decoded, Function.End,
+                        [](const InternalDecodedInst &DI, uint64_t Offset) {
+                          return DI.Offset < Offset;
+                        });
+  if (First == After || First->Offset != Function.Begin || !Ctx.LS.MIA)
+    return Flow;
+
+  Flow.GlobalFirst = static_cast<size_t>(First - Ctx.Decoded.begin());
+  const unsigned Count = static_cast<unsigned>(After - First);
+  Flow.Successors.resize(Count);
+  DenseMap<uint64_t, unsigned> OffsetToIndex;
+  OffsetToIndex.reserve(Count);
+  for (unsigned I = 0; I != Count; ++I) {
+    if (First[I].Mnemonic == "<unknown>")
+      return Flow;
+    OffsetToIndex.try_emplace(First[I].Offset, I);
+  }
+
+  auto AddFallthrough = [&](unsigned I) {
+    if (I + 1 < Count)
+      Flow.Successors[I].push_back({I + 1, false});
+  };
+  for (unsigned I = 0; I != Count; ++I) {
+    const InternalDecodedInst &DI = First[I];
+    if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+        Ctx.LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, Ctx.LS))
+      continue;
+    if (Ctx.LS.MIA->isCall(DI.Inst)) {
+      AddFallthrough(I);
+      continue;
+    }
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (Ctx.LS.MIA->isIndirectBranch(DI.Inst)) {
+        std::optional<MaterializedPcTransfer> Transfer;
+        if (Ctx.DirectControlFlowTargets)
+          Transfer = evaluateMaterializedPcTransfer(
+              Ctx.Decoded, Flow.GlobalFirst + I, *Ctx.DirectControlFlowTargets,
+              ArrayRef<uint8_t>(Ctx.Text, Ctx.TextSize), Ctx.LS, Ctx.Elf);
+        if (!Transfer)
+          return Flow;
+        Target = Transfer->Target;
+      } else if (!Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size,
+                                             Target))
+        return Flow;
+      auto It = OffsetToIndex.find(Target);
+      if (It == OffsetToIndex.end() && Target >= Function.Begin &&
+          Target < Function.End)
+        return Flow;
+      if (It != OffsetToIndex.end())
+        Flow.Successors[I].push_back({It->second, true});
+      if (Ctx.LS.MIA->isConditionalBranch(DI.Inst))
+        AddFallthrough(I);
+      else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        return Flow;
+      continue;
+    }
+    if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+      return Flow;
+    AddFallthrough(I);
+  }
+  Flow.Valid = true;
+  return Flow;
+}
+
+static std::optional<unsigned> ds2NumberedSgprIndex(const MCRegisterInfo &MRI,
+                                                    MCRegister Reg,
+                                                    unsigned MaxSgprs) {
+  if (!Reg.isValid())
+    return std::nullopt;
+  StringRef Name(MRI.getName(Reg));
+  if (!Name.consume_front("SGPR") || Name.empty() || Name.contains('_'))
+    return std::nullopt;
+  unsigned Index = 0;
+  if (Name.getAsInteger(10, Index) || Index >= MaxSgprs)
+    return std::nullopt;
+  return Index;
+}
+
+static SmallVector<MCRegister, 128>
+getDs2NumberedSgprs(const PatchContext &Ctx) {
+  SmallVector<MCRegister, 128> Registers(Ctx.Config.MaxSgprs);
+  for (unsigned Reg = 1, End = Ctx.LS.MRI->getNumRegs(); Reg != End; ++Reg) {
+    std::optional<unsigned> Index =
+        ds2NumberedSgprIndex(*Ctx.LS.MRI, MCRegister(Reg), Ctx.Config.MaxSgprs);
+    if (Index)
+      Registers[*Index] = MCRegister(Reg);
+  }
+  return Registers;
+}
+
+struct Ds2MaskTaint {
+  bool Reachable = false;
+  bool ExecUnsafe = true;
+  BitVector UnsafeMasks;
+
+  explicit Ds2MaskTaint(unsigned MaskCount = 0) : UnsafeMasks(MaskCount) {}
+};
+
+static bool getDs2MaskUnsafe(const MCOperand &Op, const Ds2MaskTaint &State,
+                             const PatchContext &Ctx,
+                             ArrayRef<MCRegister> NumberedSgprs) {
+  if (Op.isImm())
+    return Op.getImm() != 0;
+  if (!Op.isReg() || !Op.getReg())
+    return true;
+  MCRegister Reg(Op.getReg());
+  StringRef Name(Ctx.LS.MRI->getName(Reg));
+  if (Name.starts_with("EXEC"))
+    return State.ExecUnsafe;
+  if (Name.starts_with("VCC"))
+    return State.UnsafeMasks.test(Ctx.Config.MaxSgprs);
+  bool Found = false;
+  bool Unsafe = false;
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I) {
+    if (!NumberedSgprs[I].isValid() ||
+        !Ctx.LS.MRI->regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+      continue;
+    Found = true;
+    Unsafe |= State.UnsafeMasks.test(I);
+  }
+  return !Found || Unsafe;
+}
+
+static bool setDs2MaskUnsafe(MCRegister Reg, bool Unsafe, Ds2MaskTaint &State,
+                             const PatchContext &Ctx,
+                             ArrayRef<MCRegister> NumberedSgprs) {
+  if (!Reg.isValid())
+    return false;
+  StringRef Name(Ctx.LS.MRI->getName(Reg));
+  if (Name.starts_with("EXEC")) {
+    State.ExecUnsafe = Unsafe;
+    return true;
+  }
+  if (Name.starts_with("VCC")) {
+    if (Unsafe)
+      State.UnsafeMasks.set(Ctx.Config.MaxSgprs);
+    else
+      State.UnsafeMasks.reset(Ctx.Config.MaxSgprs);
+    return true;
+  }
+  bool Found = false;
+  for (unsigned I = 0; I != NumberedSgprs.size(); ++I) {
+    if (!NumberedSgprs[I].isValid() ||
+        !Ctx.LS.MRI->regsOverlap(Reg.id(), NumberedSgprs[I].id()))
+      continue;
+    if (Unsafe)
+      State.UnsafeMasks.set(I);
+    else
+      State.UnsafeMasks.reset(I);
+    Found = true;
+  }
+  return Found;
+}
+
+static void setDs2MaskDefsUnsafe(const InternalDecodedInst &DI, bool Unsafe,
+                                 Ds2MaskTaint &State, const PatchContext &Ctx,
+                                 ArrayRef<MCRegister> NumberedSgprs) {
+  const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg())
+      setDs2MaskUnsafe(MCRegister(Op.getReg()), Unsafe, State, Ctx,
+                       NumberedSgprs);
+  }
+  for (MCPhysReg Reg : Desc.implicit_defs())
+    setDs2MaskUnsafe(MCRegister(Reg), Unsafe, State, Ctx, NumberedSgprs);
+}
+
+static Ds2MaskTaint transferDs2MaskTaint(PatchContext &Ctx,
+                                         const Ds2FunctionFlow &Flow,
+                                         unsigned I, unsigned Candidate,
+                                         ArrayRef<MCRegister> NumberedSgprs,
+                                         Ds2MaskTaint State) {
+  const size_t GlobalI = Flow.GlobalFirst + I;
+  const InternalDecodedInst &DI = Ctx.Decoded[GlobalI];
+  if (I == Candidate)
+    State.ExecUnsafe = false;
+
+  if (Ctx.LS.MIA->isCall(DI.Inst)) {
+    State.ExecUnsafe = true;
+    State.UnsafeMasks.set();
+    return State;
+  }
+
+  StringRef Mnem(DI.Mnemonic);
+  if ((Mnem == "s_and_saveexec_b32" || Mnem == "s_and_not1_saveexec_b32" ||
+       Mnem == "s_or_saveexec_b32" || Mnem == "s_xor_saveexec_b32") &&
+      DI.Inst.getNumOperands() >= 2 && DI.Inst.getOperand(0).isReg()) {
+    const bool OldExecUnsafe = State.ExecUnsafe;
+    const bool SourceUnsafe =
+        getDs2MaskUnsafe(DI.Inst.getOperand(1), State, Ctx, NumberedSgprs);
+    setDs2MaskUnsafe(MCRegister(DI.Inst.getOperand(0).getReg()), OldExecUnsafe,
+                     State, Ctx, NumberedSgprs);
+    if (Mnem == "s_and_saveexec_b32")
+      State.ExecUnsafe = OldExecUnsafe && SourceUnsafe;
+    else if (Mnem == "s_and_not1_saveexec_b32")
+      State.ExecUnsafe = OldExecUnsafe;
+    else
+      State.ExecUnsafe = OldExecUnsafe || SourceUnsafe;
+    return State;
+  }
+
+  if (Mnem.starts_with("v_cmpx")) {
+    setDs2MaskDefsUnsafe(DI, State.ExecUnsafe, State, Ctx, NumberedSgprs);
+    return State; // EXEC only narrows.
+  }
+  if (Mnem.starts_with("v_cmp")) {
+    setDs2MaskDefsUnsafe(DI, State.ExecUnsafe, State, Ctx, NumberedSgprs);
+    return State;
+  }
+
+  auto TransferBinary = [&](StringRef Opcode) {
+    if (Mnem != Opcode || DI.Inst.getNumOperands() < 3 ||
+        !DI.Inst.getOperand(0).isReg())
+      return false;
+    const bool Left =
+        getDs2MaskUnsafe(DI.Inst.getOperand(1), State, Ctx, NumberedSgprs);
+    const bool Right =
+        getDs2MaskUnsafe(DI.Inst.getOperand(2), State, Ctx, NumberedSgprs);
+    bool Unsafe = true;
+    if (Opcode == "s_and_b32")
+      Unsafe = Left && Right;
+    else if (Opcode == "s_and_not1_b32")
+      Unsafe = Left;
+    else if (Opcode == "s_or_b32" || Opcode == "s_xor_b32")
+      Unsafe = Left || Right;
+    setDs2MaskUnsafe(MCRegister(DI.Inst.getOperand(0).getReg()), Unsafe, State,
+                     Ctx, NumberedSgprs);
+    return true;
+  };
+  if (TransferBinary("s_and_b32") || TransferBinary("s_and_not1_b32") ||
+      TransferBinary("s_or_b32") || TransferBinary("s_xor_b32"))
+    return State;
+
+  if (Mnem == "s_mov_b32" && DI.Inst.getNumOperands() >= 2 &&
+      DI.Inst.getOperand(0).isReg()) {
+    setDs2MaskUnsafe(
+        MCRegister(DI.Inst.getOperand(0).getReg()),
+        getDs2MaskUnsafe(DI.Inst.getOperand(1), State, Ctx, NumberedSgprs),
+        State, Ctx, NumberedSgprs);
+    return State;
+  }
+
+  setDs2MaskDefsUnsafe(DI, true, State, Ctx, NumberedSgprs);
+  return State;
+}
+
+static bool mergeDs2MaskTaint(Ds2MaskTaint &Into,
+                              const Ds2MaskTaint &Incoming) {
+  if (!Incoming.Reachable)
+    return false;
+  if (!Into.Reachable) {
+    Into = Incoming;
+    return true;
+  }
+  const bool OldExecUnsafe = Into.ExecUnsafe;
+  BitVector OldMasks = Into.UnsafeMasks;
+  Into.ExecUnsafe |= Incoming.ExecUnsafe;
+  Into.UnsafeMasks |= Incoming.UnsafeMasks;
+  return OldExecUnsafe != Into.ExecUnsafe || OldMasks != Into.UnsafeMasks;
+}
+
+static void proveLongRangeDs2Alignment(PatchContext &Ctx, size_t CandidateIdx,
+                                       MCRegister Address,
+                                       ArrayRef<size_t> Uses,
+                                       BitVector &Proven) {
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Ctx.Decoded[CandidateIdx].Offset);
+  if (!Function || Ctx.IndirectControlFlowFunctions.contains(Function->Begin) ||
+      Ctx.CrossFunctionInteriorEntryFunctions.contains(Function->Begin) ||
+      CandidateIdx >= Ctx.VgprMsbDstBefore.size())
+    return;
+  const int8_t CandidateDst = Ctx.VgprMsbDstBefore[CandidateIdx];
+  if (CandidateDst < 0)
+    return;
+
+  Ds2FunctionFlow Flow = buildDs2FunctionFlow(Ctx, *Function);
+  if (!Flow.Valid || CandidateIdx < Flow.GlobalFirst)
+    return;
+  const unsigned Candidate =
+      static_cast<unsigned>(CandidateIdx - Flow.GlobalFirst);
+  if (Candidate >= Flow.Successors.size())
+    return;
+
+  // Address redefinitions are independent of lane-mask coverage. Propagate a
+  // monotone may-clobber fact from Candidate so a loop cannot hide a clobber
+  // by executing Candidate again for a disjoint set of lanes.
+  std::vector<uint8_t> AddressFlow(Flow.Successors.size());
+  SmallVector<unsigned, 128> AddressWorklist;
+  AddressFlow[Candidate] = 1; // bit 0: reachable, bit 1: clobbered
+  AddressWorklist.push_back(Candidate);
+  for (size_t Next = 0; Next != AddressWorklist.size(); ++Next) {
+    const unsigned I = AddressWorklist[Next];
+    uint8_t Out = AddressFlow[I];
+    if (I != Candidate &&
+        (definesRegister(Ctx.Decoded[Flow.GlobalFirst + I], Address, Ctx.LS) ||
+         Ctx.LS.MIA->isCall(Ctx.Decoded[Flow.GlobalFirst + I].Inst)))
+      Out |= 2;
+    for (const Ds2FlowEdge &Edge : Flow.Successors[I]) {
+      uint8_t Merged = AddressFlow[Edge.Successor] | Out;
+      if (Merged != AddressFlow[Edge.Successor]) {
+        AddressFlow[Edge.Successor] = Merged;
+        AddressWorklist.push_back(Edge.Successor);
+      }
+    }
+  }
+
+  const unsigned MaskCount = Ctx.Config.MaxSgprs + 1;
+  SmallVector<MCRegister, 128> NumberedSgprs = getDs2NumberedSgprs(Ctx);
+  std::vector<Ds2MaskTaint> In;
+  In.reserve(Flow.Successors.size());
+  for (size_t I = 0; I != Flow.Successors.size(); ++I)
+    In.emplace_back(MaskCount);
+  In[0].Reachable = true;
+  In[0].ExecUnsafe = true;
+  In[0].UnsafeMasks.set();
+  SmallVector<unsigned, 128> Worklist;
+  Worklist.push_back(0);
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    const unsigned I = Worklist[Next];
+    Ds2MaskTaint Out =
+        transferDs2MaskTaint(Ctx, Flow, I, Candidate, NumberedSgprs, In[I]);
+    for (const Ds2FlowEdge &Edge : Flow.Successors[I]) {
+      Ds2MaskTaint EdgeOut = Out;
+      StringRef Mnem(Ctx.Decoded[Flow.GlobalFirst + I].Mnemonic);
+      if ((Mnem == "s_cbranch_execz" && Edge.IsBranchTarget) ||
+          (Mnem == "s_cbranch_execnz" && !Edge.IsBranchTarget))
+        EdgeOut.ExecUnsafe = false; // This edge proves EXEC is empty.
+      if (mergeDs2MaskTaint(In[Edge.Successor], EdgeOut))
+        Worklist.push_back(Edge.Successor);
+    }
+  }
+
+  for (size_t UseIdx : Uses) {
+    if (UseIdx < Flow.GlobalFirst ||
+        UseIdx - Flow.GlobalFirst >= Flow.Successors.size() ||
+        UseIdx >= Ctx.VgprMsbSrc0Before.size())
+      continue;
+    const unsigned Use = static_cast<unsigned>(UseIdx - Flow.GlobalFirst);
+    if (!In[Use].Reachable || In[Use].ExecUnsafe ||
+        (AddressFlow[Use] & 2) != 0 ||
+        Ctx.VgprMsbSrc0Before[UseIdx] != CandidateDst)
+      continue;
+    Proven.set(UseIdx);
+  }
 }
 
 // -- patchDs2Addr -----------------------------------------------------------
@@ -410,18 +939,21 @@ std::optional<std::vector<std::string>> expandDs2AddrImpl(const MCInst &Inst,
 // that later s_wait_dscnt immediates encode; the local drain sidesteps that
 // entirely (see the rationale in the body below).
 
-bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
-  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+SmallVector<uint8_t> buildDs2AddrReplacement(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
   StringRef ToMnem = getDs2AddrReplacement(DI.Mnemonic);
   if (ToMnem.empty())
-    return false;
-  std::optional<std::vector<std::string>> Expanded =
-      expandDs2AddrImpl(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
-  if (!Expanded)
-    return failRequiredPatch(Ctx);
+    return {};
+  std::vector<std::string> Expanded =
+      expandDs2Addr(DI.Inst, DI.Mnemonic, ToMnem, Ctx.LS);
+  if (Expanded.empty()) {
+    log() << "hotswap: error: ds_2addr expansion failed for: " << DI.Mnemonic
+          << "\n";
+    return {};
+  }
 
   std::string Combined;
-  for (const std::string &Line : *Expanded)
+  for (const std::string &Line : Expanded)
     Combined += Line + "\n";
   // Drain the DS counter right after the split pair so both halves are
   // guaranteed complete before any downstream consumer. The original code
@@ -438,15 +970,293 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
-    return failRequiredPatch(Ctx);
+    return {};
+  }
+  return Bytes;
+}
+
+struct ProtectedDs2DelayWindow {
+  size_t DelayIndex = 0;
+  size_t LastIndex = 0;
+  uint32_t SourceSize = 0;
+  unsigned FirstDependency = 0;
+  unsigned SecondDependency = 0;
+  SmallVector<size_t, 4> Ds2Indices;
+};
+
+/// A combined s_delay_alu names the immediately following instruction and a
+/// later instruction selected by instskip. LLVM forms it by folding a second
+/// standalone delay into the first. A DS2 split between those two targets
+/// changes the instruction count, so restore the two standalone delays and
+/// relocate the complete protected window as one unit.
+static std::optional<ProtectedDs2DelayWindow>
+findProtectedDs2DelayWindow(PatchContext &Ctx, size_t Ds2Index) {
+  if (Ds2Index == 0 || !Ctx.DirectControlFlowTargets || !Ctx.LS.MIA)
+    return std::nullopt;
+
+  // Locate the owner from encoded delay geometry rather than assuming the DS2
+  // immediately follows the first protected target. Demerging preserves both
+  // dependencies only when DS2 is strictly between those targets: replacing a
+  // target itself would change the operation named by that dependency.
+  std::optional<ProtectedDs2DelayWindow> Window;
+  constexpr size_t MaxClauseSpan = 64;
+  const size_t FirstPossibleOwner =
+      Ds2Index > MaxClauseSpan ? Ds2Index - MaxClauseSpan : 0;
+  unsigned DelayOwners = 0;
+  for (size_t I = FirstPossibleOwner; I != Ds2Index; ++I) {
+    const InternalDecodedInst &Candidate = Ctx.Decoded[I];
+    if (Candidate.Mnemonic == "s_delay_alu") {
+      const unsigned CandidateSpan = getDelayProtectedSpan(Candidate);
+      if (CandidateSpan < Ds2Index - I)
+        continue;
+      ++DelayOwners;
+
+      if (Candidate.Inst.getNumOperands() != 1 ||
+          !Candidate.Inst.getOperand(0).isImm())
+        continue;
+      const uint64_t Imm =
+          static_cast<uint64_t>(Candidate.Inst.getOperand(0).getImm());
+      if ((Imm & ~uint64_t{0x7FF}) != 0)
+        continue;
+      const unsigned FirstDependency = Imm & 0xF;
+      const unsigned Skip = (Imm >> 4) & 0x7;
+      const unsigned SecondDependency = (Imm >> 7) & 0xF;
+      if (FirstDependency == 0 || FirstDependency >= 12 || Skip > 5 ||
+          SecondDependency == 0 || SecondDependency >= 12)
+        continue;
+
+      const unsigned Span = Skip + 1;
+      if (getDelayProtectedSpan(Candidate) != Span ||
+          Span > Ctx.Decoded.size() - I - 1)
+        continue;
+      const size_t FirstTargetIndex = I + 1;
+      const size_t SecondTargetIndex = I + Span;
+      if (Ds2Index <= FirstTargetIndex || Ds2Index >= SecondTargetIndex)
+        continue;
+      if (Window)
+        return std::nullopt;
+      Window = ProtectedDs2DelayWindow{
+          I, SecondTargetIndex, 0, FirstDependency, SecondDependency, {}};
+      continue;
+    }
+    if (Candidate.Mnemonic != "s_clause" ||
+        Candidate.Inst.getNumOperands() != 1 ||
+        !Candidate.Inst.getOperand(0).isImm())
+      continue;
+    const unsigned ClauseSpan =
+        (static_cast<unsigned>(Candidate.Inst.getOperand(0).getImm()) & 63u) +
+        1;
+    if (ClauseSpan >= Ds2Index - I)
+      return std::nullopt;
+  }
+  if (DelayOwners != 1 || !Window)
+    return std::nullopt;
+
+  const size_t DelayIndex = Window->DelayIndex;
+  const size_t LastIndex = Window->LastIndex;
+  const InternalDecodedInst &Delay = Ctx.Decoded[DelayIndex];
+
+  // Reject an owner whose directive is itself covered by an earlier delay or
+  // hard clause. Such nested geometry cannot be preserved by this demerge.
+  if (Ctx.RelocationProtectedOffsets.contains(Delay.Offset))
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Delay.Offset);
+  if (!Function || Ctx.IndirectControlFlowFunctions.contains(Function->Begin))
+    return std::nullopt;
+
+  uint64_t ExpectedOffset = Delay.Offset;
+  uint64_t WindowEnd = Delay.Offset;
+  for (size_t I = DelayIndex; I <= LastIndex; ++I) {
+    const InternalDecodedInst &Member = Ctx.Decoded[I];
+    const bool IsDs2 = !getDs2AddrReplacement(Member.Mnemonic).empty();
+    const bool NeedsDs2Rewrite = IsDs2 && !isDs2AddressProvenAligned(Ctx, I);
+    std::optional<ElfView::FunctionTextRange> MemberFunction =
+        Ctx.Elf.findFunctionTextRangeAtOffset(Member.Offset);
+    if (!MemberFunction || MemberFunction->Begin != Function->Begin ||
+        MemberFunction->End != Function->End ||
+        Member.Offset != ExpectedOffset || Member.Offset > Ctx.TextSize ||
+        Member.Size > Ctx.TextSize - Member.Offset ||
+        Member.Mnemonic == "<unknown>" || Member.Mnemonic == "<replaced>")
+      return std::nullopt;
+    if (I != DelayIndex &&
+        (Member.Mnemonic == "s_delay_alu" || Member.Mnemonic == "s_clause" ||
+         Member.Mnemonic == "s_set_vgpr_msb" ||
+         Member.Mnemonic == "tensor_load_to_lds" ||
+         StringRef(Member.Mnemonic).contains("_pc_") ||
+         Ctx.LS.MIA->mayAffectControlFlow(Member.Inst, *Ctx.LS.MRI)))
+      return std::nullopt;
+    if (NeedsDs2Rewrite) {
+      // Demerging keeps the original dependency targets as single
+      // instructions. Required DS2 rewrites are therefore composable only
+      // at interior positions, where every replacement can move as part of
+      // the same atomic window.
+      if (I == DelayIndex + 1 || I == LastIndex ||
+          Ctx.ClaimedReplacementOffsets.contains(Member.Offset) ||
+          hasSiteReplacementReservation(Ctx, Member.Offset))
+        return std::nullopt;
+      Window->Ds2Indices.push_back(I);
+    }
+    // The outer dispatcher skips every member after this atomic relocation.
+    // Reject any as-yet-unvisited member that would need its own patch rather
+    // than silently copying the incompatible instruction into the body.
+    if (I > Ds2Index && !NeedsDs2Rewrite &&
+        requiresIndependentInstructionRewrite(Ctx, I)) {
+      log() << "hotswap: error: ds_2addr: combined-delay window member at 0x"
+            << utohexstr(Member.Offset)
+            << " requires a separate HotSwap patch\n";
+      return std::nullopt;
+    }
+    ExpectedOffset += Member.Size;
+    WindowEnd = ExpectedOffset;
   }
 
-  SmallVector<uint8_t> Replacement(Bytes.begin(), Bytes.end());
-  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-    return failRequiredPatch(Ctx);
+  if (WindowEnd < Delay.Offset ||
+      WindowEnd - Delay.Offset > std::numeric_limits<uint32_t>::max())
+    return std::nullopt;
+  for (uint64_t Offset = Delay.Offset + MinInstSize; Offset < WindowEnd;
+       Offset += MinInstSize)
+    if (Ctx.DirectControlFlowTargets->contains(Offset))
+      return std::nullopt;
 
-  DI.Mnemonic = "<replaced>";
+  Window->SourceSize = static_cast<uint32_t>(WindowEnd - Delay.Offset);
+  if (Window->Ds2Indices.empty() ||
+      !llvm::is_contained(Window->Ds2Indices, Ds2Index))
+    return std::nullopt;
+  return Window;
+}
+
+static bool
+patchProtectedDs2DelayWindow(PatchContext &Ctx, size_t Ds2Index,
+                             ArrayRef<uint8_t> Ds2Replacement,
+                             const ProtectedDs2DelayWindow &Window) {
+  SmallVector<uint8_t> FirstDelay = assembleSingleInst(
+      "s_delay_alu " + std::to_string(Window.FirstDependency), Ctx.LS);
+  SmallVector<uint8_t> SecondDelay = assembleSingleInst(
+      "s_delay_alu " + std::to_string(Window.SecondDependency), Ctx.LS);
+  if (FirstDelay.size() != MinInstSize || SecondDelay.size() != MinInstSize)
+    return false;
+
+  SmallVector<uint8_t> Replacement;
+  Replacement.append(FirstDelay.begin(), FirstDelay.end());
+  for (size_t I = Window.DelayIndex + 1; I <= Window.LastIndex; ++I) {
+    if (I == Window.LastIndex)
+      Replacement.append(SecondDelay.begin(), SecondDelay.end());
+    if (llvm::is_contained(Window.Ds2Indices, I)) {
+      if (I == Ds2Index) {
+        Replacement.append(Ds2Replacement.begin(), Ds2Replacement.end());
+        continue;
+      }
+      SmallVector<uint8_t> MemberReplacement = buildDs2AddrReplacement(Ctx, I);
+      if (MemberReplacement.empty())
+        return false;
+      Replacement.append(MemberReplacement.begin(), MemberReplacement.end());
+      continue;
+    }
+    const InternalDecodedInst &Member = Ctx.Decoded[I];
+    Replacement.append(Ctx.Text + Member.Offset,
+                       Ctx.Text + Member.Offset + Member.Size);
+  }
+
+  const uint64_t SourceOffset = Ctx.Decoded[Window.DelayIndex].Offset;
+  if (!emitReplacementCode(Ctx, SourceOffset, Window.SourceSize, Replacement,
+                           ReplacementPlacement::ProtectedCombinedDelay))
+    return false;
+
+  const uint64_t Ds2Offset = Ctx.Decoded[Ds2Index].Offset;
+  for (size_t I = Window.DelayIndex; I <= Window.LastIndex; ++I)
+    Ctx.Decoded[I].Mnemonic = "<replaced>";
+  Ctx.RequiredPatchApplied = true;
+  log() << "hotswap: ds_2addr: demerged combined s_delay_alu at 0x"
+        << utohexstr(SourceOffset) << " around protected site 0x"
+        << utohexstr(Ds2Offset) << " with " << Window.Ds2Indices.size()
+        << " DS2 rewrite(s)\n";
   return true;
+}
+
+uint32_t patchDs2Addr(PatchContext &Ctx, size_t Idx) {
+  InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  SmallVector<uint8_t> Replacement = buildDs2AddrReplacement(Ctx, Idx);
+  if (Replacement.empty()) {
+    failRequiredPatch(Ctx);
+    return 0;
+  }
+
+  if (Ctx.RelocationProtectedOffsets.contains(DI.Offset)) {
+    std::optional<ProtectedDs2DelayWindow> Window =
+        findProtectedDs2DelayWindow(Ctx, Idx);
+    if (!Window) {
+      log() << "hotswap: error: ds_2addr: protected source at 0x"
+            << utohexstr(DI.Offset)
+            << " has no supported combined-delay window\n";
+      failRequiredPatch(Ctx);
+      return 0;
+    }
+    if (!patchProtectedDs2DelayWindow(Ctx, Idx, Replacement, *Window)) {
+      failRequiredPatch(Ctx);
+      return 0;
+    }
+    return Window->Ds2Indices.size();
+  }
+
+  std::optional<ElfView::FunctionTextRange> Function =
+      Ctx.Elf.findFunctionTextRangeAtOffset(DI.Offset);
+
+  // Adjacent required DS2 rewrites need one branch-back, not one per original
+  // instruction. This preserves replacement order and every local DS drain
+  // while reducing padding pressure. Never erase a possible interior entry.
+  if (!Ctx.HasUnknownArbitraryIndirectTarget && Ctx.DirectControlFlowTargets &&
+      Function && !Ctx.IndirectControlFlowFunctions.contains(Function->Begin) &&
+      Idx + 1 < Ctx.Decoded.size()) {
+    size_t Next = Idx + 1;
+    std::optional<uint64_t> ExpectedOffset =
+        checkedAddUint64(DI.Offset, DI.Size, "adjacent ds_2addr source window");
+    if (ExpectedOffset) {
+      InternalDecodedInst &NextDI = Ctx.Decoded[Next];
+      std::optional<uint64_t> NextEnd = checkedAddUint64(
+          NextDI.Offset, NextDI.Size, "adjacent ds_2addr source end");
+      std::optional<ElfView::FunctionTextRange> NextFunction =
+          Ctx.Elf.findFunctionTextRangeAtOffset(NextDI.Offset);
+      if (NextDI.Offset == *ExpectedOffset && NextEnd &&
+          *NextEnd <= Function->End &&
+          !Ctx.DirectControlFlowTargets->contains(NextDI.Offset) &&
+          !Ctx.RelocationProtectedOffsets.contains(NextDI.Offset) &&
+          !getDs2AddrReplacement(NextDI.Mnemonic).empty() &&
+          !isDs2AddressProvenAligned(Ctx, Next) && NextFunction &&
+          NextFunction->Begin == Function->Begin &&
+          NextFunction->End == Function->End &&
+          NextDI.Size <= std::numeric_limits<uint32_t>::max() - DI.Size) {
+        SmallVector<uint8_t> NextReplacement =
+            buildDs2AddrReplacement(Ctx, Next);
+        if (!NextReplacement.empty()) {
+          SmallVector<uint8_t> Combined = Replacement;
+          Combined.append(NextReplacement.begin(), NextReplacement.end());
+          uint32_t CombinedOriginalSize = DI.Size + NextDI.Size;
+          if (emitReplacementCode(Ctx, DI.Offset, CombinedOriginalSize,
+                                  Combined, ReplacementPlacement::Ds2SourceTail,
+                                  /*DiagnoseFailure=*/false)) {
+            Ctx.RequiredPatchApplied = true;
+            DI.Mnemonic = "<replaced>";
+            NextDI.Mnemonic = "<replaced>";
+            log() << "hotswap: coalesced 2 adjacent ds_2addr rewrites at 0x"
+                  << utohexstr(DI.Offset) << "\n";
+            return 2;
+          }
+        }
+      }
+    }
+  }
+
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement,
+                           ReplacementPlacement::Ds2SourceTail)) {
+    failRequiredPatch(Ctx);
+    return 0;
+  }
+
+  Ctx.RequiredPatchApplied = true;
+  DI.Mnemonic = "<replaced>";
+  return 1;
 }
 
 // -- getDescriptorBaseSgpr --------------------------------------------------
@@ -515,20 +1325,210 @@ SmallVector<unsigned, 8> getSgprOperandIndices(const MCInst &Inst,
   return Result;
 }
 
+bool isTensorDescriptorMask(const InternalDecodedInst &DI, MCRegister BaseMCReg,
+                            const MCRegisterInfo &MRI) {
+  const MCInst &Inst = DI.Inst;
+  if (DI.Mnemonic != "s_pack_hh_b32_b16" || Inst.getNumOperands() < 3 ||
+      !Inst.getOperand(0).isReg() ||
+      !MRI.regsOverlap(Inst.getOperand(0).getReg(), BaseMCReg.id()) ||
+      !Inst.getOperand(1).isImm() || Inst.getOperand(1).getImm() != 0 ||
+      !Inst.getOperand(2).isReg())
+    return false;
+  return MRI.regsOverlap(Inst.getOperand(2).getReg(), BaseMCReg.id());
+}
+
 bool isAlreadyTensorMaskPatched(const PatchContext &Ctx, size_t Idx,
                                 MCRegister BaseMCReg) {
   if (Idx == 0)
     return false;
+  const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+  return Prev.Offset + Prev.Size == Ctx.Decoded[Idx].Offset &&
+         isTensorDescriptorMask(Prev, BaseMCReg, *Ctx.LS.MRI);
+}
+
+bool instructionTouchesRegister(const InternalDecodedInst &DI, MCRegister Reg,
+                                const LLVMState &LS) {
+  const MCRegisterInfo &MRI = *LS.MRI;
+  for (const MCOperand &Op : DI.Inst)
+    if (Op.isReg() && Op.getReg() && MRI.regsOverlap(Op.getReg(), Reg.id()))
+      return true;
+
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  for (MCPhysReg Implicit : Desc.implicit_uses())
+    if (MRI.regsOverlap(Implicit, Reg.id()))
+      return true;
+  for (MCPhysReg Implicit : Desc.implicit_defs())
+    if (MRI.regsOverlap(Implicit, Reg.id()))
+      return true;
+  return false;
+}
+
+struct LocalTensorMaskDefinition {
+  size_t Index = 0;
+  bool AlreadyMasked = false;
+};
+
+bool isDirectControlFlowTarget(const PatchContext &Ctx, uint64_t Offset) {
+  return !Ctx.DirectControlFlowTargets ||
+         Ctx.DirectControlFlowTargets->contains(Offset);
+}
+
+bool functionHasIndirectControlFlow(const PatchContext &Ctx, uint64_t Offset) {
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Offset);
+  return !Range || Ctx.IndirectControlFlowFunctions.contains(Range->Begin);
+}
+
+bool isRelocatedTensorMaskDefinition(const PatchContext &Ctx,
+                                     const InternalDecodedInst &Branch,
+                                     MCRegister BaseMCReg) {
+  if (!Ctx.LS.MIA || Branch.Mnemonic != "s_branch" ||
+      !Ctx.LS.MIA->isUnconditionalBranch(Branch.Inst) ||
+      Ctx.LS.MIA->isIndirectBranch(Branch.Inst))
+    return false;
+
+  uint64_t Target = 0;
+  if (!Ctx.LS.MIA->evaluateBranch(Branch.Inst, Branch.Offset, Branch.Size,
+                                  Target))
+    return false;
+
+  constexpr uint64_t SequenceBytes = 3 * MinInstSize;
+  std::optional<uint64_t> TargetVAddr = checkedAddUint64(
+      Ctx.Elf.textAddr(), Target, "tensor mask trampoline target");
+  if (!TargetVAddr)
+    return false;
+  const uint8_t *Bytes = Ctx.Elf.dataAtVAddr(*TargetVAddr, SequenceBytes);
+  if (!Bytes)
+    return false;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Bytes, SequenceBytes, Ctx.LS, Decoded) ||
+      Decoded.size() != 3)
+    return false;
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  const InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
-  const MCInst &PI = Prev.Inst;
-  if (Prev.Mnemonic != "s_pack_hh_b32_b16" || PI.getNumOperands() < 3)
+  const InternalDecodedInst &Def = Decoded[0];
+  const MCInstrDesc &DefDesc = Ctx.LS.MCII->get(Def.Inst.getOpcode());
+  if (Def.Mnemonic != "v_readfirstlane_b32" || DefDesc.getNumDefs() != 1 ||
+      Def.Inst.getNumOperands() < 2 || !Def.Inst.getOperand(0).isReg() ||
+      Def.Inst.getOperand(0).getReg() != BaseMCReg.id() ||
+      !isTensorDescriptorMask(Decoded[1], BaseMCReg, MRI) ||
+      Decoded[2].Mnemonic != "s_branch")
     return false;
-  if (!PI.getOperand(0).isReg() ||
-      !MRI.regsOverlap(PI.getOperand(0).getReg(), BaseMCReg.id()))
+
+  uint64_t Resume = 0;
+  if (!Ctx.LS.MIA->evaluateBranch(Decoded[2].Inst, Target + Decoded[2].Offset,
+                                  Decoded[2].Size, Resume))
     return false;
-  return PI.getOperand(1).isImm() && PI.getOperand(1).getImm() == 0;
+  return Resume == Branch.Offset + Branch.Size;
+}
+
+bool isTransparentShortTrampoline(const PatchContext &Ctx,
+                                  const InternalDecodedInst &Branch,
+                                  MCRegister BaseMCReg) {
+  if (!Ctx.LS.MIA || Branch.Mnemonic != "s_branch" ||
+      !Ctx.LS.MIA->isUnconditionalBranch(Branch.Inst) ||
+      Ctx.LS.MIA->isIndirectBranch(Branch.Inst))
+    return false;
+
+  uint64_t Target = 0;
+  if (!Ctx.LS.MIA->evaluateBranch(Branch.Inst, Branch.Offset, Branch.Size,
+                                  Target) ||
+      Target < Ctx.TextSize)
+    return false;
+  std::optional<uint64_t> TargetVAddr =
+      checkedAddUint64(Ctx.Elf.textAddr(), Target, "tensor trampoline target");
+  if (!TargetVAddr)
+    return false;
+
+  constexpr uint64_t MaxSequenceBytes = 256;
+  for (uint64_t Size = 2 * MinInstSize; Size <= MaxSequenceBytes;
+       Size += MinInstSize) {
+    const uint8_t *Bytes = Ctx.Elf.dataAtVAddr(*TargetVAddr, Size);
+    if (!Bytes)
+      return false;
+    std::vector<InternalDecodedInst> Decoded;
+    if (!decodeTextSection(Bytes, Size, Ctx.LS, Decoded) || Decoded.empty() ||
+        Decoded.back().Offset + Decoded.back().Size != Size)
+      continue;
+
+    const InternalDecodedInst &Back = Decoded.back();
+    uint64_t Resume = 0;
+    if (Back.Mnemonic != "s_branch" ||
+        !Ctx.LS.MIA->evaluateBranch(Back.Inst, Target + Back.Offset, Back.Size,
+                                    Resume))
+      continue;
+    const uint64_t Fallthrough = Branch.Offset + Branch.Size;
+    if (Resume < Fallthrough || Resume - Fallthrough > 4 * MinInstSize ||
+        (Resume - Fallthrough) % MinInstSize != 0 || Resume > Ctx.TextSize)
+      continue;
+    bool PaddingIsNop = true;
+    for (uint64_t Offset = Fallthrough; Offset < Resume; Offset += MinInstSize)
+      PaddingIsNop &= ArrayRef<uint8_t>(Ctx.Text + Offset, MinInstSize) ==
+                      ArrayRef<uint8_t>(Ctx.LS.SNopBytes);
+    if (!PaddingIsNop)
+      continue;
+
+    for (const InternalDecodedInst &DI : ArrayRef(Decoded).drop_back()) {
+      const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+      if (DI.Mnemonic == "<unknown>" ||
+          instructionTouchesRegister(DI, BaseMCReg, Ctx.LS) ||
+          Desc.mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
+        return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+// Find a descriptor definition that unconditionally precedes the tensor in
+// the same straight-line basic block. Relocating that definition and appending
+// the mask is safe only when no entry edge can skip it and no intervening
+// instruction observes or changes the descriptor base.
+std::optional<LocalTensorMaskDefinition>
+findLocalTensorMaskDefinition(const PatchContext &Ctx, size_t TensorIdx,
+                              MCRegister BaseMCReg) {
+  if (!Ctx.LS.MIA || TensorIdx == 0 ||
+      isDirectControlFlowTarget(Ctx, Ctx.Decoded[TensorIdx].Offset) ||
+      functionHasIndirectControlFlow(Ctx, Ctx.Decoded[TensorIdx].Offset))
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Ctx.Decoded[TensorIdx].Offset);
+  if (!Range)
+    return std::nullopt;
+
+  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+  uint64_t NextOffset = Ctx.Decoded[TensorIdx].Offset;
+  for (size_t I = TensorIdx; I-- > 0;) {
+    const InternalDecodedInst &Candidate = Ctx.Decoded[I];
+    if (Candidate.Offset < Range->Begin ||
+        Candidate.Offset + Candidate.Size != NextOffset ||
+        Candidate.Mnemonic == "<unknown>" || Candidate.Mnemonic == "<replaced>")
+      return std::nullopt;
+
+    if (isTensorDescriptorMask(Candidate, BaseMCReg, MRI))
+      return LocalTensorMaskDefinition{I, true};
+    if (isRelocatedTensorMaskDefinition(Ctx, Candidate, BaseMCReg))
+      return LocalTensorMaskDefinition{I, true};
+
+    const MCInstrDesc &Desc = Ctx.LS.MCII->get(Candidate.Inst.getOpcode());
+    const bool IsMatchingReadFirstLane =
+        Candidate.Mnemonic == "v_readfirstlane_b32" && Desc.getNumDefs() == 1 &&
+        Candidate.Inst.getNumOperands() >= 2 &&
+        Candidate.Inst.getOperand(0).isReg() &&
+        Candidate.Inst.getOperand(0).getReg() == BaseMCReg.id();
+    if (IsMatchingReadFirstLane)
+      return LocalTensorMaskDefinition{I, false};
+
+    if (instructionTouchesRegister(Candidate, BaseMCReg, Ctx.LS) ||
+        isDirectControlFlowTarget(Ctx, Candidate.Offset))
+      return std::nullopt;
+    if (Desc.mayAffectControlFlow(Candidate.Inst, MRI) &&
+        !isTransparentShortTrampoline(Ctx, Candidate, BaseMCReg))
+      return std::nullopt;
+    NextOffset = Candidate.Offset;
+  }
+  return std::nullopt;
 }
 
 bool isSccReg(MCRegister Reg, const MCRegisterInfo &MRI) {
@@ -722,10 +1722,6 @@ void commitScratchVgpr(PatchContext &Ctx, const ScratchAlloc &Alloc) {
 // (no KD bump needed), so unlike VGPRs this needs no liveness. Same strategy
 // the E5M3 patch uses.
 //
-// TODO: the E5M3 patch open-codes this same scratch-SGPR reservation. Hoist
-// SgprScratchAlloc / tryAllocScratchSgpr / commitScratchSgpr into shared
-// infrastructure both patches call, rather than duplicating it.
-
 struct SgprScratchAlloc {
   unsigned Sgpr = 0;
   std::string KernelName;
@@ -763,12 +1759,1376 @@ void commitScratchSgpr(PatchContext &Ctx, const SgprScratchAlloc &Alloc) {
   Stats.ExtraSgprs = std::max(Stats.ExtraSgprs, Alloc.ExtraSgprsNeeded);
 }
 
+// -- tensor descriptor must analysis ---------------------------------------
+
+std::optional<uint64_t> applyTensorSignedPcDelta(uint64_t CapturedPc,
+                                                 int64_t Delta) {
+  if (Delta >= 0) {
+    uint64_t Magnitude = static_cast<uint64_t>(Delta);
+    if (CapturedPc > std::numeric_limits<uint64_t>::max() - Magnitude)
+      return std::nullopt;
+    return CapturedPc + Magnitude;
+  }
+
+  uint64_t Magnitude = Delta == std::numeric_limits<int64_t>::min()
+                           ? uint64_t{1} << 63
+                           : static_cast<uint64_t>(-Delta);
+  if (CapturedPc < Magnitude)
+    return std::nullopt;
+  return CapturedPc - Magnitude;
+}
+
+std::optional<uint64_t>
+evaluateTensorDirectControlFlowTarget(const InternalDecodedInst &DI,
+                                      const LLVMState &LS) {
+  uint64_t Target = 0;
+  if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target))
+    return Target;
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  if (DI.Inst.getOpcode() != LS.SCallI64Opcode || !Desc.isCall() ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isReg() ||
+      !DI.Inst.getOperand(0).getReg() || !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+
+  const uint64_t Encoded =
+      static_cast<uint64_t>(DI.Inst.getOperand(1).getImm()) & 0xffffu;
+  const int64_t DwordDelta = Encoded < 0x8000u
+                                 ? static_cast<int64_t>(Encoded)
+                                 : static_cast<int64_t>(Encoded) - 0x10000;
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      DI.Offset, DI.Size, "tensor direct control-flow PC base");
+  if (!PcBase)
+    return std::nullopt;
+  if (DwordDelta >= 0)
+    return checkedAddUint64(*PcBase,
+                            static_cast<uint64_t>(DwordDelta) * MinInstSize,
+                            "tensor direct control-flow target");
+  return checkedSubUint64(*PcBase,
+                          static_cast<uint64_t>(-DwordDelta) * MinInstSize,
+                          "tensor direct control-flow target");
+}
+
+std::optional<std::pair<MCRegister, int64_t>>
+getTensorHotswapAddSetPc(ArrayRef<InternalDecodedInst> Decoded,
+                         size_t SetPcIndex) {
+  if (SetPcIndex == 0 || SetPcIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &Add = Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+  if (Add.Mnemonic != "s_add_nc_u64" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      Add.Offset > std::numeric_limits<uint64_t>::max() - Add.Size ||
+      Add.Offset + Add.Size != SetPc.Offset || Add.Inst.getNumOperands() != 3 ||
+      SetPc.Inst.getNumOperands() != 1 || !Add.Inst.getOperand(0).isReg() ||
+      !Add.Inst.getOperand(1).isReg() || !Add.Inst.getOperand(2).isImm() ||
+      !SetPc.Inst.getOperand(0).isReg())
+    return std::nullopt;
+
+  MCRegister Pair = Add.Inst.getOperand(0).getReg();
+  if (!Pair.isValid() || Add.Inst.getOperand(1).getReg() != Pair.id() ||
+      SetPc.Inst.getOperand(0).getReg() != Pair.id())
+    return std::nullopt;
+  return std::pair<MCRegister, int64_t>{Pair, Add.Inst.getOperand(2).getImm()};
+}
+
+std::optional<size_t>
+findTensorDecodedIndex(ArrayRef<InternalDecodedInst> Decoded, uint64_t Offset) {
+  auto It = llvm::lower_bound(Decoded, Offset,
+                              [](const InternalDecodedInst &DI,
+                                 uint64_t Value) { return DI.Offset < Value; });
+  if (It == Decoded.end() || It->Offset != Offset)
+    return std::nullopt;
+  return It - Decoded.begin();
+}
+
+std::optional<uint64_t>
+resolveTensorContiguousSetPc(ArrayRef<InternalDecodedInst> Decoded,
+                             size_t SetPcIndex,
+                             const DenseSet<uint64_t> &DirectTargets) {
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getTensorHotswapAddSetPc(Decoded, SetPcIndex);
+  if (!AddSet || SetPcIndex < 2)
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[SetPcIndex - 2];
+  const InternalDecodedInst &Add = Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+  if (GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size ||
+      GetPc.Offset + GetPc.Size != Add.Offset ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id())
+    return std::nullopt;
+  if (SetPc.Offset > std::numeric_limits<uint64_t>::max() - SetPc.Size)
+    return std::nullopt;
+  const uint64_t SequenceEnd = SetPc.Offset + SetPc.Size;
+  if (llvm::any_of(DirectTargets, [&](uint64_t Target) {
+        return Target > GetPc.Offset && Target < SequenceEnd;
+      }))
+    return std::nullopt;
+  return applyTensorSignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+}
+
+std::optional<uint64_t>
+resolveTensorSetPcTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                         uint64_t SetPcOffset,
+                         const DenseSet<uint64_t> &DirectTargets) {
+  std::optional<size_t> Index = findTensorDecodedIndex(AllDecoded, SetPcOffset);
+  if (!Index)
+    return std::nullopt;
+  return resolveTensorContiguousSetPc(AllDecoded, *Index, DirectTargets);
+}
+
+struct TensorTrampolinePath {
+  uint64_t ResumeOffset = 0;
+  SmallVector<size_t, 16> Instructions;
+};
+
+std::optional<TensorTrampolinePath>
+findTensorTrampolinePath(ArrayRef<InternalDecodedInst> AllDecoded,
+                         uint64_t Target, const TensorAnalysisRange &Range,
+                         size_t ExternalBegin, const LLVMState &LS,
+                         const DenseSet<uint64_t> &DirectTargets) {
+  if (!LS.MIA)
+    return std::nullopt;
+
+  TensorTrampolinePath Result;
+  // The split-relay resolver can produce a destination that already lies in
+  // the candidate range.  Re-enter it directly: walking from that address as
+  // if it were external would incorrectly compress candidate instructions
+  // (including a tensor load) into the trampoline edge.
+  if (Target >= Range.Begin && Target < Range.End) {
+    Result.ResumeOffset = Target;
+    return Result;
+  }
+  size_t RemainingInstructions = AllDecoded.size();
+  DenseSet<uint64_t> VisitedOffsets;
+  auto SegmentHasInteriorEntry = [&](uint64_t Begin, uint64_t End) {
+    return llvm::any_of(
+               DirectTargets,
+               [&](uint64_t Entry) { return Entry > Begin && Entry < End; }) ||
+           llvm::any_of(Range.ForeignExternalEntries, [&](uint64_t Entry) {
+             return Entry > Begin && Entry < End;
+           });
+  };
+  while (RemainingInstructions != 0) {
+    if (llvm::is_contained(Range.ForeignExternalEntries, Target))
+      return std::nullopt;
+    std::optional<size_t> Start = findTensorDecodedIndex(AllDecoded, Target);
+    // Instructions in another original-.text function may have independent
+    // callable roots and predecessors carrying arbitrary descriptor state.
+    // Only candidate instructions (handled by the immediate resume above) or
+    // appended executable trampoline code can be candidate-owned here.
+    if (!Start || *Start < ExternalBegin)
+      return std::nullopt;
+
+    const uint64_t SegmentStart = Target;
+    uint64_t ExpectedOffset = Target;
+    bool FollowedHop = false;
+    for (size_t I = *Start; I < AllDecoded.size(); ++I) {
+      const InternalDecodedInst &DI = AllDecoded[I];
+      if (RemainingInstructions == 0)
+        return std::nullopt;
+      --RemainingInstructions;
+      if (!VisitedOffsets.insert(DI.Offset).second ||
+          DI.Offset != ExpectedOffset || DI.Size == 0 ||
+          DI.Offset > std::numeric_limits<uint64_t>::max() - DI.Size)
+        return std::nullopt;
+      ExpectedOffset = DI.Offset + DI.Size;
+      Result.Instructions.push_back(I);
+      if (DI.Mnemonic == "<unknown>")
+        return std::nullopt;
+
+      if (DI.Mnemonic == "s_set_pc_i64") {
+        if (I < 2 || AllDecoded[I - 2].Offset < SegmentStart)
+          return std::nullopt;
+        std::optional<uint64_t> Next =
+            resolveTensorContiguousSetPc(AllDecoded, I, DirectTargets);
+        if (!Next)
+          return std::nullopt;
+        if (*Next >= Range.Begin && *Next < Range.End) {
+          if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+            return std::nullopt;
+          Result.ResumeOffset = *Next;
+          return Result;
+        }
+        if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+          return std::nullopt;
+        Target = *Next;
+        FollowedHop = true;
+        break;
+      }
+
+      const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+      const bool IsCall = LS.MIA->isCall(DI.Inst);
+      const bool IsReturn = LS.MIA->isReturn(DI.Inst);
+      const bool IsBranch = LS.MIA->isBranch(DI.Inst);
+      if (IsCall || IsReturn || Desc.isTrap())
+        return std::nullopt;
+      if (IsBranch) {
+        uint64_t Next = 0;
+        if (!LS.MIA->isUnconditionalBranch(DI.Inst) ||
+            LS.MIA->isIndirectBranch(DI.Inst) ||
+            !LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Next))
+          return std::nullopt;
+        if (Next >= Range.Begin && Next < Range.End) {
+          if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+            return std::nullopt;
+          Result.ResumeOffset = Next;
+          return Result;
+        }
+        if (SegmentHasInteriorEntry(SegmentStart, ExpectedOffset))
+          return std::nullopt;
+        Target = Next;
+        FollowedHop = true;
+        break;
+      }
+      if (Desc.isTerminator() || LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI))
+        return std::nullopt;
+    }
+    if (!FollowedHop)
+      return std::nullopt;
+  }
+  return std::nullopt;
+}
+
+std::optional<std::pair<uint64_t, SmallVector<size_t, 2>>>
+resolveTensorRelayTarget(ArrayRef<InternalDecodedInst> AllDecoded,
+                         const InternalDecodedInst &GetPc, uint64_t RelayOffset,
+                         const DenseSet<uint64_t> &DirectTargets) {
+  std::optional<size_t> AddIndex =
+      findTensorDecodedIndex(AllDecoded, RelayOffset);
+  if (!AddIndex || *AddIndex + 1 >= AllDecoded.size())
+    return std::nullopt;
+
+  const size_t SetPcIndex = *AddIndex + 1;
+  std::optional<std::pair<MCRegister, int64_t>> AddSet =
+      getTensorHotswapAddSetPc(AllDecoded, SetPcIndex);
+  if (!AddSet || GetPc.Mnemonic != "s_get_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+      GetPc.Inst.getOperand(0).getReg() != AddSet->first.id() ||
+      GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size)
+    return std::nullopt;
+  const InternalDecodedInst &SetPc = AllDecoded[SetPcIndex];
+  if (SetPc.Offset > std::numeric_limits<uint64_t>::max() - SetPc.Size)
+    return std::nullopt;
+  const uint64_t SequenceEnd = SetPc.Offset + SetPc.Size;
+  if (llvm::any_of(DirectTargets, [&](uint64_t Target) {
+        return Target > RelayOffset && Target < SequenceEnd;
+      }))
+    return std::nullopt;
+
+  std::optional<uint64_t> Target =
+      applyTensorSignedPcDelta(GetPc.Offset + GetPc.Size, AddSet->second);
+  if (!Target)
+    return std::nullopt;
+  return std::pair<uint64_t, SmallVector<size_t, 2>>{
+      *Target, SmallVector<size_t, 2>{*AddIndex, SetPcIndex}};
+}
+
+std::optional<uint64_t> resolveTensorCarrySetPc(
+    ArrayRef<InternalDecodedInst> Decoded, size_t SetPcIndex,
+    const DenseSet<uint64_t> &DirectTargets, const LLVMState &LS) {
+  if (!LS.MRI || SetPcIndex < 3 || SetPcIndex >= Decoded.size())
+    return std::nullopt;
+
+  const InternalDecodedInst &GetPc = Decoded[SetPcIndex - 3];
+  const InternalDecodedInst &AddLo = Decoded[SetPcIndex - 2];
+  const InternalDecodedInst &AddHi = Decoded[SetPcIndex - 1];
+  const InternalDecodedInst &SetPc = Decoded[SetPcIndex];
+  if (GetPc.Mnemonic != "s_get_pc_i64" || AddLo.Mnemonic != "s_add_u32" ||
+      AddHi.Mnemonic != "s_addc_u32" || SetPc.Mnemonic != "s_set_pc_i64" ||
+      GetPc.Inst.getNumOperands() != 1 || AddLo.Inst.getNumOperands() != 3 ||
+      AddHi.Inst.getNumOperands() != 3 || SetPc.Inst.getNumOperands() != 1 ||
+      !GetPc.Inst.getOperand(0).isReg() || !AddLo.Inst.getOperand(0).isReg() ||
+      !AddLo.Inst.getOperand(1).isReg() || !AddLo.Inst.getOperand(2).isImm() ||
+      !AddHi.Inst.getOperand(0).isReg() || !AddHi.Inst.getOperand(1).isReg() ||
+      !AddHi.Inst.getOperand(2).isImm() || !SetPc.Inst.getOperand(0).isReg())
+    return std::nullopt;
+
+  auto IsContiguous = [](const InternalDecodedInst &L,
+                         const InternalDecodedInst &R) {
+    return L.Offset <= std::numeric_limits<uint64_t>::max() - L.Size &&
+           L.Offset + L.Size == R.Offset;
+  };
+  if (!IsContiguous(GetPc, AddLo) || !IsContiguous(AddLo, AddHi) ||
+      !IsContiguous(AddHi, SetPc))
+    return std::nullopt;
+
+  MCRegister Pair = GetPc.Inst.getOperand(0).getReg();
+  MCRegister Lo = AddLo.Inst.getOperand(0).getReg();
+  MCRegister Hi = AddHi.Inst.getOperand(0).getReg();
+  if (!Pair.isValid() || !Lo.isValid() || !Hi.isValid() ||
+      SetPc.Inst.getOperand(0).getReg() != Pair.id() ||
+      AddLo.Inst.getOperand(1).getReg() != Lo.id() ||
+      AddHi.Inst.getOperand(1).getReg() != Hi.id())
+    return std::nullopt;
+  const unsigned LoSubReg = LS.MRI->getSubRegIndex(Pair, Lo);
+  const unsigned HiSubReg = LS.MRI->getSubRegIndex(Pair, Hi);
+  if (LoSubReg == 0 || HiSubReg == 0 || LoSubReg >= HiSubReg)
+    return std::nullopt;
+
+  std::optional<uint64_t> SequenceEnd = checkedAddUint64(
+      SetPc.Offset, SetPc.Size, "tensor carry set-PC sequence end");
+  std::optional<uint64_t> CapturedPc = checkedAddUint64(
+      GetPc.Offset, GetPc.Size, "tensor carry set-PC captured PC");
+  if (!SequenceEnd || !CapturedPc ||
+      llvm::any_of(DirectTargets, [&](uint64_t Target) {
+        return Target > GetPc.Offset && Target < *SequenceEnd;
+      }))
+    return std::nullopt;
+
+  const uint64_t LoImm =
+      static_cast<uint32_t>(AddLo.Inst.getOperand(2).getImm());
+  const uint64_t HiImm =
+      static_cast<uint32_t>(AddHi.Inst.getOperand(2).getImm());
+  return *CapturedPc + (LoImm | (HiImm << 32));
+}
+
+struct TensorExternalCfgEdge {
+  size_t SourceIndex = 0;
+  uint64_t Target = 0;
+  std::optional<unsigned> DispatchStubIndex;
+};
+
+struct TensorExternalCfg {
+  bool Valid = false;
+  size_t ExternalBegin = 0;
+  std::vector<TensorExternalCfgEdge> Edges;
+  BitVector UnresolvedSources;
+};
+
+struct TensorPcSequence {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  bool RequiresRelaySource = false;
+  SmallVector<size_t, 2> RelaySources;
+};
+
+TensorExternalCfg buildTensorExternalCfg(
+    ArrayRef<InternalDecodedInst> Decoded,
+    ArrayRef<InternalDecodedInst> AllDecoded,
+    ArrayRef<TensorDispatchStub> DispatchStubs,
+    ArrayRef<uint64_t> VirtualExternalEntries,
+    ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges,
+    ArrayRef<uint64_t> OriginalCodeEntries, const LLVMState &LS,
+    const DenseSet<uint64_t> &DirectTargets) {
+  TensorExternalCfg Result;
+  Result.UnresolvedSources = BitVector(AllDecoded.size());
+  if (!LS.MIA || !LS.MCII || !LS.MRI || AllDecoded.size() < Decoded.size())
+    return Result;
+  for (size_t I = 0; I < Decoded.size(); ++I)
+    if (AllDecoded[I].Offset != Decoded[I].Offset ||
+        AllDecoded[I].Size != Decoded[I].Size)
+      return Result;
+  Result.ExternalBegin = Decoded.size();
+
+  for (uint64_t Root : VirtualExternalEntries) {
+    std::optional<size_t> RootIndex = findTensorDecodedIndex(AllDecoded, Root);
+    if (!RootIndex || *RootIndex < Result.ExternalBegin)
+      return Result;
+    if (llvm::any_of(DispatchStubs, [&](const TensorDispatchStub &Stub) {
+          return Root >= Stub.Begin && Root < Stub.End;
+        }))
+      return Result;
+  }
+
+  DenseMap<size_t, unsigned> DispatchTerminals;
+  for (unsigned StubIndex = 0; StubIndex < DispatchStubs.size(); ++StubIndex) {
+    const TensorDispatchStub &Stub = DispatchStubs[StubIndex];
+    std::optional<size_t> Terminal =
+        findTensorDecodedIndex(AllDecoded, Stub.Terminal);
+    if (!Terminal || *Terminal < Result.ExternalBegin ||
+        !DispatchTerminals.try_emplace(*Terminal, StubIndex).second)
+      return Result;
+  }
+
+  DenseMap<size_t, uint64_t> RelayTargets;
+  DenseMap<size_t, SmallVector<size_t, 2>> RelaySources;
+  DenseSet<size_t> ConflictingRelays;
+  for (size_t I = 1; I < AllDecoded.size(); ++I) {
+    const InternalDecodedInst &Branch = AllDecoded[I];
+    const InternalDecodedInst &GetPc = AllDecoded[I - 1];
+    if (Branch.Mnemonic != "s_branch" || GetPc.Mnemonic != "s_get_pc_i64" ||
+        GetPc.Offset > std::numeric_limits<uint64_t>::max() - GetPc.Size ||
+        GetPc.Offset + GetPc.Size != Branch.Offset)
+      continue;
+    std::optional<uint64_t> RelayOffset =
+        evaluateTensorDirectControlFlowTarget(Branch, LS);
+    if (!RelayOffset)
+      continue;
+    auto Relay = resolveTensorRelayTarget(AllDecoded, GetPc, *RelayOffset,
+                                          DirectTargets);
+    if (!Relay || Relay->second.empty())
+      continue;
+    const size_t Terminal = Relay->second.back();
+    auto [It, Inserted] = RelayTargets.try_emplace(Terminal, Relay->first);
+    if (!Inserted && It->second != Relay->first)
+      ConflictingRelays.insert(Terminal);
+    RelaySources[Terminal].push_back(I);
+  }
+  if (!ConflictingRelays.empty())
+    return Result;
+
+  std::vector<TensorPcSequence> PcSequences;
+  for (size_t I = 0; I < AllDecoded.size(); ++I) {
+    if (AllDecoded[I].Mnemonic != "s_set_pc_i64" ||
+        DispatchTerminals.contains(I))
+      continue;
+    std::optional<uint64_t> Target =
+        resolveTensorContiguousSetPc(AllDecoded, I, DirectTargets);
+    size_t BeginIndex = 0;
+    bool RequiresRelaySource = false;
+    if (Target) {
+      BeginIndex = I - 2;
+    } else {
+      Target = resolveTensorCarrySetPc(AllDecoded, I, DirectTargets, LS);
+      if (Target) {
+        BeginIndex = I - 3;
+      } else {
+        auto Relay = RelayTargets.find(I);
+        if (Relay == RelayTargets.end())
+          continue;
+        Target = Relay->second;
+        BeginIndex = I - 1;
+        RequiresRelaySource = true;
+      }
+    }
+    std::optional<uint64_t> End =
+        checkedAddUint64(AllDecoded[I].Offset, AllDecoded[I].Size,
+                         "tensor computed-PC sequence end");
+    if (!End || BeginIndex >= I || AllDecoded[BeginIndex].Offset >= *End)
+      return Result;
+    TensorPcSequence Sequence{AllDecoded[BeginIndex].Offset, *End,
+                              RequiresRelaySource};
+    if (RequiresRelaySource)
+      Sequence.RelaySources = RelaySources[I];
+    PcSequences.push_back(std::move(Sequence));
+  }
+  for (const auto &[Terminal, Sources] : RelaySources)
+    for (size_t Source : Sources) {
+      if (Source == 0 || Source >= AllDecoded.size())
+        return Result;
+      std::optional<uint64_t> End =
+          checkedAddUint64(AllDecoded[Source].Offset, AllDecoded[Source].Size,
+                           "tensor relay source sequence end");
+      if (!End)
+        return Result;
+      PcSequences.push_back({AllDecoded[Source - 1].Offset, *End, false, {}});
+    }
+
+  auto AddEdge = [&](size_t Source, uint64_t Target,
+                     std::optional<unsigned> DispatchStubIndex = std::nullopt) {
+    Result.Edges.push_back({Source, Target, DispatchStubIndex});
+  };
+  auto AddFallthrough = [&](size_t I) {
+    if (I + 1 >= AllDecoded.size() ||
+        AllDecoded[I].Offset >
+            std::numeric_limits<uint64_t>::max() - AllDecoded[I].Size ||
+        AllDecoded[I].Offset + AllDecoded[I].Size != AllDecoded[I + 1].Offset)
+      return false;
+    AddEdge(I, AllDecoded[I + 1].Offset);
+    return true;
+  };
+
+  for (size_t I = Result.ExternalBegin; I < AllDecoded.size(); ++I) {
+    const InternalDecodedInst &DI = AllDecoded[I];
+    auto Dispatch = DispatchTerminals.find(I);
+    if (Dispatch != DispatchTerminals.end()) {
+      AddEdge(I, DispatchStubs[Dispatch->second].Target, Dispatch->second);
+      continue;
+    }
+
+    if (DI.Mnemonic == "<unknown>") {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (StringRef(DI.Mnemonic).starts_with("s_rfe")) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      std::optional<uint64_t> Target =
+          resolveTensorContiguousSetPc(AllDecoded, I, DirectTargets);
+      if (!Target)
+        Target = resolveTensorCarrySetPc(AllDecoded, I, DirectTargets, LS);
+      if (!Target) {
+        auto Relay = RelayTargets.find(I);
+        if (Relay != RelayTargets.end() && !ConflictingRelays.contains(I))
+          Target = Relay->second;
+      }
+      if (Target)
+        AddEdge(I, *Target);
+      else
+        Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (DI.Mnemonic == "s_code_end" || DI.Mnemonic == "s_endpgm" ||
+        DI.Mnemonic == "s_endpgm_saved")
+      continue;
+
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsCall = LS.MIA->isCall(DI.Inst) || Desc.isCall();
+    const bool IsReturn = LS.MIA->isReturn(DI.Inst) || Desc.isReturn();
+    const bool IsBranch = LS.MIA->isBranch(DI.Inst) || Desc.isBranch();
+    if (IsReturn) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (IsBranch || IsCall) {
+      if (LS.MIA->isIndirectBranch(DI.Inst) || Desc.isIndirectBranch()) {
+        Result.UnresolvedSources.set(I);
+        continue;
+      }
+      std::optional<uint64_t> Target =
+          evaluateTensorDirectControlFlowTarget(DI, LS);
+      if (!Target) {
+        Result.UnresolvedSources.set(I);
+        continue;
+      }
+      AddEdge(I, *Target);
+      const bool IsConditional =
+          LS.MIA->isConditionalBranch(DI.Inst) || Desc.isConditionalBranch();
+      if ((IsCall || IsConditional) && !AddFallthrough(I))
+        Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (Desc.isTrap() || Desc.isTerminator()) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      Result.UnresolvedSources.set(I);
+      continue;
+    }
+    if (!AddFallthrough(I))
+      Result.UnresolvedSources.set(I);
+  }
+
+  // A recognized get-PC/add/set-PC sequence has a statically known target
+  // only when execution enters through all of its prerequisites.  An edge or
+  // callable root into the middle can reuse an arbitrary pre-existing SGPR
+  // value and turn the nominally direct set-PC into an indirect transfer.
+  auto HasValidSequenceIngress = [&](std::optional<size_t> SourceIndex,
+                                     uint64_t Target) {
+    for (const TensorPcSequence &Sequence : PcSequences) {
+      if (Target < Sequence.Begin || Target >= Sequence.End)
+        continue;
+
+      if (SourceIndex) {
+        if (*SourceIndex >= AllDecoded.size())
+          return false;
+        const InternalDecodedInst &Source = AllDecoded[*SourceIndex];
+        const bool IsSequentialPrerequisite =
+            Source.Offset >= Sequence.Begin && Source.Offset < Sequence.End &&
+            Source.Offset <=
+                std::numeric_limits<uint64_t>::max() - Source.Size &&
+            Source.Offset + Source.Size == Target;
+        if (IsSequentialPrerequisite)
+          continue;
+        if (Target == Sequence.Begin &&
+            (!Sequence.RequiresRelaySource ||
+             llvm::is_contained(Sequence.RelaySources, *SourceIndex)))
+          continue;
+      } else if (Target == Sequence.Begin && !Sequence.RequiresRelaySource) {
+        continue;
+      }
+      return false;
+    }
+    return true;
+  };
+
+  // Every resolved edge must land on an exact decoded instruction boundary.
+  // Otherwise the target is outside the analyzed graph (or in the middle of
+  // an instruction), so treating it as a closed direct edge would be unsound.
+  for (const TensorExternalCfgEdge &Edge : Result.Edges) {
+    if (Edge.SourceIndex >= AllDecoded.size() ||
+        !findTensorDecodedIndex(AllDecoded, Edge.Target) ||
+        !HasValidSequenceIngress(Edge.SourceIndex, Edge.Target))
+      return TensorExternalCfg{};
+  }
+  for (const auto &[Source, Target] : OriginalControlFlowEdges) {
+    std::optional<size_t> SourceIndex =
+        findTensorDecodedIndex(AllDecoded, Source);
+    if (!SourceIndex || *SourceIndex >= Result.ExternalBegin ||
+        !findTensorDecodedIndex(AllDecoded, Target) ||
+        !HasValidSequenceIngress(*SourceIndex, Target))
+      return TensorExternalCfg{};
+  }
+  for (uint64_t Root : OriginalCodeEntries) {
+    std::optional<size_t> RootIndex = findTensorDecodedIndex(AllDecoded, Root);
+    if (!RootIndex || *RootIndex >= Result.ExternalBegin ||
+        !HasValidSequenceIngress(std::nullopt, Root))
+      return TensorExternalCfg{};
+  }
+  for (uint64_t Root : VirtualExternalEntries)
+    if (!HasValidSequenceIngress(std::nullopt, Root))
+      return TensorExternalCfg{};
+
+  for (const TensorExternalCfgEdge &Edge : Result.Edges)
+    for (const TensorDispatchStub &Stub : DispatchStubs)
+      if (Edge.Target >= Stub.Begin && Edge.Target < Stub.End) {
+        const uint64_t Source = AllDecoded[Edge.SourceIndex].Offset;
+        if (Source < Stub.Begin || Source >= Stub.End)
+          return TensorExternalCfg{};
+      }
+  Result.Valid = true;
+  return Result;
+}
+
+std::optional<unsigned> getNumberedRegFactIndex(MCRegister Reg,
+                                                const MCRegisterInfo &MRI,
+                                                unsigned MaxSgprs,
+                                                unsigned MaxVgprs) {
+  const char *RawName = MRI.getName(Reg);
+  if (!RawName)
+    return std::nullopt;
+  StringRef Name(RawName);
+  if (Name.contains('_'))
+    return std::nullopt;
+
+  unsigned Index = 0;
+  if (Name.consume_front("SGPR")) {
+    if (Name.getAsInteger(10, Index) || Index >= MaxSgprs)
+      return std::nullopt;
+    return Index;
+  }
+  if (Name.consume_front("VGPR")) {
+    if (Name.getAsInteger(10, Index) || Index >= MaxVgprs)
+      return std::nullopt;
+    return MaxSgprs + Index;
+  }
+  return std::nullopt;
+}
+
+std::optional<unsigned> getTrue16ParentFactIndex(MCRegister Reg,
+                                                 const MCRegisterInfo &MRI,
+                                                 unsigned MaxSgprs,
+                                                 unsigned MaxVgprs) {
+  StringRef Name = MRI.getName(Reg);
+  const bool IsLowHalf = Name.ends_with("_LO16");
+  const bool IsHighHalf = Name.ends_with("_HI16");
+  if (!IsLowHalf && !IsHighHalf)
+    return std::nullopt;
+
+  unsigned Index = 0;
+  if (Name.consume_front("SGPR")) {
+    Name = Name.take_until([](char C) { return C == '_'; });
+    if (!Name.getAsInteger(10, Index) && Index < MaxSgprs)
+      return Index;
+    return std::nullopt;
+  }
+  if (Name.consume_front("VGPR")) {
+    Name = Name.take_until([](char C) { return C == '_'; });
+    if (!Name.getAsInteger(10, Index) && Index < MaxVgprs)
+      return MaxSgprs + Index;
+  }
+  return std::nullopt;
+}
+
+SmallVector<MCRegister, 4> getNumberedRegLeaves(MCRegister Reg,
+                                                const MCRegisterInfo &MRI,
+                                                unsigned MaxSgprs,
+                                                unsigned MaxVgprs) {
+  if (getNumberedRegFactIndex(Reg, MRI, MaxSgprs, MaxVgprs))
+    return {Reg};
+
+  SmallVector<MCRegister, 4> Leaves;
+  for (MCRegister Sub : getDirectSubRegs(Reg, MRI))
+    if (getNumberedRegFactIndex(Sub, MRI, MaxSgprs, MaxVgprs))
+      Leaves.push_back(Sub);
+  return Leaves;
+}
+
+bool operandLow16KnownZero(const MCOperand &Op, const BitVector &State,
+                           const MCRegisterInfo &MRI, unsigned MaxSgprs,
+                           unsigned MaxVgprs) {
+  if (Op.isImm())
+    return (static_cast<uint64_t>(Op.getImm()) & 0xffff) == 0;
+  if (!Op.isReg() || !Op.getReg())
+    return false;
+  std::optional<unsigned> Fact =
+      getNumberedRegFactIndex(MCRegister(Op.getReg()), MRI, MaxSgprs, MaxVgprs);
+  return Fact && State.test(*Fact);
+}
+
+void setRegLow16Fact(BitVector &State, MCRegister Reg, bool IsKnownZero,
+                     const MCRegisterInfo &MRI, unsigned MaxSgprs,
+                     unsigned MaxVgprs) {
+  if (std::optional<unsigned> Fact =
+          getNumberedRegFactIndex(Reg, MRI, MaxSgprs, MaxVgprs)) {
+    if (IsKnownZero)
+      State.set(*Fact);
+    else
+      State.reset(*Fact);
+    return;
+  }
+
+  // True16 defs do not enumerate their 32-bit parent as a direct subregister.
+  // Conservatively kill the parent's fact for either half. This includes
+  // partial SGPR defs: retaining an SGPR descriptor fact across an overlapping
+  // subregister write would make the tensor proof unsound.
+  if (std::optional<unsigned> Parent =
+          getTrue16ParentFactIndex(Reg, MRI, MaxSgprs, MaxVgprs)) {
+    State.reset(*Parent);
+    return;
+  }
+
+  for (MCRegister Sub : getDirectSubRegs(Reg, MRI))
+    setRegLow16Fact(State, Sub, IsKnownZero, MRI, MaxSgprs, MaxVgprs);
+}
+
+bool tensorInstructionDefinesExec(const MCInst &Inst, const MCInstrDesc &Desc,
+                                  const MCRegisterInfo &MRI) {
+  auto IsExec = [&](MCRegister Reg) {
+    StringRef Name = MRI.getName(Reg);
+    return Name == "EXEC" || Name == "EXEC_LO" || Name == "EXEC_HI";
+  };
+  const unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), Inst.getNumOperands());
+  for (unsigned I = 0; I < NumDefs; ++I)
+    if (Inst.getOperand(I).isReg() && Inst.getOperand(I).getReg() &&
+        IsExec(MCRegister(Inst.getOperand(I).getReg())))
+      return true;
+  return llvm::any_of(Desc.implicit_defs(),
+                      [&](MCPhysReg Reg) { return IsExec(MCRegister(Reg)); });
+}
+
+BitVector transferTensorDescriptorFacts(const InternalDecodedInst &DI,
+                                        const BitVector &Input,
+                                        const LLVMState &LS, unsigned MaxSgprs,
+                                        unsigned MaxVgprs) {
+  const MCInst &Inst = DI.Inst;
+  const MCInstrDesc &Desc = LS.MCII->get(Inst.getOpcode());
+  const MCRegisterInfo &MRI = *LS.MRI;
+  const unsigned ExecNonemptyFact = MaxSgprs + MaxVgprs;
+  BitVector EffectiveInput = Input;
+  if (tensorInstructionDefinesExec(Inst, Desc, MRI)) {
+    EffectiveInput.reset(MaxSgprs, MaxSgprs + MaxVgprs);
+    EffectiveInput.reset(ExecNonemptyFact);
+  }
+  BitVector Output = EffectiveInput;
+
+  const unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), Inst.getNumOperands());
+  for (unsigned I = 0; I < NumDefs; ++I) {
+    const MCOperand &Def = Inst.getOperand(I);
+    if (Def.isReg() && Def.getReg())
+      setRegLow16Fact(Output, MCRegister(Def.getReg()), false, MRI, MaxSgprs,
+                      MaxVgprs);
+  }
+  for (MCPhysReg Def : Desc.implicit_defs())
+    setRegLow16Fact(Output, MCRegister(Def), false, MRI, MaxSgprs, MaxVgprs);
+
+  auto CopyOne = [&](unsigned DefOp, unsigned SourceOp) {
+    if (DefOp >= Inst.getNumOperands() || SourceOp >= Inst.getNumOperands() ||
+        !Inst.getOperand(DefOp).isReg() || !Inst.getOperand(DefOp).getReg())
+      return;
+    MCRegister Dst = MCRegister(Inst.getOperand(DefOp).getReg());
+    std::optional<unsigned> DstFact =
+        getNumberedRegFactIndex(Dst, MRI, MaxSgprs, MaxVgprs);
+    const bool FullNumberedDestination = DstFact.has_value();
+    const bool VgprDestination = DstFact && *DstFact >= MaxSgprs;
+    bool Known = FullNumberedDestination &&
+                 (!VgprDestination || EffectiveInput.test(ExecNonemptyFact)) &&
+                 operandLow16KnownZero(Inst.getOperand(SourceOp),
+                                       EffectiveInput, MRI, MaxSgprs, MaxVgprs);
+    setRegLow16Fact(Output, Dst, Known, MRI, MaxSgprs, MaxVgprs);
+  };
+
+  if ((DI.Mnemonic == "s_mov_b32" || DI.Mnemonic == "v_mov_b32") &&
+      Inst.getNumOperands() == 2) {
+    CopyOne(0, 1);
+  } else if (DI.Mnemonic == "s_mov_b64" && Inst.getNumOperands() >= 2 &&
+             Inst.getOperand(0).isReg() && Inst.getOperand(0).getReg()) {
+    SmallVector<MCRegister, 4> Dst = getNumberedRegLeaves(
+        MCRegister(Inst.getOperand(0).getReg()), MRI, MaxSgprs, MaxVgprs);
+    if (Inst.getOperand(1).isReg() && Inst.getOperand(1).getReg()) {
+      SmallVector<MCRegister, 4> Src = getNumberedRegLeaves(
+          MCRegister(Inst.getOperand(1).getReg()), MRI, MaxSgprs, MaxVgprs);
+      if (Dst.size() == Src.size()) {
+        for (unsigned I = 0; I < Dst.size(); ++I) {
+          std::optional<unsigned> SourceFact =
+              getNumberedRegFactIndex(Src[I], MRI, MaxSgprs, MaxVgprs);
+          setRegLow16Fact(Output, Dst[I],
+                          SourceFact && EffectiveInput.test(*SourceFact), MRI,
+                          MaxSgprs, MaxVgprs);
+        }
+      }
+    }
+  } else if (DI.Mnemonic == "v_dual_mov_b32" && NumDefs == 2 &&
+             Inst.getNumOperands() == 4) {
+    CopyOne(0, 2);
+    CopyOne(1, 3);
+  } else if (DI.Mnemonic == "v_readfirstlane_b32") {
+    if (EffectiveInput.test(ExecNonemptyFact))
+      CopyOne(0, 1);
+  } else if (DI.Mnemonic == "s_pack_hh_b32_b16" && Inst.getNumOperands() >= 2 &&
+             Inst.getOperand(0).isReg() && Inst.getOperand(0).getReg() &&
+             Inst.getOperand(1).isImm() && Inst.getOperand(1).getImm() == 0) {
+    setRegLow16Fact(Output, MCRegister(Inst.getOperand(0).getReg()), true, MRI,
+                    MaxSgprs, MaxVgprs);
+  }
+
+  return Output;
+}
+
+static constexpr uint64_t TensorMaskDefTop =
+    std::numeric_limits<uint64_t>::max();
+static constexpr uint64_t TensorMaskDefUnknown = TensorMaskDefTop - 1;
+using TensorMaskDefState = SmallVector<uint64_t, 8>;
+
+TensorMaskDefState transferTensorMaskDefinitions(
+    const InternalDecodedInst &DI, const TensorMaskDefState &Input,
+    const DenseMap<unsigned, unsigned> &TrackedSgprs, const LLVMState &LS,
+    unsigned MaxSgprs, unsigned MaxVgprs) {
+  TensorMaskDefState Output = Input;
+  const MCInst &Inst = DI.Inst;
+  const MCInstrDesc &Desc = LS.MCII->get(Inst.getOpcode());
+  const MCRegisterInfo &MRI = *LS.MRI;
+
+  auto KillReg = [&](MCRegister Reg) {
+    if (std::optional<unsigned> Parent =
+            getTrue16ParentFactIndex(Reg, MRI, MaxSgprs, MaxVgprs)) {
+      auto Slot = TrackedSgprs.find(*Parent);
+      if (Slot != TrackedSgprs.end())
+        Output[Slot->second] = TensorMaskDefUnknown;
+      return;
+    }
+    for (MCRegister Leaf : getNumberedRegLeaves(Reg, MRI, MaxSgprs, MaxVgprs)) {
+      std::optional<unsigned> Fact =
+          getNumberedRegFactIndex(Leaf, MRI, MaxSgprs, MaxVgprs);
+      if (!Fact)
+        continue;
+      auto Slot = TrackedSgprs.find(*Fact);
+      if (Slot != TrackedSgprs.end()) {
+        Output[Slot->second] = TensorMaskDefUnknown;
+      }
+    }
+  };
+
+  const unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), Inst.getNumOperands());
+  for (unsigned I = 0; I < NumDefs; ++I) {
+    const MCOperand &Def = Inst.getOperand(I);
+    if (Def.isReg() && Def.getReg())
+      KillReg(MCRegister(Def.getReg()));
+  }
+  for (MCPhysReg Def : Desc.implicit_defs())
+    KillReg(MCRegister(Def));
+
+  if (DI.Mnemonic == "v_readfirstlane_b32" && Inst.getNumOperands() >= 1 &&
+      Inst.getOperand(0).isReg() && Inst.getOperand(0).getReg()) {
+    std::optional<unsigned> Fact = getNumberedRegFactIndex(
+        MCRegister(Inst.getOperand(0).getReg()), MRI, MaxSgprs, MaxVgprs);
+    if (Fact) {
+      auto Slot = TrackedSgprs.find(*Fact);
+      if (Slot != TrackedSgprs.end())
+        Output[Slot->second] = DI.Offset;
+    }
+  }
+  return Output;
+}
+
+void meetTensorMaskDefinitions(TensorMaskDefState &Accumulator,
+                               const TensorMaskDefState &Candidate) {
+  assert(Accumulator.size() == Candidate.size());
+  for (unsigned I = 0; I < Accumulator.size(); ++I) {
+    if (Accumulator[I] == TensorMaskDefTop)
+      Accumulator[I] = Candidate[I];
+    else if (Accumulator[I] != Candidate[I])
+      Accumulator[I] = TensorMaskDefUnknown;
+  }
+}
+
+struct TensorCfgPredecessor {
+  unsigned From = 0;
+  SmallVector<size_t, 16> ExternalInstructions;
+};
+
+void addTensorCfgEdge(
+    unsigned From, unsigned To,
+    std::vector<SmallVector<unsigned, 2>> &Successors,
+    std::vector<SmallVector<TensorCfgPredecessor, 2>> &Predecessors,
+    ArrayRef<size_t> ExternalInstructions = {}) {
+  if (!llvm::is_contained(Successors[From], To))
+    Successors[From].push_back(To);
+  if (llvm::any_of(Predecessors[To], [&](const TensorCfgPredecessor &Pred) {
+        return Pred.From == From &&
+               llvm::equal(Pred.ExternalInstructions, ExternalInstructions);
+      }))
+    return;
+  TensorCfgPredecessor Pred;
+  Pred.From = From;
+  Pred.ExternalInstructions.append(ExternalInstructions.begin(),
+                                   ExternalInstructions.end());
+  Predecessors[To].push_back(std::move(Pred));
+}
+
+void analyzeTensorDescriptorRange(ArrayRef<InternalDecodedInst> Decoded,
+                                  ArrayRef<InternalDecodedInst> AllDecoded,
+                                  const TensorExternalCfg &ExternalCfg,
+                                  const TensorAnalysisRange &Range,
+                                  const LLVMState &LS, unsigned MaxSgprs,
+                                  unsigned MaxVgprs,
+                                  const DenseSet<uint64_t> &DirectTargets,
+                                  TensorDescriptorMustAnalysis &Result,
+                                  BitVector &Seen) {
+  SmallVector<size_t> GlobalIndices;
+  auto First = llvm::lower_bound(
+      Decoded, Range.Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  auto Last = llvm::lower_bound(
+      Decoded, Range.End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+        return DI.Offset < Offset;
+      });
+  for (auto It = First; It != Last; ++It)
+    GlobalIndices.push_back(It - Decoded.begin());
+  if (GlobalIndices.empty() ||
+      Decoded[GlobalIndices.front()].Offset != Range.Begin ||
+      !llvm::any_of(GlobalIndices, [&](size_t I) {
+        return Decoded[I].Mnemonic == "tensor_load_to_lds";
+      }))
+    return;
+  uint64_t ExpectedOffset = Range.Begin;
+  for (size_t GlobalIdx : GlobalIndices) {
+    const InternalDecodedInst &DI = Decoded[GlobalIdx];
+    if (DI.Offset != ExpectedOffset || DI.Size == 0 ||
+        DI.Offset > std::numeric_limits<uint64_t>::max() - DI.Size)
+      return;
+    ExpectedOffset = DI.Offset + DI.Size;
+  }
+  if (ExpectedOffset != Range.End)
+    return;
+
+  const unsigned Count = GlobalIndices.size();
+  DenseMap<uint64_t, unsigned> OffsetToLocal;
+  for (unsigned I = 0; I < Count; ++I)
+    OffsetToLocal.try_emplace(Decoded[GlobalIndices[I]].Offset, I);
+
+  DenseMap<unsigned, unsigned> TrackedSgprs;
+  for (size_t GlobalIdx : GlobalIndices) {
+    if (Decoded[GlobalIdx].Mnemonic != "tensor_load_to_lds")
+      continue;
+    MCRegister Base = getDescriptorBaseSgpr(Decoded[GlobalIdx].Inst, *LS.MRI);
+    std::optional<unsigned> Fact =
+        getNumberedRegFactIndex(Base, *LS.MRI, MaxSgprs, MaxVgprs);
+    if (Fact && *Fact < MaxSgprs && !TrackedSgprs.contains(*Fact))
+      TrackedSgprs.try_emplace(*Fact, TrackedSgprs.size());
+  }
+
+  std::vector<SmallVector<unsigned, 2>> Successors(Count);
+  std::vector<SmallVector<TensorCfgPredecessor, 2>> Predecessors(Count);
+  BitVector UnknownSuccessors(Count);
+  BitVector ModeledExternalInstructions(AllDecoded.size());
+  auto RecordModeledExternal = [&](const TensorTrampolinePath &Path) {
+    for (size_t ExternalIdx : Path.Instructions)
+      if (ExternalIdx < ModeledExternalInstructions.size())
+        ModeledExternalInstructions.set(ExternalIdx);
+  };
+  SmallVector<unsigned> HotswapSetPcCandidates;
+  for (unsigned I = 0; I < Count; ++I) {
+    const InternalDecodedInst &DI = Decoded[GlobalIndices[I]];
+    const bool HasFallthrough = I + 1 < Count;
+    if (DI.Mnemonic == "<unknown>" || !LS.MIA) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+    const bool IsCall = LS.MIA->isCall(DI.Inst) || Desc.isCall();
+    const bool IsReturn = LS.MIA->isReturn(DI.Inst) || Desc.isReturn();
+    const bool IsBranch = LS.MIA->isBranch(DI.Inst) || Desc.isBranch();
+    if (StringRef(DI.Mnemonic).starts_with("s_rfe")) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (IsReturn)
+      continue;
+    if (IsCall) {
+      UnknownSuccessors.set(I);
+      if (!Desc.isTerminator() && HasFallthrough)
+        addTensorCfgEdge(I, I + 1, Successors, Predecessors);
+      continue;
+    }
+    if (DI.Mnemonic == "s_set_pc_i64") {
+      HotswapSetPcCandidates.push_back(I);
+      continue;
+    }
+    if (Desc.isTrap()) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+
+    if (IsBranch) {
+      const bool IsIndirect =
+          LS.MIA->isIndirectBranch(DI.Inst) || Desc.isIndirectBranch();
+      const bool IsConditional =
+          LS.MIA->isConditionalBranch(DI.Inst) || Desc.isConditionalBranch();
+      const bool IsUnconditional = LS.MIA->isUnconditionalBranch(DI.Inst) ||
+                                   Desc.isUnconditionalBranch();
+      bool TargetKnown = false;
+      if (!IsIndirect) {
+        uint64_t Target = 0;
+        if (LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+          TargetKnown = true;
+          if (Target >= Range.Begin && Target < Range.End) {
+            auto TargetIt = OffsetToLocal.find(Target);
+            if (TargetIt == OffsetToLocal.end()) {
+              UnknownSuccessors.set(I);
+              TargetKnown = false;
+            } else {
+              addTensorCfgEdge(I, TargetIt->second, Successors, Predecessors);
+            }
+          } else {
+            // An out-of-range destination is not an ordinary function exit:
+            // generated HotSwap bodies may re-enter this range. Only a fully
+            // decoded unconditional trampoline path can preserve facts.
+            TargetKnown = false;
+          }
+          if (!TargetKnown && IsUnconditional) {
+            std::optional<TensorTrampolinePath> Path = findTensorTrampolinePath(
+                AllDecoded, Target, Range, ExternalCfg.ExternalBegin, LS,
+                DirectTargets);
+            if (!Path && I != 0 && DI.Mnemonic == "s_branch" &&
+                !DirectTargets.contains(DI.Offset)) {
+              const InternalDecodedInst &GetPc = Decoded[GlobalIndices[I - 1]];
+              if (GetPc.Offset <=
+                      std::numeric_limits<uint64_t>::max() - GetPc.Size &&
+                  GetPc.Offset + GetPc.Size == DI.Offset &&
+                  GetPc.Mnemonic == "s_get_pc_i64") {
+                auto Relay = resolveTensorRelayTarget(AllDecoded, GetPc, Target,
+                                                      DirectTargets);
+                if (Relay) {
+                  Path = findTensorTrampolinePath(
+                      AllDecoded, Relay->first, Range,
+                      ExternalCfg.ExternalBegin, LS, DirectTargets);
+                  if (Path)
+                    Path->Instructions.insert(Path->Instructions.begin(),
+                                              Relay->second.begin(),
+                                              Relay->second.end());
+                }
+              }
+            }
+            if (Path) {
+              RecordModeledExternal(*Path);
+              auto ResumeIt = OffsetToLocal.find(Path->ResumeOffset);
+              if (ResumeIt == OffsetToLocal.end()) {
+                UnknownSuccessors.set(I);
+                TargetKnown = false;
+              } else {
+                addTensorCfgEdge(I, ResumeIt->second, Successors, Predecessors,
+                                 Path->Instructions);
+                TargetKnown = true;
+              }
+            }
+          }
+        }
+      }
+      if (!TargetKnown)
+        UnknownSuccessors.set(I);
+      if (IsConditional) {
+        if (HasFallthrough)
+          addTensorCfgEdge(I, I + 1, Successors, Predecessors);
+        else
+          UnknownSuccessors.set(I);
+      } else if (!IsUnconditional) {
+        UnknownSuccessors.set(I);
+      }
+      continue;
+    }
+
+    if (Desc.isTerminator())
+      continue;
+    if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (HasFallthrough)
+      addTensorCfgEdge(I, I + 1, Successors, Predecessors);
+    else
+      UnknownSuccessors.set(I);
+  }
+
+  for (unsigned I : HotswapSetPcCandidates) {
+    const InternalDecodedInst &SetPc = Decoded[GlobalIndices[I]];
+    std::optional<uint64_t> Target =
+        resolveTensorSetPcTarget(AllDecoded, SetPc.Offset, DirectTargets);
+    if (!Target) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    if (*Target >= Range.Begin && *Target < Range.End) {
+      auto TargetIt = OffsetToLocal.find(*Target);
+      if (TargetIt == OffsetToLocal.end())
+        UnknownSuccessors.set(I);
+      else
+        addTensorCfgEdge(I, TargetIt->second, Successors, Predecessors);
+      continue;
+    }
+
+    std::optional<TensorTrampolinePath> Path =
+        findTensorTrampolinePath(AllDecoded, *Target, Range,
+                                 ExternalCfg.ExternalBegin, LS, DirectTargets);
+    if (!Path) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    auto ResumeIt = OffsetToLocal.find(Path->ResumeOffset);
+    if (ResumeIt == OffsetToLocal.end()) {
+      UnknownSuccessors.set(I);
+      continue;
+    }
+    RecordModeledExternal(*Path);
+    addTensorCfgEdge(I, ResumeIt->second, Successors, Predecessors,
+                     Path->Instructions);
+  }
+
+  // A modeled external subgraph is candidate-owned only if every decoded
+  // predecessor is candidate-owned too. Virtual KD dispatch is the sole
+  // sourceless entry and is admitted only through an exact validated stub.
+  auto OffsetTouchesModeledExternal = [&](uint64_t Offset) {
+    auto It = llvm::upper_bound(
+        AllDecoded, Offset, [](uint64_t Value, const InternalDecodedInst &DI) {
+          return Value < DI.Offset;
+        });
+    if (It == AllDecoded.begin())
+      return false;
+    --It;
+    const size_t Index = It - AllDecoded.begin();
+    return Index >= ExternalCfg.ExternalBegin &&
+           ModeledExternalInstructions.test(Index) &&
+           It->Offset <= std::numeric_limits<uint64_t>::max() - It->Size &&
+           Offset >= It->Offset && Offset < It->Offset + It->Size;
+  };
+  if (llvm::any_of(Range.ForeignExternalEntries, OffsetTouchesModeledExternal))
+    return;
+
+  auto CandidateDispatchStubContaining =
+      [&](uint64_t Offset) -> const TensorDispatchStub * {
+    auto It = llvm::find_if(Range.DispatchStubs, [&](const auto &Stub) {
+      return Stub.Target == Range.Begin && Offset >= Stub.Begin &&
+             Offset < Stub.End;
+    });
+    return It == Range.DispatchStubs.end() ? nullptr : &*It;
+  };
+  if (llvm::any_of(Range.VirtualExternalEntries, [&](uint64_t Root) {
+        return OffsetTouchesModeledExternal(Root) ||
+               CandidateDispatchStubContaining(Root) != nullptr;
+      }))
+    return;
+  if (ExternalCfg.UnresolvedSources.any())
+    return;
+
+  for (const TensorExternalCfgEdge &Edge : ExternalCfg.Edges) {
+    const bool SourceModeled =
+        ModeledExternalInstructions.test(Edge.SourceIndex);
+    const bool TargetsCandidate =
+        Edge.Target >= Range.Begin && Edge.Target < Range.End;
+    const bool IsCandidateDispatch =
+        Edge.DispatchStubIndex &&
+        *Edge.DispatchStubIndex < Range.DispatchStubs.size() &&
+        Range.DispatchStubs[*Edge.DispatchStubIndex].Target == Range.Begin &&
+        Edge.Target == Range.Begin;
+    if (TargetsCandidate && !SourceModeled && !IsCandidateDispatch)
+      return;
+    if (OffsetTouchesModeledExternal(Edge.Target) && !SourceModeled)
+      return;
+
+    if (const TensorDispatchStub *Stub =
+            CandidateDispatchStubContaining(Edge.Target)) {
+      const uint64_t Source = AllDecoded[Edge.SourceIndex].Offset;
+      if (Source < Stub->Begin || Source >= Stub->End)
+        return;
+    }
+  }
+
+  BitVector Reachable(Count);
+  SmallVector<unsigned> Worklist{0};
+  Reachable.set(0);
+  for (size_t Next = 0; Next < Worklist.size(); ++Next) {
+    unsigned I = Worklist[Next];
+    if (UnknownSuccessors.test(I))
+      return;
+    for (unsigned Succ : Successors[I])
+      if (!Reachable.test(Succ)) {
+        Reachable.set(Succ);
+        Worklist.push_back(Succ);
+      }
+  }
+
+  const unsigned FactCount = MaxSgprs + MaxVgprs + 1;
+  const unsigned ExecNonemptyFact = MaxSgprs + MaxVgprs;
+  BitVector Top(FactCount, true);
+  BitVector Bottom(FactCount);
+  BitVector EntryState = Bottom;
+  EntryState.set(ExecNonemptyFact);
+  std::vector<BitVector> MustIn(Count, Top);
+  std::vector<BitVector> MustOut(Count, Top);
+  MustIn[0] = EntryState;
+  MustOut[0] = transferTensorDescriptorFacts(
+      Decoded[GlobalIndices[0]], EntryState, LS, MaxSgprs, MaxVgprs);
+
+  TensorMaskDefState DefTop(TrackedSgprs.size(), TensorMaskDefTop);
+  TensorMaskDefState DefUnknown(TrackedSgprs.size(), TensorMaskDefUnknown);
+  std::vector<TensorMaskDefState> DefIn(Count, DefTop);
+  std::vector<TensorMaskDefState> DefOut(Count, DefTop);
+  DefIn[0] = DefUnknown;
+  DefOut[0] =
+      transferTensorMaskDefinitions(Decoded[GlobalIndices[0]], DefUnknown,
+                                    TrackedSgprs, LS, MaxSgprs, MaxVgprs);
+
+  bool Changed = true;
+  unsigned Iterations = 0;
+  const unsigned IterationLimit = std::max(Count + 1, FactCount + 1);
+  while (Changed && Iterations++ < IterationLimit) {
+    Changed = false;
+    for (unsigned I = 0; I < Count; ++I) {
+      if (!Reachable.test(I))
+        continue;
+      BitVector NewIn = I == 0 ? EntryState : Top;
+      TensorMaskDefState NewDefIn = I == 0 ? DefUnknown : DefTop;
+      bool SawPredecessor = I == 0;
+      // Node zero also has a virtual dispatch predecessor carrying EntryState.
+      // Meet real backedges with that seed instead of treating every loop to
+      // the kernel entry as a fresh dispatch with nonempty EXEC.
+      for (const TensorCfgPredecessor &Pred : Predecessors[I]) {
+        if (!Reachable.test(Pred.From))
+          continue;
+        SawPredecessor = true;
+        BitVector EdgeOut = MustOut[Pred.From];
+        TensorMaskDefState EdgeDefOut = DefOut[Pred.From];
+        for (size_t ExternalIdx : Pred.ExternalInstructions) {
+          EdgeOut = transferTensorDescriptorFacts(
+              AllDecoded[ExternalIdx], EdgeOut, LS, MaxSgprs, MaxVgprs);
+          EdgeDefOut = transferTensorMaskDefinitions(AllDecoded[ExternalIdx],
+                                                     EdgeDefOut, TrackedSgprs,
+                                                     LS, MaxSgprs, MaxVgprs);
+        }
+        NewIn &= EdgeOut;
+        meetTensorMaskDefinitions(NewDefIn, EdgeDefOut);
+      }
+      if (!SawPredecessor) {
+        NewIn.reset();
+        NewDefIn = DefUnknown;
+      }
+      BitVector NewOut = transferTensorDescriptorFacts(
+          Decoded[GlobalIndices[I]], NewIn, LS, MaxSgprs, MaxVgprs);
+      TensorMaskDefState NewDefOut =
+          transferTensorMaskDefinitions(Decoded[GlobalIndices[I]], NewDefIn,
+                                        TrackedSgprs, LS, MaxSgprs, MaxVgprs);
+      if (NewIn != MustIn[I] || NewOut != MustOut[I] || NewDefIn != DefIn[I] ||
+          NewDefOut != DefOut[I]) {
+        MustIn[I] = std::move(NewIn);
+        MustOut[I] = std::move(NewOut);
+        DefIn[I] = std::move(NewDefIn);
+        DefOut[I] = std::move(NewDefOut);
+        Changed = true;
+      }
+    }
+  }
+  if (Changed)
+    return;
+
+  for (unsigned I = 0; I < Count; ++I) {
+    const size_t GlobalIdx = GlobalIndices[I];
+    if (!Reachable.test(I) ||
+        Decoded[GlobalIdx].Mnemonic != "tensor_load_to_lds")
+      continue;
+    MCRegister Base = getDescriptorBaseSgpr(Decoded[GlobalIdx].Inst, *LS.MRI);
+    std::optional<unsigned> Fact =
+        getNumberedRegFactIndex(Base, *LS.MRI, MaxSgprs, MaxVgprs);
+    const bool KnownZero = Fact && MustIn[I].test(*Fact);
+    uint64_t MaskDef = TensorMaskDefUnknown;
+    if (Fact) {
+      auto Slot = TrackedSgprs.find(*Fact);
+      if (Slot != TrackedSgprs.end())
+        MaskDef = DefIn[I][Slot->second];
+    }
+    if (MaskDef < Range.Begin || MaskDef >= Range.End)
+      MaskDef = TensorMaskDefUnknown;
+    if (Seen.test(GlobalIdx)) {
+      if (!KnownZero)
+        Result.Low16KnownZero.reset(GlobalIdx);
+      if (Result.MaskDefinitionOffsets[GlobalIdx] != MaskDef)
+        Result.MaskDefinitionOffsets[GlobalIdx] = TensorMaskDefUnknown;
+    } else {
+      Seen.set(GlobalIdx);
+      if (KnownZero)
+        Result.Low16KnownZero.set(GlobalIdx);
+      Result.MaskDefinitionOffsets[GlobalIdx] = MaskDef;
+    }
+  }
+}
+
+TensorDescriptorMustAnalysis computeTensorDescriptorMustAnalysisImpl(
+    ArrayRef<InternalDecodedInst> Decoded,
+    ArrayRef<InternalDecodedInst> AllDecoded,
+    ArrayRef<TensorAnalysisRange> KernelRanges, const LLVMState &LS,
+    const DenseSet<uint64_t> &DirectTargets, unsigned MaxSgprs,
+    unsigned MaxVgprs) {
+  TensorDescriptorMustAnalysis Result{
+      BitVector(Decoded.size()),
+      std::vector<uint64_t>(Decoded.size(), TensorMaskDefUnknown)};
+  BitVector Seen(Decoded.size());
+  if (!LS.MCII || !LS.MRI || MaxSgprs == 0 || MaxVgprs == 0)
+    return Result;
+  if (KernelRanges.empty())
+    return Result;
+
+  ArrayRef<TensorDispatchStub> DispatchStubs =
+      KernelRanges.front().DispatchStubs;
+  auto SameDispatchStub = [](const TensorDispatchStub &L,
+                             const TensorDispatchStub &R) {
+    return L.Begin == R.Begin && L.End == R.End && L.Terminal == R.Terminal &&
+           L.Target == R.Target;
+  };
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return Range.DispatchStubs.size() != DispatchStubs.size() ||
+               !llvm::equal(Range.DispatchStubs, DispatchStubs,
+                            SameDispatchStub);
+      }))
+    return Result;
+  ArrayRef<uint64_t> VirtualExternalEntries =
+      KernelRanges.front().VirtualExternalEntries;
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return !llvm::equal(Range.VirtualExternalEntries,
+                            VirtualExternalEntries);
+      }))
+    return Result;
+  ArrayRef<std::pair<uint64_t, uint64_t>> OriginalControlFlowEdges =
+      KernelRanges.front().OriginalControlFlowEdges;
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return !llvm::equal(Range.OriginalControlFlowEdges,
+                            OriginalControlFlowEdges);
+      }))
+    return Result;
+  ArrayRef<uint64_t> OriginalCodeEntries =
+      KernelRanges.front().OriginalCodeEntries;
+  if (llvm::any_of(KernelRanges, [&](const TensorAnalysisRange &Range) {
+        return !llvm::equal(Range.OriginalCodeEntries, OriginalCodeEntries);
+      }))
+    return Result;
+  TensorExternalCfg ExternalCfg = buildTensorExternalCfg(
+      Decoded, AllDecoded, DispatchStubs, VirtualExternalEntries,
+      OriginalControlFlowEdges, OriginalCodeEntries, LS, DirectTargets);
+  if (!ExternalCfg.Valid)
+    return Result;
+  for (const TensorAnalysisRange &Range : KernelRanges)
+    analyzeTensorDescriptorRange(Decoded, AllDecoded, ExternalCfg, Range, LS,
+                                 MaxSgprs, MaxVgprs, DirectTargets, Result,
+                                 Seen);
+  return Result;
+}
+
 // -- patchTensorLoadToLdsA0 -------------------------------------------------
 //
-// Prepend s_pack_hh_b32_b16 to clear multicast routing bits in the group
-// descriptor's base SGPR. Preserve the architectural SGPR value when it is live
-// after the tensor instruction: the descriptor is a source operand, so the
-// rewrite must not make its temporary normalization visible to later code.
+// Replace the canonical one-cycle scalar delay immediately before the tensor
+// load with s_pack_hh_b32_b16. Tensor loads are PC-sensitive on gfx1250 A0, so
+// they must remain at their linked address instead of executing in a sled or
+// appended trampoline. Reuse the exact canonical delay slot to clear the
+// descriptor's multicast bits without allocating a scratch register.
 
 bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -778,6 +3138,44 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
   if (!BaseMCReg.isValid()) {
     log() << "hotswap: error: tensor_load_to_lds: could not extract descriptor "
              "base register\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  // The tensor instruction is PC-sensitive on gfx1250 A0. It must never be
+  // borrowed by generic far source-window expansion, even when its mask is
+  // placed at an earlier local descriptor definition.
+  protectNonClauseRelocationOffset(Ctx, DI.Offset);
+
+  if (Ctx.TensorDescriptorAnalysis &&
+      Idx < Ctx.TensorDescriptorAnalysis->Low16KnownZero.size() &&
+      Ctx.TensorDescriptorAnalysis->Low16KnownZero.test(Idx)) {
+    log() << "hotswap: tensor_load_to_lds: descriptor low16 already zero at 0x"
+          << utohexstr(DI.Offset) << "; tensor remains unchanged\n";
+    DI.Mnemonic = "<replaced>";
+    return false;
+  }
+
+  if (Ctx.TensorDescriptorAnalysis &&
+      Idx < Ctx.TensorDescriptorAnalysis->MaskDefinitionOffsets.size()) {
+    const uint64_t DefOffset =
+        Ctx.TensorDescriptorAnalysis->MaskDefinitionOffsets[Idx];
+    if (Ctx.TensorMaskedDefinitionOffsets.contains(DefOffset)) {
+      log() << "hotswap: tensor_load_to_lds: reusing masked descriptor "
+               "definition at 0x"
+            << utohexstr(DefOffset) << "; tensor remains at 0x"
+            << utohexstr(DI.Offset) << "\n";
+      DI.Mnemonic = "<replaced>";
+      return false;
+    }
+  }
+
+  // Every A0 mask path executes before the PC-sensitive tensor instruction.
+  // A direct edge to the tensor or any unresolved indirect entry in its
+  // function can bypass that mask, including one already present in the input.
+  if (isDirectControlFlowTarget(Ctx, DI.Offset) ||
+      functionHasIndirectControlFlow(Ctx, DI.Offset)) {
+    log() << "hotswap: error: tensor_load_to_lds at 0x" << utohexstr(DI.Offset)
+          << " may be entered without executing its descriptor mask\n";
     return failRequiredPatch(Ctx);
   }
 
@@ -794,54 +3192,84 @@ bool patchTensorLoadToLdsA0(PatchContext &Ctx, size_t Idx) {
     return failRequiredPatch(Ctx);
   }
 
-  bool SgprLive = isSgprLiveAfter(Ctx, Idx, BaseMCReg);
-  const uint8_t *OrigInst = Ctx.Text + DI.Offset;
-
-  if (SgprLive) {
-    std::optional<SafeSgprScratchBlock> Scratch =
-        findSafeSgprScratchBlock(Ctx, DI.Offset, /*Count=*/1, /*Alignment=*/1,
-                                 "tensor_load_to_lds descriptor save");
-    if (!Scratch) {
-      log() << "hotswap: error: tensor_load_to_lds: no scratch SGPR "
-               "available\n";
-      return failRequiredPatch(Ctx);
+  std::optional<LocalTensorMaskDefinition> LocalDef =
+      findLocalTensorMaskDefinition(Ctx, Idx, BaseMCReg);
+  const bool ClaimedLocalDefinition = LocalDef && !LocalDef->AlreadyMasked &&
+                                      Ctx.ClaimedReplacementOffsets.contains(
+                                          Ctx.Decoded[LocalDef->Index].Offset);
+  if (ClaimedLocalDefinition) {
+    // The definition still executes in the atomic relocated stream, but its
+    // linked address is no longer an independent patch source. Prefer the
+    // reconstructed canonical delay slot immediately before the tensor.
+    log() << "hotswap: tensor_load_to_lds: descriptor definition at 0x"
+          << utohexstr(Ctx.Decoded[LocalDef->Index].Offset)
+          << " is relocated; using linked delay slot for the mask\n";
+  } else if (LocalDef) {
+    if (LocalDef->AlreadyMasked) {
+      protectNonClauseRelocationOffset(Ctx,
+                                       Ctx.Decoded[LocalDef->Index].Offset);
+      Ctx.TensorMaskedDefinitionOffsets.insert(
+          Ctx.Decoded[LocalDef->Index].Offset);
+      log() << "hotswap: tensor_load_to_lds: descriptor already masked at 0x"
+            << utohexstr(Ctx.Decoded[LocalDef->Index].Offset)
+            << "; tensor remains at 0x" << utohexstr(DI.Offset) << "\n";
+      DI.Mnemonic = "<replaced>";
+      return false;
     }
 
-    std::string ScratchName = "s" + std::to_string(Scratch->Base);
-    SmallVector<uint8_t> Save = assembleSingleInst(
-        "s_mov_b32 " + ScratchName + ", " + BaseSreg, Ctx.LS);
-    SmallVector<uint8_t> Restore = assembleSingleInst(
-        "s_mov_b32 " + BaseSreg + ", " + ScratchName, Ctx.LS);
-    if (Save.empty() || Restore.empty()) {
-      log() << "hotswap: error: tensor_load_to_lds: failed to assemble "
-               "descriptor save/restore through "
-            << ScratchName << "\n";
+    InternalDecodedInst &Def = Ctx.Decoded[LocalDef->Index];
+    if (Def.Offset > Ctx.TextSize || Def.Size > Ctx.TextSize - Def.Offset)
       return failRequiredPatch(Ctx);
-    }
-
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(Save.begin(), Save.end());
+    SmallVector<uint8_t> Replacement(Ctx.Text + Def.Offset,
+                                     Ctx.Text + Def.Offset + Def.Size);
     Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-    Replacement.append(Restore.begin(), Restore.end());
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+    if (!emitReplacementCode(Ctx, Def.Offset, Def.Size, Replacement))
       return failRequiredPatch(Ctx);
+    protectNonClauseRelocationOffset(Ctx, Def.Offset);
+    Ctx.TensorMaskedDefinitionOffsets.insert(Def.Offset);
 
-    if (!commitSafeSgprScratchBlock(Ctx, DI.Offset, *Scratch,
-                                    "tensor_load_to_lds descriptor save"))
-      return failRequiredPatch(Ctx);
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " live, save/restore via " << ScratchName << "\n";
-  } else {
-    SmallVector<uint8_t> Replacement;
-    Replacement.append(PackBytes.begin(), PackBytes.end());
-    Replacement.append(OrigInst, OrigInst + DI.Size);
-    if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
-      return failRequiredPatch(Ctx);
-
-    log() << "hotswap: tensor_load_to_lds: " << BaseSreg
-          << " dead, no save/restore needed\n";
+    log() << "hotswap: tensor_load_to_lds: masked local descriptor definition "
+             "at 0x"
+          << utohexstr(Def.Offset) << "; tensor remains at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    Ctx.RequiredPatchApplied = true;
+    Def.Mnemonic = "<replaced>";
+    DI.Mnemonic = "<replaced>";
+    return true;
   }
+
+  SmallVector<uint8_t> DelayBytes =
+      assembleSingleInst("s_delay_alu instid0(SALU_CYCLE_1)", Ctx.LS);
+  if (DelayBytes.empty()) {
+    log() << "hotswap: tensor_load_to_lds delay assembly failed\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  if (Idx == 0) {
+    log() << "hotswap: error: tensor_load_to_lds at 0x" << utohexstr(DI.Offset)
+          << " has no preceding delay slot\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  InternalDecodedInst &Prev = Ctx.Decoded[Idx - 1];
+  ArrayRef<uint8_t> PrevBytes(Ctx.Text + Prev.Offset, Prev.Size);
+  const bool ReconstructedDelay =
+      Ctx.ClaimedReplacementOffsets.contains(Prev.Offset);
+  if ((!ReconstructedDelay && Prev.Mnemonic != "s_delay_alu") ||
+      Prev.Offset + Prev.Size != DI.Offset ||
+      PrevBytes != ArrayRef<uint8_t>(DelayBytes) ||
+      Prev.Size != PackBytes.size()) {
+    log() << "hotswap: error: tensor_load_to_lds at 0x" << utohexstr(DI.Offset)
+          << " is not preceded by the canonical scalar delay\n";
+    return failRequiredPatch(Ctx);
+  }
+
+  protectNonClauseRelocationOffset(Ctx, Prev.Offset);
+
+  std::memcpy(Ctx.Text + Prev.Offset, PackBytes.data(), PackBytes.size());
+  log() << "hotswap: tensor_load_to_lds: in-place descriptor mask at 0x"
+        << utohexstr(Prev.Offset) << "; tensor remains at 0x"
+        << utohexstr(DI.Offset) << "\n";
 
   Ctx.RequiredPatchApplied = true;
   DI.Mnemonic = "<replaced>";
@@ -1270,8 +3698,9 @@ SmallVector<std::string> buildAddtidStoreAsm(StringRef VTmpName,
 // Trampoline expansion for ds_load_addtid_b32 / ds_store_addtid_b32 on
 // A0. The replacement materialises the ADDTID address through the ALU
 // (so the full 32-bit M0 is used) and issues a regular ds_*_b32. GDS=1
-// is rejected: the rewrite stays a no-op so the original (broken on A0)
-// instruction is preserved and the failure is loud in the verbose log.
+// is rejected. Once an ADDTID mnemonic is recognized, every failure must be
+// fatal so the rewrite cannot report success with an A0-incompatible
+// instruction still present.
 
 bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
@@ -1286,14 +3715,14 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     log() << "hotswap: error: " << DI.Mnemonic << " with GDS=1 at 0x"
           << utohexstr(DI.Offset)
           << " is not supported; leaving original instruction in place\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   std::optional<uint16_t> OffsetOpt = getAddtidOffset(DI.Inst);
   if (!OffsetOpt) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": missing/non-immediate offset\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
   uint16_t Offset = *OffsetOpt;
 
@@ -1302,7 +3731,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       !DI.Inst.getOperand(AddtidOpReg).getReg()) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": missing register operand\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
@@ -1311,7 +3740,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   if (RegName.empty()) {
     log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
           << utohexstr(DI.Offset) << ": cannot resolve register name\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   bool IsLoad = isAddtidLoad(DI.Mnemonic);
@@ -1351,7 +3780,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
       log() << " at 0x" << utohexstr(DI.Offset) << "\n";
       log() << "hotswap: error: " << DI.Mnemonic << " at 0x"
             << utohexstr(DI.Offset) << ": no scratch VGPR available\n";
-      return false;
+      return failRequiredPatch(Ctx);
     }
 
     std::string TmpName = ("v" + Twine(StoreScratch->Vgpr)).str();
@@ -1366,11 +3795,11 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
     log() << "hotswap: error: " << DI.Mnemonic
           << " trampoline assembly failed at 0x" << utohexstr(DI.Offset)
           << "\n";
-    return false;
+    return failRequiredPatch(Ctx);
   }
 
   if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Bytes))
-    return false;
+    return failRequiredPatch(Ctx);
 
   // Commit the scratch-VGPR reservation only after the patch is in place:
   // any earlier failure (assembly, sled/trampoline emission) leaves no
@@ -1394,11 +3823,152 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
 
 } // anonymous namespace
 
-std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
-                                                      StringRef FromMnem,
-                                                      StringRef ToMnem,
-                                                      const LLVMState &LS) {
-  return expandDs2AddrImpl(Inst, FromMnem, ToMnem, LS);
+TensorDescriptorMustAnalysis
+computeTensorDescriptorMustAnalysis(ArrayRef<InternalDecodedInst> Decoded,
+                                    ArrayRef<InternalDecodedInst> AllDecoded,
+                                    ArrayRef<TensorAnalysisRange> KernelRanges,
+                                    const LLVMState &LS,
+                                    const DenseSet<uint64_t> &DirectTargets,
+                                    unsigned MaxSgprs, unsigned MaxVgprs) {
+  return computeTensorDescriptorMustAnalysisImpl(
+      Decoded, AllDecoded, KernelRanges, LS, DirectTargets, MaxSgprs, MaxVgprs);
+}
+
+// Keep atomic relocation eligibility aligned with both precomputed whole-pass
+// ownership and the per-instruction dispatcher. Callers may copy an earlier
+// same-size correction from current text, but must not claim a site that owns
+// an independent rewrite. Conditional families mirror their dispatch gates so
+// valid no-op variants remain relocatable.
+bool requiresIndependentInstructionRewrite(const PatchContext &Ctx,
+                                           size_t Idx) {
+  if (Idx >= Ctx.Decoded.size())
+    return true;
+
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
+  StringRef Mnemonic(DI.Mnemonic);
+  if (Mnemonic == "<unknown>" || Mnemonic == "<replaced>")
+    return true;
+
+  if (hasSiteReplacementReservation(Ctx, DI.Offset))
+    return true;
+
+  if (Mnemonic == "tensor_load_to_lds")
+    return Ctx.Config.MaskPolicy != MaskWorkaroundPolicy::None;
+
+  if (!Ctx.Config.RunB0A0Patches)
+    return false;
+
+  if (!getDs2AddrReplacement(Mnemonic).empty()) {
+    const bool ProvenAligned =
+        Ctx.Ds2AddressProvenAligned.size() == Ctx.Decoded.size() &&
+        Ctx.Ds2AddressProvenAligned.test(Idx);
+    return !ProvenAligned;
+  }
+
+  if (isClusterLoad(Mnemonic)) {
+    // The off form is demoted in-place. The SGPR-relative form survives that
+    // pass and needs the trampoline mask only for the A0 policy.
+    bool HasSgprOperand = !Ctx.LS.MRI;
+    if (Ctx.LS.MRI)
+      for (const MCOperand &Operand : DI.Inst)
+        HasSgprOperand |= Operand.isReg() && Operand.getReg() &&
+                          StringRef(Ctx.LS.MRI->getName(Operand.getReg()))
+                              .starts_with("SGPR");
+    return !HasSgprOperand || Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0;
+  }
+
+  if (!getAddtidReplacement(Mnemonic).empty() ||
+      isWmmaSplitPatchCandidate(Mnemonic) ||
+      Mnemonic == "s_barrier_signal_isfirst" ||
+      Mnemonic == "v_wmma_scale16_f32_16x16x128_f8f6f4" ||
+      Mnemonic == "v_wmma_scale16_f32_32x16x128_f4")
+    return true;
+
+  // Mirror only the dispatcher's semantic CLAMP gate. Non-CLAMP FP8
+  // conversions are valid on A0 and may move with a protected window.
+  auto NeedsClampPatchAt = [&](unsigned OperandIndex) {
+    // A missing or non-immediate CLAMP field is malformed, not a proven no-op;
+    // retain ownership so the scratch pass can reject it explicitly.
+    return OperandIndex >= DI.Inst.getNumOperands() ||
+           !DI.Inst.getOperand(OperandIndex).isImm() ||
+           DI.Inst.getOperand(OperandIndex).getImm() != 0;
+  };
+  if (Mnemonic == "v_cvt_pk_fp8_f32")
+    return (DI.Size != 8 && DI.Size != 12) || NeedsClampPatchAt(5);
+  if (Mnemonic == "v_cvt_sr_fp8_f32")
+    return DI.Size != 8 || NeedsClampPatchAt(5);
+  if (Mnemonic.starts_with("v_cvt_f32_fp8")) {
+    if (DI.Size == 4)
+      return false;
+    return DI.Size != 8 || NeedsClampPatchAt(2);
+  }
+
+  return false;
+}
+
+void precomputeDs2AddressAlignment(PatchContext &Ctx) {
+  Ctx.Ds2AddressProvenAligned.resize(Ctx.Decoded.size());
+  Ctx.Ds2AddressProvenAligned.reset();
+  if (Ctx.HasUnknownArbitraryIndirectTarget)
+    return;
+
+  DenseMap<std::pair<size_t, unsigned>, SmallVector<size_t, 4>> CandidateUses;
+  for (size_t I = 0; I != Ctx.Decoded.size(); ++I) {
+    if (getDs2AddrReplacement(Ctx.Decoded[I].Mnemonic).empty())
+      continue;
+    if (computeDs2AddressProvenAligned(Ctx, I)) {
+      Ctx.Ds2AddressProvenAligned.set(I);
+      continue;
+    }
+
+    const InternalDecodedInst &DS = Ctx.Decoded[I];
+    StringRef Mnem(DS.Mnemonic);
+    if (Mnem != "ds_load_2addr_b32" && Mnem != "ds_load_2addr_b64" &&
+        Mnem != "ds_store_2addr_b32" && Mnem != "ds_store_2addr_b64")
+      continue;
+    if (DS.Inst.getNumOperands() == 0 ||
+        !DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).isImm() ||
+        DS.Inst.getOperand(DS.Inst.getNumOperands() - 1).getImm() != 0)
+      continue;
+    std::optional<DsOperands> Ops =
+        extractDsOperands(DS.Inst, DS.Mnemonic, Ctx.LS);
+    if (!Ops)
+      continue;
+    const unsigned AddrIndex = Mnem.starts_with("ds_store_") ? 0 : 1;
+    if (Ops->Regs.size() <= AddrIndex)
+      continue;
+    MCRegister Address = Ops->Regs[AddrIndex];
+    const unsigned Alignment = Ops->IsB64 ? 8 : 4;
+    if (Ops->Off0 % Alignment != 0 || Ops->Off1 % Alignment != 0)
+      continue;
+    std::optional<ElfView::FunctionTextRange> Function =
+        Ctx.Elf.findFunctionTextRangeAtOffset(DS.Offset);
+    if (!Function ||
+        Ctx.IndirectControlFlowFunctions.contains(Function->Begin) ||
+        Ctx.CrossFunctionInteriorEntryFunctions.contains(Function->Begin) ||
+        !Ctx.DirectControlFlowTargets ||
+        Ctx.DirectControlFlowTargets->contains(DS.Offset))
+      continue;
+
+    for (size_t DefI = I; DefI-- > 0;) {
+      const InternalDecodedInst &Def = Ctx.Decoded[DefI];
+      if (Def.Offset < Function->Begin)
+        break;
+      if (!definesRegister(Def, Address, Ctx.LS))
+        continue;
+      if ((isAlignedConstantAddressDef(Def, Address, Alignment, Ctx, DefI,
+                                       /*RequireEqualMode=*/false) ||
+           isAlignedSgprCopyAddressDef(Def, Address, Alignment, Ctx, DefI)) &&
+          DefI < Ctx.VgprMsbDstBefore.size() && Ctx.VgprMsbDstBefore[DefI] >= 0)
+        CandidateUses[{DefI, Address.id()}].push_back(I);
+      break;
+    }
+  }
+
+  for (const auto &Entry : CandidateUses)
+    proveLongRangeDs2Alignment(Ctx, Entry.first.first,
+                               MCRegister(Entry.first.second), Entry.second,
+                               Ctx.Ds2AddressProvenAligned);
 }
 
 // -- applyTrampolinePatches -------------------------------------------------
@@ -1417,8 +3987,14 @@ std::optional<std::vector<std::string>> expandDs2Addr(const MCInst &Inst,
 static uint32_t applyTrampolinePatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
-  if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty())
-    return patchDs2Addr(Ctx, Idx) ? 1 : 0;
+  if (Ctx.Config.RunB0A0Patches && !getDs2AddrReplacement(Mnem).empty()) {
+    if (isDs2AddressProvenAligned(Ctx, Idx)) {
+      log() << "hotswap: ds_2addr: preserved proven-aligned " << Mnem
+            << " at 0x" << utohexstr(Ctx.Decoded[Idx].Offset) << "\n";
+      return 0;
+    }
+    return patchDs2Addr(Ctx, Idx);
+  }
 
   if (Mnem == "tensor_load_to_lds") {
     if (Ctx.Config.MaskPolicy == MaskWorkaroundPolicy::A0)

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
@@ -103,13 +103,20 @@ WmmaNopReq classifyWmmaNops(StringRef Mnemonic) {
   return {4, 4};
 }
 
+int updateWmmaHazardDeficit(DenseMap<size_t, int> &MaxDeficits,
+                            size_t ValuIndex, int Deficit) {
+  int &Maximum = MaxDeficits[ValuIndex];
+  Maximum = std::max(Maximum, Deficit);
+  return Maximum;
+}
+
 namespace {
 
-std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
+std::optional<std::vector<WmmaHazard>>
+findWmmaCoexecHazards(const PatchContext &Ctx) {
   const MCInstrInfo &MCII = *Ctx.LS.MCII;
   const MCRegisterInfo &MRI = *Ctx.LS.MRI;
-  std::vector<WmmaHazard> Hazards;
-  DenseSet<size_t> PatchedValuIndices;
+  DenseMap<size_t, int> MaxDeficitByValu;
   int WmmaScanned = 0;
 
   for (size_t WmmaIdx = 0, E = Ctx.Decoded.size(); WmmaIdx < E; ++WmmaIdx) {
@@ -125,6 +132,15 @@ std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
     int SafeSlots = 0;
     for (size_t ValuIdx = WmmaIdx + 1; ValuIdx < E; ++ValuIdx) {
       const InternalDecodedInst &Candidate = Ctx.Decoded[ValuIdx];
+
+      if (Candidate.Mnemonic == "<unknown>" ||
+          Candidate.Mnemonic == "<replaced>") {
+        log() << "hotswap: error: cannot prove WMMA co-exec spacing from 0x"
+              << utohexstr(WmmaDI.Offset) << " across instruction at 0x"
+              << utohexstr(Candidate.Offset) << " (" << Candidate.Mnemonic
+              << ")\n";
+        return std::nullopt;
+      }
 
       if (isVNop(Candidate)) {
         ++SafeSlots;
@@ -147,14 +163,16 @@ std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
           continue;
         }
 
-        if (SafeSlots < Req.A0Nops &&
-            PatchedValuIndices.insert(ValuIdx).second) {
-          Hazards.push_back({ValuIdx, Req.A0Nops - SafeSlots});
+        if (SafeSlots < Req.A0Nops) {
+          const int Deficit = Req.A0Nops - SafeSlots;
+          const int MaxDeficit =
+              updateWmmaHazardDeficit(MaxDeficitByValu, ValuIdx, Deficit);
           log() << "hotswap: WMMA co-exec hazard at 0x"
                 << utohexstr(WmmaDI.Offset) << ": " << WmmaDI.Mnemonic
                 << " needs " << Req.A0Nops << " v_nops, only " << SafeSlots
                 << " found before " << Candidate.Mnemonic << " at 0x"
-                << utohexstr(Candidate.Offset) << "\n";
+                << utohexstr(Candidate.Offset) << " (candidate max deficit "
+                << MaxDeficit << ")\n";
         }
         break;
       }
@@ -163,6 +181,12 @@ std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
     }
   }
 
+  std::vector<WmmaHazard> Hazards;
+  Hazards.reserve(MaxDeficitByValu.size());
+  for (size_t I = 0, E = Ctx.Decoded.size(); I != E; ++I)
+    if (auto It = MaxDeficitByValu.find(I); It != MaxDeficitByValu.end())
+      Hazards.push_back({I, It->second});
+
   log() << "hotswap: WMMA co-exec validation: " << Hazards.size()
         << " hazards (" << WmmaScanned << " WMMA instructions scanned)\n";
   return Hazards;
@@ -170,42 +194,105 @@ std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
 
 } // anonymous namespace
 
-static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
-  std::vector<WmmaHazard> Hazards = findWmmaCoexecHazards(Ctx);
-  if (Hazards.empty())
-    return 0;
-
-  uint32_t Patched = 0;
-  for (const WmmaHazard &H : Hazards) {
-    const InternalDecodedInst &ValuDI = Ctx.Decoded[H.ValuIdx];
-
-    uint64_t TrampolineTextOffset = Ctx.TextSize;
-    for (const Trampoline &T : Ctx.OutTrampolines)
-      TrampolineTextOffset += T.Bytes.size();
-
-    SmallVector<MCInst> Insts;
-    for (int I = 0; I < H.Deficit; ++I)
-      Insts.push_back(Ctx.LS.VNopInst);
-    Insts.push_back(ValuDI.Inst);
-
-    Trampoline T = buildTrampoline(Insts, ValuDI.Offset, ValuDI.Size,
-                                   TrampolineTextOffset, Ctx.LS);
-    if (T.Bytes.empty()) {
-      log() << "hotswap: error: WMMA hazard: buildTrampoline failed at 0x"
-            << utohexstr(ValuDI.Offset) << "\n";
-      continue;
+static bool precomputeWmmaHazardsImpl(PatchContext &Ctx) {
+  std::optional<std::vector<WmmaHazard>> Hazards =
+      findWmmaCoexecHazards(Ctx);
+  if (!Hazards) {
+    Ctx.RequiredPatchFailed = true;
+    return false;
+  }
+  for (const WmmaHazard &H : *Hazards) {
+    if (H.ValuIdx >= Ctx.Decoded.size() || H.Deficit <= 0) {
+      log() << "hotswap: error: invalid precomputed WMMA hazard candidate\n";
+      Ctx.RequiredPatchFailed = true;
+      return false;
     }
-    Ctx.OutTrampolines.push_back(std::move(T));
+    const InternalDecodedInst &DI = Ctx.Decoded[H.ValuIdx];
+    SiteReplacementState &State = Ctx.SiteReplacements[DI.Offset];
+    if (State.Committed ||
+        (State.OriginalSize != 0 && State.OriginalSize != DI.Size)) {
+      log() << "hotswap: error: WMMA hazard candidate at 0x"
+            << utohexstr(DI.Offset)
+            << " conflicts with pre-existing replacement ownership\n";
+      Ctx.RequiredPatchFailed = true;
+      return false;
+    }
+    if (State.RequiredLeadingVNops == 0)
+      Ctx.WmmaHazardSites.push_back(DI.Offset);
+    State.OriginalSize = DI.Size;
+    State.RequiredLeadingVNops =
+        std::max(State.RequiredLeadingVNops, static_cast<unsigned>(H.Deficit));
+  }
+  return true;
+}
 
-    log() << "hotswap: WMMA hazard fix at 0x" << utohexstr(ValuDI.Offset)
-          << ": inserted " << H.Deficit << " v_nop(s)\n";
-    ++Patched;
+static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
+  for (uint64_t Offset : Ctx.WmmaHazardSites) {
+    auto StateIt = Ctx.SiteReplacements.find(Offset);
+    if (StateIt == Ctx.SiteReplacements.end() ||
+        StateIt->second.RequiredLeadingVNops == 0) {
+      log() << "hotswap: error: lost precomputed WMMA hazard state at 0x"
+            << utohexstr(Offset) << "\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+    if (StateIt->second.WmmaHazardComposed)
+      continue;
+    if (StateIt->second.Committed) {
+      log() << "hotswap: error: replacement at 0x" << utohexstr(Offset)
+            << " committed without its WMMA hazard requirement\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+
+    auto DI = llvm::lower_bound(
+        Ctx.Decoded, Offset,
+        [](const InternalDecodedInst &Inst, uint64_t CandidateOffset) {
+          return Inst.Offset < CandidateOffset;
+        });
+    if (DI == Ctx.Decoded.end() || DI->Offset != Offset ||
+        DI->Size != StateIt->second.OriginalSize || Offset > Ctx.TextSize ||
+        DI->Size > Ctx.TextSize - Offset) {
+      log() << "hotswap: error: WMMA hazard source at 0x"
+            << utohexstr(Offset) << " is not a valid current instruction\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+
+    // No per-instruction pass owned this site. Preserve the bytes after all
+    // same-size in-place corrections, then let the central emission helper
+    // prepend the precomputed v_nops and commit the single site owner.
+    SmallVector<uint8_t> Current(Ctx.Text + Offset,
+                                 Ctx.Text + Offset + DI->Size);
+    if (!emitReplacementCode(Ctx, Offset, DI->Size, Current)) {
+      log() << "hotswap: error: could not emit required WMMA hazard fix at 0x"
+            << utohexstr(Offset) << "\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
+
+    StateIt = Ctx.SiteReplacements.find(Offset);
+    if (StateIt == Ctx.SiteReplacements.end() ||
+        !StateIt->second.WmmaHazardComposed) {
+      log() << "hotswap: error: WMMA hazard requirement at 0x"
+            << utohexstr(Offset) << " was not composed by emission\n";
+      Ctx.RequiredPatchFailed = true;
+      return 0;
+    }
   }
 
-  return Patched;
+  if (Ctx.WmmaHazardsComposed != Ctx.WmmaHazardSites.size()) {
+    log() << "hotswap: error: composed " << Ctx.WmmaHazardsComposed << " of "
+          << Ctx.WmmaHazardSites.size()
+          << " precomputed WMMA hazard requirements\n";
+    Ctx.RequiredPatchFailed = true;
+    return 0;
+  }
+  return Ctx.WmmaHazardsComposed;
 }
 
 void registerWmmaHazardPatch(HotswapPatchVTable &VT) {
+  VT.precomputeWmmaHazards = &precomputeWmmaHazardsImpl;
   VT.applyWmmaHazardPatch = &applyWmmaHazardPatchImpl;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
@@ -103,13 +103,6 @@ WmmaNopReq classifyWmmaNops(StringRef Mnemonic) {
   return {4, 4};
 }
 
-int updateWmmaHazardDeficit(DenseMap<size_t, int> &MaxDeficits,
-                            size_t ValuIndex, int Deficit) {
-  int &Maximum = MaxDeficits[ValuIndex];
-  Maximum = std::max(Maximum, Deficit);
-  return Maximum;
-}
-
 namespace {
 
 std::optional<std::vector<WmmaHazard>>
@@ -165,8 +158,8 @@ findWmmaCoexecHazards(const PatchContext &Ctx) {
 
         if (SafeSlots < Req.A0Nops) {
           const int Deficit = Req.A0Nops - SafeSlots;
-          const int MaxDeficit =
-              updateWmmaHazardDeficit(MaxDeficitByValu, ValuIdx, Deficit);
+          int &MaxDeficit = MaxDeficitByValu[ValuIdx];
+          MaxDeficit = std::max(MaxDeficit, Deficit);
           log() << "hotswap: WMMA co-exec hazard at 0x"
                 << utohexstr(WmmaDI.Offset) << ": " << WmmaDI.Mnemonic
                 << " needs " << Req.A0Nops << " v_nops, only " << SafeSlots
@@ -184,7 +177,8 @@ findWmmaCoexecHazards(const PatchContext &Ctx) {
   std::vector<WmmaHazard> Hazards;
   Hazards.reserve(MaxDeficitByValu.size());
   for (size_t I = 0, E = Ctx.Decoded.size(); I != E; ++I)
-    if (auto It = MaxDeficitByValu.find(I); It != MaxDeficitByValu.end())
+    if (DenseMap<size_t, int>::iterator It = MaxDeficitByValu.find(I);
+        It != MaxDeficitByValu.end())
       Hazards.push_back({I, It->second});
 
   log() << "hotswap: WMMA co-exec validation: " << Hazards.size()
@@ -195,8 +189,7 @@ findWmmaCoexecHazards(const PatchContext &Ctx) {
 } // anonymous namespace
 
 static bool precomputeWmmaHazardsImpl(PatchContext &Ctx) {
-  std::optional<std::vector<WmmaHazard>> Hazards =
-      findWmmaCoexecHazards(Ctx);
+  std::optional<std::vector<WmmaHazard>> Hazards = findWmmaCoexecHazards(Ctx);
   if (!Hazards) {
     Ctx.RequiredPatchFailed = true;
     return false;
@@ -228,7 +221,8 @@ static bool precomputeWmmaHazardsImpl(PatchContext &Ctx) {
 
 static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
   for (uint64_t Offset : Ctx.WmmaHazardSites) {
-    auto StateIt = Ctx.SiteReplacements.find(Offset);
+    std::map<uint64_t, SiteReplacementState>::iterator StateIt =
+        Ctx.SiteReplacements.find(Offset);
     if (StateIt == Ctx.SiteReplacements.end() ||
         StateIt->second.RequiredLeadingVNops == 0) {
       log() << "hotswap: error: lost precomputed WMMA hazard state at 0x"
@@ -245,7 +239,7 @@ static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
       return 0;
     }
 
-    auto DI = llvm::lower_bound(
+    std::vector<InternalDecodedInst>::iterator DI = llvm::lower_bound(
         Ctx.Decoded, Offset,
         [](const InternalDecodedInst &Inst, uint64_t CandidateOffset) {
           return Inst.Offset < CandidateOffset;
@@ -253,8 +247,8 @@ static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
     if (DI == Ctx.Decoded.end() || DI->Offset != Offset ||
         DI->Size != StateIt->second.OriginalSize || Offset > Ctx.TextSize ||
         DI->Size > Ctx.TextSize - Offset) {
-      log() << "hotswap: error: WMMA hazard source at 0x"
-            << utohexstr(Offset) << " is not a valid current instruction\n";
+      log() << "hotswap: error: WMMA hazard source at 0x" << utohexstr(Offset)
+            << " is not a valid current instruction\n";
       Ctx.RequiredPatchFailed = true;
       return 0;
     }

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -35,6 +35,11 @@ using namespace llvm;
 namespace COMGR {
 namespace hotswap {
 
+static uint32_t failRequiredScale16Patch(PatchContext &Ctx) {
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -205,19 +210,8 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   if (DI.Size != VOP3PXSize) {
     log() << "hotswap: error: wmma_scale16: unexpected inst size " << DI.Size
           << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
-
-  // Skip offsets another patch has already claimed (Trampoline entries
-  // are appended to OutTrampolines before fixupTrampolineBranches
-  // overwrites the original site with s_branch). Mirrors PR #2's wrap
-  // pass; the previous `Decoded[Idx-1] == s_branch` heuristic never
-  // fired meaningfully because Decoded[] is built from the original
-  // .text and the dispatcher's mnemonic narrowing already filters out
-  // sites the patch has rewritten on a re-rewrite.
-  for (const Trampoline &T : Ctx.OutTrampolines)
-    if (T.OriginalOffset == DI.Offset)
-      return 0;
 
   const uint8_t *Raw = Ctx.Text + DI.Offset;
 
@@ -229,7 +223,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   if (!Src0Base || !Src1Base) {
     log() << "hotswap: error: wmma_scale16: unsupported non-VGPR scale "
           << "encoding at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
 
   bool NeedReductionA = true;
@@ -272,7 +266,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
       ((NeedReductionA || NeedReductionB) && (!T1 || !T2))) {
     log() << "hotswap: error: wmma_scale16: unable to allocate " << ScratchCount
           << " scratch VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
 
   // --- Build VALU preamble for scale reduction ---
@@ -292,7 +286,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
     if (PreambleBytes.empty()) {
       log() << "hotswap: error: wmma_scale16: preamble assembly failed at "
             << "offset 0x" << utohexstr(DI.Offset) << "\n";
-      return 0;
+      return failRequiredScale16Patch(Ctx);
     }
   }
 
@@ -305,7 +299,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   SmallVector<uint8_t> WmmaBytes =
       rewriteScale16ToScale(Raw, DI.Size, NewSrc0Enc, NewSrc1Enc, Ctx.LS);
   if (WmmaBytes.empty())
-    return 0;
+    return failRequiredScale16Patch(Ctx);
 
   // --- Concatenate: VALU preamble + rewritten WMMA → replacement ---
   SmallVector<uint8_t> Replacement;
@@ -314,7 +308,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   Replacement.insert(Replacement.end(), WmmaBytes.begin(), WmmaBytes.end());
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
-    return 0;
+    return failRequiredScale16Patch(Ctx);
 
   KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
   unsigned Extra = Alloc.extraVgprsNeeded();
@@ -501,14 +495,8 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   if (DI.Size != VOP3PXSize) {
     log() << "hotswap: error: wmma_scale16: unexpected 32x16 inst size "
           << DI.Size << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
-
-  // Skip offsets another patch has already claimed. Mirrors the 16x16
-  // path (see patchWmmaScale16_16x16 for the rationale).
-  for (const Trampoline &T : Ctx.OutTrampolines)
-    if (T.OriginalOffset == DI.Offset)
-      return 0;
 
   const uint8_t *Raw = Ctx.Text + DI.Offset;
 
@@ -519,7 +507,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   if (!isVgprEncoding(Src0Enc) || !isVgprEncoding(Src1Enc)) {
     log() << "hotswap: error: wmma_scale16: 32x16 non-VGPR matrix src at "
           << "offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
 
   unsigned ABase = Src0Enc - VgprEncBase;
@@ -534,7 +522,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   if (!ScaleSrc0Base || !ScaleSrc1Base) {
     log() << "hotswap: error: wmma_scale16: 32x16 unsupported non-VGPR "
           << "scale encoding at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
 
   bool NeedReductionA = true;
@@ -581,7 +569,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
     log() << "hotswap: error: wmma_scale16: unable to allocate " << ScratchCount
           << " scratch VGPRs for 32x16 at offset 0x" << utohexstr(DI.Offset)
           << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
 
   // --- Scale reduction preamble (shared by both halves) ---
@@ -601,7 +589,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
     if (PreambleBytes.empty()) {
       log() << "hotswap: error: wmma_scale16: 32x16 preamble assembly failed "
             << "at offset 0x" << utohexstr(DI.Offset) << "\n";
-      return 0;
+      return failRequiredScale16Patch(Ctx);
     }
   }
 
@@ -612,7 +600,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   if (ScaleAStr.empty() || ScaleBStr.empty()) {
     log() << "hotswap: error: wmma_scale16: 32x16 unsupported scale encoding "
           << "at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
+    return failRequiredScale16Patch(Ctx);
   }
 
   SmallVector<uint8_t> Replacement;
@@ -634,7 +622,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
       log() << "hotswap: error: wmma_scale16: 32x16 unsupported src2 "
             << "encoding 0x" << utohexstr(Src2Enc) << " at offset 0x"
             << utohexstr(DI.Offset) << "\n";
-      return 0;
+      return failRequiredScale16Patch(Ctx);
     }
 
     std::string WmmaAsm;
@@ -682,7 +670,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
       log() << "hotswap: error: wmma_scale16: 32x16 half " << Half
             << " assembly produced " << HalfBytes.size() << " bytes (expected "
             << VOP3PXSize << ") at offset 0x" << utohexstr(DI.Offset) << "\n";
-      return 0;
+      return failRequiredScale16Patch(Ctx);
     }
 
     // Same scale_src2 = 0x100 (VGPR0) bake-in as the 16x16 path. The
@@ -698,7 +686,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   }
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
-    return 0;
+    return failRequiredScale16Patch(Ctx);
 
   KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
   unsigned Extra = Alloc.extraVgprsNeeded();

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -67,15 +67,29 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCSchedule.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstring>
+#include <limits>
 #include <optional>
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
+
+bool hasDirectControlFlowTargetInWindowInterior(
+    const std::optional<DenseSet<uint64_t>> &Targets, uint64_t Begin,
+    uint64_t End) {
+  if (!Targets || Begin >= End)
+    return true;
+  return llvm::any_of(*Targets, [=](uint64_t Target) {
+    return Target > Begin && Target < End;
+  });
+}
+
 namespace {
 
 // -- Split family table ------------------------------------------------------
@@ -430,6 +444,53 @@ std::string formatVgprRange(int Base, int Count) {
   return formatv("v[{0}:{1}]", Base, Base + Count - 1).str();
 }
 
+// Recover the persistent VGPR-MSB mode from the immutable whole-function CFG
+// fixed point. Equal predecessor states, including loop backedges, retain an
+// exact mode; conflicting paths, opaque calls, and unknown MODE writes remain
+// unknown and fail closed.
+std::optional<unsigned> findActiveVgprMsbMode(const PatchContext &Ctx,
+                                              size_t Idx) {
+  if (Idx >= Ctx.VgprMsbModeBefore.size())
+    return std::nullopt;
+  // A mandatory A0-incompatible WMMA must still be rewritten in a block that
+  // a fully validated CFG proves unreachable. Its MODE is semantically
+  // unobservable, so use the ABI entry value. Unanalyzed functions and
+  // reachable paths with conflicting MODE values continue to fail closed.
+  if (Ctx.VgprMsbModeBefore[Idx] == VgprMsbUnreachable)
+    return 0;
+  if (Ctx.VgprMsbModeBefore[Idx] < 0)
+    return std::nullopt;
+  return static_cast<unsigned>(Ctx.VgprMsbModeBefore[Idx]);
+}
+
+enum class VgprMsbOperand : unsigned {
+  Src0 = 0,
+  Src1 = 2,
+  Src2 = 4,
+  Dst = 6,
+};
+
+unsigned getVgprMsbs(unsigned Mode, VgprMsbOperand Operand) {
+  return (Mode >> static_cast<unsigned>(Operand)) & 0x3;
+}
+
+void setVgprMsbs(unsigned &Mode, VgprMsbOperand Operand, unsigned Msbs) {
+  const unsigned Shift = static_cast<unsigned>(Operand);
+  Mode = (Mode & ~(0x3u << Shift)) | (Msbs << Shift);
+}
+
+bool advanceVgprMsbMode(int &Base, VgprMsbOperand Operand, unsigned OldMode,
+                        unsigned &NewMode) {
+  unsigned OldMsbs = getVgprMsbs(OldMode, Operand);
+  unsigned PhysicalBase = (OldMsbs << 8) + static_cast<unsigned>(Base);
+  unsigned NewMsbs = PhysicalBase >> 8;
+  if (NewMsbs > 3)
+    return false;
+  Base = static_cast<int>(PhysicalBase & 0xff);
+  setVgprMsbs(NewMode, Operand, NewMsbs);
+  return true;
+}
+
 // -- Operand validation -----------------------------------------------------
 
 bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
@@ -479,7 +540,9 @@ bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
 // second half, src2 = dst (the carry from the first half).
 std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
                                               const PrintedAsm &P,
-                                              const WmmaOps &R) {
+                                              const WmmaOps &R,
+                                              unsigned ActiveVgprMsbMode,
+                                              bool &UsesVgprMsbTransition) {
   assert(R.Dst.second > 0 && (R.Src2IsImm || R.Src2.second == R.Dst.second));
   assert(R.Src0.second > 0 && R.Src0.second % 2 == 0);
   assert(R.Src1.second > 0 && R.Src1.second % 2 == 0);
@@ -496,18 +559,44 @@ std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
     return {};
 
   std::vector<std::string> Out;
-  Out.reserve(2);
+  Out.reserve(5);
+  UsesVgprMsbTransition = false;
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}", Replacement, Dst,
                         formatVgprRange(R.Src0.first, AHalf),
                         formatVgprRange(R.Src1.first, BHalf), Src2Printed,
                         *ModFirst)
                     .str());
+
+  int Src0HiBase = R.Src0.first + AHalf;
+  int Src1HiBase = R.Src1.first + BHalf;
+  unsigned OldMode = ActiveVgprMsbMode;
+  unsigned NewMode = OldMode;
+  if (!advanceVgprMsbMode(Src0HiBase, VgprMsbOperand::Src0, OldMode, NewMode) ||
+      !advanceVgprMsbMode(Src1HiBase, VgprMsbOperand::Src1, OldMode, NewMode))
+    return {};
+
+  // The upper half uses dst as src2, so src2 must select the incoming
+  // destination bank even when neither source slice crossed v255.
+  setVgprMsbs(NewMode, VgprMsbOperand::Src2,
+              getVgprMsbs(OldMode, VgprMsbOperand::Dst));
+
+  if (NewMode != OldMode) {
+    UsesVgprMsbTransition = true;
+    // Immediate bits [15:8] record the previous mode. Restore the exact
+    // incoming mode before returning from the split trampoline.
+    unsigned SetUpperMode = NewMode | (OldMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", SetUpperMode).str());
+  }
+
   // Second half: src2 = dst (the carry).
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}", Replacement, Dst,
-                        formatVgprRange(R.Src0.first + AHalf, AHalf),
-                        formatVgprRange(R.Src1.first + BHalf, BHalf), Dst,
-                        *ModSecond)
+                        formatVgprRange(Src0HiBase, AHalf),
+                        formatVgprRange(Src1HiBase, BHalf), Dst, *ModSecond)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned RestoreMode = OldMode | (NewMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", RestoreMode).str());
+  }
   return Out;
 }
 
@@ -515,9 +604,9 @@ std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
 // src2 are split in half by M. The replacement uses the f8f6f4 WMMA with
 // both matrix format modifiers forced to MATRIX_FMT_FP4 so the data layout
 // matches the original f4 instruction.
-std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
-                                            const PrintedAsm &P,
-                                            const WmmaOps &R) {
+std::vector<std::string>
+buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
+                   unsigned ActiveVgprMsbMode, bool &UsesVgprMsbTransition) {
   assert(R.Dst.second > 0 && R.Dst.second % 2 == 0);
   assert(R.Src2IsImm || R.Src2.second == R.Dst.second);
   assert(R.Src0.second > 0 && R.Src0.second % 2 == 0);
@@ -526,12 +615,22 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
   int DstHalf = R.Dst.second / 2;
   int AHalf = R.Src0.second / 2;
   StringRef B = P.Operands[2]; // broadcast: same printer-canonical form
+  int DstHiBase = R.Dst.first + DstHalf;
+  int Src0HiBase = R.Src0.first + AHalf;
+  int Src2HiBase = R.Src2IsImm ? 0 : R.Src2.first + DstHalf;
+  unsigned OldMode = ActiveVgprMsbMode;
+  unsigned NewMode = OldMode;
+  if (!advanceVgprMsbMode(DstHiBase, VgprMsbOperand::Dst, OldMode, NewMode) ||
+      !advanceVgprMsbMode(Src0HiBase, VgprMsbOperand::Src0, OldMode, NewMode) ||
+      (!R.Src2IsImm &&
+       !advanceVgprMsbMode(Src2HiBase, VgprMsbOperand::Src2, OldMode, NewMode)))
+    return {};
+
   // src2 is preserved on both halves when imm; sliced when VGPR.
   std::string CLo = R.Src2IsImm ? P.Operands[3].str()
                                 : formatVgprRange(R.Src2.first, DstHalf);
-  std::string CHi = R.Src2IsImm
-                        ? P.Operands[3].str()
-                        : formatVgprRange(R.Src2.first + DstHalf, DstHalf);
+  std::string CHi =
+      R.Src2IsImm ? P.Operands[3].str() : formatVgprRange(Src2HiBase, DstHalf);
   // Matrix format modifiers are required by the f8f6f4 destination opcode
   // and not present on the f4 source opcode, so the splitter appends them
   // explicitly. Modifier suffix from the source is preserved on both halves
@@ -544,49 +643,449 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
     return {};
 
   std::vector<std::string> Out;
-  Out.reserve(2);
+  Out.reserve(4);
+  UsesVgprMsbTransition = NewMode != OldMode;
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first, DstHalf),
                         formatVgprRange(R.Src0.first, AHalf), B, CLo, FmtSuffix,
                         *Mod)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned SetUpperMode = NewMode | (OldMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", SetUpperMode).str());
+  }
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
-                        formatVgprRange(R.Dst.first + DstHalf, DstHalf),
-                        formatVgprRange(R.Src0.first + AHalf, AHalf), B, CHi,
-                        FmtSuffix, *Mod)
+                        formatVgprRange(DstHiBase, DstHalf),
+                        formatVgprRange(Src0HiBase, AHalf), B, CHi, FmtSuffix,
+                        *Mod)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned RestoreMode = OldMode | (NewMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", RestoreMode).str());
+  }
   return Out;
+}
+
+struct ProtectedWmmaSourceWindow {
+  uint64_t Offset = 0;
+  uint32_t Size = 0;
+  size_t DelayIndex = 0;
+  size_t LastMovedIndex = 0;
+  size_t SecondTargetIndex = 0;
+  unsigned FirstInstId = 0;
+  unsigned SecondInstId = 0;
+  bool RetainsSecondTarget = false;
+
+  bool demergesCombinedDelay() const { return SecondInstId != 0; }
+};
+
+struct CombinedDelayFields {
+  unsigned FirstInstId = 0;
+  unsigned Skip = 0;
+  unsigned SecondInstId = 0;
+};
+
+std::optional<CombinedDelayFields>
+decodeDelayFields(const InternalDecodedInst &Delay) {
+  if (Delay.Mnemonic != "s_delay_alu" || Delay.Inst.getNumOperands() != 1 ||
+      !Delay.Inst.getOperand(0).isImm())
+    return std::nullopt;
+
+  uint64_t Imm = static_cast<uint64_t>(Delay.Inst.getOperand(0).getImm());
+  if ((Imm & ~uint64_t{0x7FF}) != 0)
+    return std::nullopt;
+
+  CombinedDelayFields Fields{static_cast<unsigned>(Imm & 0xF),
+                             static_cast<unsigned>((Imm >> 4) & 0x7),
+                             static_cast<unsigned>((Imm >> 7) & 0xF)};
+  if (Fields.FirstInstId >= 12 || Fields.SecondInstId >= 12 ||
+      Fields.Skip > 5 || (Fields.SecondInstId == 0 && Fields.Skip != 0))
+    return std::nullopt;
+  return Fields;
+}
+
+std::optional<InternalDecodedInst>
+decodeCurrentWindowMember(const PatchContext &Ctx,
+                          const InternalDecodedInst &Original) {
+  if (Original.Mnemonic == "<unknown>" || Original.Mnemonic == "<replaced>" ||
+      Original.Offset > Ctx.TextSize ||
+      Original.Size > Ctx.TextSize - Original.Offset)
+    return std::nullopt;
+  std::vector<InternalDecodedInst> Current;
+  if (!decodeTextSection(Ctx.Text + Original.Offset, Original.Size, Ctx.LS,
+                         Current) ||
+      Current.size() != 1 || Current.front().Offset != 0 ||
+      Current.front().Size != Original.Size)
+    return std::nullopt;
+  Current.front().Offset = Original.Offset;
+  return std::move(Current.front());
+}
+
+namespace AmdgpuDelayTSFlags {
+static constexpr uint64_t TRANS = UINT64_C(1) << 16;
+static constexpr uint64_t IsWMMA = UINT64_C(1) << 59;
+static constexpr uint64_t IsSWMMAC = UINT64_C(1) << 63;
+} // namespace AmdgpuDelayTSFlags
+
+struct DelayPipelineResources {
+  bool HasValu = false;
+  bool HasTransValu = false;
+  bool HasXdl = false;
+};
+
+std::optional<DelayPipelineResources>
+getDelayPipelineResources(const InternalDecodedInst &DI,
+                          const PatchContext &Ctx) {
+  if (!Ctx.LS.STI || !Ctx.LS.MCII)
+    return std::nullopt;
+  const MCSchedModel &Model = Ctx.LS.STI->getSchedModel();
+  if (!Model.hasInstrSchedModel())
+    return std::nullopt;
+
+  unsigned SchedClass = Ctx.LS.MCII->get(DI.Inst.getOpcode()).getSchedClass();
+  for (unsigned Depth = 0; Depth != 8; ++Depth) {
+    if (SchedClass >= Model.NumSchedClasses)
+      return std::nullopt;
+    const MCSchedClassDesc *Desc = Model.getSchedClassDesc(SchedClass);
+    if (!Desc->isValid())
+      return std::nullopt;
+    if (!Desc->isVariant()) {
+      DelayPipelineResources Resources;
+      for (const MCWriteProcResEntry *
+               It = Ctx.LS.STI->getWriteProcResBegin(Desc),
+              *End = Ctx.LS.STI->getWriteProcResEnd(Desc);
+           It != End; ++It) {
+        unsigned ResourceIndex = It->ProcResourceIdx;
+        for (unsigned ResourceDepth = 0;
+             ResourceIndex != 0 &&
+             ResourceDepth != Model.getNumProcResourceKinds();
+             ++ResourceDepth) {
+          if (ResourceIndex >= Model.getNumProcResourceKinds())
+            return std::nullopt;
+          const MCProcResourceDesc *Resource =
+              Model.getProcResource(ResourceIndex);
+          StringRef Name = Resource->Name ? Resource->Name : "";
+          Resources.HasValu |= Name == "HWVALU";
+          Resources.HasTransValu |= Name == "HWTransVALU";
+          Resources.HasXdl |= Name == "HWXDL";
+          ResourceIndex = Resource->SuperIdx;
+        }
+      }
+      if (Desc->NumWriteProcResEntries == 0)
+        return std::nullopt;
+      return Resources;
+    }
+
+    unsigned Resolved = Ctx.LS.STI->resolveVariantSchedClass(
+        SchedClass, &DI.Inst, Ctx.LS.MCII.get(), Model.getProcessorID());
+    if (Resolved == 0 || Resolved == SchedClass)
+      return std::nullopt;
+    SchedClass = Resolved;
+  }
+  return std::nullopt;
+}
+
+// Match AMDGPUInsertDelayAlu's dependency class without duplicating an opcode
+// list. TRANS32 uses the transcendental pipeline without the ordinary VALU
+// pipeline, while gfx1250 XDL WMMA uses HWXDL. In particular, F64 DPMACC and
+// non-XDL WMMA must not advance the TRANS ordinal. An incomplete scheduling
+// model is unknown rather than silently selecting the wrong producer.
+std::optional<bool> isDelayTransInstruction(const InternalDecodedInst &DI,
+                                            const PatchContext &Ctx) {
+  uint64_t Flags = Ctx.LS.MCII->get(DI.Inst.getOpcode()).TSFlags;
+  const bool HasTransFlag = (Flags & AmdgpuDelayTSFlags::TRANS) != 0;
+  const bool IsWmmaLike =
+      (Flags & (AmdgpuDelayTSFlags::IsWMMA | AmdgpuDelayTSFlags::IsSWMMAC)) !=
+      0;
+  if (!HasTransFlag && !IsWmmaLike)
+    return false;
+
+  std::optional<DelayPipelineResources> Resources =
+      getDelayPipelineResources(DI, Ctx);
+  if (!Resources)
+    return std::nullopt;
+  if (IsWmmaLike)
+    return Resources->HasXdl;
+  if (!Resources->HasTransValu)
+    return std::nullopt;
+  return !Resources->HasValu;
+}
+
+bool isPcIndependentDelayWindowMember(const InternalDecodedInst &DI,
+                                      const PatchContext &Ctx) {
+  if (!Ctx.LS.MIA || DI.Mnemonic == "<unknown>" ||
+      DI.Mnemonic == "<replaced>" || DI.Mnemonic == "s_delay_alu" ||
+      DI.Mnemonic == "s_clause" || DI.Mnemonic == "s_set_vgpr_msb" ||
+      // Tensor DMA instructions are explicitly linked-PC-sensitive on A0.
+      DI.Mnemonic == "tensor_load_to_lds" ||
+      StringRef(DI.Mnemonic).contains("_pc_"))
+    return false;
+  const MCInstrDesc &Desc = Ctx.LS.MCII->get(DI.Inst.getOpcode());
+  return !Desc.isTerminator() && !Desc.isBranch() && !Desc.isCall() &&
+         !Desc.isReturn() &&
+         !Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI);
+}
+
+bool sourceRangeOverlapsQueuedReplacement(const PatchContext &Ctx,
+                                          uint64_t Begin, uint64_t End) {
+  for (const Trampoline &T : Ctx.OutTrampolines) {
+    std::optional<uint64_t> TEnd = checkedAddUint64(
+        T.OriginalOffset, T.OriginalSize, "queued replacement source end");
+    if (!TEnd || (Begin < *TEnd && T.OriginalOffset < End))
+      return true;
+  }
+  return false;
+}
+
+bool sourceRangeOverlapsTextSymbolExtent(const PatchContext &Ctx,
+                                         uint64_t Begin, uint64_t End) {
+  if (!Ctx.TextSymbolExtents)
+    return true;
+  auto It =
+      llvm::lower_bound(*Ctx.TextSymbolExtents, Begin,
+                        [](const ElfView::TextOffsetRange &Extent,
+                           uint64_t Offset) { return Extent.End <= Offset; });
+  return It != Ctx.TextSymbolExtents->end() && It->Begin < End;
+}
+
+// A delay-protected WMMA cannot be replaced at its linked address alone: the
+// surviving s_delay_alu would describe the source branch rather than the
+// replacement. Recover the unique owner from the encoded instruction span.
+// For a combined delay, move every position-independent member before the
+// second target, split the WMMA in that ordered stream, and use the last moved
+// dword for the reconstructed second delay. No instruction mnemonic or kernel
+// schedule determines the geometry.
+std::optional<ProtectedWmmaSourceWindow>
+findProtectedWmmaSourceWindow(const PatchContext &Ctx, size_t WmmaIndex) {
+  const InternalDecodedInst &Wmma = Ctx.Decoded[WmmaIndex];
+  auto Fail =
+      [&](StringRef Reason) -> std::optional<ProtectedWmmaSourceWindow> {
+    log() << "hotswap: error: WMMA split: protected site at 0x"
+          << utohexstr(Wmma.Offset) << " " << Reason << "\n";
+    return std::nullopt;
+  };
+
+  if (WmmaIndex == 0 || !Ctx.LS.MIA || !Ctx.DirectControlFlowTargets)
+    return Fail("has no supported preceding delay window");
+  if (Ctx.HasUnknownArbitraryIndirectTarget)
+    return Fail("cannot be relocated with an unresolved indirect entry");
+
+  constexpr size_t MaxClauseSpan = 64;
+  const size_t FirstPossibleOwner =
+      WmmaIndex > MaxClauseSpan ? WmmaIndex - MaxClauseSpan : 0;
+  size_t DelayIndex = 0;
+  unsigned DelayOwners = 0;
+  std::optional<CombinedDelayFields> Fields;
+  for (size_t I = FirstPossibleOwner; I != WmmaIndex; ++I) {
+    const InternalDecodedInst &Candidate = Ctx.Decoded[I];
+    const size_t Distance = WmmaIndex - I;
+    if (Candidate.Mnemonic == "s_delay_alu" &&
+        getDelayProtectedSpan(Candidate) >= Distance) {
+      ++DelayOwners;
+      std::optional<InternalDecodedInst> Current =
+          decodeCurrentWindowMember(Ctx, Candidate);
+      std::optional<CombinedDelayFields> CandidateFields =
+          Current ? decodeDelayFields(*Current) : std::nullopt;
+      if (!CandidateFields || getDelayProtectedSpan(*Current) < Distance)
+        continue;
+      DelayIndex = I;
+      Fields = *CandidateFields;
+      continue;
+    }
+    if (Candidate.Mnemonic == "s_clause" &&
+        Candidate.Inst.getNumOperands() == 1 &&
+        Candidate.Inst.getOperand(0).isImm()) {
+      const unsigned ClauseSpan =
+          (static_cast<unsigned>(Candidate.Inst.getOperand(0).getImm()) & 63u) +
+          1;
+      if (ClauseSpan >= Distance)
+        return Fail("overlaps another delay or hard clause");
+    }
+  }
+  if (DelayOwners != 1 || !Fields)
+    return Fail(DelayOwners > 1 ? "has ambiguous delay ownership"
+                                : "has no supported preceding delay window");
+
+  const InternalDecodedInst *Delay = &Ctx.Decoded[DelayIndex];
+  const unsigned Span = getDelayProtectedSpan(*Delay);
+  if (Span == 0 || Span > Ctx.Decoded.size() - DelayIndex - 1)
+    return Fail("has an invalid delay target layout");
+  const size_t SecondTargetIndex = DelayIndex + Span;
+  if (WmmaIndex > SecondTargetIndex)
+    return Fail("has an invalid delay target layout");
+
+  const bool DemergeCombinedDelay = Span > 1;
+  if (DemergeCombinedDelay &&
+      (Fields->FirstInstId == 0 || Fields->SecondInstId == 0 ||
+       Span != Fields->Skip + 1))
+    return Fail("has an unsupported combined dependency graph");
+  const bool RetainsSecondTarget =
+      DemergeCombinedDelay && WmmaIndex < SecondTargetIndex;
+  const size_t LastMovedIndex =
+      RetainsSecondTarget ? SecondTargetIndex - 1 : WmmaIndex;
+  if (RetainsSecondTarget && Ctx.Decoded[LastMovedIndex].Size != MinInstSize)
+    return Fail("has no dword slot for the reconstructed second delay");
+
+  // collectRelocationProtectedOffsets does not mark the directive itself.
+  // Therefore a protected Delay proves that an earlier clause or another
+  // delay overlaps this two-instruction window.
+  if (Ctx.RelocationProtectedOffsets.contains(Delay->Offset))
+    return Fail("overlaps another delay or hard clause");
+
+  std::optional<ElfView::FunctionTextRange> DelayFunction =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Delay->Offset);
+  std::optional<ElfView::FunctionTextRange> WmmaFunction =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Wmma.Offset);
+  if (!DelayFunction || !WmmaFunction ||
+      DelayFunction->Begin != WmmaFunction->Begin ||
+      DelayFunction->End != WmmaFunction->End)
+    return Fail("does not share a proven function with its delay");
+  if (Ctx.IndirectControlFlowFunctions.contains(WmmaFunction->Begin))
+    return Fail("is in a function with an ambiguous indirect entry");
+
+  std::optional<uint64_t> End =
+      RetainsSecondTarget
+          ? std::optional<uint64_t>(Ctx.Decoded[LastMovedIndex].Offset)
+          : checkedAddUint64(Wmma.Offset, Wmma.Size,
+                             "delay-protected WMMA window end");
+  if (!End || *End <= Delay->Offset ||
+      *End - Delay->Offset > std::numeric_limits<uint32_t>::max())
+    return Fail("has an invalid source-window extent");
+  std::optional<uint64_t> ClaimEnd = checkedAddUint64(
+      Ctx.Decoded[LastMovedIndex].Offset, Ctx.Decoded[LastMovedIndex].Size,
+      "delay-protected WMMA claimed-window end");
+  const uint64_t EntryCheckEnd =
+      RetainsSecondTarget ? Ctx.Decoded[SecondTargetIndex].Offset : *End;
+  if (!ClaimEnd ||
+      sourceRangeOverlapsQueuedReplacement(Ctx, Delay->Offset, *ClaimEnd))
+    return Fail("overlaps an existing replacement source");
+  if (sourceRangeOverlapsTextSymbolExtent(Ctx, Delay->Offset, *ClaimEnd))
+    return Fail("overlaps a sized non-callable text symbol");
+  if (hasDirectControlFlowTargetInWindowInterior(Ctx.DirectControlFlowTargets,
+                                                 Delay->Offset, EntryCheckEnd))
+    return Fail("has a direct entry into the source-window interior "
+                "(including symbol entries)");
+  if (Delay->Offset > Ctx.TextSize || EntryCheckEnd > Ctx.TextSize)
+    return Fail("has a source window outside .text");
+
+  uint64_t ExpectedOffset = Delay->Offset;
+  for (size_t I = DelayIndex; I <= SecondTargetIndex; ++I) {
+    const InternalDecodedInst &Original = Ctx.Decoded[I];
+    std::optional<InternalDecodedInst> Current =
+        decodeCurrentWindowMember(Ctx, Original);
+    std::optional<ElfView::FunctionTextRange> Function =
+        Ctx.Elf.findFunctionTextRangeAtOffset(Original.Offset);
+    if (!Current || !Function || Function->Begin != DelayFunction->Begin ||
+        Function->End != DelayFunction->End ||
+        Original.Offset != ExpectedOffset)
+      return Fail("has a non-contiguous current instruction window");
+    ExpectedOffset += Original.Size;
+
+    if (I == WmmaIndex && Current->Inst.getOpcode() != Wmma.Inst.getOpcode())
+      return Fail("has a modified WMMA source instruction");
+
+    if (I <= LastMovedIndex &&
+        Ctx.ClaimedReplacementOffsets.contains(Original.Offset))
+      return Fail("overlaps an existing atomic replacement window");
+    if (I != DelayIndex && I != WmmaIndex && I <= LastMovedIndex &&
+        !isPcIndependentDelayWindowMember(*Current, Ctx))
+      return Fail("has a non-relocatable instruction in its delay window");
+    if (I != DelayIndex && (Current->Mnemonic == "s_delay_alu" ||
+                            Current->Mnemonic == "s_clause" ||
+                            Current->Mnemonic == "s_set_vgpr_msb"))
+      return Fail("has an unsupported nested dependency graph");
+    // Every moved position is claimed after this atomic relocation. A later
+    // per-instruction patch there would be silently skipped by the outer
+    // dispatcher, so reject before mutating bytes. The retained second target
+    // is deliberately excluded: it remains at its linked address and can
+    // compose with the reconstructed delay (tensor masking relies on this).
+    if (I != DelayIndex && I != WmmaIndex && I <= LastMovedIndex &&
+        requiresIndependentInstructionRewrite(Ctx, I)) {
+      log() << "hotswap: error: WMMA split: delay-window member at 0x"
+            << utohexstr(Original.Offset)
+            << " requires a separate HotSwap patch\n";
+      return Fail("would suppress another required HotSwap patch");
+    }
+  }
+
+  return ProtectedWmmaSourceWindow{
+      Delay->Offset,
+      static_cast<uint32_t>(*End - Delay->Offset),
+      DelayIndex,
+      LastMovedIndex,
+      SecondTargetIndex,
+      DemergeCombinedDelay ? Fields->FirstInstId : 0,
+      DemergeCombinedDelay ? Fields->SecondInstId : 0,
+      RetainsSecondTarget};
+}
+
+std::optional<unsigned> remapSecondDelayDependency(
+    const PatchContext &Ctx, const ProtectedWmmaSourceWindow &Window,
+    size_t WmmaIndex, ArrayRef<uint8_t> WmmaReplacement) {
+  unsigned Dependency = Window.SecondInstId;
+  if (!Window.RetainsSecondTarget || Dependency < 5 || Dependency > 7)
+    return Dependency;
+
+  std::optional<InternalDecodedInst> Source =
+      decodeCurrentWindowMember(Ctx, Ctx.Decoded[WmmaIndex]);
+  std::optional<bool> SourceIsTrans =
+      Source ? isDelayTransInstruction(*Source, Ctx) : std::nullopt;
+  if (!SourceIsTrans || !*SourceIsTrans)
+    return std::nullopt;
+
+  std::vector<InternalDecodedInst> Split;
+  if (!decodeTextSection(WmmaReplacement.data(), WmmaReplacement.size(), Ctx.LS,
+                         Split))
+    return std::nullopt;
+  unsigned ReplacementTrans = 0;
+  for (const InternalDecodedInst &DI : Split) {
+    std::optional<bool> IsTrans = isDelayTransInstruction(DI, Ctx);
+    if (!IsTrans)
+      return std::nullopt;
+    ReplacementTrans += *IsTrans;
+  }
+  if (ReplacementTrans == 0)
+    return std::nullopt;
+
+  // Instid counts prior operations in its dependency class. Instructions
+  // after the source WMMA retain their ordinal. The original WMMA maps to the
+  // last TRANS in its replacement and therefore also retains its ordinal.
+  // Only a producer older than the source shifts by the net extra TRANS count.
+  unsigned LaterTrans = 0;
+  for (size_t I = WmmaIndex + 1; I <= Window.LastMovedIndex; ++I) {
+    std::optional<InternalDecodedInst> Current =
+        decodeCurrentWindowMember(Ctx, Ctx.Decoded[I]);
+    if (!Current)
+      return std::nullopt;
+    std::optional<bool> IsTrans = isDelayTransInstruction(*Current, Ctx);
+    if (!IsTrans)
+      return std::nullopt;
+    LaterTrans += *IsTrans;
+  }
+
+  unsigned Ordinal = Dependency - 4;
+  if (Ordinal <= LaterTrans + 1)
+    return Dependency;
+  const unsigned ExtraTrans = ReplacementTrans - 1;
+  if (ExtraTrans > 3 || Ordinal > 3 - ExtraTrans)
+    return std::nullopt;
+  return 4 + Ordinal + ExtraTrans;
 }
 
 } // anonymous namespace
 
-// Return-value semantics (current shared dispatcher API in b0a0.cpp):
-//   0  = either "this patch did not match the instruction" OR "matched
-//        but failed to apply" -- the dispatcher cannot distinguish the
-//        two and will fall through to the next patch class. For WMMA
-//        split mnemonics no other patch class will match, so a
-//        matched-but-failed case results in the rewriter returning
-//        SUCCESS at the API level with the original A0-incompatible
-//        opcode left in .text. The runtime will then fail to load (or
-//        worse, mis-execute) the kernel with no clear error attribution.
-//   N>0 = "matched, applied N patches" (this splitter only ever returns
-//        1 since it splits one source WMMA into one trampoline).
-//
-// chinmaydd flagged this on PR #2379 as a cross-cutting concern across
-// every patch in the hotswap subsystem: the shared `uint32_t (*)(
-// PatchContext&, size_t)` signature in b0a0.cpp's weak-stub dispatcher
-// has the same ambiguity for in-place patches (#2222), the WMMA hazard
-// patch (#2265), and any future patch. A proper fix is a separate
-// follow-up that changes the dispatcher's return type to an enum
-// (NoMatch / Patched / Failed) or threads a `bool *Aborted` through
-// PatchContext, with the dispatcher checking the failure flag and
-// short-circuiting the rewrite with AMD_COMGR_STATUS_ERROR rather than
-// silently leaving the original opcode in .text.
-//
-// For now: every "matched but failed" path below logs an error via
-// log() (so the failure is at least visible when AMD_COMGR_EMIT_VERBOSE_LOGS
-// is set) and returns 0. The early "did not match" path returns 0
-// without logging.
+bool isWmmaSplitPatchCandidate(StringRef Mnemonic) {
+  return lookupSplitRule(Mnemonic).has_value();
+}
+
+// The dispatcher uses zero for both "no match" and "failed". Once a split
+// rule matches, set RequiredPatchFailed on every failure so the original
+// A0-incompatible WMMA can never be returned as a successful rewrite.
+static uint32_t failWmmaSplit(PatchContext &Ctx) {
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
 
@@ -594,11 +1093,16 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!Match)
     return 0; // Did NOT match -- correct dispatcher fall-through.
 
-  // ----- All return-0 paths below are MATCHED-BUT-FAILED -----
-  // Until the dispatcher API is refactored to distinguish these cleanly,
-  // each of these is a silent miscompile risk for the runtime; the log()
-  // line is the only signal the user gets that a recognized opcode was
-  // left in .text.
+  // Snapshot the original relocation constraint before VGPR-MSB handling adds
+  // the split site to the set to protect its generated mode transitions.
+  const bool WasRelocationProtected =
+      Ctx.RelocationProtectedOffsets.contains(DI.Offset);
+  std::optional<ProtectedWmmaSourceWindow> ProtectedWindow;
+  if (WasRelocationProtected) {
+    ProtectedWindow = findProtectedWmmaSourceWindow(Ctx, Idx);
+    if (!ProtectedWindow)
+      return failWmmaSplit(Ctx);
+  }
 
   // Structural sanity check against the opcode side. Every WMMA variant this
   // patch handles has exactly one destination operand at the MCInstrDesc
@@ -609,7 +1113,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (MCID.getNumDefs() != 1) {
     log() << "hotswap: error: WMMA split: " << DI.Mnemonic << " has "
           << MCID.getNumDefs() << " defs, expected 1\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
   std::optional<WmmaOps> Ops =
@@ -617,11 +1121,11 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!Ops) {
     log() << "hotswap: error: WMMA split: could not extract operands from "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
   if (!validateSplitOperands(Match->Kind, *Ops, DI.Mnemonic))
-    return 0; // matched-but-failed (validateSplitOperands logs the reason)
+    return failWmmaSplit(Ctx);
 
   // Print the source instruction in canonical asm form. The printer is the
   // authoritative source for src2 inline-immediate formatting (FP inline
@@ -636,20 +1140,48 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!P) {
     log() << "hotswap: error: WMMA split: could not parse printed form of "
           << DI.Mnemonic << ": " << StringRef(PrintedBuf).trim() << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
+  }
+
+  bool UsesVgprMsbTransition = false;
+  bool NeedsKnownVgprMsbMode = Match->Kind == SplitKind::Split128to64FP8BF8;
+  if (Match->Kind == SplitKind::Split32x16to16x16F4) {
+    NeedsKnownVgprMsbMode =
+        Ops->Dst.first + Ops->Dst.second / 2 > 255 ||
+        Ops->Src0.first + Ops->Src0.second / 2 > 255 ||
+        (!Ops->Src2IsImm && Ops->Src2.first + Ops->Dst.second / 2 > 255);
+  }
+
+  unsigned ActiveVgprMsbMode = 0;
+  if (NeedsKnownVgprMsbMode) {
+    std::optional<unsigned> Mode = findActiveVgprMsbMode(Ctx, Idx);
+    if (!Mode) {
+      log() << "hotswap: error: WMMA split: cannot determine VGPR-MSB mode "
+               "for "
+            << DI.Mnemonic << " at offset 0x" << utohexstr(DI.Offset) << "\n";
+      return failWmmaSplit(Ctx);
+    }
+    ActiveVgprMsbMode = *Mode;
   }
 
   std::vector<std::string> AsmLines;
   switch (Match->Kind) {
   case SplitKind::Split128to64FP8BF8:
-    AsmLines = buildSplit128to64Asm(Match->Replacement, *P, *Ops);
+    AsmLines = buildSplit128to64Asm(Match->Replacement, *P, *Ops,
+                                    ActiveVgprMsbMode, UsesVgprMsbTransition);
     break;
   case SplitKind::Split32x16to16x16F4:
-    AsmLines = buildSplit32x16Asm(Match->Replacement, *P, *Ops);
+    AsmLines = buildSplit32x16Asm(Match->Replacement, *P, *Ops,
+                                  ActiveVgprMsbMode, UsesVgprMsbTransition);
     break;
   }
-  if (AsmLines.empty())
-    return 0; // matched-but-failed (build*Asm rejected an unsupported modifier)
+  if (AsmLines.empty()) {
+    log() << "hotswap: error: WMMA split: could not build replacement for "
+          << DI.Mnemonic << "\n";
+    return failWmmaSplit(Ctx);
+  }
+  if (UsesVgprMsbTransition)
+    protectNonClauseRelocationOffset(Ctx, DI.Offset);
 
   // Assemble the split sequence and defer trampoline emission to
   // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
@@ -659,16 +1191,101 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (Replacement.empty()) {
     log() << "hotswap: error: WMMA split: trampoline assembly failed for "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
-  }
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement)) {
-    log() << "hotswap: error: WMMA split: could not emit trampoline for "
-          << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
+  uint64_t SourceOffset = DI.Offset;
+  uint32_t SourceSize = DI.Size;
+  SmallVector<uint8_t> DeferredDelayBytes;
+  if (ProtectedWindow) {
+    const InternalDecodedInst &Delay = Ctx.Decoded[ProtectedWindow->DelayIndex];
+    SmallVector<uint8_t> WithDelay;
+    if (ProtectedWindow->demergesCombinedDelay()) {
+      std::optional<unsigned> SecondInstId =
+          remapSecondDelayDependency(Ctx, *ProtectedWindow, Idx, Replacement);
+      if (!SecondInstId) {
+        log() << "hotswap: error: WMMA split: combined s_delay_alu at 0x"
+              << utohexstr(Delay.Offset)
+              << " has an unrepresentable TRANS dependency after split\n";
+        return failWmmaSplit(Ctx);
+      }
+      SmallVector<uint8_t> FirstDelayBytes = assembleSingleInst(
+          "s_delay_alu " + std::to_string(ProtectedWindow->FirstInstId),
+          Ctx.LS);
+      DeferredDelayBytes = assembleSingleInst(
+          "s_delay_alu " + std::to_string(*SecondInstId), Ctx.LS);
+      if (FirstDelayBytes.size() != MinInstSize ||
+          DeferredDelayBytes.size() != MinInstSize) {
+        log() << "hotswap: error: WMMA split: could not demerge combined "
+                 "s_delay_alu at 0x"
+              << utohexstr(Delay.Offset) << "\n";
+        return failWmmaSplit(Ctx);
+      }
+
+      WithDelay.append(FirstDelayBytes.begin(), FirstDelayBytes.end());
+      for (size_t I = ProtectedWindow->DelayIndex + 1;
+           I <= ProtectedWindow->LastMovedIndex; ++I) {
+        if (!ProtectedWindow->RetainsSecondTarget &&
+            I == ProtectedWindow->SecondTargetIndex)
+          WithDelay.append(DeferredDelayBytes.begin(),
+                           DeferredDelayBytes.end());
+        if (I == Idx) {
+          WithDelay.append(Replacement.begin(), Replacement.end());
+          continue;
+        }
+        const InternalDecodedInst &Member = Ctx.Decoded[I];
+        WithDelay.append(Ctx.Text + Member.Offset,
+                         Ctx.Text + Member.Offset + Member.Size);
+      }
+    } else {
+      WithDelay.append(Ctx.Text + Delay.Offset,
+                       Ctx.Text + Delay.Offset + Delay.Size);
+      WithDelay.append(Replacement.begin(), Replacement.end());
+    }
+    Replacement = std::move(WithDelay);
+    SourceOffset = ProtectedWindow->Offset;
+    SourceSize = ProtectedWindow->Size;
+  }
+
+  if (ProtectedWindow && ProtectedWindow->RetainsSecondTarget &&
+      !canEmitShortTrampoline(Ctx, SourceOffset, SourceSize,
+                              Replacement.size())) {
+    log() << "hotswap: error: WMMA split: combined-delay demerge at 0x"
+          << utohexstr(SourceOffset) << " requires a short trampoline\n";
+    return failWmmaSplit(Ctx);
+  }
+
+  if (!emitToTrampoline(Ctx, SourceOffset, SourceSize, Replacement)) {
+    log() << "hotswap: error: WMMA split: could not emit trampoline for "
+          << DI.Mnemonic << "\n";
+    return failWmmaSplit(Ctx);
+  }
+
+  if (ProtectedWindow && ProtectedWindow->RetainsSecondTarget) {
+    const InternalDecodedInst &LastMoved =
+        Ctx.Decoded[ProtectedWindow->LastMovedIndex];
+    std::memcpy(Ctx.Text + LastMoved.Offset, DeferredDelayBytes.data(),
+                MinInstSize);
+  }
+  if (ProtectedWindow) {
+    for (size_t I = ProtectedWindow->DelayIndex;
+         I <= ProtectedWindow->LastMovedIndex; ++I) {
+      const uint64_t Offset = Ctx.Decoded[I].Offset;
+      Ctx.ClaimedReplacementOffsets.insert(Offset);
+      protectNonClauseRelocationOffset(Ctx, Offset);
+    }
+  }
+
+  Ctx.RequiredPatchApplied = true;
   log() << "hotswap: WMMA split: patched " << DI.Mnemonic << " at offset 0x"
-        << utohexstr(DI.Offset) << "\n";
+        << utohexstr(DI.Offset);
+  if (ProtectedWindow && ProtectedWindow->demergesCombinedDelay())
+    log() << " by demerging combined delay in source window at 0x"
+          << utohexstr(SourceOffset);
+  else if (ProtectedWindow)
+    log() << " with preceding delay in source window at 0x"
+          << utohexstr(SourceOffset);
+  log() << "\n";
   return 1;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -841,7 +841,7 @@ bool sourceRangeOverlapsTextSymbolExtent(const PatchContext &Ctx,
                                          uint64_t Begin, uint64_t End) {
   if (!Ctx.TextSymbolExtents)
     return true;
-  auto It =
+  ArrayRef<ElfView::TextOffsetRange>::iterator It =
       llvm::lower_bound(*Ctx.TextSymbolExtents, Begin,
                         [](const ElfView::TextOffsetRange &Extent,
                            uint64_t Offset) { return Extent.End <= Offset; });

--- a/amd/comgr/test-lit/hotswap-wmma-combined-delay-whole-pass-ownership.s
+++ b/amd/comgr/test-lit/hotswap-wmma-combined-delay-whole-pass-ownership.s
@@ -1,0 +1,147 @@
+// A per-instruction WMMA split can atomically relocate every instruction in a
+// combined-delay window before whole-function passes run. Those later passes
+// still analyze the immutable decoded stream, so they must honor ownership of
+// the linked addresses rather than queue a second replacement for bytes that
+// are reserved for the source branch. Exercise an overlapping co-exec VALU, an
+// overlapping VOP3PX2 scale instruction, and a disjoint co-exec VALU.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.hazard.elf
+// RUN: rm -f %t.hazard.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.hazard.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.hazard.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=HAZARD %s
+// RUN: test ! -e %t.hazard.out.elf
+// HAZARD: WMMA co-exec hazard at 0x{{[0-9A-F]+}}
+// HAZARD: WMMA co-exec validation: 1 hazards (2 WMMA instructions scanned)
+// HAZARD: WMMA split: delay-window member at 0x{{[0-9A-F]+}} requires a separate HotSwap patch
+// HAZARD: WMMA split: protected site at 0x{{[0-9A-F]+}} would suppress another required HotSwap patch
+// HAZARD: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.scale.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.scale.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.scale.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=SCALE %s
+// SCALE: VOP3PX2 SRC2 fix at 0x{{[0-9A-F]+}}: v_wmma_scale_f32_16x16x128_f8f6f4 scale_src2 -> VGPR0
+// SCALE: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay
+// SCALE: RESULT: SUCCESS
+
+// The source interval is one branch plus seven padding dwords. If the later
+// bit-field pass instead touched the stale VOP3PX2 address, one of these nops
+// would be corrupted. The scale instruction itself survives in the relocated
+// body after being corrected before the source window is copied.
+// RUN: %llvm-objdump -d %t.scale.out.elf \
+// RUN:   | %FileCheck --check-prefix=SCALE-DISASM %s
+// SCALE-DISASM-LABEL: <test_whole_pass_ownership>:
+// SCALE-DISASM-NEXT: s_branch
+// SCALE-DISASM-COUNT-7: s_nop 0
+// SCALE-DISASM-NEXT: s_delay_alu instid0(VALU_DEP_1)
+// SCALE-DISASM: v_wmma_scale_f32_16x16x128_f8f6f4
+// SCALE-DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// SCALE-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+
+// RUN: hotswap-rewrite %t.scale.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.disjoint.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.disjoint.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.disjoint.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=DISJOINT %s
+// DISJOINT: WMMA co-exec hazard at 0x{{[0-9A-F]+}}
+// DISJOINT: WMMA co-exec validation: 1 hazards (2 WMMA instructions scanned)
+// DISJOINT: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay
+// DISJOINT: WMMA co-exec requirement composed into replacement at 0x{{[0-9A-F]+}} (8 leading v_nop(s))
+// DISJOINT: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.disjoint.out.elf \
+// RUN:   | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_whole_pass_ownership>:
+// DISASM: v_wmma_i32_16x16x64_iu8
+// DISASM-NEXT: s_branch
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-COUNT-8: v_nop
+// DISASM-NEXT: v_add_f32{{(_e32)?}} v16, v0, v1
+
+// RUN: hotswap-rewrite %t.disjoint.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_whole_pass_ownership
+.p2align 8
+.type test_whole_pass_ownership,@function
+test_whole_pass_ownership:
+#if CASE == 1
+  // The integer WMMA's first overlapping VALU is also the first target of the
+  // combined delay owned by the later split. The whole-function hazard pass
+  // must not install another trampoline at its stale linked address.
+  v_wmma_i32_16x16x64_iu8 v[16:23], v[0:7], v[8:15], v[16:23]
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_add_f32 v16, v0, v1
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_nop 0
+  v_mov_b32 v61, v60
+#elif CASE == 2
+  // The VOP3PX2 field fix is in-place and same-size. It must run before the
+  // combined window is copied, so the corrected bytes move with the window
+  // and no later pass mutates the linked address reserved for its source edge.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_3) | instid1(VALU_DEP_1)
+  v_mov_b32 v63, v62
+  v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[8:23], v[24:35], v[40:47], v1, v2 matrix_a_fmt:MATRIX_FMT_BF8 matrix_b_fmt:MATRIX_FMT_FP6 matrix_a_scale:MATRIX_SCALE_ROW1 matrix_b_scale:MATRIX_SCALE_ROW1
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_nop 0
+  v_mov_b32 v61, v60
+#elif CASE == 3
+  // A hazard entirely after the claimed source window is independent and
+  // remains eligible for its own trampoline.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_mov_b32 v63, v62
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_nop 0
+  v_mov_b32 v61, v60
+  v_wmma_i32_16x16x64_iu8 v[16:23], v[0:7], v[8:15], v[16:23]
+  v_add_f32 v16, v0, v1
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Ltest_whole_pass_ownership_end:
+.size test_whole_pass_ownership, .Ltest_whole_pass_ownership_end-test_whole_pass_ownership
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_whole_pass_ownership
+  .amdhsa_next_free_vgpr 64
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_whole_pass_ownership
+      .symbol: test_whole_pass_ownership.kd
+      .sgpr_count: 2
+      .vgpr_count: 64
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-hazard-composition.s
+++ b/amd/comgr/test-lit/hotswap-wmma-hazard-composition.s
@@ -1,0 +1,132 @@
+// A WMMA co-execution requirement and an ordinary FP8 CLAMP correction can
+// target the same instruction. The central replacement owner must prepend the
+// required v_nops to the FP8 emulation body instead of queuing two competing
+// source rewrites. Exercise both appended-trampoline and owned-sled placement.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trampoline.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.trampoline.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.trampoline.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=API,PACK %s
+// RUN: %llvm-objdump -d %t.trampoline.out.elf \
+// RUN:   | %FileCheck --check-prefix=TRAMPOLINE %s
+// RUN: hotswap-rewrite %t.trampoline.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.sled.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.sled.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.sled.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=API,PACK %s
+// RUN: %llvm-objdump -d %t.sled.out.elf \
+// RUN:   | %FileCheck --check-prefix=SLED %s
+// RUN: hotswap-rewrite %t.sled.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// The unpack patch calls emitToTrampoline directly rather than the sled-aware
+// emitReplacementCode entry point. It must use the same single composition
+// transaction and must not prepend the requirement twice.
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.direct.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.direct.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.direct.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=API,UNPACK %s
+// RUN: %llvm-objdump -d %t.direct.out.elf \
+// RUN:   | %FileCheck --check-prefix=DIRECT %s
+// RUN: hotswap-rewrite %t.direct.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+
+// API: WMMA co-exec hazard at 0x{{[0-9A-F]+}}: v_wmma_i32_16x16x64_iu8 needs 8 v_nops
+// API: WMMA co-exec validation: 1 hazards (1 WMMA instructions scanned)
+// API: WMMA co-exec requirement composed into replacement at 0x{{[0-9A-F]+}} (8 leading v_nop(s))
+// PACK: cvt_pk_fp8_f32: patched CLAMP=1 (E5M3) at offset 0x{{[0-9A-F]+}}
+// UNPACK: cvt_f32_fp8: patched CLAMP=1 (E5M3) at offset 0x{{[0-9A-F]+}}
+// API: applied 2 instruction patches
+// API: RESULT: SUCCESS
+// IDEM: IDEMPOTENT: YES
+
+// TRAMPOLINE-LABEL: <test_wmma_hazard_composition>:
+// TRAMPOLINE-NEXT: v_wmma_i32_16x16x64_iu8
+// TRAMPOLINE-NEXT: s_branch
+// TRAMPOLINE-NEXT: s_nop 0
+// TRAMPOLINE-NEXT: s_endpgm
+// TRAMPOLINE-COUNT-8: v_nop
+// TRAMPOLINE-NEXT: s_mov_b32
+// TRAMPOLINE-NEXT: v_and_b32{{.*}}0x7fffffff, v1
+
+// SLED-LABEL: <test_wmma_hazard_composition>:
+// SLED-NEXT: v_wmma_i32_16x16x64_iu8
+// SLED-NEXT: s_branch
+// SLED-NEXT: s_nop 0
+// SLED-NEXT: s_endpgm
+// SLED-COUNT-8: v_nop
+// SLED-NEXT: s_mov_b32
+// SLED-NEXT: v_and_b32{{.*}}0x7fffffff, v1
+
+// DIRECT-LABEL: <test_wmma_hazard_composition>:
+// DIRECT-NEXT: v_wmma_i32_16x16x64_iu8
+// DIRECT-NEXT: s_branch
+// DIRECT-NEXT: s_nop 0
+// DIRECT-NEXT: s_endpgm
+// DIRECT-COUNT-8: v_nop
+// DIRECT-NEXT: s_mov_b32
+// DIRECT-NEXT: v_and_b32{{.*}}0xff, v1
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_hazard_composition
+.p2align 8
+.type test_wmma_hazard_composition,@function
+test_wmma_hazard_composition:
+  v_wmma_i32_16x16x64_iu8 v[16:23], v[0:7], v[8:15], v[16:23]
+#if CASE == 3
+  v_cvt_f32_fp8 v16, v1 clamp
+#else
+  v_cvt_pk_fp8_f32 v16, v1, v2 clamp
+#endif
+  s_endpgm
+#if CASE == 2
+  .rept 96
+  s_nop 0
+  .endr
+#elif CASE != 1 && CASE != 3
+  .error "CASE must select a test body"
+#endif
+.Ltest_wmma_hazard_composition_end:
+.size test_wmma_hazard_composition, .Ltest_wmma_hazard_composition_end-test_wmma_hazard_composition
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_hazard_composition
+  .amdhsa_next_free_vgpr 24
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_hazard_composition
+      .symbol: test_wmma_hazard_composition.kd
+      .sgpr_count: 2
+      .vgpr_count: 24
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge-long-branch.s
@@ -1,0 +1,60 @@
+// Combined-delay demerge is limited to a short trampoline. A far source would
+// replace the delay window with generated set-PC control flow that tensor-mask
+// idempotence does not treat as a straight-line local definition. Fail before
+// mutating the predecessor or writing a partially rewritten output.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: rm -f %t.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: test ! -e %t.out.elf
+// API: WMMA split: combined-delay demerge at 0x{{[0-9A-F]+}} requires a short trampoline
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_demerge_far
+.p2align 8
+.type test_wmma_delay_demerge_far,@function
+test_wmma_delay_demerge_far:
+  v_readfirstlane_b32 s4, v40
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_wmma_delay_demerge_far_end:
+.size test_wmma_delay_demerge_far, .Ltest_wmma_delay_demerge_far_end-test_wmma_delay_demerge_far
+
+// Keep the trampoline pool beyond s_branch reach without extending the
+// function or creating another gateway sled.
+.rept 40000
+  s_mov_b32 s64, s65
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_delay_demerge_far
+  .amdhsa_next_free_vgpr 41
+  .amdhsa_next_free_sgpr 28
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_delay_demerge_far
+      .symbol: test_wmma_delay_demerge_far.kd
+      .sgpr_count: 28
+      .vgpr_count: 41
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-demerge.s
@@ -1,0 +1,79 @@
+// A combined delay can protect both a source-side v_readfirstlane and the
+// PC-sensitive tensor load after a K=128 WMMA. Splitting only the WMMA would
+// leave the original delay naming a source branch. Demerge the two dependency
+// IDs instead: relocate the first delay target, split WMMA, and barrier, then
+// execute the second single-target delay from the vacated barrier slot. The
+// tensor stays at its linked address.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: WMMA co-exec validation: 0 hazards (1 WMMA instructions scanned)
+// API: hotswap: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay in source window
+// API: hotswap: tensor_load_to_lds: masked local descriptor definition at 0x
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_delay_demerge>:
+// DISASM: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_delay_alu instid0(VALU_DEP_1)
+// DISASM-NEXT: tensor_load_to_lds s[24:27], s[4:11]
+// DISASM: v_readfirstlane_b32 s4, v40
+// DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// DISASM: s_delay_alu instid0(VALU_DEP_2)
+// DISASM-NEXT: v_readfirstlane_b32 s19, v3
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_barrier_wait 0xffff
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_demerge
+.p2align 8
+.type test_wmma_delay_demerge,@function
+test_wmma_delay_demerge:
+  v_readfirstlane_b32 s4, v40
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+  s_endpgm
+.Ltest_wmma_delay_demerge_end:
+.size test_wmma_delay_demerge, .Ltest_wmma_delay_demerge_end-test_wmma_delay_demerge
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_delay_demerge
+  .amdhsa_next_free_vgpr 41
+  .amdhsa_next_free_sgpr 20
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_delay_demerge
+      .symbol: test_wmma_delay_demerge.kd
+      .sgpr_count: 20
+      .vgpr_count: 41
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-general.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-general.s
@@ -1,0 +1,237 @@
+// Exercise combined-delay repair from encoded dependency geometry rather than
+// one compiler schedule. The positive cases vary dependency classes, skip
+// spans, and intervening TRANS history. The negative cases require fail-closed
+// behavior when the adjusted TRANS ordinal is not encodable or a moved member
+// affects control flow.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.classes.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.classes.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.classes.out \
+// RUN:   2>&1 | %FileCheck --check-prefix=CLASSES-API %s
+// RUN: %llvm-objdump -d %t.classes.out \
+// RUN:   | %FileCheck --check-prefix=CLASSES-DISASM %s
+// CLASSES-API: WMMA split: patched {{.*}} by demerging combined delay
+// CLASSES-API: RESULT: SUCCESS
+// CLASSES-DISASM-LABEL: <test_wmma_delay_general>:
+// CLASSES-DISASM: s_delay_alu instid0(VALU_DEP_3)
+// CLASSES-DISASM-NEXT: v_mov_b32_e32 v60, v60
+// CLASSES-DISASM: s_delay_alu instid0(SALU_CYCLE_2)
+// CLASSES-DISASM-NEXT: s_mov_b32 s19, s19
+// CLASSES-DISASM-NEXT: s_nop 0
+// CLASSES-DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// CLASSES-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// CLASSES-DISASM-NEXT: s_barrier_wait 0xffff
+
+// With no later TRANS, old TRANS_DEP_2 names a producer older than the source
+// WMMA. One additional split TRANS shifts it to the last encodable ordinal.
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans-remap.elf
+// RUN: hotswap-rewrite %t.trans-remap.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.trans-remap.out | %FileCheck --check-prefix=TRANS2-API %s
+// RUN: %llvm-objdump -d %t.trans-remap.out \
+// RUN:   | %FileCheck --check-prefix=TRANS2-DISASM %s
+// TRANS2-API: RESULT: SUCCESS
+// TRANS2-DISASM-LABEL: <test_wmma_delay_general>:
+// TRANS2-DISASM: s_delay_alu instid0(TRANS32_DEP_3)
+// TRANS2-DISASM-NEXT: v_mov_b32_e32 v60, v60
+
+// A later TRANS makes the original WMMA the second prior TRANS; its semantic
+// producer maps to the last split half and therefore keeps DEP_2 unchanged.
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans-later.elf
+// RUN: hotswap-rewrite %t.trans-later.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.trans-later.out | %FileCheck --check-prefix=LATER-API %s
+// RUN: %llvm-objdump -d %t.trans-later.out \
+// RUN:   | %FileCheck --check-prefix=LATER-DISASM %s
+// LATER-API: RESULT: SUCCESS
+// LATER-DISASM-LABEL: <test_wmma_delay_general>:
+// LATER-DISASM: s_delay_alu instid0(TRANS32_DEP_2)
+// LATER-DISASM-NEXT: v_mov_b32_e32 v60, v60
+// LATER-DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// LATER-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// LATER-DISASM-NEXT: v_sin_f32_e32 v50, v51
+
+// TRANS_DEP_3 with no later TRANS would require unencodable DEP_4.
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans-overflow.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.trans-overflow.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=TRANS3 %s
+// TRANS3: has an unrepresentable TRANS dependency after split
+// TRANS3: RESULT: ERROR
+
+// A branch inside the protected interval cannot be moved into the trampoline.
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.control.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.control.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CONTROL %s
+// CONTROL: has a non-relocatable instruction in its delay window
+// CONTROL: RESULT: ERROR
+
+// The second dependency may be reconstructed in a generic dword slot. When
+// that slot contains the canonical scalar delay, tensor masking may consume it
+// even though the immutable instruction there was the moved predecessor.
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.tensor.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.tensor.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode --output %t.tensor.out \
+// RUN:   2>&1 | %FileCheck --check-prefix=TENSOR-API %s
+// RUN: %llvm-objdump -d %t.tensor.out \
+// RUN:   | %FileCheck --check-prefix=TENSOR-DISASM %s
+// TENSOR-API: WMMA split: patched {{.*}} by demerging combined delay
+// TENSOR-API: tensor_load_to_lds: in-place descriptor mask
+// TENSOR-API: RESULT: SUCCESS
+// TENSOR-DISASM-LABEL: <test_wmma_delay_general>:
+// TENSOR-DISASM: s_pack_hh_b32_b16 s4, 0, s4
+// TENSOR-DISASM-NEXT: tensor_load_to_lds s[24:27], s[4:11]
+
+// A non-callable symbol can own bytes even when its start lies before the
+// source head. Its extent, not only its address, blocks relocation.
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.extent.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.extent.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=EXTENT %s
+// EXTENT: overlaps a sized non-callable text symbol
+// EXTENT: RESULT: ERROR
+
+// If the WMMA is itself the second target, both reconstructed dependencies
+// move before the replacement and no TRANS ordinal adjustment is needed.
+// RUN: %clang -x assembler-with-cpp -DCASE=8 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.second-target.elf
+// RUN: hotswap-rewrite %t.second-target.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.second-target.out \
+// RUN:   | %FileCheck --check-prefix=SECOND-API %s
+// RUN: %llvm-objdump -d %t.second-target.out \
+// RUN:   | %FileCheck --check-prefix=SECOND-DISASM %s
+// SECOND-API: RESULT: SUCCESS
+// SECOND-DISASM-LABEL: <test_wmma_delay_general>:
+// SECOND-DISASM: s_delay_alu instid0(VALU_DEP_1)
+// SECOND-DISASM-NEXT: s_mov_b32 s19, s19
+// SECOND-DISASM-NEXT: s_nop 0
+// SECOND-DISASM-NEXT: s_delay_alu instid0(TRANS32_DEP_2)
+// SECOND-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// SECOND-DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+
+// gfx1250 non-XDL WMMA uses the VALU pipeline and must not advance a TRANS
+// dependency ordinal. With no later TRANS, DEP_2 still shifts to DEP_3.
+// RUN: %clang -x assembler-with-cpp -DCASE=9 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.non-xdl.elf
+// RUN: hotswap-rewrite %t.non-xdl.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.non-xdl.out | %FileCheck --check-prefix=NON-XDL-API %s
+// RUN: %llvm-objdump -d %t.non-xdl.out \
+// RUN:   | %FileCheck --check-prefix=NON-XDL-DISASM %s
+// NON-XDL-API: RESULT: SUCCESS
+// NON-XDL-DISASM-LABEL: <test_wmma_delay_general>:
+// NON-XDL-DISASM: s_delay_alu instid0(TRANS32_DEP_3)
+// NON-XDL-DISASM-NEXT: s_barrier_wait 0xffff
+
+// F64 DPMACC may carry the TRANS TSFlag but AMDGPUInsertDelayAlu classifies it
+// as ordinary VALU. It likewise must not hide the required DEP_2 -> DEP_3
+// adjustment.
+// RUN: %clang -x assembler-with-cpp -DCASE=10 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.dpmacc.elf
+// RUN: hotswap-rewrite %t.dpmacc.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --strict-mode \
+// RUN:   --output %t.dpmacc.out | %FileCheck --check-prefix=DPMACC-API %s
+// RUN: %llvm-objdump -d %t.dpmacc.out \
+// RUN:   | %FileCheck --check-prefix=DPMACC-DISASM %s
+// DPMACC-API: RESULT: SUCCESS
+// DPMACC-DISASM-LABEL: <test_wmma_delay_general>:
+// DPMACC-DISASM: s_delay_alu instid0(TRANS32_DEP_3)
+// DPMACC-DISASM-NEXT: s_barrier_wait 0xffff
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_general
+.p2align 8
+.type test_wmma_delay_general,@function
+test_wmma_delay_general:
+#if CASE == 1
+  s_delay_alu instid0(SALU_CYCLE_2) | instskip(SKIP_3) | instid1(VALU_DEP_3)
+  s_mov_b32 s19, s19
+  s_nop 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 2
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 3
+  s_delay_alu instid0(FMA_ACCUM_CYCLE_1) | instskip(SKIP_3) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_sin_f32 v50, v51
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 4
+  s_delay_alu instid0(VALU_DEP_4) | instskip(SKIP_2) | instid1(TRANS32_DEP_3)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+#elif CASE == 5
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_3) | instid1(SALU_CYCLE_1)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_branch .Ltarget
+  s_barrier_wait 0xffff
+.Ltarget:
+  v_mov_b32 v60, v60
+#elif CASE == 6
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 7
+  .globl protected_text_object
+  .type protected_text_object,@object
+protected_text_object:
+  s_nop 0
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_2) | instid1(SALU_CYCLE_1)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  v_mov_b32 v60, v60
+.Lprotected_text_object_end:
+  .size protected_text_object, .Lprotected_text_object_end-protected_text_object
+#elif CASE == 8
+  s_delay_alu instid0(VALU_DEP_1) | instskip(SKIP_1) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  s_nop 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 9
+  s_delay_alu instid0(FMA_ACCUM_CYCLE_1) | instskip(SKIP_3) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_wmma_f32_16x16x4_f32 v[40:47], v[48:49], v[50:51], v[40:47]
+  s_nop 0
+  s_barrier_wait 0xffff
+#elif CASE == 10
+  s_delay_alu instid0(FMA_ACCUM_CYCLE_1) | instskip(SKIP_3) | instid1(TRANS32_DEP_2)
+  s_mov_b32 s19, s19
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_rcp_f64 v[48:49], v[50:51]
+  s_nop 0
+  s_barrier_wait 0xffff
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Ltest_wmma_delay_general_end:
+.size test_wmma_delay_general, .Ltest_wmma_delay_general_end-test_wmma_delay_general

--- a/amd/comgr/test-lit/hotswap-wmma-split-delay-window-reject.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-delay-window-reject.s
@@ -1,0 +1,176 @@
+// A protected WMMA is safe to split only when its immediately preceding
+// single-instruction delay can move with it as one unambiguous source window.
+// Assemble ten structural counterexamples from this file and require each to
+// fail closed.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.direct.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.direct.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=DIRECT %s
+// DIRECT: WMMA split: protected site at 0x{{[0-9A-F]+}} has a direct entry into the source-window interior
+// DIRECT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.overlap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.overlap.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=OVERLAP %s
+// OVERLAP: WMMA split: protected site at 0x{{[0-9A-F]+}} overlaps another delay or hard clause
+// OVERLAP: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.span.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.span.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SPAN %s
+// SPAN: WMMA split: protected site at 0x{{[0-9A-F]+}} has no supported preceding delay window
+// SPAN: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=4 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.indirect.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=INDIRECT %s
+// INDIRECT: WMMA split: protected site at 0x{{[0-9A-F]+}} cannot be relocated with an unresolved indirect entry
+// INDIRECT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=5 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.combined-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.combined-entry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=COMBINED-ENTRY %s
+// COMBINED-ENTRY: WMMA split: protected site at 0x{{[0-9A-F]+}} has a direct entry into the source-window interior
+// COMBINED-ENTRY: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=6 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.combined-def.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.combined-def.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=COMBINED-DEF %s
+// COMBINED-DEF: descriptor definition at 0x{{[0-9A-F]+}} is relocated; using linked delay slot for the mask
+// COMBINED-DEF: is not preceded by the canonical scalar delay
+// COMBINED-DEF: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=7 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.missing-first-id.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.missing-first-id.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=BAD-ID %s
+
+// RUN: %clang -x assembler-with-cpp -DCASE=8 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.missing-second-id.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.missing-second-id.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=BAD-ID %s
+// BAD-ID: WMMA split: protected site at 0x{{[0-9A-F]+}} {{(has no supported preceding delay window|has an unsupported combined dependency graph)}}
+// BAD-ID: RESULT: ERROR
+
+// COM: A successful WMMA demerge followed by a required tensor-mask failure
+// COM: must not write the partially mutated in-memory object to the output.
+// RUN: %clang -x assembler-with-cpp -DCASE=9 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.late-failure.elf
+// RUN: rm -f %t.late-failure.out.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.late-failure.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --output %t.late-failure.out.elf \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=LATE-FAIL %s
+// RUN: test ! -e %t.late-failure.out.elf
+// LATE-FAIL: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} by demerging combined delay
+// LATE-FAIL: tensor_load_to_lds at 0x{{[0-9A-F]+}} is not preceded by the canonical scalar delay
+// LATE-FAIL: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=10 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.trans32-dependency.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.trans32-dependency.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=TRANS32 %s
+// TRANS32: has an unrepresentable TRANS dependency after split
+// TRANS32: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_delay_reject
+.p2align 8
+.type test_wmma_delay_reject,@function
+test_wmma_delay_reject:
+#if CASE == 1
+  // Target the first literal slot, not merely the WMMA instruction boundary.
+  // s_branch simm16=2 reaches PC+12 from this instruction at PC+0.
+  .long 0xBFA00002
+  s_delay_alu instid0(VALU_DEP_1)
+.Lwmma:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 2
+  s_delay_alu instid0(SALU_CYCLE_1)
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 3
+  // Reserved dependency ID 12 is malformed and retains the conservative
+  // maximum protection span, but cannot be reconstructed.
+  s_delay_alu 0xc
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  v_nop
+  v_nop
+  v_nop
+  v_nop
+  v_nop
+#elif CASE == 4
+  s_set_pc_i64 s[0:1]
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+#elif CASE == 5
+  // The predecessor is overwritten with the demerged tensor delay, so an
+  // independent edge to that slot must reject the complete transformation.
+  s_branch .Lcombined_barrier
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+.Lcombined_barrier:
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 6
+  // Tensor masking would otherwise try to patch this definition separately,
+  // overlapping the WMMA source window.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s4, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 7
+  // Both dependency IDs are required by the demerge proof.
+  s_delay_alu 0xb0
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 8
+  // A skip field without instid1 is malformed and retains the conservative
+  // six-instruction relocation protection.
+  s_delay_alu 0x32
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 9
+  // No straight-line definition of tensor base s4 exists. The WMMA demerge
+  // is valid, but the later required tensor mask must fail the whole rewrite.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(VALU_DEP_1)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#elif CASE == 10
+  // With no later TRANS, splitting one WMMA into two would shift an older
+  // TRANS_DEP_3 producer to unencodable ordinal four.
+  s_delay_alu instid0(VALU_DEP_2) | instskip(SKIP_2) | instid1(TRANS32_DEP_3)
+  v_readfirstlane_b32 s19, v3
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_barrier_wait 0xffff
+  tensor_load_to_lds s[24:27], s[4:11]
+#else
+  .error "CASE must select a test body"
+#endif
+  s_endpgm
+.Ltest_wmma_delay_reject_end:
+.size test_wmma_delay_reject, .Ltest_wmma_delay_reject_end-test_wmma_delay_reject

--- a/amd/comgr/test-lit/hotswap-wmma-split-indirect-entry-reject.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-indirect-entry-reject.s
@@ -1,0 +1,71 @@
+// Source relocation must fail closed for an unresolved set-PC transfer. A
+// tail set-PC is a return only when MC proves it or it uses the ABI link pair;
+// likewise, the rewriter's get-PC/add/set-PC exit shape is recognized only
+// when no direct edge enters its interior.
+
+// RUN: %clang -x assembler-with-cpp -DCASE=1 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.tail-nonlink.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.tail-nonlink.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=TAIL %s
+// TAIL: source relocation disabled for function at 0x{{[0-9A-F]+}} by s_set_pc_i64 at 0x
+// TAIL: WMMA split: protected site at 0x{{[0-9A-F]+}} cannot be relocated with an unresolved indirect entry
+// TAIL: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=2 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.pc-relative-entry.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.pc-relative-entry.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=ALT %s
+// ALT: source relocation disabled for function at 0x{{[0-9A-F]+}} by s_set_pc_i64 at 0x
+// ALT: WMMA split: protected site at 0x{{[0-9A-F]+}} cannot be relocated with an unresolved indirect entry
+// ALT: RESULT: ERROR
+
+// RUN: %clang -x assembler-with-cpp -DCASE=3 -target amdgcn-amd-amdhsa \
+// RUN:   -mcpu=gfx1250 -nostdlib %s -o %t.pc-relative-exit.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.pc-relative-exit.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.pc-relative-exit.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=KNOWN %s
+// KNOWN-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8 at offset 0x{{[0-9A-F]+}} with preceding delay in source window
+// KNOWN: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_indirect_entry_reject
+.p2align 8
+.type test_wmma_indirect_entry_reject,@function
+test_wmma_indirect_entry_reject:
+#if CASE == 1
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  // An arbitrary computed tail transfer is not an ABI return.
+  s_set_pc_i64 s[0:1]
+#elif CASE == 2
+  s_branch .Ladd
+  s_get_pc_i64 s[0:1]
+.Ladd:
+  s_add_nc_u64 s[0:1], s[0:1], 0x1000
+  s_set_pc_i64 s[0:1]
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+#elif CASE == 3
+  // The exact generated shape with a statically known exit and no interior
+  // entry is not an indirect destination ambiguity.
+  s_get_pc_i64 s[0:1]
+  s_add_nc_u64 s[0:1], s[0:1], 0x1000
+  s_set_pc_i64 s[0:1]
+  // Mandatory rewrites still patch CFG-unreachable instructions. Cover both
+  // an explicit dead MODE write and a second dead site with no local MODE.
+  s_set_vgpr_msb 0
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+#else
+  .error "CASE must select a test body"
+#endif
+.Ltest_wmma_indirect_entry_reject_end:
+.size test_wmma_indirect_entry_reject, .Ltest_wmma_indirect_entry_reject_end-test_wmma_indirect_entry_reject

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -19,16 +19,12 @@
 // DISASM-LABEL: <test_wsplit_far>:
 // DISASM-NEXT: s_branch
 // DISASM: s_get_pc_i64 s[0:1]
-// DISASM-NEXT: s_add_co_u32 s0, s0,
-// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 // DISASM: v_wmma_f32_16x16x64_fp8_fp8
 // DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
-// DISASM-NEXT: s_cselect_b32 s2, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[0:1]
-// DISASM-NEXT: s_add_co_u32 s0, s0,
-// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
-// DISASM-NEXT: s_cmp_lg_u32 s2, 0
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 
 // COM: Idempotency: rewriting the output again must be a no-op.

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
@@ -1,0 +1,83 @@
+// Recover exact VGPR-MSB state through CFG joins instead of rejecting every
+// direct target. This covers a backedge loop, a nonzero fixed point, and a
+// non-MODE SETREG that must preserve the tracked fields.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-3: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_zero_loop>:
+// DISASM:       s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+// DISASM:       s_branch
+// DISASM:       s_cbranch_scc1
+// DISASM-LABEL: <test_wmma_nonzero_loop>:
+// DISASM:       s_set_vgpr_msb 0x60
+// DISASM:       s_branch
+// DISASM:       s_cbranch_scc1
+// DISASM-LABEL: <test_wmma_nonmode_setreg>:
+// DISASM:       s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_STATUS), 7
+// DISASM-NEXT:  s_branch
+// DISASM:       Disassembly of section :
+// DISASM:       v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+// DISASM-NEXT:  s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl test_wmma_zero_loop
+.p2align 8
+.type test_wmma_zero_loop,@function
+test_wmma_zero_loop:
+  // gfx1250's SETREG fixup writes VGPR-MSB fields from imm32[19:12], which
+  // are zero here even though the selected WAVE_MODE bit is set to one.
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+.Lzero_loop:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_cbranch_scc1 .Lzero_loop
+  s_endpgm
+.size test_wmma_zero_loop, .-test_wmma_zero_loop
+
+.globl test_wmma_nonzero_loop
+.p2align 8
+.type test_wmma_nonzero_loop,@function
+test_wmma_nonzero_loop:
+  s_set_vgpr_msb 0x60
+.Lnonzero_loop:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_cbranch_scc1 .Lnonzero_loop
+  s_endpgm
+.size test_wmma_nonzero_loop, .-test_wmma_nonzero_loop
+
+.globl test_wmma_nonmode_setreg
+.p2align 8
+.type test_wmma_nonmode_setreg,@function
+test_wmma_nonmode_setreg:
+  s_set_vgpr_msb 0x60
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_STATUS), 7
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_nonmode_setreg, .-test_wmma_nonmode_setreg

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
@@ -1,0 +1,27 @@
+// A merge that disagrees only in src1 must lose the complete VGPR-MSB mode.
+// This guards the four-field CFG lattice independently of the dst/src0 facts
+// used by DS2 alignment.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 | %FileCheck %s
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_src1_merge
+.p2align 8
+.type test_wmma_src1_merge,@function
+test_wmma_src1_merge:
+  s_cbranch_scc1 .Lzero
+  s_set_vgpr_msb 4
+  s_branch .Ljoin
+.Lzero:
+  s_set_vgpr_msb 0
+.Ljoin:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_src1_merge, .-test_wmma_src1_merge

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
@@ -1,0 +1,57 @@
+// A K-split's second half replaces src2 with dst. Even when neither source
+// slice crosses v255, the temporary src2 bank must therefore match the
+// incoming dst bank. Preserve and restore every other incoming mode field.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_k_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_branch
+// DISASM-LABEL: <test_wmma_k_vgpr_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[32:39], v[0:7], v[16:23], 0
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[32:39]{{.*}}, v[8:15], v[24:31], v[32:39]
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+// DISASM-NEXT: s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[32:39], v[0:7], v[16:23], v[40:47]
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[32:39]{{.*}}, v[8:15], v[24:31], v[32:39]
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_k_src2_role
+.p2align 8
+.type test_wmma_k_src2_role,@function
+test_wmma_k_src2_role:
+  // Incoming mode: dst=1, src2=2, src0=src1=0.
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_k_src2_role, .-test_wmma_k_src2_role
+
+.globl test_wmma_k_vgpr_src2_role
+.p2align 8
+.type test_wmma_k_vgpr_src2_role,@function
+test_wmma_k_vgpr_src2_role:
+  // The first half must read src2 from bank 2. The second half replaces that
+  // operand with dst and must therefore select bank 1 before restoring bank 2.
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[40:47]
+  s_endpgm
+.size test_wmma_k_vgpr_src2_role, .-test_wmma_k_vgpr_src2_role

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
@@ -1,0 +1,75 @@
+// A far crossing split needs a forward gateway. Source-window growth may move
+// the callable-entry VGPR-MSB setter only as the first copied instruction, so
+// every entry still establishes the original mode before either WMMA half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <test_wmma_vgpr_msb_far>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+// DISASM:      s_set_vgpr_msb 0
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[250:257], v[114:121], 0
+// DISASM-NEXT: s_set_vgpr_msb 1
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
+// DISASM-NEXT: s_set_vgpr_msb 0x100
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb_far
+.p2align 8
+.type test_wmma_vgpr_msb_far,@function
+test_wmma_vgpr_msb_far:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[162:169], v[250:265], v[114:129], 0
+  s_endpgm
+.Ltest_wmma_vgpr_msb_far_end:
+.size test_wmma_vgpr_msb_far, .Ltest_wmma_vgpr_msb_far_end-test_wmma_vgpr_msb_far
+
+// Safe external gateway space after the no-fallthrough terminator.
+.rept 8
+  s_nop 0
+.endr
+
+// Keep the appended pool beyond s_branch reach from the split site.
+.rept 40000
+  s_mov_b32 s3, s4
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_vgpr_msb_far
+  .amdhsa_next_free_vgpr 266
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_vgpr_msb_far
+      .symbol: test_wmma_vgpr_msb_far.kd
+      .sgpr_count: 0
+      .vgpr_count: 266
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
@@ -1,0 +1,57 @@
+// An M-split slices dst, src0, and VGPR src2 independently. Normalize every
+// upper-half base into its operand's mode field, keep broadcast src1 unchanged,
+// and restore the exact nonzero incoming mode after the upper half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-2: WMMA split: patched v_wmma_f32_32x16x128_f4
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_m_operand_roles>:
+// DISASM-NEXT:  s_set_vgpr_msb 9
+// DISASM-NEXT:  s_branch
+// DISASM-LABEL: <test_wmma_m_immediate_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 57
+// DISASM-NEXT:  s_branch
+// DISASM:      v_wmma_f32_16x16x128_f8f6f4 v[250:257], v[248:255], v[100:107], v[252:259]{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x95a
+// DISASM-NEXT: v_wmma_f32_16x16x128_f8f6f4 v[2:9]{{.*}}, v[0:7]{{.*}}, v[100:107]{{.*}}, v[4:11]{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x5a09
+// DISASM-NEXT: s_branch
+// DISASM:      v_wmma_f32_16x16x128_f8f6f4 v[250:257], v[248:255], v[100:107], 0{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x397a
+// DISASM-NEXT: v_wmma_f32_16x16x128_f8f6f4 v[2:9]{{.*}}, v[0:7]{{.*}}, v[100:107]{{.*}}, 0{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x7a39
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_m_operand_roles
+.p2align 8
+.type test_wmma_m_operand_roles,@function
+test_wmma_m_operand_roles:
+  // Incoming mode: src0=1, src1=2, src2=0, dst=0.
+  s_set_vgpr_msb 9
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], v[252:267]
+  s_endpgm
+.size test_wmma_m_operand_roles, .-test_wmma_m_operand_roles
+
+.globl test_wmma_m_immediate_src2_role
+.p2align 8
+.type test_wmma_m_immediate_src2_role,@function
+test_wmma_m_immediate_src2_role:
+  // Incoming mode: src0=1, src1=2, src2=3, dst=0. Immediate src2 does not
+  // consume its role, but the temporary mode must preserve it exactly.
+  s_set_vgpr_msb 0x39
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], 0
+  s_endpgm
+.size test_wmma_m_immediate_src2_role, .-test_wmma_m_immediate_src2_role

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
@@ -1,0 +1,35 @@
+// A direct call can enter the WMMA either with the function-entry mode or the
+// fallthrough can reach it after selecting a different destination bank. The
+// K-split sources do not cross v255, but the second half replaces immediate
+// src2 with dst and therefore still needs the ambiguous mode. Fail closed.
+// This also exercises s_call_i64's unusual target operand layout in the shared
+// direct-control-flow target index.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CHECK %s
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb_merge
+.p2align 8
+.type test_wmma_vgpr_msb_merge,@function
+test_wmma_vgpr_msb_merge:
+  s_call_i64 s[0:1], .Lwmma
+  s_set_vgpr_msb 0x40
+.Lwmma:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.Ltest_wmma_vgpr_msb_merge_end:
+.size test_wmma_vgpr_msb_merge, .Ltest_wmma_vgpr_msb_merge_end-test_wmma_vgpr_msb_merge
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_vgpr_msb_merge
+  .amdhsa_next_free_vgpr 266
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
@@ -1,0 +1,23 @@
+// A dynamic write to WAVE_MODE does not reveal the incoming VGPR-MSB fields.
+// Keep the required WMMA split fail-closed instead of assuming ABI entry mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_dynamic_mode
+.p2align 8
+.type test_wmma_dynamic_mode,@function
+test_wmma_dynamic_mode:
+  s_setreg_b32 hwreg(HW_REG_WAVE_MODE), s0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_dynamic_mode, .-test_wmma_dynamic_mode

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
@@ -1,0 +1,37 @@
+// On gfx1250, an immediate MODE write establishes all four VGPR-MSB fields.
+// Immediate bits [19:12] are rotated into s_set_vgpr_msb order; 0x81 becomes
+// mode 0x60 and must be restored around the split WMMA's upper half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_setreg_mode>:
+// DISASM:       s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 0x81000
+// DISASM:       s_branch
+// DISASM:       s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_setreg_mode
+.p2align 8
+.type test_wmma_setreg_mode,@function
+test_wmma_setreg_mode:
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 0x81000
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_setreg_mode, .-test_wmma_setreg_mode

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
@@ -1,0 +1,35 @@
+// Verify that a K-split whose upper source half crosses v255 changes the
+// gfx1250 VGPR-MSB mode around that half and restores the incoming mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_vgpr_msb>:
+// DISASM:      s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[250:257], v[114:121], 0
+// DISASM-NEXT: s_set_vgpr_msb 1
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
+// DISASM-NEXT: s_set_vgpr_msb 0x100
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb
+.p2align 8
+.type test_wmma_vgpr_msb,@function
+test_wmma_vgpr_msb:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[162:169], v[250:265], v[114:129], 0
+  s_endpgm
+.size test_wmma_vgpr_msb, .-test_wmma_vgpr_msb


### PR DESCRIPTION
Hardens the gfx1250 B0→A0 HotSwap rewriter (amd_comgr_hotswap_rewrite). Headline fix:
a silent WMMA miscompile when an operand crosses a VGPR bank boundary — plus the change
to fail closed instead of returning SUCCESS with broken code.