### PR TITLE
[WaveTransform] Fix iterator invalidation in ForwardPropSimplifier

### DIFF
--- a/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUWaveTransform.cpp
@@ -2610,12 +2610,19 @@ class ForwardPropSimplifier {
     if (MBB.pred_empty())
       return;
 
-    for (const auto &PredOUT : OUT[*MBB.pred_begin()]) {
+    auto FirstPredIt = OUT.find(*MBB.pred_begin());
+    if (FirstPredIt == OUT.end())
+      return;
+
+    for (const auto &PredOUT : FirstPredIt->second) {
       Register Reg = PredOUT.first;
       const RegIntVariant &Expected = PredOUT.second;
       if (llvm::all_of(MBB.predecessors(), [&](MachineBasicBlock *Pred) {
-            auto It = OUT[Pred].find(Reg);
-            return It != OUT[Pred].end() && It->second == Expected;
+            auto PredIt = OUT.find(Pred);
+            if (PredIt == OUT.end())
+              return false;
+            auto RegIt = PredIt->second.find(Reg);
+            return RegIt != PredIt->second.end() && RegIt->second == Expected;
           }))
         Result[Reg] = Expected;
     }

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-fwd-prop-crash.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-fwd-prop-crash.mir
@@ -1,5 +1,4 @@
-# RUN: not --crash llc -march=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-late-wave-transform=1 -run-pass=amdgpu-wave-transform -o /dev/null %s 2>&1 | FileCheck %s
-# CHECK: isHandleInSync() && "invalid iterator access!"
+# RUN: llc -march=amdgcn -mcpu=gfx1010 -amdgpu-late-wave-transform=1 -run-pass=amdgpu-wave-transform -o /dev/null %s
 
 # Regression test for iterator invalidation in ForwardPropSimplifier::mergeIncoming.
 #

--- a/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-fwd-prop-crash.mir
+++ b/llvm/test/CodeGen/AMDGPU/WaveTransform/wavetransform-fwd-prop-crash.mir
@@ -1,0 +1,323 @@
+# RUN: not --crash llc -march=amdgcn-amd-amdhsa -mcpu=gfx900 -amdgpu-late-wave-transform=1 -run-pass=amdgpu-wave-transform -o /dev/null %s 2>&1 | FileCheck %s
+# CHECK: isHandleInSync() && "invalid iterator access!"
+
+# Regression test for iterator invalidation in ForwardPropSimplifier::mergeIncoming.
+#
+# mergeIncoming() iterates over OUT[first_pred] while looking up OUT[Pred]
+# for other predecessors. Using operator[] on the outer DenseMap for a
+# predecessor not yet in the map (e.g., an unvisited loop latch) inserts a
+# default entry, causing the DenseMap to rehash (at the 48th entry with 64
+# initial buckets) and invalidating the iterator over the first predecessors
+# OUT entries. The fix uses find() instead of operator[].
+#
+# This test constructs 23 divergent diamonds preceded by an entry block (47
+# total blocks), followed by a divergent loop. When mergeIncoming processes
+# the loop header (bb.47), OUT has 47 entries. The latch (bb.48) is not yet
+# in OUT; operator[] inserts it as the 48th entry, triggering DenseMap growth
+# from 64 to 128 buckets and invalidating the active iterator.
+
+---
+name: fwd_prop_iterator_invalidation
+tracksRegLiveness: true
+body:             |
+  bb.0:
+    successors: %bb.1
+    liveins: $vgpr0, $vgpr1
+
+    %0:vgpr_32 = COPY $vgpr0
+    %1:vgpr_32 = COPY $vgpr1
+    S_BRANCH %bb.1
+
+  bb.1:
+    successors: %bb.2, %bb.3
+
+    %10:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.2, killed %10, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.3
+
+  bb.2:
+    successors: %bb.3
+
+    S_BRANCH %bb.3
+
+  bb.3:
+    successors: %bb.4, %bb.5
+
+    %11:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.4, killed %11, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.5
+
+  bb.4:
+    successors: %bb.5
+
+    S_BRANCH %bb.5
+
+  bb.5:
+    successors: %bb.6, %bb.7
+
+    %12:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.6, killed %12, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.7
+
+  bb.6:
+    successors: %bb.7
+
+    S_BRANCH %bb.7
+
+  bb.7:
+    successors: %bb.8, %bb.9
+
+    %13:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.8, killed %13, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.9
+
+  bb.8:
+    successors: %bb.9
+
+    S_BRANCH %bb.9
+
+  bb.9:
+    successors: %bb.10, %bb.11
+
+    %14:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.10, killed %14, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.11
+
+  bb.10:
+    successors: %bb.11
+
+    S_BRANCH %bb.11
+
+  bb.11:
+    successors: %bb.12, %bb.13
+
+    %15:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.12, killed %15, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.13
+
+  bb.12:
+    successors: %bb.13
+
+    S_BRANCH %bb.13
+
+  bb.13:
+    successors: %bb.14, %bb.15
+
+    %16:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.14, killed %16, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.15
+
+  bb.14:
+    successors: %bb.15
+
+    S_BRANCH %bb.15
+
+  bb.15:
+    successors: %bb.16, %bb.17
+
+    %17:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.16, killed %17, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.17
+
+  bb.16:
+    successors: %bb.17
+
+    S_BRANCH %bb.17
+
+  bb.17:
+    successors: %bb.18, %bb.19
+
+    %18:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.18, killed %18, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.19
+
+  bb.18:
+    successors: %bb.19
+
+    S_BRANCH %bb.19
+
+  bb.19:
+    successors: %bb.20, %bb.21
+
+    %19:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.20, killed %19, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.21
+
+  bb.20:
+    successors: %bb.21
+
+    S_BRANCH %bb.21
+
+  bb.21:
+    successors: %bb.22, %bb.23
+
+    %20:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.22, killed %20, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.23
+
+  bb.22:
+    successors: %bb.23
+
+    S_BRANCH %bb.23
+
+  bb.23:
+    successors: %bb.24, %bb.25
+
+    %21:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.24, killed %21, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.25
+
+  bb.24:
+    successors: %bb.25
+
+    S_BRANCH %bb.25
+
+  bb.25:
+    successors: %bb.26, %bb.27
+
+    %22:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.26, killed %22, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.27
+
+  bb.26:
+    successors: %bb.27
+
+    S_BRANCH %bb.27
+
+  bb.27:
+    successors: %bb.28, %bb.29
+
+    %23:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.28, killed %23, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.29
+
+  bb.28:
+    successors: %bb.29
+
+    S_BRANCH %bb.29
+
+  bb.29:
+    successors: %bb.30, %bb.31
+
+    %24:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.30, killed %24, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.31
+
+  bb.30:
+    successors: %bb.31
+
+    S_BRANCH %bb.31
+
+  bb.31:
+    successors: %bb.32, %bb.33
+
+    %25:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.32, killed %25, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.33
+
+  bb.32:
+    successors: %bb.33
+
+    S_BRANCH %bb.33
+
+  bb.33:
+    successors: %bb.34, %bb.35
+
+    %26:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.34, killed %26, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.35
+
+  bb.34:
+    successors: %bb.35
+
+    S_BRANCH %bb.35
+
+  bb.35:
+    successors: %bb.36, %bb.37
+
+    %27:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.36, killed %27, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.37
+
+  bb.36:
+    successors: %bb.37
+
+    S_BRANCH %bb.37
+
+  bb.37:
+    successors: %bb.38, %bb.39
+
+    %28:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.38, killed %28, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.39
+
+  bb.38:
+    successors: %bb.39
+
+    S_BRANCH %bb.39
+
+  bb.39:
+    successors: %bb.40, %bb.41
+
+    %29:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.40, killed %29, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.41
+
+  bb.40:
+    successors: %bb.41
+
+    S_BRANCH %bb.41
+
+  bb.41:
+    successors: %bb.42, %bb.43
+
+    %30:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.42, killed %30, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.43
+
+  bb.42:
+    successors: %bb.43
+
+    S_BRANCH %bb.43
+
+  bb.43:
+    successors: %bb.44, %bb.45
+
+    %31:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.44, killed %31, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.45
+
+  bb.44:
+    successors: %bb.45
+
+    S_BRANCH %bb.45
+
+  bb.45:
+    successors: %bb.46, %bb.47
+
+    %32:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.46, killed %32, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.47
+
+  bb.46:
+    successors: %bb.47
+
+    S_BRANCH %bb.47
+
+  bb.47:
+    successors: %bb.48, %bb.49
+
+    %33:sreg_32 = V_CMP_NE_U32_e64 %0, %1, implicit $exec
+    SI_BRCOND %bb.48, killed %33, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.49
+
+  bb.48:
+    successors: %bb.47, %bb.49
+
+    %34:sreg_32 = V_CMP_NE_U32_e64 %1, %0, implicit $exec
+    SI_BRCOND %bb.47, killed %34, implicit-def dead $exec, implicit-def dead $vcc, implicit $exec
+    S_BRANCH %bb.49
+
+  bb.49:
+    S_ENDPGM 0
+...


### PR DESCRIPTION
The function mergeIncoming() iterates over OUT[first_pred] while a lambda
looks up OUT[Pred] for other predecessors. Using operator[] on the outer
DenseMap for a predecessor not yet in the map (e.g., an unvisited loop
latch) inserts a default entry, potentially rehashing and invalidating
the iterator. Fix by using find() instead of operator[].