### PR TITLE
[Comgr] Guard spirv-to-reloc-debuginfo test on clang debuginfo-CFI support

### DIFF
--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -1,5 +1,7 @@
 import os
 import platform
+import subprocess
+import tempfile
 
 import lit.formats
 
@@ -20,6 +22,33 @@ if config.comgr_spirv_translator_available:
     config.available_features.add("comgr-has-spirv-translator")
 if config.comgr_amdgpu_target_available:
     config.available_features.add("comgr-has-amdgpu-target")
+
+# spirv-to-reloc-debuginfo checks that comgr forwards
+# -amdgpu-spill-cfi-saved-regs, which the AMD clang driver embeds for -g
+# amdgcnspirv compiles. That is an AMD downstream driver diff (not upstream),
+# so probe the driver and guard the test; builds whose clang lacks it skip.
+def _clang_embeds_debuginfo_cfi():
+    clang = os.path.join(config.llvm_tools_dir, "clang")
+    if not os.path.exists(clang):
+        return False
+    src = None
+    try:
+        fd, src = tempfile.mkstemp(suffix=".hip")
+        os.write(fd, b"__attribute__((global)) void k(float *p) { *p = 1.0f; }\n")
+        os.close(fd)
+        out = subprocess.run(
+            [clang, "-x", "hip", "--offload-arch=amdgcnspirv", "-nogpulib",
+             "-nogpuinc", "--offload-device-only", "-O3", "-g", "-c", "-###", src],
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=120)
+        return b"amdgpu-spill-cfi-saved-regs" in out.stdout
+    except Exception:
+        return False
+    finally:
+        if src and os.path.exists(src):
+            os.unlink(src)
+
+if _clang_embeds_debuginfo_cfi():
+    config.available_features.add("comgr-clang-embeds-debuginfo-cfi")
 
 if platform.system() == "Windows":
     config.available_features.add("system-windows")

--- a/amd/comgr/test-lit/lit.cfg.py
+++ b/amd/comgr/test-lit/lit.cfg.py
@@ -23,6 +23,7 @@ if config.comgr_spirv_translator_available:
 if config.comgr_amdgpu_target_available:
     config.available_features.add("comgr-has-amdgpu-target")
 
+
 # spirv-to-reloc-debuginfo checks that comgr forwards
 # -amdgpu-spill-cfi-saved-regs, which the AMD clang driver embeds for -g
 # amdgcnspirv compiles. That is an AMD downstream driver diff (not upstream),
@@ -37,15 +38,31 @@ def _clang_embeds_debuginfo_cfi():
         os.write(fd, b"__attribute__((global)) void k(float *p) { *p = 1.0f; }\n")
         os.close(fd)
         out = subprocess.run(
-            [clang, "-x", "hip", "--offload-arch=amdgcnspirv", "-nogpulib",
-             "-nogpuinc", "--offload-device-only", "-O3", "-g", "-c", "-###", src],
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=120)
+            [
+                clang,
+                "-x",
+                "hip",
+                "--offload-arch=amdgcnspirv",
+                "-nogpulib",
+                "-nogpuinc",
+                "--offload-device-only",
+                "-O3",
+                "-g",
+                "-c",
+                "-###",
+                src,
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=120,
+        )
         return b"amdgpu-spill-cfi-saved-regs" in out.stdout
     except Exception:
         return False
     finally:
         if src and os.path.exists(src):
             os.unlink(src)
+
 
 if _clang_embeds_debuginfo_cfi():
     config.available_features.add("comgr-clang-embeds-debuginfo-cfi")

--- a/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
+++ b/amd/comgr/test-lit/spirv-tests/spirv-to-reloc-debuginfo.hip
@@ -1,4 +1,5 @@
 // REQUIRES: comgr-has-spirv-translator
+// REQUIRES: comgr-clang-embeds-debuginfo-cfi
 
 // COM: Generate a debuginfo SPIR-V file from a HIP kernel
 // RUN: %clang -x hip --offload-arch=amdgcnspirv -nogpulib -nogpuinc \


### PR DESCRIPTION
`spirv-tests/spirv-to-reloc-debuginfo.hip` checks that comgr forwards `-mllvm -amdgpu-spill-cfi-saved-regs`. comgr only forwards it if the flag is present in the SPIR-V's embedded command-line metadata, which the **clang driver** writes during the `-g --offload-arch=amdgcnspirv` generation step (`RUN` line 1).

That embedding is an **AMD downstream clang-driver diff** (`clang/lib/Driver/ToolChains/Clang.cpp`, `HIPAMD.cpp`; listed in `README_amd_driver_trunk_diffs`) — it is **not in upstream LLVM**. So a toolchain whose clang lacks that diff never embeds the flag → the `CHECK-DBG` line can't match → the test hard-fails, even though comgr's forwarding logic is correct.

Add a `comgr-clang-embeds-debuginfo-cfi` lit feature that probes the driver (`clang -###` of the test's own `-g amdgcnspirv` command, grep for the flag) and `REQUIRES:` it on the test. Builds whose clang embeds the flag run and pass it; builds without it skip (`UNSUPPORTED`) instead of failing. Same feature-gating pattern as the other `comgr-has-*` guards.
