### PR TITLE
[comgr][hotswap] Harden ELF input validation

### DIFF
--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -21,8 +21,10 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/BinaryFormat/MsgPackReader.h"
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 
 using namespace llvm;
@@ -48,6 +50,7 @@ static_assert(
     "GRANULATED_WAVEFRONT_SGPR_COUNT layout changed unexpectedly.");
 
 static constexpr unsigned SgprEncodingGranule = 8;
+static constexpr size_t MaxMetadataNestingDepth = 64;
 
 // Page alignment for the appended trampoline pool's virtual address and file
 // offset, so its PT_LOAD segment maps consistently.
@@ -72,6 +75,12 @@ static std::optional<uint64_t> checkedSectionFileOffset(const ELFT::Shdr &Sec,
   }
 
   uint64_t Delta = VAddr - Sec.sh_addr;
+  if (Delta > Sec.sh_size || AccessSize > Sec.sh_size - Delta) {
+    log() << "hotswap: error: " << Context
+          << " extends outside its defining section.\n";
+    return std::nullopt;
+  }
+
   std::optional<uint64_t> FileOffset = checkedAddUint64(
       Sec.sh_offset, Delta, (Twine(Context) + " file offset").str());
   if (!FileOffset)
@@ -164,6 +173,91 @@ struct PendingMetadataWrite {
   std::string Blob;
 };
 
+struct MetadataContainer {
+  size_t Remaining = 0;
+  bool IsMap = false;
+};
+
+// TODO: Remove this preflight after
+// https://github.com/ROCm/llvm-project/issues/3602 teaches MsgPackDocument to
+// reject composite map keys without asserting.
+/// MsgPackDocument indexes a map before it has an opportunity to reject an
+/// array or map used as the key. Preflight one top-level object so malformed
+/// metadata fails closed instead of reaching DocNode's scalar-key assertion.
+static bool hasSupportedMetadataMapKeys(StringRef Blob, StringRef Context) {
+  msgpack::Reader Reader(Blob);
+  SmallVector<MetadataContainer, 16> Stack;
+  size_t TopLevelRemaining = 1;
+
+  while (TopLevelRemaining != 0 || !Stack.empty()) {
+    msgpack::Object Object;
+    Expected<bool> ReadObject = Reader.read(Object);
+    if (!ReadObject) {
+      log() << "hotswap: error: " << Context
+            << ": invalid AMDGPU metadata MessagePack: "
+            << toString(ReadObject.takeError()) << "\n";
+      return false;
+    }
+    if (!*ReadObject) {
+      log() << "hotswap: error: " << Context
+            << ": truncated AMDGPU metadata MessagePack.\n";
+      return false;
+    }
+
+    const bool IsMapKey =
+        !Stack.empty() && Stack.back().IsMap && Stack.back().Remaining % 2 == 0;
+    if (IsMapKey && (Object.Kind == msgpack::Type::Array ||
+                     Object.Kind == msgpack::Type::Map)) {
+      log() << "hotswap: error: " << Context
+            << ": AMDGPU metadata has a non-scalar map key.\n";
+      return false;
+    }
+
+    if (Stack.empty())
+      --TopLevelRemaining;
+    else
+      --Stack.back().Remaining;
+
+    size_t ChildCount = 0;
+    bool IsMap = false;
+    if (Object.Kind == msgpack::Type::Array) {
+      ChildCount = Object.Length;
+    } else if (Object.Kind == msgpack::Type::Map) {
+      if (Object.Length > std::numeric_limits<size_t>::max() / 2) {
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata map size overflows.\n";
+        return false;
+      }
+      ChildCount = Object.Length * 2;
+      IsMap = true;
+    }
+
+    if (ChildCount != 0) {
+      if (Stack.size() == MaxMetadataNestingDepth) {
+        log() << "hotswap: error: " << Context
+              << ": AMDGPU metadata nesting exceeds " << MaxMetadataNestingDepth
+              << ".\n";
+        return false;
+      }
+      Stack.push_back({ChildCount, IsMap});
+    }
+    while (!Stack.empty() && Stack.back().Remaining == 0)
+      Stack.pop_back();
+  }
+  return true;
+}
+
+static bool readMetadataDocument(StringRef Blob, msgpack::Document &Doc,
+                                 StringRef Context) {
+  if (!hasSupportedMetadataMapKeys(Blob, Context))
+    return false;
+  if (Doc.readFromBlob(Blob, false))
+    return true;
+  log() << "hotswap: error: " << Context
+        << ": failed to parse AMDGPU metadata note.\n";
+  return false;
+}
+
 /// Parse each AMDGPU metadata note, invoke \p Mutator on its root map, and
 /// defer changed writes until \p Validator accepts the complete traversal.
 /// This keeps multi-note updates atomic while sharing the parsing, encoded-size
@@ -199,11 +293,8 @@ static bool rewriteMetadataNotes(uint8_t *Elf, const ELFFileT &File,
 
       StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
       msgpack::Document Doc;
-      if (!Doc.readFromBlob(Blob, false)) {
-        log() << "hotswap: error: " << Context
-              << ": failed to parse AMDGPU metadata note.\n";
+      if (!readMetadataDocument(Blob, Doc, Context))
         return false;
-      }
 
       msgpack::DocNode Root = Doc.getRoot();
       if (!Root.isMap()) {
@@ -433,16 +524,101 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
   // resulting ElfView). Once ELFFile is constructed, it owns the structural
   // view over these same bytes and we do not need to store Data/Size
   // separately -- ELFFile::base() / ELFFile::getBufSize() alias them.
+  if (!Data || Size < ELF::EI_NIDENT ||
+      std::memcmp(Data, ELF::ElfMagic, std::strlen(ELF::ElfMagic)) != 0 ||
+      Data[ELF::EI_CLASS] != ELF::ELFCLASS64 ||
+      Data[ELF::EI_DATA] != ELF::ELFDATA2LSB ||
+      Data[ELF::EI_VERSION] != ELF::EV_CURRENT)
+    return createStringError(object::object_error::parse_failed,
+                             "invalid ELF identification");
+
   Expected<ELFFileT> FileOrErr =
       ELFFileT::create(StringRef(reinterpret_cast<const char *>(Data), Size));
   if (!FileOrErr)
     return FileOrErr.takeError();
 
   const ELFFileT &File = *FileOrErr;
+  const ELFT::Ehdr &Header = File.getHeader();
+  const bool SupportedType = Header.e_type == ELF::ET_REL ||
+                             Header.e_type == ELF::ET_EXEC ||
+                             Header.e_type == ELF::ET_DYN;
+  if (Header.e_machine != ELF::EM_AMDGPU || !SupportedType ||
+      Header.e_version != ELF::EV_CURRENT ||
+      Header.e_ehsize != sizeof(ELFT::Ehdr) || Header.e_phnum == ELF::PN_XNUM ||
+      (Header.e_shnum == 0 && Header.e_shoff != 0) ||
+      Header.e_shnum >= ELF::SHN_LORESERVE ||
+      Header.e_shstrndx == ELF::SHN_XINDEX ||
+      (Header.e_phnum != 0 && Header.e_phentsize != sizeof(ELFT::Phdr)) ||
+      (Header.e_shnum != 0 && Header.e_shentsize != sizeof(ELFT::Shdr)))
+    return createStringError(object::object_error::parse_failed,
+                             "invalid or unsupported ELF header");
+
   Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
   if (!SectionsOrErr)
     return SectionsOrErr.takeError();
   ELFT::ShdrRange Sections = *SectionsOrErr;
+
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (Shdr.sh_type != ELF::SHT_NOBITS && Shdr.sh_size != 0 &&
+        (Shdr.sh_offset > Size || Shdr.sh_size > Size - Shdr.sh_offset))
+      return createStringError(object::object_error::parse_failed,
+                               "section extends past end of file");
+  }
+
+  // Every descriptor symbol is an admitted address carrier. Validate all
+  // copies rather than allowing a valid DYNSYM entry to hide a malformed
+  // duplicate in SYMTAB, which could otherwise be rewritten into an object
+  // that fails a second hotswap pass.
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymbolsOrErr = File.symbols(&SymShdr);
+    if (!SymbolsOrErr)
+      return SymbolsOrErr.takeError();
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(SymShdr, Sections);
+    if (!StrTabOrErr)
+      return StrTabOrErr.takeError();
+    for (const ELFT::Sym &Sym : *SymbolsOrErr) {
+      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+      if (!NameOrErr)
+        return NameOrErr.takeError();
+      if (!NameOrErr->ends_with(".kd"))
+        continue;
+      if (Sym.st_shndx == ELF::SHN_UNDEF || Sym.st_shndx >= ELF::SHN_LORESERVE)
+        return createStringError(object::object_error::parse_failed,
+                                 "kernel descriptor has no defining section");
+      Expected<const ELFT::Shdr *> HostShdrOrErr =
+          File.getSection(Sym.st_shndx);
+      if (!HostShdrOrErr)
+        return HostShdrOrErr.takeError();
+      const ELFT::Shdr &HostShdr = **HostShdrOrErr;
+      uint64_t SectionOffset = Sym.st_value;
+      if (Header.e_type != ELF::ET_REL) {
+        if (Sym.st_value < HostShdr.sh_addr)
+          return createStringError(object::object_error::parse_failed,
+                                   "kernel descriptor precedes its section");
+        SectionOffset = Sym.st_value - HostShdr.sh_addr;
+      }
+      if (HostShdr.sh_type == ELF::SHT_NOBITS ||
+          SectionOffset > HostShdr.sh_size ||
+          KdSize > HostShdr.sh_size - SectionOffset)
+        return createStringError(
+            object::object_error::parse_failed,
+            "kernel descriptor extends outside its section");
+    }
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr)
+    return PhdrsOrErr.takeError();
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_filesz != 0 &&
+        (Phdr.p_offset > Size || Phdr.p_filesz > Size - Phdr.p_offset))
+      return createStringError(object::object_error::parse_failed,
+                               "segment extends past end of file");
+  }
 
   const ELFT::Shdr *Text = nullptr;
   unsigned TextIdx = 0;
@@ -454,7 +630,16 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
       ++Idx;
       continue;
     }
-    if (*NameOrErr == ".text" && Shdr.sh_offset + Shdr.sh_size <= Size) {
+    if (*NameOrErr != ".text") {
+      ++Idx;
+      continue;
+    }
+    const uint64_t RequiredTextFlags = ELF::SHF_ALLOC | ELF::SHF_EXECINSTR;
+    if (Shdr.sh_type != ELF::SHT_PROGBITS ||
+        (Shdr.sh_flags & RequiredTextFlags) != RequiredTextFlags)
+      return createStringError(object::object_error::parse_failed,
+                               "invalid or unsupported .text section");
+    if (Shdr.sh_offset <= Size && Shdr.sh_size <= Size - Shdr.sh_offset) {
       Text = &Shdr;
       TextIdx = Idx;
       break;
@@ -1091,11 +1276,8 @@ void ElfView::initializeKernelMetadataCache() const {
         StringRef Blob(reinterpret_cast<const char *>(Desc.data()),
                        Desc.size());
         msgpack::Document Doc;
-        if (!Doc.readFromBlob(Blob, false)) {
-          log() << "hotswap: error: metadata cache: failed to parse "
-                << "AMDGPU metadata note.\n";
+        if (!readMetadataDocument(Blob, Doc, "metadata cache"))
           return;
-        }
 
         msgpack::DocNode Root = Doc.getRoot();
         if (!Root.isMap()) {

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -63,26 +63,18 @@ enum class MetadataCountUpdateStatus {
 };
 
 static std::optional<uint64_t> checkedSectionFileOffset(const ELFT::Shdr &Sec,
-                                                        uint64_t VAddr,
+                                                        uint64_t SectionOffset,
                                                         uint64_t AccessSize,
                                                         uint64_t FileSize,
                                                         StringRef Context) {
-  if (VAddr < Sec.sh_addr) {
-    log() << "hotswap: error: " << Context << " has vaddr 0x"
-          << utohexstr(VAddr) << " before containing section vaddr 0x"
-          << utohexstr(Sec.sh_addr) << ".\n";
-    return std::nullopt;
-  }
-
-  uint64_t Delta = VAddr - Sec.sh_addr;
-  if (Delta > Sec.sh_size || AccessSize > Sec.sh_size - Delta) {
+  if (SectionOffset > Sec.sh_size || AccessSize > Sec.sh_size - SectionOffset) {
     log() << "hotswap: error: " << Context
           << " extends outside its defining section.\n";
     return std::nullopt;
   }
 
   std::optional<uint64_t> FileOffset = checkedAddUint64(
-      Sec.sh_offset, Delta, (Twine(Context) + " file offset").str());
+      Sec.sh_offset, SectionOffset, (Twine(Context) + " file offset").str());
   if (!FileOffset)
     return std::nullopt;
 
@@ -859,8 +851,27 @@ void ElfView::initializeKernelDescriptorCache() const {
         continue;
       }
       const ELFT::Shdr &HostShdr = **HostShdrOrErr;
+      uint64_t SectionOffset = Sym.st_value;
+      uint64_t DescriptorVAddr = Sym.st_value;
+      if (File.getHeader().e_type == ELF::ET_REL) {
+        std::optional<uint64_t> DescriptorVAddrOr =
+            checkedAddUint64(HostShdr.sh_addr, SectionOffset,
+                             (Twine("kernelDescriptors: descriptor symbol '") +
+                              *NameOrErr + "' address")
+                                 .str());
+        if (!DescriptorVAddrOr)
+          continue;
+        DescriptorVAddr = *DescriptorVAddrOr;
+      } else {
+        if (Sym.st_value < HostShdr.sh_addr) {
+          log() << "hotswap: error: kernelDescriptors: descriptor symbol '"
+                << *NameOrErr << "' precedes its defining section.\n";
+          continue;
+        }
+        SectionOffset = Sym.st_value - HostShdr.sh_addr;
+      }
       std::optional<uint64_t> FileOffset = checkedSectionFileOffset(
-          HostShdr, Sym.st_value, KdSize, size(),
+          HostShdr, SectionOffset, KdSize, size(),
           (Twine("kernelDescriptors: descriptor symbol '") + *NameOrErr + "'")
               .str());
       if (!FileOffset)
@@ -879,8 +890,8 @@ void ElfView::initializeKernelDescriptorCache() const {
       // one vaddr, so track the full vaddr set per name rather than only the
       // last one. (The previous per-symbol linear scan over Result made cache
       // init O(n^2).)
-      if (SeenVAddr[KernelNameRef].insert(Sym.st_value).second)
-        Result.push_back({std::move(KernelName), Sym.st_value, EntryOffset});
+      if (SeenVAddr[KernelNameRef].insert(DescriptorVAddr).second)
+        Result.push_back({std::move(KernelName), DescriptorVAddr, EntryOffset});
       FileOffsets.try_emplace(KernelNameRef, *FileOffset);
     }
   }

--- a/amd/comgr/test-lit/hotswap-elf-validation.s
+++ b/amd/comgr/test-lit/hotswap-elf-validation.s
@@ -1,0 +1,62 @@
+// COM: Test public HotSwap API validation of ELF identity and .text semantics.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status SUCCESS | %FileCheck --check-prefix=VALID %s
+// VALID: RESULT: SUCCESS
+
+// COM: e_machine must identify AMDGPU, not another ELF64 architecture.
+// RUN: cp %t.elf %t.x86.elf
+// RUN: printf '\x3e\x00' | dd of=%t.x86.elf bs=1 seek=18 conv=notrunc 2>/dev/null
+// RUN: hotswap-rewrite %t.x86.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT \
+// RUN:   | %FileCheck --check-prefix=INVALID %s
+
+// COM: ET_CORE is not a supported GPU code-object layout.
+// RUN: cp %t.elf %t.core.elf
+// RUN: printf '\x04\x00' | dd of=%t.core.elf bs=1 seek=16 conv=notrunc 2>/dev/null
+// RUN: hotswap-rewrite %t.core.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT \
+// RUN:   | %FileCheck --check-prefix=INVALID %s
+
+// COM: .text must have file-backed contents.
+// RUN: %llvm-objcopy --set-section-type=.text=8 %t.elf %t.nobits.elf
+// RUN: hotswap-rewrite %t.nobits.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT \
+// RUN:   | %FileCheck --check-prefix=INVALID %s
+
+// COM: .text must be both allocatable and executable.
+// RUN: %llvm-objcopy --set-section-flags=.text=code,contents \
+// RUN:   %t.elf %t.nonalloc.elf
+// RUN: hotswap-rewrite %t.nonalloc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT \
+// RUN:   | %FileCheck --check-prefix=INVALID %s
+// RUN: %llvm-objcopy --set-section-flags=.text=alloc,contents \
+// RUN:   %t.elf %t.nonexec.elf
+// RUN: hotswap-rewrite %t.nonexec.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status INVALID_ARGUMENT \
+// RUN:   | %FileCheck --check-prefix=INVALID %s
+// INVALID: RESULT: INVALID_ARGUMENT
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl elf_validation
+.p2align 8
+.type elf_validation,@function
+elf_validation:
+  s_endpgm
+.Lelf_validation_end:
+.size elf_validation, .Lelf_validation_end-elf_validation
+
+.rodata
+.p2align 8
+.amdhsa_kernel elf_validation
+  .amdhsa_next_free_vgpr 0
+  .amdhsa_next_free_sgpr 0
+.end_amdhsa_kernel

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -449,6 +449,30 @@ TEST(ElfView, GetKernelStaticLdsSizeReadsLdsSizeFromKernelDescriptor) {
   EXPECT_EQ(*Lds, TestLdsSize);
 }
 
+TEST(ElfView, ReadsSectionRelativeEtRelKernelDescriptor) {
+  static constexpr uint32_t TestLdsSize = 16384;
+
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.ElfType = llvm::ELF::ET_REL;
+  Opts.KernelName = "rel_kernel";
+  Opts.TextAddr = 0;
+  Opts.RodataAddr = 0x2000;
+  Opts.GroupSegmentFixedSize = TestLdsSize;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  ASSERT_NE(ViewOrErr->findKernelDescriptor("rel_kernel"), nullptr);
+  EXPECT_EQ(ViewOrErr->getKernelStaticLdsSize("rel_kernel"), TestLdsSize);
+  EXPECT_EQ(ViewOrErr->getKernelDescriptorVAddr("rel_kernel"), Opts.RodataAddr);
+  llvm::ArrayRef<KernelDescriptorInfo> KDs = ViewOrErr->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  EXPECT_EQ(KDs[0].VAddr, Opts.RodataAddr);
+  EXPECT_EQ(KDs[0].EntryOffset, Obj.EntryOffset);
+}
+
 TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
   namespace hsa = llvm::amdhsa;
 

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -20,6 +20,84 @@ static std::vector<uint8_t> makeText(size_t Size = 16) {
   return std::vector<uint8_t>(Size, 0);
 }
 
+static ElfView::ELFT::Ehdr
+readHeader(const comgr_test::KernelDescriptorElf &Obj) {
+  ElfView::ELFT::Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  return Header;
+}
+
+static void writeHeader(comgr_test::KernelDescriptorElf &Obj,
+                        const ElfView::ELFT::Ehdr &Header) {
+  std::memcpy(Obj.Bytes.data(), &Header, sizeof(Header));
+}
+
+static uint64_t
+getMetadataNoteOffset(const comgr_test::KernelDescriptorElf &Obj) {
+  ElfView::ELFT::Ehdr Header = readHeader(Obj);
+  llvm::ELF::Elf64_Phdr NoteProgram{};
+  std::memcpy(&NoteProgram, Obj.Bytes.data() + Header.e_phoff,
+              sizeof(NoteProgram));
+  return NoteProgram.p_offset;
+}
+
+static uint64_t
+getMetadataDescriptorOffset(const comgr_test::KernelDescriptorElf &Obj) {
+  const uint64_t NoteOffset = getMetadataNoteOffset(Obj);
+  llvm::ELF::Elf64_Nhdr NoteHeader{};
+  std::memcpy(&NoteHeader, Obj.Bytes.data() + NoteOffset, sizeof(NoteHeader));
+  return NoteOffset + sizeof(NoteHeader) +
+         llvm::alignTo(static_cast<uint64_t>(NoteHeader.n_namesz), 4);
+}
+
+static ElfView::ELFT::Shdr
+readSection(const comgr_test::KernelDescriptorElf &Obj, unsigned Index) {
+  ElfView::ELFT::Ehdr Header = readHeader(Obj);
+  ElfView::ELFT::Shdr Section{};
+  std::memcpy(&Section,
+              Obj.Bytes.data() + Header.e_shoff +
+                  Index * sizeof(ElfView::ELFT::Shdr),
+              sizeof(Section));
+  return Section;
+}
+
+static void writeSection(comgr_test::KernelDescriptorElf &Obj, unsigned Index,
+                         const ElfView::ELFT::Shdr &Section) {
+  ElfView::ELFT::Ehdr Header = readHeader(Obj);
+  std::memcpy(Obj.Bytes.data() + Header.e_shoff +
+                  Index * sizeof(ElfView::ELFT::Shdr),
+              &Section, sizeof(Section));
+}
+
+static ElfView::ELFT::Sym readSymbol(const comgr_test::KernelDescriptorElf &Obj,
+                                     unsigned Index) {
+  ElfView::ELFT::Shdr Symtab = readSection(Obj, 4);
+  ElfView::ELFT::Sym Symbol{};
+  std::memcpy(&Symbol,
+              Obj.Bytes.data() + Symtab.sh_offset +
+                  Index * sizeof(ElfView::ELFT::Sym),
+              sizeof(Symbol));
+  return Symbol;
+}
+
+static void writeSymbol(comgr_test::KernelDescriptorElf &Obj, unsigned Index,
+                        const ElfView::ELFT::Sym &Symbol) {
+  ElfView::ELFT::Shdr Symtab = readSection(Obj, 4);
+  std::memcpy(Obj.Bytes.data() + Symtab.sh_offset +
+                  Index * sizeof(ElfView::ELFT::Sym),
+              &Symbol, sizeof(Symbol));
+}
+
+static std::string createError(comgr_test::KernelDescriptorElf &Obj) {
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  if (ViewOrErr) {
+    ADD_FAILURE() << "expected ElfView::create to reject malformed ELF";
+    return "";
+  }
+  return llvm::toString(ViewOrErr.takeError());
+}
+
 static unsigned readReservedSgprs(const std::vector<uint8_t> &Bytes,
                                   uint64_t KernelDescriptorOffset) {
   namespace hsa = llvm::amdhsa;
@@ -65,6 +143,226 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::Expected<ElfView> ViewOrErr = ElfView::create(NotElf, sizeof(NotElf));
   EXPECT_FALSE((bool)ViewOrErr);
   llvm::consumeError(ViewOrErr.takeError());
+}
+
+TEST(ElfView, RejectsNullInput) {
+  llvm::Expected<ElfView> ViewOrErr = ElfView::create(nullptr, 64);
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
+TEST(ElfView, RejectsEachInvalidElfIdentificationField) {
+  const unsigned Fields[] = {llvm::ELF::EI_MAG0,   llvm::ELF::EI_MAG1,
+                             llvm::ELF::EI_MAG2,   llvm::ELF::EI_MAG3,
+                             llvm::ELF::EI_CLASS,  llvm::ELF::EI_DATA,
+                             llvm::ELF::EI_VERSION};
+  for (unsigned Field : Fields) {
+    SCOPED_TRACE(Field);
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText());
+    Obj.Bytes[Field] ^= 0xff;
+    EXPECT_NE(createError(Obj).find("invalid ELF identification"),
+              std::string::npos);
+  }
+}
+
+TEST(ElfView, RejectsInvalidOrUnsupportedElfHeaderFields) {
+  static constexpr unsigned CaseCount = 11;
+  for (unsigned Case = 0; Case < CaseCount; ++Case) {
+    SCOPED_TRACE(Case);
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText());
+    ElfView::ELFT::Ehdr Header = readHeader(Obj);
+    switch (Case) {
+    case 0:
+      Header.e_version = llvm::ELF::EV_NONE;
+      break;
+    case 1:
+      Header.e_ehsize = sizeof(Header) - 1;
+      break;
+    case 2:
+      Header.e_phnum = llvm::ELF::PN_XNUM;
+      break;
+    case 3:
+      Header.e_shnum = 0;
+      break;
+    case 4:
+      Header.e_shnum = llvm::ELF::SHN_LORESERVE;
+      break;
+    case 5:
+      Header.e_shstrndx = llvm::ELF::SHN_XINDEX;
+      break;
+    case 6:
+      Header.e_phnum = 1;
+      Header.e_phentsize = sizeof(ElfView::ELFT::Phdr) - 1;
+      break;
+    case 7:
+      Header.e_shentsize = sizeof(ElfView::ELFT::Shdr) - 1;
+      break;
+    case 8:
+      Header.e_machine = llvm::ELF::EM_X86_64;
+      break;
+    case 9:
+      Header.e_type = llvm::ELF::ET_CORE;
+      break;
+    case 10:
+      Header.e_type = llvm::ELF::ET_NONE;
+      break;
+    }
+    writeHeader(Obj, Header);
+    EXPECT_NE(createError(Obj).find("invalid or unsupported ELF header"),
+              std::string::npos);
+  }
+}
+
+TEST(ElfView, AcceptsSupportedElfTypes) {
+  const uint16_t SupportedTypes[] = {llvm::ELF::ET_REL, llvm::ELF::ET_EXEC,
+                                     llvm::ELF::ET_DYN};
+  for (uint16_t Type : SupportedTypes) {
+    SCOPED_TRACE(Type);
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.ElfType = Type;
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  }
+}
+
+TEST(ElfView, AcceptsAbsentProgramAndSectionTables) {
+  // A completely sectionless ELF uses zero offsets and zero counts. It is a
+  // structurally supported header even though ElfView later rejects it for
+  // having no .text section.
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  ElfView::ELFT::Ehdr Header = readHeader(Obj);
+  Header.e_shoff = 0;
+  Header.e_shnum = 0;
+  Header.e_shstrndx = 0;
+  Header.e_shentsize = 0;
+  writeHeader(Obj, Header);
+  EXPECT_EQ(createError(Obj).find("invalid or unsupported ELF header"),
+            std::string::npos);
+}
+
+TEST(ElfView, RejectsInvalidOrUnsupportedTextSections) {
+  static constexpr unsigned CaseCount = 3;
+  for (unsigned Case = 0; Case < CaseCount; ++Case) {
+    SCOPED_TRACE(Case);
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText());
+    ElfView::ELFT::Shdr Text = readSection(Obj, 1);
+    switch (Case) {
+    case 0:
+      Text.sh_type = llvm::ELF::SHT_NOBITS;
+      break;
+    case 1:
+      Text.sh_flags &= ~llvm::ELF::SHF_ALLOC;
+      break;
+    case 2:
+      Text.sh_flags &= ~llvm::ELF::SHF_EXECINSTR;
+      break;
+    }
+    writeSection(Obj, 1, Text);
+    EXPECT_NE(createError(Obj).find("invalid or unsupported .text section"),
+              std::string::npos);
+  }
+}
+
+TEST(ElfView, RejectsOutOfBoundsSectionFileRanges) {
+  static constexpr unsigned CaseCount = 3;
+  for (unsigned Case = 0; Case < CaseCount; ++Case) {
+    SCOPED_TRACE(Case);
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText());
+    ElfView::ELFT::Shdr Text = readSection(Obj, 1);
+    switch (Case) {
+    case 0:
+      Text.sh_offset = Obj.Bytes.size() + 1;
+      Text.sh_size = 1;
+      break;
+    case 1:
+      Text.sh_offset = Obj.Bytes.size();
+      Text.sh_size = 1;
+      break;
+    case 2:
+      Text.sh_offset = std::numeric_limits<uint64_t>::max();
+      Text.sh_size = 2;
+      break;
+    }
+    writeSection(Obj, 1, Text);
+    EXPECT_NE(createError(Obj).find("section extends past end of file"),
+              std::string::npos);
+  }
+}
+
+TEST(ElfView, AllowsNonFileBackedSectionRanges) {
+  for (unsigned Case = 0; Case < 2; ++Case) {
+    SCOPED_TRACE(Case);
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.ExtraAllocSectionAddr = 0x3000;
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+    ElfView::ELFT::Shdr Pad = readSection(Obj, 6);
+    Pad.sh_offset = std::numeric_limits<uint64_t>::max();
+    if (Case == 0) {
+      Pad.sh_type = llvm::ELF::SHT_NOBITS;
+      Pad.sh_size = std::numeric_limits<uint64_t>::max();
+    } else {
+      Pad.sh_type = llvm::ELF::SHT_PROGBITS;
+      Pad.sh_size = 0;
+    }
+    writeSection(Obj, 6, Pad);
+
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  }
+}
+
+TEST(ElfView, RejectsOutOfBoundsProgramFileRanges) {
+  static constexpr unsigned CaseCount = 2;
+  for (unsigned Case = 0; Case < CaseCount; ++Case) {
+    SCOPED_TRACE(Case);
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.MetadataSgprCount = 8;
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+    ElfView::ELFT::Ehdr Header = readHeader(Obj);
+    ElfView::ELFT::Phdr Program{};
+    std::memcpy(&Program, Obj.Bytes.data() + Header.e_phoff, sizeof(Program));
+    if (Case == 0) {
+      Program.p_offset = Obj.Bytes.size() + 1;
+      Program.p_filesz = 1;
+    } else {
+      Program.p_offset = Obj.Bytes.size();
+      Program.p_filesz = 2;
+    }
+    std::memcpy(Obj.Bytes.data() + Header.e_phoff, &Program, sizeof(Program));
+    EXPECT_NE(createError(Obj).find("segment extends past end of file"),
+              std::string::npos);
+  }
+}
+
+TEST(ElfView, AllowsEmptyProgramFileRangeAtLargeOffset) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataSgprCount = 8;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+  ElfView::ELFT::Ehdr Header = readHeader(Obj);
+  ElfView::ELFT::Phdr Program{};
+  std::memcpy(&Program, Obj.Bytes.data() + Header.e_phoff, sizeof(Program));
+  Program.p_offset = std::numeric_limits<uint64_t>::max();
+  Program.p_filesz = 0;
+  Program.p_memsz = 0;
+  std::memcpy(Obj.Bytes.data() + Header.e_phoff, &Program, sizeof(Program));
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 }
 
 // -- ElfView::findKernelAtAddress ---------------------------------------------
@@ -191,20 +489,58 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 16u);
 }
 
-TEST(ElfView, KernelDescriptorsSkipsKdWhenFileOffsetOverflows) {
-  comgr_test::KernelDescriptorElfOptions Opts;
-  Opts.KernelName = "overflow_kernel";
-  Opts.RodataAddr = 0x1000;
-  Opts.KernelDescriptorSymbolValue =
-      std::numeric_limits<uint64_t>::max() - 0x20;
-  comgr_test::KernelDescriptorElf Obj =
-      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+TEST(ElfView, RejectsMalformedKernelDescriptorSymbols) {
+  static constexpr unsigned CaseCount = 7;
+  for (unsigned Case = 0; Case < CaseCount; ++Case) {
+    SCOPED_TRACE(Case);
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.KernelName = "bad_descriptor";
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+    ElfView::ELFT::Sym Descriptor = readSymbol(Obj, 2);
 
-  llvm::Expected<ElfView> ViewOrErr =
-      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
-  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  EXPECT_TRUE(ViewOrErr->kernelDescriptors().empty());
-  EXPECT_EQ(ViewOrErr->findKernelDescriptor("overflow_kernel"), nullptr);
+    switch (Case) {
+    case 0:
+      Descriptor.st_shndx = llvm::ELF::SHN_UNDEF;
+      break;
+    case 1:
+      Descriptor.st_shndx = llvm::ELF::SHN_LORESERVE;
+      break;
+    case 2:
+      Descriptor.st_shndx = 42;
+      break;
+    case 3:
+      Descriptor.st_value = Opts.RodataAddr - 1;
+      break;
+    case 4:
+      Descriptor.st_value = Opts.RodataAddr + 1;
+      break;
+    case 5:
+      Descriptor.st_value = std::numeric_limits<uint64_t>::max() - 0x20;
+      break;
+    case 6: {
+      ElfView::ELFT::Shdr Rodata = readSection(Obj, 2);
+      Rodata.sh_type = llvm::ELF::SHT_NOBITS;
+      writeSection(Obj, 2, Rodata);
+      break;
+    }
+    }
+    writeSymbol(Obj, 2, Descriptor);
+    EXPECT_FALSE(createError(Obj).empty());
+  }
+}
+
+TEST(ElfView, ValidDescriptorDoesNotHideMalformedDuplicate) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  ElfView::ELFT::Sym ValidDescriptor = readSymbol(Obj, 2);
+  ElfView::ELFT::Sym Duplicate = readSymbol(Obj, 1);
+  Duplicate.st_name = ValidDescriptor.st_name;
+  Duplicate.st_shndx = llvm::ELF::SHN_UNDEF;
+  writeSymbol(Obj, 1, Duplicate);
+
+  EXPECT_NE(createError(Obj).find("kernel descriptor has no defining section"),
+            std::string::npos);
 }
 
 // growWithTrampolines appends the pool at a fresh high virtual address instead
@@ -1016,6 +1352,80 @@ TEST(ElfView, UpdateGfx1250RevisionMetadataRetagsKernelInPlace) {
                         Obj.Bytes.size());
   EXPECT_EQ(After.find("B0"), llvm::StringRef::npos);
   EXPECT_NE(After.find("A0"), llvm::StringRef::npos);
+}
+
+TEST(ElfView, UpdateGfx1250RevisionMetadataRejectsCompositeMapKeys) {
+  const uint8_t CompositeKeys[][3] = {
+      {0x81, 0x90, 0xc0}, // {[]: nil}
+      {0x81, 0x80, 0xc0}, // {{}: nil}
+  };
+  for (const uint8_t (&Prefix)[3] : CompositeKeys) {
+    comgr_test::KernelDescriptorElfOptions Opts;
+    Opts.MetadataGfx1250Revision = "B0";
+    comgr_test::KernelDescriptorElf Obj =
+        comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+    const uint64_t DescriptorOffset = getMetadataDescriptorOffset(Obj);
+    ASSERT_LE(DescriptorOffset + sizeof(Prefix), Obj.Bytes.size());
+    std::memcpy(Obj.Bytes.data() + DescriptorOffset, Prefix, sizeof(Prefix));
+
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+    EXPECT_FALSE(ViewOrErr->updateGfx1250RevisionMetadata("A0"));
+  }
+}
+
+TEST(ElfView, UpdateGfx1250RevisionMetadataRejectsTruncatedMap) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataGfx1250Revision = "B0";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  const uint64_t NoteOffset = getMetadataNoteOffset(Obj);
+  llvm::ELF::Elf64_Nhdr NoteHeader{};
+  std::memcpy(&NoteHeader, Obj.Bytes.data() + NoteOffset, sizeof(NoteHeader));
+  NoteHeader.n_descsz = 1;
+  std::memcpy(Obj.Bytes.data() + NoteOffset, &NoteHeader, sizeof(NoteHeader));
+  Obj.Bytes[getMetadataDescriptorOffset(Obj)] = 0x81;
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_FALSE(ViewOrErr->updateGfx1250RevisionMetadata("A0"));
+}
+
+TEST(ElfView, UpdateGfx1250RevisionMetadataRejectsReservedTag) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.MetadataGfx1250Revision = "B0";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  Obj.Bytes[getMetadataDescriptorOffset(Obj)] = 0xc1;
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_FALSE(ViewOrErr->updateGfx1250RevisionMetadata("A0"));
+}
+
+TEST(ElfView, UpdateGfx1250RevisionMetadataRejectsExcessiveNesting) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName.assign(128, 'k');
+  Opts.MetadataGfx1250Revision = "B0";
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  const uint64_t DescriptorOffset = getMetadataDescriptorOffset(Obj);
+  static constexpr size_t NestingDepth = 65;
+  ASSERT_LE(DescriptorOffset + NestingDepth + 1, Obj.Bytes.size());
+  std::memset(Obj.Bytes.data() + DescriptorOffset, 0x91, NestingDepth);
+  Obj.Bytes[DescriptorOffset + NestingDepth] = 0xc0;
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  EXPECT_FALSE(ViewOrErr->updateGfx1250RevisionMetadata("A0"));
 }
 
 TEST(ElfView, UpdateKernelDescriptorSgprCountCanUpdateMetadataOnly) {


### PR DESCRIPTION
## Summary

- reject malformed ELF identity, header, table, and overflowed file ranges before use
- validate every kernel descriptor symbol against its defining section
- add exhaustive unit coverage for accepted and rejected boundary cases

## Scope and review

This is an independently landable COMGR HotSwap-only split from #3552. The original PR remains unchanged as a reference.

Self-review caught and fixed a null input path, a conventions violation involving type inference, and a case where a valid duplicate kernel descriptor could hide a malformed one.

## Testing

- MI300X Release build with assertions: complete `check-comgr` passed (all unit suites, 147/147 supported LIT tests, 31/31 CTest tests)
- MI300X ASan build configured with exact `-DADDRESS_SANITIZER=On`: complete `check-comgr` passed with `ASAN_OPTIONS=use_sigaltstack=0` (host runtime workaround)
- MI400-2: `HotswapElfTests` passed 40/40