### PR TITLE
[Comgr] Correct gfx1310 VGPR ISA metadata

### DIFF
--- a/amd/comgr/src/comgr-isa-metadata.def
+++ b/amd/comgr/src/comgr-isa-metadata.def
@@ -78,7 +78,7 @@ HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1200",          false, false, EF_AMDGPU_MAC
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1201",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1201,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1250",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1250,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1251",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1251,         true, false, 327680, 64,  4,   40, 1024,  106, 800, 106,   16, 1024, 1024)
-HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1310",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1310,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   24, 1536, 256)
+HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx1310",          false, false, EF_AMDGPU_MACH_AMDGCN_GFX1310,         true,  true, 65536,  32,  4,   40, 1024,  106, 800, 106,   16, 1024, 256)
 
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx9-generic",     false,  true, EF_AMDGPU_MACH_AMDGCN_GFX9_GENERIC,    true,  true, 65536,  32,  4,   40, 1024,   16, 800, 102,    4, 256, 256)
 HANDLE_ISA("amdgcn-amd-amdhsa-", "gfx9-4-generic",   true,   true, EF_AMDGPU_MACH_AMDGCN_GFX9_4_GENERIC,  true, false, 65536,  32,  4,   40, 1024,   16, 800, 102,    8, 512, 512)


### PR DESCRIPTION
## Summary

gfx1310 was added to `comgr-isa-metadata.def` in #3076 with `VGPR_ALLOC_GRANULE=24` and `TOTAL_NUM_VGPRS=1536` — the gfx12 (RDNA4) values. gfx1310's VGPR file actually matches the gfx1250-style layout, so the correct values are `VGPR_ALLOC_GRANULE=16`, `TOTAL_NUM_VGPRS=1024` (`ADDRESSABLE_NUM_VGPRS` stays `256`).

```
-HANDLE_ISA(... "gfx1310", ... 106, 800, 106,   24, 1536, 256)
+HANDLE_ISA(... "gfx1310", ... 106, 800, 106,   16, 1024, 256)
```

These columns feed Comgr's ISA metadata queries (e.g. max/addressable VGPR reporting) for gfx1310.
