### PR TITLE
[clang][driver] Remove dead legacy flang driver residue

### DIFF
--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -24,8 +24,6 @@ namespace clang {
 namespace driver {
 namespace tools {
 
-bool needFortranLibs(const Driver &D, const llvm::opt::ArgList &Args);
-
 struct OffloadJobsOpt {
   enum class Kind { Missing, Invalid, Jobserver, Fixed };
 

--- a/clang/lib/Driver/README_amd_driver_trunk_diffs
+++ b/clang/lib/Driver/README_amd_driver_trunk_diffs
@@ -16,9 +16,6 @@ subsystems.
 
 These are the areas where amd-staging differs from the trunk:
 
-- Support for legacy/classic flang driver.  This will eventually go away
-  when llvm flang (flang) is in production. 
-
 - Support for --opaque-offload-linker. This using the same offload driver, actions
   and phases. It is only an alternative command generator in ToolChains/Clang.cpp 
   LinerWrapper:ConstructJob. Instead of the driver generating four commands


### PR DESCRIPTION
The legacy/classic flang driver support has already been removed from the downstream driver. Drop the two remaining traces:
- needFortranLibs, an unused declaration in CommonArgs.h with no definition or callers
- the now-obsolete "legacy/classic flang driver" entry in the README_amd_driver_trunk_diffs divergence list


