### PR TITLE
[comgr][hotswap] Lower wmma_scale16 exactly for FP4/FP6 matrix data

### DIFF
--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -765,6 +765,26 @@ struct VgprAllocator {
     return V;
   }
 
+  /// Allocate \p N contiguous VGPRs above the kernel's VGPR count, base rounded
+  /// up to \p Align. Scattered dead slots below KD can't guarantee contiguity
+  /// or alignment, so this always extends the allocation. Returns the base
+  /// VGPR, or std::nullopt if the block would reach MaxVgprs. Since MaxVgprs is
+  /// 256 on GFX1250, a block that fits stays in VGPR bank 0, so no
+  /// s_set_vgpr_msb switch is needed.
+  std::optional<unsigned> allocContiguousAboveKd(unsigned N,
+                                                 unsigned Align = 2) {
+    unsigned Base = NextAboveKd;
+    if (Align > 1 && (Base % Align) != 0)
+      Base += Align - (Base % Align);
+    if (Base + N > MaxVgprs)
+      return std::nullopt;
+    ExtraAllocated += (Base + N) - NextAboveKd;
+    for (unsigned V = Base; V < Base + N; ++V)
+      LiveAtPoint.set(V);
+    NextAboveKd = Base + N;
+    return Base;
+  }
+
   unsigned extraVgprsNeeded() const { return ExtraAllocated; }
 };
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-hazard.cpp
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Whole-kernel patch for the GFX1250 A0 WMMA/SWMMAC co-execution hazard.
+/// Whole-kernel patch for the gfx1250 WMMA/SWMMAC co-execution hazard.
 /// Detects WMMA/SWMMAC instructions that lack sufficient v_nop separation
 /// before the first overlapping co-executable VALU, and inserts the required
 /// v_nop padding.
@@ -15,6 +15,7 @@
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 
@@ -74,7 +75,7 @@ bool isTerminatingSalu(const MCInst &Inst, const MCInstrInfo &MCII) {
 
 // Checks are ordered most-restrictive-first. If a mnemonic matches
 // multiple substrings (e.g. contains both "_iu8" and "_f16"), the
-// first match wins. Do not reorder without verifying A0 nop counts.
+// first match wins. Do not reorder without verifying the required nop counts.
 WmmaNopReq classifyWmmaNops(StringRef Mnemonic) {
   // Redundant in production (caller filters via isWmmaLike), but kept
   // as a defensive guard since classifyWmmaNops is a public function
@@ -105,30 +106,44 @@ WmmaNopReq classifyWmmaNops(StringRef Mnemonic) {
 
 namespace {
 
-std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
-  const MCInstrInfo &MCII = *Ctx.LS.MCII;
-  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+// Scan a decoded stream for WMMA/SWMMAC -> overlapping co-executable VALU
+// hazards, returning the nop deficits keyed by VALU index (into \p Stream).
+//
+// \p RequireAbsolute picks the nop budget. The original kernel stream (false)
+// already carries the compiler-inserted spacing, so only the extra deficit
+// beyond that matters; freshly emitted trampoline bodies (true) have no such
+// baseline, so the full required count is enforced.
+std::vector<WmmaHazard> scanCoexecHazards(ArrayRef<InternalDecodedInst> Stream,
+                                          const MCInstrInfo &MCII,
+                                          const MCRegisterInfo &MRI,
+                                          bool RequireAbsolute,
+                                          int *WmmaScannedOut = nullptr) {
   std::vector<WmmaHazard> Hazards;
   DenseSet<size_t> PatchedValuIndices;
   int WmmaScanned = 0;
 
-  for (size_t WmmaIdx = 0, E = Ctx.Decoded.size(); WmmaIdx < E; ++WmmaIdx) {
-    const InternalDecodedInst &WmmaDI = Ctx.Decoded[WmmaIdx];
+  for (size_t WmmaIdx = 0, E = Stream.size(); WmmaIdx < E; ++WmmaIdx) {
+    const InternalDecodedInst &WmmaDI = Stream[WmmaIdx];
     if (!isWmmaLike(WmmaDI.Inst, MCII))
       continue;
 
     ++WmmaScanned;
     WmmaNopReq Req = classifyWmmaNops(WmmaDI.Mnemonic);
-    if (Req.A0Nops <= Req.B0Nops)
+    // Target is always the full required count. For the original stream, the
+    // compiler-inserted baseline only gates whether a scan is needed: if the
+    // requirement is no more than that baseline, the existing spacing suffices.
+    // Trampoline bodies have no baseline, so the full count is always enforced.
+    if (!RequireAbsolute && Req.A0Nops <= Req.B0Nops)
       continue;
+    int Target = Req.A0Nops;
 
     int SafeSlots = 0;
     for (size_t ValuIdx = WmmaIdx + 1; ValuIdx < E; ++ValuIdx) {
-      const InternalDecodedInst &Candidate = Ctx.Decoded[ValuIdx];
+      const InternalDecodedInst &Candidate = Stream[ValuIdx];
 
       if (isVNop(Candidate)) {
         ++SafeSlots;
-        if (SafeSlots >= Req.A0Nops)
+        if (SafeSlots >= Target)
           break;
         continue;
       }
@@ -142,17 +157,16 @@ std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
       if (isCoexecutableVALU(Candidate, MCII)) {
         if (!checkVgprOverlap(WmmaDI.Inst, Candidate.Inst, MRI)) {
           ++SafeSlots;
-          if (SafeSlots >= Req.A0Nops)
+          if (SafeSlots >= Target)
             break;
           continue;
         }
 
-        if (SafeSlots < Req.A0Nops &&
-            PatchedValuIndices.insert(ValuIdx).second) {
-          Hazards.push_back({ValuIdx, Req.A0Nops - SafeSlots});
+        if (SafeSlots < Target && PatchedValuIndices.insert(ValuIdx).second) {
+          Hazards.push_back({ValuIdx, Target - SafeSlots});
           log() << "hotswap: WMMA co-exec hazard at 0x"
                 << utohexstr(WmmaDI.Offset) << ": " << WmmaDI.Mnemonic
-                << " needs " << Req.A0Nops << " v_nops, only " << SafeSlots
+                << " needs " << Target << " v_nops, only " << SafeSlots
                 << " found before " << Candidate.Mnemonic << " at 0x"
                 << utohexstr(Candidate.Offset) << "\n";
         }
@@ -163,17 +177,65 @@ std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
     }
   }
 
+  if (WmmaScannedOut)
+    *WmmaScannedOut = WmmaScanned;
+  return Hazards;
+}
+
+std::vector<WmmaHazard> findWmmaCoexecHazards(const PatchContext &Ctx) {
+  int WmmaScanned = 0;
+  std::vector<WmmaHazard> Hazards =
+      scanCoexecHazards(Ctx.Decoded, *Ctx.LS.MCII, *Ctx.LS.MRI,
+                        /*RequireAbsolute=*/false, &WmmaScanned);
   log() << "hotswap: WMMA co-exec validation: " << Hazards.size()
         << " hazards (" << WmmaScanned << " WMMA instructions scanned)\n";
   return Hazards;
+}
+
+// Fail-closed safety net for trampoline bodies emitted by other passes (e.g.
+// the exact scale16 K-split): they contain their own WMMAs but were never in
+// Ctx.Decoded, so findWmmaCoexecHazards cannot see them, and they carry no
+// compiler-inserted spacing, so each is checked against the full required
+// count. A residual deficit means a pass shipped an unsafe WMMA/VALU ordering,
+// so we refuse the rewrite. Runs before branch fixup/coalescing, so each
+// T.Bytes is still {body, reserved-return-slot}; the reserved tail is trimmed
+// before decoding since its zero bytes are not real instructions.
+void validateTrampolineCoexec(PatchContext &Ctx) {
+  const MCInstrInfo &MCII = *Ctx.LS.MCII;
+  const MCRegisterInfo &MRI = *Ctx.LS.MRI;
+
+  for (const Trampoline &T : Ctx.OutTrampolines) {
+    unsigned Reserve = T.Long ? SetPcReturnReserveBytes : MinInstSize;
+    if (T.Bytes.size() <= Reserve)
+      continue;
+    size_t BodySize = T.Bytes.size() - Reserve;
+
+    std::vector<InternalDecodedInst> Body;
+    if (!decodeTextSection(T.Bytes.data(), BodySize, Ctx.LS, Body))
+      continue;
+
+    std::vector<WmmaHazard> TH =
+        scanCoexecHazards(Body, MCII, MRI, /*RequireAbsolute=*/true);
+    if (!TH.empty()) {
+      log() << "hotswap: error: WMMA co-exec hazard unmitigated in trampoline "
+               "for site 0x"
+            << utohexstr(T.OriginalOffset) << " (" << TH.size()
+            << " site(s)); failing closed\n";
+      Ctx.RequiredPatchFailed = true;
+    }
+  }
 }
 
 } // anonymous namespace
 
 static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
   std::vector<WmmaHazard> Hazards = findWmmaCoexecHazards(Ctx);
-  if (Hazards.empty())
+  if (Hazards.empty()) {
+    // Even with no original-stream hazards, other passes may have emitted
+    // WMMA-bearing trampolines that need their own separation validated.
+    validateTrampolineCoexec(Ctx);
     return 0;
+  }
 
   uint32_t Patched = 0;
   for (const WmmaHazard &H : Hazards) {
@@ -202,6 +264,10 @@ static uint32_t applyWmmaHazardPatchImpl(PatchContext &Ctx) {
     ++Patched;
   }
 
+  // Validate every emitted trampoline (including the ones just added above and
+  // any WMMA-bearing bodies from other passes) against the full required
+  // budget.
+  validateTrampolineCoexec(Ctx);
   return Patched;
 }
 

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -6,83 +6,70 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Scratch-patch pass for Case 3 of the B0-to-A0 scratch-patch pipeline:
-/// WMMA Scale16 (block-16) to regular Scale (block-32) decomposition.
+/// Lowers block-16 scaled WMMA (v_wmma_scale16_f32_*) for gfx1250 hardware that
+/// only has block-32 scaled WMMA (v_wmma_scale_f32_*). Done exactly, or failing
+/// closed when it cannot be applied.
 ///
-/// GFX1250 B0 uses VOP3PX3-encoded `v_wmma_scale16_f32_*` instructions with
-/// 64-bit (B64) scale operands carrying block-16 scale granularity. A0 only
-/// supports VOP3PX2-encoded `v_wmma_scale_f32_*` with 32-bit (B32) scale
-/// operands at block-32 granularity. This file reduces block-16 scales to
-/// block-32 via byte-pair max, then rewrites the encoding from VOP3PX3 to
-/// VOP3PX2.
+/// A block-32 op applies one (scaleA, scaleB) pair across all 32 K-elements of
+/// a block, so it cannot honor both block-16 sub-scales of that block at once.
+/// The earlier approach collapsed each sub-scale pair with a byte-pair max,
+/// which scaled the smaller half by a power of two and silently miscompiled
+/// scaled kernels.
 ///
-/// Covered instructions:
-///   1. v_wmma_scale16_f32_16x16x128_f8f6f4 — decompose to regular Scale
-///   2. v_wmma_scale16_f32_32x16x128_f4     — split 32x16 into 2× 16x16,
-///      then decompose each half to regular Scale
+/// Exact lowering (K-split): the scale is applied per block after the dot and
+/// before the accumulate, so we split each block-16 WMMA into two block-32
+/// WMMAs chained through the accumulator, each seeing one 16-wide K-subblock:
 ///
-/// Design document: docs/scratch-patches/3_wmma_scale16_decomp/README.md
+///   pass-low : A' = low-16 K-subblock of A, rest zeroed; even scale bytes;
+///              write D (src2 = original C).
+///   pass-high: A' = high-16 K-subblock of A, rest zeroed; odd scale bytes;
+///              accumulate (src2 = D).
+///
+/// Masking A alone suffices since A==0 => A*B==0. How a 16-K subblock maps to
+/// lanes or VGPRs depends on the matrix-A format:
+///   * FP8/BF8: subblocks split by wave lane, so a lane mask isolates one.
+///   * FP4/FP6/BF6: a whole 32-block sits in one lane group and the split runs
+///     along the VGPR index, so we null the opposite subblock's VGPRs (a lane
+///     mask would wrongly zero whole 32-blocks).
+/// Each pass's block-32 scale is a byte-gather of the block-16 scale bytes:
+/// even bytes feed the low subblocks, odd bytes the high ones.
+///
+/// The masked A copy lands in a contiguous VGPR block allocated above the
+/// kernel's VGPR count and below MaxVgprs (256 on GFX1250), so it stays in VGPR
+/// bank 0 and needs no s_set_vgpr_msb switch.
+///
+/// Fail-closed fallback: when the scratch budget (A-width VGPRs plus a few
+/// scale/temp VGPRs and one scratch SGPR) is unavailable, the pass marks the
+/// patch failed so the rewrite returns an error instead of a miscompile. A loud
+/// failure beats silent wrong results.
+///
+/// The 32x16x128_f4 (M=32) variant also needs an M-split; it is not lowered
+/// exactly yet and fails closed.
 ///
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace llvm;
 
 namespace COMGR {
 namespace hotswap {
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
+// Both Scale16 (VOP3PX3) and regular Scale (VOP3PX2) are 128-bit (16-byte)
+// fused instructions: an 8-byte LD_SCALE uop followed by an 8-byte base WMMA
+// uop.
+static constexpr unsigned VOP3PXSize = 16;
+
+// AMDGPU SRC operand encoding: VGPRs are 256 + N.
+static constexpr unsigned VgprEncBase = 256;
 
 static std::string vgprName(unsigned N) { return ("v" + Twine(N)).str(); }
-
-// ---------------------------------------------------------------------------
-// VOP3PX3 encoding field accessors
-// ---------------------------------------------------------------------------
-//
-// VOP3PX3 and VOP3PX2 are both 128-bit (16-byte) fused instructions: an
-// 8-byte LD_SCALE uop followed by an 8-byte base WMMA uop.  The encoding
-// differences between VOP3PX3 (Scale16) and VOP3PX2 (regular Scale) are:
-//   - Byte[2]: LD_SCALE opcode (0x3A for Scale16, 0x35 for regular Scale)
-//   - SCALE_SRC field interpretation (B64 vs B32)
-//
-// Field positions within the LD_SCALE uop (first 8 bytes):
-//   SCALE_SRC0: bits [40:32] = byte[4] bits [7:0] + byte[5] bit[0]
-//   SCALE_SRC1: bits [49:41] = byte[5] bits [7:1] + byte[6] bits [1:0]
-//
-// Keep these as explicit byte masks rather than C++ bitfields: the fields
-// cross byte boundaries, and bitfield layout is implementation-defined.
-
-static unsigned extractScaleSrc0(const uint8_t *Raw) {
-  return Raw[4] | ((Raw[5] & 0x01) << 8);
-}
-
-static unsigned extractScaleSrc1(const uint8_t *Raw) {
-  return ((Raw[5] >> 1) & 0x7F) | ((Raw[6] & 0x03) << 7);
-}
-
-// Write a 9-bit SCALE_SRC0 value into bits [40:32], preserving all
-// other bits.  Caller must ensure Raw points at 16+ writable bytes.
-static void writeScaleSrc0(uint8_t *Raw, unsigned Enc) {
-  Raw[4] = Enc & 0xFF;
-  Raw[5] = (Raw[5] & 0xFE) | ((Enc >> 8) & 0x01);
-}
-
-// Write a 9-bit SCALE_SRC1 value into bits [49:41], preserving all
-// other bits.  Must be called AFTER writeScaleSrc0 to avoid clobbering the
-// shared byte [5].
-static void writeScaleSrc1(uint8_t *Raw, unsigned Enc) {
-  Raw[5] = (Raw[5] & 0x01) | ((Enc & 0x7F) << 1);
-  Raw[6] = (Raw[6] & 0xFC) | ((Enc >> 7) & 0x03);
-}
-
-// AMDGPU SRC operand encoding: VGPRs are encoded as 256 + N.
-static constexpr unsigned VgprEncBase = 256;
 
 static bool isVgprEncoding(unsigned Enc) { return Enc >= VgprEncBase; }
 
@@ -92,64 +79,56 @@ static std::optional<unsigned> decodeVgprEncoding(unsigned Enc) {
   return Enc - VgprEncBase;
 }
 
-// ---------------------------------------------------------------------------
-// Block-16 → block-32 scale reduction via VALU preamble
-// ---------------------------------------------------------------------------
-//
-// Each B64 scale operand holds 8 × 8-bit block-16 scales across two VGPRs
-// (Vn and Vn+1).  The reduction computes max(even, odd) for each adjacent
-// byte pair, producing 4 × 8-bit block-32 scales in one VGPR:
-//
-//   max(Vn[7:0],     Vn[15:8])    → Vs[7:0]
-//   max(Vn[23:16],   Vn[31:24])   → Vs[15:8]
-//   max(Vn+1[7:0],   Vn+1[15:8])  → Vs[23:16]
-//   max(Vn+1[23:16], Vn+1[31:24]) → Vs[31:24]
-//
-// Max-exponent is the recommended strategy for E8M0 scales (pure exponent,
-// bias 127): taking the larger exponent ensures no element overflows the
-// scale range.  For E5M3/E4M3 scales (only valid with FP4 matrices), max
-// still provides a safe upper bound.
+// -- LD_SCALE uop field accessors (bytes 0-7) --------------------------------
+//   SCALE_SRC0: bits [40:32] = byte[4] + byte[5] bit[0]
+//   SCALE_SRC1: bits [49:41] = byte[5] bits[7:1] + byte[6] bits[1:0]
 
-static void emitScaleReduction(raw_string_ostream &OS, StringRef SrcLo,
-                               StringRef SrcHi, StringRef Dst, StringRef T1,
-                               StringRef T2) {
-  // Byte pair 0: max(SrcLo[7:0], SrcLo[15:8]) → Dst[7:0]
-  OS << "v_and_b32 " << T1 << ", 0xFF, " << SrcLo << "\n";
-  OS << "v_bfe_u32 " << T2 << ", " << SrcLo << ", 8, 8\n";
-  OS << "v_max_u32 " << Dst << ", " << T1 << ", " << T2 << "\n";
-
-  // Byte pair 1: max(SrcLo[23:16], SrcLo[31:24]) → Dst[15:8]
-  OS << "v_bfe_u32 " << T1 << ", " << SrcLo << ", 16, 8\n";
-  OS << "v_lshrrev_b32 " << T2 << ", 24, " << SrcLo << "\n";
-  OS << "v_max_u32 " << T1 << ", " << T1 << ", " << T2 << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T1 << ", 8, " << Dst << "\n";
-
-  // Byte pair 2: max(SrcHi[7:0], SrcHi[15:8]) → Dst[23:16]
-  OS << "v_and_b32 " << T1 << ", 0xFF, " << SrcHi << "\n";
-  OS << "v_bfe_u32 " << T2 << ", " << SrcHi << ", 8, 8\n";
-  OS << "v_max_u32 " << T1 << ", " << T1 << ", " << T2 << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T1 << ", 16, " << Dst << "\n";
-
-  // Byte pair 3: max(SrcHi[23:16], SrcHi[31:24]) → Dst[31:24]
-  OS << "v_bfe_u32 " << T1 << ", " << SrcHi << ", 16, 8\n";
-  OS << "v_lshrrev_b32 " << T2 << ", 24, " << SrcHi << "\n";
-  OS << "v_max_u32 " << T1 << ", " << T1 << ", " << T2 << "\n";
-  OS << "v_lshl_or_b32 " << Dst << ", " << T1 << ", 24, " << Dst << "\n";
+static unsigned extractScaleSrc0(const uint8_t *Raw) {
+  return Raw[4] | ((Raw[5] & 0x01) << 8);
 }
 
-// ---------------------------------------------------------------------------
-// VOP3PX3 → VOP3PX2 encoding rewrite
-// ---------------------------------------------------------------------------
-//
-// Both encodings are 128-bit (16-byte) fused instructions.  The rewrite:
-//   1. Replaces byte[2] (LD_SCALE opcode: 0x3A → 0x35)
-//   2. Replaces SCALE_SRC0/SCALE_SRC1 with scratch VGPR encodings
-//
-// The opcode constant is obtained by assembling a template VOP3PX2
-// instruction, keeping the code free of hardcoded encoding bits.
+static unsigned extractScaleSrc1(const uint8_t *Raw) {
+  return ((Raw[5] >> 1) & 0x7F) | ((Raw[6] & 0x03) << 7);
+}
 
-static constexpr unsigned VOP3PXSize = 16;
+static void writeScaleSrc0(uint8_t *Raw, unsigned Enc) {
+  Raw[4] = Enc & 0xFF;
+  Raw[5] = (Raw[5] & 0xFE) | ((Enc >> 8) & 0x01);
+}
 
+// Must be called after writeScaleSrc0 (both share byte[5]).
+static void writeScaleSrc1(uint8_t *Raw, unsigned Enc) {
+  Raw[5] = (Raw[5] & 0x01) | ((Enc & 0x7F) << 1);
+  Raw[6] = (Raw[6] & 0xFC) | ((Enc >> 7) & 0x03);
+}
+
+// -- Base WMMA uop field accessors (bytes 8-15) ------------------------------
+//   VDST: byte[8] (8-bit raw VGPR number, no +256)
+//   SRC0: byte[12] + byte[13] bit[0] (9-bit; matrix A)
+//   SRC2: byte[14] bits[7:2] + byte[15] bits[2:0] (9-bit; accumulator C)
+
+static unsigned extractVdst(const uint8_t *Raw) { return Raw[8]; }
+
+static void writeSrc0(uint8_t *Raw, unsigned Enc) {
+  Raw[12] = Enc & 0xFF;
+  Raw[13] = (Raw[13] & 0xFE) | ((Enc >> 8) & 0x01);
+}
+
+static void writeSrc2(uint8_t *Raw, unsigned Enc) {
+  Raw[14] = (Raw[14] & 0x03) | ((Enc & 0x3F) << 2);
+  Raw[15] = (Raw[15] & 0xF8) | ((Enc >> 6) & 0x07);
+}
+
+// -- VOP3PX3 -> VOP3PX2 encoding rewrite -------------------------------------
+//
+// Turns a block-16 (VOP3PX3) scaled WMMA into a block-32 (VOP3PX2) one: copies
+// the 16-byte instruction, swaps the LD_SCALE opcode byte (taken from a
+// template assembly so no opcode bits are hardcoded), writes the new block-32
+// scale sources, and bakes scale_src2 = VGPR0. scale_src2 is unused on
+// VOP3PX2, but leaving it 0 makes the SQ mis-decode it as an SGPR and stall;
+// baking it also keeps the bytes idempotent across passes. All other base-WMMA
+// bytes (VDST, SRC0/1/2, matrix formats, neg modifiers) survive the byte copy
+// and are patched by the caller.
 static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
                                                   unsigned OrigSize,
                                                   unsigned NewScaleSrc0Enc,
@@ -167,79 +146,212 @@ static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
   }
 
   SmallVector<uint8_t> Rewritten(OrigRaw, OrigRaw + OrigSize);
-
-  // The LD_SCALE opcode lives at byte[2]: 0x3A for Scale16 (VOP3PX3) and
-  // 0x35 for regular Scale (VOP3PX2).  All other base WMMA encoding bytes
-  // are identical between the two variants.
   Rewritten[2] = Template[2];
-
   writeScaleSrc0(Rewritten.data(), NewScaleSrc0Enc);
-
-  // Must be called after writeScaleSrc0 because both share byte [5].
   writeScaleSrc1(Rewritten.data(), NewScaleSrc1Enc);
-
-  // scale_src2 [58:50] = 0x100 (VGPR0). The field is architecturally
-  // unused on VOP3PX2 but if left at 0 the SQ mis-decodes it as an SGPR
-  // reference and stalls the SALU for 3 cycles. The in-place
-  // applyVop3px2Src2Fix pass patches this on user-emitted v_wmma_scale_*
-  // instructions in .text. Trampoline-emitted forms are NOT in Decoded[]
-  // on the first rewrite pass, so the in-place fix doesn't see them; on
-  // a second rewrite the trampolines have been appended to .text and the
-  // fix fires, producing different bytes than pass 1 -- breaking
-  // idempotency. Baking 0x100 here keeps wrap-emitted trampolines
-  // bit-identical across passes and avoids the SALU stall. Same trick
-  // PR #2 (VOP3PX2 wrap pass) uses in its LdScalePrefix bytes.
-  Rewritten[6] &= 0x03; // clear scale_src2[5:0]
-  Rewritten[7] =
-      (Rewritten[7] & 0xF8) | 0x04; // set scale_src2[8]=1, clear [7:6]
-
+  Rewritten[6] &= 0x03;                        // clear scale_src2[5:0]
+  Rewritten[7] = (Rewritten[7] & 0xF8) | 0x04; // scale_src2[8]=1, clear [7:6]
   return Rewritten;
 }
 
+// -- Block-16 scale byte-gather (deinterleave) -------------------------------
+//
+// Each B64 scale operand holds 8 8-bit block-16 scales across Vn (bytes 0-3)
+// and Vn+1 (bytes 4-7). The block-32 scale for K-block j (j=0..3) is the
+// low-subblock scale (even byte 2j) for pass-low and the high-subblock scale
+// (odd byte 2j+1) for pass-high, packed into one VGPR as
+// [byte0..3] = k-block 0..3.
+
+static void emitGatherEven(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
+                           StringRef Dst, StringRef T) {
+  // Dst = { Lo[7:0], Lo[23:16], Hi[7:0], Hi[23:16] } (bytes 0,2,4,6)
+  OS << "v_and_b32 " << Dst << ", 0xff, " << Lo << "\n";
+  OS << "v_bfe_u32 " << T << ", " << Lo << ", 16, 8\n";
+  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 8, " << Dst << "\n";
+  OS << "v_and_b32 " << T << ", 0xff, " << Hi << "\n";
+  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 16, " << Dst << "\n";
+  OS << "v_bfe_u32 " << T << ", " << Hi << ", 16, 8\n";
+  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 24, " << Dst << "\n";
+}
+
+static void emitGatherOdd(raw_string_ostream &OS, StringRef Lo, StringRef Hi,
+                          StringRef Dst, StringRef T) {
+  // Dst = { Lo[15:8], Lo[31:24], Hi[15:8], Hi[31:24] } (bytes 1,3,5,7)
+  OS << "v_bfe_u32 " << Dst << ", " << Lo << ", 8, 8\n";
+  OS << "v_bfe_u32 " << T << ", " << Lo << ", 24, 8\n";
+  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 8, " << Dst << "\n";
+  OS << "v_bfe_u32 " << T << ", " << Hi << ", 8, 8\n";
+  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 16, " << Dst << "\n";
+  OS << "v_lshrrev_b32 " << T << ", 24, " << Hi << "\n";
+  OS << "v_lshl_or_b32 " << Dst << ", " << T << ", 24, " << Dst << "\n";
+}
+
+// A' = mask ? A : 0, per lane, for W consecutive VGPRs from ABase into SBase.
+// MaskImm selects the wave lanes to keep (0x0000FFFF = lanes 0-15).
+//
+// FP8/BF8 only: a K=32 block's low-16 K-subblock lives in lanes 0-15 and the
+// high-16 in lanes 16-31, so a lane mask isolates a subblock.
+static void emitLaneMaskCopy(raw_string_ostream &OS, StringRef MaskSgpr,
+                             uint32_t MaskImm, unsigned SBase, unsigned ABase,
+                             unsigned W) {
+  OS << "s_mov_b32 " << MaskSgpr << ", 0x" << utohexstr(MaskImm) << "\n";
+  for (unsigned I = 0; I < W; ++I)
+    OS << "v_cndmask_b32_e64 " << vgprName(SBase + I) << ", 0, "
+       << vgprName(ABase + I) << ", " << MaskSgpr << "\n";
+}
+
+// A' keeps the VGPRs of the low (KeepLow=true) or high 16-K subblocks and zeros
+// the rest, copying W consecutive VGPRs from ABase into SBase.
+//
+// FP4/FP6/BF6: a whole K=32 block sits in one lane group and the low-16/high-16
+// split runs along the VGPR index. Subblocks are SubW consecutive VGPRs (FP4=2,
+// FP6=3); even-indexed ones are the low halves, odd-indexed the high. A lane
+// mask would wrongly zero whole 32-blocks here, so we null the opposite
+// subblock's VGPRs instead.
+static void emitVgprSelectCopy(raw_string_ostream &OS, bool KeepLow,
+                               unsigned SBase, unsigned ABase, unsigned W,
+                               unsigned SubW) {
+  for (unsigned I = 0; I < W; ++I) {
+    bool IsLow = ((I / SubW) % 2) == 0;
+    if (IsLow == KeepLow)
+      OS << "v_mov_b32 " << vgprName(SBase + I) << ", " << vgprName(ABase + I)
+         << "\n";
+    else
+      OS << "v_mov_b32 " << vgprName(SBase + I) << ", 0\n";
+  }
+}
+
+// Parse the matrix-A (src0) VGPR range from the printer's canonical form.
+struct VgprRange {
+  unsigned Base;
+  unsigned Width;
+};
+
+static std::optional<VgprRange>
+matrixAOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI) {
+  SmallString<256> Buf;
+  raw_svector_ostream OS(Buf);
+  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
+                         OS);
+  StringRef S = StringRef(Buf).trim();
+  size_t MnemEnd = S.find_first_of(" \t");
+  if (MnemEnd == StringRef::npos)
+    return std::nullopt;
+  StringRef Rest = S.substr(MnemEnd).ltrim();
+  // Operand 0 = vdst, operand 1 = src0 (matrix A).
+  size_t Comma0 = Rest.find(',');
+  if (Comma0 == StringRef::npos)
+    return std::nullopt;
+  Rest = Rest.substr(Comma0 + 1).ltrim();
+  size_t Comma1 = Rest.find(',');
+  StringRef A = (Comma1 == StringRef::npos) ? Rest : Rest.substr(0, Comma1);
+  A = A.trim();
+  if (!A.starts_with("v[") || !A.ends_with("]"))
+    return std::nullopt;
+  StringRef Inside = A.drop_front(2).drop_back(1);
+  StringRef LoS, HiS;
+  std::tie(LoS, HiS) = Inside.split(':');
+  unsigned Lo = 0, Hi = 0;
+  if (LoS.getAsInteger(10, Lo) || HiS.getAsInteger(10, Hi) || Hi < Lo)
+    return std::nullopt;
+  return VgprRange{Lo, Hi - Lo + 1};
+}
+
+// Matrix-A K-subblock masking scheme, chosen by the matrix-A data format.
+// The K-split must isolate each 16-K subblock, and how a subblock maps to
+// lanes/VGPRs is format-dependent:
+//   * FP8/BF8: subblocks split by wave lane  -> Lane mask.
+//   * FP6/BF6: subblocks split by VGPR index -> Vgpr select, 3 VGPRs/subblock.
+//   * FP4    : subblocks split by VGPR index -> Vgpr select, 2 VGPRs/subblock.
+enum class AMaskScheme { Lane, Vgpr };
+struct AMaskPlan {
+  AMaskScheme Scheme;
+  unsigned SubW; // VGPRs per 16-K subblock (Vgpr scheme only)
+};
+
+// Parse "matrix_a_fmt:MATRIX_FMT_<fmt>" from the printer's canonical form and
+// map it to a masking plan. FP8 is the default when the modifier is omitted.
+static std::optional<AMaskPlan> matrixAMaskPlan(PatchContext &Ctx,
+                                                const InternalDecodedInst &DI) {
+  SmallString<256> Buf;
+  raw_svector_ostream OS(Buf);
+  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
+                         OS);
+  StringRef S(Buf);
+  StringRef Key = "matrix_a_fmt:MATRIX_FMT_";
+  StringRef Fmt = "FP8"; // omitted modifier => default FP8
+  size_t P = S.find(Key);
+  if (P != StringRef::npos) {
+    StringRef R = S.substr(P + Key.size());
+    size_t E = R.find_first_of(" \t\r\n");
+    Fmt = (E == StringRef::npos) ? R : R.substr(0, E);
+  }
+  if (Fmt == "FP8" || Fmt == "BF8")
+    return AMaskPlan{AMaskScheme::Lane, /*SubW=*/4};
+  if (Fmt == "FP6" || Fmt == "BF6")
+    return AMaskPlan{AMaskScheme::Vgpr, /*SubW=*/3};
+  if (Fmt == "FP4")
+    return AMaskPlan{AMaskScheme::Vgpr, /*SubW=*/2};
+  return std::nullopt; // unknown format -> caller fails closed
+}
+
+// Fail the whole rewrite closed rather than emit a miscompile.
+static uint32_t failClosed(PatchContext &Ctx, const InternalDecodedInst &DI,
+                           const Twine &Why) {
+  log() << "hotswap: error: wmma_scale16: " << DI.Mnemonic << " at offset 0x"
+        << utohexstr(DI.Offset) << ": " << Why
+        << "; refusing to return a miscompiled code object.\n";
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
-// v_wmma_scale16_f32_16x16x128_f8f6f4 → v_wmma_scale_f32_16x16x128_f8f6f4
+// v_wmma_scale16_f32_16x16x128_f8f6f4 -> exact K-split
 // ---------------------------------------------------------------------------
 
 static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   const InternalDecodedInst &DI = Ctx.Decoded[Idx];
 
-  if (DI.Size != VOP3PXSize) {
-    log() << "hotswap: error: wmma_scale16: unexpected inst size " << DI.Size
-          << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
+  if (DI.Size != VOP3PXSize)
+    return failClosed(Ctx, DI, "unexpected instruction size " + Twine(DI.Size));
 
-  // Skip offsets another patch has already claimed (Trampoline entries
-  // are appended to OutTrampolines before fixupTrampolineBranches
-  // overwrites the original site with s_branch). Mirrors PR #2's wrap
-  // pass; the previous `Decoded[Idx-1] == s_branch` heuristic never
-  // fired meaningfully because Decoded[] is built from the original
-  // .text and the dispatcher's mnemonic narrowing already filters out
-  // sites the patch has rewritten on a re-rewrite.
+  // Skip offsets a prior pass/rewrite already claimed (idempotency).
   for (const Trampoline &T : Ctx.OutTrampolines)
     if (T.OriginalOffset == DI.Offset)
       return 0;
 
   const uint8_t *Raw = Ctx.Text + DI.Offset;
 
-  unsigned ScaleSrc0Enc = extractScaleSrc0(Raw);
-  unsigned ScaleSrc1Enc = extractScaleSrc1(Raw);
+  std::optional<unsigned> ScaleABase =
+      decodeVgprEncoding(extractScaleSrc0(Raw));
+  std::optional<unsigned> ScaleBBase =
+      decodeVgprEncoding(extractScaleSrc1(Raw));
+  if (!ScaleABase || !ScaleBBase)
+    return failClosed(Ctx, DI, "non-VGPR block-16 scale operand");
 
-  std::optional<unsigned> Src0Base = decodeVgprEncoding(ScaleSrc0Enc);
-  std::optional<unsigned> Src1Base = decodeVgprEncoding(ScaleSrc1Enc);
-  if (!Src0Base || !Src1Base) {
-    log() << "hotswap: error: wmma_scale16: unsupported non-VGPR scale "
-          << "encoding at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
+  unsigned ScaleALo = *ScaleABase, ScaleAHi = ScaleALo + 1;
+  unsigned ScaleBLo = *ScaleBBase, ScaleBHi = ScaleBLo + 1;
 
-  bool NeedReductionA = true;
-  bool NeedReductionB = true;
+  std::optional<VgprRange> ARange = matrixAOperandRange(Ctx, DI);
+  if (!ARange)
+    return failClosed(Ctx, DI, "could not determine matrix-A VGPR range");
+  unsigned ABase = ARange->Base;
+  unsigned AWidth = ARange->Width;
 
-  unsigned Src0Lo = *Src0Base;
-  unsigned Src0Hi = Src0Lo + 1;
-  unsigned Src1Lo = *Src1Base;
-  unsigned Src1Hi = Src1Lo + 1;
+  // The masking scheme depends on the matrix-A data format.
+  std::optional<AMaskPlan> Plan = matrixAMaskPlan(Ctx, DI);
+  if (!Plan)
+    return failClosed(Ctx, DI,
+                      "unrecognized matrix_a_fmt for K-subblock split");
+  // For the VGPR-select scheme the 16-K subblocks must pair up (low/high)
+  // across the matrix-A VGPRs; a partial trailing subblock would be malformed
+  // input.
+  if (Plan->Scheme == AMaskScheme::Vgpr &&
+      (Plan->SubW == 0 || AWidth % (2 * Plan->SubW) != 0))
+    return failClosed(Ctx, DI,
+                      "matrix-A width " + Twine(AWidth) +
+                          " not a multiple of subblock pair " +
+                          Twine(2 * Plan->SubW));
 
   std::string KernelName =
       Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
@@ -250,82 +362,114 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdCount,
                       Ctx.Config.MaxVgprs);
 
-  // Scratch allocation: 1 reduced-scale VGPR per operand needing reduction,
-  // plus 2 shared temporaries for byte extraction/max.
-  std::optional<unsigned> ScratchA, ScratchB, T1, T2;
-  unsigned ScratchCount = 0;
+  // Four block-32 scale VGPRs (A/B x low/high) plus one byte-extraction temp,
+  // then a contiguous, even-aligned block for the masked A copy.
+  std::optional<unsigned> ScaleAloReg = Alloc.alloc();
+  std::optional<unsigned> ScaleBloReg = Alloc.alloc();
+  std::optional<unsigned> ScaleAhiReg = Alloc.alloc();
+  std::optional<unsigned> ScaleBhiReg = Alloc.alloc();
+  std::optional<unsigned> TmpReg = Alloc.alloc();
+  std::optional<unsigned> SBase =
+      Alloc.allocContiguousAboveKd(AWidth, /*Align=*/2);
+  if (!ScaleAloReg || !ScaleBloReg || !ScaleAhiReg || !ScaleBhiReg || !TmpReg ||
+      !SBase)
+    return failClosed(Ctx, DI, "insufficient scratch VGPRs for exact K-split");
 
-  if (NeedReductionA) {
-    ScratchA = Alloc.alloc();
-    ++ScratchCount;
-  }
-  if (NeedReductionB) {
-    ScratchB = Alloc.alloc();
-    ++ScratchCount;
-  }
-  if (NeedReductionA || NeedReductionB) {
-    T1 = Alloc.alloc();
-    T2 = Alloc.alloc();
-    ScratchCount += 2;
-  }
-
-  if ((NeedReductionA && !ScratchA) || (NeedReductionB && !ScratchB) ||
-      ((NeedReductionA || NeedReductionB) && (!T1 || !T2))) {
-    log() << "hotswap: error: wmma_scale16: unable to allocate " << ScratchCount
-          << " scratch VGPRs at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
-
-  // --- Build VALU preamble for scale reduction ---
-  std::string Asm;
-  raw_string_ostream AsmOS(Asm);
-
-  if (NeedReductionA)
-    emitScaleReduction(AsmOS, vgprName(Src0Lo), vgprName(Src0Hi),
-                       vgprName(*ScratchA), vgprName(*T1), vgprName(*T2));
-  if (NeedReductionB)
-    emitScaleReduction(AsmOS, vgprName(Src1Lo), vgprName(Src1Hi),
-                       vgprName(*ScratchB), vgprName(*T1), vgprName(*T2));
-
-  SmallVector<uint8_t> PreambleBytes;
-  if (NeedReductionA || NeedReductionB) {
-    PreambleBytes = assembleInstructions(Asm, Ctx.LS);
-    if (PreambleBytes.empty()) {
-      log() << "hotswap: error: wmma_scale16: preamble assembly failed at "
-            << "offset 0x" << utohexstr(DI.Offset) << "\n";
-      return 0;
-    }
+  // The lane-mask scheme (FP8/BF8) needs one scratch SGPR for the wave-lane
+  // bitmask; the VGPR-select scheme (FP4/FP6) uses plain v_mov and needs none.
+  std::optional<SafeSgprScratchBlock> MaskSgpr;
+  std::string MaskS;
+  if (Plan->Scheme == AMaskScheme::Lane) {
+    MaskSgpr =
+        findSafeSgprScratchBlock(Ctx, DI.Offset, /*Count=*/1,
+                                 /*Alignment=*/1, "wmma_scale16 lane mask");
+    if (!MaskSgpr)
+      return failClosed(Ctx, DI, "no scratch SGPR for lane mask");
+    MaskS = ("s" + Twine(MaskSgpr->Base)).str();
   }
 
-  // --- Rewrite the WMMA encoding from VOP3PX3 → VOP3PX2 ---
-  unsigned NewSrc0Enc =
-      NeedReductionA ? (VgprEncBase + *ScratchA) : ScaleSrc0Enc;
-  unsigned NewSrc1Enc =
-      NeedReductionB ? (VgprEncBase + *ScratchB) : ScaleSrc1Enc;
+  // Preamble + pass-low masked copy (assembled together), then pass-high copy.
+  std::string PreAsm, HiAsm;
+  raw_string_ostream PreOS(PreAsm), HiOS(HiAsm);
 
-  SmallVector<uint8_t> WmmaBytes =
-      rewriteScale16ToScale(Raw, DI.Size, NewSrc0Enc, NewSrc1Enc, Ctx.LS);
-  if (WmmaBytes.empty())
-    return 0;
+  emitGatherEven(PreOS, vgprName(ScaleALo), vgprName(ScaleAHi),
+                 vgprName(*ScaleAloReg), vgprName(*TmpReg));
+  emitGatherEven(PreOS, vgprName(ScaleBLo), vgprName(ScaleBHi),
+                 vgprName(*ScaleBloReg), vgprName(*TmpReg));
+  emitGatherOdd(PreOS, vgprName(ScaleALo), vgprName(ScaleAHi),
+                vgprName(*ScaleAhiReg), vgprName(*TmpReg));
+  emitGatherOdd(PreOS, vgprName(ScaleBLo), vgprName(ScaleBHi),
+                vgprName(*ScaleBhiReg), vgprName(*TmpReg));
+  if (Plan->Scheme == AMaskScheme::Lane) {
+    // pass-low keeps lanes 0-15 (low-16 subblocks); pass-high lanes 16-31.
+    emitLaneMaskCopy(PreOS, MaskS, 0x0000FFFFu, *SBase, ABase, AWidth);
+    emitLaneMaskCopy(HiOS, MaskS, 0xFFFF0000u, *SBase, ABase, AWidth);
+  } else {
+    // pass-low keeps the low-16 subblock VGPRs; pass-high the high-16 ones.
+    emitVgprSelectCopy(PreOS, /*KeepLow=*/true, *SBase, ABase, AWidth,
+                       Plan->SubW);
+    emitVgprSelectCopy(HiOS, /*KeepLow=*/false, *SBase, ABase, AWidth,
+                       Plan->SubW);
+  }
 
-  // --- Concatenate: VALU preamble + rewritten WMMA → replacement ---
+  SmallVector<uint8_t> PreBytes = assembleInstructions(PreAsm, Ctx.LS);
+  SmallVector<uint8_t> HiBytes = assembleInstructions(HiAsm, Ctx.LS);
+  if (PreBytes.empty() || HiBytes.empty())
+    return failClosed(Ctx, DI, "preamble assembly failed");
+
+  // pass-low WMMA: matrix A = masked copy, scales = even-byte gathers, src2 =
+  // original C (preserved by the byte copy).
+  SmallVector<uint8_t> WmmaLo =
+      rewriteScale16ToScale(Raw, DI.Size, VgprEncBase + *ScaleAloReg,
+                            VgprEncBase + *ScaleBloReg, Ctx.LS);
+  if (WmmaLo.empty())
+    return failClosed(Ctx, DI, "pass-low WMMA rewrite failed");
+  writeSrc0(WmmaLo.data(), VgprEncBase + *SBase);
+
+  // pass-high WMMA: odd-byte gathers, and src2 = D so it accumulates onto the
+  // pass-low result.
+  SmallVector<uint8_t> WmmaHi =
+      rewriteScale16ToScale(Raw, DI.Size, VgprEncBase + *ScaleAhiReg,
+                            VgprEncBase + *ScaleBhiReg, Ctx.LS);
+  if (WmmaHi.empty())
+    return failClosed(Ctx, DI, "pass-high WMMA rewrite failed");
+  writeSrc0(WmmaHi.data(), VgprEncBase + *SBase);
+  writeSrc2(WmmaHi.data(), VgprEncBase + extractVdst(Raw));
+
+  // gfx1250 WMMA co-exec hazard: the pass-high copy (VALU) overwrites the
+  // masked-A block the pass-low WMMA still reads, so it must not co-execute
+  // with the in-flight WMMA. Insert the full required v_nop separation between
+  // them (trampoline bytes carry none of the compiler's own spacing). The
+  // hazard pass re-validates each trampoline against this count as a safety
+  // net.
+  int A0Nops = classifyWmmaNops(DI.Mnemonic).A0Nops;
+  SmallVector<uint8_t> VNop = assembleSingleInst("v_nop", Ctx.LS);
+  if (VNop.empty())
+    return failClosed(Ctx, DI, "v_nop assembly failed");
+
   SmallVector<uint8_t> Replacement;
-  Replacement.insert(Replacement.end(), PreambleBytes.begin(),
-                     PreambleBytes.end());
-  Replacement.insert(Replacement.end(), WmmaBytes.begin(), WmmaBytes.end());
+  Replacement.append(PreBytes.begin(), PreBytes.end());
+  Replacement.append(WmmaLo.begin(), WmmaLo.end());
+  for (int I = 0; I < A0Nops; ++I)
+    Replacement.append(VNop.begin(), VNop.end());
+  Replacement.append(HiBytes.begin(), HiBytes.end());
+  Replacement.append(WmmaHi.begin(), WmmaHi.end());
 
   unsigned Extra = Alloc.extraVgprsNeeded();
-  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Optional) !=
+  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Required) !=
       VgprBumpDecision::Apply)
-    return 0;
+    return 0; // checkKernelVgprBump set RequiredPatchFailed on the Fail path.
 
   if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
-    return 0;
+    return failClosed(Ctx, DI, "trampoline emission failed");
+
+  if (MaskSgpr && !commitSafeSgprScratchBlock(Ctx, DI.Offset, *MaskSgpr,
+                                              "wmma_scale16 lane mask"))
+    return failClosed(Ctx, DI, "scratch SGPR commit failed");
 
   KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
   if (Extra > Stats.ExtraVgprs)
     Stats.ExtraVgprs = Extra;
-  Stats.ScratchReused += ScratchCount - Extra;
   Stats.ScratchAboveKd += Extra;
 
   ScratchPatchInfo Info;
@@ -333,429 +477,31 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
   Info.ScratchRegs = Alloc.LiveAtPoint;
   Ctx.OutScratchPatches.push_back(std::move(Info));
 
-  log() << "hotswap: wmma_scale16: patched 16x16 Scale16→Scale at offset 0x"
-        << utohexstr(DI.Offset) << " (" << Replacement.size()
-        << " bytes, reductionA=" << NeedReductionA
-        << ", reductionB=" << NeedReductionB << ")\n";
-
+  log() << "hotswap: wmma_scale16: exact K-split at offset 0x"
+        << utohexstr(DI.Offset) << " ("
+        << (Plan->Scheme == AMaskScheme::Lane ? "lane-mask" : "vgpr-select")
+        << ", A=v" << ABase << ":" << (ABase + AWidth - 1) << " -> masked v"
+        << *SBase << ", +" << Extra << " vgpr, " << A0Nops << " hazard v_nop, "
+        << Replacement.size() << " bytes)\n";
   return 1;
 }
 
 // ---------------------------------------------------------------------------
-// Base WMMA uop register field extraction (bytes 8-15 of 16-byte VOP3PX)
-// ---------------------------------------------------------------------------
-//
-// The base WMMA uop follows standard VOP3P field layout:
-//   VDST:  byte[8] bits [7:0] (8-bit, raw VGPR number without +256)
-//   SRC0:  byte[12] bits [7:0] + byte[13] bit[0] << 8 (9-bit)
-//   SRC1:  byte[13] bits [7:1] >> 1 + byte[14] bits [1:0] << 7 (9-bit)
-
-static unsigned extractVdst(const uint8_t *Raw) { return Raw[8]; }
-
-static unsigned extractSrc0(const uint8_t *Raw) {
-  return Raw[12] | ((Raw[13] & 0x01u) << 8);
-}
-
-static unsigned extractSrc1(const uint8_t *Raw) {
-  return ((Raw[13] >> 1) & 0x7Fu) | ((Raw[14] & 0x03u) << 7);
-}
-
-// SRC2 (9-bit): bits [122:114] of the 128-bit VOP3PX instruction
-// (per VOP3PInstructions.td let Inst{122-114} = src2).
-//   src2[5:0] = byte[14] bits [7:2]
-//   src2[8:6] = byte[15] bits [2:0]
-static unsigned extractSrc2(const uint8_t *Raw) {
-  return ((Raw[14] >> 2) & 0x3Fu) | ((Raw[15] & 0x07u) << 6);
-}
-
-// ---------------------------------------------------------------------------
-// VOP3PX3 modifier field extraction
-// ---------------------------------------------------------------------------
-//
-// SCALE_OPSEL_HI[0] (matrix_b_scale, thread-half for B): bit 59 = byte[7] bit 3
-// matrix_a_scale_fmt[1:0]: bits [62:61] = byte[7] bits [6:5]
-// matrix_b_scale_fmt[1:0]: bits [9:8] = byte[1] bits [1:0]
-
-static bool extractBScaleRow1(const uint8_t *Raw) { return (Raw[7] >> 3) & 1; }
-
-static unsigned extractAScaleFmt(const uint8_t *Raw) {
-  return (Raw[7] >> 5) & 0x3;
-}
-
-static unsigned extractBScaleFmt(const uint8_t *Raw) { return Raw[1] & 0x3; }
-
-// VOP3PX neg_lo / neg_hi bits live in the WMMA uop's modifier fields
-// (bytes 8..15), per VOP3PInstructions.td VOP3PX2e:
-//   Inst{72} = neg_hi src0   -> byte[9]  bit 0
-//   Inst{73} = neg_hi src1   -> byte[9]  bit 1
-//   Inst{74} = neg_hi src2   -> byte[9]  bit 2
-//   Inst{125} = neg_lo src0  -> byte[15] bit 5
-//   Inst{126} = neg_lo src1  -> byte[15] bit 6
-//   Inst{127} = neg_lo src2  -> byte[15] bit 7
-//
-// For the wmma_scale16_f32_32x16x128_f4 source profile only src2's neg_lo
-// is wired by the intrinsic (it's the c_mod=NEG path: builtin's c_mod
-// short maps to src2_modifiers and the assembler prints `neg_lo:[0,0,1]`
-// when the bit is set). src0/src1 neg bits are extracted defensively in
-// case a future profile wires them.
-//
-// Returns a 6-bit packed value with bit layout matching the AMDGPU printer
-// list order [src0, src1, src2] for each of {neg_lo, neg_hi}:
-//   bit 0 = neg_lo src0, bit 1 = neg_lo src1, bit 2 = neg_lo src2,
-//   bit 3 = neg_hi src0, bit 4 = neg_hi src1, bit 5 = neg_hi src2.
-static unsigned extractNegFlags(const uint8_t *Raw) {
-  unsigned NegLo = (Raw[15] >> 5) & 0x7; // src0/1/2 neg_lo
-  unsigned NegHi = Raw[9] & 0x7;         // src0/1/2 neg_hi
-  return NegLo | (NegHi << 3);
-}
-
-// Format a scale operand for assembly output. Returns the operand string
-// (e.g. "v42" for VGPRs, "s0" for SGPRs). Returns "" on unsupported encoding.
-static std::string formatScaleOp(unsigned Enc,
-                                 std::optional<unsigned> ReducedVgpr) {
-  if (ReducedVgpr)
-    return vgprName(*ReducedVgpr);
-  if (Enc >= VgprEncBase)
-    return vgprName(Enc - VgprEncBase);
-  if (Enc <= 105)
-    return ("s" + Twine(Enc)).str();
-  return "";
-}
-
-// Format the original SRC2/C operand for one M-split half.
-//
-// The source 32x16 form's C operand may be:
-//   - An inline integer immediate (encodings 128..208 = ints -16..64;
-//     0 = encoding 128 is the common case when the kernel uses an
-//     all-zero accumulator that the compiler folds to inline-imm 0).
-//   - An inline float immediate (encodings 240..247 cover 0.5, -0.5,
-//     1.0, -1.0, 2.0, -2.0, 4.0, -4.0).
-//   - A VGPR range v[c:c+15] (encoding >= 256).
-//   - An SGPR (encoding 0..105; not expected for WMMA accumulators).
-//
-// For inline immediates the same value applies to both halves (each half
-// has its own accumulator slice on M-split, no carry between halves).
-// For a VGPR range the source's v[c:c+15] is sliced to v[c:c+7] for
-// half-0 and v[c+8:c+15] for half-1, mirroring how dst is split.
-//
-// Returns "" if the encoding falls in a range we don't know how to print
-// (the caller logs an error and bails). Inline integer / float immediates
-// share the standard AMDGPU encoding numbering -- the assembler accepts
-// either the decoded literal (e.g. "0", "1.0") or the raw encoding
-// printed as decimal.
-static std::string formatSrc2(unsigned Enc, unsigned Half) {
-  if (Enc >= VgprEncBase) {
-    unsigned Base = (Enc - VgprEncBase) + Half * 8;
-    return ("v[" + Twine(Base) + ":" + Twine(Base + 7) + "]").str();
-  }
-  // Integer inline immediates: 128 + N for N in [-16, 64].
-  if (Enc >= 128 && Enc <= 192)
-    return Twine(static_cast<int>(Enc) - 128).str();
-  if (Enc >= 193 && Enc <= 208)
-    return Twine(192 - static_cast<int>(Enc)).str();
-  // Float inline immediates: 240=0.5, 241=-0.5, 242=1.0, 243=-1.0,
-  // 244=2.0, 245=-2.0, 246=4.0, 247=-4.0.
-  switch (Enc) {
-  case 240:
-    return "0.5";
-  case 241:
-    return "-0.5";
-  case 242:
-    return "1.0";
-  case 243:
-    return "-1.0";
-  case 244:
-    return "2.0";
-  case 245:
-    return "-2.0";
-  case 246:
-    return "4.0";
-  case 247:
-    return "-4.0";
-  }
-  // SGPRs and unrecognized encodings fall through. WMMA accumulators are
-  // architecturally VGPR-or-immediate; an SGPR here would be malformed input.
-  return "";
-}
-
-// ---------------------------------------------------------------------------
-// v_wmma_scale16_f32_32x16x128_f4 → 2× v_wmma_scale_f32_16x16x128_f8f6f4
-// ---------------------------------------------------------------------------
-//
-// The 32x16 FP4 instruction is B0-only. Decompose it into two 16x16 halves
-// that split along the M dimension (rows), then each half undergoes the same
-// block-16→block-32 scale reduction as the 16x16 case.
-//
-// Register mapping (linear VGPR packing):
-//   Half 0: D=v[d:d+7],   A=v[a:a+7],   B=v[b:b+7], C=<src2-half-0>
-//   Half 1: D=v[d+8:d+15], A=v[a+8:a+15], B=v[b:b+7], C=<src2-half-1>
-//
-// C tracks the source's src2 operand:
-//   - inline-imm (e.g. 0 when the kernel accumulator is folded by clang):
-//     same literal on both halves (no accumulator carry on M-split)
-//   - VGPR range v[c:c+15]: sliced to v[c:c+7] / v[c+8:c+15]
-// See formatSrc2 above.
-//
-// Scale operands are shared: both halves use the same reduced B32 scale.
-// SCALE_OPSEL[0] (matrix_a_scale) selects the thread-half for A scales:
-//   Half 0 → ROW0 (threads 0-15), Half 1 → ROW1 (threads 16-31).
-
-static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
-  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
-
-  if (DI.Size != VOP3PXSize) {
-    log() << "hotswap: error: wmma_scale16: unexpected 32x16 inst size "
-          << DI.Size << " at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
-
-  // Skip offsets another patch has already claimed. Mirrors the 16x16
-  // path (see patchWmmaScale16_16x16 for the rationale).
-  for (const Trampoline &T : Ctx.OutTrampolines)
-    if (T.OriginalOffset == DI.Offset)
-      return 0;
-
-  const uint8_t *Raw = Ctx.Text + DI.Offset;
-
-  unsigned DBase = extractVdst(Raw);
-  unsigned Src0Enc = extractSrc0(Raw);
-  unsigned Src1Enc = extractSrc1(Raw);
-
-  if (!isVgprEncoding(Src0Enc) || !isVgprEncoding(Src1Enc)) {
-    log() << "hotswap: error: wmma_scale16: 32x16 non-VGPR matrix src at "
-          << "offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
-
-  unsigned ABase = Src0Enc - VgprEncBase;
-  unsigned BBase = Src1Enc - VgprEncBase;
-  unsigned Src2Enc = extractSrc2(Raw);
-
-  unsigned ScaleSrc0Enc = extractScaleSrc0(Raw);
-  unsigned ScaleSrc1Enc = extractScaleSrc1(Raw);
-
-  std::optional<unsigned> ScaleSrc0Base = decodeVgprEncoding(ScaleSrc0Enc);
-  std::optional<unsigned> ScaleSrc1Base = decodeVgprEncoding(ScaleSrc1Enc);
-  if (!ScaleSrc0Base || !ScaleSrc1Base) {
-    log() << "hotswap: error: wmma_scale16: 32x16 unsupported non-VGPR "
-          << "scale encoding at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
-
-  bool NeedReductionA = true;
-  bool NeedReductionB = true;
-
-  unsigned Src0Lo = *ScaleSrc0Base;
-  unsigned Src0Hi = Src0Lo + 1;
-  unsigned Src1Lo = *ScaleSrc1Base;
-  unsigned Src1Hi = Src1Lo + 1;
-
-  bool OrigBScaleRow1 = extractBScaleRow1(Raw);
-  unsigned AScaleFmt = extractAScaleFmt(Raw);
-  unsigned BScaleFmt = extractBScaleFmt(Raw);
-  unsigned NegFlags = extractNegFlags(Raw);
-
-  std::string KernelName =
-      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
-  std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
-      KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
-  unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
-
-  VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdCount,
-                      Ctx.Config.MaxVgprs);
-
-  std::optional<unsigned> ScratchA, ScratchB, T1, T2;
-  unsigned ScratchCount = 0;
-
-  if (NeedReductionA) {
-    ScratchA = Alloc.alloc();
-    ++ScratchCount;
-  }
-  if (NeedReductionB) {
-    ScratchB = Alloc.alloc();
-    ++ScratchCount;
-  }
-  if (NeedReductionA || NeedReductionB) {
-    T1 = Alloc.alloc();
-    T2 = Alloc.alloc();
-    ScratchCount += 2;
-  }
-
-  if ((NeedReductionA && !ScratchA) || (NeedReductionB && !ScratchB) ||
-      ((NeedReductionA || NeedReductionB) && (!T1 || !T2))) {
-    log() << "hotswap: error: wmma_scale16: unable to allocate " << ScratchCount
-          << " scratch VGPRs for 32x16 at offset 0x" << utohexstr(DI.Offset)
-          << "\n";
-    return 0;
-  }
-
-  // --- Scale reduction preamble (shared by both halves) ---
-  std::string Asm;
-  raw_string_ostream AsmOS(Asm);
-
-  if (NeedReductionA)
-    emitScaleReduction(AsmOS, vgprName(Src0Lo), vgprName(Src0Hi),
-                       vgprName(*ScratchA), vgprName(*T1), vgprName(*T2));
-  if (NeedReductionB)
-    emitScaleReduction(AsmOS, vgprName(Src1Lo), vgprName(Src1Hi),
-                       vgprName(*ScratchB), vgprName(*T1), vgprName(*T2));
-
-  SmallVector<uint8_t> PreambleBytes;
-  if (NeedReductionA || NeedReductionB) {
-    PreambleBytes = assembleInstructions(Asm, Ctx.LS);
-    if (PreambleBytes.empty()) {
-      log() << "hotswap: error: wmma_scale16: 32x16 preamble assembly failed "
-            << "at offset 0x" << utohexstr(DI.Offset) << "\n";
-      return 0;
-    }
-  }
-
-  // --- Assemble two 16x16 WMMA halves ---
-  std::string ScaleAStr = formatScaleOp(ScaleSrc0Enc, ScratchA);
-  std::string ScaleBStr = formatScaleOp(ScaleSrc1Enc, ScratchB);
-
-  if (ScaleAStr.empty() || ScaleBStr.empty()) {
-    log() << "hotswap: error: wmma_scale16: 32x16 unsupported scale encoding "
-          << "at offset 0x" << utohexstr(DI.Offset) << "\n";
-    return 0;
-  }
-
-  SmallVector<uint8_t> Replacement;
-  Replacement.insert(Replacement.end(), PreambleBytes.begin(),
-                     PreambleBytes.end());
-
-  for (unsigned Half = 0; Half < 2; ++Half) {
-    unsigned HalfD = DBase + Half * 8;
-    unsigned HalfA = ABase + Half * 8;
-
-    // C (src2) tracks the source's encoding: for an inline immediate the
-    // same literal applies to both halves (M-split has no accumulator
-    // carry between halves); for a VGPR range we slice it the same way
-    // as D. Always sourcing C from HalfD is wrong when the kernel
-    // accumulator is folded to inline-imm 0 -- the WMMA would then read
-    // arbitrary stale bytes from D's range as the accumulator input.
-    std::string CStr = formatSrc2(Src2Enc, Half);
-    if (CStr.empty()) {
-      log() << "hotswap: error: wmma_scale16: 32x16 unsupported src2 "
-            << "encoding 0x" << utohexstr(Src2Enc) << " at offset 0x"
-            << utohexstr(DI.Offset) << "\n";
-      return 0;
-    }
-
-    std::string WmmaAsm;
-    raw_string_ostream WOS(WmmaAsm);
-
-    WOS << "v_wmma_scale_f32_16x16x128_f8f6f4" << " v[" << HalfD << ":"
-        << (HalfD + 7) << "]," << " v[" << HalfA << ":" << (HalfA + 7) << "],"
-        << " v[" << BBase << ":" << (BBase + 7) << "]," << " " << CStr << ","
-        << " " << ScaleAStr << ", " << ScaleBStr
-        << " matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4";
-
-    if (Half == 1)
-      WOS << " matrix_a_scale:MATRIX_SCALE_ROW1";
-    if (OrigBScaleRow1)
-      WOS << " matrix_b_scale:MATRIX_SCALE_ROW1";
-    if (AScaleFmt == 1)
-      WOS << " matrix_a_scale_fmt:MATRIX_SCALE_FMT_E5M3";
-    else if (AScaleFmt == 2)
-      WOS << " matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3";
-    if (BScaleFmt == 1)
-      WOS << " matrix_b_scale_fmt:MATRIX_SCALE_FMT_E5M3";
-    else if (BScaleFmt == 2)
-      WOS << " matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3";
-
-    // Propagate per-source neg_lo / neg_hi modifiers to both halves.
-    // M-split has no accumulator carry between halves, so each half
-    // gets the full set of source modifiers verbatim. The printer
-    // formats these as `neg_lo:[a,b,c]` / `neg_hi:[a,b,c]` lists; we
-    // emit them only when at least one bit in the corresponding triple
-    // is set, since `neg_lo:[0,0,0]` is the default and most asm
-    // dialects omit it.
-    unsigned NegLo = NegFlags & 0x7;
-    unsigned NegHi = (NegFlags >> 3) & 0x7;
-    if (NegLo != 0)
-      WOS << " neg_lo:[" << ((NegLo >> 0) & 1) << "," << ((NegLo >> 1) & 1)
-          << "," << ((NegLo >> 2) & 1) << "]";
-    if (NegHi != 0)
-      WOS << " neg_hi:[" << ((NegHi >> 0) & 1) << "," << ((NegHi >> 1) & 1)
-          << "," << ((NegHi >> 2) & 1) << "]";
-
-    WOS << "\n";
-
-    SmallVector<uint8_t> HalfBytes = assembleSingleInst(WmmaAsm, Ctx.LS);
-    if (HalfBytes.size() != VOP3PXSize) {
-      log() << "hotswap: error: wmma_scale16: 32x16 half " << Half
-            << " assembly produced " << HalfBytes.size() << " bytes (expected "
-            << VOP3PXSize << ") at offset 0x" << utohexstr(DI.Offset) << "\n";
-      return 0;
-    }
-
-    // Same scale_src2 = 0x100 (VGPR0) bake-in as the 16x16 path. The
-    // assembler leaves scale_src2 = 0x80 (SGPR mis-decoded) by default;
-    // applyVop3px2Src2Fix would patch it on a second rewrite (breaking
-    // idempotency) and the SALU would stall 3 cycles per invocation on
-    // first execution. See rewriteScale16ToScale's comment for the full
-    // story.
-    HalfBytes[6] &= 0x03;
-    HalfBytes[7] = (HalfBytes[7] & 0xF8) | 0x04;
-
-    Replacement.insert(Replacement.end(), HalfBytes.begin(), HalfBytes.end());
-  }
-
-  unsigned Extra = Alloc.extraVgprsNeeded();
-  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Optional) !=
-      VgprBumpDecision::Apply)
-    return 0;
-
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
-    return 0;
-
-  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
-  if (Extra > Stats.ExtraVgprs)
-    Stats.ExtraVgprs = Extra;
-  Stats.ScratchReused += ScratchCount - Extra;
-  Stats.ScratchAboveKd += Extra;
-
-  ScratchPatchInfo Info;
-  Info.Offset = DI.Offset;
-  Info.ScratchRegs = Alloc.LiveAtPoint;
-  Ctx.OutScratchPatches.push_back(std::move(Info));
-
-  log() << "hotswap: wmma_scale16: patched 32x16→2x16x16 Scale16→Scale at "
-        << "offset 0x" << utohexstr(DI.Offset) << " (" << Replacement.size()
-        << " bytes, reductionA=" << NeedReductionA
-        << ", reductionB=" << NeedReductionB << ")\n";
-
-  return 1;
-}
-
-// ---------------------------------------------------------------------------
-// patchWmmaScale16 — dispatch for WMMA Scale16 variants
+// patchWmmaScale16 -- dispatch
 // ---------------------------------------------------------------------------
 
-static uint32_t patchWmmaScale16(PatchContext &Ctx, size_t Idx) {
+static uint32_t applyWmmaScale16PatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
   if (Mnem == "v_wmma_scale16_f32_16x16x128_f8f6f4")
     return patchWmmaScale16_16x16(Ctx, Idx);
 
-  if (Mnem == "v_wmma_scale16_f32_32x16x128_f4")
-    return patchWmmaScale16_32x16(Ctx, Idx);
-
-  return 0;
-}
-
-// ---------------------------------------------------------------------------
-// applyWmmaScale16Patches
-// ---------------------------------------------------------------------------
-//
-// Called once per decoded instruction during the rewrite loop. Returns the
-// number of patches applied (0 or 1).
-
-static uint32_t applyWmmaScale16PatchesImpl(PatchContext &Ctx, size_t Idx) {
-  StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
+  // The M=32 FP4 form needs an M-split in addition to the K-split; not yet
+  // lowered exactly, so fail closed rather than miscompile.
   if (Mnem.starts_with("v_wmma_scale16_f32_"))
-    return patchWmmaScale16(Ctx, Idx);
+    return failClosed(Ctx, Ctx.Decoded[Idx],
+                      "block-16 scaled variant has no exact lowering yet");
+
   return 0;
 }
 

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-32x16-refuse.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-32x16-refuse.s
@@ -1,0 +1,57 @@
+// COM: Fail-closed gate for the 32x16 FP4 block-16 scaled WMMA. The M=32 form
+// COM: needs an M-split on top of the K-split and has no exact lowering yet,
+// COM: so the rewrite refuses it: any unlowerable v_wmma_scale16_f32_* makes the
+// COM: rewrite return an error instead of emitting a wrong code object.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// COM: Default mode: presence of the unlowerable form fails the rewrite.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR \
+// RUN:   | %FileCheck --check-prefix=REFUSE %s
+// REFUSE: RESULT: ERROR
+
+// COM: Strict mode: same fail-closed result.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --strict-mode --expect-status ERROR \
+// RUN:   | %FileCheck --check-prefix=REFUSE %s
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// --- Scale16 32x16 FP4 (block-16) -> refuse (fail closed) ---
+.globl test_wmma_scale16_32x16
+.p2align 8
+.type test_wmma_scale16_32x16,@function
+test_wmma_scale16_32x16:
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43]
+  s_endpgm
+.Ltest_wmma_scale16_32x16_end:
+.size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_32x16
+  .amdhsa_next_free_vgpr 44
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_32x16
+      .symbol: test_wmma_scale16_32x16.kd
+      .sgpr_count: 2
+      .vgpr_count: 44
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16-fp4.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16-fp4.s
@@ -1,0 +1,65 @@
+// COM: Block-16 scaled WMMA (16x16x128) with FP4 matrix data. Unlike FP8, an
+// COM: FP4 K=32 block sits in one lane group and its low/high-16 subblocks
+// COM: split along the VGPR index, so the masked-A copy nulls the opposite
+// COM: subblock's VGPRs (v_mov ..., 0) instead of using a lane mask.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=RESULT %s
+// RESULT: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: v_wmma_scale16
+// COM: pass-low keeps the low-16 subblock VGPRs and zeros the high-16, then a
+// COM: block-32 WMMA with the even-byte scale gather writes v[0:7]. FP4 uses a
+// COM: VGPR select, never a lane mask, so no v_cndmask appears in either pass.
+// DISASM-NOT: v_cndmask_b32_e64
+// DISASM: v_mov_b32{{(_e32)?}} v{{[0-9]+}}, 0
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:39], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
+// COM: exactly one gfx1250 hazard v_nop before the pass-high masked-A VALU.
+// DISASM-COUNT-1: v_nop
+// DISASM-NEXT: v_mov_b32{{(_e32)?}} v{{[0-9]+}}, 0
+// DISASM-NOT: v_cndmask_b32_e64
+// COM: pass-high keeps the high-16 subblock VGPRs, odd-byte scale gather,
+// COM: accumulating onto pass-low through v[0:7].
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:39], v[0:7],{{.*}}matrix_a_fmt:MATRIX_FMT_FP4
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// --- Scale16 16x16 (block-16) FP4 -> exact VGPR-select K-split ---
+.globl test_wmma_scale16_16x16_fp4
+.p2align 8
+.type test_wmma_scale16_16x16_fp4,@function
+test_wmma_scale16_16x16_fp4:
+  v_wmma_scale16_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v[48:49], v[50:51] matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4
+  s_endpgm
+.Ltest_wmma_scale16_16x16_fp4_end:
+.size test_wmma_scale16_16x16_fp4, .Ltest_wmma_scale16_16x16_fp4_end-test_wmma_scale16_16x16_fp4
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_16x16_fp4
+  .amdhsa_next_free_vgpr 52
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_16x16_fp4
+      .symbol: test_wmma_scale16_16x16_fp4.kd
+      .sgpr_count: 2
+      .vgpr_count: 52
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-scale16.s
+++ b/amd/comgr/test-lit/hotswap-wmma-scale16.s
@@ -1,136 +1,35 @@
-// COM: Test WMMA Scale16 (block-16 -> block-32) decomposition patch.
-// COM:
-// COM: Creates minimal gfx1250 code objects containing v_wmma_scale16_f32_*
-// COM: instructions, runs the hotswap rewrite, and verifies the replacement
-// COM: sequence covers: byte-pair max scale reduction followed by the
-// COM: rewritten v_wmma_scale_f32_* instruction (VOP3PX2).
+// COM: The target gfx1250 has no block-16 scaled WMMA, so the rewrite lowers
+// COM: 16x16x128_f8f6f4 exactly into two block-32 WMMAs chained through the
+// COM: accumulator: each pass masks matrix A to one 16-K subblock (a lane mask
+// COM: for FP8) and byte-gathers the matching block-16 scales. When the scratch
+// COM: budget is unavailable it fails closed (see the 32x16 refuse test).
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-
 // RUN: hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
-// RUN:   | %FileCheck --check-prefix=API %s
-// API: RESULT: SUCCESS
+// RUN:   | %FileCheck --check-prefix=RESULT %s
+// RESULT: RESULT: SUCCESS
 
-// COM: -----------------------------------------------------------------------
-// COM: Verify: Scale16 16x16 instruction is patched with scale reduction
-// COM: preamble followed by the rewritten v_wmma_scale_f32_* instruction.
-// COM:
-// COM: Scale reduction per operand (13 instructions):
-// COM:   4 byte pairs x (v_and_b32/v_bfe_u32 + v_bfe_u32/v_lshrrev_b32 +
-// COM:                    v_max_u32 + optional v_lshl_or_b32)
-// COM:
-// COM: The preamble reduces block-16 scales from the B64 VGPR pairs
-// COM: (v48:v49 for scale A, v50:v51 for scale B) into B32 scratch VGPRs
-// COM: via byte-pair max, then the rewritten WMMA uses those scratch VGPRs.
-// COM: -----------------------------------------------------------------------
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=SCALE16 %s
-
-// SCALE16-LABEL: <test_wmma_scale16_16x16>:
-// SCALE16:       s_branch
-// COM: --- scale A reduction: byte pair 0 ---
-// SCALE16:       v_and_b32{{.*}}0xff, v48
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v48, 8, 8
-// SCALE16-NEXT:  v_max_u32
-// COM: --- scale A reduction: byte pair 1 ---
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v48, 16, 8
-// SCALE16-NEXT:  v_lshrrev_b32{{.*}}24, v48
-// SCALE16-NEXT:  v_max_u32
-// SCALE16-NEXT:  v_lshl_or_b32
-// COM: --- scale A reduction: byte pair 2 ---
-// SCALE16-NEXT:  v_and_b32{{.*}}0xff, v49
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v49, 8, 8
-// SCALE16-NEXT:  v_max_u32
-// SCALE16-NEXT:  v_lshl_or_b32
-// COM: --- scale A reduction: byte pair 3 ---
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v49, 16, 8
-// SCALE16-NEXT:  v_lshrrev_b32{{.*}}24, v49
-// SCALE16-NEXT:  v_max_u32
-// SCALE16-NEXT:  v_lshl_or_b32
-// COM: --- scale B reduction: byte pair 0 ---
-// SCALE16-NEXT:  v_and_b32{{.*}}0xff, v50
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v50, 8, 8
-// SCALE16-NEXT:  v_max_u32
-// COM: --- scale B reduction: byte pair 1 ---
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v50, 16, 8
-// SCALE16-NEXT:  v_lshrrev_b32{{.*}}24, v50
-// SCALE16-NEXT:  v_max_u32
-// SCALE16-NEXT:  v_lshl_or_b32
-// COM: --- scale B reduction: byte pair 2 ---
-// SCALE16-NEXT:  v_and_b32{{.*}}0xff, v51
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v51, 8, 8
-// SCALE16-NEXT:  v_max_u32
-// SCALE16-NEXT:  v_lshl_or_b32
-// COM: --- scale B reduction: byte pair 3 ---
-// SCALE16-NEXT:  v_bfe_u32{{.*}}v51, 16, 8
-// SCALE16-NEXT:  v_lshrrev_b32{{.*}}24, v51
-// SCALE16-NEXT:  v_max_u32
-// SCALE16-NEXT:  v_lshl_or_b32
-// COM: --- rewritten WMMA (VOP3PX2): regular scale with scratch VGPRs ---
-// SCALE16-NEXT:  v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:31], v[32:47], v[0:7], v64, v65
-
-// COM: -----------------------------------------------------------------------
-// COM: Verify: Scale16 32x16 instruction is decomposed into two 16x16 WMMAs.
-// COM:
-// COM: The 32x16 FP4 instruction is B0-only (no A0 counterpart). It is split
-// COM: along M into two 16x16 halves, each with scale reduction preamble and
-// COM: rewritten v_wmma_scale_f32_16x16x128_f8f6f4 (VOP3PX2).
-// COM: -----------------------------------------------------------------------
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=SPLIT32 %s
-
-// SPLIT32-LABEL: <test_wmma_scale16_32x16>:
-// SPLIT32:       s_branch
-// COM: --- scale A reduction (shared by both halves) ---
-// SPLIT32:       v_and_b32{{.*}}0xff, v40
-// SPLIT32:       v_max_u32
-// SPLIT32:       v_lshl_or_b32
-// SPLIT32:       v_lshl_or_b32
-// SPLIT32:       v_lshl_or_b32
-// COM: --- scale B reduction ---
-// SPLIT32:       v_and_b32{{.*}}0xff, v42
-// SPLIT32:       v_max_u32
-// SPLIT32:       v_lshl_or_b32
-// SPLIT32:       v_lshl_or_b32
-// SPLIT32:       v_lshl_or_b32
-// COM: --- rewritten WMMA half 0 (rows 0-15) ---
-// SPLIT32:       v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v48, v49
-// COM: --- rewritten WMMA half 1 (rows 16-31) ---
-// SPLIT32:       v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v48, v49{{.*}}matrix_a_scale:MATRIX_SCALE_ROW1
-
-// COM: -----------------------------------------------------------------------
-// COM: Verify: 32x16 split preserves float inline-immediate src2.
-// COM: -----------------------------------------------------------------------
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=SRC2FLOAT %s
-
-// SRC2FLOAT-LABEL: <test_wmma_scale16_32x16_src2_neg_half>:
-// SRC2FLOAT:       s_branch
-// SRC2FLOAT:       v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], -0.5, v48, v49
-// SRC2FLOAT:       v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], -0.5, v48, v49{{.*}}matrix_a_scale:MATRIX_SCALE_ROW1
-
-// COM: -----------------------------------------------------------------------
-// COM: Verify: regular Scale instruction is NOT patched.
-// COM: -----------------------------------------------------------------------
-// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=NOPATCH %s
-
-// NOPATCH-LABEL: <test_wmma_scale_16x16>:
-// NOPATCH-NEXT:  v_wmma_scale_f32_16x16x128_f8f6f4
-
-// COM: -----------------------------------------------------------------------
-// COM: Idempotency: running the rewrite a second time should succeed and
-// COM: produce the same output.
-// COM: -----------------------------------------------------------------------
-// RUN: hotswap-rewrite %t.out.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --output %t.out2.elf \
-// RUN:   | %FileCheck --check-prefix=IDEMP %s
-// IDEMP: RESULT: SUCCESS
-// RUN: cmp %t.out.elf %t.out2.elf
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// COM: block-16 form gone, replaced by the two block-32 passes: pass-low masks
+// COM: the low-16 subblock (lane mask 0xffff), pass-high the high-16
+// COM: (0xffff0000), the second accumulating onto the first through v[0:7].
+// DISASM-NOT: v_wmma_scale16
+// DISASM: s_mov_b32 s{{[0-9]+}}, 0xffff {{.*$}}
+// DISASM: v_cndmask_b32_e64
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:47], v[0:7],
+// COM: exactly one gfx1250 hazard v_nop before the pass-high lane-mask VALU that
+// COM: overwrites the masked-A scratch block.
+// DISASM-COUNT-1: v_nop
+// DISASM-NEXT: s_mov_b32 s{{[0-9]+}}, 0xffff0000
+// DISASM: v_cndmask_b32_e64
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[{{[0-9]+}}:{{[0-9]+}}], v[32:47], v[0:7],
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
 
-// --- Kernel 1: Scale16 (should be patched) ---
+// --- Scale16 16x16 (block-16) -> exact lane-masked K-split ---
 .globl test_wmma_scale16_16x16
 .p2align 8
 .type test_wmma_scale16_16x16,@function
@@ -140,54 +39,9 @@ test_wmma_scale16_16x16:
 .Ltest_wmma_scale16_16x16_end:
 .size test_wmma_scale16_16x16, .Ltest_wmma_scale16_16x16_end-test_wmma_scale16_16x16
 
-// --- Kernel 2: Scale16 32x16 FP4 (should be split into two 16x16) ---
-.globl test_wmma_scale16_32x16
-.p2align 8
-.type test_wmma_scale16_32x16,@function
-test_wmma_scale16_32x16:
-  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43]
-  s_endpgm
-.Ltest_wmma_scale16_32x16_end:
-.size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16
-
-// --- Kernel 3: Scale16 32x16 with float inline src2 (should preserve src2) ---
-.globl test_wmma_scale16_32x16_src2_neg_half
-.p2align 8
-.type test_wmma_scale16_32x16_src2_neg_half,@function
-test_wmma_scale16_32x16_src2_neg_half:
-  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], -0.5, v[40:41], v[42:43]
-  s_endpgm
-.Ltest_wmma_scale16_32x16_src2_neg_half_end:
-.size test_wmma_scale16_32x16_src2_neg_half, .Ltest_wmma_scale16_32x16_src2_neg_half_end-test_wmma_scale16_32x16_src2_neg_half
-
-// --- Kernel 4: regular Scale (should NOT be patched) ---
-.globl test_wmma_scale_16x16
-.p2align 8
-.type test_wmma_scale_16x16,@function
-test_wmma_scale_16x16:
-  v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:31], v[32:47], v[0:7], v48, v50
-  s_endpgm
-.Ltest_wmma_scale_16x16_end:
-.size test_wmma_scale_16x16, .Ltest_wmma_scale_16x16_end-test_wmma_scale_16x16
-
 .rodata
 .p2align 8
 .amdhsa_kernel test_wmma_scale16_16x16
-  .amdhsa_next_free_vgpr 52
-  .amdhsa_next_free_sgpr 2
-  .amdhsa_wavefront_size32 1
-.end_amdhsa_kernel
-.amdhsa_kernel test_wmma_scale16_32x16
-  .amdhsa_next_free_vgpr 44
-  .amdhsa_next_free_sgpr 2
-  .amdhsa_wavefront_size32 1
-.end_amdhsa_kernel
-.amdhsa_kernel test_wmma_scale16_32x16_src2_neg_half
-  .amdhsa_next_free_vgpr 44
-  .amdhsa_next_free_sgpr 2
-  .amdhsa_wavefront_size32 1
-.end_amdhsa_kernel
-.amdhsa_kernel test_wmma_scale_16x16
   .amdhsa_next_free_vgpr 52
   .amdhsa_next_free_sgpr 2
   .amdhsa_wavefront_size32 1
@@ -200,36 +54,6 @@ test_wmma_scale_16x16:
   amdhsa.kernels:
     - .name: test_wmma_scale16_16x16
       .symbol: test_wmma_scale16_16x16.kd
-      .sgpr_count: 2
-      .vgpr_count: 52
-      .kernarg_segment_size: 0
-      .group_segment_fixed_size: 0
-      .private_segment_fixed_size: 0
-      .kernarg_segment_align: 8
-      .wavefront_size: 32
-      .max_flat_workgroup_size: 256
-    - .name: test_wmma_scale16_32x16
-      .symbol: test_wmma_scale16_32x16.kd
-      .sgpr_count: 2
-      .vgpr_count: 44
-      .kernarg_segment_size: 0
-      .group_segment_fixed_size: 0
-      .private_segment_fixed_size: 0
-      .kernarg_segment_align: 8
-      .wavefront_size: 32
-      .max_flat_workgroup_size: 256
-    - .name: test_wmma_scale16_32x16_src2_neg_half
-      .symbol: test_wmma_scale16_32x16_src2_neg_half.kd
-      .sgpr_count: 2
-      .vgpr_count: 44
-      .kernarg_segment_size: 0
-      .group_segment_fixed_size: 0
-      .private_segment_fixed_size: 0
-      .kernarg_segment_align: 8
-      .wavefront_size: 32
-      .max_flat_workgroup_size: 256
-    - .name: test_wmma_scale_16x16
-      .symbol: test_wmma_scale_16x16.kd
       .sgpr_count: 2
       .vgpr_count: 52
       .kernarg_segment_size: 0


### PR DESCRIPTION
## Summary
Fixes ROCM-28167: the ROCr HotSwap code-object rewrite miscompiles gfx1250 `wmma_scaled` kernels that use block-16 scales (`v_wmma_scale16_f32_16x16x128_f8f6f4`) when the matrix data format is FP4/FP6.

When retargeting a B0 gfx1250 code object to A0, HotSwap lowers the block-16 scaled WMMA (`v_wmma_scale16_*`) into block-32 scaled WMMA (`v_wmma_scale_*`) via a masked K-split. The previous lowering applied a **wave-lane mask** for the
sub-block isolation. That is only correct for FP8/BF8, where each scale maps to a
contiguous lane group. 
For FP4/FP6/BF6, the per-scale data is laid out across VGPR groups, not lanes, so the lane mask selects the wrong elements and the accumulation is numerically wrong(observed max abs diff = 19712.0 on the reference repro).

## Fix
Make the sub-block masking format-aware, driven by the `matrix_a_fmt` field parsed from the instruction:
- FP8 / BF8 : keep the existing wave-lane mask.
- FP4 / FP6 / BF6:  use a VGPR-select mask that zeroes the appropriate VGPR groups for each block-32 half, matching the hardware data layout.

A `matrixAMaskPlan` helper parses `matrix_a_fmt:MATRIX_FMT_*` from the disassembly and chooses the masking scheme and sub-block width; a new `emitVgprSelectCopy` implements the VGPR-group masking used by the FP4/FP6 path.

## Testing
- **Lit** (`amd/comgr/test-lit`):
  - `hotswap-wmma-scale16.s` FP8 lane-mask path (updated), PASS
  - `hotswap-wmma-scale16-fp4.s` new FP4 VGPR-select path (no `v_cndmask`), PASS
  - `hotswap-wmma-scale16-32x16-refuse.s` refuse-guard for unsupported shape, PASS
- End-to-end correctness on real gfx1250 with the canonical ROCM-28167

  | comgr | hotswap | result |
  |---|---|---|
  | stock | ON | FAIL (max abs diff 19712.0) |
  | stock | OFF | PASS |
  | this fix | ON | PASS |

## Notes
- No behavior change for FP8/BF8 kernels (same lane-mask lowering as before).
- Only the HotSwap comgr rewrite path is affected.