### PR TITLE
[AMDGPU] Raise the MachinePipeliner MII cap via a target hook

### DIFF
--- a/llvm/include/llvm/CodeGen/TargetInstrInfo.h
+++ b/llvm/include/llvm/CodeGen/TargetInstrInfo.h
@@ -855,6 +855,11 @@ public:
       return std::nullopt;
     }
 
+    /// Return a target-specific cap on the minimum initiation interval (MII)
+    /// above which a loop is not pipelined, or nullopt to use the default cap.
+    /// An explicit -pipeliner-max-mii takes precedence over this hook.
+    virtual std::optional<unsigned> getMaxMII() const { return std::nullopt; }
+
     /// Create a condition to determine if the trip count of the loop is greater
     /// than TC, where TC is always one more than for the previous prologue or
     /// 0 if this is being called for the outermost prologue.

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -809,16 +809,21 @@ void SwingSchedulerDAG::schedule() {
   }
 
   // Don't pipeline large loops.
-  if (SwpMaxMii != -1 && (int)MII > SwpMaxMii) {
-    LLVM_DEBUG(dbgs() << "MII > " << SwpMaxMii
+  int MaxMII = SwpMaxMii;
+  if (SwpMaxMii.getNumOccurrences() == 0 && LoopPipelinerInfo)
+    if (std::optional<unsigned> TargetMaxMII = LoopPipelinerInfo->getMaxMII())
+      MaxMII = (int)*TargetMaxMII;
+
+  if (MaxMII != -1 && (int)MII > MaxMII) {
+    LLVM_DEBUG(dbgs() << "MII > " << MaxMII
                       << ", we don't pipeline large loops\n");
     NumFailLargeMaxMII++;
     Pass.ORE->emit([&]() {
       return MachineOptimizationRemarkAnalysis(
                  DEBUG_TYPE, "schedule", Loop.getStartLoc(), Loop.getHeader())
              << "Minimal Initiation Interval too large: "
-             << ore::NV("MII", (int)MII) << " > "
-             << ore::NV("SwpMaxMii", SwpMaxMii) << "."
+             << ore::NV("MII", (int)MII) << " > " << ore::NV("MaxMII", MaxMII)
+             << "."
              << "Refer to -pipeliner-max-mii.";
     });
     return;

--- a/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/llvm/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -3349,6 +3349,10 @@ public:
     return VGPRPressure > MaxArchVGPRs || AGPRPressure > MaxArchVGPRs;
   }
 
+  // The generic default of 27 is too low for real AMDGPU loops; use a wider
+  // cap that still rejects pathologically large ones.
+  std::optional<unsigned> getMaxMII() const override { return 128; }
+
   std::optional<bool> createTripCountGreaterCondition(
       int TC, MachineBasicBlock &MBB,
       SmallVectorImpl<MachineOperand> &CondParam) override {

--- a/llvm/test/CodeGen/AMDGPU/swp-amdgpu-pipeline-max-mii.ll
+++ b/llvm/test/CodeGen/AMDGPU/swp-amdgpu-pipeline-max-mii.ll
@@ -1,12 +1,12 @@
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-enable-pipeliner -pass-remarks-analysis=pipeliner %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=DEFAULT
-; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-enable-pipeliner -pipeliner-max-mii=64 --verify-machineinstrs -pass-remarks-analysis=pipeliner %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=RAISED
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-enable-pipeliner --verify-machineinstrs -pass-remarks-analysis=pipeliner %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=DEFAULT
+; RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx950 -amdgpu-enable-pipeliner -pipeliner-max-mii=27 -pass-remarks-analysis=pipeliner %s -o /dev/null 2>&1 | FileCheck %s --check-prefix=CAPPED
 
 ; This loop's MII is 32: two independent accumulators each issue one MFMA per
 ; iteration, and each MFMA holds the XDL pipe for 16 cycles (res=32). That
-; exceeds the generic default cap of 27. At default, pipeliner aborts and
-; only a raised cap lets it schedule.
-; DEFAULT: Minimal Initiation Interval too large: 32 > 27
-; RAISED: Schedule found with Initiation Interval
+; exceeds the generic default cap of 27. Loop pipelines at default but an
+; explicit -pipeliner-max-mii below the MII still rejects it.
+; DEFAULT: Schedule found with Initiation Interval
+; CAPPED: Minimal Initiation Interval too large: 32 > 27
 
 declare <16 x float> @llvm.amdgcn.mfma.f32.32x32x2f32(float, float, <16 x float>, i32 immarg, i32 immarg, i32 immarg) #0
 


### PR DESCRIPTION
The pipeliner rejects any loop whose minimum initiation interval (MII)
exceeds -pipeliner-max-mii, default 27. That is far too low for real
AMDGPU loops: resource-bound GEMM/attention bodies routinely have an MII
well above 27 and are dropped before scheduling even starts.

Add a PipelinerLoopInfo::getMaxMII() hook so a target can raise the cap,
and override it to 128 for AMDGPU. The generic default is unchanged, and
an explicit -pipeliner-max-mii still takes precedence.

The cap of 128 is chosen from the II distributions of two AMDGPU
workloads.

Composable Kernels:
  II range   count    pct
    0- 24     2305   36.7%
   25- 49     1681   26.8%
   50- 99     1582   25.3%
  100-149      578    9.2%
  150-299       64    1.0%

Triton:
  II range   count    pct
   96-128       19   50.0%
  128-160       11   28.9%
  160-192        2    5.3%
  192-224        2    5.3%
  224-256        4   10.5%

128 captures the bulk of both workloads while still rejecting
pathologically large loops up front.
