### PR TITLE
[Comgr][hotswap] Add the canonical-op enum and AMDGPU MC stack

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -653,12 +653,12 @@ target_link_libraries(amd_comgr
 #
 # The rewriter (byte-level rewrite path) backs the always-on
 # amd_comgr_hotswap_rewrite API, so it is linked unconditionally. The raiser
-# (IR transpiler path) and the code-object loader are opt-in behind
-# COMGR_ENABLE_HOTSWAP_TRANSPILE.
+# (IR transpiler path), the code-object loader, and the MC decoder are opt-in
+# behind COMGR_ENABLE_HOTSWAP_TRANSPILE.
 target_link_libraries(amd_comgr PRIVATE hotswap::rewriter)
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   target_link_libraries(amd_comgr
-    PRIVATE hotswap::common hotswap::loader hotswap::raiser)
+    PRIVATE hotswap::common hotswap::loader hotswap::raiser hotswap::decoder)
 endif()
 
 if(TARGET embedded-resource-dir)

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -443,9 +443,10 @@ target_include_directories(amd_comgr
 # amd_comgr and the hotswap test drivers, so the drivers reuse the exact same
 # objects (and the buffer-facing getMetadataRoot / getElfIsaName /
 # lookupSymbolByName entry points) instead of recompiling the sources with
-# divergent flags. Function/data sections let a standalone driver drop the parts
-# of these translation units it does not reference (the amd_comgr build keeps
-# them).
+# divergent flags. Per-function/data sections let a standalone driver drop the
+# parts of these translation units it does not reference (the amd_comgr build
+# keeps them); the GCC/Clang spelling is -ffunction-sections/-fdata-sections,
+# the MSVC equivalent is /Gy plus /Gw.
 add_library(comgr-object-utils OBJECT ${COMGR_OBJECT_UTILS_SOURCES})
 # These sources include LLVM headers that pull in TableGen-generated .inc files.
 # amd_comgr is ordered after those generators by its LLVM link libraries, but an
@@ -465,9 +466,6 @@ target_include_directories(comgr-object-utils
     ${LLVM_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/src
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>)
-# The GCC/Clang-driver spelling of the section-splitting flags above is not
-# understood by the MSVC front end (including clang-cl), which spells the same
-# behavior /Gy /Gw.
 if(MSVC)
   target_compile_options(comgr-object-utils
     PRIVATE "${AMD_COMGR_PRIVATE_COMPILE_OPTIONS}" /Gy /Gw)

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -645,20 +645,6 @@ target_link_libraries(amd_comgr
     ${LLVM_LIBS}
     ${CLANG_LIBS})
 
-# hotswap link edges. These are OBJECT libraries with PRIVATE LLVM deps, so they
-# contribute only their objects and leave the curated LLVM set above unchanged;
-# keep them after that block regardless.
-#
-# The rewriter (byte-level rewrite path) backs the always-on
-# amd_comgr_hotswap_rewrite API, so it is linked unconditionally. The raiser
-# (IR transpiler path), the code-object loader, and the MC decoder are opt-in
-# behind COMGR_ENABLE_HOTSWAP_TRANSPILE.
-target_link_libraries(amd_comgr PRIVATE hotswap::rewriter)
-if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
-  target_link_libraries(amd_comgr
-    PRIVATE hotswap::common hotswap::loader hotswap::raiser hotswap::decoder)
-endif()
-
 if(TARGET embedded-resource-dir)
   target_link_libraries(amd_comgr PRIVATE embedded-resource-dir)
 endif()
@@ -684,12 +670,13 @@ if (NOT WIN32)
       ${CMAKE_DL_LIBS})
 endif()
 
-# Hotswap subproject — rewriter (byte-level) and raiser (IR transpiler)
-# OBJECT libraries. Always added so the libraries are available to the
-# test-unit suite. The rewriter is linked into amd_comgr unconditionally; the
-# raiser and code-object loader link edges are gated on
-# COMGR_ENABLE_HOTSWAP_TRANSPILE (see the hotswap link edges above).
+# Hotswap subproject. Builds the rewriter (byte-level rewrite path) plus, under
+# COMGR_ENABLE_HOTSWAP_TRANSPILE, the transpile-path OBJECT libraries, and
+# exports the set amd_comgr links as COMGR_HOTSWAP_LIBS. These OBJECT libraries
+# keep their LLVM deps PRIVATE, so they contribute only their objects and leave
+# the curated LLVM set linked above unchanged.
 add_subdirectory(src/hotswap)
+target_link_libraries(amd_comgr PRIVATE ${COMGR_HOTSWAP_LIBS})
 
 include(CTest)
 

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -25,3 +25,14 @@ if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_subdirectory(loader)
   add_subdirectory(decoder)
 endif()
+
+# The OBJECT libraries amd_comgr links, exported to the parent scope so the
+# top-level CMakeLists links the set without naming each library: the rewriter
+# always, the transpile-path libraries only under COMGR_ENABLE_HOTSWAP_TRANSPILE.
+# Adding a hotswap library updates this list, not the top-level CMakeLists.
+set(COMGR_HOTSWAP_LIBS hotswap::rewriter)
+if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
+  list(APPEND COMGR_HOTSWAP_LIBS
+    hotswap::common hotswap::loader hotswap::raiser hotswap::decoder)
+endif()
+set(COMGR_HOTSWAP_LIBS "${COMGR_HOTSWAP_LIBS}" PARENT_SCOPE)

--- a/amd/comgr/src/hotswap/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/CMakeLists.txt
@@ -3,11 +3,12 @@
 #   hotswap::rewriter  byte-level rewrite path (linked unconditionally)
 #   hotswap::raiser    IR transpiler path (opt-in, COMGR_ENABLE_HOTSWAP_TRANSPILE)
 #   hotswap::loader    code-object metadata loader feeding the raiser (opt-in)
+#   hotswap::decoder   per-ISA AMDGPU MC stack + canonical-op identity (opt-in)
 #   hotswap::common    small shared pieces the transpile path links (opt-in)
 # common/ is mostly header-only (kernel-meta.h); hotswap::common compiles the
-# one out-of-line HotswapError::ID symbol the loader (and later decoder) share.
+# one out-of-line HotswapError::ID symbol the loader and decoder share.
 #
-# All four keep their LLVM dependencies PRIVATE. Their objects land in
+# All five keep their LLVM dependencies PRIVATE. Their objects land in
 # amd_comgr, which already links the full curated LLVM set; propagating a
 # partial set onto amd_comgr's link line perturbs static-archive resolution
 # (dropping LLVMCodeGen's -mcpu registration and breaking in-process LLD) and
@@ -16,10 +17,11 @@
 add_subdirectory(rewriter)
 add_subdirectory(raiser)
 
-# The loader consumes AMDGPU target-private headers an install-tree-only build
-# does not expose, so the transpile-path libraries are entered only when the
-# transpile entry point is on.
+# The loader and decoder consume AMDGPU target-private headers an
+# install-tree-only build does not expose, so the transpile-path libraries are
+# entered only when the transpile entry point is on.
 if(COMGR_ENABLE_HOTSWAP_TRANSPILE)
   add_subdirectory(common)
   add_subdirectory(loader)
+  add_subdirectory(decoder)
 endif()

--- a/amd/comgr/src/hotswap/common/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/common/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
-project(hotswap-common LANGUAGES CXX)
+
+# No project() here: this is an add_subdirectory component of amd_comgr, not a
+# standalone build. A nested project() re-runs the superbuild dependency provider
+# and re-imports LLVM, which links a second copy of the AMDGPU static libraries
+# into amd_comgr and double-registers their cl::opts under a non-folding linker.
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -32,6 +36,17 @@ if(NOT TARGET hotswap::common)
 endif()
 
 llvm_update_compile_flags(hotswap-common)
+# llvm_update_compile_flags does not reliably carry LLVM's -fno-rtti to a
+# standalone find_package(LLVM) consumer, and HotswapError derives from
+# llvm::ErrorInfo. Mirror LLVM_ENABLE_RTTI explicitly so we do not emit typeinfo
+# an RTTI-off LLVM cannot resolve at link time.
+if(NOT LLVM_ENABLE_RTTI)
+  if(MSVC)
+    target_compile_options(hotswap-common PRIVATE /GR-)
+  else()
+    target_compile_options(hotswap-common PRIVATE -fno-rtti)
+  endif()
+endif()
 set_target_properties(hotswap-common PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Match LLVM's RTTI setting explicitly. llvm_update_compile_flags only adds

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(hotswap-decoder OBJECT
   mc-state.cpp
   amdgpu-formats.cpp
   canonical-op.cpp
+  isa-profile.cpp
 )
 
 if(NOT TARGET hotswap::decoder)

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -1,0 +1,109 @@
+cmake_minimum_required(VERSION 3.20)
+project(hotswap-decoder LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# --- LLVM ---------------------------------------------------------------------
+if(NOT TARGET LLVMSupport)
+  find_package(LLVM REQUIRED CONFIG)
+endif()
+if(NOT COMMAND llvm_update_compile_flags)
+  list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+  include(AddLLVM)
+endif()
+
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+
+# --- Library ------------------------------------------------------------------
+# The per-ISA AMDGPU MC stack (mc-state) plus the architecture-neutral
+# instruction identity the raiser dispatches on (canonical-op) and the MCInst
+# format helpers (amdgpu-formats). Its own OBJECT library so the MC/decoder
+# role stays distinct from the raiser and the code-object loader.
+
+# Follow COMGR's selected LLVM linkage mode: in a dylib build link the single
+# `LLVM` shared library, otherwise the individual static components. Linking
+# fixed component libraries unconditionally can pull both the dylib and the
+# static components into a dylib build, risking duplicate symbols. Kept PUBLIC
+# so consumers inherit the same set when they link this OBJECT library.
+if(LLVM_LINK_LLVM_DYLIB)
+  set(HOTSWAP_LLVM_LIBS LLVM)
+else()
+  set(HOTSWAP_LLVM_LIBS
+    LLVMAMDGPUAsmParser
+    LLVMAMDGPUCodeGen
+    LLVMAMDGPUDesc
+    LLVMAMDGPUDisassembler
+    LLVMAMDGPUInfo
+    LLVMAMDGPUUtils
+    LLVMAnalysis
+    LLVMAsmPrinter
+    LLVMBinaryFormat
+    LLVMCodeGen
+    LLVMCore
+    LLVMMC
+    LLVMMCDisassembler
+    LLVMMCParser
+    LLVMObject
+    LLVMPasses
+    LLVMSupport
+    LLVMTarget
+    LLVMTargetParser
+    LLVMTransformUtils)
+endif()
+
+add_library(hotswap-decoder OBJECT
+  mc-state.cpp
+  amdgpu-formats.cpp
+  canonical-op.cpp
+)
+
+if(NOT TARGET hotswap::decoder)
+  add_library(hotswap::decoder ALIAS hotswap-decoder)
+endif()
+
+llvm_update_compile_flags(hotswap-decoder)
+set_target_properties(hotswap-decoder PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+# Public include root (src/) so consumers can `#include "hotswap/..."`.
+target_include_directories(hotswap-decoder PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
+)
+
+# The MC stack consumes AMDGPU target-private headers (AMDGPUMCTargetDesc.h,
+# AMDGPUBaseInfo.h, SIDefines.h), which transitively include the TableGen-
+# generated AMDGPUGen*.inc files. Those live in the LLVM source and build trees
+# and are not exposed by an install tree.
+# SIDefines.h and its siblings are hand-written AMDGPU headers that live only
+# in the LLVM source tree; the build tree carries just the generated *.inc.
+# Locate that source across the layouts comgr builds in: an in-tree monorepo
+# build exposes it as LLVM_MAIN_SRC_DIR, a find_package(LLVM) consumer as
+# LLVM_BUILD_MAIN_SRC_DIR, and the ROCm superbuild sets neither but keeps
+# amd/comgr next to llvm/ under a shared root. Probe for the header rather than
+# trust one variable, so a wrong or empty root fails the configure loudly.
+set(HOTSWAP_AMDGPU_SRC_DIR "")
+foreach(HotswapLLVMRoot
+    "${LLVM_MAIN_SRC_DIR}"
+    "${LLVM_BUILD_MAIN_SRC_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../../../../../llvm")
+  if(HotswapLLVMRoot AND
+     EXISTS "${HotswapLLVMRoot}/lib/Target/AMDGPU/SIDefines.h")
+    get_filename_component(HOTSWAP_AMDGPU_SRC_DIR
+      "${HotswapLLVMRoot}/lib/Target/AMDGPU" ABSOLUTE)
+    break()
+  endif()
+endforeach()
+if(NOT HOTSWAP_AMDGPU_SRC_DIR)
+  message(FATAL_ERROR
+    "hotswap-decoder: cannot find the LLVM AMDGPU target sources "
+    "(SIDefines.h); set LLVM_MAIN_SRC_DIR to the llvm source directory.")
+endif()
+target_include_directories(hotswap-decoder PRIVATE
+  "${HOTSWAP_AMDGPU_SRC_DIR}"
+  "${HOTSWAP_AMDGPU_SRC_DIR}/Utils"
+  "${LLVM_BINARY_DIR}/lib/Target/AMDGPU"
+)
+
+target_link_libraries(hotswap-decoder PUBLIC ${HOTSWAP_LLVM_LIBS})

--- a/amd/comgr/src/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/decoder/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
-project(hotswap-decoder LANGUAGES CXX)
 
+# No project() here: this is an add_subdirectory component of amd_comgr, not a
+# standalone build. A nested project() re-runs the superbuild dependency provider
+# and re-imports LLVM, which links a second copy of the AMDGPU static libraries
+# into amd_comgr and double-registers their cl::opts under a non-folding linker.
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -65,6 +68,17 @@ if(NOT TARGET hotswap::decoder)
 endif()
 
 llvm_update_compile_flags(hotswap-decoder)
+# llvm_update_compile_flags does not reliably carry LLVM's -fno-rtti to a
+# standalone find_package(LLVM) consumer, and the MC stack raises HotswapError
+# (an llvm::ErrorInfo). Mirror LLVM_ENABLE_RTTI explicitly so we do not emit
+# typeinfo an RTTI-off LLVM cannot resolve at link time.
+if(NOT LLVM_ENABLE_RTTI)
+  if(MSVC)
+    target_compile_options(hotswap-decoder PRIVATE /GR-)
+  else()
+    target_compile_options(hotswap-decoder PRIVATE -fno-rtti)
+  endif()
+endif()
 set_target_properties(hotswap-decoder PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Public include root (src/) so consumers can `#include "hotswap/..."`.
@@ -73,16 +87,16 @@ target_include_directories(hotswap-decoder PUBLIC
 )
 
 # The MC stack consumes AMDGPU target-private headers (AMDGPUMCTargetDesc.h,
-# AMDGPUBaseInfo.h, SIDefines.h), which transitively include the TableGen-
-# generated AMDGPUGen*.inc files. Those live in the LLVM source and build trees
-# and are not exposed by an install tree.
-# SIDefines.h and its siblings are hand-written AMDGPU headers that live only
-# in the LLVM source tree; the build tree carries just the generated *.inc.
-# Locate that source across the layouts comgr builds in: an in-tree monorepo
-# build exposes it as LLVM_MAIN_SRC_DIR, a find_package(LLVM) consumer as
-# LLVM_BUILD_MAIN_SRC_DIR, and the ROCm superbuild sets neither but keeps
-# amd/comgr next to llvm/ under a shared root. Probe for the header rather than
-# trust one variable, so a wrong or empty root fails the configure loudly.
+# AMDGPUBaseInfo.h, SIDefines.h). SIDefines.h and its siblings are hand-written
+# headers that live only in the LLVM source tree; the TableGen-generated
+# AMDGPUGen*.inc they transitively include live only in the LLVM build tree.
+# Neither is exposed by an install tree, so locate both.
+#
+# Source: an in-tree monorepo build exposes it as LLVM_MAIN_SRC_DIR, a
+# find_package(LLVM) consumer as LLVM_BUILD_MAIN_SRC_DIR, and the ROCm
+# superbuild sets neither but keeps amd/comgr next to llvm/ under a shared root.
+# Probe for the header rather than trust one variable, so a wrong or empty root
+# fails the configure loudly.
 set(HOTSWAP_AMDGPU_SRC_DIR "")
 foreach(HotswapLLVMRoot
     "${LLVM_MAIN_SRC_DIR}"
@@ -100,10 +114,51 @@ if(NOT HOTSWAP_AMDGPU_SRC_DIR)
     "hotswap-decoder: cannot find the LLVM AMDGPU target sources "
     "(SIDefines.h); set LLVM_MAIN_SRC_DIR to the llvm source directory.")
 endif()
+
+# Generated headers: the TableGen-generated AMDGPUGen*.inc live in the LLVM
+# build tree, never an install prefix, so in an installed LLVMConfig.cmake
+# LLVM_BINARY_DIR (the install prefix) carries none of them. Probe, in order:
+#   1. LLVM_BUILD_BINARY_DIR, if a consumer points us straight at its LLVM build;
+#   2. LLVM_BINARY_DIR, correct for an in-tree monorepo build;
+#   3. the ROCm/TheRock superbuild layout, where comgr consumes the installed
+#      LLVM under <root>/dist/lib/llvm while the producing build sits beside it
+#      at <root>/build (LLVM_BINARY_DIR is .../dist/lib/llvm there).
+# Validate every header the MC stack pulls in so an unrecognised layout fails
+# the configure loudly.
+set(HOTSWAP_AMDGPU_GEN_DIR "")
+foreach(HotswapLLVMBuild
+    "${LLVM_BUILD_BINARY_DIR}"
+    "${LLVM_BINARY_DIR}"
+    "${LLVM_BINARY_DIR}/../../../build")
+  if(HotswapLLVMBuild AND
+     EXISTS "${HotswapLLVMBuild}/lib/Target/AMDGPU/AMDGPUGenInstrInfo.inc")
+    get_filename_component(HOTSWAP_AMDGPU_GEN_DIR
+      "${HotswapLLVMBuild}/lib/Target/AMDGPU" ABSOLUTE)
+    break()
+  endif()
+endforeach()
+foreach(HotswapGenInc
+    AMDGPUGenInstrInfo.inc
+    AMDGPUGenRegisterInfo.inc
+    AMDGPUGenSubtargetInfo.inc)
+  if(NOT EXISTS "${HOTSWAP_AMDGPU_GEN_DIR}/${HotswapGenInc}")
+    message(FATAL_ERROR
+      "hotswap-decoder: cannot find the generated AMDGPU headers "
+      "(${HotswapGenInc}); pass -DLLVM_BUILD_BINARY_DIR=<llvm build dir>.")
+  endif()
+endforeach()
+
+# comgr.h (pulled in for COMGR::ensureLLVMInitialized) includes the configured
+# amd_comgr.h from comgr's binary include/ tree
+# (src/hotswap/decoder -> src/hotswap -> src -> comgr root).
+get_filename_component(HOTSWAP_COMGR_BINARY_DIR
+  "${CMAKE_CURRENT_BINARY_DIR}/../../.." ABSOLUTE)
+
 target_include_directories(hotswap-decoder PRIVATE
   "${HOTSWAP_AMDGPU_SRC_DIR}"
   "${HOTSWAP_AMDGPU_SRC_DIR}/Utils"
-  "${LLVM_BINARY_DIR}/lib/Target/AMDGPU"
+  "${HOTSWAP_AMDGPU_GEN_DIR}"
+  "${HOTSWAP_COMGR_BINARY_DIR}/include"
 )
 
 target_link_libraries(hotswap-decoder PUBLIC ${HOTSWAP_LLVM_LIBS})

--- a/amd/comgr/src/hotswap/decoder/amdgpu-formats.cpp
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-formats.cpp
@@ -1,0 +1,64 @@
+//===- amdgpu-formats.cpp - Hotswap transpiler ----------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "amdgpu-formats.h"
+
+#include "SIDefines.h"
+#include "Utils/AMDGPUBaseInfo.h"
+
+namespace COMGR::hotswap {
+
+llvm::StringRef formatName(uint64_t TSFlags, unsigned Opcode) {
+  using namespace llvm;
+  // VOPD has no dedicated TSFlags bit; MAI is a VOP3 subclass and VOP3P
+  // coexists with VOP3, so the more specific tests must come first.
+  if (AMDGPU::isVOPD(Opcode))
+    return "VOPD";
+  if (TSFlags & SIInstrFlags::IsMAI)
+    return "MFMA";
+  if (TSFlags & SIInstrFlags::DPP)
+    return "DPP";
+  if (TSFlags & SIInstrFlags::SDWA)
+    return "SDWA";
+  if (TSFlags & SIInstrFlags::SOPP)
+    return "SOPP";
+  if (TSFlags & SIInstrFlags::SOPC)
+    return "SOPC";
+  if (TSFlags & SIInstrFlags::SOP1)
+    return "SOP1";
+  if (TSFlags & SIInstrFlags::SOP2)
+    return "SOP2";
+  if (TSFlags & SIInstrFlags::SOPK)
+    return "SOPK";
+  if (TSFlags & SIInstrFlags::VOPC)
+    return "VOPC";
+  if (TSFlags & SIInstrFlags::VOP3P)
+    return "VOP3P";
+  if (TSFlags & SIInstrFlags::VOP3)
+    return "VOP3";
+  if (TSFlags & SIInstrFlags::VOP2)
+    return "VOP2";
+  if (TSFlags & SIInstrFlags::VOP1)
+    return "VOP1";
+  if (TSFlags & SIInstrFlags::SMRD)
+    return "SMEM";
+  if (TSFlags & SIInstrFlags::FLAT)
+    return "FLAT";
+  if (TSFlags & SIInstrFlags::MUBUF)
+    return "MUBUF";
+  if (TSFlags & SIInstrFlags::DS)
+    return "DS";
+  if (TSFlags & SIInstrFlags::VIMAGE)
+    return "VIMAGE";
+  // The gfx1250 TENSOR pseudos set TENSOR_CNT without the VIMAGE bit.
+  if (TSFlags & SIInstrFlags::TENSOR_CNT)
+    return "VIMAGE";
+  return "Unknown";
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/amdgpu-formats.cpp
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-formats.cpp
@@ -9,55 +9,76 @@
 #include "amdgpu-formats.h"
 
 #include "SIDefines.h"
-#include "Utils/AMDGPUBaseInfo.h"
 
 namespace COMGR::hotswap {
 
-llvm::StringRef formatName(uint64_t TSFlags, unsigned Opcode) {
+llvm::StringRef formatName(uint64_t TSFlags) {
   using namespace llvm;
-  // VOPD has no dedicated TSFlags bit; MAI is a VOP3 subclass and VOP3P
-  // coexists with VOP3, so the more specific tests must come first.
-  if (AMDGPU::isVOPD(Opcode))
+  // Only the gfx1250 VOPD3 form carries a TSFlags bit; classic (gfx11) VOPD has
+  // none, but the transpiler's target ISAs do not emit it. MAI is a VOP3
+  // subclass and VOP3P coexists with VOP3, so the more specific tests come
+  // first.
+  if (TSFlags & SIInstrFlags::VOPD3) {
     return "VOPD";
-  if (TSFlags & SIInstrFlags::IsMAI)
+  }
+  if (TSFlags & SIInstrFlags::IsMAI) {
     return "MFMA";
-  if (TSFlags & SIInstrFlags::DPP)
+  }
+  if (TSFlags & SIInstrFlags::DPP) {
     return "DPP";
-  if (TSFlags & SIInstrFlags::SDWA)
+  }
+  if (TSFlags & SIInstrFlags::SDWA) {
     return "SDWA";
-  if (TSFlags & SIInstrFlags::SOPP)
+  }
+  if (TSFlags & SIInstrFlags::SOPP) {
     return "SOPP";
-  if (TSFlags & SIInstrFlags::SOPC)
+  }
+  if (TSFlags & SIInstrFlags::SOPC) {
     return "SOPC";
-  if (TSFlags & SIInstrFlags::SOP1)
+  }
+  if (TSFlags & SIInstrFlags::SOP1) {
     return "SOP1";
-  if (TSFlags & SIInstrFlags::SOP2)
+  }
+  if (TSFlags & SIInstrFlags::SOP2) {
     return "SOP2";
-  if (TSFlags & SIInstrFlags::SOPK)
+  }
+  if (TSFlags & SIInstrFlags::SOPK) {
     return "SOPK";
-  if (TSFlags & SIInstrFlags::VOPC)
+  }
+  if (TSFlags & SIInstrFlags::VOPC) {
     return "VOPC";
-  if (TSFlags & SIInstrFlags::VOP3P)
+  }
+  if (TSFlags & SIInstrFlags::VOP3P) {
     return "VOP3P";
-  if (TSFlags & SIInstrFlags::VOP3)
+  }
+  if (TSFlags & SIInstrFlags::VOP3) {
     return "VOP3";
-  if (TSFlags & SIInstrFlags::VOP2)
+  }
+  if (TSFlags & SIInstrFlags::VOP2) {
     return "VOP2";
-  if (TSFlags & SIInstrFlags::VOP1)
+  }
+  if (TSFlags & SIInstrFlags::VOP1) {
     return "VOP1";
-  if (TSFlags & SIInstrFlags::SMRD)
+  }
+  if (TSFlags & SIInstrFlags::SMRD) {
     return "SMEM";
-  if (TSFlags & SIInstrFlags::FLAT)
+  }
+  if (TSFlags & SIInstrFlags::FLAT) {
     return "FLAT";
-  if (TSFlags & SIInstrFlags::MUBUF)
+  }
+  if (TSFlags & SIInstrFlags::MUBUF) {
     return "MUBUF";
-  if (TSFlags & SIInstrFlags::DS)
+  }
+  if (TSFlags & SIInstrFlags::DS) {
     return "DS";
-  if (TSFlags & SIInstrFlags::VIMAGE)
+  }
+  if (TSFlags & SIInstrFlags::VIMAGE) {
     return "VIMAGE";
+  }
   // The gfx1250 TENSOR pseudos set TENSOR_CNT without the VIMAGE bit.
-  if (TSFlags & SIInstrFlags::TENSOR_CNT)
+  if (TSFlags & SIInstrFlags::TENSOR_CNT) {
     return "VIMAGE";
+  }
   return "Unknown";
 }
 

--- a/amd/comgr/src/hotswap/decoder/amdgpu-formats.h
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-formats.h
@@ -16,9 +16,9 @@
 namespace COMGR::hotswap {
 
 // The AMDGPU instruction-format label (e.g. "SOP1", "VOP3", "FLAT") for an
-// instruction with the given MC `TSFlags` and `Opcode`, or "Unknown". Consumed
-// only by diagnostics; there is no dispatch on the returned string.
-llvm::StringRef formatName(uint64_t TSFlags, unsigned Opcode);
+// instruction with the given MC `TSFlags`, or "Unknown". Consumed only by
+// diagnostics; there is no dispatch on the returned string.
+llvm::StringRef formatName(uint64_t TSFlags);
 
 } // namespace COMGR::hotswap
 

--- a/amd/comgr/src/hotswap/decoder/amdgpu-formats.h
+++ b/amd/comgr/src/hotswap/decoder/amdgpu-formats.h
@@ -1,0 +1,25 @@
+//===- amdgpu-formats.h - Hotswap transpiler ------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_AMDGPU_FORMATS_H
+#define HOTSWAP_TRANSPILER_AMDGPU_FORMATS_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+
+namespace COMGR::hotswap {
+
+// The AMDGPU instruction-format label (e.g. "SOP1", "VOP3", "FLAT") for an
+// instruction with the given MC `TSFlags` and `Opcode`, or "Unknown". Consumed
+// only by diagnostics; there is no dispatch on the returned string.
+llvm::StringRef formatName(uint64_t TSFlags, unsigned Opcode);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/canonical-op.cpp
+++ b/amd/comgr/src/hotswap/decoder/canonical-op.cpp
@@ -1,0 +1,28 @@
+//===- canonical-op.cpp - Hotswap transpiler ------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "canonical-op.h"
+
+#include "llvm/Support/ErrorHandling.h"
+
+namespace COMGR::hotswap {
+
+llvm::StringRef canonicalOpName(CanonicalOp Op) {
+  switch (Op) {
+#define CANONICAL_OP(Name)                                                     \
+  case CanonicalOp::Name:                                                      \
+    return #Name;
+#include "canonical-op.def"
+#undef CANONICAL_OP
+  case CanonicalOp::CanonicalOp_COUNT:
+    break;
+  }
+  llvm_unreachable("canonicalOpName: invalid CanonicalOp");
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/canonical-op.def
+++ b/amd/comgr/src/hotswap/decoder/canonical-op.def
@@ -1,0 +1,15 @@
+//===- canonical-op.def - Hotswap transpiler ------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CANONICAL_OP
+#error "define CANONICAL_OP(Name) before including canonical-op.def"
+#endif
+
+CANONICAL_OP(Unknown)
+CANONICAL_OP(S_MOV_B32)
+CANONICAL_OP(S_ENDPGM)

--- a/amd/comgr/src/hotswap/decoder/canonical-op.h
+++ b/amd/comgr/src/hotswap/decoder/canonical-op.h
@@ -1,0 +1,35 @@
+//===- canonical-op.h - Hotswap transpiler --------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_CANONICAL_OP_H
+#define HOTSWAP_TRANSPILER_CANONICAL_OP_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+
+namespace COMGR::hotswap {
+
+// Architecture-neutral instruction identity used for dispatch in the raiser.
+// Each value maps to one or more MC opcodes via OpcodeMap; an MC opcode with no
+// mapping is `Unknown` and is refused. The values come from canonical-op.def.
+enum class CanonicalOp : uint16_t {
+#define CANONICAL_OP(Name) Name,
+#include "canonical-op.def"
+#undef CANONICAL_OP
+  CanonicalOp_COUNT
+};
+
+// The enum's spelling for `Op` (e.g. `"S_MOV_B32"` for
+// `CanonicalOp::S_MOV_B32`), for use in diagnostics that name the instruction
+// class rather than a raw enum position.
+llvm::StringRef canonicalOpName(CanonicalOp Op);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/decoded-inst.h
+++ b/amd/comgr/src/hotswap/decoder/decoded-inst.h
@@ -1,0 +1,107 @@
+//===- decoded-inst.h - Hotswap transpiler --------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_DECODED_INST_H
+#define HOTSWAP_TRANSPILER_DECODED_INST_H
+
+#include "canonical-op.h"
+
+#include "llvm/ADT/Bitfields.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCInst.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+
+namespace COMGR::hotswap {
+
+// If operand `OpIdx` of `Inst` is a compile-time constant -- an immediate, or
+// an expression that folds to one -- returns its value; otherwise std::nullopt
+// (including when `OpIdx` is out of range).
+inline std::optional<int64_t> evalOperandAsConst(const llvm::MCInst &Inst,
+                                                 unsigned OpIdx) {
+  if (OpIdx >= Inst.getNumOperands())
+    return std::nullopt;
+  const llvm::MCOperand &Operand = Inst.getOperand(OpIdx);
+  if (Operand.isImm())
+    return Operand.getImm();
+  if (Operand.isExpr()) {
+    int64_t Val = 0;
+    if (Operand.getExpr()->evaluateAsAbsolute(Val))
+      return Val;
+  }
+  return std::nullopt;
+}
+
+// One decoded source-ISA instruction: the MC instruction plus the facts the
+// raiser dispatches on. The mnemonic is not stored -- reconstruct it on demand
+// from `Inst` with strippedMnemonic (see mc-state.h) where a diagnostic needs
+// it.
+struct DecodedInst {
+  llvm::MCInst Inst;
+  CanonicalOp CanonOp = CanonicalOp::Unknown;
+
+  // The instruction's MCInstrDesc::TSFlags, whose AMDGPU-specific bits carry
+  // the instruction-format the raiser dispatches on (see amdgpu-formats.h).
+  uint64_t TargetSpecificFlags = 0;
+
+  // Byte offset of this instruction within the kernel's .text.
+  uint64_t Offset = 0;
+
+  // Number of leading MCInst operands that are definitions (results); the
+  // logical sources start at operand index FirstSrcIdx.
+  unsigned NumDefs = 0;
+  unsigned FirstSrcIdx = 0;
+
+  // Operand index of each logical source, and of its source modifier (or
+  // UINT_MAX when the source has none). Parallel, one entry per source.
+  llvm::SmallVector<unsigned> SrcMap;
+  llvm::SmallVector<unsigned> ModMap;
+
+  // Instruction length in bytes. The AMDGPU maximum is 20
+  // (AMDGPUMCAsmInfo::MaxInstLength), so five bits suffice.
+  unsigned sizeInBytes() const { return llvm::Bitfield::get<SizeField>(Flags); }
+  void setSizeInBytes(unsigned Bytes) {
+    llvm::Bitfield::set<SizeField>(Flags, Bytes);
+  }
+
+  // Whether the instruction writes the SCC / VCC / EXEC condition registers.
+  bool defsScc() const { return llvm::Bitfield::get<DefsSccField>(Flags); }
+  void setDefsScc(bool V) { llvm::Bitfield::set<DefsSccField>(Flags, V); }
+  bool defsVcc() const { return llvm::Bitfield::get<DefsVccField>(Flags); }
+  void setDefsVcc(bool V) { llvm::Bitfield::set<DefsVccField>(Flags, V); }
+  bool defsExec() const { return llvm::Bitfield::get<DefsExecField>(Flags); }
+  void setDefsExec(bool V) { llvm::Bitfield::set<DefsExecField>(Flags, V); }
+
+  unsigned numOperands() const { return Inst.getNumOperands(); }
+  bool isReg(unsigned I) const {
+    assert(I < numOperands() && "operand index out of range");
+    return Inst.getOperand(I).isReg();
+  }
+  bool isImm(unsigned I) const {
+    assert(I < numOperands() && "operand index out of range");
+    return Inst.getOperand(I).isImm();
+  }
+  unsigned getReg(unsigned I) const { return Inst.getOperand(I).getReg(); }
+  int64_t getImm(unsigned I) const { return Inst.getOperand(I).getImm(); }
+
+private:
+  // `Flags` byte layout: the 5-bit instruction size packed next to the three
+  // condition-register def bits.
+  using SizeField = llvm::Bitfield::Element<unsigned, 0, 5>;
+  using DefsSccField = llvm::Bitfield::Element<bool, 5, 1>;
+  using DefsVccField = llvm::Bitfield::Element<bool, 6, 1>;
+  using DefsExecField = llvm::Bitfield::Element<bool, 7, 1>;
+  uint8_t Flags = 0;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/isa-profile.cpp
+++ b/amd/comgr/src/hotswap/decoder/isa-profile.cpp
@@ -1,0 +1,43 @@
+//===- isa-profile.cpp - Hotswap transpiler -------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The ISAProfile queries live here rather than in the header so only this
+// translation unit pulls the AMDGPU target-private subtarget-feature enum (via
+// its TableGen-generated includes); consumers include a clean isa-profile.h.
+// The queries read feature bits through MCSubtargetInfo directly rather than
+// the AMDGPU:: helper functions, whose out-of-line symbols an
+// LLVM_LINK_LLVM_DYLIB build does not export.
+//
+//===----------------------------------------------------------------------===//
+
+#include "isa-profile.h"
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+
+namespace COMGR::hotswap {
+
+unsigned ISAProfile::waveSize() const {
+  return STI->hasFeature(llvm::AMDGPU::FeatureWavefrontSize32) ? 32 : 64;
+}
+
+bool ISAProfile::isWave32() const { return waveSize() == 32; }
+
+bool ISAProfile::hasValidWaveSize() const {
+  return waveSize() == 32 || waveSize() == 64;
+}
+
+bool ISAProfile::hasAgpr() const {
+  return STI->hasFeature(llvm::AMDGPU::FeatureMAIInsts);
+}
+
+bool ISAProfile::hasGfx125UserSgprCountField() const {
+  return STI->hasFeature(llvm::AMDGPU::FeatureGFX1250Insts);
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/isa-profile.h
+++ b/amd/comgr/src/hotswap/decoder/isa-profile.h
@@ -1,0 +1,51 @@
+//===- isa-profile.h - Hotswap transpiler ---------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_ISA_PROFILE_H
+#define HOTSWAP_TRANSPILER_ISA_PROFILE_H
+
+#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
+#include "Utils/AMDGPUBaseInfo.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+
+namespace COMGR::hotswap {
+
+// The subset of AMDGPU subtarget capabilities the raiser branches on, queried
+// on demand from the MCSubtargetInfo rather than cached. Construct via
+// `fromSubtarget`; the referenced subtarget must outlive the profile.
+class ISAProfile {
+public:
+  static ISAProfile fromSubtarget(const llvm::MCSubtargetInfo &STI) {
+    return ISAProfile(STI);
+  }
+
+  // Wavefront width in lanes (32 or 64).
+  unsigned waveSize() const {
+    return STI->hasFeature(llvm::AMDGPU::FeatureWavefrontSize32) ? 32 : 64;
+  }
+  bool isWave32() const { return waveSize() == 32; }
+  bool hasValidWaveSize() const { return waveSize() == 32 || waveSize() == 64; }
+
+  // Whether the target has AGPRs / the MAI (matrix) instruction set.
+  bool hasAgpr() const { return llvm::AMDGPU::hasMAIInsts(*STI); }
+
+  // Whether compute_pgm_rsrc2.USER_SGPR_COUNT is the wider gfx1250 6-bit field
+  // rather than the older 5-bit field.
+  bool hasGfx125UserSgprCountField() const {
+    return llvm::AMDGPU::isGFX1250Plus(*STI);
+  }
+
+private:
+  explicit ISAProfile(const llvm::MCSubtargetInfo &STI) : STI(&STI) {}
+
+  const llvm::MCSubtargetInfo *STI;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/isa-profile.h
+++ b/amd/comgr/src/hotswap/decoder/isa-profile.h
@@ -9,15 +9,17 @@
 #ifndef HOTSWAP_TRANSPILER_ISA_PROFILE_H
 #define HOTSWAP_TRANSPILER_ISA_PROFILE_H
 
-#include "MCTargetDesc/AMDGPUMCTargetDesc.h"
-#include "Utils/AMDGPUBaseInfo.h"
-#include "llvm/MC/MCSubtargetInfo.h"
+namespace llvm {
+class MCSubtargetInfo;
+} // namespace llvm
 
 namespace COMGR::hotswap {
 
 // The subset of AMDGPU subtarget capabilities the raiser branches on, queried
 // on demand from the MCSubtargetInfo rather than cached. Construct via
-// `fromSubtarget`; the referenced subtarget must outlive the profile.
+// `fromSubtarget`; the referenced subtarget must outlive the profile. The
+// queries are defined in isa-profile.cpp so this header stays free of the
+// AMDGPU target-private headers they need.
 class ISAProfile {
 public:
   static ISAProfile fromSubtarget(const llvm::MCSubtargetInfo &STI) {
@@ -25,20 +27,16 @@ public:
   }
 
   // Wavefront width in lanes (32 or 64).
-  unsigned waveSize() const {
-    return STI->hasFeature(llvm::AMDGPU::FeatureWavefrontSize32) ? 32 : 64;
-  }
-  bool isWave32() const { return waveSize() == 32; }
-  bool hasValidWaveSize() const { return waveSize() == 32 || waveSize() == 64; }
+  unsigned waveSize() const;
+  bool isWave32() const;
+  bool hasValidWaveSize() const;
 
   // Whether the target has AGPRs / the MAI (matrix) instruction set.
-  bool hasAgpr() const { return llvm::AMDGPU::hasMAIInsts(*STI); }
+  bool hasAgpr() const;
 
   // Whether compute_pgm_rsrc2.USER_SGPR_COUNT is the wider gfx1250 6-bit field
   // rather than the older 5-bit field.
-  bool hasGfx125UserSgprCountField() const {
-    return llvm::AMDGPU::isGFX1250Plus(*STI);
-  }
+  bool hasGfx125UserSgprCountField() const;
 
 private:
   explicit ISAProfile(const llvm::MCSubtargetInfo &STI) : STI(&STI) {}

--- a/amd/comgr/src/hotswap/decoder/mc-state.cpp
+++ b/amd/comgr/src/hotswap/decoder/mc-state.cpp
@@ -86,7 +86,7 @@ llvm::Expected<MCState> initMCState(StringRef TargetIsa) {
   // today. But the disassembler here can emit diagnostics on malformed
   // instruction bytes, and any future reuse of this MCContext for an
   // MC emission path (e.g. an assembly-based post-rewrite pass or a
-  // new cross-widening lowering that goes through MC) would hit the
+  // new widening lowering that goes through MC) would hit the
   // same abort. Attaching an inline SourceMgr here keeps the failure
   // mode graceful for both current and future callers -- the cost is
   // one pointer and one default-constructed SourceMgr per MCState.

--- a/amd/comgr/src/hotswap/decoder/mc-state.cpp
+++ b/amd/comgr/src/hotswap/decoder/mc-state.cpp
@@ -1,0 +1,122 @@
+//===- mc-state.cpp - Hotswap transpiler ----------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mc-state.h"
+#include "hotswap/common/hotswap-error.h"
+#include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
+
+using namespace llvm;
+
+namespace COMGR::hotswap {
+
+Expected<std::unique_ptr<MCSubtargetInfo>>
+buildSubtargetInfo(const Target &Target, StringRef Isa) {
+  Triple Triple(kAMDGPUTriple);
+  std::unique_ptr<MCSubtargetInfo> STI(
+      Target.createMCSubtargetInfo(Triple, Isa, ""));
+  if (!STI)
+    return makeHotswapError("buildSubtargetInfo: failed to create "
+                            "MCSubtargetInfo for ISA '" +
+                            Isa + "'");
+  return STI;
+}
+
+llvm::Expected<MCState> initMCState(StringRef TargetIsa) {
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTarget();
+  LLVMInitializeAMDGPUTargetMC();
+  LLVMInitializeAMDGPUDisassembler();
+  LLVMInitializeAMDGPUAsmParser();
+  LLVMInitializeAMDGPUAsmPrinter();
+
+  Triple Triple(kAMDGPUTriple);
+  std::string LookupError;
+  MCState State;
+  State.Target = TargetRegistry::lookupTarget(Triple, LookupError);
+  if (!State.Target)
+    return makeHotswapError("initMCState: Target lookup for '" + kAMDGPUTriple +
+                            "' failed: " + LookupError);
+
+  State.InstrInfo.reset(State.Target->createMCInstrInfo());
+  State.RegInfo.reset(State.Target->createMCRegInfo(Triple));
+  Expected<std::unique_ptr<MCSubtargetInfo>> STIOrErr =
+      buildSubtargetInfo(*State.Target, TargetIsa);
+  if (!STIOrErr)
+    return STIOrErr.takeError();
+
+  State.SubtargetInfo = std::move(*STIOrErr);
+  State.AsmInfo.reset(
+      State.Target->createMCAsmInfo(*State.RegInfo, Triple, MCTargetOptions()));
+  if (!State.AsmInfo)
+    return makeHotswapError("initMCState: createMCAsmInfo returned null");
+
+  State.Ctx = std::make_unique<MCContext>(Triple, *State.AsmInfo,
+                                          *State.RegInfo, *State.SubtargetInfo);
+  // The MCContext ctor defaults `SourceMgr *Mgr = nullptr`, so any
+  // MC-layer diagnostic that reaches `MCContext::reportCommon` or
+  // `MCContext::diagnose` with a valid SMLoc and no SrcMgr trips an
+  // `llvm_unreachable("Either SourceMgr should be available")` abort
+  // inside `llvm/lib/MC/MCContext.cpp`.
+  //
+  // The hotswap IR-raise pipeline does not currently exercise the MC
+  // assembler (codegen runs through `llc`/`lld` on lifted IR, not
+  // through this MCContext), so the abort does not fire on hotswap
+  // today. But the disassembler here can emit diagnostics on malformed
+  // instruction bytes, and any future reuse of this MCContext for an
+  // MC emission path (e.g. an assembly-based post-rewrite pass or a
+  // new cross-widening lowering that goes through MC) would hit the
+  // same abort. Attaching an inline SourceMgr here keeps the failure
+  // mode graceful for both current and future callers -- the cost is
+  // one pointer and one default-constructed SourceMgr per MCState.
+  State.Ctx->initInlineSourceManager();
+  State.Disasm.reset(
+      State.Target->createMCDisassembler(*State.SubtargetInfo, *State.Ctx));
+  if (!State.Disasm)
+    return makeHotswapError("initMCState: createMCDisassembler returned null");
+
+  State.Printer.reset(State.Target->createMCInstPrinter(
+      Triple, 0, *State.AsmInfo, *State.InstrInfo, *State.RegInfo));
+  if (!State.Printer)
+    return makeHotswapError("initMCState: createMCInstPrinter returned null");
+
+  State.Printer->setPrintImmHex(true);
+
+  return State;
+}
+
+std::string getMnemonic(const MCState &State, const MCInst &Inst) {
+  std::string S;
+  raw_string_ostream Os(S);
+  State.Printer->printInst(&Inst, 0, "", *State.SubtargetInfo, Os);
+  StringRef Sr(S);
+  Sr = Sr.ltrim();
+  return Sr.split('\t').first.split(' ').first.str();
+}
+
+std::string printInst(const MCState &State, const MCInst &Inst) {
+  std::string S;
+  raw_string_ostream Os(S);
+  State.Printer->printInst(&Inst, 0, "", *State.SubtargetInfo, Os);
+  return StringRef(S).ltrim().str();
+}
+
+StringRef stripEncoding(StringRef Mnemonic) {
+  for (StringRef Suffix : {"_e32", "_e64", "_vi"})
+    if (Mnemonic.ends_with(Suffix))
+      return Mnemonic.drop_back(Suffix.size());
+  return Mnemonic;
+}
+
+std::string strippedMnemonic(const MCState &State, const MCInst &Inst) {
+  return stripEncoding(getMnemonic(State, Inst)).str();
+}
+
+} // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/mc-state.cpp
+++ b/amd/comgr/src/hotswap/decoder/mc-state.cpp
@@ -7,11 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 #include "mc-state.h"
+#include "comgr.h"
 #include "hotswap/common/hotswap-error.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/TargetSelect.h"
+#include "llvm/TargetParser/AMDGPUTargetParser.h"
+
+#include <cassert>
 
 using namespace llvm;
 
@@ -19,44 +22,55 @@ namespace COMGR::hotswap {
 
 Expected<std::unique_ptr<MCSubtargetInfo>>
 buildSubtargetInfo(const Target &Target, StringRef Isa) {
+  // createMCSubtargetInfo does not reject an unknown CPU: it diagnoses to
+  // stderr and returns a featureless default, and building the AMDGPU
+  // disassembler from that trips reportFatalUsageError and aborts the host.
+  // Reject the bare processor name up front so malformed ISA input returns an
+  // error instead.
+  if (AMDGPU::parseArchAMDGCN(Isa) == AMDGPU::GK_NONE) {
+    return makeHotswapError("buildSubtargetInfo: unknown AMDGPU processor '" +
+                            Isa + "'");
+  }
   Triple Triple(kAMDGPUTriple);
   std::unique_ptr<MCSubtargetInfo> STI(
       Target.createMCSubtargetInfo(Triple, Isa, ""));
-  if (!STI)
-    return makeHotswapError("buildSubtargetInfo: failed to create "
-                            "MCSubtargetInfo for ISA '" +
-                            Isa + "'");
+  // The ISA is a validated AMDGPU processor by here, so the registered factory
+  // always returns a subtarget.
+  assert(STI && "AMDGPU target must provide an MCSubtargetInfo");
   return STI;
 }
 
 llvm::Expected<MCState> initMCState(StringRef TargetIsa) {
-  LLVMInitializeAMDGPUTargetInfo();
-  LLVMInitializeAMDGPUTarget();
-  LLVMInitializeAMDGPUTargetMC();
-  LLVMInitializeAMDGPUDisassembler();
-  LLVMInitializeAMDGPUAsmParser();
-  LLVMInitializeAMDGPUAsmPrinter();
+  // Registering the AMDGPU target mutates the process-global TargetRegistry,
+  // which is not thread-safe. Reuse COMGR's shared one-time initializer (mutex
+  // plus run-once guard) rather than re-registering on every call.
+  COMGR::ensureLLVMInitialized();
 
   Triple Triple(kAMDGPUTriple);
   std::string LookupError;
   MCState State;
   State.Target = TargetRegistry::lookupTarget(Triple, LookupError);
-  if (!State.Target)
+  if (!State.Target) {
     return makeHotswapError("initMCState: Target lookup for '" + kAMDGPUTriple +
                             "' failed: " + LookupError);
+  }
 
+  // Once the AMDGPU target is registered, its instr/reg tables are built from
+  // static data and never fail; a null here is a broken build, not bad input.
   State.InstrInfo.reset(State.Target->createMCInstrInfo());
+  assert(State.InstrInfo && "AMDGPU target must provide an MCInstrInfo");
   State.RegInfo.reset(State.Target->createMCRegInfo(Triple));
+  assert(State.RegInfo && "AMDGPU target must provide an MCRegInfo");
   Expected<std::unique_ptr<MCSubtargetInfo>> STIOrErr =
       buildSubtargetInfo(*State.Target, TargetIsa);
-  if (!STIOrErr)
+  if (!STIOrErr) {
     return STIOrErr.takeError();
+  }
 
   State.SubtargetInfo = std::move(*STIOrErr);
   State.AsmInfo.reset(
       State.Target->createMCAsmInfo(*State.RegInfo, Triple, MCTargetOptions()));
-  if (!State.AsmInfo)
-    return makeHotswapError("initMCState: createMCAsmInfo returned null");
+  assert(State.AsmInfo && "AMDGPU target must provide an MCAsmInfo");
 
   State.Ctx = std::make_unique<MCContext>(Triple, *State.AsmInfo,
                                           *State.RegInfo, *State.SubtargetInfo);
@@ -79,13 +93,11 @@ llvm::Expected<MCState> initMCState(StringRef TargetIsa) {
   State.Ctx->initInlineSourceManager();
   State.Disasm.reset(
       State.Target->createMCDisassembler(*State.SubtargetInfo, *State.Ctx));
-  if (!State.Disasm)
-    return makeHotswapError("initMCState: createMCDisassembler returned null");
+  assert(State.Disasm && "AMDGPU target must provide an MCDisassembler");
 
   State.Printer.reset(State.Target->createMCInstPrinter(
       Triple, 0, *State.AsmInfo, *State.InstrInfo, *State.RegInfo));
-  if (!State.Printer)
-    return makeHotswapError("initMCState: createMCInstPrinter returned null");
+  assert(State.Printer && "AMDGPU target must provide an MCInstPrinter");
 
   State.Printer->setPrintImmHex(true);
 
@@ -109,9 +121,11 @@ std::string printInst(const MCState &State, const MCInst &Inst) {
 }
 
 StringRef stripEncoding(StringRef Mnemonic) {
-  for (StringRef Suffix : {"_e32", "_e64", "_vi"})
-    if (Mnemonic.ends_with(Suffix))
+  for (StringRef Suffix : {"_e32", "_e64", "_vi"}) {
+    if (Mnemonic.ends_with(Suffix)) {
       return Mnemonic.drop_back(Suffix.size());
+    }
+  }
   return Mnemonic;
 }
 

--- a/amd/comgr/src/hotswap/decoder/mc-state.h
+++ b/amd/comgr/src/hotswap/decoder/mc-state.h
@@ -80,8 +80,10 @@ std::string printInst(const MCState &State, const llvm::MCInst &Inst);
 llvm::StringRef stripEncoding(llvm::StringRef Mnemonic);
 
 /// Return the mnemonic of `Inst` with any encoding suffix removed (e.g.
-/// "v_mov_b32" for `v_mov_b32_e32`). This is the identity the raiser dispatches
-/// on; it is reconstructed on demand rather than stored on every instruction.
+/// "v_mov_b32" for `v_mov_b32_e32`), for diagnostics that name the instruction.
+/// The raiser's dispatch identity is `CanonicalOp` (see canonical-op.h), not
+/// this string; it is reconstructed on demand rather than stored per
+/// instruction.
 std::string strippedMnemonic(const MCState &State, const llvm::MCInst &Inst);
 
 } // namespace COMGR::hotswap

--- a/amd/comgr/src/hotswap/decoder/mc-state.h
+++ b/amd/comgr/src/hotswap/decoder/mc-state.h
@@ -1,0 +1,89 @@
+//===- mc-state.h - Hotswap transpiler ------------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Per-ISA AMDGPU MC stack used by the hotswap raiser: target lookup, MC
+// instr/reg/subtarget info, MCContext (with an inline SourceMgr attached
+// so MC-layer diagnostics do not abort), MC disassembler, and MC inst
+// printer. `initMCState` constructs the bundle for a given AMDGPU CPU
+// name (e.g. `gfx942`); `getMnemonic` and `stripEncoding` are
+// thin helpers for canonicalizing MCInst mnemonic strings.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_MC_STATE_H
+#define HOTSWAP_TRANSPILER_MC_STATE_H
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCAsmInfo.h"
+#include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCDisassembler/MCDisassembler.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstPrinter.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+#include "llvm/MC/MCSubtargetInfo.h"
+#include "llvm/MC/TargetRegistry.h"
+#include "llvm/Support/Error.h"
+
+#include <memory>
+#include <string>
+
+namespace COMGR::hotswap {
+
+/// Owns the LLVM MC objects used by the hotswap raiser for one AMDGPU
+/// subtarget. Populated by `initMCState`; every member is non-null after
+/// a successful init.
+struct MCState {
+  const llvm::Target *Target = nullptr;
+  std::unique_ptr<llvm::MCInstrInfo> InstrInfo;
+  std::unique_ptr<llvm::MCRegisterInfo> RegInfo;
+  std::unique_ptr<llvm::MCSubtargetInfo> SubtargetInfo;
+  std::unique_ptr<const llvm::MCAsmInfo> AsmInfo;
+  std::unique_ptr<llvm::MCContext> Ctx;
+  std::unique_ptr<llvm::MCDisassembler> Disasm;
+  std::unique_ptr<llvm::MCInstPrinter> Printer;
+};
+
+/// The AMDGPU triple shared by every MC object we construct here.
+inline constexpr llvm::StringLiteral kAMDGPUTriple = "amdgcn-amd-amdhsa";
+
+/// Populate `State` with the AMDGPU MC stack for `TargetIsa`. Returns
+/// `Error::success()` on success; on failure returns either a
+/// hotswap-originated `HotswapError` (Target lookup, MCSubtargetInfo /
+/// MCAsmInfo / MCDisassembler / MCInstPrinter creation failures) or
+/// forwards an upstream LLVM ErrorInfo unchanged.
+llvm::Expected<MCState> initMCState(llvm::StringRef TargetIsa);
+
+/// Thin wrapper around `Target::createMCSubtargetInfo` for the AMDGPU
+/// triple. Returns a fully populated MCSubtargetInfo (feature bits honor
+/// the CPU name) or a `HotswapError` when the Target rejects the ISA
+/// string.
+llvm::Expected<std::unique_ptr<llvm::MCSubtargetInfo>>
+buildSubtargetInfo(const llvm::Target &Target, llvm::StringRef Isa);
+
+/// Return the mnemonic token at the start of the printed disassembly of
+/// `Inst`. Strips leading whitespace and discards everything from the
+/// first space or tab onwards.
+std::string getMnemonic(const MCState &State, const llvm::MCInst &Inst);
+
+/// Return the full printed disassembly of `Inst` (mnemonic and operands),
+/// with leading whitespace stripped.
+std::string printInst(const MCState &State, const llvm::MCInst &Inst);
+
+/// Drop a recognised LLVM mnemonic-suffix token (e.g. `_e32`, `_e64`,
+/// `_vi`) from `Mnemonic` if present; otherwise return `Mnemonic` unchanged.
+llvm::StringRef stripEncoding(llvm::StringRef Mnemonic);
+
+/// Return the mnemonic of `Inst` with any encoding suffix removed (e.g.
+/// "v_mov_b32" for `v_mov_b32_e32`). This is the identity the raiser dispatches
+/// on; it is reconstructed on demand rather than stored on every instruction.
+std::string strippedMnemonic(const MCState &State, const llvm::MCInst &Inst);
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/decoder/parsed-reg.h
+++ b/amd/comgr/src/hotswap/decoder/parsed-reg.h
@@ -1,0 +1,64 @@
+//===- parsed-reg.h - Hotswap transpiler ----------------------------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef HOTSWAP_TRANSPILER_PARSED_REG_H
+#define HOTSWAP_TRANSPILER_PARSED_REG_H
+
+#include <cstdint>
+#include <optional>
+
+namespace COMGR::hotswap {
+
+struct ISAProfile; // forward declaration
+
+struct ParsedReg {
+  // Compact-predicate "source-only" registers (SIRegisterInfo.td:198-200):
+  //   SRC_VCCZ : i1 == (VCC == 0)   read as i32 in VOP/SOP src slots
+  //   SRC_EXECZ: i1 == (EXEC == 0)
+  //   SRC_SCC  : i1 == SCC
+  // These cannot be written. We model them as their own kinds so
+  // readOp32 / readOp64 can materialise the boolean result on demand
+  // (see raise-context.cpp). Tensile gfx1250 emits them as F16 source
+  // operands (e.g. `v_sub_f16 v64, src_vccz, v48`), so the dispatch
+  // path must recognise them or the kernel crashes inside parseReg.
+  // VCC_HI_SCRATCH / EXEC_HI_SCRATCH: on a WAVE32 source, hardware VCC and
+  // EXEC are only 32 bits (== VCC_LO / EXEC_LO), so the registers named VCC_HI
+  // and EXEC_HI are free general-purpose scalars the compiler uses as scratch
+  // They must not alias the (target wave64) VCC/EXEC wave masks, or a `v_cmp`
+  // writing VCC (or an EXEC update) would clobber the kernel's scratch value.
+  // Each is modelled as its own i32 scalar slot.
+  enum Kind {
+    SGPR,
+    VGPR,
+    AGPR,
+    VCC,
+    EXEC,
+    SCC,
+    MODE,
+    M0,
+    FLAT_SCR,
+    TTMP,
+    LDS_DIRECT,
+    SRC_VCCZ,
+    SRC_EXECZ,
+    SRC_SCC,
+    VCC_HI_SCRATCH,
+    EXEC_HI_SCRATCH,
+    NOREG,
+    OTHER
+  };
+  Kind RegKind = OTHER;
+  std::optional<unsigned> BaseIdx;
+  // The width of the register in 32-bit double words, 1 means 32 bit, 2 means
+  // 64 bit.
+  uint8_t WidthInDwords = 1;
+};
+
+} // namespace COMGR::hotswap
+
+#endif

--- a/amd/comgr/src/hotswap/loader/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/loader/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
-project(hotswap-loader LANGUAGES CXX)
+
+# No project() here: this is an add_subdirectory component of amd_comgr, not a
+# standalone build. A nested project() re-runs the superbuild dependency provider
+# and re-imports LLVM, which links a second copy of the AMDGPU static libraries
+# into amd_comgr and double-registers their cl::opts under a non-folding linker.
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -63,6 +67,17 @@ if(NOT TARGET hotswap::loader)
 endif()
 
 llvm_update_compile_flags(hotswap-loader)
+# llvm_update_compile_flags does not reliably carry LLVM's -fno-rtti to a
+# standalone find_package(LLVM) consumer, and the loader raises HotswapError
+# (an llvm::ErrorInfo). Mirror LLVM_ENABLE_RTTI explicitly so we do not emit
+# typeinfo an RTTI-off LLVM cannot resolve at link time.
+if(NOT LLVM_ENABLE_RTTI)
+  if(MSVC)
+    target_compile_options(hotswap-loader PRIVATE /GR-)
+  else()
+    target_compile_options(hotswap-loader PRIVATE -fno-rtti)
+  endif()
+endif()
 set_target_properties(hotswap-loader PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 # Match LLVM's RTTI setting explicitly. llvm_update_compile_flags only adds
@@ -115,10 +130,44 @@ if(NOT HOTSWAP_AMDGPU_SRC_DIR)
     "hotswap-loader: cannot find the LLVM AMDGPU target sources "
     "(SIDefines.h); set LLVM_MAIN_SRC_DIR to the llvm source directory.")
 endif()
+
+# Generated headers: the TableGen-generated AMDGPUGen*.inc live in the LLVM
+# build tree, never an install prefix, so in an installed LLVMConfig.cmake
+# LLVM_BINARY_DIR (the install prefix) carries none of them. Probe, in order:
+#   1. LLVM_BUILD_BINARY_DIR, if a consumer points us straight at its LLVM build;
+#   2. LLVM_BINARY_DIR, correct for an in-tree monorepo build;
+#   3. the ROCm/TheRock superbuild layout, where comgr consumes the installed
+#      LLVM under <root>/dist/lib/llvm while the producing build sits beside it
+#      at <root>/build (LLVM_BINARY_DIR is .../dist/lib/llvm there).
+# Validate every header the MC stack pulls in so an unrecognised layout fails
+# the configure loudly.
+set(HOTSWAP_AMDGPU_GEN_DIR "")
+foreach(HotswapLLVMBuild
+    "${LLVM_BUILD_BINARY_DIR}"
+    "${LLVM_BINARY_DIR}"
+    "${LLVM_BINARY_DIR}/../../../build")
+  if(HotswapLLVMBuild AND
+     EXISTS "${HotswapLLVMBuild}/lib/Target/AMDGPU/AMDGPUGenInstrInfo.inc")
+    get_filename_component(HOTSWAP_AMDGPU_GEN_DIR
+      "${HotswapLLVMBuild}/lib/Target/AMDGPU" ABSOLUTE)
+    break()
+  endif()
+endforeach()
+foreach(HotswapGenInc
+    AMDGPUGenInstrInfo.inc
+    AMDGPUGenRegisterInfo.inc
+    AMDGPUGenSubtargetInfo.inc)
+  if(NOT EXISTS "${HOTSWAP_AMDGPU_GEN_DIR}/${HotswapGenInc}")
+    message(FATAL_ERROR
+      "hotswap-loader: cannot find the generated AMDGPU headers "
+      "(${HotswapGenInc}); pass -DLLVM_BUILD_BINARY_DIR=<llvm build dir>.")
+  endif()
+endforeach()
+
 target_include_directories(hotswap-loader PRIVATE
   "${HOTSWAP_AMDGPU_SRC_DIR}"
   "${HOTSWAP_AMDGPU_SRC_DIR}/Utils"
-  "${LLVM_BINARY_DIR}/lib/Target/AMDGPU"
+  "${HOTSWAP_AMDGPU_GEN_DIR}"
   "${HOTSWAP_COMGR_BINARY_DIR}/include"
 )
 

--- a/amd/comgr/src/hotswap/raiser/CMakeLists.txt
+++ b/amd/comgr/src/hotswap/raiser/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.20)
-project(hotswap-raiser LANGUAGES CXX)
+
+# No project() here: this is an add_subdirectory component of amd_comgr, not a
+# standalone build. A nested project() re-runs the superbuild dependency provider
+# and re-imports LLVM, which links a second copy of the AMDGPU static libraries
+# into amd_comgr and double-registers their cl::opts under a non-folding linker.
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -138,4 +138,13 @@ add_custom_target(test-unit
   COMMAND $<TARGET_FILE:LoggerTests>)
 add_dependencies(test-unit HotswapElfTests HotswapMCTests HotswapProfileTests
   RaiserScaffoldingTests DemangleSymbolNameTest LoggerTests)
+
+# DecoderTests builds only when the hotswap decoder library is present
+# (COMGR_ENABLE_HOTSWAP_TRANSPILE); run it under test-unit when it does.
+if(TARGET DecoderTests)
+  add_custom_command(TARGET test-unit POST_BUILD
+    COMMAND $<TARGET_FILE:DecoderTests>)
+  add_dependencies(test-unit DecoderTests)
+endif()
+
 add_dependencies(check-comgr test-unit)

--- a/amd/comgr/test-unit/hotswap/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/CMakeLists.txt
@@ -1,2 +1,8 @@
 add_subdirectory(rewriter)
 add_subdirectory(raiser)
+
+# The decoder unit tests link the hotswap::decoder library, which only exists
+# when COMGR_ENABLE_HOTSWAP_TRANSPILE is on; skip them otherwise.
+if(TARGET hotswap::decoder)
+  add_subdirectory(decoder)
+endif()

--- a/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
+++ b/amd/comgr/test-unit/hotswap/decoder/CMakeLists.txt
@@ -1,0 +1,31 @@
+# Unit tests for the hotswap decoder (AMDGPU MC stack, canonical-op identity,
+# ISA profile, and the decoded-instruction model).
+
+# -- DecoderTests -------------------------------------------------------------
+#
+# Links the hotswap::decoder OBJECT library, which carries the AMDGPU MC/CodeGen
+# LLVM components as PUBLIC usage requirements; initMCState registers the target
+# itself, so the test needs no separate target-init step.
+
+add_executable(DecoderTests
+  DecoderTest.cpp)
+
+target_link_libraries(DecoderTests PRIVATE
+  ${COMGR_GTEST_LIBS}
+  hotswap::decoder
+  hotswap::common
+  ${LLVM_PTHREAD_LIB})
+
+target_include_directories(DecoderTests PRIVATE
+  ${LLVM_INCLUDE_DIRS}
+  ${PROJECT_SOURCE_DIR}/src
+  ${COMGR_GTEST_INCLUDE_DIRS}
+  $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>)
+
+comgr_configure_test_target(DecoderTests)
+
+# The decoder headers this test includes are built as C++20 by the
+# hotswap::decoder library; match it (comgr_configure_test_target pins C++17).
+set_target_properties(DecoderTests PROPERTIES
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON)

--- a/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
+++ b/amd/comgr/test-unit/hotswap/decoder/DecoderTest.cpp
@@ -1,0 +1,213 @@
+//===- DecoderTest.cpp - Hotswap transpiler decoder unit tests ------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Unit tests for the decoder library: the AMDGPU MC stack (mc-state), the
+// architecture-neutral instruction identity (canonical-op), the per-subtarget
+// capability queries (isa-profile), and the decoded-instruction model
+// (decoded-inst). Each exercises the piece directly, without a code object or
+// the raiser, so the coverage matches what the decoder alone provides.
+//
+//===----------------------------------------------------------------------===//
+
+#include "hotswap/decoder/canonical-op.h"
+#include "hotswap/decoder/decoded-inst.h"
+#include "hotswap/decoder/isa-profile.h"
+#include "hotswap/decoder/mc-state.h"
+
+#include "llvm/MC/MCDisassembler/MCDisassembler.h"
+#include "llvm/MC/MCExpr.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdint>
+#include <mutex>
+
+using namespace COMGR::hotswap;
+
+// initMCState registers the AMDGPU target through COMGR::ensureLLVMInitialized,
+// whose production definition lives in libamd_comgr. Provide the registration
+// here so the test binary stays minimal instead of linking the full Comgr.
+namespace COMGR {
+void ensureLLVMInitialized() {
+  static std::once_flag Once;
+  std::call_once(Once, [] {
+    LLVMInitializeAMDGPUTargetInfo();
+    LLVMInitializeAMDGPUTargetMC();
+    LLVMInitializeAMDGPUDisassembler();
+    LLVMInitializeAMDGPUAsmParser();
+    LLVMInitializeAMDGPUAsmPrinter();
+    LLVMInitializeAMDGPUTarget();
+  });
+}
+} // namespace COMGR
+
+namespace {
+
+// Real gfx942 encodings (from `llvm-mc -mcpu=gfx942 -show-encoding`), decoded
+// through the MCState disassembler so the mnemonic helpers run on genuine
+// MCInsts rather than hand-built ones.
+constexpr uint8_t SMovB32Bytes[] = {0x80, 0x00, 0x80, 0xbe}; // s_mov_b32 s0, 0
+constexpr uint8_t SEndpgmBytes[] = {0x00, 0x00, 0x81, 0xbf}; // s_endpgm
+constexpr uint8_t VMovB32Bytes[] = {0x80, 0x02, 0x00,
+                                    0x7e}; // v_mov_b32_e32 v0, 0
+
+// Holds one gfx942 MCState for the tests that need the disassembler or an
+// MCContext. initMCState registers the AMDGPU target itself, so no separate
+// target-init step is required.
+class DecoderTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    llvm::Expected<MCState> StateOrErr = initMCState("gfx942");
+    ASSERT_TRUE(static_cast<bool>(StateOrErr))
+        << llvm::toString(StateOrErr.takeError());
+    State = std::move(*StateOrErr);
+  }
+
+  // Decode a single instruction from `Bytes` into `Inst`.
+  void decode(llvm::ArrayRef<uint8_t> Bytes, llvm::MCInst &Inst) {
+    uint64_t Size = 0;
+    llvm::MCDisassembler::DecodeStatus Status = State.Disasm->getInstruction(
+        Inst, Size, Bytes, /*Address=*/0, llvm::nulls());
+    ASSERT_EQ(Status, llvm::MCDisassembler::Success);
+    EXPECT_EQ(Size, Bytes.size());
+  }
+
+  MCState State;
+};
+
+TEST_F(DecoderTest, InitMCStatePopulatesEveryMember) {
+  EXPECT_NE(State.Target, nullptr);
+  EXPECT_NE(State.InstrInfo, nullptr);
+  EXPECT_NE(State.RegInfo, nullptr);
+  EXPECT_NE(State.SubtargetInfo, nullptr);
+  EXPECT_NE(State.AsmInfo, nullptr);
+  EXPECT_NE(State.Ctx, nullptr);
+  EXPECT_NE(State.Disasm, nullptr);
+  EXPECT_NE(State.Printer, nullptr);
+}
+
+TEST_F(DecoderTest, MnemonicHelpersOnScalarMove) {
+  llvm::MCInst Inst;
+  decode(SMovB32Bytes, Inst);
+  EXPECT_EQ(getMnemonic(State, Inst), "s_mov_b32");
+  EXPECT_EQ(strippedMnemonic(State, Inst), "s_mov_b32");
+  EXPECT_EQ(printInst(State, Inst), "s_mov_b32 s0, 0");
+}
+
+TEST_F(DecoderTest, MnemonicHelpersOnProgramEnd) {
+  llvm::MCInst Inst;
+  decode(SEndpgmBytes, Inst);
+  EXPECT_EQ(getMnemonic(State, Inst), "s_endpgm");
+  EXPECT_EQ(strippedMnemonic(State, Inst), "s_endpgm");
+}
+
+TEST_F(DecoderTest, StrippedMnemonicDropsEncodingSuffix) {
+  llvm::MCInst Inst;
+  decode(VMovB32Bytes, Inst);
+  // The printer keeps the `_e32` encoding suffix; strippedMnemonic drops it so
+  // the raiser dispatches on the bare mnemonic.
+  EXPECT_EQ(getMnemonic(State, Inst), "v_mov_b32_e32");
+  EXPECT_EQ(strippedMnemonic(State, Inst), "v_mov_b32");
+}
+
+TEST_F(DecoderTest, EvalOperandAsConstFoldsExpr) {
+  llvm::MCInst Inst;
+  Inst.addOperand(llvm::MCOperand::createImm(7));
+  Inst.addOperand(llvm::MCOperand::createExpr(
+      llvm::MCConstantExpr::create(42, *State.Ctx)));
+  Inst.addOperand(llvm::MCOperand::createReg(1));
+
+  EXPECT_EQ(evalOperandAsConst(Inst, 0), 7);
+  EXPECT_EQ(evalOperandAsConst(Inst, 1), 42);
+  EXPECT_EQ(evalOperandAsConst(Inst, 2), std::nullopt); // register: not const
+  EXPECT_EQ(evalOperandAsConst(Inst, 3), std::nullopt); // out of range
+}
+
+// -- canonical-op -------------------------------------------------------------
+
+TEST(CanonicalOp, NameRoundTrip) {
+  EXPECT_EQ(canonicalOpName(CanonicalOp::Unknown), "Unknown");
+  EXPECT_EQ(canonicalOpName(CanonicalOp::S_MOV_B32), "S_MOV_B32");
+  EXPECT_EQ(canonicalOpName(CanonicalOp::S_ENDPGM), "S_ENDPGM");
+}
+
+TEST(CanonicalOp, EveryValueIsNamed) {
+  for (uint16_t I = 0;
+       I < static_cast<uint16_t>(CanonicalOp::CanonicalOp_COUNT); ++I)
+    EXPECT_FALSE(canonicalOpName(static_cast<CanonicalOp>(I)).empty());
+}
+
+// -- stripEncoding (pure string helper) ---------------------------------------
+
+TEST(StripEncoding, DropsKnownSuffixes) {
+  EXPECT_EQ(stripEncoding("v_mov_b32_e32"), "v_mov_b32");
+  EXPECT_EQ(stripEncoding("v_add_f32_e64"), "v_add_f32");
+  EXPECT_EQ(stripEncoding("v_cvt_f32_i32_vi"), "v_cvt_f32_i32");
+}
+
+TEST(StripEncoding, LeavesUnsuffixedUnchanged) {
+  EXPECT_EQ(stripEncoding("s_mov_b32"), "s_mov_b32");
+  EXPECT_EQ(stripEncoding("s_endpgm"), "s_endpgm");
+}
+
+// -- isa-profile --------------------------------------------------------------
+
+TEST_F(DecoderTest, ISAProfileGfx942) {
+  ISAProfile Profile = ISAProfile::fromSubtarget(*State.SubtargetInfo);
+  EXPECT_EQ(Profile.waveSize(), 64u);
+  EXPECT_FALSE(Profile.isWave32());
+  EXPECT_TRUE(Profile.hasValidWaveSize());
+  EXPECT_TRUE(Profile.hasAgpr());
+  EXPECT_FALSE(Profile.hasGfx125UserSgprCountField());
+}
+
+TEST_F(DecoderTest, ISAProfileGfx1250) {
+  llvm::Expected<std::unique_ptr<llvm::MCSubtargetInfo>> STIOrErr =
+      buildSubtargetInfo(*State.Target, "gfx1250");
+  ASSERT_TRUE(static_cast<bool>(STIOrErr))
+      << llvm::toString(STIOrErr.takeError());
+  ISAProfile Profile = ISAProfile::fromSubtarget(**STIOrErr);
+  EXPECT_EQ(Profile.waveSize(), 32u);
+  EXPECT_TRUE(Profile.isWave32());
+  EXPECT_TRUE(Profile.hasValidWaveSize());
+  EXPECT_FALSE(Profile.hasAgpr());
+  EXPECT_TRUE(Profile.hasGfx125UserSgprCountField());
+}
+
+// -- decoded-inst bitfields ---------------------------------------------------
+
+TEST(DecodedInstFlags, SizeAndCondRegBitsAreIndependent) {
+  DecodedInst Di;
+  EXPECT_EQ(Di.sizeInBytes(), 0u);
+  EXPECT_FALSE(Di.defsScc());
+  EXPECT_FALSE(Di.defsVcc());
+  EXPECT_FALSE(Di.defsExec());
+
+  // The size field is 5 bits; 20 is the AMDGPU maximum instruction length.
+  Di.setSizeInBytes(20);
+  Di.setDefsScc(true);
+  Di.setDefsExec(true);
+  EXPECT_EQ(Di.sizeInBytes(), 20u);
+  EXPECT_TRUE(Di.defsScc());
+  EXPECT_FALSE(Di.defsVcc());
+  EXPECT_TRUE(Di.defsExec());
+
+  // Toggling one condition-register bit leaves the size and the others intact.
+  Di.setDefsVcc(true);
+  Di.setDefsScc(false);
+  EXPECT_EQ(Di.sizeInBytes(), 20u);
+  EXPECT_FALSE(Di.defsScc());
+  EXPECT_TRUE(Di.defsVcc());
+  EXPECT_TRUE(Di.defsExec());
+}
+
+} // namespace


### PR DESCRIPTION
Stacked on #3536; base it there once that merges. Until then this targets
`amd-staging`, so its diff also contains #3536's commit -- review commit
`d8ffb28634f0`.

The raiser dispatches on an architecture-neutral instruction identity rather
than on raw AMDGPU MC opcodes, whose numbering differs across subtargets.
`canonical-op` is that enum: it names only instructions the raiser can lift and
maps every other MC opcode to `Unknown`, so the enum never claims coverage the
raiser does not have. It seeds with the scalar move and program-end lifted
first.

`mc-state` stands up the per-ISA AMDGPU MC stack from LLVM (target, instr / reg
/ subtarget info, disassembler, inst printer) for a bare processor name such as
`gfx942`, and `decoded-inst` is the per-instruction model the decoder populates.
