### PR TITLE
[RegAlloc] Drop blank-line divergence in allocVirtRegUndef

### DIFF
--- a/llvm/lib/CodeGen/RegAllocFast.cpp
+++ b/llvm/lib/CodeGen/RegAllocFast.cpp
@@ -1014,7 +1014,6 @@ void RegAllocFastImpl::allocVirtReg(MachineInstr &MI, LiveReg &LR,
 void RegAllocFastImpl::allocVirtRegUndef(MachineOperand &MO) {
   assert(MO.isUndef() && "expected undef use");
   Register VirtReg = MO.getReg();
-
   assert(VirtReg.isVirtual() && "Expected virtreg");
   if (!shouldAllocateRegister(VirtReg))
     return;


### PR DESCRIPTION
Remove a stray blank line in RegAllocFastImpl::allocVirtRegUndef that diverges from trunk. No functional change.


