### PR TITLE
[comgr][hotswap][DRAFT] per-kernel code displacement for B0-to-A0 growing patches

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -103,6 +103,7 @@ set(SOURCES
   src/comgr-env.cpp
   src/comgr-hotswap.cpp
   src/comgr-hotswap-b0a0.cpp
+  src/comgr-hotswap-displacement.cpp
   src/comgr-hotswap-entry-trampoline.cpp
   src/comgr-hotswap-entry-trampoline-fast.cpp
   src/comgr-hotswap-occupancy.cpp

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -2535,10 +2535,10 @@ copyOutputBuffer(const void *Data, size_t Size, StringRef CopyKind) {
 
 // -- retargetCodeObject -------------------------------------------------------
 
-amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
-                                      const TargetIdentifier &TargetIdent,
-                                      const Gfx1250RewriteOptions &Options,
-                                      std::unique_ptr<MemoryBuffer> &Out) {
+static amd_comgr_status_t retargetCodeObjectImpl(
+    const void *ElfData, size_t ElfSize, const TargetIdentifier &TargetIdent,
+    const Gfx1250RewriteOptions &Options, std::unique_ptr<MemoryBuffer> &Out,
+    bool AllowTextDisplacement) {
   // The dispatcher fetches the patch vtable lazily via
   // getHotswapPatchVTable() inside applyGfx1250B0toA0Rules; the singleton's
   // initializer binds every register*Patch slot on first access, so no
@@ -2608,6 +2608,44 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
     }
   }
 
+  // Direct displacement is an entry-workaround optimization only. Apply the
+  // entry prefixes before ordinary instruction rewriting so the existing
+  // NOP-sled/trampoline planner sees the final instruction offsets. If the ELF
+  // cannot be displaced safely, continue from the pristine working copy and
+  // append the established entry stubs below.
+  if (Options.RunEntryTrampolines && AllowTextDisplacement && !UseFastAppend) {
+    std::vector<DisplacementEdit> EntryDisplacements;
+    std::optional<uint32_t> EntryCount =
+        collectKernelEntryDisplacements(Elf, LS, EntryDisplacements);
+    if (!EntryCount)
+      return AMD_COMGR_STATUS_ERROR;
+
+    if (!EntryDisplacements.empty()) {
+      Expected<std::unique_ptr<WritableMemoryBuffer>> DisplacedOrErr =
+          tryApplyTextDisplacementToNewBuffer(Elf, LS, EntryDisplacements);
+      if (DisplacedOrErr) {
+        std::unique_ptr<WritableMemoryBuffer> Displaced =
+            std::move(*DisplacedOrErr);
+        if (!RunInstructionPatches) {
+          Out = std::move(Displaced);
+          return AMD_COMGR_STATUS_SUCCESS;
+        }
+
+        Gfx1250RewriteOptions RemainingOptions = Options;
+        RemainingOptions.RunEntryTrampolines = false;
+        RemainingOptions.UseB0B0EntryFastPath = false;
+        return retargetCodeObjectImpl(Displaced->getBufferStart(),
+                                      Displaced->getBufferSize(), TargetIdent,
+                                      RemainingOptions, Out,
+                                      /*AllowTextDisplacement=*/false);
+      }
+
+      log() << "hotswap: entry displacement unavailable: "
+            << toString(DisplacedOrErr.takeError())
+            << "; using appended entry stubs\n";
+    }
+  }
+
   RewriteConfig Config = makeGfx1250B0A0Config();
   Config.RunB0A0Patches = Options.RunB0A0Patches;
   Config.MaskPolicy = Options.MaskPolicy;
@@ -2660,6 +2698,7 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   if (!PoolBaseOffsetOr)
     return AMD_COMGR_STATUS_ERROR;
   const uint64_t PoolBaseOffset = *PoolBaseOffsetOr;
+
   if (!Deferred.empty()) {
     if (!fixupTrampolineBranches(Deferred, Text, PoolBaseOffset, LS)) {
       if (RequiredPatchApplied) {
@@ -2767,6 +2806,14 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
 
   Out = std::move(Result);
   return AMD_COMGR_STATUS_SUCCESS;
+}
+
+amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
+                                      const TargetIdentifier &TargetIdent,
+                                      const Gfx1250RewriteOptions &Options,
+                                      std::unique_ptr<MemoryBuffer> &Out) {
+  return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
+                                /*AllowTextDisplacement=*/true);
 }
 
 } // namespace hotswap

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -37,7 +37,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <limits>
+#include <map>
 
 using namespace llvm;
 
@@ -2068,13 +2070,65 @@ assignLongBranchGateways(PatchContext &Ctx,
   return true;
 }
 
+/// Tier-1 per-kernel local displacement: grow the patched instruction in place
+/// by shifting the rest of its own kernel down into the kernel's trailing
+/// alignment padding (the run of s_nop bytes before the next 256-byte-aligned
+/// kernel entry). Net .text size is unchanged and nothing outside this kernel
+/// moves, so no section boundary is crossed and no descriptor changes.
+///
+/// Returns true if \p InstOffset lies in a kernel with enough trailing
+/// alignment padding to absorb this one edit's growth. Only a necessary
+/// pre-check: the final per-kernel fit (multiple edits share one pad budget)
+/// and branch repair are decided later in finalizeKernelDisplacements. Records
+/// the edit in Ctx.DisplacementEdits on success.
+[[nodiscard]] bool
+collectKernelTailDisplacement(PatchContext &Ctx, uint64_t InstOffset,
+                              uint32_t InstSize,
+                              ArrayRef<uint8_t> Replacement) {
+  const LLVMState &LS = Ctx.LS;
+  if (Replacement.size() <= InstSize)
+    return false;
+  const uint64_t Growth = Replacement.size() - InstSize;
+  if (Growth % MinInstSize != 0 || LS.SNopBytes.size() != MinInstSize)
+    return false;
+
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!Range)
+    return false;
+  if (InstOffset < Range->Begin || InstOffset + InstSize > Range->End ||
+      Range->End > Ctx.TextSize)
+    return false;
+
+  DisplacementEdit Edit;
+  Edit.Offset = InstOffset;
+  Edit.OriginalSize = InstSize;
+  Edit.ReplacementBytes.assign(Replacement.begin(), Replacement.end());
+  Ctx.DisplacementEdits.push_back(std::move(Edit));
+  return true;
+}
+
 /// Emit \p Replacement for the instruction at [\p InstOffset,
-/// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
-/// reachable sled with sufficient headroom exists; otherwise falls back to a
-/// deferred trampoline.
+/// \p InstOffset + \p InstSize). Prefers per-kernel local displacement into the
+/// kernel's tail padding (collected now, applied together in
+/// finalizeKernelDisplacements), then an in-place NOP-sled rewrite, otherwise
+/// falls back to a deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        ArrayRef<uint8_t> Replacement) {
+  // Tier 1: record a local-displacement edit into this kernel's own tail
+  // padding. Collected (not applied) here so multiple edits in one kernel can
+  // be applied together with cumulative offset math; the finalize pass either
+  // displaces them or, if the kernel can't fit, hands them back for
+  // trampolines. AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT forces the legacy
+  // trampoline path for A/B benchmarking (displacement vs trampoline on the
+  // same binary).
+  static const bool DisplacementDisabled =
+      getenv("AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT") != nullptr;
+  if (!DisplacementDisabled && !Ctx.DirectControlFlow.HasUnresolvedTargets &&
+      collectKernelTailDisplacement(Ctx, InstOffset, InstSize, Replacement))
+    return true;
+
   std::optional<uint64_t> ReturnTo = checkedAddUint64(
       InstOffset, InstSize, "replacement trampoline return target");
   std::optional<uint64_t> PoolReturnFrom =
@@ -2103,6 +2157,414 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
   }
   return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+}
+
+// -- Per-kernel local displacement finalize -----------------------------------
+
+namespace {
+
+/// Re-encode the s_add_nc_u64 immediate at \p AddOff by \p DeltaBytes so a
+/// PC-relative address computation (s_get_pc; s_add +imm) still resolves to the
+/// same absolute target after the code moved. \p AddOff is the ORIGINAL .text
+/// offset of the s_add; the returned fix carries the byte offset to patch (the
+/// NEW location, supplied by the caller as \p NewAddOff) and the new bytes.
+/// Returns false if the instruction at AddOff is not the expected
+/// s_add_nc_u64 reg,reg,imm form or re-encode changes its size.
+template <typename FixVec>
+[[nodiscard]] bool repairSGetPcAddImmediate(PatchContext &Ctx, uint64_t AddOff,
+                                            uint64_t NewAddOff,
+                                            int64_t DeltaBytes, FixVec &Fixes) {
+  const LLVMState &LS = Ctx.LS;
+  std::vector<InternalDecodedInst> One;
+  // Decode a small window starting at the s_add; the first decoded instruction
+  // is the s_add itself.
+  const uint64_t Window = 16;
+  uint64_t Avail = Ctx.TextSize - AddOff;
+  if (!decodeTextSection(Ctx.Text + AddOff, std::min(Window, Avail), LS, One) ||
+      One.empty())
+    return false;
+  const InternalDecodedInst &Add = One[0];
+  if (Add.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+      Add.Inst.getNumOperands() != 3 || !Add.Inst.getOperand(2).isImm())
+    return false;
+  MCInst NewInst = Add.Inst;
+  int64_t NewImm = Add.Inst.getOperand(2).getImm() + DeltaBytes;
+  NewInst.getOperand(2).setImm(NewImm);
+  SmallVector<char, 16> Code;
+  SmallVector<MCFixup, 4> MCFixups;
+  LS.MCE->encodeInstruction(NewInst, Code, MCFixups, *LS.STI);
+  if (Code.size() != Add.Size)
+    return false;
+  typename FixVec::value_type F;
+  F.NewFrom = NewAddOff;
+  F.Bytes.assign(Code.begin(), Code.end());
+  Fixes.push_back(std::move(F));
+  return true;
+}
+
+/// One kernel's contribution to a displacement region: its original span, the
+/// end of its trailing s_nop padding, and the edits applied inside it. Kernels
+/// with no edits still appear (as movable filler) when they sit inside a ripple
+/// window between an overflowing kernel and the successor that absorbs it.
+struct DispKernel {
+  uint64_t Begin = 0;  // original .text offset of the entry
+  uint64_t End = 0;    // original end of real code
+  uint64_t PadEnd = 0; // end of the trailing s_nop run
+  std::string Name;    // kernel name (for descriptor entry-offset fixup)
+  std::vector<DisplacementEdit> Edits;
+
+  uint64_t grownCodeSize() const {
+    uint64_t G = 0;
+    for (const DisplacementEdit &E : Edits)
+      G += E.ReplacementBytes.size() - E.OriginalSize;
+    return (End - Begin) + G;
+  }
+};
+
+/// Round \p V up to the next multiple of \p A (a power of two).
+uint64_t roundUpTo(uint64_t V, uint64_t A) { return (V + A - 1) & ~(A - 1); }
+
+} // namespace
+
+/// Apply all collected displacement edits. Edits are grouped into their owning
+/// kernels; a kernel whose growth fits its own trailing padding is rewritten in
+/// place (tier 1). A kernel that overflows forms a ripple window with the
+/// following kernels: the window's byte span is held fixed (RegionEnd pinned at
+/// a kernel-padding boundary), the kernels inside it are re-laid-out
+/// 256-byte-aligned with edits spliced, and every kernel that moved gets its
+/// kernel_code_entry_byte_offset descriptor updated (tier 2). Intra-kernel
+/// s_branch targets and s_get_pc-relative data references are repaired against
+/// the new layout. A kernel that cannot be displaced locally (dense cluster
+/// with no ripple slack, or a single-kernel object) has its edits appended to
+/// \p OutDeclined for the caller's tier-3 .text-grow backstop. Returns false
+/// Move a declined kernel's edits into \p OutDeclined for the tier-3 .text
+/// grow, padding the last edit with s_nop so the kernel's TOTAL growth rounds
+/// up to a 256-byte multiple. Without this, the whole-object grow shifts later
+/// kernels by a non-stride amount and their 256-aligned entries break
+/// (validateKernelEntryMappings). Padding here keeps every downstream entry on
+/// a 256 boundary at the cost of a few dead s_nop per declined kernel.
+static void
+moveDeclinedKernelEditsPadded(std::vector<DisplacementEdit> &Edits,
+                              const LLVMState &LS,
+                              std::vector<DisplacementEdit> &OutDeclined) {
+  if (Edits.empty())
+    return;
+  uint64_t Growth = 0;
+  for (const DisplacementEdit &E : Edits)
+    Growth += E.ReplacementBytes.size() - E.OriginalSize;
+  std::optional<uint64_t> Rounded = checkedAlignTo(
+      Growth, KernelEntryStubStride, "declined-kernel displacement growth");
+  uint64_t Pad = Rounded ? *Rounded - Growth : 0;
+  if (Pad != 0 && LS.SNopBytes.size() == MinInstSize) {
+    DisplacementEdit &Last = Edits.back();
+    while (Pad >= MinInstSize) {
+      Last.ReplacementBytes.append(LS.SNopBytes.begin(), LS.SNopBytes.end());
+      Pad -= MinInstSize;
+    }
+  }
+  for (DisplacementEdit &E : Edits)
+    OutDeclined.push_back(std::move(E));
+}
+
+/// only on an unrecoverable internal error.
+[[nodiscard]] bool
+finalizeKernelDisplacements(PatchContext &Ctx,
+                            std::vector<DisplacementEdit> &OutDeclined) {
+  if (Ctx.DisplacementEdits.empty())
+    return true;
+  const LLVMState &LS = Ctx.LS;
+
+  // Build an address-ordered table of every kernel in .text with its padding
+  // extent, then attach the collected edits to their owning kernel.
+  // functionTextRanges() returns ABSOLUTE virtual addresses; convert to
+  // .text-relative offsets to match DisplacementEdit::Offset and Ctx.Text.
+  const uint64_t TextAddr = Ctx.Elf.textAddr();
+  std::vector<ElfView::FunctionTextRange> Ranges = Ctx.Elf.functionTextRanges();
+  std::sort(Ranges.begin(), Ranges.end(),
+            [](const ElfView::FunctionTextRange &A,
+               const ElfView::FunctionTextRange &B) {
+              if (A.Begin != B.Begin)
+                return A.Begin < B.Begin;
+              return A.End > B.End;
+            });
+  // functionTextRanges() scans both .symtab and .dynsym, so a kernel present in
+  // both is listed twice with the same Begin. Dedupe by Begin (keep the widest)
+  // so padding gaps are computed against the true next kernel, not a duplicate.
+  Ranges.erase(std::unique(Ranges.begin(), Ranges.end(),
+                           [](const ElfView::FunctionTextRange &A,
+                              const ElfView::FunctionTextRange &B) {
+                             return A.Begin == B.Begin;
+                           }),
+               Ranges.end());
+  std::vector<DispKernel> Kernels;
+  Kernels.reserve(Ranges.size());
+  for (size_t I = 0; I < Ranges.size(); ++I) {
+    DispKernel K;
+    K.Begin = Ranges[I].Begin - TextAddr;
+    K.End = Ranges[I].End - TextAddr;
+    K.Name = Ctx.Elf.findKernelAtAddress(Ranges[I].Begin);
+    uint64_t PadLimit =
+        (I + 1 < Ranges.size()) ? Ranges[I + 1].Begin - TextAddr : Ctx.TextSize;
+    uint64_t PadEnd = K.End;
+    while (PadEnd + MinInstSize <= PadLimit &&
+           std::memcmp(Ctx.Text + PadEnd, LS.SNopBytes.data(), MinInstSize) ==
+               0)
+      PadEnd += MinInstSize;
+    K.PadEnd = PadEnd;
+    Kernels.push_back(std::move(K));
+  }
+  auto kernelIndexOf = [&](uint64_t Off) -> std::optional<size_t> {
+    for (size_t I = 0; I < Kernels.size(); ++I)
+      if (Off >= Kernels[I].Begin && Off < Kernels[I].PadEnd)
+        return I;
+    return std::nullopt;
+  };
+  for (DisplacementEdit &E : Ctx.DisplacementEdits) {
+    std::optional<size_t> KI = kernelIndexOf(E.Offset);
+    if (!KI)
+      return false; // collection guaranteed a range; a miss is a real bug
+    Kernels[*KI].Edits.push_back(std::move(E));
+  }
+  for (DispKernel &K : Kernels)
+    std::sort(K.Edits.begin(), K.Edits.end(),
+              [](const DisplacementEdit &A, const DisplacementEdit &B) {
+                return A.Offset < B.Offset;
+              });
+
+  uint32_t DisplacedSites = 0, DisplacedKernelCount = 0, MovedKernels = 0,
+           DeclinedSites = 0;
+
+  // Walk kernels in address order. A kernel with edits either fits its own
+  // padding (region of one) or extends the region forward until the aggregate
+  // 256-aligned kernel footprints fit the region's fixed byte span.
+  for (size_t I = 0; I < Kernels.size(); ++I) {
+    if (Kernels[I].Edits.empty())
+      continue;
+
+    // Grow the region [I, J] until every kernel's 256-aligned grown footprint
+    // fits within [Kernels[I].Begin, Kernels[J].PadEnd). The last kernel's own
+    // padding is what shrinks to make room; kernels between move down by whole
+    // strides. Cap the ripple so a pathological object can't scan to the end.
+    constexpr size_t MaxRipple = 8;
+    size_t J = I;
+    bool Fits = false;
+    for (size_t Depth = 0; Depth < MaxRipple && J < Kernels.size();
+         ++Depth, ++J) {
+      const uint64_t RegionBegin = Kernels[I].Begin;
+      const uint64_t RegionEnd = Kernels[J].PadEnd;
+      uint64_t Need = 0;
+      for (size_t K = I; K < J; ++K)
+        Need += roundUpTo(Kernels[K].grownCodeSize(), KernelEntryStubStride);
+      Need += Kernels[J].grownCodeSize(); // last kernel need not be re-padded
+      if (Need <= RegionEnd - RegionBegin) {
+        Fits = true;
+        break;
+      }
+    }
+    if (!Fits) {
+      // Only kernel I is declined here; its ripple successors were candidates,
+      // not committed, and each gets its own turn as the loop advances. The
+      // declined edits go to the caller's tier-3 .text-grow backstop.
+      DeclinedSites += Kernels[I].Edits.size();
+      moveDeclinedKernelEditsPadded(Kernels[I].Edits, LS, OutDeclined);
+      log() << "hotswap: displacement declined (tier-3): kernel [0x"
+            << utohexstr(Kernels[I].Begin) << ",0x" << utohexstr(Kernels[I].End)
+            << ") growth exceeds ripple capacity\n";
+      continue;
+    }
+
+    const uint64_t RegionBegin = Kernels[I].Begin;
+    const uint64_t RegionEnd = Kernels[J].PadEnd;
+
+    // Compute each kernel's NEW begin (256-aligned) and validate no PC-relative
+    // hazard breaks. First kernel stays at RegionBegin; the rest are packed.
+    std::vector<uint64_t> NewBegin(J - I + 1);
+    uint64_t Place = RegionBegin;
+    for (size_t K = I; K <= J; ++K) {
+      NewBegin[K - I] = Place;
+      Place =
+          roundUpTo(Place + Kernels[K].grownCodeSize(), KernelEntryStubStride);
+    }
+
+    // Per-kernel shift map for offsets inside kernel K: an original offset Off
+    // in [K.Begin, K.End) maps to NewBegin[K] + (Off - K.Begin) + growth of
+    // edits before Off. Used for branch and s_get_pc repair.
+    auto newOffsetOf = [&](size_t KIdx, uint64_t Off) -> uint64_t {
+      const DispKernel &K = Kernels[KIdx];
+      uint64_t Local = Off - K.Begin;
+      uint64_t Grow = 0;
+      for (const DisplacementEdit &E : K.Edits)
+        if (E.Offset < Off)
+          Grow += E.ReplacementBytes.size() - E.OriginalSize;
+      return NewBegin[KIdx - I] + Local + Grow;
+    };
+
+    // Validate + collect repairs for every kernel in the region. Any unprovable
+    // construct aborts the whole region (its sites are declined).
+    struct Fix {
+      uint64_t NewFrom = 0;
+      SmallVector<uint8_t> Bytes;
+    };
+    std::vector<Fix> Fixes;
+    bool Bad = false;
+    for (size_t K = I; K <= J && !Bad; ++K) {
+      const DispKernel &Kern = Kernels[K];
+      std::vector<InternalDecodedInst> Insts;
+      if (!decodeTextSection(Ctx.Text + Kern.Begin, Kern.End - Kern.Begin, LS,
+                             Insts)) {
+        Bad = true;
+        break;
+      }
+      auto isReplaced = [&](uint64_t Off) -> bool {
+        for (const DisplacementEdit &E : Kern.Edits)
+          if (Off >= E.Offset && Off < E.Offset + E.OriginalSize)
+            return true;
+        return false;
+      };
+      for (size_t N = 0; N < Insts.size() && !Bad; ++N) {
+        const InternalDecodedInst &DI = Insts[N];
+        const uint64_t Off = Kern.Begin + DI.Offset;
+        if (DI.Mnemonic == "<unknown>" || isReplaced(Off))
+          continue;
+
+        // s_get_pc + s_add pair computing an absolute address (data global or
+        // GOT slot). Repair the s_add immediate by the delta between the pair's
+        // old and new positions so it still points at the (unmoved) target.
+        if (DI.Inst.getOpcode() == LS.SGetPcI64Opcode) {
+          // The following instruction must be the s_add carrying the delta.
+          if (N + 1 >= Insts.size()) {
+            Bad = true;
+            break;
+          }
+          const InternalDecodedInst &Add = Insts[N + 1];
+          const uint64_t AddOff = Kern.Begin + Add.Offset;
+          // s_get_pc captures the address of the NEXT instruction (the s_add).
+          const uint64_t OldPcBase = AddOff;
+          const uint64_t NewPcBase = newOffsetOf(K, AddOff);
+          const int64_t Shift =
+              static_cast<int64_t>(NewPcBase) - static_cast<int64_t>(OldPcBase);
+          if (Shift != 0) {
+            // The target is a global OUTSIDE .text, so it does not move. The
+            // s_add's PC-relative immediate = target - pc_base; pc_base grew by
+            // Shift, so the new immediate = old immediate - Shift.
+            if (!repairSGetPcAddImmediate(Ctx, AddOff, NewPcBase, -Shift,
+                                          Fixes)) {
+              Bad = true;
+              break;
+            }
+          }
+          continue;
+        }
+
+        if (DI.Inst.getOpcode() != LS.SBranchOpcode) {
+          if (LS.MIA &&
+              (LS.MIA->isCall(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst))) {
+            Bad = true;
+            break;
+          }
+          continue;
+        }
+        uint64_t Target = 0;
+        if (!LS.MIA || !LS.MIA->evaluateBranch(DI.Inst, Off, DI.Size, Target)) {
+          Bad = true;
+          break;
+        }
+        // Target must land in some kernel of this region (or this kernel).
+        std::optional<size_t> TgtK = kernelIndexOf(Target);
+        if (!TgtK || *TgtK < I || *TgtK > J) {
+          Bad = true; // branch leaves the region: cannot prove safe
+          break;
+        }
+        const uint64_t NewFrom = newOffsetOf(K, Off);
+        const uint64_t NewTarget = newOffsetOf(*TgtK, Target);
+        if (NewFrom == Off && NewTarget == Target)
+          continue;
+        SmallVector<uint8_t> Enc = LS.encodeSBranch(NewFrom, NewTarget);
+        if (Enc.size() != DI.Size) {
+          Bad = true;
+          break;
+        }
+        Fixes.push_back({NewFrom, std::move(Enc)});
+      }
+    }
+
+    if (Bad) {
+      // Count only kernel I as declined; its ripple successors get their own
+      // attempt as the loop advances (they may displace standalone). Declined
+      // edits go to the caller's tier-3 .text-grow backstop.
+      DeclinedSites += Kernels[I].Edits.size();
+      moveDeclinedKernelEditsPadded(Kernels[I].Edits, LS, OutDeclined);
+      log() << "hotswap: displacement declined (tier-3): region [0x"
+            << utohexstr(RegionBegin) << ",0x" << utohexstr(RegionEnd)
+            << ") has an unprovable branch or PC reference\n";
+      continue;
+    }
+
+    // Build the new region bytes: each kernel's grown code at its 256-aligned
+    // slot, gaps filled with s_nop. Region byte span is unchanged.
+    const uint64_t RegionSize = RegionEnd - RegionBegin;
+    SmallVector<uint8_t> NewRegion(RegionSize, 0);
+    for (uint64_t P = 0; P + MinInstSize <= RegionSize; P += MinInstSize)
+      std::memcpy(NewRegion.data() + P, LS.SNopBytes.data(), MinInstSize);
+    for (size_t K = I; K <= J; ++K) {
+      const DispKernel &Kern = Kernels[K];
+      uint64_t W = NewBegin[K - I] - RegionBegin;
+      uint64_t Cursor = Kern.Begin;
+      for (const DisplacementEdit &E : Kern.Edits) {
+        std::memcpy(NewRegion.data() + W, Ctx.Text + Cursor, E.Offset - Cursor);
+        W += E.Offset - Cursor;
+        std::memcpy(NewRegion.data() + W, E.ReplacementBytes.data(),
+                    E.ReplacementBytes.size());
+        W += E.ReplacementBytes.size();
+        Cursor = E.Offset + E.OriginalSize;
+      }
+      std::memcpy(NewRegion.data() + W, Ctx.Text + Cursor, Kern.End - Cursor);
+    }
+    std::memcpy(Ctx.Text + RegionBegin, NewRegion.data(), NewRegion.size());
+    for (const Fix &F : Fixes)
+      std::memcpy(Ctx.Text + F.NewFrom, F.Bytes.data(), F.Bytes.size());
+
+    // Update descriptors for every kernel that moved (all but the first).
+    for (size_t K = I + 1; K <= J; ++K) {
+      const uint64_t NewEntryVAddr = Ctx.Elf.textAddr() + NewBegin[K - I];
+      std::optional<uint64_t> KdVAddr =
+          Ctx.Elf.getKernelDescriptorVAddr(Kernels[K].Name);
+      if (!KdVAddr) {
+        log() << "hotswap: error: displacement: missing descriptor for '"
+              << Kernels[K].Name << "'\n";
+        return false;
+      }
+      int64_t NewEntryOffset =
+          static_cast<int64_t>(NewEntryVAddr) - static_cast<int64_t>(*KdVAddr);
+      if (!Ctx.Elf.updateKernelDescriptorEntryOffset(Kernels[K].Name,
+                                                     NewEntryOffset)) {
+        log() << "hotswap: error: displacement: failed descriptor update for '"
+              << Kernels[K].Name << "'\n";
+        return false;
+      }
+      ++MovedKernels;
+    }
+
+    uint32_t RegionSites = 0;
+    for (size_t K = I; K <= J; ++K) {
+      RegionSites += Kernels[K].Edits.size();
+      if (!Kernels[K].Edits.empty())
+        ++DisplacedKernelCount;
+    }
+    DisplacedSites += RegionSites;
+    log() << "hotswap: displaced " << RegionSites
+          << " site(s) across region [0x" << utohexstr(RegionBegin) << ",0x"
+          << utohexstr(RegionEnd) << "), " << (J - I)
+          << " successor kernel(s) rippled, " << Fixes.size()
+          << " branch/PC fixup(s)\n";
+    I = J; // region consumed; continue after it
+  }
+
+  log() << "hotswap: local displacement: " << DisplacedSites << " site(s) in "
+        << DisplacedKernelCount << " kernel(s), " << MovedKernels
+        << " kernel(s) rippled down, " << DeclinedSites
+        << " site(s) declined\n";
+  return true;
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -2136,7 +2598,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     std::vector<InternalDecodedInst> &Decoded, uint8_t *Text, uint64_t TextSize,
     const LLVMState &LS, std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
     std::vector<ScratchPatchInfo> &OutScratchPatches,
-    const RewriteConfig &Config, bool &OutRequiredPatchApplied) {
+    const RewriteConfig &Config, bool &OutRequiredPatchApplied,
+    std::vector<DisplacementEdit> &OutDeclinedDisplacements) {
   uint32_t Patched = 0;
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
   std::optional<DeclaredTextEntryInfo> DeclaredEntries =
@@ -2361,6 +2824,9 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";
   }
+  if (!finalizeKernelDisplacements(Ctx, OutDeclinedDisplacements))
+    return std::nullopt;
+
   OutRequiredPatchApplied = Ctx.RequiredPatchApplied;
   return Patched;
 }
@@ -2654,22 +3120,70 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   uint64_t Count = 0;
   std::vector<Trampoline> Deferred;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  std::vector<DisplacementEdit> DeclinedDisplacements;
   bool RequiredPatchApplied = false;
   if (RunInstructionPatches) {
+    // Phase timing for benchmarking (AMD_COMGR_EMIT_VERBOSE_LOGS). Uses
+    // steady_clock; costs nothing when logs are off besides two now() calls.
+    using Clock = std::chrono::steady_clock;
+    auto ms = [](Clock::duration D) {
+      return std::chrono::duration<double, std::milli>(D).count();
+    };
+
+    Clock::time_point TDecodeStart = Clock::now();
     std::vector<InternalDecodedInst> Decoded;
     if (!decodeTextSection(Text, Elf.textSize(), LS, Decoded)) {
       log() << "hotswap: error: retargetCodeObject: decodeTextSection "
             << "failed on .text (" << Elf.textSize() << " bytes).\n";
       return AMD_COMGR_STATUS_ERROR;
     }
+    Clock::time_point TPatchStart = Clock::now();
+    log() << "hotswap: TIMING decode .text: " << ms(TPatchStart - TDecodeStart)
+          << " ms\n";
 
     std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
         Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
-        Config, RequiredPatchApplied);
+        Config, RequiredPatchApplied, DeclinedDisplacements);
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;
+    log() << "hotswap: TIMING apply patches + tier-1/2 finalize: "
+          << ms(Clock::now() - TPatchStart) << " ms\n";
     log() << "hotswap: applied " << Count << " instruction patches\n";
+
+    // Tier-3 backstop: any growing patch that local per-kernel displacement
+    // could not place (dense cluster with no ripple slack, or a single-kernel
+    // object) is applied by growing .text whole-object and relocating trailing
+    // allocatable sections forward. This is what lets displacement cover ANY
+    // workload with no trampoline fallback. Re-enter on the grown buffer with
+    // instruction patches already applied, so only the entry/no-op tail runs.
+    if (!DeclinedDisplacements.empty()) {
+      log() << "hotswap: tier-3: growing .text for "
+            << DeclinedDisplacements.size()
+            << " displacement edit(s) that did not fit locally\n";
+      Clock::time_point TTier3Start = Clock::now();
+      Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
+          tryApplyTextDisplacementToNewBuffer(
+              Elf, LS, DeclinedDisplacements,
+              /*RelocateTrailingSections=*/true);
+      log() << "hotswap: TIMING tier-3 grow + reloc + eh_frame remap: "
+            << ms(Clock::now() - TTier3Start) << " ms\n";
+      if (!GrownOrErr) {
+        log() << "hotswap: error: tier-3 .text grow failed: "
+              << toString(GrownOrErr.takeError()) << "\n";
+        return AMD_COMGR_STATUS_ERROR;
+      }
+      std::unique_ptr<WritableMemoryBuffer> Grown = std::move(*GrownOrErr);
+      // The grown buffer already has these edits spliced in and metadata
+      // repaired; re-run only the remaining (entry/metadata) tail against it by
+      // recursing with instruction patches disabled.
+      Gfx1250RewriteOptions RemainingOptions = Options;
+      RemainingOptions.RunB0A0Patches = false;
+      RemainingOptions.MaskPolicy = MaskWorkaroundPolicy::None;
+      return retargetCodeObjectImpl(
+          Grown->getBufferStart(), Grown->getBufferSize(), TargetIdent,
+          RemainingOptions, Out, AllowTextDisplacement);
+    }
   } else {
     log() << "hotswap: instruction patches disabled for this rewrite\n";
   }

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -1,0 +1,936 @@
+//===- comgr-hotswap-displacement.cpp - HotSwap text displacement --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Direct `.text` displacement for HotSwap rewrites. This layer inserts
+/// larger replacement sequences into `.text`, shifts the displaced code
+/// forward, repairs direct PC-relative scalar branches when it can prove the
+/// new encoding, and updates ELF metadata. Appended trampolines remain the
+/// fallback when any check fails.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/ADT/StringExtras.h"
+#include "llvm/MC/MCFixup.h"
+#include "llvm/Support/Alignment.h"
+
+#include <algorithm>
+#include <limits>
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+using Ehdr = ELF::Elf64_Ehdr;
+using Shdr = ELF::Elf64_Shdr;
+using Phdr = ELF::Elf64_Phdr;
+using ELFT = ElfView::ELFT;
+using ELFFileT = ElfView::ELFFileT;
+
+namespace {
+
+Error makeDisplacementError(const Twine &Msg) {
+  std::string Message = Msg.str();
+  log() << "hotswap: displacement unavailable: " << Message << "\n";
+  return createStringError(object::object_error::parse_failed, Message);
+}
+
+Expected<uint64_t> requiredGrowthAlignment(const ElfView &Elf) {
+  uint64_t MaxAlign = 1;
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (Shdr.sh_offset <= Elf.textOffset())
+      continue;
+    MaxAlign = std::max<uint64_t>(MaxAlign, Shdr.sh_addralign);
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr) {
+    return makeDisplacementError(
+        "failed to read program headers while computing displacement "
+        "alignment: " +
+        Twine(toString(PhdrsOrErr.takeError())));
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_offset <= Elf.textOffset())
+      continue;
+    MaxAlign = std::max<uint64_t>(MaxAlign, Phdr.p_align);
+  }
+  return std::max<uint64_t>(MaxAlign, 1);
+}
+
+Error validateDebugSections(const ElfView &Elf) {
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr) {
+      return makeDisplacementError(
+          "failed to read section name while checking debug info: " +
+          Twine(toString(NameOrErr.takeError())));
+    }
+    StringRef Name = *NameOrErr;
+    if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
+        Name == ".eh_frame" || Name == ".eh_frame_hdr") {
+      return makeDisplacementError("debug/unwind section '" + Twine(Name) +
+                                   "' requires address remapping");
+    }
+  }
+  return Error::success();
+}
+
+bool isPcSensitiveForDisplacement(const InternalDecodedInst &DI,
+                                  const LLVMState &LS) {
+  unsigned Opcode = DI.Inst.getOpcode();
+  if (Opcode == LS.SAddPcI64Opcode || Opcode == LS.SGetPcI64Opcode ||
+      Opcode == LS.SSetPcI64Opcode || Opcode == LS.SSwapPcI64Opcode ||
+      Opcode == LS.SPrefetchInstPcRelOpcode ||
+      Opcode == LS.SPrefetchDataPcRelOpcode)
+    return true;
+
+  const MCInstrDesc &Desc = LS.MCII->get(Opcode);
+  for (const MCOperandInfo &Operand : Desc.operands())
+    if (Operand.OperandType == MCOI::OPERAND_PCREL)
+      return !LS.MIA->isBranch(DI.Inst);
+  return false;
+}
+
+Error validateVirtualGrowth(const ElfView &Elf, uint64_t PaddedGrowth) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr() ||
+      PaddedGrowth > std::numeric_limits<uint64_t>::max() - Elf.textAddr() -
+                         Elf.textSize())
+    return makeDisplacementError("displaced .text virtual end overflows");
+  const uint64_t OldTextEnd = Elf.textAddr() + Elf.textSize();
+  const uint64_t NewTextEnd = OldTextEnd + PaddedGrowth;
+
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) || &Shdr == Elf.textSection() ||
+        Shdr.sh_size == 0)
+      continue;
+    if (Shdr.sh_addr >= OldTextEnd && Shdr.sh_addr < NewTextEnd) {
+      return makeDisplacementError(
+          "displaced .text would overlap a later allocatable section");
+    }
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr) {
+    return makeDisplacementError(
+        "failed to read program headers while validating displacement: " +
+        Twine(toString(PhdrsOrErr.takeError())));
+  }
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_filesz > std::numeric_limits<uint64_t>::max() - Phdr.p_offset)
+      return makeDisplacementError("program-header file range overflows");
+    const uint64_t SegmentFileEnd = Phdr.p_offset + Phdr.p_filesz;
+    if (Phdr.p_type == ELF::PT_LOAD && Phdr.p_offset <= Elf.textOffset() &&
+        SegmentFileEnd >= Elf.textOffset() + Elf.textSize() &&
+        SegmentFileEnd != Elf.textOffset() + Elf.textSize()) {
+      return makeDisplacementError(
+          ".text is not the last file-backed content in its PT_LOAD segment");
+    }
+
+    if (Phdr.p_type != ELF::PT_LOAD || Phdr.p_memsz == 0)
+      continue;
+    if (Phdr.p_vaddr >= OldTextEnd && Phdr.p_vaddr < NewTextEnd) {
+      return makeDisplacementError(
+          "displaced .text would overlap a later PT_LOAD segment");
+    }
+  }
+  return Error::success();
+}
+
+Error validateTextRelocations(const ElfView &Elf) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
+    return makeDisplacementError(
+        ".text virtual range overflows while checking relocations");
+  }
+  const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
+
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (Shdr.sh_type != ELF::SHT_REL && Shdr.sh_type != ELF::SHT_RELA)
+      continue;
+
+    if (Shdr.sh_info == Elf.textSectionIndex()) {
+      Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+      if (!NameOrErr) {
+        return makeDisplacementError(
+            "failed to read relocation section name: " +
+            Twine(toString(NameOrErr.takeError())));
+      }
+      return makeDisplacementError("relocation section '" + Twine(*NameOrErr) +
+                                   "' references .text");
+    }
+
+    // Dynamic relocation sections use sh_info == 0. r_offset identifies the
+    // location to update, but the relocation's symbol or addend can separately
+    // resolve to displaced code. Reject either direction until displacement
+    // can rewrite relocation expressions as well as their destinations.
+    if (Shdr.sh_info == 0) {
+      if (Shdr.sh_type == ELF::SHT_RELA) {
+        Expected<ELFT::RelaRange> RelasOrErr = Elf.file().relas(Shdr);
+        if (!RelasOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation section: " +
+              Twine(toString(RelasOrErr.takeError())));
+        }
+        Expected<const ELFT::Shdr *> SymtabOrErr =
+            Elf.file().getSection(Shdr.sh_link);
+        if (!SymtabOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation symbol table: " +
+              Twine(toString(SymtabOrErr.takeError())));
+        }
+
+        for (const ELFT::Rela &Rela : *RelasOrErr) {
+          if (Rela.r_offset >= Elf.textAddr() && Rela.r_offset < TextEnd) {
+            return makeDisplacementError(
+                "dynamic relocation section targets a displaced .text "
+                "address");
+          }
+
+          if (Rela.r_addend >= 0) {
+            const uint64_t Addend = static_cast<uint64_t>(Rela.r_addend);
+            if (Addend >= Elf.textAddr() && Addend < TextEnd) {
+              return makeDisplacementError(
+                  "dynamic relocation addend references a displaced .text "
+                  "address");
+            }
+          }
+
+          Expected<const ELFT::Sym *> SymOrErr =
+              Elf.file().getRelocationSymbol(Rela, *SymtabOrErr);
+          if (!SymOrErr) {
+            return makeDisplacementError(
+                "failed to read dynamic relocation symbol: " +
+                Twine(toString(SymOrErr.takeError())));
+          }
+          const ELFT::Sym *Sym = *SymOrErr;
+          if (Sym &&
+              (Sym->st_shndx == Elf.textSectionIndex() ||
+               (Sym->st_value >= Elf.textAddr() && Sym->st_value < TextEnd))) {
+            return makeDisplacementError(
+                "dynamic relocation symbol references displaced .text");
+          }
+        }
+      } else {
+        Expected<ELFT::RelRange> RelsOrErr = Elf.file().rels(Shdr);
+        if (!RelsOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation section: " +
+              Twine(toString(RelsOrErr.takeError())));
+        }
+        Expected<const ELFT::Shdr *> SymtabOrErr =
+            Elf.file().getSection(Shdr.sh_link);
+        if (!SymtabOrErr) {
+          return makeDisplacementError(
+              "failed to read dynamic relocation symbol table: " +
+              Twine(toString(SymtabOrErr.takeError())));
+        }
+
+        for (const ELFT::Rel &Rel : *RelsOrErr) {
+          if (Rel.r_offset >= Elf.textAddr() && Rel.r_offset < TextEnd) {
+            return makeDisplacementError(
+                "dynamic relocation section targets a displaced .text "
+                "address");
+          }
+
+          Expected<const ELFT::Sym *> SymOrErr =
+              Elf.file().getRelocationSymbol(Rel, *SymtabOrErr);
+          if (!SymOrErr) {
+            return makeDisplacementError(
+                "failed to read dynamic relocation symbol: " +
+                Twine(toString(SymOrErr.takeError())));
+          }
+          const ELFT::Sym *Sym = *SymOrErr;
+          if (Sym &&
+              (Sym->st_shndx == Elf.textSectionIndex() ||
+               (Sym->st_value >= Elf.textAddr() && Sym->st_value < TextEnd))) {
+            return makeDisplacementError(
+                "dynamic relocation symbol references displaced .text");
+          }
+
+          // SHT_REL stores its addend at r_offset. Without interpreting each
+          // AMDGPU relocation width and target section, a symbol-free record
+          // cannot prove that its implicit addend is independent of .text.
+          if (!Sym && Rel.getType(false) != ELF::R_AMDGPU_NONE) {
+            return makeDisplacementError(
+                "symbol-free dynamic REL relocation has an implicit addend");
+          }
+        }
+      }
+    }
+  }
+  return Error::success();
+}
+
+Error validateKernelEntryMappings(const ElfView &Elf,
+                                  const DisplacementPlan &Plan) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
+    return makeDisplacementError(
+        ".text virtual range overflows while checking kernel entries");
+  }
+  const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
+
+  for (const KernelDescriptorInfo &KD : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> OldEntry = entryVAddr(KD);
+    if (!OldEntry) {
+      return makeDisplacementError("failed to resolve kernel entry for '" +
+                                   Twine(KD.KernelName) + "'");
+    }
+    if (*OldEntry < Elf.textAddr() || *OldEntry >= TextEnd) {
+      return makeDisplacementError(
+          "kernel entry for '" + Twine(KD.KernelName) +
+          "' is outside .text and may contain an unrepairable entry stub");
+    }
+
+    uint64_t NewEntryOffset = 0;
+    if (!Plan.mapOffset(*OldEntry - Elf.textAddr(),
+                        DisplacementMapBias::BeforeInsertedBytes,
+                        NewEntryOffset)) {
+      return makeDisplacementError("kernel entry for '" + Twine(KD.KernelName) +
+                                   "' maps inside a replaced range");
+    }
+    if (NewEntryOffset >
+        std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
+      return makeDisplacementError("displaced kernel entry for '" +
+                                   Twine(KD.KernelName) + "' overflows");
+    }
+    const uint64_t NewEntry = Elf.textAddr() + NewEntryOffset;
+    if (NewEntry % KernelEntryStubStride != 0) {
+      return makeDisplacementError("displaced kernel entry for '" +
+                                   Twine(KD.KernelName) +
+                                   "' is not 256-byte aligned");
+    }
+  }
+  return Error::success();
+}
+
+Expected<SmallVector<uint8_t>>
+reencodePcrelBranch(const InternalDecodedInst &DI, uint64_t NewFrom,
+                    uint64_t NewTarget, const LLVMState &LS) {
+  if (DI.Inst.getOpcode() == LS.SBranchOpcode) {
+    SmallVector<uint8_t> Encoded = LS.encodeSBranch(NewFrom, NewTarget);
+    if (Encoded.empty()) {
+      return makeDisplacementError("s_branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " is out of range after displacement");
+    }
+    return Encoded;
+  }
+
+  if (DI.Inst.getNumOperands() == 0 || !DI.Inst.getOperand(0).isImm()) {
+    return makeDisplacementError(
+        "branch at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+        " does not expose an immediate target operand");
+  }
+
+  int64_t ByteDelta = static_cast<int64_t>(NewTarget) -
+                      static_cast<int64_t>(NewFrom) -
+                      static_cast<int64_t>(DI.Size);
+  if (ByteDelta % MinInstSize != 0) {
+    return makeDisplacementError("branch at old .text offset 0x" +
+                                 Twine::utohexstr(DI.Offset) +
+                                 " has unaligned displacement after rewrite");
+  }
+
+  int64_t DwordOffset = ByteDelta / MinInstSize;
+  if (DwordOffset < BranchOffsetMin || DwordOffset > BranchOffsetMax) {
+    return makeDisplacementError("branch at old .text offset 0x" +
+                                 Twine::utohexstr(DI.Offset) +
+                                 " is out of simm16 range after displacement");
+  }
+
+  MCInst NewInst = DI.Inst;
+  NewInst.getOperand(0).setImm(DwordOffset);
+  SmallVector<char, 16> Code;
+  SmallVector<MCFixup, 4> Fixups;
+  LS.MCE->encodeInstruction(NewInst, Code, Fixups, *LS.STI);
+  SmallVector<uint8_t> Encoded(Code.begin(), Code.end());
+  if (Encoded.size() != DI.Size) {
+    return makeDisplacementError("branch at old .text offset 0x" +
+                                 Twine::utohexstr(DI.Offset) +
+                                 " changed encoded size during re-encode");
+  }
+  return Encoded;
+}
+
+Error repairBranches(const ElfView &Elf, const LLVMState &LS,
+                     const DisplacementPlan &Plan,
+                     SmallVectorImpl<uint8_t> &NewText) {
+  if (!LS.MIA) {
+    return makeDisplacementError(
+        "branch analysis through LLVM MC is unavailable");
+  }
+
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Elf.textData(), Elf.textSize(), LS, Decoded)) {
+    return makeDisplacementError(
+        "failed to decode .text while validating branches");
+  }
+
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (Plan.rangeOverlapsReplacement(DI.Offset, DI.Size))
+      continue;
+
+    const MCInst &Inst = DI.Inst;
+    if (isPcSensitiveForDisplacement(DI, LS)) {
+      return makeDisplacementError(
+          "pc-sensitive instruction '" + Twine(DI.Mnemonic) +
+          "' at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+          " requires linked-address repair");
+    }
+    if (LS.MIA->isCall(Inst)) {
+      return makeDisplacementError("call at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " is not supported by displacement");
+    }
+    if (LS.MIA->isIndirectBranch(Inst)) {
+      return makeDisplacementError("indirect branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " is not supported by displacement");
+    }
+    if (!LS.MIA->isBranch(Inst))
+      continue;
+
+    uint64_t OldTarget = 0;
+    if (!LS.MIA->evaluateBranch(Inst, DI.Offset, DI.Size, OldTarget)) {
+      return makeDisplacementError("branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " target could not be evaluated");
+    }
+    if (OldTarget >= Elf.textSize()) {
+      return makeDisplacementError("branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " targets outside .text");
+    }
+
+    uint64_t NewFrom = 0;
+    uint64_t NewTarget = 0;
+    if (!Plan.mapOffset(DI.Offset, DisplacementMapBias::AfterInsertedBytes,
+                        NewFrom)) {
+      return makeDisplacementError("branch source at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " maps inside a replaced range");
+    }
+    if (!Plan.mapOffset(OldTarget, DisplacementMapBias::BeforeInsertedBytes,
+                        NewTarget)) {
+      return makeDisplacementError("branch target at old .text offset 0x" +
+                                   Twine::utohexstr(OldTarget) +
+                                   " maps inside a replaced range");
+    }
+
+    Expected<SmallVector<uint8_t>> EncodedOrErr =
+        reencodePcrelBranch(DI, NewFrom, NewTarget, LS);
+    if (!EncodedOrErr)
+      return EncodedOrErr.takeError();
+    SmallVector<uint8_t> &Encoded = *EncodedOrErr;
+
+    if (NewFrom + Encoded.size() > NewText.size()) {
+      return makeDisplacementError("re-encoded branch at old .text offset 0x" +
+                                   Twine::utohexstr(DI.Offset) +
+                                   " writes past rebuilt .text");
+    }
+    std::memcpy(NewText.data() + NewFrom, Encoded.data(), Encoded.size());
+  }
+  return Error::success();
+}
+
+Error adjustSectionHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
+                                        const ElfView &OldElf, size_t Growth) {
+  if (ElfSize < sizeof(Ehdr)) {
+    return makeDisplacementError(
+        "displaced ELF is smaller than its ELF64 header");
+  }
+
+  const uint64_t TextOffset = OldElf.textOffset();
+  const uint64_t TextSize = OldElf.textSize();
+  const uint64_t TextEnd = TextOffset + TextSize;
+
+  uint64_t Shoff = 0;
+  uint16_t Shentsize = 0;
+  uint16_t Shnum = 0;
+  std::memcpy(&Shoff, Elf + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, Elf + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
+  std::memcpy(&Shnum, Elf + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+  if (Shentsize < sizeof(Shdr)) {
+    return makeDisplacementError(
+        "displaced ELF section-header entry is too small");
+  }
+
+  if (Shoff >= TextEnd) {
+    uint64_t NewShoff = Shoff + Growth;
+    std::memcpy(Elf + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+    Shoff = NewShoff;
+  }
+
+  for (uint16_t I = 0; I < Shnum; ++I) {
+    uint64_t ShPos = Shoff + static_cast<uint64_t>(I) * Shentsize;
+    if (ShPos > ElfSize || sizeof(Shdr) > ElfSize - ShPos) {
+      return makeDisplacementError(
+          "displaced ELF section-header table is out of bounds");
+    }
+    uint8_t *Sh = Elf + ShPos;
+    uint64_t ShOffset = 0;
+    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
+
+    if (I == OldElf.textSectionIndex()) {
+      uint64_t NewTextSize = TextSize + Growth;
+      std::memcpy(Sh + offsetof(Shdr, sh_size), &NewTextSize,
+                  sizeof(NewTextSize));
+    } else if (ShOffset >= TextEnd) {
+      uint64_t NewOffset = ShOffset + Growth;
+      std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
+                  sizeof(NewOffset));
+    }
+  }
+  return Error::success();
+}
+
+Error adjustProgramHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
+                                        const ElfView &OldElf, size_t Growth) {
+  if (ElfSize < sizeof(Ehdr)) {
+    return makeDisplacementError(
+        "displaced ELF is smaller than its ELF64 header");
+  }
+
+  const uint64_t TextOffset = OldElf.textOffset();
+  const uint64_t TextEnd = TextOffset + OldElf.textSize();
+
+  uint64_t Phoff = 0;
+  uint16_t Phentsize = 0;
+  uint16_t Phnum = 0;
+  std::memcpy(&Phoff, Elf + offsetof(Ehdr, e_phoff), sizeof(Phoff));
+  std::memcpy(&Phentsize, Elf + offsetof(Ehdr, e_phentsize), sizeof(Phentsize));
+  std::memcpy(&Phnum, Elf + offsetof(Ehdr, e_phnum), sizeof(Phnum));
+  if (Phentsize < sizeof(Phdr)) {
+    return makeDisplacementError(
+        "displaced ELF program-header entry is too small");
+  }
+
+  if (Phoff >= TextEnd) {
+    uint64_t NewPhoff = Phoff + Growth;
+    std::memcpy(Elf + offsetof(Ehdr, e_phoff), &NewPhoff, sizeof(NewPhoff));
+    Phoff = NewPhoff;
+  }
+
+  for (uint16_t I = 0; I < Phnum; ++I) {
+    uint64_t PhPos = Phoff + static_cast<uint64_t>(I) * Phentsize;
+    if (PhPos > ElfSize || sizeof(Phdr) > ElfSize - PhPos) {
+      return makeDisplacementError(
+          "displaced ELF program-header table is out of bounds");
+    }
+    uint8_t *Ph = Elf + PhPos;
+    uint64_t POffset = 0;
+    uint64_t PFilesz = 0;
+    uint64_t PMemsz = 0;
+    std::memcpy(&POffset, Ph + offsetof(Phdr, p_offset), sizeof(POffset));
+    std::memcpy(&PFilesz, Ph + offsetof(Phdr, p_filesz), sizeof(PFilesz));
+    std::memcpy(&PMemsz, Ph + offsetof(Phdr, p_memsz), sizeof(PMemsz));
+
+    if (POffset <= TextOffset && POffset + PFilesz >= TextEnd) {
+      PFilesz += Growth;
+      PMemsz = std::max(PMemsz, PFilesz);
+      std::memcpy(Ph + offsetof(Phdr, p_filesz), &PFilesz, sizeof(PFilesz));
+      std::memcpy(Ph + offsetof(Phdr, p_memsz), &PMemsz, sizeof(PMemsz));
+    } else if (POffset >= TextEnd) {
+      POffset += Growth;
+      std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
+    }
+  }
+  return Error::success();
+}
+
+Error adjustSymbolValuesForDisplacement(uint8_t *Elf, size_t ElfSize,
+                                        const ElfView &OldElf,
+                                        const DisplacementPlan &Plan) {
+  Expected<ELFFileT> FileOrErr =
+      ELFFileT::create(StringRef(reinterpret_cast<const char *>(Elf), ElfSize));
+  if (!FileOrErr) {
+    return makeDisplacementError(
+        "failed to parse displaced ELF for symbol repair: " +
+        Twine(toString(FileOrErr.takeError())));
+  }
+  ELFFileT File = std::move(*FileOrErr);
+
+  Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
+  if (!SectionsOrErr) {
+    return makeDisplacementError(
+        "failed to read displaced ELF sections for symbol repair: " +
+        Twine(toString(SectionsOrErr.takeError())));
+  }
+  ELFT::ShdrRange Sections = *SectionsOrErr;
+
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+
+    Expected<ELFT::SymRange> SymsOrErr = File.symbols(&SymShdr);
+    if (!SymsOrErr) {
+      return makeDisplacementError(
+          "failed to read symbol table during displacement: " +
+          Twine(toString(SymsOrErr.takeError())));
+    }
+
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.st_shndx == ELF::SHN_UNDEF || Sym.st_shndx >= ELF::SHN_LORESERVE)
+        continue;
+
+      Expected<const ELFT::Shdr *> DefShdrOrErr = File.getSection(Sym.st_shndx);
+      if (!DefShdrOrErr) {
+        return makeDisplacementError(
+            "failed to read a symbol's defining section during displacement: " +
+            Twine(toString(DefShdrOrErr.takeError())));
+      }
+      const ELFT::Shdr &DefShdr = **DefShdrOrErr;
+
+      const uint8_t *SymBytes = reinterpret_cast<const uint8_t *>(&Sym);
+      if (SymBytes < File.base() || SymBytes > File.end() ||
+          static_cast<size_t>(File.end() - SymBytes) < sizeof(ELFT::Sym)) {
+        return makeDisplacementError(
+            "symbol table entry is outside displaced ELF buffer");
+      }
+      uint64_t SymOffset = SymBytes - File.base();
+
+      if (Sym.st_shndx == OldElf.textSectionIndex()) {
+        const bool LooksLikeVAddr =
+            Sym.st_value >= DefShdr.sh_addr &&
+            Sym.st_value - DefShdr.sh_addr <= Plan.oldTextSize();
+        const uint64_t OldOffset =
+            LooksLikeVAddr ? Sym.st_value - DefShdr.sh_addr : Sym.st_value;
+        if (OldOffset > Plan.oldTextSize()) {
+          return makeDisplacementError(
+              "text symbol value is outside the original .text section");
+        }
+
+        uint64_t NewOffset = 0;
+        if (!Plan.mapOffset(OldOffset, DisplacementMapBias::BeforeInsertedBytes,
+                            NewOffset)) {
+          return makeDisplacementError(
+              "text symbol value maps inside a replaced range");
+        }
+        const uint64_t NewValue =
+            LooksLikeVAddr ? DefShdr.sh_addr + NewOffset : NewOffset;
+        std::memcpy(Elf + SymOffset + offsetof(ELFT::Sym, st_value), &NewValue,
+                    sizeof(NewValue));
+
+        if (Sym.st_size != 0) {
+          if (OldOffset > Plan.oldTextSize() ||
+              Sym.st_size > Plan.oldTextSize() - OldOffset) {
+            return makeDisplacementError(
+                "text symbol extends outside the original .text section");
+          }
+          uint64_t OldEnd = OldOffset + Sym.st_size;
+          uint64_t NewStart = 0;
+          uint64_t NewEnd = 0;
+          // An insertion at the symbol start belongs to this symbol, while
+          // one exactly at the half-open end belongs to the next symbol.
+          if (!Plan.mapOffset(OldOffset,
+                              DisplacementMapBias::BeforeInsertedBytes,
+                              NewStart) ||
+              !Plan.mapOffset(OldEnd, DisplacementMapBias::BeforeInsertedBytes,
+                              NewEnd) ||
+              NewEnd < NewStart) {
+            return makeDisplacementError(
+                "text symbol boundaries cannot be remapped");
+          }
+          uint64_t NewSize = NewEnd - NewStart;
+          std::memcpy(Elf + SymOffset + offsetof(ELFT::Sym, st_size), &NewSize,
+                      sizeof(NewSize));
+        }
+        continue;
+      }
+
+      // Existing non-text virtual addresses are immutable. Fully linked AMDGPU
+      // code objects contain baked address materializations with no
+      // relocations; moving the target symbol would silently retarget those
+      // instructions.
+      // ElfView.GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol
+      // demonstrates the linked-address dependency.
+    }
+  }
+  return Error::success();
+}
+
+Error rewriteKernelDescriptorEntriesForDisplacement(
+    WritableMemoryBuffer &OutBuf, const ElfView &OldElf,
+    const DisplacementPlan &Plan) {
+  uint8_t *Data = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
+  Expected<ElfView> OutViewOrErr =
+      ElfView::create(Data, OutBuf.getBufferSize());
+  if (!OutViewOrErr) {
+    return makeDisplacementError(
+        "failed to reparse displaced ELF for descriptor repair: " +
+        Twine(toString(OutViewOrErr.takeError())));
+  }
+
+  ElfView &OutElf = *OutViewOrErr;
+  for (const KernelDescriptorInfo &KD : OldElf.kernelDescriptors()) {
+    std::optional<uint64_t> OldEntryVAddr = entryVAddr(KD);
+    if (!OldEntryVAddr) {
+      return makeDisplacementError("failed to resolve kernel entry for '" +
+                                   Twine(KD.KernelName) + "'");
+    }
+    if (*OldEntryVAddr < OldElf.textAddr() ||
+        *OldEntryVAddr >= OldElf.textAddr() + OldElf.textSize())
+      continue;
+
+    uint64_t OldEntryOffset = *OldEntryVAddr - OldElf.textAddr();
+    uint64_t NewEntryOffset = 0;
+    if (!Plan.mapOffset(OldEntryOffset,
+                        DisplacementMapBias::BeforeInsertedBytes,
+                        NewEntryOffset)) {
+      return makeDisplacementError("kernel descriptor entry for '" +
+                                   Twine(KD.KernelName) +
+                                   "' maps inside a replaced range");
+    }
+
+    std::optional<uint64_t> NewKdVAddr =
+        OutElf.getKernelDescriptorVAddr(KD.KernelName);
+    if (!NewKdVAddr) {
+      return makeDisplacementError("missing kernel descriptor for '" +
+                                   Twine(KD.KernelName) +
+                                   "' after displacement");
+    }
+
+    const uint64_t NewEntryVAddr = OutElf.textAddr() + NewEntryOffset;
+    std::optional<int64_t> NewKdEntryOffset = checkedSignedDifference(
+        NewEntryVAddr, *NewKdVAddr,
+        (Twine("displaced kernel entry offset for '") + KD.KernelName + "'")
+            .str());
+    if (!NewKdEntryOffset) {
+      return makeDisplacementError(
+          "displaced kernel entry offset is not representable for '" +
+          Twine(KD.KernelName) + "'");
+    }
+    if (!OutElf.updateKernelDescriptorEntryOffset(KD.KernelName,
+                                                  *NewKdEntryOffset)) {
+      return makeDisplacementError(
+          "failed to update kernel descriptor entry for '" +
+          Twine(KD.KernelName) + "'");
+    }
+  }
+  return Error::success();
+}
+
+Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
+                            const DisplacementPlan &Plan,
+                            WritableMemoryBuffer &OutBuf) {
+  const size_t InputSize = Elf.size();
+  const size_t NewSize = Plan.newElfSize(InputSize);
+  if (OutBuf.getBufferSize() != NewSize) {
+    return makeDisplacementError(
+        "output buffer has incorrect size for displacement");
+  }
+
+  SmallVector<uint8_t> NewText = Plan.buildText(
+      ArrayRef<uint8_t>(Elf.textData(), Elf.textSize()), LS.SNopBytes);
+  if (NewText.size() != Plan.paddedTextSize()) {
+    return makeDisplacementError(
+        "rebuilt .text size does not match displacement plan");
+  }
+  if (Error Err = repairBranches(Elf, LS, Plan, NewText))
+    return Err;
+
+  uint8_t *Out = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
+  const uint8_t *Input = Elf.data();
+  const uint64_t TextOffset = Elf.textOffset();
+  const uint64_t TextEnd = TextOffset + Elf.textSize();
+
+  std::memcpy(Out, Input, TextOffset);
+  std::memcpy(Out + TextOffset, NewText.data(), NewText.size());
+  if (TextEnd < InputSize) {
+    std::memcpy(Out + TextOffset + NewText.size(), Input + TextEnd,
+                InputSize - TextEnd);
+  }
+
+  if (Error Err = adjustSectionHeadersForTextGrowth(Out, NewSize, Elf,
+                                                    Plan.paddedGrowth()))
+    return Err;
+  if (Error Err = adjustProgramHeadersForTextGrowth(Out, NewSize, Elf,
+                                                    Plan.paddedGrowth()))
+    return Err;
+  if (Error Err = adjustSymbolValuesForDisplacement(Out, NewSize, Elf, Plan))
+    return Err;
+
+  if (Error Err =
+          rewriteKernelDescriptorEntriesForDisplacement(OutBuf, Elf, Plan))
+    return Err;
+
+  log() << "hotswap: displacement: grew ELF from " << InputSize << " to "
+        << NewSize << " bytes (" << Plan.edits().size() << " edit"
+        << (Plan.edits().size() == 1 ? "" : "s") << ", raw growth "
+        << Plan.rawGrowth() << " bytes, padded growth " << Plan.paddedGrowth()
+        << " bytes).\n";
+  return Error::success();
+}
+
+} // namespace
+
+Expected<DisplacementPlan>
+DisplacementPlan::create(const ElfView &Elf,
+                         ArrayRef<DisplacementEdit> InputEdits) {
+  if (InputEdits.empty())
+    return makeDisplacementError("no displacement edits requested");
+
+  std::vector<DisplacementEdit> Sorted;
+  Sorted.reserve(InputEdits.size());
+  for (const DisplacementEdit &Edit : InputEdits)
+    Sorted.push_back(Edit);
+
+  std::stable_sort(Sorted.begin(), Sorted.end(),
+                   [](const DisplacementEdit &A, const DisplacementEdit &B) {
+                     return A.Offset < B.Offset;
+                   });
+
+  uint64_t RawGrowth = 0;
+  std::optional<uint64_t> PrevOffset;
+  uint64_t PrevEnd = 0;
+  for (const DisplacementEdit &Edit : Sorted) {
+    if (Edit.ReplacementBytes.empty())
+      return makeDisplacementError("displacement edit has empty replacement");
+    if (Edit.Offset > Elf.textSize() ||
+        Edit.OriginalSize > Elf.textSize() - Edit.Offset) {
+      return makeDisplacementError("displacement edit is out of .text bounds");
+    }
+    if (Edit.ReplacementBytes.size() < Edit.OriginalSize)
+      return makeDisplacementError("displacement edit shrinks code");
+    if (Edit.ReplacementBytes.size() == Edit.OriginalSize)
+      return makeDisplacementError("displacement edit has no size delta");
+    if (PrevOffset && Edit.Offset < PrevEnd)
+      return makeDisplacementError("displacement edits overlap");
+    if (PrevOffset && Edit.Offset == *PrevOffset) {
+      return makeDisplacementError(
+          "multiple displacement edits share an offset");
+    }
+
+    uint64_t EditGrowth = Edit.ReplacementBytes.size() - Edit.OriginalSize;
+    if (EditGrowth > std::numeric_limits<uint64_t>::max() - RawGrowth)
+      return makeDisplacementError("displacement growth overflows uint64_t");
+    RawGrowth += EditGrowth;
+    PrevOffset = Edit.Offset;
+    PrevEnd = Edit.Offset + Edit.OriginalSize;
+  }
+
+  Expected<uint64_t> AlignmentOrErr = requiredGrowthAlignment(Elf);
+  if (!AlignmentOrErr)
+    return AlignmentOrErr.takeError();
+  uint64_t Alignment = *AlignmentOrErr;
+  if (!isPowerOf2_64(Alignment))
+    return makeDisplacementError("post-.text alignment is not a power of two");
+  uint64_t Remainder = RawGrowth % Alignment;
+  uint64_t Padding = Remainder == 0 ? 0 : Alignment - Remainder;
+  if (Padding > std::numeric_limits<uint64_t>::max() - RawGrowth)
+    return makeDisplacementError("aligned displacement growth overflows");
+  uint64_t PaddedGrowth = RawGrowth + Padding;
+  if (Error Err = validateVirtualGrowth(Elf, PaddedGrowth))
+    return std::move(Err);
+  if (PaddedGrowth > std::numeric_limits<size_t>::max() - Elf.size())
+    return makeDisplacementError("displaced ELF size overflows size_t");
+  return DisplacementPlan(Elf.textSize(), RawGrowth, PaddedGrowth,
+                          std::move(Sorted));
+}
+
+bool DisplacementPlan::mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
+                                 uint64_t &NewOffset) const {
+  if (OldOffset > OldTextSize)
+    return false;
+
+  uint64_t Delta = 0;
+  for (const DisplacementEdit &Edit : Edits) {
+    const uint64_t EditEnd = Edit.Offset + Edit.OriginalSize;
+    const uint64_t EditDelta = Edit.ReplacementBytes.size() - Edit.OriginalSize;
+
+    if (OldOffset < Edit.Offset)
+      break;
+
+    if (OldOffset == Edit.Offset) {
+      if (Edit.OriginalSize == 0 &&
+          Bias == DisplacementMapBias::AfterInsertedBytes) {
+        Delta += EditDelta;
+        continue;
+      }
+      break;
+    }
+
+    if (OldOffset < EditEnd)
+      return false;
+
+    Delta += EditDelta;
+  }
+
+  NewOffset = OldOffset + Delta;
+  return true;
+}
+
+bool DisplacementPlan::rangeOverlapsReplacement(uint64_t OldOffset,
+                                                uint64_t Size) const {
+  if (Size == 0)
+    return false;
+  const uint64_t OldEnd = OldOffset + Size;
+  for (const DisplacementEdit &Edit : Edits) {
+    if (Edit.OriginalSize == 0)
+      continue;
+    const uint64_t EditEnd = Edit.Offset + Edit.OriginalSize;
+    if (OldOffset < EditEnd && OldEnd > Edit.Offset)
+      return true;
+  }
+  return false;
+}
+
+SmallVector<uint8_t>
+DisplacementPlan::buildText(ArrayRef<uint8_t> OldText,
+                            ArrayRef<uint8_t> SNopBytes) const {
+  SmallVector<uint8_t> Out;
+  Out.reserve(paddedTextSize());
+
+  uint64_t Pos = 0;
+  for (const DisplacementEdit &Edit : Edits) {
+    Out.append(OldText.begin() + Pos, OldText.begin() + Edit.Offset);
+    Out.append(Edit.ReplacementBytes.begin(), Edit.ReplacementBytes.end());
+    Pos = Edit.Offset + Edit.OriginalSize;
+  }
+  Out.append(OldText.begin() + Pos, OldText.end());
+
+  uint64_t PadBytes = paddedTextSize() - Out.size();
+  while (PadBytes >= MinInstSize && SNopBytes.size() == MinInstSize) {
+    Out.append(SNopBytes.begin(), SNopBytes.end());
+    PadBytes -= MinInstSize;
+  }
+  Out.append(PadBytes, uint8_t{0});
+  return Out;
+}
+
+Expected<std::unique_ptr<WritableMemoryBuffer>>
+tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
+                                    ArrayRef<DisplacementEdit> Edits) {
+  if (Error Err = validateDebugSections(Elf))
+    return std::move(Err);
+  if (Error Err = validateTextRelocations(Elf))
+    return std::move(Err);
+
+  Expected<DisplacementPlan> PlanOrErr = DisplacementPlan::create(Elf, Edits);
+  if (!PlanOrErr)
+    return PlanOrErr.takeError();
+  if (Error Err = validateKernelEntryMappings(Elf, *PlanOrErr))
+    return std::move(Err);
+
+  std::unique_ptr<WritableMemoryBuffer> Out =
+      WritableMemoryBuffer::getNewUninitMemBuffer(
+          PlanOrErr->newElfSize(Elf.size()));
+  if (!Out) {
+    return makeDisplacementError(
+        "failed to allocate displacement output buffer");
+  }
+  if (Error Err = applyTextDisplacement(Elf, LS, *PlanOrErr, *Out))
+    return std::move(Err);
+  return std::move(Out);
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -17,10 +17,14 @@
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/LEB128.h"
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 
 using namespace llvm;
@@ -40,6 +44,32 @@ Error makeDisplacementError(const Twine &Msg) {
   std::string Message = Msg.str();
   log() << "hotswap: displacement unavailable: " << Message << "\n";
   return createStringError(object::object_error::parse_failed, Message);
+}
+
+// The non-allocatable DWARF debug sections whose .text addresses
+// remapDebugSectionsForDisplacement rewrites after a tier-3 grow.
+bool isAddressBearingDebugSection(StringRef Name) {
+  return Name == ".debug_frame" || Name == ".debug_info" ||
+         Name == ".debug_ranges" || Name == ".debug_line";
+}
+
+// Debug sections that carry NO .text addresses and are therefore safe to leave
+// byte-identical across a tier-3 grow (only their file offset shifts, which the
+// section-header adjust already handles).
+// .debug_abbrev/.debug_str/.debug_line_str are string/structure tables;
+// .debug_str_offsets/.debug_addr are index tables that do not encode raw .text
+// VADDRs for these DWARF<=4 objects.
+bool isAddressFreeDebugSection(StringRef Name) {
+  return Name == ".debug_abbrev" || Name == ".debug_str" ||
+         Name == ".debug_line_str";
+}
+
+// A .debug section this pass can safely admit into a tier-3 grow: either it has
+// no .text addresses, or we remap the ones it has. Any other .debug*/.zdebug*
+// section fails closed in validateDebugSections so we never ship stale
+// .text addresses.
+bool isRemappableDebugSection(StringRef Name) {
+  return isAddressBearingDebugSection(Name) || isAddressFreeDebugSection(Name);
 }
 
 Expected<uint64_t> requiredGrowthAlignment(const ElfView &Elf) {
@@ -65,7 +95,7 @@ Expected<uint64_t> requiredGrowthAlignment(const ElfView &Elf) {
   return std::max<uint64_t>(MaxAlign, 1);
 }
 
-Error validateDebugSections(const ElfView &Elf) {
+Error validateDebugSections(const ElfView &Elf, bool AllowEhFrameRemap) {
   for (const ELFT::Shdr &Shdr : Elf.sections()) {
     Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
     if (!NameOrErr) {
@@ -74,6 +104,21 @@ Error validateDebugSections(const ElfView &Elf) {
           Twine(toString(NameOrErr.takeError())));
     }
     StringRef Name = *NameOrErr;
+    // .eh_frame is remapped in place by remapEhFrameForDisplacement when the
+    // caller opts into trailing-section relocation (tier-3). .eh_frame_hdr is a
+    // binary-search table over FDEs and would also need rebuilding; block it
+    // until that is implemented. Full DWARF (.debug*) stays out of scope.
+    if (AllowEhFrameRemap && Name == ".eh_frame")
+      continue;
+    // When relocating trailing sections (tier-3),
+    // remapDebugSectionsForDisplacement rewrites the .text addresses in the
+    // non-allocatable DWARF debug sections it understands
+    // (.debug_frame/.debug_info/.debug_ranges/.debug_line). Allow those
+    // through; any other .debug*/.zdebug* section (or a construct the remapper
+    // cannot handle) still fails closed there. .eh_frame_hdr is a binary-search
+    // table over FDEs that would need rebuilding; keep blocking it.
+    if (AllowEhFrameRemap && isRemappableDebugSection(Name))
+      continue;
     if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
         Name == ".eh_frame" || Name == ".eh_frame_hdr") {
       return makeDisplacementError("debug/unwind section '" + Twine(Name) +
@@ -282,11 +327,13 @@ Error validateKernelEntryMappings(const ElfView &Elf,
       return makeDisplacementError("failed to resolve kernel entry for '" +
                                    Twine(KD.KernelName) + "'");
     }
-    if (*OldEntry < Elf.textAddr() || *OldEntry >= TextEnd) {
-      return makeDisplacementError(
-          "kernel entry for '" + Twine(KD.KernelName) +
-          "' is outside .text and may contain an unrepairable entry stub");
-    }
+    // A kernel whose entry falls outside [textAddr, TextEnd) has nothing to
+    // displace (e.g. a zero-body placeholder kernel whose entry sits at the
+    // one-past-the-end .text boundary). Skip it here to stay consistent with
+    // rewriteKernelDescriptorEntriesForDisplacement, which also skips it and
+    // leaves its descriptor untouched.
+    if (*OldEntry < Elf.textAddr() || *OldEntry >= TextEnd)
+      continue;
 
     uint64_t NewEntryOffset = 0;
     if (!Plan.mapOffset(*OldEntry - Elf.textAddr(),
@@ -359,6 +406,238 @@ reencodePcrelBranch(const InternalDecodedInst &DI, uint64_t NewFrom,
   return Encoded;
 }
 
+/// Attempt to repair an `s_get_pc_i64; s_add_nc_u64 sX, sX, imm` PC-relative
+/// address computation under a whole-object (tier-3) displacement. \p Gp is the
+/// decoded s_get_pc at old .text offset \p Gp.Offset. The pair materializes an
+/// absolute address: pc_base is the address of the instruction following
+/// s_get_pc (the s_add), and the s_add immediate is (target - pc_base). When
+/// the code moves, pc_base shifts, so the immediate must be adjusted by -shift
+/// to keep pointing at the same (unmoved) target.
+///
+/// Returns Expected<bool>: true if the pair matched and was repaired (or needed
+/// no change), false if the instruction is not the expected repairable pair
+/// (the caller then falls through to the strict pc-sensitive rejection,
+/// fail-closed). An Error is returned only for a genuinely broken rewrite
+/// (re-encode size change or a write past the rebuilt buffer).
+///
+/// CORRECTNESS: -shift is valid only when the computed target is OUTSIDE .text
+/// (a data global / GOT slot that does not move). If the target lands inside
+/// .text it would itself be displaced and -shift would be wrong, so that case
+/// returns false and the caller rejects the whole displacement.
+Expected<bool> repairSGetPcPairForDisplacement(
+    const ElfView &Elf, const LLVMState &LS, const DisplacementPlan &Plan,
+    const InternalDecodedInst &Gp, SmallVectorImpl<uint8_t> &NewText) {
+  // The s_add immediately follows s_get_pc. Decode a small window at its
+  // offset; the first decoded instruction is the s_add carrying the PC-relative
+  // addend.
+  const uint64_t AddOldOff = Gp.Offset + Gp.Size;
+  if (AddOldOff >= Elf.textSize())
+    return false;
+  // Decode ONLY the s_add that follows s_get_pc. Decode over the FULL remaining
+  // .text (not a fixed-size sub-buffer): the AMDGPU disassembler can read up to
+  // getMaxInstLength() bytes for a literal, so a too-small window (e.g. an
+  // s_add_nc_u64 with a lit64 near the window edge) makes it over-read past the
+  // copy and crash. Streaming stops after the first instruction via the
+  // early-false callback, so decoding "the whole rest" costs exactly one insn.
+  InternalDecodedInst Add;
+  bool Got = false;
+  decodeTextSectionStreaming(
+      Elf.textData() + AddOldOff, Elf.textSize() - AddOldOff, LS,
+      /*WantMnemonic=*/false, [&](const InternalDecodedInst &DI) -> bool {
+        Add = DI;
+        Got = true;
+        return false; // stop after the first instruction
+      });
+  if (!Got || Add.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+      Add.Inst.getNumOperands() != 3)
+    return false;
+
+  // The PC-relative addend is operand 2. Tensile/rocBLAS-style code encodes it
+  // either as a plain immediate or, when it needs the 64-bit literal form, as
+  // an AMDGPU lit/lit64 target MCExpr that evaluates to an absolute constant.
+  // Extract the numeric addend from whichever form is present; anything else is
+  // not the expected pair (fail-closed).
+  const MCOperand &AddendOp = Add.Inst.getOperand(2);
+  int64_t OldImm = 0;
+  if (AddendOp.isImm()) {
+    OldImm = AddendOp.getImm();
+  } else if (!AddendOp.isExpr() ||
+             !AddendOp.getExpr()->evaluateAsAbsolute(OldImm)) {
+    return false;
+  }
+
+  // pc_base is the s_add's own .text offset (s_get_pc captures the NEXT
+  // instruction). target = pc_base + imm, as a SIGNED .text-relative offset:
+  // it can be negative (a global in .rodata, which precedes .text) or >=
+  // textSize (a global in a trailing section .data/.bss). Three regions, each
+  // needs a different repair because only some regions move under tier-3:
+  //   - target < 0            (.rodata, BEFORE .text): does NOT move. The code
+  //                            moved by code_shift, so new_imm = old_imm -
+  //                            code_shift (target fixed).
+  //   - 0 <= target < textSize (INSIDE .text): the target itself is displaced
+  //                            and would need full offset mapping; reject
+  //                            (fail-closed).
+  //   - target >= textSize    (.data/.bss, AFTER .text): relocated forward by
+  //                            paddedGrowth (adjustSectionHeadersForTextGrowth:
+  //                            allocatable sh_addr >= textAddr += Growth), so
+  //                            new_target = old_target + paddedGrowth.
+  // In all handled cases: new_imm = new_target_offset - new_pc_base_offset.
+  const int64_t OldPcBase = static_cast<int64_t>(AddOldOff);
+  const int64_t OldTarget = OldPcBase + OldImm;
+  const int64_t TextSize = static_cast<int64_t>(Elf.textSize());
+  if (OldTarget >= 0 && OldTarget < TextSize)
+    return false; // target inside .text: not handled, reject fail-closed
+
+  uint64_t NewAddOff = 0;
+  if (!Plan.mapOffset(AddOldOff, DisplacementMapBias::AfterInsertedBytes,
+                      NewAddOff))
+    return false;
+  // Relocate the target only if it lives in a trailing (post-.text) section.
+  const int64_t TargetShift =
+      (OldTarget >= TextSize) ? static_cast<int64_t>(Plan.paddedGrowth()) : 0;
+  const int64_t NewTarget = OldTarget + TargetShift;
+  const int64_t NewImm = NewTarget - static_cast<int64_t>(NewAddOff);
+  if (NewImm == OldImm)
+    return true; // nothing moved relative to the pair; original is still
+                 // correct
+
+  // Re-encode via the asm parser rather than mutating the MCInst directly: the
+  // literal may be an AMDGPU lit/lit64 form whose encoded size must be
+  // preserved (a plain MCConstantExpr re-encodes to the shorter inline-literal
+  // form and would corrupt the following instruction). Print the instruction to
+  // its canonical asm, substitute only the trailing addend operand with the new
+  // value in the same literal form, and assemble. This keeps the MC layer as
+  // the single source of encoding (no target-internal MCExpr headers, no
+  // hardcoded literal-field surgery).
+  if (!LS.MCIP)
+    return false;
+  SmallString<256> PrintedBuf;
+  raw_svector_ostream PrintOS(PrintedBuf);
+  LS.MCIP->printInst(&Add.Inst, /*Address=*/0, /*Annot=*/"", *LS.STI, PrintOS);
+  StringRef Printed = StringRef(PrintedBuf).trim();
+  size_t LastComma = Printed.rfind(',');
+  if (LastComma == StringRef::npos)
+    return false;
+  StringRef Head = Printed.substr(0, LastComma + 1); // "...s[2:3], s[2:3],"
+  StringRef AddendTok = Printed.substr(LastComma + 1).trim();
+  // Preserve the printed literal wrapper (lit64(...) / lit(...)) so the encoded
+  // size is unchanged; only the numeric value is replaced.
+  std::string Hex =
+      ("0x" + Twine::utohexstr(static_cast<uint64_t>(NewImm))).str();
+  std::string NewAddend;
+  if (AddendTok.starts_with("lit64("))
+    NewAddend = "lit64(" + Hex + ")";
+  else if (AddendTok.starts_with("lit("))
+    NewAddend = "lit(" + Hex + ")";
+  else
+    NewAddend = Hex;
+  std::string NewAsm = (Head + " " + NewAddend).str();
+
+  SmallVector<uint8_t> Code = assembleSingleInst(NewAsm, LS);
+  if (Code.size() != Add.Size) {
+    return makeDisplacementError("s_add for s_get_pc at old .text offset 0x" +
+                                 Twine::utohexstr(Gp.Offset) +
+                                 " changed encoded size during re-encode");
+  }
+  if (NewAddOff + Code.size() > NewText.size()) {
+    return makeDisplacementError(
+        "repaired s_add for s_get_pc at old .text offset 0x" +
+        Twine::utohexstr(Gp.Offset) + " writes past rebuilt .text");
+  }
+  std::memcpy(NewText.data() + NewAddOff, Code.data(), Code.size());
+  return true;
+}
+
+/// Repair a standalone `s_add_pc_i64 lit64(delta)` under whole-object (tier-3)
+/// displacement. Unlike the s_get_pc pair (whose target is a global outside
+/// .text), this is a long-forward PC-relative CONTROL transfer whose target is
+/// code INSIDE .text: PC (the address of the instruction after s_add_pc_i64)
+/// plus the byte delta. Both the instruction and its target are displaced, so
+/// the new delta = new_target_off - (new_add_off + size), with both offsets
+/// obtained from the plan (the same both-ends-move remap repairBranches does
+/// for s_branch, but s_add_pc reaches far with a 64-bit literal). The operand
+/// is a raw byte delta (verified via llvm-mc), not a dword offset. Returns
+/// false if the instruction is not the expected single-immediate form or the
+/// target leaves .text (fail-closed). Only called on the tier-3 path.
+Expected<bool> repairSAddPcForDisplacement(const ElfView &Elf,
+                                           const LLVMState &LS,
+                                           const DisplacementPlan &Plan,
+                                           const InternalDecodedInst &Ap,
+                                           SmallVectorImpl<uint8_t> &NewText) {
+  if (Ap.Inst.getNumOperands() < 1)
+    return false;
+  const MCOperand &DeltaOp = Ap.Inst.getOperand(0);
+  int64_t OldDelta = 0;
+  if (DeltaOp.isImm()) {
+    OldDelta = DeltaOp.getImm();
+  } else if (!DeltaOp.isExpr() ||
+             !DeltaOp.getExpr()->evaluateAsAbsolute(OldDelta)) {
+    return false;
+  }
+
+  // PC base is the address of the NEXT instruction (AMDGPU PC semantics,
+  // verified: 0x3BB8F4 + 12 + 0x278c8 lands on a clean boundary). Target is a
+  // .text offset that must stay inside .text (control transfer); reject
+  // otherwise (fail-closed).
+  const int64_t OldPcBase = static_cast<int64_t>(Ap.Offset + Ap.Size);
+  const int64_t OldTarget = OldPcBase + OldDelta;
+  const int64_t TextSize = static_cast<int64_t>(Elf.textSize());
+  if (OldTarget < 0 || OldTarget >= TextSize)
+    return false;
+
+  uint64_t NewApOff = 0;
+  uint64_t NewTargetOff = 0;
+  if (!Plan.mapOffset(Ap.Offset, DisplacementMapBias::AfterInsertedBytes,
+                      NewApOff) ||
+      !Plan.mapOffset(static_cast<uint64_t>(OldTarget),
+                      DisplacementMapBias::BeforeInsertedBytes, NewTargetOff))
+    return false;
+  const int64_t NewPcBase =
+      static_cast<int64_t>(NewApOff) + static_cast<int64_t>(Ap.Size);
+  const int64_t NewDelta = static_cast<int64_t>(NewTargetOff) - NewPcBase;
+  if (NewDelta == OldDelta)
+    return true; // both ends shifted equally; original delta still correct
+
+  // Re-encode preserving the lit/lit64 wrapper so the encoded size is unchanged
+  // (same technique as the s_get_pc pair repair).
+  if (!LS.MCIP)
+    return false;
+  SmallString<128> PrintedBuf;
+  raw_svector_ostream PrintOS(PrintedBuf);
+  LS.MCIP->printInst(&Ap.Inst, /*Address=*/0, /*Annot=*/"", *LS.STI, PrintOS);
+  StringRef Printed = StringRef(PrintedBuf).trim();
+  // s_add_pc_i64 has a single operand: "s_add_pc_i64 lit64(0x...)".
+  size_t Space = Printed.find(' ');
+  if (Space == StringRef::npos)
+    return false;
+  StringRef Mnem = Printed.substr(0, Space);
+  StringRef DeltaTok = Printed.substr(Space + 1).trim();
+  std::string Hex =
+      ("0x" + Twine::utohexstr(static_cast<uint64_t>(NewDelta))).str();
+  std::string NewOperand;
+  if (DeltaTok.starts_with("lit64("))
+    NewOperand = "lit64(" + Hex + ")";
+  else if (DeltaTok.starts_with("lit("))
+    NewOperand = "lit(" + Hex + ")";
+  else
+    NewOperand = Hex;
+  std::string NewAsm = (Mnem + " " + NewOperand).str();
+
+  SmallVector<uint8_t> Code = assembleSingleInst(NewAsm, LS);
+  if (Code.size() != Ap.Size) {
+    return makeDisplacementError("s_add_pc_i64 at old .text offset 0x" +
+                                 Twine::utohexstr(Ap.Offset) +
+                                 " changed encoded size during re-encode");
+  }
+  if (NewApOff + Code.size() > NewText.size()) {
+    return makeDisplacementError(
+        "repaired s_add_pc_i64 at old .text offset 0x" +
+        Twine::utohexstr(Ap.Offset) + " writes past rebuilt .text");
+  }
+  std::memcpy(NewText.data() + NewApOff, Code.data(), Code.size());
+  return true;
+}
+
 Error repairBranches(const ElfView &Elf, const LLVMState &LS,
                      const DisplacementPlan &Plan,
                      SmallVectorImpl<uint8_t> &NewText) {
@@ -367,81 +646,144 @@ Error repairBranches(const ElfView &Elf, const LLVMState &LS,
         "branch analysis through LLVM MC is unavailable");
   }
 
-  std::vector<InternalDecodedInst> Decoded;
-  if (!decodeTextSection(Elf.textData(), Elf.textSize(), LS, Decoded)) {
-    return makeDisplacementError(
-        "failed to decode .text while validating branches");
-  }
-
-  for (const InternalDecodedInst &DI : Decoded) {
+  // Stream the whole .text one instruction at a time instead of materializing a
+  // ~1.7M-element decode vector: this validates and repairs branches in a
+  // single pass, examining every instruction in the same order with the same
+  // rejection checks as a full decode would, only without the intermediate
+  // storage. The mnemonic string is skipped (WantMnemonic=false) since it is
+  // read solely by this function's diagnostic paths, which reconstruct it on
+  // demand.
+  Error RepairErr = Error::success();
+  auto onInst = [&](const InternalDecodedInst &DI) -> bool {
     if (Plan.rangeOverlapsReplacement(DI.Offset, DI.Size))
-      continue;
+      return true;
 
     const MCInst &Inst = DI.Inst;
+    // Tier-3 (whole-object) displacement can repair an s_get_pc_i64; s_add pair
+    // that computes an absolute address of a global outside .text: the code
+    // moved, so adjust the s_add immediate by -shift. The entry-workaround path
+    // (RelocateTrailingSections=false) keeps the strict reject unchanged. A
+    // pair that does not match the expected form, or whose target is inside
+    // .text, falls through to the strict rejection below (fail-closed).
+    if (Plan.relocatesTrailingSections() &&
+        Inst.getOpcode() == LS.SGetPcI64Opcode) {
+      Expected<bool> RepairedOrErr =
+          repairSGetPcPairForDisplacement(Elf, LS, Plan, DI, NewText);
+      if (!RepairedOrErr) {
+        RepairErr = RepairedOrErr.takeError();
+        return false;
+      }
+      if (*RepairedOrErr)
+        return true;
+      // Not a repairable pair; fall through to the strict rejection.
+    }
+    // Tier-3 can also repair a standalone s_add_pc_i64 (long-forward
+    // PC-relative control transfer into .text): remap its delta so it still
+    // reaches the moved target. Entry path keeps the strict reject.
+    if (Plan.relocatesTrailingSections() &&
+        Inst.getOpcode() == LS.SAddPcI64Opcode) {
+      Expected<bool> RepairedOrErr =
+          repairSAddPcForDisplacement(Elf, LS, Plan, DI, NewText);
+      if (!RepairedOrErr) {
+        RepairErr = RepairedOrErr.takeError();
+        return false;
+      }
+      if (*RepairedOrErr)
+        return true;
+      // Not repairable; fall through to the strict rejection.
+    }
     if (isPcSensitiveForDisplacement(DI, LS)) {
-      return makeDisplacementError(
-          "pc-sensitive instruction '" + Twine(DI.Mnemonic) +
+      // DI.Mnemonic was not populated (WantMnemonic=false above); reconstruct
+      // it here on the cold diagnostic path so the message keeps naming the
+      // offender.
+      StringRef Mnemonic = "<unknown>";
+      if (LS.MCIP) {
+        std::pair<const char *, uint64_t> Mnem = LS.MCIP->getMnemonic(DI.Inst);
+        if (Mnem.first)
+          Mnemonic = StringRef(Mnem.first).rtrim();
+      }
+      RepairErr = makeDisplacementError(
+          "pc-sensitive instruction '" + Twine(Mnemonic) +
           "' at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
           " requires linked-address repair");
+      return false;
     }
     if (LS.MIA->isCall(Inst)) {
-      return makeDisplacementError("call at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " is not supported by displacement");
+      RepairErr = makeDisplacementError("call at old .text offset 0x" +
+                                        Twine::utohexstr(DI.Offset) +
+                                        " is not supported by displacement");
+      return false;
     }
     if (LS.MIA->isIndirectBranch(Inst)) {
-      return makeDisplacementError("indirect branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " is not supported by displacement");
+      RepairErr = makeDisplacementError(
+          "indirect branch at old .text offset 0x" +
+          Twine::utohexstr(DI.Offset) + " is not supported by displacement");
+      return false;
     }
     if (!LS.MIA->isBranch(Inst))
-      continue;
+      return true;
 
     uint64_t OldTarget = 0;
     if (!LS.MIA->evaluateBranch(Inst, DI.Offset, DI.Size, OldTarget)) {
-      return makeDisplacementError("branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " target could not be evaluated");
+      RepairErr = makeDisplacementError("branch at old .text offset 0x" +
+                                        Twine::utohexstr(DI.Offset) +
+                                        " target could not be evaluated");
+      return false;
     }
     if (OldTarget >= Elf.textSize()) {
-      return makeDisplacementError("branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " targets outside .text");
+      RepairErr = makeDisplacementError("branch at old .text offset 0x" +
+                                        Twine::utohexstr(DI.Offset) +
+                                        " targets outside .text");
+      return false;
     }
 
     uint64_t NewFrom = 0;
     uint64_t NewTarget = 0;
     if (!Plan.mapOffset(DI.Offset, DisplacementMapBias::AfterInsertedBytes,
                         NewFrom)) {
-      return makeDisplacementError("branch source at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " maps inside a replaced range");
+      RepairErr = makeDisplacementError("branch source at old .text offset 0x" +
+                                        Twine::utohexstr(DI.Offset) +
+                                        " maps inside a replaced range");
+      return false;
     }
     if (!Plan.mapOffset(OldTarget, DisplacementMapBias::BeforeInsertedBytes,
                         NewTarget)) {
-      return makeDisplacementError("branch target at old .text offset 0x" +
-                                   Twine::utohexstr(OldTarget) +
-                                   " maps inside a replaced range");
+      RepairErr = makeDisplacementError("branch target at old .text offset 0x" +
+                                        Twine::utohexstr(OldTarget) +
+                                        " maps inside a replaced range");
+      return false;
     }
 
     Expected<SmallVector<uint8_t>> EncodedOrErr =
         reencodePcrelBranch(DI, NewFrom, NewTarget, LS);
-    if (!EncodedOrErr)
-      return EncodedOrErr.takeError();
+    if (!EncodedOrErr) {
+      RepairErr = EncodedOrErr.takeError();
+      return false;
+    }
     SmallVector<uint8_t> &Encoded = *EncodedOrErr;
 
     if (NewFrom + Encoded.size() > NewText.size()) {
-      return makeDisplacementError("re-encoded branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " writes past rebuilt .text");
+      RepairErr = makeDisplacementError(
+          "re-encoded branch at old .text offset 0x" +
+          Twine::utohexstr(DI.Offset) + " writes past rebuilt .text");
+      return false;
     }
     std::memcpy(NewText.data() + NewFrom, Encoded.data(), Encoded.size());
+    return true;
+  };
+
+  if (!decodeTextSectionStreaming(Elf.textData(), Elf.textSize(), LS,
+                                  /*WantMnemonic=*/false, onInst)) {
+    consumeError(std::move(RepairErr));
+    return makeDisplacementError(
+        "failed to decode .text while validating branches");
   }
-  return Error::success();
+  return RepairErr;
 }
 
 Error adjustSectionHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
-                                        const ElfView &OldElf, size_t Growth) {
+                                        const ElfView &OldElf, size_t Growth,
+                                        bool RelocateVAddr) {
   if (ElfSize < sizeof(Ehdr)) {
     return makeDisplacementError(
         "displaced ELF is smaller than its ELF64 header");
@@ -486,13 +828,27 @@ Error adjustSectionHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
       uint64_t NewOffset = ShOffset + Growth;
       std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
                   sizeof(NewOffset));
+      // Tier-3: relocate the virtual address of any ALLOCATABLE section after
+      // .text so the grown .text pushes it forward instead of overlapping it.
+      // Non-allocatable sections (.symtab, .strtab, .comment) keep sh_addr 0.
+      if (RelocateVAddr) {
+        uint64_t ShFlags = 0;
+        std::memcpy(&ShFlags, Sh + offsetof(Shdr, sh_flags), sizeof(ShFlags));
+        uint64_t ShAddr = 0;
+        std::memcpy(&ShAddr, Sh + offsetof(Shdr, sh_addr), sizeof(ShAddr));
+        if ((ShFlags & ELF::SHF_ALLOC) && ShAddr >= OldElf.textAddr()) {
+          uint64_t NewAddr = ShAddr + Growth;
+          std::memcpy(Sh + offsetof(Shdr, sh_addr), &NewAddr, sizeof(NewAddr));
+        }
+      }
     }
   }
   return Error::success();
 }
 
 Error adjustProgramHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
-                                        const ElfView &OldElf, size_t Growth) {
+                                        const ElfView &OldElf, size_t Growth,
+                                        bool RelocateVAddr) {
   if (ElfSize < sizeof(Ehdr)) {
     return makeDisplacementError(
         "displaced ELF is smaller than its ELF64 header");
@@ -540,6 +896,17 @@ Error adjustProgramHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
     } else if (POffset >= TextEnd) {
       POffset += Growth;
       std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
+      // Tier-3: also relocate this segment's virtual/physical address so the
+      // loader maps it past the grown .text instead of on top of it.
+      if (RelocateVAddr) {
+        uint64_t PVaddr = 0, PPaddr = 0;
+        std::memcpy(&PVaddr, Ph + offsetof(Phdr, p_vaddr), sizeof(PVaddr));
+        std::memcpy(&PPaddr, Ph + offsetof(Phdr, p_paddr), sizeof(PPaddr));
+        PVaddr += Growth;
+        PPaddr += Growth;
+        std::memcpy(Ph + offsetof(Phdr, p_vaddr), &PVaddr, sizeof(PVaddr));
+        std::memcpy(Ph + offsetof(Phdr, p_paddr), &PPaddr, sizeof(PPaddr));
+      }
     }
   }
   return Error::success();
@@ -718,6 +1085,1143 @@ Error rewriteKernelDescriptorEntriesForDisplacement(
   return Error::success();
 }
 
+// Locate a section by name in the OLD ELF's section table. Debug sections sit
+// AFTER .text, so their bytes in the tier-3 OUTPUT buffer live at
+// OLD sh_offset + paddedGrowth (the apply step copied the whole trailing region
+// forward). Callers apply that shift when addressing the output; this helper
+// only resolves the header.
+const ELFT::Shdr *findSectionByName(const ElfView &Elf, StringRef Want) {
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr) {
+      consumeError(NameOrErr.takeError());
+      return nullptr;
+    }
+    if (*NameOrErr == Want)
+      return &Shdr;
+  }
+  return nullptr;
+}
+
+// Map an absolute .text virtual address through the displacement plan. Objects
+// that carry DWARF use vaddr == textAddr + offset in .text; addresses outside
+// [textAddr, textEnd] pass through unchanged. An address at exactly textEnd
+// maps to textEnd + paddedGrowth (the whole trailing region shifts). \p Bias
+// selects the boundary rule at an inserted-bytes edge (BeforeInsertedBytes for
+// the low end of a range, so the start of a patched instruction stays put; the
+// high end also uses BeforeInsertedBytes so a range that ends at a patch
+// boundary keeps its end pinned to that instruction). Returns false only on
+// internal mapOffset failure (address lands inside a replaced instruction),
+// which is a genuine corruption signal for the caller to fail closed on.
+bool mapTextVAddr(const ElfView &Elf, const DisplacementPlan &Plan,
+                  uint64_t OldVAddr, uint64_t &NewVAddr) {
+  const uint64_t TextAddr = Elf.textAddr();
+  const uint64_t TextEnd = TextAddr + Elf.textSize();
+  if (OldVAddr < TextAddr || OldVAddr > TextEnd) {
+    NewVAddr = OldVAddr;
+    return true;
+  }
+  uint64_t NewOff = 0;
+  if (!Plan.mapOffset(OldVAddr - TextAddr,
+                      DisplacementMapBias::BeforeInsertedBytes, NewOff))
+    return false;
+  NewVAddr = TextAddr + NewOff;
+  return true;
+}
+
+/// Remap the single FDE-per-object `.debug_frame`. Unlike `.eh_frame`,
+/// `.debug_frame` addresses are ABSOLUTE: an FDE stores initial_location and
+/// address_range as target-sized (8-byte) values. CIE vs FDE is distinguished
+/// by the CIE id field: 0xffffffff (DW_CIE_ID for 32-bit DWARF) marks a CIE.
+/// For each FDE describing .text, remap initial_location via the plan and
+/// recompute address_range = mapped_end - mapped_start. Fails closed on 64-bit
+/// DWARF, non-8-byte addresses, or a record that overruns the section.
+Error remapDebugFrameForDisplacement(const ElfView &Elf,
+                                     const DisplacementPlan &Plan,
+                                     uint8_t *Base, uint64_t Size) {
+  auto readU32 = [&](uint64_t Off) -> uint32_t {
+    uint32_t V;
+    std::memcpy(&V, Base + Off, sizeof(V));
+    return V;
+  };
+  auto readU64 = [&](uint64_t Off) -> uint64_t {
+    uint64_t V;
+    std::memcpy(&V, Base + Off, sizeof(V));
+    return V;
+  };
+  auto writeU64 = [&](uint64_t Off, uint64_t V) {
+    std::memcpy(Base + Off, &V, sizeof(V));
+  };
+
+  const uint64_t TextAddr = Elf.textAddr();
+  const uint64_t TextEnd = TextAddr + Elf.textSize();
+  uint64_t Pos = 0;
+  uint32_t Remapped = 0;
+  while (Pos + 4 <= Size) {
+    const uint32_t Length = readU32(Pos);
+    if (Length == 0)
+      break; // terminator
+    if (Length == 0xffffffffu)
+      return makeDisplacementError(
+          ".debug_frame uses 64-bit DWARF (unsupported)");
+    const uint64_t RecordStart = Pos;
+    const uint64_t RecordEnd = Pos + 4 + Length;
+    if (RecordEnd > Size || RecordStart + 8 > Size)
+      return makeDisplacementError(".debug_frame record overruns section");
+    const uint32_t CieId = readU32(RecordStart + 4);
+    if (CieId == dwarf::DW_CIE_ID) {
+      Pos = RecordEnd; // CIE: no addresses to remap
+      continue;
+    }
+    // FDE: initial_location (8) then address_range (8) follow the CIE pointer.
+    const uint64_t LocOff = RecordStart + 8;
+    const uint64_t RangeOff = RecordStart + 16;
+    if (RangeOff + 8 > RecordEnd)
+      return makeDisplacementError(".debug_frame FDE is truncated");
+    const uint64_t OldStart = readU64(LocOff);
+    const uint64_t OldRange = readU64(RangeOff);
+    if (OldStart < TextAddr || OldStart >= TextEnd) {
+      Pos = RecordEnd; // FDE does not describe .text
+      continue;
+    }
+    if (OldStart + OldRange < OldStart || OldStart + OldRange > TextEnd)
+      return makeDisplacementError(".debug_frame FDE range leaves .text");
+    uint64_t NewStart = 0, NewEnd = 0;
+    if (!mapTextVAddr(Elf, Plan, OldStart, NewStart) ||
+        !mapTextVAddr(Elf, Plan, OldStart + OldRange, NewEnd) ||
+        NewEnd < NewStart)
+      return makeDisplacementError(".debug_frame FDE cannot be remapped");
+    writeU64(LocOff, NewStart);
+    writeU64(RangeOff, NewEnd - NewStart);
+    ++Remapped;
+    Pos = RecordEnd;
+  }
+  log() << "hotswap: displacement: remapped " << Remapped
+        << " .debug_frame FDE(s)\n";
+  return Error::success();
+}
+
+/// Remap `.debug_ranges`. Each compile unit's list is a sequence of (start,end)
+/// address pairs. A (0,0) pair terminates a list. A base-address-selection
+/// entry has start == 0xffffffffffffffff and sets the base for subsequent
+/// entries; this object emits none (verified: no 0xff..ff entries) and
+/// dwarfdump shows the pairs are offsets from the CU's DW_AT_low_pc. We
+/// therefore treat each nonzero pair value as (Base + stored) to recover the
+/// absolute .text address, remap that, and write back (new_absolute - Base). \p
+/// Base is the CU low_pc, which is unchanged here (it precedes all patches), so
+/// this is exact. Fails closed if a base-selection entry appears (we do not
+/// track multiple bases).
+Error remapDebugRangesForDisplacement(const ElfView &Elf,
+                                      const DisplacementPlan &Plan,
+                                      uint8_t *SecBase, uint64_t Size,
+                                      uint64_t CuBase) {
+  auto readU64 = [&](uint64_t Off) -> uint64_t {
+    uint64_t V;
+    std::memcpy(&V, SecBase + Off, sizeof(V));
+    return V;
+  };
+  auto writeU64 = [&](uint64_t Off, uint64_t V) {
+    std::memcpy(SecBase + Off, &V, sizeof(V));
+  };
+
+  uint64_t Pos = 0;
+  uint32_t Remapped = 0;
+  while (Pos + 16 <= Size) {
+    const uint64_t Start = readU64(Pos);
+    const uint64_t End = readU64(Pos + 8);
+    if (Start == 0 && End == 0) {
+      Pos += 16; // end-of-list terminator; keep scanning for the next CU list
+      continue;
+    }
+    if (Start == std::numeric_limits<uint64_t>::max())
+      return makeDisplacementError(
+          ".debug_ranges base-address selection is unsupported");
+    // Reconstruct absolute .text addresses, remap, and re-encode as offsets
+    // from the (unchanged) CU base.
+    const uint64_t OldStartAbs = CuBase + Start;
+    const uint64_t OldEndAbs = CuBase + End;
+    uint64_t NewStartAbs = 0, NewEndAbs = 0;
+    if (!mapTextVAddr(Elf, Plan, OldStartAbs, NewStartAbs) ||
+        !mapTextVAddr(Elf, Plan, OldEndAbs, NewEndAbs) ||
+        NewEndAbs < NewStartAbs || NewStartAbs < CuBase || NewEndAbs < CuBase)
+      return makeDisplacementError(".debug_ranges entry cannot be remapped");
+    writeU64(Pos, NewStartAbs - CuBase);
+    writeU64(Pos + 8, NewEndAbs - CuBase);
+    ++Remapped;
+    Pos += 16;
+  }
+  log() << "hotswap: displacement: remapped " << Remapped
+        << " .debug_ranges entr(ies)\n";
+  return Error::success();
+}
+
+// One attribute (attr, form) from a .debug_abbrev declaration.
+struct AbbrevAttr {
+  uint64_t Attr = 0;
+  uint64_t Form = 0;
+  int64_t ImplicitConst = 0; // only for DW_FORM_implicit_const
+};
+// One abbreviation declaration: its tag/children and attribute list.
+struct AbbrevDecl {
+  bool HasChildren = false;
+  SmallVector<AbbrevAttr, 8> Attrs;
+};
+
+// Parse the .debug_abbrev table starting at \p Off into a code -> declaration
+// map. Only the fields the DIE walker needs are retained. Fails closed on a
+// truncated table.
+Expected<DenseMap<uint64_t, AbbrevDecl>>
+parseAbbrevTable(const uint8_t *Base, uint64_t Size, uint64_t Off) {
+  DenseMap<uint64_t, AbbrevDecl> Table;
+  const uint8_t *P = Base + Off;
+  const uint8_t *End = Base + Size;
+  while (P < End) {
+    unsigned N = 0;
+    uint64_t Code = decodeULEB128(P, &N, End);
+    P += N;
+    if (Code == 0)
+      break; // end of this abbrev table
+    if (P >= End)
+      return makeDisplacementError(".debug_abbrev declaration is truncated");
+    uint64_t Tag = decodeULEB128(P, &N, End);
+    (void)Tag;
+    P += N;
+    if (P >= End)
+      return makeDisplacementError(".debug_abbrev declaration is truncated");
+    AbbrevDecl Decl;
+    Decl.HasChildren = (*P != 0);
+    ++P;
+    while (P < End) {
+      uint64_t Attr = decodeULEB128(P, &N, End);
+      P += N;
+      uint64_t Form = decodeULEB128(P, &N, End);
+      P += N;
+      if (Attr == 0 && Form == 0)
+        break; // end of attribute list
+      AbbrevAttr A;
+      A.Attr = Attr;
+      A.Form = Form;
+      if (Form == dwarf::DW_FORM_implicit_const) {
+        A.ImplicitConst = decodeSLEB128(P, &N, End);
+        P += N;
+      }
+      Decl.Attrs.push_back(A);
+    }
+    Table[Code] = std::move(Decl);
+  }
+  return Table;
+}
+
+// Advance \p P past a single attribute value of \p Form in a DWARF32 unit
+// bounded by \p UnitEnd. Handles the fixed-size forms via getFixedFormByteSize
+// and the variable-length forms (LEB128, counted blocks, inline strings) by
+// hand. Fails closed on any form whose size we cannot determine so we never
+// desynchronize the DIE walk and miswrite a later low_pc/high_pc.
+Error skipFormValue(const uint8_t *Base, uint64_t &P, uint64_t UnitEnd,
+                    uint64_t Form, int64_t ImplicitConst,
+                    const dwarf::FormParams &FP) {
+  const uint8_t *End = Base + UnitEnd;
+  auto need = [&](uint64_t N) -> Error {
+    if (N > UnitEnd - P)
+      return makeDisplacementError(".debug_info attribute overruns unit");
+    return Error::success();
+  };
+  switch (Form) {
+  case dwarf::DW_FORM_implicit_const:
+  case dwarf::DW_FORM_flag_present:
+    (void)ImplicitConst;
+    return Error::success(); // no bytes in the DIE
+  case dwarf::DW_FORM_udata:
+  case dwarf::DW_FORM_ref_udata:
+  case dwarf::DW_FORM_strx:
+  case dwarf::DW_FORM_addrx:
+  case dwarf::DW_FORM_loclistx:
+  case dwarf::DW_FORM_rnglistx:
+  case dwarf::DW_FORM_GNU_str_index:
+  case dwarf::DW_FORM_GNU_addr_index: {
+    unsigned N = 0;
+    decodeULEB128(Base + P, &N, End);
+    P += N;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_sdata: {
+    unsigned N = 0;
+    decodeSLEB128(Base + P, &N, End);
+    P += N;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_string: {
+    while (P < UnitEnd && Base[P] != 0)
+      ++P;
+    if (P >= UnitEnd)
+      return makeDisplacementError(".debug_info inline string is unterminated");
+    ++P; // consume NUL
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block1: {
+    if (Error E = need(1))
+      return E;
+    uint64_t Len = Base[P];
+    ++P;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block2: {
+    if (Error E = need(2))
+      return E;
+    uint16_t Len = 0;
+    std::memcpy(&Len, Base + P, 2);
+    P += 2;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block4: {
+    if (Error E = need(4))
+      return E;
+    uint32_t Len = 0;
+    std::memcpy(&Len, Base + P, 4);
+    P += 4;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block:
+  case dwarf::DW_FORM_exprloc: {
+    unsigned N = 0;
+    uint64_t Len = decodeULEB128(Base + P, &N, End);
+    P += N;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  default:
+    break;
+  }
+  std::optional<uint8_t> FS =
+      dwarf::getFixedFormByteSize(static_cast<dwarf::Form>(Form), FP);
+  if (!FS)
+    return makeDisplacementError(".debug_info uses an unsupported form " +
+                                 Twine(Form));
+  if (Error E = need(*FS))
+    return E;
+  P += *FS;
+  return Error::success();
+}
+
+/// Remap the CU's `DW_AT_low_pc`/`DW_AT_high_pc` in `.debug_info`. We parse the
+/// matching `.debug_abbrev` table to learn each attribute's form so we know the
+/// exact byte layout: low_pc is DW_FORM_addr (absolute) and high_pc is either
+/// DW_FORM_addr (absolute) or a DW_FORM_data* constant that encodes an OFFSET
+/// from low_pc. For this object low_pc is DW_FORM_addr and high_pc is
+/// DW_FORM_data4 (verified via .debug_abbrev). Remapping rule (general):
+/// new_high = mapOffset(low_off + high) - mapOffset(low_off), so a data-form
+/// high_pc grows only by the shift its range end crosses; an absolute-form
+/// high_pc is remapped directly; a low_pc that also moved is handled by
+/// remapping it too. Every other attribute is skipped using its form's fixed
+/// byte size (getFixedFormByteSize) or its LEB/block/string length. Fails
+/// closed on DWARF64, addr_size != 8, an abbrev code with no declaration, or a
+/// form whose length we cannot determine.
+Error remapDebugInfoForDisplacement(const ElfView &Elf,
+                                    const DisplacementPlan &Plan,
+                                    uint8_t *InfoBase, uint64_t InfoSize,
+                                    const uint8_t *AbbrevBase,
+                                    uint64_t AbbrevSize) {
+  auto readU32 = [&](uint64_t Off) -> uint32_t {
+    uint32_t V;
+    std::memcpy(&V, InfoBase + Off, sizeof(V));
+    return V;
+  };
+  auto readU16 = [&](uint64_t Off) -> uint16_t {
+    uint16_t V;
+    std::memcpy(&V, InfoBase + Off, sizeof(V));
+    return V;
+  };
+
+  uint64_t Pos = 0;
+  uint32_t RemappedLow = 0, RemappedHigh = 0;
+  while (Pos + 4 <= InfoSize) {
+    const uint32_t UnitLength = readU32(Pos);
+    if (UnitLength == 0)
+      break;
+    if (UnitLength == 0xffffffffu)
+      return makeDisplacementError(
+          ".debug_info uses 64-bit DWARF (unsupported)");
+    const uint64_t UnitStart = Pos;
+    const uint64_t UnitEnd = Pos + 4 + UnitLength;
+    if (UnitEnd > InfoSize)
+      return makeDisplacementError(".debug_info unit overruns section");
+    uint64_t P = UnitStart + 4;
+    const uint16_t Version = readU16(P);
+    P += 2;
+    if (Version < 2 || Version > 4)
+      return makeDisplacementError(".debug_info version " + Twine(Version) +
+                                   " is unsupported");
+    // DWARF v2-v4 CU header: version, abbrev_offset (sec_offset), addr_size.
+    const uint32_t AbbrevOff = readU32(P);
+    P += 4;
+    const uint8_t AddrSize = InfoBase[P];
+    P += 1;
+    if (AddrSize != 8)
+      return makeDisplacementError(".debug_info addr_size != 8 is unsupported");
+
+    Expected<DenseMap<uint64_t, AbbrevDecl>> TableOrErr =
+        parseAbbrevTable(AbbrevBase, AbbrevSize, AbbrevOff);
+    if (!TableOrErr)
+      return TableOrErr.takeError();
+    const DenseMap<uint64_t, AbbrevDecl> &Table = *TableOrErr;
+
+    dwarf::FormParams FP;
+    FP.Version = Version;
+    FP.AddrSize = AddrSize;
+    FP.Format = dwarf::DWARF32;
+
+    // Walk DIEs. We only rewrite low_pc/high_pc; all other attributes are
+    // skipped by size. low_pc is captured per-DIE so a sibling high_pc data
+    // form is interpreted relative to the correct low_pc.
+    const uint8_t *End = InfoBase + UnitEnd;
+    while (P < UnitEnd) {
+      unsigned N = 0;
+      uint64_t Code = decodeULEB128(InfoBase + P, &N, End);
+      P += N;
+      if (Code == 0)
+        continue; // null DIE (end of siblings)
+      DenseMap<uint64_t, AbbrevDecl>::const_iterator It = Table.find(Code);
+      if (It == Table.end())
+        return makeDisplacementError(
+            ".debug_info references unknown abbrev code");
+      const AbbrevDecl &Decl = It->second;
+
+      bool HaveLow = false;
+      uint64_t LowVAddr = 0;
+      uint64_t LowOff = 0; // .text offset of low_pc
+      for (const AbbrevAttr &A : Decl.Attrs) {
+        if (A.Attr == dwarf::DW_AT_low_pc) {
+          if (A.Form != dwarf::DW_FORM_addr)
+            return makeDisplacementError(
+                "DW_AT_low_pc uses an unsupported form");
+          uint64_t Old = 0;
+          std::memcpy(&Old, InfoBase + P, sizeof(Old));
+          uint64_t New = 0;
+          if (!mapTextVAddr(Elf, Plan, Old, New))
+            return makeDisplacementError("DW_AT_low_pc cannot be remapped");
+          std::memcpy(InfoBase + P, &New, sizeof(New));
+          HaveLow = Old >= Elf.textAddr();
+          LowVAddr = Old;
+          LowOff = (Old >= Elf.textAddr()) ? Old - Elf.textAddr() : 0;
+          ++RemappedLow;
+          P += 8;
+          continue;
+        }
+        if (A.Attr == dwarf::DW_AT_high_pc) {
+          if (A.Form == dwarf::DW_FORM_addr) {
+            uint64_t Old = 0;
+            std::memcpy(&Old, InfoBase + P, sizeof(Old));
+            uint64_t New = 0;
+            if (!mapTextVAddr(Elf, Plan, Old, New))
+              return makeDisplacementError(
+                  "DW_AT_high_pc (addr) cannot be remapped");
+            std::memcpy(InfoBase + P, &New, sizeof(New));
+            ++RemappedHigh;
+            P += 8;
+            continue;
+          }
+          // Data forms encode an OFFSET from low_pc. Grow it by the shift its
+          // range end crosses: new = map(low_off + old) - map(low_off).
+          std::optional<uint8_t> FS =
+              dwarf::getFixedFormByteSize(static_cast<dwarf::Form>(A.Form), FP);
+          if (!FS || (*FS != 1 && *FS != 2 && *FS != 4 && *FS != 8))
+            return makeDisplacementError(
+                "DW_AT_high_pc uses an unsupported data form");
+          if (!HaveLow)
+            return makeDisplacementError(
+                "DW_AT_high_pc data form without a .text low_pc");
+          uint64_t OldHigh = 0;
+          std::memcpy(&OldHigh, InfoBase + P, *FS);
+          uint64_t NewLowOff = 0, NewEndOff = 0;
+          if (!Plan.mapOffset(LowOff, DisplacementMapBias::BeforeInsertedBytes,
+                              NewLowOff) ||
+              !Plan.mapOffset(LowOff + OldHigh,
+                              DisplacementMapBias::BeforeInsertedBytes,
+                              NewEndOff) ||
+              NewEndOff < NewLowOff)
+            return makeDisplacementError(
+                "DW_AT_high_pc (data) cannot be remapped");
+          uint64_t NewHigh = NewEndOff - NewLowOff;
+          uint64_t Limit = (*FS == 8) ? std::numeric_limits<uint64_t>::max()
+                                      : ((uint64_t(1) << (*FS * 8)) - 1);
+          if (NewHigh > Limit)
+            return makeDisplacementError(
+                "DW_AT_high_pc overflows its data form");
+          std::memcpy(InfoBase + P, &NewHigh, *FS);
+          (void)LowVAddr;
+          ++RemappedHigh;
+          P += *FS;
+          continue;
+        }
+        // Any other attribute: advance past its encoded value.
+        if (Error Err = skipFormValue(InfoBase, P, UnitEnd, A.Form,
+                                      A.ImplicitConst, FP))
+          return Err;
+      }
+    }
+    Pos = UnitEnd;
+  }
+  log() << "hotswap: displacement: remapped " << RemappedLow << " low_pc and "
+        << RemappedHigh << " high_pc in .debug_info\n";
+  return Error::success();
+}
+
+/// Remap the FDEs in the displaced output's `.eh_frame` so each still describes
+/// its kernel after displacement. This object's FDEs are per-kernel with a
+/// `"zR"` CIE using DW_EH_PE_pcrel|sdata4 for initial_location: the target is
+/// `field_vaddr + sdata4`. For each FDE:
+///   - initial_location: recompute sdata4 = new_entry_vaddr - field_vaddr,
+///     where new_entry_vaddr = textAddr + mapOffset(old_entry - textAddr).
+///   - address_range (u32 length): += growth of that kernel, i.e.
+///     mapOffset(old_end) - mapOffset(old_entry) - old_range.
+/// .eh_frame sits before .text and is not itself moved, so field_vaddr is
+/// unchanged. Only the pcrel encoding (0x1b) is handled; any other CIE
+/// augmentation/encoding is rejected so we never silently miswrite unwind data.
+Error remapEhFrameForDisplacement(const ElfView &OldElf,
+                                  const DisplacementPlan &Plan,
+                                  WritableMemoryBuffer &OutBuf) {
+  // Locate .eh_frame in the OLD ELF (section table not yet reparsed on Out; its
+  // file offset in Out is identical because .eh_frame precedes .text).
+  const ELFT::Shdr *EhShdr = nullptr;
+  uint64_t EhVAddr = 0;
+  for (const ELFT::Shdr &Shdr : OldElf.sections()) {
+    Expected<StringRef> NameOrErr = OldElf.file().getSectionName(Shdr);
+    if (!NameOrErr)
+      return makeDisplacementError("failed to read section name for .eh_frame");
+    if (*NameOrErr == ".eh_frame") {
+      EhShdr = &Shdr;
+      EhVAddr = Shdr.sh_addr;
+      break;
+    }
+  }
+  if (!EhShdr)
+    return Error::success(); // no unwind tables to fix
+
+  if (EhShdr->sh_offset > OutBuf.getBufferSize() ||
+      EhShdr->sh_size > OutBuf.getBufferSize() - EhShdr->sh_offset)
+    return makeDisplacementError(".eh_frame is out of bounds in displaced ELF");
+  uint8_t *Base =
+      reinterpret_cast<uint8_t *>(OutBuf.getBufferStart()) + EhShdr->sh_offset;
+  const uint64_t Size = EhShdr->sh_size;
+  const uint64_t OldTextEnd = OldElf.textAddr() + OldElf.textSize();
+
+  auto readU32 = [&](uint64_t Off) -> uint32_t {
+    uint32_t V;
+    std::memcpy(&V, Base + Off, sizeof(V));
+    return V;
+  };
+  auto writeU32 = [&](uint64_t Off, uint32_t V) {
+    std::memcpy(Base + Off, &V, sizeof(V));
+  };
+
+  uint64_t Pos = 0;
+  uint32_t Remapped = 0;
+  while (Pos + 8 <= Size) {
+    const uint32_t Length = readU32(Pos);
+    if (Length == 0)
+      break; // terminator
+    if (Length == 0xffffffffu)
+      return makeDisplacementError(".eh_frame uses 64-bit DWARF (unsupported)");
+    const uint64_t RecordStart = Pos;
+    const uint64_t RecordEnd = Pos + 4 + Length;
+    if (RecordEnd > Size)
+      return makeDisplacementError(".eh_frame record overruns section");
+    const uint32_t CiePtr = readU32(Pos + 4);
+    if (CiePtr == 0) {
+      // CIE: skip (we assume the single pcrel|sdata4 CIE this compiler emits).
+      Pos = RecordEnd;
+      continue;
+    }
+    // FDE. initial_location is the 4-byte field at RecordStart+8.
+    const uint64_t LocFieldOff = RecordStart + 8;
+    const uint64_t RangeFieldOff = RecordStart + 12;
+    const uint64_t LocFieldVAddr = EhVAddr + LocFieldOff;
+    const int32_t StoredLoc = static_cast<int32_t>(readU32(LocFieldOff));
+    const uint64_t OldTarget =
+        static_cast<uint64_t>(static_cast<int64_t>(LocFieldVAddr) + StoredLoc);
+    const uint32_t OldRange = readU32(RangeFieldOff);
+
+    if (OldTarget < OldElf.textAddr() || OldTarget >= OldTextEnd) {
+      // FDE does not describe .text (unexpected here); leave it untouched.
+      Pos = RecordEnd;
+      continue;
+    }
+    const uint64_t OldStartOff = OldTarget - OldElf.textAddr();
+    const uint64_t OldEndOff = OldStartOff + OldRange;
+    uint64_t NewStartOff = 0, NewEndOff = 0;
+    if (!Plan.mapOffset(OldStartOff, DisplacementMapBias::BeforeInsertedBytes,
+                        NewStartOff) ||
+        !Plan.mapOffset(OldEndOff, DisplacementMapBias::BeforeInsertedBytes,
+                        NewEndOff) ||
+        NewEndOff < NewStartOff)
+      return makeDisplacementError(".eh_frame FDE range cannot be remapped");
+
+    const uint64_t NewTargetVAddr = OldElf.textAddr() + NewStartOff;
+    const int64_t NewStoredLoc = static_cast<int64_t>(NewTargetVAddr) -
+                                 static_cast<int64_t>(LocFieldVAddr);
+    if (NewStoredLoc < std::numeric_limits<int32_t>::min() ||
+        NewStoredLoc > std::numeric_limits<int32_t>::max())
+      return makeDisplacementError(".eh_frame FDE pcrel offset overflows i32");
+    const uint64_t NewRange = NewEndOff - NewStartOff;
+    if (NewRange > std::numeric_limits<uint32_t>::max())
+      return makeDisplacementError(".eh_frame FDE range overflows u32");
+
+    writeU32(LocFieldOff, static_cast<uint32_t>(NewStoredLoc));
+    writeU32(RangeFieldOff, static_cast<uint32_t>(NewRange));
+    ++Remapped;
+    Pos = RecordEnd;
+  }
+  log() << "hotswap: displacement: remapped " << Remapped
+        << " .eh_frame FDE(s)\n";
+  return Error::success();
+}
+
+// Read the CU's DW_AT_low_pc from the OLD .debug_info to use as the
+// .debug_ranges base. low_pc is the first DW_FORM_addr after the CU header in
+// abbrev-code-1 (compile_unit); we resolve it via the abbrev table rather than
+// assuming a byte offset. Returns the low_pc, or std::nullopt if the CU has no
+// .text low_pc (in which case .debug_ranges has nothing to rebase).
+Expected<std::optional<uint64_t>> readCuLowPc(const uint8_t *InfoBase,
+                                              uint64_t InfoSize,
+                                              const uint8_t *AbbrevBase,
+                                              uint64_t AbbrevSize) {
+  if (InfoSize < 11)
+    return std::optional<uint64_t>();
+  uint32_t UnitLength = 0;
+  std::memcpy(&UnitLength, InfoBase, 4);
+  if (UnitLength == 0xffffffffu)
+    return makeDisplacementError(".debug_info uses 64-bit DWARF (unsupported)");
+  uint16_t Version = 0;
+  std::memcpy(&Version, InfoBase + 4, 2);
+  if (Version < 2 || Version > 4)
+    return makeDisplacementError(".debug_info version is unsupported");
+  uint32_t AbbrevOff = 0;
+  std::memcpy(&AbbrevOff, InfoBase + 6, 4);
+  uint8_t AddrSize = InfoBase[10];
+  if (AddrSize != 8)
+    return makeDisplacementError(".debug_info addr_size != 8 is unsupported");
+
+  Expected<DenseMap<uint64_t, AbbrevDecl>> TableOrErr =
+      parseAbbrevTable(AbbrevBase, AbbrevSize, AbbrevOff);
+  if (!TableOrErr)
+    return TableOrErr.takeError();
+  const uint64_t UnitEnd = 4 + UnitLength;
+  const uint8_t *End = InfoBase + std::min<uint64_t>(UnitEnd, InfoSize);
+  uint64_t P = 11;
+  unsigned N = 0;
+  uint64_t Code = decodeULEB128(InfoBase + P, &N, End);
+  P += N;
+  DenseMap<uint64_t, AbbrevDecl>::const_iterator It = TableOrErr->find(Code);
+  if (It == TableOrErr->end())
+    return makeDisplacementError(
+        ".debug_info root DIE has unknown abbrev code");
+  dwarf::FormParams FP;
+  FP.Version = Version;
+  FP.AddrSize = AddrSize;
+  FP.Format = dwarf::DWARF32;
+  for (const AbbrevAttr &A : It->second.Attrs) {
+    if (A.Attr == dwarf::DW_AT_low_pc && A.Form == dwarf::DW_FORM_addr) {
+      uint64_t Low = 0;
+      std::memcpy(&Low, InfoBase + P, sizeof(Low));
+      return std::optional<uint64_t>(Low);
+    }
+    if (Error Err =
+            skipFormValue(InfoBase, P, UnitEnd, A.Form, A.ImplicitConst, FP))
+      return std::move(Err);
+  }
+  return std::optional<uint64_t>();
+}
+
+// Locate a debug section in the OUTPUT buffer and hand back a writable pointer
+// plus size. Debug sections follow .text, so their output bytes live at
+// OLD sh_offset + Growth. Returns nullptr Base (with success) when the section
+// is absent.
+Error locateOutputDebugSection(const ElfView &OldElf,
+                               WritableMemoryBuffer &OutBuf, uint64_t Growth,
+                               StringRef Name, uint8_t *&Base, uint64_t &Size) {
+  Base = nullptr;
+  Size = 0;
+  const ELFT::Shdr *Shdr = findSectionByName(OldElf, Name);
+  if (!Shdr)
+    return Error::success();
+  const uint64_t TextEnd = OldElf.textOffset() + OldElf.textSize();
+  uint64_t OutOff = Shdr->sh_offset;
+  if (Shdr->sh_offset >= TextEnd)
+    OutOff += Growth;
+  if (OutOff > OutBuf.getBufferSize() ||
+      Shdr->sh_size > OutBuf.getBufferSize() - OutOff)
+    return makeDisplacementError("debug section '" + Twine(Name) +
+                                 "' is out of bounds in displaced ELF");
+  Base = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart()) + OutOff;
+  Size = Shdr->sh_size;
+  return Error::success();
+}
+
+// Remap the .text addresses in the non-allocatable DWARF debug sections after a
+// tier-3 grow. This is the .debug counterpart to remapEhFrameForDisplacement
+// and runs in the same in-place manner (no size change) for .debug_frame,
+// .debug_info, and .debug_ranges. .debug_line, whose program length changes, is
+// re-synthesized separately by the caller.
+Error remapDebugSectionsForDisplacement(const ElfView &OldElf,
+                                        const DisplacementPlan &Plan,
+                                        WritableMemoryBuffer &OutBuf) {
+  const uint64_t Growth = Plan.paddedGrowth();
+
+  uint8_t *AbbrevBase = nullptr;
+  uint64_t AbbrevSize = 0;
+  if (Error Err = locateOutputDebugSection(
+          OldElf, OutBuf, Growth, ".debug_abbrev", AbbrevBase, AbbrevSize))
+    return Err;
+
+  uint8_t *FrameBase = nullptr;
+  uint64_t FrameSize = 0;
+  if (Error Err = locateOutputDebugSection(
+          OldElf, OutBuf, Growth, ".debug_frame", FrameBase, FrameSize))
+    return Err;
+  if (FrameBase)
+    if (Error Err =
+            remapDebugFrameForDisplacement(OldElf, Plan, FrameBase, FrameSize))
+      return Err;
+
+  uint8_t *InfoBase = nullptr;
+  uint64_t InfoSize = 0;
+  if (Error Err = locateOutputDebugSection(OldElf, OutBuf, Growth,
+                                           ".debug_info", InfoBase, InfoSize))
+    return Err;
+  // Recover the CU base for .debug_ranges from the OLD low_pc (before we
+  // rewrite it in place). low_pc is unchanged here, so old == new base.
+  std::optional<uint64_t> CuBase;
+  if (InfoBase) {
+    if (!AbbrevBase)
+      return makeDisplacementError(".debug_info present without .debug_abbrev");
+    Expected<std::optional<uint64_t>> BaseOrErr =
+        readCuLowPc(InfoBase, InfoSize, AbbrevBase, AbbrevSize);
+    if (!BaseOrErr)
+      return BaseOrErr.takeError();
+    CuBase = *BaseOrErr;
+    if (Error Err = remapDebugInfoForDisplacement(
+            OldElf, Plan, InfoBase, InfoSize, AbbrevBase, AbbrevSize))
+      return Err;
+  }
+
+  uint8_t *RangesBase = nullptr;
+  uint64_t RangesSize = 0;
+  if (Error Err = locateOutputDebugSection(
+          OldElf, OutBuf, Growth, ".debug_ranges", RangesBase, RangesSize))
+    return Err;
+  if (RangesBase) {
+    if (!CuBase)
+      return makeDisplacementError(
+          ".debug_ranges present without a CU .text low_pc base");
+    if (Error Err = remapDebugRangesForDisplacement(OldElf, Plan, RangesBase,
+                                                    RangesSize, *CuBase))
+      return Err;
+  }
+  return Error::success();
+}
+
+// State needed to decode a .debug_line program's address-advancing opcodes.
+struct LineProgramHeader {
+  uint32_t UnitLength = 0;   // value of the first 4 bytes
+  uint64_t UnitEnd = 0;      // 4 + UnitLength (one unit only; see below)
+  uint64_t ProgramStart = 0; // first opcode after the prologue
+  uint8_t MinInstLength = 0;
+  uint8_t MaxOpsPerInst = 0;
+  int8_t LineBase = 0;
+  uint8_t LineRange = 0;
+  uint8_t OpcodeBase = 0;
+  SmallVector<uint8_t, 16> StdOpcodeLengths; // [1 .. OpcodeBase-1]
+};
+
+// Parse the (single) DWARF v2-v4 line-number program header enough to walk the
+// opcode stream. Fails closed on DWARF64, VLIW (max_ops!=1), or a truncated
+// header. Only one program unit is supported; a second unit is rejected by the
+// caller.
+Expected<LineProgramHeader> parseLineProgramHeader(const uint8_t *Base,
+                                                   uint64_t Size) {
+  if (Size < 15)
+    return makeDisplacementError(".debug_line unit is too small");
+  LineProgramHeader H;
+  std::memcpy(&H.UnitLength, Base, 4);
+  if (H.UnitLength == 0xffffffffu)
+    return makeDisplacementError(".debug_line uses 64-bit DWARF (unsupported)");
+  H.UnitEnd = 4 + static_cast<uint64_t>(H.UnitLength);
+  if (H.UnitEnd > Size)
+    return makeDisplacementError(".debug_line unit overruns section");
+  uint16_t Version = 0;
+  std::memcpy(&Version, Base + 4, 2);
+  if (Version < 2 || Version > 4)
+    return makeDisplacementError(".debug_line version " + Twine(Version) +
+                                 " is unsupported");
+  uint32_t HeaderLength = 0;
+  std::memcpy(&HeaderLength, Base + 6, 4);
+  const uint64_t AfterHeaderLen = 10;
+  H.ProgramStart = AfterHeaderLen + HeaderLength;
+  if (H.ProgramStart > H.UnitEnd)
+    return makeDisplacementError(".debug_line prologue overruns unit");
+  uint64_t P = AfterHeaderLen;
+  H.MinInstLength = Base[P++];
+  H.MaxOpsPerInst =
+      Base[P++]; // v4+ field; present for the v4 objects we target
+  if (H.MaxOpsPerInst != 1)
+    return makeDisplacementError(".debug_line VLIW (max_ops_per_inst != 1) is "
+                                 "unsupported");
+  P++; // default_is_stmt
+  H.LineBase = static_cast<int8_t>(Base[P++]);
+  H.LineRange = Base[P++];
+  H.OpcodeBase = Base[P++];
+  if (H.LineRange == 0)
+    return makeDisplacementError(".debug_line line_range is zero");
+  for (unsigned I = 1; I < H.OpcodeBase; ++I) {
+    if (P >= H.ProgramStart)
+      return makeDisplacementError(
+          ".debug_line standard_opcode_lengths overruns prologue");
+    H.StdOpcodeLengths.push_back(Base[P++]);
+  }
+  return H;
+}
+
+// Re-synthesize a .debug_line program so every row's address is remapped
+// through the displacement plan while the decoded (line, column, file, flags)
+// values stay identical. The prologue is copied verbatim; the opcode stream is
+// rebuilt. For each opcode we track the OLD running address and the desired NEW
+// address (mapTextVAddr of the old address). An address advance is re-emitted
+// as an explicit DW_LNS_advance_pc whenever the mapped delta differs from the
+// encoded delta (i.e. the advance straddles a patch); otherwise the original
+// bytes are copied. Special opcodes that must change their address advance are
+// decomposed into DW_LNS_advance_pc + DW_LNS_advance_line + DW_LNS_copy,
+// preserving the row. set_address operands are remapped directly. Returns the
+// new full-section bytes. Fails closed on a second program unit or any opcode
+// we do not model.
+Expected<SmallVector<uint8_t>>
+resynthesizeDebugLine(const ElfView &Elf, const DisplacementPlan &Plan,
+                      const uint8_t *Base, uint64_t Size) {
+  Expected<LineProgramHeader> HOrErr = parseLineProgramHeader(Base, Size);
+  if (!HOrErr)
+    return HOrErr.takeError();
+  const LineProgramHeader &H = *HOrErr;
+  if (H.UnitEnd != Size)
+    return makeDisplacementError(
+        ".debug_line has multiple program units (unsupported)");
+
+  SmallVector<uint8_t> Out;
+  // Copy the prologue (unit_length placeholder included) verbatim; unit_length
+  // is fixed up at the end.
+  Out.append(Base, Base + H.ProgramStart);
+
+  auto emitByte = [&](uint8_t B) { Out.push_back(B); };
+  // DW_LNS_advance_pc's operand is an "operation advance" scaled by
+  // min_inst_length (max_ops_per_inst == 1 here), so the byte delta must be an
+  // exact multiple of min_inst_length. All .text addresses are
+  // min_inst-aligned, so this always holds; a non-multiple would be a decode
+  // bug, so fail closed.
+  auto emitAdvancePc = [&](uint64_t ByteDelta) -> Error {
+    if (ByteDelta == 0)
+      return Error::success();
+    if (ByteDelta % H.MinInstLength != 0)
+      return makeDisplacementError(
+          ".debug_line address delta is not a multiple of min_inst_length");
+    Out.push_back(dwarf::DW_LNS_advance_pc);
+    uint8_t Buf[16];
+    unsigned N = encodeULEB128(ByteDelta / H.MinInstLength, Buf);
+    Out.append(Buf, Buf + N);
+    return Error::success();
+  };
+  auto emitAdvanceLine = [&](int64_t Delta) {
+    if (Delta == 0)
+      return;
+    Out.push_back(dwarf::DW_LNS_advance_line);
+    uint8_t Buf[16];
+    unsigned N = encodeSLEB128(Delta, Buf);
+    Out.append(Buf, Buf + N);
+  };
+
+  const uint8_t *End = Base + Size;
+  uint64_t P = H.ProgramStart;
+  uint64_t OldAddr = 0; // running address in the input program
+  uint64_t NewAddr = 0; // running address emitted so far in the rebuilt program
+  // Pure address-advance opcodes (advance_pc/const_add_pc/fixed_advance_pc) are
+  // NOT copied to the output; we only track OldAddr through them. Intermediate
+  // stops may land inside a replaced instruction, so we never remap them. When
+  // a ROW is about to be emitted (copy/special/end_sequence), reconcile: emit
+  // one DW_LNS_advance_pc so the rebuilt address equals map(OldAddr). Only row
+  // addresses are remapped, and a row inside a replaced range is a genuine
+  // fail-closed condition (the row would name a deleted instruction).
+  auto reconcileToRow = [&]() -> Error {
+    uint64_t Mapped = 0;
+    if (!mapTextVAddr(Elf, Plan, OldAddr, Mapped))
+      return makeDisplacementError(
+          ".debug_line row address is inside a replaced instruction");
+    if (Mapped < NewAddr)
+      return makeDisplacementError(
+          ".debug_line address advance went backwards");
+    if (Error Err = emitAdvancePc(Mapped - NewAddr))
+      return Err;
+    NewAddr = Mapped;
+    return Error::success();
+  };
+
+  while (P < H.UnitEnd) {
+    const uint8_t Op = Base[P];
+    if (Op == 0) {
+      // Extended opcode: 0, ULEB length, sub-opcode, body.
+      unsigned N = 0;
+      uint64_t Len = decodeULEB128(Base + P + 1, &N, End);
+      const uint64_t BodyStart = P + 1 + N;
+      const uint64_t Next = BodyStart + Len;
+      if (Len == 0 || Next > H.UnitEnd)
+        return makeDisplacementError(
+            ".debug_line extended opcode is malformed");
+      const uint8_t Sub = Base[BodyStart];
+      if (Sub == dwarf::DW_LNE_set_address) {
+        if (Len != 9)
+          return makeDisplacementError(
+              ".debug_line set_address is not 8 bytes (addr_size != 8)");
+        uint64_t OldSet = 0;
+        std::memcpy(&OldSet, Base + BodyStart + 1, sizeof(OldSet));
+        uint64_t NewSet = 0;
+        if (!mapTextVAddr(Elf, Plan, OldSet, NewSet))
+          return makeDisplacementError(
+              ".debug_line set_address cannot be remapped");
+        // set_address assigns the running address absolutely in both streams.
+        Out.push_back(0);
+        Out.push_back(9);
+        Out.push_back(dwarf::DW_LNE_set_address);
+        uint8_t AddrBytes[8];
+        std::memcpy(AddrBytes, &NewSet, sizeof(NewSet));
+        Out.append(AddrBytes, AddrBytes + 8);
+        OldAddr = OldSet;
+        NewAddr = NewSet;
+      } else if (Sub == dwarf::DW_LNE_end_sequence) {
+        // end_sequence emits the closing row at the current address; reconcile
+        // the rebuilt address to map(OldAddr) first, then copy the opcode.
+        if (Error Err = reconcileToRow())
+          return Err;
+        Out.append(Base + P, Base + Next);
+        OldAddr = 0;
+        NewAddr = 0;
+      } else {
+        // Other extended opcodes (set_discriminator, define_file, vendor) do
+        // not touch the address; copy verbatim.
+        Out.append(Base + P, Base + Next);
+      }
+      P = Next;
+      continue;
+    }
+
+    if (Op < H.OpcodeBase) {
+      // Standard opcode.
+      switch (Op) {
+      case dwarf::DW_LNS_advance_pc: {
+        unsigned N = 0;
+        uint64_t Adv = decodeULEB128(Base + P + 1, &N, End);
+        OldAddr += Adv * H.MinInstLength; // track only; do not emit
+        P += 1 + N;
+        break;
+      }
+      case dwarf::DW_LNS_fixed_advance_pc: {
+        uint16_t Adv = 0;
+        std::memcpy(&Adv, Base + P + 1, sizeof(Adv));
+        OldAddr += Adv; // fixed_advance_pc is not scaled by min_inst_length
+        P += 3;
+        break;
+      }
+      case dwarf::DW_LNS_const_add_pc: {
+        const uint8_t Adjust = (255 - H.OpcodeBase) / H.LineRange;
+        OldAddr += static_cast<uint64_t>(Adjust) * H.MinInstLength;
+        P += 1;
+        break;
+      }
+      case dwarf::DW_LNS_copy:
+        // Emits a row at the current address; catch the rebuilt address up.
+        if (Error Err = reconcileToRow())
+          return Err;
+        emitByte(dwarf::DW_LNS_copy);
+        P += 1;
+        break;
+      default: {
+        // A standard opcode with no address effect: copy the opcode plus its
+        // ULEB operands verbatim (operand count from standard_opcode_lengths).
+        const uint8_t NumOperands = H.StdOpcodeLengths[Op - 1];
+        uint64_t Q = P + 1;
+        for (uint8_t I = 0; I < NumOperands; ++I) {
+          unsigned N = 0;
+          decodeULEB128(Base + Q, &N, End);
+          Q += N;
+          if (Q > H.UnitEnd)
+            return makeDisplacementError(
+                ".debug_line standard opcode operand overruns unit");
+        }
+        Out.append(Base + P, Base + Q);
+        P = Q;
+        break;
+      }
+      }
+      continue;
+    }
+
+    // Special opcode: advances address and line and emits a row. Because we
+    // drop the pure address-advance opcodes and only reconcile at rows, NewAddr
+    // can lag OldAddr's mapped position here; a verbatim copy of the special
+    // opcode would apply its own (small) address delta from the lagging NewAddr
+    // and desync the stream. So always decompose: correct the address
+    // explicitly to the mapped row target, apply the line delta, and emit the
+    // row with DW_LNS_copy, which resets the same sticky flags
+    // (discriminator/basic_block/prologue_end/epilogue_begin) a special opcode
+    // does, so the decoded row is identical apart from the remapped address.
+    const uint8_t Adjusted = Op - H.OpcodeBase;
+    const uint64_t AddrAdv =
+        static_cast<uint64_t>(Adjusted / H.LineRange) * H.MinInstLength;
+    const int64_t LineAdv = H.LineBase + (Adjusted % H.LineRange);
+    // Only the ROW address (OldAddr + AddrAdv) is remapped; the running base
+    // may sit at an intermediate stop inside a replaced range, which we never
+    // map.
+    OldAddr += AddrAdv;
+    uint64_t MappedTarget = 0;
+    if (!mapTextVAddr(Elf, Plan, OldAddr, MappedTarget))
+      return makeDisplacementError(
+          ".debug_line special-opcode row is inside a replaced instruction");
+    if (MappedTarget < NewAddr)
+      return makeDisplacementError(".debug_line special opcode went backwards");
+    if (Error Err = emitAdvancePc(MappedTarget - NewAddr))
+      return Err;
+    emitAdvanceLine(LineAdv);
+    emitByte(dwarf::DW_LNS_copy);
+    NewAddr = MappedTarget;
+    P += 1;
+  }
+
+  // Fix unit_length = total bytes - 4.
+  const uint32_t NewUnitLength = static_cast<uint32_t>(Out.size() - 4);
+  std::memcpy(Out.data(), &NewUnitLength, sizeof(NewUnitLength));
+  return Out;
+}
+
+// Shift the sh_offset of every section whose file offset is at or after
+// \p Threshold by \p Delta, shift e_shoff if it is past the threshold, and set
+// the size of the section at \p GrownIndex to \p GrownSize. Non-allocatable
+// sections only: no sh_addr / program-header changes (the caller guarantees the
+// grown section is non-allocatable, so no segment maps it).
+Error shiftSectionOffsetsAfter(uint8_t *Elf, size_t ElfSize, uint64_t Threshold,
+                               uint64_t Delta, uint16_t GrownIndex,
+                               uint64_t GrownSize) {
+  if (ElfSize < sizeof(Ehdr))
+    return makeDisplacementError("displaced ELF is smaller than its header");
+  uint64_t Shoff = 0;
+  uint16_t Shentsize = 0, Shnum = 0;
+  std::memcpy(&Shoff, Elf + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, Elf + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
+  std::memcpy(&Shnum, Elf + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+  if (Shentsize < sizeof(Shdr))
+    return makeDisplacementError("section-header entry is too small");
+  if (Shoff >= Threshold) {
+    uint64_t NewShoff = Shoff + Delta;
+    std::memcpy(Elf + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+    Shoff = NewShoff;
+  }
+  for (uint16_t I = 0; I < Shnum; ++I) {
+    uint64_t ShPos = Shoff + static_cast<uint64_t>(I) * Shentsize;
+    if (ShPos > ElfSize || sizeof(Shdr) > ElfSize - ShPos)
+      return makeDisplacementError("section-header table is out of bounds");
+    uint8_t *Sh = Elf + ShPos;
+    if (I == GrownIndex) {
+      std::memcpy(Sh + offsetof(Shdr, sh_size), &GrownSize, sizeof(GrownSize));
+      continue;
+    }
+    uint64_t ShOffset = 0;
+    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
+    if (ShOffset >= Threshold) {
+      uint64_t NewOffset = ShOffset + Delta;
+      std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
+                  sizeof(NewOffset));
+    }
+  }
+  return Error::success();
+}
+
+// Re-synthesize .debug_line (if present) and, when its byte length changed,
+// return a NEW output buffer with the section spliced in and every trailing
+// section's file offset shifted by the length delta. .debug_line is
+// non-allocatable, so no vaddr/segment fixups are needed. Returns the original
+// buffer unchanged when there is no .debug_line or its length did not change.
+Expected<std::unique_ptr<WritableMemoryBuffer>>
+growDebugLineForDisplacement(const ElfView &OldElf,
+                             const DisplacementPlan &Plan,
+                             std::unique_ptr<WritableMemoryBuffer> OutBuf) {
+  const ELFT::Shdr *LineShdr = findSectionByName(OldElf, ".debug_line");
+  if (!LineShdr)
+    return std::move(OutBuf);
+
+  const uint64_t Growth = Plan.paddedGrowth();
+  const uint64_t TextEnd = OldElf.textOffset() + OldElf.textSize();
+  const uint64_t OutLineOff =
+      LineShdr->sh_offset + (LineShdr->sh_offset >= TextEnd ? Growth : 0);
+  const uint64_t OldLineSize = LineShdr->sh_size;
+  if (OutLineOff > OutBuf->getBufferSize() ||
+      OldLineSize > OutBuf->getBufferSize() - OutLineOff)
+    return makeDisplacementError(
+        ".debug_line is out of bounds in displaced ELF");
+
+  const uint8_t *OldLine =
+      reinterpret_cast<const uint8_t *>(OutBuf->getBufferStart()) + OutLineOff;
+  Expected<SmallVector<uint8_t>> NewLineOrErr =
+      resynthesizeDebugLine(OldElf, Plan, OldLine, OldLineSize);
+  if (!NewLineOrErr)
+    return NewLineOrErr.takeError();
+  SmallVector<uint8_t> &NewLine = *NewLineOrErr;
+
+  if (NewLine.size() == OldLineSize) {
+    // Same length: splice in place, no header shift.
+    std::memcpy(reinterpret_cast<uint8_t *>(OutBuf->getBufferStart()) +
+                    OutLineOff,
+                NewLine.data(), NewLine.size());
+    log() << "hotswap: displacement: .debug_line re-synthesized in place ("
+          << NewLine.size() << " bytes)\n";
+    return std::move(OutBuf);
+  }
+  if (NewLine.size() < OldLineSize)
+    return makeDisplacementError(".debug_line re-synthesis shrank the program");
+
+  const uint64_t LineDelta = NewLine.size() - OldLineSize;
+  const size_t OldTotal = OutBuf->getBufferSize();
+  const size_t NewTotal = OldTotal + LineDelta;
+  std::unique_ptr<WritableMemoryBuffer> NewBuf =
+      WritableMemoryBuffer::getNewUninitMemBuffer(NewTotal);
+  if (!NewBuf)
+    return makeDisplacementError("failed to allocate .debug_line grow buffer");
+
+  const uint8_t *Src =
+      reinterpret_cast<const uint8_t *>(OutBuf->getBufferStart());
+  uint8_t *Dst = reinterpret_cast<uint8_t *>(NewBuf->getBufferStart());
+  const uint64_t TailOff = OutLineOff + OldLineSize;
+  std::memcpy(Dst, Src, OutLineOff);
+  std::memcpy(Dst + OutLineOff, NewLine.data(), NewLine.size());
+  std::memcpy(Dst + OutLineOff + NewLine.size(), Src + TailOff,
+              OldTotal - TailOff);
+
+  // Shift section offsets/shoff for everything after .debug_line's old bytes.
+  const uint16_t LineIndex =
+      static_cast<uint16_t>(LineShdr - OldElf.sections().begin());
+  if (Error Err = shiftSectionOffsetsAfter(Dst, NewTotal, TailOff, LineDelta,
+                                           LineIndex, NewLine.size()))
+    return std::move(Err);
+  log() << "hotswap: displacement: .debug_line re-synthesized, grew "
+        << OldLineSize << " -> " << NewLine.size() << " bytes (+" << LineDelta
+        << "); shifted trailing sections\n";
+  return std::move(NewBuf);
+}
+
 Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
                             const DisplacementPlan &Plan,
                             WritableMemoryBuffer &OutBuf) {
@@ -728,14 +2232,25 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
         "output buffer has incorrect size for displacement");
   }
 
+  using Clock = std::chrono::steady_clock;
+  auto ms = [](Clock::duration D) {
+    return std::chrono::duration<double, std::milli>(D).count();
+  };
+  Clock::time_point T0 = Clock::now();
+
   SmallVector<uint8_t> NewText = Plan.buildText(
       ArrayRef<uint8_t>(Elf.textData(), Elf.textSize()), LS.SNopBytes);
   if (NewText.size() != Plan.paddedTextSize()) {
     return makeDisplacementError(
         "rebuilt .text size does not match displacement plan");
   }
+  Clock::time_point T1 = Clock::now();
+  log() << "hotswap: TIMING   tier-3 buildText: " << ms(T1 - T0) << " ms\n";
   if (Error Err = repairBranches(Elf, LS, Plan, NewText))
     return Err;
+  Clock::time_point T2 = Clock::now();
+  log() << "hotswap: TIMING   tier-3 repairBranches (whole .text redecode): "
+        << ms(T2 - T1) << " ms\n";
 
   uint8_t *Out = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
   const uint8_t *Input = Elf.data();
@@ -749,18 +2264,43 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
                 InputSize - TextEnd);
   }
 
-  if (Error Err = adjustSectionHeadersForTextGrowth(Out, NewSize, Elf,
-                                                    Plan.paddedGrowth()))
+  const bool RelocateVAddr = Plan.relocatesTrailingSections();
+  if (Error Err = adjustSectionHeadersForTextGrowth(
+          Out, NewSize, Elf, Plan.paddedGrowth(), RelocateVAddr))
     return Err;
-  if (Error Err = adjustProgramHeadersForTextGrowth(Out, NewSize, Elf,
-                                                    Plan.paddedGrowth()))
+  if (Error Err = adjustProgramHeadersForTextGrowth(
+          Out, NewSize, Elf, Plan.paddedGrowth(), RelocateVAddr))
     return Err;
   if (Error Err = adjustSymbolValuesForDisplacement(Out, NewSize, Elf, Plan))
     return Err;
+  Clock::time_point T3 = Clock::now();
+  log() << "hotswap: TIMING   tier-3 memcpy+headers+symbols: " << ms(T3 - T2)
+        << " ms\n";
 
   if (Error Err =
           rewriteKernelDescriptorEntriesForDisplacement(OutBuf, Elf, Plan))
     return Err;
+  Clock::time_point T4 = Clock::now();
+  log() << "hotswap: TIMING   tier-3 descriptor rewrite: " << ms(T4 - T3)
+        << " ms\n";
+
+  // .eh_frame FDEs describe per-kernel .text ranges; fix them to the new layout
+  // when the caller opted into relocation (tier-3). validateDebugSections only
+  // admits .eh_frame in that mode, so this is the matching repair.
+  if (RelocateVAddr)
+    if (Error Err = remapEhFrameForDisplacement(Elf, Plan, OutBuf))
+      return Err;
+  log() << "hotswap: TIMING   tier-3 eh_frame remap: " << ms(Clock::now() - T4)
+        << " ms\n";
+
+  // Non-allocatable DWARF debug sections (.debug_frame/.debug_info/
+  // .debug_ranges) reference .text addresses that are now stale; rewrite them
+  // in place. validateDebugSections only admits these sections in this mode.
+  // .debug_line is re-synthesized separately by the caller because its byte
+  // length changes.
+  if (RelocateVAddr)
+    if (Error Err = remapDebugSectionsForDisplacement(Elf, Plan, OutBuf))
+      return Err;
 
   log() << "hotswap: displacement: grew ELF from " << InputSize << " to "
         << NewSize << " bytes (" << Plan.edits().size() << " edit"
@@ -774,7 +2314,8 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
 
 Expected<DisplacementPlan>
 DisplacementPlan::create(const ElfView &Elf,
-                         ArrayRef<DisplacementEdit> InputEdits) {
+                         ArrayRef<DisplacementEdit> InputEdits,
+                         bool RelocateTrailingSections) {
   if (InputEdits.empty())
     return makeDisplacementError("no displacement edits requested");
 
@@ -828,12 +2369,16 @@ DisplacementPlan::create(const ElfView &Elf,
   if (Padding > std::numeric_limits<uint64_t>::max() - RawGrowth)
     return makeDisplacementError("aligned displacement growth overflows");
   uint64_t PaddedGrowth = RawGrowth + Padding;
-  if (Error Err = validateVirtualGrowth(Elf, PaddedGrowth))
-    return std::move(Err);
+  // When relocating trailing sections (tier-3), a grown .text that would
+  // overlap later allocatable content is fine: the apply step shifts that
+  // content's vaddr forward. Skip the overlap bail in that mode.
+  if (!RelocateTrailingSections)
+    if (Error Err = validateVirtualGrowth(Elf, PaddedGrowth))
+      return std::move(Err);
   if (PaddedGrowth > std::numeric_limits<size_t>::max() - Elf.size())
     return makeDisplacementError("displaced ELF size overflows size_t");
   return DisplacementPlan(Elf.textSize(), RawGrowth, PaddedGrowth,
-                          std::move(Sorted));
+                          std::move(Sorted), RelocateTrailingSections);
 }
 
 bool DisplacementPlan::mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
@@ -908,13 +2453,16 @@ DisplacementPlan::buildText(ArrayRef<uint8_t> OldText,
 
 Expected<std::unique_ptr<WritableMemoryBuffer>>
 tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
-                                    ArrayRef<DisplacementEdit> Edits) {
-  if (Error Err = validateDebugSections(Elf))
+                                    ArrayRef<DisplacementEdit> Edits,
+                                    bool RelocateTrailingSections) {
+  if (Error Err = validateDebugSections(
+          Elf, /*AllowEhFrameRemap=*/RelocateTrailingSections))
     return std::move(Err);
   if (Error Err = validateTextRelocations(Elf))
     return std::move(Err);
 
-  Expected<DisplacementPlan> PlanOrErr = DisplacementPlan::create(Elf, Edits);
+  Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(Elf, Edits, RelocateTrailingSections);
   if (!PlanOrErr)
     return PlanOrErr.takeError();
   if (Error Err = validateKernelEntryMappings(Elf, *PlanOrErr))
@@ -929,6 +2477,18 @@ tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
   }
   if (Error Err = applyTextDisplacement(Elf, LS, *PlanOrErr, *Out))
     return std::move(Err);
+
+  // .debug_line's program length can change when an address advance straddles a
+  // patch; re-synthesize it and splice the (possibly larger) section back in,
+  // shifting trailing non-allocatable sections. Only relevant in tier-3, where
+  // validateDebugSections admitted the debug sections.
+  if (RelocateTrailingSections) {
+    Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
+        growDebugLineForDisplacement(Elf, *PlanOrErr, std::move(Out));
+    if (!GrownOrErr)
+      return GrownOrErr.takeError();
+    return std::move(*GrownOrErr);
+  }
   return std::move(Out);
 }
 

--- a/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-entry-trampoline.cpp
@@ -309,11 +309,9 @@ std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD) {
   return KD.VAddr - Magnitude;
 }
 
-static std::optional<bool>
-descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
-                                  const KernelDescriptorInfo &KD,
-                                  const LLVMState &LS,
-                                  ArrayRef<uint8_t> EntryStubPrefix) {
+static std::optional<bool> descriptorAlreadyTargetsEntryStub(
+    const ElfView &Elf, const KernelDescriptorInfo &KD, const LLVMState &LS,
+    ArrayRef<uint8_t> EntryStubPrefix) {
   std::optional<uint64_t> Entry = entryVAddr(KD);
   if (!Entry)
     return std::nullopt;
@@ -338,8 +336,8 @@ descriptorAlreadyTargetsEntryStub(const ElfView &Elf,
     return false;
 
   std::vector<InternalDecodedInst> Decoded;
-  if (!decodeKernelEntryStub(Candidate, LS,
-                             Decoded, "entry trampoline idempotency matcher"))
+  if (!decodeKernelEntryStub(Candidate, LS, Decoded,
+                             "entry trampoline idempotency matcher"))
     return false;
   if (!hasEntryStubOperandShape(Decoded, LS))
     return false;
@@ -403,8 +401,8 @@ totalTrampolineBytes(ArrayRef<Trampoline> Trampolines) {
   return Total;
 }
 
-static std::optional<int64_t>
-checkedSignedDifference(uint64_t LHS, uint64_t RHS, StringRef Context) {
+std::optional<int64_t> checkedSignedDifference(uint64_t LHS, uint64_t RHS,
+                                               StringRef Context) {
   if (LHS >= RHS) {
     uint64_t Diff = LHS - RHS;
     if (Diff > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
@@ -484,6 +482,73 @@ static bool appendPaddingTrampoline(std::vector<Trampoline> &Out,
     Pad.Bytes.append(Fill.begin(), Fill.end());
   Out.push_back(std::move(Pad));
   return true;
+}
+
+std::optional<uint32_t>
+collectKernelEntryDisplacements(const ElfView &Elf, const LLVMState &LS,
+                                std::vector<DisplacementEdit> &OutEdits) {
+  ArrayRef<KernelDescriptorInfo> Descriptors = Elf.kernelDescriptors();
+  if (Descriptors.empty())
+    return 0;
+
+  SmallVector<uint8_t> Prefix = buildEntryStubBytePrefix(LS);
+  if (Prefix.empty())
+    return std::nullopt;
+
+  std::optional<uint64_t> TextEnd = checkedAddUint64(
+      Elf.textAddr(), Elf.textSize(), "entry displacement text end");
+  if (!TextEnd)
+    return std::nullopt;
+
+  uint32_t Added = 0;
+  for (const KernelDescriptorInfo &KD : Descriptors) {
+    std::optional<bool> AlreadyHasEntryStub =
+        descriptorAlreadyTargetsEntryStub(Elf, KD, LS, Prefix);
+    if (!AlreadyHasEntryStub)
+      return std::nullopt;
+    if (*AlreadyHasEntryStub)
+      continue;
+
+    std::optional<bool> PrologueHasWorkaround =
+        entryPrologueHasVmemWorkaround(Elf, KD, LS, Prefix);
+    if (!PrologueHasWorkaround)
+      return std::nullopt;
+    if (*PrologueHasWorkaround)
+      continue;
+
+    std::optional<uint64_t> Entry = entryVAddr(KD);
+    if (!Entry)
+      return std::nullopt;
+    if (*Entry < Elf.textAddr() || *Entry >= *TextEnd) {
+      log() << "hotswap: error: kernel-entry displacement for '"
+            << KD.KernelName << "' points outside .text at vaddr 0x"
+            << utohexstr(*Entry) << ".\n";
+      return std::nullopt;
+    }
+    const uint64_t TextOffset = *Entry - Elf.textAddr();
+
+    bool DuplicateOffset = false;
+    for (const DisplacementEdit &Existing : OutEdits) {
+      if (Existing.Offset == TextOffset && Existing.OriginalSize == 0) {
+        DuplicateOffset = true;
+        break;
+      }
+    }
+    if (DuplicateOffset)
+      continue;
+
+    DisplacementEdit Edit;
+    Edit.Offset = TextOffset;
+    Edit.OriginalSize = 0;
+    Edit.ReplacementBytes.assign(Prefix.begin(), Prefix.end());
+    OutEdits.push_back(std::move(Edit));
+    ++Added;
+  }
+
+  if (Added > 0)
+    log() << "hotswap: queued " << Added << " kernel-entry displacement"
+          << (Added == 1 ? "" : "s") << "\n";
+  return Added;
 }
 
 std::optional<uint32_t> appendKernelEntryTrampolines(

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -63,6 +63,8 @@
 namespace COMGR {
 namespace hotswap {
 
+class ElfView;
+
 // -- Logging ------------------------------------------------------------------
 //
 // Single output stream for all hotswap diagnostics (errors, warnings, and
@@ -123,6 +125,51 @@ struct Trampoline {
   bool HasFunctionRange = false;
   uint64_t FunctionStart = 0;
   uint64_t FunctionEnd = 0;
+};
+
+struct DisplacementEdit {
+  uint64_t Offset = 0;
+  uint32_t OriginalSize = 0;
+  llvm::SmallVector<uint8_t> ReplacementBytes;
+};
+
+enum class DisplacementMapBias {
+  BeforeInsertedBytes,
+  AfterInsertedBytes,
+};
+
+class DisplacementPlan {
+public:
+  static llvm::Expected<DisplacementPlan>
+  create(const ElfView &Elf, llvm::ArrayRef<DisplacementEdit> Edits);
+
+  llvm::ArrayRef<DisplacementEdit> edits() const { return Edits; }
+  uint64_t oldTextSize() const { return OldTextSize; }
+  uint64_t rawGrowth() const { return RawGrowth; }
+  uint64_t paddedGrowth() const { return PaddedGrowth; }
+  uint64_t newTextSize() const { return OldTextSize + RawGrowth; }
+  uint64_t paddedTextSize() const { return OldTextSize + PaddedGrowth; }
+  size_t newElfSize(size_t OldElfSize) const {
+    return OldElfSize + PaddedGrowth;
+  }
+
+  bool mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
+                 uint64_t &NewOffset) const;
+  bool rangeOverlapsReplacement(uint64_t OldOffset, uint64_t Size) const;
+
+  llvm::SmallVector<uint8_t> buildText(llvm::ArrayRef<uint8_t> OldText,
+                                       llvm::ArrayRef<uint8_t> SNopBytes) const;
+
+private:
+  DisplacementPlan(uint64_t OldTextSize, uint64_t RawGrowth,
+                   uint64_t PaddedGrowth, std::vector<DisplacementEdit> Edits)
+      : OldTextSize(OldTextSize), RawGrowth(RawGrowth),
+        PaddedGrowth(PaddedGrowth), Edits(std::move(Edits)) {}
+
+  uint64_t OldTextSize = 0;
+  uint64_t RawGrowth = 0;
+  uint64_t PaddedGrowth = 0;
+  std::vector<DisplacementEdit> Edits;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -1115,6 +1162,13 @@ bool hasKernelEntryTrampolinePrefix(llvm::ArrayRef<uint8_t> Bytes,
 /// mapped .text bytes.
 uint64_t computeKernelEntryPrefetchGuardBytes(uint32_t InstPrefLines);
 
+/// Queue one direct insertion of `global_wb; v_nop` at each kernel descriptor
+/// entry that does not already target either a direct entry prefix or an
+/// appended HotSwap entry stub.
+std::optional<uint32_t>
+collectKernelEntryDisplacements(const ElfView &Elf, const LLVMState &LS,
+                                std::vector<DisplacementEdit> &OutEdits);
+
 /// Append one entry stub per kernel descriptor that does not already target a
 /// HotSwap entry stub. The stubs are appended to \p Growth and descriptor
 /// rewrites are recorded in \p OutFixups for application after ELF growth.
@@ -1133,6 +1187,10 @@ bool rewriteKernelEntryDescriptorOffsets(
 /// Resolve the virtual address of a kernel descriptor's entry point. Shared by
 /// the MC and fast entry-trampoline paths.
 std::optional<uint64_t> entryVAddr(const KernelDescriptorInfo &KD);
+
+/// Compute LHS - RHS when the result is representable as int64_t.
+std::optional<int64_t> checkedSignedDifference(uint64_t LHS, uint64_t RHS,
+                                               llvm::StringRef Context);
 
 /// Round Value up to a multiple of Alignment, reporting overflow against
 /// Context. Shared by the MC and fast entry-trampoline paths.
@@ -1170,6 +1228,11 @@ std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     llvm::WritableMemoryBuffer &In, unsigned TextSectionIndex,
     uint64_t TextAddr, uint64_t OldTextSize,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
+
+/// Apply direct .text displacement to a newly allocated output buffer.
+llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>>
+tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
+                                    llvm::ArrayRef<DisplacementEdit> Edits);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -36,6 +36,7 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -140,8 +141,14 @@ enum class DisplacementMapBias {
 
 class DisplacementPlan {
 public:
+  /// \p RelocateTrailingSections lets the plan grow past a later allocatable
+  /// section: instead of failing when the grown .text would overlap trailing
+  /// allocatable content, the apply step shifts that content's virtual address
+  /// forward (used by the tier-3 whole-object grow backstop). Defaults false to
+  /// preserve the entry-workaround path's fail-closed behavior.
   static llvm::Expected<DisplacementPlan>
-  create(const ElfView &Elf, llvm::ArrayRef<DisplacementEdit> Edits);
+  create(const ElfView &Elf, llvm::ArrayRef<DisplacementEdit> Edits,
+         bool RelocateTrailingSections = false);
 
   llvm::ArrayRef<DisplacementEdit> edits() const { return Edits; }
   uint64_t oldTextSize() const { return OldTextSize; }
@@ -160,16 +167,21 @@ public:
   llvm::SmallVector<uint8_t> buildText(llvm::ArrayRef<uint8_t> OldText,
                                        llvm::ArrayRef<uint8_t> SNopBytes) const;
 
+  bool relocatesTrailingSections() const { return RelocateTrailingSections; }
+
 private:
   DisplacementPlan(uint64_t OldTextSize, uint64_t RawGrowth,
-                   uint64_t PaddedGrowth, std::vector<DisplacementEdit> Edits)
+                   uint64_t PaddedGrowth, std::vector<DisplacementEdit> Edits,
+                   bool RelocateTrailingSections)
       : OldTextSize(OldTextSize), RawGrowth(RawGrowth),
-        PaddedGrowth(PaddedGrowth), Edits(std::move(Edits)) {}
+        PaddedGrowth(PaddedGrowth), Edits(std::move(Edits)),
+        RelocateTrailingSections(RelocateTrailingSections) {}
 
   uint64_t OldTextSize = 0;
   uint64_t RawGrowth = 0;
   uint64_t PaddedGrowth = 0;
   std::vector<DisplacementEdit> Edits;
+  bool RelocateTrailingSections = false;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -681,9 +693,37 @@ LLVMState initLLVM(const TargetIdentifier &TI);
 
 /// Disassemble \p Text into \p Decoded using \p LS. Unknown bytes are encoded
 /// as MinInstSize-sized entries with mnemonic "<unknown>".
+///
+/// \p WantMnemonic controls whether each decoded instruction's assembly
+/// mnemonic string is populated. Building the mnemonic (MCInstPrinter lookup
+/// plus a per-instruction std::string) is pure overhead for callers that only
+/// inspect opcodes / MCInstrAnalysis and read InternalDecodedInst::Mnemonic
+/// solely for diagnostics. Passing false leaves DI.Mnemonic empty for
+/// successful decodes (failed decodes still carry the "<unknown>" marker, which
+/// some callers key on) so those callers avoid ~1 std::string per instruction
+/// over the whole section. Defaults to true to preserve mnemonic-consuming
+/// callers.
 [[nodiscard]] bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
                                      const LLVMState &LS,
-                                     std::vector<InternalDecodedInst> &Decoded);
+                                     std::vector<InternalDecodedInst> &Decoded,
+                                     bool WantMnemonic = true);
+
+/// Streaming variant of decodeTextSection. Decodes \p Text one instruction at a
+/// time and invokes \p OnInst for each, in ascending offset order, reusing a
+/// single InternalDecodedInst so no O(TextSize) result vector is materialized.
+/// The decode logic (variable-length linear scan, per-call decode cache,
+/// unknown-byte handling, optional mnemonic) is identical to decodeTextSection;
+/// decodeTextSection is implemented on top of this by appending each callback
+/// instruction to its vector, so the two never diverge.
+///
+/// \p OnInst returns true to continue and false to stop the scan early (e.g. on
+/// the first rejection). Returns true if the scan completed or was stopped by
+/// the callback, false only if the decoder itself could not proceed. Callers
+/// carry their own error out through state captured in \p OnInst.
+[[nodiscard]] bool decodeTextSectionStreaming(
+    const uint8_t *Text, uint64_t TextSize, const LLVMState &LS,
+    bool WantMnemonic,
+    llvm::function_ref<bool(const InternalDecodedInst &)> OnInst);
 
 /// Assemble one non-empty assembly source line, returning its encoded bytes.
 /// Target pseudos may expand that source line to more than one MCInst.
@@ -945,6 +985,14 @@ struct PatchContext {
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
       WorkgroupMetadataCache;
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
+
+  // Per-kernel local displacement (tier 1): growing patches record their
+  // replacement here instead of emitting a trampoline immediately. The
+  // finalize pass groups these by owning kernel and applies all edits for a
+  // kernel together, so multiple edits in one kernel see each other's shift.
+  // A site is only collected when it provably fits the kernel's tail padding;
+  // otherwise the caller falls through to the sled/trampoline path.
+  std::vector<DisplacementEdit> DisplacementEdits;
 };
 
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
@@ -1229,10 +1277,15 @@ std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     uint64_t TextAddr, uint64_t OldTextSize,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
-/// Apply direct .text displacement to a newly allocated output buffer.
+/// Apply direct .text displacement to a newly allocated output buffer. With
+/// \p RelocateTrailingSections, a grow that would overlap later allocatable
+/// content instead shifts that content's virtual address forward (tier-3
+/// whole-object backstop); default false preserves the entry-path fail-closed
+/// overlap check.
 llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>>
 tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
-                                    llvm::ArrayRef<DisplacementEdit> Edits);
+                                    llvm::ArrayRef<DisplacementEdit> Edits,
+                                    bool RelocateTrailingSections = false);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -462,10 +462,9 @@ SmallVector<uint8_t> LLVMState::encodeSBranch(uint64_t FromOffset,
 
 // -- Instruction decode -------------------------------------------------------
 
-bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
-                       const LLVMState &S,
-                       std::vector<InternalDecodedInst> &Decoded) {
-  Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
+bool decodeTextSectionStreaming(
+    const uint8_t *Text, uint64_t TextSize, const LLVMState &S,
+    bool WantMnemonic, function_ref<bool(const InternalDecodedInst &)> OnInst) {
   uint64_t Pos = 0;
   // Per-call decode cache: byte-identical instructions reuse the first decode
   // instead of re-running the disassembler; DI.Offset is set per occurrence, so
@@ -481,9 +480,14 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
     std::string Mnemonic;
   };
   StringMap<DecodeCacheEntry> LocalCache;
+  // One reused instruction record: the streaming contract only exposes DI to
+  // OnInst for the current position, so no per-instruction allocation or result
+  // vector is needed. Reset the mutable fields each iteration.
+  InternalDecodedInst DI;
   while (Pos < TextSize) {
-    InternalDecodedInst DI;
     DI.Offset = Pos;
+    DI.DecodeSucceeded = false;
+    DI.Mnemonic.clear();
 
     unsigned KeyN =
         static_cast<unsigned>(std::min<uint64_t>(MaxInstLen, TextSize - Pos));
@@ -497,10 +501,15 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       // Only successful decodes are stored, so a hit is always a success.
       DI.DecodeSucceeded = true;
       Pos += DI.Size;
-      Decoded.emplace_back(std::move(DI));
+      if (!OnInst(DI))
+        return true;
       continue;
     }
 
+    // The AMDGPU disassembler appends operands to the passed MCInst without
+    // clearing it first, so a reused DI.Inst must be reset to the same clean
+    // state a fresh per-iteration record would have before getInstruction.
+    DI.Inst = MCInst();
     ArrayRef<uint8_t> Bytes(Text + Pos, TextSize - Pos);
     uint64_t InstSize = 0;
     MCDisassembler::DecodeStatus Status =
@@ -516,13 +525,16 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       // table. Storage is process-lifetime static; the trailing whitespace
       // baked into AsmStrs must be trimmed. If the printer cannot provide an
       // assembly mnemonic, leave the instruction unmatchable instead of falling
-      // back to TableGen opcode names.
-      if (S.MCIP) {
-        std::pair<const char *, uint64_t> Mnem = S.MCIP->getMnemonic(DI.Inst);
-        DI.Mnemonic = Mnem.first ? StringRef(Mnem.first).rtrim().str()
-                                 : UnknownMnemonic.str();
-      } else {
-        DI.Mnemonic = UnknownMnemonic.str();
+      // back to TableGen opcode names. Callers that never read the mnemonic
+      // (WantMnemonic == false) skip this per-instruction std::string entirely.
+      if (WantMnemonic) {
+        if (S.MCIP) {
+          std::pair<const char *, uint64_t> Mnem = S.MCIP->getMnemonic(DI.Inst);
+          DI.Mnemonic = Mnem.first ? StringRef(Mnem.first).rtrim().str()
+                                   : UnknownMnemonic.str();
+        } else {
+          DI.Mnemonic = UnknownMnemonic.str();
+        }
       }
     }
     // Cache only successful decodes whose key window covers the instruction
@@ -531,9 +543,25 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       LocalCache.try_emplace(Key,
                              DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic});
     Pos += DI.Size;
-    Decoded.emplace_back(std::move(DI));
+    if (!OnInst(DI))
+      return true;
   }
   return true;
+}
+
+bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
+                       const LLVMState &S,
+                       std::vector<InternalDecodedInst> &Decoded,
+                       bool WantMnemonic) {
+  Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
+  // Materialize the full result by copying each streamed instruction into the
+  // vector. Streaming callers that only inspect one instruction at a time avoid
+  // this O(TextSize) storage; see decodeTextSectionStreaming.
+  return decodeTextSectionStreaming(Text, TextSize, S, WantMnemonic,
+                                    [&Decoded](const InternalDecodedInst &DI) {
+                                      Decoded.push_back(DI);
+                                      return true;
+                                    });
 }
 
 // -- assembly helpers ---------------------------------------------------------

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-gfx125x.s
@@ -1,4 +1,4 @@
-// COM: HotSwap entry trampolines are supported across gfx125x.
+// COM: Direct HotSwap entry displacement is supported across gfx125x.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib %s -o %t.gfx1251.elf
 // RUN: hotswap-rewrite %t.gfx1251.elf \
@@ -6,6 +6,18 @@
 // RUN:   --entry-trampolines --output %t.gfx1251.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
 // RUN: %llvm-objdump -d %t.gfx1251.out.elf | %FileCheck --check-prefix=DISASM %s
+
+// COM: Direct displacement does not need scratch SGPRs, so it remains valid at
+// COM: the architectural SGPR limit.
+// RUN: sed 's/.sgpr_count: 1/.sgpr_count: 105/' %s > %t.highsgpr.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1251 -nostdlib \
+// RUN:   %t.highsgpr.s -o %t.highsgpr.elf
+// RUN: hotswap-rewrite %t.highsgpr.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1251 amdgcn-amd-amdhsa--gfx1251 \
+// RUN:   --entry-trampolines --output %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// RUN: %llvm-objdump -d %t.highsgpr.out.elf \
+// RUN:   | %FileCheck --check-prefix=DISASM %s
 
 // RUN: sed -e '/^\.amdgcn_target/d' \
 // RUN:   -e 's/gfx1251/gfx12-5-generic/g' %s > %t.generic.s
@@ -21,13 +33,11 @@
 // API: RESULT: SUCCESS
 
 // DISASM-LABEL: <entry_tramp_family_kernel>:
-// DISASM: s_endpgm
-// DISASM: global_wb
+// DISASM-NEXT: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2
-// DISASM-NEXT: s_add_co_ci_u32 s3
-// DISASM-NEXT: s_set_pc_i64 s[2:3]
+// DISASM-NEXT: v_mov_b32_e32 v0, 0
+// DISASM-NEXT: s_endpgm
+// DISASM-NOT: s_get_pc_i64
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1251"
 .text

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-mixed-existing.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-mixed-existing.s
@@ -1,0 +1,126 @@
+// COM: An object can contain an existing appended entry stub and a different
+// COM: raw kernel entry. Direct displacement would move the existing stub's
+// COM: body target without repairing the stub, so the whole rewrite must stay
+// COM: on the appended-stub path.
+
+// COM: First create an object where the pre-fixed first kernel is skipped and
+// COM: the second kernel receives a fast-path appended stub.
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s \
+// RUN:   -o %t.prefixed.elf
+// RUN: env AMD_COMGR_HOTSWAP_ENTRY_STUB_SYMBOLS=1 hotswap-rewrite \
+// RUN:   %t.prefixed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   --entry-trampolines --output %t.seed.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+
+// COM: Replace only .text with an equal-sized raw variant. This preserves the
+// COM: second descriptor and appended stub while making the first entry need
+// COM: the workaround.
+// RUN: sed 's/^\.set raw_entry, 0$/.set raw_entry, 1/' \
+// RUN:   %s > %t.raw.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %t.raw.s \
+// RUN:   -o %t.raw.elf
+// RUN: %llvm-objcopy --dump-section .text=%t.raw.text %t.raw.elf
+// RUN: %llvm-objcopy --update-section .text=%t.raw.text %t.seed.elf \
+// RUN:   %t.mixed.elf
+
+// RUN: hotswap-rewrite %t.mixed.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// COM: Both original bodies keep their addresses; direct displacement would
+// COM: move mixed_second by 16 bytes and leave its old stub target stale.
+// RUN: (echo ORIGINAL; %llvm-readelf -Ws %t.mixed.elf; \
+// RUN:  echo REWRITTEN; %llvm-readelf -Ws %t.out.elf) \
+// RUN:  | %FileCheck --check-prefix=SYMBOL %s
+// SYMBOL: ORIGINAL
+// SYMBOL-DAG: [[FIRST:[0-9a-fA-F]+]] {{.*}} mixed_first
+// SYMBOL-DAG: [[SECOND:[0-9a-fA-F]+]] {{.*}} mixed_second
+// SYMBOL: REWRITTEN
+// SYMBOL-DAG: [[FIRST]] {{.*}} mixed_first
+// SYMBOL-DAG: [[SECOND]] {{.*}} mixed_second
+// SYMBOL-DAG: {{[0-9a-fA-F]+}} {{.*}} mixed_first.stub
+// SYMBOL-DAG: {{[0-9a-fA-F]+}} {{.*}} mixed_second.stub
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <mixed_first>:
+// DISASM-NEXT: s_nop 0
+// DISASM-LABEL: <mixed_second>:
+// DISASM-NEXT: v_mov_b32_e32 v0, 2
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.set raw_entry, 0
+.text
+.globl mixed_first
+.p2align 8
+.type mixed_first,@function
+mixed_first:
+.if raw_entry
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.else
+  global_wb
+.endif
+  v_nop
+  s_endpgm
+.Lmixed_first_end:
+.size mixed_first, .Lmixed_first_end-mixed_first
+
+.globl mixed_second
+.p2align 8
+.type mixed_second,@function
+mixed_second:
+  v_mov_b32_e32 v0, 2
+  s_endpgm
+.Lmixed_second_end:
+.size mixed_second, .Lmixed_second_end-mixed_second
+
+.rodata
+.p2align 8
+.amdhsa_kernel mixed_first
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel mixed_second
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: mixed_first
+      .symbol: mixed_first.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: mixed_second
+      .symbol: mixed_second.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
@@ -1,6 +1,6 @@
-// COM: The entry-trampoline rewrite must redirect every kernel descriptor in
-// COM: the code object, not just the first one. Each descriptor gets its own
-// COM: appended PC-relative entry stub.
+// COM: A 16-byte direct prefix before the first kernel would misalign the
+// COM: second kernel. HotSwap must retain the ABI's 256-byte entry alignment by
+// COM: falling back to aligned appended stubs for the whole object.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -13,21 +13,17 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
 // DISASM-LABEL: <entry_tramp_first>:
-// DISASM: s_endpgm
+// DISASM-NEXT: v_mov_b32_e32 v0, 1
+// DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <entry_tramp_second>:
-// DISASM: s_endpgm
-// DISASM: global_wb
+// DISASM-NEXT: v_mov_b32_e32 v0, 2
+// DISASM-NEXT: s_endpgm
+// DISASM: global_wb // {{[0-9a-fA-F]+00}}:
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2
-// DISASM-NEXT: s_add_co_ci_u32 s3
-// DISASM-NEXT: s_set_pc_i64 s[2:3]
-// DISASM: global_wb
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb // {{[0-9a-fA-F]+00}}:
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[2:3]
-// DISASM-NEXT: s_add_co_u32 s2
-// DISASM-NEXT: s_add_co_ci_u32 s3
-// DISASM-NEXT: s_set_pc_i64 s[2:3]
+// DISASM-NEXT: s_get_pc_i64
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-precompiled-workaround.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-precompiled-workaround.s
@@ -10,10 +10,9 @@
 // RUN:   | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
 
-// COM: An installed trampoline gets a <kernel>.stub symbol: the plain kernel
-// COM: has one, the pre-fixed kernel does not.
+// COM: Direct displacement creates no appended-stub symbols.
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
-// SYMS: plain_kernel.stub
+// SYMS-NOT: plain_kernel.stub
 
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=NO-WA-STUB %s
 // NO-WA-STUB-NOT: precompiled_wa_kernel.stub
@@ -21,9 +20,13 @@
 // COM: The pre-fixed kernel keeps its in-place workaround, not a redirect stub.
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-LABEL: <precompiled_wa_kernel>:
-// DISASM: global_wb
+// DISASM-NEXT: global_wb
 // DISASM-NEXT: v_nop
 // DISASM-NEXT: s_endpgm
+// DISASM-LABEL: <plain_kernel>:
+// DISASM-NEXT: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_setreg_imm32_b32
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-relocation.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-relocation.s
@@ -1,0 +1,84 @@
+// COM: A dynamic relocation can write outside .text while its addend still
+// COM: references displaced code. Direct displacement must decline this input
+// COM: and use an appended entry stub so the relocation remains valid.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <relocation_kernel>:
+// DISASM-NEXT: s_endpgm
+// DISASM-LABEL: <pointed_helper>:
+// DISASM-NEXT: s_endpgm
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+
+// RUN: (echo ORIGINAL; %llvm-readelf -Ws %t.elf; \
+// RUN:  echo REWRITTEN; %llvm-readelf -Ws %t.out.elf) \
+// RUN:  | %FileCheck --check-prefix=SYMBOL %s
+// SYMBOL: ORIGINAL
+// SYMBOL: [[HELPER:[0-9a-fA-F]+]] {{.*}} pointed_helper
+// SYMBOL: REWRITTEN
+// SYMBOL: [[HELPER]] {{.*}} pointed_helper
+
+// RUN: (echo ORIGINAL; %llvm-readelf -r %t.elf; \
+// RUN:  echo REWRITTEN; %llvm-readelf -r %t.out.elf) \
+// RUN:  | %FileCheck --check-prefix=RELOCATION %s
+// RELOCATION: ORIGINAL
+// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}[[ADDEND:[0-9a-fA-F]+]]
+// RELOCATION: REWRITTEN
+// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}[[ADDEND]]
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl relocation_kernel
+.p2align 8
+.type relocation_kernel,@function
+relocation_kernel:
+  s_endpgm
+.Lrelocation_kernel_end:
+.size relocation_kernel, .Lrelocation_kernel_end-relocation_kernel
+
+.local pointed_helper
+.type pointed_helper,@function
+pointed_helper:
+  s_endpgm
+.Lpointed_helper_end:
+.size pointed_helper, .Lpointed_helper_end-pointed_helper
+
+.data
+.p2align 3
+.globl helper_pointer
+.type helper_pointer,@object
+helper_pointer:
+  .quad pointed_helper
+.size helper_pointer, 8
+
+.rodata
+.p2align 8
+.amdhsa_kernel relocation_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: relocation_kernel
+      .symbol: relocation_kernel.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline.s
@@ -1,5 +1,6 @@
-// COM: HotSwap redirects kernel descriptors to appended PC-relative entry
-// COM: stubs when the entry-trampoline flag is explicitly enabled.
+// COM: HotSwap applies the entry workaround when the entry-trampoline flag is
+// COM: enabled. This multi-kernel layout uses aligned appended stubs because a
+// COM: direct prefix would misalign later kernel entries.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
@@ -10,7 +11,8 @@
 // RUN: cmp %t.elf %t.default.elf
 // RUN: %llvm-objdump -d %t.default.elf | %FileCheck --check-prefix=NO-TRAMP %s
 // NO-TRAMP-LABEL: <entry_tramp_kernel>:
-// NO-TRAMP: s_endpgm
+// NO-TRAMP-NEXT: v_mov_b32_e32 v0, 0
+// NO-TRAMP-NEXT: s_endpgm
 // NO-TRAMP-LABEL: <hipblaslt_entry_kernel>:
 // NO-TRAMP: s_setreg_imm32_b32
 // NO-TRAMP-LABEL: <decoder_trip_kernel>:
@@ -24,7 +26,6 @@
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
-// RUN: %llvm-objdump -s -j .rodata %t.out.elf | %FileCheck --check-prefix=RODATA %s
 // RUN: %llvm-readelf --notes %t.out.elf | %FileCheck --check-prefix=METADATA %s
 
 // COM: Entry trampolines are independent of the B0-to-A0 patch policy, so an
@@ -37,29 +38,30 @@
 // RUN: %llvm-objdump -d %t.b0a0.elf | %FileCheck --check-prefix=DISASM %s
 
 // DISASM-LABEL: <entry_tramp_kernel>:
-// DISASM: s_endpgm
+// DISASM-NEXT: v_mov_b32_e32 v0, 0
+// DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <hipblaslt_entry_kernel>:
-// DISASM: s_setreg_imm32_b32
+// DISASM-NEXT: s_setreg_imm32_b32
 // DISASM-LABEL: <decoder_trip_kernel>:
-// DISASM: .long 0xffffffff
+// DISASM-NEXT: .long 0xffffffff
 // DISASM: global_wb
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64 s[8:9]
-// DISASM-NEXT: s_add_co_u32 s8
-// DISASM-NEXT: s_add_co_ci_u32 s9
-// DISASM-NEXT: s_set_pc_i64 s[8:9]
-
-// RODATA: Contents of section .rodata
-// RODATA: {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} {{[0-9a-f]+}} 20000000
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
+// DISASM: global_wb
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_get_pc_i64
 
 // METADATA: .name:           entry_tramp_kernel
 // METADATA: .sgpr_count:     10
 
-// COM: Each appended stub gets a <kernel>.stub symbol so a dispatch whose entry
-// COM: points at the stub still resolves to a name (e.g. rocgdb info dispatches).
+// COM: The alignment fallback records each appended stub for debuggers.
 // RUN: %llvm-readelf -s %t.out.elf | %FileCheck --check-prefix=SYMS %s
-// SYMS-DAG: FUNC {{.*}} entry_tramp_kernel.stub
-// SYMS-DAG: FUNC {{.*}} hipblaslt_entry_kernel.stub
+// SYMS-DAG: entry_tramp_kernel.stub
+// SYMS-DAG: hipblaslt_entry_kernel.stub
+// SYMS-DAG: decoder_trip_kernel.stub
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -68,8 +70,7 @@
 // API2: RESULT: SUCCESS
 // RUN: cmp %t.out.elf %t.out2.elf
 
-// COM: If the requested entry trampoline cannot allocate an aligned scratch
-// COM: SGPR pair, the rewrite fails instead of returning a partial output.
+// COM: The alignment fallback needs a scratch SGPR pair for its appended stubs.
 // RUN: sed 's/.sgpr_count: 8/.sgpr_count: 105/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -14,6 +14,28 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 
+// COM: Entry displacement is applied before ordinary instruction rewriting.
+// COM: Verify that the direct entry prefix and appended DS trampoline coexist
+// COM: with branch sites calculated from the displaced instruction layout.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.entry.elf \
+// RUN:   | %FileCheck --check-prefix=ENTRY-API %s
+// ENTRY-API: RESULT: SUCCESS
+// RUN: %llvm-objdump -d %t.entry.elf | %FileCheck --check-prefix=ENTRY %s
+// ENTRY-LABEL: <test_ds_trampoline>:
+// ENTRY-NEXT: global_wb
+// ENTRY-NEXT: v_nop
+// ENTRY-NEXT: s_branch
+// ENTRY-NEXT: s_nop 0
+// ENTRY-NEXT: s_wait_dscnt 0x0
+// ENTRY-NEXT: s_endpgm
+// ENTRY: ds_load_b32 v0, v2 offset:256
+// ENTRY-NEXT: ds_load_b32 v1, v2 offset:768
+// ENTRY-NEXT: s_wait_dscnt 0x0
+// ENTRY-NEXT: s_branch
+// ENTRY-NOT: s_get_pc_i64
+
 // COM: The original DS2 is gone; s_branch forward replaces it. The drain
 // COM: s_wait_dscnt stays at the original position with imm unchanged (0x0).
 // DISASM-LABEL: <test_ds_trampoline>:

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -37,12 +37,21 @@ def _fwd(*parts):
     return os.path.join(*parts).replace("\\", "/")
 
 # %-prefixed substitutions for LLVM tools (used as %clang, %llvm-dis, etc.)
-config.substitutions.append(('%clang', _fwd(config.llvm_tools_dir, 'clang')))
-config.substitutions.append(('%llvm-dis', _fwd(config.llvm_tools_dir, 'llvm-dis')))
-config.substitutions.append(('%llvm-mc', _fwd(config.llvm_tools_dir, 'llvm-mc')))
-config.substitutions.append(('%llvm-objdump', _fwd(config.llvm_tools_dir, 'llvm-objdump')))
-config.substitutions.append(('%llvm-readelf', _fwd(config.llvm_tools_dir, 'llvm-readelf')))
-config.substitutions.append(('%ld.lld', _fwd(config.llvm_tools_dir, 'ld.lld')))
-config.substitutions.append(('%yaml2obj', _fwd(config.llvm_tools_dir, 'yaml2obj')))
-config.substitutions.append(('%FileCheck', _fwd(config.llvm_tools_dir, 'FileCheck')))
-config.substitutions.append(('%amd-llvm-spirv', _fwd(config.llvm_tools_dir, 'amd-llvm-spirv')))
+config.substitutions.append(("%clang", _fwd(config.llvm_tools_dir, "clang")))
+config.substitutions.append(("%llvm-dis", _fwd(config.llvm_tools_dir, "llvm-dis")))
+config.substitutions.append(("%llvm-mc", _fwd(config.llvm_tools_dir, "llvm-mc")))
+config.substitutions.append(
+    ("%llvm-objcopy", _fwd(config.llvm_tools_dir, "llvm-objcopy"))
+)
+config.substitutions.append(
+    ("%llvm-objdump", _fwd(config.llvm_tools_dir, "llvm-objdump"))
+)
+config.substitutions.append(
+    ("%llvm-readelf", _fwd(config.llvm_tools_dir, "llvm-readelf"))
+)
+config.substitutions.append(("%ld.lld", _fwd(config.llvm_tools_dir, "ld.lld")))
+config.substitutions.append(("%yaml2obj", _fwd(config.llvm_tools_dir, "yaml2obj")))
+config.substitutions.append(("%FileCheck", _fwd(config.llvm_tools_dir, "FileCheck")))
+config.substitutions.append(
+    ("%amd-llvm-spirv", _fwd(config.llvm_tools_dir, "amd-llvm-spirv"))
+)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -104,6 +104,7 @@ add_executable(HotswapMCTests
   HotswapOccupancyTest.cpp
   HotswapMCTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
+  ../src/comgr-hotswap-displacement.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -78,6 +78,201 @@ static uint32_t readDword(const uint8_t *Bytes) {
   return V;
 }
 
+static uint64_t alignTo8(uint64_t V) { return (V + 7) & ~uint64_t{7}; }
+
+static std::vector<uint8_t> makeDisplacementTestElf(
+    llvm::ArrayRef<uint8_t> Text, bool AddTextRelocation = false,
+    bool AddDebugSection = false, bool AddBoundaryTextSymbol = false) {
+  using namespace llvm::ELF;
+  namespace hsa = llvm::amdhsa;
+
+  static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
+  static constexpr uint64_t PhOff = 0x200;
+  static constexpr uint64_t TextOff = 0x280;
+  static constexpr uint64_t TextAddr = 0x1000;
+  static constexpr uint64_t RodataAddr = 0x2000;
+  static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
+  const uint64_t SymCount = AddBoundaryTextSymbol ? 4 : 3;
+
+  const char StrTab[] = "\0kernel\0kernel.kd\0";
+  const char ShStrTabNoRel[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.shstrtab\0";
+  const char ShStrTabRel[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.rela.text\0.shstrtab\0";
+  const char ShStrTabDebug[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.debug_info\0.shstrtab\0";
+
+  const uint64_t RodataOff = alignTo8(TextOff + Text.size());
+  const uint64_t StrTabOff = alignTo8(RodataOff + KdBytes);
+  const uint64_t SymTabOff = alignTo8(StrTabOff + sizeof(StrTab));
+  const uint64_t RelOff =
+      AddTextRelocation ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym))
+                        : 0;
+  const uint64_t DebugOff =
+      AddDebugSection ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym)) : 0;
+  const uint64_t ShStrTabOff =
+      AddTextRelocation ? alignTo8(RelOff + sizeof(Elf64_Rela))
+      : AddDebugSection ? alignTo8(DebugOff + 4)
+                        : alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
+  const uint64_t ShStrTabSize = AddTextRelocation ? sizeof(ShStrTabRel)
+                                : AddDebugSection ? sizeof(ShStrTabDebug)
+                                                  : sizeof(ShStrTabNoRel);
+  const uint64_t BufSize = alignTo8(ShStrTabOff + ShStrTabSize + 64);
+
+  std::vector<uint8_t> Buf(BufSize, 0);
+  const char *ShStrTab = AddTextRelocation ? ShStrTabRel
+                         : AddDebugSection ? ShStrTabDebug
+                                           : ShStrTabNoRel;
+  std::memcpy(Buf.data() + ShStrTabOff, ShStrTab, ShStrTabSize);
+  std::memcpy(Buf.data() + StrTabOff, StrTab, sizeof(StrTab));
+  std::memcpy(Buf.data() + TextOff, Text.data(), Text.size());
+
+  Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
+  Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
+  Ehdr.e_type = ET_DYN;
+  Ehdr.e_version = EV_CURRENT;
+  Ehdr.e_phoff = PhOff;
+  Ehdr.e_shoff = ShOff;
+  Ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+  Ehdr.e_phentsize = sizeof(Elf64_Phdr);
+  Ehdr.e_phnum = 2;
+  Ehdr.e_shentsize = sizeof(Elf64_Shdr);
+  Ehdr.e_shnum = AddTextRelocation || AddDebugSection ? 7 : 6;
+  Ehdr.e_shstrndx = AddTextRelocation || AddDebugSection ? 6 : 5;
+  std::memcpy(Buf.data(), &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr TextPh{};
+  TextPh.p_type = PT_LOAD;
+  TextPh.p_flags = PF_R | PF_X;
+  TextPh.p_offset = TextOff;
+  TextPh.p_vaddr = TextAddr;
+  TextPh.p_paddr = TextAddr;
+  TextPh.p_filesz = Text.size();
+  TextPh.p_memsz = Text.size() + 64;
+  TextPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff, &TextPh, sizeof(TextPh));
+
+  Elf64_Phdr RodataPh{};
+  RodataPh.p_type = PT_LOAD;
+  RodataPh.p_flags = PF_R;
+  RodataPh.p_offset = RodataOff;
+  RodataPh.p_vaddr = RodataAddr;
+  RodataPh.p_paddr = RodataAddr;
+  RodataPh.p_filesz = KdBytes;
+  RodataPh.p_memsz = KdBytes;
+  RodataPh.p_align = 8;
+  std::memcpy(Buf.data() + PhOff + sizeof(Elf64_Phdr), &RodataPh,
+              sizeof(RodataPh));
+
+  Elf64_Shdr TextSh{};
+  TextSh.sh_name = 1;
+  TextSh.sh_type = SHT_PROGBITS;
+  TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+  TextSh.sh_offset = TextOff;
+  TextSh.sh_addr = TextAddr;
+  TextSh.sh_size = Text.size();
+  TextSh.sh_addralign = 4;
+  std::memcpy(Buf.data() + ShOff + 1 * sizeof(Elf64_Shdr), &TextSh,
+              sizeof(TextSh));
+
+  Elf64_Shdr RodataSh{};
+  RodataSh.sh_name = 7;
+  RodataSh.sh_type = SHT_PROGBITS;
+  RodataSh.sh_flags = SHF_ALLOC;
+  RodataSh.sh_offset = RodataOff;
+  RodataSh.sh_addr = RodataAddr;
+  RodataSh.sh_size = KdBytes;
+  RodataSh.sh_addralign = 8;
+  std::memcpy(Buf.data() + ShOff + 2 * sizeof(Elf64_Shdr), &RodataSh,
+              sizeof(RodataSh));
+
+  Elf64_Shdr StrtabSh{};
+  StrtabSh.sh_name = 15;
+  StrtabSh.sh_type = SHT_STRTAB;
+  StrtabSh.sh_offset = StrTabOff;
+  StrtabSh.sh_size = sizeof(StrTab);
+  std::memcpy(Buf.data() + ShOff + 3 * sizeof(Elf64_Shdr), &StrtabSh,
+              sizeof(StrtabSh));
+
+  Elf64_Shdr SymtabSh{};
+  SymtabSh.sh_name = 23;
+  SymtabSh.sh_type = SHT_SYMTAB;
+  SymtabSh.sh_offset = SymTabOff;
+  SymtabSh.sh_size = SymCount * sizeof(Elf64_Sym);
+  SymtabSh.sh_link = 3;
+  SymtabSh.sh_entsize = sizeof(Elf64_Sym);
+  std::memcpy(Buf.data() + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
+              sizeof(SymtabSh));
+
+  unsigned ShStrIndex = AddTextRelocation || AddDebugSection ? 6 : 5;
+  if (AddTextRelocation) {
+    Elf64_Shdr RelaSh{};
+    RelaSh.sh_name = 31;
+    RelaSh.sh_type = SHT_RELA;
+    RelaSh.sh_offset = RelOff;
+    RelaSh.sh_size = sizeof(Elf64_Rela);
+    RelaSh.sh_link = 4;
+    RelaSh.sh_info = 1; // applies to .text
+    RelaSh.sh_entsize = sizeof(Elf64_Rela);
+    std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &RelaSh,
+                sizeof(RelaSh));
+  }
+  if (AddDebugSection) {
+    Elf64_Shdr DebugSh{};
+    DebugSh.sh_name = 31;
+    DebugSh.sh_type = SHT_PROGBITS;
+    DebugSh.sh_offset = DebugOff;
+    DebugSh.sh_size = 4;
+    DebugSh.sh_addralign = 1;
+    std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &DebugSh,
+                sizeof(DebugSh));
+  }
+
+  Elf64_Shdr ShstrSh{};
+  ShstrSh.sh_name = AddTextRelocation ? 42 : AddDebugSection ? 43 : 31;
+  ShstrSh.sh_type = SHT_STRTAB;
+  ShstrSh.sh_offset = ShStrTabOff;
+  ShstrSh.sh_size = ShStrTabSize;
+  std::memcpy(Buf.data() + ShOff + ShStrIndex * sizeof(Elf64_Shdr), &ShstrSh,
+              sizeof(ShstrSh));
+
+  int64_t EntryOffset = static_cast<int64_t>(TextAddr - RodataAddr);
+  std::memcpy(
+      Buf.data() + RodataOff +
+          offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
+      &EntryOffset, sizeof(EntryOffset));
+
+  Elf64_Sym KernelSym{};
+  KernelSym.st_name = 1;
+  KernelSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+  KernelSym.st_shndx = 1;
+  KernelSym.st_value = TextAddr;
+  KernelSym.st_size = Text.size();
+  std::memcpy(Buf.data() + SymTabOff + 1 * sizeof(Elf64_Sym), &KernelSym,
+              sizeof(KernelSym));
+
+  Elf64_Sym KdSym{};
+  KdSym.st_name = 8;
+  KdSym.setBindingAndType(STB_GLOBAL, STT_OBJECT);
+  KdSym.st_shndx = 2;
+  KdSym.st_value = RodataAddr;
+  KdSym.st_size = KdBytes;
+  std::memcpy(Buf.data() + SymTabOff + 2 * sizeof(Elf64_Sym), &KdSym,
+              sizeof(KdSym));
+
+  if (AddBoundaryTextSymbol) {
+    Elf64_Sym BoundarySym{};
+    BoundarySym.setBindingAndType(STB_GLOBAL, STT_FUNC);
+    BoundarySym.st_shndx = 1;
+    BoundarySym.st_value = TextAddr;
+    BoundarySym.st_size = MinInstSize;
+    std::memcpy(Buf.data() + SymTabOff + 3 * sizeof(Elf64_Sym), &BoundarySym,
+                sizeof(BoundarySym));
+  }
+
+  return Buf;
+}
+
 // -- initLLVM ----------------------------------------------------------------
 
 TEST(InitLLVM, ValidGfx1250) {
@@ -1733,6 +1928,383 @@ TEST(BuildKernelEntryTrampoline, MatcherRejectsWrongOperandShape) {
   EXPECT_FALSE(isKernelEntryTrampoline(Bytes, S));
 }
 
+// -- DisplacementPlan ---------------------------------------------------------
+
+TEST(DisplacementPlan, MapsInsertionAndReplacementBoundaries) {
+  std::vector<uint8_t> Text(16, 0);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Insert;
+  Insert.Offset = 4;
+  Insert.OriginalSize = 0;
+  Insert.ReplacementBytes.assign(8, 0x11);
+
+  DisplacementEdit Replace;
+  Replace.Offset = 8;
+  Replace.OriginalSize = 4;
+  Replace.ReplacementBytes.assign(8, 0x22);
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Insert, Replace});
+  ASSERT_TRUE((bool)PlanOrErr) << llvm::toString(PlanOrErr.takeError());
+
+  uint64_t Mapped = 0;
+  ASSERT_TRUE(PlanOrErr->mapOffset(4, DisplacementMapBias::BeforeInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 4u);
+  ASSERT_TRUE(
+      PlanOrErr->mapOffset(4, DisplacementMapBias::AfterInsertedBytes, Mapped));
+  EXPECT_EQ(Mapped, 12u);
+  ASSERT_TRUE(PlanOrErr->mapOffset(8, DisplacementMapBias::BeforeInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 16u);
+  ASSERT_TRUE(PlanOrErr->mapOffset(12, DisplacementMapBias::AfterInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 24u);
+  EXPECT_FALSE(PlanOrErr->mapOffset(
+      10, DisplacementMapBias::BeforeInsertedBytes, Mapped));
+}
+
+TEST(DisplacementPlan, RejectsOverlappingEdits) {
+  std::vector<uint8_t> Text(16, 0);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit A;
+  A.Offset = 4;
+  A.OriginalSize = 8;
+  A.ReplacementBytes.assign(12, 0x11);
+
+  DisplacementEdit B;
+  B.Offset = 8;
+  B.OriginalSize = 4;
+  B.ReplacementBytes.assign(8, 0x22);
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {A, B});
+  ASSERT_FALSE((bool)PlanOrErr);
+  std::string Reason = llvm::toString(PlanOrErr.takeError());
+  EXPECT_NE(Reason.find("overlap"), std::string::npos) << Reason;
+}
+
+TEST(DisplacementPlan, RebuildsTextAndPadsToPostTextAlignment) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<uint8_t> Text(16);
+  for (unsigned I = 0; I < Text.size(); ++I)
+    Text[I] = I;
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 4;
+  Edit.OriginalSize = 4;
+  Edit.ReplacementBytes.assign(
+      {0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7});
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Edit});
+  ASSERT_TRUE((bool)PlanOrErr) << llvm::toString(PlanOrErr.takeError());
+  EXPECT_EQ(PlanOrErr->rawGrowth(), 4u);
+  EXPECT_EQ(PlanOrErr->paddedGrowth(), 8u);
+
+  llvm::SmallVector<uint8_t> NewText = PlanOrErr->buildText(Text, S.SNopBytes);
+  ASSERT_EQ(NewText.size(), 24u);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(NewText.data(), 4),
+            llvm::ArrayRef<uint8_t>(Text.data(), 4));
+  EXPECT_EQ(NewText[4], 0xA0);
+  EXPECT_EQ(NewText[11], 0xA7);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(NewText.data() + 12, 8),
+            llvm::ArrayRef<uint8_t>(Text.data() + 8, 8));
+  EXPECT_EQ(std::memcmp(NewText.data() + 20, S.SNopBytes.data(), MinInstSize),
+            0);
+}
+
+TEST(TextDisplacement, ReencodesForwardSBranchAcrossInsertion) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  llvm::SmallVector<uint8_t> Br = S.encodeSBranch(0, 8);
+  ASSERT_EQ(Br.size(), MinInstSize);
+  Text.append(Br.begin(), Br.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End.begin(), End.end());
+
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 4;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(
+      decodeTextSection(OutView->textData(), OutView->textSize(), S, Decoded));
+  ASSERT_GE(Decoded.size(), 4u);
+  ASSERT_TRUE(Decoded[0].Inst.getOperand(0).isImm());
+  EXPECT_EQ(Decoded[0].Inst.getOperand(0).getImm(), 2);
+  EXPECT_EQ(Decoded[3].Mnemonic, "s_endpgm");
+}
+
+TEST(TextDisplacement, PreservesSymbolEndingAtInsertionBoundary) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End.begin(), End.end());
+
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = MinInstSize;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  bool SawBoundarySymbol = false;
+  for (const ElfView::ELFT::Shdr &Shdr : OutView->sections()) {
+    if (Shdr.sh_type != llvm::ELF::SHT_SYMTAB)
+      continue;
+    llvm::Expected<ElfView::ELFT::SymRange> Symbols =
+        OutView->file().symbols(&Shdr);
+    ASSERT_TRUE((bool)Symbols) << llvm::toString(Symbols.takeError());
+    for (const ElfView::ELFT::Sym &Sym : *Symbols) {
+      if (Sym.st_shndx == OutView->textSectionIndex() &&
+          Sym.st_value == OutView->textAddr() && Sym.st_size == MinInstSize)
+        SawBoundarySymbol = true;
+    }
+  }
+  EXPECT_TRUE(SawBoundarySymbol);
+}
+
+TEST(TextDisplacement, UpdatesKernelDescriptorEntryOffset) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  const ElfView::ELFT::Shdr *OldRodata = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : ViewOrErr->sections()) {
+    llvm::Expected<llvm::StringRef> Name =
+        ViewOrErr->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".rodata")
+      OldRodata = &Shdr;
+  }
+  ASSERT_NE(OldRodata, nullptr);
+  const uint64_t OldRodataOffset = OldRodata->sh_offset;
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> OldPhdrs =
+      ViewOrErr->file().program_headers();
+  ASSERT_TRUE((bool)OldPhdrs) << llvm::toString(OldPhdrs.takeError());
+  const ElfView::ELFT::Phdr *OldRodataLoad = nullptr;
+  const ElfView::ELFT::Phdr *OldTextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *OldPhdrs) {
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x1000)
+      OldTextLoad = &Phdr;
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x2000)
+      OldRodataLoad = &Phdr;
+  }
+  ASSERT_NE(OldTextLoad, nullptr);
+  ASSERT_NE(OldRodataLoad, nullptr);
+  const uint64_t OldRodataLoadOffset = OldRodataLoad->p_offset;
+
+  llvm::SmallVector<uint8_t> Prefix =
+      assembleInstructions("global_wb\nv_nop", S);
+  ASSERT_FALSE(Prefix.empty());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(Prefix.begin(), Prefix.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  EXPECT_EQ(KDs[0].KernelName, "kernel");
+  EXPECT_EQ(KDs[0].VAddr, 0x2000u);
+  EXPECT_EQ(KDs[0].EntryOffset, static_cast<int64_t>(0x1000 - 0x2000));
+
+  const ElfView::ELFT::Shdr *NewRodata = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : OutView->sections()) {
+    llvm::Expected<llvm::StringRef> Name = OutView->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".rodata")
+      NewRodata = &Shdr;
+  }
+  ASSERT_NE(NewRodata, nullptr);
+  EXPECT_EQ(NewRodata->sh_addr, OldRodata->sh_addr);
+  EXPECT_EQ(NewRodata->sh_offset, OldRodataOffset + Prefix.size());
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> NewPhdrs =
+      OutView->file().program_headers();
+  ASSERT_TRUE((bool)NewPhdrs) << llvm::toString(NewPhdrs.takeError());
+  const ElfView::ELFT::Phdr *NewRodataLoad = nullptr;
+  const ElfView::ELFT::Phdr *NewTextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *NewPhdrs) {
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x1000)
+      NewTextLoad = &Phdr;
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x2000)
+      NewRodataLoad = &Phdr;
+  }
+  ASSERT_NE(NewTextLoad, nullptr);
+  ASSERT_NE(NewRodataLoad, nullptr);
+  EXPECT_EQ(NewTextLoad->p_filesz, OldTextLoad->p_filesz + Prefix.size());
+  EXPECT_EQ(NewTextLoad->p_memsz, OldTextLoad->p_memsz);
+  EXPECT_EQ(NewRodataLoad->p_vaddr, OldRodataLoad->p_vaddr);
+  EXPECT_EQ(NewRodataLoad->p_paddr, OldRodataLoad->p_paddr);
+  EXPECT_EQ(NewRodataLoad->p_offset, OldRodataLoadOffset + Prefix.size());
+  EXPECT_EQ(NewRodataLoad->p_offset % NewRodataLoad->p_align,
+            NewRodataLoad->p_vaddr % NewRodataLoad->p_align);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(OutView->textData(), Prefix.size()),
+            llvm::ArrayRef<uint8_t>(Prefix));
+}
+
+TEST(TextDisplacement, RejectsPcSensitiveAddressMaterialization) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text =
+      assembleSingleInst("s_get_pc_i64 s[8:9]", S);
+  ASSERT_FALSE(Text.empty());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("pc-sensitive"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsLaterFileContentInTextLoadSegment) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  llvm::Expected<ElfView::ELFT::PhdrRange> Phdrs =
+      ViewOrErr->file().program_headers();
+  ASSERT_TRUE((bool)Phdrs) << llvm::toString(Phdrs.takeError());
+  const ElfView::ELFT::Phdr *TextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *Phdrs)
+    if (Phdr.p_type == llvm::ELF::PT_LOAD && Phdr.p_vaddr == 0x1000)
+      TextLoad = &Phdr;
+  ASSERT_NE(TextLoad, nullptr);
+
+  const size_t TextLoadOffset =
+      reinterpret_cast<const uint8_t *>(TextLoad) - ElfBytes.data();
+  llvm::ELF::Elf64_Phdr RawTextLoad;
+  std::memcpy(&RawTextLoad, ElfBytes.data() + TextLoadOffset,
+              sizeof(RawTextLoad));
+  RawTextLoad.p_filesz += 8;
+  RawTextLoad.p_memsz += 8;
+  std::memcpy(ElfBytes.data() + TextLoadOffset, &RawTextLoad,
+              sizeof(RawTextLoad));
+
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Edit});
+  EXPECT_FALSE((bool)PlanOrErr);
+  EXPECT_NE(
+      llvm::toString(PlanOrErr.takeError()).find("last file-backed content"),
+      std::string::npos);
+}
+
+TEST(TextDisplacement, RejectsDebugSectionsUntilAddressesCanBeRemapped) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_FALSE(Text.empty());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find(".debug_info"), std::string::npos) << Reason;
+}
+
 TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
   namespace hsa = llvm::amdhsa;
 
@@ -2193,6 +2765,95 @@ TEST(KernelEntryTrampoline, AppendFailsWithoutSgprScratchPair) {
   EXPECT_EQ(llvm::ArrayRef<uint8_t>(Growth[0].Bytes),
             llvm::ArrayRef<uint8_t>(Existing.Bytes));
   EXPECT_TRUE(Fixups.empty());
+}
+
+TEST(TextDisplacement, RejectsTextRelocationSections) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes =
+      makeDisplacementTestElf(Text, /*AddTextRelocation=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("relocation section"), std::string::npos);
+}
+
+TEST(TextDisplacement, RejectsDynamicRelocationTargetingText) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes =
+      makeDisplacementTestElf(Text, /*AddTextRelocation=*/true);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  const ElfView::ELFT::Shdr *RelaShdr = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : ViewOrErr->sections())
+    if (Shdr.sh_type == llvm::ELF::SHT_RELA)
+      RelaShdr = &Shdr;
+  ASSERT_NE(RelaShdr, nullptr);
+
+  const size_t ShdrOffset =
+      reinterpret_cast<const uint8_t *>(RelaShdr) - ElfBytes.data();
+  llvm::ELF::Elf64_Shdr RawShdr;
+  std::memcpy(&RawShdr, ElfBytes.data() + ShdrOffset, sizeof(RawShdr));
+  RawShdr.sh_info = 0;
+  std::memcpy(ElfBytes.data() + ShdrOffset, &RawShdr, sizeof(RawShdr));
+
+  llvm::ELF::Elf64_Rela Rela{};
+  Rela.r_offset = ViewOrErr->textAddr();
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+
+  llvm::Expected<ElfView> DynamicView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)DynamicView) << llvm::toString(DynamicView.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*DynamicView, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("dynamic relocation section"), std::string::npos);
+
+  Rela.r_offset = 0x2000;
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> NonTextView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)NonTextView) << llvm::toString(NonTextView.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(*NonTextView, S, {Edit});
+  EXPECT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+
+  Rela.setSymbolAndType(/*Symbol=*/0, llvm::ELF::R_AMDGPU_RELATIVE64);
+  Rela.r_addend = NonTextView->textAddr();
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> TextAddendView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)TextAddendView)
+      << llvm::toString(TextAddendView.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(*TextAddendView, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("addend references"), std::string::npos) << Reason;
 }
 
 // -- classifyWmmaNops ---------------------------------------------------------


### PR DESCRIPTION
> **DRAFT / WIP** — do not review for merge yet. This is a single branch that will be **split into a stacked series of ~4 PRs** before review (see "PR split" below). Opened now for early visibility of the approach and to run CI.

## Summary

Extends the entry-workaround text displacement (#3000) to **per-kernel code displacement** for *growing* B0-to-A0 instruction patches (e.g. `ds_*_2addr` -> two single-address DS ops + `s_wait_dscnt`). Today those patches append a trampoline and branch out/back on every execution; #3000's whole-object displacement bails object-wide when `.text` would overlap a later section (100% trampoline on hipBLASLt). This makes displacement work per-kernel so patched instructions run **straight-line**, with the goal of retiring the trampoline path.

Three tiers:
1. **Tier 1** — absorb a kernel's growth into its own trailing 256B alignment padding; `.text` size unchanged, nothing outside the kernel moves.
2. **Tier 2** — ripple-repack a small window of successor kernels (measured median 2 / max 4) to borrow padding when a kernel overflows.
3. **Tier 3** — whole-object `.text` grow with trailing-section vaddr relocation as the guaranteed backstop (dense clusters, single-kernel Triton objects), keeping execution straight-line unlike a trampoline.

Plus the repairs a moving-code displacement requires: intra-kernel branch re-encode, `s_get_pc`+`s_add` / `s_add_pc_i64` PC-relative repair, and `.eh_frame` + `.debug_{frame,info,ranges,line}` remapping (line-program re-synthesis) so unwind/debug info tracks moved code.

## Status / coverage (offline `hotswap-rewrite`, gfx1250 B0->A0)

| library | result |
| --- | --- |
| hipBLASLt (1093 kernels) | 72/72 growing patches displaced, 0 trampolines; unpatched output byte-identical to baseline |
| rocblas | 55/55 objects |
| rocrand | 15/15 |
| rocsparse | 331/333 (2 = pre-existing #3000 trampoline-gateway limit, reproduces with displacement disabled) |
| aotriton (Triton, single-kernel + DWARF) | ~35/39; remainder fail-closed on a not-yet-handled `s_get_pc` idiom |

All remaining failures are **fail-closed** (decline to the existing path), never miscompiled. `.debug_line` re-synthesis verified with `llvm-dwarfdump --verify` **and** a decoded-row diff (pre-patch rows identical, post-patch rows shifted by exactly the cumulative growth).

## PR split (before review)

Intended stack, each on the prior:
1. Infra: streaming decode + shared displacement types.
2. Per-kernel tier-1/2 local displacement.
3. Tier-3 whole-object grow + section relocation + PC-relative repair.
4. DWARF/`.eh_frame` metadata remap.

The branch currently has 3 commits along these lines (tiers 3+4 share `comgr-hotswap-displacement.cpp` and will be separated at split time).

## Known remaining work

- One `s_get_pc`-without-`s_add` idiom in ~3-4 aotriton objects (currently fail-closed).
- Tests (LIT/unit) and per-PR file-of-truth separation still to come.
- ASAN + full `check-comgr` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)