### PR TITLE
[openmp] Remove dead AOCC task-dependency wrapper to converge with trunk

### DIFF
--- a/openmp/runtime/src/kmp.h
+++ b/openmp/runtime/src/kmp.h
@@ -4127,8 +4127,6 @@ extern kmp_task_t *__kmp_task_alloc(ident_t *loc_ref, kmp_int32 gtid,
                                     size_t sizeof_kmp_task_t,
                                     size_t sizeof_shareds,
                                     kmp_routine_entry_t task_entry);
-extern int __kmpc_omp_task_alloc_with_deps(ident_t *loc_ref, kmp_int32 gtid, kmp_task_t *new_task,
-                                           int ndeps, int nargs, ...); //AOCC
 extern void __kmp_init_implicit_task(ident_t *loc_ref, kmp_info_t *this_thr,
                                      kmp_team_t *team, int tid,
                                      int set_curr_task);

--- a/openmp/runtime/src/kmp_taskdeps.cpp
+++ b/openmp/runtime/src/kmp_taskdeps.cpp
@@ -669,46 +669,6 @@ static bool __kmp_check_deps(kmp_int32 gtid, kmp_depnode_t *node,
   return npredecessors > 0 ? true : false;
 }
 
-/* AOCC begin */
-/*
- * a wrapper function to __kmpc_omp_task_with_deps
- */
-int __kmpc_omp_task_alloc_with_deps(ident_t *loc_ref, kmp_int32 gtid, kmp_task_t *new_task,
-                                    int ndeps, int nargs, ...) {
-  int *dependinfo = (int*)malloc(nargs*sizeof(int)); 
-  va_list valist;
-  va_start(valist, nargs);
-  for (int k = 0; k < nargs; k++) {
-    dependinfo[k] = va_arg(valist, int);
-  }
-  va_end(valist);
-  kmp_depend_info_t *deplist = (kmp_depend_info_t*)malloc(ndeps*sizeof(kmp_depend_info_t));
-
-  for (int i = 0, j = 0; i < ndeps && j < ndeps*3; i++, j+=3) {
-    kmp_depend_info_t depinfo;
-    depinfo.base_addr = dependinfo[j+2];
-    depinfo.len = dependinfo[j+1];
-    int deptype = dependinfo[j];
-    depinfo.flags.mtx = 1;
-    if (deptype == DI_DEP_TYPE_INOUT) {
-      depinfo.flags.in = 1;
-      depinfo.flags.out = 1;
-    } else if (deptype == DI_DEP_TYPE_IN) {
-      depinfo.flags.in = 1;
-    } else if (deptype == DI_DEP_TYPE_OUT) {
-      depinfo.flags.out = 1;
-    }
-    deplist[i] = depinfo;
-  }
-  free(dependinfo);  
-  __kmp_assert_valid_gtid(gtid);
-
-  int ret = __kmpc_omp_task_with_deps(loc_ref, gtid, new_task, ndeps, deplist, 0, deplist);
-  free(deplist);
-  return ret;
-}
-/* AOCC end */
-
 /*!
 @ingroup TASKING
 @param loc_ref location of the original task directive

--- a/openmp/runtime/src/kmp_taskdeps.h
+++ b/openmp/runtime/src/kmp_taskdeps.h
@@ -21,12 +21,6 @@
 #define KMP_ACQUIRE_DEPNODE(gtid, n) __kmp_acquire_lock(&(n)->dn.lock, (gtid))
 #define KMP_RELEASE_DEPNODE(gtid, n) __kmp_release_lock(&(n)->dn.lock, (gtid))
 
-/* AOCC begin */
-#define DI_DEP_TYPE_IN 11
-#define DI_DEP_TYPE_OUT 12
-#define DI_DEP_TYPE_INOUT 13
-/* AOCC end */
-
 static inline void __kmp_node_deref(kmp_info_t *thread, kmp_depnode_t *node) {
   if (!node)
     return;


### PR DESCRIPTION
__kmpc_omp_task_alloc_with_deps is an AOCC-only runtime entry point that has no in-tree callers and is absent from upstream. Only the closed-source AOCC compiler emits calls to it, so it is dead weight in the ROCm OpenMP runtime. Drop the function, its declaration, and the DI_DEP_TYPE_* macros it relied on.


