### PR TITLE
[lld] Remove downstream delta in Common/Args.cpp

### DIFF
--- a/lld/Common/Args.cpp
+++ b/lld/Common/Args.cpp
@@ -11,14 +11,14 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/CodeGen/CommandFlags.h"
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Path.h"
-#include "llvm/TargetParser/TargetParser.h"
 
 using namespace llvm;
 using namespace lld;
 
+// TODO(sbc): Remove this once CGOptLevel can be set completely based on bitcode
+// function metadata.
 int lld::args::getCGOptLevel(int optLevelLTO) {
   return std::clamp(optLevelLTO, 2, 3);
 }


### PR DESCRIPTION
Drop two unused includes (llvm/CodeGen/CommandFlags.h and llvm/TargetParser/TargetParser.h) and restore the TODO(sbc) comment above getCGOptLevel so the file matches upstream with no delta.


