### PR TITLE
ockl: make single-grid cooperative counter a pointer (cache-line isolation)

### DIFF
--- a/amd/device-libs/ockl/src/cg.cl
+++ b/amd/device-libs/ockl/src/cg.cl
@@ -25,9 +25,10 @@ struct mg_info {
     uint num_grids;
     ulong prev_sum;
     ulong all_sum;
-
-    struct mg_sync sgs;
     uint num_wg;
+    uint pad0[23];          // pad so sgs starts on a new 128B cache line
+    struct mg_sync sgs;     // offset 128, alone on its line
+    uint pad1[30];          // keep the rest of the line to itself
 };
 
 static inline size_t

--- a/amd/device-libs/ockl/src/cg.cl
+++ b/amd/device-libs/ockl/src/cg.cl
@@ -26,9 +26,9 @@ struct mg_info {
     ulong prev_sum;
     ulong all_sum;
     uint num_wg;
-    uint pad0[23];          // pad so sgs starts on a new 128B cache line
-    struct mg_sync sgs;     // offset 128, alone on its line
-    uint pad1[30];          // keep the rest of the line to itself
+    // 256 covers the largest cache line across supported GPUs, so the counter's
+    // atomics never share a line with the fields above.
+    struct mg_sync sgs __attribute__((aligned(256)));
 };
 
 static inline size_t


### PR DESCRIPTION
  ## Grid-barrier latency
  
Cooperative-groups single-grid barrier (`this_grid().sync()`), device-scope atomic on the single-grid counter. Correctness: cross-workgroup producer/consumer, 1000 iterations x 500 relaunch (500k barrier instances).
  
| GPU | Config (CUs, grid) | Without PR | With PR | Speedup |
|-----|--------------------|-----------|---------|---------|
| MI355X (gfx950) | 256 CU, grid 2048 | 196,830 ns | 58,464 ns | 3.37x |

### Previous approach (reworked)

Make the single-grid cooperative counter (`mg_info.sgs`) a pointer to a separately-allocated counter, so its device-scope atomic traffic no longer shares a cache line with the read-only `mg_info` fields. The language runtime allocates that counter on its own cache line and stores the pointer in `mg_info`. 

ABI-lockstep with the runtime change in https://github.com/ROCm/rocm-systems/pull/8820, which allocates the counter and fills the pointer.  Both must merge together - merging either side alone changes the shared `mg_info`/`MGSyncInfo` layout contract and breaks cooperative-groups grid sync. 

Validated on MI300X (gfx942) and MI355X (gfx950): correctness PASS (500k barrier episodes) with the matching runtime change.