### PR TITLE
[psdb] Make compiler-runtime tests non-blocking via label

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -380,37 +380,44 @@ jobs:
 
       - name: LLVM Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-llvm
 
       - name: Clang Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-clang
 
       - name: Flang Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-flang
 
       - name: MLIR Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-mlir
 
       - name: LLD Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-lld
 
       - name: COMGR Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           "${BUILD_DIR}"/compiler/amd-llvm/build/bin/llvm-lit \
             "${BUILD_DIR}"/compiler/amd-comgr/build/test-lit -v
 
       - name: COMGR CTest
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ctest --test-dir "${BUILD_DIR}"/compiler/amd-comgr/build --output-on-failure
 

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -443,6 +443,7 @@ jobs:
 
       - name: COMGR CTest
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ctest --test-dir "${BUILD_DIR}"/compiler/amd-comgr/build --output-on-failure
 


### PR DESCRIPTION
Adds an opt-in escape hatch so a PR can run the compiler-runtime test suites without being blocked by their failures, controlled by the `ci:non-blocking-compiler-tests` label.
When a PR carries this label, the compiler-runtime test steps still run (and their failures are still visible), but they no longer fail the job. Without the label, behavior is unchanged: the tests remain a hard gate.

Testing: See behaviour in https://github.com/ROCm/llvm-project/pull/3523 with introduced two failing LIT tests in COMGR and Clang -- https://github.com/ROCm/llvm-project/actions/runs/29966512530/job/89079285055?pr=3523

