### PR TITLE
[AMDGPU] Fail truncated literal disassembly

### DIFF
--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -486,13 +486,14 @@ DecodeStatus AMDGPUDisassembler::tryDecodeInst(const uint8_t *Table, MCInst &MI,
   SmallString<64> LocalComments;
   raw_svector_ostream LocalCommentStream(LocalComments);
   CommentStream = &LocalCommentStream;
+  HasDecodeError = false;
 
   DecodeStatus Res =
       decodeInstruction(Table, TmpInst, Inst, Address, this, STI);
 
   CommentStream = nullptr;
 
-  if (Res != MCDisassembler::Fail) {
+  if (Res != MCDisassembler::Fail && !HasDecodeError) {
     MI = TmpInst;
     Comments << LocalComments;
     return MCDisassembler::Success;
@@ -835,7 +836,12 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
 
   DecodeStatus Status = MCDisassembler::Success;
 
+  CommentStream = &CS;
+  HasDecodeError = false;
   decodeImmOperands(MI, *MCII);
+  CommentStream = nullptr;
+  if (HasDecodeError)
+    return MCDisassembler::Fail;
 
   if (SIInstrFlags::isDPP(*MCII, MI)) {
     if (isMacDPP(MI))
@@ -1552,7 +1558,9 @@ const char* AMDGPUDisassembler::getRegClassName(unsigned RegClassID) const {
 inline
 MCOperand AMDGPUDisassembler::errOperand(unsigned V,
                                          const Twine& ErrMsg) const {
-  *CommentStream << "Error: " + ErrMsg;
+  HasDecodeError = true;
+  if (CommentStream)
+    *CommentStream << "Error: " + ErrMsg;
 
   // ToDo: add support for error operands to MCInst.h
   // return MCOperand::createError(V);

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -46,6 +46,7 @@ private:
   mutable ArrayRef<uint8_t> Bytes;
   mutable uint64_t Literal;
   mutable bool HasLiteral;
+  mutable bool HasDecodeError = false;
   mutable std::optional<bool> EnableWavefrontSize32;
   unsigned CodeObjectVersion;
   const MCExpr *UCVersionW64Expr;

--- a/llvm/unittests/MC/AMDGPU/Disassembler.cpp
+++ b/llvm/unittests/MC/AMDGPU/Disassembler.cpp
@@ -64,6 +64,48 @@ TEST(AMDGPUDisassembler, Basic) {
   LLVMDisasmDispose(DCR);
 }
 
+TEST(AMDGPUDisassembler, LiteralLengthAndErrorState) {
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTargetMC();
+  LLVMInitializeAMDGPUDisassembler();
+
+  // s_mov_b32 s14, 0xb0a00001. The first dword selects a literal operand and
+  // the second dword supplies it.
+  uint8_t Bytes[] = {0xff, 0x00, 0x8e, 0xbe, 0x01, 0x00, 0xa0, 0xb0};
+  char OutString[100];
+  LLVMDisasmContextRef DCR =
+      LLVMCreateDisasmCPU("amdgcn-amd-amdhsa", "gfx1250", nullptr, 0, nullptr,
+                          symbolLookupCallback);
+
+  // Skip test if AMDGPU not built.
+  if (!DCR)
+    GTEST_SKIP();
+
+  // Every truncation must fail, including buffers that contain only part of
+  // the literal dword.
+  for (size_t Size = 0; Size != sizeof(Bytes); ++Size)
+    EXPECT_EQ(LLVMDisasmInstruction(DCR, Bytes, Size, 0, OutString,
+                                    sizeof(OutString)),
+              0U)
+        << "size " << Size;
+
+  // A failed decode must not poison the next instruction decoded by the same
+  // disassembler.
+  EXPECT_EQ(LLVMDisasmInstruction(DCR, Bytes, sizeof(Bytes), 0, OutString,
+                                  sizeof(OutString)),
+            sizeof(Bytes));
+  EXPECT_TRUE(StringRef(OutString).contains("s_mov_b32"));
+
+  // Exercise the state transition in both directions once more.
+  EXPECT_EQ(LLVMDisasmInstruction(DCR, Bytes, sizeof(uint32_t), 0, OutString,
+                                  sizeof(OutString)),
+            0U);
+  EXPECT_EQ(LLVMDisasmInstruction(DCR, Bytes, sizeof(Bytes), 0, OutString,
+                                  sizeof(OutString)),
+            sizeof(Bytes));
+  LLVMDisasmDispose(DCR);
+}
+
 // Check multiple disassemblers in same MCContext.
 TEST(AMDGPUDisassembler, MultiDisassembler) {
   LLVMInitializeAMDGPUTargetInfo();


### PR DESCRIPTION
## Summary

- reject AMDGPU instructions whose decoded operands require bytes beyond the supplied buffer
- reset the per-attempt decode error state so a failed candidate cannot poison a later decode
- cover every truncated length of an 8-byte literal instruction and a failure-then-success sequence

This is an independently landable correctness fix extracted from #3552.

## Testing

- MI300X, Release + assertions: `AMDGPUMCTests` (6/6 passed)
- MI300X, AddressSanitizer + assertions: `AMDGPUMCTests` (6/6 passed)
- MI400 (`mi400-2`), Release binary: `AMDGPUMCTests` (6/6 passed)

## Review

- verified the error flag is reset for each decoder-table attempt
- verified failed partial `MCInst` state is never returned to callers
- verified the comment stream is only dereferenced after initialization
- `git diff --check`
