### PR TITLE
comgr: share far branch gateways across hotswap sites

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -34,6 +34,7 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Support/Compiler.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
@@ -1131,6 +1132,331 @@ matchPcMaterializedCall(ArrayRef<InternalDecodedInst> Decoded, size_t CallIndex,
                                 MCRegister(Call.Inst.getOperand(0).getReg())};
 }
 
+using ReachingCallTargets = SmallVector<uint64_t, 8>;
+
+struct ReachingPcState {
+  bool Reached = false;
+  bool HasUnknown = false;
+  ReachingCallTargets Targets;
+  SmallVector<size_t, 4> ActiveMaterializations;
+};
+
+static bool mergeReachingPcState(ReachingPcState &Into,
+                                 const ReachingPcState &From) {
+  if (!From.Reached)
+    return false;
+  ReachingPcState Before = Into;
+  Into.Reached = true;
+  Into.HasUnknown |= From.HasUnknown;
+  for (uint64_t Target : From.Targets)
+    if (!llvm::is_contained(Into.Targets, Target))
+      Into.Targets.push_back(Target);
+  for (size_t Completion : From.ActiveMaterializations)
+    if (!llvm::is_contained(Into.ActiveMaterializations, Completion))
+      Into.ActiveMaterializations.push_back(Completion);
+  llvm::sort(Into.Targets);
+  llvm::sort(Into.ActiveMaterializations);
+  return Before.Reached != Into.Reached ||
+         Before.HasUnknown != Into.HasUnknown ||
+         Before.Targets != Into.Targets ||
+         Before.ActiveMaterializations != Into.ActiveMaterializations;
+}
+
+static bool isExactRegisterOperand(const MCInst &Inst, unsigned Index,
+                                   MCRegister Reg) {
+  return Index < Inst.getNumOperands() && Inst.getOperand(Index).isReg() &&
+         Inst.getOperand(Index).getReg() == Reg;
+}
+
+/// Recognize the two compiler-emitted ways a reusable register-call target is
+/// materialized. The first is the canonical get-PC/add-nc pair. Tensile also
+/// computes a 32-bit displacement in a temporary and propagates carry into the
+/// high half:
+///
+///   s_get_pc_i64 Pair
+///   s_add_co_i32 Tmp, Imm0, Imm1
+///   s_add_co_u32 Pair.lo, Pair.lo, Tmp
+///   s_add_co_ci_u32 Pair.hi, Pair.hi, 0
+///
+/// Return the completion instruction and absolute target. Intermediate
+/// definitions deliberately remain "unknown" in the reaching-value solver.
+static std::optional<std::pair<size_t, uint64_t>>
+matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
+                               size_t GetPcIndex, size_t FunctionEndIndex,
+                               MCRegister Pair, const LLVMState &LS,
+                               uint64_t TextAddr, ArrayRef<uint8_t> Text) {
+  const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
+  if (!GetPc.DecodeSucceeded || GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+      !isExactRegisterOperand(GetPc.Inst, 0, Pair))
+    return std::nullopt;
+  std::optional<uint64_t> Pc =
+      checkedAddUint64(TextAddr, GetPc.Offset, "reusable get-PC address");
+  if (!Pc)
+    return std::nullopt;
+  Pc = checkedAddUint64(*Pc, GetPc.Size, "reusable get-PC value");
+  if (!Pc)
+    return std::nullopt;
+
+  for (size_t I = GetPcIndex + 1; I < FunctionEndIndex; ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded || isControlFlowBoundary(DI, LS))
+      break;
+    if (!definesOverlappingRegister(DI, LS, Pair))
+      continue;
+    if (DI.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+        DI.Inst.getNumOperands() != 3 ||
+        !isExactRegisterOperand(DI.Inst, 0, Pair) ||
+        !isExactRegisterOperand(DI.Inst, 1, Pair) ||
+        !DI.Inst.getOperand(2).isImm())
+      break;
+    uint64_t Delta = static_cast<uint64_t>(DI.Inst.getOperand(2).getImm());
+    return std::make_pair(I, *Pc + Delta);
+  }
+
+  if (GetPcIndex + 3 >= FunctionEndIndex)
+    return std::nullopt;
+  const InternalDecodedInst &MakeDelta = Decoded[GetPcIndex + 1];
+  const InternalDecodedInst &AddLow = Decoded[GetPcIndex + 2];
+  const InternalDecodedInst &AddHigh = Decoded[GetPcIndex + 3];
+  if (MakeDelta.Mnemonic != "s_add_co_i32" ||
+      AddLow.Mnemonic != "s_add_co_u32" ||
+      AddHigh.Mnemonic != "s_add_co_ci_u32" ||
+      MakeDelta.Inst.getNumOperands() != 3 ||
+      !MakeDelta.Inst.getOperand(0).isReg() ||
+      !MakeDelta.Inst.getOperand(0).getReg() ||
+      !MakeDelta.Inst.getOperand(2).isImm())
+    return std::nullopt;
+  MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
+  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+      !AddLow.Inst.getOperand(1).isReg() ||
+      !AddLow.Inst.getOperand(0).getReg() ||
+      AddLow.Inst.getOperand(0).getReg() !=
+          AddLow.Inst.getOperand(1).getReg() ||
+      !isExactRegisterOperand(AddLow.Inst, 2, DeltaReg) ||
+      AddHigh.Inst.getNumOperands() != 3 ||
+      !AddHigh.Inst.getOperand(0).isReg() ||
+      !AddHigh.Inst.getOperand(1).isReg() ||
+      !AddHigh.Inst.getOperand(0).getReg() ||
+      AddHigh.Inst.getOperand(0).getReg() !=
+          AddHigh.Inst.getOperand(1).getReg() ||
+      !AddHigh.Inst.getOperand(2).isImm() ||
+      AddHigh.Inst.getOperand(2).getImm() != 0)
+    return std::nullopt;
+  MCRegister Low(AddLow.Inst.getOperand(0).getReg());
+  MCRegister High(AddHigh.Inst.getOperand(0).getReg());
+  std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, Low);
+  std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, High);
+  if (!LowIndex || !HighIndex || *HighIndex != *LowIndex + 1 ||
+      !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
+    return std::nullopt;
+
+  std::optional<uint32_t> FirstAddend;
+  if (MakeDelta.Inst.getOperand(1).isImm()) {
+    FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
+  } else if (MakeDelta.Size >= 2 * MinInstSize &&
+             MakeDelta.Offset <= Text.size() &&
+             MakeDelta.Size <= Text.size() - MakeDelta.Offset) {
+    // The disassembler represents a SOP2 literal source as its literal
+    // register marker, not as an immediate operand. The literal dword is the
+    // final dword in this otherwise exact compiler-emitted instruction.
+    FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
+                                            MakeDelta.Size - MinInstSize);
+  }
+  if (!FirstAddend)
+    return std::nullopt;
+  uint32_t Delta = *FirstAddend +
+                   static_cast<uint32_t>(MakeDelta.Inst.getOperand(2).getImm());
+  return std::make_pair(GetPcIndex + 3, *Pc + Delta);
+}
+
+struct ReachingCallGroup {
+  uint64_t Begin = 0;
+  uint64_t End = 0;
+  MCRegister TargetRegister;
+  SmallVector<size_t, 8> Calls;
+};
+
+/// Resolve register calls whose target pair is selected once and reused across
+/// control flow. A monotone intraprocedural solver propagates finite target
+/// sets from proven get-PC materializations. Any unrecognized pair definition
+/// introduces Unknown, so a bypass around the selector remains fail-closed.
+static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
+    ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
+    ArrayRef<uint8_t> Text) {
+  std::vector<ReachingCallTargets> Resolved(Decoded.size());
+  SmallVector<ReachingCallGroup, 8> Groups;
+
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &Call = Decoded[I];
+    if (LocalCalls[I] || !Call.DecodeSucceeded ||
+        Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+        Call.Inst.getNumOperands() < 2)
+      continue;
+    const MCOperand &TargetOp =
+        Call.Inst.getOperand(Call.Inst.getNumOperands() - 1);
+    if (!TargetOp.isReg() || !TargetOp.getReg())
+      continue;
+    MCRegister TargetRegister(TargetOp.getReg());
+
+    const ElfView::FunctionTextRange *Best = nullptr;
+    uint64_t Address = TextAddr + Call.Offset;
+    for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+      if (Range.Begin <= Address && Address < Range.End &&
+          (!Best || Range.Begin > Best->Begin))
+        Best = &Range;
+    if (!Best || Best->Begin < TextAddr || Best->End > TextEnd)
+      continue;
+    uint64_t Begin = Best->Begin - TextAddr;
+    uint64_t End = Best->End - TextAddr;
+    ReachingCallGroup *Group = nullptr;
+    for (ReachingCallGroup &Candidate : Groups)
+      if (Candidate.Begin == Begin && Candidate.End == End &&
+          Candidate.TargetRegister == TargetRegister) {
+        Group = &Candidate;
+        break;
+      }
+    if (!Group) {
+      Groups.push_back({Begin, End, TargetRegister, {}});
+      Group = &Groups.back();
+    }
+    Group->Calls.push_back(I);
+  }
+
+  DenseMap<uint64_t, size_t> OffsetToIndex;
+  for (size_t I = 0; I != Decoded.size(); ++I)
+    OffsetToIndex[Decoded[I].Offset] = I;
+
+  for (const ReachingCallGroup &Group : Groups) {
+    size_t BeginIndex = 0;
+    while (BeginIndex != Decoded.size() &&
+           Decoded[BeginIndex].Offset < Group.Begin)
+      ++BeginIndex;
+    size_t EndIndex = BeginIndex;
+    while (EndIndex != Decoded.size() && Decoded[EndIndex].Offset < Group.End)
+      ++EndIndex;
+    if (BeginIndex == EndIndex)
+      continue;
+
+    DenseMap<size_t, size_t> Starters;
+    DenseMap<size_t, uint64_t> Completions;
+    DenseMap<size_t, SmallVector<size_t, 2>> Intermediates;
+    for (size_t I = BeginIndex; I != EndIndex; ++I) {
+      std::optional<std::pair<size_t, uint64_t>> Match =
+          matchReusablePcMaterialization(
+              Decoded, I, EndIndex, Group.TargetRegister, LS, TextAddr, Text);
+      if (Match) {
+        Starters[I] = Match->first;
+        Completions[Match->first] = Match->second;
+        for (size_t J = I + 1; J != Match->first; ++J)
+          if (definesOverlappingRegister(Decoded[J], LS, Group.TargetRegister))
+            Intermediates[J].push_back(Match->first);
+      }
+    }
+    if (Completions.empty())
+      continue;
+
+    std::vector<ReachingPcState> Before(EndIndex - BeginIndex);
+    Before.front().Reached = true;
+    Before.front().HasUnknown = true;
+    SmallVector<size_t, 32> Worklist;
+    BitVector Queued(EndIndex - BeginIndex);
+    Worklist.push_back(BeginIndex);
+    Queued.set(0);
+
+    while (!Worklist.empty()) {
+      size_t I = Worklist.pop_back_val();
+      Queued.reset(I - BeginIndex);
+      ReachingPcState State = Before[I - BeginIndex];
+      const InternalDecodedInst &DI = Decoded[I];
+
+      DenseMap<size_t, size_t>::const_iterator Starter = Starters.find(I);
+      DenseMap<size_t, uint64_t>::const_iterator Completion =
+          Completions.find(I);
+      if (Starter != Starters.end()) {
+        // The get-PC instruction overwrites the complete target pair. Record a
+        // token proving that this path entered the exact materialization; the
+        // completion may only produce a known target from that token.
+        State.HasUnknown = false;
+        State.Targets.clear();
+        State.ActiveMaterializations.assign(1, Starter->second);
+      } else if (Completion != Completions.end()) {
+        bool HasMatchingToken =
+            llvm::is_contained(State.ActiveMaterializations, I);
+        bool HasBypassPath =
+            State.HasUnknown || !State.Targets.empty() ||
+            llvm::any_of(State.ActiveMaterializations,
+                         [I](size_t Active) { return Active != I; });
+        State.HasUnknown = HasBypassPath || !HasMatchingToken;
+        State.Targets.clear();
+        State.ActiveMaterializations.clear();
+        if (HasMatchingToken)
+          State.Targets.push_back(Completion->second);
+      } else if (definesOverlappingRegister(DI, LS, Group.TargetRegister)) {
+        // Preserve only tokens for which this is a proven instruction inside
+        // the exact matched sequence. All other reaching values are clobbered.
+        SmallVector<size_t, 4> Preserved;
+        DenseMap<size_t, SmallVector<size_t, 2>>::const_iterator Intermediate =
+            Intermediates.find(I);
+        if (Intermediate != Intermediates.end())
+          for (size_t Active : State.ActiveMaterializations)
+            if (llvm::is_contained(Intermediate->second, Active))
+              Preserved.push_back(Active);
+        if (State.HasUnknown || !State.Targets.empty() ||
+            Preserved.size() != State.ActiveMaterializations.size())
+          State.HasUnknown = true;
+        State.Targets.clear();
+        State.ActiveMaterializations = std::move(Preserved);
+      }
+
+      if (llvm::is_contained(Group.Calls, I) && !State.HasUnknown &&
+          State.ActiveMaterializations.empty() && !State.Targets.empty())
+        Resolved[I] = State.Targets;
+
+      SmallVector<size_t, 2> Successors;
+      auto appendFallthrough = [&]() {
+        if (I + 1 < EndIndex)
+          Successors.push_back(I + 1);
+      };
+      if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+          DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+          LS.MIA->isReturn(DI.Inst)) {
+        // No successor.
+      } else if (LS.MIA->isCall(DI.Inst)) {
+        appendFallthrough();
+      } else if (LS.MIA->isIndirectBranch(DI.Inst)) {
+        // An indirect jump or bounded return leaves this intraprocedural path.
+      } else if (LS.MIA->isBranch(DI.Inst)) {
+        std::optional<uint64_t> Target =
+            evaluateDirectControlFlowTarget(DI, LS);
+        if (Target) {
+          DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+              OffsetToIndex.find(*Target);
+          if (TargetIndex != OffsetToIndex.end() &&
+              TargetIndex->second >= BeginIndex &&
+              TargetIndex->second < EndIndex)
+            Successors.push_back(TargetIndex->second);
+        }
+        if (!LS.MIA->isUnconditionalBranch(DI.Inst))
+          appendFallthrough();
+      } else {
+        appendFallthrough();
+      }
+
+      for (size_t Successor : Successors) {
+        if (mergeReachingPcState(Before[Successor - BeginIndex], State) &&
+            !Queued.test(Successor - BeginIndex)) {
+          Worklist.push_back(Successor);
+          Queued.set(Successor - BeginIndex);
+        }
+      }
+    }
+  }
+  return Resolved;
+}
+
 struct KnownCallSite {
   size_t InstIndex = 0;
   uint64_t Target = 0;
@@ -1210,7 +1536,8 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
 static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls) {
+    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls,
+    ArrayRef<ReachingCallTargets> ReusableCalls) {
   SmallVector<KnownCallSite, 4> Calls;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
@@ -1218,22 +1545,43 @@ static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
     if (!ReturnRegister)
       continue;
 
-    std::optional<uint64_t> Target;
     if (MaterializedCalls[I]) {
       uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
-      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
-        Target = AbsoluteTarget - TextAddr;
-    } else {
-      Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
-    }
-    if (!Target)
+      if (AbsoluteTarget < TextAddr || AbsoluteTarget >= TextEnd)
+        continue;
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "known call continuation address");
+      if (!Continuation)
+        return std::nullopt;
+      Calls.push_back(
+          {I, AbsoluteTarget - TextAddr, *Continuation, *ReturnRegister});
       continue;
+    }
 
-    std::optional<uint64_t> Continuation =
-        checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
-    if (!Continuation)
-      return std::nullopt;
-    Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    if (!ReusableCalls[I].empty()) {
+      if (llvm::any_of(ReusableCalls[I], [TextAddr, TextEnd](uint64_t Target) {
+            return Target < TextAddr || Target >= TextEnd;
+          }))
+        continue;
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "known call continuation address");
+      if (!Continuation)
+        return std::nullopt;
+      for (uint64_t AbsoluteTarget : ReusableCalls[I])
+        Calls.push_back(
+            {I, AbsoluteTarget - TextAddr, *Continuation, *ReturnRegister});
+      continue;
+    }
+
+    std::optional<uint64_t> Target =
+        getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+    if (Target) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "known call continuation address");
+      if (!Continuation)
+        return std::nullopt;
+      Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    }
   }
   return Calls;
 }
@@ -1621,7 +1969,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<uint64_t> ExternalEntries) {
+    ArrayRef<uint64_t> ExternalEntries, ArrayRef<uint8_t> Text) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -1637,9 +1985,11 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       Decoded.size());
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
+  std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls, Text);
 
-  std::optional<SmallVector<KnownCallSite, 4>> Calls =
-      collectKnownCallSites(Decoded, LS, TextAddr, *TextEnd, MaterializedCalls);
+  std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
+      Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);
   if (!Calls)
     return std::nullopt;
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
@@ -1685,6 +2035,25 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                      MaterializedCalls[InstIndex]->SequenceEnd)) {
         Target = MaterializedCalls[InstIndex]->Target;
       }
+      if (!ReusableCalls[InstIndex].empty()) {
+        if (llvm::any_of(ReusableCalls[InstIndex],
+                         [TextAddr, TextEnd](uint64_t ReusableTarget) {
+                           return ReusableTarget < TextAddr ||
+                                  ReusableTarget >= *TextEnd;
+                         })) {
+          log() << "hotswap: unresolved call target at 0x"
+                << utohexstr(DI.Offset) << " (reusable target outside .text)\n";
+          Info.HasUnresolvedTargets = true;
+          continue;
+        }
+        for (uint64_t ReusableTarget : ReusableCalls[InstIndex])
+          Info.Targets.insert(ReusableTarget - TextAddr);
+        Info.BoundedIndirectTransfers.insert(DI.Offset);
+        log() << "hotswap: resolved reusable PC-materialized call at 0x"
+              << utohexstr(DI.Offset) << " to "
+              << ReusableCalls[InstIndex].size() << " target(s)\n";
+        continue;
+      }
       if (!Target) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
               << " (" << DI.Mnemonic << ")\n";
@@ -1699,6 +2068,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
           log() << "hotswap: resolved PC-materialized call at 0x"
                 << utohexstr(DI.Offset) << " to .text+0x"
                 << utohexstr(RelativeTarget) << "\n";
+        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
+          Info.BoundedIndirectTransfers.insert(DI.Offset);
       }
       continue;
     }
@@ -1713,6 +2084,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     }
     Info.Targets.insert(*Target);
   }
+  for (const BoundedSetPcReturn &Return : *BoundedReturns)
+    Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
   return Info;
 }
 
@@ -1857,12 +2230,15 @@ collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
 /// indirect destination, so leave the complete function in place.
 static DenseSet<uint64_t>
 collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
-                                    const LLVMState &LS, const ElfView &Elf) {
+                                    const LLVMState &LS, const ElfView &Elf,
+                                    const DenseSet<uint64_t> &Bounded) {
   DenseSet<uint64_t> Functions;
   if (!LS.MIA)
     return Functions;
 
   for (const InternalDecodedInst &DI : Decoded) {
+    if (Bounded.contains(DI.Offset))
+      continue;
     if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
       continue;
     if (!LS.MIA->isIndirectBranch(DI.Inst) &&
@@ -1892,7 +2268,9 @@ expandStraightLineTrampolines(PatchContext &Ctx,
   DenseSet<uint64_t> Protected = collectRelocationProtectedOffsets(
       Ctx.Decoded, Ctx.LS, !Ctx.Config.RunB0A0Patches);
   DenseSet<uint64_t> IndirectControlFlowFunctions =
-      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+      collectIndirectControlFlowFunctions(
+          Ctx.Decoded, Ctx.LS, Ctx.Elf,
+          Ctx.DirectControlFlow.BoundedIndirectTransfers);
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     if (Ctx.OutTrampolines[I].HasFunctionRange &&
@@ -2096,6 +2474,7 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   uint64_t Current = FromOffset;
 
   while (!isSBranchReachable(Current, TargetOffset)) {
+    bool Forward = TargetOffset > Current;
     size_t BestIndex = Gateways.size();
     uint64_t BestOffset = 0;
     for (size_t I = 0; I != Gateways.size(); ++I) {
@@ -2104,12 +2483,15 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
           FromOffset >= Sled.FunctionEnd)
         continue;
       uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
-      if (Sled.WritePos >= TargetOffset || Sled.WritePos <= Current ||
-          Sled.WritePos > UsableEnd ||
+      bool MakesProgress =
+          Forward ? Sled.WritePos > Current && Sled.WritePos < TargetOffset
+                  : Sled.WritePos < Current && Sled.WritePos > TargetOffset;
+      if (!MakesProgress || Sled.WritePos > UsableEnd ||
           MinInstSize > UsableEnd - Sled.WritePos ||
           !isSBranchReachable(Current, Sled.WritePos))
         continue;
-      if (BestIndex == Gateways.size() || Sled.WritePos > BestOffset) {
+      if (BestIndex == Gateways.size() ||
+          (Forward ? Sled.WritePos > BestOffset : Sled.WritePos < BestOffset)) {
         BestIndex = I;
         BestOffset = Sled.WritePos;
       }
@@ -2133,6 +2515,456 @@ allocateForwardBranchIslands(std::vector<NopSled> &Gateways,
   return Islands;
 }
 
+static SmallVector<uint8_t> encodeScc1Branch(const LLVMState &LS,
+                                             uint64_t FromOffset,
+                                             uint64_t TargetOffset) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(FromOffset, MinInstSize, "conditional branch PC base");
+  if (!PcBase || ((TargetOffset - *PcBase) & (MinInstSize - 1)) != 0)
+    return {};
+  int64_t DwordDelta =
+      static_cast<int64_t>(TargetOffset - *PcBase) / MinInstSize;
+  if (DwordDelta < BranchOffsetMin || DwordDelta > BranchOffsetMax)
+    return {};
+  return assembleSingleInst("s_cbranch_scc1 " + std::to_string(DwordDelta), LS);
+}
+
+/// Plan common far gateways before the final pool layout. An 8-byte source
+/// cannot hold the 20-byte SCC-neutral set-PC sequence, but it can preserve
+/// its identity without touching SCC:
+///
+///   s_get_pc_i64 ScratchSource
+///   s_branch CommonGateway
+///
+/// The common gateway reaches a dispatcher in the pool through a second
+/// scratch pair. The dispatcher saves SCC, compares the recorded source PCs,
+/// restores SCC in the selected stub, and branches to the matching trampoline
+/// body. One 20-byte .text gateway can therefore serve hundreds of otherwise
+/// independent 8-byte patch sites.
+static bool planSharedDispatchGateways(PatchContext &Ctx,
+                                       std::vector<NopSled> &TextGateways) {
+  struct Candidate {
+    size_t Index = 0;
+    unsigned ScratchBase = 0;
+  };
+  SmallVector<Candidate, 64> Candidates;
+  uint64_t MissingScratchCandidates = 0;
+  uint64_t FirstMissingScratch = 0;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    Trampoline &T = Ctx.OutTrampolines[I];
+    uint64_t ThisTP = TP;
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "shared dispatcher pool layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+    if (!T.Long || T.OriginalSize < 2 * MinInstSize ||
+        isSBranchReachable(T.OriginalOffset, ThisTP))
+      continue;
+    std::optional<SmallVector<uint8_t>> Direct = encodeSetPCLongBranch(
+        Ctx.LS, T.OriginalOffset, ThisTP, T.LongBranchSgprBase);
+    if (Direct && Direct->size() <= T.OriginalSize)
+      continue;
+    std::optional<SafeSgprScratchBlock> Scratch = findSafeSgprScratchBlock(
+        Ctx, T.OriginalOffset, /*Count=*/4,
+        /*Alignment=*/2, "shared far-dispatch gateway");
+    if (Scratch) {
+      Candidates.push_back({I, Scratch->Base});
+    } else {
+      if (MissingScratchCandidates == 0)
+        FirstMissingScratch = T.OriginalOffset;
+      ++MissingScratchCandidates;
+    }
+  }
+  if (MissingScratchCandidates != 0)
+    log() << "hotswap: shared far-dispatch skipped " << MissingScratchCandidates
+          << " site(s) without four safe SGPRs"
+          << " (first at 0x" << utohexstr(FirstMissingScratch) << ")\n";
+
+  // The ordinary planner is simpler and uses fewer scratch registers for
+  // small objects. Shared dispatch is a capacity mechanism for dense far-site
+  // workloads, not a replacement for individual gateways.
+  if (Candidates.size() < 8)
+    return true;
+
+  BitVector Assigned(Ctx.OutTrampolines.size());
+  SmallVector<SmallVector<size_t, 32>, 8> Groups;
+  constexpr size_t MaxGroupSites = 1024;
+  for (const Candidate &Seed : Candidates) {
+    if (Assigned.test(Seed.Index))
+      continue;
+    const Trampoline &SeedT = Ctx.OutTrampolines[Seed.Index];
+
+    size_t SledIndex = TextGateways.size();
+    uint64_t BestDistance = std::numeric_limits<uint64_t>::max();
+    for (size_t I = 0; I != TextGateways.size(); ++I) {
+      const NopSled &Sled = TextGateways[I];
+      uint64_t From = SeedT.OriginalOffset + MinInstSize;
+      if (SeedT.OriginalOffset < Sled.FunctionStart ||
+          SeedT.OriginalOffset >= Sled.FunctionEnd)
+        continue;
+      uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+      if (Sled.WritePos > UsableEnd ||
+          SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos ||
+          !isSBranchReachable(From, Sled.WritePos))
+        continue;
+      uint64_t Distance =
+          From > Sled.WritePos ? From - Sled.WritePos : Sled.WritePos - From;
+      if (Distance < BestDistance) {
+        BestDistance = Distance;
+        SledIndex = I;
+      }
+    }
+    uint64_t GatewayOffset = 0;
+    uint64_t SecondaryGatewayOffset = 0;
+    std::vector<NopSled> WorkingGateways;
+    SmallVector<uint64_t, 4> SeedIslands;
+    if (SledIndex != TextGateways.size()) {
+      GatewayOffset = TextGateways[SledIndex].WritePos;
+      WorkingGateways = TextGateways;
+      WorkingGateways[SledIndex].WritePos += SetPcForwardSequenceBytes;
+    } else {
+      size_t BestIslandCount = std::numeric_limits<size_t>::max();
+      for (size_t I = 0; I != TextGateways.size(); ++I) {
+        const NopSled &Sled = TextGateways[I];
+        uint64_t UsableEnd = std::min(Sled.End, Sled.FunctionEnd);
+        if (Sled.WritePos > UsableEnd ||
+            SetPcForwardSequenceBytes > UsableEnd - Sled.WritePos)
+          continue;
+        std::vector<NopSled> Trial = TextGateways;
+        uint64_t TrialGateway = Trial[I].WritePos;
+        Trial[I].WritePos += SetPcForwardSequenceBytes;
+        std::optional<SmallVector<uint64_t, 4>> Islands =
+            allocateForwardBranchIslands(
+                Trial, SeedT.OriginalOffset + MinInstSize, TrialGateway);
+        if (!Islands || Islands->empty() || Islands->size() >= BestIslandCount)
+          continue;
+        BestIslandCount = Islands->size();
+        GatewayOffset = TrialGateway;
+        WorkingGateways = std::move(Trial);
+        SeedIslands = std::move(*Islands);
+      }
+      if (WorkingGateways.empty()) {
+        // Split the SCC-neutral 20-byte sequence across an 8-byte get-PC
+        // segment and a 16-byte add/set-PC segment. This admits functions
+        // that have no single 20-byte padding window.
+        for (size_t I = 0; I != TextGateways.size() && WorkingGateways.empty();
+             ++I) {
+          const NopSled &First = TextGateways[I];
+          uint64_t FirstEnd = std::min(First.End, First.FunctionEnd);
+          uint64_t SourceBranch = SeedT.OriginalOffset + MinInstSize;
+          if (SeedT.OriginalOffset < First.FunctionStart ||
+              SeedT.OriginalOffset >= First.FunctionEnd ||
+              First.WritePos > FirstEnd ||
+              2 * MinInstSize > FirstEnd - First.WritePos ||
+              !isSBranchReachable(SourceBranch, First.WritePos))
+            continue;
+          std::vector<NopSled> FirstReserved = TextGateways;
+          GatewayOffset = FirstReserved[I].WritePos;
+          FirstReserved[I].WritePos += 2 * MinInstSize;
+          for (size_t J = 0; J != FirstReserved.size(); ++J) {
+            const NopSled &Second = FirstReserved[J];
+            uint64_t SecondEnd = std::min(Second.End, Second.FunctionEnd);
+            if (SeedT.OriginalOffset < Second.FunctionStart ||
+                SeedT.OriginalOffset >= Second.FunctionEnd ||
+                Second.WritePos > SecondEnd ||
+                4 * MinInstSize > SecondEnd - Second.WritePos ||
+                !isSBranchReachable(GatewayOffset + MinInstSize,
+                                    Second.WritePos))
+              continue;
+            WorkingGateways = FirstReserved;
+            SecondaryGatewayOffset = WorkingGateways[J].WritePos;
+            WorkingGateways[J].WritePos += 4 * MinInstSize;
+            break;
+          }
+        }
+      }
+      if (WorkingGateways.empty())
+        continue;
+    }
+
+    SmallVector<size_t, 32> Members;
+    DenseMap<size_t, SmallVector<uint64_t, 4>> MemberIslands;
+    DenseMap<size_t, uint64_t> MemberRelays;
+    uint64_t GroupBodyBytes = 0;
+    constexpr uint64_t MaxDispatcherSpan = 120 * 1024;
+    for (const Candidate &C : Candidates) {
+      if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+          C.ScratchBase != Seed.ScratchBase)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      uint64_t ProposedSpan =
+          8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+      if (ProposedSpan > MaxDispatcherSpan)
+        continue;
+      uint64_t From = T.OriginalOffset + MinInstSize;
+      SmallVector<uint64_t, 4> Islands;
+      if (C.Index == Seed.Index && !SeedIslands.empty()) {
+        Islands = SeedIslands;
+      } else if (!isSBranchReachable(From, GatewayOffset)) {
+        continue;
+      }
+      Members.push_back(C.Index);
+      GroupBodyBytes += T.Bytes.size();
+      if (!Islands.empty())
+        MemberIslands[C.Index] = std::move(Islands);
+    }
+    DenseSet<size_t> LocalMembers;
+    SmallVector<std::pair<uint64_t, size_t>, 32> RelayAnchors;
+    for (size_t Index : Members) {
+      LocalMembers.insert(Index);
+      RelayAnchors.push_back(
+          {Ctx.OutTrampolines[Index].OriginalOffset + MinInstSize, Index});
+    }
+    llvm::sort(RelayAnchors);
+    for (const Candidate &C : Candidates) {
+      if (Members.size() == MaxGroupSites || Assigned.test(C.Index) ||
+          LocalMembers.contains(C.Index) || C.ScratchBase != Seed.ScratchBase)
+        continue;
+      const Trampoline &T = Ctx.OutTrampolines[C.Index];
+      uint64_t ProposedSpan =
+          8 + 28 * (Members.size() + 1) + GroupBodyBytes + T.Bytes.size();
+      if (ProposedSpan > MaxDispatcherSpan)
+        continue;
+      uint64_t From = T.OriginalOffset + MinInstSize;
+      auto It =
+          llvm::lower_bound(RelayAnchors, std::make_pair(From, size_t{0}));
+      std::optional<uint64_t> Relay;
+      if (It != RelayAnchors.end() && isSBranchReachable(From, It->first))
+        Relay = It->first;
+      if (It != RelayAnchors.begin()) {
+        --It;
+        if (isSBranchReachable(From, It->first))
+          Relay = It->first;
+      }
+      if (!Relay)
+        continue;
+      Members.push_back(C.Index);
+      LocalMembers.insert(C.Index);
+      MemberRelays[C.Index] = *Relay;
+      GroupBodyBytes += T.Bytes.size();
+      RelayAnchors.insert(
+          llvm::lower_bound(RelayAnchors, std::make_pair(From, C.Index)),
+          {From, C.Index});
+    }
+    // A single site with a normal 20-byte gateway gains nothing from the
+    // dispatcher and would unnecessarily consume two extra SGPRs. Leave it to
+    // the established direct planner. A split 8+16-byte gateway is retained
+    // because the established planner cannot represent it.
+    if (Members.size() == 1 && SecondaryGatewayOffset == 0)
+      continue;
+    if (Members.empty())
+      continue;
+    TextGateways = std::move(WorkingGateways);
+
+    uint32_t Group = Groups.size() + 1;
+    for (size_t Index : Members) {
+      Trampoline &T = Ctx.OutTrampolines[Index];
+      SafeSgprScratchBlock Scratch{Seed.ScratchBase, 4};
+      if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Scratch,
+                                      "shared far-dispatch gateway"))
+        return false;
+      T.UsesSharedDispatcherForward = true;
+      T.SharedDispatcherGroup = Group;
+      T.SharedDispatcherSgprBase = Seed.ScratchBase;
+      T.SharedDispatcherGatewayOffset = GatewayOffset;
+      DenseMap<size_t, uint64_t>::const_iterator Relay =
+          MemberRelays.find(Index);
+      if (Relay != MemberRelays.end())
+        T.SharedDispatcherRelayOffset = Relay->second;
+      T.SharedDispatcherSecondaryGatewayOffset = SecondaryGatewayOffset;
+      DenseMap<size_t, SmallVector<uint64_t, 4>>::iterator Islands =
+          MemberIslands.find(Index);
+      if (Islands != MemberIslands.end()) {
+        T.ForwardBranchIslands = std::move(Islands->second);
+        T.ForwardBranchTargetOffset = GatewayOffset;
+      }
+      Assigned.set(Index);
+    }
+    Groups.push_back(std::move(Members));
+  }
+
+  if (Groups.empty())
+    return true;
+
+  std::vector<Trampoline> Reordered;
+  Reordered.reserve(Ctx.OutTrampolines.size());
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I)
+    if (!Assigned.test(I))
+      Reordered.push_back(std::move(Ctx.OutTrampolines[I]));
+  for (const SmallVector<size_t, 32> &Group : Groups)
+    for (size_t Index : Group)
+      Reordered.push_back(std::move(Ctx.OutTrampolines[Index]));
+  Ctx.OutTrampolines = std::move(Reordered);
+
+  for (size_t I = 0; I != Ctx.OutTrampolines.size();) {
+    Trampoline &First = Ctx.OutTrampolines[I];
+    if (!First.UsesSharedDispatcherForward) {
+      ++I;
+      continue;
+    }
+    uint32_t Group = First.SharedDispatcherGroup;
+    size_t Count = 0;
+    while (I + Count != Ctx.OutTrampolines.size() &&
+           Ctx.OutTrampolines[I + Count].SharedDispatcherGroup == Group)
+      ++Count;
+    uint64_t Prefix = 8 + 28 * Count;
+    if (Prefix > std::numeric_limits<uint32_t>::max())
+      return false;
+    First.PoolEntryPrefixBytes = static_cast<uint32_t>(Prefix);
+    First.Bytes.insert(First.Bytes.begin(), Prefix, uint8_t{0});
+    I += Count;
+  }
+
+  log() << "hotswap: planned " << Groups.size()
+        << " shared far-dispatch gateway group(s) for " << Assigned.count()
+        << " source site(s)\n";
+  return true;
+}
+
+static bool emitSharedDispatchers(PatchContext &Ctx) {
+  DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
+  SmallVector<uint64_t, 64> PoolOffsets;
+  uint64_t TP = Ctx.PoolBaseOffset;
+  for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
+    PoolOffsets.push_back(TP);
+    Trampoline &T = Ctx.OutTrampolines[I];
+    if (T.UsesSharedDispatcherForward)
+      Groups[T.SharedDispatcherGroup].push_back(I);
+    std::optional<uint64_t> Next =
+        checkedAddUint64(TP, T.Bytes.size(), "shared dispatcher final layout");
+    if (!Next)
+      return false;
+    TP = *Next;
+  }
+
+  for (auto &KV : Groups) {
+    ArrayRef<size_t> Members = KV.second;
+    if (Members.empty())
+      continue;
+    Trampoline &Owner = Ctx.OutTrampolines[Members.front()];
+    uint64_t DispatcherOffset = PoolOffsets[Members.front()];
+    auto fail = [&](const Twine &Reason) {
+      log() << "hotswap: error: shared dispatcher group " << KV.first
+            << " at 0x" << utohexstr(DispatcherOffset) << ": " << Reason
+            << "\n";
+      return false;
+    };
+    unsigned Base = Owner.SharedDispatcherSgprBase;
+    const std::string SourceLow = "s" + std::to_string(Base);
+    const std::string CursorLow = "s" + std::to_string(Base + 2);
+    // After the SCC-neutral gateway has transferred control, only the low
+    // cursor half is needed: every source and pool address differs by less
+    // than 4 GiB, so modulo-2^32 deltas remain exact across a load-address
+    // wrap. Reuse the cursor high half to preserve SCC.
+    const std::string Save = "s" + std::to_string(Base + 3);
+
+    Owner.HasForwardGateway = true;
+    Owner.ForwardGatewayOffset = Owner.SharedDispatcherGatewayOffset;
+    if (Owner.SharedDispatcherSecondaryGatewayOffset == 0) {
+      std::optional<SmallVector<uint8_t>> Gateway =
+          encodeSetPCLongBranch(Ctx.LS, Owner.SharedDispatcherGatewayOffset,
+                                DispatcherOffset, Base + 2);
+      if (!Gateway || Gateway->size() > SetPcForwardSequenceBytes)
+        return fail("single-segment gateway encoding failed");
+      Owner.ForwardGatewayBytes = std::move(*Gateway);
+    } else {
+      const std::string GatewayPair = "s[" + std::to_string(Base + 2) + ":" +
+                                      std::to_string(Base + 3) + "]";
+      Owner.ForwardGatewayBytes =
+          assembleSingleInst("s_get_pc_i64 " + GatewayPair, Ctx.LS);
+      SmallVector<uint8_t> ToSecond =
+          Ctx.LS.encodeSBranch(Owner.SharedDispatcherGatewayOffset +
+                                   Owner.ForwardGatewayBytes.size(),
+                               Owner.SharedDispatcherSecondaryGatewayOffset);
+      if (Owner.ForwardGatewayBytes.size() != MinInstSize ||
+          ToSecond.size() != MinInstSize)
+        return fail("split gateway first segment encoding failed");
+      Owner.ForwardGatewayBytes.append(ToSecond);
+
+      uint64_t PcBase = Owner.SharedDispatcherGatewayOffset + MinInstSize;
+      uint64_t Delta = DispatcherOffset - PcBase;
+      SmallVector<std::string, 2> Lines;
+      Lines.push_back("s_add_nc_u64 " + GatewayPair + ", " + GatewayPair +
+                      ", 0x" + utohexstr(Delta));
+      Lines.push_back("s_set_pc_i64 " + GatewayPair);
+      Owner.SecondaryForwardGatewayBytes =
+          assembleInstructions(joinAsmLines(Lines), Ctx.LS);
+      if (Owner.SecondaryForwardGatewayBytes.empty() ||
+          Owner.SecondaryForwardGatewayBytes.size() > 4 * MinInstSize)
+        return fail("split gateway second segment encoding failed");
+      while (Owner.SecondaryForwardGatewayBytes.size() < 4 * MinInstSize)
+        Owner.SecondaryForwardGatewayBytes.append(Ctx.LS.SNopBytes);
+    }
+
+    SmallVector<uint64_t, 32> BodyOffsets;
+    for (size_t Member : Members)
+      BodyOffsets.push_back(PoolOffsets[Member] +
+                            Ctx.OutTrampolines[Member].PoolEntryPrefixBytes);
+
+    SmallVector<uint8_t> Bytes;
+    auto appendInst = [&](StringRef Asm) {
+      SmallVector<uint8_t> Encoded = assembleSingleInst(Asm, Ctx.LS);
+      if (Encoded.empty())
+        return false;
+      Bytes.append(Encoded);
+      return true;
+    };
+    if (!appendInst("s_cselect_b32 " + Save + ", 1, 0"))
+      return fail("SCC save encoding failed");
+
+    uint64_t CursorValue = DispatcherOffset;
+    uint64_t StubBase =
+        DispatcherOffset + 4 + 20 * Members.size() + MinInstSize;
+    for (size_t J = 0; J != Members.size(); ++J) {
+      const Trampoline &T = Ctx.OutTrampolines[Members[J]];
+      uint64_t SourcePc = T.OriginalOffset + MinInstSize;
+      uint64_t Distance = SourcePc > CursorValue ? SourcePc - CursorValue
+                                                 : CursorValue - SourcePc;
+      if (Distance >= (uint64_t{1} << 32))
+        return fail("source-to-dispatcher span exceeds 32 bits");
+      uint64_t Delta = SourcePc - CursorValue;
+      SmallVector<uint8_t> Add = assembleSingleInst(
+          "s_add_co_u32 " + CursorLow + ", " + CursorLow + ", 0x" +
+              utohexstr(static_cast<uint32_t>(Delta)),
+          Ctx.LS);
+      if (Add.empty() || Add.size() > 3 * MinInstSize)
+        return fail("source-PC cursor add encoding failed");
+      Bytes.append(Add);
+      while (Add.size() < 3 * MinInstSize) {
+        Bytes.append(Ctx.LS.SNopBytes);
+        Add.append(Ctx.LS.SNopBytes);
+      }
+      if (!appendInst("s_cmp_eq_u32 " + SourceLow + ", " + CursorLow))
+        return fail("source-PC compare encoding failed");
+      uint64_t BranchFrom = DispatcherOffset + Bytes.size();
+      SmallVector<uint8_t> Branch =
+          encodeScc1Branch(Ctx.LS, BranchFrom, StubBase + J * 2 * MinInstSize);
+      if (Branch.size() != MinInstSize)
+        return fail("source-PC conditional branch is out of range");
+      Bytes.append(Branch);
+      CursorValue = SourcePc;
+    }
+    if (!appendInst("s_trap 2"))
+      return fail("unmatched-source trap encoding failed");
+    for (size_t J = 0; J != Members.size(); ++J) {
+      if (!appendInst("s_cmp_lg_u32 " + Save + ", 0"))
+        return fail("SCC restore encoding failed");
+      uint64_t BranchFrom = DispatcherOffset + Bytes.size();
+      SmallVector<uint8_t> Branch =
+          Ctx.LS.encodeSBranch(BranchFrom, BodyOffsets[J]);
+      if (Branch.size() != MinInstSize)
+        return fail("selected trampoline body is out of branch range");
+      Bytes.append(Branch);
+    }
+    if (Bytes.size() != Owner.PoolEntryPrefixBytes)
+      return fail("dispatcher size differs from reserved prefix");
+    std::memcpy(Owner.Bytes.data(), Bytes.data(), Bytes.size());
+  }
+  return true;
+}
+
 static bool
 assignLongBranchGateways(PatchContext &Ctx,
                          const DenseSet<uint64_t> &DirectBranchTargets,
@@ -2144,6 +2976,9 @@ assignLongBranchGateways(PatchContext &Ctx,
         DirectBranchTargets);
     for (const NopSled &Sled : Ctx.NopSleds)
       Gateways.push_back(Sled);
+    if (!planSharedDispatchGateways(Ctx, Gateways) ||
+        !emitSharedDispatchers(Ctx))
+      return false;
   }
 
   DenseMap<uint64_t, size_t> PoolIslandOwners;
@@ -2182,6 +3017,8 @@ assignLongBranchGateways(PatchContext &Ctx,
     TrampOffset = *Next;
     if (!T.Long)
       continue;
+    if (T.UsesSharedDispatcherForward)
+      continue;
 
     if (isSBranchReachable(T.OriginalOffset, TP)) {
       T.UsesShortBranchForward = true;
@@ -2210,9 +3047,42 @@ assignLongBranchGateways(PatchContext &Ctx,
     P.InitialCandidateSlots = *CandidateSlots;
   }
 
+  std::stable_sort(Pending.begin(), Pending.end(),
+                   [](const PendingGateway &LHS, const PendingGateway &RHS) {
+                     return LHS.InitialCandidateSlots <
+                            RHS.InitialCandidateSlots;
+                   });
+
   std::vector<PendingGateway> StillPending;
   StillPending.reserve(Pending.size());
+  uint64_t AssignedGateways = 0;
+  for (const PendingGateway &P : Pending) {
+    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
+        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
+                                P.TargetOffset, T.LongBranchSgprBase);
+    if (!GatewayOrErr) {
+      log() << "hotswap: error: failed to plan gateway for far site 0x"
+            << utohexstr(T.OriginalOffset) << ": "
+            << toString(GatewayOrErr.takeError()) << "\n";
+      return false;
+    }
+    std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
+    if (!Gateway) {
+      StillPending.push_back(P);
+      continue;
+    }
+    T.HasForwardGateway = true;
+    T.ForwardGatewayOffset = Gateway->Sled->WritePos;
+    T.ForwardGatewayBytes = std::move(Gateway->Bytes);
+    Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
+    ++AssignedGateways;
+  }
+  Pending = std::move(StillPending);
+
   uint64_t BranchIslandChains = 0;
+  StillPending.clear();
+  StillPending.reserve(Pending.size());
   for (const PendingGateway &P : Pending) {
     Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
     std::optional<SmallVector<uint64_t, 4>> Islands =
@@ -2228,38 +3098,15 @@ assignLongBranchGateways(PatchContext &Ctx,
   }
   Pending = std::move(StillPending);
 
-  std::stable_sort(Pending.begin(), Pending.end(),
-                   [](const PendingGateway &LHS, const PendingGateway &RHS) {
-                     return LHS.InitialCandidateSlots <
-                            RHS.InitialCandidateSlots;
-                   });
-
-  uint64_t AssignedGateways = 0;
-  for (const PendingGateway &P : Pending) {
-    Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
-    Expected<std::optional<EncodedSetPcGateway>> GatewayOrErr =
-        findNearestSetPcGateway(Gateways, Ctx.LS, T.OriginalOffset,
-                                P.TargetOffset, T.LongBranchSgprBase);
-    if (!GatewayOrErr) {
-      log() << "hotswap: error: failed to plan gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << ": "
-            << toString(GatewayOrErr.takeError()) << "\n";
-      return false;
-    }
-    std::optional<EncodedSetPcGateway> Gateway = std::move(*GatewayOrErr);
-    if (!Gateway) {
-      log() << "hotswap: error: no safe short-branch gateway for far site 0x"
-            << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
-            << " initial candidate slot(s))\n";
-      return false;
-    }
-    T.HasForwardGateway = true;
-    T.ForwardGatewayOffset = Gateway->Sled->WritePos;
-    T.ForwardGatewayBytes = std::move(Gateway->Bytes);
-    Gateway->Sled->WritePos += T.ForwardGatewayBytes.size();
-    ++AssignedGateways;
+  if (!Pending.empty()) {
+    const PendingGateway &P = Pending.front();
+    const Trampoline &T = Ctx.OutTrampolines[P.TrampolineIndex];
+    log() << "hotswap: error: no safe short-branch gateway for far site 0x"
+          << utohexstr(T.OriginalOffset) << " (" << P.InitialCandidateSlots
+          << " initial candidate slot(s))\n";
+    return false;
   }
-  if (!Pending.empty())
+  if (AssignedGateways != 0)
     log() << "hotswap: assigned " << AssignedGateways
           << " SCC-neutral forward gateway(s)\n";
   if (BranchIslandChains != 0)
@@ -2277,6 +3124,17 @@ assignLongBranchGateways(PatchContext &Ctx,
       }
       std::memcpy(Ctx.Text + T.ForwardGatewayOffset,
                   T.ForwardGatewayBytes.data(), T.ForwardGatewayBytes.size());
+      if (!T.SecondaryForwardGatewayBytes.empty()) {
+        uint64_t Offset = T.SharedDispatcherSecondaryGatewayOffset;
+        if (Offset > Ctx.TextSize ||
+            T.SecondaryForwardGatewayBytes.size() > Ctx.TextSize - Offset) {
+          log() << "hotswap: error: secondary forward gateway at 0x"
+                << utohexstr(Offset) << " extends past .text.\n";
+          return false;
+        }
+        std::memcpy(Ctx.Text + Offset, T.SecondaryForwardGatewayBytes.data(),
+                    T.SecondaryForwardGatewayBytes.size());
+      }
     }
     for (size_t I = 0; I != T.ForwardBranchIslands.size(); ++I) {
       uint64_t From = T.ForwardBranchIslands[I];
@@ -2394,7 +3252,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       Elf.functionTextRanges();
   std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
       Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
-      FunctionRanges, DeclaredEntries->ExternalEntries);
+      FunctionRanges, DeclaredEntries->ExternalEntries,
+      ArrayRef<uint8_t>(Text, TextSize));
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {
@@ -2716,7 +3575,23 @@ fixupTrampolineBranches(std::vector<Trampoline> &Trampolines, uint8_t *Text,
 
     SmallVector<uint8_t> BrFwd;
     if (T.Long) {
-      if (T.UsesShortBranchForward) {
+      if (T.UsesSharedDispatcherForward) {
+        const std::string Pair =
+            "s[" + std::to_string(T.SharedDispatcherSgprBase) + ":" +
+            std::to_string(T.SharedDispatcherSgprBase + 1) + "]";
+        BrFwd = assembleSingleInst("s_get_pc_i64 " + Pair, LS);
+        if (BrFwd.size() != MinInstSize)
+          return false;
+        uint64_t BranchTarget =
+            T.SharedDispatcherRelayOffset    ? T.SharedDispatcherRelayOffset
+            : T.ForwardBranchIslands.empty() ? T.SharedDispatcherGatewayOffset
+                                             : T.ForwardBranchIslands.front();
+        SmallVector<uint8_t> Branch =
+            LS.encodeSBranch(T.OriginalOffset + BrFwd.size(), BranchTarget);
+        if (Branch.size() != MinInstSize)
+          return false;
+        BrFwd.append(Branch);
+      } else if (T.UsesShortBranchForward) {
         BrFwd = LS.encodeSBranch(T.OriginalOffset, TP);
       } else if (!T.ForwardBranchIslands.empty()) {
         BrFwd =

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -1141,8 +1141,8 @@ struct ReachingPcState {
   SmallVector<size_t, 4> ActiveMaterializations;
 };
 
-static bool mergeReachingPcState(ReachingPcState &Into,
-                                 const ReachingPcState &From) {
+[[nodiscard]] static bool mergeReachingPcState(ReachingPcState &Into,
+                                               const ReachingPcState &From) {
   if (!From.Reached)
     return false;
   ReachingPcState Before = Into;
@@ -1162,8 +1162,8 @@ static bool mergeReachingPcState(ReachingPcState &Into,
          Before.ActiveMaterializations != Into.ActiveMaterializations;
 }
 
-static bool isExactRegisterOperand(const MCInst &Inst, unsigned Index,
-                                   MCRegister Reg) {
+[[nodiscard]] static bool
+isExactRegisterOperand(const MCInst &Inst, unsigned Index, MCRegister Reg) {
   return Index < Inst.getNumOperands() && Inst.getOperand(Index).isReg() &&
          Inst.getOperand(Index).getReg() == Reg;
 }
@@ -1233,9 +1233,11 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
   const InternalDecodedInst &MakeDelta = Decoded[GetPcIndex + 1];
   const InternalDecodedInst &AddLow = Decoded[GetPcIndex + 2];
   const InternalDecodedInst &AddHigh = Decoded[GetPcIndex + 3];
-  if (MakeDelta.Mnemonic != "s_add_co_i32" ||
-      AddLow.Mnemonic != "s_add_co_u32" ||
-      AddHigh.Mnemonic != "s_add_co_ci_u32" ||
+  if (!MakeDelta.DecodeSucceeded || !AddLow.DecodeSucceeded ||
+      !AddHigh.DecodeSucceeded ||
+      MakeDelta.Inst.getOpcode() != LS.SAddCoI32Opcode ||
+      AddLow.Inst.getOpcode() != LS.SAddU32Opcode ||
+      AddHigh.Inst.getOpcode() != LS.SAddcU32Opcode ||
       MakeDelta.Inst.getNumOperands() != 3 ||
       !MakeDelta.Inst.getOperand(0).isReg() ||
       !MakeDelta.Inst.getOperand(0).getReg() ||
@@ -1289,7 +1291,7 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
 /// A reusable target value remains valid after a call only when the exact local
 /// callee is fully decoded, returns through the call's link pair, and cannot
 /// transitively or directly clobber the target pair.
-static bool calleePreservesReusableTarget(
+[[nodiscard]] static bool calleePreservesReusableTarget(
     uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
@@ -1441,7 +1443,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
         Starters[I] = Match->first;
         Completions[Match->first] = Match->second;
         for (size_t J = I + 1; J != Match->first; ++J)
-          if (definesOverlappingRegister(Decoded[J], LS, Group.TargetRegister))
+          if (Decoded[J].DecodeSucceeded &&
+              definesOverlappingRegister(Decoded[J], LS, Group.TargetRegister))
             Intermediates[J].push_back(Match->first);
       }
     }
@@ -2726,8 +2729,9 @@ static SmallVector<uint8_t> encodeScc1Branch(const LLVMState &LS,
 /// restores SCC in the selected stub, and branches to the matching trampoline
 /// body. One 20-byte .text gateway can therefore serve hundreds of otherwise
 /// independent 8-byte patch sites.
-static bool planSharedDispatchGateways(PatchContext &Ctx,
-                                       std::vector<NopSled> &TextGateways) {
+[[nodiscard]] static bool
+planSharedDispatchGateways(PatchContext &Ctx,
+                           std::vector<NopSled> &TextGateways) {
   struct Candidate {
     size_t Index = 0;
     unsigned ScratchBase = 0;
@@ -2913,7 +2917,7 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
       if (ProposedSpan > MaxDispatcherSpan)
         continue;
       uint64_t From = T.OriginalOffset + MinInstSize;
-      auto It =
+      SmallVector<std::pair<uint64_t, size_t>, 32>::iterator It =
           llvm::lower_bound(RelayAnchors, std::make_pair(From, size_t{0}));
       std::optional<uint64_t> Relay;
       if (It != RelayAnchors.end() && isSBranchReachable(From, It->first))
@@ -2946,6 +2950,13 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
     uint32_t Group = Groups.size() + 1;
     for (size_t Index : Members) {
       Trampoline &T = Ctx.OutTrampolines[Index];
+      // findSafeSgprScratchBlock derives Base from the declared SGPR count and
+      // does not read KernelStats.ExtraSgprs, so this dispatcher block can
+      // share a base with the member's own LongBranchSgprBase. That is safe
+      // because the two uses are lifetime-disjoint: the source-PC pair here
+      // lives only across the source->gateway->dispatcher transfer and is dead
+      // once the dispatcher branches into the trampoline body, which is where
+      // LongBranchSgprBase's set-PC back-branch pair becomes live.
       SafeSgprScratchBlock Scratch{Seed.ScratchBase, 4};
       if (!commitSafeSgprScratchBlock(Ctx, T.OriginalOffset, Scratch,
                                       "shared far-dispatch gateway"))
@@ -3012,7 +3023,7 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
   return true;
 }
 
-static bool emitSharedDispatchers(PatchContext &Ctx) {
+[[nodiscard]] static bool emitSharedDispatchers(PatchContext &Ctx) {
   DenseMap<uint32_t, SmallVector<size_t, 32>> Groups;
   SmallVector<uint64_t, 64> PoolOffsets;
   uint64_t TP = Ctx.PoolBaseOffset;
@@ -3028,7 +3039,8 @@ static bool emitSharedDispatchers(PatchContext &Ctx) {
     TP = *Next;
   }
 
-  for (auto &KV : Groups) {
+  for (llvm::detail::DenseMapPair<uint32_t, SmallVector<size_t, 32>> &KV :
+       Groups) {
     ArrayRef<size_t> Members = KV.second;
     if (Members.empty())
       continue;
@@ -3135,6 +3147,10 @@ static bool emitSharedDispatchers(PatchContext &Ctx) {
       Bytes.append(Branch);
       CursorValue = SourcePc;
     }
+    // Planning routes every source that branches here into Members, so the
+    // compare chain above always matches. This trap is a runtime safety net: if
+    // a future planning bug let an unrecorded PC reach the dispatcher, halt
+    // rather than fall through into the first stub with the wrong cursor.
     if (!appendInst("s_trap 2"))
       return fail("unmatched-source trap encoding failed");
     for (size_t J = 0; J != Members.size(); ++J) {

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -1227,7 +1227,8 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !MakeDelta.Inst.getOperand(2).isImm())
     return std::nullopt;
   MCRegister DeltaReg(MakeDelta.Inst.getOperand(0).getReg());
-  if (AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
+  if (LS.MRI->regsOverlap(DeltaReg, Pair) ||
+      AddLow.Inst.getNumOperands() != 3 || !AddLow.Inst.getOperand(0).isReg() ||
       !AddLow.Inst.getOperand(1).isReg() ||
       !AddLow.Inst.getOperand(0).getReg() ||
       AddLow.Inst.getOperand(0).getReg() !=
@@ -1253,12 +1254,14 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
   std::optional<uint32_t> FirstAddend;
   if (MakeDelta.Inst.getOperand(1).isImm()) {
     FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
-  } else if (MakeDelta.Size >= 2 * MinInstSize &&
+  } else if (MakeDelta.Size == 2 * MinInstSize &&
              MakeDelta.Offset <= Text.size() &&
-             MakeDelta.Size <= Text.size() - MakeDelta.Offset) {
+             MakeDelta.Size <= Text.size() - MakeDelta.Offset &&
+             Text[MakeDelta.Offset] == 0xff) {
     // The disassembler represents a SOP2 literal source as its literal
-    // register marker, not as an immediate operand. The literal dword is the
-    // final dword in this otherwise exact compiler-emitted instruction.
+    // register marker, not as an immediate operand. Require the gfx12 SOP2
+    // src0 literal selector before interpreting the final dword as that
+    // literal; an ordinary register source is not a constant displacement.
     FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
                                             MakeDelta.Size - MinInstSize);
   }
@@ -1276,6 +1279,71 @@ struct ReachingCallGroup {
   SmallVector<size_t, 8> Calls;
 };
 
+static std::optional<uint64_t>
+getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
+                    uint64_t TextAddr, uint64_t TextEnd);
+
+/// A reusable target value remains valid after a call only when the exact local
+/// callee is fully decoded, returns through the call's link pair, and cannot
+/// transitively or directly clobber the target pair.
+static bool calleePreservesReusableTarget(
+    uint64_t Target, MCRegister TargetRegister, MCRegister ReturnRegister,
+    ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
+    uint64_t TextAddr, uint64_t TextEnd,
+    ArrayRef<ElfView::FunctionTextRange> FunctionRanges) {
+  const ElfView::FunctionTextRange *Callee = nullptr;
+  for (const ElfView::FunctionTextRange &Range : FunctionRanges)
+    if (Range.Begin == Target && Range.Begin >= TextAddr &&
+        Range.End > Range.Begin && Range.End <= TextEnd &&
+        (!Callee || Range.End < Callee->End))
+      Callee = &Range;
+  if (!Callee)
+    return false;
+
+  uint64_t CalleeBegin = Callee->Begin - TextAddr;
+  uint64_t CalleeEnd = Callee->End - TextAddr;
+  bool SawInstruction = false;
+  for (const InternalDecodedInst &DI : Decoded) {
+    if (DI.Offset < CalleeBegin || DI.Offset >= CalleeEnd)
+      continue;
+    SawInstruction = true;
+    if (!DI.DecodeSucceeded || LS.MIA->isCall(DI.Inst) ||
+        definesOverlappingRegister(DI, LS, TargetRegister))
+      return false;
+
+    if (DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (DI.Inst.getNumOperands() != 1 ||
+          !isExactRegisterOperand(DI.Inst, 0, ReturnRegister))
+        return false;
+      continue;
+    }
+    if (DI.Inst.getOpcode() == LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == LS.SEndPgmSavedOpcode ||
+        LS.MIA->isReturn(DI.Inst))
+      continue;
+    if (LS.MIA->isIndirectBranch(DI.Inst) ||
+        DI.Inst.getOpcode() == LS.SAddPcI64Opcode)
+      return false;
+
+    bool HasFallthrough = true;
+    if (LS.MIA->isBranch(DI.Inst)) {
+      std::optional<uint64_t> BranchTarget =
+          getDirectTextTarget(DI, LS, TextAddr, TextEnd);
+      if (!BranchTarget || *BranchTarget < CalleeBegin ||
+          *BranchTarget >= CalleeEnd)
+        return false;
+      HasFallthrough = !LS.MIA->isUnconditionalBranch(DI.Inst);
+    }
+    if (!HasFallthrough)
+      continue;
+    std::optional<uint64_t> Fallthrough =
+        checkedAddUint64(DI.Offset, DI.Size, "reusable callee fallthrough");
+    if (!Fallthrough || *Fallthrough >= CalleeEnd)
+      return false;
+  }
+  return SawInstruction;
+}
+
 /// Resolve register calls whose target pair is selected once and reused across
 /// control flow. A monotone intraprocedural solver propagates finite target
 /// sets from proven get-PC materializations. Any unrecognized pair definition
@@ -1285,7 +1353,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint8_t> Text) {
+    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint8_t> Text) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
 
@@ -1329,14 +1397,33 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     OffsetToIndex[Decoded[I].Offset] = I;
 
+  SmallVector<std::pair<size_t, uint64_t>, 16> DirectEntries;
+  for (size_t SourceIndex = 0; SourceIndex != Decoded.size(); ++SourceIndex) {
+    const InternalDecodedInst &Source = Decoded[SourceIndex];
+    if (!Source.DecodeSucceeded ||
+        (!LS.MIA->isBranch(Source.Inst) && !LS.MIA->isCall(Source.Inst)) ||
+        LS.MIA->isReturn(Source.Inst))
+      continue;
+    std::optional<uint64_t> Target =
+        getDirectTextTarget(Source, LS, TextAddr, TextEnd);
+    if (Target)
+      DirectEntries.emplace_back(SourceIndex, *Target);
+  }
+  DenseMap<std::pair<uint64_t, uint64_t>, bool> CalleePreservation;
+
   for (const ReachingCallGroup &Group : Groups) {
-    size_t BeginIndex = 0;
-    while (BeginIndex != Decoded.size() &&
-           Decoded[BeginIndex].Offset < Group.Begin)
-      ++BeginIndex;
-    size_t EndIndex = BeginIndex;
-    while (EndIndex != Decoded.size() && Decoded[EndIndex].Offset < Group.End)
-      ++EndIndex;
+    ArrayRef<InternalDecodedInst>::const_iterator Begin =
+        std::lower_bound(Decoded.begin(), Decoded.end(), Group.Begin,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
+    ArrayRef<InternalDecodedInst>::const_iterator End =
+        std::lower_bound(Begin, Decoded.end(), Group.End,
+                         [](const InternalDecodedInst &DI, uint64_t Offset) {
+                           return DI.Offset < Offset;
+                         });
+    size_t BeginIndex = static_cast<size_t>(Begin - Decoded.begin());
+    size_t EndIndex = static_cast<size_t>(End - Decoded.begin());
     if (BeginIndex == EndIndex)
       continue;
 
@@ -1359,12 +1446,38 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       continue;
 
     std::vector<ReachingPcState> Before(EndIndex - BeginIndex);
-    Before.front().Reached = true;
-    Before.front().HasUnknown = true;
     SmallVector<size_t, 32> Worklist;
     BitVector Queued(EndIndex - BeginIndex);
-    Worklist.push_back(BeginIndex);
-    Queued.set(0);
+    auto seedUnknownEntry = [&](size_t Index) {
+      ReachingPcState &Entry = Before[Index - BeginIndex];
+      Entry.Reached = true;
+      Entry.HasUnknown = true;
+      if (!Queued.test(Index - BeginIndex)) {
+        Worklist.push_back(Index);
+        Queued.set(Index - BeginIndex);
+      }
+    };
+    seedUnknownEntry(BeginIndex);
+
+    // Every declared entry and direct cross-function target is an independent
+    // root. An entry into a materialization interior must not inherit the
+    // token established by the containing function's ordinary entry path.
+    for (uint64_t Entry : DeclaredEntries) {
+      DenseMap<uint64_t, size_t>::const_iterator EntryIndex =
+          OffsetToIndex.find(Entry);
+      if (EntryIndex != OffsetToIndex.end() &&
+          EntryIndex->second >= BeginIndex && EntryIndex->second < EndIndex)
+        seedUnknownEntry(EntryIndex->second);
+    }
+    for (const std::pair<size_t, uint64_t> &Entry : DirectEntries) {
+      if (Entry.first >= BeginIndex && Entry.first < EndIndex)
+        continue;
+      DenseMap<uint64_t, size_t>::const_iterator TargetIndex =
+          OffsetToIndex.find(Entry.second);
+      if (TargetIndex != OffsetToIndex.end() &&
+          TargetIndex->second >= BeginIndex && TargetIndex->second < EndIndex)
+        seedUnknownEntry(TargetIndex->second);
+    }
 
     while (!Worklist.empty()) {
       size_t I = Worklist.pop_back_val();
@@ -1411,9 +1524,45 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
         State.ActiveMaterializations = std::move(Preserved);
       }
 
-      if (llvm::is_contained(Group.Calls, I) && !State.HasUnknown &&
-          State.ActiveMaterializations.empty() && !State.Targets.empty())
+      bool IsReusableCall = llvm::is_contained(Group.Calls, I);
+      bool HasFiniteTargets = IsReusableCall && !State.HasUnknown &&
+                              State.ActiveMaterializations.empty() &&
+                              !State.Targets.empty();
+      if (HasFiniteTargets)
         Resolved[I] = State.Targets;
+
+      bool CalleesPreserve =
+          HasFiniteTargets && DI.Inst.getNumOperands() != 0 &&
+          DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg();
+      if (CalleesPreserve) {
+        MCRegister ReturnRegister(DI.Inst.getOperand(0).getReg());
+        uint64_t RegisterKey = static_cast<uint64_t>(Group.TargetRegister.id())
+                                   << 32 |
+                               ReturnRegister.id();
+        for (uint64_t Target : State.Targets) {
+          std::pair<uint64_t, uint64_t> Key{Target, RegisterKey};
+          DenseMap<std::pair<uint64_t, uint64_t>, bool>::iterator Cached =
+              CalleePreservation.find(Key);
+          if (Cached == CalleePreservation.end())
+            Cached =
+                CalleePreservation
+                    .try_emplace(Key, calleePreservesReusableTarget(
+                                          Target, Group.TargetRegister,
+                                          ReturnRegister, Decoded, LS, TextAddr,
+                                          TextEnd, FunctionRanges))
+                    .first;
+          CalleesPreserve &= Cached->second;
+        }
+      }
+
+      if (LS.MIA->isCall(DI.Inst) && !CalleesPreserve) {
+        // MC call operands do not describe transitive clobbers. Carry the
+        // finite set past this call only after proving every exact local
+        // target preserves the reusable target pair.
+        State.HasUnknown = true;
+        State.Targets.clear();
+        State.ActiveMaterializations.clear();
+      }
 
       SmallVector<size_t, 2> Successors;
       auto appendFallthrough = [&]() {
@@ -1986,7 +2135,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
   std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
-      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls, Text);
+      Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
+      DeclaredEntries, Text);
 
   std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
       Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -1525,15 +1525,29 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       }
 
       bool IsReusableCall = llvm::is_contained(Group.Calls, I);
-      bool HasFiniteTargets = IsReusableCall && !State.HasUnknown &&
-                              State.ActiveMaterializations.empty() &&
-                              !State.Targets.empty();
-      if (HasFiniteTargets)
+      bool HasFiniteState = !State.HasUnknown &&
+                            State.ActiveMaterializations.empty() &&
+                            !State.Targets.empty();
+      if (IsReusableCall && HasFiniteState)
         Resolved[I] = State.Targets;
 
-      bool CalleesPreserve =
-          HasFiniteTargets && DI.Inst.getNumOperands() != 0 &&
-          DI.Inst.getOperand(0).isReg() && DI.Inst.getOperand(0).getReg();
+      // The first call after a straight-line materialization is also resolved
+      // by the one-shot matcher. Let that bootstrap call preserve the reaching
+      // value only when both analyses prove the same singleton target through
+      // this exact target pair.
+      bool IsMatchingBootstrapCall = false;
+      if (LocalCalls[I] && HasFiniteState && State.Targets.size() == 1 &&
+          State.Targets.front() == LocalCalls[I]->Target &&
+          DI.Inst.getNumOperands() >= 2) {
+        const MCOperand &TargetOp =
+            DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+        IsMatchingBootstrapCall =
+            TargetOp.isReg() && TargetOp.getReg() == Group.TargetRegister;
+      }
+      bool CalleesPreserve = (IsReusableCall || IsMatchingBootstrapCall) &&
+                             HasFiniteState && DI.Inst.getNumOperands() != 0 &&
+                             DI.Inst.getOperand(0).isReg() &&
+                             DI.Inst.getOperand(0).getReg();
       if (CalleesPreserve) {
         MCRegister ReturnRegister(DI.Inst.getOperand(0).getReg());
         uint64_t RegisterKey = static_cast<uint64_t>(Group.TargetRegister.id())

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -33,8 +33,8 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/Support/Compiler.h"
-#include "llvm/Support/Endian.h"
 #include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
@@ -1168,6 +1168,21 @@ static bool isExactRegisterOperand(const MCInst &Inst, unsigned Index,
          Inst.getOperand(Index).getReg() == Reg;
 }
 
+/// Read a constant 32-bit source operand through MC. A decoded SOP2 literal is
+/// an immediate; an assembled operand may be an absolute expression. Anything
+/// else (a register source) is not a constant displacement.
+static std::optional<uint32_t>
+evaluateAbsoluteUint32Operand(const MCOperand &Operand) {
+  if (Operand.isImm())
+    return static_cast<uint32_t>(Operand.getImm());
+  if (!Operand.isExpr())
+    return std::nullopt;
+  int64_t Value = 0;
+  if (!Operand.getExpr()->evaluateAsAbsolute(Value))
+    return std::nullopt;
+  return static_cast<uint32_t>(Value);
+}
+
 /// Recognize the two compiler-emitted ways a reusable register-call target is
 /// materialized. The first is the canonical get-PC/add-nc pair. Tensile also
 /// computes a 32-bit displacement in a temporary and propagates carry into the
@@ -1184,7 +1199,7 @@ static std::optional<std::pair<size_t, uint64_t>>
 matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
                                size_t GetPcIndex, size_t FunctionEndIndex,
                                MCRegister Pair, const LLVMState &LS,
-                               uint64_t TextAddr, ArrayRef<uint8_t> Text) {
+                               uint64_t TextAddr) {
   const InternalDecodedInst &GetPc = Decoded[GetPcIndex];
   if (!GetPc.DecodeSucceeded || GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
       !isExactRegisterOperand(GetPc.Inst, 0, Pair))
@@ -1251,20 +1266,8 @@ matchReusablePcMaterialization(ArrayRef<InternalDecodedInst> Decoded,
       !LS.MRI->regsOverlap(Low, Pair) || !LS.MRI->regsOverlap(High, Pair))
     return std::nullopt;
 
-  std::optional<uint32_t> FirstAddend;
-  if (MakeDelta.Inst.getOperand(1).isImm()) {
-    FirstAddend = static_cast<uint32_t>(MakeDelta.Inst.getOperand(1).getImm());
-  } else if (MakeDelta.Size == 2 * MinInstSize &&
-             MakeDelta.Offset <= Text.size() &&
-             MakeDelta.Size <= Text.size() - MakeDelta.Offset &&
-             Text[MakeDelta.Offset] == 0xff) {
-    // The disassembler represents a SOP2 literal source as its literal
-    // register marker, not as an immediate operand. Require the gfx12 SOP2
-    // src0 literal selector before interpreting the final dword as that
-    // literal; an ordinary register source is not a constant displacement.
-    FirstAddend = support::endian::read32le(Text.data() + MakeDelta.Offset +
-                                            MakeDelta.Size - MinInstSize);
-  }
+  std::optional<uint32_t> FirstAddend =
+      evaluateAbsoluteUint32Operand(MakeDelta.Inst.getOperand(1));
   if (!FirstAddend)
     return std::nullopt;
   uint32_t Delta = *FirstAddend +
@@ -1353,7 +1356,7 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
     ArrayRef<std::optional<PcMaterializedCallInfo>> LocalCalls,
-    ArrayRef<uint64_t> DeclaredEntries, ArrayRef<uint8_t> Text) {
+    ArrayRef<uint64_t> DeclaredEntries) {
   std::vector<ReachingCallTargets> Resolved(Decoded.size());
   SmallVector<ReachingCallGroup, 8> Groups;
 
@@ -1432,8 +1435,8 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
     DenseMap<size_t, SmallVector<size_t, 2>> Intermediates;
     for (size_t I = BeginIndex; I != EndIndex; ++I) {
       std::optional<std::pair<size_t, uint64_t>> Match =
-          matchReusablePcMaterialization(
-              Decoded, I, EndIndex, Group.TargetRegister, LS, TextAddr, Text);
+          matchReusablePcMaterialization(Decoded, I, EndIndex,
+                                         Group.TargetRegister, LS, TextAddr);
       if (Match) {
         Starters[I] = Match->first;
         Completions[Match->first] = Match->second;
@@ -1488,7 +1491,16 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       DenseMap<size_t, size_t>::const_iterator Starter = Starters.find(I);
       DenseMap<size_t, uint64_t>::const_iterator Completion =
           Completions.find(I);
-      if (Starter != Starters.end()) {
+      if (!DI.DecodeSucceeded) {
+        // An undecoded slot has an unknown effect on the target pair and on
+        // control flow, so any reaching value it carries forward is unproven.
+        // Fail closed to Unknown; the finite-state test below then refuses
+        // every reusable call this path reaches. Starters and Completions are
+        // built only from decoded materializations, so neither can name I.
+        State.HasUnknown = true;
+        State.Targets.clear();
+        State.ActiveMaterializations.clear();
+      } else if (Starter != Starters.end()) {
         // The get-PC instruction overwrites the complete target pair. Record a
         // token proving that this path entered the exact materialization; the
         // completion may only produce a known target from that token.
@@ -1528,8 +1540,11 @@ static std::vector<ReachingCallTargets> resolveReusablePcCallTargets(
       bool HasFiniteState = !State.HasUnknown &&
                             State.ActiveMaterializations.empty() &&
                             !State.Targets.empty();
-      if (IsReusableCall && HasFiniteState)
-        Resolved[I] = State.Targets;
+      // Recompute Resolved[I] on every visit so a later reconvergent path that
+      // makes this call Unknown erases an earlier finite result. Writing only
+      // on finite state would leave a stale target set from the first visit.
+      if (IsReusableCall)
+        Resolved[I] = HasFiniteState ? State.Targets : ReachingCallTargets();
 
       // The first call after a straight-line materialization is also resolved
       // by the one-shot matcher. Let that bootstrap call preserve the reaching
@@ -2150,7 +2165,7 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
   std::vector<ReachingCallTargets> ReusableCalls = resolveReusablePcCallTargets(
       Decoded, LS, TextAddr, *TextEnd, FunctionRanges, MaterializedCalls,
-      DeclaredEntries, Text);
+      DeclaredEntries);
 
   std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
       Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, ReusableCalls);
@@ -2248,8 +2263,14 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     }
     Info.Targets.insert(*Target);
   }
-  for (const BoundedSetPcReturn &Return : *BoundedReturns)
+  for (const BoundedSetPcReturn &Return : *BoundedReturns) {
+    // A bounded return lands on each proven continuation, so those offsets are
+    // control-flow targets that must not be relocated over. Record them before
+    // exempting the return itself from the unbounded-indirect treatment.
+    for (uint64_t Continuation : Return.Targets)
+      Info.Targets.insert(Continuation);
     Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
+  }
   return Info;
 }
 
@@ -2974,8 +2995,12 @@ static bool planSharedDispatchGateways(PatchContext &Ctx,
            Ctx.OutTrampolines[I + Count].SharedDispatcherGroup == Group)
       ++Count;
     uint64_t Prefix = 8 + 28 * Count;
-    if (Prefix > std::numeric_limits<uint32_t>::max())
+    if (Prefix > std::numeric_limits<uint32_t>::max()) {
+      log() << "hotswap: shared far-dispatch group " << Group << " dispatcher "
+            << "prefix (" << Prefix << " bytes for " << Count
+            << " site(s)) exceeds the 32-bit pool-entry limit\n";
       return false;
+    }
     First.PoolEntryPrefixBytes = static_cast<uint32_t>(Prefix);
     First.Bytes.insert(First.Bytes.begin(), Prefix, uint8_t{0});
     I += Count;

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -329,6 +329,17 @@ struct Trampoline {
   bool HasForwardGateway = false;
   uint64_t ForwardGatewayOffset = 0;
   llvm::SmallVector<uint8_t> ForwardGatewayBytes;
+  // Multiple 8-byte far sites can share one SCC-neutral gateway. Each source
+  // records its PC and branches to that gateway; a dispatcher prefixed to the
+  // first group trampoline maps the source PC to the corresponding body.
+  bool UsesSharedDispatcherForward = false;
+  uint32_t SharedDispatcherGroup = 0;
+  unsigned SharedDispatcherSgprBase = 0;
+  uint64_t SharedDispatcherGatewayOffset = 0;
+  uint64_t SharedDispatcherRelayOffset = 0;
+  uint64_t SharedDispatcherSecondaryGatewayOffset = 0;
+  llvm::SmallVector<uint8_t> SecondaryForwardGatewayBytes;
+  uint32_t PoolEntryPrefixBytes = 0;
   // A far-site run may only be coalesced within one known function. Unknown
   // ranges stay unmerged because adjacent symbols are independent entries.
   bool HasFunctionRange = false;
@@ -1211,6 +1222,10 @@ struct SafeSgprUsageSummary {
 
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
+  // Register-based transfers whose complete finite target set was proven.
+  // These do not make every instruction in their containing function a
+  // potential indirect destination.
+  llvm::DenseSet<uint64_t> BoundedIndirectTransfers;
   bool HasUnresolvedTargets = false;
 };
 
@@ -1421,7 +1436,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     uint64_t TextAddr, uint64_t TextSize,
     llvm::ArrayRef<uint64_t> DeclaredEntries,
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
-    llvm::ArrayRef<uint64_t> ExternalEntries = {});
+    llvm::ArrayRef<uint64_t> ExternalEntries = {},
+    llvm::ArrayRef<uint8_t> Text = {});
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -854,6 +854,7 @@ struct LLVMState {
   unsigned GlobalPrefetchB8Opcode = 0;
   unsigned SGetPcI64Opcode = 0;
   unsigned SAddNcU64Opcode = 0;
+  unsigned SAddCoI32Opcode = 0;
   unsigned SAddU32Opcode = 0;
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;

--- a/amd/comgr/src/hotswap/rewriter/llvm.cpp
+++ b/amd/comgr/src/hotswap/rewriter/llvm.cpp
@@ -335,6 +335,13 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_add_nc_u64 s[0:1], s[0:1], 0",
                                      "s_add_nc_u64", S, S.SAddNcU64Opcode))
     return S;
+  // Carry-out add used by the Tensile reusable-call materialization. On gfx12
+  // s_add_co_u32 / s_add_co_ci_u32 share encodings with s_add_u32 / s_addc_u32
+  // (S_ADD_U32_gfx12 / S_ADDC_U32_gfx12), so only the i32 form needs its own
+  // cached opcode.
+  if (!resolveRequiredOpcodeViaParse("s_add_co_i32 s0, 0, 0", "s_add_co_i32", S,
+                                     S.SAddCoI32Opcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_add_u32 s0, s0, 0", "s_add_u32", S,
                                      S.SAddU32Opcode))
     return S;

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -24,10 +24,63 @@
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=BYPASS,FAIL %s
 // BYPASS: hotswap: unresolved call target
+// OVERLAP: hotswap: unresolved call target
+// CLOBBER: hotswap: resolved reusable PC-materialized call
+// CLOBBER: hotswap: unresolved call target
+// TAIL: hotswap: resolved reusable PC-materialized call
+// TAIL: hotswap: unresolved call target
+// INDIRECT: hotswap: resolved reusable PC-materialized call
+// INDIRECT: hotswap: unresolved call target
+// EXTERNAL: hotswap: unresolved call target
 // FAIL: hotswap: unresolved control-flow target disables NOP-sled emission,
 // FAIL-SAME: trampoline coalescing, source relocation, and .text gateways
 // FAIL: hotswap: error: no safe short-branch gateway for far site
 // FAIL: RESULT: ERROR
+
+// RUN: sed 's/^\.set overlap_delta, 0$/.set overlap_delta, 1/' \
+// RUN:   %s > %t.overlap.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.overlap.s -o %t.overlap.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.overlap.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=OVERLAP,FAIL %s
+
+// RUN: sed 's/^\.set clobber_target, 0$/.set clobber_target, 1/' \
+// RUN:   %s > %t.clobber.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.clobber.s -o %t.clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.clobber.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=CLOBBER,FAIL %s
+
+// RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
+// RUN:   %s > %t.tail.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.tail.s -o %t.tail.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.tail.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=TAIL,FAIL %s
+
+// RUN: sed 's/^\.set indirect_escape, 0$/.set indirect_escape, 1/' \
+// RUN:   %s > %t.indirect.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.indirect.s -o %t.indirect.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.indirect.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=INDIRECT,FAIL %s
+
+// RUN: sed 's/^\.set external_entry, 0$/.set external_entry, 1/' \
+// RUN:   %s > %t.external.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.external.s -o %t.external.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.external.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=EXTERNAL,FAIL %s
 
 // RUN: sed 's/^\.set outside_selector, 0$/.set outside_selector, 1/' \
 // RUN:   %s > %t.outside.s
@@ -67,9 +120,23 @@
 
 .set unsafe_selector, 0
 .set outside_selector, 0
+.set overlap_delta, 0
+.set clobber_target, 0
+.set tail_escape, 0
+.set indirect_escape, 0
+.set external_entry, 0
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
+.if external_entry
+.type external_materialization_entry,@function
+external_materialization_entry:
+  // This independent function enters after get-PC and delta creation.
+  s_branch .Lfirst_add_low
+  s_endpgm
+.size external_materialization_entry, .-external_materialization_entry
+.endif
+
 .globl reusable_pc_targets
 .p2align 8
 .type reusable_pc_targets,@function
@@ -87,14 +154,27 @@ reusable_pc_targets:
   s_cbranch_scc1 .Lselect_second
 .Lselect_first:
   s_get_pc_i64 s[2:3]
+.if overlap_delta
+  // The temporary aliases the PC pair and destroys its low half.
+  s_add_co_i32 s2, callee_first-(.Lselect_first+4)-4, 4
+.Lfirst_add_low:
+  s_add_co_u32 s2, s2, s2
+.else
   s_add_co_i32 s4, callee_first-(.Lselect_first+4)-4, 4
+.Lfirst_add_low:
   s_add_co_u32 s2, s2, s4
+.endif
   s_add_co_ci_u32 s3, s3, 0
   s_branch .Lselected
 .Lselect_second:
   s_get_pc_i64 s[2:3]
+.if overlap_delta
+  s_add_co_i32 s2, callee_second-(.Lselect_second+4)-4, 4
+  s_add_co_u32 s2, s2, s2
+.else
   s_add_co_i32 s4, callee_second-(.Lselect_second+4)-4, 4
   s_add_co_u32 s2, s2, s4
+.endif
   s_add_co_ci_u32 s3, s3, 0
 .if outside_selector
   s_branch .Lselected
@@ -105,6 +185,8 @@ reusable_pc_targets:
   s_add_co_ci_u32 s3, s3, 0
 .endif
 .Lselected:
+  s_swap_pc_i64 s[6:7], s[2:3]
+  // Production kernels reuse this selected pair for multiple calls.
   s_swap_pc_i64 s[6:7], s[2:3]
   s_branch .Lpatch0
 .Lpatch0:
@@ -139,6 +221,15 @@ reusable_pc_targets:
 .type callee_first,@function
 callee_first:
   s_mov_b32 s8, 1
+.if clobber_target
+  s_mov_b32 s2, 0
+.endif
+.if tail_escape
+  s_branch clobber_helper
+.endif
+.if indirect_escape
+  s_set_pc_i64 s[10:11]
+.endif
   s_set_pc_i64 s[6:7]
 .size callee_first, .-callee_first
 
@@ -146,8 +237,26 @@ callee_first:
 .type callee_second,@function
 callee_second:
   s_mov_b32 s8, 2
+.if clobber_target
+  s_mov_b32 s2, 0
+.endif
+.if tail_escape
+  s_branch clobber_helper
+.endif
+.if indirect_escape
+  s_set_pc_i64 s[10:11]
+.endif
   s_set_pc_i64 s[6:7]
 .size callee_second, .-callee_second
+
+.if tail_escape
+.local clobber_helper
+.type clobber_helper,@function
+clobber_helper:
+  s_mov_b32 s2, 0
+  s_set_pc_i64 s[6:7]
+.size clobber_helper, .-clobber_helper
+.endif
 
 .type gateway_barrier,@function
 gateway_barrier:

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -1,0 +1,185 @@
+// COM: Production activation kernels select one of several local callees with
+// COM: get-PC/carry materialization, merge the selected address, and reuse it
+// COM: across many register calls. Resolve the finite reaching-target set so
+// COM: an unrelated required far rewrite may safely use external gateway
+// COM: padding. A selector bypass would leave the target unknown and must
+// COM: continue to fail closed.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved reusable PC-materialized call
+// LOG-SAME: to 2 target(s)
+// LOG-NOT: hotswap: unresolved call target
+// LOG: hotswap: planned 1 shared far-dispatch gateway group(s) for 8 source site(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: sed 's/^\.set unsafe_selector, 0$/.set unsafe_selector, 1/' \
+// RUN:   %s > %t.bypass.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.bypass.s -o %t.bypass.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.bypass.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=BYPASS,FAIL %s
+// BYPASS: hotswap: unresolved call target
+// FAIL: hotswap: unresolved control-flow target disables NOP-sled emission,
+// FAIL-SAME: trampoline coalescing, source relocation, and .text gateways
+// FAIL: hotswap: error: no safe short-branch gateway for far site
+// FAIL: RESULT: ERROR
+
+// RUN: sed 's/^\.set outside_selector, 0$/.set outside_selector, 1/' \
+// RUN:   %s > %t.outside.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.outside.s -o %t.outside.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.outside.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefix=OUTSIDE %s
+// OUTSIDE: hotswap: unresolved call target
+// OUTSIDE-SAME: (reusable target outside .text)
+// OUTSIDE: hotswap: unresolved control-flow target disables NOP-sled emission,
+// OUTSIDE-SAME: trampoline coalescing, source relocation, and .text gateways
+// OUTSIDE: hotswap: error: no safe short-branch gateway for far site
+// OUTSIDE: RESULT: ERROR
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
+// RUN:   --implicit-check-not=s_add_pc_i64 %s
+// DISASM-LABEL: <reusable_pc_targets>:
+// DISASM: s_swap_pc_i64
+// DISASM: s_get_pc_i64
+// DISASM: s_branch
+// DISASM: s_get_pc_i64
+// DISASM-NEXT: s_branch
+// DISASM-LABEL: <gateway_barrier>:
+// DISASM-NEXT: s_endpgm
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_add_nc_u64
+// DISASM-NEXT: s_set_pc_i64
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.set unsafe_selector, 0
+.set outside_selector, 0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl reusable_pc_targets
+.p2align 8
+.type reusable_pc_targets,@function
+reusable_pc_targets:
+.if unsafe_selector
+  // This edge reaches the call without executing either get-PC sequence.
+  s_cmp_eq_u32 s0, 2
+  s_cbranch_scc1 .Lselected
+.endif
+.if outside_selector
+  s_cmp_eq_u32 s0, 3
+  s_cbranch_scc1 .Lselect_outside
+.endif
+  s_cmp_eq_u32 s0, 0
+  s_cbranch_scc1 .Lselect_second
+.Lselect_first:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, callee_first-(.Lselect_first+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+  s_branch .Lselected
+.Lselect_second:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, callee_second-(.Lselect_second+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+.if outside_selector
+  s_branch .Lselected
+.Lselect_outside:
+  s_get_pc_i64 s[2:3]
+  s_add_co_i32 s4, outside_text_end-(.Lselect_outside+4)-4, 4
+  s_add_co_u32 s2, s2, s4
+  s_add_co_ci_u32 s3, s3, 0
+.endif
+.Lselected:
+  s_swap_pc_i64 s[6:7], s[2:3]
+  s_branch .Lpatch0
+.Lpatch0:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch1
+.Lpatch1:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch2
+.Lpatch2:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch3
+.Lpatch3:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch4
+.Lpatch4:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch5
+.Lpatch5:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch6
+.Lpatch6:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_branch .Lpatch7
+.Lpatch7:
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+.Lpatch_done:
+  s_wait_dscnt 0x0
+  s_endpgm
+.size reusable_pc_targets, .-reusable_pc_targets
+
+.local callee_first
+.type callee_first,@function
+callee_first:
+  s_mov_b32 s8, 1
+  s_set_pc_i64 s[6:7]
+.size callee_first, .-callee_first
+
+.local callee_second
+.type callee_second,@function
+callee_second:
+  s_mov_b32 s8, 2
+  s_set_pc_i64 s[6:7]
+.size callee_second, .-callee_second
+
+.type gateway_barrier,@function
+gateway_barrier:
+  s_endpgm
+.size gateway_barrier, .-gateway_barrier
+.fill 20, 1, 0
+
+.rept 40000
+  s_mov_b32 s10, s11
+.endr
+
+outside_text_end:
+.rodata
+.p2align 8
+.amdhsa_kernel reusable_pc_targets
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: reusable_pc_targets
+      .symbol: reusable_pc_targets.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap-reusable-pc-call-targets.s
@@ -9,6 +9,9 @@
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved PC-materialized call
+// LOG: hotswap: resolved reusable PC-materialized call
+// LOG-SAME: to 1 target(s)
 // LOG: hotswap: resolved reusable PC-materialized call
 // LOG-SAME: to 2 target(s)
 // LOG-NOT: hotswap: unresolved call target
@@ -27,6 +30,8 @@
 // OVERLAP: hotswap: unresolved call target
 // CLOBBER: hotswap: resolved reusable PC-materialized call
 // CLOBBER: hotswap: unresolved call target
+// BOOTSTRAP-CLOBBER: hotswap: resolved PC-materialized call
+// BOOTSTRAP-CLOBBER: hotswap: unresolved call target
 // TAIL: hotswap: resolved reusable PC-materialized call
 // TAIL: hotswap: unresolved call target
 // INDIRECT: hotswap: resolved reusable PC-materialized call
@@ -54,6 +59,15 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=CLOBBER,FAIL %s
+
+// RUN: sed 's/^\.set clobber_bootstrap, 0$/.set clobber_bootstrap, 1/' \
+// RUN:   %s > %t.bootstrap-clobber.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.bootstrap-clobber.s -o %t.bootstrap-clobber.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.bootstrap-clobber.elf amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=BOOTSTRAP-CLOBBER,FAIL %s
 
 // RUN: sed 's/^\.set tail_escape, 0$/.set tail_escape, 1/' \
 // RUN:   %s > %t.tail.s
@@ -100,10 +114,13 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 // DISASM-LABEL: <reusable_pc_targets>:
-// DISASM: s_swap_pc_i64
-// DISASM: s_get_pc_i64
-// DISASM: s_branch
-// DISASM: s_get_pc_i64
+// DISASM: s_swap_pc_i64 s[6:7]
+// DISASM-NEXT: s_swap_pc_i64 s[6:7]
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_get_pc_i64
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_branch
+// DISASM-NEXT: s_get_pc_i64
 // DISASM-NEXT: s_branch
 // DISASM-LABEL: <gateway_barrier>:
 // DISASM-NEXT: s_endpgm
@@ -122,6 +139,7 @@
 .set outside_selector, 0
 .set overlap_delta, 0
 .set clobber_target, 0
+.set clobber_bootstrap, 0
 .set tail_escape, 0
 .set indirect_escape, 0
 .set external_entry, 0
@@ -137,10 +155,27 @@ external_materialization_entry:
 .size external_materialization_entry, .-external_materialization_entry
 .endif
 
+.local callee_bootstrap
+.type callee_bootstrap,@function
+callee_bootstrap:
+  s_mov_b32 s8, 3
+.if clobber_bootstrap
+  s_mov_b32 s10, 0
+.endif
+  s_set_pc_i64 s[12:13]
+.size callee_bootstrap, .-callee_bootstrap
+
 .globl reusable_pc_targets
 .p2align 8
 .type reusable_pc_targets,@function
 reusable_pc_targets:
+  // A straight-line first call is resolved by the one-shot matcher. Its
+  // proven target remains reusable after the audited callee returns.
+.Lbootstrap_getpc:
+  s_get_pc_i64 s[10:11]
+  s_add_nc_u64 s[10:11], s[10:11], callee_bootstrap-(.Lbootstrap_getpc+4)
+  s_swap_pc_i64 s[12:13], s[10:11]
+  s_swap_pc_i64 s[12:13], s[10:11]
 .if unsafe_selector
   // This edge reaches the call without executing either get-PC sequence.
   s_cmp_eq_u32 s0, 2
@@ -273,7 +308,7 @@ outside_text_end:
 .p2align 8
 .amdhsa_kernel reusable_pc_targets
   .amdhsa_next_free_vgpr 3
-  .amdhsa_next_free_sgpr 12
+  .amdhsa_next_free_sgpr 14
 .end_amdhsa_kernel
 
 .amdgpu_metadata
@@ -283,7 +318,7 @@ outside_text_end:
   amdhsa.kernels:
     - .name: reusable_pc_targets
       .symbol: reusable_pc_targets.kd
-      .sgpr_count: 12
+      .sgpr_count: 14
       .vgpr_count: 3
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-reusable-pc-call-targets.s
@@ -37,6 +37,10 @@
 // INDIRECT: hotswap: resolved reusable PC-materialized call
 // INDIRECT: hotswap: unresolved call target
 // EXTERNAL: hotswap: unresolved call target
+// UNDECODED: hotswap: resolved reusable PC-materialized call
+// UNDECODED: hotswap: unresolved call target
+// RECONVERGE: hotswap: resolved reusable PC-materialized call
+// RECONVERGE: hotswap: unresolved call target
 // FAIL: hotswap: unresolved control-flow target disables NOP-sled emission,
 // FAIL-SAME: trampoline coalescing, source relocation, and .text gateways
 // FAIL: hotswap: error: no safe short-branch gateway for far site
@@ -104,8 +108,7 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefix=OUTSIDE %s
-// OUTSIDE: hotswap: unresolved call target
-// OUTSIDE-SAME: (reusable target outside .text)
+// OUTSIDE: hotswap: unresolved call target{{.*}}(reusable target outside .text)
 // OUTSIDE: hotswap: unresolved control-flow target disables NOP-sled emission,
 // OUTSIDE-SAME: trampoline coalescing, source relocation, and .text gateways
 // OUTSIDE: hotswap: error: no safe short-branch gateway for far site
@@ -121,8 +124,6 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=UNDECODED,FAIL %s
-// UNDECODED: hotswap: resolved reusable PC-materialized call
-// UNDECODED: hotswap: unresolved call target
 
 // A back-edge that reloads the target pair through an unprovable definition
 // makes the reconverged call Unknown; a stale finite result from the first
@@ -135,8 +136,6 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=RECONVERGE,FAIL %s
-// RECONVERGE: hotswap: resolved reusable PC-materialized call
-// RECONVERGE: hotswap: unresolved call target
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-reusable-pc-call-targets.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-reusable-pc-call-targets.s
@@ -111,6 +111,33 @@
 // OUTSIDE: hotswap: error: no safe short-branch gateway for far site
 // OUTSIDE: RESULT: ERROR
 
+// An undecoded slot between the two reused calls must not let the later call
+// resolve: its bytes could clobber the target pair or divert control flow.
+// RUN: sed 's/^\.set undecoded_gap, 0$/.set undecoded_gap, 1/' \
+// RUN:   %s > %t.undecoded.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.undecoded.s -o %t.undecoded.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.undecoded.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=UNDECODED,FAIL %s
+// UNDECODED: hotswap: resolved reusable PC-materialized call
+// UNDECODED: hotswap: unresolved call target
+
+// A back-edge that reloads the target pair through an unprovable definition
+// makes the reconverged call Unknown; a stale finite result from the first
+// visit must not survive.
+// RUN: sed 's/^\.set reconverge_reload, 0$/.set reconverge_reload, 1/' \
+// RUN:   %s > %t.reconverge.s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   %t.reconverge.s -o %t.reconverge.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.reconverge.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=RECONVERGE,FAIL %s
+// RECONVERGE: hotswap: resolved reusable PC-materialized call
+// RECONVERGE: hotswap: unresolved call target
+
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM \
 // RUN:   --implicit-check-not=s_add_pc_i64 %s
 // DISASM-LABEL: <reusable_pc_targets>:
@@ -143,6 +170,8 @@
 .set tail_escape, 0
 .set indirect_escape, 0
 .set external_entry, 0
+.set undecoded_gap, 0
+.set reconverge_reload, 0
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -221,6 +250,24 @@ reusable_pc_targets:
 .endif
 .Lselected:
   s_swap_pc_i64 s[6:7], s[2:3]
+.if undecoded_gap
+  // An undecoded word between the reused calls has an unknown effect on the
+  // target pair. The solver must not carry the finite target set across it.
+  .long 0xffffffff
+.endif
+.if reconverge_reload
+  // One path reaches the second reused call with the proven pair; a sibling
+  // path reloads it through an unprovable definition. They reconverge on the
+  // second call, which must therefore be Unknown -- not the finite result the
+  // proven path alone recorded on its earlier visit.
+  s_cmp_eq_u32 s0, 5
+  s_cbranch_scc1 .Lreload_join
+  s_branch .Lreused_second
+.Lreload_join:
+  s_mov_b32 s2, 0
+  s_mov_b32 s3, 0
+.Lreused_second:
+.endif
   // Production kernels reuse this selected pair for multiple calls.
   s_swap_pc_i64 s[6:7], s[2:3]
   s_branch .Lpatch0

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -1147,9 +1147,14 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  ASSERT_EQ(Info->Targets.size(), 2u);
+  // Targets: the declared entry, the s_branch destination, and the bounded
+  // return's continuation (the instruction after the call). The continuation
+  // is a landing site of the return and must be protected from relocation.
+  ASSERT_EQ(Info->Targets.size(), 3u);
   EXPECT_TRUE(Info->Targets.contains(0));
   EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(Info->Targets.contains(Decoded[5].Offset + Decoded[5].Size));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded[1].Offset));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -3591,4 +3596,79 @@ TEST(LivenessInfo, ZeroVgprConservativeModeIsExplicit) {
   EXPECT_EQ(Info.perInstructionCount(), 0u);
   EXPECT_TRUE(Info.liveBefore(0).empty());
   EXPECT_EQ(&Info.liveBefore(0), &Info.liveAfter(0));
+}
+
+// The one-shot PC-materialization matcher (resolveMaterializedPcTarget) accepts
+// the plain s_get_pc_i64 + s_add_nc_u64 pair. The reusable-call lit fixture
+// reaches the matcher only through the carry form, so cover the plain form here
+// through the public collectDirectBranchTargets entry. The carry form with an
+// inline-immediate first addend is exercised in hotswap-reusable-pc-call-
+// targets.s (inline_immediate_delta), the path that actually resolves it.
+TEST(PcMaterialization, PlainAddNcU64ResolvesCallTarget) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // s_get_pc_i64 captures the address after its own dword (.text+0x4); adding
+  // 0x10 yields the local target .text+0x14.
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[2:3]\n"
+                           "s_add_nc_u64 s[2:3], s[2:3], 0x10\n"
+                           "s_swap_pc_i64 s[6:7], s[2:3]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x20, /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+  EXPECT_TRUE(Info->Targets.contains(0x14u));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+}
+
+TEST(PcMaterialization, CarryFormInlineImmediateResolvesReusedCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // Carry form reached through the reusable solver: a selector branch picks one
+  // of two s_get_pc_i64 + s_add_co_i32 arms that build the low displacement,
+  // the pair is completed, and two register calls reuse it. The first addend
+  // 0x24 (36) is in the SOP2 inline range [-16, 64], so it is encoded inline
+  // rather than as a trailing 32-bit literal dword -- the matcher branch a
+  // label-relative operand (always a relocatable literal) never reaches.
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_cmp_eq_u32 s0, 0\n"
+                           "s_cbranch_scc1 5\n"
+                           "s_get_pc_i64 s[2:3]\n"
+                           "s_add_co_i32 s4, 0x1c, 4\n"
+                           "s_add_co_u32 s2, s2, s4\n"
+                           "s_add_co_ci_u32 s3, s3, 0\n"
+                           "s_branch 4\n"
+                           "s_get_pc_i64 s[2:3]\n"
+                           "s_add_co_i32 s4, 0x8, 4\n"
+                           "s_add_co_u32 s2, s2, s4\n"
+                           "s_add_co_ci_u32 s3, s3, 0\n"
+                           "s_swap_pc_i64 s[6:7], s[2:3]\n"
+                           "s_swap_pc_i64 s[6:7], s[2:3]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+
+  llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
+      {0, Bytes.size()}};
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0, Bytes.size(),
+                                 DeclaredEntries, FunctionRanges);
+  ASSERT_TRUE(Info);
+  // The reused register call is resolved to a finite target through the
+  // inline-immediate carry materialization.
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.empty());
 }


### PR DESCRIPTION
Dense gfx1250 HotSwap workloads can exhaust every 20-byte forward gateway even
though each source site has an 8-byte patch window. Add an SCC-preserving
shared dispatcher that records each source PC, relays through other patched
sites when necessary, and maps groups of far sites to their trampoline bodies
through one gateway. Split gateways across 8+16-byte sleds when no contiguous
20-byte sled exists.

Also resolve compiler-emitted reusable PC-materialized call targets with a
fail-closed reaching-value analysis, allowing bounded indirect transfers to
retain safe relocation and gateway planning. The final proof:

- treats every declared entry and direct cross-function target as an
  independent unknown root;
- requires exact non-overlapping carry materializations and the gfx12 literal
  selector;
- carries reusable state across a call only after proving the exact local
  callee preserves the target pair and returns through the expected link;
- permits the first straight-line one-shot call to bootstrap later reuse only
  when both analyses agree on the same singleton target and exact target pair;
- preserves the existing fail-closed behavior for bypass paths, target
  clobbers, escaping control flow, and targets outside `.text`.

Validation at `0d4ee51d683d6335ef4b3d5e32d6853bd0e833b1`:

- `HotswapMCTests`: 118/118 passed
- COMGR HotSwap lit: 125/125 passed
- focused adversarial coverage passes for selector bypass, outside-`.text`,
  overlapping carry temporary, callee and bootstrap-callee clobbers, escaping
  tail branch, wrong-link indirect transfer, and external entry into a
  materialization interior
- both production `46f0062d...` paths pass first rewrite, `llvm-readobj`,
  A0-to-A0 second rewrite, and byte-identical comparison
- audited 2,685-object corpus: 2,591 successes and 94 failures
- path-for-path versus the 2,651-object `356f87b8` baseline: 33
  failure-to-success, 90 failure-to-failure, 2,528 success-to-success, and 0
  success-to-failure
- path-for-path versus the original PR head: 90 failure-to-failure, 2,561
  success-to-success, and 0 regressions
- three newly added approximately 224 MB objects reached the campaign's
  1,800-second timeout; they are outside the 2,651-object contract
- on `mi400-3`, the final host/container library hash matched, rocThrust Test
  #64 passed all 16 typed tests and CTest 1/1, and `/opt/hotswap-corpus`
  contained 2,685 code objects

Authoritative evidence:

- corpus: `/home/harsh/pr3576/evidence/full2685-0d4ee51d683d-r2`
- MI400: `/home/harmenon/logs/pr3576-final-r2`
- consolidated review: `/home/harsh/codereview/review_3576.md`

Excluded setup evidence:

- `full2685-0d4ee51d683d` contains loader-only failures from an initially
  missing `libamd_comgr.so.3` SONAME symlink
- the first final MI400 attempt stopped during preflight when
  `rocminfo | grep -m1` propagated SIGPIPE under `pipefail`, before the library
  swap or test

Neither setup attempt is used for acceptance; the distinct `-r2` evidence
above is authoritative.
