### PR TITLE
[comgr][hotswap] Split single and sequence assembly APIs

### DIFF
--- a/amd/comgr/AGENT_CONVENTIONS.md
+++ b/amd/comgr/AGENT_CONVENTIONS.md
@@ -57,8 +57,8 @@ fix upstream. Do not implement a parallel version inside Comgr.
     and will fail to build.
   - No GCC/Clang-only attributes without an LLVM-portable wrapper.
 - All assembly / disassembly goes through the MC layer (e.g.,
-  `assembleSingleInst`, `parseAsmToMCInsts`). **No hardcoded
-  instruction opcodes or encoded byte sequences** — let the asm parser
+  `assembleSingleInst`, `assembleInstructions`, `parseAsmToMCInsts`). **No
+  hardcoded instruction opcodes or encoded byte sequences** — let the asm parser
   resolve them, and round-trip through `MCCodeEmitter::encodeInstruction`
   for any modification.
 - When invoking the asm parser, register the SourceMgr with `MCContext`

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -429,7 +429,7 @@ std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
   AsmLines.push_back("s_add_nc_u64 " + Pair + ", " + Pair + ", 0x" +
                      utohexstr(Delta));
   AsmLines.push_back("s_set_pc_i64 " + Pair);
-  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), LS);
+  SmallVector<uint8_t> Bytes = assembleInstructions(joinAsmLines(AsmLines), LS);
   if (Bytes.empty() || Bytes.size() > SetPcReturnReserveBytes) {
     log() << "hotswap: error: failed to assemble SCC-neutral set-PC branch via "
           << Pair << "\n";

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -638,12 +638,18 @@ LLVMState initLLVM(const TargetIdentifier &TI);
                                      const LLVMState &LS,
                                      std::vector<InternalDecodedInst> &Decoded);
 
-/// Assemble a single instruction string, returning its encoded bytes.
+/// Assemble one non-empty assembly source line, returning its encoded bytes.
+/// Target pseudos may expand that source line to more than one MCInst.
 llvm::SmallVector<uint8_t> assembleSingleInst(llvm::StringRef AsmStr,
                                               const LLVMState &LS);
 
+/// Assemble a newline-separated instruction sequence, returning its encoded
+/// bytes.
+llvm::SmallVector<uint8_t> assembleInstructions(llvm::StringRef AsmStr,
+                                                const LLVMState &LS);
+
 /// Join \p AsmLines into a single newline-terminated assembly source string,
-/// as expected by assembleSingleInst (which accepts multiple instructions).
+/// as expected by assembleInstructions.
 std::string joinAsmLines(llvm::ArrayRef<std::string> AsmLines);
 
 /// Assemble \p AsmLines and append a branch-back to the next instruction

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -136,7 +136,7 @@ static SmallVector<uint8_t> encodeMCInst(const MCInst &Inst,
 }
 
 /// Run the AMDGPU asm parser over \p AsmStr and return the captured MCInsts.
-/// Used by assembleSingleInst() for the full parse-and-encode path, and by
+/// Used by the assembly helpers for the full parse-and-encode path, and by
 /// initLLVM() / resolveOpcodeViaParse() for instructions where parsing the
 /// assembly mnemonic is the least fragile way to pick the target opcode.
 static SmallVector<MCInst, 2> parseAsmToMCInsts(StringRef AsmStr,
@@ -536,15 +536,16 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
   return true;
 }
 
-// -- assembleSingleInst -------------------------------------------------------
+// -- assembly helpers ---------------------------------------------------------
 
-SmallVector<uint8_t> assembleSingleInst(StringRef AsmStr, const LLVMState &S) {
+SmallVector<uint8_t> assembleInstructions(StringRef AsmStr,
+                                          const LLVMState &S) {
   // Parse \p AsmStr through the shared parseAsmToMCInsts helper, then encode
   // each captured MCInst via the cached MCCodeEmitter. Avoids the old
   // createMCObjectStreamer -> ELF parse -> extract .text round trip.
   SmallVector<MCInst, 2> Insts = parseAsmToMCInsts(AsmStr, S);
   if (Insts.empty()) {
-    log() << "hotswap: error: assembleSingleInst: parser produced no "
+    log() << "hotswap: error: assembleInstructions: parser produced no "
           << "instructions for asm:\n    " << AsmStr << "\n";
     return {};
   }
@@ -555,6 +556,22 @@ SmallVector<uint8_t> assembleSingleInst(StringRef AsmStr, const LLVMState &S) {
     Bytes.append(InstBytes.begin(), InstBytes.end());
   }
   return Bytes;
+}
+
+SmallVector<uint8_t> assembleSingleInst(StringRef AsmStr, const LLVMState &S) {
+  SmallVector<StringRef, 2> Lines;
+  AsmStr.split(Lines, '\n');
+  unsigned InstructionLines = 0;
+  for (StringRef Line : Lines)
+    if (!Line.trim().empty())
+      ++InstructionLines;
+  if (InstructionLines != 1) {
+    log() << "hotswap: error: assembleSingleInst: expected one non-empty "
+             "assembly line, got "
+          << InstructionLines << " for asm:\n    " << AsmStr << "\n";
+    return {};
+  }
+  return assembleInstructions(AsmStr, S);
 }
 
 // -- buildTrampoline ----------------------------------------------------------
@@ -575,9 +592,9 @@ Trampoline buildTrampoline(ArrayRef<std::string> AsmLines,
   Result.OriginalOffset = OriginalOffset;
   Result.OriginalSize = OriginalSize;
 
-  SmallVector<uint8_t> Bytes = assembleSingleInst(joinAsmLines(AsmLines), S);
+  SmallVector<uint8_t> Bytes = assembleInstructions(joinAsmLines(AsmLines), S);
   if (Bytes.empty()) {
-    log() << "hotswap: error: buildTrampoline: assembleSingleInst returned "
+    log() << "hotswap: error: buildTrampoline: assembleInstructions returned "
           << "empty for trampoline originating at offset 0x"
           << utohexstr(OriginalOffset) << " (" << AsmLines.size()
           << " asm lines).\n";

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -396,7 +396,7 @@ uint32_t patchCvtPkFp8F32(PatchContext &Ctx, size_t Idx) {
   // Restore VCC to its pre-patch value.
   AsmOS << "s_mov_b32 vcc_lo, " << VccSaveName << "\n";
 
-  SmallVector<uint8_t> ReplacementBytes = assembleSingleInst(Asm, Ctx.LS);
+  SmallVector<uint8_t> ReplacementBytes = assembleInstructions(Asm, Ctx.LS);
   if (ReplacementBytes.empty()) {
     log() << "hotswap: error: cvt_pk_fp8_f32: assembly failed for "
           << "replacement at offset 0x" << utohexstr(DI.Offset) << "\n";
@@ -594,7 +594,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
   // Restore VCC to its pre-patch value.
   AsmOS << "s_mov_b32 vcc_lo, " << VccSaveName << "\n";
 
-  SmallVector<uint8_t> ReplacementBytes = assembleSingleInst(Asm, Ctx.LS);
+  SmallVector<uint8_t> ReplacementBytes = assembleInstructions(Asm, Ctx.LS);
   if (ReplacementBytes.empty()) {
     log() << "hotswap: error: cvt_sr_fp8_f32: assembly failed for "
           << "replacement at offset 0x" << utohexstr(DI.Offset) << "\n";
@@ -763,7 +763,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
   // Restore VCC to its pre-patch value.
   AsmOS << "s_mov_b32 vcc_lo, " << VccSaveName << "\n";
 
-  SmallVector<uint8_t> ReplacementBytes = assembleSingleInst(Asm, Ctx.LS);
+  SmallVector<uint8_t> ReplacementBytes = assembleInstructions(Asm, Ctx.LS);
   if (ReplacementBytes.empty()) {
     log() << "hotswap: error: cvt_f32_fp8: assembly failed for "
           << "replacement at offset 0x" << utohexstr(DI.Offset) << "\n";

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -435,7 +435,7 @@ bool patchDs2Addr(PatchContext &Ctx, size_t Idx) {
   // local drain is unconditionally correct; a precise per-wait dataflow
   // recomputation is the eventual optimization (tracked separately).
   Combined += "s_wait_dscnt 0\n";
-  SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
+  SmallVector<uint8_t> Bytes = assembleInstructions(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: ds_2addr: assembly failed: " << Combined << "\n";
     return failRequiredPatch(Ctx);
@@ -1367,7 +1367,7 @@ bool patchDsAddtid(PatchContext &Ctx, size_t Idx) {
   std::string Combined;
   for (const std::string &Line : AsmLines)
     Combined += Line + "\n";
-  SmallVector<uint8_t> Bytes = assembleSingleInst(Combined, Ctx.LS);
+  SmallVector<uint8_t> Bytes = assembleInstructions(Combined, Ctx.LS);
   if (Bytes.empty()) {
     log() << "hotswap: error: " << DI.Mnemonic
           << " trampoline assembly failed at 0x" << utohexstr(DI.Offset)

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -289,7 +289,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 
   SmallVector<uint8_t> PreambleBytes;
   if (NeedReductionA || NeedReductionB) {
-    PreambleBytes = assembleSingleInst(Asm, Ctx.LS);
+    PreambleBytes = assembleInstructions(Asm, Ctx.LS);
     if (PreambleBytes.empty()) {
       log() << "hotswap: error: wmma_scale16: preamble assembly failed at "
             << "offset 0x" << utohexstr(DI.Offset) << "\n";
@@ -602,7 +602,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
 
   SmallVector<uint8_t> PreambleBytes;
   if (NeedReductionA || NeedReductionB) {
-    PreambleBytes = assembleSingleInst(Asm, Ctx.LS);
+    PreambleBytes = assembleInstructions(Asm, Ctx.LS);
     if (PreambleBytes.empty()) {
       log() << "hotswap: error: wmma_scale16: 32x16 preamble assembly failed "
             << "at offset 0x" << utohexstr(DI.Offset) << "\n";

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -655,7 +655,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
   // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
   // gateway based on the site's distance from the appended pool.
   SmallVector<uint8_t> Replacement =
-      assembleSingleInst(joinAsmLines(AsmLines), Ctx.LS);
+      assembleInstructions(joinAsmLines(AsmLines), Ctx.LS);
   if (Replacement.empty()) {
     log() << "hotswap: error: WMMA split: trampoline assembly failed for "
           << DI.Mnemonic << "\n";

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -600,11 +600,11 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], 0xffffffffffed1230\n"
-                         "v_mov_b32 v0, v1\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0xffffffffffed1230\n"
+                           "v_mov_b32 v0, v1\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -629,11 +629,11 @@ TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -4\n"
-                         "s_mov_b32 s0, 0\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -4\n"
+                           "s_mov_b32 s0, 0\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -652,11 +652,11 @@ TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoMaterialization) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_branch 1\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], 4\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_branch 1\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 4\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -677,10 +677,10 @@ TEST(CollectDirectBranchTargets, RejectsDeclaredEntryIntoMaterialization) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], 4\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 4\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -701,11 +701,11 @@ TEST(CollectDirectBranchTargets, RejectsUndecodedMaterializationSlot) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], 8\n"
-                         "v_mov_b32 v0, v1\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 8\n"
+                           "v_mov_b32 v0, v1\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -728,11 +728,11 @@ TEST(CollectDirectBranchTargets, RejectsUnboundedIndirectEntry) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_set_pc_i64 s[4:5]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], 4\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_set_pc_i64 s[4:5]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 4\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -753,13 +753,13 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_branch -2\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -16\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_branch -2\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -16\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -789,12 +789,12 @@ TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_mov_b32 s31, 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_mov_b32 s31, 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -818,14 +818,14 @@ TEST(CollectDirectBranchTargets, RejectsNestedCallSetPcReturn) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_call_i64 s[4:5], 1\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_mov_b32 s30, 0\n"
-                         "s_set_pc_i64 s[4:5]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -20\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_call_i64 s[4:5], 1\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_mov_b32 s30, 0\n"
+                           "s_set_pc_i64 s[4:5]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -20\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -851,15 +851,15 @@ TEST(CollectDirectBranchTargets, RejectsIndirectFallthroughChainEntry) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_branch -1\n"
-                         "s_nop 0\n"
-                         "s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_set_pc_i64 s[2:3]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_branch -1\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_set_pc_i64 s[2:3]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -884,14 +884,14 @@ TEST(CollectDirectBranchTargets, RejectsAlternateEntryIntoReturnFunction) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_branch -2\n"
-                         "s_branch -2\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -20\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_branch -2\n"
+                           "s_branch -2\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -20\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -916,15 +916,15 @@ TEST(CollectDirectBranchTargets,
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_get_pc_i64 s[4:5]\n"
-                         "s_add_nc_u64 s[4:5], s[4:5], -12\n"
-                         "s_swap_pc_i64 s[30:31], s[4:5]\n"
-                         "s_get_pc_i64 s[6:7]\n"
-                         "s_add_nc_u64 s[6:7], s[6:7], -20\n"
-                         "s_swap_pc_i64 s[2:3], s[6:7]",
-                         S);
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[4:5]\n"
+                           "s_add_nc_u64 s[4:5], s[4:5], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[4:5]\n"
+                           "s_get_pc_i64 s[6:7]\n"
+                           "s_add_nc_u64 s[6:7], s[6:7], -20\n"
+                           "s_swap_pc_i64 s[2:3], s[6:7]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -949,12 +949,12 @@ TEST(CollectDirectBranchTargets, RejectsExternalAliasAtLocalFunctionEntry) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -979,13 +979,13 @@ TEST(CollectDirectBranchTargets, RejectsFallthroughIntoReturnFunction) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_nop 0\n"
-                         "s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -1009,15 +1009,15 @@ TEST(CollectDirectBranchTargets, AllowsUnreachablePaddingBeforeReturnFunction) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
   llvm::SmallVector<uint8_t> Bytes =
-      assembleSingleInst("s_branch -1\n"
-                         "s_nop 0\n"
-                         "s_nop 0\n"
-                         "s_nop 0\n"
-                         "s_set_pc_i64 s[30:31]\n"
-                         "s_get_pc_i64 s[0:1]\n"
-                         "s_add_nc_u64 s[0:1], s[0:1], -12\n"
-                         "s_swap_pc_i64 s[30:31], s[0:1]",
-                         S);
+      assembleInstructions("s_branch -1\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -12\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
   ASSERT_FALSE(Bytes.empty());
 
   std::vector<InternalDecodedInst> Decoded;
@@ -1261,6 +1261,29 @@ TEST(AssembleDecode, SNopRoundTrip) {
   EXPECT_TRUE(Decoded[0].DecodeSucceeded);
   EXPECT_EQ(Decoded[0].Size, MinInstSize);
   EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
+}
+
+TEST(AssembleDecode, SingleInstructionRejectsSequence) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst("s_nop 0\ns_endpgm", S);
+  EXPECT_TRUE(Bytes.empty());
+}
+
+TEST(AssembleDecode, InstructionSequenceRoundTrip) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_nop 0\ns_endpgm", S);
+  ASSERT_EQ(Bytes.size(), 2u * MinInstSize);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 2u);
+  EXPECT_EQ(Decoded[0].Mnemonic, "s_nop");
+  EXPECT_EQ(Decoded[1].Mnemonic, "s_endpgm");
 }
 
 TEST(AssembleDecode, CvtPkFp8LiteralSourcesDecodeAsTwelveBytes) {


### PR DESCRIPTION
Follow-up to the assembly API review on #3418: https://github.com/ROCm/llvm-project/pull/3418#discussion_r3598223770

## Summary

- Add assembleInstructions for intentional newline-separated instruction sequences.
- Make assembleSingleInst reject input with anything other than one non-empty assembly source line. Target pseudos may still expand that one line to multiple MCInsts.
- Migrate production and unit-test sequence callers to the new API.
- Document the distinction in the COMGR agent conventions.
- Add unit coverage for sequence round-tripping and single-instruction rejection.

This is an API-contract cleanup only; it does not change the generated HotSwap instruction sequences.

## Validation

Release build:
- HotswapMCTests: 102/102 passed
- HotswapElfTests: 30/30 passed
- HotSwap LIT: 88/88 passed

AddressSanitizer build with leak detection:
- HotswapMCTests: 102/102 passed
- HotswapElfTests: 30/30 passed
- HotSwap LIT: 88/88 passed

- git diff --check: passed
- git clang-format -f rocm/amd-staging --diff: clean

A full local check-comgr run is not a reliable compiler-pipeline signal in this checkout because COMGR is linked against a separately built LLVM tree; the known compiler/cache/VFS cases fail in that mixed environment. All affected unit and HotSwap LIT suites pass in both release and ASAN builds.