### PR TITLE
[clang][Driver] Remove dead getOrCheckAMDGPUCodeObjectVersion

### DIFF
--- a/clang/include/clang/Driver/CommonArgs.h
+++ b/clang/include/clang/Driver/CommonArgs.h
@@ -249,10 +249,6 @@ void addX86AlignBranchArgs(const Driver &D, const llvm::opt::ArgList &Args,
                            llvm::opt::ArgStringList &CmdArgs, bool IsLTO,
                            const StringRef PluginOptPrefix = "");
 
-unsigned getOrCheckAMDGPUCodeObjectVersion(const Driver &D,
-                              const llvm::opt::ArgList &Args,
-                              bool Diagnose = false);
-
 void checkAMDGPUCodeObjectVersion(const Driver &D,
                                   const llvm::opt::ArgList &Args);
 

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -3164,13 +3164,6 @@ unsigned tools::getAMDGPUCodeObjectVersion(const Driver &D,
   return CodeObjVer;
 }
 
-unsigned tools::getOrCheckAMDGPUCodeObjectVersion(
-    const Driver &D, const llvm::opt::ArgList &Args, bool Diagnose) {
-  if (Diagnose)
-    checkAMDGPUCodeObjectVersion(D, Args);
-  return getAMDGPUCodeObjectVersion(D, Args);
-}
-
 bool tools::haveAMDGPUCodeObjectVersionArgument(
     const Driver &D, const llvm::opt::ArgList &Args) {
   return getAMDGPUCodeObjectArgument(D, Args) != nullptr;


### PR DESCRIPTION
Converges with trunk - the downstream wrapper getOrCheckAMDGPUCodeObjectVersion (added in 29ad166190f0) lost its last caller when the AMDGPUOpenMP toolchain files were removed (3f29f893b2f7); it now has zero callers tree-wide. Upstream does not carry this wrapper. Drop the definition and its declaration to eliminate the surviving downstream delta against trunk.


