### PR TITLE
[comgr][hotswap] Use SCC-neutral far transfers

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -402,78 +402,35 @@ std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
                                                           uint64_t FromOffset,
                                                           uint64_t TargetOffset,
                                                           unsigned SgprBase) {
-  if ((SgprBase & 1u) != 0 ||
-      SgprBase > std::numeric_limits<unsigned>::max() - 2) {
-    log() << "hotswap: error: set-PC long branch requires an aligned "
-             "three-SGPR block, got s"
-          << SgprBase << "\n";
-    return std::nullopt;
-  }
-
-  const std::string Lo = "s" + std::to_string(SgprBase);
-  const std::string Hi = "s" + std::to_string(SgprBase + 1);
-  const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
-                           std::to_string(SgprBase + 1) + "]";
-  const std::string SccSave = "s" + std::to_string(SgprBase + 2);
-
-  // Per the AMDGPU ISA, s_get_pc_i64 captures the address immediately after
-  // itself. EncodeSetPCLongBranch.ForwardLandsOnTarget pins this PC base.
-  std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, 2 * MinInstSize, "set-PC long branch PC base");
-  if (!PcBase)
-    return std::nullopt;
-  uint64_t Delta = TargetOffset - *PcBase;
-  uint32_t LoDelta = static_cast<uint32_t>(Delta);
-  uint32_t HiDelta = static_cast<uint32_t>(Delta >> 32);
-
-  SmallVector<std::string, 6> AsmLines;
-  AsmLines.push_back("s_cselect_b32 " + SccSave + ", 1, 0");
-  AsmLines.push_back("s_get_pc_i64 " + Pair);
-  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
-                     utohexstr(LoDelta));
-  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
-                     utohexstr(HiDelta));
-  AsmLines.push_back("s_cmp_lg_u32 " + SccSave + ", 0");
-  AsmLines.push_back("s_set_pc_i64 " + Pair);
-  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
-  if (Bytes.empty()) {
-    log() << "hotswap: error: failed to assemble set-PC long branch via "
-          << Pair << "\n";
-    return std::nullopt;
-  }
-  return Bytes;
-}
-
-static std::optional<SmallVector<uint8_t>>
-encodeSetPCLongBranchClobberSCC(const LLVMState &LS, uint64_t FromOffset,
-                                uint64_t TargetOffset, unsigned SgprBase) {
   if ((SgprBase & 1u) != 0) {
-    log() << "hotswap: error: SCC-dead set-PC branch requires an aligned "
+    log() << "hotswap: error: set-PC long branch requires an aligned "
              "SGPR pair, got s"
           << SgprBase << "\n";
     return std::nullopt;
   }
 
-  const std::string Lo = "s" + std::to_string(SgprBase);
-  const std::string Hi = "s" + std::to_string(SgprBase + 1);
   const std::string Pair = "s[" + std::to_string(SgprBase) + ":" +
                            std::to_string(SgprBase + 1) + "]";
-  std::optional<uint64_t> PcBase = checkedAddUint64(
-      FromOffset, MinInstSize, "SCC-dead set-PC branch PC base");
+  SmallVector<uint8_t> GetPc = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
+  if (GetPc.empty())
+    return std::nullopt;
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, GetPc.size(), "set-PC long branch PC base");
   if (!PcBase)
     return std::nullopt;
   uint64_t Delta = TargetOffset - *PcBase;
-
-  SmallVector<std::string, 4> AsmLines;
+  // AMDGPU/SOPInstructions.td defines S_ADD_U64 as an SOP2_64 outside the
+  // Defs = [SCC] scope and maps its gfx12 encoding to s_add_nc_u64. It can
+  // therefore add the complete PC displacement without saving or clobbering
+  // SCC.
+  SmallVector<std::string, 3> AsmLines;
   AsmLines.push_back("s_get_pc_i64 " + Pair);
-  AsmLines.push_back("s_add_u32 " + Lo + ", " + Lo + ", 0x" +
-                     utohexstr(static_cast<uint32_t>(Delta)));
-  AsmLines.push_back("s_addc_u32 " + Hi + ", " + Hi + ", 0x" +
-                     utohexstr(static_cast<uint32_t>(Delta >> 32)));
+  AsmLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
+                     utohexstr(Delta));
   AsmLines.push_back("s_set_pc_i64 " + Pair);
   SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
-  if (Bytes.empty()) {
-    log() << "hotswap: error: failed to assemble SCC-dead set-PC branch via "
+  if (Bytes.empty() || Bytes.size() > SetPcReturnReserveBytes) {
+    log() << "hotswap: error: failed to assemble SCC-neutral set-PC branch via "
           << Pair << "\n";
     return std::nullopt;
   }
@@ -732,7 +689,7 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
 static std::optional<SafeSgprScratchBlock>
 reserveSafeFarReturn(PatchContext &Ctx, uint64_t InstOffset) {
   std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
-      Ctx, InstOffset, /*Count=*/3, /*Alignment=*/2, "safe far return");
+      Ctx, InstOffset, /*Count=*/2, /*Alignment=*/2, "safe far return");
   if (!Scratch)
     return std::nullopt;
   if (!commitSafeSgprScratchBlock(Ctx, InstOffset, *Scratch, "safe far return"))
@@ -757,11 +714,11 @@ bool isSBranchReachable(uint64_t From, uint64_t To) {
 /// Queue a deferred trampoline for [\p InstOffset, +\p InstSize) with
 /// \p Replacement as its body; fixupTrampolineBranches fills in the edges once
 /// the pool layout is known. A site beyond s_branch reach of the appended pool
-/// uses an SCC-preserving get-PC/add/set-PC sequence on the backward edge.
+/// uses an SCC-neutral get-PC/add/set-PC sequence on the backward edge.
 /// Adjacent far sites are coalesced after patching to reduce gateway pressure.
 /// Every far source edge then uses a short branch to nearby safe NOP padding;
-/// that gateway uses the pre-Gen5 SGPR-backed set-PC sequence. No source or
-/// return edge executes gfx1250's broken s_add_pc_i64 instruction.
+/// that gateway uses the gfx12 SGPR-backed set-PC sequence. No source or return
+/// edge executes gfx1250's broken s_add_pc_i64 instruction.
 [[nodiscard]] bool emitToTrampoline(PatchContext &Ctx, uint64_t InstOffset,
                                     uint32_t InstSize,
                                     ArrayRef<uint8_t> Replacement) {
@@ -1696,7 +1653,7 @@ collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
 /// Grow undersized far-site windows only through proven straight-line code.
 /// Patched neighbors are merged; ordinary instructions are copied verbatim
 /// into the trampoline body and retain their original order. This is bounded
-/// to the 28 bytes required by the accepted pre-Gen5 forward sequence.
+/// to the 20 bytes required by the gfx12 SCC-neutral forward sequence.
 static void
 expandStraightLineTrampolines(PatchContext &Ctx,
                               const DenseSet<uint64_t> &DirectBranchTargets) {
@@ -1862,79 +1819,6 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
-enum class SccScanResult {
-  Unresolved,
-  Used,
-  Defined,
-};
-
-static SccScanResult scanSccInstruction(const InternalDecodedInst &DI,
-                                        const LLVMState &LS, MCRegister SCC) {
-  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
-  if (Desc.hasImplicitUseOfPhysReg(SCC))
-    return SccScanResult::Used;
-  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
-  for (unsigned I = DefCount; I != DI.Inst.getNumOperands(); ++I) {
-    const MCOperand &Op = DI.Inst.getOperand(I);
-    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
-      return SccScanResult::Used;
-  }
-
-  if (Desc.hasImplicitDefOfPhysReg(SCC, LS.MRI.get()))
-    return SccScanResult::Defined;
-  for (unsigned I = 0; I != DefCount; ++I) {
-    const MCOperand &Op = DI.Inst.getOperand(I);
-    if (Op.isReg() && LS.MRI->regsOverlap(Op.getReg(), SCC))
-      return SccScanResult::Defined;
-  }
-  return SccScanResult::Unresolved;
-}
-
-/// Prove that clobbering SCC on the forward edge cannot affect the replacement
-/// body or its continuation. Stop conservatively at unresolved control flow.
-static bool isIncomingSccDead(const PatchContext &Ctx, const Trampoline &T) {
-  MCRegister SCC = Ctx.LS.SCCRegister;
-  uint64_t TrailingBytes = SetPcReturnReserveBytes +
-                           (T.HasPoolBranchIsland ? PoolBranchIslandBytes : 0);
-  if (!SCC || T.Bytes.size() < TrailingBytes)
-    return false;
-
-  uint64_t BodySize = T.Bytes.size() - TrailingBytes;
-  std::vector<InternalDecodedInst> Body;
-  if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body))
-    return false;
-  for (const InternalDecodedInst &DI : Body) {
-    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
-    if (Result == SccScanResult::Used)
-      return false;
-    if (Result == SccScanResult::Defined)
-      return true;
-    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
-      return false;
-  }
-
-  std::optional<uint64_t> End = checkedAddUint64(
-      T.OriginalOffset, T.OriginalSize, "SCC-dead continuation start");
-  if (!End)
-    return false;
-  for (const InternalDecodedInst &DI : Ctx.Decoded) {
-    if (DI.Offset < *End)
-      continue;
-    if (T.HasFunctionRange && DI.Offset >= T.FunctionEnd)
-      break;
-    SccScanResult Result = scanSccInstruction(DI, Ctx.LS, SCC);
-    if (Result == SccScanResult::Used)
-      return false;
-    if (Result == SccScanResult::Defined)
-      return true;
-    if (isEndProgram(DI, Ctx.LS))
-      return true;
-    if (Ctx.LS.MIA && Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI))
-      return false;
-  }
-  return true;
-}
-
 static uint64_t countReachableGatewaySlots(ArrayRef<NopSled> Gateways,
                                            uint64_t Offset, uint64_t Needed) {
   uint64_t Slots = 0;
@@ -2038,7 +1922,6 @@ assignLongBranchGateways(PatchContext &Ctx,
   struct PendingGateway {
     size_t TrampolineIndex = 0;
     uint64_t TargetOffset = 0;
-    bool IncomingSccDead = false;
     uint64_t NeededBytes = 0;
     uint64_t InitialCandidateSlots = 0;
   };
@@ -2059,7 +1942,6 @@ assignLongBranchGateways(PatchContext &Ctx,
       T.UsesShortBranchForward = true;
       continue;
     }
-    bool IncomingSccDead = isIncomingSccDead(Ctx, T);
     std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
         Ctx.LS, T.OriginalOffset, TP, T.LongBranchSgprBase);
     if (Direct && Direct->size() <= T.OriginalSize) {
@@ -2067,20 +1949,9 @@ assignLongBranchGateways(PatchContext &Ctx,
       T.DirectSetPCForwardBytes = std::move(*Direct);
       continue;
     }
-    if (IncomingSccDead) {
-      Direct = encodeSetPCLongBranchClobberSCC(Ctx.LS, T.OriginalOffset, TP,
-                                               T.LongBranchSgprBase);
-      if (Direct && Direct->size() <= T.OriginalSize) {
-        T.UsesDirectSetPCForward = true;
-        T.DirectSetPCForwardBytes = std::move(*Direct);
-        continue;
-      }
-    }
-
-    uint64_t Needed =
-        IncomingSccDead ? SetPcMinGatewayBytes : SetPcForwardSequenceBytes;
+    uint64_t Needed = SetPcForwardSequenceBytes;
     Pending.push_back(
-        {I, TP, IncomingSccDead, Needed,
+        {I, TP, Needed,
          countReachableGatewaySlots(Gateways, T.OriginalOffset, Needed)});
   }
 
@@ -2102,9 +1973,6 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
   Pending = std::move(StillPending);
 
-  // Allocate SCC-preserving gateways first. They need more contiguous bytes
-  // and have fewer placement options; SCC-dead gateways can fill the remaining
-  // 20-byte fragments afterward.
   std::stable_sort(Pending.begin(), Pending.end(),
                    [](const PendingGateway &LHS, const PendingGateway &RHS) {
                      if (LHS.NeededBytes != RHS.NeededBytes)
@@ -2113,8 +1981,7 @@ assignLongBranchGateways(PatchContext &Ctx,
                             RHS.InitialCandidateSlots;
                    });
 
-  uint64_t PreservingGateways = 0;
-  uint64_t SccDeadGateways = 0;
+  uint64_t AssignedGateways = 0;
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     NopSled *Sled = findNearestSled(Gateways, T.OriginalOffset, P.NeededBytes);
@@ -2125,12 +1992,8 @@ assignLongBranchGateways(PatchContext &Ctx,
             << " initial candidate slot(s))\n";
       return false;
     }
-    std::optional<SmallVector<uint8_t>> Gateway =
-        P.IncomingSccDead
-            ? encodeSetPCLongBranchClobberSCC(
-                  Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase)
-            : encodeSetPCLongBranch(Ctx.LS, Sled->WritePos, P.TargetOffset,
-                                    T.LongBranchSgprBase);
+    std::optional<SmallVector<uint8_t>> Gateway = encodeSetPCLongBranch(
+        Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase);
     if (!Gateway || Gateway->size() > P.NeededBytes) {
       log() << "hotswap: error: failed to encode far-site gateway at 0x"
             << utohexstr(Sled->WritePos) << "\n";
@@ -2140,15 +2003,11 @@ assignLongBranchGateways(PatchContext &Ctx,
     T.ForwardGatewayOffset = Sled->WritePos;
     T.ForwardGatewayBytes = std::move(*Gateway);
     Sled->WritePos += T.ForwardGatewayBytes.size();
-    if (P.IncomingSccDead)
-      ++SccDeadGateways;
-    else
-      ++PreservingGateways;
+    ++AssignedGateways;
   }
   if (!Pending.empty())
-    log() << "hotswap: assigned " << PreservingGateways
-          << " SCC-preserving and " << SccDeadGateways
-          << " SCC-dead forward gateway(s)\n";
+    log() << "hotswap: assigned " << AssignedGateways
+          << " SCC-neutral forward gateway(s)\n";
   if (BranchIslandChains != 0)
     log() << "hotswap: assigned " << BranchIslandChains
           << " forward s_branch island chain(s)\n";

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -102,7 +102,7 @@ struct Trampoline {
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> Bytes;
   // When set, the pool is beyond s_branch reach. The source site branches to a
-  // nearby NOP gateway, which uses the scratch-backed pre-Gen5 set-PC sequence
+  // nearby NOP gateway, which uses the scratch-backed gfx12 set-PC sequence
   // to reach the pool without executing s_add_pc_i64.
   bool Long = false;
   bool UsesSetPCBack = false;
@@ -208,14 +208,10 @@ static constexpr uint64_t MinNopSledSize = 8;
 // Minimum AMDGPU instruction size (one dword).
 static constexpr uint32_t MinInstSize = 4;
 
-// Fixed reservation for the SCC-preserving set-PC return. The assembled
-// sequence is 28 bytes for a same-object forward or backward delta.
-static constexpr uint32_t SetPcReturnReserveBytes = 28;
+// Fixed reservation for the SCC-neutral set-PC sequence.
+static constexpr uint32_t SetPcReturnReserveBytes = 20;
 
-// A gateway needs at least 20 bytes when incoming SCC is proven dead. Live SCC
-// uses the 28-byte preserving sequence.
-static constexpr uint32_t SetPcMinGatewayBytes = 20;
-static constexpr uint32_t SetPcForwardSequenceBytes = 28;
+static constexpr uint32_t SetPcForwardSequenceBytes = SetPcReturnReserveBytes;
 static constexpr uint32_t PoolBranchIslandBytes = MinInstSize;
 
 // s_branch encoding: 16-bit signed dword offset field bounds. Used by
@@ -863,10 +859,9 @@ bool commitSafeSgprScratchBlock(PatchContext &Ctx, uint64_t TextOffset,
                                     uint32_t InstSize,
                                     llvm::ArrayRef<uint8_t> Replacement);
 
-/// Encode an SCC-preserving indirect long branch using three numbered SGPRs:
-/// an aligned PC pair at \p SgprBase and an SCC-save temporary at Base + 2.
-/// The displacement is materialized as two 32-bit literals; no
-/// s_add_pc_i64 or 64-bit literal is emitted.
+/// Encode an SCC-neutral indirect long branch using the aligned SGPR pair at
+/// \p SgprBase. The displacement uses gfx12's s_add_nc_u64; no s_add_pc_i64
+/// is emitted.
 std::optional<llvm::SmallVector<uint8_t>>
 encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
                       uint64_t TargetOffset, unsigned SgprBase);

--- a/amd/comgr/test-lit/hotswap-absolute-call.s
+++ b/amd/comgr/test-lit/hotswap-absolute-call.s
@@ -34,7 +34,7 @@ test_absolute_call:
 .Ltest_absolute_call_end:
 .size test_absolute_call, .Ltest_absolute_call_end-test_absolute_call
 
-// Two separate long sites need two 28-byte SCC-preserving gateways. This
+// Two separate long sites need two 20-byte SCC-neutral gateways. This
 // padding follows s_endpgm and lies outside the function, so it is safe.
 .fill 64, 1, 0
 

--- a/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
+++ b/amd/comgr/test-lit/hotswap-large-sgpr-usage-cache.s
@@ -17,16 +17,16 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
 
 // DISASM-LABEL: <test_large_usage_cache>:
-// DISASM: s_cselect_b32
+// DISASM: s_get_pc_i64
 // DISASM: s_set_pc_i64
 // DISASM: s_call_i64
-// DISASM: s_cselect_b32
+// DISASM: s_get_pc_i64
 // DISASM: s_set_pc_i64
 // DISASM: tensor_load_to_lds
 // DISASM: tensor_load_to_lds
 
 // META: .name:           test_large_usage_cache
-// META: .sgpr_count:     39
+// META: .sgpr_count:     38
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call.s
@@ -74,7 +74,7 @@ test_pc_materialized_call:
 .Ltest_pc_materialized_call_end:
 .size test_pc_materialized_call, .Ltest_pc_materialized_call_end-test_pc_materialized_call
 
-// Each far site needs its own 28-byte SCC-preserving gateway. This padding
+// Each far site needs its own 20-byte SCC-neutral gateway. This padding
 // follows s_endpgm and lies outside the function, so it is safe.
 .fill 64, 1, 0
 

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -37,11 +37,8 @@
 // DISASM-NEXT: s_branch
 // DISASM: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_cselect_b32 s16, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[14:15]
-// DISASM-NEXT: s_add_co_u32 s14, s14,
-// DISASM-NEXT: s_add_co_ci_u32 s15, s15,
-// DISASM-NEXT: s_cmp_lg_u32 s16, 0
+// DISASM-NEXT: s_add_nc_u64 s[14:15], s[14:15],
 // DISASM-NEXT: s_set_pc_i64 s[14:15]
 
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-device-function-long-branch.s
@@ -18,27 +18,21 @@
 // DISASM-NEXT: s_nop
 // DISASM-LABEL: <kernel_b>:
 // DISASM: s_endpgm
-// DISASM-NEXT: s_cselect_b32 s68, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[66:67]
-// DISASM-NEXT: s_add_co_u32 s66, s66,
-// DISASM-NEXT: s_add_co_ci_u32 s67, s67,
-// DISASM-NEXT: s_cmp_lg_u32 s68, 0
+// DISASM-NEXT: s_add_nc_u64 s[66:67], s[66:67],
 // DISASM-NEXT: s_set_pc_i64 s[66:67]
 // DISASM: s_mov_b32 s66, s4
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
 // DISASM-NEXT: s_mov_b32 s4, s66
-// DISASM-NEXT: s_cselect_b32 s68, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[66:67]
-// DISASM-NEXT: s_add_co_u32 s66, s66,
-// DISASM-NEXT: s_add_co_ci_u32 s67, s67,
-// DISASM-NEXT: s_cmp_lg_u32 s68, 0
+// DISASM-NEXT: s_add_nc_u64 s[66:67], s[66:67],
 // DISASM-NEXT: s_set_pc_i64 s[66:67]
 
 // META: .name:           kernel_a
-// META: .sgpr_count:     71
+// META: .sgpr_count:     70
 // META: .name:           kernel_b
-// META: .sgpr_count:     71
+// META: .sgpr_count:     70
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-long-branch.s
@@ -7,9 +7,10 @@
 // COM: forwarding in another wave on the same SIMD, causing wrong results,
 // COM: hangs, or a GPU page fault.
 // COM:
-// COM: Fix: use the pre-Gen5 SGPR-backed set-PC sequence on both edges. Merge
-// COM: adjacent sites and bounded straight-line neighbors when they provide
-// COM: enough source bytes; otherwise short-branch through safe NOP padding.
+// COM: Fix: use the gfx12 SCC-neutral SGPR-backed set-PC sequence on both
+// COM: edges. Merge adjacent sites and bounded straight-line neighbors when
+// COM: they provide enough source bytes; otherwise short-branch through safe
+// COM: NOP padding.
 // COM: No path emits the broken instruction.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
@@ -30,11 +31,8 @@
 
 // COM: Case 2 (adjacent sites coalesced into a set-PC forward gateway).
 // DISASM-LABEL: <test_ds2addr_far_adjacent>:
-// DISASM-NEXT: s_cselect_b32 s4, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2, s2,
-// DISASM-NEXT: s_add_co_ci_u32 s3, s3, 0
-// DISASM-NEXT: s_cmp_lg_u32 s4, 0
+// DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3],
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 
 // COM: Case 3 (an interior direct-branch target must prevent coalescing).
@@ -63,33 +61,27 @@
 // DISASM-NEXT: ds_load_b64 v[12:13], v16 offset:3584
 // DISASM-NEXT: ds_load_b64 v[14:15], v16 offset:4096
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_cselect_b32 s4, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2, s2,
-// DISASM-NEXT: s_add_co_ci_u32 s3, s3,
-// DISASM-NEXT: s_cmp_lg_u32 s4, 0
+// DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3],
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 // DISASM: ds_store_b32 v2, v0 offset:256
 // DISASM-NEXT: ds_store_b32 v2, v1 offset:768
 // DISASM-NEXT: s_wait_dscnt 0x0
 // DISASM-NEXT: s_wait_dscnt 0x0
-// DISASM-NEXT: s_cselect_b32 s4, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2, s2,
-// DISASM-NEXT: s_add_co_ci_u32 s3, s3,
-// DISASM-NEXT: s_cmp_lg_u32 s4, 0
+// DISASM-NEXT: s_add_nc_u64 s[2:3], s[2:3],
 // DISASM-NEXT: s_set_pc_i64 s[2:3]
 
 // METADATA: .name:           test_ds2addr_far_load
-// METADATA: .sgpr_count:     7
+// METADATA: .sgpr_count:     6
 // METADATA: .name:           test_ds2addr_far_store
-// METADATA: .sgpr_count:     7
+// METADATA: .sgpr_count:     6
 // METADATA: .name:           test_ds2addr_far_adjacent
-// METADATA: .sgpr_count:     7
+// METADATA: .sgpr_count:     6
 // METADATA: .name:           test_ds2addr_far_branch_target
-// METADATA: .sgpr_count:     7
+// METADATA: .sgpr_count:     6
 // METADATA: .name:           test_ds2addr_far_call_target
-// METADATA: .sgpr_count:     7
+// METADATA: .sgpr_count:     6
 
 // COM: Idempotency: rewriting the patched output again is a no-op.
 // RUN: hotswap-rewrite %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
@@ -1,0 +1,88 @@
+// COM: Production activation, quantization, and shared-expert objects exposed
+// COM: gateway fragments that can hold the 20-byte SCC-neutral gfx12 set-PC
+// COM: sequence but not the former 28-byte SCC save/restore sequence. Keep SCC
+// COM: live across this required DS2 rewrite and provide exactly one 20-byte
+// COM: gateway. The pool is beyond s_branch range and no island chain exists.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 \
+// RUN:   --implicit-check-not=s_add_co_u32 \
+// RUN:   --implicit-check-not=s_add_co_ci_u32 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <fragmented_gateway>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
+
+// META: .name:           fragmented_gateway
+// META: .sgpr_count:     4
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl fragmented_gateway
+.p2align 8
+.type fragmented_gateway,@function
+fragmented_gateway:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_cbranch_scc1 .Lexit
+  s_endpgm
+.Lexit:
+  s_endpgm
+.size fragmented_gateway, .-fragmented_gateway
+
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 20, 1, 0
+
+.rept 40000
+  s_mov_b32 s4, s5
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel fragmented_gateway
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: fragmented_gateway
+      .symbol: fragmented_gateway.kd
+      .sgpr_count: 0
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -1,8 +1,7 @@
 // COM: A0 cannot execute s_add_pc_i64. Both edges use an SGPR-backed set-PC
-// COM: sequence; the short source slot reaches that sequence through safe
-// COM: external zero-filled gateway space. A large non-NOP .rept filler
-// COM: (~160 KB)
-// COM: pushes the pool past s_branch's reach to force the far case.
+// COM: sequence. The 20-byte source window carries the forward sequence
+// COM: directly. A large non-NOP .rept filler (~160 KB) pushes the pool past
+// COM: s_branch's reach to force the far case.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -17,25 +16,21 @@
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // DISASM-LABEL: <test_far>:
-// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_get_pc_i64 s[12:13]
+// DISASM-NEXT: s_add_nc_u64 s[12:13], s[12:13],
+// DISASM-NEXT: s_set_pc_i64 s[12:13]
+// DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <gateway_barrier>:
 // DISASM-NEXT: s_endpgm
-// DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_co_u32 s12, s12,
-// DISASM-NEXT: s_add_co_ci_u32 s13, s13,
-// DISASM-NEXT: s_set_pc_i64 s[12:13]
 // DISASM: s_mov_b64 vcc, -1
 // DISASM-NEXT: s_pack_hh_b32_b16 s4, 0, s4
 // DISASM-NEXT: tensor_load_to_lds s[0:3], s[4:11]
-// DISASM-NEXT: s_cselect_b32 s14, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[12:13]
-// DISASM-NEXT: s_add_co_u32 s12, s12,
-// DISASM-NEXT: s_add_co_ci_u32 s13, s13,
-// DISASM-NEXT: s_cmp_lg_u32 s14, 0
+// DISASM-NEXT: s_add_nc_u64 s[12:13], s[12:13],
 // DISASM-NEXT: s_set_pc_i64 s[12:13]
 
 // METADATA: .name:           test_far
-// METADATA: .sgpr_count:     17
+// METADATA: .sgpr_count:     16
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -43,7 +38,7 @@
 // RUN:   | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES
 
-// COM: A kernel with no aligned three-SGPR block fails closed instead of
+// COM: A kernel with no aligned two-SGPR block fails closed instead of
 // COM: emitting the unsafe return or clobbering a live register.
 // RUN: sed -e 's/s_mov_b64 vcc, -1/s_mov_b32 s105, 0/' \
 // RUN:   -e 's/\.amdhsa_next_free_sgpr 12/.amdhsa_next_free_sgpr 106/' \

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -15,20 +15,16 @@
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 
 // COM: The site redirects through a safe gateway to two K=64 halves and
-// COM: returns through the SCC-preserving set-PC sequence.
+// COM: returns through the SCC-neutral set-PC sequence.
 // DISASM-LABEL: <test_wsplit_far>:
 // DISASM-NEXT: s_branch
 // DISASM: s_get_pc_i64 s[0:1]
-// DISASM-NEXT: s_add_co_u32 s0, s0,
-// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 // DISASM: v_wmma_f32_16x16x64_fp8_fp8
 // DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
-// DISASM-NEXT: s_cselect_b32 s2, 1, 0
 // DISASM-NEXT: s_get_pc_i64 s[0:1]
-// DISASM-NEXT: s_add_co_u32 s0, s0,
-// DISASM-NEXT: s_add_co_ci_u32 s1, s1,
-// DISASM-NEXT: s_cmp_lg_u32 s2, 0
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 
 // COM: Idempotency: rewriting the output again must be a no-op.

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -195,7 +195,7 @@ TEST(EncodeSBranch, FailsOnInvalidState) {
 
 // -- encodeSetPCLongBranch ---------------------------------------------------
 
-TEST(EncodeSetPCLongBranch, UsesSccPreservingSequenceWithoutAddPc) {
+TEST(EncodeSetPCLongBranch, BackwardLandsOnTarget) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
@@ -204,23 +204,29 @@ TEST(EncodeSetPCLongBranch, UsesSccPreservingSequenceWithoutAddPc) {
   std::optional<llvm::SmallVector<uint8_t>> Out =
       encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
   ASSERT_TRUE(Out);
+  EXPECT_EQ(Out->size(), SetPcReturnReserveBytes);
 
   std::vector<InternalDecodedInst> Dec;
   ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Dec));
-  ASSERT_EQ(Dec.size(), 6u);
-  EXPECT_EQ(Dec[0].Mnemonic, "s_cselect_b32");
-  EXPECT_EQ(Dec[1].Mnemonic, "s_get_pc_i64");
-  EXPECT_EQ(Dec[2].Mnemonic, "s_add_co_u32");
-  EXPECT_EQ(Dec[3].Mnemonic, "s_add_co_ci_u32");
-  EXPECT_EQ(Dec[4].Mnemonic, "s_cmp_lg_u32");
-  EXPECT_EQ(Dec[5].Mnemonic, "s_set_pc_i64");
+  ASSERT_EQ(Dec.size(), 3u);
+  EXPECT_EQ(Dec[0].Mnemonic, "s_get_pc_i64");
+  EXPECT_EQ(Dec[1].Mnemonic, "s_add_nc_u64");
+  EXPECT_EQ(Dec[2].Mnemonic, "s_set_pc_i64");
   for (const InternalDecodedInst &DI : Dec)
     EXPECT_NE(DI.Mnemonic, "s_add_pc_i64");
 
-  // s_get_pc_i64 is the second dword and captures From + 8. The two add
-  // immediates materialize this exact two's-complement displacement.
-  uint64_t Delta = To - (From + 2 * MinInstSize);
-  EXPECT_EQ(static_cast<uint32_t>(Delta), 0xFFF7FFFCu);
+  const llvm::MCInstrDesc &AddDesc = S.MCII->get(Dec[1].Inst.getOpcode());
+  EXPECT_FALSE(AddDesc.hasImplicitUseOfPhysReg(S.SCCRegister));
+  EXPECT_FALSE(AddDesc.hasImplicitDefOfPhysReg(S.SCCRegister, S.MRI.get()));
+
+  // s_get_pc_i64 captures the PC immediately after its own dword.
+  uint64_t Delta = To - (From + MinInstSize);
+  ASSERT_TRUE(Dec[1].Inst.getOperand(2).isImm());
+  uint64_t EncodedDelta =
+      static_cast<uint64_t>(Dec[1].Inst.getOperand(2).getImm());
+  EXPECT_EQ(EncodedDelta, Delta);
+  EXPECT_EQ(From + MinInstSize + EncodedDelta, To);
+  EXPECT_EQ(static_cast<uint32_t>(Delta), 0xFFF80000u);
   EXPECT_EQ(static_cast<uint32_t>(Delta >> 32), 0xFFFFFFFFu);
 }
 
@@ -236,20 +242,18 @@ TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
-  ASSERT_EQ(Decoded.size(), 6u);
-  ASSERT_TRUE(Decoded[2].Inst.getOperand(2).isImm());
-  ASSERT_TRUE(Decoded[3].Inst.getOperand(2).isImm());
-  uint64_t Lo = static_cast<uint32_t>(Decoded[2].Inst.getOperand(2).getImm());
-  uint64_t Hi = static_cast<uint32_t>(Decoded[3].Inst.getOperand(2).getImm());
-  uint64_t Delta = Lo | (Hi << 32);
-  EXPECT_EQ(From + 2 * MinInstSize + Delta, To);
+  ASSERT_EQ(Decoded.size(), 3u);
+  ASSERT_TRUE(Decoded[1].Inst.getOperand(2).isImm());
+  uint64_t Delta =
+      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
+  EXPECT_EQ(From + MinInstSize + Delta, To);
 }
 
 TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   EXPECT_FALSE(encodeSetPCLongBranch(
-      S, std::numeric_limits<uint64_t>::max() - MinInstSize, 0,
+      S, std::numeric_limits<uint64_t>::max() - MinInstSize + 1, 0,
       /*SgprBase=*/12));
 }
 


### PR DESCRIPTION
## Summary

- replace the 28-byte, three-SGPR SCC save/restore far-transfer sequence with
  the gfx12 SCC-neutral `s_get_pc_i64` + `s_add_nc_u64` + `s_set_pc_i64`
  sequence
- reduce far-transfer reservations to 20 bytes and one aligned SGPR pair
- remove the SCC-dead versus SCC-preserving gateway split because the new
  sequence preserves SCC on every path
- add production-shaped LIT coverage for a fragmented 20-byte gateway and MC
  coverage for size, target calculation, and SCC use/def behavior

This PR is stacked on #3414 and should merge after it. The current head is
`43b66ade624626b633868960f1171659c8a1885b`, rebased on #3414 commit
`49eefd84b29bd4b3da8c5b8a857a2e6311761680`. Its single commit is patch-identical
to the previously validated pre-restack commit.

## Root cause

The failing production objects had usable far-transfer capacity, but much of it
was fragmented into 20-byte windows. The existing live-SCC route required 28
contiguous bytes and three SGPRs:

`save SCC; get PC; add low; add high; restore SCC; set PC`

AMDGPU TableGen defines gfx12 `S_ADD_U64` as `s_add_nc_u64` outside the
`Defs = [SCC]` scope. This permits the equivalent transfer without reading or
writing SCC:

`get PC; add 64-bit displacement without carry; set PC`

That sequence is 20 bytes with a literal displacement and needs only one
aligned SGPR pair. It fits the production gateway fragments, so no global
matching or gateway-ownership change is needed.

The LIT reproducer fails on the #3414 binary with:

`hotswap: error: no safe short-branch gateway for far site 0x0 (0 initial candidate slot(s))`

The same object passes with this change and reports one SCC-neutral forward
gateway.

## Validation

Clean Release validation after rebasing onto current `amd-staging`, at head
`9ed45d29eff6`:

- `HotswapMCTests`: 91/91 passed
- `HotswapElfTests`: 26/26 passed
- all nine LIT tests modified by this PR passed
- `git range-diff` shows the single commit patch-identical to the validated
  pre-restack commit
- `git diff --check` and clang-format pass

The pre-restack implementation was also validated in release and AddressSanitizer
builds, with the unfiltered COMGR LIT suite and the activation, quantization,
and shared-expert production objects. Those runs had no test or sanitizer
failure; all three rewritten objects contained zero `s_add_pc_i64`
instructions and were idempotent on a second rewrite.

### Exact production replay at the current head

The captured Shared Expert HSACO was replayed twice:

| Input SHA-256 | Input bytes | Output SHA-256 | Output bytes | Result |
|---|---:|---|---:|---|
| `4c4bd45992ad7ce9fe0878804b45362fa7e54cfda42733e72e02182a6d9778fc` | 1,615,504 | `123f39daa288c26a629b0bdbe52a2ca5411c88ad0ce5e3cf689d237e7f4b1b07` | 1,670,952 | success; second pass byte-identical |

- resolved the production calls at `0x12EE30` and `0x14676C`
- assigned 61 SCC-neutral forward gateways and 48 forward `s_branch` island
  chains
- applied 512 instruction patches
- the first and second outputs compare byte-for-byte equal
- disassembly contains zero `s_add_pc_i64` instructions

### Physical GPU 2 validation

The patch-identical pre-restack stack was validated on `mi400` with one physical
GPU, fresh processes, and separate fresh caches for HotSwap enabled and
disabled. The process map assertion confirmed that every mapped COMGR file had
the selected build's SHA-256 and ROCr came from the selected runtime prefix.

The exact command in both states was
`python3 python/repro_shared_expert_chain.py --iterations 100`, with
`ROCR_VISIBLE_DEVICES=2`, `HIP_VISIBLE_DEVICES=0`, and
`AITER_FORCE_GFX1250_EX=1`.

- HotSwap enabled: passed 100/100 iterations
- `HSA_HOTSWAP_DISABLE=1`: passed 100/100 iterations
- both: max absolute error `0.02978134`
- both: activation SHA-256
  `582984779b6f9f57a3d236647969fc15603da38514f62511797837183b803229`
- both: quantization SHA-256
  `8a30fa998c2c85b2e196b8e9a0f09cee033e030c122863caaa7aac8476abec6c`
- both: scale SHA-256
  `cae42ccb28b58aa932ba659d1d3e7db379f3482efdb1b5f423a73b10d2001e1a`
- both: quant sum `37553.437500`, scale sum `19.024853`
- no rewrite failure, memory-access fault, page fault, assertion, or traceback;
  GPU 2 was idle after validation

Earlier broader validation also passed activation HotSwap on/off for 1,000
iterations and quantization HotSwap on/off for 1,000 iterations with identical
`y_sum=15215.937500` and `scale_sum=16.396538`.