### PR TITLE
[MachinePipeliner][NFC] Extract buildAndAttemptSchedule from schedule()

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePipeliner.h
+++ b/llvm/include/llvm/CodeGen/MachinePipeliner.h
@@ -453,6 +453,13 @@ public:
                              const MachineInstr *OtherMI) const;
 
 private:
+  /// Result of a single scheduling attempt.
+  enum class ScheduleAttemptResult {
+    Scheduled,    ///< Found a schedule.
+    FailedSearch, ///< Searched [MII, MAX_II] with no schedule.
+    AbortEarly    ///< Bailed before searching (e.g. invalid MII).
+  };
+  ScheduleAttemptResult buildAndAttemptSchedule(SMSchedule &Schedule);
   LoopCarriedEdges addLoopCarriedDependences();
   void updatePhiDependences();
   void changeDependences();

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -758,9 +758,9 @@ void SwingSchedulerDAG::setMAX_II() {
     MAX_II = MII + SwpIISearchRange;
 }
 
-/// We override the schedule function in ScheduleDAGInstrs to implement the
-/// scheduling part of the Swing Modulo Scheduling algorithm.
-void SwingSchedulerDAG::schedule() {
+/// Build the dependence graph and attempt to find a modulo schedule once.
+SwingSchedulerDAG::ScheduleAttemptResult
+SwingSchedulerDAG::buildAndAttemptSchedule(SMSchedule &Schedule) {
   buildSchedGraph(AA);
   const LoopCarriedEdges LCE = addLoopCarriedDependences();
   updatePhiDependences();
@@ -805,7 +805,7 @@ void SwingSchedulerDAG::schedule() {
                  DEBUG_TYPE, "schedule", Loop.getStartLoc(), Loop.getHeader())
              << "Invalid Minimal Initiation Interval: 0";
     });
-    return;
+    return ScheduleAttemptResult::AbortEarly;
   }
 
   // Don't pipeline large loops.
@@ -826,7 +826,7 @@ void SwingSchedulerDAG::schedule() {
              << "."
              << "Refer to -pipeliner-max-mii.";
     });
-    return;
+    return ScheduleAttemptResult::AbortEarly;
   }
 
   computeNodeFunctions(NodeSets);
@@ -862,17 +862,28 @@ void SwingSchedulerDAG::schedule() {
   // check for node order issues
   checkValidNodeOrder(Circuits);
 
-  SMSchedule Schedule(Pass.MF, this);
-  Scheduled = schedulePipeline(Schedule);
+  if (!schedulePipeline(Schedule))
+    return ScheduleAttemptResult::FailedSearch;
+  return ScheduleAttemptResult::Scheduled;
+}
 
-  if (!Scheduled){
-    LLVM_DEBUG(dbgs() << "No schedule found, return\n");
-    NumFailNoSchedule++;
-    Pass.ORE->emit([&]() {
-      return MachineOptimizationRemarkAnalysis(
-                 DEBUG_TYPE, "schedule", Loop.getStartLoc(), Loop.getHeader())
-             << "Unable to find schedule";
-    });
+/// We override the schedule function in ScheduleDAGInstrs to implement the
+/// scheduling part of the Swing Modulo Scheduling algorithm.
+void SwingSchedulerDAG::schedule() {
+  SMSchedule Schedule(Pass.MF, this);
+  ScheduleAttemptResult Result = buildAndAttemptSchedule(Schedule);
+
+  Scheduled = Result == ScheduleAttemptResult::Scheduled;
+  if (!Scheduled) {
+    if (Result == ScheduleAttemptResult::FailedSearch) {
+      LLVM_DEBUG(dbgs() << "No schedule found, return\n");
+      NumFailNoSchedule++;
+      Pass.ORE->emit([&]() {
+        return MachineOptimizationRemarkAnalysis(
+                   DEBUG_TYPE, "schedule", Loop.getStartLoc(), Loop.getHeader())
+               << "Unable to find schedule";
+      });
+    }
     return;
   }
 


### PR DESCRIPTION
Move the dependence-graph build and modulo-schedule search out of schedule()
into a new buildAndAttemptSchedule() helper that returns a ScheduleAttemptResult
(Scheduled, FailedSearch, or AbortEarly). schedule() now dispatches on that
result.

No functional change: with a single attempt the control flow, statistics, and
optimization remarks are identical (AbortEarly returns silently as before,
FailedSearch still emits NumFailNoSchedule and the "Unable to find schedule"
remark). This prepares for a follow-up that retries scheduling without
CopyToPhi.
