### PR TITLE
[MachinePipeliner] Add opt-in fallback to reschedule without CopyToPhi

### DIFF
--- a/llvm/include/llvm/CodeGen/MachinePipeliner.h
+++ b/llvm/include/llvm/CodeGen/MachinePipeliner.h
@@ -290,6 +290,11 @@ class LLVM_ABI SwingSchedulerDAG : public ScheduleDAGInstrs {
   unsigned MAX_II = 0;
   /// Set to true if a valid pipelined schedule is found for the loop.
   bool Scheduled = false;
+
+  /// Set to true if CopyToPhiMutation added an edge in the current attempt.
+  bool AddedCopyToPhiEdges = false;
+  /// Set to true while retrying this loop with CopyToPhiMutation disabled.
+  bool DisableCopyToPhi = false;
   MachineLoop &Loop;
   LiveIntervals &LIS;
   const RegisterClassInfo &RegClassInfo;
@@ -445,6 +450,12 @@ public:
     Mutations.push_back(std::move(Mutation));
   }
 
+  /// Record that CopyToPhiMutation added an edge.
+  void noteCopyToPhiEdgeAdded() { AddedCopyToPhiEdges = true; }
+
+  /// Return true if CopyToPhiMutation is disabled for this attempt.
+  bool isCopyToPhiDisabled() const { return DisableCopyToPhi; }
+
   static bool classof(const ScheduleDAGInstrs *DAG) { return true; }
 
   const SwingSchedulerDDG *getDDG() const { return DDG.get(); }
@@ -460,6 +471,8 @@ private:
     AbortEarly    ///< Bailed before searching (e.g. invalid MII).
   };
   ScheduleAttemptResult buildAndAttemptSchedule(SMSchedule &Schedule);
+  /// Reset per-attempt state so the loop can be scheduled again.
+  void resetForReschedule();
   LoopCarriedEdges addLoopCarriedDependences();
   void updatePhiDependences();
   void changeDependences();

--- a/llvm/lib/CodeGen/MachinePipeliner.cpp
+++ b/llvm/lib/CodeGen/MachinePipeliner.cpp
@@ -112,6 +112,8 @@ STATISTIC(NumFailNoSchedule, "Pipeliner abort due to no schedule found");
 STATISTIC(NumFailZeroStage, "Pipeliner abort due to zero stage");
 STATISTIC(NumFailLargeMaxStage, "Pipeliner abort due to too many stages");
 STATISTIC(NumFailTooManyStores, "Pipeliner abort due to too many stores");
+STATISTIC(NumRetryWithoutCopyToPhi,
+          "Number of loops rescheduled without CopyToPhi");
 
 /// A command line option to turn software pipelining on or off.
 static cl::opt<bool> EnableSWP("enable-pipeliner", cl::Hidden, cl::init(true),
@@ -207,6 +209,11 @@ cl::opt<bool>
     llvm::SwpEnableCopyToPhi("pipeliner-enable-copytophi", cl::ReallyHidden,
                              cl::init(true),
                              cl::desc("Enable CopyToPhi DAG Mutation"));
+
+// Retry the loop once with CopyToPhi disabled if the first attempt fails.
+static cl::opt<bool> SwpCopyToPhiFallback(
+    "pipeliner-copytophi-fallback", cl::Hidden, cl::init(false),
+    cl::desc("Retry scheduling without CopyToPhi if the first attempt fails"));
 
 /// A command line argument to force pipeliner to use specified issue
 /// width.
@@ -758,6 +765,16 @@ void SwingSchedulerDAG::setMAX_II() {
     MAX_II = MII + SwpIISearchRange;
 }
 
+/// Clear the per-attempt state so the loop can be scheduled again.
+void SwingSchedulerDAG::resetForReschedule() {
+  InstrChanges.clear();
+  ScheduleInfo.clear();
+  NodeOrder.clear();
+  MII = 0;
+  MAX_II = 0;
+  AddedCopyToPhiEdges = false;
+}
+
 /// Build the dependence graph and attempt to find a modulo schedule once.
 SwingSchedulerDAG::ScheduleAttemptResult
 SwingSchedulerDAG::buildAndAttemptSchedule(SMSchedule &Schedule) {
@@ -867,11 +884,30 @@ SwingSchedulerDAG::buildAndAttemptSchedule(SMSchedule &Schedule) {
   return ScheduleAttemptResult::Scheduled;
 }
 
-/// We override the schedule function in ScheduleDAGInstrs to implement the
-/// scheduling part of the Swing Modulo Scheduling algorithm.
+/// Schedule the loop, retrying once without CopyToPhi if the first attempt
+/// fails and -pipeliner-copytophi-fallback is set.
 void SwingSchedulerDAG::schedule() {
   SMSchedule Schedule(Pass.MF, this);
   ScheduleAttemptResult Result = buildAndAttemptSchedule(Schedule);
+
+  // Only retry on FailedSearch: the II search exhausted its range without
+  // finding a schedule. AbortEarly (invalid or too-large MII) is not retried
+  // because MII cannot change -- ResMII depends only on resources, and
+  // CopyToPhi adds only artificial edges, which findCircuits ignores, so RecMII
+  // is unaffected. A Scheduled result needs no retry.
+  //
+  // Retrying is safe because a FailedSearch happens before any code generation,
+  // so the MachineFunction and LiveIntervals are still unmodified and
+  // buildAndAttemptSchedule() can rebuild the DAG from the original loop.
+  if (Result == ScheduleAttemptResult::FailedSearch && SwpCopyToPhiFallback &&
+      AddedCopyToPhiEdges) {
+    LLVM_DEBUG(dbgs() << "No schedule found; retrying without CopyToPhi\n");
+    ++NumRetryWithoutCopyToPhi;
+    resetForReschedule();
+    DisableCopyToPhi = true;
+    Schedule.reset();
+    Result = buildAndAttemptSchedule(Schedule);
+  }
 
   Scheduled = Result == ScheduleAttemptResult::Scheduled;
   if (!Scheduled) {
@@ -2143,6 +2179,11 @@ void SwingSchedulerDAG::findCircuits(NodeSetType &NodeSets) {
 // USEOfPHI --- SRCOfCopy---  COPY/REG_SEQUENCE.
 
 void SwingSchedulerDAG::CopyToPhiMutation::apply(ScheduleDAGInstrs *DAG) {
+  SwingSchedulerDAG *SDAG = cast<SwingSchedulerDAG>(DAG);
+  // Skip the mutation while retrying without CopyToPhi.
+  if (SDAG->isCopyToPhiDisabled())
+    return;
+
   for (SUnit &SU : DAG->SUnits) {
     // Find the COPY/REG_SEQUENCE instruction.
     if (!SU.getInstr()->isCopy() && !SU.getInstr()->isRegSequence())
@@ -2191,13 +2232,13 @@ void SwingSchedulerDAG::CopyToPhiMutation::apply(ScheduleDAGInstrs *DAG) {
     if (UseSUs.size() == 0)
       continue;
 
-    SwingSchedulerDAG *SDAG = cast<SwingSchedulerDAG>(DAG);
     // Add the artificial dependencies if it does not form a cycle.
     for (auto *I : UseSUs) {
       for (auto *Src : SrcSUs) {
         if (!SDAG->Topo.IsReachable(I, Src) && Src != I) {
           Src->addPred(SDep(I, SDep::Artificial));
           SDAG->Topo.AddPred(Src, I);
+          SDAG->noteCopyToPhiEdgeAdded();
         }
       }
     }

--- a/llvm/test/CodeGen/AMDGPU/swp-amdgpu-pipeline-copytophi.mir
+++ b/llvm/test/CodeGen/AMDGPU/swp-amdgpu-pipeline-copytophi.mir
@@ -1,0 +1,83 @@
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -amdgpu-enable-pipeliner \
+# RUN:   -run-pass=pipeliner -pipeliner-copytophi-fallback=1 -debug-only=pipeliner \
+# RUN:   --verify-machineinstrs -o /dev/null %s 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=FALLBACK
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -amdgpu-enable-pipeliner \
+# RUN:   -run-pass=pipeliner -debug-only=pipeliner -o /dev/null %s 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=DEFAULT
+# RUN: llc -mtriple=amdgcn-amd-amdhsa -mcpu=gfx942 -amdgpu-enable-pipeliner \
+# RUN:   -run-pass=pipeliner -pipeliner-enable-copytophi=0 --verify-machineinstrs \
+# RUN:   -debug-only=pipeliner -o /dev/null %s 2>&1 | \
+# RUN:   FileCheck %s --check-prefix=NOCOPYTOPHI
+# REQUIRES: asserts
+
+# Reduced from a Composable Kernels HIP kernel. CopyToPhi's artificial edges
+# block a schedule here. The opt-in fallback retries without them and pipelines
+# the loop.
+
+# FALLBACK: Schedule Found? 0
+# FALLBACK: No schedule found; retrying without CopyToPhi
+# FALLBACK: Schedule Found? 1 (II={{[0-9]+}})
+
+# DEFAULT: Schedule Found? 0
+# DEFAULT-NOT: retrying without CopyToPhi
+
+# NOCOPYTOPHI: Schedule Found? 1 (II={{[0-9]+}})
+
+--- |
+  define amdgpu_kernel void @swp_amdgpu_pipeline_copytophi() {
+    ret void
+  }
+...
+---
+name:            swp_amdgpu_pipeline_copytophi
+tracksRegLiveness: true
+machineFunctionInfo:
+  isEntryFunction: true
+  scratchRSrcReg:  '$private_rsrc_reg'
+  stackPtrOffsetReg: '$sgpr32'
+body:             |
+  bb.0:
+    successors: %bb.1(0x80000000)
+    liveins: $vgpr0
+
+    %22:sreg_32 = S_MOV_B32 0
+    %24:vreg_64_align2 = AV_MOV_B64_IMM_PSEUDO 0, implicit $exec
+    %57:vgpr_32 = COPY $vgpr0, implicit $exec
+    %59:vgpr_32 = COPY $vgpr0, implicit $exec
+    %62:sreg_64 = IMPLICIT_DEF
+    %31:sgpr_128 = REG_SEQUENCE %22, %subreg.sub0, %22, %subreg.sub1, %22, %subreg.sub2, %22, %subreg.sub3
+
+  bb.1:
+    successors: %bb.2(0x04000000), %bb.1(0x7c000000)
+
+    %64:sreg_64 = PHI %62, %bb.0, %11, %bb.1
+    %2:vgpr_32 = PHI %57, %bb.0, %58, %bb.1
+    %3:vgpr_32 = PHI %59, %bb.0, %60, %bb.1
+    %4:av_64_align2 = PHI %24, %bb.0, %7, %bb.1
+    %5:sreg_32 = PHI %22, %bb.0, %28, %bb.1
+    %28:sreg_32 = S_MOV_B32 1
+    %29:sreg_64_xexec = V_CMP_GT_I32_e64 1, %3, implicit $exec
+    %32:vreg_64_align2 = BUFFER_LOAD_DWORDX2_OFFEN %2, %31, 0, 0, 0, 0, implicit $exec :: (dereferenceable load (s64) from `ptr addrspace(8) null`, align 1, addrspace 8)
+    %34:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, %32.sub1, %29, implicit $exec
+    %37:vgpr_32 = V_CNDMASK_B32_e64 0, 0, 0, %32.sub0, %29, implicit $exec
+    %39:vreg_64_align2 = REG_SEQUENCE %37, %subreg.sub0, %34, %subreg.sub1
+    %41:vreg_64_align2 = V_ADD_F64_e64 0, %39, 0, 0, 0, 0, implicit $mode, implicit $exec
+    %7:av_64_align2 = COPY %41
+    %42:vgpr_32 = V_OR_B32_e32 1, %2, implicit $exec
+    %43:vgpr_32 = V_OR_B32_e32 1, %42, implicit $exec
+    %65:sreg_64 = S_ANDN2_B64 %64, $exec, implicit-def $scc
+    %66:sreg_64 = S_AND_B64 %29, $exec, implicit-def $scc
+    %11:sreg_64_xexec = S_OR_B64 %65, %66, implicit-def $scc
+    S_CMP_LG_U32 %5, 0, implicit-def $scc
+    %58:vgpr_32 = COPY %43, implicit $exec
+    %60:vgpr_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    S_CBRANCH_SCC1 %bb.1, implicit $scc
+    S_BRANCH %bb.2
+
+  bb.2:
+    %10:av_64_align2 = PHI %4, %bb.1
+    %44:vgpr_32 = AV_MOV_B32_IMM_PSEUDO 0, implicit $exec
+    DS_WRITE_B64_gfx9 %44, %10, 0, 0, implicit $exec :: (store (s64) into `ptr addrspace(3) null`, addrspace 3)
+    S_ENDPGM 0
+...


### PR DESCRIPTION
CopyToPhiMutation adds artificial USE->SRC edges to reduce cross-iteration
copies. These edges can over-constrain the DAG and prevent an otherwise-legal
modulo schedule for a loop.

Add an opt-in fallback (-pipeliner-copytophi-fallback, default off): if the
first scheduling attempt fails to find a schedule and CopyToPhi added edges to
the loop, reschedule the loop once with the mutation disabled. The edges are
dropped from every scheduling phase, so the retry is equivalent to
-pipeliner-enable-copytophi=0 for that loop and remains correct.

Only the FailedSearch case retries: an invalid or too-large MII cannot change
on retry, since CopyToPhi edges never form a cycle and MII depends only on
resources and recurrences.

With the flag off the default path is unchanged. Adds the
NumRetryWithoutCopyToPhi statistic and an AMDGPU MIR test (reduced from a HIP
kernel) covering the fallback, the default-off behavior, and the equivalent
-pipeliner-enable-copytophi=0 result.

The fallback can be enabled by default for AMDGPU once Composable Kernels
testing is complete and the compile-time and codegen tradeoffs are understood.
