### PR TITLE
[comgr][hotswap] Add inert RegisterSet data layer for register liveness (1/5)

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCES
   src/comgr-hotswap-occupancy.cpp
   src/comgr-hotswap-patch-trampoline.cpp
   src/comgr-hotswap-elf.cpp
+  src/comgr-hotswap-liveness.cpp
   src/comgr-hotswap-llvm.cpp
   src/comgr-hotswap-patch-f32-to-e5m3.cpp
   src/comgr-hotswap-patch-inplace.cpp

--- a/amd/comgr/src/comgr-hotswap-liveness.cpp
+++ b/amd/comgr/src/comgr-hotswap-liveness.cpp
@@ -1,0 +1,140 @@
+//===- comgr-hotswap-liveness.cpp - HotSwap register set / liveness ------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// RegisterSet method bodies for the HotSwap register-liveness data layer.
+/// See comgr-hotswap-liveness.h. Not wired into any production rewrite path.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-liveness.h"
+
+namespace COMGR {
+namespace hotswap {
+namespace reglive {
+
+namespace {
+
+/// Apply \p Op to each tracked lane covered by \p Ref, dispatching on the
+/// register class. Lanes that fall outside a bitset's capacity are ignored so
+/// a malformed decoded index can never trap. Untracked classes are a no-op.
+template <typename Op>
+void forEachLane(RegisterRef Ref, std::bitset<RegisterSetMaxSgprs> &Sgprs,
+                 std::bitset<RegisterSetMaxVgprs> &Vgprs,
+                 std::bitset<RegisterSetMaxAccVgprs> &AccVgprs, Op &&Apply) {
+  const unsigned Base = Ref.Index;
+  const unsigned Width = Ref.Width == 0 ? 1u : Ref.Width;
+  switch (Ref.Cls) {
+  case RegClass::SGPR:
+    for (unsigned I = 0; I < Width; ++I)
+      if (Base + I < Sgprs.size())
+        Apply(Sgprs, Base + I);
+    return;
+  case RegClass::VGPR:
+    for (unsigned I = 0; I < Width; ++I)
+      if (Base + I < Vgprs.size())
+        Apply(Vgprs, Base + I);
+    return;
+  case RegClass::ACC_VGPR:
+    for (unsigned I = 0; I < Width; ++I)
+      if (Base + I < AccVgprs.size())
+        Apply(AccVgprs, Base + I);
+    return;
+  default:
+    // Untracked register class: no storage.
+    return;
+  }
+}
+
+} // namespace
+
+void RegisterSet::expand(RegisterRef Ref) {
+  forEachLane(Ref, Sgprs, Vgprs, AccVgprs,
+              [](auto &Bits, unsigned Pos) { Bits.set(Pos); });
+}
+
+void RegisterSet::erase(RegisterRef Ref) {
+  forEachLane(Ref, Sgprs, Vgprs, AccVgprs,
+              [](auto &Bits, unsigned Pos) { Bits.reset(Pos); });
+}
+
+void RegisterSet::clearClass(RegClass Cls) {
+  switch (Cls) {
+  case RegClass::SGPR:
+    Sgprs.reset();
+    return;
+  case RegClass::VGPR:
+    Vgprs.reset();
+    return;
+  case RegClass::ACC_VGPR:
+    AccVgprs.reset();
+    return;
+  default:
+    return;
+  }
+}
+
+bool RegisterSet::contains(RegisterRef Ref) const {
+  const unsigned Base = Ref.Index;
+  const unsigned Width = Ref.Width == 0 ? 1u : Ref.Width;
+  auto allSet = [&](const auto &Bits) {
+    for (unsigned I = 0; I < Width; ++I) {
+      if (Base + I >= Bits.size() || !Bits.test(Base + I))
+        return false;
+    }
+    return true;
+  };
+  switch (Ref.Cls) {
+  case RegClass::SGPR:
+    return allSet(Sgprs);
+  case RegClass::VGPR:
+    return allSet(Vgprs);
+  case RegClass::ACC_VGPR:
+    return allSet(AccVgprs);
+  default:
+    return false;
+  }
+}
+
+bool RegisterSet::none() const {
+  return Sgprs.none() && Vgprs.none() && AccVgprs.none();
+}
+
+size_t RegisterSet::size() const {
+  return Sgprs.count() + Vgprs.count() + AccVgprs.count();
+}
+
+bool RegisterSet::intersects(const RegisterSet &Rhs) const {
+  return (Sgprs & Rhs.Sgprs).any() || (Vgprs & Rhs.Vgprs).any() ||
+         (AccVgprs & Rhs.AccVgprs).any();
+}
+
+RegisterSet &RegisterSet::operator|=(const RegisterSet &Rhs) {
+  Sgprs |= Rhs.Sgprs;
+  Vgprs |= Rhs.Vgprs;
+  AccVgprs |= Rhs.AccVgprs;
+  return *this;
+}
+
+RegisterSet &RegisterSet::operator&=(const RegisterSet &Rhs) {
+  Sgprs &= Rhs.Sgprs;
+  Vgprs &= Rhs.Vgprs;
+  AccVgprs &= Rhs.AccVgprs;
+  return *this;
+}
+
+RegisterSet &RegisterSet::operator-=(const RegisterSet &Rhs) {
+  Sgprs &= ~Rhs.Sgprs;
+  Vgprs &= ~Rhs.Vgprs;
+  AccVgprs &= ~Rhs.AccVgprs;
+  return *this;
+}
+
+} // namespace reglive
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-liveness.h
+++ b/amd/comgr/src/comgr-hotswap-liveness.h
@@ -1,0 +1,176 @@
+//===- comgr-hotswap-liveness.h - HotSwap register set / liveness --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ISA-independent register references and register sets for HotSwap
+/// dataflow analyses (register liveness, def/use, scratch allocation).
+///
+/// This is the leaf data layer of the HotSwap register-liveness port. It has
+/// no dependency on the LLVM MC layer or on the rest of the HotSwap pipeline
+/// and is intentionally not wired into any production rewrite path yet: later
+/// stages build def/use extraction, a CFG-scoped dataflow solver, and scratch
+/// finders on top of these types before anything consumes them.
+///
+/// Only ordinary SGPRs, VGPRs, and CDNA-style accumulator VGPRs are tracked.
+/// Special architectural state (EXEC, VCC, SCC, M0, FLAT_SCRATCH, ...) is
+/// deliberately ignored: it is represented in \c RegClass so callers can name
+/// it, but a \c RegisterSet stores no bits for it.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_HOTSWAP_LIVENESS_H
+#define COMGR_HOTSWAP_LIVENESS_H
+
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+
+namespace COMGR {
+namespace hotswap {
+namespace reglive {
+
+/// Register-file storage capacities for the tracked classes.
+///
+/// These are storage bounds for an ISA-independent analysis set, not
+/// per-kernel allocation limits. They are fixed constants sized for the
+/// gfx125x targets HotSwap rewrites today; a later stage can derive them from
+/// \c MCSubtargetInfo / \c MCRegisterInfo if the analysis is widened past
+/// gfx1250. They are kept generous so a decoded register index never overflows
+/// the underlying bitset.
+inline constexpr unsigned RegisterSetMaxSgprs = 128;
+inline constexpr unsigned RegisterSetMaxVgprs = 256;
+inline constexpr unsigned RegisterSetMaxAccVgprs = 256;
+
+/// Ordinary SGPRs considered safe for scratch allocation. Conservative bound
+/// used by later scratch-selection stages; liveness itself tracks up to
+/// \c RegisterSetMaxSgprs.
+inline constexpr unsigned RegisterSetAllocatableSgprs = 106;
+
+/// ISA-independent register-file class.
+///
+/// Each class has its own index namespace: SGPR 4 and VGPR 4 are different
+/// registers and never collide in the same set. The special classes below are
+/// nameable for parity with the eventual MC mapping, but a \c RegisterSet
+/// stores no bits for them.
+enum class RegClass : uint8_t {
+  SGPR,         ///< Scalar general-purpose register, indexed as sN.
+  VGPR,         ///< Vector general-purpose register, indexed as vN.
+  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN.
+  EXEC,         ///< EXEC mask. Not tracked by RegisterSet.
+  VCC,          ///< VCC condition mask. Not tracked by RegisterSet.
+  SCC,          ///< Scalar condition code bit. Not tracked by RegisterSet.
+  M0,           ///< M0 special scalar register. Not tracked by RegisterSet.
+  FLAT_SCRATCH, ///< Flat-scratch base pair. Not tracked by RegisterSet.
+  TTMP,         ///< Trap-temporary registers. Not tracked by RegisterSet.
+  PC,           ///< Program counter dependency. Not tracked by RegisterSet.
+};
+
+/// A contiguous register reference within one register file.
+///
+/// \c Index is relative to \c Cls, not a raw operand encoding value. \c Width
+/// is measured in 32-bit register lanes, so a 64-bit SGPR pair is
+/// <tt>{RegClass::SGPR, base, 2}</tt>.
+struct RegisterRef {
+  RegClass Cls;
+  uint16_t Index;
+  uint8_t Width = 1;
+
+  constexpr bool operator==(const RegisterRef &Rhs) const {
+    return Cls == Rhs.Cls && Index == Rhs.Index && Width == Rhs.Width;
+  }
+  constexpr bool operator!=(const RegisterRef &Rhs) const {
+    return !(*this == Rhs);
+  }
+};
+
+/// Per-class register set used for def/use and liveness dataflow.
+///
+/// A RegisterSet can represent an instruction's use set, def set, a block
+/// live-in/live-out set, or a live-before/live-after set. Set operations are
+/// member-wise across the tracked register classes, so SGPR, VGPR, and
+/// AccVGPR lanes stay disjoint.
+class RegisterSet {
+public:
+  /// Add every 32-bit register lane covered by \p Ref. No-op for untracked
+  /// classes.
+  void expand(RegisterRef Ref);
+
+  /// Remove every 32-bit register lane covered by \p Ref. No-op for untracked
+  /// classes.
+  void erase(RegisterRef Ref);
+
+  /// Remove all tracked registers in one register class.
+  void clearClass(RegClass Cls);
+
+  /// Return true if every lane covered by \p Ref is present. Always false for
+  /// untracked classes.
+  [[nodiscard]] bool contains(RegisterRef Ref) const;
+
+  /// Return true when no tracked register class contains any live bits.
+  [[nodiscard]] bool none() const;
+
+  /// Total number of single-lane registers tracked across all classes.
+  [[nodiscard]] size_t size() const;
+
+  /// Return true if any register lane is present in both sets.
+  [[nodiscard]] bool intersects(const RegisterSet &Rhs) const;
+
+  RegisterSet &operator|=(const RegisterSet &Rhs);
+  RegisterSet &operator&=(const RegisterSet &Rhs);
+  RegisterSet &operator-=(const RegisterSet &Rhs);
+
+  friend RegisterSet operator|(RegisterSet Lhs, const RegisterSet &Rhs) {
+    Lhs |= Rhs;
+    return Lhs;
+  }
+  friend RegisterSet operator&(RegisterSet Lhs, const RegisterSet &Rhs) {
+    Lhs &= Rhs;
+    return Lhs;
+  }
+  friend RegisterSet operator-(RegisterSet Lhs, const RegisterSet &Rhs) {
+    Lhs -= Rhs;
+    return Lhs;
+  }
+
+  [[nodiscard]] bool operator==(const RegisterSet &Rhs) const {
+    return Sgprs == Rhs.Sgprs && Vgprs == Rhs.Vgprs && AccVgprs == Rhs.AccVgprs;
+  }
+  [[nodiscard]] bool operator!=(const RegisterSet &Rhs) const {
+    return !(*this == Rhs);
+  }
+
+  /// Invoke \p F with each tracked single-lane register in the set, visiting
+  /// SGPRs, then VGPRs, then AccVGPRs in ascending index order. Each yielded
+  /// RegisterRef has \c Width==1 -- multi-lane refs inserted via \c expand are
+  /// visited as their constituent lanes.
+  template <typename F> void forEach(F &&Fn) const {
+    for (size_t I = 0; I < Sgprs.size(); ++I) {
+      if (Sgprs.test(I))
+        Fn(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(I), 1});
+    }
+    for (size_t I = 0; I < Vgprs.size(); ++I) {
+      if (Vgprs.test(I))
+        Fn(RegisterRef{RegClass::VGPR, static_cast<uint16_t>(I), 1});
+    }
+    for (size_t I = 0; I < AccVgprs.size(); ++I) {
+      if (AccVgprs.test(I))
+        Fn(RegisterRef{RegClass::ACC_VGPR, static_cast<uint16_t>(I), 1});
+    }
+  }
+
+private:
+  std::bitset<RegisterSetMaxSgprs> Sgprs;
+  std::bitset<RegisterSetMaxVgprs> Vgprs;
+  std::bitset<RegisterSetMaxAccVgprs> AccVgprs;
+};
+
+} // namespace reglive
+} // namespace hotswap
+} // namespace COMGR
+
+#endif // COMGR_HOTSWAP_LIVENESS_H

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -103,11 +103,13 @@ comgr_configure_test_target(HotswapElfTests)
 add_executable(HotswapMCTests
   HotswapOccupancyTest.cpp
   HotswapMCTest.cpp
+  HotswapRegisterSetTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
   ../src/comgr-hotswap-displacement.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp
+  ../src/comgr-hotswap-liveness.cpp
   ../src/comgr-hotswap-llvm.cpp
   ../src/comgr-hotswap-occupancy.cpp
   ../src/comgr-hotswap-patch-f32-to-e5m3.cpp

--- a/amd/comgr/test-unit/HotswapRegisterSetTest.cpp
+++ b/amd/comgr/test-unit/HotswapRegisterSetTest.cpp
@@ -1,0 +1,160 @@
+//===- HotswapRegisterSetTest.cpp - Unit tests for reglive::RegisterSet --===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Tests for the ISA-independent register set/reference types in
+/// comgr-hotswap-liveness.h. These types are the leaf data layer of the
+/// HotSwap register-liveness port and have no MC dependency, so the suite is
+/// self-contained.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-liveness.h"
+#include "gtest/gtest.h"
+
+#include <vector>
+
+using namespace COMGR::hotswap::reglive;
+
+TEST(HotswapRegisterSet, KeepsRegisterClassesSeparate) {
+  RegisterSet Set;
+  Set.expand({RegClass::SGPR, 4, 1});
+
+  EXPECT_TRUE(Set.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 4, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::ACC_VGPR, 4, 1}));
+}
+
+TEST(HotswapRegisterSet, IgnoresSpecialRegisterClasses) {
+  RegisterSet Set;
+  Set.expand({RegClass::EXEC, 0, 2});
+  Set.expand({RegClass::SCC, 0, 1});
+  Set.expand({RegClass::FLAT_SCRATCH, 0, 2});
+
+  EXPECT_TRUE(Set.none());
+  EXPECT_FALSE(Set.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::SCC, 0, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+}
+
+TEST(HotswapRegisterSet, ExpandMultiLaneSetsAllLanes) {
+  RegisterSet Set;
+  Set.expand({RegClass::VGPR, 4, 4});
+
+  EXPECT_TRUE(Set.contains({RegClass::VGPR, 4, 4}));
+  for (uint16_t I = 4; I < 8; ++I)
+    EXPECT_TRUE(Set.contains({RegClass::VGPR, I, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 3, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 8, 1}));
+  // A wider ref that runs past the set lanes is not fully contained.
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 4, 5}));
+}
+
+TEST(HotswapRegisterSet, EraseIsLanePrecise) {
+  RegisterSet Set;
+  Set.expand({RegClass::SGPR, 6, 2});
+  Set.erase({RegClass::SGPR, 6, 1});
+
+  EXPECT_FALSE(Set.contains({RegClass::SGPR, 6, 1}));
+  EXPECT_TRUE(Set.contains({RegClass::SGPR, 7, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::SGPR, 6, 2}));
+}
+
+TEST(HotswapRegisterSet, ClearClassOnlyClearsThatClass) {
+  RegisterSet Set;
+  Set.expand({RegClass::SGPR, 4, 1});
+  Set.expand({RegClass::VGPR, 4, 1});
+  Set.expand({RegClass::ACC_VGPR, 4, 1});
+
+  Set.clearClass(RegClass::VGPR);
+
+  EXPECT_TRUE(Set.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 4, 1}));
+  EXPECT_TRUE(Set.contains({RegClass::ACC_VGPR, 4, 1}));
+}
+
+TEST(HotswapRegisterSet, UnionSubtractIntersectAreMemberWise) {
+  RegisterSet A;
+  A.expand({RegClass::VGPR, 0, 1});
+  A.expand({RegClass::SGPR, 2, 1});
+
+  RegisterSet B;
+  B.expand({RegClass::VGPR, 1, 1});
+  B.expand({RegClass::SGPR, 2, 1});
+
+  RegisterSet Union = A | B;
+  EXPECT_TRUE(Union.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(Union.contains({RegClass::VGPR, 1, 1}));
+  EXPECT_TRUE(Union.contains({RegClass::SGPR, 2, 1}));
+
+  RegisterSet Inter = A & B;
+  EXPECT_FALSE(Inter.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(Inter.contains({RegClass::SGPR, 2, 1}));
+  EXPECT_EQ(Inter.size(), 1u);
+
+  RegisterSet Diff = A - B;
+  EXPECT_TRUE(Diff.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_FALSE(Diff.contains({RegClass::SGPR, 2, 1}));
+}
+
+TEST(HotswapRegisterSet, IntersectsDetectsSharedLane) {
+  RegisterSet A;
+  A.expand({RegClass::VGPR, 5, 1});
+  RegisterSet B;
+  B.expand({RegClass::VGPR, 5, 1});
+  RegisterSet C;
+  C.expand({RegClass::VGPR, 6, 1});
+
+  EXPECT_TRUE(A.intersects(B));
+  EXPECT_FALSE(A.intersects(C));
+  // Same index in a different class does not intersect.
+  RegisterSet D;
+  D.expand({RegClass::SGPR, 5, 1});
+  EXPECT_FALSE(A.intersects(D));
+}
+
+TEST(HotswapRegisterSet, SizeCountsLanesAcrossClasses) {
+  RegisterSet Set;
+  EXPECT_EQ(Set.size(), 0u);
+  EXPECT_TRUE(Set.none());
+
+  Set.expand({RegClass::SGPR, 0, 2});
+  Set.expand({RegClass::VGPR, 10, 1});
+  Set.expand({RegClass::ACC_VGPR, 3, 4});
+
+  EXPECT_EQ(Set.size(), 2u + 1u + 4u);
+  EXPECT_FALSE(Set.none());
+}
+
+TEST(HotswapRegisterSet, ForEachVisitsAscendingSgprThenVgprThenAcc) {
+  RegisterSet Set;
+  Set.expand({RegClass::ACC_VGPR, 2, 1});
+  Set.expand({RegClass::VGPR, 7, 1});
+  Set.expand({RegClass::VGPR, 1, 1});
+  Set.expand({RegClass::SGPR, 5, 1});
+
+  std::vector<RegisterRef> Visited;
+  Set.forEach([&](RegisterRef Ref) { Visited.push_back(Ref); });
+
+  ASSERT_EQ(Visited.size(), 4u);
+  EXPECT_EQ(Visited[0], (RegisterRef{RegClass::SGPR, 5, 1}));
+  EXPECT_EQ(Visited[1], (RegisterRef{RegClass::VGPR, 1, 1}));
+  EXPECT_EQ(Visited[2], (RegisterRef{RegClass::VGPR, 7, 1}));
+  EXPECT_EQ(Visited[3], (RegisterRef{RegClass::ACC_VGPR, 2, 1}));
+}
+
+TEST(HotswapRegisterSet, EqualityIsMemberWise) {
+  RegisterSet A;
+  A.expand({RegClass::VGPR, 3, 2});
+  RegisterSet B;
+  B.expand({RegClass::VGPR, 3, 1});
+  EXPECT_FALSE(A == B);
+
+  B.expand({RegClass::VGPR, 4, 1});
+  EXPECT_TRUE(A == B);
+}


### PR DESCRIPTION
Introduces COMGR::hotswap::reglive::{RegClass, RegisterRef, RegisterSet},
the leaf data layer of a register-liveness analysis ported from rocjitsu.
Tracks SGPR, VGPR, and ACC_VGPR lanes in disjoint per-class bitsets with
union/intersect/subtract set algebra; special registers (EXEC, VCC, SCC,
...) are nameable but untracked.
This is intentionally inert: compiled into amd_comgr and HotswapMCTests but
referenced by nothing in the rewrite path, and named in its own namespace so
it does not override the weak computeLiveness/buildCfg/getInstRegDefUse stubs.
Adds 10 self-contained unit tests (HotswapRegisterSetTest).