### PR TITLE
Revert "A+A compiler components selection

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -798,10 +798,6 @@ def warn_drv_amd_opt_removed : Warning<
   "[AMD] proprietary optimization compiler has been removed">,
   InGroup<UnusedCommandLineArgument>;
 
-def warn_drv_amd_opt_not_found : Warning<
-  "[AMD] proprietary optimization compiler installation was not found">,
-  InGroup<UnusedCommandLineArgument>;
-
 def warn_drv_moutline_unsupported_opt : Warning<
   "'%0' does not support '-moutline'; flag ignored">,
   InGroup<OptionIgnored>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8442,9 +8442,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.AddAllArgs(CmdArgs, options::OPT_undef);
 
-  std::string AltPath = D.getInstalledDir();
-  AltPath += "/../alt/bin/clang-" + std::to_string(LLVM_VERSION_MAJOR);
-
   const char *Exec = D.getDriverProgramPath();
 
   // Optionally embed the -cc1 level arguments into the debug info or a


### PR DESCRIPTION
Removes the remaining remnants of dced16de485a not already covered by ROCm/llvm-project#3518: the warn_drv_amd_opt_not_found diagnostic and the orphaned alt/bin/clang-N AltPath fragment in Clang.cpp. The famd-opt/ fno-amd-opt options and the A+A.c test are left to #3518.


