### PR TITLE
[comgr][hotswap] Enable kernel-entry trampolines for gfx1030 and gfx1200

### DIFF
--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -839,6 +839,12 @@ ElfView::getKernelDescriptorInstPrefSize(StringRef KernelName,
                            hsa::COMPUTE_PGM_RSRC3_GFX12_PLUS_INST_PREF_SIZE);
   }
 
+  // COMPUTE_PGM_RSRC3.INST_PREF_SIZE was introduced on gfx11; gfx10 has no
+  // instruction-prefetch field, so there is no prefetch guard to account for
+  // after an appended entry stub. Report zero prefetch lines.
+  if (TargetCpu.starts_with("gfx10"))
+    return 0;
+
   log() << "hotswap: error: getKernelDescriptorInstPrefSize: unsupported "
         << "target CPU '" << TargetCpu << "' for kernel '" << KernelName
         << "'.\n";
@@ -855,6 +861,13 @@ bool ElfView::updateKernelDescriptorInstPrefSize(StringRef KernelName,
           << "descriptor symbol '" << KernelName << ".kd' not found.\n";
     return false;
   }
+
+  // gfx10 has no COMPUTE_PGM_RSRC3.INST_PREF_SIZE field (introduced on gfx11),
+  // so there is nothing to update after an appended entry stub. The matching
+  // getKernelDescriptorInstPrefSize() reports zero prefetch lines for gfx10, so
+  // InstPrefLines is zero here; treat the write as a successful no-op.
+  if (TargetCpu.starts_with("gfx10"))
+    return true;
 
   if (!TargetCpu.starts_with("gfx12")) {
     log() << "hotswap: error: updateKernelDescriptorInstPrefSize: unsupported "

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -65,11 +65,19 @@ SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
 
   // Assemble through the MC layer instead of spelling encoded bytes; the LIT
   // test pins the generated stub's disassembly.
-  if (!appendAsm(Bytes, "global_wb", LS))
-    return {};
-  if (!appendAsm(Bytes, "v_nop", LS))
-    return {};
-  if (!appendAsm(Bytes, "s_get_pc_i64 " + ScratchPair, LS))
+  //
+  // The global_wb + v_nop prefix is a gfx12.5-only marker; other subtargets
+  // (gfx12.0, which has global_wb but does not use it, and gfx10.3, which lacks
+  // it) emit a prefix-less stub that is a pure PC-relative jump back to the
+  // original entry. The get-/set-PC spelling is the one the active subtarget
+  // accepts, resolved at initLLVM() time.
+  if (LS.EntryStubHasWbPrefix) {
+    if (!appendAsm(Bytes, "global_wb", LS))
+      return {};
+    if (!appendAsm(Bytes, "v_nop", LS))
+      return {};
+  }
+  if (!appendAsm(Bytes, LS.EntryStubGetPcAsm + " " + ScratchPair, LS))
     return {};
 
   // s_get_pc_i64 returns the address of the following s_add_u32 instruction.
@@ -96,7 +104,7 @@ SmallVector<uint8_t> buildKernelEntryTrampoline(uint64_t StubVAddr,
                      utohexstr(Hi),
                  LS))
     return {};
-  if (!appendAsm(Bytes, "s_set_pc_i64 " + ScratchPair, LS))
+  if (!appendAsm(Bytes, LS.EntryStubSetPcAsm + " " + ScratchPair, LS))
     return {};
 
   SmallVector<uint8_t> CodeEnd = getCodeEndBytes(LS);
@@ -126,8 +134,23 @@ uint64_t computeKernelEntryPrefetchGuardBytes(uint32_t InstPrefLines) {
   return PrefetchBytes - KernelEntryStubStride;
 }
 
+// Number of leading marker instructions (global_wb + v_nop) in the kernel-entry
+// stub. Two on gfx12.5, zero elsewhere (gfx12.0 and gfx10.3 build a prefix-less
+// stub). The get-PC / add / addc / set-PC quartet follows the prefix.
+static unsigned entryStubPrefixInstCount(const LLVMState &LS) {
+  return LS.EntryStubHasWbPrefix ? 2u : 0u;
+}
+
+// Minimum decoded instruction count for a well-formed stub: prefix + the
+// four-instruction PC-relative jump sequence.
+static unsigned entryStubMinDecodedInsts(const LLVMState &LS) {
+  return entryStubPrefixInstCount(LS) + 4u;
+}
+
 static bool hasResolvedEntryStubState(const LLVMState &LS, StringRef Context) {
-  if (!LS.MCII || LS.GlobalWbOpcode >= LS.MCII->getNumOpcodes() ||
+  if (!LS.MCII ||
+      (LS.EntryStubHasWbPrefix &&
+       LS.GlobalWbOpcode >= LS.MCII->getNumOpcodes()) ||
       LS.SGetPcI64Opcode >= LS.MCII->getNumOpcodes() ||
       LS.SAddU32Opcode >= LS.MCII->getNumOpcodes() ||
       LS.SAddcU32Opcode >= LS.MCII->getNumOpcodes() ||
@@ -160,7 +183,7 @@ static bool decodeKernelEntryStub(ArrayRef<uint8_t> Bytes, const LLVMState &LS,
           << KernelEntryStubStride << "-byte candidate.\n";
     return false;
   }
-  return Decoded.size() >= 6;
+  return Decoded.size() >= entryStubMinDecodedInsts(LS);
 }
 
 static bool startsWithBytes(ArrayRef<uint8_t> Bytes, ArrayRef<uint8_t> Prefix) {
@@ -169,6 +192,11 @@ static bool startsWithBytes(ArrayRef<uint8_t> Bytes, ArrayRef<uint8_t> Prefix) {
 }
 
 static SmallVector<uint8_t> buildEntryStubBytePrefix(const LLVMState &LS) {
+  // Prefix-less subtargets (gfx12.0, gfx10.3) have no fixed-byte marker; the
+  // empty prefix is a valid, expected result there, not a failure.
+  if (!LS.EntryStubHasWbPrefix)
+    return {};
+
   SmallVector<uint8_t> GlobalWb = assembleSingleInst("global_wb", LS);
   SmallVector<uint8_t> VNop = assembleSingleInst("v_nop", LS);
   if (GlobalWb.empty() || VNop.empty())
@@ -196,27 +224,33 @@ static bool sameRegOperand(const MCInst &LHS, unsigned LHSIndex,
 
 static bool hasEntryStubOperandShape(ArrayRef<InternalDecodedInst> Decoded,
                                      const LLVMState &LS) {
-  if (Decoded.size() < 6)
+  const unsigned Base = entryStubPrefixInstCount(LS);
+  if (Decoded.size() < entryStubMinDecodedInsts(LS))
     return false;
 
-  if (Decoded[0].Inst.getOpcode() != LS.GlobalWbOpcode ||
-      Decoded[1].Inst.getOpcode() != LS.VNopInst.getOpcode() ||
-      Decoded[2].Inst.getOpcode() != LS.SGetPcI64Opcode ||
-      Decoded[3].Inst.getOpcode() != LS.SAddU32Opcode ||
-      Decoded[4].Inst.getOpcode() != LS.SAddcU32Opcode ||
-      Decoded[5].Inst.getOpcode() != LS.SSetPcI64Opcode)
+  // The gfx12.5 prefix (global_wb + v_nop) precedes the jump quartet; on
+  // prefix-less subtargets (gfx12.0, gfx10.3) the quartet starts at index 0.
+  if (LS.EntryStubHasWbPrefix) {
+    const MCInst &GlobalWb = Decoded[0].Inst;
+    const MCInst &VNop = Decoded[1].Inst;
+    if (GlobalWb.getOpcode() != LS.GlobalWbOpcode ||
+        VNop.getOpcode() != LS.VNopInst.getOpcode())
+      return false;
+    if (GlobalWb.getNumOperands() != 1 || !GlobalWb.getOperand(0).isImm() ||
+        GlobalWb.getOperand(0).getImm() != 0 || VNop.getNumOperands() != 0)
+      return false;
+  }
+
+  if (Decoded[Base].Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      Decoded[Base + 1].Inst.getOpcode() != LS.SAddU32Opcode ||
+      Decoded[Base + 2].Inst.getOpcode() != LS.SAddcU32Opcode ||
+      Decoded[Base + 3].Inst.getOpcode() != LS.SSetPcI64Opcode)
     return false;
 
-  const MCInst &GlobalWb = Decoded[0].Inst;
-  const MCInst &VNop = Decoded[1].Inst;
-  const MCInst &GetPc = Decoded[2].Inst;
-  const MCInst &AddLo = Decoded[3].Inst;
-  const MCInst &AddHi = Decoded[4].Inst;
-  const MCInst &SetPc = Decoded[5].Inst;
-
-  if (GlobalWb.getNumOperands() != 1 || !GlobalWb.getOperand(0).isImm() ||
-      GlobalWb.getOperand(0).getImm() != 0 || VNop.getNumOperands() != 0)
-    return false;
+  const MCInst &GetPc = Decoded[Base].Inst;
+  const MCInst &AddLo = Decoded[Base + 1].Inst;
+  const MCInst &AddHi = Decoded[Base + 2].Inst;
+  const MCInst &SetPc = Decoded[Base + 3].Inst;
 
   if (GetPc.getNumOperands() != 1 || SetPc.getNumOperands() != 1 ||
       !sameRegOperand(GetPc, 0, SetPc, 0))
@@ -239,9 +273,15 @@ static bool hasEntryStubOperandShape(ArrayRef<InternalDecodedInst> Decoded,
 
 static std::optional<uint64_t>
 decodeEntryStubTargetVAddr(ArrayRef<InternalDecodedInst> Decoded,
-                           uint64_t StubVAddr) {
+                           uint64_t StubVAddr, const LLVMState &LS) {
+  // Indices are relative to the (possibly empty) global_wb + v_nop prefix:
+  // get-PC at Base, then the add-lo / add-hi immediates that materialize the
+  // PC-relative delta.
+  const unsigned Base = entryStubPrefixInstCount(LS);
+  if (Decoded.size() < entryStubMinDecodedInsts(LS))
+    return std::nullopt;
   std::optional<uint64_t> PcBaseOffset =
-      checkedAddUint64(Decoded[2].Offset, Decoded[2].Size,
+      checkedAddUint64(Decoded[Base].Offset, Decoded[Base].Size,
                        "decoded kernel-entry stub PC-base offset");
   if (!PcBaseOffset)
     return std::nullopt;
@@ -251,9 +291,9 @@ decodeEntryStubTargetVAddr(ArrayRef<InternalDecodedInst> Decoded,
     return std::nullopt;
 
   const uint64_t Lo =
-      static_cast<uint32_t>(Decoded[3].Inst.getOperand(2).getImm());
+      static_cast<uint32_t>(Decoded[Base + 1].Inst.getOperand(2).getImm());
   const uint64_t Hi =
-      static_cast<uint32_t>(Decoded[4].Inst.getOperand(2).getImm());
+      static_cast<uint32_t>(Decoded[Base + 2].Inst.getOperand(2).getImm());
   const uint64_t Delta = Lo | (Hi << 32);
   return *PcBase + Delta;
 }
@@ -269,14 +309,34 @@ bool isKernelEntryTrampoline(ArrayRef<uint8_t> Bytes, const LLVMState &LS) {
 
 bool hasKernelEntryTrampolinePrefix(ArrayRef<uint8_t> Bytes,
                                     const LLVMState &LS) {
-  SmallVector<uint8_t> Prefix;
-  if (!appendAsm(Prefix, "global_wb", LS))
+  // gfx12.5: the global_wb + v_nop marker is register-independent, so a
+  // byte-exact compare is a cheap, robust prefilter.
+  if (LS.EntryStubHasWbPrefix) {
+    SmallVector<uint8_t> Prefix;
+    if (!appendAsm(Prefix, "global_wb", LS))
+      return false;
+    if (!appendAsm(Prefix, "v_nop", LS))
+      return false;
+
+    return Bytes.size() >= Prefix.size() &&
+           std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
+  }
+
+  // Prefix-less subtargets (gfx12.0, gfx10.3): the stub has no fixed-byte
+  // marker because the leading s_getpc_b64 encodes its scratch register. Decode
+  // only the first instruction (one dword) -- cheap, and it avoids running the
+  // disassembler over an entire arbitrary 256-byte candidate region -- and
+  // check it is the get-PC opcode. False positives are harmless: the full
+  // isKernelEntryTrampoline matcher still validates the whole shape.
+  if (Bytes.size() < MinInstSize)
     return false;
-  if (!appendAsm(Prefix, "v_nop", LS))
+  if (!hasResolvedEntryStubState(LS, "hasKernelEntryTrampolinePrefix"))
     return false;
 
-  return Bytes.size() >= Prefix.size() &&
-         std::equal(Prefix.begin(), Prefix.end(), Bytes.begin());
+  std::vector<InternalDecodedInst> First;
+  if (!decodeTextSection(Bytes.data(), MinInstSize, LS, First) || First.empty())
+    return false;
+  return First.front().Inst.getOpcode() == LS.SGetPcI64Opcode;
 }
 
 static std::optional<uint64_t>
@@ -343,7 +403,8 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;
 
-  std::optional<uint64_t> Target = decodeEntryStubTargetVAddr(Decoded, *Entry);
+  std::optional<uint64_t> Target =
+      decodeEntryStubTargetVAddr(Decoded, *Entry, LS);
   if (!Target)
     return std::nullopt;
 
@@ -488,8 +549,13 @@ std::optional<uint32_t> appendKernelEntryTrampolines(
   if (Descriptors.empty())
     return 0;
 
+  // gfx12.5 stubs carry a global_wb + v_nop byte prefix used as a cheap
+  // idempotency prefilter. Prefix-less subtargets (gfx12.0, gfx10.3) return an
+  // empty prefix here, which is expected -- the matchers fall back to decoding
+  // the leading get-PC instruction. Only treat an empty prefix as a failure
+  // when the subtarget is supposed to have one.
   SmallVector<uint8_t> EntryStubPrefix = buildEntryStubBytePrefix(LS);
-  if (EntryStubPrefix.empty()) {
+  if (LS.EntryStubHasWbPrefix && EntryStubPrefix.empty()) {
     log() << "hotswap: error: entry trampoline: failed to assemble byte "
           << "prefix for idempotency matching.\n";
     return std::nullopt;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -522,11 +522,31 @@ struct LLVMState {
   /// initLLVM() time by parsing representative asm snippets. The idempotency
   /// matcher compares decoded opcodes against these cached values instead of
   /// matching disassembled mnemonic strings.
+  ///
+  /// GlobalWbOpcode is only meaningful when EntryStubHasWbPrefix is true (the
+  /// global_wb writeback + v_nop marker prefixes the stub only on gfx12.5;
+  /// gfx12.0 and gfx10 stubs omit it and are a pure PC-relative jump).
+  /// SGetPcI64Opcode / SSetPcI64Opcode hold the resolved get-/set-PC opcode
+  /// regardless of which mnemonic spelling the subtarget accepts (the gfx12.5
+  /// "s_get_pc_i64" and gfx12.0/gfx10 "s_getpc_b64" forms encode identically).
   unsigned GlobalWbOpcode = 0;
   unsigned SGetPcI64Opcode = 0;
   unsigned SAddU32Opcode = 0;
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
+
+  /// True when the kernel-entry stub is prefixed with global_wb + v_nop. This
+  /// is gfx12.5 only: gfx10.3 lacks global_wb, and gfx12.0 has it but does not
+  /// use the prefix. When false the stub is the bare get-PC / add / addc /
+  /// set-PC jump sequence.
+  bool EntryStubHasWbPrefix = false;
+
+  /// Assembler mnemonic spellings for the get-PC / set-PC instructions that the
+  /// active subtarget accepts ("s_get_pc_i64" / "s_set_pc_i64" on gfx12.5,
+  /// "s_getpc_b64" / "s_setpc_b64" on gfx12.0 and gfx10). Used by
+  /// buildKernelEntryTrampoline so it need not rediscover the spelling per stub.
+  std::string EntryStubGetPcAsm;
+  std::string EntryStubSetPcAsm;
 
   /// MC identities used by far-trampoline relocation analysis. Each opcode is
   /// resolved once through the asm parser so policy code never compares

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -29,6 +29,7 @@
 #include "llvm/MC/MCTargetOptions.h"
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/TargetParser/AMDGPUTargetParser.h"
 
 using namespace llvm;
 
@@ -135,6 +136,19 @@ static SmallVector<uint8_t> encodeMCInst(const MCInst &Inst,
   return SmallVector<uint8_t>(Code.begin(), Code.end());
 }
 
+// Route MC asm-parser diagnostics to the hotswap log (quiet unless verbose
+// logs are enabled) instead of letting SourceMgr print them straight to stderr.
+// initLLVM's dual-spelling opcode probe intentionally assembles the gfx12.5
+// mnemonics (s_get_pc_i64 / s_set_pc_i64) that fail on gfx12.0 / gfx10 before
+// falling back to the b64 spelling; those expected failures must not reach the
+// user's terminal.
+static void hotswapSrcMgrDiagHandler(const SMDiagnostic &Diag, void *) {
+  std::string Msg;
+  raw_string_ostream OS(Msg);
+  Diag.print(/*ProgName=*/nullptr, OS, /*ShowColors=*/false);
+  log() << OS.str();
+}
+
 /// Run the AMDGPU asm parser over \p AsmStr and return the captured MCInsts.
 /// Used by assembleSingleInst() for the full parse-and-encode path, and by
 /// initLLVM() / resolveOpcodeViaParse() for instructions where parsing the
@@ -151,6 +165,7 @@ static SmallVector<MCInst, 2> parseAsmToMCInsts(StringRef AsmStr,
   // aborts at `Either SourceMgr should be available` in MCContext.cpp.
   S.Ctx->initInlineSourceManager();
   SourceMgr *SrcMgr = S.Ctx->getInlineSourceManager();
+  SrcMgr->setDiagHandler(hotswapSrcMgrDiagHandler, nullptr);
 
   std::string FullAsm = (".text\n" + AsmStr).str();
   std::unique_ptr<MemoryBuffer> Buf =
@@ -325,11 +340,60 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   }
   S.VNopInst = VNopInsts[0];
 
-  if (!resolveRequiredOpcodeViaParse("global_wb", "global_wb", S,
-                                     S.GlobalWbOpcode))
-    return S;
-  if (!resolveRequiredOpcodeViaParse("s_get_pc_i64 s[0:1]", "s_get_pc_i64", S,
-                                     S.SGetPcI64Opcode))
+  // The global_wb writeback is a gfx12-family instruction, but the global_wb +
+  // v_nop stub prefix is only required on gfx12.5. Other subtargets build a
+  // bare PC-relative jump: gfx10.3 lacks global_wb entirely, and gfx12.0 has it
+  // but does not need the prefix. Resolve the opcode when available (used by
+  // the prefix matcher on gfx12.5) but gate the prefix on the ISA version,
+  // since gfx12.0 and gfx12.5 both provide the instruction.
+  S.GlobalWbOpcode = resolveOpcodeViaParse("global_wb", S);
+  llvm::AMDGPU::IsaVersion Version = llvm::AMDGPU::getIsaVersion(S.Cpu);
+  S.EntryStubHasWbPrefix = Version.Major == 12 && Version.Minor == 5 &&
+                           S.GlobalWbOpcode < S.MCII->getNumOpcodes();
+
+  // Resolve get-PC / set-PC by the subtarget-preferred spelling: gfx12.5 spells
+  // them s_get_pc_i64 / s_set_pc_i64, gfx12.0 / gfx10 s_getpc_b64 /
+  // s_setpc_b64. The two spellings encode identically on gfx12, so either
+  // produces the same opcode there; the cached asm spelling is reused by
+  // buildKernelEntryTrampoline.
+  auto resolveDualSpelling = [&](StringRef PreferredAsm, StringRef PreferredMnem,
+                                 StringRef FallbackAsm, StringRef FallbackMnem,
+                                 unsigned &OutOpcode,
+                                 std::string &OutAsm) -> bool {
+    OutOpcode = resolveOpcodeViaParse(PreferredAsm, S);
+    if (OutOpcode < S.MCII->getNumOpcodes()) {
+      OutAsm = PreferredMnem.str();
+      return true;
+    }
+    OutOpcode = resolveOpcodeViaParse(FallbackAsm, S);
+    if (OutOpcode < S.MCII->getNumOpcodes()) {
+      OutAsm = FallbackMnem.str();
+      return true;
+    }
+    log() << "hotswap: error: initLLVM: failed to resolve get-/set-PC opcode "
+          << "via '" << PreferredMnem << "' or '" << FallbackMnem
+          << "' for CPU '" << S.Cpu << "'.\n";
+    return false;
+  };
+
+  // The far-trampoline relocation analysis (comgr-hotswap-b0a0.cpp) runs only
+  // on the gfx1250 instruction-patch path. Its opcodes are gfx1250-specific
+  // (s_add_pc_i64 / s_call_i64 / s_swap_pc_i64 / s_prefetch_*) or gfx11+
+  // (s_delay_alu) and are absent on gfx12.0 / gfx10.3, which run only the
+  // entry-trampoline path. Require them on gfx1250; resolve best-effort
+  // elsewhere, where they are never consumed.
+  const bool IsGfx1250 = Version.Major == 12 && Version.Minor == 5;
+  auto resolveFarTrampolineOpcode = [&](StringRef Asm, StringRef Name,
+                                        unsigned &Out) -> bool {
+    if (IsGfx1250)
+      return resolveRequiredOpcodeViaParse(Asm, Name, S, Out);
+    Out = resolveOpcodeViaParse(Asm, S);
+    return true;
+  };
+
+  if (!resolveDualSpelling("s_get_pc_i64 s[0:1]", "s_get_pc_i64",
+                           "s_getpc_b64 s[0:1]", "s_getpc_b64",
+                           S.SGetPcI64Opcode, S.EntryStubGetPcAsm))
     return S;
   if (!resolveRequiredOpcodeViaParse("s_add_u32 s0, s0, 0", "s_add_u32", S,
                                      S.SAddU32Opcode))
@@ -337,14 +401,15 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_addc_u32 s1, s1, 0", "s_addc_u32", S,
                                      S.SAddcU32Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_set_pc_i64 s[0:1]", "s_set_pc_i64", S,
-                                     S.SSetPcI64Opcode))
+  if (!resolveDualSpelling("s_set_pc_i64 s[0:1]", "s_set_pc_i64",
+                           "s_setpc_b64 s[0:1]", "s_setpc_b64",
+                           S.SSetPcI64Opcode, S.EntryStubSetPcAsm))
     return S;
   if (!resolveRequiredOpcodeViaParse("s_clause 0", "s_clause", S,
                                      S.SClauseOpcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_delay_alu instid0(VALU_DEP_1)",
-                                     "s_delay_alu", S, S.SDelayAluOpcode))
+  if (!resolveFarTrampolineOpcode("s_delay_alu instid0(VALU_DEP_1)",
+                                  "s_delay_alu", S.SDelayAluOpcode))
     return S;
   if (!resolveRequiredOpcodeViaParse("s_endpgm", "s_endpgm", S,
                                      S.SEndPgmOpcode))
@@ -352,22 +417,22 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_endpgm_saved", "s_endpgm_saved", S,
                                      S.SEndPgmSavedOpcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_add_pc_i64 0", "s_add_pc_i64", S,
-                                     S.SAddPcI64Opcode))
+  if (!resolveFarTrampolineOpcode("s_add_pc_i64 0", "s_add_pc_i64",
+                                  S.SAddPcI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_call_i64 s[0:1], 0", "s_call_i64", S,
-                                     S.SCallI64Opcode))
+  if (!resolveFarTrampolineOpcode("s_call_i64 s[0:1], 0", "s_call_i64",
+                                  S.SCallI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[0:1], s[2:3]",
-                                     "s_swap_pc_i64", S, S.SSwapPcI64Opcode))
+  if (!resolveFarTrampolineOpcode("s_swap_pc_i64 s[0:1], s[2:3]",
+                                  "s_swap_pc_i64", S.SSwapPcI64Opcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_prefetch_inst_pc_rel 100, s10, 7",
-                                     "s_prefetch_inst_pc_rel", S,
-                                     S.SPrefetchInstPcRelOpcode))
+  if (!resolveFarTrampolineOpcode("s_prefetch_inst_pc_rel 100, s10, 7",
+                                  "s_prefetch_inst_pc_rel",
+                                  S.SPrefetchInstPcRelOpcode))
     return S;
-  if (!resolveRequiredOpcodeViaParse("s_prefetch_data_pc_rel 100, s10, 7",
-                                     "s_prefetch_data_pc_rel", S,
-                                     S.SPrefetchDataPcRelOpcode))
+  if (!resolveFarTrampolineOpcode("s_prefetch_data_pc_rel 100, s10, 7",
+                                  "s_prefetch_data_pc_rel",
+                                  S.SPrefetchDataPcRelOpcode))
     return S;
 
   SmallVector<MCInst, 2> SccDefInsts =

--- a/amd/comgr/src/comgr-hotswap.cpp
+++ b/amd/comgr/src/comgr-hotswap.cpp
@@ -46,6 +46,33 @@ static bool isGfx12_5Processor(llvm::StringRef Processor) {
   return Version.Major == 12 && Version.Minor == 5;
 }
 
+// gfx12.0 (e.g. gfx1200 / gfx1201) supports the kernel-entry trampoline
+// rewrite. Like gfx10.3, its stub is a bare PC-relative jump with no global_wb
+// + v_nop prefix (that marker is emitted only on gfx12.5); gfx12.0 also spells
+// get-/set-PC as s_getpc_b64 / s_setpc_b64 (encoding identically to gfx12.5's
+// s_get_pc_i64 forms). The gfx1250 B0-to-A0 patches are NOT applied here.
+static bool isGfx12_0Processor(llvm::StringRef Processor) {
+  llvm::AMDGPU::IsaVersion Version = llvm::AMDGPU::getIsaVersion(Processor);
+  return Version.Major == 12 && Version.Minor == 0;
+}
+
+// gfx10.3 (e.g. gfx1030) supports the kernel-entry trampoline rewrite: the stub
+// is a bare PC-relative jump back to the original entrypoint, assembled from
+// instructions common to gfx10 (s_getpc_b64 / s_add_u32 / s_addc_u32 /
+// s_setpc_b64). gfx10 lacks global_wb, so the stub carries no prefix. The
+// gfx1250 B0-to-A0 patches are NOT applied here.
+static bool isGfx10_3Processor(llvm::StringRef Processor) {
+  llvm::AMDGPU::IsaVersion Version = llvm::AMDGPU::getIsaVersion(Processor);
+  return Version.Major == 10 && Version.Minor == 3;
+}
+
+// Processors for which any hotswap rewrite (entry trampolines and/or the
+// gfx1250 stepping patches) is supported.
+static bool isHotswapSupportedProcessor(llvm::StringRef Processor) {
+  return isGfx12_5Processor(Processor) || isGfx12_0Processor(Processor) ||
+         isGfx10_3Processor(Processor);
+}
+
 static amd_comgr_status_t parseHotswapIsaName(const char *IsaName,
                                               ParsedHotswapIsa &Parsed) {
   Parsed = ParsedHotswapIsa{};
@@ -208,12 +235,12 @@ hotswapRewrite(amd_comgr_data_t input, const char *source_isa_name,
       parseHotswapIsaName(target_isa_name, TargetIdent))
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
 
-  if (!isGfx12_5Processor(SourceIdent.Ident.Processor) ||
-      !isGfx12_5Processor(TargetIdent.Ident.Processor)) {
+  if (!isHotswapSupportedProcessor(SourceIdent.Ident.Processor) ||
+      !isHotswapSupportedProcessor(TargetIdent.Ident.Processor)) {
     hotswap::log() << "hotswap: error: " << ApiName
-                   << ": only gfx125x processors are supported, got source '"
-                   << SourceIdent.Ident.Processor << "' and target '"
-                   << TargetIdent.Ident.Processor << "'\n";
+                   << ": only gfx125x, gfx12.0, and gfx10.3 processors are "
+                   << "supported, got source '" << SourceIdent.Ident.Processor
+                   << "' and target '" << TargetIdent.Ident.Processor << "'\n";
     return AMD_COMGR_STATUS_ERROR_INVALID_ARGUMENT;
   }
   if (SourceIdent.Ident.Processor != TargetIdent.Ident.Processor) {

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx1030.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx1030.s
@@ -1,0 +1,108 @@
+// COM: HotSwap redirects kernel descriptors to appended PC-relative entry
+// COM: stubs on gfx10.3. Unlike gfx12.5, the gfx1030 stub has no global_wb +
+// COM: v_nop marker: it is a bare get-PC / add / addc / set-PC jump back to the
+// COM: original kernel entrypoint, spelled with the gfx10-style s_getpc_b64 /
+// COM: s_setpc_b64.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1030 -nostdlib %s -o %t.elf
+
+// COM: Without the flag the rewrite is a no-op copy of the input.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1030 amdgcn-amd-amdhsa--gfx1030 \
+// RUN:   --output %t.default.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: cmp %t.elf %t.default.elf
+// RUN: %llvm-objdump -d %t.default.elf | %FileCheck --check-prefix=NO-TRAMP %s
+// NO-TRAMP-LABEL: <entry_tramp_kernel>:
+// NO-TRAMP: s_endpgm
+// NO-TRAMP-LABEL: <second_kernel>:
+// NO-TRAMP: s_endpgm
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1030 amdgcn-amd-amdhsa--gfx1030 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The gfx1030 stub is a bare PC-relative jump: no global_wb, no v_nop.
+// DISASM-NOT: global_wb
+// DISASM: s_getpc_b64 s[8:9]
+// DISASM-NEXT: s_add_u32 s8
+// DISASM-NEXT: s_addc_u32 s9
+// DISASM-NEXT: s_setpc_b64 s[8:9]
+
+// COM: Each appended stub gets a <kernel>.stub symbol so a dispatch whose entry
+// COM: points at the stub still resolves to a name (e.g. rocgdb info dispatches).
+// RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
+// SYMS-DAG: FUNC {{.*}} entry_tramp_kernel.stub
+// SYMS-DAG: FUNC {{.*}} second_kernel.stub
+
+// COM: The rewrite is idempotent: a second pass detects the existing stubs and
+// COM: produces byte-identical output.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1030 amdgcn-amd-amdhsa--gfx1030 \
+// RUN:   --entry-trampolines --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1030"
+.text
+.globl entry_tramp_kernel
+.p2align 8
+.type entry_tramp_kernel,@function
+entry_tramp_kernel:
+  v_mov_b32_e32 v0, 0
+  s_endpgm
+.Lentry_tramp_kernel_end:
+.size entry_tramp_kernel, .Lentry_tramp_kernel_end-entry_tramp_kernel
+
+.globl second_kernel
+.p2align 8
+.type second_kernel,@function
+second_kernel:
+  s_nop 0
+  s_endpgm
+.Lsecond_kernel_end:
+.size second_kernel, .Lsecond_kernel_end-second_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel entry_tramp_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: entry_tramp_kernel
+      .symbol: entry_tramp_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: second_kernel
+      .symbol: second_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx1200.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx1200.s
@@ -1,0 +1,113 @@
+// COM: HotSwap redirects kernel descriptors to appended PC-relative entry
+// COM: stubs on gfx12.0 (gfx1200). Although gfx1200 has global_wb, the
+// COM: global_wb + v_nop prefix marker is emitted only on gfx12.5: the gfx1200
+// COM: stub is a bare PC-relative jump back to the original kernel entrypoint,
+// COM: spelled with the gfx10-style s_getpc_b64 / s_setpc_b64 (gfx1200 does not
+// COM: accept s_get_pc_i64 / s_set_pc_i64; the b64 forms encode identically to
+// COM: the gfx1250 spelling).
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1200 -nostdlib %s -o %t.elf
+
+// COM: Without the flag the rewrite is a no-op copy of the input.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1200 amdgcn-amd-amdhsa--gfx1200 \
+// RUN:   --output %t.default.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: cmp %t.elf %t.default.elf
+// RUN: %llvm-objdump -d %t.default.elf | %FileCheck --check-prefix=NO-TRAMP %s
+// NO-TRAMP-LABEL: <entry_tramp_kernel>:
+// NO-TRAMP: s_endpgm
+// NO-TRAMP-LABEL: <second_kernel>:
+// NO-TRAMP: s_endpgm
+// NO-TRAMP-NOT: global_wb
+
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1200 amdgcn-amd-amdhsa--gfx1200 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: The gfx1200 stub has no global_wb / v_nop prefix: it is a bare
+// COM: PC-relative jump via the b64-spelled get-PC / add / addc / set-PC quartet.
+// DISASM-NOT: global_wb
+// DISASM: s_getpc_b64 s[8:9]
+// DISASM-NEXT: s_add_co_u32 s8
+// DISASM-NEXT: s_add_co_ci_u32 s9
+// DISASM-NEXT: s_setpc_b64 s[8:9]
+
+// COM: Each appended stub gets a <kernel>.stub symbol so a dispatch whose entry
+// COM: points at the stub still resolves to a name (e.g. rocgdb info dispatches).
+// RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
+// SYMS-DAG: FUNC {{.*}} entry_tramp_kernel.stub
+// SYMS-DAG: FUNC {{.*}} second_kernel.stub
+
+// COM: The rewrite is idempotent: a second pass detects the existing stubs and
+// COM: produces byte-identical output.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1200 amdgcn-amd-amdhsa--gfx1200 \
+// RUN:   --entry-trampolines --output %t.out2.elf \
+// RUN:   | %FileCheck --check-prefix=API2 %s
+// API2: RESULT: SUCCESS
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1200"
+.text
+.globl entry_tramp_kernel
+.p2align 8
+.type entry_tramp_kernel,@function
+entry_tramp_kernel:
+  v_mov_b32_e32 v0, 0
+  s_endpgm
+.Lentry_tramp_kernel_end:
+.size entry_tramp_kernel, .Lentry_tramp_kernel_end-entry_tramp_kernel
+
+.globl second_kernel
+.p2align 8
+.type second_kernel,@function
+second_kernel:
+  s_nop 0
+  s_endpgm
+.Lsecond_kernel_end:
+.size second_kernel, .Lsecond_kernel_end-second_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel entry_tramp_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_inst_pref_size 7
+.end_amdhsa_kernel
+
+.amdhsa_kernel second_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: entry_tramp_kernel
+      .symbol: entry_tramp_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: second_kernel
+      .symbol: second_kernel.kd
+      .sgpr_count: 8
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -71,6 +71,33 @@ static TargetIdentifier makeGfx1250Ident() {
   return TI;
 }
 
+// gfx10.3 subtarget identifier. gfx1030 lacks global_wb / s_get_pc_i64 /
+// s_set_pc_i64, so its kernel-entry stub is the prefix-less get-PC / add / addc
+// / set-PC jump assembled from the gfx10 mnemonic spellings.
+static TargetIdentifier makeGfx1030Ident() {
+  TargetIdentifier TI;
+  TI.Arch = "amdgcn";
+  TI.Vendor = "amd";
+  TI.OS = "amdhsa";
+  TI.Environ = "";
+  TI.Processor = "gfx1030";
+  return TI;
+}
+
+// gfx12.0 subtarget identifier. gfx1200 has global_wb, but the global_wb + v_nop
+// prefix is emitted only on gfx12.5; gfx1200 therefore builds a prefix-less
+// stub and accepts only the b64 get-/set-PC spelling (identical encoding to
+// gfx1250's i64 forms).
+static TargetIdentifier makeGfx1200Ident() {
+  TargetIdentifier TI;
+  TI.Arch = "amdgcn";
+  TI.Vendor = "amd";
+  TI.OS = "amdhsa";
+  TI.Environ = "";
+  TI.Processor = "gfx1200";
+  return TI;
+}
+
 // Helper: decode the little-endian 32-bit dword at \p Bytes.
 static uint32_t readDword(const uint8_t *Bytes) {
   uint32_t V;
@@ -759,6 +786,81 @@ TEST(BuildKernelEntryTrampoline, BuildsRecognizedPcRelativeStub) {
       Decoded[4].Inst,
       (llvm::Twine("s_addc_u32 s9, s9, 0x") + llvm::utohexstr(Hi)).str(), S);
   expectInstMatchesAsm(Decoded[5].Inst, "s_set_pc_i64 s[8:9]", S);
+}
+
+TEST(InitLLVM, ValidGfx1030NoWbPrefix) {
+  LLVMState S = initLLVM(makeGfx1030Ident());
+  ASSERT_TRUE(S.Valid);
+  EXPECT_EQ(S.Cpu, "gfx1030");
+  // gfx1030 has no global_wb, so the entry stub carries no prefix marker and
+  // the get-/set-PC opcodes resolve via the b64 spelling.
+  EXPECT_FALSE(S.EntryStubHasWbPrefix);
+  EXPECT_EQ(S.EntryStubGetPcAsm, "s_getpc_b64");
+  EXPECT_EQ(S.EntryStubSetPcAsm, "s_setpc_b64");
+  EXPECT_LT(S.SGetPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SSetPcI64Opcode, S.MCII->getNumOpcodes());
+}
+
+TEST(InitLLVM, ValidGfx1200NoWbPrefixB64Spelling) {
+  LLVMState S = initLLVM(makeGfx1200Ident());
+  ASSERT_TRUE(S.Valid);
+  EXPECT_EQ(S.Cpu, "gfx1200");
+  // gfx1200 has global_wb, but the prefix is gfx12.5-only, so gfx1200 builds a
+  // prefix-less stub and accepts only the b64 get-/set-PC spelling.
+  EXPECT_FALSE(S.EntryStubHasWbPrefix);
+  EXPECT_EQ(S.EntryStubGetPcAsm, "s_getpc_b64");
+  EXPECT_EQ(S.EntryStubSetPcAsm, "s_setpc_b64");
+  EXPECT_LT(S.SGetPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SSetPcI64Opcode, S.MCII->getNumOpcodes());
+}
+
+// Shared checker: a prefix-less stub is a bare get-PC / add / addc / set-PC
+// jump (no global_wb + v_nop), spelled with the b64 get-/set-PC forms.
+static void expectPrefixlessStub(const TargetIdentifier &TI) {
+  LLVMState S = initLLVM(TI);
+  ASSERT_TRUE(S.Valid);
+  ASSERT_FALSE(S.EntryStubHasWbPrefix);
+
+  constexpr uint64_t StubVAddr = 0x200000;
+  constexpr uint64_t EntryVAddr = 0x10100;
+  llvm::SmallVector<uint8_t> Bytes =
+      buildKernelEntryTrampoline(StubVAddr, EntryVAddr, /*ScratchSgpr=*/8, S);
+
+  ASSERT_EQ(Bytes.size(), KernelEntryStubStride);
+  EXPECT_TRUE(isKernelEntryTrampoline(Bytes, S));
+  EXPECT_TRUE(hasKernelEntryTrampolinePrefix(Bytes, S));
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_GE(Decoded.size(), 4u);
+  // No global_wb / v_nop prefix: the jump quartet starts at index 0.
+  EXPECT_EQ(Decoded[0].Inst.getOpcode(), S.SGetPcI64Opcode);
+  EXPECT_EQ(Decoded[1].Inst.getOpcode(), S.SAddU32Opcode);
+  EXPECT_EQ(Decoded[2].Inst.getOpcode(), S.SAddcU32Opcode);
+  EXPECT_EQ(Decoded[3].Inst.getOpcode(), S.SSetPcI64Opcode);
+
+  const uint64_t PcBase = StubVAddr + Decoded[0].Offset + Decoded[0].Size;
+  const uint64_t Delta = EntryVAddr - PcBase;
+  const uint32_t Lo = static_cast<uint32_t>(Delta);
+  const uint32_t Hi = static_cast<uint32_t>(Delta >> 32);
+  expectInstMatchesAsm(Decoded[0].Inst, "s_getpc_b64 s[8:9]", S);
+  expectInstMatchesAsm(
+      Decoded[1].Inst,
+      (llvm::Twine("s_add_u32 s8, s8, 0x") + llvm::utohexstr(Lo)).str(), S);
+  expectInstMatchesAsm(
+      Decoded[2].Inst,
+      (llvm::Twine("s_addc_u32 s9, s9, 0x") + llvm::utohexstr(Hi)).str(), S);
+  expectInstMatchesAsm(Decoded[3].Inst, "s_setpc_b64 s[8:9]", S);
+}
+
+TEST(BuildKernelEntryTrampoline, BuildsPrefixlessGfx1030Stub) {
+  expectPrefixlessStub(makeGfx1030Ident());
+}
+
+// Regression guard: a gfx12 subtarget that *has* global_wb must still build a
+// bare-jump stub, since the prefix is gfx12.5-only.
+TEST(BuildKernelEntryTrampoline, BuildsPrefixlessGfx1200Stub) {
+  expectPrefixlessStub(makeGfx1200Ident());
 }
 
 TEST(BuildKernelEntryTrampoline, PrefixPrefiltersNonStubBytes) {


### PR DESCRIPTION
HotSwap's entry-trampoline rewrite was gated to gfx12.5 processors only. Extend it to gfx10.3 (gfx1030) and gfx12.0 (gfx1200 / gfx1201). On both new targets the stub is a bare PC-relative jump back to the original entrypoint:

    s_getpc_b64 s[N:N+1]
    s_add_u32   sN,   sN,   <lo>
    s_addc_u32  sN+1, sN+1, <hi>
    s_setpc_b64 s[N:N+1]

The global_wb + v_nop prefix is the unclaused-VMEM hardware workaround, which is only required on gfx12.5; gfx10.3 and gfx12.0 do not need that workaround, so their stubs omit the prefix and are a plain PC-relative jump. Prefix selection is therefore gated on the ISA version (gfx12.5), not on whether global_wb happens to be available -- gfx12.0 provides the instruction but still does not need the workaround. gfx12.0 and gfx10.3 also reject the s_get_pc_i64 / s_set_pc_i64 mnemonics, so get-/set-PC use the gfx10-style s_getpc_b64 / s_setpc_b64 spelling (identical encoding to the gfx12.5 forms), resolved by a dual-spelling probe at initLLVM() time.

Changes:
- comgr-hotswap.cpp: add isGfx12_0Processor / isGfx10_3Processor / isHotswapSupportedProcessor and relax the rewrite gate. The gfx1250 B0-to-A0 patches remain gated on Processor == "gfx1250".
- comgr-hotswap-llvm.cpp / -internal.h: resolve global_wb optionally and gate EntryStubHasWbPrefix on the gfx12.5 ISA version; resolve get-/set-PC via the i64 spelling with a b64 fallback, caching the chosen spelling in LLVMState. Require the far-trampoline opcodes (s_delay_alu / s_add_pc_i64 / s_call_i64 / s_swap_pc_i64 / s_prefetch_*) only on gfx12.5 -- they are gfx1250-specific and absent on gfx12.0 / gfx10.3, and are consumed only by the gfx1250 instruction- patch path -- resolving them best-effort elsewhere. Route asm-parser diagnostics to the hotswap log so the expected dual-spelling / optional-opcode probe failures do not reach the terminal.
- comgr-hotswap-entry-trampoline.cpp: emit the writeback prefix only when present, use the resolved spelling, and make the stub builder / matchers prefix-count aware (2 prefix insts on gfx12.5, 0 elsewhere). buildEntryStub- BytePrefix returns empty for prefix-less targets, and appendKernelEntry- Trampolines treats an empty prefix as expected there.
- comgr-hotswap-elf.cpp: getKernelDescriptorInstPrefSize returns 0 for gfx10 and updateKernelDescriptorInstPrefSize is a no-op success for gfx10 (no COMPUTE_PGM_RSRC3.INST_PREF_SIZE before gfx11).

Tests:
- test-lit/hotswap-kernel-entry-trampoline-gfx1030.s and -gfx1200.s: prefix-less bare-jump stub, <kernel>.stub symbols, and idempotency.
- test-unit/HotswapMCTest.cpp: gfx1030 / gfx1200 initLLVM (prefix-less, b64 spelling) and prefix-less stub-build coverage, guarding that a gfx12 target with global_wb still omits the prefix.

gfx1250 output is unchanged (same 6-instruction stub). Verified end-to-end on gfx1030 hardware: a hotswapped hello-world code object loads and runs correctly through the entry stub.


