### PR TITLE
[clang] Remove dead NVPTX OpenMPLinker to converge Cuda.h with trunk

### DIFF
--- a/clang/lib/Driver/ToolChains/Cuda.h
+++ b/clang/lib/Driver/ToolChains/Cuda.h
@@ -66,22 +66,10 @@ public:
                     const char *LinkingOutput) const override;
 };
 
-class LLVM_LIBRARY_VISIBILITY OpenMPLinker : public Tool {
- public:
-   OpenMPLinker(const ToolChain &TC)
-       : Tool("NVPTX::OpenMPLinker", "nvlink", TC) {}
-       
-   bool hasIntegratedCPP() const override { return false; }
-
-   void ConstructJob(Compilation &C, const JobAction &JA,
-                     const InputInfo &Output, const InputInfoList &Inputs,
-                     const llvm::opt::ArgList &TCArgs,
-                     const char *LinkingOutput) const override;
-};
-
 void getNVPTXTargetFeatures(const Driver &D, const llvm::Triple &Triple,
                             const llvm::opt::ArgList &Args,
                             std::vector<StringRef> &Features);
+
 } // end namespace NVPTX
 } // end namespace tools
 


### PR DESCRIPTION
NVPTX::OpenMPLinker was declared in Cuda.h but never defined or instantiated, and does not exist upstream. Removing the dead class (and restoring the trunk blank line before the namespace close) eliminates the residual Cuda.h divergence attributed to the prior nfc-cleanup commits.


