### PR TITLE
[comgr][hotswap] Preserve VGPR-MSB mode when splitting gfx1250 WMMAs

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -989,23 +989,18 @@ struct PcMaterializedCallInfo {
 /// by llvm/test/MC/AMDGPU/gfx1250_asm_salu_lit64.s. Stop at the first
 /// overlapping definition or control-flow boundary, so any variation remains
 /// unresolved and follows the existing fail-closed policy.
-static std::optional<PcMaterializedCallInfo>
-matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
-                        const LLVMState &LS, uint64_t TextAddr) {
-  const InternalDecodedInst &Call = Decoded[CallIndex];
-  if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
-      Call.Inst.getNumOperands() < 2 || !Call.Inst.getOperand(0).isReg() ||
-      !Call.Inst.getOperand(0).getReg())
-    return std::nullopt;
-  const MCOperand &TargetOperand =
-      Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
-  if (!TargetOperand.isReg() || !TargetOperand.getReg())
-    return std::nullopt;
-  MCRegister TargetRegister(TargetOperand.getReg());
-
+// Shared get-PC/add resolver behind matchPcMaterializedCall (s_swap_pc_i64
+// calls) and the WMMA split pass's s_set_pc_i64 jump handling. The backward
+// scan and fail-closed policy are identical for both transfer kinds; only the
+// terminating opcode and the return-register semantics differ, which the
+// callers handle.
+std::optional<MaterializedPcSequence>
+resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
+                            size_t TransferIndex, MCRegister TargetRegister,
+                            const LLVMState &LS, uint64_t TextAddr) {
   std::optional<size_t> AddIndex;
   int64_t AddImmediate = 0;
-  for (size_t I = CallIndex; I != 0;) {
+  for (size_t I = TransferIndex; I != 0;) {
     --I;
     const InternalDecodedInst &Candidate = Decoded[I];
     if (!Candidate.DecodeSucceeded || isControlFlowBoundary(Candidate, LS))
@@ -1041,21 +1036,41 @@ matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
       return std::nullopt;
 
     std::optional<uint64_t> GetPcAddress = checkedAddUint64(
-        TextAddr, Candidate.Offset, "PC-materialized call instruction");
+        TextAddr, Candidate.Offset, "PC-materialized transfer instruction");
     if (!GetPcAddress)
       return std::nullopt;
     std::optional<uint64_t> PcValue = checkedAddUint64(
-        *GetPcAddress, Candidate.Size, "PC-materialized call PC value");
+        *GetPcAddress, Candidate.Size, "PC-materialized transfer PC value");
     if (!PcValue)
       return std::nullopt;
     // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
     // immediate to uint64_t and adding it reproduces both positive and
     // negative literals, including INT64_MIN, without signed overflow.
-    return PcMaterializedCallInfo{
-        *PcValue + static_cast<uint64_t>(AddImmediate), Candidate.Offset,
-        Call.Offset, MCRegister(Call.Inst.getOperand(0).getReg())};
+    return MaterializedPcSequence{
+        *PcValue + static_cast<uint64_t>(AddImmediate), Candidate.Offset};
   }
   return std::nullopt;
+}
+
+static std::optional<PcMaterializedCallInfo>
+matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
+                        const LLVMState &LS, uint64_t TextAddr) {
+  const InternalDecodedInst &Call = Decoded[CallIndex];
+  if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+      Call.Inst.getNumOperands() < 2 || !Call.Inst.getOperand(0).isReg() ||
+      !Call.Inst.getOperand(0).getReg())
+    return std::nullopt;
+  const MCOperand &TargetOperand =
+      Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
+  if (!TargetOperand.isReg() || !TargetOperand.getReg())
+    return std::nullopt;
+  std::optional<MaterializedPcSequence> Sequence = resolveMaterializedPcTarget(
+      Decoded, CallIndex, MCRegister(TargetOperand.getReg()), LS, TextAddr);
+  if (!Sequence)
+    return std::nullopt;
+  return PcMaterializedCallInfo{Sequence->Target, Sequence->SequenceStart,
+                                Call.Offset,
+                                MCRegister(Call.Inst.getOperand(0).getReg())};
 }
 
 struct KnownCallSite {
@@ -2273,10 +2288,11 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       *PoolVAddr, Elf.textAddr(), "trampoline pool base offset");
   if (!PoolBaseOffset)
     return std::nullopt;
-  PatchContext Ctx{
-      Config,      Decoded,           Text,         TextSize, *PoolBaseOffset,
-      LS,          OutTrampolines,    Sleds,        Elf,      Liveness,
-      KernelStats, OutScratchPatches, *ControlFlow, Profile};
+  PatchContext Ctx{Config,         Decoded,         Text,
+                   TextSize,       *PoolBaseOffset, LS,
+                   OutTrampolines, Sleds,           Elf,
+                   Liveness,       KernelStats,     OutScratchPatches,
+                   *ControlFlow,   Profile,         DeclaredEntries->Entries};
 
   const HotswapPatchVTable &VT = getHotswapPatchVTable();
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -844,6 +844,15 @@ struct LLVMState {
   unsigned SPrefetchInstPcRelOpcode = 0;
   unsigned SPrefetchDataPcRelOpcode = 0;
 
+  /// MC opcodes for the gfx1250 VGPR-MSB mode instructions, resolved once at
+  /// initLLVM() time so the WMMA split pass matches them by opcode instead of
+  /// disassembled mnemonic strings. These are gfx1250-only, so they are
+  /// resolved non-fatally: on subtargets without them the field keeps the
+  /// MCII::getNumOpcodes() sentinel and never matches a decoded opcode.
+  unsigned SSetVgprMsbOpcode = 0;
+  unsigned SSetregImm32Opcode = 0;
+  unsigned SSetregB32Opcode = 0;
+
   /// SCC, recovered from the implicit definition on a parsed scalar compare.
   /// This avoids scanning target register names in policy code.
   llvm::MCRegister SCCRegister;
@@ -1314,7 +1323,7 @@ struct MaterializedPcSequence {
 /// the first control-flow boundary or unexpected clobber so any variation
 /// stays unresolved (nullopt) for fail-closed callers. \p TextAddr is the
 /// .text base virtual address.
-std::optional<MaterializedPcSequence>
+[[nodiscard]] std::optional<MaterializedPcSequence>
 resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
                             size_t TransferIndex, llvm::MCRegister TargetReg,
                             const LLVMState &LS, uint64_t TextAddr);

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1133,6 +1133,16 @@ struct DirectControlFlowInfo {
   bool HasUnresolvedTargets = false;
 };
 
+// Per-instruction persistent gfx1250 VGPR-MSB mode (packed src0/src1/src2/dst,
+// two bits each, values 0-255) recovered by the WMMA split pass's
+// whole-function CFG fixed point. The sentinels distinguish "not analyzed",
+// "validated unreachable", and "reachable but ambiguous" so a required WMMA
+// split can fail closed when the incoming mode cannot be proven. See
+// comgr-hotswap-patch-wmma-split.cpp.
+inline constexpr int8_t VgprMsbUnanalyzed = -3;
+inline constexpr int8_t VgprMsbUnreachable = -2;
+inline constexpr int8_t VgprMsbUnknown = -1;
+
 /// Mutable per-run context threaded through all patch passes. Bundles the
 /// input config, decoded instruction stream, raw .text bytes, MC state,
 /// output streams (trampolines / scratch info), and the shared ELF view +
@@ -1158,10 +1168,21 @@ struct PatchContext {
   // Per-rewrite profiling session (inert unless AMD_COMGR_TIME_STATISTICS is
   // set). Deep patch sites record into its lock-free local array.
   HotswapProfile &Profile;
+  // Text-relative declared entry offsets (function symbol starts and kernel
+  // descriptor entries) from collectDeclaredTextEntries(). The WMMA split
+  // pass's VGPR-MSB analysis seeds each in-range entry as an ABI entry point so
+  // an interior kernel-descriptor entry is analyzed from the real entry mode
+  // instead of being misclassified as unreachable.
+  llvm::ArrayRef<uint64_t> DeclaredEntries;
   // Required patches are transformations whose unpatched original code is
   // unsafe to return when the selected rewrite policy needs the patch.
   bool RequiredPatchFailed = false;
   bool RequiredPatchApplied = false;
+  // Packed per-instruction gfx1250 VGPR-MSB mode, lazily populated by the WMMA
+  // split pass (empty until then). Indexed by position in Decoded; each entry
+  // is a VgprMsb* sentinel or a 0-255 mode. See
+  // comgr-hotswap-patch-wmma-split.cpp.
+  std::vector<int16_t> VgprMsbModeBefore;
   // Sum of the bytes already queued in OutTrampolines. Keeping this in the
   // per-rewrite context makes each new pool-position calculation constant
   // time even for code objects with many thousands of patch sites.
@@ -1276,6 +1297,27 @@ bool isSBranchReachable(uint64_t From, uint64_t To);
 std::optional<uint64_t>
 evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
+
+/// A canonical get-PC/add materialized address feeding a PC-materialized
+/// transfer (s_get_pc_i64 / s_add_nc_u64 / s_{swap,set}_pc_i64). \p Target is
+/// the absolute in-.text virtual address; \p SequenceStart is the .text offset
+/// of the s_get_pc_i64 that begins the sequence.
+struct MaterializedPcSequence {
+  uint64_t Target = 0;
+  uint64_t SequenceStart = 0;
+};
+
+/// Resolve the target of a PC-materialized transfer whose target register is
+/// \p TargetReg and whose transfer instruction (an s_swap_pc_i64 call or an
+/// s_set_pc_i64 jump) is \p Decoded[TransferIndex]. Scans backward for the
+/// single s_add_nc_u64 then s_get_pc_i64 that define \p TargetReg, stopping at
+/// the first control-flow boundary or unexpected clobber so any variation
+/// stays unresolved (nullopt) for fail-closed callers. \p TextAddr is the
+/// .text base virtual address.
+std::optional<MaterializedPcSequence>
+resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
+                            size_t TransferIndex, llvm::MCRegister TargetReg,
+                            const LLVMState &LS, uint64_t TextAddr);
 
 /// Collect branch and call targets used to protect interior entry points from
 /// trampoline coalescing. Absolute addresses in TextAddr .. TextAddr +

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -373,6 +373,16 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
                                      S.SPrefetchDataPcRelOpcode))
     return S;
 
+  // The gfx1250 VGPR-MSB mode instructions are resolved non-fatally: they are
+  // gfx1250-only, so on other subtargets resolveOpcodeViaParse returns the
+  // MCII::getNumOpcodes() sentinel, which never matches a decoded opcode. Only
+  // the WMMA split pass consumes them, and it only runs for gfx1250.
+  S.SSetVgprMsbOpcode = resolveOpcodeViaParse("s_set_vgpr_msb 0", S);
+  S.SSetregImm32Opcode = resolveOpcodeViaParse(
+      "s_setreg_imm32_b32 hwreg(HW_REG_MODE, 0, 1), 0", S);
+  S.SSetregB32Opcode =
+      resolveOpcodeViaParse("s_setreg_b32 hwreg(HW_REG_MODE, 0, 1), s0", S);
+
   SmallVector<MCInst, 2> SccDefInsts =
       parseAsmToMCInsts("s_cmp_eq_u32 s0, s0", S);
   if (SccDefInsts.size() != 1) {

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -82,6 +82,20 @@
 
 using namespace llvm;
 
+// convertSetRegImmToVgprMSBs is declared in the backend-private
+// llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h, which is not installed in the
+// LLVM dist and is not on comgr's include path. The symbol has external linkage
+// and is provided by LLVMAMDGPUUtils, which comgr already links, so forward-
+// declare it here rather than mirror the HW_REG_WAVE_MODE field layout.
+// TODO: replace this forward declaration with a proper include once the helper
+// is promoted to a public TargetParser header.
+namespace llvm {
+namespace AMDGPU {
+std::optional<unsigned> convertSetRegImmToVgprMSBs(const MCInst &MI,
+                                                   bool HasSetregVGPRMSBFixup);
+} // namespace AMDGPU
+} // namespace llvm
+
 namespace COMGR {
 namespace hotswap {
 namespace {
@@ -521,22 +535,20 @@ int16_t exactVgprMsbMode(VgprMsbState State) {
                               (State.Src2 << 4) | (State.Dst << 6));
 }
 
-// gfx1250's setreg-vgpr-msb-fixup makes an immediate HW_REG_WAVE_MODE (ID 1)
-// write load all four two-bit VGPR-MSB fields from simm bits [19:12], rotated
-// into s_set_vgpr_msb order. Mirror that here rather than depend on the
-// backend-private AMDGPUBaseInfo.h.
+// gfx1250 reaches the persistent VGPR-MSB bank mode through an immediate
+// HW_REG_WAVE_MODE (ID_MODE) write. Decode it with the backend helper
+// convertSetRegImmToVgprMSBs (forward-declared above) rather than mirror the
+// field layout. gfx1250 has the setreg VGPR-MSB fixup, so pass true; the helper
+// returns std::nullopt for any non-ID_MODE write. The mnemonic guard keeps the
+// helper's opcode assertion satisfied (only S_SETREG_IMM32_B32_gfx12 reaches
+// it) and the operand guards keep its getImm() accesses in range.
 std::optional<unsigned>
 decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI) {
   if (DI.Mnemonic != "s_setreg_imm32_b32" || DI.Inst.getNumOperands() != 2 ||
       !DI.Inst.getOperand(0).isImm() || !DI.Inst.getOperand(1).isImm())
     return std::nullopt;
-  constexpr unsigned ModeHwregId = 1;
-  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
-  if ((Simm16 & 0x3f) != ModeHwregId)
-    return std::nullopt;
-  unsigned Raw =
-      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> 12) & 0xff;
-  return ((Raw >> 2) | (Raw << 6)) & 0xff;
+  return llvm::AMDGPU::convertSetRegImmToVgprMSBs(
+      DI.Inst, /*HasSetregVGPRMSBFixup=*/true);
 }
 
 std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI) {

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -63,6 +63,11 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/BitVector.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -70,7 +75,10 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <functional>
 #include <optional>
+#include <utility>
+#include <vector>
 
 using namespace llvm;
 
@@ -434,7 +442,7 @@ std::string formatVgprRange(int Base, int Count) {
 
 bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
                            StringRef Mnemonic) {
-  auto LogError = [&](StringRef Reason) {
+  std::function<void(StringRef)> LogError = [&](StringRef Reason) {
     log() << "hotswap: error: WMMA split: invalid operands for " << Mnemonic
           << ": " << Reason << "\n";
   };
@@ -473,13 +481,487 @@ bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
   return false;
 }
 
+// -- VGPR-MSB mode recovery -------------------------------------------------
+//
+// A K=128 (or M=32) WMMA is split into two narrower WMMAs. When a split
+// operand's upper half crosses v255 the upper WMMA must execute under a
+// different persistent VGPR-MSB bank, bracketed by s_set_vgpr_msb, and the
+// incoming bank restored afterwards. Emitting that bracket correctly requires
+// knowing the persistent VGPR-MSB mode live at the WMMA. This is a
+// self-contained forward-CFG fixed point over the immutable decoded stream:
+// ambiguous, conflicting, or unanalyzable sites stay unknown so a required
+// split fails closed rather than guessing a mode.
+//
+// The four two-bit fields are packed exactly as s_set_vgpr_msb encodes them:
+//   bits [1:0]=src0, [3:2]=src1, [5:4]=src2, [7:6]=dst.
+
+struct VgprMsbState {
+  int8_t Dst = VgprMsbUnreachable;
+  int8_t Src0 = VgprMsbUnreachable;
+  int8_t Src1 = VgprMsbUnreachable;
+  int8_t Src2 = VgprMsbUnreachable;
+};
+
+VgprMsbState vgprMsbStateFromMode(unsigned Mode) {
+  Mode &= 0xff;
+  return {static_cast<int8_t>((Mode >> 6) & 0x3),
+          static_cast<int8_t>(Mode & 0x3),
+          static_cast<int8_t>((Mode >> 2) & 0x3),
+          static_cast<int8_t>((Mode >> 4) & 0x3)};
+}
+
+VgprMsbState unknownVgprMsbState() {
+  return {VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown};
+}
+
+int16_t exactVgprMsbMode(VgprMsbState State) {
+  if (State.Dst < 0 || State.Src0 < 0 || State.Src1 < 0 || State.Src2 < 0)
+    return VgprMsbUnknown;
+  return static_cast<int16_t>(State.Src0 | (State.Src1 << 2) |
+                              (State.Src2 << 4) | (State.Dst << 6));
+}
+
+// gfx1250's setreg-vgpr-msb-fixup makes an immediate HW_REG_WAVE_MODE (ID 1)
+// write load all four two-bit VGPR-MSB fields from simm bits [19:12], rotated
+// into s_set_vgpr_msb order. Mirror that here rather than depend on the
+// backend-private AMDGPUBaseInfo.h.
+std::optional<unsigned>
+decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI) {
+  if (DI.Mnemonic != "s_setreg_imm32_b32" || DI.Inst.getNumOperands() != 2 ||
+      !DI.Inst.getOperand(0).isImm() || !DI.Inst.getOperand(1).isImm())
+    return std::nullopt;
+  constexpr unsigned ModeHwregId = 1;
+  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
+  if ((Simm16 & 0x3f) != ModeHwregId)
+    return std::nullopt;
+  unsigned Raw =
+      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> 12) & 0xff;
+  return ((Raw >> 2) | (Raw << 6)) & 0xff;
+}
+
+std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI) {
+  if (!StringRef(DI.Mnemonic).starts_with("s_setreg") ||
+      DI.Inst.getNumOperands() == 0 ||
+      !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
+    return std::nullopt;
+  return static_cast<unsigned>(
+             DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
+         0x3f;
+}
+
+bool instructionDefinesNamedRegister(const InternalDecodedInst &DI,
+                                     StringRef Name, const LLVMState &LS) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned NumDefs =
+      std::min<unsigned>(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != NumDefs; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (Op.isReg() && Op.getReg() &&
+        StringRef(LS.MRI->getName(Op.getReg())) == Name)
+      return true;
+  }
+  return llvm::any_of(Desc.implicit_defs(), [&](MCPhysReg Reg) {
+    return StringRef(LS.MRI->getName(Reg)) == Name;
+  });
+}
+
+std::optional<unsigned>
+getExactVgprMsbModeWritten(const InternalDecodedInst &DI) {
+  if (DI.Mnemonic == "s_set_vgpr_msb") {
+    if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
+      return std::nullopt;
+    return static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 0xff;
+  }
+  return decodeSetregImmVgprMsbMode(DI);
+}
+
+bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS) {
+  return DI.Inst.getOpcode() == LS.SSetPcI64Opcode &&
+         DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isReg() &&
+         DI.Inst.getOperand(0).getReg() &&
+         StringRef(LS.MRI->getName(DI.Inst.getOperand(0).getReg())) ==
+             "SGPR30_SGPR31";
+}
+
+// Forward transfer function: how an instruction changes the incoming mode.
+// Exact MODE writes install a known mode; unknown MODE writes, opaque calls,
+// and undecoded slots poison it to unknown.
+VgprMsbState transferVgprMsbState(VgprMsbState In,
+                                  const InternalDecodedInst &DI,
+                                  const LLVMState &LS) {
+  if (In.Dst == VgprMsbUnreachable)
+    return In;
+  if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(DI))
+    return vgprMsbStateFromMode(*Mode);
+  if (DI.Mnemonic == "s_set_vgpr_msb")
+    return unknownVgprMsbState();
+  if (StringRef(DI.Mnemonic).starts_with("s_setreg")) {
+    std::optional<unsigned> HwregId = getSetregHwregId(DI);
+    if (!HwregId)
+      return unknownVgprMsbState();
+    constexpr unsigned ModeHwregId = 1;
+    if (*HwregId != ModeHwregId)
+      return In;
+    return unknownVgprMsbState();
+  }
+  if (DI.Mnemonic == "<unknown>" ||
+      instructionDefinesNamedRegister(DI, "MODE", LS) ||
+      (LS.MIA && LS.MIA->isCall(DI.Inst)))
+    return unknownVgprMsbState();
+  return In;
+}
+
+int8_t mergeVgprMsbValue(int8_t Old, int8_t Incoming) {
+  if (Old == VgprMsbUnreachable)
+    return Incoming;
+  if (Incoming == VgprMsbUnreachable || Old == Incoming)
+    return Old;
+  return VgprMsbUnknown;
+}
+
+VgprMsbState mergeVgprMsbState(VgprMsbState Old, VgprMsbState Incoming) {
+  return {mergeVgprMsbValue(Old.Dst, Incoming.Dst),
+          mergeVgprMsbValue(Old.Src0, Incoming.Src0),
+          mergeVgprMsbValue(Old.Src1, Incoming.Src1),
+          mergeVgprMsbValue(Old.Src2, Incoming.Src2)};
+}
+
+// Populate Ctx.VgprMsbModeBefore with a per-instruction packed VGPR-MSB mode
+// via a forward CFG fixed point over each analyzable function. Fail-closed:
+// only exact, consistent modes are recorded; any conflict, unknown MODE write,
+// opaque call, unresolved/indirect branch, or non-start cross-function entry
+// leaves the affected sites unknown/unanalyzed so a required split declines.
+void computeVgprMsbModes(PatchContext &Ctx) {
+  const std::vector<InternalDecodedInst> &Decoded = Ctx.Decoded;
+  const LLVMState &LS = Ctx.LS;
+  ElfView &Elf = Ctx.Elf;
+  ArrayRef<uint8_t> Text(Ctx.Text, Ctx.TextSize);
+  std::vector<int16_t> &ModeBefore = Ctx.VgprMsbModeBefore;
+  ModeBefore.assign(Decoded.size(), VgprMsbUnanalyzed);
+  if (!LS.MIA || !LS.MCII || !LS.MRI)
+    return;
+
+  // An unresolved call target (collectDirectBranchTargets could not prove its
+  // destination) may enter any function at an interior offset, bypassing that
+  // function's s_set_vgpr_msb prefix. The incoming mode is then unprovable
+  // object-wide, so decline the whole analysis and let each required split fail
+  // closed rather than risk seeding a wrong mode.
+  if (Ctx.DirectControlFlow.HasUnresolvedTargets)
+    return;
+
+  // Functions entered at a non-start offset by a cross-function branch or call
+  // cannot be seeded at their entry with the ABI mode; skip them (fail closed).
+  // Resolve targets over the same control-flow surface the rewrite uses:
+  // direct branches/calls plus absolute-immediate and PC-materialized
+  // s_swap_pc_i64 / s_set_pc_i64 transfers, so an interior cross-function
+  // s_swap_pc_i64 entry is caught instead of being analyzed from the wrong
+  // incoming mode.
+  std::function<std::optional<uint64_t>(const InternalDecodedInst &, size_t)>
+      resolveInteriorEntryTarget =
+          [&](const InternalDecodedInst &DI,
+              size_t Index) -> std::optional<uint64_t> {
+    if (std::optional<uint64_t> Direct =
+            evaluateDirectControlFlowTarget(DI, LS))
+      return Direct;
+    unsigned Opcode = DI.Inst.getOpcode();
+    if ((Opcode != LS.SSwapPcI64Opcode && Opcode != LS.SSetPcI64Opcode) ||
+        DI.Inst.getNumOperands() == 0)
+      return std::nullopt;
+    const MCOperand &TargetOp =
+        DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+    if (TargetOp.isImm()) {
+      uint64_t Absolute = static_cast<uint64_t>(TargetOp.getImm());
+      if (Absolute < Elf.textAddr())
+        return std::nullopt;
+      return Absolute - Elf.textAddr();
+    }
+    if (TargetOp.isReg() && TargetOp.getReg()) {
+      std::optional<MaterializedPcSequence> Sequence =
+          resolveMaterializedPcTarget(Decoded, Index,
+                                      MCRegister(TargetOp.getReg()), LS,
+                                      Elf.textAddr());
+      if (Sequence && Sequence->Target >= Elf.textAddr())
+        return Sequence->Target - Elf.textAddr();
+    }
+    return std::nullopt;
+  };
+
+  DenseSet<uint64_t> CrossFunctionInteriorEntries;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    unsigned Opcode = DI.Inst.getOpcode();
+    bool IsMaterializablePcTransfer =
+        Opcode == LS.SSwapPcI64Opcode || Opcode == LS.SSetPcI64Opcode;
+    // s_set_pc_i64 is an indirect transfer the generic MC layer classifies as a
+    // return rather than a branch, so the branch/call/return filter would skip
+    // it. Always attempt to resolve a materialized/absolute PC transfer target
+    // so a cross-function interior jump is caught; a genuine register return
+    // has no provable target and resolves to nullopt below.
+    if (!IsMaterializablePcTransfer &&
+        ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
+         LS.MIA->isReturn(DI.Inst)))
+      continue;
+    std::optional<uint64_t> Target = resolveInteriorEntryTarget(DI, I);
+    if (!Target || *Target >= Text.size())
+      continue;
+    std::optional<ElfView::FunctionTextRange> SourceOwner =
+        Elf.findFunctionTextRangeAtOffset(DI.Offset);
+    std::optional<ElfView::FunctionTextRange> TargetOwner =
+        Elf.findFunctionTextRangeAtOffset(*Target);
+    if (TargetOwner && *Target != TargetOwner->Begin &&
+        (!SourceOwner || SourceOwner->Begin != TargetOwner->Begin ||
+         SourceOwner->End != TargetOwner->End))
+      CrossFunctionInteriorEntries.insert(TargetOwner->Begin);
+  }
+
+  DenseSet<std::pair<uint64_t, uint64_t>> SeenRanges;
+  std::vector<ElfView::FunctionTextRange> FunctionRanges =
+      Elf.functionTextRanges();
+  for (size_t RangeIndex = 0; RangeIndex != FunctionRanges.size();
+       ++RangeIndex) {
+    const ElfView::FunctionTextRange &VirtualRange = FunctionRanges[RangeIndex];
+    if (VirtualRange.Begin < Elf.textAddr() ||
+        VirtualRange.End < VirtualRange.Begin ||
+        VirtualRange.End > Elf.textAddr() + Text.size())
+      continue;
+    uint64_t Begin = VirtualRange.Begin - Elf.textAddr();
+    uint64_t End = VirtualRange.End - Elf.textAddr();
+    if (Begin >= End || !SeenRanges.insert({Begin, End}).second ||
+        CrossFunctionInteriorEntries.contains(Begin))
+      continue;
+
+    // An outer symbol must not donate facts to instructions owned by a nested
+    // function symbol; skip overlapping / alias ranges.
+    size_t NextRange = RangeIndex + 1;
+    while (NextRange != FunctionRanges.size() &&
+           FunctionRanges[NextRange].Begin == VirtualRange.Begin)
+      ++NextRange;
+    if (NextRange != FunctionRanges.size() &&
+        FunctionRanges[NextRange].Begin < VirtualRange.End)
+      continue;
+    std::optional<ElfView::FunctionTextRange> Owner =
+        Elf.findFunctionTextRangeAtOffset(Begin);
+    if (!Owner || Owner->Begin != Begin || Owner->End != End)
+      continue;
+
+    std::vector<InternalDecodedInst>::const_iterator First = llvm::lower_bound(
+        Decoded, Begin, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    std::vector<InternalDecodedInst>::const_iterator After = llvm::lower_bound(
+        Decoded, End, [](const InternalDecodedInst &DI, uint64_t Offset) {
+          return DI.Offset < Offset;
+        });
+    if (First == After || First->Offset != Begin)
+      continue;
+
+    const size_t GlobalFirst = static_cast<size_t>(First - Decoded.begin());
+    const size_t Count = static_cast<size_t>(After - First);
+    DenseMap<uint64_t, unsigned> OffsetToLocalIndex;
+    OffsetToLocalIndex.reserve(Count);
+    bool Valid = true;
+    for (unsigned I = 0; I != Count; ++I) {
+      OffsetToLocalIndex.try_emplace(First[I].Offset, I);
+      if (First[I].Mnemonic == "<unknown>")
+        Valid = false;
+    }
+    if (!Valid)
+      continue;
+
+    std::vector<SmallVector<unsigned, 2>> Successors(Count);
+    BitVector CallableEntries(Count);
+    std::function<bool(SmallVectorImpl<unsigned> &, uint64_t)> AddTarget =
+        [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+          if (Target < Begin || Target >= End)
+            return true;
+          DenseMap<uint64_t, unsigned>::iterator It =
+              OffsetToLocalIndex.find(Target);
+          if (It == OffsetToLocalIndex.end())
+            return false;
+          Out.push_back(It->second);
+          return true;
+        };
+    std::function<void(SmallVectorImpl<unsigned> &, unsigned)> AddFallthrough =
+        [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+          if (I + 1 < Count)
+            Out.push_back(I + 1);
+        };
+
+    for (unsigned I = 0; I != Count && Valid; ++I) {
+      const InternalDecodedInst &DI = First[I];
+      SmallVectorImpl<unsigned> &Out = Successors[I];
+      if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+          LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, LS))
+        continue;
+      // A materialized-PC jump (s_get_pc_i64 / s_add_nc_u64 / s_set_pc_i64)
+      // with a provable target is not an unanalyzable indirect branch: a
+      // target inside this function is a CFG edge; a target outside exits the
+      // function (no fallthrough), so the following code is unreachable and its
+      // mode is unobservable. An unresolved s_set_pc_i64 stays fail-closed.
+      if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+        std::optional<MaterializedPcSequence> Sequence;
+        if (DI.Inst.getNumOperands() >= 1) {
+          const MCOperand &TargetOp =
+              DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+          if (TargetOp.isReg() && TargetOp.getReg())
+            Sequence = resolveMaterializedPcTarget(
+                Decoded, GlobalFirst + I, MCRegister(TargetOp.getReg()), LS,
+                Elf.textAddr());
+        }
+        if (!Sequence || Sequence->Target < Elf.textAddr()) {
+          Valid = false;
+          break;
+        }
+        Valid &= AddTarget(Out, Sequence->Target - Elf.textAddr());
+        continue;
+      }
+      if (LS.MIA->isCall(DI.Inst)) {
+        if (!LS.MIA->isIndirectBranch(DI.Inst))
+          if (std::optional<uint64_t> Target =
+                  evaluateDirectControlFlowTarget(DI, LS))
+            if (*Target >= Begin && *Target < End) {
+              DenseMap<uint64_t, unsigned>::iterator It =
+                  OffsetToLocalIndex.find(*Target);
+              if (It != OffsetToLocalIndex.end())
+                CallableEntries.set(It->second);
+            }
+        AddFallthrough(Out, I);
+        continue;
+      }
+      if (LS.MIA->isBranch(DI.Inst)) {
+        if (LS.MIA->isIndirectBranch(DI.Inst)) {
+          Valid = false;
+          break;
+        }
+        std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (!Target) {
+          Valid = false;
+          break;
+        }
+        Valid &= AddTarget(Out, *Target);
+        if (LS.MIA->isConditionalBranch(DI.Inst))
+          AddFallthrough(Out, I);
+        else if (!LS.MIA->isUnconditionalBranch(DI.Inst))
+          Valid = false;
+        continue;
+      }
+      if (LS.MIA->mayAffectControlFlow(DI.Inst, *LS.MRI)) {
+        Valid = false;
+        break;
+      }
+      AddFallthrough(Out, I);
+    }
+    if (!Valid)
+      continue;
+
+    // A validated CFG distinguishes dead instructions (unreachable; their mode
+    // is semantically unobservable, so treat as the ABI entry value) from
+    // sites we could not analyze at all (left VgprMsbUnanalyzed above).
+    for (size_t I = 0; I != Count; ++I)
+      ModeBefore[GlobalFirst + I] = VgprMsbUnreachable;
+
+    std::vector<VgprMsbState> In(Count);
+    SmallVector<unsigned, 64> Worklist;
+    // The gfx1250 VGPR-lowering ABI requires all four MSB fields to be zero on
+    // function entry. Calls transfer to unknown (this object-level proof does
+    // not inspect a callee's return), so callable entries reseed the ABI mode.
+    std::function<void(unsigned)> SeedAbiEntry = [&](unsigned I) {
+      In[I] = mergeVgprMsbState(In[I], vgprMsbStateFromMode(0));
+      Worklist.push_back(I);
+    };
+    SeedAbiEntry(0);
+    for (int I = CallableEntries.find_first(); I >= 0;
+         I = CallableEntries.find_next(I))
+      if (I != 0)
+        SeedAbiEntry(static_cast<unsigned>(I));
+    // Declared text entries (kernel-descriptor entry points) are real ABI
+    // entries even when no intra-object transfer targets them. Seeding any that
+    // land inside this function keeps an interior KD-entry block from being
+    // classified unreachable (then read as mode 0) when the real entry path
+    // sets the mode before reaching a WMMA there.
+    for (uint64_t Entry : Ctx.DeclaredEntries) {
+      if (Entry < Begin || Entry >= End)
+        continue;
+      DenseMap<uint64_t, unsigned>::iterator It =
+          OffsetToLocalIndex.find(Entry);
+      if (It != OffsetToLocalIndex.end() && It->second != 0)
+        SeedAbiEntry(It->second);
+    }
+
+    for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+      unsigned I = Worklist[Next];
+      ModeBefore[GlobalFirst + I] = exactVgprMsbMode(In[I]);
+      VgprMsbState Out = transferVgprMsbState(In[I], First[I], LS);
+      for (unsigned Succ : Successors[I]) {
+        VgprMsbState Merged = mergeVgprMsbState(In[Succ], Out);
+        if (Merged.Dst != In[Succ].Dst || Merged.Src0 != In[Succ].Src0 ||
+            Merged.Src1 != In[Succ].Src1 || Merged.Src2 != In[Succ].Src2) {
+          In[Succ] = Merged;
+          Worklist.push_back(Succ);
+        }
+      }
+    }
+  }
+}
+
+// -- Mode-aware split emission ----------------------------------------------
+
+// Recover the persistent VGPR-MSB mode at Idx from the CFG fixed point. Equal
+// predecessor states (including loop backedges) retain an exact mode;
+// conflicting paths, opaque calls, and unknown MODE writes fail closed. A
+// mandatory WMMA in a validated-unreachable block uses the ABI entry mode.
+std::optional<unsigned> findActiveVgprMsbMode(const PatchContext &Ctx,
+                                              size_t Idx) {
+  if (Idx >= Ctx.VgprMsbModeBefore.size())
+    return std::nullopt;
+  if (Ctx.VgprMsbModeBefore[Idx] == VgprMsbUnreachable)
+    return 0;
+  if (Ctx.VgprMsbModeBefore[Idx] < 0)
+    return std::nullopt;
+  return static_cast<unsigned>(Ctx.VgprMsbModeBefore[Idx]);
+}
+
+enum class VgprMsbOperand : unsigned {
+  Src0 = 0,
+  Src1 = 2,
+  Src2 = 4,
+  Dst = 6,
+};
+
+unsigned getVgprMsbs(unsigned Mode, VgprMsbOperand Operand) {
+  return (Mode >> static_cast<unsigned>(Operand)) & 0x3;
+}
+
+void setVgprMsbs(unsigned &Mode, VgprMsbOperand Operand, unsigned Msbs) {
+  const unsigned Shift = static_cast<unsigned>(Operand);
+  Mode = (Mode & ~(0x3u << Shift)) | (Msbs << Shift);
+}
+
+// Rebase an operand's upper-half index into the [0,255] encoding field and
+// record the bank it now selects. Returns false when the physical index needs
+// a bank > 3 (unrepresentable), so the caller fails closed.
+bool advanceVgprMsbMode(int &Base, VgprMsbOperand Operand, unsigned OldMode,
+                        unsigned &NewMode) {
+  unsigned OldMsbs = getVgprMsbs(OldMode, Operand);
+  unsigned PhysicalBase = (OldMsbs << 8) + static_cast<unsigned>(Base);
+  unsigned NewMsbs = PhysicalBase >> 8;
+  if (NewMsbs > 3)
+    return false;
+  Base = static_cast<int>(PhysicalBase & 0xff);
+  setVgprMsbs(NewMode, Operand, NewMsbs);
+  return true;
+}
+
 // -- Replacement asm builders -----------------------------------------------
 
 // K-dimension split: dst and src2 are unchanged on the first half. For the
 // second half, src2 = dst (the carry from the first half).
 std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
                                               const PrintedAsm &P,
-                                              const WmmaOps &R) {
+                                              const WmmaOps &R,
+                                              unsigned ActiveVgprMsbMode,
+                                              bool &UsesVgprMsbTransition) {
   assert(R.Dst.second > 0 && (R.Src2IsImm || R.Src2.second == R.Dst.second));
   assert(R.Src0.second > 0 && R.Src0.second % 2 == 0);
   assert(R.Src1.second > 0 && R.Src1.second % 2 == 0);
@@ -496,18 +978,44 @@ std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
     return {};
 
   std::vector<std::string> Out;
-  Out.reserve(2);
+  Out.reserve(5);
+  UsesVgprMsbTransition = false;
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}", Replacement, Dst,
                         formatVgprRange(R.Src0.first, AHalf),
                         formatVgprRange(R.Src1.first, BHalf), Src2Printed,
                         *ModFirst)
                     .str());
+
+  int Src0HiBase = R.Src0.first + AHalf;
+  int Src1HiBase = R.Src1.first + BHalf;
+  unsigned OldMode = ActiveVgprMsbMode;
+  unsigned NewMode = OldMode;
+  if (!advanceVgprMsbMode(Src0HiBase, VgprMsbOperand::Src0, OldMode, NewMode) ||
+      !advanceVgprMsbMode(Src1HiBase, VgprMsbOperand::Src1, OldMode, NewMode))
+    return {};
+
+  // The upper half uses dst as src2, so src2 must select the incoming
+  // destination bank even when neither source slice crossed v255.
+  setVgprMsbs(NewMode, VgprMsbOperand::Src2,
+              getVgprMsbs(OldMode, VgprMsbOperand::Dst));
+
+  if (NewMode != OldMode) {
+    UsesVgprMsbTransition = true;
+    // Immediate bits [15:8] record the previous mode. Restore the exact
+    // incoming mode before returning from the split trampoline.
+    unsigned SetUpperMode = NewMode | (OldMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", SetUpperMode).str());
+  }
+
   // Second half: src2 = dst (the carry).
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}", Replacement, Dst,
-                        formatVgprRange(R.Src0.first + AHalf, AHalf),
-                        formatVgprRange(R.Src1.first + BHalf, BHalf), Dst,
-                        *ModSecond)
+                        formatVgprRange(Src0HiBase, AHalf),
+                        formatVgprRange(Src1HiBase, BHalf), Dst, *ModSecond)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned RestoreMode = OldMode | (NewMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", RestoreMode).str());
+  }
   return Out;
 }
 
@@ -515,9 +1023,9 @@ std::vector<std::string> buildSplit128to64Asm(StringRef Replacement,
 // src2 are split in half by M. The replacement uses the f8f6f4 WMMA with
 // both matrix format modifiers forced to MATRIX_FMT_FP4 so the data layout
 // matches the original f4 instruction.
-std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
-                                            const PrintedAsm &P,
-                                            const WmmaOps &R) {
+std::vector<std::string>
+buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
+                   unsigned ActiveVgprMsbMode, bool &UsesVgprMsbTransition) {
   assert(R.Dst.second > 0 && R.Dst.second % 2 == 0);
   assert(R.Src2IsImm || R.Src2.second == R.Dst.second);
   assert(R.Src0.second > 0 && R.Src0.second % 2 == 0);
@@ -526,12 +1034,22 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
   int DstHalf = R.Dst.second / 2;
   int AHalf = R.Src0.second / 2;
   StringRef B = P.Operands[2]; // broadcast: same printer-canonical form
+  int DstHiBase = R.Dst.first + DstHalf;
+  int Src0HiBase = R.Src0.first + AHalf;
+  int Src2HiBase = R.Src2IsImm ? 0 : R.Src2.first + DstHalf;
+  unsigned OldMode = ActiveVgprMsbMode;
+  unsigned NewMode = OldMode;
+  if (!advanceVgprMsbMode(DstHiBase, VgprMsbOperand::Dst, OldMode, NewMode) ||
+      !advanceVgprMsbMode(Src0HiBase, VgprMsbOperand::Src0, OldMode, NewMode) ||
+      (!R.Src2IsImm &&
+       !advanceVgprMsbMode(Src2HiBase, VgprMsbOperand::Src2, OldMode, NewMode)))
+    return {};
+
   // src2 is preserved on both halves when imm; sliced when VGPR.
   std::string CLo = R.Src2IsImm ? P.Operands[3].str()
                                 : formatVgprRange(R.Src2.first, DstHalf);
-  std::string CHi = R.Src2IsImm
-                        ? P.Operands[3].str()
-                        : formatVgprRange(R.Src2.first + DstHalf, DstHalf);
+  std::string CHi =
+      R.Src2IsImm ? P.Operands[3].str() : formatVgprRange(Src2HiBase, DstHalf);
   // Matrix format modifiers are required by the f8f6f4 destination opcode
   // and not present on the f4 source opcode, so the splitter appends them
   // explicitly. Modifier suffix from the source is preserved on both halves
@@ -544,17 +1062,26 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
     return {};
 
   std::vector<std::string> Out;
-  Out.reserve(2);
+  Out.reserve(4);
+  UsesVgprMsbTransition = NewMode != OldMode;
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
                         formatVgprRange(R.Dst.first, DstHalf),
                         formatVgprRange(R.Src0.first, AHalf), B, CLo, FmtSuffix,
                         *Mod)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned SetUpperMode = NewMode | (OldMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", SetUpperMode).str());
+  }
   Out.push_back(formatv("{0} {1}, {2}, {3}, {4}{5}{6}", Replacement,
-                        formatVgprRange(R.Dst.first + DstHalf, DstHalf),
-                        formatVgprRange(R.Src0.first + AHalf, AHalf), B, CHi,
-                        FmtSuffix, *Mod)
+                        formatVgprRange(DstHiBase, DstHalf),
+                        formatVgprRange(Src0HiBase, AHalf), B, CHi, FmtSuffix,
+                        *Mod)
                     .str());
+  if (UsesVgprMsbTransition) {
+    unsigned RestoreMode = OldMode | (NewMode << 8);
+    Out.push_back(formatv("s_set_vgpr_msb {0}", RestoreMode).str());
+  }
   return Out;
 }
 
@@ -587,6 +1114,14 @@ std::vector<std::string> buildSplit32x16Asm(StringRef Replacement,
 // log() (so the failure is at least visible when AMD_COMGR_EMIT_VERBOSE_LOGS
 // is set) and returns 0. The early "did not match" path returns 0
 // without logging.
+// Fail closed: a recognized A0-incompatible WMMA that cannot be safely split
+// must abort the whole rewrite (the dispatcher checks RequiredPatchFailed)
+// rather than leave the original B0 opcode in .text and return SUCCESS.
+static uint32_t failWmmaSplit(PatchContext &Ctx) {
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
 
@@ -594,11 +1129,9 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!Match)
     return 0; // Did NOT match -- correct dispatcher fall-through.
 
-  // ----- All return-0 paths below are MATCHED-BUT-FAILED -----
-  // Until the dispatcher API is refactored to distinguish these cleanly,
-  // each of these is a silent miscompile risk for the runtime; the log()
-  // line is the only signal the user gets that a recognized opcode was
-  // left in .text.
+  // ----- All failure paths below fail closed via failWmmaSplit -----
+  // A recognized WMMA opcode that is invalid on A0 must never be left in
+  // .text with the rewrite still reporting SUCCESS.
 
   // Structural sanity check against the opcode side. Every WMMA variant this
   // patch handles has exactly one destination operand at the MCInstrDesc
@@ -609,7 +1142,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (MCID.getNumDefs() != 1) {
     log() << "hotswap: error: WMMA split: " << DI.Mnemonic << " has "
           << MCID.getNumDefs() << " defs, expected 1\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
   std::optional<WmmaOps> Ops =
@@ -617,11 +1150,11 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!Ops) {
     log() << "hotswap: error: WMMA split: could not extract operands from "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
   if (!validateSplitOperands(Match->Kind, *Ops, DI.Mnemonic))
-    return 0; // matched-but-failed (validateSplitOperands logs the reason)
+    return failWmmaSplit(Ctx); // validateSplitOperands logs the reason
 
   // Print the source instruction in canonical asm form. The printer is the
   // authoritative source for src2 inline-immediate formatting (FP inline
@@ -636,20 +1169,54 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (!P) {
     log() << "hotswap: error: WMMA split: could not parse printed form of "
           << DI.Mnemonic << ": " << StringRef(PrintedBuf).trim() << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
+  }
+
+  // Recover the persistent VGPR-MSB mode once per rewrite (lazy; WMMA-only).
+  // A split whose upper half crosses v255 needs the incoming mode to bracket
+  // the transition and restore it. K-splits always consult the mode (the
+  // upper half reuses dst as src2). M-splits consult it only when a half
+  // actually crosses v255.
+  if (Ctx.VgprMsbModeBefore.empty())
+    computeVgprMsbModes(Ctx);
+
+  bool UsesVgprMsbTransition = false;
+  bool NeedsKnownVgprMsbMode = Match->Kind == SplitKind::Split128to64FP8BF8;
+  if (Match->Kind == SplitKind::Split32x16to16x16F4) {
+    NeedsKnownVgprMsbMode =
+        Ops->Dst.first + Ops->Dst.second / 2 > 255 ||
+        Ops->Src0.first + Ops->Src0.second / 2 > 255 ||
+        (!Ops->Src2IsImm && Ops->Src2.first + Ops->Dst.second / 2 > 255);
+  }
+
+  unsigned ActiveVgprMsbMode = 0;
+  if (NeedsKnownVgprMsbMode) {
+    std::optional<unsigned> Mode = findActiveVgprMsbMode(Ctx, Idx);
+    if (!Mode) {
+      log() << "hotswap: error: WMMA split: cannot determine VGPR-MSB mode "
+               "for "
+            << DI.Mnemonic << " at offset 0x" << utohexstr(DI.Offset) << "\n";
+      return failWmmaSplit(Ctx);
+    }
+    ActiveVgprMsbMode = *Mode;
   }
 
   std::vector<std::string> AsmLines;
   switch (Match->Kind) {
   case SplitKind::Split128to64FP8BF8:
-    AsmLines = buildSplit128to64Asm(Match->Replacement, *P, *Ops);
+    AsmLines = buildSplit128to64Asm(Match->Replacement, *P, *Ops,
+                                    ActiveVgprMsbMode, UsesVgprMsbTransition);
     break;
   case SplitKind::Split32x16to16x16F4:
-    AsmLines = buildSplit32x16Asm(Match->Replacement, *P, *Ops);
+    AsmLines = buildSplit32x16Asm(Match->Replacement, *P, *Ops,
+                                  ActiveVgprMsbMode, UsesVgprMsbTransition);
     break;
   }
-  if (AsmLines.empty())
-    return 0; // matched-but-failed (build*Asm rejected an unsupported modifier)
+  if (AsmLines.empty()) {
+    log() << "hotswap: error: WMMA split: could not build replacement for "
+          << DI.Mnemonic << "\n";
+    return failWmmaSplit(Ctx);
+  }
 
   // Assemble the split sequence and defer trampoline emission to
   // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
@@ -659,14 +1226,15 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   if (Replacement.empty()) {
     log() << "hotswap: error: WMMA split: trampoline assembly failed for "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement)) {
     log() << "hotswap: error: WMMA split: could not emit trampoline for "
           << DI.Mnemonic << "\n";
-    return 0; // matched-but-failed
+    return failWmmaSplit(Ctx);
   }
 
+  Ctx.RequiredPatchApplied = true;
   log() << "hotswap: WMMA split: patched " << DI.Mnemonic << " at offset 0x"
         << utohexstr(DI.Offset) << "\n";
   return 1;

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -456,7 +456,7 @@ std::string formatVgprRange(int Base, int Count) {
 
 bool validateSplitOperands(SplitKind Kind, const WmmaOps &R,
                            StringRef Mnemonic) {
-  std::function<void(StringRef)> LogError = [&](StringRef Reason) {
+  auto LogError = [&](StringRef Reason) {
     log() << "hotswap: error: WMMA split: invalid operands for " << Mnemonic
           << ": " << Reason << "\n";
   };
@@ -528,32 +528,41 @@ VgprMsbState unknownVgprMsbState() {
   return {VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown, VgprMsbUnknown};
 }
 
-int16_t exactVgprMsbMode(VgprMsbState State) {
+[[nodiscard]] int16_t exactVgprMsbMode(VgprMsbState State) {
   if (State.Dst < 0 || State.Src0 < 0 || State.Src1 < 0 || State.Src2 < 0)
     return VgprMsbUnknown;
   return static_cast<int16_t>(State.Src0 | (State.Src1 << 2) |
                               (State.Src2 << 4) | (State.Dst << 6));
 }
 
+// True for either gfx1250 s_setreg form (register or immediate) that can write
+// the HW_REG_WAVE_MODE bank fields. Matched by cached opcode rather than
+// disassembled mnemonic string.
+bool isSetregOpcode(const InternalDecodedInst &DI, const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  return Opcode == LS.SSetregImm32Opcode || Opcode == LS.SSetregB32Opcode;
+}
+
 // gfx1250 reaches the persistent VGPR-MSB bank mode through an immediate
 // HW_REG_WAVE_MODE (ID_MODE) write. Decode it with the backend helper
 // convertSetRegImmToVgprMSBs (forward-declared above) rather than mirror the
 // field layout. gfx1250 has the setreg VGPR-MSB fixup, so pass true; the helper
-// returns std::nullopt for any non-ID_MODE write. The mnemonic guard keeps the
+// returns std::nullopt for any non-ID_MODE write. The opcode guard keeps the
 // helper's opcode assertion satisfied (only S_SETREG_IMM32_B32_gfx12 reaches
 // it) and the operand guards keep its getImm() accesses in range.
 std::optional<unsigned>
-decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI) {
-  if (DI.Mnemonic != "s_setreg_imm32_b32" || DI.Inst.getNumOperands() != 2 ||
-      !DI.Inst.getOperand(0).isImm() || !DI.Inst.getOperand(1).isImm())
+decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() != LS.SSetregImm32Opcode ||
+      DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isImm() ||
+      !DI.Inst.getOperand(1).isImm())
     return std::nullopt;
   return llvm::AMDGPU::convertSetRegImmToVgprMSBs(
       DI.Inst, /*HasSetregVGPRMSBFixup=*/true);
 }
 
-std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI) {
-  if (!StringRef(DI.Mnemonic).starts_with("s_setreg") ||
-      DI.Inst.getNumOperands() == 0 ||
+std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI,
+                                         const LLVMState &LS) {
+  if (!isSetregOpcode(DI, LS) || DI.Inst.getNumOperands() == 0 ||
       !DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm())
     return std::nullopt;
   return static_cast<unsigned>(
@@ -577,14 +586,14 @@ bool instructionDefinesNamedRegister(const InternalDecodedInst &DI,
   });
 }
 
-std::optional<unsigned>
-getExactVgprMsbModeWritten(const InternalDecodedInst &DI) {
-  if (DI.Mnemonic == "s_set_vgpr_msb") {
+[[nodiscard]] std::optional<unsigned>
+getExactVgprMsbModeWritten(const InternalDecodedInst &DI, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SSetVgprMsbOpcode) {
     if (DI.Inst.getNumOperands() != 1 || !DI.Inst.getOperand(0).isImm())
       return std::nullopt;
     return static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 0xff;
   }
-  return decodeSetregImmVgprMsbMode(DI);
+  return decodeSetregImmVgprMsbMode(DI, LS);
 }
 
 bool isStandardLinkReturn(const InternalDecodedInst &DI, const LLVMState &LS) {
@@ -603,12 +612,12 @@ VgprMsbState transferVgprMsbState(VgprMsbState In,
                                   const LLVMState &LS) {
   if (In.Dst == VgprMsbUnreachable)
     return In;
-  if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(DI))
+  if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(DI, LS))
     return vgprMsbStateFromMode(*Mode);
-  if (DI.Mnemonic == "s_set_vgpr_msb")
+  if (DI.Inst.getOpcode() == LS.SSetVgprMsbOpcode)
     return unknownVgprMsbState();
-  if (StringRef(DI.Mnemonic).starts_with("s_setreg")) {
-    std::optional<unsigned> HwregId = getSetregHwregId(DI);
+  if (isSetregOpcode(DI, LS)) {
+    std::optional<unsigned> HwregId = getSetregHwregId(DI, LS);
     if (!HwregId)
       return unknownVgprMsbState();
     constexpr unsigned ModeHwregId = 1;
@@ -643,6 +652,14 @@ VgprMsbState mergeVgprMsbState(VgprMsbState Old, VgprMsbState Incoming) {
 // only exact, consistent modes are recorded; any conflict, unknown MODE write,
 // opaque call, unresolved/indirect branch, or non-start cross-function entry
 // leaves the affected sites unknown/unanalyzed so a required split declines.
+//
+// Pass-ordering invariant: this analysis reads Ctx.Decoded as an immutable
+// snapshot (per HOTSWAP_CONVENTIONS) and recovers the mode from the bytes of
+// the VGPR-MSB mode instructions (s_set_vgpr_msb and s_setreg writes to
+// HW_REG_WAVE_MODE). It must therefore run before, or be re-decoded after, any
+// pass that rewrites those specific instructions' bytes. This holds today: the
+// in-place pass only touches cluster loads / s_barrier_signal_isfirst and the
+// trampoline pass preserves instruction sizes and mode-instruction bytes.
 void computeVgprMsbModes(PatchContext &Ctx) {
   const std::vector<InternalDecodedInst> &Decoded = Ctx.Decoded;
   const LLVMState &LS = Ctx.LS;
@@ -668,10 +685,9 @@ void computeVgprMsbModes(PatchContext &Ctx) {
   // s_swap_pc_i64 / s_set_pc_i64 transfers, so an interior cross-function
   // s_swap_pc_i64 entry is caught instead of being analyzed from the wrong
   // incoming mode.
-  std::function<std::optional<uint64_t>(const InternalDecodedInst &, size_t)>
-      resolveInteriorEntryTarget =
-          [&](const InternalDecodedInst &DI,
-              size_t Index) -> std::optional<uint64_t> {
+  auto resolveInteriorEntryTarget =
+      [&](const InternalDecodedInst &DI,
+          size_t Index) -> std::optional<uint64_t> {
     if (std::optional<uint64_t> Direct =
             evaluateDirectControlFlowTarget(DI, LS))
       return Direct;
@@ -782,27 +798,26 @@ void computeVgprMsbModes(PatchContext &Ctx) {
 
     std::vector<SmallVector<unsigned, 2>> Successors(Count);
     BitVector CallableEntries(Count);
-    std::function<bool(SmallVectorImpl<unsigned> &, uint64_t)> AddTarget =
-        [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
-          if (Target < Begin || Target >= End)
-            return true;
-          DenseMap<uint64_t, unsigned>::iterator It =
-              OffsetToLocalIndex.find(Target);
-          if (It == OffsetToLocalIndex.end())
-            return false;
-          Out.push_back(It->second);
-          return true;
-        };
-    std::function<void(SmallVectorImpl<unsigned> &, unsigned)> AddFallthrough =
-        [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
-          if (I + 1 < Count)
-            Out.push_back(I + 1);
-        };
+    auto AddTarget = [&](SmallVectorImpl<unsigned> &Out, uint64_t Target) {
+      if (Target < Begin || Target >= End)
+        return true;
+      DenseMap<uint64_t, unsigned>::iterator It =
+          OffsetToLocalIndex.find(Target);
+      if (It == OffsetToLocalIndex.end())
+        return false;
+      Out.push_back(It->second);
+      return true;
+    };
+    auto AddFallthrough = [&](SmallVectorImpl<unsigned> &Out, unsigned I) {
+      if (I + 1 < Count)
+        Out.push_back(I + 1);
+    };
 
     for (unsigned I = 0; I != Count && Valid; ++I) {
       const InternalDecodedInst &DI = First[I];
       SmallVectorImpl<unsigned> &Out = Successors[I];
-      if (DI.Mnemonic == "s_endpgm" || DI.Mnemonic == "s_endpgm_saved" ||
+      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
           LS.MIA->isReturn(DI.Inst) || isStandardLinkReturn(DI, LS))
         continue;
       // A materialized-PC jump (s_get_pc_i64 / s_add_nc_u64 / s_set_pc_i64)
@@ -890,7 +905,7 @@ void computeVgprMsbModes(PatchContext &Ctx) {
     // The gfx1250 VGPR-lowering ABI requires all four MSB fields to be zero on
     // function entry. Calls transfer to unknown (this object-level proof does
     // not inspect a callee's return), so callable entries reseed the ABI mode.
-    std::function<void(unsigned)> SeedAbiEntry = [&](unsigned I) {
+    auto SeedAbiEntry = [&](unsigned I) {
       In[I] = mergeVgprMsbState(In[I], vgprMsbStateFromMode(0));
       Worklist.push_back(I);
     };
@@ -935,8 +950,8 @@ void computeVgprMsbModes(PatchContext &Ctx) {
 // predecessor states (including loop backedges) retain an exact mode;
 // conflicting paths, opaque calls, and unknown MODE writes fail closed. A
 // mandatory WMMA in a validated-unreachable block uses the ABI entry mode.
-std::optional<unsigned> findActiveVgprMsbMode(const PatchContext &Ctx,
-                                              size_t Idx) {
+[[nodiscard]] std::optional<unsigned>
+findActiveVgprMsbMode(const PatchContext &Ctx, size_t Idx) {
   if (Idx >= Ctx.VgprMsbModeBefore.size())
     return std::nullopt;
   if (Ctx.VgprMsbModeBefore[Idx] == VgprMsbUnreachable)
@@ -965,8 +980,8 @@ void setVgprMsbs(unsigned &Mode, VgprMsbOperand Operand, unsigned Msbs) {
 // Rebase an operand's upper-half index into the [0,255] encoding field and
 // record the bank it now selects. Returns false when the physical index needs
 // a bank > 3 (unrepresentable), so the caller fails closed.
-bool advanceVgprMsbMode(int &Base, VgprMsbOperand Operand, unsigned OldMode,
-                        unsigned &NewMode) {
+[[nodiscard]] bool advanceVgprMsbMode(int &Base, VgprMsbOperand Operand,
+                                      unsigned OldMode, unsigned &NewMode) {
   unsigned OldMsbs = getVgprMsbs(OldMode, Operand);
   unsigned PhysicalBase = (OldMsbs << 8) + static_cast<unsigned>(Base);
   unsigned NewMsbs = PhysicalBase >> 8;

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -82,20 +82,6 @@
 
 using namespace llvm;
 
-// convertSetRegImmToVgprMSBs is declared in the backend-private
-// llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h, which is not installed in the
-// LLVM dist and is not on comgr's include path. The symbol has external linkage
-// and is provided by LLVMAMDGPUUtils, which comgr already links, so forward-
-// declare it here rather than mirror the HW_REG_WAVE_MODE field layout.
-// TODO: replace this forward declaration with a proper include once the helper
-// is promoted to a public TargetParser header.
-namespace llvm {
-namespace AMDGPU {
-std::optional<unsigned> convertSetRegImmToVgprMSBs(const MCInst &MI,
-                                                   bool HasSetregVGPRMSBFixup);
-} // namespace AMDGPU
-} // namespace llvm
-
 namespace COMGR {
 namespace hotswap {
 namespace {
@@ -544,20 +530,40 @@ bool isSetregOpcode(const InternalDecodedInst &DI, const LLVMState &LS) {
 }
 
 // gfx1250 reaches the persistent VGPR-MSB bank mode through an immediate
-// HW_REG_WAVE_MODE (ID_MODE) write. Decode it with the backend helper
-// convertSetRegImmToVgprMSBs (forward-declared above) rather than mirror the
-// field layout. gfx1250 has the setreg VGPR-MSB fixup, so pass true; the helper
-// returns std::nullopt for any non-ID_MODE write. The opcode guard keeps the
-// helper's opcode assertion satisfied (only S_SETREG_IMM32_B32_gfx12 reaches
-// it) and the operand guards keep its getImm() accesses in range.
+// HW_REG_WAVE_MODE (ID_MODE) write. The exact decode is implemented upstream by
+// llvm::AMDGPU::convertSetRegImmToVgprMSBs (the MCInst overload at
+// llvm/lib/Target/AMDGPU/Utils/AMDGPUBaseInfo.h:1790), but comgr cannot call
+// it: it lives in the target-internal LLVMAMDGPUUtils component, which is not
+// reachable when comgr links libLLVM.so (LLVM_LINK_LLVM_DYLIB, used by the
+// multi-arch build) -- doing so fails to link with an undefined reference. So
+// mirror the setreg-VGPR-MSB-fixup decode here. The constants mirror the
+// HW_REG_WAVE_MODE encoding in llvm/lib/Target/AMDGPU/SIDefines.h; keep them in
+// sync with that header.
+// TODO(https://github.com/ROCm/llvm-project/issues/3516): replace this mirror
+// with a direct call to llvm::AMDGPU::convertSetRegImmToVgprMSBs once that
+// helper is exported for comgr to link.
+constexpr unsigned HwregIdMask = 0x3f; // Hwreg::HwregEncoding ID field [5:0]
+constexpr unsigned HwregIdMode = 1;    // AMDGPU::Hwreg::ID_MODE
+constexpr unsigned VgprMsbShift = 12;  // countr_zero(Hwreg::DST_VGPR_MSB)
+constexpr unsigned VgprMsbFieldMask = 0xff; // VGPR_MSB_MASK >> VgprMsbShift:
+                                            // four packed 2-bit fields
+constexpr unsigned VgprMsbRotate = 2; // rotr into s_set_vgpr_msb field order
+
 std::optional<unsigned>
 decodeSetregImmVgprMsbMode(const InternalDecodedInst &DI, const LLVMState &LS) {
   if (DI.Inst.getOpcode() != LS.SSetregImm32Opcode ||
       DI.Inst.getNumOperands() != 2 || !DI.Inst.getOperand(0).isImm() ||
       !DI.Inst.getOperand(1).isImm())
     return std::nullopt;
-  return llvm::AMDGPU::convertSetRegImmToVgprMSBs(
-      DI.Inst, /*HasSetregVGPRMSBFixup=*/true);
+  unsigned Simm16 = static_cast<unsigned>(DI.Inst.getOperand(1).getImm());
+  if ((Simm16 & HwregIdMask) != HwregIdMode)
+    return std::nullopt;
+  unsigned Raw =
+      (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) >> VgprMsbShift) &
+      VgprMsbFieldMask;
+  // Equivalent to llvm::rotr<uint8_t>(Raw, VgprMsbRotate).
+  return ((Raw >> VgprMsbRotate) | (Raw << (8 - VgprMsbRotate))) &
+         VgprMsbFieldMask;
 }
 
 std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI,
@@ -567,7 +573,7 @@ std::optional<unsigned> getSetregHwregId(const InternalDecodedInst &DI,
     return std::nullopt;
   return static_cast<unsigned>(
              DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm()) &
-         0x3f;
+         HwregIdMask;
 }
 
 bool instructionDefinesNamedRegister(const InternalDecodedInst &DI,
@@ -620,8 +626,7 @@ VgprMsbState transferVgprMsbState(VgprMsbState In,
     std::optional<unsigned> HwregId = getSetregHwregId(DI, LS);
     if (!HwregId)
       return unknownVgprMsbState();
-    constexpr unsigned ModeHwregId = 1;
-    if (*HwregId != ModeHwregId)
+    if (*HwregId != HwregIdMode)
       return In;
     return unknownVgprMsbState();
   }

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -828,15 +828,27 @@ void computeVgprMsbModes(PatchContext &Ctx) {
         continue;
       }
       if (LS.MIA->isCall(DI.Inst)) {
-        if (!LS.MIA->isIndirectBranch(DI.Inst))
-          if (std::optional<uint64_t> Target =
-                  evaluateDirectControlFlowTarget(DI, LS))
-            if (*Target >= Begin && *Target < End) {
-              DenseMap<uint64_t, unsigned>::iterator It =
-                  OffsetToLocalIndex.find(*Target);
-              if (It != OffsetToLocalIndex.end())
-                CallableEntries.set(It->second);
-            }
+        // A call target inside this function is a fresh ABI (mode-0) entry and
+        // must be seeded like the function start. Resolve it over the same
+        // control-flow surface the interior-entry pre-pass uses (direct,
+        // absolute-immediate, and PC-materialized) rather than direct targets
+        // only: a same-function materialized/absolute call whose block is also
+        // reached by a differing-mode fallthrough/branch would otherwise drop
+        // the mode-0 contribution and let the join converge on a more specific
+        // mode than is provable. An unresolved call target could enter this
+        // function anywhere, so fail closed rather than seed too few entries.
+        std::optional<uint64_t> Target =
+            resolveInteriorEntryTarget(DI, GlobalFirst + I);
+        if (!Target) {
+          Valid = false;
+          break;
+        }
+        if (*Target >= Begin && *Target < End) {
+          DenseMap<uint64_t, unsigned>::iterator It =
+              OffsetToLocalIndex.find(*Target);
+          if (It != OffsetToLocalIndex.end())
+            CallableEntries.set(It->second);
+        }
         AddFallthrough(Out, I);
         continue;
       }

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-callable-entry-materialized.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-callable-entry-materialized.s
@@ -22,7 +22,7 @@
 // failure comes from the unprovable join at the shared block, not that bail.
 // CHECK: hotswap: resolved PC-materialized call
 // CHECK-NOT: hotswap: unresolved call target
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-callable-entry-materialized.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-callable-entry-materialized.s
@@ -1,0 +1,102 @@
+// A block that holds a mandatory WMMA is reached two ways inside one function:
+// by fallthrough from an s_set_vgpr_msb prefix (a concrete mode) and by a
+// same-function PC-materialized s_swap_pc_i64 call. A call target is a fresh
+// ABI (mode-0) entry, so it must be seeded like the function start. Because
+// collectDirectBranchTargets resolves the canonical materialized call there is
+// no unresolved-target bail, but evaluateDirectControlFlowTarget cannot resolve
+// a register-target call. The VGPR-MSB analysis must therefore seed the call
+// target over the same control-flow surface it uses for interior entries; the
+// mode-0 contribution then conflicts with the fallthrough mode and the join is
+// unprovable, so the mandatory split fails closed. Without seeding the
+// materialized call target, the analysis drops the mode-0 edge, converges on
+// the fallthrough mode, and patches the WMMA under a mode that is not provable.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// The materialized call must resolve (no global unresolved-target bail), so the
+// failure comes from the unprovable join at the shared block, not that bail.
+// CHECK: hotswap: resolved PC-materialized call
+// CHECK-NOT: hotswap: unresolved call target
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// A canonical local return helper at .text+0. MC lowering turns the compiler
+// return pseudo into plain s_set_pc_i64, whose destination is proven from the
+// incoming call's link register. It is the first call's target below.
+.type local_return_helper,@function
+local_return_helper:
+  s_nop 0
+.Llocal_return_epilogue:
+  s_set_pc_i64 s[0:1]
+  s_branch .Llocal_return_epilogue
+.Llocal_return_helper_end:
+.size local_return_helper, .Llocal_return_helper_end-local_return_helper
+
+.globl test_callable_entry
+.p2align 8
+.type test_callable_entry,@function
+test_callable_entry:
+  // First canonical PC-materialized call (to local_return_helper at .text+0).
+  s_get_pc_i64 s[4:5]
+  s_add_nc_u64 s[4:5], s[4:5], -260
+  s_swap_pc_i64 s[0:1], s[4:5]
+
+  // Second canonical PC-materialized call whose target is the shared block
+  // below (.Lshared), making it a mode-0 callable entry. The displacement is a
+  // constant that lands on .Lshared given the instruction sizes here.
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], 20
+  s_swap_pc_i64 s[0:1], s[2:3]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+
+  // Fallthrough path establishes a concrete VGPR-MSB mode before the shared
+  // block. Its join with the call's mode-0 entry is unprovable, so the
+  // mandatory WMMA split at .Lshared must fail closed.
+  s_set_vgpr_msb 0x60
+.Lshared:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_wait_dscnt 0x0
+  s_endpgm
+.Ltest_callable_entry_end:
+.size test_callable_entry, .Ltest_callable_entry_end-test_callable_entry
+
+// Padding after s_endpgm, outside the function, so it stays safe.
+.fill 64, 1, 0
+
+// Push the appended trampoline pool beyond s_branch's signed 16-bit dword
+// range so far-site handling matches the production materialized-call shape.
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_callable_entry
+  .amdhsa_next_free_vgpr 40
+  .amdhsa_next_free_sgpr 6
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_callable_entry
+      .symbol: test_callable_entry.kd
+      .sgpr_count: 6
+      .vgpr_count: 40
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
@@ -1,0 +1,83 @@
+// Recover exact VGPR-MSB state through CFG joins instead of rejecting every
+// direct target. This covers a backedge loop, a nonzero fixed point, and a
+// non-MODE SETREG that must preserve the tracked fields.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-3: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_zero_loop>:
+// DISASM:       s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+// DISASM:       s_branch
+// DISASM:       s_cbranch_scc1
+// DISASM-LABEL: <test_wmma_nonzero_loop>:
+// DISASM:       s_set_vgpr_msb 0x60
+// DISASM:       s_branch
+// DISASM:       s_cbranch_scc1
+// DISASM-LABEL: <test_wmma_nonmode_setreg>:
+// DISASM:       s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_STATUS), 7
+// DISASM-NEXT:  s_branch
+// DISASM:       Disassembly of section :
+// DISASM:       v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+// DISASM-NEXT:  s_branch
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+// DISASM-NEXT:  s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl test_wmma_zero_loop
+.p2align 8
+.type test_wmma_zero_loop,@function
+test_wmma_zero_loop:
+  // gfx1250's SETREG fixup writes VGPR-MSB fields from imm32[19:12], which
+  // are zero here even though the selected WAVE_MODE bit is set to one.
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 1
+.Lzero_loop:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_cbranch_scc1 .Lzero_loop
+  s_endpgm
+.size test_wmma_zero_loop, .-test_wmma_zero_loop
+
+.globl test_wmma_nonzero_loop
+.p2align 8
+.type test_wmma_nonzero_loop,@function
+test_wmma_nonzero_loop:
+  s_set_vgpr_msb 0x60
+.Lnonzero_loop:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_cbranch_scc1 .Lnonzero_loop
+  s_endpgm
+.size test_wmma_nonzero_loop, .-test_wmma_nonzero_loop
+
+.globl test_wmma_nonmode_setreg
+.p2align 8
+.type test_wmma_nonmode_setreg,@function
+test_wmma_nonmode_setreg:
+  s_set_vgpr_msb 0x60
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_STATUS), 7
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_nonmode_setreg, .-test_wmma_nonmode_setreg

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
@@ -7,7 +7,7 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --strict-mode --expect-status ERROR 2>&1 | %FileCheck %s
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-field-merge.s
@@ -1,0 +1,27 @@
+// A merge that disagrees only in src1 must lose the complete VGPR-MSB mode.
+// This guards the four-field CFG lattice independently of the dst/src0 facts
+// used by DS2 alignment.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --expect-status ERROR 2>&1 | %FileCheck %s
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_src1_merge
+.p2align 8
+.type test_wmma_src1_merge,@function
+test_wmma_src1_merge:
+  s_cbranch_scc1 .Lzero
+  s_set_vgpr_msb 4
+  s_branch .Ljoin
+.Lzero:
+  s_set_vgpr_msb 0
+.Ljoin:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_src1_merge, .-test_wmma_src1_merge

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-absolute.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-absolute.s
@@ -12,7 +12,7 @@
 // RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck %s
 // RUN: test ! -e %t.out.elf
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-absolute.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-absolute.s
@@ -1,0 +1,38 @@
+// s_swap_pc_i64 also accepts an absolute-immediate target. A call that lands
+// in the interior of another function bypasses its s_set_vgpr_msb prefix, so
+// the VGPR-MSB analysis must resolve the absolute target over the same surface
+// the rewrite uses, mark the callee as entered at a non-start offset, and fail
+// a mandatory WMMA split there closed rather than seed the wrong mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wl,--section-start=.text=0x1000 %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_caller
+.p2align 8
+.type test_caller,@function
+test_caller:
+  // test_caller sits at the .text start (0x1000), so this folds to the
+  // absolute virtual address of .Lcallee_interior.
+  s_swap_pc_i64 s[0:1], .Lcallee_interior-test_caller+0x1000
+  s_endpgm
+.size test_caller, .-test_caller
+
+.globl test_callee
+.p2align 8
+.type test_callee,@function
+test_callee:
+  s_set_vgpr_msb 0x60
+.Lcallee_interior:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_callee, .-test_callee

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-materialized.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-materialized.s
@@ -11,7 +11,7 @@
 // RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck %s
 // RUN: test ! -e %t.out.elf
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-materialized.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-call-materialized.s
@@ -1,0 +1,41 @@
+// A PC-materialized s_swap_pc_i64 that calls into the interior of another
+// function skips that function's s_set_vgpr_msb prefix. The VGPR-MSB analysis
+// must treat the callee as entered at a non-start offset and refuse to seed it
+// from the symbol start, so a mandatory WMMA split there fails closed instead
+// of bracketing for the wrong incoming mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_caller
+.p2align 8
+.type test_caller,@function
+test_caller:
+  // Materialize the interior label of test_callee and call it. s_get_pc_i64
+  // captures the address of the following instruction (.Lcaller_pc), so the
+  // add displacement is (target - captured PC).
+  s_get_pc_i64 s[4:5]
+.Lcaller_pc:
+  s_add_nc_u64 s[4:5], s[4:5], .Lcallee_interior-.Lcaller_pc
+  s_swap_pc_i64 s[0:1], s[4:5]
+  s_endpgm
+.size test_caller, .-test_caller
+
+.globl test_callee
+.p2align 8
+.type test_callee,@function
+test_callee:
+  s_set_vgpr_msb 0x60
+.Lcallee_interior:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_callee, .-test_callee

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-jump-setpc.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-jump-setpc.s
@@ -17,7 +17,7 @@
 // RUN:   | %FileCheck %s
 // RUN: test ! -e %t.out.elf
 // CHECK-NOT: unresolved call target
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-jump-setpc.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-interior-jump-setpc.s
@@ -1,0 +1,46 @@
+// A PC-materialized s_set_pc_i64 jump (not a call) into the interior of another
+// function is not tracked as an unresolved call target, so it does not trip the
+// object-wide unresolved-target guard. The VGPR-MSB analysis must still resolve
+// the jump's materialized target over the rewrite's control-flow surface, see
+// that it enters test_target at a non-start offset (skipping the s_set_vgpr_msb
+// prefix), and decline the mandatory WMMA split there. Analyzing test_target
+// from its symbol start would emit brackets for the wrong incoming mode.
+//
+// CHECK-NOT verifies the decline comes from the interior-entry resolver, not
+// from the unresolved-call bail: no "unresolved call target" is logged here.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK-NOT: unresolved call target
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_source
+.p2align 8
+.type test_source,@function
+test_source:
+  // Materialize test_target's interior (.text+0x104) and tail-jump to it. The
+  // captured PC is the s_add address (.text+0x4), so the +0x100 displacement
+  // lands past test_target's s_set_vgpr_msb prefix. The small inline immediate
+  // keeps the compiler-canonical s_add form the target resolver understands.
+  s_get_pc_i64 s[0:1]
+  s_add_nc_u64 s[0:1], s[0:1], 0x100
+  s_set_pc_i64 s[0:1]
+.size test_source, .-test_source
+
+.globl test_target
+.p2align 8
+.type test_target,@function
+test_target:
+  s_set_vgpr_msb 0x60
+.Ltarget_interior:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_target, .-test_target

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
@@ -1,0 +1,57 @@
+// A K-split's second half replaces src2 with dst. Even when neither source
+// slice crosses v255, the temporary src2 bank must therefore match the
+// incoming dst bank. Preserve and restore every other incoming mode field.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_k_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_branch
+// DISASM-LABEL: <test_wmma_k_vgpr_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 0x60
+// DISASM-NEXT:  s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[32:39], v[0:7], v[16:23], 0
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[32:39]{{.*}}, v[8:15], v[24:31], v[32:39]
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+// DISASM-NEXT: s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[32:39], v[0:7], v[16:23], v[40:47]
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[32:39]{{.*}}, v[8:15], v[24:31], v[32:39]
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_k_src2_role
+.p2align 8
+.type test_wmma_k_src2_role,@function
+test_wmma_k_src2_role:
+  // Incoming mode: dst=1, src2=2, src0=src1=0.
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_k_src2_role, .-test_wmma_k_src2_role
+
+.globl test_wmma_k_vgpr_src2_role
+.p2align 8
+.type test_wmma_k_vgpr_src2_role,@function
+test_wmma_k_vgpr_src2_role:
+  // The first half must read src2 from bank 2. The second half replaces that
+  // operand with dst and must therefore select bank 1 before restoring bank 2.
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], v[40:47]
+  s_endpgm
+.size test_wmma_k_vgpr_src2_role, .-test_wmma_k_vgpr_src2_role

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-kd-interior-entry.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-kd-interior-entry.s
@@ -1,0 +1,59 @@
+// A kernel-descriptor entry that points into a function interior is a real ABI
+// entry point even when no intra-object branch or call reaches it. The VGPR-MSB
+// analysis must seed that declared entry so the interior block is analyzed from
+// the entry mode and the local s_set_vgpr_msb before the WMMA is honored,
+// instead of being treated as unreachable and read as mode 0. The function
+// symbol start terminates immediately, so the interior KD-entry block is only
+// reachable through the descriptor; its s_set_vgpr_msb selects bank 0x60, so a
+// correct split must bracket the crossing half for 0x60 (0x6050 / 0x5060). A
+// mode-0 misread would emit no bracket at all.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: error:
+// API-COUNT-1: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// The A0-incompatible K=128 form must not survive, and the seeded 0x60 mode
+// must produce the bank-crossing brackets around the second K=64 half.
+// DISASM-NOT: v_wmma_f32_16x16x128_fp8_fp8
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_set_vgpr_msb 0x6050
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT: s_set_vgpr_msb 0x5060
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_kd_interior
+.p2align 8
+.type test_kd_interior,@function
+test_kd_interior:
+  // The symbol-start path terminates, so nothing falls through into the
+  // interior block below; it is reachable only via the kernel-descriptor entry.
+  s_endpgm
+.Lkd_entry:
+  s_set_vgpr_msb 0x60
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_kd_interior, .-test_kd_interior
+
+// Hand-built kernel descriptor whose kernel_code_entry_byte_offset (at offset
+// 0x10) resolves to the interior .Lkd_entry block rather than the symbol start.
+.rodata
+.p2align 6
+.type test_kd_interior.kd,@object
+.size test_kd_interior.kd, 64
+test_kd_interior.kd:
+  .zero 16
+  .quad .Lkd_entry - test_kd_interior.kd
+  .zero 40

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
@@ -1,0 +1,75 @@
+// A far crossing split needs a forward gateway. Source-window growth may move
+// the callable-entry VGPR-MSB setter only as the first copied instruction, so
+// every entry still establishes the original mode before either WMMA half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <test_wmma_vgpr_msb_far>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: s_endpgm
+// DISASM:      s_set_vgpr_msb 0
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[250:257], v[114:121], 0
+// DISASM-NEXT: s_set_vgpr_msb 1
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
+// DISASM-NEXT: s_set_vgpr_msb 0x100
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb_far
+.p2align 8
+.type test_wmma_vgpr_msb_far,@function
+test_wmma_vgpr_msb_far:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[162:169], v[250:265], v[114:129], 0
+  s_endpgm
+.Ltest_wmma_vgpr_msb_far_end:
+.size test_wmma_vgpr_msb_far, .Ltest_wmma_vgpr_msb_far_end-test_wmma_vgpr_msb_far
+
+// Safe external gateway space after the no-fallthrough terminator.
+.rept 8
+  s_nop 0
+.endr
+
+// Keep the appended pool beyond s_branch reach from the split site.
+.rept 40000
+  s_mov_b32 s3, s4
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_vgpr_msb_far
+  .amdhsa_next_free_vgpr 266
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_vgpr_msb_far
+      .symbol: test_wmma_vgpr_msb_far.kd
+      .sgpr_count: 0
+      .vgpr_count: 266
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
@@ -1,0 +1,57 @@
+// An M-split slices dst, src0, and VGPR src2 independently. Normalize every
+// upper-half base into its operand's mode field, keep broadcast src1 unchanged,
+// and restore the exact nonzero incoming mode after the upper half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-COUNT-2: WMMA split: patched v_wmma_f32_32x16x128_f4
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_m_operand_roles>:
+// DISASM-NEXT:  s_set_vgpr_msb 9
+// DISASM-NEXT:  s_branch
+// DISASM-LABEL: <test_wmma_m_immediate_src2_role>:
+// DISASM-NEXT:  s_set_vgpr_msb 57
+// DISASM-NEXT:  s_branch
+// DISASM:      v_wmma_f32_16x16x128_f8f6f4 v[250:257], v[248:255], v[100:107], v[252:259]{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x95a
+// DISASM-NEXT: v_wmma_f32_16x16x128_f8f6f4 v[2:9]{{.*}}, v[0:7]{{.*}}, v[100:107]{{.*}}, v[4:11]{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x5a09
+// DISASM-NEXT: s_branch
+// DISASM:      v_wmma_f32_16x16x128_f8f6f4 v[250:257], v[248:255], v[100:107], 0{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x397a
+// DISASM-NEXT: v_wmma_f32_16x16x128_f8f6f4 v[2:9]{{.*}}, v[0:7]{{.*}}, v[100:107]{{.*}}, 0{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NEXT: s_set_vgpr_msb 0x7a39
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_m_operand_roles
+.p2align 8
+.type test_wmma_m_operand_roles,@function
+test_wmma_m_operand_roles:
+  // Incoming mode: src0=1, src1=2, src2=0, dst=0.
+  s_set_vgpr_msb 9
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], v[252:267]
+  s_endpgm
+.size test_wmma_m_operand_roles, .-test_wmma_m_operand_roles
+
+.globl test_wmma_m_immediate_src2_role
+.p2align 8
+.type test_wmma_m_immediate_src2_role,@function
+test_wmma_m_immediate_src2_role:
+  // Incoming mode: src0=1, src1=2, src2=3, dst=0. Immediate src2 does not
+  // consume its role, but the temporary mode must preserve it exactly.
+  s_set_vgpr_msb 0x39
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], 0
+  s_endpgm
+.size test_wmma_m_immediate_src2_role, .-test_wmma_m_immediate_src2_role

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
@@ -10,7 +10,7 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=CHECK %s
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-merge.s
@@ -1,0 +1,35 @@
+// A direct call can enter the WMMA either with the function-entry mode or the
+// fallthrough can reach it after selecting a different destination bank. The
+// K-split sources do not cross v255, but the second half replaces immediate
+// src2 with dst and therefore still needs the ambiguous mode. Fail closed.
+// This also exercises s_call_i64's unusual target operand layout in the shared
+// direct-control-flow target index.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=CHECK %s
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb_merge
+.p2align 8
+.type test_wmma_vgpr_msb_merge,@function
+test_wmma_vgpr_msb_merge:
+  s_call_i64 s[0:1], .Lwmma
+  s_set_vgpr_msb 0x40
+.Lwmma:
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.Ltest_wmma_vgpr_msb_merge_end:
+.size test_wmma_vgpr_msb_merge, .Ltest_wmma_vgpr_msb_merge_end-test_wmma_vgpr_msb_merge
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_vgpr_msb_merge
+  .amdhsa_next_free_vgpr 266
+  .amdhsa_next_free_sgpr 2
+.end_amdhsa_kernel

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
@@ -8,7 +8,7 @@
 // RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck %s
 // RUN: test ! -e %t.out.elf
-// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK-LABEL: WMMA split: cannot determine VGPR-MSB mode
 // CHECK: RESULT: ERROR
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg-unknown.s
@@ -1,0 +1,23 @@
+// A dynamic write to WAVE_MODE does not reveal the incoming VGPR-MSB fields.
+// Keep the required WMMA split fail-closed instead of assuming ABI entry mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck %s
+// RUN: test ! -e %t.out.elf
+// CHECK: WMMA split: cannot determine VGPR-MSB mode
+// CHECK: RESULT: ERROR
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_dynamic_mode
+.p2align 8
+.type test_wmma_dynamic_mode,@function
+test_wmma_dynamic_mode:
+  s_setreg_b32 hwreg(HW_REG_WAVE_MODE), s0
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_dynamic_mode, .-test_wmma_dynamic_mode

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
@@ -1,0 +1,37 @@
+// On gfx1250, an immediate MODE write establishes all four VGPR-MSB fields.
+// Immediate bits [19:12] are rotated into s_set_vgpr_msb order; 0x81 becomes
+// mode 0x60 and must be restored around the split WMMA's upper half.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_setreg_mode>:
+// DISASM:       s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 0x81000
+// DISASM:       s_branch
+// DISASM:       s_set_vgpr_msb 0x6050
+// DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
+// DISASM-NEXT:  s_set_vgpr_msb 0x5060
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_setreg_mode
+.p2align 8
+.type test_wmma_setreg_mode,@function
+test_wmma_setreg_mode:
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_MODE, 25, 1), 0x81000
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.size test_wmma_setreg_mode, .-test_wmma_setreg_mode

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-table-coverage.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-table-coverage.s
@@ -1,0 +1,113 @@
+// Table coverage: exercise every entry in the WMMA split table through the
+// VGPR-MSB-aware split + bracket path. Each kernel holds one splittable opcode
+// whose upper source half crosses v255, so the split runs and brackets the
+// crossing half. The per-SplitKind bracket bytes are checked in detail by
+// hotswap-wmma-split-vgpr-msb.s (Split128to64FP8BF8) and
+// hotswap-wmma-split-vgpr-msb-m-roles.s (Split32x16to16x16F4); this test
+// guarantees no table entry is left unsplit.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: error:
+// API: WMMA split: patched v_wmma_f16_16x16x128_fp8_fp8
+// API: WMMA split: patched v_wmma_f16_16x16x128_fp8_bf8
+// API: WMMA split: patched v_wmma_f16_16x16x128_bf8_fp8
+// API: WMMA split: patched v_wmma_f16_16x16x128_bf8_bf8
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_bf8
+// API: WMMA split: patched v_wmma_f32_16x16x128_bf8_fp8
+// API: WMMA split: patched v_wmma_f32_16x16x128_bf8_bf8
+// API: WMMA split: patched v_wmma_f32_32x16x128_f4
+// API: RESULT: SUCCESS
+
+// A second rewrite must be byte-identical.
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl k_f16_fp8_fp8
+.p2align 8
+.type k_f16_fp8_fp8,@function
+k_f16_fp8_fp8:
+  s_set_vgpr_msb 0
+  v_wmma_f16_16x16x128_fp8_fp8 v[16:19], v[250:265], v[100:115], v[16:19]
+  s_endpgm
+.size k_f16_fp8_fp8, .-k_f16_fp8_fp8
+
+.globl k_f16_fp8_bf8
+.p2align 8
+.type k_f16_fp8_bf8,@function
+k_f16_fp8_bf8:
+  s_set_vgpr_msb 0
+  v_wmma_f16_16x16x128_fp8_bf8 v[16:19], v[250:265], v[100:115], v[16:19]
+  s_endpgm
+.size k_f16_fp8_bf8, .-k_f16_fp8_bf8
+
+.globl k_f16_bf8_fp8
+.p2align 8
+.type k_f16_bf8_fp8,@function
+k_f16_bf8_fp8:
+  s_set_vgpr_msb 0
+  v_wmma_f16_16x16x128_bf8_fp8 v[16:19], v[250:265], v[100:115], v[16:19]
+  s_endpgm
+.size k_f16_bf8_fp8, .-k_f16_bf8_fp8
+
+.globl k_f16_bf8_bf8
+.p2align 8
+.type k_f16_bf8_bf8,@function
+k_f16_bf8_bf8:
+  s_set_vgpr_msb 0
+  v_wmma_f16_16x16x128_bf8_bf8 v[16:19], v[250:265], v[100:115], v[16:19]
+  s_endpgm
+.size k_f16_bf8_bf8, .-k_f16_bf8_bf8
+
+.globl k_f32_fp8_fp8
+.p2align 8
+.type k_f32_fp8_fp8,@function
+k_f32_fp8_fp8:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[16:23], v[250:265], v[100:115], v[16:23]
+  s_endpgm
+.size k_f32_fp8_fp8, .-k_f32_fp8_fp8
+
+.globl k_f32_fp8_bf8
+.p2align 8
+.type k_f32_fp8_bf8,@function
+k_f32_fp8_bf8:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_bf8 v[16:23], v[250:265], v[100:115], v[16:23]
+  s_endpgm
+.size k_f32_fp8_bf8, .-k_f32_fp8_bf8
+
+.globl k_f32_bf8_fp8
+.p2align 8
+.type k_f32_bf8_fp8,@function
+k_f32_bf8_fp8:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_bf8_fp8 v[16:23], v[250:265], v[100:115], v[16:23]
+  s_endpgm
+.size k_f32_bf8_fp8, .-k_f32_bf8_fp8
+
+.globl k_f32_bf8_bf8
+.p2align 8
+.type k_f32_bf8_bf8,@function
+k_f32_bf8_bf8:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_bf8_bf8 v[16:23], v[250:265], v[100:115], v[16:23]
+  s_endpgm
+.size k_f32_bf8_bf8, .-k_f32_bf8_bf8
+
+.globl k_f32_32x16x128_f4
+.p2align 8
+.type k_f32_32x16x128_f4,@function
+k_f32_32x16x128_f4:
+  s_set_vgpr_msb 0
+  v_wmma_f32_32x16x128_f4 v[250:265], v[248:263], v[100:107], v[252:267]
+  s_endpgm
+.size k_f32_32x16x128_f4, .-k_f32_32x16x128_f4

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-unreachable-cfg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-unreachable-cfg.s
@@ -1,0 +1,47 @@
+// A mandatory K=128 WMMA split in a block proven unreachable by a
+// materialized-PC jump (s_get_pc_i64 / s_add_nc_u64 / s_set_pc_i64) out of the
+// function must succeed using the ABI entry VGPR-MSB mode, not fail closed:
+// the code never executes, so its incoming mode is semantically unobservable,
+// but the A0-incompatible opcode must still be legalized. The first WMMA
+// follows an explicit dead MODE write; the second has no local MODE write.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API-NOT: error:
+// API-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API: applied 2 instruction patches
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// The A0-incompatible K=128 form must not survive; both halves are K=64. These
+// operands stay in bank 0, so no s_set_vgpr_msb bracketing is required.
+// DISASM-NOT: v_wmma_f32_16x16x128_fp8_fp8
+// DISASM: v_wmma_f32_16x16x64_fp8_fp8
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_unreachable_cfg
+.p2align 8
+.type test_wmma_unreachable_cfg,@function
+test_wmma_unreachable_cfg:
+  // Generated get-PC/add/set-PC with a statically known target outside the
+  // function, so the instructions below are CFG-unreachable.
+  s_get_pc_i64 s[0:1]
+  s_add_nc_u64 s[0:1], s[0:1], 0x1000
+  s_set_pc_i64 s[0:1]
+
+  s_set_vgpr_msb 0
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_delay_alu instid0(VALU_DEP_1)
+  v_wmma_f32_16x16x128_fp8_fp8 v[32:39], v[0:15], v[16:31], 0
+  s_endpgm
+.Ltest_wmma_unreachable_cfg_end:
+.size test_wmma_unreachable_cfg, .Ltest_wmma_unreachable_cfg_end-test_wmma_unreachable_cfg

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
@@ -1,0 +1,35 @@
+// Verify that a K-split whose upper source half crosses v255 changes the
+// gfx1250 VGPR-MSB mode around that half and restores the incoming mode.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_vgpr_msb>:
+// DISASM:      s_branch
+// DISASM:      v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[250:257], v[114:121], 0
+// DISASM-NEXT: s_set_vgpr_msb 1
+// DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
+// DISASM-NEXT: s_set_vgpr_msb 0x100
+// DISASM-NEXT: s_branch
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_wmma_vgpr_msb
+.p2align 8
+.type test_wmma_vgpr_msb,@function
+test_wmma_vgpr_msb:
+  s_set_vgpr_msb 0
+  v_wmma_f32_16x16x128_fp8_fp8 v[162:169], v[250:265], v[114:129], 0
+  s_endpgm
+.size test_wmma_vgpr_msb, .-test_wmma_vgpr_msb


### PR DESCRIPTION
## Summary
The WMMA split pass rewrites gfx1250 B0-only WMMAs into pairs of narrower WMMAs that also run on A0. On gfx1250, VGPR operands past v255 are reached through a persistent VGPR-MSB bank mode, so a split whose upper half crosses
v255 (or a K-split whose second half reuses `dst` as `src2`) must execute that half under a different bank.

This makes the pass VGPR-MSB aware:
- Recovers the live VGPR-MSB mode at each WMMA via a whole-function CFG fixed point, fail-closed: an ambiguous or unprovable mode declines the split.
- Brackets the upper half with `s_set_vgpr_msb` (switch before, restore after), and emits nothing when no bank change is needed.
- Fails closed on every matched-but-unsplittable path (`RequiredPatchFailed`) instead of silently leaving an A0-illegal opcode in `.text`.
- Shares the PC-materialized target resolver between `s_swap_pc_i64` calls and `s_set_pc_i64` jumps so the CFG can follow materialized-PC jumps.