### PR TITLE
[comgr][hotswap] Place entry-stub symbols in the trampoline pool, not .text

### DIFF
--- a/amd/comgr/src/comgr-compiler.cpp
+++ b/amd/comgr/src/comgr-compiler.cpp
@@ -1904,7 +1904,7 @@ amd_comgr_status_t AMDGPUCompiler::unpackage() {
 
           if (env::shouldEmitVerboseLogs()) {
             LogS << "\tPackage Entry Target: " << Target << "\n"
-                << "\tOutput Filename: " << OutputFilePath << "\n";
+                 << "\tOutput Filename: " << OutputFilePath << "\n";
             LogS.flush();
           }
         }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2750,9 +2750,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
         !UseFastAppend || env::shouldAddEntryTrampolineSymbols();
     if (!EntryFixups.empty() && AddStubSymbols) {
       std::unique_ptr<WritableMemoryBuffer> WithSyms =
-          addKernelEntryTrampolineSymbols(*Result, Elf.textSectionIndex(),
-                                          Elf.textAddr(), Elf.textSize(),
-                                          EntryFixups);
+          addKernelEntryTrampolineSymbols(*Result, PoolVAddr, EntryFixups);
       if (WithSyms)
         Result = std::move(WithSyms);
     }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -1410,8 +1410,8 @@ std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
 // -- addKernelEntryTrampolineSymbols ------------------------------------------
 
 std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    WritableMemoryBuffer &In, unsigned TextSectionIndex, uint64_t TextAddr,
-    uint64_t OldTextSize, ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+    WritableMemoryBuffer &In, uint64_t PoolVAddr,
+    ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return nullptr;
 
@@ -1432,6 +1432,22 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     return nullptr;
   }
   ELFT::ShdrRange Secs = *SecsOrErr;
+
+  // Locate the appended trampoline-pool section by its virtual address: the
+  // stubs live there (at PoolVAddr + StubTextOffset), not immediately after
+  // .text, so the stub symbols must reference this section, not .text.
+  unsigned PoolSectionIndex = 0;
+  for (unsigned I = 0; I < Secs.size(); ++I)
+    if ((Secs[I].sh_flags & ELF::SHF_ALLOC) && Secs[I].sh_addr == PoolVAddr) {
+      PoolSectionIndex = I;
+      break;
+    }
+  if (PoolSectionIndex == 0) {
+    log() << "hotswap: addKernelEntryTrampolineSymbols: trampoline-pool section "
+          << "at vaddr 0x" << utohexstr(PoolVAddr) << " not found; skipping "
+          << "stub symbols.\n";
+    return nullptr;
+  }
 
   // Locate .symtab and its linked string table. Scan from the end, since the
   // symbol table sits near the end of the section list in these code objects.
@@ -1479,12 +1495,8 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     StrBlob.append(Name.begin(), Name.end());
     StrBlob.push_back(0);
 
-    std::optional<uint64_t> StubOff = checkedAddUint64(
-        OldTextSize, F.StubTextOffset, "stub symbol .text offset");
-    if (!StubOff)
-      return nullptr;
-    std::optional<uint64_t> StubVAddr =
-        checkedAddUint64(TextAddr, *StubOff, "stub symbol vaddr");
+    std::optional<uint64_t> StubVAddr = checkedAddUint64(
+        PoolVAddr, F.StubTextOffset, "stub symbol vaddr");
     if (!StubVAddr)
       return nullptr;
 
@@ -1492,7 +1504,7 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     Sym.st_name = NameOff;
     Sym.st_info = (ELF::STB_GLOBAL << 4) | ELF::STT_FUNC;
     Sym.st_other = ELF::STV_DEFAULT;
-    Sym.st_shndx = static_cast<uint16_t>(TextSectionIndex);
+    Sym.st_shndx = static_cast<uint16_t>(PoolSectionIndex);
     Sym.st_value = *StubVAddr;
     Sym.st_size = KernelEntryStubStride;
     const uint8_t *P = reinterpret_cast<const uint8_t *>(&Sym);

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -1409,9 +1409,9 @@ std::optional<uint64_t> ElfView::trampolinePoolVAddr() const {
 
 // -- addKernelEntryTrampolineSymbols ------------------------------------------
 
-std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    WritableMemoryBuffer &In, uint64_t PoolVAddr,
-    ArrayRef<KernelEntryTrampolineFixup> Fixups) {
+std::unique_ptr<WritableMemoryBuffer>
+addKernelEntryTrampolineSymbols(WritableMemoryBuffer &In, uint64_t PoolVAddr,
+                                ArrayRef<KernelEntryTrampolineFixup> Fixups) {
   if (Fixups.empty())
     return nullptr;
 
@@ -1436,16 +1436,33 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
   // Locate the appended trampoline-pool section by its virtual address: the
   // stubs live there (at PoolVAddr + StubTextOffset), not immediately after
   // .text, so the stub symbols must reference this section, not .text.
+  //
+  // Match by containment (sh_addr <= PoolVAddr < sh_addr + sh_size), not by an
+  // exact sh_addr == PoolVAddr scan: a zero-sized allocatable section can begin
+  // at PoolVAddr (trampolinePoolVAddr() would still pick that address, and
+  // growWithTrampolines() appends the real pool after it). An exact-address
+  // scan could select that empty section, leaving the symbols' values outside
+  // their declared section. The pool is the only allocatable section that
+  // actually spans PoolVAddr, since PoolVAddr is aligned past every
+  // pre-existing allocatable section's end.
   unsigned PoolSectionIndex = 0;
-  for (unsigned I = 0; I < Secs.size(); ++I)
-    if ((Secs[I].sh_flags & ELF::SHF_ALLOC) && Secs[I].sh_addr == PoolVAddr) {
+  for (unsigned I = 0; I < Secs.size(); ++I) {
+    if (!(Secs[I].sh_flags & ELF::SHF_ALLOC))
+      continue;
+    std::optional<uint64_t> SecEnd = checkedAddUint64(
+        Secs[I].sh_addr, Secs[I].sh_size, "trampoline-pool section end");
+    if (!SecEnd)
+      return nullptr;
+    if (Secs[I].sh_addr <= PoolVAddr && PoolVAddr < *SecEnd) {
       PoolSectionIndex = I;
       break;
     }
+  }
   if (PoolSectionIndex == 0) {
-    log() << "hotswap: addKernelEntryTrampolineSymbols: trampoline-pool section "
-          << "at vaddr 0x" << utohexstr(PoolVAddr) << " not found; skipping "
-          << "stub symbols.\n";
+    log()
+        << "hotswap: addKernelEntryTrampolineSymbols: trampoline-pool section "
+        << "at vaddr 0x" << utohexstr(PoolVAddr) << " not found; skipping "
+        << "stub symbols.\n";
     return nullptr;
   }
 
@@ -1495,8 +1512,8 @@ std::unique_ptr<WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     StrBlob.append(Name.begin(), Name.end());
     StrBlob.push_back(0);
 
-    std::optional<uint64_t> StubVAddr = checkedAddUint64(
-        PoolVAddr, F.StubTextOffset, "stub symbol vaddr");
+    std::optional<uint64_t> StubVAddr =
+        checkedAddUint64(PoolVAddr, F.StubTextOffset, "stub symbol vaddr");
     if (!StubVAddr)
       return nullptr;
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -309,11 +309,9 @@ std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   return KD.VAddr - Magnitude;
 }
 
-static std::optional<bool>
-descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
-                                  const KernelDescriptorInfo &KD,
-                                  const LLVMState &LS,
-                                  ArrayRef<uint8_t> EntryStubPrefix) {
+static std::optional<bool> descriptorAlreadyTargetsEntryStub(
+    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS,
+    ArrayRef<uint8_t> EntryStubPrefix) {
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
@@ -338,8 +336,8 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
     return false;
 
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(Candidate, LS,
-                             Decoded, "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+                             "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1166,9 +1166,12 @@ std::optional<uint32_t> appendKernelEntryTrampolinesFast(
 /// Only the trailing non-alloc `.symtab` / `.strtab` sections grow, so no
 /// virtual addresses, program headers, or relocations change; `.dynsym` (used
 /// by the loader) is left untouched.
+/// \p PoolVAddr is the virtual address of the appended trampoline pool (the
+/// same base rewriteKernelEntryDescriptorOffsets() redirects each descriptor
+/// to); each stub symbol is placed at PoolVAddr + StubTextOffset in the pool's
+/// section, so it matches the address the dispatch entry now targets.
 std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
-    llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex,
-    uint64_t TextAddr, uint64_t OldTextSize,
+    llvm::WritableMemoryBuffer &In, uint64_t PoolVAddr,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -666,6 +666,84 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   }
 }
 
+// A zero-sized allocatable section can share the trampoline pool's base
+// address: trampolinePoolVAddr() still selects that address and
+// growWithTrampolines() appends the real pool after it. The stub symbol must
+// land in the real, non-empty pool section that spans PoolVAddr -- not the
+// empty section at the same address -- so its [value, value + size) range stays
+// inside its declared section. Guards the pool-section lookup against an exact
+// sh_addr == PoolVAddr scan that could select the empty section first.
+TEST(ElfView, AddKernelEntryTrampolineSymbolsSkipsZeroSizedSectionAtPoolVAddr) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "entry_kernel";
+  Opts.ExtraAllocSectionAddr = 0x3000; // page-aligned, past .rodata
+
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddrOr.has_value());
+  const uint64_t PoolVAddr = *PoolVAddrOr;
+  // The zero-sized section shares the pool base -- the scenario under test.
+  ASSERT_EQ(PoolVAddr, 0x3000u);
+
+  Trampoline Stub;
+  Stub.Bytes.assign(KernelEntryStubStride, 0xAA);
+  std::vector<Trampoline> Growth{Stub};
+  const uint8_t SNop[4] = {};
+  std::unique_ptr<llvm::WritableMemoryBuffer> Grown =
+      ViewOrErr->growWithTrampolines(Growth, SNop);
+  ASSERT_NE(Grown, nullptr);
+
+  std::vector<KernelEntryTrampolineFixup> Fixups = {
+      {"kernel_a", /*StubTextOffset=*/0, /*RequiredSgprs=*/10}};
+  std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
+      addKernelEntryTrampolineSymbols(*Grown, PoolVAddr, Fixups);
+  ASSERT_NE(WithSyms, nullptr);
+
+  using ELFT = llvm::object::ELF64LE;
+  llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
+      llvm::object::ELFFile<ELFT>::create(llvm::StringRef(
+          reinterpret_cast<const char *>(WithSyms->getBufferStart()),
+          WithSyms->getBufferSize()));
+  ASSERT_TRUE((bool)FileOrErr) << llvm::toString(FileOrErr.takeError());
+  llvm::object::ELFFile<ELFT> &File = *FileOrErr;
+  llvm::Expected<ELFT::ShdrRange> SecsOrErr = File.sections();
+  ASSERT_TRUE((bool)SecsOrErr) << llvm::toString(SecsOrErr.takeError());
+  const ELFT::Shdr *Symtab = nullptr;
+  for (const ELFT::Shdr &S : *SecsOrErr)
+    if (S.sh_type == llvm::ELF::SHT_SYMTAB) {
+      Symtab = &S;
+      break;
+    }
+  ASSERT_NE(Symtab, nullptr);
+  llvm::Expected<ELFT::SymRange> Syms = File.symbols(Symtab);
+  ASSERT_TRUE((bool)Syms) << llvm::toString(Syms.takeError());
+  llvm::Expected<llvm::StringRef> Str = File.getStringTableForSymtab(*Symtab);
+  ASSERT_TRUE((bool)Str) << llvm::toString(Str.takeError());
+  const ELFT::Sym *StubSym = nullptr;
+  for (const ELFT::Sym &Sym : *Syms) {
+    llvm::Expected<llvm::StringRef> N = Sym.getName(*Str);
+    ASSERT_TRUE((bool)N) << llvm::toString(N.takeError());
+    if (*N == "kernel_a.stub") {
+      StubSym = &Sym;
+      break;
+    }
+  }
+  ASSERT_NE(StubSym, nullptr);
+
+  // The symbol must reference the real pool section (non-empty, spanning
+  // PoolVAddr), not the zero-sized section at the same address.
+  ASSERT_LT(StubSym->st_shndx, SecsOrErr->size());
+  const ELFT::Shdr &Sec = (*SecsOrErr)[StubSym->st_shndx];
+  EXPECT_NE(Sec.sh_size, 0u);
+  EXPECT_GE(StubSym->st_value, Sec.sh_addr);
+  EXPECT_LT(StubSym->st_value, Sec.sh_addr + Sec.sh_size);
+  EXPECT_EQ(StubSym->st_value, PoolVAddr);
+}
+
 TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -566,10 +566,10 @@ TEST(ElfView, GrowWithTrampolinesKeepsDwarfConsistentWithSymbol) {
 // names and the two stub offsets (0 and KernelEntryStubStride). Re-parse the
 // returned buffer with llvm::object::ELFFile and, for each fixup, assert a
 // "<name>.stub" symbol exists in .symtab that is (a) STT_FUNC, (b) defined in
-// the .text section (st_shndx), (c) located at TextAddr + OldTextSize +
-// StubTextOffset, and (d) sized to KernelEntryStubStride. Two fixups (rather
-// than one) prove each stub gets its own name at its own address, not a single
-// shared or mis-placed entry.
+// the appended trampoline-pool section (st_shndx), (c) located at PoolVAddr +
+// StubTextOffset (where the dispatch entry now points), and (d) sized to
+// KernelEntryStubStride. Two fixups (rather than one) prove each stub gets its
+// own name at its own address, not a single shared or mis-placed entry.
 TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "entry_kernel";
@@ -579,9 +579,9 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   llvm::Expected<ElfView> ViewOrErr =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  const unsigned TextIdx = ViewOrErr->textSectionIndex();
-  const uint64_t TextAddr = ViewOrErr->textAddr();
-  const uint64_t OldTextSize = ViewOrErr->textSize();
+  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddrOr.has_value());
+  const uint64_t PoolVAddr = *PoolVAddrOr;
 
   // Grow .text by two entry-stub-sized blocks, mirroring the entry-trampoline
   // pass appending one stub per kernel.
@@ -602,8 +602,7 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
        /*RequiredSgprs=*/12},
   };
   std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
-      addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
-                                      Fixups);
+      addKernelEntryTrampolineSymbols(*Grown, PoolVAddr, Fixups);
   ASSERT_NE(WithSyms, nullptr);
 
   using ELFT = llvm::object::ELF64LE;
@@ -618,12 +617,20 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   llvm::Expected<ELFT::ShdrRange> SecsOrErr = File.sections();
   ASSERT_TRUE((bool)SecsOrErr) << llvm::toString(SecsOrErr.takeError());
   const ELFT::Shdr *SymtabShdr = nullptr;
-  for (const ELFT::Shdr &S : *SecsOrErr)
-    if (S.sh_type == llvm::ELF::SHT_SYMTAB) {
-      SymtabShdr = &S;
-      break;
+  unsigned PoolIdx = 0;
+  {
+    unsigned I = 0;
+    for (const ELFT::Shdr &S : *SecsOrErr) {
+      if (S.sh_type == llvm::ELF::SHT_SYMTAB && !SymtabShdr)
+        SymtabShdr = &S;
+      if ((S.sh_flags & llvm::ELF::SHF_ALLOC) && S.sh_addr == PoolVAddr &&
+          PoolIdx == 0)
+        PoolIdx = I;
+      ++I;
     }
+  }
   ASSERT_NE(SymtabShdr, nullptr);
+  ASSERT_NE(PoolIdx, 0u) << "trampoline-pool section not found at PoolVAddr";
   llvm::Expected<ELFT::SymRange> SymsOrErr = File.symbols(SymtabShdr);
   ASSERT_TRUE((bool)SymsOrErr) << llvm::toString(SymsOrErr.takeError());
   llvm::Expected<llvm::StringRef> StrTabOrErr =
@@ -640,14 +647,15 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
   };
 
   // Every appended stub must have a <kernel>.stub STT_FUNC symbol covering the
-  // stub, in the .text section, at the stub's virtual address.
+  // stub, in the trampoline-pool section, at the stub's virtual address (where
+  // the dispatch entry now points).
   for (const KernelEntryTrampolineFixup &F : Fixups) {
     const ELFT::Sym *Sym = FindSym(F.KernelName + ".stub");
     ASSERT_NE(Sym, nullptr) << "missing stub symbol for " << F.KernelName;
     EXPECT_EQ(static_cast<unsigned>(Sym->getType()),
               static_cast<unsigned>(llvm::ELF::STT_FUNC));
-    EXPECT_EQ(Sym->st_shndx, TextIdx);
-    EXPECT_EQ(Sym->st_value, TextAddr + OldTextSize + F.StubTextOffset);
+    EXPECT_EQ(Sym->st_shndx, PoolIdx);
+    EXPECT_EQ(Sym->st_value, PoolVAddr + F.StubTextOffset);
     EXPECT_EQ(Sym->st_size, KernelEntryStubStride);
   }
 }
@@ -662,9 +670,9 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
   llvm::Expected<ElfView> ViewOrErr =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  const unsigned TextIdx = ViewOrErr->textSectionIndex();
-  const uint64_t TextAddr = ViewOrErr->textAddr();
-  const uint64_t OldTextSize = ViewOrErr->textSize();
+  std::optional<uint64_t> PoolVAddrOr = ViewOrErr->trampolinePoolVAddr();
+  ASSERT_TRUE(PoolVAddrOr.has_value());
+  const uint64_t PoolVAddr = *PoolVAddrOr;
 
   Trampoline Stub;
   Stub.Bytes.assign(2 * KernelEntryStubStride, 0xAA);
@@ -680,8 +688,7 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsPreservesPhdr) {
        /*RequiredSgprs=*/12},
   };
   std::unique_ptr<llvm::WritableMemoryBuffer> WithSyms =
-      addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
-                                      Fixups);
+      addKernelEntryTrampolineSymbols(*Grown, PoolVAddr, Fixups);
   ASSERT_NE(WithSyms, nullptr);
 
   using ELFT = llvm::object::ELF64LE;

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -657,6 +657,12 @@ TEST(ElfView, AddKernelEntryTrampolineSymbolsNamesEachStub) {
     EXPECT_EQ(Sym->st_shndx, PoolIdx);
     EXPECT_EQ(Sym->st_value, PoolVAddr + F.StubTextOffset);
     EXPECT_EQ(Sym->st_size, KernelEntryStubStride);
+    // The symbol's [value, value + size) range must lie fully inside the
+    // section it claims (st_shndx), catching a symbol placed in the wrong
+    // section or past its bounds.
+    const ELFT::Shdr &StubSec = (*SecsOrErr)[Sym->st_shndx];
+    EXPECT_GE(Sym->st_value, StubSec.sh_addr);
+    EXPECT_LE(Sym->st_value + Sym->st_size, StubSec.sh_addr + StubSec.sh_size);
   }
 }
 

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1993,9 +1993,6 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   llvm::Expected<ElfView> View1 =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)View1) << llvm::toString(View1.takeError());
-  const unsigned TextIdx = View1->textSectionIndex();
-  const uint64_t TextAddr = View1->textAddr();
-  const uint64_t OldTextSize = View1->textSize();
 
   std::vector<Trampoline> Growth1;
   std::vector<KernelEntryTrampolineFixup> Fixups1;
@@ -2012,8 +2009,7 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   ASSERT_TRUE(
       rewriteKernelEntryDescriptorOffsets(*Grown, *PoolVAddr, S.Cpu, Fixups1));
   std::unique_ptr<llvm::WritableMemoryBuffer> Pass1 =
-      addKernelEntryTrampolineSymbols(*Grown, TextIdx, TextAddr, OldTextSize,
-                                      Fixups1);
+      addKernelEntryTrampolineSymbols(*Grown, *PoolVAddr, Fixups1);
   ASSERT_NE(Pass1, nullptr);
   ASSERT_EQ(countSymtabSymbolsNamed(*Pass1, "kernel.stub"), 1u);
 
@@ -2035,8 +2031,7 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
   // With no fixups the symbol pass is a no-op (returns nullptr, keeping the
   // existing buffer), so no second "kernel.stub" can be defined.
   std::unique_ptr<llvm::WritableMemoryBuffer> Pass2 =
-      addKernelEntryTrampolineSymbols(*Pass1, TextIdx, TextAddr,
-                                      View2->textSize(), Fixups2);
+      addKernelEntryTrampolineSymbols(*Pass1, *PoolVAddr, Fixups2);
   EXPECT_EQ(Pass2, nullptr);
   EXPECT_EQ(countSymtabSymbolsNamed(*Pass1, "kernel.stub"), 1u);
 }

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1969,9 +1969,10 @@ static unsigned countSymtabSymbolsNamed(llvm::WritableMemoryBuffer &Buf,
 //       at (what amd-dbgapi / rocgdb resolve for the dispatch),
 //   (2) real entry-stub bytes live at that address, and
 //   (3) its [st_value, st_value + st_size) range lies inside its own section.
-static void expectStubSymbolMatchesDispatchEntry(llvm::WritableMemoryBuffer &Buf,
-                                                  llvm::StringRef KernelName,
-                                                  const LLVMState &S) {
+static void
+expectStubSymbolMatchesDispatchEntry(llvm::WritableMemoryBuffer &Buf,
+                                     llvm::StringRef KernelName,
+                                     const LLVMState &S) {
   using ELFT = llvm::object::ELF64LE;
   llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
       llvm::object::ELFFile<ELFT>::create(
@@ -1990,7 +1991,8 @@ static void expectStubSymbolMatchesDispatchEntry(llvm::WritableMemoryBuffer &Buf
   ASSERT_NE(Symtab, nullptr);
   llvm::Expected<ELFT::SymRange> Syms = File.symbols(Symtab);
   ASSERT_TRUE((bool)Syms) << llvm::toString(Syms.takeError());
-  llvm::Expected<llvm::StringRef> StrTab = File.getStringTableForSymtab(*Symtab);
+  llvm::Expected<llvm::StringRef> StrTab =
+      File.getStringTableForSymtab(*Symtab);
   ASSERT_TRUE((bool)StrTab) << llvm::toString(StrTab.takeError());
 
   const std::string StubName = (KernelName + ".stub").str();
@@ -2025,7 +2027,8 @@ static void expectStubSymbolMatchesDispatchEntry(llvm::WritableMemoryBuffer &Buf
     }
   ASSERT_NE(KD, nullptr);
   ASSERT_GE(KD->EntryOffset, 0);
-  const uint64_t EntryVAddr = KD->VAddr + static_cast<uint64_t>(KD->EntryOffset);
+  const uint64_t EntryVAddr =
+      KD->VAddr + static_cast<uint64_t>(KD->EntryOffset);
   EXPECT_EQ(Stub->st_value, EntryVAddr)
       << "stub symbol must name the descriptor's entry address";
 

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -1962,6 +1962,81 @@ static unsigned countSymtabSymbolsNamed(llvm::WritableMemoryBuffer &Buf,
   return Count;
 }
 
+// Cross-check that the <kernel>.stub symbol in Buf resolves to exactly what the
+// debugger relies on, tying it to independently-produced artifacts rather than
+// to the address formula the symbol writer itself uses:
+//   (1) it names the address the rewritten kernel descriptor's entry now points
+//       at (what amd-dbgapi / rocgdb resolve for the dispatch),
+//   (2) real entry-stub bytes live at that address, and
+//   (3) its [st_value, st_value + st_size) range lies inside its own section.
+static void expectStubSymbolMatchesDispatchEntry(llvm::WritableMemoryBuffer &Buf,
+                                                  llvm::StringRef KernelName,
+                                                  const LLVMState &S) {
+  using ELFT = llvm::object::ELF64LE;
+  llvm::Expected<llvm::object::ELFFile<ELFT>> FileOrErr =
+      llvm::object::ELFFile<ELFT>::create(
+          llvm::StringRef(reinterpret_cast<const char *>(Buf.getBufferStart()),
+                          Buf.getBufferSize()));
+  ASSERT_TRUE((bool)FileOrErr) << llvm::toString(FileOrErr.takeError());
+  llvm::object::ELFFile<ELFT> &File = *FileOrErr;
+  llvm::Expected<ELFT::ShdrRange> Secs = File.sections();
+  ASSERT_TRUE((bool)Secs) << llvm::toString(Secs.takeError());
+  const ELFT::Shdr *Symtab = nullptr;
+  for (const ELFT::Shdr &Sh : *Secs)
+    if (Sh.sh_type == llvm::ELF::SHT_SYMTAB) {
+      Symtab = &Sh;
+      break;
+    }
+  ASSERT_NE(Symtab, nullptr);
+  llvm::Expected<ELFT::SymRange> Syms = File.symbols(Symtab);
+  ASSERT_TRUE((bool)Syms) << llvm::toString(Syms.takeError());
+  llvm::Expected<llvm::StringRef> StrTab = File.getStringTableForSymtab(*Symtab);
+  ASSERT_TRUE((bool)StrTab) << llvm::toString(StrTab.takeError());
+
+  const std::string StubName = (KernelName + ".stub").str();
+  const ELFT::Sym *Stub = nullptr;
+  for (const ELFT::Sym &Sym : *Syms) {
+    llvm::Expected<llvm::StringRef> N = Sym.getName(*StrTab);
+    ASSERT_TRUE((bool)N) << llvm::toString(N.takeError());
+    if (*N == StubName) {
+      Stub = &Sym;
+      break;
+    }
+  }
+  ASSERT_NE(Stub, nullptr) << "missing symbol " << StubName;
+
+  // (3) The symbol range lies fully inside its own section.
+  ASSERT_LT(Stub->st_shndx, Secs->size());
+  const ELFT::Shdr &Sec = (*Secs)[Stub->st_shndx];
+  EXPECT_GE(Stub->st_value, Sec.sh_addr);
+  EXPECT_LE(Stub->st_value + Stub->st_size, Sec.sh_addr + Sec.sh_size);
+
+  llvm::Expected<ElfView> ViewOrErr = ElfView::create(
+      reinterpret_cast<uint8_t *>(Buf.getBufferStart()), Buf.getBufferSize());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ElfView &View = *ViewOrErr;
+
+  // (1) The symbol names exactly the address the descriptor entry now targets.
+  const KernelDescriptorInfo *KD = nullptr;
+  for (const KernelDescriptorInfo &Info : View.kernelDescriptors())
+    if (Info.KernelName == KernelName) {
+      KD = &Info;
+      break;
+    }
+  ASSERT_NE(KD, nullptr);
+  ASSERT_GE(KD->EntryOffset, 0);
+  const uint64_t EntryVAddr = KD->VAddr + static_cast<uint64_t>(KD->EntryOffset);
+  EXPECT_EQ(Stub->st_value, EntryVAddr)
+      << "stub symbol must name the descriptor's entry address";
+
+  // (2) Real entry-stub bytes live at the symbol's address.
+  const uint8_t *StubBytes =
+      View.dataAtVAddr(Stub->st_value, KernelEntryStubStride);
+  ASSERT_NE(StubBytes, nullptr);
+  EXPECT_TRUE(isKernelEntryTrampoline(
+      llvm::ArrayRef<uint8_t>(StubBytes, KernelEntryStubStride), S));
+}
+
 // Covers: the entry-trampoline rewrite is idempotent -- a second pass over an
 // already-rewritten code object installs no new stub, and therefore defines no
 // duplicate `<kernel>.stub` symbol. This backs the idempotency claim made by
@@ -2012,6 +2087,9 @@ TEST(KernelEntryTrampoline, SecondPassAddsNoDuplicateStubSymbol) {
       addKernelEntryTrampolineSymbols(*Grown, *PoolVAddr, Fixups1);
   ASSERT_NE(Pass1, nullptr);
   ASSERT_EQ(countSymtabSymbolsNamed(*Pass1, "kernel.stub"), 1u);
+  // The stub symbol must resolve to the dispatch entry, cover real stub bytes,
+  // and stay within its section -- not merely match the writer's own formula.
+  expectStubSymbolMatchesDispatchEntry(*Pass1, "kernel", S);
 
   // -- Second pass over the already-rewritten object. --
   uint8_t *Pass1Data = reinterpret_cast<uint8_t *>(Pass1->getBufferStart());

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -81,6 +81,11 @@ struct KernelDescriptorElfOptions {
   std::vector<MetadataKernel> MetadataKernels;
   bool MetadataOmitVgprCount = false;
   bool MetadataVgprCountAsString = false;
+  // When set, emit an extra zero-sized SHF_ALLOC section (".pad") at this
+  // virtual address. Used to reproduce a zero-sized allocatable section sharing
+  // the trampoline pool's base address, exercising the pool-section lookup in
+  // addKernelEntryTrampolineSymbols.
+  std::optional<uint64_t> ExtraAllocSectionAddr;
 };
 
 struct KernelDescriptorElf {
@@ -186,7 +191,9 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   static constexpr uint64_t TextOffset = 0x240;
   static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
   static constexpr char ShStrTab[] =
-      "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
+      "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0.pad\0";
+  static constexpr uint32_t PadNameOff = 41; // offset of ".pad" in ShStrTab
+  const bool HasPad = Options.ExtraAllocSectionAddr.has_value();
 
   std::string StrTab;
   StrTab.push_back('\0');
@@ -253,7 +260,7 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   }
   Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
   Ehdr.e_shentsize = sizeof(Elf64_Shdr);
-  Ehdr.e_shnum = 6;
+  Ehdr.e_shnum = HasPad ? 7 : 6;
   Ehdr.e_shstrndx = 5;
   std::memcpy(Buf, &Ehdr, sizeof(Ehdr));
 
@@ -302,6 +309,19 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
   ShstrSh.sh_offset = ShStrTabOff;
   ShstrSh.sh_size = sizeof(ShStrTab);
   std::memcpy(Buf + ShOff + 5 * sizeof(Elf64_Shdr), &ShstrSh, sizeof(ShstrSh));
+
+  if (HasPad) {
+    // A zero-sized allocatable section sharing a base address with (what will
+    // become) the appended trampoline pool. NOBITS so it needs no file content.
+    Elf64_Shdr PadSh{};
+    PadSh.sh_name = PadNameOff;
+    PadSh.sh_type = SHT_NOBITS;
+    PadSh.sh_flags = SHF_ALLOC;
+    PadSh.sh_addr = *Options.ExtraAllocSectionAddr;
+    PadSh.sh_size = 0;
+    PadSh.sh_addralign = 1;
+    std::memcpy(Buf + ShOff + 6 * sizeof(Elf64_Shdr), &PadSh, sizeof(PadSh));
+  }
 
   if (HasMetadataNote) {
     Elf64_Phdr NotePhdr{};


### PR DESCRIPTION
… .text

addKernelEntryTrampolineSymbols emitted each <kernel>.stub symbol at TextAddr + OldTextSize + StubTextOffset in the .text section -- the old "stubs are appended immediately after .text" layout. Since the entry-stub pool is now appended at a fresh virtual address in its own section (trampolinePoolVAddr(), the same base rewriteKernelEntryDescriptorOffsets() redirects each descriptor to), the symbol landed at the wrong address and in the wrong section whenever the pool is not contiguous with .text (the common case: .dynamic / .bss extend past .text, so the pool starts a page or more later).

The dispatch entry points at PoolVAddr + StubTextOffset, but the symbol named PoolVAddr's stub sat back at the end of .text, so amd-dbgapi / rocgdb could not resolve the dispatch entry to a name -- `info dispatches` showed a bare address instead of `<kernel>[stub]`, and disassembly/symbol lookups at the entry address failed.

Fix: pass the trampoline pool's virtual address into addKernelEntryTrampolineSymbols and emit each stub symbol at PoolVAddr + StubTextOffset with st_shndx set to the pool's section (located by matching sh_addr == PoolVAddr in the grown ELF). This matches the address the descriptor entry now targets, so the debugger resolves the dispatch to the stub symbol.

- comgr-hotswap-elf.cpp / -internal.h: replace the (TextSectionIndex, TextAddr, OldTextSize) parameters with PoolVAddr; look up the pool section by vaddr and place the symbol there.
- comgr-hotswap-b0a0.cpp: pass PoolVAddr (already computed for the descriptor rewrite) instead of the .text address/size/index.
- test-unit/HotswapElfTest.cpp, HotswapMCTest.cpp: assert the stub symbol is in the trampoline-pool section at PoolVAddr + StubTextOffset.

Verified on gfx1030 hardware: rocgdb `info dispatches` now reports the kernel function as `hello[stub]` (and names the waiting thread `hello[stub]`) instead of a bare address. Applies to every hotswap entry-trampoline target.


