### PR TITLE
[clang][driver] - Guard tail options in clang config

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1444,6 +1444,21 @@ bool Driver::loadDefaultConfigFiles(llvm::cl::ExpansionContext &ExpCtx) {
   return false;
 }
 
+// TODO: This is a short term downstream fix to ignore $ prefixed
+// entries in a clang config file. A long term fix will be
+// upstreamed that will most likely include setting
+// FinalPhase = phase::Precompile for all PCH invocations.
+static bool anyInputReachesLinkPhase(const InputList &Inputs,
+                                     phases::ID FinalPhase) {
+  for (const auto &I : Inputs) {
+    llvm::SmallVector<phases::ID, phases::MaxNumberOfPhases> PL =
+        types::getCompilationPhases(I.first, FinalPhase);
+    if (!PL.empty() && PL.back() == phases::Link)
+      return true;
+  }
+  return false;
+}
+
 Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   llvm::PrettyStackTraceString CrashInfo("Compilation construction");
 
@@ -1786,8 +1801,10 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   InputList Inputs;
   BuildInputs(C->getDefaultToolChain(), *TranslatedArgs, Inputs);
   if (HasConfigFileTail && Inputs.size()) {
-    Arg *FinalPhaseArg;
-    if (getFinalPhase(*TranslatedArgs, &FinalPhaseArg) == phases::Link) {
+    Arg *FinalPhaseArg = nullptr;
+    phases::ID FinalPhase = getFinalPhase(*TranslatedArgs, &FinalPhaseArg);
+    if (FinalPhase == phases::Link &&
+        anyInputReachesLinkPhase(Inputs, FinalPhase)) {
       DerivedArgList TranslatedLinkerIns(*CfgOptionsTail);
       for (Arg *A : *CfgOptionsTail)
         TranslatedLinkerIns.append(A);

--- a/clang/test/Driver/Inputs/config-7.cfg
+++ b/clang/test/Driver/Inputs/config-7.cfg
@@ -1,0 +1,3 @@
+-Wall $-lm
+$-Wl,--as-needed $-Wl,-Bstatic
+$-lhappy $-Wl,-Bdynamic

--- a/clang/test/Driver/config-file.c
+++ b/clang/test/Driver/config-file.c
@@ -108,3 +108,8 @@
 // CHECK-NOLINKING-MSVC: Configuration file: {{.*}}Inputs{{.}}config-l.cfg
 // CHECK-NOLINKING-MSVC: "-Wall"
 // CHECK-NOLINKING-MSVC-NO: "m.lib" "-Bstatic" "happy.lib" "-Bdynamic"
+//
+// RUN: %clang --target=aarch64-unknown-linux-gnu --config %S/Inputs/config-7.cfg \
+// RUN:   -x c++-header %s -o %t.h.pch -### 2>&1 | FileCheck %s --check-prefix=CHECK-PCH-NOLINK
+// CHECK-PCH-NOLINK: "-Wall"
+// CHECK-PCH-NOLINK-NOT: "-lm" "--as-needed" "-Bstatic" "-lhappy" "-Bdynamic"


### PR DESCRIPTION
Adding a linker option via "$-Wl,--enable-new-dtags" in a clang config will break precompiled header compilation with: error: cannot specify -o when generating multiple output files

A PCH compilation with this option will create a Precompile action as well as a Link action (FinalPhase = phase::Link).

Ensure that input files actually make it to the link phase first and then add the tail linker option.


