### PR TITLE
[clang][AST] Drop unused ErrorHandling.h include to converge with trunk

### DIFF
--- a/clang/include/clang/AST/MangleNumberingContext.h
+++ b/clang/include/clang/AST/MangleNumberingContext.h
@@ -16,7 +16,6 @@
 
 #include "clang/Basic/LLVM.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
-#include "llvm/Support/ErrorHandling.h"
 
 namespace clang {
 


### PR DESCRIPTION
The include is the sole surviving downstream delta in this header, left over from the device-lambda-on-Windows fix (167f1901456a) whose logic was long since upstreamed. Nothing in the header uses llvm_unreachable or report_fatal_error, so removing it makes the file identical to trunk.


