### PR TITLE
[comgr][hotswap] Size set-PC gateways without assembly

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -447,12 +447,57 @@ std::optional<SmallVector<uint8_t>> encodeSetPCLongBranch(const LLVMState &LS,
   return Bytes;
 }
 
+static bool isSetPcDeltaInline(uint64_t Delta) {
+  int64_t SignedDelta = static_cast<int64_t>(Delta);
+  if (SignedDelta >= -16 && SignedDelta <= 64)
+    return true;
+
+  // AMDGPU::isInlinableLiteral64 is target-internal and unavailable to
+  // standalone COMGR builds. Keep this mirror in sync with it. HotSwap only
+  // invokes this gfx1250 path, whose subtarget includes the inv2pi inline
+  // immediate.
+  switch (Delta) {
+  case 0x3ff0000000000000ULL: // 1.0
+  case 0xbff0000000000000ULL: // -1.0
+  case 0x3fe0000000000000ULL: // 0.5
+  case 0xbfe0000000000000ULL: // -0.5
+  case 0x4000000000000000ULL: // 2.0
+  case 0xc000000000000000ULL: // -2.0
+  case 0x4010000000000000ULL: // 4.0
+  case 0xc010000000000000ULL: // -4.0
+  case 0x3fc45f306dc9c882ULL: // 1 / (2 * pi)
+    return true;
+  default:
+    return false;
+  }
+}
+
+static std::optional<uint32_t>
+getSetPcLongBranchLayoutSize(uint64_t FromOffset, uint64_t TargetOffset) {
+  std::optional<uint64_t> PcBase = checkedAddUint64(
+      FromOffset, MinInstSize, "set-PC long branch layout PC base");
+  if (!PcBase)
+    return std::nullopt;
+  uint64_t Delta = TargetOffset - *PcBase;
+
+  // This model is gfx1250-specific. s_get_pc_i64 and s_set_pc_i64 each occupy
+  // one dword. The intervening s_add_nc_u64 occupies one dword for an inline
+  // immediate, two for a non-negative signed-32-bit literal, and three for a
+  // 64-bit literal.
+  if (isSetPcDeltaInline(Delta))
+    return 3 * MinInstSize;
+  if (Delta <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max()))
+    return 4 * MinInstSize;
+  return SetPcReturnReserveBytes;
+}
+
 Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
                         unsigned SgprBase) {
   NopSled *Best = nullptr;
-  SmallVector<uint8_t> BestBytes;
+  uint32_t BestLayoutSize = 0;
+  uint64_t BestUsableEnd = 0;
   uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
   for (NopSled &Sled : Gateways) {
     if (FromOffset < Sled.FunctionStart || FromOffset >= Sled.FunctionEnd)
@@ -465,22 +510,37 @@ findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
     if (Distance >= MaxSledDistance || Distance >= BestDistance ||
         LS.encodeSBranch(FromOffset, Sled.WritePos).empty())
       continue;
-    std::optional<SmallVector<uint8_t>> Bytes =
-        encodeSetPCLongBranch(LS, Sled.WritePos, TargetOffset, SgprBase);
-    if (!Bytes)
+
+    std::optional<uint32_t> LayoutSize =
+        getSetPcLongBranchLayoutSize(Sled.WritePos, TargetOffset);
+    if ((SgprBase & 1u) != 0 || !LayoutSize)
       return createStringError(
           Twine("failed to encode set-PC gateway at candidate offset 0x") +
           utohexstr(Sled.WritePos));
-    if (Bytes->size() > UsableEnd - Sled.WritePos)
+    if (*LayoutSize > UsableEnd - Sled.WritePos)
       continue;
+
     Best = &Sled;
-    BestBytes = std::move(*Bytes);
+    BestLayoutSize = *LayoutSize;
+    BestUsableEnd = UsableEnd;
     BestDistance = Distance;
   }
   if (!Best)
     return std::nullopt;
+  std::optional<SmallVector<uint8_t>> BestBytes =
+      encodeSetPCLongBranch(LS, Best->WritePos, TargetOffset, SgprBase);
+  if (!BestBytes)
+    return createStringError(
+        Twine("failed to encode set-PC gateway at candidate offset 0x") +
+        utohexstr(Best->WritePos));
+  if (BestBytes->size() != BestLayoutSize ||
+      BestBytes->size() > BestUsableEnd - Best->WritePos)
+    return createStringError(
+        Twine("set-PC gateway layout mismatch at candidate offset 0x") +
+        utohexstr(Best->WritePos) + ": predicted " + Twine(BestLayoutSize) +
+        " bytes, encoded " + Twine(BestBytes->size()) + " bytes");
   return std::optional<EncodedSetPcGateway>(
-      EncodedSetPcGateway{Best, std::move(BestBytes)});
+      EncodedSetPcGateway{Best, std::move(*BestBytes)});
 }
 
 static std::optional<unsigned> numberedSgprIndex(const MCRegisterInfo &MRI,
@@ -1917,17 +1977,18 @@ countReachableSetPcGatewaySlots(ArrayRef<NopSled> Gateways, const LLVMState &LS,
       if (Distance >= MaxSledDistance ||
           LS.encodeSBranch(FromOffset, Candidate).empty())
         break;
-      std::optional<SmallVector<uint8_t>> Bytes =
-          encodeSetPCLongBranch(LS, Candidate, TargetOffset, SgprBase);
-      if (!Bytes)
+
+      std::optional<uint32_t> LayoutSize =
+          getSetPcLongBranchLayoutSize(Candidate, TargetOffset);
+      if ((SgprBase & 1u) != 0 || !LayoutSize)
         return createStringError(
-            Twine("failed to encode set-PC gateway while counting candidate "
+            Twine("invalid set-PC gateway while counting candidate "
                   "offset 0x") +
             utohexstr(Candidate));
-      if (Bytes->size() > UsableEnd - Candidate)
+      if (*LayoutSize > UsableEnd - Candidate)
         break;
       ++Slots;
-      Candidate += Bytes->size();
+      Candidate += *LayoutSize;
     }
     if (Slots == MaxSlots)
       break;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1290,16 +1290,17 @@ struct EncodedSetPcGateway {
 };
 
 /// Find the nearest short-branch-reachable gateway whose remaining space fits
-/// the set-PC sequence encoded for that candidate's address. The returned
-/// plan does not advance the sled or modify text.
+/// the set-PC sequence. Candidate widths are computed from the displacement;
+/// only the selected candidate is encoded. The returned plan does not advance
+/// the sled or modify text.
 llvm::Expected<std::optional<EncodedSetPcGateway>>
 findNearestSetPcGateway(std::vector<NopSled> &Gateways, const LLVMState &LS,
                         uint64_t FromOffset, uint64_t TargetOffset,
                         unsigned SgprBase);
 
 /// Count set-PC gateway slots reachable from \p FromOffset, up to \p MaxSlots.
-/// Zero means that no candidate fits; an Error means that a reachable
-/// candidate could not be encoded.
+/// Candidate widths are computed without assembly. Zero means that no
+/// candidate fits; an Error means that a reachable candidate is invalid.
 llvm::Expected<uint64_t> countReachableSetPcGatewaySlots(
     llvm::ArrayRef<NopSled> Gateways, const LLVMState &LS, uint64_t FromOffset,
     uint64_t TargetOffset, unsigned SgprBase, uint64_t MaxSlots);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -533,6 +533,61 @@ TEST(FindNearestSetPcGateway, DistinguishesNoFitFromEncodingFailure) {
             std::string::npos);
 }
 
+TEST(FindNearestSetPcGateway, AnalyticalWidthsMatchEncodedBoundaries) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  struct WidthCase {
+    uint64_t Delta;
+    uint32_t ExpectedSize;
+  };
+  constexpr WidthCase Cases[] = {
+      {static_cast<uint64_t>(-16), 12},
+      {0, 12},
+      {64, 12},
+      {65, 16},
+      {static_cast<uint64_t>(std::numeric_limits<int32_t>::max()), 16},
+      {static_cast<uint64_t>(std::numeric_limits<int32_t>::max()) + 1, 20},
+      {static_cast<uint64_t>(-17), 20},
+      {0x3ff0000000000000ULL, 12},
+      {0xbff0000000000000ULL, 12},
+      {0x3fe0000000000000ULL, 12},
+      {0xbfe0000000000000ULL, 12},
+      {0x4000000000000000ULL, 12},
+      {0xc000000000000000ULL, 12},
+      {0x4010000000000000ULL, 12},
+      {0xc010000000000000ULL, 12},
+      {0x3fc45f306dc9c882ULL, 12},
+  };
+
+  constexpr uint64_t GatewayOffset = 0x100;
+  constexpr uint64_t PcBase = GatewayOffset + MinInstSize;
+  for (const WidthCase &C : Cases) {
+    SCOPED_TRACE("delta=0x" + llvm::utohexstr(C.Delta));
+    uint64_t TargetOffset = PcBase + C.Delta;
+    std::optional<llvm::SmallVector<uint8_t>> Encoded =
+        encodeSetPCLongBranch(S, GatewayOffset, TargetOffset, /*SgprBase=*/12);
+    ASSERT_TRUE(Encoded);
+    ASSERT_EQ(Encoded->size(), C.ExpectedSize);
+
+    // Give the candidate exactly the space required by the real encoding.
+    // An analytical overestimate rejects the candidate; an underestimate is
+    // rejected by findNearestSetPcGateway's post-encode consistency check.
+    std::vector<NopSled> Gateways = {
+        {/*Start=*/GatewayOffset,
+         /*End=*/GatewayOffset + Encoded->size(),
+         /*WritePos=*/GatewayOffset,
+         /*FunctionStart=*/0,
+         /*FunctionEnd=*/std::numeric_limits<uint64_t>::max()}};
+    llvm::Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+        findNearestSetPcGateway(Gateways, S, /*FromOffset=*/0, TargetOffset,
+                                /*SgprBase=*/12);
+    ASSERT_TRUE((bool)GatewayOrErr) << llvm::toString(GatewayOrErr.takeError());
+    ASSERT_TRUE(*GatewayOrErr);
+    EXPECT_EQ((*GatewayOrErr)->Bytes.size(), Encoded->size());
+  }
+}
+
 TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -551,8 +606,22 @@ TEST(CountReachableSetPcGatewaySlots, DistinguishesZeroFromEncodingFailure) {
       /*SgprBase=*/3, /*MaxSlots=*/1);
   ASSERT_FALSE((bool)EncodingFailure);
   std::string Error = llvm::toString(EncodingFailure.takeError());
-  EXPECT_NE(Error.find("failed to encode set-PC gateway while counting"),
+  EXPECT_NE(Error.find("invalid set-PC gateway while counting"),
             std::string::npos);
+}
+
+TEST(CountReachableSetPcGatewaySlots, UsesExactWidthsWithoutEncoding) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::vector<NopSled> Gateways = {
+      {/*Start=*/0x100, /*End=*/0x130, /*WritePos=*/0x100,
+       /*FunctionStart=*/0, /*FunctionEnd=*/0x1000}};
+  llvm::Expected<uint64_t> Slots = countReachableSetPcGatewaySlots(
+      Gateways, S, /*FromOffset=*/0, /*TargetOffset=*/0x108,
+      /*SgprBase=*/12, /*MaxSlots=*/8);
+  ASSERT_TRUE((bool)Slots) << llvm::toString(Slots.takeError());
+  EXPECT_EQ(*Slots, 3u);
 }
 
 TEST(EncodeSetPCLongBranch, RejectsPcBaseOverflow) {


### PR DESCRIPTION
Select an exact-width set-PC sequence analytically and assemble only the chosen gateway.

DeepSeek V4 Flash (110 code objects, five runs):
CPU: 12.3 s -> 10.5 s (1.18x)
Peak RSS: 1.72 GiB -> 1.74 GiB (+1.3%)

Outputs are byte-identical.


