### PR TITLE
[OpenMP][IRBuilder] Don't force alwaysinline on outlined parallel region.

### DIFF
--- a/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
+++ b/llvm/lib/Frontend/OpenMP/OMPIRBuilder.cpp
@@ -985,8 +985,6 @@ void OpenMPIRBuilder::finalize(Function *Fn) {
 
     Function *OutlinedFn =
         Extractor->extractCodeRegion(CEAC, OI->Inputs, OI->Outputs);
-    if (Config.isGPU())
-      OutlinedFn->addFnAttr(Attribute::AlwaysInline);
 
     // Forward target-cpu, target-features attributes to the outlined function.
     auto TargetCpuAttr = OuterFn->getFnAttribute("target-cpu");

--- a/mlir/test/Target/LLVMIR/omptarget-parallel-wsloop.mlir
+++ b/mlir/test/Target/LLVMIR/omptarget-parallel-wsloop.mlir
@@ -47,9 +47,5 @@ module attributes {dlti.dl_spec = #dlti.dl_spec<#dlti.dl_entry<"dlti.alloca_memo
 // CHECK:        call void @[[PARALLEL_FUNC]]({{.*}})
 // CHECK-NEXT:   ret void
 
-// CHECK:      attributes #[[ATTRS1]] = {
-// CHECK-SAME:  "target-cpu"="gfx90a"
-// CHECK-SAME:  "target-features"="+gfx9-insts,+wavefrontsize64"
-// CHECK:      attributes #[[ATTRS2]] = {
-// CHECK-SAME:  "target-cpu"="gfx90a"
-// CHECK-SAME:  "target-features"="+gfx9-insts,+wavefrontsize64"
+// CHECK-DAG:  attributes #[[ATTRS1]] = {{{.*}}"target-cpu"="gfx90a"{{.*}}"target-features"="+gfx9-insts,+wavefrontsize64"
+// CHECK-DAG:  attributes #[[ATTRS2]] = {{{.*}}"target-cpu"="gfx90a"{{.*}}"target-features"="+gfx9-insts,+wavefrontsize64"


### PR DESCRIPTION
On GPU targets, OMPIRBuilder marked outlined OpenMP parallel-region functions alwaysinline, forcing them to be inlined into their kernel regardless of cost. The enlarged kernel then exceeded the AMDGPU inliner's basic-block budget, so __kmpc_target_init could no longer be inlined/specialized and stayed a shared, out-of-line generic-mode runtime entry. As a result, SPMD reduction kernels that never run in generic mode still inherited the module-wide amdgpu.max_num_vgpr worst case — over-reserving registers and collapsing occupancy. A single generic-mode kernel anywhere in the module was enough to trigger this for unrelated, otherwise-lean kernels. Letting cost-based inlining decide (matching upstream) keeps these kernels small so __kmpc_target_init is inlined and register usage/occupancy return to normal.