### PR TITLE
[comgr][hotswap] Reject unproven nested-call return clobbers

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1299,6 +1299,16 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
       for (const InternalDecodedInst &DI : Decoded) {
         if (DI.Offset < FunctionBegin || DI.Offset >= FunctionEnd)
           continue;
+        // MC call instructions carry no transitive callee-clobber information.
+        // Without interprocedural proof, a nested callee may overwrite the
+        // outer link pair even when the call defines a different return pair.
+        if (DI.DecodeSucceeded && LS.MIA->isCall(DI.Inst)) {
+          log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
+                << " is not a bounded return: nested call at 0x"
+                << utohexstr(DI.Offset) << " may clobber the link register\n";
+          Safe = false;
+          break;
+        }
         if (!DI.DecodeSucceeded ||
             definesOverlappingRegister(DI, LS, ReturnRegister)) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)

--- a/amd/comgr/test-lit/hotswap-pc-materialized-call-nested-clobber.s
+++ b/amd/comgr/test-lit/hotswap-pc-materialized-call-nested-clobber.s
@@ -1,0 +1,78 @@
+// COM: A nested call can clobber its caller's return pair even when the call
+// COM: instruction writes a different link pair. Without interprocedural
+// COM: clobber proof, the outer s_set_pc_i64 must remain unresolved and the
+// COM: rewrite must use the existing fail-closed path.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=LOG,API %s
+// LOG: hotswap: s_set_pc_i64 at 0x4 is not a bounded return:
+// LOG-SAME: nested call at 0x0 may clobber the link register
+// LOG: hotswap: unresolved call target
+// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
+// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
+// LOG: hotswap: error: no safe short-branch gateway for far site
+// API: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.type local_outer,@function
+local_outer:
+  s_call_i64 s[4:5], 1
+  s_set_pc_i64 s[0:1]
+.Llocal_outer_end:
+.size local_outer, .Llocal_outer_end-local_outer
+
+.type local_callee,@function
+local_callee:
+  s_mov_b32 s0, 0
+  s_set_pc_i64 s[4:5]
+.Llocal_callee_end:
+.size local_callee, .Llocal_callee_end-local_callee
+
+.globl test_nested_clobber
+.p2align 8
+.type test_nested_clobber,@function
+test_nested_clobber:
+  // Captured PC is .text+0x104 and local_outer starts at .text+0.
+  s_get_pc_i64 s[6:7]
+  s_add_nc_u64 s[6:7], s[6:7], -260
+  s_swap_pc_i64 s[0:1], s[6:7]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_end:
+.size test_nested_clobber, .Ltest_end-test_nested_clobber
+
+.fill 64, 1, 0
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_nested_clobber
+  .amdhsa_next_free_vgpr 5
+  .amdhsa_next_free_sgpr 8
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_nested_clobber
+      .symbol: test_nested_clobber.kd
+      .sgpr_count: 8
+      .vgpr_count: 5
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -803,6 +803,72 @@ TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, RejectsNestedCallSetPcReturn) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[4:5], 1\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_mov_b32 s30, 0\n"
+                         "s_set_pc_i64 s[4:5]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -20\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 7u);
+  llvm::SmallVector<uint64_t, 3> DeclaredEntries{0, Decoded[2].Offset,
+                                                 Decoded[4].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 2> FunctionRanges{
+      {0, Decoded[2].Offset}, {Decoded[2].Offset, Decoded[4].Offset}};
+
+  // The nested call uses a different link pair, so its instruction does not
+  // directly define s[30:31]. Its callee can still clobber that outer return
+  // pair, making a function-local definition scan insufficient.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsIndirectFallthroughChainEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_branch -1\n"
+                         "s_nop 0\n"
+                         "s_nop 0\n"
+                         "s_set_pc_i64 s[30:31]\n"
+                         "s_set_pc_i64 s[2:3]\n"
+                         "s_get_pc_i64 s[0:1]\n"
+                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                         "s_swap_pc_i64 s[30:31], s[0:1]",
+                         S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 8u);
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{Decoded[3].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {Decoded[3].Offset, Decoded[4].Offset}};
+
+  // The unknown s_set_pc_i64 target may enter the unreachable padding before
+  // the helper. Global indirect-entry detection must keep the materialized
+  // call unresolved even though direct and fallthrough checks accept it.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoReturnFunction) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);


### PR DESCRIPTION
Follow-up to #3414.

## Summary

- Treat a nested call inside a candidate bounded-return function as an unproven clobber of the outer link register.
- Leave that return unresolved so the existing fail-closed path disables unsafe relocation and gateway planning.
- Add unit coverage for both the nested-call clobber and the already-conservative handling of unknown indirect entries into a fallthrough chain.
- Add a production-shaped LIT regression that requires the nested-call diagnostic and safe rewrite failure.

The final HSACO MC representation has no transitive callee-clobber information. Until COMGR has an interprocedural binary clobber proof, accepting such a nested call would make the bounded-return conclusion unsound.

## Review concerns from #3414

- Nested callee clobber: addressed conservatively in this PR.
- Indirect entry into a fallthrough chain: no behavior change is needed. Unknown indirect transfers already set `HasUnresolvedTargets`; the new unit test pins that invariant.
- Richer IR/dataflow representation: not included. COMGR receives final HSACO without compiler IR, and introducing a new binary IR is substantially broader than this safety fix.

## Validation

- `HotswapMCTests`: 93/93 passed
- `HotswapElfTests`: 26/26 passed
- Focused new unit tests: passed
- `git diff --check`: passed
- `git clang-format -f rocm/amd-staging --diff`: clean

The production HSACO replay is pending because `mi400` is currently unreachable. The local LIT environment uses an older LLVM build that also fails the unchanged #3414 baseline LIT before reaching this new diagnostic; CI with a matching compiler is the authoritative LIT run.