### PR TITLE
[comgr][hotswap] Commit growing rewrites transactionally

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -71,11 +71,12 @@ static constexpr unsigned Gfx1250MaxSgprs = 106;
 static constexpr unsigned Gfx1250VgprGranuleSize = 16;
 
 /// Sample the test/A-B switch once for each public rewrite. Empty and "0"
-/// preserve the default displacement path; every other non-empty value selects
-/// trampoline placement. Sampling here, rather than in a function-local
-/// static, lets long-lived COMGR clients change the mode between requests
-/// without changing it partway through one transaction.
-static bool displacementDisabledForRequest() {
+/// preserve transactional displacement for growing instruction replacements;
+/// every other non-empty value selects trampoline placement for those
+/// replacements. Sampling here, rather than in a function-local static, lets
+/// long-lived COMGR clients change the mode between requests without changing
+/// it partway through one transaction.
+static bool transactionalDisplacementDisabledForRequest() {
   const char *Value = std::getenv("AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT");
   return Value && !StringRef(Value).empty() && StringRef(Value) != "0";
 }
@@ -2893,7 +2894,7 @@ copyOutputBuffer(const void *Data, size_t Size, StringRef CopyKind) {
 static amd_comgr_status_t retargetCodeObjectImpl(
     const void *ElfData, size_t ElfSize, const TargetIdentifier &TargetIdent,
     const Gfx1250RewriteOptions &Options, std::unique_ptr<MemoryBuffer> &Out,
-    bool AllowTextDisplacement, HotswapProfile &Profile) {
+    bool AllowTransactionalDisplacement, HotswapProfile &Profile) {
   // The dispatcher fetches the patch vtable lazily via
   // getHotswapPatchVTable() inside applyGfx1250B0toA0Rules; the singleton's
   // initializer binds every register*Patch slot on first access, so no
@@ -2970,7 +2971,7 @@ static amd_comgr_status_t retargetCodeObjectImpl(
   // NOP-sled/trampoline planner sees the final instruction offsets. If the ELF
   // cannot be displaced safely, continue from the pristine working copy and
   // append the established entry stubs below.
-  if (Options.RunEntryTrampolines && AllowTextDisplacement && !UseFastAppend) {
+  if (Options.RunEntryTrampolines && !UseFastAppend) {
     std::vector<DisplacementEdit> EntryDisplacements;
     std::optional<uint32_t> EntryCount =
         collectKernelEntryDisplacements(Elf, LS, EntryDisplacements);
@@ -2991,9 +2992,10 @@ static amd_comgr_status_t retargetCodeObjectImpl(
         Gfx1250RewriteOptions RemainingOptions = Options;
         RemainingOptions.RunEntryTrampolines = false;
         RemainingOptions.UseB0B0EntryFastPath = false;
-        return retargetCodeObjectImpl(
-            Displaced->getBufferStart(), Displaced->getBufferSize(),
-            TargetIdent, RemainingOptions, Out, AllowTextDisplacement, Profile);
+        return retargetCodeObjectImpl(Displaced->getBufferStart(),
+                                      Displaced->getBufferSize(), TargetIdent,
+                                      RemainingOptions, Out,
+                                      AllowTransactionalDisplacement, Profile);
       }
 
       log() << "hotswap: entry displacement unavailable: "
@@ -3004,7 +3006,7 @@ static amd_comgr_status_t retargetCodeObjectImpl(
 
   RewriteConfig Config = makeGfx1250B0A0Config();
   Config.RunB0A0Patches = Options.RunB0A0Patches;
-  Config.AllowTextDisplacement = AllowTextDisplacement;
+  Config.AllowTextDisplacement = AllowTransactionalDisplacement;
   Config.MaskPolicy = Options.MaskPolicy;
 
   uint8_t *Text = Elf.textData();
@@ -3033,11 +3035,12 @@ static amd_comgr_status_t retargetCodeObjectImpl(
         DisplacementDeclined, Profile);
     if (Prof)
       Profile.add(HotswapMetric::B0A0Dispatch, profNowNs() - DispatchT0, 0);
-    if (!Patched && AllowTextDisplacement && DisplacementDeclined) {
+    if (!Patched && AllowTransactionalDisplacement && DisplacementDeclined) {
       log() << "hotswap: displacement collection declined; retrying the "
                "original object with trampoline placement\n";
       return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
-                                    /*AllowTextDisplacement=*/false, Profile);
+                                    /*AllowTransactionalDisplacement=*/false,
+                                    Profile);
     }
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
@@ -3054,9 +3057,9 @@ static amd_comgr_status_t retargetCodeObjectImpl(
         std::string Reason = toString(GrownOrErr.takeError());
         log() << "hotswap: transactional displacement declined: " << Reason
               << "; retrying the original object with trampoline placement\n";
-        return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options,
-                                      Out,
-                                      /*AllowTextDisplacement=*/false, Profile);
+        return retargetCodeObjectImpl(
+            ElfData, ElfSize, TargetIdent, Options, Out,
+            /*AllowTransactionalDisplacement=*/false, Profile);
       }
 
       std::unique_ptr<WritableMemoryBuffer> Grown = std::move(*GrownOrErr);
@@ -3080,7 +3083,7 @@ static amd_comgr_status_t retargetCodeObjectImpl(
       RemainingOptions.MaskPolicy = MaskWorkaroundPolicy::None;
       return retargetCodeObjectImpl(
           Grown->getBufferStart(), Grown->getBufferSize(), TargetIdent,
-          RemainingOptions, Out, AllowTextDisplacement, Profile);
+          RemainingOptions, Out, AllowTransactionalDisplacement, Profile);
     }
   } else {
     log() << "hotswap: instruction patches disabled for this rewrite\n";
@@ -3276,9 +3279,10 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   [[maybe_unused]] HotswapProfile::Scope TotalScope =
       Profile.time(HotswapMetric::RewriteTotal);
 
-  const bool AllowTextDisplacement = !displacementDisabledForRequest();
+  const bool AllowTransactionalDisplacement =
+      !transactionalDisplacementDisabledForRequest();
   return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
-                                AllowTextDisplacement, Profile);
+                                AllowTransactionalDisplacement, Profile);
 }
 
 } // namespace hotswap

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -40,6 +40,7 @@
 #include <cassert>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
 #include <limits>
 #include <mutex>
 
@@ -68,6 +69,16 @@ static constexpr unsigned Gfx1250MaxVgprs = 1024;
 // GFX12 wave32: 106 user-addressable SGPRs (s0-s105); s106-s107 are VCC.
 static constexpr unsigned Gfx1250MaxSgprs = 106;
 static constexpr unsigned Gfx1250VgprGranuleSize = 16;
+
+/// Sample the test/A-B switch once for each public rewrite. Empty and "0"
+/// preserve the default displacement path; every other non-empty value selects
+/// trampoline placement. Sampling here, rather than in a function-local
+/// static, lets long-lived COMGR clients change the mode between requests
+/// without changing it partway through one transaction.
+static bool displacementDisabledForRequest() {
+  const char *Value = std::getenv("AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT");
+  return Value && !StringRef(Value).empty() && StringRef(Value) != "0";
+}
 
 /// Build the default RewriteConfig used for the GFX1250 B0-to-A0 rewrite:
 /// fills in the identity source / target ISA (both gfx1250) and the
@@ -2310,13 +2321,55 @@ assignLongBranchGateways(PatchContext &Ctx,
   return true;
 }
 
+/// Queue one growing replacement without changing the working .text. The
+/// complete edit set is validated and rebuilt later by DisplacementPlan.
+static bool collectTransactionalDisplacement(PatchContext &Ctx,
+                                             uint64_t InstOffset,
+                                             uint32_t InstSize,
+                                             ArrayRef<uint8_t> Replacement) {
+  if (Replacement.size() <= InstSize || Ctx.DisplacementDeclined)
+    return false;
+  const uint64_t Growth = Replacement.size() - InstSize;
+  if (Growth % MinInstSize != 0 || Ctx.LS.SNopBytes.size() != MinInstSize)
+    return false;
+  if (InstOffset > Ctx.TextSize || InstSize > Ctx.TextSize - InstOffset)
+    return false;
+
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!Range || InstOffset < Range->Begin || InstOffset >= Range->End ||
+      InstSize > Range->End - InstOffset)
+    return false;
+
+  DisplacementEdit Edit;
+  Edit.Offset = InstOffset;
+  Edit.OriginalSize = InstSize;
+  Edit.ReplacementBytes.assign(Replacement.begin(), Replacement.end());
+  Ctx.DisplacementEdits.push_back(std::move(Edit));
+  return true;
+}
+
 /// Emit \p Replacement for the instruction at [\p InstOffset,
-/// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
-/// reachable sled with sufficient headroom exists; otherwise falls back to a
-/// deferred trampoline.
+/// \p InstOffset + \p InstSize). Growing replacements first join the
+/// whole-object transaction when control-flow closure is known. Other
+/// replacements prefer an in-place NOP-sled rewrite and then a deferred
+/// trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        ArrayRef<uint8_t> Replacement) {
+  if (Ctx.Config.AllowTextDisplacement &&
+      !Ctx.DirectControlFlow.HasUnresolvedTargets &&
+      Replacement.size() > InstSize) {
+    if (collectTransactionalDisplacement(Ctx, InstOffset, InstSize,
+                                         Replacement))
+      return true;
+    Ctx.DisplacementDeclined = true;
+    log() << "hotswap: transactional displacement could not collect growing "
+             "replacement at 0x"
+          << utohexstr(InstOffset) << "\n";
+    return false;
+  }
+
   std::optional<uint64_t> ReturnTo = checkedAddUint64(
       InstOffset, InstSize, "replacement trampoline return target");
   std::optional<uint64_t> PoolReturnFrom =
@@ -2379,8 +2432,11 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     const LLVMState &LS, std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
     std::vector<ScratchPatchInfo> &OutScratchPatches,
     const RewriteConfig &Config, bool &OutRequiredPatchApplied,
-    HotswapProfile &Profile) {
+    std::vector<DisplacementEdit> &OutTransactionalDisplacements,
+    bool &OutDisplacementDeclined, HotswapProfile &Profile) {
   uint32_t Patched = 0;
+  OutTransactionalDisplacements.clear();
+  OutDisplacementDeclined = false;
 
   HotswapProfile::Scope SledScope = Profile.time(HotswapMetric::NopSledScan);
   std::vector<NopSled> Sleds = buildNopSledMap(Decoded, LS, Elf);
@@ -2477,8 +2533,10 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
         Pass.Nanos += profNowNs() - T0;
         Pass.Patches += P.value_or(0);
       }
-      if (!P)
+      if (!P) {
+        OutDisplacementDeclined = Ctx.DisplacementDeclined;
         return std::nullopt;
+      }
       if (*P == 0)
         continue;
       Patched += *P;
@@ -2516,6 +2574,23 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     Vop3Scope.addPatches(P);
     Vop3Scope.finish();
     Patched += P;
+  }
+
+  if (Ctx.DisplacementDeclined) {
+    OutDisplacementDeclined = true;
+    return std::nullopt;
+  }
+  if (!Ctx.DisplacementEdits.empty() && !OutTrampolines.empty()) {
+    log() << "hotswap: transactional displacement cannot be mixed with "
+             "deferred trampolines; retrying with trampoline placement\n";
+    OutDisplacementDeclined = true;
+    return std::nullopt;
+  }
+  if (!Ctx.DisplacementEdits.empty() && !OutScratchPatches.empty()) {
+    log() << "hotswap: transactional displacement cannot preserve scratch "
+             "verification offsets; retrying with trampoline placement\n";
+    OutDisplacementDeclined = true;
+    return std::nullopt;
   }
 
   if (!OutTrampolines.empty()) {
@@ -2640,6 +2715,7 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";
   }
+  OutTransactionalDisplacements = std::move(Ctx.DisplacementEdits);
   OutRequiredPatchApplied = Ctx.RequiredPatchApplied;
   return Patched;
 }
@@ -2915,10 +2991,9 @@ static amd_comgr_status_t retargetCodeObjectImpl(
         Gfx1250RewriteOptions RemainingOptions = Options;
         RemainingOptions.RunEntryTrampolines = false;
         RemainingOptions.UseB0B0EntryFastPath = false;
-        return retargetCodeObjectImpl(Displaced->getBufferStart(),
-                                      Displaced->getBufferSize(), TargetIdent,
-                                      RemainingOptions, Out,
-                                      /*AllowTextDisplacement=*/false, Profile);
+        return retargetCodeObjectImpl(
+            Displaced->getBufferStart(), Displaced->getBufferSize(),
+            TargetIdent, RemainingOptions, Out, AllowTextDisplacement, Profile);
       }
 
       log() << "hotswap: entry displacement unavailable: "
@@ -2929,12 +3004,15 @@ static amd_comgr_status_t retargetCodeObjectImpl(
 
   RewriteConfig Config = makeGfx1250B0A0Config();
   Config.RunB0A0Patches = Options.RunB0A0Patches;
+  Config.AllowTextDisplacement = AllowTextDisplacement;
   Config.MaskPolicy = Options.MaskPolicy;
 
   uint8_t *Text = Elf.textData();
   uint64_t Count = 0;
   std::vector<Trampoline> Deferred;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  std::vector<DisplacementEdit> TransactionalDisplacements;
+  bool DisplacementDeclined = false;
   bool RequiredPatchApplied = false;
   if (RunInstructionPatches) {
     std::vector<InternalDecodedInst> Decoded;
@@ -2951,13 +3029,59 @@ static amd_comgr_status_t retargetCodeObjectImpl(
     uint64_t DispatchT0 = Prof ? profNowNs() : 0;
     std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
         Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
-        Config, RequiredPatchApplied, Profile);
+        Config, RequiredPatchApplied, TransactionalDisplacements,
+        DisplacementDeclined, Profile);
     if (Prof)
       Profile.add(HotswapMetric::B0A0Dispatch, profNowNs() - DispatchT0, 0);
+    if (!Patched && AllowTextDisplacement && DisplacementDeclined) {
+      log() << "hotswap: displacement collection declined; retrying the "
+               "original object with trampoline placement\n";
+      return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
+                                    /*AllowTextDisplacement=*/false, Profile);
+    }
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;
     log() << "hotswap: applied " << Count << " instruction patches\n";
+
+    if (!TransactionalDisplacements.empty()) {
+      log() << "hotswap: transactional displacement: collected "
+            << TransactionalDisplacements.size() << " growing edit(s)\n";
+      Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
+          tryApplyTextDisplacementToNewBuffer(Elf, LS,
+                                              TransactionalDisplacements);
+      if (!GrownOrErr) {
+        std::string Reason = toString(GrownOrErr.takeError());
+        log() << "hotswap: transactional displacement declined: " << Reason
+              << "; retrying the original object with trampoline placement\n";
+        return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options,
+                                      Out,
+                                      /*AllowTextDisplacement=*/false, Profile);
+      }
+
+      std::unique_ptr<WritableMemoryBuffer> Grown = std::move(*GrownOrErr);
+      if (Options.RunB0A0Patches) {
+        uint8_t *GrownData =
+            reinterpret_cast<uint8_t *>(Grown->getBufferStart());
+        Expected<ElfView> GrownViewOrErr =
+            ElfView::create(GrownData, Grown->getBufferSize());
+        if (!GrownViewOrErr) {
+          log() << "hotswap: error: could not parse transaction output for "
+                   "gfx1250 revision retag: "
+                << toString(GrownViewOrErr.takeError()) << "\n";
+          return AMD_COMGR_STATUS_ERROR;
+        }
+        if (!GrownViewOrErr->updateGfx1250RevisionMetadata("A0"))
+          return AMD_COMGR_STATUS_ERROR;
+      }
+
+      Gfx1250RewriteOptions RemainingOptions = Options;
+      RemainingOptions.RunB0A0Patches = false;
+      RemainingOptions.MaskPolicy = MaskWorkaroundPolicy::None;
+      return retargetCodeObjectImpl(
+          Grown->getBufferStart(), Grown->getBufferSize(), TargetIdent,
+          RemainingOptions, Out, AllowTextDisplacement, Profile);
+    }
   } else {
     log() << "hotswap: instruction patches disabled for this rewrite\n";
   }
@@ -3152,8 +3276,9 @@ amd_comgr_status_t retargetCodeObject(const void *ElfData, size_t ElfSize,
   [[maybe_unused]] HotswapProfile::Scope TotalScope =
       Profile.time(HotswapMetric::RewriteTotal);
 
+  const bool AllowTextDisplacement = !displacementDisabledForRequest();
   return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
-                                /*AllowTextDisplacement=*/true, Profile);
+                                AllowTextDisplacement, Profile);
 }
 
 } // namespace hotswap

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -785,6 +785,9 @@ struct RewriteConfig {
   unsigned MaxSgprs = 0;
   unsigned VgprGranuleSize = 0;
   bool RunB0A0Patches = true;
+  // A retry clears this flag so every growing replacement uses the established
+  // trampoline path instead of mixing deferred and displaced code.
+  bool AllowTextDisplacement = true;
   MaskWorkaroundPolicy MaskPolicy = MaskWorkaroundPolicy::None;
 };
 
@@ -1279,6 +1282,13 @@ struct PatchContext {
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
       WorkgroupMetadataCache;
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
+  // Growing replacements are collected without changing instruction
+  // boundaries. The dispatcher commits the complete set through one
+  // DisplacementPlan after all patch passes succeed.
+  std::vector<DisplacementEdit> DisplacementEdits;
+  // A growing site could not join the transaction. The caller must discard
+  // this speculative run and retry the original object with trampolines.
+  bool DisplacementDeclined = false;
 };
 
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -619,7 +619,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
       VgprBumpDecision::Apply)
     return 0;
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {
@@ -789,7 +789,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
       VgprBumpDecision::Apply)
     return 0;
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -460,8 +460,8 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
       VgprBumpDecision::Apply)
     return 0; // checkKernelVgprBump set RequiredPatchFailed on the Fail path.
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
-    return failClosed(Ctx, DI, "trampoline emission failed");
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+    return failClosed(Ctx, DI, "replacement emission failed");
 
   if (MaskSgpr && !commitSafeSgprScratchBlock(Ctx, DI.Offset, *MaskSgpr,
                                               "wmma_scale16 lane mask"))

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -1262,9 +1262,8 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
     return failWmmaSplit(Ctx);
   }
 
-  // Assemble the split sequence and defer trampoline emission to
-  // emitToTrampoline, which picks a short s_branch or an SGPR-backed set-PC
-  // gateway based on the site's distance from the appended pool.
+  // Assemble the split sequence. The shared emitter either joins the
+  // displacement transaction or selects the established trampoline path.
   SmallVector<uint8_t> Replacement =
       assembleInstructions(joinAsmLines(AsmLines), Ctx.LS);
   if (Replacement.empty()) {
@@ -1272,8 +1271,8 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
           << DI.Mnemonic << "\n";
     return failWmmaSplit(Ctx);
   }
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement)) {
-    log() << "hotswap: error: WMMA split: could not emit trampoline for "
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement)) {
+    log() << "hotswap: error: WMMA split: could not emit replacement for "
           << DI.Mnemonic << "\n";
     return failWmmaSplit(Ctx);
   }

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -37,9 +37,11 @@ input.
 
 For testing and A/B investigations,
 `AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT` selects the established trampoline
-placement path when set to a non-empty value other than `0`. COMGR samples this
-switch once at the start of each rewrite request, so changing it affects the
-next request but cannot change an in-flight transaction.
+placement path for growing instruction replacements when set to a non-empty
+value other than `0`. Entry-prefix displacement remains enabled when the caller
+requests entry trampolines. COMGR samples this switch once at the start of each
+rewrite request, so changing it affects the next request but cannot change an
+in-flight transaction.
 
 ## Register accounting
 

--- a/amd/comgr/src/hotswap/README.md
+++ b/amd/comgr/src/hotswap/README.md
@@ -35,6 +35,12 @@ necessarily that the output bytes changed. If the source/target ISA pair and
 rewrite options select no enabled transformation, the output is a copy of the
 input.
 
+For testing and A/B investigations,
+`AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT` selects the established trampoline
+placement path when set to a non-empty value other than `0`. COMGR samples this
+switch once at the start of each rewrite request, so changing it affects the
+next request but cannot change an in-flight transaction.
+
 ## Register accounting
 
 A patch that allocates VGPRs above the kernel descriptor's existing allocation

--- a/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
+++ b/amd/comgr/test-lit/comgr-sources/hotswap-rewrite.c
@@ -13,6 +13,10 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include "amd_comgr.h"
 #include "common.h"
 
@@ -34,6 +38,38 @@ runRewrite(amd_comgr_data_t InputData, const char *SourceISA,
 
   return amd_comgr_hotswap_rewrite_with_options(InputData, SourceISA, TargetISA,
                                                 &Options, OutputData);
+}
+
+static void setDisplacementDisabled(const char *Value) {
+#ifdef _WIN32
+  if (_putenv_s("AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT", Value) != 0)
+    fail("could not set AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT");
+#else
+  if (setenv("AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT", Value, 1) != 0)
+    fail("could not set AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT");
+#endif
+}
+
+static int dataEqual(amd_comgr_data_t Left, amd_comgr_data_t Right) {
+  size_t LeftSize = 0;
+  size_t RightSize = 0;
+  amd_comgr_(get_data(Left, &LeftSize, NULL));
+  amd_comgr_(get_data(Right, &RightSize, NULL));
+  if (LeftSize != RightSize)
+    return 0;
+  if (LeftSize == 0)
+    return 1;
+
+  char *LeftBytes = (char *)malloc(LeftSize);
+  char *RightBytes = (char *)malloc(RightSize);
+  if (!LeftBytes || !RightBytes)
+    fail("malloc failed while comparing rewrite outputs");
+  amd_comgr_(get_data(Left, &LeftSize, LeftBytes));
+  amd_comgr_(get_data(Right, &RightSize, RightBytes));
+  int Equal = memcmp(LeftBytes, RightBytes, LeftSize) == 0;
+  free(LeftBytes);
+  free(RightBytes);
+  return Equal;
 }
 
 int main(int argc, char *argv[]) {
@@ -59,7 +95,8 @@ int main(int argc, char *argv[]) {
         "usage: hotswap-rewrite <elf_file> <source_isa> <target_isa> "
         "[--entry-trampolines] [--strict-mode] [--bad-options-size] "
         "[--bad-options-flags] [--zero-size] [--output <path>] [--dump <file>] "
-        "[--check-idempotent] [--expect-status <status>]");
+        "[--check-idempotent] [--check-displacement-toggle] "
+        "[--expect-status <status>]");
 
   const char *ElfFile = argv[1];
   const char *SourceISA = argv[2];
@@ -69,6 +106,7 @@ int main(int argc, char *argv[]) {
   const char *DumpFile = NULL;
   const char *ExpectStatus = NULL;
   int CheckIdempotent = 0;
+  int CheckDisplacementToggle = 0;
   int BadOptionsSize = 0;
   int BadOptionsFlags = 0;
   uint64_t RewriteFlags = AMD_COMGR_HOTSWAP_REWRITE_FLAG_NONE;
@@ -90,6 +128,8 @@ int main(int argc, char *argv[]) {
       DumpFile = argv[++I];
     else if (strcmp(argv[I], "--check-idempotent") == 0)
       CheckIdempotent = 1;
+    else if (strcmp(argv[I], "--check-displacement-toggle") == 0)
+      CheckDisplacementToggle = 1;
     else if (strcmp(argv[I], "--expect-status") == 0 && I + 1 < argc)
       ExpectStatus = argv[++I];
     else {
@@ -108,6 +148,8 @@ int main(int argc, char *argv[]) {
   }
 
   amd_comgr_data_t OutputData;
+  if (CheckDisplacementToggle)
+    setDisplacementDisabled("1");
   amd_comgr_status_t Status =
       runRewrite(InputData, SourceISA, TargetISA, RewriteFlags, BadOptionsSize,
                  BadOptionsFlags, &OutputData);
@@ -135,6 +177,32 @@ int main(int argc, char *argv[]) {
 
   if (Status != AMD_COMGR_STATUS_SUCCESS)
     fail("unexpected error status %s", StatusString);
+
+  if (CheckDisplacementToggle) {
+    setDisplacementDisabled("0");
+    amd_comgr_data_t DisplacementOutput;
+    Status = runRewrite(InputData, SourceISA, TargetISA, RewriteFlags,
+                        BadOptionsSize, BadOptionsFlags, &DisplacementOutput);
+    if (Status != AMD_COMGR_STATUS_SUCCESS)
+      fail("rewrite after displacement toggle failed with status %d",
+           (int)Status);
+    if (dataEqual(OutputData, DisplacementOutput))
+      fail("displacement environment toggle was not observed by the next "
+           "rewrite request");
+
+    setDisplacementDisabled("");
+    amd_comgr_data_t EmptyValueOutput;
+    Status = runRewrite(InputData, SourceISA, TargetISA, RewriteFlags,
+                        BadOptionsSize, BadOptionsFlags, &EmptyValueOutput);
+    if (Status != AMD_COMGR_STATUS_SUCCESS)
+      fail("rewrite with empty displacement switch failed with status %d",
+           (int)Status);
+    if (!dataEqual(DisplacementOutput, EmptyValueOutput))
+      fail("empty displacement switch did not preserve the default path");
+    amd_comgr_(release_data(EmptyValueOutput));
+    amd_comgr_(release_data(DisplacementOutput));
+    printf("DISPLACEMENT_TOGGLE: OBSERVED\n");
+  }
 
   size_t OutSize = 0;
   amd_comgr_(get_data(OutputData, &OutSize, NULL));

--- a/amd/comgr/test-lit/hotswap-inplace-saddr.s
+++ b/amd/comgr/test-lit/hotswap-inplace-saddr.s
@@ -9,7 +9,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@
 // DISASM-NEXT: s_mov_b32 m0, [[SCRATCH]]
 
 // COM: Idempotency: output should be identical on second rewrite.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-multi.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --entry-trampolines --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
@@ -3,7 +3,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
@@ -22,7 +22,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -81,7 +81,7 @@ test_addtid_nosled:
 // COM: produce identical bytes. The trampoline body uses plain ds_load_b32
 // COM: (no ADDTID mnemonic), so the dispatcher leaves it untouched on
 // COM: subsequent runs.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -3,7 +3,7 @@
 // COM: trampoline return uses the accepted SGPR-backed set-PC sequence.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
@@ -11,14 +11,14 @@
 // COM: Exercise the large-object planning path with verbose accounting. This
 // COM: fixture contains more than 250 KiB of text and requires a deterministic
 // COM: forward branch-island chain.
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.scale.elf 2>&1 | %FileCheck --check-prefix=SCALE %s
 // SCALE: hotswap: assigned 1 forward s_branch island chain(s)
 // SCALE: hotswap: applied 1 instruction patches
 // SCALE: hotswap: growWithTrampolines: appended 1 trampoline
 
-// RUN: hotswap-rewrite %t.scale.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.scale.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=SCALE-IDEM %s
 // SCALE-IDEM: IDEMPOTENT: YES
@@ -41,7 +41,7 @@
 // DISASM-NEXT: s_add_nc_u64 s[14:15], s[14:15],
 // DISASM-NEXT: s_set_pc_i64 s[14:15]
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-cluster-scc.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-cluster-scc.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -27,7 +27,7 @@
 // METADATA: .name:           test_cluster_scc_live
 // METADATA: .sgpr_count:     9
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-cluster-scratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-cluster-scratch.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-trampoline-cluster.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-cluster.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -63,7 +63,7 @@
 // METADATA: .sgpr_count:     17
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s
@@ -75,7 +75,7 @@
 // RUN:     -e 's/.sgpr_count: 16/.sgpr_count: 106/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
-// RUN: hotswap-rewrite %t.highsgpr.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR \
 // RUN:   | %FileCheck --check-prefix=NO-SCRATCH %s

--- a/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
@@ -4,7 +4,7 @@
 // COM: size instead of requiring the 20-byte worst-case reservation.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
 // LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
@@ -34,7 +34,7 @@
 // META: .name:           compact_gateway
 // META: .sgpr_count:     4
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-direct-target-sled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-direct-target-sled.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -29,7 +29,7 @@
 // DISASM-NEXT: s_wait_dscnt 0x0
 // DISASM-NEXT: s_branch
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -23,7 +23,7 @@
 // DISASM: s_wait_dscnt 0x0
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -17,7 +17,7 @@
 // COM: Entry displacement is applied before ordinary instruction rewriting.
 // COM: Verify that the direct entry prefix and appended DS trampoline coexist
 // COM: with branch sites calculated from the displaced instruction layout.
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --entry-trampolines --output %t.entry.elf \
 // RUN:   | %FileCheck --check-prefix=ENTRY-API %s
@@ -53,7 +53,7 @@
 // DISASM-NEXT: s_code_end
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -13,7 +13,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -77,7 +77,7 @@ test_multi_ds_nostride64:
 .size test_multi_ds_nostride64, .Ltest_multi_ds_nostride64_end-test_multi_ds_nostride64
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -21,7 +21,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -343,7 +343,7 @@ test_ds_combo_nostride64:
 
 // COM: Idempotency: rewriting the output again should produce identical
 // COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -27,7 +27,7 @@
 // DISASM: s_branch
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
@@ -7,7 +7,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -43,7 +43,7 @@
 
 // COM: Idempotency: a second rewrite produces identical bytes (the 2-addr
 // COM: forms are gone, so there is nothing left to split).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds.s
@@ -15,7 +15,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -64,7 +64,7 @@
 // DISASM: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
@@ -5,7 +5,7 @@
 // COM: gateway. The pool is beyond s_branch range and no island chain exists.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
 // LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
@@ -35,7 +35,7 @@
 // META: .name:           fragmented_gateway
 // META: .sgpr_count:     4
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -32,7 +32,7 @@
 // METADATA: .name:           test_far
 // METADATA: .sgpr_count:     16
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s
@@ -45,7 +45,7 @@
 // RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
-// RUN: hotswap-rewrite %t.full-sgpr.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 // FAIL: RESULT: ERROR
@@ -55,7 +55,7 @@
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.nometa.s -o %t.nometa.elf
-// RUN: hotswap-rewrite %t.nometa.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-known.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-known.s
@@ -5,7 +5,7 @@
 // RUN:   --amdhsa-code-object-version=6 -filetype=obj %s -o %t.o
 // RUN: %ld.lld -flavor gnu -m elf64_amdgpu %t.o -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --output %t.default.elf \
@@ -19,7 +19,7 @@
 // DEFAULTDIS: tensor_load_to_lds s[0:3], s[4:11]
 // DEFAULTDIS: s_endpgm
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \
@@ -60,7 +60,7 @@
 // METADATA: .name:           test_tensor_b0_known_cluster
 // METADATA: .sgpr_count:     17
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --check-idempotent \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scc.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scc.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \
@@ -32,7 +32,7 @@
 // METADATA: .name:           test_tensor_b0_scc_live
 // METADATA: .sgpr_count:     18
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --check-idempotent \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scratch.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --output %t.default.elf \
@@ -19,7 +19,7 @@
 // DEFAULTDIS: cluster_load_b32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 // DEFAULTDIS: s_endpgm
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \
@@ -47,7 +47,7 @@
 // METADATA: .name:           test_tensor_b0_dynamic
 // METADATA: .sgpr_count:     17
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --check-idempotent \
@@ -58,7 +58,7 @@
 // RUN:     -e 's/.sgpr_count: 16/.sgpr_count: 106/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
-// RUN: hotswap-rewrite %t.highsgpr.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --expect-status ERROR \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -28,7 +28,7 @@
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-post-use.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-mask-post-use.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   2>&1 \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -56,7 +56,7 @@
 // DISASM: s_endpgm
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -52,7 +52,7 @@
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -17,7 +17,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   2>&1 \
@@ -111,7 +111,7 @@
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-transactional-displacement-fallback.s
+++ b/amd/comgr/test-lit/hotswap-transactional-displacement-fallback.s
@@ -1,0 +1,68 @@
+// COM: If whole-object displacement rejects the input, the speculative run is
+// COM: discarded and the growing patch is emitted through the established
+// COM: trampoline path from the original object.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: transactional displacement: collected 1 growing edit(s)
+// LOG: transactional displacement declined: debug/unwind section '.debug_info'
+// LOG: retrying the original object with trampoline placement
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <transactional_fallback>:
+// DISASM-NOT:   ds_load_2addr_stride64_b32
+// DISASM:       s_branch
+// DISASM:       s_endpgm
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf
+// RUN: cmp %t.out.elf %t.out2.elf
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl transactional_fallback
+.p2align 8
+.type transactional_fallback,@function
+transactional_fallback:
+  ds_load_2addr_stride64_b32 v[4:5], v2 offset0:1 offset1:3
+  s_endpgm
+.Lend:
+.size transactional_fallback, .Lend-transactional_fallback
+
+.rodata
+.p2align 8
+.amdhsa_kernel transactional_fallback
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_group_segment_fixed_size 256
+.end_amdhsa_kernel
+
+.section .debug_info,"",@progbits
+.byte 0
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: transactional_fallback
+      .symbol: transactional_fallback.kd
+      .sgpr_count: 1
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 256
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-transactional-displacement.s
+++ b/amd/comgr/test-lit/hotswap-transactional-displacement.s
@@ -1,0 +1,80 @@
+// COM: Multiple growing replacements are committed through one displacement
+// COM: transaction. Expanded instructions stay on the straight-line path and
+// COM: a second rewrite is byte-identical.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: transactional displacement: collected 2 growing edit(s)
+// LOG: displacement: grew ELF
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <transactional_ds2>:
+// DISASM-NOT:   ds_load_2addr_stride64_b32
+// DISASM-NOT:   s_branch
+// DISASM:       ds_load_b32 v4, v2 offset:256
+// DISASM-NEXT:  ds_load_b32 v5, v2 offset:768
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  ds_load_b32 v6, v3 offset:512
+// DISASM-NEXT:  ds_load_b32 v7, v3 offset:1024
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  s_endpgm
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out2.elf
+// RUN: cmp %t.out.elf %t.out2.elf
+
+// COM: A long-lived process samples the displacement switch per request.
+// RUN: hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-displacement-toggle --output %t.toggle.elf \
+// RUN:   | %FileCheck --check-prefix=TOGGLE %s
+// TOGGLE: DISPLACEMENT_TOGGLE: OBSERVED
+// TOGGLE: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl transactional_ds2
+.p2align 8
+.type transactional_ds2,@function
+transactional_ds2:
+  ds_load_2addr_stride64_b32 v[4:5], v2 offset0:1 offset1:3
+  ds_load_2addr_stride64_b32 v[6:7], v3 offset0:2 offset1:4
+  s_endpgm
+.Lend:
+.size transactional_ds2, .Lend-transactional_ds2
+
+.rodata
+.p2align 8
+.amdhsa_kernel transactional_ds2
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 8
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_group_segment_fixed_size 256
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: transactional_ds2
+      .symbol: transactional_ds2.kd
+      .sgpr_count: 1
+      .vgpr_count: 8
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 256
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-wmma-split-fp-imm.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-fp-imm.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -37,7 +37,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-int-imm.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-int-imm.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -28,7 +28,7 @@
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 
 // COM: Idempotency: rewriting the output again must be a no-op.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-matrix-a-reuse.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-matrix-a-reuse.s
@@ -9,7 +9,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -42,7 +42,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-matrix-b-reuse.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-matrix-b-reuse.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-msplit-fp-imm.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-msplit-fp-imm.s
@@ -11,7 +11,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -38,7 +38,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-msplit-neg-lo.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-msplit-neg-lo.s
@@ -7,7 +7,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -34,7 +34,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-multi-wmma.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-multi-wmma.s
@@ -10,7 +10,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -58,7 +58,7 @@ kernel:
 // bytes (same invariant as the omnibus test, asserted here for the
 // >1-trampoline path so a regression specific to the second trampoline
 // would surface).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-neg-hi-k.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-neg-hi-k.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-neg-lo-k.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-neg-lo-k.s
@@ -11,7 +11,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -43,7 +43,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-src2-eq-dst.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-src2-eq-dst.s
@@ -10,7 +10,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -46,7 +46,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
@@ -3,7 +3,7 @@
 // non-MODE SETREG that must preserve the tracked fields.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
@@ -39,7 +39,7 @@
 // DISASM-NEXT:  s_set_vgpr_msb 0x5060
 // DISASM-NEXT:  s_branch
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
@@ -3,7 +3,7 @@
 // incoming dst bank. Preserve and restore every other incoming mode field.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
@@ -28,7 +28,7 @@
 // DISASM-NEXT: s_set_vgpr_msb 0x5060
 // DISASM-NEXT: s_branch
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
@@ -3,7 +3,7 @@
 // every entry still establishes the original mode before either WMMA half.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
@@ -23,7 +23,7 @@
 // DISASM-NEXT: v_wmma_f32_16x16x64_fp8_fp8 v[162:169], v[2:9]{{.*v\[258:265\].*}}, v[122:129], v[162:169]
 // DISASM-NEXT: s_set_vgpr_msb 0x100
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
@@ -3,7 +3,7 @@
 // and restore the exact nonzero incoming mode after the upper half.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API-COUNT-2: WMMA split: patched v_wmma_f32_32x16x128_f4
@@ -28,7 +28,7 @@
 // DISASM-NEXT: s_set_vgpr_msb 0x7a39
 // DISASM-NEXT: s_branch
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
@@ -3,7 +3,7 @@
 // mode 0x60 and must be restored around the split WMMA's upper half.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
@@ -19,7 +19,7 @@
 // DISASM-NEXT:  v_wmma_f32_16x16x64_fp8_fp8
 // DISASM-NEXT:  s_set_vgpr_msb 0x5060
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
@@ -2,7 +2,7 @@
 // gfx1250 VGPR-MSB mode around that half and restores the incoming mode.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8
@@ -18,7 +18,7 @@
 // DISASM-NEXT: s_set_vgpr_msb 0x100
 // DISASM-NEXT: s_branch
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-wmma-split.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split.s
@@ -21,7 +21,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -219,7 +219,7 @@ test_no_split_required:
 // bytes (the splitter only fires on K=128 mnemonics, which no longer exist
 // in the rewritten ELF).
 //
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s


### PR DESCRIPTION
## Summary

- collect every growing HotSwap replacement without mutating `.text`, then commit the complete edit set through whole-object displacement
- discard speculative work and retry the pristine input through the established trampoline path when displacement is unsafe or would conflict with deferred trampolines or scratch-verification offsets
- keep legacy trampoline-layout tests explicit with `AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT`
- cover multi-edit rewriting, metadata retagging, fallback, same-process policy changes, and byte-identical second rewrites

## Scope

This is an independently landable COMGR HotSwap-only split from #3552. All changes are under COMGR HotSwap implementation, documentation, or HotSwap tests. It does not depend on the other splits, and the original #3552 remains unchanged as a reference.

## Review fixes

Post-write review fixed the displacement policy switch:

- it was previously cached by a function-local static, so the first rewrite fixed policy for the process lifetime
- empty and `"0"` values incorrectly disabled displacement

The variable is now sampled for each public rewrite. Empty and `"0"` preserve the enabled default; other nonempty values disable displacement. A same-process public-driver regression switches from disabled to enabled and covers the empty-string case. The README documents the contract.

The public test driver's equality helper also handles zero-length buffers explicitly.
Its non-Windows build now requests POSIX.1-2008 before using `setenv`, fixing
an implicit-function warning found by the final standalone rebuild while
preserving the `_putenv_s` Windows path.

## Validation

- MI300X Release: 118/118 `HotswapMCTests`; targeted transactional LIT tests pass
- MI300X exact `-DADDRESS_SANITIZER=On`: 118/118; targeted transactional LIT tests pass
- final Release and ASAN standalone driver rebuilds are warning-free
- MI400-2: 118/118; public transactional and fallback artifacts were byte-identical across hosts and idempotent
- standalone HotSwap LIT: 125 pass, one unrelated tool-version mismatch in `hotswap-trampoline-ds-nosled.s`; both new tests pass
- prior GitHub CI was green; `git diff --check` is clean
