### PR TITLE
[comgr][hotswap] Convert s_clause instructions to s_nop

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1606,11 +1606,13 @@ decodeCurrentInstruction(const PatchContext &Ctx,
 }
 
 /// Instructions covered by a hard clause or a delay directive must remain in
-/// place relative to that directive. Mark the complete encoded clause and the
-/// maximum six-instruction forward span addressable by s_delay_alu.
+/// place relative to that directive. B0-to-A0 rewrites have already replaced
+/// clauses with s_nop, so only preserve clause members when requested. Always
+/// mark the maximum six-instruction forward span addressable by s_delay_alu.
 static DenseSet<uint64_t>
 collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
-                                  const LLVMState &LS) {
+                                  const LLVMState &LS,
+                                  bool ProtectClauseMembers) {
   DenseSet<uint64_t> Protected;
   unsigned ClauseRemaining = 0;
   unsigned DelayRemaining = 0;
@@ -1625,7 +1627,7 @@ collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
       --DelayRemaining;
     }
 
-    if (DI.Inst.getOpcode() == LS.SClauseOpcode &&
+    if (ProtectClauseMembers && DI.Inst.getOpcode() == LS.SClauseOpcode &&
         DI.Inst.getNumOperands() == 1 && DI.Inst.getOperand(0).isImm())
       ClauseRemaining =
           (static_cast<unsigned>(DI.Inst.getOperand(0).getImm()) & 63u) + 1;
@@ -1672,8 +1674,8 @@ expandStraightLineTrampolines(PatchContext &Ctx,
   DenseMap<uint64_t, size_t> DecodedAt;
   for (size_t I = 0; I != Ctx.Decoded.size(); ++I)
     DecodedAt[Ctx.Decoded[I].Offset] = I;
-  DenseSet<uint64_t> Protected =
-      collectRelocationProtectedOffsets(Ctx.Decoded, Ctx.LS);
+  DenseSet<uint64_t> Protected = collectRelocationProtectedOffsets(
+      Ctx.Decoded, Ctx.LS, !Ctx.Config.RunB0A0Patches);
   DenseSet<uint64_t> IndirectControlFlowFunctions =
       collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
 
@@ -2638,8 +2640,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   // gfx1250 revision is recorded per kernel in the AMDGPU metadata note.
   // Running a B0 object on A0 requires retagging that metadata even when no
-  // machine instruction needed rewriting. Native A0 code generation preserves
-  // s_clause and emits the same instructions as B0 for valid clauses.
+  // machine instruction needed rewriting.
   if (Options.RunB0A0Patches && !Elf.updateGfx1250RevisionMetadata("A0"))
     return AMD_COMGR_STATUS_ERROR;
 

--- a/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-inplace.cpp
@@ -9,6 +9,7 @@
 /// Strong-symbol override for applyInPlacePatches.  Handles instruction
 /// rewrites that fit in the same code size as the original:
 ///
+///   - s_clause                 -> s_nop 0
 ///   - cluster_load             -> global_load    (opcode swap via MCInst +
 ///                                                 MCCodeEmitter)
 ///   - s_barrier_signal_isfirst -> s_barrier_signal
@@ -116,6 +117,14 @@ bool swapOpcode(InternalDecodedInst &DI, uint8_t *Text, const LLVMState &LS,
 static uint32_t applyInPlacePatchesImpl(PatchContext &Ctx, size_t Idx) {
   InternalDecodedInst &DI = Ctx.Decoded[Idx];
   StringRef Mnemonic(DI.Mnemonic);
+
+  if (DI.Inst.getOpcode() == Ctx.LS.SClauseOpcode) {
+    std::memcpy(Ctx.Text + DI.Offset, Ctx.LS.SNopBytes.data(),
+                Ctx.LS.SNopBytes.size());
+    log() << "hotswap: inplace: s_clause -> s_nop 0 at 0x"
+          << utohexstr(DI.Offset) << "\n";
+    return 1;
+  }
 
   StringRef ReplacementAsm = getClusterLoadReplacementAsm(Mnemonic);
   if (!ReplacementAsm.empty()) {

--- a/amd/comgr/test-lit/hotswap-inplace-mixed.s
+++ b/amd/comgr/test-lit/hotswap-inplace-mixed.s
@@ -1,5 +1,5 @@
-// COM: Test HotSwap in-place cluster_load -> global_load patches and verify
-// COM: that valid s_clause instructions are preserved.
+// COM: Test HotSwap in-place cluster_load -> global_load and blanket
+// COM: s_clause -> s_nop 0 patches.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -13,20 +13,20 @@
 // RUN: %llvm-readelf --notes %t.out.elf | \
 // RUN:   %FileCheck --check-prefix=METADATA %s
 
-// COM: cluster_load mnemonics should be gone, replaced by global_load
-// DISASM-NOT: cluster_load_b32
-// DISASM-NOT: cluster_load_b128
-
-// COM: Replacement global_load instructions should be present
-// DISASM-DAG: global_load_b32 v0
-// DISASM-DAG: global_load_b128 v[4:7]
-
-// COM: Native A0 code generation preserves valid clauses.
-// DISASM: s_clause 0x1
-
-// COM: Original global_load instructions should still be there
-// DISASM-DAG: global_load_b32 v10
-// DISASM-DAG: global_load_b32 v11
+// COM: Every s_clause is removed, including both initial and later clauses,
+// COM: while the surrounding in-place rewrites and instructions are retained.
+// DISASM-NOT: s_clause
+// DISASM-LABEL: <test_inplace_kernel>:
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v0
+// DISASM-NEXT: s_wait_loadcnt 0x0
+// DISASM-NEXT: global_load_b128 v[4:7]
+// DISASM-NEXT: s_wait_loadcnt 0x0
+// DISASM-NEXT: s_nop 0
+// DISASM-NEXT: global_load_b32 v10
+// DISASM-NEXT: global_load_b32 v11
+// DISASM-NEXT: s_wait_loadcnt 0x0
+// DISASM-NEXT: s_endpgm
 
 // COM: Every rewritten gfx1250 kernel must be labeled for A0.
 // METADATA-NOT: .gfx1250_revision: B0
@@ -47,6 +47,7 @@
 .p2align 8
 .type test_inplace_kernel,@function
 test_inplace_kernel:
+  s_clause 0x0
   cluster_load_b32 v0, v[2:3], off
   s_wait_loadcnt 0x0
   cluster_load_b128 v[4:7], v[8:9], off


### PR DESCRIPTION
Because of rewriting, it is possible that we make a clause invalid, which can cause gpu faults. As conservative measure, we convert s_clause to s_nop until we have a better analysis that can preserve them.

Note that program correctness cannot depend on s_clause, because clauses can break on context switching, a program depending on clauses has a potential data race.


