### PR TITLE
[MachinePipeliner] Add PipelinerLoopInfo hooks to reuse the reg-pressure detector

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -841,6 +841,20 @@ public:
       return true;
     }
 
+    /// Return true to run the generic register-pressure detector for this loop
+    /// even without -pipeliner-register-pressure. A rejected schedule then
+    /// retries at a higher II instead of disabling pipelining.
+    virtual bool shouldLimitRegPressure() const { return false; }
+
+    /// Given the detector's per-pressure-set maxima \p MaxSetPressure for a
+    /// candidate schedule, return whether it uses too many registers, or
+    /// nullopt to defer to the detector's default per-set limit check. A
+    /// non-nullopt verdict takes precedence over that check (and its margin).
+    virtual std::optional<bool>
+    isScheduleRegPressureTooHigh(ArrayRef<unsigned> MaxSetPressure) const {
+      return std::nullopt;
+    }
+
     /// Create a condition to determine if the trip count of the loop is greater
     /// than TC, where TC is always one more than for the previous prologue or
     /// 0 if this is being called for the outermost prologue.

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -1891,9 +1891,11 @@ public:
   }
 
   // Calculate the maximum register pressures of the loop and check if they
-  // exceed the limit
+  // exceed the limit, or defer to the target's verdict via
+  // PipelinerLoopInfo::isScheduleRegPressureTooHigh.
   bool detect(const SwingSchedulerDAG *SSD, SMSchedule &Schedule,
-              const unsigned MaxStage) const {
+              const unsigned MaxStage,
+              const TargetInstrInfo::PipelinerLoopInfo *PLI) const {
     assert(0 <= RegPressureMargin && RegPressureMargin <= 100 &&
            "the percentage of the margin must be between 0 to 100");
 
@@ -1910,6 +1912,18 @@ public:
       }
       dbgs() << '\n';
     });
+
+    if (PLI) {
+      if (std::optional<bool> TooHigh =
+              PLI->isScheduleRegPressureTooHigh(MaxSetPressure)) {
+        LLVM_DEBUG(dbgs() << (*TooHigh
+                                  ? "Rejected the schedule because of too high "
+                                    "register pressure (per target verdict)\n"
+                                  : "Accepted the schedule (per target "
+                                    "verdict)\n"));
+        return *TooHigh;
+      }
+    }
 
     for (unsigned PSet = 0; PSet < PSetNum; PSet++) {
       unsigned Limit = PressureSetLimit[PSet];
@@ -2789,7 +2803,8 @@ bool SwingSchedulerDAG::schedulePipeline(SMSchedule &Schedule) {
 
   bool scheduleFound = false;
   std::unique_ptr<HighRegisterPressureDetector> HRPDetector;
-  if (LimitRegPressure) {
+  if (LimitRegPressure ||
+      (LoopPipelinerInfo && LoopPipelinerInfo->shouldLimitRegPressure())) {
     HRPDetector =
         std::make_unique<HighRegisterPressureDetector>(Loop.getHeader(), MF);
     HRPDetector->init(RegClassInfo);
@@ -2873,11 +2888,11 @@ bool SwingSchedulerDAG::schedulePipeline(SMSchedule &Schedule) {
     if (scheduleFound)
       scheduleFound = Schedule.isValidSchedule(this);
 
-    // If a schedule was found and the option is enabled, check if the schedule
-    // might generate additional register spills/fills.
-    if (scheduleFound && LimitRegPressure)
-      scheduleFound =
-          !HRPDetector->detect(this, Schedule, Schedule.getMaxStageCount());
+    // If a schedule was found and the detector is enabled, check if the
+    // schedule might generate additional register spills/fills.
+    if (scheduleFound && HRPDetector)
+      scheduleFound = !HRPDetector->detect(
+          this, Schedule, Schedule.getMaxStageCount(), LoopPipelinerInfo);
   }
 
   LLVM_DEBUG(dbgs() << "Schedule Found? " << scheduleFound


### PR DESCRIPTION
The generic MachinePipeliner register-pressure detector (added in #74807)
was only reachable via the global -pipeliner-register-pressure flag, which
cannot be enabled per-target, and it judges pressure against generic
per-pressure-set limits. Add two PipelinerLoopInfo hooks so a target can
reuse that detector on its own terms:

- shouldLimitRegPressure(): opt the loop into the detector without the
  global flag. The detector runs inside the II search, so a schedule
  rejected on register pressure is retried at a higher II rather than
  abandoning the loop.
- isScheduleRegPressureTooHigh(MaxSetPressure): let the target replace the
  detector's generic per-pressure-set limit check with its own verdict, or
  return nullopt to keep that check.

Both hooks default to preserving current behavior, so targets that do not
override them are unaffected: the detector stays gated on
-pipeliner-register-pressure and the generic per-set check is unchanged.

Exercised by the AMDGPU adoption in the following commit.
