### PR TITLE
[comgr][hotswap] Add inert instruction def/use extraction for register liveness (2/5)

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -111,6 +111,7 @@ set(SOURCES
   src/comgr-hotswap-patch-trampoline.cpp
   src/comgr-hotswap-elf.cpp
   src/comgr-hotswap-liveness.cpp
+  src/comgr-hotswap-def-use.cpp
   src/comgr-hotswap-llvm.cpp
   src/comgr-hotswap-patch-f32-to-e5m3.cpp
   src/comgr-hotswap-patch-inplace.cpp

--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCES
   src/comgr-hotswap-occupancy.cpp
   src/comgr-hotswap-patch-trampoline.cpp
   src/comgr-hotswap-elf.cpp
+  src/comgr-hotswap-liveness.cpp
   src/comgr-hotswap-llvm.cpp
   src/comgr-hotswap-patch-f32-to-e5m3.cpp
   src/comgr-hotswap-patch-inplace.cpp

--- a/amd/comgr/src/comgr-hotswap-def-use.cpp
+++ b/amd/comgr/src/comgr-hotswap-def-use.cpp
@@ -1,0 +1,151 @@
+//===- comgr-hotswap-def-use.cpp - HotSwap instruction def/use -----------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Implementation of the InstDefUse extraction and the MCRegister ->
+/// RegisterRef mapping. See comgr-hotswap-def-use.h. Not wired into any
+/// production rewrite path.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-def-use.h"
+
+#include "llvm/ADT/StringRef.h"
+#include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
+#include "llvm/MC/MCRegisterInfo.h"
+
+namespace COMGR {
+namespace hotswap {
+namespace reglive {
+
+namespace {
+
+// Low 10 bits index a VGPR/SGPR/AGPR within its file; the same masking the
+// WMMA-split pass uses for VGPR base extraction.
+constexpr unsigned RegIndexMask = 0x3ff;
+
+// Number of 32-bit lanes covered by \p Reg within its own register file.
+//
+// The width is taken from the smallest register class that contains \p Reg
+// *and* belongs to the same register file (name prefix), so a single sN/vN is
+// 1 lane and an aligned pair s[i:i+1] is 2. Restricting to the register's own
+// file is essential: the AMDGPU MC layer also defines synthetic cross-file
+// operand classes (e.g. the nominally 16-bit "VS_16", which lists full 32-bit
+// SGPRs as members for operand-legality reasons). Considering those would
+// report a bogus sub-dword width.
+unsigned laneWidth(llvm::MCRegister Reg, const llvm::MCRegisterInfo &MRI,
+                   llvm::StringRef Prefix, llvm::StringRef AltPrefix) {
+  unsigned Bits = 0;
+  for (unsigned I = 0, E = MRI.getNumRegClasses(); I < E; ++I) {
+    const llvm::MCRegisterClass &RC = MRI.getRegClass(I);
+    llvm::StringRef Name = MRI.getRegClassName(&RC);
+    if (!Name.starts_with(Prefix) && !Name.starts_with(AltPrefix))
+      continue;
+    if (RC.getSizeInBits() < 32)
+      continue; // ignore sub-dword sibling classes (lo16/hi16, SReg_1, ...).
+    if (!RC.contains(Reg))
+      continue;
+    if (Bits == 0 || RC.getSizeInBits() < Bits)
+      Bits = RC.getSizeInBits();
+  }
+  return Bits / 32;
+}
+
+bool isExecMaskedDefClass(RegClass Cls) {
+  return Cls == RegClass::VGPR || Cls == RegClass::ACC_VGPR;
+}
+
+void addUse(InstDefUse &DU, llvm::MCRegister Reg,
+            const llvm::MCRegisterInfo &MRI) {
+  if (auto Ref = toRegisterRef(Reg, MRI))
+    DU.Uses.expand(*Ref);
+}
+
+void addDef(InstDefUse &DU, llvm::MCRegister Reg,
+            const llvm::MCRegisterInfo &MRI, bool TrackExecMask) {
+  auto Ref = toRegisterRef(Reg, MRI);
+  if (!Ref)
+    return;
+  DU.Defs.expand(*Ref);
+  if (TrackExecMask && isExecMaskedDefClass(Ref->Cls))
+    DU.HasExecMaskedVectorDef = true;
+}
+
+} // namespace
+
+std::optional<RegisterRef> toRegisterRef(llvm::MCRegister Reg,
+                                         const llvm::MCRegisterInfo &MRI) {
+  if (!Reg)
+    return std::nullopt;
+
+  // Classify by the MCRegisterInfo record-name prefix. Numbered GPR registers
+  // (and their tuple aliases, e.g. "SGPR0_SGPR1") begin with the file prefix;
+  // special registers (VCC, EXEC, SCC, M0, FLAT_SCR, TTMP, NULL, ...) do not,
+  // so they map to no tracked ref.
+  llvm::StringRef Name = MRI.getName(Reg);
+  RegClass Cls;
+  llvm::StringRef Prefix;
+  llvm::StringRef AltPrefix;
+  if (Name.starts_with("VGPR")) {
+    Cls = RegClass::VGPR;
+    Prefix = "VGPR";
+    AltPrefix = "VReg";
+  } else if (Name.starts_with("AGPR")) {
+    Cls = RegClass::ACC_VGPR;
+    Prefix = "AGPR";
+    AltPrefix = "AReg";
+  } else if (Name.starts_with("SGPR")) {
+    Cls = RegClass::SGPR;
+    Prefix = "SGPR";
+    AltPrefix = "SReg";
+  } else {
+    return std::nullopt;
+  }
+
+  const unsigned Width = laneWidth(Reg, MRI, Prefix, AltPrefix);
+  if (Width == 0)
+    return std::nullopt; // sub-dword (e.g. 16-bit register halves) not tracked.
+
+  const unsigned Base = MRI.getEncodingValue(Reg) & RegIndexMask;
+  return RegisterRef{Cls, static_cast<uint16_t>(Base),
+                     static_cast<uint8_t>(Width)};
+}
+
+InstDefUse::InstDefUse(const llvm::MCInst &Inst, const llvm::MCInstrInfo &MCII,
+                       const llvm::MCRegisterInfo &MRI) {
+  const llvm::MCInstrDesc &Desc = MCII.get(Inst.getOpcode());
+  const unsigned NumDefs = Desc.getNumDefs();
+
+  // Explicit operands: the leading NumDefs register operands are defs, the
+  // remaining register operands are uses. A register that appears in both a
+  // def slot and a use slot (read-modify-write / two-address form) is added to
+  // both sets, so it stays live before the instruction.
+  for (unsigned I = 0, E = Inst.getNumOperands(); I < E; ++I) {
+    const llvm::MCOperand &Op = Inst.getOperand(I);
+    if (!Op.isReg())
+      continue;
+    if (I < NumDefs)
+      addDef(*this, Op.getReg(), MRI, /*TrackExecMask=*/true);
+    else
+      addUse(*this, Op.getReg(), MRI);
+  }
+
+  // Implicit defs/uses are not part of the operand list. They do not
+  // participate in the EXEC-masked-vector-def signal, matching the source
+  // analysis (which derives that flag from explicit destinations only).
+  for (llvm::MCPhysReg Reg : Desc.implicit_defs())
+    addDef(*this, llvm::MCRegister(Reg), MRI, /*TrackExecMask=*/false);
+  for (llvm::MCPhysReg Reg : Desc.implicit_uses())
+    addUse(*this, llvm::MCRegister(Reg), MRI);
+}
+
+} // namespace reglive
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-def-use.h
+++ b/amd/comgr/src/comgr-hotswap-def-use.h
@@ -1,0 +1,85 @@
+//===- comgr-hotswap-def-use.h - HotSwap instruction def/use extraction --===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Instruction-level register def/use extraction for the HotSwap register
+/// liveness port. This is the bridge between a decoded LLVM MC instruction and
+/// the ISA-independent RegisterSet dataflow layer in comgr-hotswap-liveness.h.
+///
+/// Direction is determined by operand position: the leading MCInstrDesc def
+/// operands define registers, the remaining explicit operands use registers,
+/// and MCInstrDesc implicit defs/uses are added on top. Register identity and
+/// class are resolved from the LLVM MCRegisterInfo via toRegisterRef(): only
+/// numbered SGPRs, VGPRs, and AccVGPRs are tracked; special registers (EXEC,
+/// VCC, SCC, M0, FLAT_SCR, ...) map to no RegisterRef and are ignored.
+///
+/// Like the rest of the register-liveness port, this is not wired into any
+/// production rewrite path yet.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_HOTSWAP_DEF_USE_H
+#define COMGR_HOTSWAP_DEF_USE_H
+
+#include "comgr-hotswap-liveness.h"
+
+#include "llvm/MC/MCRegister.h"
+
+#include <optional>
+
+namespace llvm {
+class MCInst;
+class MCInstrInfo;
+class MCRegisterInfo;
+} // namespace llvm
+
+namespace COMGR {
+namespace hotswap {
+namespace reglive {
+
+/// Map a physical MC register to a tracked RegisterRef.
+///
+/// Classifies \p Reg by its MCRegisterInfo record-name prefix (VGPR*, SGPR*,
+/// AGPR*) so special registers such as EXEC/VCC/SCC/M0/FLAT_SCR are naturally
+/// excluded (they map to std::nullopt). The lane width comes from the smallest
+/// enclosing register class and the base index from the register's hardware
+/// encoding, so a 64-bit pair such as s[6:7] becomes {SGPR, 6, 2}. Registers
+/// narrower than 32 bits (e.g. 16-bit VGPR halves) are not tracked and return
+/// std::nullopt.
+[[nodiscard]] std::optional<RegisterRef>
+toRegisterRef(llvm::MCRegister Reg, const llvm::MCRegisterInfo &MRI);
+
+/// Registers read and written by one decoded MC instruction.
+class InstDefUse {
+public:
+  /// Extract explicit operand and implicit def/use register refs from \p Inst.
+  /// \p MCII supplies the instruction description (def count, implicit
+  /// defs/uses); \p MRI resolves register identities.
+  InstDefUse(const llvm::MCInst &Inst, const llvm::MCInstrInfo &MCII,
+             const llvm::MCRegisterInfo &MRI);
+
+  RegisterSet Defs; ///< Registers overwritten by the instruction.
+  RegisterSet Uses; ///< Registers read by the instruction.
+
+  /// True if any explicit vector (VGPR/ACC_VGPR) def is present. Such writes
+  /// are EXEC-masked, so inactive lanes preserve their old value; a later
+  /// liveness stage must not treat them as unconditional kills.
+  bool HasExecMaskedVectorDef = false;
+
+  /// True if the destination update is conditional and must not kill the old
+  /// value. AMDGPU MC exposes no direct signal for this today, so it is
+  /// currently always false; it stays in the interface for parity with the
+  /// source analysis and for a later, target-specific refinement.
+  bool HasPredicatedDef = false;
+};
+
+} // namespace reglive
+} // namespace hotswap
+} // namespace COMGR
+
+#endif // COMGR_HOTSWAP_DEF_USE_H

--- a/amd/comgr/src/comgr-hotswap-liveness.cpp
+++ b/amd/comgr/src/comgr-hotswap-liveness.cpp
@@ -1,0 +1,140 @@
+//===- comgr-hotswap-liveness.cpp - HotSwap register set / liveness ------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// RegisterSet method bodies for the HotSwap register-liveness data layer.
+/// See comgr-hotswap-liveness.h. Not wired into any production rewrite path.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-liveness.h"
+
+namespace COMGR {
+namespace hotswap {
+namespace reglive {
+
+namespace {
+
+/// Apply \p Op to each tracked lane covered by \p Ref, dispatching on the
+/// register class. Lanes that fall outside a bitset's capacity are ignored so
+/// a malformed decoded index can never trap. Untracked classes are a no-op.
+template <typename Op>
+void forEachLane(RegisterRef Ref, std::bitset<RegisterSetMaxSgprs> &Sgprs,
+                 std::bitset<RegisterSetMaxVgprs> &Vgprs,
+                 std::bitset<RegisterSetMaxAccVgprs> &AccVgprs, Op &&Apply) {
+  const unsigned Base = Ref.Index;
+  const unsigned Width = Ref.Width == 0 ? 1u : Ref.Width;
+  switch (Ref.Cls) {
+  case RegClass::SGPR:
+    for (unsigned I = 0; I < Width; ++I)
+      if (Base + I < Sgprs.size())
+        Apply(Sgprs, Base + I);
+    return;
+  case RegClass::VGPR:
+    for (unsigned I = 0; I < Width; ++I)
+      if (Base + I < Vgprs.size())
+        Apply(Vgprs, Base + I);
+    return;
+  case RegClass::ACC_VGPR:
+    for (unsigned I = 0; I < Width; ++I)
+      if (Base + I < AccVgprs.size())
+        Apply(AccVgprs, Base + I);
+    return;
+  default:
+    // Untracked register class: no storage.
+    return;
+  }
+}
+
+} // namespace
+
+void RegisterSet::expand(RegisterRef Ref) {
+  forEachLane(Ref, Sgprs, Vgprs, AccVgprs,
+              [](auto &Bits, unsigned Pos) { Bits.set(Pos); });
+}
+
+void RegisterSet::erase(RegisterRef Ref) {
+  forEachLane(Ref, Sgprs, Vgprs, AccVgprs,
+              [](auto &Bits, unsigned Pos) { Bits.reset(Pos); });
+}
+
+void RegisterSet::clearClass(RegClass Cls) {
+  switch (Cls) {
+  case RegClass::SGPR:
+    Sgprs.reset();
+    return;
+  case RegClass::VGPR:
+    Vgprs.reset();
+    return;
+  case RegClass::ACC_VGPR:
+    AccVgprs.reset();
+    return;
+  default:
+    return;
+  }
+}
+
+bool RegisterSet::contains(RegisterRef Ref) const {
+  const unsigned Base = Ref.Index;
+  const unsigned Width = Ref.Width == 0 ? 1u : Ref.Width;
+  auto allSet = [&](const auto &Bits) {
+    for (unsigned I = 0; I < Width; ++I) {
+      if (Base + I >= Bits.size() || !Bits.test(Base + I))
+        return false;
+    }
+    return true;
+  };
+  switch (Ref.Cls) {
+  case RegClass::SGPR:
+    return allSet(Sgprs);
+  case RegClass::VGPR:
+    return allSet(Vgprs);
+  case RegClass::ACC_VGPR:
+    return allSet(AccVgprs);
+  default:
+    return false;
+  }
+}
+
+bool RegisterSet::none() const {
+  return Sgprs.none() && Vgprs.none() && AccVgprs.none();
+}
+
+size_t RegisterSet::size() const {
+  return Sgprs.count() + Vgprs.count() + AccVgprs.count();
+}
+
+bool RegisterSet::intersects(const RegisterSet &Rhs) const {
+  return (Sgprs & Rhs.Sgprs).any() || (Vgprs & Rhs.Vgprs).any() ||
+         (AccVgprs & Rhs.AccVgprs).any();
+}
+
+RegisterSet &RegisterSet::operator|=(const RegisterSet &Rhs) {
+  Sgprs |= Rhs.Sgprs;
+  Vgprs |= Rhs.Vgprs;
+  AccVgprs |= Rhs.AccVgprs;
+  return *this;
+}
+
+RegisterSet &RegisterSet::operator&=(const RegisterSet &Rhs) {
+  Sgprs &= Rhs.Sgprs;
+  Vgprs &= Rhs.Vgprs;
+  AccVgprs &= Rhs.AccVgprs;
+  return *this;
+}
+
+RegisterSet &RegisterSet::operator-=(const RegisterSet &Rhs) {
+  Sgprs &= ~Rhs.Sgprs;
+  Vgprs &= ~Rhs.Vgprs;
+  AccVgprs &= ~Rhs.AccVgprs;
+  return *this;
+}
+
+} // namespace reglive
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-liveness.h
+++ b/amd/comgr/src/comgr-hotswap-liveness.h
@@ -1,0 +1,176 @@
+//===- comgr-hotswap-liveness.h - HotSwap register set / liveness --------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// ISA-independent register references and register sets for HotSwap
+/// dataflow analyses (register liveness, def/use, scratch allocation).
+///
+/// This is the leaf data layer of the HotSwap register-liveness port. It has
+/// no dependency on the LLVM MC layer or on the rest of the HotSwap pipeline
+/// and is intentionally not wired into any production rewrite path yet: later
+/// stages build def/use extraction, a CFG-scoped dataflow solver, and scratch
+/// finders on top of these types before anything consumes them.
+///
+/// Only ordinary SGPRs, VGPRs, and CDNA-style accumulator VGPRs are tracked.
+/// Special architectural state (EXEC, VCC, SCC, M0, FLAT_SCRATCH, ...) is
+/// deliberately ignored: it is represented in \c RegClass so callers can name
+/// it, but a \c RegisterSet stores no bits for it.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef COMGR_HOTSWAP_LIVENESS_H
+#define COMGR_HOTSWAP_LIVENESS_H
+
+#include <bitset>
+#include <cstddef>
+#include <cstdint>
+
+namespace COMGR {
+namespace hotswap {
+namespace reglive {
+
+/// Register-file storage capacities for the tracked classes.
+///
+/// These are storage bounds for an ISA-independent analysis set, not
+/// per-kernel allocation limits. They are fixed constants sized for the
+/// gfx125x targets HotSwap rewrites today; a later stage can derive them from
+/// \c MCSubtargetInfo / \c MCRegisterInfo if the analysis is widened past
+/// gfx1250. They are kept generous so a decoded register index never overflows
+/// the underlying bitset.
+inline constexpr unsigned RegisterSetMaxSgprs = 128;
+inline constexpr unsigned RegisterSetMaxVgprs = 256;
+inline constexpr unsigned RegisterSetMaxAccVgprs = 256;
+
+/// Ordinary SGPRs considered safe for scratch allocation. Conservative bound
+/// used by later scratch-selection stages; liveness itself tracks up to
+/// \c RegisterSetMaxSgprs.
+inline constexpr unsigned RegisterSetAllocatableSgprs = 106;
+
+/// ISA-independent register-file class.
+///
+/// Each class has its own index namespace: SGPR 4 and VGPR 4 are different
+/// registers and never collide in the same set. The special classes below are
+/// nameable for parity with the eventual MC mapping, but a \c RegisterSet
+/// stores no bits for them.
+enum class RegClass : uint8_t {
+  SGPR,         ///< Scalar general-purpose register, indexed as sN.
+  VGPR,         ///< Vector general-purpose register, indexed as vN.
+  ACC_VGPR,     ///< CDNA accumulator VGPR, indexed as accN.
+  EXEC,         ///< EXEC mask. Not tracked by RegisterSet.
+  VCC,          ///< VCC condition mask. Not tracked by RegisterSet.
+  SCC,          ///< Scalar condition code bit. Not tracked by RegisterSet.
+  M0,           ///< M0 special scalar register. Not tracked by RegisterSet.
+  FLAT_SCRATCH, ///< Flat-scratch base pair. Not tracked by RegisterSet.
+  TTMP,         ///< Trap-temporary registers. Not tracked by RegisterSet.
+  PC,           ///< Program counter dependency. Not tracked by RegisterSet.
+};
+
+/// A contiguous register reference within one register file.
+///
+/// \c Index is relative to \c Cls, not a raw operand encoding value. \c Width
+/// is measured in 32-bit register lanes, so a 64-bit SGPR pair is
+/// <tt>{RegClass::SGPR, base, 2}</tt>.
+struct RegisterRef {
+  RegClass Cls;
+  uint16_t Index;
+  uint8_t Width = 1;
+
+  constexpr bool operator==(const RegisterRef &Rhs) const {
+    return Cls == Rhs.Cls && Index == Rhs.Index && Width == Rhs.Width;
+  }
+  constexpr bool operator!=(const RegisterRef &Rhs) const {
+    return !(*this == Rhs);
+  }
+};
+
+/// Per-class register set used for def/use and liveness dataflow.
+///
+/// A RegisterSet can represent an instruction's use set, def set, a block
+/// live-in/live-out set, or a live-before/live-after set. Set operations are
+/// member-wise across the tracked register classes, so SGPR, VGPR, and
+/// AccVGPR lanes stay disjoint.
+class RegisterSet {
+public:
+  /// Add every 32-bit register lane covered by \p Ref. No-op for untracked
+  /// classes.
+  void expand(RegisterRef Ref);
+
+  /// Remove every 32-bit register lane covered by \p Ref. No-op for untracked
+  /// classes.
+  void erase(RegisterRef Ref);
+
+  /// Remove all tracked registers in one register class.
+  void clearClass(RegClass Cls);
+
+  /// Return true if every lane covered by \p Ref is present. Always false for
+  /// untracked classes.
+  [[nodiscard]] bool contains(RegisterRef Ref) const;
+
+  /// Return true when no tracked register class contains any live bits.
+  [[nodiscard]] bool none() const;
+
+  /// Total number of single-lane registers tracked across all classes.
+  [[nodiscard]] size_t size() const;
+
+  /// Return true if any register lane is present in both sets.
+  [[nodiscard]] bool intersects(const RegisterSet &Rhs) const;
+
+  RegisterSet &operator|=(const RegisterSet &Rhs);
+  RegisterSet &operator&=(const RegisterSet &Rhs);
+  RegisterSet &operator-=(const RegisterSet &Rhs);
+
+  friend RegisterSet operator|(RegisterSet Lhs, const RegisterSet &Rhs) {
+    Lhs |= Rhs;
+    return Lhs;
+  }
+  friend RegisterSet operator&(RegisterSet Lhs, const RegisterSet &Rhs) {
+    Lhs &= Rhs;
+    return Lhs;
+  }
+  friend RegisterSet operator-(RegisterSet Lhs, const RegisterSet &Rhs) {
+    Lhs -= Rhs;
+    return Lhs;
+  }
+
+  [[nodiscard]] bool operator==(const RegisterSet &Rhs) const {
+    return Sgprs == Rhs.Sgprs && Vgprs == Rhs.Vgprs && AccVgprs == Rhs.AccVgprs;
+  }
+  [[nodiscard]] bool operator!=(const RegisterSet &Rhs) const {
+    return !(*this == Rhs);
+  }
+
+  /// Invoke \p F with each tracked single-lane register in the set, visiting
+  /// SGPRs, then VGPRs, then AccVGPRs in ascending index order. Each yielded
+  /// RegisterRef has \c Width==1 -- multi-lane refs inserted via \c expand are
+  /// visited as their constituent lanes.
+  template <typename F> void forEach(F &&Fn) const {
+    for (size_t I = 0; I < Sgprs.size(); ++I) {
+      if (Sgprs.test(I))
+        Fn(RegisterRef{RegClass::SGPR, static_cast<uint16_t>(I), 1});
+    }
+    for (size_t I = 0; I < Vgprs.size(); ++I) {
+      if (Vgprs.test(I))
+        Fn(RegisterRef{RegClass::VGPR, static_cast<uint16_t>(I), 1});
+    }
+    for (size_t I = 0; I < AccVgprs.size(); ++I) {
+      if (AccVgprs.test(I))
+        Fn(RegisterRef{RegClass::ACC_VGPR, static_cast<uint16_t>(I), 1});
+    }
+  }
+
+private:
+  std::bitset<RegisterSetMaxSgprs> Sgprs;
+  std::bitset<RegisterSetMaxVgprs> Vgprs;
+  std::bitset<RegisterSetMaxAccVgprs> AccVgprs;
+};
+
+} // namespace reglive
+} // namespace hotswap
+} // namespace COMGR
+
+#endif // COMGR_HOTSWAP_LIVENESS_H

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -104,7 +104,9 @@ add_executable(HotswapMCTests
   HotswapOccupancyTest.cpp
   HotswapMCTest.cpp
   HotswapRegisterSetTest.cpp
+  HotswapDefUseTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
+  ../src/comgr-hotswap-def-use.cpp
   ../src/comgr-hotswap-displacement.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -103,11 +103,13 @@ comgr_configure_test_target(HotswapElfTests)
 add_executable(HotswapMCTests
   HotswapOccupancyTest.cpp
   HotswapMCTest.cpp
+  HotswapRegisterSetTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
   ../src/comgr-hotswap-displacement.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp
+  ../src/comgr-hotswap-liveness.cpp
   ../src/comgr-hotswap-llvm.cpp
   ../src/comgr-hotswap-occupancy.cpp
   ../src/comgr-hotswap-patch-f32-to-e5m3.cpp

--- a/amd/comgr/test-unit/HotswapDefUseTest.cpp
+++ b/amd/comgr/test-unit/HotswapDefUseTest.cpp
@@ -1,0 +1,160 @@
+//===- HotswapDefUseTest.cpp - Unit tests for InstDefUse extraction ------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Tests for the register def/use extraction in comgr-hotswap-def-use.cpp:
+/// the MCRegister -> RegisterRef mapping (toRegisterRef) and per-instruction
+/// InstDefUse def/use classification. Instructions are assembled and decoded
+/// through a real gfx1250 LLVMState so the tests exercise the same MCInst /
+/// MCInstrDesc / MCRegisterInfo objects the production path would see.
+///
+/// COMGR::ensureLLVMInitialized() is provided by HotswapMCTest.cpp, which is
+/// linked into the same HotswapMCTests binary; it is not redefined here.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-def-use.h"
+#include "comgr-hotswap-internal.h"
+#include "comgr.h"
+#include "llvm/MC/MCInst.h"
+#include "gtest/gtest.h"
+
+#include <optional>
+#include <vector>
+
+using namespace COMGR;
+using namespace COMGR::hotswap;
+using namespace COMGR::hotswap::reglive;
+
+namespace {
+
+TargetIdentifier makeGfx1250Ident() {
+  TargetIdentifier TI;
+  TI.Arch = "amdgcn";
+  TI.Vendor = "amd";
+  TI.OS = "amdhsa";
+  TI.Environ = "";
+  TI.Processor = "gfx1250";
+  return TI;
+}
+
+// Assemble a single asm line and return its first decoded MCInst.
+std::optional<llvm::MCInst> assembleOne(const LLVMState &S,
+                                        llvm::StringRef Asm) {
+  llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Asm, S);
+  if (Bytes.empty())
+    return std::nullopt;
+  std::vector<InternalDecodedInst> Decoded;
+  if (!decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded))
+    return std::nullopt;
+  if (Decoded.empty() || !Decoded.front().DecodeSucceeded)
+    return std::nullopt;
+  return Decoded.front().Inst;
+}
+
+// -- toRegisterRef ----------------------------------------------------------
+
+TEST(ToRegisterRef, SpecialRegistersAreUntracked) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_TRUE(S.MRI);
+
+  // VCC and SCC are cached by initLLVM; neither is a tracked GPR.
+  EXPECT_FALSE(toRegisterRef(S.VCCRegister, *S.MRI).has_value());
+  EXPECT_FALSE(toRegisterRef(S.SCCRegister, *S.MRI).has_value());
+  EXPECT_FALSE(toRegisterRef(llvm::MCRegister(), *S.MRI).has_value());
+}
+
+// -- InstDefUse: single-lane def / use --------------------------------------
+
+TEST(InstDefUse, VectorMoveDefIsExecMasked) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::optional<llvm::MCInst> Inst = assembleOne(S, "v_mov_b32 v3, v5");
+  ASSERT_TRUE(Inst.has_value());
+
+  InstDefUse DU(*Inst, *S.MCII, *S.MRI);
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::VGPR, 3, 1}));
+  EXPECT_EQ(DU.Defs.size(), 1u);
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::VGPR, 5, 1}));
+  EXPECT_FALSE(DU.Uses.contains(RegisterRef{RegClass::VGPR, 3, 1}));
+  EXPECT_TRUE(DU.HasExecMaskedVectorDef);
+  EXPECT_FALSE(DU.HasPredicatedDef);
+}
+
+TEST(InstDefUse, ScalarMoveDefIsNotExecMasked) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::optional<llvm::MCInst> Inst = assembleOne(S, "s_mov_b32 s7, s9");
+  ASSERT_TRUE(Inst.has_value());
+
+  InstDefUse DU(*Inst, *S.MCII, *S.MRI);
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::SGPR, 7, 1}));
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::SGPR, 9, 1}));
+  EXPECT_FALSE(DU.HasExecMaskedVectorDef);
+}
+
+// -- InstDefUse: multi-lane (register pair) ---------------------------------
+
+TEST(InstDefUse, ScalarPairSpansTwoLanes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  std::optional<llvm::MCInst> Inst = assembleOne(S, "s_mov_b64 s[4:5], s[6:7]");
+  ASSERT_TRUE(Inst.has_value());
+
+  InstDefUse DU(*Inst, *S.MCII, *S.MRI);
+  // The 64-bit pair expands to both constituent lanes.
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::SGPR, 4, 2}));
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::SGPR, 4, 1}));
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::SGPR, 5, 1}));
+  EXPECT_EQ(DU.Defs.size(), 2u);
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::SGPR, 6, 2}));
+  EXPECT_EQ(DU.Uses.size(), 2u);
+}
+
+// -- InstDefUse: implicit defs stay untracked -------------------------------
+
+TEST(InstDefUse, ImplicitSccDefIsNotTracked) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // s_add_co_u32 writes its explicit SGPR result plus SCC (implicit). Only the
+  // explicit SGPR result is a tracked def; SCC is dropped.
+  std::optional<llvm::MCInst> Inst = assembleOne(S, "s_add_co_u32 s0, s1, s2");
+  ASSERT_TRUE(Inst.has_value());
+
+  InstDefUse DU(*Inst, *S.MCII, *S.MRI);
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::SGPR, 0, 1}));
+  EXPECT_EQ(DU.Defs.size(), 1u);
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::SGPR, 1, 1}));
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::SGPR, 2, 1}));
+  EXPECT_FALSE(DU.HasExecMaskedVectorDef);
+}
+
+// -- InstDefUse: read-modify-write (same reg def and use) -------------------
+
+TEST(InstDefUse, SameRegisterInDefAndUse) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  // v0 is both written (dst) and read (src0): it must appear in both sets so a
+  // later liveness pass keeps it live before the instruction.
+  std::optional<llvm::MCInst> Inst = assembleOne(S, "v_add_f32 v0, v0, v1");
+  ASSERT_TRUE(Inst.has_value());
+
+  InstDefUse DU(*Inst, *S.MCII, *S.MRI);
+  EXPECT_TRUE(DU.Defs.contains(RegisterRef{RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(DU.Uses.contains(RegisterRef{RegClass::VGPR, 1, 1}));
+  EXPECT_TRUE(DU.HasExecMaskedVectorDef);
+}
+
+} // namespace

--- a/amd/comgr/test-unit/HotswapRegisterSetTest.cpp
+++ b/amd/comgr/test-unit/HotswapRegisterSetTest.cpp
@@ -1,0 +1,160 @@
+//===- HotswapRegisterSetTest.cpp - Unit tests for reglive::RegisterSet --===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+// amd/comgr/LICENSE.TXT in this repository for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Tests for the ISA-independent register set/reference types in
+/// comgr-hotswap-liveness.h. These types are the leaf data layer of the
+/// HotSwap register-liveness port and have no MC dependency, so the suite is
+/// self-contained.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-liveness.h"
+#include "gtest/gtest.h"
+
+#include <vector>
+
+using namespace COMGR::hotswap::reglive;
+
+TEST(HotswapRegisterSet, KeepsRegisterClassesSeparate) {
+  RegisterSet Set;
+  Set.expand({RegClass::SGPR, 4, 1});
+
+  EXPECT_TRUE(Set.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 4, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::ACC_VGPR, 4, 1}));
+}
+
+TEST(HotswapRegisterSet, IgnoresSpecialRegisterClasses) {
+  RegisterSet Set;
+  Set.expand({RegClass::EXEC, 0, 2});
+  Set.expand({RegClass::SCC, 0, 1});
+  Set.expand({RegClass::FLAT_SCRATCH, 0, 2});
+
+  EXPECT_TRUE(Set.none());
+  EXPECT_FALSE(Set.contains({RegClass::EXEC, 0, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::SCC, 0, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::FLAT_SCRATCH, 0, 2}));
+}
+
+TEST(HotswapRegisterSet, ExpandMultiLaneSetsAllLanes) {
+  RegisterSet Set;
+  Set.expand({RegClass::VGPR, 4, 4});
+
+  EXPECT_TRUE(Set.contains({RegClass::VGPR, 4, 4}));
+  for (uint16_t I = 4; I < 8; ++I)
+    EXPECT_TRUE(Set.contains({RegClass::VGPR, I, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 3, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 8, 1}));
+  // A wider ref that runs past the set lanes is not fully contained.
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 4, 5}));
+}
+
+TEST(HotswapRegisterSet, EraseIsLanePrecise) {
+  RegisterSet Set;
+  Set.expand({RegClass::SGPR, 6, 2});
+  Set.erase({RegClass::SGPR, 6, 1});
+
+  EXPECT_FALSE(Set.contains({RegClass::SGPR, 6, 1}));
+  EXPECT_TRUE(Set.contains({RegClass::SGPR, 7, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::SGPR, 6, 2}));
+}
+
+TEST(HotswapRegisterSet, ClearClassOnlyClearsThatClass) {
+  RegisterSet Set;
+  Set.expand({RegClass::SGPR, 4, 1});
+  Set.expand({RegClass::VGPR, 4, 1});
+  Set.expand({RegClass::ACC_VGPR, 4, 1});
+
+  Set.clearClass(RegClass::VGPR);
+
+  EXPECT_TRUE(Set.contains({RegClass::SGPR, 4, 1}));
+  EXPECT_FALSE(Set.contains({RegClass::VGPR, 4, 1}));
+  EXPECT_TRUE(Set.contains({RegClass::ACC_VGPR, 4, 1}));
+}
+
+TEST(HotswapRegisterSet, UnionSubtractIntersectAreMemberWise) {
+  RegisterSet A;
+  A.expand({RegClass::VGPR, 0, 1});
+  A.expand({RegClass::SGPR, 2, 1});
+
+  RegisterSet B;
+  B.expand({RegClass::VGPR, 1, 1});
+  B.expand({RegClass::SGPR, 2, 1});
+
+  RegisterSet Union = A | B;
+  EXPECT_TRUE(Union.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(Union.contains({RegClass::VGPR, 1, 1}));
+  EXPECT_TRUE(Union.contains({RegClass::SGPR, 2, 1}));
+
+  RegisterSet Inter = A & B;
+  EXPECT_FALSE(Inter.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_TRUE(Inter.contains({RegClass::SGPR, 2, 1}));
+  EXPECT_EQ(Inter.size(), 1u);
+
+  RegisterSet Diff = A - B;
+  EXPECT_TRUE(Diff.contains({RegClass::VGPR, 0, 1}));
+  EXPECT_FALSE(Diff.contains({RegClass::SGPR, 2, 1}));
+}
+
+TEST(HotswapRegisterSet, IntersectsDetectsSharedLane) {
+  RegisterSet A;
+  A.expand({RegClass::VGPR, 5, 1});
+  RegisterSet B;
+  B.expand({RegClass::VGPR, 5, 1});
+  RegisterSet C;
+  C.expand({RegClass::VGPR, 6, 1});
+
+  EXPECT_TRUE(A.intersects(B));
+  EXPECT_FALSE(A.intersects(C));
+  // Same index in a different class does not intersect.
+  RegisterSet D;
+  D.expand({RegClass::SGPR, 5, 1});
+  EXPECT_FALSE(A.intersects(D));
+}
+
+TEST(HotswapRegisterSet, SizeCountsLanesAcrossClasses) {
+  RegisterSet Set;
+  EXPECT_EQ(Set.size(), 0u);
+  EXPECT_TRUE(Set.none());
+
+  Set.expand({RegClass::SGPR, 0, 2});
+  Set.expand({RegClass::VGPR, 10, 1});
+  Set.expand({RegClass::ACC_VGPR, 3, 4});
+
+  EXPECT_EQ(Set.size(), 2u + 1u + 4u);
+  EXPECT_FALSE(Set.none());
+}
+
+TEST(HotswapRegisterSet, ForEachVisitsAscendingSgprThenVgprThenAcc) {
+  RegisterSet Set;
+  Set.expand({RegClass::ACC_VGPR, 2, 1});
+  Set.expand({RegClass::VGPR, 7, 1});
+  Set.expand({RegClass::VGPR, 1, 1});
+  Set.expand({RegClass::SGPR, 5, 1});
+
+  std::vector<RegisterRef> Visited;
+  Set.forEach([&](RegisterRef Ref) { Visited.push_back(Ref); });
+
+  ASSERT_EQ(Visited.size(), 4u);
+  EXPECT_EQ(Visited[0], (RegisterRef{RegClass::SGPR, 5, 1}));
+  EXPECT_EQ(Visited[1], (RegisterRef{RegClass::VGPR, 1, 1}));
+  EXPECT_EQ(Visited[2], (RegisterRef{RegClass::VGPR, 7, 1}));
+  EXPECT_EQ(Visited[3], (RegisterRef{RegClass::ACC_VGPR, 2, 1}));
+}
+
+TEST(HotswapRegisterSet, EqualityIsMemberWise) {
+  RegisterSet A;
+  A.expand({RegClass::VGPR, 3, 2});
+  RegisterSet B;
+  B.expand({RegClass::VGPR, 3, 1});
+  EXPECT_FALSE(A == B);
+
+  B.expand({RegClass::VGPR, 4, 1});
+  EXPECT_TRUE(A == B);
+}


### PR DESCRIPTION
## Summary
Second stage of the HotSwap register-liveness port (ported from rocjitsu's
`def_use_chain`). Adds a `reglive::InstDefUse` type that extracts the registers
read and written by one decoded LLVM MC instruction into per-class
`RegisterSet` def/use sets, building on the `RegisterSet` data layer from the
previous PR.
This is **inert**: the new code compiles into `libamd_comgr` but is not called
by any production rewrite path yet. Later stages (CFG scoping, the dataflow
solver, scratch allocation) build on top before anything consumes it.