### PR TITLE
[comgr][hotswap] Share conservative liveness state

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -227,11 +227,9 @@ LLVM_ATTRIBUTE_WEAK CFG buildCfg(ArrayRef<InternalDecodedInst> Decoded,
 LLVM_ATTRIBUTE_WEAK LivenessInfo computeLiveness(
     ArrayRef<InternalDecodedInst> Decoded, const CFG &, const MCInstrInfo &,
     const MCRegisterInfo &, unsigned MaxVgprs) {
+  (void)Decoded;
   LivenessInfo Info;
-  BitVector AllLive(MaxVgprs);
-  AllLive.set(0, MaxVgprs);
-  Info.LiveBefore.resize(Decoded.size(), AllLive);
-  Info.LiveAfter.resize(Decoded.size(), AllLive);
+  Info.setConservativeAllLive(MaxVgprs);
   Info.Converged = true;
   return Info;
 }
@@ -2270,12 +2268,7 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
   if (!Liveness.Converged) {
     log() << "hotswap: error: liveness analysis did not converge, using "
           << "conservative all-VGPRs-live fallback\n";
-    BitVector AllVgprs(Config.MaxVgprs);
-    AllVgprs.set(0, Config.MaxVgprs);
-    for (size_t I = 0, LE = Liveness.LiveBefore.size(); I < LE; ++I) {
-      Liveness.LiveBefore[I] = AllVgprs;
-      Liveness.LiveAfter[I] = AllVgprs;
-    }
+    Liveness.setConservativeAllLive(Config.MaxVgprs);
   }
 
   StringMap<KernelPatchStats> KernelStats;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -996,14 +996,63 @@ struct CFG {
   llvm::DenseMap<uint64_t, unsigned> OffsetToBlock;
 };
 
-/// Dataflow-liveness result for a kernel's VGPR set. \c LiveBefore[i] and
-/// \c LiveAfter[i] are the live-in / live-out bitvectors for Decoded[i].
+/// Dataflow-liveness result for a kernel's VGPR set. Per-instruction live-in
+/// and live-out bitvectors are accessed through \c liveBefore and \c liveAfter.
+/// Conservative mode replaces those arrays with one shared all-live vector,
+/// avoiding two identical BitVector allocations per decoded instruction in the
+/// weak fallback solver.
 /// \c Converged is false when the iterative solver hit its iteration cap;
 /// callers fall back to a conservative all-VGPRs-live analysis in that case.
 struct LivenessInfo {
+  bool Converged = false;
+
+  const llvm::BitVector &liveBefore(size_t Index) const {
+    if (IsConservative)
+      return ConservativeAllLive;
+    assert(Index < LiveBefore.size() &&
+           "live-before instruction index out of range");
+    return LiveBefore[Index];
+  }
+
+  const llvm::BitVector &liveAfter(size_t Index) const {
+    if (IsConservative)
+      return ConservativeAllLive;
+    assert(Index < LiveAfter.size() &&
+           "live-after instruction index out of range");
+    return LiveAfter[Index];
+  }
+
+  void setPerInstructionLiveness(std::vector<llvm::BitVector> Before,
+                                 std::vector<llvm::BitVector> After) {
+    assert(Before.size() == After.size() &&
+           "live-before and live-after sizes must match");
+    LiveBefore = std::move(Before);
+    LiveAfter = std::move(After);
+    ConservativeAllLive.clear();
+    IsConservative = false;
+  }
+
+  void setConservativeAllLive(unsigned MaxVgprs) {
+    LiveBefore.clear();
+    LiveAfter.clear();
+    ConservativeAllLive.resize(MaxVgprs);
+    ConservativeAllLive.set(0, MaxVgprs);
+    IsConservative = true;
+  }
+
+  bool usesConservativeAllLive() const { return IsConservative; }
+
+  size_t perInstructionCount() const {
+    assert(LiveBefore.size() == LiveAfter.size() &&
+           "live-before and live-after sizes must match");
+    return LiveBefore.size();
+  }
+
+private:
   std::vector<llvm::BitVector> LiveBefore;
   std::vector<llvm::BitVector> LiveAfter;
-  bool Converged = false;
+  llvm::BitVector ConservativeAllLive;
+  bool IsConservative = false;
 };
 
 /// Allocates scratch VGPRs for a patch point, preferring to reuse dead slots

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -191,7 +191,7 @@ ScratchAllocation allocateScratch(PatchContext &Ctx, size_t Idx) {
   std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
       KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
   unsigned VgprKdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
-  VgprAllocator VgprAlloc(Ctx.Liveness.LiveBefore[Idx], VgprKdCount,
+  VgprAllocator VgprAlloc(Ctx.Liveness.liveBefore(Idx), VgprKdCount,
                           Ctx.Config.MaxVgprs);
 
   std::optional<unsigned> KdSgprs = Ctx.Elf.getKernelSgprCount(KernelName);

--- a/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-trampoline.cpp
@@ -692,7 +692,7 @@ std::optional<ScratchAlloc> tryAllocScratchVgpr(PatchContext &Ctx, size_t Idx) {
           KernelName, getKernelVgprGranuleSize(Ctx, KernelName)))
     KdVgprs = *Opt;
 
-  VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdVgprs,
+  VgprAllocator Alloc(Ctx.Liveness.liveBefore(Idx), KdVgprs,
                       Ctx.Config.MaxVgprs);
   std::optional<unsigned> ScratchOpt = Alloc.alloc();
   if (!ScratchOpt)

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -359,7 +359,7 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
       KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
   unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
 
-  VgprAllocator Alloc(Ctx.Liveness.LiveBefore[Idx], KdCount,
+  VgprAllocator Alloc(Ctx.Liveness.liveBefore(Idx), KdCount,
                       Ctx.Config.MaxVgprs);
 
   // Four block-32 scale VGPRs (A/B x low/high) plus one byte-extraction temp,

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -3480,3 +3480,46 @@ TEST(DecodeCache, TruncatedFinalWindowDecodesWithoutStaleHit) {
   // Stream consumed exactly (no over-run).
   EXPECT_EQ(Consumed, Text.size());
 }
+
+TEST(LivenessInfo, ConservativeFallbackSharesOneAllLiveVector) {
+  LivenessInfo Info;
+  std::vector<llvm::BitVector> Before(3, llvm::BitVector(64));
+  std::vector<llvm::BitVector> After(3, llvm::BitVector(64));
+  Info.setPerInstructionLiveness(std::move(Before), std::move(After));
+  ASSERT_EQ(Info.perInstructionCount(), 3u);
+
+  Info.setConservativeAllLive(/*MaxVgprs=*/64);
+
+  EXPECT_TRUE(Info.usesConservativeAllLive());
+  EXPECT_EQ(Info.perInstructionCount(), 0u);
+  ASSERT_EQ(Info.liveBefore(0).size(), 64u);
+  EXPECT_TRUE(Info.liveBefore(0).all());
+  EXPECT_EQ(&Info.liveBefore(0), &Info.liveBefore(1));
+  EXPECT_EQ(&Info.liveBefore(1), &Info.liveAfter(2));
+}
+
+TEST(LivenessInfo, PerInstructionAccessorsReturnIndexedVectors) {
+  LivenessInfo Info;
+  std::vector<llvm::BitVector> Before(3, llvm::BitVector(64));
+  std::vector<llvm::BitVector> After(3, llvm::BitVector(64));
+  Before[1].set(7);
+  After[2].set(9);
+  Info.setPerInstructionLiveness(std::move(Before), std::move(After));
+
+  EXPECT_FALSE(Info.usesConservativeAllLive());
+  EXPECT_EQ(Info.perInstructionCount(), 3u);
+  EXPECT_FALSE(Info.liveBefore(0).test(7));
+  EXPECT_TRUE(Info.liveBefore(1).test(7));
+  EXPECT_TRUE(Info.liveAfter(2).test(9));
+  EXPECT_NE(&Info.liveBefore(0), &Info.liveBefore(1));
+}
+
+TEST(LivenessInfo, ZeroVgprConservativeModeIsExplicit) {
+  LivenessInfo Info;
+  Info.setConservativeAllLive(/*MaxVgprs=*/0);
+
+  EXPECT_TRUE(Info.usesConservativeAllLive());
+  EXPECT_EQ(Info.perInstructionCount(), 0u);
+  EXPECT_TRUE(Info.liveBefore(0).empty());
+  EXPECT_EQ(&Info.liveBefore(0), &Info.liveAfter(0));
+}


### PR DESCRIPTION
Reuse one all-live fallback vector across patch sites instead of rebuilding it for every query.

DeepSeek V4 Flash (110 code objects, ten runs):
CPU: 12.3 s -> 12.0 s (1.03x)
Peak RSS: 1.72 GiB -> 747 MiB (-57.5%)

Outputs are byte-identical.