### PR TITLE
[comgr][hotswap] Size far gateways from MC encodings

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -32,6 +32,7 @@
 
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/Twine.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -438,7 +439,7 @@ std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
   return Bytes;
 }
 
-std::optional<EncodedSetPcGateway>
+Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
                         unsigned SgprBase) {
@@ -458,7 +459,11 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
       continue;
     std::optional<SmallVector<uint8_t>> Bytes =
         encodeSetPCLongBranch(LS, Sled.WritePos, TargetOffset, SgprBase);
-    if (!Bytes || Bytes->size() > UsableEnd - Sled.WritePos)
+    if (!Bytes)
+      return createStringError(
+          Twine("failed to encode set-PC gateway at candidate offset 0x") +
+          utohexstr(Sled.WritePos));
+    if (Bytes->size() > UsableEnd - Sled.WritePos)
       continue;
     Best = &Sled;
     BestBytes = std::move(*Bytes);
@@ -466,7 +471,8 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
   }
   if (!Best)
     return std::nullopt;
-  return EncodedSetPcGateway{Best, std::move(BestBytes)};
+  return std::optional<EncodedSetPcGateway>(
+      EncodedSetPcGateway{Best, std::move(BestBytes)});
 }
 
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
@@ -1862,10 +1868,10 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
-static uint64_t
-countReachableGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
-                           uint64_t FromOffset, uint64_t TargetOffset,
-                           unsigned SgprBase, uint64_t MaxSlots) {
+Expected<uint64_t>
+countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
+                                uint64_t FromOffset, uint64_t TargetOffset,
+                                unsigned SgprBase, uint64_t MaxSlots) {
   uint64_t Slots = 0;
   for (const NopSled &Sled : Gateways) {
     if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
@@ -1880,7 +1886,12 @@ countReachableGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
         break;
       std::optional<SmallVector<uint8_t>> Bytes =
           encodeSetPCLongBranch(LS, Candidate, TargetOffset, SgprBase);
-      if (!Bytes || Bytes->size() > UsableEnd - Candidate)
+      if (!Bytes)
+        return createStringError(
+            Twine("failed to encode set-PC gateway while counting candidate "
+                  "offset 0x") +
+            utohexstr(Candidate));
+      if (Bytes->size() > UsableEnd - Candidate)
         break;
       ++Slots;
       Candidate += Bytes->size();
@@ -2006,9 +2017,16 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
   for (PendingGateway &P : Pending) {
     const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    P.InitialCandidateSlots = countReachableGatewaySlots(
+    Expected<uint64_t> CandidateSlots = countReachableSetPcGatewaySlots(
         Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
         T.LongBranchSgprBase, Pending.size());
+    if (!CandidateSlots) {
+      log() << "hotswap: error: failed to count gateways for far site 0x"
+            << utohexstr(T.OriginalOffset) << ": "
+            << toString(CandidateSlots.takeError()) << "\n";
+      return false;
+    }
+    P.InitialCandidateSlots = *CandidateSlots;
   }
 
   std::vector<PendingGateway> StillPending;
@@ -2038,9 +2056,16 @@ assignLongBranchGateways(PatchContext &Ctx,
   uint64_t AssignedGateways = 0;
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    std::optional<EncodedSetPcGateway> Gateway =
+    Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
         findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
                                 P.TargetOffset, T.LongBranchSgprBase);
+    if (!GatewayOrErr) {
+      log() << "hotswap: error: failed to plan gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << ": "
+            << toString(GatewayOrErr.takeError()) << "\n";
+      return false;
+    }
+    std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
     if (!Gateway) {
       log() << "hotswap: error: no safe short-branch gateway for far site 0x"
             << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -438,6 +438,37 @@ std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
   return Bytes;
 }
 
+std::optional<EncodedSetPcGateway>
+findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
+                        uint64_t FromOffset, uint64_t TargetOffset,
+                        unsigned SgprBase) {
+  NopSled *Best = nullptr;
+  SmallVector<uint8_t> BestBytes;
+  uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+  for (NopSled &Sled : Gateways) {
+    if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
+      continue;
+    uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+    if (Sled.WritePos > UsableEnd)
+      continue;
+    uint64_t Distance = Sled.WritePos > FromOffset ? Sled.WritePos - FromOffset
+                                                   : FromOffset - Sled.WritePos;
+    if (Distance >= MaxSledDistance || Distance >= BestDistance ||
+        LS.encodeSBranch(FromOffset, Sled.WritePos).empty())
+      continue;
+    std::optional<SmallVector<uint8_t>> Bytes =
+        encodeSetPCLongBranch(LS, Sled.WritePos, TargetOffset, SgprBase);
+    if (!Bytes || Bytes->size() > UsableEnd - Sled.WritePos)
+      continue;
+    Best = &Sled;
+    BestBytes = std::move(*Bytes);
+    BestDistance = Distance;
+  }
+  if (!Best)
+    return std::nullopt;
+  return EncodedSetPcGateway{Best, std::move(BestBytes)};
+}
+
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
                                                  MCRegister Reg) {
   // TODO(https://github.com/ROCm/llvm-project/issues/3350): Replace this
@@ -1831,20 +1862,31 @@ buildExternalGatewaySleds(ArrayRef<InternalDecodedInst> Decoded,
   return Sleds;
 }
 
-static uint64_t countReachableGatewaySlots(ArrayRef<NopSled> Gateways,
-                                           uint64_t Offset, uint64_t Needed) {
+static uint64_t
+countReachableGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
+                           uint64_t FromOffset, uint64_t TargetOffset,
+                           unsigned SgprBase, uint64_t MaxSlots) {
   uint64_t Slots = 0;
   for (const NopSled &Sled : Gateways) {
-    if (Offset < Sled.FunctionStart || Offset >= Sled.FunctionEnd)
+    if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
       continue;
     uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-    if (Sled.WritePos > UsableEnd || Needed > UsableEnd - Sled.WritePos)
-      continue;
-    uint64_t Distance = Sled.WritePos > Offset ? Sled.WritePos - Offset
-                                               : Offset - Sled.WritePos;
-    if (Distance >= MaxSledDistance)
-      continue;
-    Slots += (UsableEnd - Sled.WritePos) / Needed;
+    uint64_t Candidate = Sled.WritePos;
+    while (Candidate <= UsableEnd && Slots < MaxSlots) {
+      uint64_t Distance = Candidate > FromOffset ? Candidate - FromOffset
+                                                 : FromOffset - Candidate;
+      if (Distance >= MaxSledDistance ||
+          LS.encodeSBranch(FromOffset, Candidate).empty())
+        break;
+      std::optional<SmallVector<uint8_t>> Bytes =
+          encodeSetPCLongBranch(LS, Candidate, TargetOffset, SgprBase);
+      if (!Bytes || Bytes->size() > UsableEnd - Candidate)
+        break;
+      ++Slots;
+      Candidate += Bytes->size();
+    }
+    if (Slots == MaxSlots)
+      break;
   }
   return Slots;
 }
@@ -1934,7 +1976,6 @@ assignLongBranchGateways(PatchContext &Ctx,
   struct PendingGateway {
     size_t TrampolineIndex = 0;
     uint64_t TargetOffset = 0;
-    uint64_t NeededBytes = 0;
     uint64_t InitialCandidateSlots = 0;
   };
   std::vector<PendingGateway> Pending;
@@ -1961,10 +2002,13 @@ assignLongBranchGateways(PatchContext &Ctx,
       T.DirectSetPCForwardBytes = std::move(*Direct);
       continue;
     }
-    uint64_t Needed = SetPcForwardSequenceBytes;
-    Pending.push_back(
-        {I, TP, Needed,
-         countReachableGatewaySlots(Gateways, T.OriginalOffset, Needed)});
+    Pending.push_back({I, TP, 0});
+  }
+  for (PendingGateway &P : Pending) {
+    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    P.InitialCandidateSlots = countReachableGatewaySlots(
+        Gateways, Ctx.LS, T.OriginalOffset, P.TargetOffset,
+        T.LongBranchSgprBase, Pending.size());
   }
 
   std::vector<PendingGateway> StillPending;
@@ -1987,8 +2031,6 @@ assignLongBranchGateways(PatchContext &Ctx,
 
   std::stable_sort(Pending.begin(), Pending.end(),
                    [](const PendingGateway &LHS, const PendingGateway &RHS) {
-                     if (LHS.NeededBytes != RHS.NeededBytes)
-                       return LHS.NeededBytes > RHS.NeededBytes;
                      return LHS.InitialCandidateSlots <
                             RHS.InitialCandidateSlots;
                    });
@@ -1996,25 +2038,19 @@ assignLongBranchGateways(PatchContext &Ctx,
   uint64_t AssignedGateways = 0;
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    NopSled *Sled = findNearestSled(Gateways, T.OriginalOffset, P.NeededBytes);
-    if (!Sled ||
-        Ctx.LS.encodeSBranch(T.OriginalOffset, Sled->WritePos).empty()) {
+    std::optional<EncodedSetPcGateway> Gateway =
+        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                P.TargetOffset, T.LongBranchSgprBase);
+    if (!Gateway) {
       log() << "hotswap: error: no safe short-branch gateway for far site 0x"
             << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
             << " initial candidate slot(s))\n";
       return false;
     }
-    std::optional<SmallVector<uint8_t>> Gateway = encodeSetPCLongBranch(
-        Ctx.LS, Sled->WritePos, P.TargetOffset, T.LongBranchSgprBase);
-    if (!Gateway || Gateway->size() > P.NeededBytes) {
-      log() << "hotswap: error: failed to encode far-site gateway at 0x"
-            << utohexstr(Sled->WritePos) << "\n";
-      return false;
-    }
     T.HasForwardGateway = true;
-    T.ForwardGatewayOffset = Sled->WritePos;
-    T.ForwardGatewayBytes = std::move(*Gateway);
-    Sled->WritePos += T.ForwardGatewayBytes.size();
+    T.ForwardGatewayOffset = Gateway->Sled->WritePos;
+    T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+    Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
     ++AssignedGateways;
   }
   if (!Pending.empty())

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -969,10 +969,17 @@ struct EncodedSetPcGateway {
 /// Find the nearest short-branch-reachable gateway whose remaining space fits
 /// the set-PC sequence encoded for that candidate's address. The returned
 /// plan does not advance the sled or modify text.
-std::optional<EncodedSetPcGateway>
+llvm::Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
                         unsigned SgprBase);
+
+/// Count set-PC gateway slots reachable from \p FromOffset, up to \p MaxSlots.
+/// Zero means that no candidate fits; an Error means that a reachable
+/// candidate could not be encoded.
+llvm::Expected<uint64_t> countReachableSetPcGatewaySlots(
+    llvm::ArrayRef<NopSled> Gateways, const LLVMState &LS, uint64_t FromOffset,
+    uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots);
 
 /// Return whether an s_branch at \p From can encode \p To, including the
 /// instruction-relative PC base, alignment, signed range, and overflow checks.

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -961,6 +961,19 @@ std::optional<llvm::SmallVector<uint8_t>>
 encodeSetPCLongBranch(const LLVMState &LS, uint64_t FromOffset,
                       uint64_t TargetOffset, unsigned SgprBase);
 
+struct EncodedSetPcGateway {
+  NopSled *Sled = nullptr;
+  llvm::SmallVector<uint8_t> Bytes;
+};
+
+/// Find the nearest short-branch-reachable gateway whose remaining space fits
+/// the set-PC sequence encoded for that candidate's address. The returned
+/// plan does not advance the sled or modify text.
+std::optional<EncodedSetPcGateway>
+findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
+                        uint64_t FromOffset, uint64_t TargetOffset,
+                        unsigned SgprBase);
+
 /// Return whether an s_branch at \p From can encode \p To, including the
 /// instruction-relative PC base, alignment, signed range, and overflow checks.
 bool isSBranchReachable(uint64_t From, uint64_t To);

--- a/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
@@ -1,0 +1,87 @@
+// COM: A far required DS2 rewrite has exactly one safe 16-byte external
+// COM: gateway. The gfx1250 SCC-neutral set-PC sequence encodes in 16 bytes
+// COM: for this forward displacement, so planning must use its MC-encoded
+// COM: size instead of requiring the 20-byte worst-case reservation.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 \
+// RUN:   --implicit-check-not=s_add_co_u32 \
+// RUN:   --implicit-check-not=s_add_co_ci_u32 %s
+// RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=META %s
+
+// DISASM-LABEL: <compact_gateway>:
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_nop
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+// DISASM-NEXT: s_wait_dscnt 0x0
+// DISASM-NEXT: s_get_pc_i64 s[0:1]
+// DISASM-NEXT: s_add_nc_u64 s[0:1], s[0:1],
+// DISASM-NEXT: s_set_pc_i64 s[0:1]
+
+// META: .name:           compact_gateway
+// META: .sgpr_count:     4
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl compact_gateway
+.p2align 8
+.type compact_gateway,@function
+compact_gateway:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_cbranch_scc1 .Lexit
+  s_endpgm
+.Lexit:
+  s_endpgm
+.size compact_gateway, .-compact_gateway
+
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 16, 1, 0
+
+.rept 40000
+  s_mov_b32 s4, s5
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel compact_gateway
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: compact_gateway
+      .symbol: compact_gateway.kd
+      .sgpr_count: 0
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -246,6 +246,7 @@ TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
   std::optional<llvm::SmallVector<uint8_t>> Out =
       encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
   ASSERT_TRUE(Out);
+  EXPECT_EQ(Out->size(), 16u);
 
   std::vector<InternalDecodedInst> Decoded;
   ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
@@ -254,6 +255,61 @@ TEST(EncodeSetPCLongBranch, ForwardLandsOnTarget) {
   uint64_t Delta =
       static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
   EXPECT_EQ(From + MinInstSize + Delta, To);
+}
+
+TEST(EncodeSetPCLongBranch, InlineDisplacementUsesTwelveBytes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  constexpr uint64_t From = 0x1000;
+  constexpr uint64_t To = From + 2 * MinInstSize;
+  std::optional<llvm::SmallVector<uint8_t>> Out =
+      encodeSetPCLongBranch(S, From, To, /*SgprBase=*/12);
+  ASSERT_TRUE(Out);
+  EXPECT_EQ(Out->size(), 12u);
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Out->data(), Out->size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  ASSERT_TRUE(Decoded[1].Inst.getOperand(2).isImm());
+  uint64_t Delta =
+      static_cast<uint64_t>(Decoded[1].Inst.getOperand(2).getImm());
+  EXPECT_EQ(From + MinInstSize + Delta, To);
+}
+
+TEST(FindNearestSetPcGateway, FitsActualSixteenByteEncoding) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x110, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  std::optional<EncodedSetPcGateway> Gateway = findNearestSetPcGateway(
+      Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x81000,
+      /*SgprBase=*/12);
+  ASSERT_TRUE(Gateway);
+  EXPECT_EQ(Gateway->Sled, &Gateways[0]);
+  EXPECT_EQ(Gateway->Bytes.size(), 16u);
+  EXPECT_EQ(Gateways[0].WritePos, 0x100u);
+}
+
+TEST(FindNearestSetPcGateway, SkipsNearerUndersizedCandidate) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x80100, /*End=*/0x80110, /*WritePos=*/0x80100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x100000},
+      {/*Start=*/0x80200, /*End=*/0x80214, /*WritePos=*/0x80200,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x100000}};
+  std::optional<EncodedSetPcGateway> Gateway = findNearestSetPcGateway(
+      Gateways, S, /*FromOffset=*/0x80000, /*TargetOffset=*/0x1004,
+      /*SgprBase=*/12);
+  ASSERT_TRUE(Gateway);
+  EXPECT_EQ(Gateway->Sled, &Gateways[1]);
+  EXPECT_EQ(Gateway->Bytes.size(), SetPcReturnReserveBytes);
+  EXPECT_EQ(Gateways[0].WritePos, 0x80100u);
+  EXPECT_EQ(Gateways[1].WritePos, 0x80200u);
 }
 
 TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -284,9 +284,11 @@ TEST(FindNearestSetPcGateway, FitsActualSixteenByteEncoding) {
   std::vector<NopSled> Gateways = {
       {/*Start=*/0x100, /*End=*/0x110, /*WritePos=*/0x100,
        /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
-  std::optional<EncodedSetPcGateway> Gateway = findNearestSetPcGateway(
-      Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x81000,
-      /*SgprBase=*/12);
+  llvm::Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+      findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0,
+                              /*TargetOffset=*/0x81000, /*SgprBase=*/12);
+  ASSERT_TRUE((bool)GatewayOrErr) << llvm::toString(GatewayOrErr.takeError());
+  std::optional<EncodedSetPcGateway> &Gateway = *GatewayOrErr;
   ASSERT_TRUE(Gateway);
   EXPECT_EQ(Gateway->Sled, &Gateways[0]);
   EXPECT_EQ(Gateway->Bytes.size(), 16u);
@@ -302,14 +304,60 @@ TEST(FindNearestSetPcGateway, SkipsNearerUndersizedCandidate) {
        /*FunctionStart=*/0, /*FunctionEnd=*/0x100000},
       {/*Start=*/0x80200, /*End=*/0x80214, /*WritePos=*/0x80200,
        /*FunctionStart=*/0, /*FunctionEnd=*/0x100000}};
-  std::optional<EncodedSetPcGateway> Gateway = findNearestSetPcGateway(
-      Gateways, S, /*FromOffset=*/0x80000, /*TargetOffset=*/0x1004,
-      /*SgprBase=*/12);
+  llvm::Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+      findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0x80000,
+                              /*TargetOffset=*/0x1004, /*SgprBase=*/12);
+  ASSERT_TRUE((bool)GatewayOrErr) << llvm::toString(GatewayOrErr.takeError());
+  std::optional<EncodedSetPcGateway> &Gateway = *GatewayOrErr;
   ASSERT_TRUE(Gateway);
   EXPECT_EQ(Gateway->Sled, &Gateways[1]);
   EXPECT_EQ(Gateway->Bytes.size(), SetPcReturnReserveBytes);
   EXPECT_EQ(Gateways[0].WritePos, 0x80100u);
   EXPECT_EQ(Gateways[1].WritePos, 0x80200u);
+}
+
+TEST(FindNearestSetPcGateway, DistinguishesNoFitFromEncodingFailure) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  llvm::Expected<std::optional<EncodedSetPcGateway>> NoFit =
+      findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0,
+                              /*TargetOffset=*/0x81000, /*SgprBase=*/12);
+  ASSERT_TRUE((bool)NoFit) << llvm::toString(NoFit.takeError());
+  EXPECT_FALSE(*NoFit);
+
+  llvm::Expected<std::optional<EncodedSetPcGateway>> EncodingFailure =
+      findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0,
+                              /*TargetOffset=*/0x81000, /*SgprBase=*/3);
+  ASSERT_FALSE((bool)EncodingFailure);
+  std::string Error = llvm::toString(EncodingFailure.takeError());
+  EXPECT_NE(Error.find("failed to encode set-PC gateway at candidate"),
+            std::string::npos);
+}
+
+TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x108, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  llvm::Expected<uint64_t> NoSlots = countReachableSetPcGatewaySlots(
+      Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x81000,
+      /*SgprBase=*/12, /*MaxSlots=*/1);
+  ASSERT_TRUE((bool)NoSlots) << llvm::toString(NoSlots.takeError());
+  EXPECT_EQ(*NoSlots, 0u);
+
+  llvm::Expected<uint64_t> EncodingFailure = countReachableSetPcGatewaySlots(
+      Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x81000,
+      /*SgprBase=*/3, /*MaxSlots=*/1);
+  ASSERT_FALSE((bool)EncodingFailure);
+  std::string Error = llvm::toString(EncodingFailure.takeError());
+  EXPECT_NE(Error.find("failed to encode set-PC gateway while counting"),
+            std::string::npos);
 }
 
 TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {


### PR DESCRIPTION
Follow-up to the long-term planner review on #3418: https://github.com/ROCm/llvm-project/pull/3418#pullrequestreview-4716932035

## Summary

- Encode the set-PC sequence at each gateway candidate address and check its actual MC-produced size against that candidate.
- Reserve exactly the selected 12-, 16-, or 20-byte encoding instead of requiring the 20-byte worst case for every gateway.
- Count candidate capacity using the actual successive encodings before route assignment.
- Distinguish hard MC encoding failures from successful zero-capacity and no-fitting-candidate results, and propagate encoding errors with far-site and candidate context.
- Preserve the existing planning order: direct s_branch, branch islands, direct set-PC, then per-candidate gateway selection, with all routes reserved before text is modified.
- Add a production-shaped LIT regression with exactly 16 safe gateway bytes. The prior fixed-size planner rejects this object; the new planner rewrites it successfully and remains idempotent.
- Add unit coverage for 12-, 16-, and 20-byte encodings, candidate selection, and the distinct no-fit, zero-capacity, and encoding-failure outcomes.

The suggested s_sub_nc_i64 optimization for backward branches is not included. It is an independent code-size optimization and is not needed for correct candidate sizing.

## Validation

Fail-before/pass-after regression:
- Unmodified amd-staging: rejects the 16-byte gateway with no safe short-branch gateway
- This PR: assigns the gateway and reports RESULT: SUCCESS

Release build:
- HotswapMCTests: 105/105 passed
- HotswapElfTests: 30/30 passed
- HotSwap LIT: 89/89 passed

AddressSanitizer build with leak detection:
- HotswapMCTests: 105/105 passed
- HotswapElfTests: 30/30 passed
- HotSwap LIT: 89/89 passed

- git diff --check: passed
- git clang-format -f rocm/amd-staging --diff: clean

A full local check-comgr run reaches 98 passing and 11 unsupported LIT tests but remains red on 13 known compiler/cache/VFS cases in this mixed COMGR/LLVM checkout. All affected unit and HotSwap LIT suites pass in both release and ASAN builds.