### PR TITLE
[clang][Driver] Drop redundant LLVM_PTHREAD_LIB link

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -120,5 +120,4 @@ add_clang_library(clangDriver
   clangLex
   clangOptions
   ${system_libs}
-  ${LLVM_PTHREAD_LIB}
   )


### PR DESCRIPTION
Converges with trunk - the clangDriver LINK_LIBS list carried an explicit ${LLVM_PTHREAD_LIB} (added downstream in a03740b012c7) on top of ${system_libs}. Upstream already appends the pthread lib into system_libs via "if(LLVM_PTHREAD_LIB) list(APPEND system_libs ${LLVM_PTHREAD_LIB})", so the extra entry links pthread twice. Removing it is a no-op functionally and eliminates the surviving downstream delta against trunk.


