### PR TITLE
[comgr][hotswap] Cache kernel metadata in one pass

### DIFF
--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -115,6 +115,46 @@ readUnsignedMetadataNode(const msgpack::DocNode &Node, StringRef KernelName,
   return std::nullopt;
 }
 
+static std::optional<unsigned>
+readOptionalUnsignedMetadataField(msgpack::MapDocNode &KernelMap,
+                                  StringRef KernelName, StringRef Key) {
+  msgpack::DocNode::MapTy::iterator ValueIt = KernelMap.find(Key);
+  if (ValueIt == KernelMap.end())
+    return std::nullopt;
+  return readUnsignedMetadataNode(ValueIt->second, KernelName, Key,
+                                  "metadata cache");
+}
+
+static std::optional<KernelClusterDims>
+readOptionalClusterDimsMetadataField(msgpack::MapDocNode &KernelMap,
+                                     StringRef KernelName) {
+  msgpack::DocNode::MapTy::iterator DimsIt = KernelMap.find(".cluster_dims");
+  if (DimsIt == KernelMap.end())
+    return std::nullopt;
+  if (!DimsIt->second.isArray()) {
+    log() << "hotswap: error: metadata cache: .cluster_dims for '" << KernelName
+          << "' is not an array.\n";
+    return std::nullopt;
+  }
+
+  msgpack::ArrayDocNode &Dims = DimsIt->second.getArray();
+  if (Dims.size() != 3) {
+    log() << "hotswap: error: metadata cache: .cluster_dims for '" << KernelName
+          << "' has " << Dims.size() << " entries, expected 3.\n";
+    return std::nullopt;
+  }
+
+  std::optional<unsigned> X = readUnsignedMetadataNode(
+      Dims[0], KernelName, ".cluster_dims[0]", "metadata cache");
+  std::optional<unsigned> Y = readUnsignedMetadataNode(
+      Dims[1], KernelName, ".cluster_dims[1]", "metadata cache");
+  std::optional<unsigned> Z = readUnsignedMetadataNode(
+      Dims[2], KernelName, ".cluster_dims[2]", "metadata cache");
+  if (!X || !Y || !Z)
+    return std::nullopt;
+  return KernelClusterDims{*X, *Y, *Z};
+}
+
 using MetadataNoteMutator = function_ref<std::optional<bool>(
     msgpack::Document &, msgpack::MapDocNode &)>;
 using MetadataNoteValidator = function_ref<bool(bool)>;
@@ -782,14 +822,11 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
   // On pre-gfx10 targets, NotFound is allowed for minimal code objects without
   // AMDGPU metadata because the descriptor remains the canonical count.
 
-  if (SgprCacheState == KernelSgprCacheState::Metadata &&
+  if (MetadataCacheState == KernelMetadataCacheState::Metadata &&
       MetadataStatus == MetadataCountUpdateStatus::Found) {
-    StringMap<std::optional<unsigned>>::iterator Cached =
-        KernelSgprCountCache.find(KernelName);
-    if (Cached == KernelSgprCountCache.end())
-      KernelSgprCountCache.try_emplace(KernelName, RequiredSgprs);
-    else if (!Cached->second || RequiredSgprs > *Cached->second)
-      Cached->second = RequiredSgprs;
+    std::optional<unsigned> &Cached = KernelMetadataCache[KernelName].SgprCount;
+    if (!Cached || RequiredSgprs > *Cached)
+      Cached = RequiredSgprs;
   }
 
   if (!RequiredGranulated)
@@ -799,8 +836,8 @@ bool ElfView::updateKernelDescriptorSgprCount(StringRef KernelName,
                   *RequiredGranulated);
   std::memcpy(Kd + offsetof(hsa::kernel_descriptor_t, compute_pgm_rsrc1),
               &Rsrc1, sizeof(Rsrc1));
-  if (SgprCacheState == KernelSgprCacheState::NoMetadata)
-    KernelSgprCountCache.erase(KernelName);
+  if (MetadataCacheState == KernelMetadataCacheState::NoMetadata)
+    KernelMetadataCache.erase(KernelName);
   return true;
 }
 
@@ -817,14 +854,12 @@ bool ElfView::updateKernelMetadataSgprCounts(
     return false;
   }
 
-  if (SgprCacheState == KernelSgprCacheState::Metadata) {
+  if (MetadataCacheState == KernelMetadataCacheState::Metadata) {
     for (const StringMapEntry<unsigned> &Required : RequiredSgprs) {
-      StringMap<std::optional<unsigned>>::iterator Cached =
-          KernelSgprCountCache.find(Required.first());
-      if (Cached == KernelSgprCountCache.end())
-        KernelSgprCountCache.try_emplace(Required.first(), Required.second);
-      else if (!Cached->second || Required.second > *Cached->second)
-        Cached->second = Required.second;
+      std::optional<unsigned> &Cached =
+          KernelMetadataCache[Required.first()].SgprCount;
+      if (!Cached || Required.second > *Cached)
+        Cached = Required.second;
     }
   }
   return true;
@@ -841,6 +876,15 @@ bool ElfView::updateKernelMetadataVgprCounts(
     log() << "hotswap: error: updateKernelMetadataVgprCounts: code object "
              "has no AMDGPU metadata note.\n";
     return false;
+  }
+
+  if (MetadataCacheState == KernelMetadataCacheState::Metadata) {
+    for (const StringMapEntry<unsigned> &Required : RequiredVgprs) {
+      std::optional<unsigned> &Cached =
+          KernelMetadataCache[Required.first()].VgprCount;
+      if (!Cached || Required.second > *Cached)
+        Cached = Required.second;
+    }
   }
   return true;
 }
@@ -947,100 +991,38 @@ ElfView::getKernelVgprCount(StringRef KernelName,
   return static_cast<unsigned>(VgprCount);
 }
 
-static std::optional<unsigned> getKernelUnsignedMetadata(const ELFFileT &File,
-                                                         StringRef KernelName,
-                                                         StringRef Key,
-                                                         StringRef Context) {
-  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
-  if (!PhdrsOrErr) {
-    log() << "hotswap: error: " << Context
-          << ": failed to read program headers: "
-          << toString(PhdrsOrErr.takeError()) << "\n";
-    return std::nullopt;
-  }
-
-  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
-    if (Phdr.p_type != ELF::PT_NOTE)
-      continue;
-
-    Error Err = Error::success();
-    for (ELFT::Note Note : File.notes(Phdr, Err)) {
-      if (Note.getName() != "AMDGPU" ||
-          Note.getType() != ELF::NT_AMDGPU_METADATA)
-        continue;
-
-      ArrayRef<uint8_t> Desc = Note.getDesc(4);
-      if (Desc.empty()) {
-        log() << "hotswap: error: " << Context
-              << ": AMDGPU metadata note has an empty descriptor.\n";
-        return std::nullopt;
-      }
-
-      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
-      msgpack::Document Doc;
-      if (!Doc.readFromBlob(Blob, false)) {
-        log() << "hotswap: error: " << Context
-              << ": failed to parse AMDGPU metadata note.\n";
-        return std::nullopt;
-      }
-
-      msgpack::DocNode Root = Doc.getRoot();
-      if (!Root.isMap()) {
-        log() << "hotswap: error: " << Context
-              << ": AMDGPU metadata root is not a map.\n";
-        return std::nullopt;
-      }
-
-      msgpack::MapDocNode &RootMap = Root.getMap();
-      msgpack::DocNode::MapTy::iterator KernelsIt =
-          RootMap.find("amdhsa.kernels");
-      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
-        continue;
-
-      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
-      for (msgpack::DocNode &KernelNode : KernelArray) {
-        if (!KernelNode.isMap())
-          continue;
-        msgpack::MapDocNode &KernelMap = KernelNode.getMap();
-        msgpack::DocNode::MapTy::iterator NameIt = KernelMap.find(".name");
-        if (NameIt == KernelMap.end() || !NameIt->second.isString() ||
-            NameIt->second.getString() != KernelName)
-          continue;
-
-        msgpack::DocNode::MapTy::iterator ValueIt = KernelMap.find(Key);
-        if (ValueIt == KernelMap.end())
-          return std::nullopt;
-        return readUnsignedMetadataNode(ValueIt->second, KernelName, Key,
-                                        Context);
-      }
-    }
-
-    if (Err) {
-      log() << "hotswap: error: " << Context
-            << ": failed to iterate AMDGPU notes: " << toString(std::move(Err))
-            << "\n";
-      return std::nullopt;
-    }
-  }
-  return std::nullopt;
-}
-
 std::optional<unsigned>
 ElfView::getKernelMaxFlatWorkgroupSize(StringRef KernelName) const {
-  return getKernelUnsignedMetadata(File, KernelName, ".max_flat_workgroup_size",
-                                   "getKernelMaxFlatWorkgroupSize");
+  initializeKernelMetadataCache();
+  if (MetadataCacheState != KernelMetadataCacheState::Metadata)
+    return std::nullopt;
+  StringMap<CachedKernelMetadata>::const_iterator Cached =
+      KernelMetadataCache.find(KernelName);
+  return Cached == KernelMetadataCache.end()
+             ? std::nullopt
+             : Cached->second.MaxFlatWorkgroupSize;
 }
 
 std::optional<unsigned>
 ElfView::getKernelMetadataVgprCount(StringRef KernelName) const {
-  return getKernelUnsignedMetadata(File, KernelName, ".vgpr_count",
-                                   "getKernelMetadataVgprCount");
+  initializeKernelMetadataCache();
+  if (MetadataCacheState != KernelMetadataCacheState::Metadata)
+    return std::nullopt;
+  StringMap<CachedKernelMetadata>::const_iterator Cached =
+      KernelMetadataCache.find(KernelName);
+  return Cached == KernelMetadataCache.end() ? std::nullopt
+                                             : Cached->second.VgprCount;
 }
 
 std::optional<unsigned>
 ElfView::getKernelWavefrontSize(StringRef KernelName) const {
-  return getKernelUnsignedMetadata(File, KernelName, ".wavefront_size",
-                                   "getKernelWavefrontSize");
+  initializeKernelMetadataCache();
+  if (MetadataCacheState != KernelMetadataCacheState::Metadata)
+    return std::nullopt;
+  StringMap<CachedKernelMetadata>::const_iterator Cached =
+      KernelMetadataCache.find(KernelName);
+  return Cached == KernelMetadataCache.end() ? std::nullopt
+                                             : Cached->second.WavefrontSize;
 }
 
 // Reads the static (compile-time-fixed) LDS allocation from the kernel
@@ -1069,21 +1051,23 @@ ElfView::getKernelStaticLdsSize(StringRef KernelName) const {
   return LdsSize;
 }
 
-// -- ElfView::getKernelSgprCount ----------------------------------------------
+// -- ElfView kernel metadata cache --------------------------------------------
 //
-// Reads .sgpr_count from the amdhsa.kernels msgpack metadata note.
-// On GFX10+ GRANULATED_WAVEFRONT_SGPR_COUNT in the kernel descriptor is
-// architecturally reserved (must be zero), so the metadata note is the
-// preferred source. Falls back to the KD field when no metadata note is
-// present (e.g. minimal test ELFs assembled with -nostdlib).
+// Materializes the metadata fields used by HotSwap in one pass. New metadata
+// consumers should extend this cache rather than add another note walker. On
+// GFX10+ GRANULATED_WAVEFRONT_SGPR_COUNT in the kernel descriptor is
+// architecturally reserved (must be zero), so .sgpr_count is preferred when
+// metadata exists. getKernelSgprCount falls back to the descriptor only when
+// the code object has no AMDGPU metadata note (e.g. minimal test ELFs assembled
+// with -nostdlib).
 
-void ElfView::initializeKernelSgprCountCache() const {
-  if (SgprCacheState != KernelSgprCacheState::Uninitialized)
+void ElfView::initializeKernelMetadataCache() const {
+  if (MetadataCacheState != KernelMetadataCacheState::Uninitialized)
     return;
 
   // Default to Error so every malformed-note early return leaves an explicit
   // terminal cache state instead of reparsing the same large blob.
-  SgprCacheState = KernelSgprCacheState::Error;
+  MetadataCacheState = KernelMetadataCacheState::Error;
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
   bool SawMetadataNote = false;
   if (PhdrsOrErr) {
@@ -1099,7 +1083,7 @@ void ElfView::initializeKernelSgprCountCache() const {
 
         ArrayRef<uint8_t> Desc = Note.getDesc(4);
         if (Desc.empty()) {
-          log() << "hotswap: error: SGPR cache: AMDGPU metadata note "
+          log() << "hotswap: error: metadata cache: AMDGPU metadata note "
                 << "has an empty descriptor.\n";
           return;
         }
@@ -1108,14 +1092,14 @@ void ElfView::initializeKernelSgprCountCache() const {
                        Desc.size());
         msgpack::Document Doc;
         if (!Doc.readFromBlob(Blob, false)) {
-          log() << "hotswap: error: SGPR cache: failed to parse "
+          log() << "hotswap: error: metadata cache: failed to parse "
                 << "AMDGPU metadata note.\n";
           return;
         }
 
         msgpack::DocNode Root = Doc.getRoot();
         if (!Root.isMap()) {
-          log() << "hotswap: error: SGPR cache: AMDGPU metadata root "
+          log() << "hotswap: error: metadata cache: AMDGPU metadata root "
                 << "is not a map.\n";
           return;
         }
@@ -1132,60 +1116,63 @@ void ElfView::initializeKernelSgprCountCache() const {
           msgpack::MapDocNode &KMap = KNode.getMap();
           msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
           if (NameIt == KMap.end() || !NameIt->second.isString() ||
-              KernelSgprCountCache.find(NameIt->second.getString()) !=
-                  KernelSgprCountCache.end())
+              KernelMetadataCache.find(NameIt->second.getString()) !=
+                  KernelMetadataCache.end())
             continue;
 
-          msgpack::DocNode::MapTy::iterator SgprIt = KMap.find(".sgpr_count");
-          if (SgprIt == KMap.end()) {
-            KernelSgprCountCache.try_emplace(NameIt->second.getString(),
-                                             std::nullopt);
-            continue;
-          }
           StringRef Name = NameIt->second.getString();
-          KernelSgprCountCache.try_emplace(
-              Name, readUnsignedMetadataNode(SgprIt->second, Name,
-                                             ".sgpr_count", "SGPR cache"));
+          CachedKernelMetadata Metadata;
+          Metadata.SgprCount =
+              readOptionalUnsignedMetadataField(KMap, Name, ".sgpr_count");
+          Metadata.VgprCount =
+              readOptionalUnsignedMetadataField(KMap, Name, ".vgpr_count");
+          Metadata.MaxFlatWorkgroupSize = readOptionalUnsignedMetadataField(
+              KMap, Name, ".max_flat_workgroup_size");
+          Metadata.WavefrontSize =
+              readOptionalUnsignedMetadataField(KMap, Name, ".wavefront_size");
+          Metadata.ClusterDims =
+              readOptionalClusterDimsMetadataField(KMap, Name);
+          KernelMetadataCache.try_emplace(Name, std::move(Metadata));
         }
       }
       if (Err) {
-        log() << "hotswap: error: SGPR cache: failed to iterate "
+        log() << "hotswap: error: metadata cache: failed to iterate "
               << "AMDGPU notes: " << toString(std::move(Err)) << "\n";
         return;
       }
     }
   } else {
-    log() << "hotswap: error: SGPR cache: failed to read program "
+    log() << "hotswap: error: metadata cache: failed to read program "
           << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
     return;
   }
 
-  SgprCacheState = SawMetadataNote ? KernelSgprCacheState::Metadata
-                                   : KernelSgprCacheState::NoMetadata;
+  MetadataCacheState = SawMetadataNote ? KernelMetadataCacheState::Metadata
+                                       : KernelMetadataCacheState::NoMetadata;
 }
 
 std::optional<unsigned>
 ElfView::getKernelSgprCount(StringRef KernelName) const {
-  initializeKernelSgprCountCache();
-  if (SgprCacheState == KernelSgprCacheState::Error)
+  initializeKernelMetadataCache();
+  if (MetadataCacheState == KernelMetadataCacheState::Error)
     return std::nullopt;
 
-  StringMap<std::optional<unsigned>>::const_iterator Cached =
-      KernelSgprCountCache.find(KernelName);
-  if (SgprCacheState == KernelSgprCacheState::Metadata) {
-    if (Cached != KernelSgprCountCache.end()) {
-      if (!Cached->second)
+  StringMap<CachedKernelMetadata>::const_iterator Cached =
+      KernelMetadataCache.find(KernelName);
+  if (MetadataCacheState == KernelMetadataCacheState::Metadata) {
+    if (Cached != KernelMetadataCache.end()) {
+      if (!Cached->second.SgprCount)
         log() << "hotswap: error: getKernelSgprCount: metadata for kernel '"
               << KernelName << "' has no valid .sgpr_count.\n";
-      return Cached->second;
+      return Cached->second.SgprCount;
     }
     log() << "hotswap: error: getKernelSgprCount: AMDGPU metadata has no "
           << ".sgpr_count entry for kernel '" << KernelName << "'.\n";
     return std::nullopt;
   }
 
-  if (Cached != KernelSgprCountCache.end())
-    return Cached->second;
+  if (Cached != KernelMetadataCache.end())
+    return Cached->second.SgprCount;
 
   // --- Fallback: read the KD field. ---
   // The LLVM assembler populates GRANULATED_WAVEFRONT_SGPR_COUNT even on
@@ -1194,7 +1181,7 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
   namespace hsa = amdhsa;
   uint8_t *Kd = const_cast<ElfView *>(this)->findKernelDescriptor(KernelName);
   if (!Kd) {
-    KernelSgprCountCache.try_emplace(KernelName, std::nullopt);
+    KernelMetadataCache[KernelName].SgprCount = std::nullopt;
     return std::nullopt;
   }
   uint32_t Rsrc1;
@@ -1211,7 +1198,7 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
     return std::nullopt;
   }
   std::optional<unsigned> Result = static_cast<unsigned>(SgprCount);
-  KernelSgprCountCache.try_emplace(KernelName, Result);
+  KernelMetadataCache[KernelName].SgprCount = Result;
   return Result;
 }
 
@@ -1223,99 +1210,13 @@ ElfView::getKernelSgprCount(StringRef KernelName) const {
 
 std::optional<KernelClusterDims>
 ElfView::getKernelClusterDims(StringRef KernelName) const {
-  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
-  if (!PhdrsOrErr) {
-    log() << "hotswap: error: getKernelClusterDims: failed to read program "
-          << "headers: " << toString(PhdrsOrErr.takeError()) << "\n";
+  initializeKernelMetadataCache();
+  if (MetadataCacheState != KernelMetadataCacheState::Metadata)
     return std::nullopt;
-  }
-
-  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
-    if (Phdr.p_type != ELF::PT_NOTE)
-      continue;
-
-    Error Err = Error::success();
-    for (ELFT::Note Note : File.notes(Phdr, Err)) {
-      if (Note.getName() != "AMDGPU" ||
-          Note.getType() != ELF::NT_AMDGPU_METADATA)
-        continue;
-
-      ArrayRef<uint8_t> Desc = Note.getDesc(4);
-      if (Desc.empty()) {
-        log() << "hotswap: error: getKernelClusterDims: AMDGPU metadata note "
-              << "has an empty descriptor.\n";
-        return std::nullopt;
-      }
-
-      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
-      msgpack::Document Doc;
-      if (!Doc.readFromBlob(Blob, false)) {
-        log() << "hotswap: error: getKernelClusterDims: failed to parse "
-              << "AMDGPU metadata note.\n";
-        return std::nullopt;
-      }
-
-      msgpack::DocNode Root = Doc.getRoot();
-      if (!Root.isMap()) {
-        log() << "hotswap: error: getKernelClusterDims: AMDGPU metadata root "
-              << "is not a map.\n";
-        return std::nullopt;
-      }
-
-      msgpack::MapDocNode &RootMap = Root.getMap();
-      msgpack::DocNode::MapTy::iterator KernelsIt =
-          RootMap.find("amdhsa.kernels");
-      if (KernelsIt == RootMap.end() || !KernelsIt->second.isArray())
-        continue;
-
-      msgpack::ArrayDocNode &KernelArray = KernelsIt->second.getArray();
-      for (msgpack::DocNode &KNode : KernelArray) {
-        if (!KNode.isMap())
-          continue;
-
-        msgpack::MapDocNode &KMap = KNode.getMap();
-        msgpack::DocNode::MapTy::iterator NameIt = KMap.find(".name");
-        if (NameIt == KMap.end() || !NameIt->second.isString() ||
-            NameIt->second.getString() != KernelName)
-          continue;
-
-        msgpack::DocNode::MapTy::iterator DimsIt = KMap.find(".cluster_dims");
-        if (DimsIt == KMap.end())
-          return std::nullopt;
-        if (!DimsIt->second.isArray()) {
-          log() << "hotswap: error: getKernelClusterDims: .cluster_dims for '"
-                << KernelName << "' is not an array.\n";
-          return std::nullopt;
-        }
-
-        msgpack::ArrayDocNode &Dims = DimsIt->second.getArray();
-        if (Dims.size() != 3) {
-          log() << "hotswap: error: getKernelClusterDims: .cluster_dims for '"
-                << KernelName << "' has " << Dims.size()
-                << " entries, expected 3.\n";
-          return std::nullopt;
-        }
-
-        std::optional<unsigned> X = readUnsignedMetadataNode(
-            Dims[0], KernelName, ".cluster_dims[0]", "getKernelClusterDims");
-        std::optional<unsigned> Y = readUnsignedMetadataNode(
-            Dims[1], KernelName, ".cluster_dims[1]", "getKernelClusterDims");
-        std::optional<unsigned> Z = readUnsignedMetadataNode(
-            Dims[2], KernelName, ".cluster_dims[2]", "getKernelClusterDims");
-        if (!X || !Y || !Z)
-          return std::nullopt;
-        return KernelClusterDims{*X, *Y, *Z};
-      }
-    }
-
-    if (Err) {
-      log() << "hotswap: error: getKernelClusterDims: failed to iterate "
-            << "AMDGPU notes: " << toString(std::move(Err)) << "\n";
-      return std::nullopt;
-    }
-  }
-
-  return std::nullopt;
+  StringMap<CachedKernelMetadata>::const_iterator Cached =
+      KernelMetadataCache.find(KernelName);
+  return Cached == KernelMetadataCache.end() ? std::nullopt
+                                             : Cached->second.ClusterDims;
 }
 
 // -- ElfView::updateKernelDescriptorVgprCount ---------------------------------

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -707,7 +707,15 @@ public:
                       llvm::ArrayRef<uint8_t> SNopBytes) const;
 
 private:
-  enum class KernelSgprCacheState {
+  struct CachedKernelMetadata {
+    std::optional<unsigned> SgprCount;
+    std::optional<unsigned> VgprCount;
+    std::optional<unsigned> MaxFlatWorkgroupSize;
+    std::optional<unsigned> WavefrontSize;
+    std::optional<KernelClusterDims> ClusterDims;
+  };
+
+  enum class KernelMetadataCacheState {
     Uninitialized,
     Metadata,
     NoMetadata,
@@ -723,7 +731,7 @@ private:
   const FunctionTextRange *
   findFunctionTextRangeAtAddress(uint64_t TextAddress) const;
   void initializeKernelDescriptorCache() const;
-  void initializeKernelSgprCountCache() const;
+  void initializeKernelMetadataCache() const;
 
   ELFFileT File;
   ELFT::ShdrRange Sections;
@@ -734,9 +742,9 @@ private:
       KernelDescriptorCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorFileOffsetCache;
   mutable llvm::StringMap<uint64_t> KernelDescriptorVAddrCache;
-  mutable KernelSgprCacheState SgprCacheState =
-      KernelSgprCacheState::Uninitialized;
-  mutable llvm::StringMap<std::optional<unsigned>> KernelSgprCountCache;
+  mutable KernelMetadataCacheState MetadataCacheState =
+      KernelMetadataCacheState::Uninitialized;
+  mutable llvm::StringMap<CachedKernelMetadata> KernelMetadataCache;
 };
 
 // -- Free-function ELF helpers (no ELF state required) ------------------------

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -10,6 +10,7 @@
 #include "comgr-test-elf-utils.h"
 #include "gtest/gtest.h"
 
+#include <array>
 #include <cstring>
 #include <limits>
 
@@ -830,6 +831,7 @@ TEST(ElfView, ReadsWorkgroupCapacityMetadata) {
   Opts.MetadataVgprCount = 120;
   Opts.MetadataMaxFlatWorkgroupSize = 1024;
   Opts.MetadataWavefrontSize = 32;
+  Opts.MetadataClusterDims = std::array<unsigned, 3>{2, 3, 4};
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText(), Opts);
 
@@ -839,6 +841,104 @@ TEST(ElfView, ReadsWorkgroupCapacityMetadata) {
   EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("entry_kernel"), 120u);
   EXPECT_EQ(ViewOrErr->getKernelMaxFlatWorkgroupSize("entry_kernel"), 1024u);
   EXPECT_EQ(ViewOrErr->getKernelWavefrontSize("entry_kernel"), 32u);
+  std::optional<KernelClusterDims> ClusterDims =
+      ViewOrErr->getKernelClusterDims("entry_kernel");
+  ASSERT_TRUE(ClusterDims);
+  EXPECT_EQ(ClusterDims->X, 2u);
+  EXPECT_EQ(ClusterDims->Y, 3u);
+  EXPECT_EQ(ClusterDims->Z, 4u);
+}
+
+TEST(ElfView, RejectsMalformedClusterDimsMetadata) {
+  using MalformedClusterDims =
+      comgr_test::KernelDescriptorElfOptions::MalformedClusterDims;
+  constexpr MalformedClusterDims Cases[] = {
+      MalformedClusterDims::NotArray,
+      MalformedClusterDims::WrongArity,
+      MalformedClusterDims::NonInteger,
+  };
+
+  for (MalformedClusterDims Case : Cases) {
+    SCOPED_TRACE(static_cast<unsigned>(Case));
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.MetadataVgprCount = 120;
+    Opts.MalformedMetadataClusterDims = Case;
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+    EXPECT_EQ(ViewOrErr->getKernelClusterDims("kernel"), std::nullopt);
+    EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("kernel"), 120u);
+  }
+}
+
+TEST(ElfView, CachesAllMetadataFieldsPerKernelAndDeduplicatesNames) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataKernels = {
+      {"first", 8, 16, 128, 32, std::array<unsigned, 3>{1, 2, 3}},
+      {"second", 12, 24, 256, 64, std::array<unsigned, 3>{4, 5, 6}},
+      {"first", 99, 99, 999, 99, std::array<unsigned, 3>{9, 9, 9}},
+  };
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("first"), 8u);
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("first"), 16u);
+  EXPECT_EQ(ViewOrErr->getKernelMaxFlatWorkgroupSize("first"), 128u);
+  EXPECT_EQ(ViewOrErr->getKernelWavefrontSize("first"), 32u);
+  std::optional<KernelClusterDims> FirstDims =
+      ViewOrErr->getKernelClusterDims("first");
+  ASSERT_TRUE(FirstDims);
+  EXPECT_EQ(FirstDims->X, 1u);
+  EXPECT_EQ(FirstDims->Y, 2u);
+  EXPECT_EQ(FirstDims->Z, 3u);
+
+  EXPECT_EQ(ViewOrErr->getKernelSgprCount("second"), 12u);
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("second"), 24u);
+  EXPECT_EQ(ViewOrErr->getKernelMaxFlatWorkgroupSize("second"), 256u);
+  EXPECT_EQ(ViewOrErr->getKernelWavefrontSize("second"), 64u);
+  std::optional<KernelClusterDims> SecondDims =
+      ViewOrErr->getKernelClusterDims("second");
+  ASSERT_TRUE(SecondDims);
+  EXPECT_EQ(SecondDims->X, 4u);
+  EXPECT_EQ(SecondDims->Y, 5u);
+  EXPECT_EQ(SecondDims->Z, 6u);
+}
+
+TEST(ElfView, MalformedMetadataLeavesTerminalErrorCacheState) {
+  comgr_test::KernelDescriptorElfOptions ValidOpts;
+  ValidOpts.MetadataVgprCount = 120;
+  std::string ValidBlob = comgr_test::makeAmdgpuMetadataBlob(ValidOpts);
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.RawMetadataBlob = std::string(ValidBlob.size(), '\xc1');
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+  llvm::StringRef Bytes(reinterpret_cast<const char *>(Obj.Bytes.data()),
+                        Obj.Bytes.size());
+  size_t BlobOffset = Bytes.find(*Opts.RawMetadataBlob);
+  ASSERT_NE(BlobOffset, llvm::StringRef::npos);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("kernel"), std::nullopt);
+
+  std::memcpy(Obj.Bytes.data() + BlobOffset, ValidBlob.data(),
+              ValidBlob.size());
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("kernel"), std::nullopt);
+
+  llvm::Expected<ElfView> FreshViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)FreshViewOrErr)
+      << llvm::toString(FreshViewOrErr.takeError());
+  EXPECT_EQ(FreshViewOrErr->getKernelMetadataVgprCount("kernel"), 120u);
 }
 
 TEST(ElfView, UpdateKernelDescriptorVgprCountIsChecked) {
@@ -874,6 +974,7 @@ TEST(ElfView, UpdateKernelMetadataVgprCountsUpdatesInPlace) {
   llvm::Expected<ElfView> ViewOrErr =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_EQ(ViewOrErr->getKernelMetadataVgprCount("entry_kernel"), 9u);
   llvm::StringMap<unsigned> RequiredVgprs;
   RequiredVgprs.try_emplace("entry_kernel", 10u);
   ASSERT_TRUE(ViewOrErr->updateKernelMetadataVgprCounts(RequiredVgprs));

--- a/amd/comgr/test-unit/comgr-test-elf-utils.h
+++ b/amd/comgr/test-unit/comgr-test-elf-utils.h
@@ -16,6 +16,7 @@
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -23,6 +24,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace comgr_test {
@@ -50,9 +52,30 @@ inline uint64_t alignTo4(uint64_t V) { return llvm::alignTo(V, 4); }
 inline uint64_t alignTo8(uint64_t V) { return llvm::alignTo(V, 8); }
 
 struct KernelDescriptorElfOptions {
+  enum class MalformedClusterDims {
+    None,
+    NotArray,
+    WrongArity,
+    NonInteger,
+  };
+
   struct MetadataKernel {
     std::string Name;
     unsigned SgprCount = 0;
+    std::optional<unsigned> VgprCount;
+    std::optional<unsigned> MaxFlatWorkgroupSize;
+    std::optional<unsigned> WavefrontSize;
+    std::optional<std::array<unsigned, 3>> ClusterDims;
+
+    MetadataKernel(
+        std::string Name, unsigned SgprCount,
+        std::optional<unsigned> VgprCount = std::nullopt,
+        std::optional<unsigned> MaxFlatWorkgroupSize = std::nullopt,
+        std::optional<unsigned> WavefrontSize = std::nullopt,
+        std::optional<std::array<unsigned, 3>> ClusterDims = std::nullopt)
+        : Name(std::move(Name)), SgprCount(SgprCount), VgprCount(VgprCount),
+          MaxFlatWorkgroupSize(MaxFlatWorkgroupSize),
+          WavefrontSize(WavefrontSize), ClusterDims(ClusterDims) {}
   };
 
   uint16_t ElfType = llvm::ELF::ET_DYN;
@@ -73,7 +96,11 @@ struct KernelDescriptorElfOptions {
   std::optional<unsigned> MetadataVgprCount;
   std::optional<unsigned> MetadataMaxFlatWorkgroupSize;
   std::optional<unsigned> MetadataWavefrontSize;
+  std::optional<std::array<unsigned, 3>> MetadataClusterDims;
+  MalformedClusterDims MalformedMetadataClusterDims =
+      MalformedClusterDims::None;
   std::optional<std::string> MetadataGfx1250Revision;
+  std::optional<std::string> RawMetadataBlob;
   bool MetadataOmitSgprCount = false;
   bool MetadataSgprCountAsString = false;
   // When non-empty, emit these kernel metadata entries instead of the single
@@ -106,6 +133,19 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
       llvm::msgpack::MapDocNode Kernel = Doc.getMapNode();
       Kernel[".name"] = Doc.getNode(Spec.Name, /*Copy=*/true);
       Kernel[".sgpr_count"] = static_cast<uint64_t>(Spec.SgprCount);
+      if (Spec.VgprCount)
+        Kernel[".vgpr_count"] = static_cast<uint64_t>(*Spec.VgprCount);
+      if (Spec.MaxFlatWorkgroupSize)
+        Kernel[".max_flat_workgroup_size"] =
+            static_cast<uint64_t>(*Spec.MaxFlatWorkgroupSize);
+      if (Spec.WavefrontSize)
+        Kernel[".wavefront_size"] = static_cast<uint64_t>(*Spec.WavefrontSize);
+      if (Spec.ClusterDims) {
+        llvm::msgpack::ArrayDocNode Dims = Doc.getArrayNode();
+        for (unsigned Dim : *Spec.ClusterDims)
+          Dims.push_back(Doc.getNode(Dim));
+        Kernel[".cluster_dims"] = Dims;
+      }
       Kernels.push_back(Kernel);
     }
   } else {
@@ -134,6 +174,36 @@ makeAmdgpuMetadataBlob(const KernelDescriptorElfOptions &Options) {
     if (Options.MetadataWavefrontSize)
       Kernel[".wavefront_size"] =
           static_cast<uint64_t>(*Options.MetadataWavefrontSize);
+    if (Options.MetadataClusterDims) {
+      llvm::msgpack::ArrayDocNode Dims = Doc.getArrayNode();
+      for (unsigned Dim : *Options.MetadataClusterDims)
+        Dims.push_back(Doc.getNode(Dim));
+      Kernel[".cluster_dims"] = Dims;
+    } else if (Options.MalformedMetadataClusterDims !=
+               KernelDescriptorElfOptions::MalformedClusterDims::None) {
+      switch (Options.MalformedMetadataClusterDims) {
+      case KernelDescriptorElfOptions::MalformedClusterDims::None:
+        break;
+      case KernelDescriptorElfOptions::MalformedClusterDims::NotArray:
+        Kernel[".cluster_dims"] = static_cast<uint64_t>(3);
+        break;
+      case KernelDescriptorElfOptions::MalformedClusterDims::WrongArity: {
+        llvm::msgpack::ArrayDocNode Dims = Doc.getArrayNode();
+        Dims.push_back(Doc.getNode(2));
+        Dims.push_back(Doc.getNode(3));
+        Kernel[".cluster_dims"] = Dims;
+        break;
+      }
+      case KernelDescriptorElfOptions::MalformedClusterDims::NonInteger: {
+        llvm::msgpack::ArrayDocNode Dims = Doc.getArrayNode();
+        Dims.push_back(Doc.getNode(2));
+        Dims.push_back(Doc.getNode("not-an-integer", /*Copy=*/true));
+        Dims.push_back(Doc.getNode(4));
+        Kernel[".cluster_dims"] = Dims;
+        break;
+      }
+      }
+    }
     if (Options.MetadataGfx1250Revision)
       Kernel[".gfx1250_revision"] =
           Doc.getNode(*Options.MetadataGfx1250Revision, /*Copy=*/true);
@@ -209,11 +279,16 @@ makeKernelDescriptorElf(llvm::ArrayRef<uint8_t> Text,
       Options.MetadataSgprCount || Options.MetadataGfx1250Revision ||
       Options.MetadataOmitSgprCount || Options.MetadataSgprCountAsString ||
       Options.MetadataMaxFlatWorkgroupSize || Options.MetadataWavefrontSize ||
-      Options.MetadataVgprCount || Options.MetadataOmitVgprCount ||
-      Options.MetadataVgprCountAsString || !Options.MetadataKernels.empty();
+      Options.MetadataClusterDims || Options.MetadataVgprCount ||
+      Options.MetadataOmitVgprCount || Options.MetadataVgprCountAsString ||
+      Options.MalformedMetadataClusterDims !=
+          KernelDescriptorElfOptions::MalformedClusterDims::None ||
+      Options.RawMetadataBlob || !Options.MetadataKernels.empty();
   std::vector<uint8_t> MetadataNote;
   if (HasMetadataNote) {
-    std::string MetadataBlob = makeAmdgpuMetadataBlob(Options);
+    std::string MetadataBlob = Options.RawMetadataBlob
+                                   ? *Options.RawMetadataBlob
+                                   : makeAmdgpuMetadataBlob(Options);
     MetadataNote = makeAmdgpuMetadataNote(MetadataBlob);
   }
 


### PR DESCRIPTION
Read kernel resource metadata once into per-kernel records and keep the cache coherent when descriptors are updated.

DeepSeek V4 Flash (110 code objects, five runs):
CPU: 12.3 s -> 11.8 s (1.04x)
Peak RSS: 1.72 GiB -> 1.73 GiB (+1.0%)

Outputs are byte-identical.


