### PR TITLE
[OpenMP][device] Place ompdevice archive in top-level per-target lib dir

### DIFF
--- a/openmp/device/CMakeLists.txt
+++ b/openmp/device/CMakeLists.txt
@@ -141,7 +141,7 @@ set_property(TARGET ompdevice.all_objs APPEND PROPERTY IMPORTED_OBJECTS
 add_library(ompdevice STATIC)
 add_dependencies(ompdevice libompdevice)
 set_target_properties(ompdevice PROPERTIES
-   ARCHIVE_OUTPUT_DIRECTORY "${OPENMP_INSTALL_LIBDIR}"
+   ARCHIVE_OUTPUT_DIRECTORY "${LLVM_LIBRARY_OUTPUT_INTDIR}/${OPENMP_TARGET_SUBDIR}"
    ARCHIVE_OUTPUT_NAME ompdevice
   LINKER_LANGUAGE CXX
 )


### PR DESCRIPTION
The `ompdevice` static archive set ARCHIVE_OUTPUT_DIRECTORY to the relative OPENMP_INSTALL_LIBDIR, so libompdevice.a landed in the runtimes-build subtree instead of the top-level lib/<triple> directory where the other per-target runtimes (libc, libc++) are placed. As a result the offload tests failed to link with
"unable to find library -lompdevice".

Restore the absolute output directory (matching upstream and the other runtimes) so the archive is emitted into
${LLVM_LIBRARY_OUTPUT_INTDIR}/${OPENMP_TARGET_SUBDIR}. This reverts the regression introduced downstream in 2ca1509d6d20 ("Put the RTL, Back!").

Claude assisted with this patch.


