### PR TITLE
TEST: add deliberate Clang + COMGR lit failures to validate ci:non-blocking-compiler-tests

### DIFF
--- a/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
+++ b/.github/workflows/multi_arch_build_portable_linux_artifacts.yml
@@ -380,37 +380,44 @@ jobs:
 
       - name: LLVM Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-llvm
 
       - name: Clang Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-clang
 
       - name: Flang Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-flang
 
       - name: MLIR Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-mlir
 
       - name: LLD Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ninja -C "${BUILD_DIR}"/compiler/amd-llvm/build check-lld
 
       - name: COMGR Lit Tests
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           "${BUILD_DIR}"/compiler/amd-llvm/build/bin/llvm-lit \
             "${BUILD_DIR}"/compiler/amd-comgr/build/test-lit -v
 
       - name: COMGR CTest
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ctest --test-dir "${BUILD_DIR}"/compiler/amd-comgr/build --output-on-failure
 

--- a/.github/workflows/multi_arch_build_windows_artifacts.yml
+++ b/.github/workflows/multi_arch_build_windows_artifacts.yml
@@ -443,6 +443,7 @@ jobs:
 
       - name: COMGR CTest
         if: ${{ inputs.stage_name == 'compiler-runtime' }}
+        continue-on-error: ${{ contains(github.event.pull_request.labels.*.name, 'ci:non-blocking-compiler-tests') }}
         run: |
           ctest --test-dir "${BUILD_DIR}"/compiler/amd-comgr/build --output-on-failure
 

--- a/amd/comgr/test-lit/nonblocking-label-validation.cl
+++ b/amd/comgr/test-lit/nonblocking-label-validation.cl
@@ -1,0 +1,3 @@
+// Intentional failure to validate the ci:non-blocking-compiler-tests label.
+// DO NOT MERGE - remove after validating the non-blocking behavior.
+// RUN: false

--- a/clang/test/Driver/amdgpu-nonblocking-label-validation.c
+++ b/clang/test/Driver/amdgpu-nonblocking-label-validation.c
@@ -1,0 +1,3 @@
+// Intentional failure to validate the ci:non-blocking-compiler-tests label.
+// DO NOT MERGE - remove after validating the non-blocking behavior.
+// RUN: false


### PR DESCRIPTION
Testing for https://github.com/ROCm/llvm-project/pull/3522 