### PR TITLE
[clang][AMDGPU] Remove vestigial CodeObjectVersion toolchain member

### DIFF
--- a/clang/lib/Driver/ToolChains/AMDGPU.h
+++ b/clang/lib/Driver/ToolChains/AMDGPU.h
@@ -92,7 +92,6 @@ namespace toolchains {
 
 class LLVM_LIBRARY_VISIBILITY AMDGPUToolChain : public Generic_ELF {
 protected:
-  unsigned CodeObjectVersion = 5;
   const std::map<options::ID, StringRef> OptionsDefault;
 
   // Optional host toolchain for offloading modes.
@@ -162,8 +161,6 @@ public:
 
   /// Should skip argument.
   bool shouldSkipArgument(const llvm::opt::Arg *Arg) const;
-
-  unsigned GetCodeObjectVersion() const { return CodeObjectVersion; }
 
   /// Uses amdgpu-arch tool to get arch of the system GPU. Will return error
   /// if unable to find one.


### PR DESCRIPTION
The AMDGPUToolChain::CodeObjectVersion member and its GetCodeObjectVersion() accessor were left behind after upstream refactoring removed them. They are unused in amd-staging (all code uses tools::getAMDGPUCodeObjectVersion()) and the member was stale at 5 while the effective default is 6. Removing them reconverges this portion of AMDGPU.h with llvm/llvm-project main.


