### PR TITLE
[CI] Build rocr-runtime and clr as Release in SPIRV Linux CI

### DIFF
--- a/.github/workflows/spirv-ci-linux-amd-staging.yml
+++ b/.github/workflows/spirv-ci-linux-amd-staging.yml
@@ -136,6 +136,7 @@ jobs:
       - name: Configure ROCR-Runtime
         run: |
           cmake -G Ninja -S rocm-systems/projects/rocr-runtime -B "$ROCR_BUILD" \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=$PWD/$LLVM_BUILD/bin/clang \
             -DCMAKE_CXX_COMPILER=$PWD/$LLVM_BUILD/bin/clang++ \
             -DBUILD_SHARED_LIBS=ON \
@@ -152,6 +153,7 @@ jobs:
       - name: Configure CLR (HIP runtime)
         run: |
           cmake -G Ninja -S rocm-systems/projects/clr -B "$CLR_BUILD" \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER=$PWD/$LLVM_BUILD/bin/clang \
             -DCMAKE_CXX_COMPILER=$PWD/$LLVM_BUILD/bin/clang++ \
             -DBUILD_SHARED_LIBS=ON \


### PR DESCRIPTION
## Problem

The Linux SPIRV CI (`spirv-ci-linux-amd-staging.yml`) configures `rocr-runtime` and `clr` with **no `CMAKE_BUILD_TYPE`**, so CMake omits `-DNDEBUG`. That leaves debug-only code paths compiled in — e.g. rocr's `debug_print` macro, which is a no-op under `NDEBUG` but expands to real `fprintf(...)` otherwise.

This exposed the CI to `ROCm/rocm-systems#7502`'s regression (`arithmetic on a pointer to void` in `amd_core_dump.cpp`): the offending expressions live only inside `debug_print` arguments, so they compile only in a non-`NDEBUG` build. Release builds — how rocr/clr actually ship — never compile them.

## Fix

Set `-DCMAKE_BUILD_TYPE=Release` on the `rocr-runtime` and `clr` configures. Matches the shipped configuration and stops the CI from compiling debug-only paths that release consumers never exercise.

Ports ROCm/SPIRV-LLVM-Translator#254 (already merged) to the llvm-project copy of the workflow.

## Notes

- Scope limited to the two rocm-systems runtime components. LLVM/comgr/device-libs are left as-is (comgr is under test; LLVM uses `LLVM_ENABLE_ASSERTIONS` deliberately).
