### PR TITLE
[COMGR][Hotswap] Relax displaced short branches with guarded islands

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -40,7 +40,9 @@
 #include <cassert>
 #include <chrono>
 #include <cstdio>
+#include <iterator>
 #include <limits>
+#include <map>
 #include <mutex>
 
 using namespace llvm;
@@ -1128,7 +1130,8 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
 static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
-    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls) {
+    ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls,
+    ArrayRef<RelocationTableDispatch> RelocationDispatches) {
   SmallVector<KnownCallSite, 4> Calls;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
@@ -1144,14 +1147,18 @@ static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
     } else {
       Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
     }
-    if (!Target)
-      continue;
-
     std::optional<uint64_t> Continuation =
         checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
     if (!Continuation)
       return std::nullopt;
-    Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    if (Target) {
+      Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+      continue;
+    }
+    for (const RelocationTableDispatch &Dispatch : RelocationDispatches)
+      if (Dispatch.CallOffset == DI.Offset)
+        for (uint64_t TableTarget : Dispatch.Targets)
+          Calls.push_back({I, TableTarget, *Continuation, *ReturnRegister});
   }
   return Calls;
 }
@@ -1250,7 +1257,8 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
                            uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                            ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
                            ArrayRef<KnownCallSite> Calls,
-                           ArrayRef<uint64_t> ExternalEntries) {
+                           ArrayRef<uint64_t> ExternalEntries,
+                           ArrayRef<uint64_t> TableCallableEntries) {
   SmallVector<BoundedSetPcReturn, 2> Returns;
   for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex) {
     const InternalDecodedInst &Return = Decoded[ReturnIndex];
@@ -1268,17 +1276,27 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
     bool IsBounded = false;
     for (const ElfView::FunctionTextRange &Range : FunctionRanges) {
       if (Range.Begin < TextAddr || Range.Begin >= TextEnd ||
-          Range.End <= Range.Begin || Range.End > TextEnd ||
-          (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL))
+          Range.End <= Range.Begin || Range.End > TextEnd)
         continue;
       uint64_t FunctionBegin = Range.Begin - TextAddr;
       uint64_t FunctionEnd = Range.End - TextAddr;
+      // Link visibility alone does not make a device function a runtime
+      // dispatch entry. A complete relocation table supplies its closed-world
+      // callers; the table matcher separately rejects kernel-descriptor
+      // entries, which remain external.
+      const bool IsTableCallable =
+          std::binary_search(TableCallableEntries.begin(),
+                             TableCallableEntries.end(), FunctionBegin);
+      if (Range.Symbol && Range.Symbol->getBinding() != ELF::STB_LOCAL &&
+          !IsTableCallable)
+        continue;
       if (Return.Offset < FunctionBegin || Return.Offset >= FunctionEnd)
         continue;
 
       bool Safe = true;
       for (uint64_t Entry : ExternalEntries)
-        if (Entry >= FunctionBegin && Entry < FunctionEnd) {
+        if (Entry >= FunctionBegin && Entry < FunctionEnd &&
+            !(IsTableCallable && Entry == FunctionBegin)) {
           log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(Return.Offset)
                 << " is not a bounded return: externally reachable entry at "
                    "0x"
@@ -1474,7 +1492,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize, ArrayRef<uint64_t> DeclaredEntries,
     ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
-    ArrayRef<uint64_t> ExternalEntries) {
+    ArrayRef<uint64_t> ExternalEntries,
+    ArrayRef<RelocationTableDispatch> RelocationDispatches) {
   if (!LS.MIA) {
     log() << "hotswap: MC branch analysis is unavailable; adjacent far "
              "trampolines will not be coalesced\n";
@@ -1491,18 +1510,32 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
 
-  std::optional<SmallVector<KnownCallSite, 4>> Calls =
-      collectKnownCallSites(Decoded, LS, TextAddr, *TextEnd, MaterializedCalls);
+  std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
+      Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, RelocationDispatches);
   if (!Calls)
     return std::nullopt;
+  SmallVector<uint64_t, 16> TableCallableEntries;
+  for (const RelocationTableDispatch &Dispatch : RelocationDispatches)
+    TableCallableEntries.append(Dispatch.Targets.begin(),
+                                Dispatch.Targets.end());
+  llvm::sort(TableCallableEntries);
+  TableCallableEntries.erase(
+      std::unique(TableCallableEntries.begin(), TableCallableEntries.end()),
+      TableCallableEntries.end());
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
       collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
                                  DeclaredEntries, FunctionRanges, *Calls,
-                                 ExternalEntries);
+                                 ExternalEntries, TableCallableEntries);
   if (!BoundedReturns)
     return std::nullopt;
 
   DirectControlFlowInfo Info;
+  for (const BoundedSetPcReturn &Return : *BoundedReturns) {
+    const InternalDecodedInst &DI = Decoded[Return.InstIndex];
+    Info.RelocatableIndirectTransfers.insert(DI.Offset);
+    for (uint64_t Target : Return.Targets)
+      Info.Targets.insert(Target);
+  }
   for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
@@ -1525,6 +1558,12 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       if (!LS.MIA->isCall(DI.Inst))
         continue;
       std::optional<uint64_t> Target;
+      const RelocationTableDispatch *TableDispatch = nullptr;
+      for (const RelocationTableDispatch &Dispatch : RelocationDispatches)
+        if (Dispatch.CallOffset == DI.Offset) {
+          TableDispatch = &Dispatch;
+          break;
+        }
       if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
           DI.Inst.getNumOperands() != 0 &&
           DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
@@ -1537,6 +1576,30 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                      MaterializedCalls[InstIndex]->SequenceStart,
                      MaterializedCalls[InstIndex]->SequenceEnd)) {
         Target = MaterializedCalls[InstIndex]->Target;
+      }
+      if (TableDispatch) {
+        bool HasInteriorEntry = hasKnownControlFlowEntry(
+            Decoded, LS, TextAddr, *TextEnd, DeclaredEntries, *BoundedReturns,
+            TableDispatch->SequenceStart, TableDispatch->SequenceEnd);
+        for (const RelocationTableDispatch &Dispatch : RelocationDispatches)
+          for (uint64_t TableTarget : Dispatch.Targets)
+            HasInteriorEntry |= TableTarget > TableDispatch->SequenceStart &&
+                                TableTarget <= TableDispatch->SequenceEnd;
+        if (HasInteriorEntry) {
+          log() << "hotswap: relocation-table call at 0x"
+                << utohexstr(DI.Offset)
+                << " has an entry that bypasses its address proof\n";
+          TableDispatch = nullptr;
+        }
+      }
+      if (TableDispatch) {
+        Info.RelocatableIndirectTransfers.insert(DI.Offset);
+        for (uint64_t TableTarget : TableDispatch->Targets)
+          Info.Targets.insert(TableTarget);
+        log() << "hotswap: resolved relocation-table call at 0x"
+              << utohexstr(DI.Offset) << " to " << TableDispatch->Targets.size()
+              << " finite target(s)\n";
+        continue;
       }
       if (!Target) {
         log() << "hotswap: unresolved call target at 0x" << utohexstr(DI.Offset)
@@ -1567,6 +1630,28 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     Info.Targets.insert(*Target);
   }
   return Info;
+}
+
+std::optional<DirectControlFlowInfo>
+analyzeDirectControlFlow(const ElfView &Elf,
+                         ArrayRef<InternalDecodedInst> Decoded,
+                         const LLVMState &LS) {
+  std::optional<DeclaredTextEntryInfo> DeclaredEntries =
+      collectDeclaredTextEntries(Elf);
+  if (!DeclaredEntries)
+    return std::nullopt;
+  Expected<std::vector<RelocationTableDispatch>> RelocationDispatchesOrErr =
+      analyzeRelocationTableDispatches(Elf, Decoded, LS);
+  if (!RelocationDispatchesOrErr) {
+    log() << "hotswap: error: failed to analyze relocation-backed dispatch "
+             "tables: "
+          << toString(RelocationDispatchesOrErr.takeError()) << "\n";
+    return std::nullopt;
+  }
+  return collectDirectBranchTargets(
+      Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
+      Elf.functionTextRanges(), DeclaredEntries->ExternalEntries,
+      *RelocationDispatchesOrErr);
 }
 
 /// Coalesce runs of adjacent far patch sites when the same SGPR scratch block
@@ -2162,13 +2247,57 @@ assignLongBranchGateways(PatchContext &Ctx,
   return true;
 }
 
+/// Collect a growing replacement for the transactional displacement pass.
+/// Collection is deliberately side-effect free: all code and metadata are
+/// rebuilt later from the pristine object through one DisplacementPlan.
+[[nodiscard]] bool
+collectTransactionalDisplacement(PatchContext &Ctx, uint64_t InstOffset,
+                                 uint32_t InstSize,
+                                 ArrayRef<uint8_t> Replacement) {
+  const LLVMState &LS = Ctx.LS;
+  if (Replacement.size() <= InstSize)
+    return false;
+  const uint64_t Growth = Replacement.size() - InstSize;
+  if (Growth % MinInstSize != 0 || LS.SNopBytes.size() != MinInstSize)
+    return false;
+
+  std::optional<ElfView::FunctionTextRange> Range =
+      Ctx.Elf.findFunctionTextRangeAtOffset(InstOffset);
+  if (!Range)
+    return false;
+  if (InstOffset < Range->Begin || InstOffset + InstSize > Range->End ||
+      Range->End > Ctx.TextSize)
+    return false;
+
+  DisplacementEdit Edit;
+  Edit.Offset = InstOffset;
+  Edit.OriginalSize = InstSize;
+  Edit.ReplacementBytes.assign(Replacement.begin(), Replacement.end());
+  Ctx.DisplacementEdits.push_back(std::move(Edit));
+  return true;
+}
+
 /// Emit \p Replacement for the instruction at [\p InstOffset,
-/// \p InstOffset + \p InstSize). Prefers an in-place NOP-sled rewrite when a
-/// reachable sled with sufficient headroom exists; otherwise falls back to a
+/// \p InstOffset + \p InstSize). Prefer transactional straight-line
+/// displacement, then an in-place NOP-sled rewrite, otherwise fall back to a
 /// deferred trampoline.
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
                                        ArrayRef<uint8_t> Replacement) {
+  // Collect first and mutate only after one plan has validated the complete
+  // object. AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT forces the legacy
+  // trampoline path for A/B benchmarking.
+  static const bool DisplacementDisabled =
+      getenv("AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT") != nullptr;
+  if (Ctx.Config.AllowTextDisplacement && !DisplacementDisabled &&
+      !Ctx.DirectControlFlow.HasUnresolvedTargets) {
+    if (collectTransactionalDisplacement(Ctx, InstOffset, InstSize,
+                                         Replacement))
+      return true;
+    Ctx.DisplacementDeclined = true;
+    return false;
+  }
+
   std::optional<uint64_t> ReturnTo = checkedAddUint64(
       InstOffset, InstSize, "replacement trampoline return target");
   std::optional<uint64_t> PoolReturnFrom =
@@ -2197,6 +2326,127 @@ assignLongBranchGateways(PatchContext &Ctx,
     }
   }
   return emitToTrampoline(Ctx, InstOffset, InstSize, Replacement);
+}
+
+// -- Transactional displacement finalize -------------------------------------
+
+/// Prepare all collected edits for one whole-object transaction. Insert only
+/// the padding needed immediately before each kernel entry whose mapped address
+/// would otherwise lose its 256-byte alignment. The old entry maps after that
+/// insertion, so no padding enters the kernel's executed path. This is the
+/// unique minimal extension of the monotone displacement map that preserves
+/// every kernel-entry congruence.
+[[nodiscard]] bool finalizeTransactionalDisplacements(
+    PatchContext &Ctx, std::vector<DisplacementEdit> &OutDisplacements) {
+  if (Ctx.DisplacementEdits.empty())
+    return !Ctx.DisplacementDeclined;
+  if (Ctx.DisplacementDeclined)
+    return false;
+  if (Ctx.LS.SNopBytes.size() != MinInstSize)
+    return false;
+
+  llvm::sort(Ctx.DisplacementEdits,
+             [](const DisplacementEdit &LHS, const DisplacementEdit &RHS) {
+               return LHS.Offset < RHS.Offset;
+             });
+
+  const size_t GrowingEditCount = Ctx.DisplacementEdits.size();
+  for (const DisplacementEdit &Edit : Ctx.DisplacementEdits) {
+    std::optional<ElfView::FunctionTextRange> Range =
+        Ctx.Elf.findFunctionTextRangeAtOffset(Edit.Offset);
+    if (!Range || Edit.Offset + Edit.OriginalSize > Range->End)
+      return false;
+  }
+
+  if (Ctx.TextSize > std::numeric_limits<uint64_t>::max() - Ctx.Elf.textAddr())
+    return false;
+  const uint64_t TextEnd = Ctx.Elf.textAddr() + Ctx.TextSize;
+  SmallVector<uint64_t, 8> KernelEntries;
+  for (const KernelDescriptorInfo &Descriptor : Ctx.Elf.kernelDescriptors()) {
+    std::optional<uint64_t> EntryAddress;
+    if (Descriptor.EntryOffset >= 0) {
+      EntryAddress = checkedAddUint64(
+          Descriptor.VAddr, static_cast<uint64_t>(Descriptor.EntryOffset),
+          "transactional kernel entry");
+    } else {
+      uint64_t Magnitude =
+          Descriptor.EntryOffset == std::numeric_limits<int64_t>::min()
+              ? uint64_t{1} << 63
+              : static_cast<uint64_t>(-Descriptor.EntryOffset);
+      EntryAddress = checkedSubUint64(Descriptor.VAddr, Magnitude,
+                                      "transactional kernel entry");
+    }
+    if (!EntryAddress)
+      return false;
+    if (*EntryAddress >= Ctx.Elf.textAddr() && *EntryAddress < TextEnd)
+      KernelEntries.push_back(*EntryAddress - Ctx.Elf.textAddr());
+  }
+  llvm::sort(KernelEntries);
+  KernelEntries.erase(std::unique(KernelEntries.begin(), KernelEntries.end()),
+                      KernelEntries.end());
+
+  std::vector<DisplacementEdit> AlignmentEdits;
+  size_t EditIndex = 0;
+  uint64_t GrowingDelta = 0;
+  uint64_t AlignmentDelta = 0;
+  for (uint64_t Entry : KernelEntries) {
+    while (EditIndex != Ctx.DisplacementEdits.size() &&
+           Ctx.DisplacementEdits[EditIndex].Offset < Entry) {
+      const DisplacementEdit &Edit = Ctx.DisplacementEdits[EditIndex++];
+      if (Edit.Offset + Edit.OriginalSize > Entry)
+        return false;
+      uint64_t Growth = Edit.ReplacementBytes.size() - Edit.OriginalSize;
+      if (Growth > std::numeric_limits<uint64_t>::max() - GrowingDelta)
+        return false;
+      GrowingDelta += Growth;
+    }
+
+    std::optional<uint64_t> OldEntryAddress = checkedAddUint64(
+        Ctx.Elf.textAddr(), Entry, "transactional old kernel entry");
+    if (!OldEntryAddress)
+      return false;
+    std::optional<uint64_t> EntryAfterGrowth = checkedAddUint64(
+        *OldEntryAddress, GrowingDelta, "transactional displaced kernel entry");
+    if (!EntryAfterGrowth)
+      return false;
+    std::optional<uint64_t> MappedEntry =
+        checkedAddUint64(*EntryAfterGrowth, AlignmentDelta,
+                         "transactional aligned kernel entry");
+    if (!MappedEntry)
+      return false;
+    std::optional<uint64_t> Aligned =
+        checkedAlignTo(*MappedEntry, KernelEntryStubStride,
+                       "transactional kernel entry alignment");
+    if (!Aligned)
+      return false;
+    uint64_t Padding = *Aligned - *MappedEntry;
+    if (Padding == 0)
+      continue;
+    if (Padding % MinInstSize != 0 ||
+        Padding > std::numeric_limits<uint64_t>::max() - AlignmentDelta)
+      return false;
+
+    DisplacementEdit Alignment;
+    Alignment.Offset = Entry;
+    Alignment.MapsOldOffsetAfterInsertion = true;
+    for (uint64_t I = 0; I != Padding; I += MinInstSize)
+      Alignment.ReplacementBytes.append(Ctx.LS.SNopBytes.begin(),
+                                        Ctx.LS.SNopBytes.end());
+    AlignmentEdits.push_back(std::move(Alignment));
+    AlignmentDelta += Padding;
+  }
+
+  Ctx.DisplacementEdits.insert(Ctx.DisplacementEdits.end(),
+                               std::make_move_iterator(AlignmentEdits.begin()),
+                               std::make_move_iterator(AlignmentEdits.end()));
+  OutDisplacements.insert(
+      OutDisplacements.end(),
+      std::make_move_iterator(Ctx.DisplacementEdits.begin()),
+      std::make_move_iterator(Ctx.DisplacementEdits.end()));
+  log() << "hotswap: transactional displacement: collected " << GrowingEditCount
+        << " growing edit(s) and " << AlignmentEdits.size()
+        << " alignment insertion(s)\n";
+  return true;
 }
 
 // -- applyGfx1250B0toA0Rules --------------------------------------------------
@@ -2231,7 +2481,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
     const LLVMState &LS, std::vector<Trampoline> &OutTrampolines, ElfView &Elf,
     std::vector<ScratchPatchInfo> &OutScratchPatches,
     const RewriteConfig &Config, bool &OutRequiredPatchApplied,
-    HotswapProfile &Profile) {
+    HotswapProfile &Profile,
+    std::vector<DisplacementEdit> &OutTransactionalDisplacements) {
   uint32_t Patched = 0;
 
   HotswapProfile::Scope SledScope = Profile.time(HotswapMetric::NopSledScan);
@@ -2242,11 +2493,8 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
       collectDeclaredTextEntries(Elf);
   if (!DeclaredEntries)
     return std::nullopt;
-  std::vector<ElfView::FunctionTextRange> FunctionRanges =
-      Elf.functionTextRanges();
-  std::optional<DirectControlFlowInfo> ControlFlow = collectDirectBranchTargets(
-      Decoded, LS, Elf.textAddr(), Elf.textSize(), DeclaredEntries->Entries,
-      FunctionRanges, DeclaredEntries->ExternalEntries);
+  std::optional<DirectControlFlowInfo> ControlFlow =
+      analyzeDirectControlFlow(Elf, Decoded, LS);
   if (!ControlFlow)
     return std::nullopt;
   if (ControlFlow->HasUnresolvedTargets) {
@@ -2497,6 +2745,9 @@ static std::optional<uint32_t> applyGfx1250B0toA0Rules(
           << ", scratch_reused=" << Stats.ScratchReused
           << ", scratch_above_kd=" << Stats.ScratchAboveKd << "\n";
   }
+  if (!finalizeTransactionalDisplacements(Ctx, OutTransactionalDisplacements))
+    return std::nullopt;
+
   OutRequiredPatchApplied = Ctx.RequiredPatchApplied;
   return Patched;
 }
@@ -2760,7 +3011,9 @@ static amd_comgr_status_t retargetCodeObjectImpl(
 
     if (!EntryDisplacements.empty()) {
       Expected<std::unique_ptr<WritableMemoryBuffer>> DisplacedOrErr =
-          tryApplyTextDisplacementToNewBuffer(Elf, LS, EntryDisplacements);
+          tryApplyTextDisplacementToNewBuffer(
+              Elf, LS, EntryDisplacements,
+              /*RelocateTrailingSections=*/true);
       if (DisplacedOrErr) {
         std::unique_ptr<WritableMemoryBuffer> Displaced =
             std::move(*DisplacedOrErr);
@@ -2786,14 +3039,24 @@ static amd_comgr_status_t retargetCodeObjectImpl(
 
   RewriteConfig Config = makeGfx1250B0A0Config();
   Config.RunB0A0Patches = Options.RunB0A0Patches;
+  Config.AllowTextDisplacement = AllowTextDisplacement;
   Config.MaskPolicy = Options.MaskPolicy;
 
   uint8_t *Text = Elf.textData();
   uint64_t Count = 0;
   std::vector<Trampoline> Deferred;
   std::vector<ScratchPatchInfo> ScratchPatches;
+  std::vector<DisplacementEdit> TransactionalDisplacements;
   bool RequiredPatchApplied = false;
   if (RunInstructionPatches) {
+    // Phase timing for benchmarking (AMD_COMGR_EMIT_VERBOSE_LOGS). Uses
+    // steady_clock; costs nothing when logs are off besides two now() calls.
+    using Clock = std::chrono::steady_clock;
+    auto ms = [](Clock::duration D) {
+      return std::chrono::duration<double, std::milli>(D).count();
+    };
+
+    Clock::time_point TDecodeStart = Clock::now();
     std::vector<InternalDecodedInst> Decoded;
     uint64_t DecodeT0 = Prof ? profNowNs() : 0;
     bool DecodedOk = decodeTextSection(Text, Elf.textSize(), LS, Decoded);
@@ -2804,17 +3067,84 @@ static amd_comgr_status_t retargetCodeObjectImpl(
             << "failed on .text (" << Elf.textSize() << " bytes).\n";
       return AMD_COMGR_STATUS_ERROR;
     }
+    Clock::time_point TPatchStart = Clock::now();
+    log() << "hotswap: TIMING decode .text: " << ms(TPatchStart - TDecodeStart)
+          << " ms\n";
 
     uint64_t DispatchT0 = Prof ? profNowNs() : 0;
     std::optional<uint32_t> Patched = applyGfx1250B0toA0Rules(
         Decoded, Text, Elf.textSize(), LS, Deferred, Elf, ScratchPatches,
-        Config, RequiredPatchApplied, Profile);
+        Config, RequiredPatchApplied, Profile, TransactionalDisplacements);
     if (Prof)
       Profile.add(HotswapMetric::B0A0Dispatch, profNowNs() - DispatchT0, 0);
+    if (!Patched && AllowTextDisplacement) {
+      log() << "hotswap: displacement collection declined; retrying the "
+               "original object with trampoline placement\n";
+      return retargetCodeObjectImpl(ElfData, ElfSize, TargetIdent, Options, Out,
+                                    /*AllowTextDisplacement=*/false, Profile);
+    }
     if (!Patched)
       return AMD_COMGR_STATUS_ERROR;
     Count = *Patched;
+    log() << "hotswap: TIMING apply patches + displacement collection: "
+          << ms(Clock::now() - TPatchStart) << " ms\n";
     log() << "hotswap: applied " << Count << " instruction patches\n";
+
+    // Commit every growing replacement through one whole-object transaction.
+    // The transaction is constructed and validated before its output becomes
+    // visible, so all address-bearing views of .text move together.
+    if (!TransactionalDisplacements.empty()) {
+      log() << "hotswap: growing .text transactionally for "
+            << TransactionalDisplacements.size() << " displacement edit(s)\n";
+      Clock::time_point TDisplacementStart = Clock::now();
+      Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
+          tryApplyTextDisplacementToNewBuffer(
+              Elf, LS, TransactionalDisplacements,
+              /*RelocateTrailingSections=*/true);
+      log() << "hotswap: TIMING transactional grow + metadata remap: "
+            << ms(Clock::now() - TDisplacementStart) << " ms\n";
+      if (!GrownOrErr) {
+        std::string Reason = toString(GrownOrErr.takeError());
+        if (AllowTextDisplacement) {
+          log() << "hotswap: transactional displacement declined: " << Reason
+                << "; retrying the original object with trampoline placement\n";
+          return retargetCodeObjectImpl(
+              ElfData, ElfSize, TargetIdent, Options, Out,
+              /*AllowTextDisplacement=*/false, Profile);
+        }
+        log() << "hotswap: error: transactional .text grow failed: " << Reason
+              << "\n";
+        return AMD_COMGR_STATUS_ERROR;
+      }
+      std::unique_ptr<WritableMemoryBuffer> Grown = std::move(*GrownOrErr);
+      // Instruction rewriting is disabled in the recursive tail below so the
+      // spliced replacements cannot be applied twice. Retag the private grown
+      // buffer first: stepping metadata is a property of the completed
+      // transaction, not another instruction patch.
+      if (Options.RunB0A0Patches) {
+        uint8_t *GrownData =
+            reinterpret_cast<uint8_t *>(Grown->getBufferStart());
+        Expected<ElfView> GrownViewOrErr =
+            ElfView::create(GrownData, Grown->getBufferSize());
+        if (!GrownViewOrErr) {
+          log() << "hotswap: error: could not parse transaction output for "
+                   "gfx1250 revision retag: "
+                << toString(GrownViewOrErr.takeError()) << "\n";
+          return AMD_COMGR_STATUS_ERROR;
+        }
+        if (!GrownViewOrErr->updateGfx1250RevisionMetadata("A0"))
+          return AMD_COMGR_STATUS_ERROR;
+      }
+      // The grown buffer already has these edits spliced in and metadata
+      // repaired; re-run only the remaining (entry/metadata) tail against it by
+      // recursing with instruction patches disabled.
+      Gfx1250RewriteOptions RemainingOptions = Options;
+      RemainingOptions.RunB0A0Patches = false;
+      RemainingOptions.MaskPolicy = MaskWorkaroundPolicy::None;
+      return retargetCodeObjectImpl(
+          Grown->getBufferStart(), Grown->getBufferSize(), TargetIdent,
+          RemainingOptions, Out, AllowTextDisplacement, Profile);
+    }
   } else {
     log() << "hotswap: instruction patches disabled for this rewrite\n";
   }

--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -33,6 +33,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MathExtras.h"
 
@@ -984,6 +985,8 @@ struct PcMaterializedCallInfo {
 ///   s_get_pc_i64 Target
 ///   ...                         // no Target definition or control flow
 ///   s_add_nc_u64 Target, Target, Immediate
+///   // or: s_add_co_u32 TargetLo, TargetLo, ImmediateLo
+///   //     s_add_co_ci_u32 TargetHi, TargetHi, ImmediateHi
 ///   ...                         // no Target definition or control flow
 ///   s_swap_pc_i64 Return, Target
 ///
@@ -1000,8 +1003,19 @@ std::optional<MaterializedPcSequence>
 resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
                             size_t TransferIndex, MCRegister TargetRegister,
                             const LLVMState &LS, uint64_t TextAddr) {
+  auto getAbsoluteImmediate = [](const MCOperand &Operand)
+      -> std::optional<int64_t> {
+    int64_t Value = 0;
+    if (Operand.isImm())
+      return Operand.getImm();
+    if (!Operand.isExpr() ||
+        !Operand.getExpr()->evaluateAsAbsolute(Value))
+      return std::nullopt;
+    return Value;
+  };
+
   std::optional<size_t> AddIndex;
-  int64_t AddImmediate = 0;
+  uint64_t AddImmediate = 0;
   for (size_t I = TransferIndex; I != 0;) {
     --I;
     const InternalDecodedInst &Candidate = Decoded[I];
@@ -1009,16 +1023,60 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
       return std::nullopt;
     if (!definesOverlappingRegister(Candidate, LS, TargetRegister))
       continue;
-    if (Candidate.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+    if (Candidate.Inst.getOpcode() == LS.SAddNcU64Opcode) {
+      if (Candidate.Inst.getNumOperands() != 3 ||
+          !Candidate.Inst.getOperand(0).isReg() ||
+          Candidate.Inst.getOperand(0).getReg() != TargetRegister ||
+          !Candidate.Inst.getOperand(1).isReg() ||
+          Candidate.Inst.getOperand(1).getReg() != TargetRegister)
+        return std::nullopt;
+      std::optional<int64_t> Immediate =
+          getAbsoluteImmediate(Candidate.Inst.getOperand(2));
+      if (!Immediate)
+        return std::nullopt;
+      AddIndex = I;
+      AddImmediate = static_cast<uint64_t>(*Immediate);
+      break;
+    }
+
+    if (Candidate.Inst.getOpcode() != LS.SAddCoCiU32Opcode || I == 0 ||
         Candidate.Inst.getNumOperands() != 3 ||
         !Candidate.Inst.getOperand(0).isReg() ||
-        Candidate.Inst.getOperand(0).getReg() != TargetRegister ||
         !Candidate.Inst.getOperand(1).isReg() ||
-        Candidate.Inst.getOperand(1).getReg() != TargetRegister ||
-        !Candidate.Inst.getOperand(2).isImm())
+        Candidate.Inst.getOperand(0).getReg() !=
+            Candidate.Inst.getOperand(1).getReg())
       return std::nullopt;
-    AddIndex = I;
-    AddImmediate = Candidate.Inst.getOperand(2).getImm();
+
+    const InternalDecodedInst &LowAdd = Decoded[I - 1];
+    if (!LowAdd.DecodeSucceeded ||
+        LowAdd.Inst.getOpcode() != LS.SAddCoU32Opcode ||
+        LowAdd.Inst.getNumOperands() != 3 ||
+        !LowAdd.Inst.getOperand(0).isReg() ||
+        !LowAdd.Inst.getOperand(1).isReg() ||
+        LowAdd.Inst.getOperand(0).getReg() !=
+            LowAdd.Inst.getOperand(1).getReg())
+      return std::nullopt;
+
+    MCRegister LowReg(LowAdd.Inst.getOperand(0).getReg());
+    MCRegister HighReg(Candidate.Inst.getOperand(0).getReg());
+    std::optional<unsigned> LowIndex = numberedSgprIndex(*LS.MRI, LowReg);
+    std::optional<unsigned> HighIndex = numberedSgprIndex(*LS.MRI, HighReg);
+    if (!LowIndex || !HighIndex || *HighIndex != *LowIndex + 1 ||
+        !LS.MRI->regsOverlap(TargetRegister, LowReg) ||
+        !LS.MRI->regsOverlap(TargetRegister, HighReg))
+      return std::nullopt;
+
+    std::optional<int64_t> LowImmediate =
+        getAbsoluteImmediate(LowAdd.Inst.getOperand(2));
+    std::optional<int64_t> HighImmediate =
+        getAbsoluteImmediate(Candidate.Inst.getOperand(2));
+    if (!LowImmediate || !HighImmediate)
+      return std::nullopt;
+    const uint32_t LowWord = static_cast<uint32_t>(*LowImmediate);
+    const uint32_t HighWord = static_cast<uint32_t>(*HighImmediate);
+    AddIndex = I - 1;
+    AddImmediate = static_cast<uint64_t>(LowWord) |
+                   (static_cast<uint64_t>(HighWord) << 32);
     break;
   }
   if (!AddIndex)
@@ -1045,11 +1103,8 @@ resolveMaterializedPcTarget(ArrayRef<InternalDecodedInst> Decoded,
         *GetPcAddress, Candidate.Size, "PC-materialized transfer PC value");
     if (!PcValue)
       return std::nullopt;
-    // s_add_nc_u64 uses modulo-2^64 arithmetic. Casting the signed MC
-    // immediate to uint64_t and adding it reproduces both positive and
-    // negative literals, including INT64_MIN, without signed overflow.
-    return MaterializedPcSequence{
-        *PcValue + static_cast<uint64_t>(AddImmediate), Candidate.Offset};
+    // Both supported add forms use modulo-2^64 arithmetic.
+    return MaterializedPcSequence{*PcValue + AddImmediate, Candidate.Offset};
   }
   return std::nullopt;
 }
@@ -1448,7 +1503,9 @@ hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
                          const LLVMState &LS, uint64_t TextAddr,
                          uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                          ArrayRef<BoundedSetPcReturn> BoundedReturns,
-                         uint64_t SequenceStart, uint64_t SequenceEnd) {
+                         uint64_t SequenceStart, uint64_t SequenceEnd,
+                         ArrayRef<std::optional<MaterializedPcSequence>>
+                             MaterializedJumps = {}) {
   for (uint64_t Entry : DeclaredEntries)
     if (Entry > SequenceStart && Entry <= SequenceEnd)
       return true;
@@ -1456,6 +1513,16 @@ hasKnownControlFlowEntry(ArrayRef<InternalDecodedInst> Decoded,
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
     if (DI.DecodeSucceeded && DI.Inst.getOpcode() == LS.SSetPcI64Opcode) {
+      if (MaterializedJumps.size() == Decoded.size() &&
+          MaterializedJumps[I]) {
+        uint64_t Target = MaterializedJumps[I]->Target;
+        if (Target < TextAddr || Target >= TextEnd)
+          return true;
+        uint64_t RelativeTarget = Target - TextAddr;
+        if (RelativeTarget > SequenceStart && RelativeTarget <= SequenceEnd)
+          return true;
+        continue;
+      }
       const BoundedSetPcReturn *Return =
           findBoundedSetPcReturn(BoundedReturns, I);
       if (!Return)
@@ -1510,6 +1577,25 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
 
+  SmallVector<std::optional<MaterializedPcSequence>, 16> MaterializedJumps(
+      Decoded.size());
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    const InternalDecodedInst &DI = Decoded[I];
+    if (!DI.DecodeSucceeded || DI.Inst.getOpcode() != LS.SSetPcI64Opcode ||
+        DI.Inst.getNumOperands() == 0)
+      continue;
+    const MCOperand &TargetOperand =
+        DI.Inst.getOperand(DI.Inst.getNumOperands() - 1);
+    if (!TargetOperand.isReg() || !TargetOperand.getReg())
+      continue;
+    std::optional<MaterializedPcSequence> Sequence =
+        resolveMaterializedPcTarget(
+            Decoded, I, MCRegister(TargetOperand.getReg()), LS, TextAddr);
+    if (Sequence && Sequence->Target >= TextAddr &&
+        Sequence->Target < *TextEnd)
+      MaterializedJumps[I] = *Sequence;
+  }
+
   std::optional<SmallVector<KnownCallSite, 4>> Calls = collectKnownCallSites(
       Decoded, LS, TextAddr, *TextEnd, MaterializedCalls, RelocationDispatches);
   if (!Calls)
@@ -1536,8 +1622,46 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     for (uint64_t Target : Return.Targets)
       Info.Targets.insert(Target);
   }
+
+  // Prove all canonical PC-materialized jumps as one closed set. Treating one
+  // candidate as finite while another candidate remained "unbounded" made the
+  // proof circular and rejected every production kernel-entry skip sequence.
+  // The group is accepted only if every s_set_pc_i64 is either an already
+  // bounded return or one of these candidates, and no declared/direct/finite
+  // indirect target enters the middle of any candidate materialization.
+  bool MaterializedJumpsAreClosed = true;
+  for (size_t I = 0; I != Decoded.size(); ++I) {
+    if (!MaterializedJumps[I])
+      continue;
+    const InternalDecodedInst &DI = Decoded[I];
+    if (hasKnownControlFlowEntry(
+            Decoded, LS, TextAddr, *TextEnd, DeclaredEntries, *BoundedReturns,
+            MaterializedJumps[I]->SequenceStart, DI.Offset,
+            MaterializedJumps)) {
+      MaterializedJumpsAreClosed = false;
+      break;
+    }
+  }
+  ArrayRef<std::optional<MaterializedPcSequence>> ProvenMaterializedJumps;
+  if (MaterializedJumpsAreClosed) {
+    ProvenMaterializedJumps = MaterializedJumps;
+    for (size_t I = 0; I != Decoded.size(); ++I) {
+      if (!MaterializedJumps[I])
+        continue;
+      const InternalDecodedInst &DI = Decoded[I];
+      uint64_t RelativeTarget = MaterializedJumps[I]->Target - TextAddr;
+      Info.RelocatableIndirectTransfers.insert(DI.Offset);
+      Info.Targets.insert(RelativeTarget);
+      log() << "hotswap: resolved PC-materialized jump at 0x"
+            << utohexstr(DI.Offset) << " to .text+0x"
+            << utohexstr(RelativeTarget) << "\n";
+    }
+  }
+
   for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
+    if (MaterializedJumpsAreClosed && MaterializedJumps[InstIndex])
+      continue;
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
         LS.MIA->isReturn(DI.Inst))
       continue;
@@ -1574,13 +1698,16 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
                      Decoded, LS, TextAddr, *TextEnd, DeclaredEntries,
                      *BoundedReturns,
                      MaterializedCalls[InstIndex]->SequenceStart,
-                     MaterializedCalls[InstIndex]->SequenceEnd)) {
+                     MaterializedCalls[InstIndex]->SequenceEnd,
+                     ProvenMaterializedJumps)) {
         Target = MaterializedCalls[InstIndex]->Target;
+        Info.RelocatableIndirectTransfers.insert(DI.Offset);
       }
       if (TableDispatch) {
         bool HasInteriorEntry = hasKnownControlFlowEntry(
             Decoded, LS, TextAddr, *TextEnd, DeclaredEntries, *BoundedReturns,
-            TableDispatch->SequenceStart, TableDispatch->SequenceEnd);
+            TableDispatch->SequenceStart, TableDispatch->SequenceEnd,
+            ProvenMaterializedJumps);
         for (const RelocationTableDispatch &Dispatch : RelocationDispatches)
           for (uint64_t TableTarget : Dispatch.Targets)
             HasInteriorEntry |= TableTarget > TableDispatch->SequenceStart &&

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -1186,6 +1186,84 @@ Error validateKernelEntryMappings(const ElfView &Elf,
   return Error::success();
 }
 
+// A guarded branch island is a 256-byte pure insertion:
+//
+//   island_start:
+//     s_branch original_boundary  // ordinary fallthrough skips the island
+//     s_branch far_target         // relaxed source branches here
+//     s_nop ...
+//   original_boundary:
+//
+// Keeping the insertion at the kernel-entry alignment preserves every later
+// 256-byte entry alignment. The plan initially contains only NOP placeholders;
+// repairBranches writes the two branches after all old offsets have their final
+// mappings.
+static constexpr uint64_t BranchIslandBlockBytes = KernelEntryStubStride;
+static constexpr uint64_t BranchIslandBranchOffset = MinInstSize;
+static constexpr uint64_t MaxBranchIslands = 64;
+
+struct DisplacementBranchIsland {
+  uint64_t SourceOffset = 0;
+  uint64_t TargetOffset = 0;
+  uint64_t InsertionOffset = 0;
+};
+
+struct BranchRangeFailure {
+  uint64_t SourceOffset = 0;
+  uint32_t SourceSize = 0;
+  uint64_t TargetOffset = 0;
+  uint64_t NewSource = 0;
+  uint64_t NewTarget = 0;
+};
+
+std::optional<int64_t> shortBranchDwordOffset(uint64_t From, uint32_t Size,
+                                              uint64_t To) {
+  std::optional<uint64_t> PcBase =
+      checkedAddUint64(From, Size, "short-branch PC base");
+  if (!PcBase)
+    return std::nullopt;
+  std::optional<int64_t> ByteDelta =
+      checkedSignedDifference(To, *PcBase, "short-branch displacement");
+  if (!ByteDelta || *ByteDelta % MinInstSize != 0)
+    return std::nullopt;
+  return *ByteDelta / MinInstSize;
+}
+
+bool shortBranchCanReach(uint64_t From, uint32_t Size, uint64_t To) {
+  std::optional<int64_t> DwordOffset =
+      shortBranchDwordOffset(From, Size, To);
+  if (!DwordOffset)
+    return false;
+  return *DwordOffset >= BranchOffsetMin && *DwordOffset <= BranchOffsetMax;
+}
+
+bool shortBranchCanReachWithMargin(uint64_t From, uint32_t Size, uint64_t To,
+                                   uint64_t MarginBytes) {
+  std::optional<int64_t> DwordOffset =
+      shortBranchDwordOffset(From, Size, To);
+  if (!DwordOffset)
+    return false;
+  const uint64_t MarginDwords =
+      divideCeil(MarginBytes, static_cast<uint64_t>(MinInstSize));
+  if (MarginDwords >
+      static_cast<uint64_t>(BranchOffsetMax - BranchOffsetMin) / 2)
+    return false;
+  const int64_t MinWithMargin =
+      BranchOffsetMin + static_cast<int64_t>(MarginDwords);
+  const int64_t MaxWithMargin =
+      BranchOffsetMax - static_cast<int64_t>(MarginDwords);
+  return *DwordOffset >= MinWithMargin && *DwordOffset <= MaxWithMargin;
+}
+
+bool isRelaxableDisplacedBranch(const MCInst &Inst, const LLVMState &LS) {
+  const unsigned Opcode = Inst.getOpcode();
+  return Opcode == LS.SBranchOpcode || Opcode == LS.SCBranchScc0Opcode ||
+         Opcode == LS.SCBranchScc1Opcode || Opcode == LS.SCBranchVcczOpcode ||
+         Opcode == LS.SCBranchVccnzOpcode ||
+         Opcode == LS.SCBranchExeczOpcode ||
+         Opcode == LS.SCBranchExecnzOpcode;
+}
+
 Expected<SmallVector<uint8_t>>
 reencodePcrelBranch(const InternalDecodedInst &DI, uint64_t NewFrom,
                     uint64_t NewTarget, const LLVMState &LS) {
@@ -1629,6 +1707,8 @@ Expected<bool> repairSAddPcForDisplacement(const ElfView &Elf,
 Error repairBranches(const ElfView &Elf, const LLVMState &LS,
                      const DisplacementPlan &Plan,
                      const DirectControlFlowInfo &ControlFlow,
+                     ArrayRef<DisplacementBranchIsland> BranchIslands,
+                     SmallVectorImpl<BranchRangeFailure> *RangeFailures,
                      SmallVectorImpl<uint8_t> &NewText) {
   if (!LS.MIA) {
     return makeDisplacementError(
@@ -1767,6 +1847,83 @@ Error repairBranches(const ElfView &Elf, const LLVMState &LS,
       return false;
     }
 
+    const DisplacementBranchIsland *Island = nullptr;
+    for (const DisplacementBranchIsland &Candidate : BranchIslands)
+      if (Candidate.SourceOffset == DI.Offset) {
+        Island = &Candidate;
+        break;
+      }
+
+    if (!shortBranchCanReach(NewFrom, DI.Size, NewTarget)) {
+      if (!Island) {
+        if (!isRelaxableDisplacedBranch(Inst, LS)) {
+          RepairErr.emplace(makeDisplacementError(
+              "branch at old .text offset 0x" +
+              Twine::utohexstr(DI.Offset) +
+              " uses an opcode that is not eligible for guarded-island "
+              "relaxation"));
+          return false;
+        }
+        if (RangeFailures)
+          RangeFailures->push_back(
+              BranchRangeFailure{DI.Offset, DI.Size, OldTarget, NewFrom,
+                                 NewTarget});
+        return true;
+      }
+
+      uint64_t NewBoundary = 0;
+      if (!Plan.mapOffset(Island->InsertionOffset,
+                          DisplacementMapBias::BeforeInsertedBytes,
+                          NewBoundary) ||
+          NewBoundary < BranchIslandBlockBytes) {
+        RepairErr.emplace(makeDisplacementError(
+            "branch island at old .text offset 0x" +
+            Twine::utohexstr(Island->InsertionOffset) +
+            " cannot be mapped after displacement"));
+        return false;
+      }
+      const uint64_t IslandStart = NewBoundary - BranchIslandBlockBytes;
+      const uint64_t IslandBranch = IslandStart + BranchIslandBranchOffset;
+      if (!shortBranchCanReach(NewFrom, DI.Size, IslandBranch) ||
+          !shortBranchCanReach(IslandBranch, MinInstSize, NewTarget)) {
+        RepairErr.emplace(makeDisplacementError(
+            "branch island for old .text offset 0x" +
+            Twine::utohexstr(DI.Offset) +
+            " is out of range after displacement"));
+        return false;
+      }
+
+      Expected<SmallVector<uint8_t>> SourceOrErr =
+          reencodePcrelBranch(DI, NewFrom, IslandBranch, LS);
+      if (!SourceOrErr) {
+        RepairErr.emplace(SourceOrErr.takeError());
+        return false;
+      }
+      SmallVector<uint8_t> Guard =
+          LS.encodeSBranch(IslandStart, NewBoundary);
+      SmallVector<uint8_t> IslandJump =
+          LS.encodeSBranch(IslandBranch, NewTarget);
+      if (Guard.size() != MinInstSize ||
+          IslandJump.size() != MinInstSize ||
+          NewFrom + SourceOrErr->size() > NewText.size() ||
+          IslandBranch + IslandJump.size() > NewText.size()) {
+        RepairErr.emplace(makeDisplacementError(
+            "branch island encoding for old .text offset 0x" +
+            Twine::utohexstr(DI.Offset) + " is invalid"));
+        return false;
+      }
+      std::memcpy(NewText.data() + NewFrom, SourceOrErr->data(),
+                  SourceOrErr->size());
+      std::memcpy(NewText.data() + IslandStart, Guard.data(), Guard.size());
+      std::memcpy(NewText.data() + IslandBranch, IslandJump.data(),
+                  IslandJump.size());
+      log() << "hotswap: displacement: relaxed branch at old .text offset 0x"
+            << utohexstr(DI.Offset) << " through guarded island at old "
+            << ".text boundary 0x" << utohexstr(Island->InsertionOffset)
+            << "\n";
+      return true;
+    }
+
     Expected<SmallVector<uint8_t>> EncodedOrErr =
         reencodePcrelBranch(DI, NewFrom, NewTarget, LS);
     if (!EncodedOrErr) {
@@ -1787,11 +1944,18 @@ Error repairBranches(const ElfView &Elf, const LLVMState &LS,
 
   bool Decoded = decodeTextSectionStreaming(Elf.textData(), Elf.textSize(), LS,
                                             /*WantMnemonic=*/false, onInst);
-  if (RepairErr)
+  if (RepairErr) {
+    if (RangeFailures)
+      RangeFailures->clear();
     return std::move(*RepairErr);
+  }
   if (!Decoded)
     return makeDisplacementError(
         "failed to decode .text while validating branches");
+  if (RangeFailures && !RangeFailures->empty())
+    return makeDisplacementError(
+        Twine(RangeFailures->size()) +
+        " branch(es) are out of simm16 range after displacement");
   return Error::success();
 }
 
@@ -3550,9 +3714,11 @@ Error validateDisplacementEditBoundaries(const ElfView &Elf,
 }
 
 Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
-                            const DisplacementPlan &Plan,
-                            const DirectControlFlowInfo &ControlFlow,
-                            WritableMemoryBuffer &OutBuf) {
+                             const DisplacementPlan &Plan,
+                             const DirectControlFlowInfo &ControlFlow,
+                             ArrayRef<DisplacementBranchIsland> BranchIslands,
+                             SmallVectorImpl<BranchRangeFailure> *RangeFailures,
+                             WritableMemoryBuffer &OutBuf) {
   const size_t InputSize = Elf.size();
   const size_t NewSize = Plan.newElfSize(InputSize);
   if (OutBuf.getBufferSize() != NewSize) {
@@ -3575,7 +3741,8 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
   Clock::time_point T1 = Clock::now();
   log() << "hotswap: TIMING   displacement buildText: " << ms(T1 - T0)
         << " ms\n";
-  if (Error Err = repairBranches(Elf, LS, Plan, ControlFlow, NewText))
+  if (Error Err = repairBranches(Elf, LS, Plan, ControlFlow, BranchIslands,
+                                 RangeFailures, NewText))
     return Err;
   bool ValidNewText = true;
   bool NewTextDecoded = decodeTextSectionStreaming(
@@ -3821,6 +3988,108 @@ DisplacementPlan::buildText(ArrayRef<uint8_t> OldText,
   return Out;
 }
 
+struct PlannedBranchIslandEdit {
+  DisplacementEdit Edit;
+  DisplacementBranchIsland Island;
+};
+
+Expected<PlannedBranchIslandEdit>
+planBranchIsland(const LLVMState &LS, const DisplacementPlan &Plan,
+                 const BranchRangeFailure &Failure,
+                 ArrayRef<uint64_t> InstructionBoundaries,
+                 const DenseSet<uint64_t> &ReservedBoundaries) {
+  if (LS.SNopBytes.size() != MinInstSize ||
+      BranchIslandBlockBytes % MinInstSize != 0)
+    return makeDisplacementError(
+        "branch-island planning requires a complete s_nop encoding");
+
+  const uint64_t RangeBegin =
+      std::min(Failure.SourceOffset, Failure.TargetOffset);
+  const uint64_t RangeEnd =
+      std::max(Failure.SourceOffset, Failure.TargetOffset);
+  std::optional<uint64_t> BestBoundary;
+  uint64_t BestScore = std::numeric_limits<uint64_t>::max();
+
+  auto hasPureInsertionAt = [&](uint64_t Offset) {
+    if (ReservedBoundaries.contains(Offset))
+      return true;
+    for (const DisplacementEdit &Edit : Plan.edits())
+      if (Edit.Offset == Offset && Edit.OriginalSize == 0)
+        return true;
+    return false;
+  };
+  auto addIslandShift = [](uint64_t Offset, uint64_t Boundary,
+                           uint64_t Mapped) -> std::optional<uint64_t> {
+    if (Offset < Boundary)
+      return Mapped;
+    if (Mapped > std::numeric_limits<uint64_t>::max() -
+                     BranchIslandBlockBytes)
+      return std::nullopt;
+    return Mapped + BranchIslandBlockBytes;
+  };
+  auto distance = [](uint64_t A, uint64_t B) {
+    return A > B ? A - B : B - A;
+  };
+
+  auto Begin =
+      llvm::upper_bound(InstructionBoundaries, RangeBegin);
+  auto End = llvm::lower_bound(InstructionBoundaries, RangeEnd);
+  const uint64_t SafetyMarginBytes =
+      MaxBranchIslands * BranchIslandBlockBytes;
+  for (auto It = Begin; It != End; ++It) {
+    const uint64_t Boundary = *It;
+    if (hasPureInsertionAt(Boundary))
+      continue;
+
+    uint64_t MappedBoundary = 0;
+    if (!Plan.mapOffset(Boundary, DisplacementMapBias::BeforeInsertedBytes,
+                        MappedBoundary))
+      continue;
+    std::optional<uint64_t> NewSource =
+        addIslandShift(Failure.SourceOffset, Boundary, Failure.NewSource);
+    std::optional<uint64_t> NewTarget =
+        addIslandShift(Failure.TargetOffset, Boundary, Failure.NewTarget);
+    if (!NewSource || !NewTarget ||
+        MappedBoundary > std::numeric_limits<uint64_t>::max() -
+                             BranchIslandBranchOffset)
+      continue;
+    const uint64_t IslandBranch =
+        MappedBoundary + BranchIslandBranchOffset;
+    if (!shortBranchCanReachWithMargin(*NewSource, Failure.SourceSize,
+                                       IslandBranch, SafetyMarginBytes) ||
+        !shortBranchCanReachWithMargin(IslandBranch, MinInstSize, *NewTarget,
+                                       SafetyMarginBytes))
+      continue;
+
+    const uint64_t Score =
+        std::max(distance(*NewSource, IslandBranch),
+                 distance(IslandBranch, *NewTarget));
+    if (Score < BestScore) {
+      BestScore = Score;
+      BestBoundary = Boundary;
+    }
+  }
+  if (!BestBoundary)
+    return makeDisplacementError(
+        "no guarded branch-island boundary can relax branch at old .text "
+        "offset 0x" +
+        Twine::utohexstr(Failure.SourceOffset));
+
+  SmallVector<uint8_t> Placeholder;
+  Placeholder.reserve(BranchIslandBlockBytes);
+  while (Placeholder.size() < BranchIslandBlockBytes)
+    Placeholder.append(LS.SNopBytes.begin(), LS.SNopBytes.end());
+
+  DisplacementEdit Edit;
+  Edit.Offset = *BestBoundary;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes = std::move(Placeholder);
+  Edit.MapsOldOffsetAfterInsertion = true;
+  DisplacementBranchIsland Island{Failure.SourceOffset, Failure.TargetOffset,
+                                  *BestBoundary};
+  return PlannedBranchIslandEdit{std::move(Edit), Island};
+}
+
 Expected<std::unique_ptr<WritableMemoryBuffer>>
 tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
                                     ArrayRef<DisplacementEdit> Edits,
@@ -3832,15 +4101,6 @@ tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
           Elf, /*AllowEhFrameRemap=*/RelocateTrailingSections))
     return std::move(Err);
   if (Error Err = validateTextRelocations(Elf))
-    return std::move(Err);
-
-  Expected<DisplacementPlan> PlanOrErr =
-      DisplacementPlan::create(Elf, Edits, RelocateTrailingSections);
-  if (!PlanOrErr)
-    return PlanOrErr.takeError();
-  if (Error Err = validateDisplacementEditBoundaries(Elf, LS, *PlanOrErr))
-    return std::move(Err);
-  if (Error Err = validateKernelEntryMappings(Elf, *PlanOrErr))
     return std::move(Err);
 
   DirectControlFlowInfo ControlFlow;
@@ -3872,28 +4132,89 @@ tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
     ControlFlow = std::move(*Info);
   }
 
-  std::unique_ptr<WritableMemoryBuffer> Out =
-      WritableMemoryBuffer::getNewUninitMemBuffer(
-          PlanOrErr->newElfSize(Elf.size()));
-  if (!Out) {
-    return makeDisplacementError(
-        "failed to allocate displacement output buffer");
-  }
-  if (Error Err = applyTextDisplacement(Elf, LS, *PlanOrErr, ControlFlow, *Out))
-    return std::move(Err);
+  std::vector<DisplacementEdit> PlannedEdits(Edits.begin(), Edits.end());
+  std::vector<DisplacementBranchIsland> BranchIslands;
+  std::vector<uint64_t> InstructionBoundaries;
+  for (;;) {
+    Expected<DisplacementPlan> PlanOrErr = DisplacementPlan::create(
+        Elf, PlannedEdits, RelocateTrailingSections);
+    if (!PlanOrErr)
+      return PlanOrErr.takeError();
+    if (Error Err = validateDisplacementEditBoundaries(Elf, LS, *PlanOrErr))
+      return std::move(Err);
+    if (Error Err = validateKernelEntryMappings(Elf, *PlanOrErr))
+      return std::move(Err);
 
-  // .debug_line's program length can change when an address advance straddles a
-  // patch; re-synthesize it and splice the (possibly larger) section back in,
-  // shifting trailing non-allocatable sections. Only relevant when
-  // validateDebugSections admitted the debug sections.
-  if (RelocateTrailingSections) {
-    Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
-        growDebugLineForDisplacement(Elf, *PlanOrErr, std::move(Out));
-    if (!GrownOrErr)
-      return GrownOrErr.takeError();
-    return std::move(*GrownOrErr);
+    std::unique_ptr<WritableMemoryBuffer> Out =
+        WritableMemoryBuffer::getNewUninitMemBuffer(
+            PlanOrErr->newElfSize(Elf.size()));
+    if (!Out)
+      return makeDisplacementError(
+          "failed to allocate displacement output buffer");
+
+    SmallVector<BranchRangeFailure, 16> RangeFailures;
+    if (Error Err =
+            applyTextDisplacement(Elf, LS, *PlanOrErr, ControlFlow,
+                                  BranchIslands, &RangeFailures, *Out)) {
+      if (!RelocateTrailingSections || RangeFailures.empty())
+        return std::move(Err);
+      consumeError(std::move(Err));
+      if (RangeFailures.size() >
+          MaxBranchIslands - std::min<uint64_t>(BranchIslands.size(),
+                                                MaxBranchIslands))
+        return makeDisplacementError(
+            "branch-island relaxation exceeded the safety limit");
+
+      if (InstructionBoundaries.empty()) {
+        bool Decoded = decodeTextSectionStreaming(
+            Elf.textData(), Elf.textSize(), LS, /*WantMnemonic=*/false,
+            [&](const InternalDecodedInst &DI) {
+              if (!DI.DecodeSucceeded)
+                return false;
+              InstructionBoundaries.push_back(DI.Offset);
+              return true;
+            });
+        if (!Decoded)
+          return makeDisplacementError(
+              "failed to collect instruction boundaries for branch islands");
+      }
+
+      DenseSet<uint64_t> ReservedBoundaries;
+      for (const DisplacementEdit &Edit : PlanOrErr->edits())
+        if (Edit.OriginalSize == 0)
+          ReservedBoundaries.insert(Edit.Offset);
+      for (const BranchRangeFailure &RangeFailure : RangeFailures) {
+        Expected<PlannedBranchIslandEdit> IslandOrErr = planBranchIsland(
+            LS, *PlanOrErr, RangeFailure, InstructionBoundaries,
+            ReservedBoundaries);
+        if (!IslandOrErr)
+          return IslandOrErr.takeError();
+        log() << "hotswap: displacement: planned guarded branch island for old "
+              << ".text offset 0x" << utohexstr(RangeFailure.SourceOffset)
+              << " at old .text boundary 0x"
+              << utohexstr(IslandOrErr->Island.InsertionOffset) << "\n";
+        ReservedBoundaries.insert(IslandOrErr->Island.InsertionOffset);
+        PlannedEdits.push_back(std::move(IslandOrErr->Edit));
+        BranchIslands.push_back(IslandOrErr->Island);
+      }
+      log() << "hotswap: displacement: planned " << RangeFailures.size()
+            << " guarded branch island(s) in one batch\n";
+      continue;
+    }
+
+    // .debug_line's program length can change when an address advance
+    // straddles a patch; re-synthesize it and splice the (possibly larger)
+    // section back in, shifting trailing non-allocatable sections. Only
+    // relevant when validateDebugSections admitted the debug sections.
+    if (RelocateTrailingSections) {
+      Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
+          growDebugLineForDisplacement(Elf, *PlanOrErr, std::move(Out));
+      if (!GrownOrErr)
+        return GrownOrErr.takeError();
+      return std::move(*GrownOrErr);
+    }
+    return std::move(Out);
   }
-  return std::move(Out);
 }
 
 } // namespace hotswap

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -9,18 +9,24 @@
 /// Direct `.text` displacement for HotSwap rewrites. This layer inserts
 /// larger replacement sequences into `.text`, shifts the displaced code
 /// forward, repairs direct PC-relative scalar branches when it can prove the
-/// new encoding, and updates ELF metadata. Appended trampolines remain the
-/// fallback when any check fails.
+/// new encoding, and updates ELF metadata. Objects with an address-bearing
+/// construct outside this layer's proof and repair set fail closed.
 ///
 //===----------------------------------------------------------------------===//
 
 #include "comgr-hotswap-internal.h"
 
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/BinaryFormat/MsgPackDocument.h"
+#include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCFixup.h"
 #include "llvm/Support/Alignment.h"
+#include "llvm/Support/LEB128.h"
+#include "llvm/Support/MathExtras.h"
 
 #include <algorithm>
+#include <chrono>
 #include <limits>
 
 using namespace llvm;
@@ -42,7 +48,501 @@ Error makeDisplacementError(const Twine &Msg) {
   return createStringError(object::object_error::parse_failed, Message);
 }
 
+// The non-allocatable DWARF debug sections whose .text addresses
+// remapDebugSectionsForDisplacement rewrites after whole-object growth.
+bool isAddressBearingDebugSection(StringRef Name) {
+  return Name == ".debug_frame" || Name == ".debug_info" ||
+         Name == ".debug_ranges" || Name == ".debug_line";
+}
+
+// Debug sections that carry NO .text addresses and are therefore safe to leave
+// byte-identical across whole-object growth (only their file offset shifts,
+// which the section-header adjust already handles).
+// .debug_abbrev/.debug_str/.debug_line_str are string/structure tables;
+// .debug_str_offsets/.debug_addr are index tables that do not encode raw .text
+// VADDRs for these DWARF<=4 objects.
+bool isAddressFreeDebugSection(StringRef Name) {
+  return Name == ".debug_abbrev" || Name == ".debug_str" ||
+         Name == ".debug_line_str";
+}
+
+// A .debug section this pass can safely admit into whole-object growth: either
+// it has no .text addresses, or we remap the ones it has. Any other
+// .debug*/.zdebug* section fails closed in validateDebugSections so we never
+// ship stale .text addresses.
+bool isRemappableDebugSection(StringRef Name) {
+  return isAddressBearingDebugSection(Name) || isAddressFreeDebugSection(Name);
+}
+
+Expected<const ELFT::Shdr *> findUniqueAllocatedSection(const ElfView &Elf,
+                                                        uint64_t Address,
+                                                        bool RequireExecutable,
+                                                        StringRef Context) {
+  const ELFT::Shdr *Owner = nullptr;
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) || Shdr.sh_size == 0 ||
+        Address < Shdr.sh_addr || Address - Shdr.sh_addr >= Shdr.sh_size)
+      continue;
+    if (Owner)
+      return makeDisplacementError(Twine(Context) +
+                                   " is covered by overlapping allocated "
+                                   "sections");
+    Owner = &Shdr;
+  }
+  if (!Owner)
+    return makeDisplacementError(Twine(Context) +
+                                 " is outside every allocated section");
+  if (RequireExecutable && !(Owner->sh_flags & ELF::SHF_EXECINSTR))
+    return makeDisplacementError(Twine(Context) +
+                                 " is not in an executable section");
+  return Owner;
+}
+
+Expected<uint64_t> remapAllocatedAddress(const ElfView &Elf,
+                                         const DisplacementPlan &Plan,
+                                         uint64_t OldAddress,
+                                         bool RequireExecutable,
+                                         StringRef Context) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr())
+    return makeDisplacementError(Twine(Context) +
+                                 " cannot resolve an overflowing .text");
+  const uint64_t OldTextEnd = Elf.textAddr() + Elf.textSize();
+  if (OldAddress >= Elf.textAddr() && OldAddress < OldTextEnd) {
+    if (RequireExecutable &&
+        !(Elf.textSection()->sh_flags & ELF::SHF_EXECINSTR))
+      return makeDisplacementError(Twine(Context) +
+                                   " is not in an executable section");
+    uint64_t NewOffset = 0;
+    if (!Plan.mapOffset(OldAddress - Elf.textAddr(),
+                        DisplacementMapBias::BeforeInsertedBytes, NewOffset))
+      return makeDisplacementError(Twine(Context) +
+                                   " maps inside a replaced instruction");
+    if (NewOffset > std::numeric_limits<uint64_t>::max() - Elf.textAddr())
+      return makeDisplacementError(Twine(Context) +
+                                   " overflows after .text displacement");
+    return Elf.textAddr() + NewOffset;
+  }
+
+  Expected<const ELFT::Shdr *> OwnerOrErr =
+      findUniqueAllocatedSection(Elf, OldAddress, RequireExecutable, Context);
+  if (!OwnerOrErr)
+    return OwnerOrErr.takeError();
+  const ELFT::Shdr &Owner = **OwnerOrErr;
+  if (Owner.sh_addr < OldTextEnd || !Plan.relocatesTrailingSections())
+    return OldAddress;
+  if (OldAddress > std::numeric_limits<uint64_t>::max() - Plan.paddedGrowth())
+    return makeDisplacementError(Twine(Context) +
+                                 " overflows after section displacement");
+  return OldAddress + Plan.paddedGrowth();
+}
+
+Expected<uint64_t> remapLoadAddress(const ElfView &Elf,
+                                    const DisplacementPlan &Plan,
+                                    uint64_t OldAddress, StringRef Context) {
+  if (OldAddress == 0)
+    return uint64_t{0};
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr())
+    return makeDisplacementError(Twine(Context) +
+                                 " cannot resolve an overflowing .text");
+  const uint64_t OldTextEnd = Elf.textAddr() + Elf.textSize();
+  if (OldAddress >= Elf.textAddr() && OldAddress < OldTextEnd)
+    return remapAllocatedAddress(Elf, Plan, OldAddress,
+                                 /*RequireExecutable=*/true, Context);
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr)
+    return makeDisplacementError(Twine(Context) +
+                                 " cannot read program headers: " +
+                                 Twine(toString(PhdrsOrErr.takeError())));
+  const ELFT::Phdr *Owner = nullptr;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD || Phdr.p_memsz == 0 ||
+        Phdr.p_memsz > std::numeric_limits<uint64_t>::max() - Phdr.p_vaddr)
+      continue;
+    if (OldAddress < Phdr.p_vaddr || OldAddress - Phdr.p_vaddr >= Phdr.p_memsz)
+      continue;
+    if (Owner)
+      return makeDisplacementError(
+          Twine(Context) + " is covered by overlapping PT_LOAD segments");
+    Owner = &Phdr;
+  }
+  if (!Owner)
+    return makeDisplacementError(Twine(Context) +
+                                 " is outside every PT_LOAD segment");
+  if (Owner->p_vaddr >= OldTextEnd && Plan.relocatesTrailingSections()) {
+    if (OldAddress > std::numeric_limits<uint64_t>::max() - Plan.paddedGrowth())
+      return makeDisplacementError(Twine(Context) +
+                                   " overflows after segment displacement");
+    return OldAddress + Plan.paddedGrowth();
+  }
+  if (Owner->p_vaddr >= OldTextEnd ||
+      Owner->p_vaddr + Owner->p_memsz <= Elf.textAddr() ||
+      OldAddress < Elf.textAddr())
+    return OldAddress;
+  return makeDisplacementError(
+      Twine(Context) + " points into unclassified post-.text segment padding");
+}
+
+enum class DynamicTagClass {
+  Value,
+  Address,
+  UnsupportedAddress,
+  Unknown,
+};
+
+DynamicTagClass classifyDynamicTag(int64_t Tag) {
+  switch (Tag) {
+  case ELF::DT_NULL:
+  case ELF::DT_NEEDED:
+  case ELF::DT_PLTRELSZ:
+  case ELF::DT_RELASZ:
+  case ELF::DT_RELAENT:
+  case ELF::DT_STRSZ:
+  case ELF::DT_SYMENT:
+  case ELF::DT_SONAME:
+  case ELF::DT_RPATH:
+  case ELF::DT_SYMBOLIC:
+  case ELF::DT_RELSZ:
+  case ELF::DT_RELENT:
+  case ELF::DT_PLTREL:
+  case ELF::DT_TEXTREL:
+  case ELF::DT_BIND_NOW:
+  case ELF::DT_INIT_ARRAYSZ:
+  case ELF::DT_FINI_ARRAYSZ:
+  case ELF::DT_RUNPATH:
+  case ELF::DT_FLAGS:
+  case ELF::DT_PREINIT_ARRAYSZ:
+  case ELF::DT_RELRSZ:
+  case ELF::DT_RELRENT:
+  case ELF::DT_RELACOUNT:
+  case ELF::DT_RELCOUNT:
+  case ELF::DT_FLAGS_1:
+  case ELF::DT_VERDEFNUM:
+  case ELF::DT_VERNEEDNUM:
+    return DynamicTagClass::Value;
+
+  case ELF::DT_HASH:
+  case ELF::DT_STRTAB:
+  case ELF::DT_SYMTAB:
+  case ELF::DT_RELA:
+  case ELF::DT_REL:
+  case ELF::DT_SYMTAB_SHNDX:
+  case ELF::DT_GNU_HASH:
+  case ELF::DT_VERSYM:
+  case ELF::DT_VERDEF:
+  case ELF::DT_VERNEED:
+    return DynamicTagClass::Address;
+
+  // These tags introduce executable entry points, pointer arrays, GOT/PLT
+  // state, TLS callbacks, or relocation encodings outside the displacement
+  // proof. Supporting only their container address would leave the contents
+  // or an externally callable entry unproved.
+  case ELF::DT_PLTGOT:
+  case ELF::DT_INIT:
+  case ELF::DT_FINI:
+  case ELF::DT_DEBUG:
+  case ELF::DT_JMPREL:
+  case ELF::DT_INIT_ARRAY:
+  case ELF::DT_FINI_ARRAY:
+  case ELF::DT_PREINIT_ARRAY:
+  case ELF::DT_RELR:
+  case ELF::DT_CREL:
+  case ELF::DT_ANDROID_REL:
+  case ELF::DT_ANDROID_RELA:
+  case ELF::DT_ANDROID_RELR:
+  case ELF::DT_TLSDESC_PLT:
+  case ELF::DT_TLSDESC_GOT:
+    return DynamicTagClass::UnsupportedAddress;
+  }
+  return DynamicTagClass::Unknown;
+}
+
+bool isKnownAllocatedSectionType(uint32_t Type) {
+  switch (Type) {
+  case ELF::SHT_PROGBITS:
+  case ELF::SHT_SYMTAB:
+  case ELF::SHT_STRTAB:
+  case ELF::SHT_RELA:
+  case ELF::SHT_HASH:
+  case ELF::SHT_DYNAMIC:
+  case ELF::SHT_NOTE:
+  case ELF::SHT_NOBITS:
+  case ELF::SHT_REL:
+  case ELF::SHT_DYNSYM:
+  case ELF::SHT_GROUP:
+  case ELF::SHT_SYMTAB_SHNDX:
+  case ELF::SHT_GNU_HASH:
+  case ELF::SHT_GNU_verdef:
+  case ELF::SHT_GNU_verneed:
+  case ELF::SHT_GNU_versym:
+    return true;
+  }
+  return false;
+}
+
+bool dynamicTagMatchesSection(int64_t Tag, uint32_t Type) {
+  switch (Tag) {
+  case ELF::DT_HASH:
+    return Type == ELF::SHT_HASH;
+  case ELF::DT_STRTAB:
+    return Type == ELF::SHT_STRTAB;
+  case ELF::DT_SYMTAB:
+    return Type == ELF::SHT_DYNSYM;
+  case ELF::DT_RELA:
+    return Type == ELF::SHT_RELA;
+  case ELF::DT_REL:
+    return Type == ELF::SHT_REL;
+  case ELF::DT_SYMTAB_SHNDX:
+    return Type == ELF::SHT_SYMTAB_SHNDX;
+  case ELF::DT_GNU_HASH:
+    return Type == ELF::SHT_GNU_HASH;
+  case ELF::DT_VERSYM:
+    return Type == ELF::SHT_GNU_versym;
+  case ELF::DT_VERDEF:
+    return Type == ELF::SHT_GNU_verdef;
+  case ELF::DT_VERNEED:
+    return Type == ELF::SHT_GNU_verneed;
+  }
+  return false;
+}
+
+Error validateMetadataNotes(const ElfView &Elf) {
+  StringMap<bool> MetadataKernels;
+  bool SawMetadata = false;
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (Shdr.sh_type != ELF::SHT_NOTE)
+      continue;
+    Error Err = Error::success();
+    for (ELFT::Note Note : Elf.file().notes(Shdr, Err)) {
+      if (Note.getName() != "AMDGPU" ||
+          Note.getType() != ELF::NT_AMDGPU_METADATA)
+        return makeDisplacementError(
+            "allocated note is not address-free AMDGPU metadata");
+      SawMetadata = true;
+      ArrayRef<uint8_t> Desc =
+          Note.getDesc(std::max<uint64_t>(Shdr.sh_addralign, uint64_t{4}));
+      if (Desc.empty())
+        return makeDisplacementError("AMDGPU metadata note is empty");
+      StringRef Blob(reinterpret_cast<const char *>(Desc.data()), Desc.size());
+      msgpack::Document Doc;
+      if (!Doc.readFromBlob(Blob, false))
+        return makeDisplacementError("AMDGPU metadata note is malformed");
+      msgpack::DocNode Root = Doc.getRoot();
+      if (!Root.isMap())
+        return makeDisplacementError("AMDGPU metadata root is not a map");
+      msgpack::MapDocNode &RootMap = Root.getMap();
+      msgpack::DocNode::MapTy::iterator Kernels =
+          RootMap.find("amdhsa.kernels");
+      if (Kernels == RootMap.end() || !Kernels->second.isArray())
+        continue;
+      for (msgpack::DocNode &Kernel : Kernels->second.getArray()) {
+        if (!Kernel.isMap())
+          return makeDisplacementError(
+              "AMDGPU metadata kernel entry is not a map");
+        msgpack::MapDocNode &KernelMap = Kernel.getMap();
+        msgpack::DocNode::MapTy::iterator Name = KernelMap.find(".name");
+        msgpack::DocNode::MapTy::iterator Symbol = KernelMap.find(".symbol");
+        if (Name == KernelMap.end() || !Name->second.isString() ||
+            Symbol == KernelMap.end() || !Symbol->second.isString())
+          return makeDisplacementError(
+              "AMDGPU metadata kernel lacks string .name/.symbol fields");
+        StringRef KernelName = Name->second.getString();
+        if (Symbol->second.getString() != (Twine(KernelName) + ".kd").str())
+          return makeDisplacementError(
+              "AMDGPU metadata kernel symbol does not name its descriptor");
+        if (!MetadataKernels.try_emplace(KernelName, true).second)
+          return makeDisplacementError("AMDGPU metadata repeats a kernel name");
+      }
+    }
+    if (Err)
+      return makeDisplacementError(
+          "failed to iterate an allocated note section: " +
+          Twine(toString(std::move(Err))));
+  }
+
+  if (!SawMetadata)
+    return Error::success();
+  for (const KernelDescriptorInfo &Descriptor : Elf.kernelDescriptors())
+    if (!MetadataKernels.contains(Descriptor.KernelName))
+      return makeDisplacementError(
+          "kernel descriptor is absent from AMDGPU metadata");
+  for (const StringMapEntry<bool> &Kernel : MetadataKernels)
+    if (!Elf.getKernelDescriptorVAddr(Kernel.first()))
+      return makeDisplacementError(
+          "AMDGPU metadata names a missing kernel descriptor");
+  return Error::success();
+}
+
+Error validateWholeObjectLayout(const ElfView &Elf) {
+  if (Elf.file().getHeader().e_type != ELF::ET_DYN)
+    return makeDisplacementError(
+        "whole-object displacement requires a linked ET_DYN code object");
+  if (!(Elf.textSection()->sh_flags & ELF::SHF_ALLOC) ||
+      !(Elf.textSection()->sh_flags & ELF::SHF_EXECINSTR))
+    return makeDisplacementError(
+        ".text must be an allocated executable section");
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr() ||
+      Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textOffset())
+    return makeDisplacementError(".text range overflows");
+  const uint64_t TextAddrEnd = Elf.textAddr() + Elf.textSize();
+  const uint64_t TextFileEnd = Elf.textOffset() + Elf.textSize();
+
+  SmallVector<const ELFT::Shdr *, 16> AllocatedSections;
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    if (Shdr.sh_addralign > 1 && !isPowerOf2_64(Shdr.sh_addralign))
+      return makeDisplacementError("section alignment is not a power of two");
+    if (Shdr.sh_type == ELF::SHT_RELR || Shdr.sh_type == ELF::SHT_CREL ||
+        Shdr.sh_type == ELF::SHT_ANDROID_REL ||
+        Shdr.sh_type == ELF::SHT_ANDROID_RELA ||
+        Shdr.sh_type == ELF::SHT_ANDROID_RELR ||
+        Shdr.sh_type == ELF::SHT_INIT_ARRAY ||
+        Shdr.sh_type == ELF::SHT_FINI_ARRAY ||
+        Shdr.sh_type == ELF::SHT_PREINIT_ARRAY ||
+        Shdr.sh_type == ELF::SHT_GNU_SFRAME ||
+        Shdr.sh_type == ELF::SHT_LLVM_BB_ADDR_MAP ||
+        Shdr.sh_type == ELF::SHT_LLVM_JT_SIZES ||
+        Shdr.sh_type == ELF::SHT_LLVM_CFI_JUMP_TABLE ||
+        Shdr.sh_type == ELF::SHT_LLVM_CALL_GRAPH)
+      return makeDisplacementError(
+          "code object has an unsupported address-bearing section type");
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) || Shdr.sh_size == 0)
+      continue;
+    if (!isKnownAllocatedSectionType(Shdr.sh_type))
+      return makeDisplacementError(
+          "allocated section type is outside the displacement whitelist");
+    if (Shdr.sh_size > std::numeric_limits<uint64_t>::max() - Shdr.sh_addr)
+      return makeDisplacementError("allocated section address range overflows");
+    AllocatedSections.push_back(&Shdr);
+    if (&Shdr == Elf.textSection())
+      continue;
+    if (Shdr.sh_flags & ELF::SHF_EXECINSTR)
+      return makeDisplacementError(
+          "whole-object displacement supports one executable section");
+    const bool AddressBefore = Shdr.sh_addr + Shdr.sh_size <= Elf.textAddr();
+    const bool AddressAfter = Shdr.sh_addr >= TextAddrEnd;
+    if (!AddressBefore && !AddressAfter)
+      return makeDisplacementError(
+          "allocated section overlaps .text in virtual memory");
+
+    if (Shdr.sh_type != ELF::SHT_NOBITS) {
+      if (Shdr.sh_size > std::numeric_limits<uint64_t>::max() - Shdr.sh_offset)
+        return makeDisplacementError("allocated section file range overflows");
+      const bool FileBefore = Shdr.sh_offset + Shdr.sh_size <= Elf.textOffset();
+      const bool FileAfter = Shdr.sh_offset >= TextFileEnd;
+      if ((!FileBefore && !FileAfter) || FileBefore != AddressBefore)
+        return makeDisplacementError(
+            "allocated section file and virtual ordering disagree");
+    } else if ((AddressBefore && Shdr.sh_offset > Elf.textOffset()) ||
+               (AddressAfter && Shdr.sh_offset < TextFileEnd)) {
+      return makeDisplacementError(
+          "NOBITS section file and virtual ordering disagree");
+    }
+  }
+
+  for (size_t I = 0; I != AllocatedSections.size(); ++I) {
+    const ELFT::Shdr &LHS = *AllocatedSections[I];
+    const uint64_t LHSEnd = LHS.sh_addr + LHS.sh_size;
+    for (size_t J = I + 1; J != AllocatedSections.size(); ++J) {
+      const ELFT::Shdr &RHS = *AllocatedSections[J];
+      const uint64_t RHSEnd = RHS.sh_addr + RHS.sh_size;
+      if (LHS.sh_addr < RHSEnd && RHS.sh_addr < LHSEnd)
+        return makeDisplacementError(
+            "allocated sections overlap in virtual memory");
+    }
+  }
+
+  for (const ELFT::Shdr &SymShdr : Elf.sections()) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymbolsOrErr = Elf.file().symbols(&SymShdr);
+    if (!SymbolsOrErr)
+      return makeDisplacementError(
+          "failed to read symbols while validating absolute addresses: " +
+          Twine(toString(SymbolsOrErr.takeError())));
+    for (const ELFT::Sym &Symbol : *SymbolsOrErr) {
+      if (Symbol.st_shndx != ELF::SHN_ABS || Symbol.st_value == 0)
+        continue;
+      if (Symbol.getType() == ELF::STT_FUNC)
+        return makeDisplacementError(
+            "absolute function symbol is outside the displacement map");
+      for (const ELFT::Shdr &Owner : Elf.sections()) {
+        if (!(Owner.sh_flags & ELF::SHF_ALLOC) || Owner.sh_size == 0 ||
+            Symbol.st_value < Owner.sh_addr ||
+            Symbol.st_value - Owner.sh_addr >= Owner.sh_size)
+          continue;
+        return makeDisplacementError(
+            "absolute symbol aliases movable allocated content");
+      }
+    }
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr)
+    return makeDisplacementError(
+        "failed to read program headers while validating object layout: " +
+        Twine(toString(PhdrsOrErr.takeError())));
+  bool FoundTextLoad = false;
+  SmallVector<const ELFT::Phdr *, 8> LoadSegments;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_align > 1 && !isPowerOf2_64(Phdr.p_align))
+      return makeDisplacementError(
+          "program-header alignment is not a power of two");
+    if (Phdr.p_type != ELF::PT_LOAD)
+      continue;
+    if (Phdr.p_filesz > std::numeric_limits<uint64_t>::max() - Phdr.p_offset ||
+        Phdr.p_memsz > std::numeric_limits<uint64_t>::max() - Phdr.p_vaddr)
+      return makeDisplacementError("PT_LOAD range overflows");
+    if (Phdr.p_align != 0 &&
+        Phdr.p_offset % Phdr.p_align != Phdr.p_vaddr % Phdr.p_align)
+      return makeDisplacementError(
+          "PT_LOAD file/virtual alignment congruence is invalid");
+    LoadSegments.push_back(&Phdr);
+
+    const uint64_t FileEnd = Phdr.p_offset + Phdr.p_filesz;
+    const uint64_t VAddrEnd = Phdr.p_vaddr + Phdr.p_memsz;
+    const bool ContainsTextFile =
+        Phdr.p_offset <= Elf.textOffset() && FileEnd >= TextFileEnd;
+    const bool ContainsTextVAddr =
+        Phdr.p_vaddr <= Elf.textAddr() && VAddrEnd >= TextAddrEnd;
+    if (ContainsTextFile || ContainsTextVAddr) {
+      if (!ContainsTextFile || !ContainsTextVAddr || FileEnd != TextFileEnd)
+        return makeDisplacementError(
+            ".text is not the last file-backed content in its PT_LOAD");
+      FoundTextLoad = true;
+      continue;
+    }
+
+    const bool FileBefore = FileEnd <= Elf.textOffset();
+    const bool FileAfter = Phdr.p_offset >= TextFileEnd;
+    const bool VAddrBefore = VAddrEnd <= Elf.textAddr();
+    const bool VAddrAfter = Phdr.p_vaddr >= TextAddrEnd;
+    if ((!FileBefore && !FileAfter) || (!VAddrBefore && !VAddrAfter) ||
+        FileBefore != VAddrBefore)
+      return makeDisplacementError(
+          "PT_LOAD file and virtual ordering around .text disagree");
+  }
+  if (!FoundTextLoad)
+    return makeDisplacementError(".text is not covered by a PT_LOAD segment");
+  for (size_t I = 0; I != LoadSegments.size(); ++I) {
+    const ELFT::Phdr &LHS = *LoadSegments[I];
+    const uint64_t LHSEnd = LHS.p_vaddr + LHS.p_memsz;
+    for (size_t J = I + 1; J != LoadSegments.size(); ++J) {
+      const ELFT::Phdr &RHS = *LoadSegments[J];
+      const uint64_t RHSEnd = RHS.p_vaddr + RHS.p_memsz;
+      if (LHS.p_vaddr < RHSEnd && RHS.p_vaddr < LHSEnd)
+        return makeDisplacementError(
+            "PT_LOAD segments overlap in virtual memory");
+    }
+  }
+  return validateMetadataNotes(Elf);
+}
+
 Expected<uint64_t> requiredGrowthAlignment(const ElfView &Elf) {
+  // validateWholeObjectLayout proves every alignment is a power of two.
+  // Therefore their maximum is also their least common multiple, and rounding
+  // growth to it adds the fewest bytes that preserve every downstream file
+  // and virtual-address alignment simultaneously.
   uint64_t MaxAlign = 1;
   for (const ELFT::Shdr &Shdr : Elf.sections()) {
     if (Shdr.sh_offset <= Elf.textOffset())
@@ -65,7 +565,7 @@ Expected<uint64_t> requiredGrowthAlignment(const ElfView &Elf) {
   return std::max<uint64_t>(MaxAlign, 1);
 }
 
-Error validateDebugSections(const ElfView &Elf) {
+Error validateDebugSections(const ElfView &Elf, bool AllowEhFrameRemap) {
   for (const ELFT::Shdr &Shdr : Elf.sections()) {
     Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
     if (!NameOrErr) {
@@ -74,6 +574,21 @@ Error validateDebugSections(const ElfView &Elf) {
           Twine(toString(NameOrErr.takeError())));
     }
     StringRef Name = *NameOrErr;
+    // .eh_frame is remapped in place by remapEhFrameForDisplacement when the
+    // caller opts into trailing-section relocation. .eh_frame_hdr is a
+    // binary-search table over FDEs and would also need rebuilding; block it
+    // until that is implemented. Full DWARF (.debug*) stays out of scope.
+    if (AllowEhFrameRemap && Name == ".eh_frame")
+      continue;
+    // When relocating trailing sections,
+    // remapDebugSectionsForDisplacement rewrites the .text addresses in the
+    // non-allocatable DWARF debug sections it understands
+    // (.debug_frame/.debug_info/.debug_ranges/.debug_line). Allow those
+    // through; any other .debug*/.zdebug* section (or a construct the remapper
+    // cannot handle) still fails closed there. .eh_frame_hdr is a binary-search
+    // table over FDEs that would need rebuilding; keep blocking it.
+    if (AllowEhFrameRemap && isRemappableDebugSection(Name))
+      continue;
     if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
         Name == ".eh_frame" || Name == ".eh_frame_hdr") {
       return makeDisplacementError("debug/unwind section '" + Twine(Name) +
@@ -144,13 +659,362 @@ Error validateVirtualGrowth(const ElfView &Elf, uint64_t PaddedGrowth) {
   return Error::success();
 }
 
+/// Linked-ELF proof object for an indirect dispatch table. Every slot must be
+/// either a symbol-less RELATIVE64 pointer into .text or a literal zero; any
+/// other contents make the candidate ineligible.
+struct RelocationTableCandidate {
+  uint64_t Address = 0;
+  uint64_t Size = 0;
+  SmallVector<std::optional<uint64_t>, 8> Targets;
+  SmallVector<bool, 8> ZeroSlots;
+  bool Valid = true;
+};
+
+RelocationTableCandidate *
+findContainingCandidate(std::vector<RelocationTableCandidate> &Candidates,
+                        uint64_t Address) {
+  std::vector<RelocationTableCandidate>::iterator It = std::upper_bound(
+      Candidates.begin(), Candidates.end(), Address,
+      [](uint64_t Value, const RelocationTableCandidate &Candidate) {
+        return Value < Candidate.Address;
+      });
+  if (It == Candidates.begin())
+    return nullptr;
+  --It;
+  return Address - It->Address < It->Size ? &*It : nullptr;
+}
+
+Expected<bool> isRuntimeImmutableRange(const ElfView &Elf, uint64_t Address,
+                                       uint64_t Size) {
+  if (Size == 0 || Size > std::numeric_limits<uint64_t>::max() - Address)
+    return false;
+  const uint64_t End = Address + Size;
+  Expected<ELFT::PhdrRange> PhdrsOrErr = Elf.file().program_headers();
+  if (!PhdrsOrErr)
+    return PhdrsOrErr.takeError();
+
+  bool Covered = false;
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_type != ELF::PT_LOAD || Phdr.p_memsz == 0)
+      continue;
+    if (Phdr.p_memsz > std::numeric_limits<uint64_t>::max() - Phdr.p_vaddr)
+      return makeDisplacementError(
+          "PT_LOAD range overflows while proving table immutability");
+    const uint64_t SegmentEnd = Phdr.p_vaddr + Phdr.p_memsz;
+    if (Address < SegmentEnd && Phdr.p_vaddr < End &&
+        (Phdr.p_flags & ELF::PF_W))
+      return false;
+    Covered |= Phdr.p_vaddr <= Address && SegmentEnd >= End;
+  }
+  return Covered;
+}
+
+template <typename RecordT>
+Expected<uint64_t> getRecordOffset(const ELFFileT &File,
+                                   const RecordT &Record) {
+  const uint8_t *Bytes = reinterpret_cast<const uint8_t *>(&Record);
+  if (Bytes < File.base() || Bytes > File.end() ||
+      static_cast<size_t>(File.end() - Bytes) < sizeof(RecordT))
+    return makeDisplacementError(
+        "relocation record is outside displaced ELF buffer");
+  return static_cast<uint64_t>(Bytes - File.base());
+}
+
+Expected<std::vector<RelocationTableCandidate>>
+discoverCompleteRelocationTables(const ElfView &Elf) {
+  if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr())
+    return makeDisplacementError(
+        ".text virtual range overflows while discovering function tables");
+  std::vector<RelocationTableCandidate> Candidates;
+  for (const ELFT::Shdr &SymShdr : Elf.sections()) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymsOrErr = Elf.file().symbols(&SymShdr);
+    if (!SymsOrErr)
+      return SymsOrErr.takeError();
+    for (const ELFT::Sym &Sym : *SymsOrErr) {
+      if (Sym.getType() != ELF::STT_OBJECT || Sym.st_size == 0 ||
+          Sym.st_size % sizeof(uint64_t) != 0 ||
+          Sym.st_shndx == ELF::SHN_UNDEF || Sym.st_shndx >= ELF::SHN_LORESERVE)
+        continue;
+      Expected<const ELFT::Shdr *> DefShdrOrErr =
+          Elf.file().getSection(Sym.st_shndx);
+      if (!DefShdrOrErr)
+        return DefShdrOrErr.takeError();
+      const ELFT::Shdr &DefShdr = **DefShdrOrErr;
+      if (DefShdr.sh_type == ELF::SHT_NOBITS ||
+          !(DefShdr.sh_flags & ELF::SHF_ALLOC) ||
+          (DefShdr.sh_flags & (ELF::SHF_WRITE | ELF::SHF_EXECINSTR)))
+        continue;
+      Expected<bool> ImmutableOrErr =
+          isRuntimeImmutableRange(Elf, Sym.st_value, Sym.st_size);
+      if (!ImmutableOrErr)
+        return ImmutableOrErr.takeError();
+      if (!*ImmutableOrErr)
+        continue;
+      if (Sym.st_value < DefShdr.sh_addr ||
+          Sym.st_value - DefShdr.sh_addr > DefShdr.sh_size ||
+          Sym.st_size > DefShdr.sh_size - (Sym.st_value - DefShdr.sh_addr))
+        continue;
+      std::vector<RelocationTableCandidate>::iterator Duplicate =
+          llvm::find_if(Candidates, [&](const RelocationTableCandidate &C) {
+            return C.Address == Sym.st_value && C.Size == Sym.st_size;
+          });
+      if (Duplicate != Candidates.end())
+        continue;
+
+      const uint64_t ObjectOffset =
+          DefShdr.sh_offset + Sym.st_value - DefShdr.sh_addr;
+      if (ObjectOffset > Elf.size() || Sym.st_size > Elf.size() - ObjectOffset)
+        return makeDisplacementError(
+            "function-table object extends outside the ELF image");
+      const size_t SlotCount = Sym.st_size / sizeof(uint64_t);
+      RelocationTableCandidate Candidate{
+          Sym.st_value, Sym.st_size,
+          SmallVector<std::optional<uint64_t>, 8>(SlotCount),
+          SmallVector<bool, 8>(SlotCount), true};
+      for (size_t I = 0; I != SlotCount; ++I) {
+        uint64_t Value = 0;
+        std::memcpy(&Value, Elf.data() + ObjectOffset + I * sizeof(uint64_t),
+                    sizeof(Value));
+        Candidate.ZeroSlots[I] = Value == 0;
+      }
+      Candidates.push_back(std::move(Candidate));
+    }
+  }
+
+  if (Candidates.empty())
+    return Candidates;
+  llvm::sort(Candidates, [](const RelocationTableCandidate &LHS,
+                            const RelocationTableCandidate &RHS) {
+    if (LHS.Address != RHS.Address)
+      return LHS.Address < RHS.Address;
+    return LHS.Size < RHS.Size;
+  });
+  // Ambiguous overlapping object symbols are not a sound ownership proof for
+  // a relocation slot. Reject both intervals and retain a sorted, disjoint set
+  // so every lookup below is O(log N) with one possible owner.
+  size_t FarthestEnd = 0;
+  for (size_t I = 1; I != Candidates.size(); ++I) {
+    uint64_t StartDelta =
+        Candidates[I].Address - Candidates[FarthestEnd].Address;
+    if (StartDelta < Candidates[FarthestEnd].Size) {
+      Candidates[FarthestEnd].Valid = false;
+      Candidates[I].Valid = false;
+      if (Candidates[I].Size > Candidates[FarthestEnd].Size - StartDelta)
+        FarthestEnd = I;
+    } else {
+      FarthestEnd = I;
+    }
+  }
+  llvm::erase_if(Candidates, [](const RelocationTableCandidate &Candidate) {
+    return !Candidate.Valid;
+  });
+  if (Candidates.empty())
+    return Candidates;
+
+  const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
+  for (const ELFT::Shdr &RelocShdr : Elf.sections()) {
+    if (RelocShdr.sh_type != ELF::SHT_RELA)
+      continue;
+    Expected<ELFT::RelaRange> RelasOrErr = Elf.file().relas(RelocShdr);
+    if (!RelasOrErr)
+      return RelasOrErr.takeError();
+    for (const ELFT::Rela &Rela : *RelasOrErr) {
+      RelocationTableCandidate *Candidate =
+          findContainingCandidate(Candidates, Rela.r_offset);
+      if (!Candidate)
+        continue;
+      const uint64_t SlotOffset = Rela.r_offset - Candidate->Address;
+      if (SlotOffset % sizeof(uint64_t) != 0 || Rela.getSymbol(false) != 0 ||
+          Rela.getType(false) != ELF::R_AMDGPU_RELATIVE64 ||
+          Rela.r_addend < 0) {
+        Candidate->Valid = false;
+        continue;
+      }
+      const uint64_t Target = static_cast<uint64_t>(Rela.r_addend);
+      if (Target < Elf.textAddr() || Target >= TextEnd) {
+        Candidate->Valid = false;
+        continue;
+      }
+      std::optional<uint64_t> &OldTarget =
+          Candidate->Targets[SlotOffset / sizeof(uint64_t)];
+      const uint64_t TextOffset = Target - Elf.textAddr();
+      if (OldTarget && *OldTarget != TextOffset) {
+        Candidate->Valid = false;
+        continue;
+      }
+      OldTarget = TextOffset;
+    }
+  }
+
+  llvm::erase_if(Candidates, [](const RelocationTableCandidate &Candidate) {
+    if (!Candidate.Valid)
+      return true;
+    bool SawTarget = false;
+    for (size_t I = 0; I != Candidate.Targets.size(); ++I) {
+      if (Candidate.Targets[I]) {
+        SawTarget = true;
+        continue;
+      }
+      if (!Candidate.ZeroSlots[I])
+        return true;
+    }
+    return !SawTarget;
+  });
+  return Candidates;
+}
+
+bool definesRegister(const InternalDecodedInst &DI, const LLVMState &LS,
+                     MCRegister Register) {
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  unsigned DefCount = std::min(Desc.getNumDefs(), DI.Inst.getNumOperands());
+  for (unsigned I = 0; I != DefCount; ++I) {
+    const MCOperand &Operand = DI.Inst.getOperand(I);
+    if (Operand.isReg() && Operand.getReg() &&
+        LS.MRI->regsOverlap(MCRegister(Operand.getReg()), Register))
+      return true;
+  }
+  for (MCPhysReg ImplicitDef : Desc.implicit_defs())
+    if (LS.MRI->regsOverlap(MCRegister(ImplicitDef), Register))
+      return true;
+  return false;
+}
+
+bool isProvenanceBoundary(const InternalDecodedInst &DI, const LLVMState &LS) {
+  return !DI.DecodeSucceeded || LS.MIA->isBranch(DI.Inst) ||
+         LS.MIA->isCall(DI.Inst) || LS.MIA->isReturn(DI.Inst) ||
+         LS.MIA->isIndirectBranch(DI.Inst) || LS.MIA->isBarrier(DI.Inst);
+}
+
+std::optional<size_t> findDefBefore(ArrayRef<InternalDecodedInst> Decoded,
+                                    size_t Before, const LLVMState &LS,
+                                    MCRegister Register) {
+  for (size_t I = Before; I != 0;) {
+    --I;
+    const InternalDecodedInst &Candidate = Decoded[I];
+    if (isProvenanceBoundary(Candidate, LS))
+      return std::nullopt;
+    if (definesRegister(Candidate, LS, Register))
+      return I;
+  }
+  return std::nullopt;
+}
+
+std::vector<RelocationTableDispatch> matchRelocationTableDispatches(
+    const ElfView &Elf, ArrayRef<InternalDecodedInst> Decoded,
+    const LLVMState &LS, ArrayRef<RelocationTableCandidate> Tables) {
+  std::vector<RelocationTableDispatch> Dispatches;
+  DenseSet<uint64_t> KernelEntries;
+  for (const KernelDescriptorInfo &Descriptor : Elf.kernelDescriptors()) {
+    std::optional<uint64_t> Entry = entryVAddr(Descriptor);
+    if (Entry && *Entry >= Elf.textAddr() &&
+        *Entry - Elf.textAddr() < Elf.textSize())
+      KernelEntries.insert(*Entry - Elf.textAddr());
+  }
+  for (size_t CallIndex = 0; CallIndex != Decoded.size(); ++CallIndex) {
+    const InternalDecodedInst &Call = Decoded[CallIndex];
+    if (!Call.DecodeSucceeded || Call.Inst.getOpcode() != LS.SSwapPcI64Opcode ||
+        Call.Inst.getNumOperands() < 2 ||
+        !Call.Inst.getOperand(Call.Inst.getNumOperands() - 1).isReg())
+      continue;
+    MCRegister TargetRegister(
+        Call.Inst.getOperand(Call.Inst.getNumOperands() - 1).getReg());
+    if (!TargetRegister)
+      continue;
+
+    std::optional<size_t> LoadIndex =
+        findDefBefore(Decoded, CallIndex, LS, TargetRegister);
+    if (!LoadIndex)
+      continue;
+    const InternalDecodedInst &Load = Decoded[*LoadIndex];
+    if (Load.Inst.getOpcode() != LS.SLoadB64Opcode ||
+        Load.Inst.getNumOperands() < 4 || !Load.Inst.getOperand(0).isReg() ||
+        Load.Inst.getOperand(0).getReg() != TargetRegister ||
+        !Load.Inst.getOperand(1).isReg() || !Load.Inst.getOperand(1).getReg() ||
+        !Load.Inst.getOperand(3).isImm() ||
+        Load.Inst.getOperand(3).getImm() != 0)
+      continue;
+    MCRegister BaseRegister(Load.Inst.getOperand(1).getReg());
+
+    // The source-level table access is defined only while its dynamic index is
+    // in bounds. Since the table's ELF section is non-writable, every such
+    // load observes one of the relocation-complete slots proved above.
+    std::optional<size_t> AddIndex =
+        findDefBefore(Decoded, *LoadIndex, LS, BaseRegister);
+    if (!AddIndex)
+      continue;
+    const InternalDecodedInst &Add = Decoded[*AddIndex];
+    if (Add.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+        Add.Inst.getNumOperands() != 3 || !Add.Inst.getOperand(0).isReg() ||
+        Add.Inst.getOperand(0).getReg() != BaseRegister ||
+        !Add.Inst.getOperand(1).isReg() ||
+        Add.Inst.getOperand(1).getReg() != BaseRegister ||
+        !Add.Inst.getOperand(2).isImm())
+      continue;
+
+    std::optional<size_t> GetPcIndex =
+        findDefBefore(Decoded, *AddIndex, LS, BaseRegister);
+    if (!GetPcIndex)
+      continue;
+    const InternalDecodedInst &GetPc = Decoded[*GetPcIndex];
+    if (GetPc.Inst.getOpcode() != LS.SGetPcI64Opcode ||
+        GetPc.Inst.getNumOperands() != 1 || !GetPc.Inst.getOperand(0).isReg() ||
+        GetPc.Inst.getOperand(0).getReg() != BaseRegister)
+      continue;
+
+    // s_get_pc_i64 produces the next instruction's address; s_add_nc_u64 is
+    // modulo-2^64, so the unsigned addition also handles a table below .text.
+    const uint64_t TableAddress =
+        Elf.textAddr() + GetPc.Offset + GetPc.Size +
+        static_cast<uint64_t>(Add.Inst.getOperand(2).getImm());
+    ArrayRef<RelocationTableCandidate>::iterator Table =
+        llvm::find_if(Tables, [&](const RelocationTableCandidate &T) {
+          return T.Address == TableAddress;
+        });
+    if (Table == Tables.end())
+      continue;
+
+    RelocationTableDispatch Dispatch;
+    Dispatch.CallOffset = Call.Offset;
+    Dispatch.SequenceStart = GetPc.Offset;
+    Dispatch.SequenceEnd = Call.Offset;
+    bool HasInvalidTarget = false;
+    for (const std::optional<uint64_t> &Target : Table->Targets) {
+      if (!Target)
+        continue;
+      ArrayRef<InternalDecodedInst>::iterator TargetInst =
+          std::lower_bound(Decoded.begin(), Decoded.end(), *Target,
+                           [](const InternalDecodedInst &DI, uint64_t Offset) {
+                             return DI.Offset < Offset;
+                           });
+      if (KernelEntries.contains(*Target) || TargetInst == Decoded.end() ||
+          TargetInst->Offset != *Target || !TargetInst->DecodeSucceeded) {
+        HasInvalidTarget = true;
+        break;
+      }
+      Dispatch.Targets.push_back(*Target);
+    }
+    if (HasInvalidTarget)
+      continue;
+    llvm::sort(Dispatch.Targets);
+    Dispatch.Targets.erase(
+        std::unique(Dispatch.Targets.begin(), Dispatch.Targets.end()),
+        Dispatch.Targets.end());
+    Dispatches.push_back(std::move(Dispatch));
+  }
+  return Dispatches;
+}
+
+bool isInRelocatedTrailingSection(const ElfView &OldElf, uint64_t VAddr);
+
 Error validateTextRelocations(const ElfView &Elf) {
   if (Elf.textSize() > std::numeric_limits<uint64_t>::max() - Elf.textAddr()) {
     return makeDisplacementError(
         ".text virtual range overflows while checking relocations");
   }
   const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
-
   for (const ELFT::Shdr &Shdr : Elf.sections()) {
     if (Shdr.sh_type != ELF::SHT_REL && Shdr.sh_type != ELF::SHT_RELA)
       continue;
@@ -166,10 +1030,12 @@ Error validateTextRelocations(const ElfView &Elf) {
                                    "' references .text");
     }
 
-    // Dynamic relocation sections use sh_info == 0. r_offset identifies the
-    // location to update, but the relocation's symbol or addend can separately
-    // resolve to displaced code. Reject either direction until displacement
-    // can rewrite relocation expressions as well as their destinations.
+    // Dynamic relocation sections use sh_info == 0. A relocation place in
+    // .text is never safe because instruction expansion changes the bytes the
+    // loader would patch. A symbol-less R_AMDGPU_RELATIVE64 explicit addend,
+    // however, is an exact load-bias-relative code pointer: DisplacementPlan
+    // can remap it without knowing the source-language table type. RCCL device
+    // dispatch tables use precisely this representation.
     if (Shdr.sh_info == 0) {
       if (Shdr.sh_type == ELF::SHT_RELA) {
         Expected<ELFT::RelaRange> RelasOrErr = Elf.file().relas(Shdr);
@@ -193,15 +1059,7 @@ Error validateTextRelocations(const ElfView &Elf) {
                 "address");
           }
 
-          if (Rela.r_addend >= 0) {
-            const uint64_t Addend = static_cast<uint64_t>(Rela.r_addend);
-            if (Addend >= Elf.textAddr() && Addend < TextEnd) {
-              return makeDisplacementError(
-                  "dynamic relocation addend references a displaced .text "
-                  "address");
-            }
-          }
-
+          const ELFT::Sym *Sym = nullptr;
           Expected<const ELFT::Sym *> SymOrErr =
               Elf.file().getRelocationSymbol(Rela, *SymtabOrErr);
           if (!SymOrErr) {
@@ -209,7 +1067,23 @@ Error validateTextRelocations(const ElfView &Elf) {
                 "failed to read dynamic relocation symbol: " +
                 Twine(toString(SymOrErr.takeError())));
           }
-          const ELFT::Sym *Sym = *SymOrErr;
+          Sym = *SymOrErr;
+
+          const uint64_t Addend = static_cast<uint64_t>(Rela.r_addend);
+          const bool ReferencesText =
+              Addend >= Elf.textAddr() && Addend < TextEnd;
+          const bool ReferencesTrailingSection =
+              isInRelocatedTrailingSection(Elf, Addend);
+          if (ReferencesText || ReferencesTrailingSection) {
+            if (Sym || Rela.getType(false) != ELF::R_AMDGPU_RELATIVE64) {
+              return makeDisplacementError(
+                  "dynamic relocation addend references displaced content "
+                  "in an unsupported form");
+            }
+            // Keep scanning: one supported pointer does not make a second
+            // unsupported relocation safe.
+          }
+
           if (Sym &&
               (Sym->st_shndx == Elf.textSectionIndex() ||
                (Sym->st_value >= Elf.textAddr() && Sym->st_value < TextEnd))) {
@@ -282,11 +1156,13 @@ Error validateKernelEntryMappings(const ElfView &Elf,
       return makeDisplacementError("failed to resolve kernel entry for '" +
                                    Twine(KD.KernelName) + "'");
     }
-    if (*OldEntry < Elf.textAddr() || *OldEntry >= TextEnd) {
-      return makeDisplacementError(
-          "kernel entry for '" + Twine(KD.KernelName) +
-          "' is outside .text and may contain an unrepairable entry stub");
-    }
+    // A kernel whose entry falls outside [textAddr, TextEnd) has nothing to
+    // displace (e.g. a zero-body placeholder kernel whose entry sits at the
+    // one-past-the-end .text boundary). Skip it here to stay consistent with
+    // rewriteKernelDescriptorEntriesForDisplacement, which also skips it and
+    // leaves its descriptor untouched.
+    if (*OldEntry < Elf.textAddr() || *OldEntry >= TextEnd)
+      continue;
 
     uint64_t NewEntryOffset = 0;
     if (!Plan.mapOffset(*OldEntry - Elf.textAddr(),
@@ -359,89 +1235,415 @@ reencodePcrelBranch(const InternalDecodedInst &DI, uint64_t NewFrom,
   return Encoded;
 }
 
+/// Attempt to repair an `s_get_pc_i64; s_add_nc_u64 sX, sX, imm` PC-relative
+/// address computation under whole-object displacement. \p Gp is the
+/// decoded s_get_pc at old .text offset \p Gp.Offset. The pair materializes an
+/// absolute address: pc_base is the address of the instruction following
+/// s_get_pc (the s_add), and the s_add immediate is (target - pc_base). When
+/// the code moves, pc_base shifts, so the immediate must be adjusted by -shift
+/// to keep pointing at the same (unmoved) target.
+///
+/// Returns Expected<bool>: true if the pair matched and was repaired (or needed
+/// no change), false if the instruction is not the expected repairable pair
+/// (the caller then falls through to the strict pc-sensitive rejection,
+/// fail-closed). An Error is returned only for a genuinely broken rewrite
+/// (re-encode size change or a write past the rebuilt buffer).
+///
+/// CORRECTNESS: -shift is valid only when the computed target is OUTSIDE .text
+/// (a data global / GOT slot that does not move). If the target lands inside
+/// .text it would itself be displaced and -shift would be wrong, so that case
+/// returns false and the caller rejects the whole displacement.
+Expected<bool> repairSGetPcPairForDisplacement(
+    const ElfView &Elf, const LLVMState &LS, const DisplacementPlan &Plan,
+    const InternalDecodedInst &Gp, SmallVectorImpl<uint8_t> &NewText) {
+  // The s_add immediately follows s_get_pc. Decode a small window at its
+  // offset; the first decoded instruction is the s_add carrying the PC-relative
+  // addend.
+  const uint64_t AddOldOff = Gp.Offset + Gp.Size;
+  if (AddOldOff >= Elf.textSize())
+    return false;
+  // Decode ONLY the s_add that follows s_get_pc. Decode over the FULL remaining
+  // .text (not a fixed-size sub-buffer): the AMDGPU disassembler can read up to
+  // getMaxInstLength() bytes for a literal, so a too-small window (e.g. an
+  // s_add_nc_u64 with a lit64 near the window edge) makes it over-read past the
+  // copy and crash. Streaming stops after the first instruction via the
+  // early-false callback, so decoding "the whole rest" costs exactly one insn.
+  InternalDecodedInst Add;
+  bool Got = false;
+  (void)decodeTextSectionStreaming(
+      Elf.textData() + AddOldOff, Elf.textSize() - AddOldOff, LS,
+      /*WantMnemonic=*/false, [&](const InternalDecodedInst &DI) -> bool {
+        Add = DI;
+        Got = true;
+        return false; // stop after the first instruction
+      });
+  if (!Got || Add.Inst.getOpcode() != LS.SAddNcU64Opcode ||
+      Add.Inst.getNumOperands() != 3)
+    return false;
+
+  // The PC-relative addend is operand 2. Tensile/rocBLAS-style code encodes it
+  // either as a plain immediate or, when it needs the 64-bit literal form, as
+  // an AMDGPU lit/lit64 target MCExpr that evaluates to an absolute constant.
+  // Extract the numeric addend from whichever form is present; anything else is
+  // not the expected pair (fail-closed).
+  const MCOperand &AddendOp = Add.Inst.getOperand(2);
+  int64_t OldImm = 0;
+  if (AddendOp.isImm()) {
+    OldImm = AddendOp.getImm();
+  } else if (!AddendOp.isExpr() ||
+             !AddendOp.getExpr()->evaluateAsAbsolute(OldImm)) {
+    return false;
+  }
+
+  // s_get_pc captures the address of the following s_add. Resolve the signed
+  // immediate to an actual allocated object address rather than assuming that
+  // every negative target is pre-.text data and every positive target is a
+  // trailing section. Exotic gaps or out-of-object values fail closed.
+  std::optional<uint64_t> OldPcBase =
+      checkedAddUint64(Elf.textAddr(), AddOldOff, "s_get_pc old PC base");
+  if (!OldPcBase)
+    return false;
+  std::optional<uint64_t> OldTarget;
+  if (OldImm >= 0) {
+    OldTarget = checkedAddUint64(*OldPcBase, static_cast<uint64_t>(OldImm),
+                                 "s_get_pc old target");
+  } else {
+    const uint64_t Magnitude = OldImm == std::numeric_limits<int64_t>::min()
+                                   ? uint64_t{1} << 63
+                                   : static_cast<uint64_t>(-OldImm);
+    OldTarget = checkedSubUint64(*OldPcBase, Magnitude, "s_get_pc old target");
+  }
+  if (!OldTarget)
+    return false;
+  const uint64_t TextEnd = Elf.textAddr() + Elf.textSize();
+  if (*OldTarget >= Elf.textAddr() && *OldTarget < TextEnd)
+    return false;
+
+  uint64_t NewAddOff = 0;
+  if (!Plan.mapOffset(AddOldOff, DisplacementMapBias::AfterInsertedBytes,
+                      NewAddOff))
+    return false;
+  Expected<uint64_t> NewTargetOrErr =
+      remapAllocatedAddress(Elf, Plan, *OldTarget, /*RequireExecutable=*/false,
+                            "s_get_pc materialized target");
+  if (!NewTargetOrErr) {
+    consumeError(NewTargetOrErr.takeError());
+    return false;
+  }
+  std::optional<uint64_t> NewPcBase =
+      checkedAddUint64(Elf.textAddr(), NewAddOff, "s_get_pc displaced PC base");
+  if (!NewPcBase)
+    return false;
+  std::optional<int64_t> NewImmOrErr = checkedSignedDifference(
+      *NewTargetOrErr, *NewPcBase, "s_get_pc displaced immediate");
+  if (!NewImmOrErr)
+    return false;
+  const int64_t NewImm = *NewImmOrErr;
+  if (NewImm == OldImm)
+    return true; // nothing moved relative to the pair; original is still
+                 // correct
+
+  // Re-encode via the asm parser rather than mutating the MCInst directly: the
+  // literal may be an AMDGPU lit/lit64 form whose encoded size must be
+  // preserved (a plain MCConstantExpr re-encodes to the shorter inline-literal
+  // form and would corrupt the following instruction). Print the instruction to
+  // its canonical asm, substitute only the trailing addend operand with the new
+  // value in the same literal form, and assemble. This keeps the MC layer as
+  // the single source of encoding (no target-internal MCExpr headers, no
+  // hardcoded literal-field surgery).
+  if (!LS.MCIP)
+    return false;
+  SmallString<256> PrintedBuf;
+  raw_svector_ostream PrintOS(PrintedBuf);
+  LS.MCIP->printInst(&Add.Inst, /*Address=*/0, /*Annot=*/"", *LS.STI, PrintOS);
+  StringRef Printed = StringRef(PrintedBuf).trim();
+  size_t LastComma = Printed.rfind(',');
+  if (LastComma == StringRef::npos)
+    return false;
+  StringRef Head = Printed.substr(0, LastComma + 1); // "...s[2:3], s[2:3],"
+  StringRef AddendTok = Printed.substr(LastComma + 1).trim();
+  // Preserve the printed literal wrapper (lit64(...) / lit(...)) so the encoded
+  // size is unchanged; only the numeric value is replaced.
+  std::string Hex =
+      ("0x" + Twine::utohexstr(static_cast<uint64_t>(NewImm))).str();
+  std::string NewAddend;
+  if (AddendTok.starts_with("lit64("))
+    NewAddend = "lit64(" + Hex + ")";
+  else if (AddendTok.starts_with("lit("))
+    NewAddend = "lit(" + Hex + ")";
+  else
+    NewAddend = Hex;
+  std::string NewAsm = (Head + " " + NewAddend).str();
+
+  SmallVector<uint8_t> Code = assembleSingleInst(NewAsm, LS);
+  if (Code.size() != Add.Size) {
+    return makeDisplacementError("s_add for s_get_pc at old .text offset 0x" +
+                                 Twine::utohexstr(Gp.Offset) +
+                                 " changed encoded size during re-encode");
+  }
+  if (NewAddOff + Code.size() > NewText.size()) {
+    return makeDisplacementError(
+        "repaired s_add for s_get_pc at old .text offset 0x" +
+        Twine::utohexstr(Gp.Offset) + " writes past rebuilt .text");
+  }
+  std::memcpy(NewText.data() + NewAddOff, Code.data(), Code.size());
+  return true;
+}
+
+/// Repair a standalone `s_add_pc_i64 lit64(delta)` under whole-object
+/// displacement. Unlike the s_get_pc pair (whose target is a global outside
+/// .text), this is a long-forward PC-relative CONTROL transfer whose target is
+/// code INSIDE .text: PC (the address of the instruction after s_add_pc_i64)
+/// plus the byte delta. Both the instruction and its target are displaced, so
+/// the new delta = new_target_off - (new_add_off + size), with both offsets
+/// obtained from the plan (the same both-ends-move remap repairBranches does
+/// for s_branch, but s_add_pc reaches far with a 64-bit literal). The operand
+/// is a raw byte delta (verified via llvm-mc), not a dword offset. Returns
+/// false if the instruction is not the expected single-immediate form or the
+/// target leaves .text (fail-closed). Only called for whole-object growth.
+Expected<bool> repairSAddPcForDisplacement(const ElfView &Elf,
+                                           const LLVMState &LS,
+                                           const DisplacementPlan &Plan,
+                                           const InternalDecodedInst &Ap,
+                                           SmallVectorImpl<uint8_t> &NewText) {
+  if (Ap.Inst.getNumOperands() < 1)
+    return false;
+  const MCOperand &DeltaOp = Ap.Inst.getOperand(0);
+  int64_t OldDelta = 0;
+  if (DeltaOp.isImm()) {
+    OldDelta = DeltaOp.getImm();
+  } else if (!DeltaOp.isExpr() ||
+             !DeltaOp.getExpr()->evaluateAsAbsolute(OldDelta)) {
+    return false;
+  }
+
+  // PC base is the address of the NEXT instruction (AMDGPU PC semantics,
+  // verified: 0x3BB8F4 + 12 + 0x278c8 lands on a clean boundary). Target is a
+  // .text offset that must stay inside .text (control transfer); reject
+  // otherwise (fail-closed).
+  const int64_t OldPcBase = static_cast<int64_t>(Ap.Offset + Ap.Size);
+  const int64_t OldTarget = OldPcBase + OldDelta;
+  const int64_t TextSize = static_cast<int64_t>(Elf.textSize());
+  if (OldTarget < 0 || OldTarget >= TextSize)
+    return false;
+
+  uint64_t NewApOff = 0;
+  uint64_t NewTargetOff = 0;
+  if (!Plan.mapOffset(Ap.Offset, DisplacementMapBias::AfterInsertedBytes,
+                      NewApOff) ||
+      !Plan.mapOffset(static_cast<uint64_t>(OldTarget),
+                      DisplacementMapBias::BeforeInsertedBytes, NewTargetOff))
+    return false;
+  const int64_t NewPcBase =
+      static_cast<int64_t>(NewApOff) + static_cast<int64_t>(Ap.Size);
+  const int64_t NewDelta = static_cast<int64_t>(NewTargetOff) - NewPcBase;
+  if (NewDelta == OldDelta)
+    return true; // both ends shifted equally; original delta still correct
+
+  // Re-encode preserving the lit/lit64 wrapper so the encoded size is unchanged
+  // (same technique as the s_get_pc pair repair).
+  if (!LS.MCIP)
+    return false;
+  SmallString<128> PrintedBuf;
+  raw_svector_ostream PrintOS(PrintedBuf);
+  LS.MCIP->printInst(&Ap.Inst, /*Address=*/0, /*Annot=*/"", *LS.STI, PrintOS);
+  StringRef Printed = StringRef(PrintedBuf).trim();
+  // s_add_pc_i64 has a single operand: "s_add_pc_i64 lit64(0x...)".
+  size_t Space = Printed.find(' ');
+  if (Space == StringRef::npos)
+    return false;
+  StringRef Mnem = Printed.substr(0, Space);
+  StringRef DeltaTok = Printed.substr(Space + 1).trim();
+  std::string Hex =
+      ("0x" + Twine::utohexstr(static_cast<uint64_t>(NewDelta))).str();
+  std::string NewOperand;
+  if (DeltaTok.starts_with("lit64("))
+    NewOperand = "lit64(" + Hex + ")";
+  else if (DeltaTok.starts_with("lit("))
+    NewOperand = "lit(" + Hex + ")";
+  else
+    NewOperand = Hex;
+  std::string NewAsm = (Mnem + " " + NewOperand).str();
+
+  SmallVector<uint8_t> Code = assembleSingleInst(NewAsm, LS);
+  if (Code.size() != Ap.Size) {
+    return makeDisplacementError("s_add_pc_i64 at old .text offset 0x" +
+                                 Twine::utohexstr(Ap.Offset) +
+                                 " changed encoded size during re-encode");
+  }
+  if (NewApOff + Code.size() > NewText.size()) {
+    return makeDisplacementError(
+        "repaired s_add_pc_i64 at old .text offset 0x" +
+        Twine::utohexstr(Ap.Offset) + " writes past rebuilt .text");
+  }
+  std::memcpy(NewText.data() + NewApOff, Code.data(), Code.size());
+  return true;
+}
+
 Error repairBranches(const ElfView &Elf, const LLVMState &LS,
                      const DisplacementPlan &Plan,
+                     const DirectControlFlowInfo &ControlFlow,
                      SmallVectorImpl<uint8_t> &NewText) {
   if (!LS.MIA) {
     return makeDisplacementError(
         "branch analysis through LLVM MC is unavailable");
   }
-
-  std::vector<InternalDecodedInst> Decoded;
-  if (!decodeTextSection(Elf.textData(), Elf.textSize(), LS, Decoded)) {
-    return makeDisplacementError(
-        "failed to decode .text while validating branches");
+  for (uint64_t OldTarget : ControlFlow.Targets) {
+    uint64_t NewTarget = 0;
+    if (!Plan.mapOffset(OldTarget, DisplacementMapBias::BeforeInsertedBytes,
+                        NewTarget))
+      return makeDisplacementError(
+          "linked control-flow target at old .text offset 0x" +
+          Twine::utohexstr(OldTarget) + " maps inside a replaced range");
   }
 
-  for (const InternalDecodedInst &DI : Decoded) {
+  // Stream the whole .text one instruction at a time instead of materializing a
+  // ~1.7M-element decode vector: this validates and repairs branches in a
+  // single pass, examining every instruction in the same order with the same
+  // rejection checks as a full decode would, only without the intermediate
+  // storage. The mnemonic string is skipped (WantMnemonic=false) since it is
+  // read solely by this function's diagnostic paths, which reconstruct it on
+  // demand.
+  std::optional<Error> RepairErr;
+  auto onInst = [&](const InternalDecodedInst &DI) -> bool {
+    if (!DI.DecodeSucceeded) {
+      RepairErr.emplace(makeDisplacementError(
+          "undecodable instruction at old .text offset 0x" +
+          Twine::utohexstr(DI.Offset)));
+      return false;
+    }
     if (Plan.rangeOverlapsReplacement(DI.Offset, DI.Size))
-      continue;
+      return true;
 
     const MCInst &Inst = DI.Inst;
+    if (ControlFlow.RelocatableIndirectTransfers.contains(DI.Offset))
+      return true;
+    // Whole-object displacement can repair an s_get_pc_i64; s_add pair
+    // that computes an absolute address of a global outside .text: the code
+    // moved, so adjust the s_add immediate by -shift. The entry-workaround path
+    // (RelocateTrailingSections=false) keeps the strict reject unchanged. A
+    // pair that does not match the expected form, or whose target is inside
+    // .text, falls through to the strict rejection below (fail-closed).
+    if (Plan.relocatesTrailingSections() &&
+        Inst.getOpcode() == LS.SGetPcI64Opcode) {
+      Expected<bool> RepairedOrErr =
+          repairSGetPcPairForDisplacement(Elf, LS, Plan, DI, NewText);
+      if (!RepairedOrErr) {
+        RepairErr.emplace(RepairedOrErr.takeError());
+        return false;
+      }
+      if (*RepairedOrErr)
+        return true;
+      // Not a repairable pair; fall through to the strict rejection.
+    }
+    // Whole-object displacement can also repair a standalone s_add_pc_i64
+    // (long-forward PC-relative control transfer into .text): remap its delta
+    // so it still reaches the moved target. Entry path keeps the strict reject.
+    if (Plan.relocatesTrailingSections() &&
+        Inst.getOpcode() == LS.SAddPcI64Opcode) {
+      Expected<bool> RepairedOrErr =
+          repairSAddPcForDisplacement(Elf, LS, Plan, DI, NewText);
+      if (!RepairedOrErr) {
+        RepairErr.emplace(RepairedOrErr.takeError());
+        return false;
+      }
+      if (*RepairedOrErr)
+        return true;
+      // Not repairable; fall through to the strict rejection.
+    }
     if (isPcSensitiveForDisplacement(DI, LS)) {
-      return makeDisplacementError(
-          "pc-sensitive instruction '" + Twine(DI.Mnemonic) +
+      // DI.Mnemonic was not populated (WantMnemonic=false above); reconstruct
+      // it here on the cold diagnostic path so the message keeps naming the
+      // offender.
+      StringRef Mnemonic = "<unknown>";
+      if (LS.MCIP) {
+        std::pair<const char *, uint64_t> Mnem = LS.MCIP->getMnemonic(DI.Inst);
+        if (Mnem.first)
+          Mnemonic = StringRef(Mnem.first).rtrim();
+      }
+      RepairErr.emplace(makeDisplacementError(
+          "pc-sensitive instruction '" + Twine(Mnemonic) +
           "' at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
-          " requires linked-address repair");
+          " requires linked-address repair"));
+      return false;
     }
     if (LS.MIA->isCall(Inst)) {
-      return makeDisplacementError("call at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " is not supported by displacement");
+      RepairErr.emplace(makeDisplacementError(
+          "call at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+          " is not supported by displacement"));
+      return false;
     }
     if (LS.MIA->isIndirectBranch(Inst)) {
-      return makeDisplacementError("indirect branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " is not supported by displacement");
+      RepairErr.emplace(makeDisplacementError(
+          "indirect branch at old .text offset 0x" +
+          Twine::utohexstr(DI.Offset) + " is not supported by displacement"));
+      return false;
     }
     if (!LS.MIA->isBranch(Inst))
-      continue;
+      return true;
 
     uint64_t OldTarget = 0;
     if (!LS.MIA->evaluateBranch(Inst, DI.Offset, DI.Size, OldTarget)) {
-      return makeDisplacementError("branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " target could not be evaluated");
+      RepairErr.emplace(makeDisplacementError(
+          "branch at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+          " target could not be evaluated"));
+      return false;
     }
     if (OldTarget >= Elf.textSize()) {
-      return makeDisplacementError("branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " targets outside .text");
+      RepairErr.emplace(makeDisplacementError("branch at old .text offset 0x" +
+                                              Twine::utohexstr(DI.Offset) +
+                                              " targets outside .text"));
+      return false;
     }
 
     uint64_t NewFrom = 0;
     uint64_t NewTarget = 0;
     if (!Plan.mapOffset(DI.Offset, DisplacementMapBias::AfterInsertedBytes,
                         NewFrom)) {
-      return makeDisplacementError("branch source at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " maps inside a replaced range");
+      RepairErr.emplace(makeDisplacementError(
+          "branch source at old .text offset 0x" + Twine::utohexstr(DI.Offset) +
+          " maps inside a replaced range"));
+      return false;
     }
     if (!Plan.mapOffset(OldTarget, DisplacementMapBias::BeforeInsertedBytes,
                         NewTarget)) {
-      return makeDisplacementError("branch target at old .text offset 0x" +
-                                   Twine::utohexstr(OldTarget) +
-                                   " maps inside a replaced range");
+      RepairErr.emplace(makeDisplacementError(
+          "branch target at old .text offset 0x" + Twine::utohexstr(OldTarget) +
+          " maps inside a replaced range"));
+      return false;
     }
 
     Expected<SmallVector<uint8_t>> EncodedOrErr =
         reencodePcrelBranch(DI, NewFrom, NewTarget, LS);
-    if (!EncodedOrErr)
-      return EncodedOrErr.takeError();
+    if (!EncodedOrErr) {
+      RepairErr.emplace(EncodedOrErr.takeError());
+      return false;
+    }
     SmallVector<uint8_t> &Encoded = *EncodedOrErr;
 
     if (NewFrom + Encoded.size() > NewText.size()) {
-      return makeDisplacementError("re-encoded branch at old .text offset 0x" +
-                                   Twine::utohexstr(DI.Offset) +
-                                   " writes past rebuilt .text");
+      RepairErr.emplace(makeDisplacementError(
+          "re-encoded branch at old .text offset 0x" +
+          Twine::utohexstr(DI.Offset) + " writes past rebuilt .text"));
+      return false;
     }
     std::memcpy(NewText.data() + NewFrom, Encoded.data(), Encoded.size());
-  }
+    return true;
+  };
+
+  bool Decoded = decodeTextSectionStreaming(Elf.textData(), Elf.textSize(), LS,
+                                            /*WantMnemonic=*/false, onInst);
+  if (RepairErr)
+    return std::move(*RepairErr);
+  if (!Decoded)
+    return makeDisplacementError(
+        "failed to decode .text while validating branches");
   return Error::success();
 }
 
 Error adjustSectionHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
-                                        const ElfView &OldElf, size_t Growth) {
+                                        const ElfView &OldElf, size_t Growth,
+                                        bool RelocateVAddr) {
   if (ElfSize < sizeof(Ehdr)) {
     return makeDisplacementError(
         "displaced ELF is smaller than its ELF64 header");
@@ -486,13 +1688,30 @@ Error adjustSectionHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
       uint64_t NewOffset = ShOffset + Growth;
       std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
                   sizeof(NewOffset));
+      // Relocate the virtual address of any ALLOCATABLE section after
+      // .text so the grown .text pushes it forward instead of overlapping it.
+      // Non-allocatable sections (.symtab, .strtab, .comment) keep sh_addr 0.
+      if (RelocateVAddr) {
+        uint64_t ShFlags = 0;
+        std::memcpy(&ShFlags, Sh + offsetof(Shdr, sh_flags), sizeof(ShFlags));
+        uint64_t ShAddr = 0;
+        std::memcpy(&ShAddr, Sh + offsetof(Shdr, sh_addr), sizeof(ShAddr));
+        if ((ShFlags & ELF::SHF_ALLOC) && ShAddr >= OldElf.textAddr()) {
+          if (ShAddr > std::numeric_limits<uint64_t>::max() - Growth)
+            return makeDisplacementError(
+                "section virtual address overflows after displacement");
+          uint64_t NewAddr = ShAddr + Growth;
+          std::memcpy(Sh + offsetof(Shdr, sh_addr), &NewAddr, sizeof(NewAddr));
+        }
+      }
     }
   }
   return Error::success();
 }
 
 Error adjustProgramHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
-                                        const ElfView &OldElf, size_t Growth) {
+                                        const ElfView &OldElf, size_t Growth,
+                                        bool RelocateVAddr) {
   if (ElfSize < sizeof(Ehdr)) {
     return makeDisplacementError(
         "displaced ELF is smaller than its ELF64 header");
@@ -540,8 +1759,233 @@ Error adjustProgramHeadersForTextGrowth(uint8_t *Elf, size_t ElfSize,
     } else if (POffset >= TextEnd) {
       POffset += Growth;
       std::memcpy(Ph + offsetof(Phdr, p_offset), &POffset, sizeof(POffset));
+      // Also relocate this segment's virtual/physical address so the
+      // loader maps it past the grown .text instead of on top of it.
+      if (RelocateVAddr) {
+        uint64_t PVaddr = 0, PPaddr = 0;
+        std::memcpy(&PVaddr, Ph + offsetof(Phdr, p_vaddr), sizeof(PVaddr));
+        std::memcpy(&PPaddr, Ph + offsetof(Phdr, p_paddr), sizeof(PPaddr));
+        if (PVaddr > std::numeric_limits<uint64_t>::max() - Growth ||
+            PPaddr > std::numeric_limits<uint64_t>::max() - Growth)
+          return makeDisplacementError(
+              "program-header address overflows after displacement");
+        PVaddr += Growth;
+        PPaddr += Growth;
+        std::memcpy(Ph + offsetof(Phdr, p_vaddr), &PVaddr, sizeof(PVaddr));
+        std::memcpy(Ph + offsetof(Phdr, p_paddr), &PPaddr, sizeof(PPaddr));
+      }
     }
   }
+  return Error::success();
+}
+
+Error adjustElfEntryForDisplacement(uint8_t *Elf, size_t ElfSize,
+                                    const ElfView &OldElf,
+                                    const DisplacementPlan &Plan) {
+  if (ElfSize < sizeof(Ehdr))
+    return makeDisplacementError(
+        "displaced ELF is too small to repair e_entry");
+  const uint64_t OldEntry = OldElf.file().getHeader().e_entry;
+  if (OldEntry == 0)
+    return Error::success();
+  Expected<uint64_t> NewEntryOrErr = remapAllocatedAddress(
+      OldElf, Plan, OldEntry, /*RequireExecutable=*/true, "ELF e_entry");
+  if (!NewEntryOrErr)
+    return NewEntryOrErr.takeError();
+  std::memcpy(Elf + offsetof(Ehdr, e_entry), &*NewEntryOrErr,
+              sizeof(*NewEntryOrErr));
+  return Error::success();
+}
+
+Error adjustDynamicEntriesForDisplacement(uint8_t *Elf, size_t ElfSize,
+                                          const ElfView &OldElf,
+                                          const DisplacementPlan &Plan) {
+  Expected<ELFFileT> FileOrErr =
+      ELFFileT::create(StringRef(reinterpret_cast<const char *>(Elf), ElfSize));
+  if (!FileOrErr)
+    return makeDisplacementError(
+        "failed to parse displaced ELF for dynamic-tag repair: " +
+        Twine(toString(FileOrErr.takeError())));
+  ELFFileT File = std::move(*FileOrErr);
+  Expected<ELFT::DynRange> EntriesOrErr = File.dynamicEntries();
+  if (!EntriesOrErr)
+    return makeDisplacementError(
+        "failed to read dynamic tags during displacement: " +
+        Twine(toString(EntriesOrErr.takeError())));
+
+  for (const ELFT::Dyn &Entry : *EntriesOrErr) {
+    const int64_t Tag = static_cast<int64_t>(Entry.d_tag);
+    DynamicTagClass Class = classifyDynamicTag(Tag);
+    if (Class == DynamicTagClass::Unknown)
+      return makeDisplacementError("unknown dynamic tag 0x" +
+                                   Twine::utohexstr(Entry.d_tag) +
+                                   " may carry an unclassified address");
+    if (Class == DynamicTagClass::UnsupportedAddress)
+      return makeDisplacementError(
+          "dynamic tag 0x" + Twine::utohexstr(Entry.d_tag) +
+          " introduces an unsupported address-bearing construct");
+    if (Entry.d_un.d_val != 0 &&
+        (Tag == ELF::DT_PLTRELSZ || Tag == ELF::DT_PLTREL ||
+         Tag == ELF::DT_INIT_ARRAYSZ || Tag == ELF::DT_FINI_ARRAYSZ ||
+         Tag == ELF::DT_PREINIT_ARRAYSZ || Tag == ELF::DT_RELRSZ ||
+         Tag == ELF::DT_RELRENT))
+      return makeDisplacementError(
+          "dynamic tag enables an unsupported pointer/relocation table");
+    if (Class != DynamicTagClass::Address || Entry.d_un.d_ptr == 0)
+      continue;
+
+    Expected<const ELFT::Shdr *> OwnerOrErr = findUniqueAllocatedSection(
+        OldElf, Entry.d_un.d_ptr, /*RequireExecutable=*/false,
+        "dynamic-tag address");
+    if (!OwnerOrErr)
+      return OwnerOrErr.takeError();
+    if (!dynamicTagMatchesSection(Tag, (**OwnerOrErr).sh_type))
+      return makeDisplacementError(
+          "dynamic tag points to a section of the wrong type");
+    Expected<uint64_t> NewAddressOrErr = remapAllocatedAddress(
+        OldElf, Plan, Entry.d_un.d_ptr, /*RequireExecutable=*/false,
+        "dynamic-tag address");
+    if (!NewAddressOrErr)
+      return NewAddressOrErr.takeError();
+    if (*NewAddressOrErr == Entry.d_un.d_ptr)
+      continue;
+    Expected<uint64_t> EntryOffsetOrErr = getRecordOffset(File, Entry);
+    if (!EntryOffsetOrErr)
+      return EntryOffsetOrErr.takeError();
+    ELFT::Dyn NewEntry = Entry;
+    NewEntry.d_un.d_ptr = *NewAddressOrErr;
+    std::memcpy(Elf + *EntryOffsetOrErr, &NewEntry, sizeof(NewEntry));
+  }
+  return Error::success();
+}
+
+bool isInRelocatedTrailingSection(const ElfView &OldElf, uint64_t VAddr) {
+  const uint64_t OldTextEnd = OldElf.textAddr() + OldElf.textSize();
+  for (const ELFT::Shdr &Shdr : OldElf.sections()) {
+    if (!(Shdr.sh_flags & ELF::SHF_ALLOC) || &Shdr == OldElf.textSection() ||
+        Shdr.sh_size == 0 || Shdr.sh_addr < OldTextEnd)
+      continue;
+    if (VAddr >= Shdr.sh_addr && VAddr - Shdr.sh_addr < Shdr.sh_size)
+      return true;
+  }
+  return false;
+}
+
+/// Repair the two address-bearing fields in dynamic relocation records:
+///
+/// * r_offset is the loader write location. When displacement moves its
+/// allocated
+///   section, the place moves by the padded text growth.
+/// * a symbol-less R_AMDGPU_RELATIVE64 r_addend is a runtime-dereferenced
+///   allocated address. Map it through the same DisplacementPlan used for
+///   branches, symbols, descriptors, and debug information.
+///
+/// This structural rewrite is both smaller and more exact than recovering the
+/// source-level dataflow: hotswap preserves every allocated target exactly
+/// once, so the ELF relocation already supplies all required proof.
+Error adjustRelocationsForDisplacement(uint8_t *Elf, size_t ElfSize,
+                                       const ElfView &OldElf,
+                                       const DisplacementPlan &Plan) {
+  Expected<ELFFileT> FileOrErr =
+      ELFFileT::create(StringRef(reinterpret_cast<const char *>(Elf), ElfSize));
+  if (!FileOrErr) {
+    return makeDisplacementError(
+        "failed to parse displaced ELF for relocation repair: " +
+        Twine(toString(FileOrErr.takeError())));
+  }
+  ELFFileT File = std::move(*FileOrErr);
+
+  Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
+  if (!SectionsOrErr) {
+    return makeDisplacementError(
+        "failed to read displaced ELF sections for relocation repair: " +
+        Twine(toString(SectionsOrErr.takeError())));
+  }
+
+  const bool UsesVirtualRelocationPlaces =
+      OldElf.file().getHeader().e_type != ELF::ET_REL;
+  uint64_t ShiftedPlaces = 0;
+  uint64_t RemappedAddends = 0;
+
+  for (const ELFT::Shdr &RelocShdr : *SectionsOrErr) {
+    if (RelocShdr.sh_type == ELF::SHT_RELA) {
+      Expected<ELFT::RelaRange> RelasOrErr = File.relas(RelocShdr);
+      if (!RelasOrErr) {
+        return makeDisplacementError(
+            "failed to read RELA records during displacement: " +
+            Twine(toString(RelasOrErr.takeError())));
+      }
+      for (const ELFT::Rela &Rela : *RelasOrErr) {
+        ELFT::Rela NewRela = Rela;
+        bool Changed = false;
+
+        if (Plan.relocatesTrailingSections() && UsesVirtualRelocationPlaces &&
+            isInRelocatedTrailingSection(OldElf, NewRela.r_offset)) {
+          if (NewRela.r_offset >
+              std::numeric_limits<uint64_t>::max() - Plan.paddedGrowth())
+            return makeDisplacementError(
+                "relocation place overflows after displacement");
+          NewRela.r_offset += Plan.paddedGrowth();
+          Changed = true;
+          ++ShiftedPlaces;
+        }
+
+        if (NewRela.getSymbol(false) == 0 &&
+            NewRela.getType(false) == ELF::R_AMDGPU_RELATIVE64) {
+          const uint64_t Addend = static_cast<uint64_t>(NewRela.r_addend);
+          Expected<uint64_t> NewAddendOrErr = remapLoadAddress(
+              OldElf, Plan, Addend, "R_AMDGPU_RELATIVE64 addend");
+          if (!NewAddendOrErr)
+            return NewAddendOrErr.takeError();
+          if (*NewAddendOrErr != Addend) {
+            static_assert(sizeof(NewRela.r_addend) == sizeof(*NewAddendOrErr));
+            std::memcpy(&NewRela.r_addend, &*NewAddendOrErr,
+                        sizeof(NewRela.r_addend));
+            Changed = true;
+            ++RemappedAddends;
+          }
+        }
+
+        if (!Changed)
+          continue;
+        Expected<uint64_t> OffsetOrErr = getRecordOffset(File, Rela);
+        if (!OffsetOrErr)
+          return OffsetOrErr.takeError();
+        std::memcpy(Elf + *OffsetOrErr, &NewRela, sizeof(NewRela));
+      }
+      continue;
+    }
+
+    if (RelocShdr.sh_type != ELF::SHT_REL ||
+        !Plan.relocatesTrailingSections() || !UsesVirtualRelocationPlaces)
+      continue;
+    Expected<ELFT::RelRange> RelsOrErr = File.rels(RelocShdr);
+    if (!RelsOrErr) {
+      return makeDisplacementError(
+          "failed to read REL records during displacement: " +
+          Twine(toString(RelsOrErr.takeError())));
+    }
+    for (const ELFT::Rel &Rel : *RelsOrErr) {
+      if (!isInRelocatedTrailingSection(OldElf, Rel.r_offset))
+        continue;
+      if (Rel.r_offset >
+          std::numeric_limits<uint64_t>::max() - Plan.paddedGrowth())
+        return makeDisplacementError(
+            "relocation place overflows after displacement");
+      ELFT::Rel NewRel = Rel;
+      NewRel.r_offset += Plan.paddedGrowth();
+      Expected<uint64_t> OffsetOrErr = getRecordOffset(File, Rel);
+      if (!OffsetOrErr)
+        return OffsetOrErr.takeError();
+      std::memcpy(Elf + *OffsetOrErr, &NewRel, sizeof(NewRel));
+      ++ShiftedPlaces;
+    }
+  }
+
+  if (ShiftedPlaces != 0 || RemappedAddends != 0)
+    log() << "hotswap: displacement: shifted " << ShiftedPlaces
+          << " relocation place(s), remapped " << RemappedAddends
+          << " R_AMDGPU_RELATIVE64 code pointer(s)\n";
   return Error::success();
 }
 
@@ -646,12 +2090,29 @@ Error adjustSymbolValuesForDisplacement(uint8_t *Elf, size_t ElfSize,
         continue;
       }
 
-      // Existing non-text virtual addresses are immutable. Fully linked AMDGPU
-      // code objects contain baked address materializations with no
-      // relocations; moving the target symbol would silently retarget those
-      // instructions.
-      // ElfView.GrowWithTrampolinesKeepsIsaReferenceConsistentWithSymbol
-      // demonstrates the linked-address dependency.
+      // Whole-object displacement moves every allocated section after .text as
+      // one unit. Keep its symbols attached to the same section-relative byte.
+      // PC-relative code references are repaired separately from their original
+      // target address; relocation-backed references observe this updated
+      // symbol value.
+      if (Plan.relocatesTrailingSections() &&
+          OldElf.file().getHeader().e_type != ELF::ET_REL &&
+          Sym.st_shndx < OldElf.sections().size()) {
+        const ELFT::Shdr &OldDefShdr = OldElf.sections()[Sym.st_shndx];
+        const uint64_t OldTextEnd = OldElf.textAddr() + OldElf.textSize();
+        if ((OldDefShdr.sh_flags & ELF::SHF_ALLOC) &&
+            OldDefShdr.sh_addr >= OldTextEnd &&
+            Sym.st_value >= OldDefShdr.sh_addr &&
+            Sym.st_value - OldDefShdr.sh_addr <= OldDefShdr.sh_size) {
+          if (Sym.st_value >
+              std::numeric_limits<uint64_t>::max() - Plan.paddedGrowth())
+            return makeDisplacementError(
+                "non-text symbol value overflows after displacement");
+          const uint64_t NewValue = Sym.st_value + Plan.paddedGrowth();
+          std::memcpy(Elf + SymOffset + offsetof(ELFT::Sym, st_value),
+                      &NewValue, sizeof(NewValue));
+        }
+      }
     }
   }
   return Error::success();
@@ -718,8 +2179,1225 @@ Error rewriteKernelDescriptorEntriesForDisplacement(
   return Error::success();
 }
 
+// Locate a section by name in the OLD ELF's section table. Debug sections sit
+// AFTER .text, so their bytes in the grown OUTPUT buffer live at
+// OLD sh_offset + paddedGrowth (the apply step copied the whole trailing region
+// forward). Callers apply that shift when addressing the output; this helper
+// only resolves the header.
+const ELFT::Shdr *findSectionByName(const ElfView &Elf, StringRef Want) {
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr) {
+      consumeError(NameOrErr.takeError());
+      return nullptr;
+    }
+    if (*NameOrErr == Want)
+      return &Shdr;
+  }
+  return nullptr;
+}
+
+// Map an absolute .text virtual address through the displacement plan. Objects
+// that carry DWARF use vaddr == textAddr + offset in .text; addresses outside
+// [textAddr, textEnd] pass through unchanged. An address at exactly textEnd
+// maps to textEnd + paddedGrowth (the whole trailing region shifts). \p Bias
+// selects the boundary rule at an inserted-bytes edge (BeforeInsertedBytes for
+// the low end of a range, so the start of a patched instruction stays put; the
+// high end also uses BeforeInsertedBytes so a range that ends at a patch
+// boundary keeps its end pinned to that instruction). Returns false only on
+// internal mapOffset failure (address lands inside a replaced instruction),
+// which is a genuine corruption signal for the caller to fail closed on.
+bool mapTextVAddr(const ElfView &Elf, const DisplacementPlan &Plan,
+                  uint64_t OldVAddr, uint64_t &NewVAddr) {
+  const uint64_t TextAddr = Elf.textAddr();
+  const uint64_t TextEnd = TextAddr + Elf.textSize();
+  if (OldVAddr < TextAddr || OldVAddr > TextEnd) {
+    NewVAddr = OldVAddr;
+    return true;
+  }
+  uint64_t NewOff = 0;
+  if (!Plan.mapOffset(OldVAddr - TextAddr,
+                      DisplacementMapBias::BeforeInsertedBytes, NewOff))
+    return false;
+  NewVAddr = TextAddr + NewOff;
+  return true;
+}
+
+/// Remap the single FDE-per-object `.debug_frame`. Unlike `.eh_frame`,
+/// `.debug_frame` addresses are ABSOLUTE: an FDE stores initial_location and
+/// address_range as target-sized (8-byte) values. CIE vs FDE is distinguished
+/// by the CIE id field: 0xffffffff (DW_CIE_ID for 32-bit DWARF) marks a CIE.
+/// For each FDE describing .text, remap initial_location via the plan and
+/// recompute address_range = mapped_end - mapped_start. Fails closed on 64-bit
+/// DWARF, non-8-byte addresses, or a record that overruns the section.
+Error remapDebugFrameForDisplacement(const ElfView &Elf,
+                                     const DisplacementPlan &Plan,
+                                     uint8_t *Base, uint64_t Size) {
+  auto readU32 = [&](uint64_t Off) -> uint32_t {
+    uint32_t V;
+    std::memcpy(&V, Base + Off, sizeof(V));
+    return V;
+  };
+  auto readU64 = [&](uint64_t Off) -> uint64_t {
+    uint64_t V;
+    std::memcpy(&V, Base + Off, sizeof(V));
+    return V;
+  };
+  auto writeU64 = [&](uint64_t Off, uint64_t V) {
+    std::memcpy(Base + Off, &V, sizeof(V));
+  };
+
+  const uint64_t TextAddr = Elf.textAddr();
+  const uint64_t TextEnd = TextAddr + Elf.textSize();
+  uint64_t Pos = 0;
+  uint32_t Remapped = 0;
+  while (Pos + 4 <= Size) {
+    const uint32_t Length = readU32(Pos);
+    if (Length == 0)
+      break; // terminator
+    if (Length == 0xffffffffu)
+      return makeDisplacementError(
+          ".debug_frame uses 64-bit DWARF (unsupported)");
+    const uint64_t RecordStart = Pos;
+    const uint64_t RecordEnd = Pos + 4 + Length;
+    if (RecordEnd > Size || RecordStart + 8 > Size)
+      return makeDisplacementError(".debug_frame record overruns section");
+    const uint32_t CieId = readU32(RecordStart + 4);
+    if (CieId == dwarf::DW_CIE_ID) {
+      Pos = RecordEnd; // CIE: no addresses to remap
+      continue;
+    }
+    // FDE: initial_location (8) then address_range (8) follow the CIE pointer.
+    const uint64_t LocOff = RecordStart + 8;
+    const uint64_t RangeOff = RecordStart + 16;
+    if (RangeOff + 8 > RecordEnd)
+      return makeDisplacementError(".debug_frame FDE is truncated");
+    const uint64_t OldStart = readU64(LocOff);
+    const uint64_t OldRange = readU64(RangeOff);
+    if (OldStart < TextAddr || OldStart >= TextEnd) {
+      Pos = RecordEnd; // FDE does not describe .text
+      continue;
+    }
+    if (OldStart + OldRange < OldStart || OldStart + OldRange > TextEnd)
+      return makeDisplacementError(".debug_frame FDE range leaves .text");
+    uint64_t NewStart = 0, NewEnd = 0;
+    if (!mapTextVAddr(Elf, Plan, OldStart, NewStart) ||
+        !mapTextVAddr(Elf, Plan, OldStart + OldRange, NewEnd) ||
+        NewEnd < NewStart)
+      return makeDisplacementError(".debug_frame FDE cannot be remapped");
+    writeU64(LocOff, NewStart);
+    writeU64(RangeOff, NewEnd - NewStart);
+    ++Remapped;
+    Pos = RecordEnd;
+  }
+  log() << "hotswap: displacement: remapped " << Remapped
+        << " .debug_frame FDE(s)\n";
+  return Error::success();
+}
+
+/// Remap `.debug_ranges`. Each compile unit's list is a sequence of (start,end)
+/// address pairs. A (0,0) pair terminates a list. A base-address-selection
+/// entry has start == 0xffffffffffffffff and sets the base for subsequent
+/// entries; this object emits none (verified: no 0xff..ff entries) and
+/// dwarfdump shows the pairs are offsets from the CU's DW_AT_low_pc. We
+/// therefore treat each nonzero pair value as (Base + stored) to recover the
+/// absolute .text address, remap that, and write back (new_absolute - Base). \p
+/// Base is the CU low_pc, which is unchanged here (it precedes all patches), so
+/// this is exact. Fails closed if a base-selection entry appears (we do not
+/// track multiple bases).
+Error remapDebugRangesForDisplacement(const ElfView &Elf,
+                                      const DisplacementPlan &Plan,
+                                      uint8_t *SecBase, uint64_t Size,
+                                      uint64_t CuBase) {
+  auto readU64 = [&](uint64_t Off) -> uint64_t {
+    uint64_t V;
+    std::memcpy(&V, SecBase + Off, sizeof(V));
+    return V;
+  };
+  auto writeU64 = [&](uint64_t Off, uint64_t V) {
+    std::memcpy(SecBase + Off, &V, sizeof(V));
+  };
+
+  uint64_t Pos = 0;
+  uint32_t Remapped = 0;
+  while (Pos + 16 <= Size) {
+    const uint64_t Start = readU64(Pos);
+    const uint64_t End = readU64(Pos + 8);
+    if (Start == 0 && End == 0) {
+      Pos += 16; // end-of-list terminator; keep scanning for the next CU list
+      continue;
+    }
+    if (Start == std::numeric_limits<uint64_t>::max())
+      return makeDisplacementError(
+          ".debug_ranges base-address selection is unsupported");
+    // Reconstruct absolute .text addresses, remap, and re-encode as offsets
+    // from the (unchanged) CU base.
+    const uint64_t OldStartAbs = CuBase + Start;
+    const uint64_t OldEndAbs = CuBase + End;
+    uint64_t NewStartAbs = 0, NewEndAbs = 0;
+    if (!mapTextVAddr(Elf, Plan, OldStartAbs, NewStartAbs) ||
+        !mapTextVAddr(Elf, Plan, OldEndAbs, NewEndAbs) ||
+        NewEndAbs < NewStartAbs || NewStartAbs < CuBase || NewEndAbs < CuBase)
+      return makeDisplacementError(".debug_ranges entry cannot be remapped");
+    writeU64(Pos, NewStartAbs - CuBase);
+    writeU64(Pos + 8, NewEndAbs - CuBase);
+    ++Remapped;
+    Pos += 16;
+  }
+  log() << "hotswap: displacement: remapped " << Remapped
+        << " .debug_ranges entr(ies)\n";
+  return Error::success();
+}
+
+// One attribute (attr, form) from a .debug_abbrev declaration.
+struct AbbrevAttr {
+  uint64_t Attr = 0;
+  uint64_t Form = 0;
+  int64_t ImplicitConst = 0; // only for DW_FORM_implicit_const
+};
+// One abbreviation declaration: its tag/children and attribute list.
+struct AbbrevDecl {
+  bool HasChildren = false;
+  SmallVector<AbbrevAttr, 8> Attrs;
+};
+
+// Parse the .debug_abbrev table starting at \p Off into a code -> declaration
+// map. Only the fields the DIE walker needs are retained. Fails closed on a
+// truncated table.
+Expected<DenseMap<uint64_t, AbbrevDecl>>
+parseAbbrevTable(const uint8_t *Base, uint64_t Size, uint64_t Off) {
+  DenseMap<uint64_t, AbbrevDecl> Table;
+  const uint8_t *P = Base + Off;
+  const uint8_t *End = Base + Size;
+  while (P < End) {
+    unsigned N = 0;
+    uint64_t Code = decodeULEB128(P, &N, End);
+    P += N;
+    if (Code == 0)
+      break; // end of this abbrev table
+    if (P >= End)
+      return makeDisplacementError(".debug_abbrev declaration is truncated");
+    uint64_t Tag = decodeULEB128(P, &N, End);
+    (void)Tag;
+    P += N;
+    if (P >= End)
+      return makeDisplacementError(".debug_abbrev declaration is truncated");
+    AbbrevDecl Decl;
+    Decl.HasChildren = (*P != 0);
+    ++P;
+    while (P < End) {
+      uint64_t Attr = decodeULEB128(P, &N, End);
+      P += N;
+      uint64_t Form = decodeULEB128(P, &N, End);
+      P += N;
+      if (Attr == 0 && Form == 0)
+        break; // end of attribute list
+      AbbrevAttr A;
+      A.Attr = Attr;
+      A.Form = Form;
+      if (Form == dwarf::DW_FORM_implicit_const) {
+        A.ImplicitConst = decodeSLEB128(P, &N, End);
+        P += N;
+      }
+      Decl.Attrs.push_back(A);
+    }
+    Table[Code] = std::move(Decl);
+  }
+  return Table;
+}
+
+// Advance \p P past a single attribute value of \p Form in a DWARF32 unit
+// bounded by \p UnitEnd. Handles the fixed-size forms via getFixedFormByteSize
+// and the variable-length forms (LEB128, counted blocks, inline strings) by
+// hand. Fails closed on any form whose size we cannot determine so we never
+// desynchronize the DIE walk and miswrite a later low_pc/high_pc.
+Error skipFormValue(const uint8_t *Base, uint64_t &P, uint64_t UnitEnd,
+                    uint64_t Form, int64_t ImplicitConst,
+                    const dwarf::FormParams &FP) {
+  const uint8_t *End = Base + UnitEnd;
+  auto need = [&](uint64_t N) -> Error {
+    if (N > UnitEnd - P)
+      return makeDisplacementError(".debug_info attribute overruns unit");
+    return Error::success();
+  };
+  switch (Form) {
+  case dwarf::DW_FORM_implicit_const:
+  case dwarf::DW_FORM_flag_present:
+    (void)ImplicitConst;
+    return Error::success(); // no bytes in the DIE
+  case dwarf::DW_FORM_udata:
+  case dwarf::DW_FORM_ref_udata:
+  case dwarf::DW_FORM_strx:
+  case dwarf::DW_FORM_addrx:
+  case dwarf::DW_FORM_loclistx:
+  case dwarf::DW_FORM_rnglistx:
+  case dwarf::DW_FORM_GNU_str_index:
+  case dwarf::DW_FORM_GNU_addr_index: {
+    unsigned N = 0;
+    decodeULEB128(Base + P, &N, End);
+    P += N;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_sdata: {
+    unsigned N = 0;
+    decodeSLEB128(Base + P, &N, End);
+    P += N;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_string: {
+    while (P < UnitEnd && Base[P] != 0)
+      ++P;
+    if (P >= UnitEnd)
+      return makeDisplacementError(".debug_info inline string is unterminated");
+    ++P; // consume NUL
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block1: {
+    if (Error E = need(1))
+      return E;
+    uint64_t Len = Base[P];
+    ++P;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block2: {
+    if (Error E = need(2))
+      return E;
+    uint16_t Len = 0;
+    std::memcpy(&Len, Base + P, 2);
+    P += 2;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block4: {
+    if (Error E = need(4))
+      return E;
+    uint32_t Len = 0;
+    std::memcpy(&Len, Base + P, 4);
+    P += 4;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  case dwarf::DW_FORM_block:
+  case dwarf::DW_FORM_exprloc: {
+    unsigned N = 0;
+    uint64_t Len = decodeULEB128(Base + P, &N, End);
+    P += N;
+    if (Error E = need(Len))
+      return E;
+    P += Len;
+    return Error::success();
+  }
+  default:
+    break;
+  }
+  std::optional<uint8_t> FS =
+      dwarf::getFixedFormByteSize(static_cast<dwarf::Form>(Form), FP);
+  if (!FS)
+    return makeDisplacementError(".debug_info uses an unsupported form " +
+                                 Twine(Form));
+  if (Error E = need(*FS))
+    return E;
+  P += *FS;
+  return Error::success();
+}
+
+/// Remap the CU's `DW_AT_low_pc`/`DW_AT_high_pc` in `.debug_info`. We parse the
+/// matching `.debug_abbrev` table to learn each attribute's form so we know the
+/// exact byte layout: low_pc is DW_FORM_addr (absolute) and high_pc is either
+/// DW_FORM_addr (absolute) or a DW_FORM_data* constant that encodes an OFFSET
+/// from low_pc. For this object low_pc is DW_FORM_addr and high_pc is
+/// DW_FORM_data4 (verified via .debug_abbrev). Remapping rule (general):
+/// new_high = mapOffset(low_off + high) - mapOffset(low_off), so a data-form
+/// high_pc grows only by the shift its range end crosses; an absolute-form
+/// high_pc is remapped directly; a low_pc that also moved is handled by
+/// remapping it too. Every other attribute is skipped using its form's fixed
+/// byte size (getFixedFormByteSize) or its LEB/block/string length. Fails
+/// closed on DWARF64, addr_size != 8, an abbrev code with no declaration, or a
+/// form whose length we cannot determine.
+Error remapDebugInfoForDisplacement(const ElfView &Elf,
+                                    const DisplacementPlan &Plan,
+                                    uint8_t *InfoBase, uint64_t InfoSize,
+                                    const uint8_t *AbbrevBase,
+                                    uint64_t AbbrevSize) {
+  auto readU32 = [&](uint64_t Off) -> uint32_t {
+    uint32_t V;
+    std::memcpy(&V, InfoBase + Off, sizeof(V));
+    return V;
+  };
+  auto readU16 = [&](uint64_t Off) -> uint16_t {
+    uint16_t V;
+    std::memcpy(&V, InfoBase + Off, sizeof(V));
+    return V;
+  };
+
+  uint64_t Pos = 0;
+  uint32_t RemappedLow = 0, RemappedHigh = 0;
+  while (Pos + 4 <= InfoSize) {
+    const uint32_t UnitLength = readU32(Pos);
+    if (UnitLength == 0)
+      break;
+    if (UnitLength == 0xffffffffu)
+      return makeDisplacementError(
+          ".debug_info uses 64-bit DWARF (unsupported)");
+    const uint64_t UnitStart = Pos;
+    const uint64_t UnitEnd = Pos + 4 + UnitLength;
+    if (UnitEnd > InfoSize)
+      return makeDisplacementError(".debug_info unit overruns section");
+    uint64_t P = UnitStart + 4;
+    const uint16_t Version = readU16(P);
+    P += 2;
+    if (Version < 2 || Version > 4)
+      return makeDisplacementError(".debug_info version " + Twine(Version) +
+                                   " is unsupported");
+    // DWARF v2-v4 CU header: version, abbrev_offset (sec_offset), addr_size.
+    const uint32_t AbbrevOff = readU32(P);
+    P += 4;
+    const uint8_t AddrSize = InfoBase[P];
+    P += 1;
+    if (AddrSize != 8)
+      return makeDisplacementError(".debug_info addr_size != 8 is unsupported");
+
+    Expected<DenseMap<uint64_t, AbbrevDecl>> TableOrErr =
+        parseAbbrevTable(AbbrevBase, AbbrevSize, AbbrevOff);
+    if (!TableOrErr)
+      return TableOrErr.takeError();
+    const DenseMap<uint64_t, AbbrevDecl> &Table = *TableOrErr;
+
+    dwarf::FormParams FP;
+    FP.Version = Version;
+    FP.AddrSize = AddrSize;
+    FP.Format = dwarf::DWARF32;
+
+    // Walk DIEs. We only rewrite low_pc/high_pc; all other attributes are
+    // skipped by size. low_pc is captured per-DIE so a sibling high_pc data
+    // form is interpreted relative to the correct low_pc.
+    const uint8_t *End = InfoBase + UnitEnd;
+    while (P < UnitEnd) {
+      unsigned N = 0;
+      uint64_t Code = decodeULEB128(InfoBase + P, &N, End);
+      P += N;
+      if (Code == 0)
+        continue; // null DIE (end of siblings)
+      DenseMap<uint64_t, AbbrevDecl>::const_iterator It = Table.find(Code);
+      if (It == Table.end())
+        return makeDisplacementError(
+            ".debug_info references unknown abbrev code");
+      const AbbrevDecl &Decl = It->second;
+
+      bool HaveLow = false;
+      uint64_t LowVAddr = 0;
+      uint64_t LowOff = 0; // .text offset of low_pc
+      for (const AbbrevAttr &A : Decl.Attrs) {
+        if (A.Attr == dwarf::DW_AT_low_pc) {
+          if (A.Form != dwarf::DW_FORM_addr)
+            return makeDisplacementError(
+                "DW_AT_low_pc uses an unsupported form");
+          uint64_t Old = 0;
+          std::memcpy(&Old, InfoBase + P, sizeof(Old));
+          uint64_t New = 0;
+          if (!mapTextVAddr(Elf, Plan, Old, New))
+            return makeDisplacementError("DW_AT_low_pc cannot be remapped");
+          std::memcpy(InfoBase + P, &New, sizeof(New));
+          HaveLow = Old >= Elf.textAddr();
+          LowVAddr = Old;
+          LowOff = (Old >= Elf.textAddr()) ? Old - Elf.textAddr() : 0;
+          ++RemappedLow;
+          P += 8;
+          continue;
+        }
+        if (A.Attr == dwarf::DW_AT_high_pc) {
+          if (A.Form == dwarf::DW_FORM_addr) {
+            uint64_t Old = 0;
+            std::memcpy(&Old, InfoBase + P, sizeof(Old));
+            uint64_t New = 0;
+            if (!mapTextVAddr(Elf, Plan, Old, New))
+              return makeDisplacementError(
+                  "DW_AT_high_pc (addr) cannot be remapped");
+            std::memcpy(InfoBase + P, &New, sizeof(New));
+            ++RemappedHigh;
+            P += 8;
+            continue;
+          }
+          // Data forms encode an OFFSET from low_pc. Grow it by the shift its
+          // range end crosses: new = map(low_off + old) - map(low_off).
+          std::optional<uint8_t> FS =
+              dwarf::getFixedFormByteSize(static_cast<dwarf::Form>(A.Form), FP);
+          if (!FS || (*FS != 1 && *FS != 2 && *FS != 4 && *FS != 8))
+            return makeDisplacementError(
+                "DW_AT_high_pc uses an unsupported data form");
+          if (!HaveLow)
+            return makeDisplacementError(
+                "DW_AT_high_pc data form without a .text low_pc");
+          uint64_t OldHigh = 0;
+          std::memcpy(&OldHigh, InfoBase + P, *FS);
+          uint64_t NewLowOff = 0, NewEndOff = 0;
+          if (!Plan.mapOffset(LowOff, DisplacementMapBias::BeforeInsertedBytes,
+                              NewLowOff) ||
+              !Plan.mapOffset(LowOff + OldHigh,
+                              DisplacementMapBias::BeforeInsertedBytes,
+                              NewEndOff) ||
+              NewEndOff < NewLowOff)
+            return makeDisplacementError(
+                "DW_AT_high_pc (data) cannot be remapped");
+          uint64_t NewHigh = NewEndOff - NewLowOff;
+          uint64_t Limit = (*FS == 8) ? std::numeric_limits<uint64_t>::max()
+                                      : ((uint64_t(1) << (*FS * 8)) - 1);
+          if (NewHigh > Limit)
+            return makeDisplacementError(
+                "DW_AT_high_pc overflows its data form");
+          std::memcpy(InfoBase + P, &NewHigh, *FS);
+          (void)LowVAddr;
+          ++RemappedHigh;
+          P += *FS;
+          continue;
+        }
+        // Any other attribute: advance past its encoded value.
+        if (Error Err = skipFormValue(InfoBase, P, UnitEnd, A.Form,
+                                      A.ImplicitConst, FP))
+          return Err;
+      }
+    }
+    Pos = UnitEnd;
+  }
+  log() << "hotswap: displacement: remapped " << RemappedLow << " low_pc and "
+        << RemappedHigh << " high_pc in .debug_info\n";
+  return Error::success();
+}
+
+/// Remap the FDEs in the displaced output's `.eh_frame` so each still describes
+/// its kernel after displacement. This object's FDEs are per-kernel with a
+/// `"zR"` CIE using DW_EH_PE_pcrel|sdata4 for initial_location: the target is
+/// `field_vaddr + sdata4`. For each FDE:
+///   - initial_location: recompute sdata4 = new_entry_vaddr - field_vaddr,
+///     where new_entry_vaddr = textAddr + mapOffset(old_entry - textAddr).
+///   - address_range (u32 length): += growth of that kernel, i.e.
+///     mapOffset(old_end) - mapOffset(old_entry) - old_range.
+/// .eh_frame sits before .text and is not itself moved, so field_vaddr is
+/// unchanged. Only the pcrel encoding (0x1b) is handled; any other CIE
+/// augmentation/encoding is rejected so we never silently miswrite unwind data.
+Error remapEhFrameForDisplacement(const ElfView &OldElf,
+                                  const DisplacementPlan &Plan,
+                                  WritableMemoryBuffer &OutBuf) {
+  // Locate .eh_frame in the OLD ELF (section table not yet reparsed on Out; its
+  // file offset in Out is identical because .eh_frame precedes .text).
+  const ELFT::Shdr *EhShdr = nullptr;
+  uint64_t EhVAddr = 0;
+  for (const ELFT::Shdr &Shdr : OldElf.sections()) {
+    Expected<StringRef> NameOrErr = OldElf.file().getSectionName(Shdr);
+    if (!NameOrErr)
+      return makeDisplacementError("failed to read section name for .eh_frame");
+    if (*NameOrErr == ".eh_frame") {
+      EhShdr = &Shdr;
+      EhVAddr = Shdr.sh_addr;
+      break;
+    }
+  }
+  if (!EhShdr)
+    return Error::success(); // no unwind tables to fix
+
+  if (EhShdr->sh_offset > OutBuf.getBufferSize() ||
+      EhShdr->sh_size > OutBuf.getBufferSize() - EhShdr->sh_offset)
+    return makeDisplacementError(".eh_frame is out of bounds in displaced ELF");
+  uint8_t *Base =
+      reinterpret_cast<uint8_t *>(OutBuf.getBufferStart()) + EhShdr->sh_offset;
+  const uint64_t Size = EhShdr->sh_size;
+  const uint64_t OldTextEnd = OldElf.textAddr() + OldElf.textSize();
+
+  auto readU32 = [&](uint64_t Off) -> uint32_t {
+    uint32_t V;
+    std::memcpy(&V, Base + Off, sizeof(V));
+    return V;
+  };
+  auto writeU32 = [&](uint64_t Off, uint32_t V) {
+    std::memcpy(Base + Off, &V, sizeof(V));
+  };
+
+  uint64_t Pos = 0;
+  uint32_t Remapped = 0;
+  while (Pos + 8 <= Size) {
+    const uint32_t Length = readU32(Pos);
+    if (Length == 0)
+      break; // terminator
+    if (Length == 0xffffffffu)
+      return makeDisplacementError(".eh_frame uses 64-bit DWARF (unsupported)");
+    const uint64_t RecordStart = Pos;
+    const uint64_t RecordEnd = Pos + 4 + Length;
+    if (RecordEnd > Size)
+      return makeDisplacementError(".eh_frame record overruns section");
+    const uint32_t CiePtr = readU32(Pos + 4);
+    if (CiePtr == 0) {
+      // CIE: skip (we assume the single pcrel|sdata4 CIE this compiler emits).
+      Pos = RecordEnd;
+      continue;
+    }
+    // FDE. initial_location is the 4-byte field at RecordStart+8.
+    const uint64_t LocFieldOff = RecordStart + 8;
+    const uint64_t RangeFieldOff = RecordStart + 12;
+    const uint64_t LocFieldVAddr = EhVAddr + LocFieldOff;
+    const int32_t StoredLoc = static_cast<int32_t>(readU32(LocFieldOff));
+    const uint64_t OldTarget =
+        static_cast<uint64_t>(static_cast<int64_t>(LocFieldVAddr) + StoredLoc);
+    const uint32_t OldRange = readU32(RangeFieldOff);
+
+    if (OldTarget < OldElf.textAddr() || OldTarget >= OldTextEnd) {
+      // FDE does not describe .text (unexpected here); leave it untouched.
+      Pos = RecordEnd;
+      continue;
+    }
+    const uint64_t OldStartOff = OldTarget - OldElf.textAddr();
+    const uint64_t OldEndOff = OldStartOff + OldRange;
+    uint64_t NewStartOff = 0, NewEndOff = 0;
+    if (!Plan.mapOffset(OldStartOff, DisplacementMapBias::BeforeInsertedBytes,
+                        NewStartOff) ||
+        !Plan.mapOffset(OldEndOff, DisplacementMapBias::BeforeInsertedBytes,
+                        NewEndOff) ||
+        NewEndOff < NewStartOff)
+      return makeDisplacementError(".eh_frame FDE range cannot be remapped");
+
+    const uint64_t NewTargetVAddr = OldElf.textAddr() + NewStartOff;
+    const int64_t NewStoredLoc = static_cast<int64_t>(NewTargetVAddr) -
+                                 static_cast<int64_t>(LocFieldVAddr);
+    if (NewStoredLoc < std::numeric_limits<int32_t>::min() ||
+        NewStoredLoc > std::numeric_limits<int32_t>::max())
+      return makeDisplacementError(".eh_frame FDE pcrel offset overflows i32");
+    const uint64_t NewRange = NewEndOff - NewStartOff;
+    if (NewRange > std::numeric_limits<uint32_t>::max())
+      return makeDisplacementError(".eh_frame FDE range overflows u32");
+
+    writeU32(LocFieldOff, static_cast<uint32_t>(NewStoredLoc));
+    writeU32(RangeFieldOff, static_cast<uint32_t>(NewRange));
+    ++Remapped;
+    Pos = RecordEnd;
+  }
+  log() << "hotswap: displacement: remapped " << Remapped
+        << " .eh_frame FDE(s)\n";
+  return Error::success();
+}
+
+// Read the CU's DW_AT_low_pc from the OLD .debug_info to use as the
+// .debug_ranges base. low_pc is the first DW_FORM_addr after the CU header in
+// abbrev-code-1 (compile_unit); we resolve it via the abbrev table rather than
+// assuming a byte offset. Returns the low_pc, or std::nullopt if the CU has no
+// .text low_pc (in which case .debug_ranges has nothing to rebase).
+Expected<std::optional<uint64_t>> readCuLowPc(const uint8_t *InfoBase,
+                                              uint64_t InfoSize,
+                                              const uint8_t *AbbrevBase,
+                                              uint64_t AbbrevSize) {
+  if (InfoSize < 11)
+    return std::optional<uint64_t>();
+  uint32_t UnitLength = 0;
+  std::memcpy(&UnitLength, InfoBase, 4);
+  if (UnitLength == 0xffffffffu)
+    return makeDisplacementError(".debug_info uses 64-bit DWARF (unsupported)");
+  uint16_t Version = 0;
+  std::memcpy(&Version, InfoBase + 4, 2);
+  if (Version < 2 || Version > 4)
+    return makeDisplacementError(".debug_info version is unsupported");
+  uint32_t AbbrevOff = 0;
+  std::memcpy(&AbbrevOff, InfoBase + 6, 4);
+  uint8_t AddrSize = InfoBase[10];
+  if (AddrSize != 8)
+    return makeDisplacementError(".debug_info addr_size != 8 is unsupported");
+
+  Expected<DenseMap<uint64_t, AbbrevDecl>> TableOrErr =
+      parseAbbrevTable(AbbrevBase, AbbrevSize, AbbrevOff);
+  if (!TableOrErr)
+    return TableOrErr.takeError();
+  const uint64_t UnitEnd = 4 + UnitLength;
+  const uint8_t *End = InfoBase + std::min<uint64_t>(UnitEnd, InfoSize);
+  uint64_t P = 11;
+  unsigned N = 0;
+  uint64_t Code = decodeULEB128(InfoBase + P, &N, End);
+  P += N;
+  DenseMap<uint64_t, AbbrevDecl>::const_iterator It = TableOrErr->find(Code);
+  if (It == TableOrErr->end())
+    return makeDisplacementError(
+        ".debug_info root DIE has unknown abbrev code");
+  dwarf::FormParams FP;
+  FP.Version = Version;
+  FP.AddrSize = AddrSize;
+  FP.Format = dwarf::DWARF32;
+  for (const AbbrevAttr &A : It->second.Attrs) {
+    if (A.Attr == dwarf::DW_AT_low_pc && A.Form == dwarf::DW_FORM_addr) {
+      uint64_t Low = 0;
+      std::memcpy(&Low, InfoBase + P, sizeof(Low));
+      return std::optional<uint64_t>(Low);
+    }
+    if (Error Err =
+            skipFormValue(InfoBase, P, UnitEnd, A.Form, A.ImplicitConst, FP))
+      return std::move(Err);
+  }
+  return std::optional<uint64_t>();
+}
+
+// Locate a debug section in the OUTPUT buffer and hand back a writable pointer
+// plus size. Debug sections follow .text, so their output bytes live at
+// OLD sh_offset + Growth. Returns nullptr Base (with success) when the section
+// is absent.
+Error locateOutputDebugSection(const ElfView &OldElf,
+                               WritableMemoryBuffer &OutBuf, uint64_t Growth,
+                               StringRef Name, uint8_t *&Base, uint64_t &Size) {
+  Base = nullptr;
+  Size = 0;
+  const ELFT::Shdr *Shdr = findSectionByName(OldElf, Name);
+  if (!Shdr)
+    return Error::success();
+  const uint64_t TextEnd = OldElf.textOffset() + OldElf.textSize();
+  uint64_t OutOff = Shdr->sh_offset;
+  if (Shdr->sh_offset >= TextEnd)
+    OutOff += Growth;
+  if (OutOff > OutBuf.getBufferSize() ||
+      Shdr->sh_size > OutBuf.getBufferSize() - OutOff)
+    return makeDisplacementError("debug section '" + Twine(Name) +
+                                 "' is out of bounds in displaced ELF");
+  Base = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart()) + OutOff;
+  Size = Shdr->sh_size;
+  return Error::success();
+}
+
+// Remap the .text addresses in the non-allocatable DWARF debug sections after a
+// whole-object growth. This is the .debug counterpart to
+// remapEhFrameForDisplacement
+// and runs in the same in-place manner (no size change) for .debug_frame,
+// .debug_info, and .debug_ranges. .debug_line, whose program length changes, is
+// re-synthesized separately by the caller.
+Error remapDebugSectionsForDisplacement(const ElfView &OldElf,
+                                        const DisplacementPlan &Plan,
+                                        WritableMemoryBuffer &OutBuf) {
+  const uint64_t Growth = Plan.paddedGrowth();
+
+  uint8_t *AbbrevBase = nullptr;
+  uint64_t AbbrevSize = 0;
+  if (Error Err = locateOutputDebugSection(
+          OldElf, OutBuf, Growth, ".debug_abbrev", AbbrevBase, AbbrevSize))
+    return Err;
+
+  uint8_t *FrameBase = nullptr;
+  uint64_t FrameSize = 0;
+  if (Error Err = locateOutputDebugSection(
+          OldElf, OutBuf, Growth, ".debug_frame", FrameBase, FrameSize))
+    return Err;
+  if (FrameBase)
+    if (Error Err =
+            remapDebugFrameForDisplacement(OldElf, Plan, FrameBase, FrameSize))
+      return Err;
+
+  uint8_t *InfoBase = nullptr;
+  uint64_t InfoSize = 0;
+  if (Error Err = locateOutputDebugSection(OldElf, OutBuf, Growth,
+                                           ".debug_info", InfoBase, InfoSize))
+    return Err;
+  // Recover the CU base for .debug_ranges from the OLD low_pc (before we
+  // rewrite it in place). low_pc is unchanged here, so old == new base.
+  std::optional<uint64_t> CuBase;
+  if (InfoBase) {
+    if (!AbbrevBase)
+      return makeDisplacementError(".debug_info present without .debug_abbrev");
+    Expected<std::optional<uint64_t>> BaseOrErr =
+        readCuLowPc(InfoBase, InfoSize, AbbrevBase, AbbrevSize);
+    if (!BaseOrErr)
+      return BaseOrErr.takeError();
+    CuBase = *BaseOrErr;
+    if (Error Err = remapDebugInfoForDisplacement(
+            OldElf, Plan, InfoBase, InfoSize, AbbrevBase, AbbrevSize))
+      return Err;
+  }
+
+  uint8_t *RangesBase = nullptr;
+  uint64_t RangesSize = 0;
+  if (Error Err = locateOutputDebugSection(
+          OldElf, OutBuf, Growth, ".debug_ranges", RangesBase, RangesSize))
+    return Err;
+  if (RangesBase) {
+    if (!CuBase)
+      return makeDisplacementError(
+          ".debug_ranges present without a CU .text low_pc base");
+    if (Error Err = remapDebugRangesForDisplacement(OldElf, Plan, RangesBase,
+                                                    RangesSize, *CuBase))
+      return Err;
+  }
+  return Error::success();
+}
+
+// State needed to decode a .debug_line program's address-advancing opcodes.
+struct LineProgramHeader {
+  uint32_t UnitLength = 0;   // value of the first 4 bytes
+  uint64_t UnitEnd = 0;      // 4 + UnitLength (one unit only; see below)
+  uint64_t ProgramStart = 0; // first opcode after the prologue
+  uint8_t MinInstLength = 0;
+  uint8_t MaxOpsPerInst = 0;
+  int8_t LineBase = 0;
+  uint8_t LineRange = 0;
+  uint8_t OpcodeBase = 0;
+  SmallVector<uint8_t, 16> StdOpcodeLengths; // [1 .. OpcodeBase-1]
+};
+
+// Parse the (single) DWARF v2-v4 line-number program header enough to walk the
+// opcode stream. Fails closed on DWARF64, VLIW (max_ops!=1), or a truncated
+// header. Only one program unit is supported; a second unit is rejected by the
+// caller.
+Expected<LineProgramHeader> parseLineProgramHeader(const uint8_t *Base,
+                                                   uint64_t Size) {
+  if (Size < 15)
+    return makeDisplacementError(".debug_line unit is too small");
+  LineProgramHeader H;
+  std::memcpy(&H.UnitLength, Base, 4);
+  if (H.UnitLength == 0xffffffffu)
+    return makeDisplacementError(".debug_line uses 64-bit DWARF (unsupported)");
+  H.UnitEnd = 4 + static_cast<uint64_t>(H.UnitLength);
+  if (H.UnitEnd > Size)
+    return makeDisplacementError(".debug_line unit overruns section");
+  uint16_t Version = 0;
+  std::memcpy(&Version, Base + 4, 2);
+  if (Version < 2 || Version > 4)
+    return makeDisplacementError(".debug_line version " + Twine(Version) +
+                                 " is unsupported");
+  uint32_t HeaderLength = 0;
+  std::memcpy(&HeaderLength, Base + 6, 4);
+  const uint64_t AfterHeaderLen = 10;
+  H.ProgramStart = AfterHeaderLen + HeaderLength;
+  if (H.ProgramStart > H.UnitEnd)
+    return makeDisplacementError(".debug_line prologue overruns unit");
+  uint64_t P = AfterHeaderLen;
+  H.MinInstLength = Base[P++];
+  H.MaxOpsPerInst =
+      Base[P++]; // v4+ field; present for the v4 objects we target
+  if (H.MaxOpsPerInst != 1)
+    return makeDisplacementError(".debug_line VLIW (max_ops_per_inst != 1) is "
+                                 "unsupported");
+  P++; // default_is_stmt
+  H.LineBase = static_cast<int8_t>(Base[P++]);
+  H.LineRange = Base[P++];
+  H.OpcodeBase = Base[P++];
+  if (H.LineRange == 0)
+    return makeDisplacementError(".debug_line line_range is zero");
+  for (unsigned I = 1; I < H.OpcodeBase; ++I) {
+    if (P >= H.ProgramStart)
+      return makeDisplacementError(
+          ".debug_line standard_opcode_lengths overruns prologue");
+    H.StdOpcodeLengths.push_back(Base[P++]);
+  }
+  return H;
+}
+
+// Re-synthesize a .debug_line program so every row's address is remapped
+// through the displacement plan while the decoded (line, column, file, flags)
+// values stay identical. The prologue is copied verbatim; the opcode stream is
+// rebuilt. For each opcode we track the OLD running address and the desired NEW
+// address (mapTextVAddr of the old address). An address advance is re-emitted
+// as an explicit DW_LNS_advance_pc whenever the mapped delta differs from the
+// encoded delta (i.e. the advance straddles a patch); otherwise the original
+// bytes are copied. Special opcodes that must change their address advance are
+// decomposed into DW_LNS_advance_pc + DW_LNS_advance_line + DW_LNS_copy,
+// preserving the row. set_address operands are remapped directly. Returns the
+// new full-section bytes. Fails closed on a second program unit or any opcode
+// we do not model.
+Expected<SmallVector<uint8_t>>
+resynthesizeDebugLine(const ElfView &Elf, const DisplacementPlan &Plan,
+                      const uint8_t *Base, uint64_t Size) {
+  Expected<LineProgramHeader> HOrErr = parseLineProgramHeader(Base, Size);
+  if (!HOrErr)
+    return HOrErr.takeError();
+  const LineProgramHeader &H = *HOrErr;
+  if (H.UnitEnd != Size)
+    return makeDisplacementError(
+        ".debug_line has multiple program units (unsupported)");
+
+  SmallVector<uint8_t> Out;
+  // Copy the prologue (unit_length placeholder included) verbatim; unit_length
+  // is fixed up at the end.
+  Out.append(Base, Base + H.ProgramStart);
+
+  auto emitByte = [&](uint8_t B) { Out.push_back(B); };
+  // DW_LNS_advance_pc's operand is an "operation advance" scaled by
+  // min_inst_length (max_ops_per_inst == 1 here), so the byte delta must be an
+  // exact multiple of min_inst_length. All .text addresses are
+  // min_inst-aligned, so this always holds; a non-multiple would be a decode
+  // bug, so fail closed.
+  auto emitAdvancePc = [&](uint64_t ByteDelta) -> Error {
+    if (ByteDelta == 0)
+      return Error::success();
+    if (ByteDelta % H.MinInstLength != 0)
+      return makeDisplacementError(
+          ".debug_line address delta is not a multiple of min_inst_length");
+    Out.push_back(dwarf::DW_LNS_advance_pc);
+    uint8_t Buf[16];
+    unsigned N = encodeULEB128(ByteDelta / H.MinInstLength, Buf);
+    Out.append(Buf, Buf + N);
+    return Error::success();
+  };
+  auto emitAdvanceLine = [&](int64_t Delta) {
+    if (Delta == 0)
+      return;
+    Out.push_back(dwarf::DW_LNS_advance_line);
+    uint8_t Buf[16];
+    unsigned N = encodeSLEB128(Delta, Buf);
+    Out.append(Buf, Buf + N);
+  };
+
+  const uint8_t *End = Base + Size;
+  uint64_t P = H.ProgramStart;
+  uint64_t OldAddr = 0; // running address in the input program
+  uint64_t NewAddr = 0; // running address emitted so far in the rebuilt program
+  // Pure address-advance opcodes (advance_pc/const_add_pc/fixed_advance_pc) are
+  // NOT copied to the output; we only track OldAddr through them. Intermediate
+  // stops may land inside a replaced instruction, so we never remap them. When
+  // a ROW is about to be emitted (copy/special/end_sequence), reconcile: emit
+  // one DW_LNS_advance_pc so the rebuilt address equals map(OldAddr). Only row
+  // addresses are remapped, and a row inside a replaced range is a genuine
+  // fail-closed condition (the row would name a deleted instruction).
+  auto reconcileToRow = [&]() -> Error {
+    uint64_t Mapped = 0;
+    if (!mapTextVAddr(Elf, Plan, OldAddr, Mapped))
+      return makeDisplacementError(
+          ".debug_line row address is inside a replaced instruction");
+    if (Mapped < NewAddr)
+      return makeDisplacementError(
+          ".debug_line address advance went backwards");
+    if (Error Err = emitAdvancePc(Mapped - NewAddr))
+      return Err;
+    NewAddr = Mapped;
+    return Error::success();
+  };
+
+  while (P < H.UnitEnd) {
+    const uint8_t Op = Base[P];
+    if (Op == 0) {
+      // Extended opcode: 0, ULEB length, sub-opcode, body.
+      unsigned N = 0;
+      uint64_t Len = decodeULEB128(Base + P + 1, &N, End);
+      const uint64_t BodyStart = P + 1 + N;
+      const uint64_t Next = BodyStart + Len;
+      if (Len == 0 || Next > H.UnitEnd)
+        return makeDisplacementError(
+            ".debug_line extended opcode is malformed");
+      const uint8_t Sub = Base[BodyStart];
+      if (Sub == dwarf::DW_LNE_set_address) {
+        if (Len != 9)
+          return makeDisplacementError(
+              ".debug_line set_address is not 8 bytes (addr_size != 8)");
+        uint64_t OldSet = 0;
+        std::memcpy(&OldSet, Base + BodyStart + 1, sizeof(OldSet));
+        uint64_t NewSet = 0;
+        if (!mapTextVAddr(Elf, Plan, OldSet, NewSet))
+          return makeDisplacementError(
+              ".debug_line set_address cannot be remapped");
+        // set_address assigns the running address absolutely in both streams.
+        Out.push_back(0);
+        Out.push_back(9);
+        Out.push_back(dwarf::DW_LNE_set_address);
+        uint8_t AddrBytes[8];
+        std::memcpy(AddrBytes, &NewSet, sizeof(NewSet));
+        Out.append(AddrBytes, AddrBytes + 8);
+        OldAddr = OldSet;
+        NewAddr = NewSet;
+      } else if (Sub == dwarf::DW_LNE_end_sequence) {
+        // end_sequence emits the closing row at the current address; reconcile
+        // the rebuilt address to map(OldAddr) first, then copy the opcode.
+        if (Error Err = reconcileToRow())
+          return Err;
+        Out.append(Base + P, Base + Next);
+        OldAddr = 0;
+        NewAddr = 0;
+      } else {
+        // Other extended opcodes (set_discriminator, define_file, vendor) do
+        // not touch the address; copy verbatim.
+        Out.append(Base + P, Base + Next);
+      }
+      P = Next;
+      continue;
+    }
+
+    if (Op < H.OpcodeBase) {
+      // Standard opcode.
+      switch (Op) {
+      case dwarf::DW_LNS_advance_pc: {
+        unsigned N = 0;
+        uint64_t Adv = decodeULEB128(Base + P + 1, &N, End);
+        OldAddr += Adv * H.MinInstLength; // track only; do not emit
+        P += 1 + N;
+        break;
+      }
+      case dwarf::DW_LNS_fixed_advance_pc: {
+        uint16_t Adv = 0;
+        std::memcpy(&Adv, Base + P + 1, sizeof(Adv));
+        OldAddr += Adv; // fixed_advance_pc is not scaled by min_inst_length
+        P += 3;
+        break;
+      }
+      case dwarf::DW_LNS_const_add_pc: {
+        const uint8_t Adjust = (255 - H.OpcodeBase) / H.LineRange;
+        OldAddr += static_cast<uint64_t>(Adjust) * H.MinInstLength;
+        P += 1;
+        break;
+      }
+      case dwarf::DW_LNS_copy:
+        // Emits a row at the current address; catch the rebuilt address up.
+        if (Error Err = reconcileToRow())
+          return Err;
+        emitByte(dwarf::DW_LNS_copy);
+        P += 1;
+        break;
+      default: {
+        // A standard opcode with no address effect: copy the opcode plus its
+        // ULEB operands verbatim (operand count from standard_opcode_lengths).
+        const uint8_t NumOperands = H.StdOpcodeLengths[Op - 1];
+        uint64_t Q = P + 1;
+        for (uint8_t I = 0; I < NumOperands; ++I) {
+          unsigned N = 0;
+          decodeULEB128(Base + Q, &N, End);
+          Q += N;
+          if (Q > H.UnitEnd)
+            return makeDisplacementError(
+                ".debug_line standard opcode operand overruns unit");
+        }
+        Out.append(Base + P, Base + Q);
+        P = Q;
+        break;
+      }
+      }
+      continue;
+    }
+
+    // Special opcode: advances address and line and emits a row. Because we
+    // drop the pure address-advance opcodes and only reconcile at rows, NewAddr
+    // can lag OldAddr's mapped position here; a verbatim copy of the special
+    // opcode would apply its own (small) address delta from the lagging NewAddr
+    // and desync the stream. So always decompose: correct the address
+    // explicitly to the mapped row target, apply the line delta, and emit the
+    // row with DW_LNS_copy, which resets the same sticky flags
+    // (discriminator/basic_block/prologue_end/epilogue_begin) a special opcode
+    // does, so the decoded row is identical apart from the remapped address.
+    const uint8_t Adjusted = Op - H.OpcodeBase;
+    const uint64_t AddrAdv =
+        static_cast<uint64_t>(Adjusted / H.LineRange) * H.MinInstLength;
+    const int64_t LineAdv = H.LineBase + (Adjusted % H.LineRange);
+    // Only the ROW address (OldAddr + AddrAdv) is remapped; the running base
+    // may sit at an intermediate stop inside a replaced range, which we never
+    // map.
+    OldAddr += AddrAdv;
+    uint64_t MappedTarget = 0;
+    if (!mapTextVAddr(Elf, Plan, OldAddr, MappedTarget))
+      return makeDisplacementError(
+          ".debug_line special-opcode row is inside a replaced instruction");
+    if (MappedTarget < NewAddr)
+      return makeDisplacementError(".debug_line special opcode went backwards");
+    if (Error Err = emitAdvancePc(MappedTarget - NewAddr))
+      return Err;
+    emitAdvanceLine(LineAdv);
+    emitByte(dwarf::DW_LNS_copy);
+    NewAddr = MappedTarget;
+    P += 1;
+  }
+
+  // Fix unit_length = total bytes - 4.
+  const uint32_t NewUnitLength = static_cast<uint32_t>(Out.size() - 4);
+  std::memcpy(Out.data(), &NewUnitLength, sizeof(NewUnitLength));
+  return Out;
+}
+
+// Shift the sh_offset of every section whose file offset is at or after
+// \p Threshold by \p Delta, shift e_shoff if it is past the threshold, and set
+// the size of the section at \p GrownIndex to \p GrownSize. Non-allocatable
+// sections only: no sh_addr / program-header changes (the caller guarantees the
+// grown section is non-allocatable, so no segment maps it).
+Error shiftSectionOffsetsAfter(uint8_t *Elf, size_t ElfSize, uint64_t Threshold,
+                               uint64_t Delta, uint16_t GrownIndex,
+                               uint64_t GrownSize) {
+  if (ElfSize < sizeof(Ehdr))
+    return makeDisplacementError("displaced ELF is smaller than its header");
+  uint64_t Shoff = 0;
+  uint16_t Shentsize = 0, Shnum = 0;
+  std::memcpy(&Shoff, Elf + offsetof(Ehdr, e_shoff), sizeof(Shoff));
+  std::memcpy(&Shentsize, Elf + offsetof(Ehdr, e_shentsize), sizeof(Shentsize));
+  std::memcpy(&Shnum, Elf + offsetof(Ehdr, e_shnum), sizeof(Shnum));
+  if (Shentsize < sizeof(Shdr))
+    return makeDisplacementError("section-header entry is too small");
+  if (Shoff >= Threshold) {
+    uint64_t NewShoff = Shoff + Delta;
+    std::memcpy(Elf + offsetof(Ehdr, e_shoff), &NewShoff, sizeof(NewShoff));
+    Shoff = NewShoff;
+  }
+  for (uint16_t I = 0; I < Shnum; ++I) {
+    uint64_t ShPos = Shoff + static_cast<uint64_t>(I) * Shentsize;
+    if (ShPos > ElfSize || sizeof(Shdr) > ElfSize - ShPos)
+      return makeDisplacementError("section-header table is out of bounds");
+    uint8_t *Sh = Elf + ShPos;
+    if (I == GrownIndex) {
+      std::memcpy(Sh + offsetof(Shdr, sh_size), &GrownSize, sizeof(GrownSize));
+      continue;
+    }
+    uint64_t ShOffset = 0;
+    std::memcpy(&ShOffset, Sh + offsetof(Shdr, sh_offset), sizeof(ShOffset));
+    if (ShOffset >= Threshold) {
+      uint64_t NewOffset = ShOffset + Delta;
+      std::memcpy(Sh + offsetof(Shdr, sh_offset), &NewOffset,
+                  sizeof(NewOffset));
+    }
+  }
+  return Error::success();
+}
+
+// Re-synthesize .debug_line (if present) and, when its byte length changed,
+// return a NEW output buffer with the section spliced in and every trailing
+// section's file offset shifted by the length delta. .debug_line is
+// non-allocatable, so no vaddr/segment fixups are needed. Returns the original
+// buffer unchanged when there is no .debug_line or its length did not change.
+Expected<std::unique_ptr<WritableMemoryBuffer>>
+growDebugLineForDisplacement(const ElfView &OldElf,
+                             const DisplacementPlan &Plan,
+                             std::unique_ptr<WritableMemoryBuffer> OutBuf) {
+  const ELFT::Shdr *LineShdr = findSectionByName(OldElf, ".debug_line");
+  if (!LineShdr)
+    return std::move(OutBuf);
+
+  const uint64_t Growth = Plan.paddedGrowth();
+  const uint64_t TextEnd = OldElf.textOffset() + OldElf.textSize();
+  const uint64_t OutLineOff =
+      LineShdr->sh_offset + (LineShdr->sh_offset >= TextEnd ? Growth : 0);
+  const uint64_t OldLineSize = LineShdr->sh_size;
+  if (OutLineOff > OutBuf->getBufferSize() ||
+      OldLineSize > OutBuf->getBufferSize() - OutLineOff)
+    return makeDisplacementError(
+        ".debug_line is out of bounds in displaced ELF");
+
+  const uint8_t *OldLine =
+      reinterpret_cast<const uint8_t *>(OutBuf->getBufferStart()) + OutLineOff;
+  Expected<SmallVector<uint8_t>> NewLineOrErr =
+      resynthesizeDebugLine(OldElf, Plan, OldLine, OldLineSize);
+  if (!NewLineOrErr)
+    return NewLineOrErr.takeError();
+  SmallVector<uint8_t> &NewLine = *NewLineOrErr;
+
+  if (NewLine.size() == OldLineSize) {
+    // Same length: splice in place, no header shift.
+    std::memcpy(reinterpret_cast<uint8_t *>(OutBuf->getBufferStart()) +
+                    OutLineOff,
+                NewLine.data(), NewLine.size());
+    log() << "hotswap: displacement: .debug_line re-synthesized in place ("
+          << NewLine.size() << " bytes)\n";
+    return std::move(OutBuf);
+  }
+  if (NewLine.size() < OldLineSize)
+    return makeDisplacementError(".debug_line re-synthesis shrank the program");
+
+  const uint64_t LineDelta = NewLine.size() - OldLineSize;
+  const size_t OldTotal = OutBuf->getBufferSize();
+  const size_t NewTotal = OldTotal + LineDelta;
+  std::unique_ptr<WritableMemoryBuffer> NewBuf =
+      WritableMemoryBuffer::getNewUninitMemBuffer(NewTotal);
+  if (!NewBuf)
+    return makeDisplacementError("failed to allocate .debug_line grow buffer");
+
+  const uint8_t *Src =
+      reinterpret_cast<const uint8_t *>(OutBuf->getBufferStart());
+  uint8_t *Dst = reinterpret_cast<uint8_t *>(NewBuf->getBufferStart());
+  const uint64_t TailOff = OutLineOff + OldLineSize;
+  std::memcpy(Dst, Src, OutLineOff);
+  std::memcpy(Dst + OutLineOff, NewLine.data(), NewLine.size());
+  std::memcpy(Dst + OutLineOff + NewLine.size(), Src + TailOff,
+              OldTotal - TailOff);
+
+  // Shift section offsets/shoff for everything after .debug_line's old bytes.
+  const uint16_t LineIndex =
+      static_cast<uint16_t>(LineShdr - OldElf.sections().begin());
+  if (Error Err = shiftSectionOffsetsAfter(Dst, NewTotal, TailOff, LineDelta,
+                                           LineIndex, NewLine.size()))
+    return std::move(Err);
+  log() << "hotswap: displacement: .debug_line re-synthesized, grew "
+        << OldLineSize << " -> " << NewLine.size() << " bytes (+" << LineDelta
+        << "); shifted trailing sections\n";
+  return std::move(NewBuf);
+}
+
+Error validateDisplacementEditBoundaries(const ElfView &Elf,
+                                         const LLVMState &LS,
+                                         const DisplacementPlan &Plan) {
+  size_t EditIndex = 0;
+  std::optional<Error> BoundaryError;
+  bool Decoded = decodeTextSectionStreaming(
+      Elf.textData(), Elf.textSize(), LS, /*WantMnemonic=*/false,
+      [&](const InternalDecodedInst &DI) {
+        if (!DI.DecodeSucceeded) {
+          BoundaryError.emplace(makeDisplacementError(
+              "old .text contains an undecodable instruction"));
+          return false;
+        }
+        while (EditIndex != Plan.edits().size() &&
+               Plan.edits()[EditIndex].Offset == DI.Offset &&
+               Plan.edits()[EditIndex].OriginalSize == 0)
+          ++EditIndex;
+        if (EditIndex != Plan.edits().size() &&
+            Plan.edits()[EditIndex].Offset == DI.Offset) {
+          const DisplacementEdit &Edit = Plan.edits()[EditIndex];
+          if (Edit.OriginalSize != DI.Size) {
+            BoundaryError.emplace(makeDisplacementError(
+                "growing edit does not replace exactly one decoded "
+                "instruction"));
+            return false;
+          }
+          ++EditIndex;
+        }
+        if (EditIndex != Plan.edits().size() &&
+            Plan.edits()[EditIndex].Offset < DI.Offset + DI.Size) {
+          BoundaryError.emplace(makeDisplacementError(
+              "displacement edit begins inside a decoded instruction"));
+          return false;
+        }
+        return true;
+      });
+  if (BoundaryError)
+    return std::move(*BoundaryError);
+  if (!Decoded)
+    return makeDisplacementError(
+        "failed to decode .text while validating edit boundaries");
+  while (EditIndex != Plan.edits().size() &&
+         Plan.edits()[EditIndex].Offset == Elf.textSize() &&
+         Plan.edits()[EditIndex].OriginalSize == 0)
+    ++EditIndex;
+  if (EditIndex != Plan.edits().size())
+    return makeDisplacementError(
+        "displacement edit is not on a decoded instruction boundary");
+
+  for (const DisplacementEdit &Edit : Plan.edits()) {
+    std::optional<Error> ReplacementError;
+    bool ReplacementDecoded = decodeTextSectionStreaming(
+        Edit.ReplacementBytes.data(), Edit.ReplacementBytes.size(), LS,
+        /*WantMnemonic=*/false, [&](const InternalDecodedInst &DI) {
+          if (!DI.DecodeSucceeded) {
+            ReplacementError.emplace(makeDisplacementError(
+                "replacement contains an undecodable instruction"));
+            return false;
+          }
+          if (isPcSensitiveForDisplacement(DI, LS) ||
+              LS.MIA->isBranch(DI.Inst) || LS.MIA->isCall(DI.Inst) ||
+              LS.MIA->isReturn(DI.Inst) || LS.MIA->isIndirectBranch(DI.Inst)) {
+            ReplacementError.emplace(makeDisplacementError(
+                "replacement contains unrelocated control flow or a "
+                "PC-sensitive instruction"));
+            return false;
+          }
+          return true;
+        });
+    if (ReplacementError)
+      return std::move(*ReplacementError);
+    if (!ReplacementDecoded)
+      return makeDisplacementError(
+          "replacement bytes do not form a complete instruction sequence");
+  }
+  return Error::success();
+}
+
 Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
                             const DisplacementPlan &Plan,
+                            const DirectControlFlowInfo &ControlFlow,
                             WritableMemoryBuffer &OutBuf) {
   const size_t InputSize = Elf.size();
   const size_t NewSize = Plan.newElfSize(InputSize);
@@ -728,14 +3406,37 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
         "output buffer has incorrect size for displacement");
   }
 
+  using Clock = std::chrono::steady_clock;
+  auto ms = [](Clock::duration D) {
+    return std::chrono::duration<double, std::milli>(D).count();
+  };
+  Clock::time_point T0 = Clock::now();
+
   SmallVector<uint8_t> NewText = Plan.buildText(
       ArrayRef<uint8_t>(Elf.textData(), Elf.textSize()), LS.SNopBytes);
   if (NewText.size() != Plan.paddedTextSize()) {
     return makeDisplacementError(
         "rebuilt .text size does not match displacement plan");
   }
-  if (Error Err = repairBranches(Elf, LS, Plan, NewText))
+  Clock::time_point T1 = Clock::now();
+  log() << "hotswap: TIMING   displacement buildText: " << ms(T1 - T0)
+        << " ms\n";
+  if (Error Err = repairBranches(Elf, LS, Plan, ControlFlow, NewText))
     return Err;
+  bool ValidNewText = true;
+  bool NewTextDecoded = decodeTextSectionStreaming(
+      NewText.data(), NewText.size(), LS, /*WantMnemonic=*/false,
+      [&](const InternalDecodedInst &DI) {
+        ValidNewText &= DI.DecodeSucceeded;
+        return ValidNewText;
+      });
+  if (!NewTextDecoded || !ValidNewText)
+    return makeDisplacementError(
+        "rebuilt .text does not form a complete instruction sequence");
+  Clock::time_point T2 = Clock::now();
+  log() << "hotswap: TIMING   displacement repairBranches "
+           "(whole .text redecode): "
+        << ms(T2 - T1) << " ms\n";
 
   uint8_t *Out = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
   const uint8_t *Input = Elf.data();
@@ -749,18 +3450,51 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
                 InputSize - TextEnd);
   }
 
-  if (Error Err = adjustSectionHeadersForTextGrowth(Out, NewSize, Elf,
-                                                    Plan.paddedGrowth()))
+  const bool RelocateVAddr = Plan.relocatesTrailingSections();
+  if (Error Err = adjustSectionHeadersForTextGrowth(
+          Out, NewSize, Elf, Plan.paddedGrowth(), RelocateVAddr))
     return Err;
-  if (Error Err = adjustProgramHeadersForTextGrowth(Out, NewSize, Elf,
-                                                    Plan.paddedGrowth()))
+  if (Error Err = adjustProgramHeadersForTextGrowth(
+          Out, NewSize, Elf, Plan.paddedGrowth(), RelocateVAddr))
+    return Err;
+  if (Error Err = adjustElfEntryForDisplacement(Out, NewSize, Elf, Plan))
+    return Err;
+  if (RelocateVAddr)
+    if (Error Err =
+            adjustDynamicEntriesForDisplacement(Out, NewSize, Elf, Plan))
+      return Err;
+  if (Error Err = adjustRelocationsForDisplacement(Out, NewSize, Elf, Plan))
     return Err;
   if (Error Err = adjustSymbolValuesForDisplacement(Out, NewSize, Elf, Plan))
     return Err;
+  Clock::time_point T3 = Clock::now();
+  log() << "hotswap: TIMING   displacement memcpy+metadata: " << ms(T3 - T2)
+        << " ms\n";
 
   if (Error Err =
           rewriteKernelDescriptorEntriesForDisplacement(OutBuf, Elf, Plan))
     return Err;
+  Clock::time_point T4 = Clock::now();
+  log() << "hotswap: TIMING   displacement descriptor rewrite: " << ms(T4 - T3)
+        << " ms\n";
+
+  // .eh_frame FDEs describe per-kernel .text ranges; fix them to the new layout
+  // when the caller opted into relocation. validateDebugSections only
+  // admits .eh_frame in that mode, so this is the matching repair.
+  if (RelocateVAddr)
+    if (Error Err = remapEhFrameForDisplacement(Elf, Plan, OutBuf))
+      return Err;
+  log() << "hotswap: TIMING   displacement eh_frame remap: "
+        << ms(Clock::now() - T4) << " ms\n";
+
+  // Non-allocatable DWARF debug sections (.debug_frame/.debug_info/
+  // .debug_ranges) reference .text addresses that are now stale; rewrite them
+  // in place. validateDebugSections only admits these sections in this mode.
+  // .debug_line is re-synthesized separately by the caller because its byte
+  // length changes.
+  if (RelocateVAddr)
+    if (Error Err = remapDebugSectionsForDisplacement(Elf, Plan, OutBuf))
+      return Err;
 
   log() << "hotswap: displacement: grew ELF from " << InputSize << " to "
         << NewSize << " bytes (" << Plan.edits().size() << " edit"
@@ -772,9 +3506,21 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
 
 } // namespace
 
+Expected<std::vector<RelocationTableDispatch>>
+analyzeRelocationTableDispatches(const ElfView &Elf,
+                                 ArrayRef<InternalDecodedInst> Decoded,
+                                 const LLVMState &LS) {
+  Expected<std::vector<RelocationTableCandidate>> TablesOrErr =
+      discoverCompleteRelocationTables(Elf);
+  if (!TablesOrErr)
+    return TablesOrErr.takeError();
+  return matchRelocationTableDispatches(Elf, Decoded, LS, *TablesOrErr);
+}
+
 Expected<DisplacementPlan>
 DisplacementPlan::create(const ElfView &Elf,
-                         ArrayRef<DisplacementEdit> InputEdits) {
+                         ArrayRef<DisplacementEdit> InputEdits,
+                         bool RelocateTrailingSections) {
   if (InputEdits.empty())
     return makeDisplacementError("no displacement edits requested");
 
@@ -785,15 +3531,22 @@ DisplacementPlan::create(const ElfView &Elf,
 
   std::stable_sort(Sorted.begin(), Sorted.end(),
                    [](const DisplacementEdit &A, const DisplacementEdit &B) {
-                     return A.Offset < B.Offset;
+                     if (A.Offset != B.Offset)
+                       return A.Offset < B.Offset;
+                     return A.MapsOldOffsetAfterInsertion &&
+                            !B.MapsOldOffsetAfterInsertion;
                    });
 
   uint64_t RawGrowth = 0;
   std::optional<uint64_t> PrevOffset;
+  const DisplacementEdit *PrevEdit = nullptr;
   uint64_t PrevEnd = 0;
   for (const DisplacementEdit &Edit : Sorted) {
     if (Edit.ReplacementBytes.empty())
       return makeDisplacementError("displacement edit has empty replacement");
+    if (Edit.MapsOldOffsetAfterInsertion && Edit.OriginalSize != 0)
+      return makeDisplacementError(
+          "boundary-after displacement edit is not a pure insertion");
     if (Edit.Offset > Elf.textSize() ||
         Edit.OriginalSize > Elf.textSize() - Edit.Offset) {
       return makeDisplacementError("displacement edit is out of .text bounds");
@@ -805,8 +3558,10 @@ DisplacementPlan::create(const ElfView &Elf,
     if (PrevOffset && Edit.Offset < PrevEnd)
       return makeDisplacementError("displacement edits overlap");
     if (PrevOffset && Edit.Offset == *PrevOffset) {
-      return makeDisplacementError(
-          "multiple displacement edits share an offset");
+      if (!PrevEdit || !PrevEdit->MapsOldOffsetAfterInsertion ||
+          PrevEdit->OriginalSize != 0 || Edit.OriginalSize == 0)
+        return makeDisplacementError(
+            "multiple displacement edits share an offset");
     }
 
     uint64_t EditGrowth = Edit.ReplacementBytes.size() - Edit.OriginalSize;
@@ -814,6 +3569,7 @@ DisplacementPlan::create(const ElfView &Elf,
       return makeDisplacementError("displacement growth overflows uint64_t");
     RawGrowth += EditGrowth;
     PrevOffset = Edit.Offset;
+    PrevEdit = &Edit;
     PrevEnd = Edit.Offset + Edit.OriginalSize;
   }
 
@@ -828,12 +3584,16 @@ DisplacementPlan::create(const ElfView &Elf,
   if (Padding > std::numeric_limits<uint64_t>::max() - RawGrowth)
     return makeDisplacementError("aligned displacement growth overflows");
   uint64_t PaddedGrowth = RawGrowth + Padding;
-  if (Error Err = validateVirtualGrowth(Elf, PaddedGrowth))
-    return std::move(Err);
+  // When relocating trailing sections, a grown .text that would
+  // overlap later allocatable content is fine: the apply step shifts that
+  // content's vaddr forward. Skip the overlap bail in that mode.
+  if (!RelocateTrailingSections)
+    if (Error Err = validateVirtualGrowth(Elf, PaddedGrowth))
+      return std::move(Err);
   if (PaddedGrowth > std::numeric_limits<size_t>::max() - Elf.size())
     return makeDisplacementError("displaced ELF size overflows size_t");
   return DisplacementPlan(Elf.textSize(), RawGrowth, PaddedGrowth,
-                          std::move(Sorted));
+                          std::move(Sorted), RelocateTrailingSections);
 }
 
 bool DisplacementPlan::mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
@@ -851,7 +3611,8 @@ bool DisplacementPlan::mapOffset(uint64_t OldOffset, DisplacementMapBias Bias,
 
     if (OldOffset == Edit.Offset) {
       if (Edit.OriginalSize == 0 &&
-          Bias == DisplacementMapBias::AfterInsertedBytes) {
+          (Edit.MapsOldOffsetAfterInsertion ||
+           Bias == DisplacementMapBias::AfterInsertedBytes)) {
         Delta += EditDelta;
         continue;
       }
@@ -908,17 +3669,54 @@ DisplacementPlan::buildText(ArrayRef<uint8_t> OldText,
 
 Expected<std::unique_ptr<WritableMemoryBuffer>>
 tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
-                                    ArrayRef<DisplacementEdit> Edits) {
-  if (Error Err = validateDebugSections(Elf))
+                                    ArrayRef<DisplacementEdit> Edits,
+                                    bool RelocateTrailingSections) {
+  if (RelocateTrailingSections)
+    if (Error Err = validateWholeObjectLayout(Elf))
+      return std::move(Err);
+  if (Error Err = validateDebugSections(
+          Elf, /*AllowEhFrameRemap=*/RelocateTrailingSections))
     return std::move(Err);
   if (Error Err = validateTextRelocations(Elf))
     return std::move(Err);
 
-  Expected<DisplacementPlan> PlanOrErr = DisplacementPlan::create(Elf, Edits);
+  Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(Elf, Edits, RelocateTrailingSections);
   if (!PlanOrErr)
     return PlanOrErr.takeError();
+  if (Error Err = validateDisplacementEditBoundaries(Elf, LS, *PlanOrErr))
+    return std::move(Err);
   if (Error Err = validateKernelEntryMappings(Elf, *PlanOrErr))
     return std::move(Err);
+
+  DirectControlFlowInfo ControlFlow;
+  bool NeedsLinkedControlFlowProof = false;
+  struct IndirectTransferScanner {
+    const LLVMState &LS;
+    bool &Found;
+
+    bool operator()(const InternalDecodedInst &DI) const {
+      Found |= DI.Inst.getOpcode() == LS.SSwapPcI64Opcode ||
+               DI.Inst.getOpcode() == LS.SSetPcI64Opcode;
+      return true;
+    }
+  };
+  IndirectTransferScanner FindIndirectTransfer{LS, NeedsLinkedControlFlowProof};
+  if (!decodeTextSectionStreaming(Elf.textData(), Elf.textSize(), LS,
+                                  /*WantMnemonic=*/false, FindIndirectTransfer))
+    return makeDisplacementError(
+        "failed to scan .text for indirect control flow");
+  if (NeedsLinkedControlFlowProof) {
+    std::vector<InternalDecodedInst> Decoded;
+    if (!decodeTextSection(Elf.textData(), Elf.textSize(), LS, Decoded))
+      return makeDisplacementError(
+          "failed to decode .text for linked control-flow proof");
+    std::optional<DirectControlFlowInfo> Info =
+        analyzeDirectControlFlow(Elf, Decoded, LS);
+    if (!Info)
+      return makeDisplacementError("linked control-flow proof failed");
+    ControlFlow = std::move(*Info);
+  }
 
   std::unique_ptr<WritableMemoryBuffer> Out =
       WritableMemoryBuffer::getNewUninitMemBuffer(
@@ -927,8 +3725,20 @@ tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
     return makeDisplacementError(
         "failed to allocate displacement output buffer");
   }
-  if (Error Err = applyTextDisplacement(Elf, LS, *PlanOrErr, *Out))
+  if (Error Err = applyTextDisplacement(Elf, LS, *PlanOrErr, ControlFlow, *Out))
     return std::move(Err);
+
+  // .debug_line's program length can change when an address advance straddles a
+  // patch; re-synthesize it and splice the (possibly larger) section back in,
+  // shifting trailing non-allocatable sections. Only relevant when
+  // validateDebugSections admitted the debug sections.
+  if (RelocateTrailingSections) {
+    Expected<std::unique_ptr<WritableMemoryBuffer>> GrownOrErr =
+        growDebugLineForDisplacement(Elf, *PlanOrErr, std::move(Out));
+    if (!GrownOrErr)
+      return GrownOrErr.takeError();
+    return std::move(*GrownOrErr);
+  }
   return std::move(Out);
 }
 

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -1390,6 +1390,152 @@ Expected<bool> repairSGetPcPairForDisplacement(
   return true;
 }
 
+/// Repair the gfx1250 carry-chain form
+///
+///   s_get_pc_i64 Pair
+///   s_add_co_u32 PairLo, PairLo, Low
+///   s_add_co_ci_u32 PairHi, PairHi, High
+///   s_{swap,set}_pc_i64 ..., Pair
+///
+/// when whole-object displacement moves both the sequence and its in-.text
+/// target. The two adds implement one modulo-2^64 addition, so remapping only
+/// requires splitting the new PC-relative delta back into low/high words while
+/// preserving each instruction's literal encoding width.
+Expected<bool> repairSGetPcCarryPairForDisplacement(
+    const ElfView &Elf, const LLVMState &LS, const DisplacementPlan &Plan,
+    const InternalDecodedInst &Gp, SmallVectorImpl<uint8_t> &NewText) {
+  if (Gp.Inst.getNumOperands() != 1 || !Gp.Inst.getOperand(0).isReg())
+    return false;
+  MCRegister PairReg(Gp.Inst.getOperand(0).getReg());
+
+  const uint64_t LowOldOff = Gp.Offset + Gp.Size;
+  if (LowOldOff >= Elf.textSize())
+    return false;
+  SmallVector<InternalDecodedInst, 2> Adds;
+  (void)decodeTextSectionStreaming(
+      Elf.textData() + LowOldOff, Elf.textSize() - LowOldOff, LS,
+      /*WantMnemonic=*/false, [&](const InternalDecodedInst &DI) -> bool {
+        Adds.push_back(DI);
+        return Adds.size() != 2;
+      });
+  if (Adds.size() != 2)
+    return false;
+  const InternalDecodedInst &Low = Adds[0];
+  const InternalDecodedInst &High = Adds[1];
+  if (!Low.DecodeSucceeded || !High.DecodeSucceeded ||
+      Low.Inst.getOpcode() != LS.SAddCoU32Opcode ||
+      High.Inst.getOpcode() != LS.SAddCoCiU32Opcode ||
+      Low.Inst.getNumOperands() != 3 || High.Inst.getNumOperands() != 3 ||
+      !Low.Inst.getOperand(0).isReg() ||
+      !Low.Inst.getOperand(1).isReg() ||
+      !High.Inst.getOperand(0).isReg() ||
+      !High.Inst.getOperand(1).isReg() ||
+      Low.Inst.getOperand(0).getReg() !=
+          Low.Inst.getOperand(1).getReg() ||
+      High.Inst.getOperand(0).getReg() !=
+          High.Inst.getOperand(1).getReg())
+    return false;
+
+  MCRegister LowReg(Low.Inst.getOperand(0).getReg());
+  MCRegister HighReg(High.Inst.getOperand(0).getReg());
+  if (LowReg == HighReg || !LS.MRI->regsOverlap(PairReg, LowReg) ||
+      !LS.MRI->regsOverlap(PairReg, HighReg))
+    return false;
+
+  auto getU32Immediate = [](const MCOperand &Operand)
+      -> std::optional<uint32_t> {
+    int64_t Value = 0;
+    if (Operand.isImm())
+      Value = Operand.getImm();
+    else if (!Operand.isExpr() ||
+             !Operand.getExpr()->evaluateAsAbsolute(Value))
+      return std::nullopt;
+    return static_cast<uint32_t>(Value);
+  };
+  std::optional<uint32_t> OldLow =
+      getU32Immediate(Low.Inst.getOperand(2));
+  std::optional<uint32_t> OldHigh =
+      getU32Immediate(High.Inst.getOperand(2));
+  if (!OldLow || !OldHigh)
+    return false;
+  const uint64_t OldDelta = static_cast<uint64_t>(*OldLow) |
+                            (static_cast<uint64_t>(*OldHigh) << 32);
+
+  std::optional<uint64_t> OldPcBase =
+      checkedAddUint64(Elf.textAddr(), LowOldOff,
+                       "carry-chain s_get_pc old PC base");
+  if (!OldPcBase)
+    return false;
+  const uint64_t OldTarget = *OldPcBase + OldDelta;
+  Expected<uint64_t> NewTargetOrErr =
+      remapAllocatedAddress(Elf, Plan, OldTarget,
+                            /*RequireExecutable=*/true,
+                            "carry-chain s_get_pc target");
+  if (!NewTargetOrErr) {
+    consumeError(NewTargetOrErr.takeError());
+    return false;
+  }
+
+  uint64_t NewLowOff = 0;
+  const uint64_t HighOldOff = LowOldOff + Low.Size;
+  uint64_t NewHighOff = 0;
+  if (!Plan.mapOffset(LowOldOff, DisplacementMapBias::AfterInsertedBytes,
+                      NewLowOff) ||
+      !Plan.mapOffset(HighOldOff, DisplacementMapBias::AfterInsertedBytes,
+                      NewHighOff))
+    return false;
+  std::optional<uint64_t> NewPcBase =
+      checkedAddUint64(Elf.textAddr(), NewLowOff,
+                       "carry-chain s_get_pc displaced PC base");
+  if (!NewPcBase)
+    return false;
+  const uint64_t NewDelta = *NewTargetOrErr - *NewPcBase;
+  const uint32_t NewLow = static_cast<uint32_t>(NewDelta);
+  const uint32_t NewHigh = static_cast<uint32_t>(NewDelta >> 32);
+
+  auto repairAdd = [&](const InternalDecodedInst &Add, uint32_t NewImmediate,
+                       uint64_t NewOffset) -> Error {
+    if (!LS.MCIP)
+      return makeDisplacementError(
+          "MC instruction printer unavailable for carry-chain repair");
+    SmallString<256> PrintedBuf;
+    raw_svector_ostream PrintOS(PrintedBuf);
+    LS.MCIP->printInst(&Add.Inst, /*Address=*/0, /*Annot=*/"", *LS.STI,
+                       PrintOS);
+    StringRef Printed = StringRef(PrintedBuf).trim();
+    size_t LastComma = Printed.rfind(',');
+    if (LastComma == StringRef::npos)
+      return makeDisplacementError(
+          "carry-chain add has no trailing immediate operand");
+    StringRef Head = Printed.substr(0, LastComma + 1);
+    StringRef AddendTok = Printed.substr(LastComma + 1).trim();
+    std::string Hex = ("0x" + Twine::utohexstr(NewImmediate)).str();
+    std::string NewAddend;
+    if (AddendTok.starts_with("lit64("))
+      NewAddend = "lit64(" + Hex + ")";
+    else if (AddendTok.starts_with("lit("))
+      NewAddend = "lit(" + Hex + ")";
+    else
+      NewAddend = Hex;
+    SmallVector<uint8_t> Code =
+        assembleSingleInst((Head + " " + NewAddend).str(), LS);
+    if (Code.size() != Add.Size)
+      return makeDisplacementError(
+          "carry-chain add changed encoded size during re-encode");
+    if (NewOffset + Code.size() > NewText.size())
+      return makeDisplacementError(
+          "carry-chain add writes past rebuilt .text");
+    std::memcpy(NewText.data() + NewOffset, Code.data(), Code.size());
+    return Error::success();
+  };
+
+  if (Error Err = repairAdd(Low, NewLow, NewLowOff))
+    return std::move(Err);
+  if (Error Err = repairAdd(High, NewHigh, NewHighOff))
+    return std::move(Err);
+  return true;
+}
+
 /// Repair a standalone `s_add_pc_i64 lit64(delta)` under whole-object
 /// displacement. Unlike the s_get_pc pair (whose target is a global outside
 /// .text), this is a long-forward PC-relative CONTROL transfer whose target is
@@ -1533,6 +1679,14 @@ Error repairBranches(const ElfView &Elf, const LLVMState &LS,
         return false;
       }
       if (*RepairedOrErr)
+        return true;
+      Expected<bool> CarryRepairedOrErr =
+          repairSGetPcCarryPairForDisplacement(Elf, LS, Plan, DI, NewText);
+      if (!CarryRepairedOrErr) {
+        RepairErr.emplace(CarryRepairedOrErr.takeError());
+        return false;
+      }
+      if (*CarryRepairedOrErr)
         return true;
       // Not a repairable pair; fall through to the strict rejection.
     }

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -73,6 +73,12 @@ static std::optional<uint64_t> checkedSectionFileOffset(const ELFT::Shdr &Sec,
   }
 
   uint64_t Delta = VAddr - Sec.sh_addr;
+  if (Delta > Sec.sh_size || AccessSize > Sec.sh_size - Delta) {
+    log() << "hotswap: error: " << Context
+          << " extends outside its defining section.\n";
+    return std::nullopt;
+  }
+
   std::optional<uint64_t> FileOffset = checkedAddUint64(
       Sec.sh_offset, Delta, (Twine(Context) + " file offset").str());
   if (!FileOffset)
@@ -429,6 +435,51 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
         (Shdr.sh_offset > Size || Shdr.sh_size > Size - Shdr.sh_offset))
       return createStringError(object::object_error::parse_failed,
                                "section extends past end of file");
+  }
+
+  // Every descriptor symbol is an admitted address carrier. Validate all
+  // copies rather than allowing a valid DYNSYM entry to hide a malformed
+  // duplicate in SYMTAB, which could otherwise be rewritten into an object
+  // that fails a second hotswap pass.
+  for (const ELFT::Shdr &SymShdr : Sections) {
+    if (SymShdr.sh_type != ELF::SHT_SYMTAB &&
+        SymShdr.sh_type != ELF::SHT_DYNSYM)
+      continue;
+    Expected<ELFT::SymRange> SymbolsOrErr = File.symbols(&SymShdr);
+    if (!SymbolsOrErr)
+      return SymbolsOrErr.takeError();
+    Expected<StringRef> StrTabOrErr =
+        File.getStringTableForSymtab(SymShdr, Sections);
+    if (!StrTabOrErr)
+      return StrTabOrErr.takeError();
+    for (const ELFT::Sym &Sym : *SymbolsOrErr) {
+      Expected<StringRef> NameOrErr = Sym.getName(*StrTabOrErr);
+      if (!NameOrErr)
+        return NameOrErr.takeError();
+      if (!NameOrErr->ends_with(".kd"))
+        continue;
+      if (Sym.st_shndx == ELF::SHN_UNDEF || Sym.st_shndx >= ELF::SHN_LORESERVE)
+        return createStringError(object::object_error::parse_failed,
+                                 "kernel descriptor has no defining section");
+      Expected<const ELFT::Shdr *> HostShdrOrErr =
+          File.getSection(Sym.st_shndx);
+      if (!HostShdrOrErr)
+        return HostShdrOrErr.takeError();
+      const ELFT::Shdr &HostShdr = **HostShdrOrErr;
+      uint64_t SectionOffset = Sym.st_value;
+      if (Header.e_type != ELF::ET_REL) {
+        if (Sym.st_value < HostShdr.sh_addr)
+          return createStringError(object::object_error::parse_failed,
+                                   "kernel descriptor precedes its section");
+        SectionOffset = Sym.st_value - HostShdr.sh_addr;
+      }
+      if (HostShdr.sh_type == ELF::SHT_NOBITS ||
+          SectionOffset > HostShdr.sh_size ||
+          KdSize > HostShdr.sh_size - SectionOffset)
+        return createStringError(
+            object::object_error::parse_failed,
+            "kernel descriptor extends outside its section");
+    }
   }
 
   Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -23,6 +23,7 @@
 #include "llvm/BinaryFormat/MsgPackDocument.h"
 
 #include <algorithm>
+#include <cstring>
 #include <limits>
 
 using namespace llvm;
@@ -393,6 +394,14 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
   // resulting ElfView). Once ELFFile is constructed, it owns the structural
   // view over these same bytes and we do not need to store Data/Size
   // separately -- ELFFile::base() / ELFFile::getBufSize() alias them.
+  if (Size < ELF::EI_NIDENT ||
+      std::memcmp(Data, ELF::ElfMagic, std::strlen(ELF::ElfMagic)) != 0 ||
+      Data[ELF::EI_CLASS] != ELF::ELFCLASS64 ||
+      Data[ELF::EI_DATA] != ELF::ELFDATA2LSB ||
+      Data[ELF::EI_VERSION] != ELF::EV_CURRENT)
+    return createStringError(object::object_error::parse_failed,
+                             "invalid ELF identification");
+
   Expected<ELFFileT> FileOrErr =
       ELFFileT::create(StringRef(reinterpret_cast<const char *>(Data), Size));
   if (!FileOrErr)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -410,8 +410,7 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
   const ELFFileT &File = *FileOrErr;
   const auto &Header = File.getHeader();
   if (Header.e_version != ELF::EV_CURRENT ||
-      Header.e_ehsize != sizeof(ELFT::Ehdr) ||
-      Header.e_phnum == ELF::PN_XNUM ||
+      Header.e_ehsize != sizeof(ELFT::Ehdr) || Header.e_phnum == ELF::PN_XNUM ||
       (Header.e_shnum == 0 && Header.e_shoff != 0) ||
       Header.e_shnum >= ELF::SHN_LORESERVE ||
       Header.e_shstrndx == ELF::SHN_XINDEX ||

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -408,6 +408,14 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
     return FileOrErr.takeError();
 
   const ELFFileT &File = *FileOrErr;
+  const auto &Header = File.getHeader();
+  if (Header.e_version != ELF::EV_CURRENT ||
+      Header.e_ehsize != sizeof(ELFT::Ehdr) ||
+      (Header.e_phnum != 0 && Header.e_phentsize != sizeof(ELFT::Phdr)) ||
+      (Header.e_shnum != 0 && Header.e_shentsize != sizeof(ELFT::Shdr)))
+    return createStringError(object::object_error::parse_failed,
+                             "invalid ELF header sizes or version");
+
   Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
   if (!SectionsOrErr)
     return SectionsOrErr.takeError();

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -411,10 +411,14 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
   const auto &Header = File.getHeader();
   if (Header.e_version != ELF::EV_CURRENT ||
       Header.e_ehsize != sizeof(ELFT::Ehdr) ||
+      Header.e_phnum == ELF::PN_XNUM ||
+      (Header.e_shnum == 0 && Header.e_shoff != 0) ||
+      Header.e_shnum >= ELF::SHN_LORESERVE ||
+      Header.e_shstrndx == ELF::SHN_XINDEX ||
       (Header.e_phnum != 0 && Header.e_phentsize != sizeof(ELFT::Phdr)) ||
       (Header.e_shnum != 0 && Header.e_shentsize != sizeof(ELFT::Shdr)))
     return createStringError(object::object_error::parse_failed,
-                             "invalid ELF header sizes or version");
+                             "invalid or unsupported ELF header");
 
   Expected<ELFT::ShdrRange> SectionsOrErr = File.sections();
   if (!SectionsOrErr)

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -414,7 +414,8 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
       ++Idx;
       continue;
     }
-    if (*NameOrErr == ".text" && Shdr.sh_offset + Shdr.sh_size <= Size) {
+    if (*NameOrErr == ".text" && Shdr.sh_offset <= Size &&
+        Shdr.sh_size <= Size - Shdr.sh_offset) {
       Text = &Shdr;
       TextIdx = Idx;
       break;

--- a/amd/comgr/src/comgr-hotswap-elf.cpp
+++ b/amd/comgr/src/comgr-hotswap-elf.cpp
@@ -404,6 +404,23 @@ Expected<ElfView> ElfView::create(uint8_t *Data, size_t Size) {
     return SectionsOrErr.takeError();
   ELFT::ShdrRange Sections = *SectionsOrErr;
 
+  for (const ELFT::Shdr &Shdr : Sections) {
+    if (Shdr.sh_type != ELF::SHT_NOBITS && Shdr.sh_size != 0 &&
+        (Shdr.sh_offset > Size || Shdr.sh_size > Size - Shdr.sh_offset))
+      return createStringError(object::object_error::parse_failed,
+                               "section extends past end of file");
+  }
+
+  Expected<ELFT::PhdrRange> PhdrsOrErr = File.program_headers();
+  if (!PhdrsOrErr)
+    return PhdrsOrErr.takeError();
+  for (const ELFT::Phdr &Phdr : *PhdrsOrErr) {
+    if (Phdr.p_filesz != 0 &&
+        (Phdr.p_offset > Size || Phdr.p_filesz > Size - Phdr.p_offset))
+      return createStringError(object::object_error::parse_failed,
+                               "segment extends past end of file");
+  }
+
   const ELFT::Shdr *Text = nullptr;
   unsigned TextIdx = 0;
   unsigned Idx = 0;

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -835,6 +835,12 @@ struct LLVMState {
   /// asm parser. Used by encodeSBranch() below to construct a fresh MCInst
   /// per call.
   unsigned SBranchOpcode = 0;
+  unsigned SCBranchScc0Opcode = 0;
+  unsigned SCBranchScc1Opcode = 0;
+  unsigned SCBranchVcczOpcode = 0;
+  unsigned SCBranchVccnzOpcode = 0;
+  unsigned SCBranchExeczOpcode = 0;
+  unsigned SCBranchExecnzOpcode = 0;
 
   /// MC opcode index for `s_nop`. Resolved via the asm parser at initLLVM()
   /// time so decoded-stream consumers (e.g. buildNopSledMap) can match NOPs

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -45,6 +45,7 @@
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/STLFunctionalExtras.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
@@ -340,6 +341,9 @@ struct DisplacementEdit {
   uint64_t Offset = 0;
   uint32_t OriginalSize = 0;
   llvm::SmallVector<uint8_t> ReplacementBytes;
+  /// For a pure insertion, map the old boundary after the inserted bytes.
+  /// Used for non-executable padding immediately before a kernel entry.
+  bool MapsOldOffsetAfterInsertion = false;
 };
 
 enum class DisplacementMapBias {
@@ -349,8 +353,18 @@ enum class DisplacementMapBias {
 
 class DisplacementPlan {
 public:
+  /// A validated plan defines one partial monotone map from old `.text`
+  /// boundaries to new boundaries. The map is undefined strictly inside a
+  /// replaced range; every code or metadata address must map through it or the
+  /// transaction is rejected.
+  /// \p RelocateTrailingSections lets the plan grow past a later allocatable
+  /// section: instead of failing when the grown .text would overlap trailing
+  /// allocatable content, the apply step shifts that content's virtual address
+  /// forward (used by transactional whole-object growth). Defaults false to
+  /// preserve the entry-workaround path's fail-closed behavior.
   static llvm::Expected<DisplacementPlan>
-  create(const ElfView &Elf, llvm::ArrayRef<DisplacementEdit> Edits);
+  create(const ElfView &Elf, llvm::ArrayRef<DisplacementEdit> Edits,
+         bool RelocateTrailingSections = false);
 
   llvm::ArrayRef<DisplacementEdit> edits() const { return Edits; }
   uint64_t oldTextSize() const { return OldTextSize; }
@@ -369,16 +383,21 @@ public:
   llvm::SmallVector<uint8_t> buildText(llvm::ArrayRef<uint8_t> OldText,
                                        llvm::ArrayRef<uint8_t> SNopBytes) const;
 
+  bool relocatesTrailingSections() const { return RelocateTrailingSections; }
+
 private:
   DisplacementPlan(uint64_t OldTextSize, uint64_t RawGrowth,
-                   uint64_t PaddedGrowth, std::vector<DisplacementEdit> Edits)
+                   uint64_t PaddedGrowth, std::vector<DisplacementEdit> Edits,
+                   bool RelocateTrailingSections)
       : OldTextSize(OldTextSize), RawGrowth(RawGrowth),
-        PaddedGrowth(PaddedGrowth), Edits(std::move(Edits)) {}
+        PaddedGrowth(PaddedGrowth), Edits(std::move(Edits)),
+        RelocateTrailingSections(RelocateTrailingSections) {}
 
   uint64_t OldTextSize = 0;
   uint64_t RawGrowth = 0;
   uint64_t PaddedGrowth = 0;
   std::vector<DisplacementEdit> Edits;
+  bool RelocateTrailingSections = false;
 };
 
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
@@ -777,6 +796,10 @@ struct RewriteConfig {
   unsigned MaxSgprs = 0;
   unsigned VgprGranuleSize = 0;
   bool RunB0A0Patches = true;
+  /// Permit growing replacements to participate in one whole-object
+  /// displacement transaction. A retry sets this false so every growing
+  /// replacement uses the legacy trampoline placement consistently.
+  bool AllowTextDisplacement = true;
   MaskWorkaroundPolicy MaskPolicy = MaskWorkaroundPolicy::None;
 };
 
@@ -849,6 +872,7 @@ struct LLVMState {
   unsigned SAddPcI64Opcode = 0;
   unsigned SCallI64Opcode = 0;
   unsigned SSwapPcI64Opcode = 0;
+  unsigned SLoadB64Opcode = 0;
   unsigned SPrefetchInstPcRelOpcode = 0;
   unsigned SPrefetchDataPcRelOpcode = 0;
 
@@ -907,9 +931,37 @@ LLVMState initLLVM(const TargetIdentifier &TI);
 
 /// Disassemble \p Text into \p Decoded using \p LS. Unknown bytes are encoded
 /// as MinInstSize-sized entries with mnemonic "<unknown>".
+///
+/// \p WantMnemonic controls whether each decoded instruction's assembly
+/// mnemonic string is populated. Building the mnemonic (MCInstPrinter lookup
+/// plus a per-instruction std::string) is pure overhead for callers that only
+/// inspect opcodes / MCInstrAnalysis and read InternalDecodedInst::Mnemonic
+/// solely for diagnostics. Passing false leaves DI.Mnemonic empty for
+/// successful decodes (failed decodes still carry the "<unknown>" marker, which
+/// some callers key on) so those callers avoid ~1 std::string per instruction
+/// over the whole section. Defaults to true to preserve mnemonic-consuming
+/// callers.
 [[nodiscard]] bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
                                      const LLVMState &LS,
-                                     std::vector<InternalDecodedInst> &Decoded);
+                                     std::vector<InternalDecodedInst> &Decoded,
+                                     bool WantMnemonic = true);
+
+/// Streaming variant of decodeTextSection. Decodes \p Text one instruction at a
+/// time and invokes \p OnInst for each, in ascending offset order, reusing a
+/// single InternalDecodedInst so no O(TextSize) result vector is materialized.
+/// The decode logic (variable-length linear scan, per-call decode cache,
+/// unknown-byte handling, optional mnemonic) is identical to decodeTextSection;
+/// decodeTextSection is implemented on top of this by appending each callback
+/// instruction to its vector, so the two never diverge.
+///
+/// \p OnInst returns true to continue and false to stop the scan early (e.g. on
+/// the first rejection). Returns true if the scan completed or was stopped by
+/// the callback, false only if the decoder itself could not proceed. Callers
+/// carry their own error out through state captured in \p OnInst.
+[[nodiscard]] bool decodeTextSectionStreaming(
+    const uint8_t *Text, uint64_t TextSize, const LLVMState &LS,
+    bool WantMnemonic,
+    llvm::function_ref<bool(const InternalDecodedInst &)> OnInst);
 
 /// Assemble one non-empty assembly source line, returning its encoded bytes.
 /// Target pseudos may expand that source line to more than one MCInst.
@@ -1147,6 +1199,9 @@ struct SafeSgprUsageSummary {
 
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
+  /// Calls/returns whose finite destination set was proved from linked ELF
+  /// metadata and straight-line register provenance.
+  llvm::DenseSet<uint64_t> RelocatableIndirectTransfers;
   bool HasUnresolvedTargets = false;
 };
 
@@ -1159,6 +1214,20 @@ struct DirectControlFlowInfo {
 inline constexpr int8_t VgprMsbUnanalyzed = -3;
 inline constexpr int8_t VgprMsbUnreachable = -2;
 inline constexpr int8_t VgprMsbUnknown = -1;
+
+/// One indirect call whose target register is loaded from a relocation-backed
+/// function table. Targets are .text-relative instruction offsets.
+struct RelocationTableDispatch {
+  uint64_t CallOffset = 0;
+  uint64_t SequenceStart = 0;
+  uint64_t SequenceEnd = 0;
+  llvm::SmallVector<uint64_t, 8> Targets;
+};
+
+llvm::Expected<std::vector<RelocationTableDispatch>>
+analyzeRelocationTableDispatches(const ElfView &Elf,
+                                 llvm::ArrayRef<InternalDecodedInst> Decoded,
+                                 const LLVMState &LS);
 
 /// Mutable per-run context threaded through all patch passes. Bundles the
 /// input config, decoded instruction stream, raw .text bytes, MC state,
@@ -1215,6 +1284,15 @@ struct PatchContext {
   llvm::StringMap<std::optional<KernelWorkgroupMetadata>>
       WorkgroupMetadataCache;
   llvm::StringMap<unsigned> KernelVgprGranuleCache;
+
+  // Growing patches are collected without mutating .text. The finalize pass
+  // adds the minimum kernel-entry alignment insertions and commits the complete
+  // edit set through one transactional DisplacementPlan.
+  std::vector<DisplacementEdit> DisplacementEdits;
+  // One growing site could not join the transaction. The caller must discard
+  // this speculative run and retry the original object with displacement
+  // disabled; mixing deferred trampolines and displacement is not valid.
+  bool DisplacementDeclined = false;
 };
 
 /// Return occupancy limits for \p Processor from COMGR's ISA metadata table.
@@ -1348,15 +1426,24 @@ resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
 /// contains text-relative function and kernel entry offsets; \p FunctionRanges
 /// supplies the symbol ranges used for the return proof; \p ExternalEntries
 /// identifies externally reachable symbol and kernel entries, including
-/// aliases at a local function's start. Other register-target control flow
-/// sets HasUnresolvedTargets so callers can disable transformations that
-/// consume possible destinations.
+/// aliases at a local function's start. \p RelocationDispatches supplies the
+/// finite targets of structurally proved relocation-table calls. Other
+/// register-target control flow sets HasUnresolvedTargets so callers can
+/// disable transformations that consume possible destinations.
 std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextSize,
     llvm::ArrayRef<uint64_t> DeclaredEntries,
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
-    llvm::ArrayRef<uint64_t> ExternalEntries = {});
+    llvm::ArrayRef<uint64_t> ExternalEntries = {},
+    llvm::ArrayRef<RelocationTableDispatch> RelocationDispatches = {});
+
+/// Run the linked-object control-flow proof used by both patch placement and
+/// transactional displacement validation.
+std::optional<DirectControlFlowInfo>
+analyzeDirectControlFlow(const ElfView &Elf,
+                         llvm::ArrayRef<InternalDecodedInst> Decoded,
+                         const LLVMState &LS);
 
 [[nodiscard]] bool emitReplacementCode(PatchContext &Ctx, uint64_t InstOffset,
                                        uint32_t InstSize,
@@ -1543,10 +1630,14 @@ std::unique_ptr<llvm::WritableMemoryBuffer> addKernelEntryTrampolineSymbols(
     llvm::WritableMemoryBuffer &In, uint64_t PoolVAddr,
     llvm::ArrayRef<KernelEntryTrampolineFixup> Fixups);
 
-/// Apply direct .text displacement to a newly allocated output buffer.
+/// Apply direct .text displacement to a newly allocated output buffer. With
+/// \p RelocateTrailingSections, a grow that would overlap later allocatable
+/// content instead shifts that content's virtual address forward; default
+/// false preserves the entry-path fail-closed overlap check.
 llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>>
 tryApplyTextDisplacementToNewBuffer(const ElfView &Elf, const LLVMState &LS,
-                                    llvm::ArrayRef<DisplacementEdit> Edits);
+                                    llvm::ArrayRef<DisplacementEdit> Edits,
+                                    bool RelocateTrailingSections = false);
 
 // -- Function declarations (GFX1250 hotswap policy layer) ---------------------
 

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -858,6 +858,8 @@ struct LLVMState {
   unsigned GlobalPrefetchB8Opcode = 0;
   unsigned SGetPcI64Opcode = 0;
   unsigned SAddNcU64Opcode = 0;
+  unsigned SAddCoU32Opcode = 0;
+  unsigned SAddCoCiU32Opcode = 0;
   unsigned SAddU32Opcode = 0;
   unsigned SAddcU32Opcode = 0;
   unsigned SSetPcI64Opcode = 0;
@@ -1394,7 +1396,8 @@ evaluateDirectControlFlowTarget(const InternalDecodedInst &DI,
                                 const LLVMState &LS);
 
 /// A canonical get-PC/add materialized address feeding a PC-materialized
-/// transfer (s_get_pc_i64 / s_add_nc_u64 / s_{swap,set}_pc_i64). \p Target is
+/// transfer. Supported add forms are `s_add_nc_u64` and the adjacent
+/// `s_add_co_u32` / `s_add_co_ci_u32` carry chain. \p Target is
 /// the absolute in-.text virtual address; \p SequenceStart is the .text offset
 /// of the s_get_pc_i64 that begins the sequence.
 struct MaterializedPcSequence {
@@ -1405,10 +1408,10 @@ struct MaterializedPcSequence {
 /// Resolve the target of a PC-materialized transfer whose target register is
 /// \p TargetReg and whose transfer instruction (an s_swap_pc_i64 call or an
 /// s_set_pc_i64 jump) is \p Decoded[TransferIndex]. Scans backward for the
-/// single s_add_nc_u64 then s_get_pc_i64 that define \p TargetReg, stopping at
-/// the first control-flow boundary or unexpected clobber so any variation
-/// stays unresolved (nullopt) for fail-closed callers. \p TextAddr is the
-/// .text base virtual address.
+/// supported add sequence then s_get_pc_i64 that define \p TargetReg, stopping
+/// at the first control-flow boundary or unexpected clobber so any variation
+/// stays unresolved (nullopt) for fail-closed callers. \p TextAddr is the .text
+/// base virtual address.
 [[nodiscard]] std::optional<MaterializedPcSequence>
 resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
                             size_t TransferIndex, llvm::MCRegister TargetReg,

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -365,6 +365,9 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_swap_pc_i64 s[0:1], s[2:3]",
                                      "s_swap_pc_i64", S, S.SSwapPcI64Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_load_b64 s[0:1], s[2:3], s4",
+                                     "s_load_b64", S, S.SLoadB64Opcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_prefetch_inst_pc_rel 100, s10, 7",
                                      "s_prefetch_inst_pc_rel", S,
                                      S.SPrefetchInstPcRelOpcode))
@@ -473,10 +476,9 @@ SmallVector<uint8_t> LLVMState::encodeSBranch(uint64_t FromOffset,
 
 // -- Instruction decode -------------------------------------------------------
 
-bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
-                       const LLVMState &S,
-                       std::vector<InternalDecodedInst> &Decoded) {
-  Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
+bool decodeTextSectionStreaming(
+    const uint8_t *Text, uint64_t TextSize, const LLVMState &S,
+    bool WantMnemonic, function_ref<bool(const InternalDecodedInst &)> OnInst) {
   uint64_t Pos = 0;
   // Per-call decode cache: byte-identical instructions reuse the first decode
   // instead of re-running the disassembler; DI.Offset is set per occurrence, so
@@ -492,9 +494,14 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
     std::string Mnemonic;
   };
   StringMap<DecodeCacheEntry> LocalCache;
+  // One reused instruction record: the streaming contract only exposes DI to
+  // OnInst for the current position, so no per-instruction allocation or result
+  // vector is needed. Reset the mutable fields each iteration.
+  InternalDecodedInst DI;
   while (Pos < TextSize) {
-    InternalDecodedInst DI;
     DI.Offset = Pos;
+    DI.DecodeSucceeded = false;
+    DI.Mnemonic.clear();
 
     unsigned KeyN =
         static_cast<unsigned>(std::min<uint64_t>(MaxInstLen, TextSize - Pos));
@@ -508,10 +515,15 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       // Only successful decodes are stored, so a hit is always a success.
       DI.DecodeSucceeded = true;
       Pos += DI.Size;
-      Decoded.emplace_back(std::move(DI));
+      if (!OnInst(DI))
+        return true;
       continue;
     }
 
+    // The AMDGPU disassembler appends operands to the passed MCInst without
+    // clearing it first, so a reused DI.Inst must be reset to the same clean
+    // state a fresh per-iteration record would have before getInstruction.
+    DI.Inst = MCInst();
     ArrayRef<uint8_t> Bytes(Text + Pos, TextSize - Pos);
     uint64_t InstSize = 0;
     MCDisassembler::DecodeStatus Status =
@@ -527,13 +539,16 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       // table. Storage is process-lifetime static; the trailing whitespace
       // baked into AsmStrs must be trimmed. If the printer cannot provide an
       // assembly mnemonic, leave the instruction unmatchable instead of falling
-      // back to TableGen opcode names.
-      if (S.MCIP) {
-        std::pair<const char *, uint64_t> Mnem = S.MCIP->getMnemonic(DI.Inst);
-        DI.Mnemonic = Mnem.first ? StringRef(Mnem.first).rtrim().str()
-                                 : UnknownMnemonic.str();
-      } else {
-        DI.Mnemonic = UnknownMnemonic.str();
+      // back to TableGen opcode names. Callers that never read the mnemonic
+      // (WantMnemonic == false) skip this per-instruction std::string entirely.
+      if (WantMnemonic) {
+        if (S.MCIP) {
+          std::pair<const char *, uint64_t> Mnem = S.MCIP->getMnemonic(DI.Inst);
+          DI.Mnemonic = Mnem.first ? StringRef(Mnem.first).rtrim().str()
+                                   : UnknownMnemonic.str();
+        } else {
+          DI.Mnemonic = UnknownMnemonic.str();
+        }
       }
     }
     // Cache only successful decodes whose key window covers the instruction
@@ -542,9 +557,25 @@ bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
       LocalCache.try_emplace(Key,
                              DecodeCacheEntry{DI.Inst, DI.Size, DI.Mnemonic});
     Pos += DI.Size;
-    Decoded.emplace_back(std::move(DI));
+    if (!OnInst(DI))
+      return true;
   }
   return true;
+}
+
+bool decodeTextSection(const uint8_t *Text, uint64_t TextSize,
+                       const LLVMState &S,
+                       std::vector<InternalDecodedInst> &Decoded,
+                       bool WantMnemonic) {
+  Decoded.reserve(Decoded.size() + TextSize / MinInstSize);
+  // Materialize the full result by copying each streamed instruction into the
+  // vector. Streaming callers that only inspect one instruction at a time avoid
+  // this O(TextSize) storage; see decodeTextSectionStreaming.
+  return decodeTextSectionStreaming(Text, TextSize, S, WantMnemonic,
+                                    [&Decoded](const InternalDecodedInst &DI) {
+                                      Decoded.push_back(DI);
+                                      return true;
+                                    });
 }
 
 // -- assembly helpers ---------------------------------------------------------

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -300,6 +300,20 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
           << "via asm parser for CPU '" << S.Cpu << "'.\n";
     return S;
   }
+  if (!resolveRequiredOpcodeViaParse("s_cbranch_scc0 0", "s_cbranch_scc0", S,
+                                     S.SCBranchScc0Opcode) ||
+      !resolveRequiredOpcodeViaParse("s_cbranch_scc1 0", "s_cbranch_scc1", S,
+                                     S.SCBranchScc1Opcode) ||
+      !resolveRequiredOpcodeViaParse("s_cbranch_vccz 0", "s_cbranch_vccz", S,
+                                     S.SCBranchVcczOpcode) ||
+      !resolveRequiredOpcodeViaParse("s_cbranch_vccnz 0", "s_cbranch_vccnz", S,
+                                     S.SCBranchVccnzOpcode) ||
+      !resolveRequiredOpcodeViaParse("s_cbranch_execz 0", "s_cbranch_execz", S,
+                                     S.SCBranchExeczOpcode) ||
+      !resolveRequiredOpcodeViaParse("s_cbranch_execnz 0",
+                                     "s_cbranch_execnz", S,
+                                     S.SCBranchExecnzOpcode))
+    return S;
 
   SmallVector<MCInst, 2> NopInsts = parseAsmToMCInsts("s_nop 0", S);
   if (NopInsts.size() != 1) {

--- a/amd/comgr/src/comgr-hotswap-llvm.cpp
+++ b/amd/comgr/src/comgr-hotswap-llvm.cpp
@@ -335,6 +335,13 @@ LLVMState initLLVM(const TargetIdentifier &TI) {
   if (!resolveRequiredOpcodeViaParse("s_add_nc_u64 s[0:1], s[0:1], 0",
                                      "s_add_nc_u64", S, S.SAddNcU64Opcode))
     return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_co_u32 s0, s0, 0", "s_add_co_u32",
+                                     S, S.SAddCoU32Opcode))
+    return S;
+  if (!resolveRequiredOpcodeViaParse("s_add_co_ci_u32 s1, s1, 0",
+                                     "s_add_co_ci_u32", S,
+                                     S.SAddCoCiU32Opcode))
+    return S;
   if (!resolveRequiredOpcodeViaParse("s_add_u32 s0, s0, 0", "s_add_u32", S,
                                      S.SAddU32Opcode))
     return S;

--- a/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-f32-to-e5m3.cpp
@@ -619,7 +619,7 @@ uint32_t patchCvtSrFp8F32(PatchContext &Ctx, size_t Idx) {
       VgprBumpDecision::Apply)
     return 0;
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {
@@ -789,7 +789,7 @@ uint32_t patchCvtF32Fp8(PatchContext &Ctx, size_t Idx) {
       VgprBumpDecision::Apply)
     return 0;
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, ReplacementBytes))
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, ReplacementBytes))
     return 0;
 
   if (!SA.KernelName.empty()) {

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-scale16.cpp
@@ -460,8 +460,8 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
       VgprBumpDecision::Apply)
     return 0; // checkKernelVgprBump set RequiredPatchFailed on the Fail path.
 
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
-    return failClosed(Ctx, DI, "trampoline emission failed");
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement))
+    return failClosed(Ctx, DI, "replacement emission failed");
 
   if (MaskSgpr && !commitSafeSgprScratchBlock(Ctx, DI.Offset, *MaskSgpr,
                                               "wmma_scale16 lane mask"))

--- a/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
+++ b/amd/comgr/src/comgr-hotswap-patch-wmma-split.cpp
@@ -1272,7 +1272,7 @@ static uint32_t applyWmmaSplitPatchesImpl(PatchContext &Ctx, size_t Idx) {
           << DI.Mnemonic << "\n";
     return failWmmaSplit(Ctx);
   }
-  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement)) {
+  if (!emitReplacementCode(Ctx, DI.Offset, DI.Size, Replacement)) {
     log() << "hotswap: error: WMMA split: could not emit trampoline for "
           << DI.Mnemonic << "\n";
     return failWmmaSplit(Ctx);

--- a/amd/comgr/test-lit/hotswap-cvt-f32-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-f32-fp8.s
@@ -13,7 +13,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-bytesel.s
@@ -16,7 +16,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-modifiers.s
@@ -16,7 +16,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-multi.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-multi.s
@@ -1,7 +1,7 @@
 // COM: Test multiple FP8 E5M3 patch sites in a single kernel.
 // COM:
-// COM: Exercises: stacking of multiple trampolines, cross-instruction-type
-// COM: coexistence, overlapping src/dst registers.
+// COM: Exercises: transactional inlining of multiple translations,
+// COM: cross-instruction-type coexistence, overlapping src/dst registers.
 // COM:
 // COM: Companion tests:
 // COM:   hotswap-cvt-pk-fp8.s   — v_cvt_pk_fp8_f32  (pack F32->E5M3)
@@ -23,24 +23,19 @@
 
 // ---- Kernel 1: two v_cvt_pk_fp8_f32 clamp sites (same type) ------------------
 //
-// COM: Both pk instructions must be replaced by s_branch, and both trampolines
-// COM: must appear in the output. Tests trampoline stacking for identical
-// COM: instruction types.
+// COM: Both pk instructions must be replaced inline, in source order.
 
 // SAME-LABEL: <test_multi_fp8_same>:
 // SAME-NOT:   v_cvt_pk_fp8_f32
-// SAME:       s_branch
-// SAME-NOT:   v_cvt_pk_fp8_f32
-// SAME:       s_branch
-// SAME:       s_endpgm
-// COM: --- First pk trampoline (vdst=v0, src0=v1, src1=v2) ---
+// COM: --- First pk translation (vdst=v0, src0=v1, src1=v2) ---
 // SAME:       v_and_b32{{.*}}0x7fffffff, v1
 // SAME:       v_lshl_or_b32
 // SAME-NEXT:  v_bfi_b32 v0,
-// COM: --- Second pk trampoline (vdst=v4, src0=v5, src1=v6) ---
+// COM: --- Second pk translation (vdst=v4, src0=v5, src1=v6) ---
 // SAME:       v_and_b32{{.*}}0x7fffffff, v5
 // SAME:       v_lshl_or_b32
 // SAME-NEXT:  v_bfi_b32 v4,
+// SAME:       s_endpgm
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
@@ -57,29 +52,26 @@ test_multi_fp8_same:
 
 // ---- Kernel 2: all three FP8 types in one kernel (mixed) ---------------------
 //
-// COM: Each instruction type gets its own s_branch + trampoline with a distinct
+// COM: Each instruction type gets an inline translation with a distinct
 // COM: signature: pk uses v_lshl_or_b32, sr uses v_lshrrev_b32 12 for noise
 // COM: injection, unpack uses v_or_b32 0x47800000 for exp-31 construction.
 
 // MIXED-LABEL: <test_multi_fp8_mixed>:
 // MIXED-NOT:  v_cvt_pk_fp8_f32
-// MIXED:      s_branch
 // MIXED-NOT:  v_cvt_sr_fp8_f32
-// MIXED:      s_branch
 // MIXED-NOT:  v_cvt_f32_fp8
-// MIXED:      s_branch
-// MIXED:      s_endpgm
-// COM: --- pk trampoline: pack via v_lshl_or_b32 + merge into v0 ---
+// COM: --- pk translation: pack via v_lshl_or_b32 + merge into v0 ---
 // MIXED:      v_and_b32{{.*}}0x7fffffff, v1
 // MIXED:      v_lshl_or_b32
 // MIXED-NEXT: v_bfi_b32 v0,
-// COM: --- sr trampoline: noise injection via v_lshrrev_b32 12 ---
+// COM: --- sr translation: noise injection via v_lshrrev_b32 12 ---
 // MIXED:      v_lshrrev_b32{{.*}}, 12, v6
 // MIXED:      v_bfi_b32 v4,
-// COM: --- unpack trampoline: byte extraction + exp-31 F32 construction ---
+// COM: --- unpack translation: byte extraction + exp-31 F32 construction ---
 // MIXED:      v_and_b32{{.*}}0xff, v9
 // MIXED:      v_or_b32{{.*}}0x47800000
 // MIXED:      v_cvt_f32_f16
+// MIXED:      s_endpgm
 
 .globl test_multi_fp8_mixed
 .p2align 8
@@ -101,8 +93,7 @@ test_multi_fp8_mixed:
 
 // OVERLAP-LABEL: <test_multi_fp8_overlap>:
 // OVERLAP-NOT:   v_cvt_pk_fp8_f32
-// OVERLAP:       s_branch
-// COM: --- Trampoline applied despite vdst==src0 overlap ---
+// COM: --- Translation applied despite vdst==src0 overlap ---
 // OVERLAP:       v_and_b32{{.*}}0x7fffffff, v0
 // OVERLAP:       v_bfi_b32 v0,
 

--- a/amd/comgr/test-lit/hotswap-cvt-fp8-nosled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-fp8-nosled.s
@@ -13,7 +13,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-in-function.s
@@ -7,7 +7,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8-zero-fill-sled.s
@@ -7,7 +7,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-pk-fp8.s
@@ -14,7 +14,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent 2>&1 \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
+++ b/amd/comgr/test-lit/hotswap-cvt-sr-fp8.s
@@ -13,7 +13,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --dump %t.out.elf --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-indirect-call-far.s
+++ b/amd/comgr/test-lit/hotswap-indirect-call-far.s
@@ -1,20 +1,20 @@
-// COM: An unresolved register call may target any original text instruction.
-// COM: In particular, it can target the second of two adjacent far patch sites.
-// COM: The rewriter must not coalesce those sites or consume original .text
-// COM: gateway space. This object has no safe target-independent route to the
-// COM: far trampoline pool, so it must fail closed instead of returning a
-// COM: successful object whose register call lands on rewritten padding.
+// COM: The add-with-carry PC-materialization form has one finite target. The
+// COM: rewriter can therefore protect that target while coalescing the two
+// COM: adjacent far patch sites and using original .text gateway space.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR 2>&1 \
+// RUN:   --output %t.out.elf 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=LOG,API %s
-// LOG: hotswap: unresolved control-flow target disables NOP-sled emission,
-// LOG-SAME: trampoline coalescing, source relocation, and .text gateways
-// LOG: hotswap: error: no safe short-branch gateway for far site
-// API: RESULT: ERROR
+// LOG: hotswap: resolved PC-materialized call at 0xC to .text+0x18
+// LOG-NOT: unresolved control-flow target disables
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM: s_swap_pc_i64 s[0:1], s[2:3]
+// DISASM-NOT: ds_load_2addr_stride64_b64
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-indirect-call-lit64-far.s
+++ b/amd/comgr/test-lit/hotswap-indirect-call-lit64-far.s
@@ -1,0 +1,57 @@
+// COM: A compiler-emitted lit64 s_add_nc_u64 materializes one finite call
+// COM: target. Absolute MC expressions must be accepted like immediates.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved PC-materialized call at 0x14 to .text+0x20
+// LOG-NOT: unresolved control-flow target disables
+// LOG: RESULT: SUCCESS
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl test_indirect_call_lit64_far
+.p2align 8
+.type test_indirect_call_lit64_far,@function
+test_indirect_call_lit64_far:
+  // s_get_pc_i64 captures .text+4. The 64-bit literal reaches .text+32.
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], lit64(28)
+  s_mov_b64 s[4:5], s[0:1]
+  s_swap_pc_i64 s[0:1], s[2:3]
+  ds_load_2addr_stride64_b64 v[0:3], v4 offset0:1 offset1:2
+.Lindirect_target:
+  ds_load_2addr_stride64_b64 v[4:7], v8 offset0:3 offset1:4
+  s_wait_dscnt 0x0
+  s_endpgm
+.size test_indirect_call_lit64_far, .-test_indirect_call_lit64_far
+
+.fill 64, 1, 0
+.rept 40000
+  s_mov_b32 s0, s1
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_indirect_call_lit64_far
+  .amdhsa_next_free_vgpr 9
+  .amdhsa_next_free_sgpr 6
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_indirect_call_lit64_far
+      .symbol: test_indirect_call_lit64_far.kd
+      .sgpr_count: 6
+      .vgpr_count: 9
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-inplace-saddr.s
+++ b/amd/comgr/test-lit/hotswap-inplace-saddr.s
@@ -9,7 +9,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@
 // DISASM-NEXT: s_mov_b32 m0, [[SCRATCH]]
 
 // COM: Idempotency: output should be identical on second rewrite.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-relocation.s
+++ b/amd/comgr/test-lit/hotswap-kernel-entry-trampoline-relocation.s
@@ -1,6 +1,6 @@
-// COM: A dynamic relocation can write outside .text while its addend still
-// COM: references displaced code. Direct displacement must decline this input
-// COM: and use an appended entry stub so the relocation remains valid.
+// COM: A dynamic relocation can write outside .text while its addend references
+// COM: displaced code. Direct entry displacement must move the helper and
+// COM: rewrite the R_AMDGPU_RELATIVE64 addend in the same transaction.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: hotswap-rewrite %t.elf \
@@ -11,28 +11,28 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-LABEL: <relocation_kernel>:
+// DISASM-NEXT: global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+// DISASM-NEXT: v_nop
 // DISASM-NEXT: s_endpgm
 // DISASM-LABEL: <pointed_helper>:
 // DISASM-NEXT: s_endpgm
-// DISASM: global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
-// DISASM-NEXT: v_nop
-// DISASM-NEXT: s_get_pc_i64
+// DISASM-NOT: s_get_pc_i64
 
 // RUN: (echo ORIGINAL; %llvm-readelf -Ws %t.elf; \
 // RUN:  echo REWRITTEN; %llvm-readelf -Ws %t.out.elf) \
 // RUN:  | %FileCheck --check-prefix=SYMBOL %s
 // SYMBOL: ORIGINAL
-// SYMBOL: [[HELPER:[0-9a-fA-F]+]] {{.*}} pointed_helper
+// SYMBOL: 0000000000001604 {{.*}} pointed_helper
 // SYMBOL: REWRITTEN
-// SYMBOL: [[HELPER]] {{.*}} pointed_helper
+// SYMBOL: 0000000000001614 {{.*}} pointed_helper
 
 // RUN: (echo ORIGINAL; %llvm-readelf -r %t.elf; \
 // RUN:  echo REWRITTEN; %llvm-readelf -r %t.out.elf) \
 // RUN:  | %FileCheck --check-prefix=RELOCATION %s
 // RELOCATION: ORIGINAL
-// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}[[ADDEND:[0-9a-fA-F]+]]
+// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}1604
 // RELOCATION: REWRITTEN
-// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}[[ADDEND]]
+// RELOCATION: R_AMDGPU_RELATIVE64{{ +}}1614
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text

--- a/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
+++ b/amd/comgr/test-lit/hotswap-nop-sled-function-scope.s
@@ -3,7 +3,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid-nosled.s
@@ -22,7 +22,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -81,7 +81,7 @@ test_addtid_nosled:
 // COM: produce identical bytes. The trampoline body uses plain ds_load_b32
 // COM: (no ADDTID mnemonic), so the dispatcher leaves it untouched on
 // COM: subsequent runs.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-addtid.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-addtid.s
@@ -23,7 +23,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -235,7 +235,7 @@ test_addtid_store:
 // COM: Idempotency: rewriting the output a second time must produce
 // COM: identical bytes (the patched body has no ADDTID mnemonic so the
 // COM: dispatcher leaves it untouched on subsequent runs).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-branch-islands.s
@@ -3,7 +3,7 @@
 // COM: trampoline return uses the accepted SGPR-backed set-PC sequence.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf | %FileCheck --check-prefix=API %s
 // API: RESULT: SUCCESS
@@ -11,14 +11,14 @@
 // COM: Exercise the large-object planning path with verbose accounting. This
 // COM: fixture contains more than 250 KiB of text and requires a deterministic
 // COM: forward branch-island chain.
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.scale.elf 2>&1 | %FileCheck --check-prefix=SCALE %s
 // SCALE: hotswap: assigned 1 forward s_branch island chain(s)
 // SCALE: hotswap: applied 1 instruction patches
 // SCALE: hotswap: growWithTrampolines: appended 1 trampoline
 
-// RUN: hotswap-rewrite %t.scale.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.scale.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=SCALE-IDEM %s
 // SCALE-IDEM: IDEMPOTENT: YES
@@ -41,7 +41,7 @@
 // DISASM-NEXT: s_add_nc_u64 s[14:15], s[14:15],
 // DISASM-NEXT: s_set_pc_i64 s[14:15]
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-cluster-scc.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-cluster-scc.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -27,7 +27,7 @@
 // METADATA: .name:           test_cluster_scc_live
 // METADATA: .sgpr_count:     9
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-cluster-scratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-cluster-scratch.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-trampoline-cluster.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-cluster.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -63,7 +63,7 @@
 // METADATA: .sgpr_count:     17
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s
@@ -75,7 +75,7 @@
 // RUN:     -e 's/.sgpr_count: 16/.sgpr_count: 106/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
-// RUN: hotswap-rewrite %t.highsgpr.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR \
 // RUN:   | %FileCheck --check-prefix=NO-SCRATCH %s

--- a/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-compact-gateway.s
@@ -4,7 +4,8 @@
 // COM: size instead of requiring the 20-byte worst-case reservation.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
 // LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)

--- a/amd/comgr/test-lit/hotswap-trampoline-direct-target-sled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-direct-target-sled.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -29,7 +29,7 @@
 // DISASM-NEXT: s_wait_dscnt 0x0
 // DISASM-NEXT: s_branch
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-multi.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -23,7 +23,7 @@
 // DISASM: s_wait_dscnt 0x0
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nosled.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -17,7 +17,7 @@
 // COM: Entry displacement is applied before ordinary instruction rewriting.
 // COM: Verify that the direct entry prefix and appended DS trampoline coexist
 // COM: with branch sites calculated from the displaced instruction layout.
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --entry-trampolines --output %t.entry.elf \
 // RUN:   | %FileCheck --check-prefix=ENTRY-API %s
@@ -53,7 +53,7 @@
 // DISASM-NEXT: s_code_end
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64-multi.s
@@ -13,7 +13,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -77,7 +77,7 @@ test_multi_ds_nostride64:
 .size test_multi_ds_nostride64, .Ltest_multi_ds_nostride64_end-test_multi_ds_nostride64
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nostride64.s
@@ -21,7 +21,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -343,7 +343,7 @@ test_ds_combo_nostride64:
 
 // COM: Idempotency: rewriting the output again should produce identical
 // COM: bytes (no DS2 mnemonic remains, second pass is a no-op).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-nowait.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -27,7 +27,7 @@
 // DISASM: s_branch
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds-pipelined.s
@@ -7,7 +7,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -43,7 +43,7 @@
 
 // COM: Idempotency: a second rewrite produces identical bytes (the 2-addr
 // COM: forms are gone, so there is nothing left to split).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-ds.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-ds.s
@@ -15,7 +15,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -64,7 +64,7 @@
 // DISASM: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-fragmented-gateway.s
@@ -5,7 +5,7 @@
 // COM: gateway. The pool is beyond s_branch range and no island chain exists.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
 // LOG: hotswap: assigned 1 SCC-neutral forward gateway(s)
@@ -35,7 +35,7 @@
 // META: .name:           fragmented_gateway
 // META: .sgpr_count:     4
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
 // IDEM: IDEMPOTENT: YES

--- a/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-long-branch.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -32,7 +32,7 @@
 // METADATA: .name:           test_far
 // METADATA: .sgpr_count:     16
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s
@@ -45,7 +45,7 @@
 // RUN:   -e 's/\.sgpr_count: 14/.sgpr_count: 106/' %s > %t.full-sgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.full-sgpr.s -o %t.full-sgpr.elf
-// RUN: hotswap-rewrite %t.full-sgpr.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.full-sgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 // FAIL: RESULT: ERROR
@@ -55,7 +55,7 @@
 // RUN: sed '/^.amdgpu_metadata$/,/^.end_amdgpu_metadata$/d' %s > %t.nometa.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.nometa.s -o %t.nometa.elf
-// RUN: hotswap-rewrite %t.nometa.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.nometa.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --expect-status ERROR | %FileCheck --check-prefix=FAIL %s
 

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-known.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-known.s
@@ -5,7 +5,7 @@
 // RUN:   --amdhsa-code-object-version=6 -filetype=obj %s -o %t.o
 // RUN: %ld.lld -flavor gnu -m elf64_amdgpu %t.o -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --output %t.default.elf \
@@ -19,7 +19,7 @@
 // DEFAULTDIS: tensor_load_to_lds s[0:3], s[4:11]
 // DEFAULTDIS: s_endpgm
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \
@@ -60,7 +60,7 @@
 // METADATA: .name:           test_tensor_b0_known_cluster
 // METADATA: .sgpr_count:     17
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --check-idempotent \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scc.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scc.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \
@@ -32,7 +32,7 @@
 // METADATA: .name:           test_tensor_b0_scc_live
 // METADATA: .sgpr_count:     18
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --check-idempotent \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scratch.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0-scratch.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-b0.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-b0.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --output %t.default.elf \
@@ -19,7 +19,7 @@
 // DEFAULTDIS: cluster_load_b32 v{{[0-9]+}}, v{{[0-9]+}}, s[{{[0-9:]+}}]
 // DEFAULTDIS: s_endpgm
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --output %t.out.elf \
@@ -47,7 +47,7 @@
 // METADATA: .name:           test_tensor_b0_dynamic
 // METADATA: .sgpr_count:     17
 
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --check-idempotent \
@@ -58,7 +58,7 @@
 // RUN:     -e 's/.sgpr_count: 16/.sgpr_count: 106/' %s > %t.highsgpr.s
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
 // RUN:   %t.highsgpr.s -o %t.highsgpr.elf
-// RUN: hotswap-rewrite %t.highsgpr.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.highsgpr.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   --strict-mode --expect-status ERROR \

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-liveness.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -28,7 +28,7 @@
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-multi.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -56,7 +56,7 @@
 // DISASM: s_endpgm
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor-nosled.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -52,7 +52,7 @@
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --strict-mode --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-trampoline-tensor.s
+++ b/amd/comgr/test-lit/hotswap-trampoline-tensor.s
@@ -17,7 +17,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   2>&1 \
@@ -111,7 +111,7 @@
 // DISASM-NEXT: s_branch
 
 // COM: Idempotency: rewriting the output again should produce identical bytes.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-transactional-displacement-addcarry.s
+++ b/amd/comgr/test-lit/hotswap-transactional-displacement-addcarry.s
@@ -1,0 +1,69 @@
+// COM: Transactional displacement repairs the carry-chain PC materialization
+// COM: used by production rocSOLVER objects. The growing DS rewrite moves the
+// COM: in-.text target, so the low/high add immediates must be re-encoded.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: transactional displacement: collected 1 growing edit(s)
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <transactional_addcarry>:
+// DISASM:       s_get_pc_i64 s[0:1]
+// DISASM-NEXT:  s_add_co_u32 s0, s0, {{(0x[0-9a-f]+|[0-9]+)}}
+// DISASM-NEXT:  s_add_co_ci_u32 s1, s1, {{(lit\(0x[0-9a-f]+\)|0x[0-9a-f]+|[0-9]+)}}
+// DISASM-NEXT:  s_set_pc_i64 s[0:1]
+// DISASM-NOT:   ds_load_2addr_stride64_b32
+// DISASM:       ds_load_b32 v4, v2 offset:256
+// DISASM-NEXT:  ds_load_b32 v5, v2 offset:768
+// DISASM:       s_endpgm
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl transactional_addcarry
+.p2align 8
+.type transactional_addcarry,@function
+transactional_addcarry:
+  // s_get_pc_i64 captures the address of the following low-word add. The
+  // original target is 20 bytes after that PC base.
+  s_get_pc_i64 s[0:1]
+  s_add_co_u32 s0, s0, 20
+  s_add_co_ci_u32 s1, s1, 0
+  s_set_pc_i64 s[0:1]
+  ds_load_2addr_stride64_b32 v[4:5], v2 offset0:1 offset1:3
+.Ltarget:
+  s_endpgm
+.Lend:
+.size transactional_addcarry, .Lend-transactional_addcarry
+
+.rodata
+.p2align 8
+.amdhsa_kernel transactional_addcarry
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_group_segment_fixed_size 256
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: transactional_addcarry
+      .symbol: transactional_addcarry.kd
+      .sgpr_count: 2
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 256
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-transactional-displacement-branch-island.s
+++ b/amd/comgr/test-lit/hotswap-transactional-displacement-branch-island.s
@@ -1,0 +1,70 @@
+// COM: Transactional displacement relaxes a conditional branch whose target
+// COM: moves just beyond simm16 range. A guarded 256-byte island preserves
+// COM: ordinary fallthrough and all later kernel-entry alignment.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: displacement: planned guarded branch island
+// LOG: displacement: relaxed branch
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <transactional_branch_island>:
+// DISASM-NEXT:  s_cbranch_execz 16416
+// DISASM:       s_branch 63
+// DISASM-NEXT:  s_branch 16417
+// DISASM-NOT:   ds_load_2addr_stride64_b32
+// DISASM:       ds_load_b32 v4, v2 offset:256
+// DISASM-NEXT:  ds_load_b32 v5, v2 offset:768
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  s_endpgm
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl transactional_branch_island
+.p2align 8
+.type transactional_branch_island,@function
+transactional_branch_island:
+  // The original target is exactly +32767 dwords from the branch PC. Growing
+  // the DS instruction between the branch and target requires relaxation.
+  s_cbranch_execz .Ltarget
+  .rept 32765
+    s_nop 0
+  .endr
+  ds_load_2addr_stride64_b32 v[4:5], v2 offset0:1 offset1:3
+.Ltarget:
+  s_endpgm
+.Lend:
+.size transactional_branch_island, .Lend-transactional_branch_island
+
+.rodata
+.p2align 8
+.amdhsa_kernel transactional_branch_island
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_group_segment_fixed_size 256
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: transactional_branch_island
+      .symbol: transactional_branch_island.kd
+      .sgpr_count: 1
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 256
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-transactional-displacement.s
+++ b/amd/comgr/test-lit/hotswap-transactional-displacement.s
@@ -1,0 +1,68 @@
+// COM: A growing B0-to-A0 instruction rewrite is committed in place through
+// COM: one whole-object displacement transaction. The expanded instructions
+// COM: remain on the original straight-line path; no trampoline branch or
+// COM: executable alignment padding is introduced.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: transactional displacement: collected 1 growing edit(s)
+// LOG: displacement: grew ELF
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <transactional_ds2>:
+// DISASM-NOT:   ds_load_2addr_stride64_b32
+// DISASM-NOT:   s_branch
+// DISASM:       ds_load_b32 v4, v2 offset:256
+// DISASM-NEXT:  ds_load_b32 v5, v2 offset:768
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  s_wait_dscnt 0x0
+// DISASM-NEXT:  s_endpgm
+
+// RUN: %llvm-readelf -n %t.out.elf | %FileCheck --check-prefix=METADATA %s
+// METADATA-NOT: .gfx1250_revision: B0
+// METADATA:     .gfx1250_revision: A0
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl transactional_ds2
+.p2align 8
+.type transactional_ds2,@function
+transactional_ds2:
+  ds_load_2addr_stride64_b32 v[4:5], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.Lend:
+.size transactional_ds2, .Lend-transactional_ds2
+
+.rodata
+.p2align 8
+.amdhsa_kernel transactional_ds2
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 6
+  .amdhsa_next_free_sgpr 1
+  .amdhsa_group_segment_fixed_size 256
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: transactional_ds2
+      .symbol: transactional_ds2.kd
+      .sgpr_count: 1
+      .vgpr_count: 6
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 256
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-vgpr-workgroup-capacity.s
+++ b/amd/comgr/test-lit/hotswap-vgpr-workgroup-capacity.s
@@ -4,7 +4,7 @@
 // COM: bump updates runtime-visible .vgpr_count metadata.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-and-hazard.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-and-hazard.s
@@ -20,7 +20,7 @@
 
 // RUN: %clang --target=amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -93,7 +93,7 @@ test_split_and_hazard:
 // hazard pass only fires on WMMA integer + overlapping VALU within the
 // hazard window (the v_add_f32 has been relocated past the deficit nops,
 // so it's no longer within the window).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-fp-imm.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-fp-imm.s
@@ -6,7 +6,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -37,7 +37,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-int-imm.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-int-imm.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-long-branch.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -28,7 +28,7 @@
 // DISASM-NEXT: s_set_pc_i64 s[0:1]
 
 // COM: Idempotency: rewriting the output again must be a no-op.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --check-idempotent \
 // RUN:   | %FileCheck --check-prefix=IDEM %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-matrix-a-reuse.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-matrix-a-reuse.s
@@ -9,7 +9,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -42,7 +42,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-matrix-b-reuse.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-matrix-b-reuse.s
@@ -4,7 +4,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-msplit-fp-imm.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-msplit-fp-imm.s
@@ -11,7 +11,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -38,7 +38,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-msplit-neg-lo.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-msplit-neg-lo.s
@@ -7,7 +7,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -34,7 +34,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-multi-wmma.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-multi-wmma.s
@@ -10,7 +10,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -58,7 +58,7 @@ kernel:
 // bytes (same invariant as the omnibus test, asserted here for the
 // >1-trampoline path so a regression specific to the second trampoline
 // would surface).
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-neg-hi-k.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-neg-hi-k.s
@@ -5,7 +5,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -33,7 +33,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-neg-lo-k.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-neg-lo-k.s
@@ -11,7 +11,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -43,7 +43,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-src2-eq-dst.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-src2-eq-dst.s
@@ -10,7 +10,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -46,7 +46,7 @@ kernel:
 .size kernel, .-kernel
 
 // Idempotency.
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-cfg.s
@@ -3,7 +3,8 @@
 // non-MODE SETREG that must preserve the tracked fields.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-k-src2-role.s
@@ -3,7 +3,8 @@
 // incoming dst bank. Preserve and restore every other incoming mode field.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API-COUNT-2: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-long-branch.s
@@ -3,7 +3,8 @@
 // every entry still establishes the original mode before either WMMA half.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-m-roles.s
@@ -3,7 +3,8 @@
 // and restore the exact nonzero incoming mode after the upper half.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API-COUNT-2: WMMA split: patched v_wmma_f32_32x16x128_f4

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb-setreg.s
@@ -3,7 +3,8 @@
 // mode 0x60 and must be restored around the split WMMA's upper half.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s

--- a/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split-vgpr-msb.s
@@ -2,7 +2,8 @@
 // gfx1250 VGPR-MSB mode around that half and restores the incoming mode.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
-// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 \
+// RUN:   AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API: WMMA split: patched v_wmma_f32_16x16x128_fp8_fp8

--- a/amd/comgr/test-lit/hotswap-wmma-split.s
+++ b/amd/comgr/test-lit/hotswap-wmma-split.s
@@ -21,7 +21,7 @@
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 
-// RUN: hotswap-rewrite %t.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out.elf \
 // RUN:   | %FileCheck --check-prefix=API %s
@@ -219,7 +219,7 @@ test_no_split_required:
 // bytes (the splitter only fires on K=128 mnemonics, which no longer exist
 // in the rewritten ELF).
 //
-// RUN: hotswap-rewrite %t.out.elf \
+// RUN: env AMD_COMGR_HOTSWAP_DISABLE_DISPLACEMENT=1 hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
 // RUN:   --output %t.out2.elf \
 // RUN:   | %FileCheck --check-prefix=API2 %s

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -89,6 +89,29 @@ TEST(ElfView, RejectsOverflowingTextFileRange) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+TEST(ElfView, RejectsOutOfBoundsDynamicSegment) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  ElfView::ELFT::Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  Header.e_phoff = Obj.Bytes.size();
+  Header.e_phentsize = sizeof(ElfView::ELFT::Phdr);
+  Header.e_phnum = 1;
+  Obj.Bytes.resize(Obj.Bytes.size() + sizeof(ElfView::ELFT::Phdr));
+  std::memcpy(Obj.Bytes.data(), &Header, sizeof(Header));
+
+  ElfView::ELFT::Phdr BadDynamic{};
+  BadDynamic.p_type = llvm::ELF::PT_DYNAMIC;
+  BadDynamic.p_filesz = std::numeric_limits<uint32_t>::max();
+  std::memcpy(Obj.Bytes.data() + Header.e_phoff, &BadDynamic,
+              sizeof(BadDynamic));
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
 TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -66,6 +66,29 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+TEST(ElfView, RejectsOverflowingTextFileRange) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  llvm::Expected<ElfView> ValidViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  ASSERT_TRUE((bool)ValidViewOrErr)
+      << llvm::toString(ValidViewOrErr.takeError());
+
+  const auto *Text = ValidViewOrErr->textSection();
+  ASSERT_GT(Text->sh_offset, 0u);
+  size_t TextHeaderOffset =
+      reinterpret_cast<const uint8_t *>(Text) - Obj.Bytes.data();
+  auto BadText = *Text;
+  BadText.sh_size =
+      std::numeric_limits<uint64_t>::max() - BadText.sh_offset + 1;
+  std::memcpy(Obj.Bytes.data() + TextHeaderOffset, &BadText, sizeof(BadText));
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
 // -- ElfView::findKernelAtAddress ---------------------------------------------
 
 TEST(ElfView, FindKernelAtAddressResolvesNearestPrecedingForZeroSizeSymbol) {

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -78,6 +78,20 @@ TEST(ElfView, RejectsCorruptedElfIdentification) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+TEST(ElfView, RejectsInvalidElfHeaderSize) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  ElfView::ELFT::Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  Header.e_ehsize = 4095;
+  std::memcpy(Obj.Bytes.data(), &Header, sizeof(Header));
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
 TEST(ElfView, RejectsOverflowingTextFileRange) {
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText());

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -92,6 +92,20 @@ TEST(ElfView, RejectsInvalidElfHeaderSize) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+TEST(ElfView, RejectsExtendedProgramHeaderCount) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  ElfView::ELFT::Ehdr Header{};
+  std::memcpy(&Header, Obj.Bytes.data(), sizeof(Header));
+  Header.e_phnum = llvm::ELF::PN_XNUM;
+  std::memcpy(Obj.Bytes.data(), &Header, sizeof(Header));
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
 TEST(ElfView, RejectsOverflowingTextFileRange) {
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText());

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -276,7 +276,7 @@ TEST(ElfView, KernelDescriptorsEnumeratesAndUpdatesEntryOffset) {
   EXPECT_EQ(ViewOrErr->getKernelSgprCount("entry_kernel"), 16u);
 }
 
-TEST(ElfView, KernelDescriptorsSkipsKdWhenFileOffsetOverflows) {
+TEST(ElfView, RejectsKernelDescriptorWhenFileOffsetOverflows) {
   comgr_test::KernelDescriptorElfOptions Opts;
   Opts.KernelName = "overflow_kernel";
   Opts.RodataAddr = 0x1000;
@@ -287,9 +287,21 @@ TEST(ElfView, KernelDescriptorsSkipsKdWhenFileOffsetOverflows) {
 
   llvm::Expected<ElfView> ViewOrErr =
       ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
-  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
-  EXPECT_TRUE(ViewOrErr->kernelDescriptors().empty());
-  EXPECT_EQ(ViewOrErr->findKernelDescriptor("overflow_kernel"), nullptr);
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
+TEST(ElfView, RejectsKernelDescriptorOutsideDefiningSection) {
+  comgr_test::KernelDescriptorElfOptions Opts;
+  Opts.KernelName = "outside_kernel";
+  Opts.KernelDescriptorSymbolValue = Opts.RodataAddr + 0x1400;
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText(), Opts);
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
 }
 
 // growWithTrampolines appends the pool at a fresh high virtual address instead

--- a/amd/comgr/test-unit/HotswapElfTest.cpp
+++ b/amd/comgr/test-unit/HotswapElfTest.cpp
@@ -66,6 +66,18 @@ TEST(ElfView, RejectsNonElfInput) {
   llvm::consumeError(ViewOrErr.takeError());
 }
 
+TEST(ElfView, RejectsCorruptedElfIdentification) {
+  comgr_test::KernelDescriptorElf Obj =
+      comgr_test::makeKernelDescriptorElf(makeText());
+  Obj.Bytes[llvm::ELF::EI_MAG2] ^= 0xff;
+  Obj.Bytes[llvm::ELF::EI_CLASS] ^= 0xff;
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(Obj.Bytes.data(), Obj.Bytes.size());
+  EXPECT_FALSE((bool)ViewOrErr);
+  llvm::consumeError(ViewOrErr.takeError());
+}
+
 TEST(ElfView, RejectsOverflowingTextFileRange) {
   comgr_test::KernelDescriptorElf Obj =
       comgr_test::makeKernelDescriptorElf(makeText());

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -24,6 +24,7 @@
 #include "gtest/gtest.h"
 
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -273,6 +274,71 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   return Buf;
 }
 
+static std::vector<uint8_t>
+makeDynamicDisplacementTestElf(llvm::ArrayRef<uint8_t> Text,
+                               llvm::ArrayRef<llvm::ELF::Elf64_Dyn> Entries) {
+  using namespace llvm::ELF;
+
+  std::vector<uint8_t> Buf = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr = ElfView::create(Buf.data(), Buf.size());
+  if (!ViewOrErr) {
+    llvm::consumeError(ViewOrErr.takeError());
+    return {};
+  }
+
+  const ElfView::ELFT::Shdr &Rodata = ViewOrErr->sections()[2];
+  const ElfView::ELFT::Shdr &OldSymtab = ViewOrErr->sections()[4];
+  if (Entries.size() * sizeof(Elf64_Dyn) > OldSymtab.sh_size)
+    return {};
+
+  ElfView::ELFT::Ehdr Ehdr = ViewOrErr->file().getHeader();
+  const uint64_t OldPhOff = Ehdr.e_phoff;
+  Ehdr.e_phoff = 0x1c0;
+  Ehdr.e_phnum = 3;
+  std::memcpy(Buf.data(), &Ehdr, sizeof(Ehdr));
+
+  Elf64_Phdr TextLoad;
+  Elf64_Phdr RodataLoad;
+  std::memcpy(&TextLoad, Buf.data() + OldPhOff, sizeof(TextLoad));
+  std::memcpy(&RodataLoad, Buf.data() + OldPhOff + sizeof(Elf64_Phdr),
+              sizeof(RodataLoad));
+  std::memcpy(Buf.data() + Ehdr.e_phoff, &TextLoad, sizeof(TextLoad));
+  std::memcpy(Buf.data() + Ehdr.e_phoff + sizeof(Elf64_Phdr), &RodataLoad,
+              sizeof(RodataLoad));
+
+  Elf64_Phdr DynamicPh{};
+  DynamicPh.p_type = PT_DYNAMIC;
+  DynamicPh.p_flags = PF_R | PF_W;
+  DynamicPh.p_offset = OldSymtab.sh_offset;
+  DynamicPh.p_vaddr = 0x3000;
+  DynamicPh.p_paddr = 0x3000;
+  DynamicPh.p_filesz = Entries.size() * sizeof(Elf64_Dyn);
+  DynamicPh.p_memsz = DynamicPh.p_filesz;
+  DynamicPh.p_align = 8;
+  std::memcpy(Buf.data() + Ehdr.e_phoff + 2 * sizeof(Elf64_Phdr), &DynamicPh,
+              sizeof(DynamicPh));
+
+  ElfView::ELFT::Shdr TargetSh = Rodata;
+  TargetSh.sh_type = SHT_STRTAB;
+  std::memcpy(Buf.data() + Ehdr.e_shoff + 2 * sizeof(Elf64_Shdr), &TargetSh,
+              sizeof(TargetSh));
+
+  ElfView::ELFT::Shdr DynamicSh = OldSymtab;
+  DynamicSh.sh_type = SHT_DYNAMIC;
+  DynamicSh.sh_flags = SHF_ALLOC | SHF_WRITE;
+  DynamicSh.sh_addr = DynamicPh.p_vaddr;
+  DynamicSh.sh_size = DynamicPh.p_filesz;
+  DynamicSh.sh_link = 3;
+  DynamicSh.sh_entsize = sizeof(Elf64_Dyn);
+  DynamicSh.sh_addralign = 8;
+  std::memcpy(Buf.data() + Ehdr.e_shoff + 4 * sizeof(Elf64_Shdr), &DynamicSh,
+              sizeof(DynamicSh));
+  std::memset(Buf.data() + DynamicSh.sh_offset, 0, OldSymtab.sh_size);
+  std::memcpy(Buf.data() + DynamicSh.sh_offset, Entries.data(),
+              Entries.size() * sizeof(Elf64_Dyn));
+  return Buf;
+}
+
 // -- initLLVM ----------------------------------------------------------------
 
 TEST(InitLLVM, ValidGfx1250) {
@@ -290,6 +356,7 @@ TEST(InitLLVM, ValidGfx1250) {
   EXPECT_LT(S.SAddPcI64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SCallI64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SSwapPcI64Opcode, S.MCII->getNumOpcodes());
+  EXPECT_LT(S.SLoadB64Opcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SPrefetchInstPcRelOpcode, S.MCII->getNumOpcodes());
   EXPECT_LT(S.SPrefetchDataPcRelOpcode, S.MCII->getNumOpcodes());
   EXPECT_TRUE(S.SCCRegister.isValid());
@@ -1067,8 +1134,10 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
   ASSERT_EQ(Decoded[1].Inst.getOpcode(), S.SSetPcI64Opcode);
   ASSERT_EQ(Decoded[3].Inst.getOpcode(), S.SGetPcI64Opcode);
   llvm::SmallVector<uint64_t, 1> DeclaredEntries{0};
+  ElfView::ELFT::Sym FunctionSymbol{};
+  FunctionSymbol.setBindingAndType(llvm::ELF::STB_LOCAL, llvm::ELF::STT_FUNC);
   llvm::SmallVector<ElfView::FunctionTextRange, 1> FunctionRanges{
-      {0, Decoded[3].Offset}};
+      {0, Decoded[3].Offset, &FunctionSymbol}};
 
   // The helper preserves the link pair from its entry through s_set_pc_i64.
   // The block laid out after the return can branch back into the epilogue,
@@ -1078,10 +1147,30 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  ASSERT_EQ(Info->Targets.size(), 2u);
+  ASSERT_EQ(Info->Targets.size(), 3u);
   EXPECT_TRUE(Info->Targets.contains(0));
   EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(
+      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
+  EXPECT_TRUE(Info->RelocatableIndirectTransfers.contains(Decoded[1].Offset));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+
+  // A link-visible device function is still closed-world callable when a
+  // complete relocation table proves its entry and every call/return edge.
+  FunctionSymbol.setBindingAndType(llvm::ELF::STB_GLOBAL, llvm::ELF::STT_FUNC);
+  RelocationTableDispatch Dispatch;
+  Dispatch.CallOffset = Decoded.back().Offset;
+  Dispatch.SequenceStart = Decoded[3].Offset;
+  Dispatch.SequenceEnd = Decoded.back().Offset;
+  Dispatch.Targets.push_back(0);
+  llvm::SmallVector<uint64_t, 1> ExternalEntries{0};
+  Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x1000, DeclaredEntries,
+                                 FunctionRanges, ExternalEntries, {Dispatch});
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+  EXPECT_TRUE(Info->RelocatableIndirectTransfers.contains(Decoded[1].Offset));
 }
 
 TEST(CollectDirectBranchTargets, RejectsClobberedSetPcReturn) {
@@ -2081,6 +2170,42 @@ TEST(DisplacementPlan, MapsInsertionAndReplacementBoundaries) {
       10, DisplacementMapBias::BeforeInsertedBytes, Mapped));
 }
 
+TEST(DisplacementPlan, MapsAlignmentInsertionBeforeSameOffsetReplacement) {
+  std::vector<uint8_t> Text(16);
+  for (unsigned I = 0; I < Text.size(); ++I)
+    Text[I] = I;
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Replace;
+  Replace.Offset = 8;
+  Replace.OriginalSize = 4;
+  Replace.ReplacementBytes.assign(8, 0x22);
+
+  DisplacementEdit Alignment;
+  Alignment.Offset = 8;
+  Alignment.ReplacementBytes.assign(4, 0x11);
+  Alignment.MapsOldOffsetAfterInsertion = true;
+
+  llvm::Expected<DisplacementPlan> PlanOrErr =
+      DisplacementPlan::create(*ViewOrErr, {Replace, Alignment});
+  ASSERT_TRUE((bool)PlanOrErr) << llvm::toString(PlanOrErr.takeError());
+
+  uint64_t Mapped = 0;
+  ASSERT_TRUE(PlanOrErr->mapOffset(8, DisplacementMapBias::BeforeInsertedBytes,
+                                   Mapped));
+  EXPECT_EQ(Mapped, 12u);
+  llvm::SmallVector<uint8_t> NewText =
+      PlanOrErr->buildText(Text, /*SNopBytes=*/{});
+  ASSERT_GE(NewText.size(), 20u);
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(NewText.data() + 8, 4),
+            llvm::ArrayRef<uint8_t>(Alignment.ReplacementBytes));
+  EXPECT_EQ(llvm::ArrayRef<uint8_t>(NewText.data() + 12, 8),
+            llvm::ArrayRef<uint8_t>(Replace.ReplacementBytes));
+}
+
 TEST(DisplacementPlan, RejectsOverlappingEdits) {
   std::vector<uint8_t> Text(16, 0);
   std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
@@ -2416,6 +2541,287 @@ TEST(TextDisplacement, RejectsDebugSectionsUntilAddressesCanBeRemapped) {
   ASSERT_FALSE((bool)OutOrErr);
   std::string Reason = llvm::toString(OutOrErr.takeError());
   EXPECT_NE(Reason.find(".debug_info"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsEditInsideInstruction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 1;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("inside a decoded instruction"), std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RejectsPcSensitiveReplacement) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = MinInstSize;
+  llvm::SmallVector<uint8_t> GetPc =
+      assembleSingleInst("s_get_pc_i64 s[8:9]", S);
+  ASSERT_EQ(GetPc.size(), MinInstSize);
+  Edit.ReplacementBytes.append(GetPc.begin(), GetPc.end());
+  Edit.ReplacementBytes.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("PC-sensitive"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RemapsElfEntryAndRejectsInteriorEntry) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End.begin(), End.end());
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+
+  llvm::ELF::Elf64_Ehdr Ehdr;
+  std::memcpy(&Ehdr, ElfBytes.data(), sizeof(Ehdr));
+  Ehdr.e_entry = 0x1000 + MinInstSize;
+  std::memcpy(ElfBytes.data(), &Ehdr, sizeof(Ehdr));
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Insert;
+  Insert.Offset = 0;
+  Insert.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Insert},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  llvm::Expected<ElfView> OutView = ElfView::create(
+      reinterpret_cast<uint8_t *>(Out->getBufferStart()), Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  EXPECT_EQ(OutView->file().getHeader().e_entry, 0x1000u + 2 * MinInstSize);
+
+  std::memcpy(&Ehdr, ElfBytes.data(), sizeof(Ehdr));
+  Ehdr.e_entry = 0x1001;
+  std::memcpy(ElfBytes.data(), &Ehdr, sizeof(Ehdr));
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  DisplacementEdit Replace;
+  Replace.Offset = 0;
+  Replace.OriginalSize = MinInstSize;
+  Replace.ReplacementBytes.assign(2 * MinInstSize, 0);
+  std::memcpy(Replace.ReplacementBytes.data(), S.SNopBytes.data(), MinInstSize);
+  std::memcpy(Replace.ReplacementBytes.data() + MinInstSize, S.SNopBytes.data(),
+              MinInstSize);
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(
+      *ViewOrErr, S, {Replace}, /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("maps inside a replaced instruction"),
+            std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RemapsDynamicPointerAndRejectsUnknownTag) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+
+  llvm::ELF::Elf64_Dyn Strtab{};
+  Strtab.d_tag = llvm::ELF::DT_STRTAB;
+  Strtab.d_un.d_ptr = 0x2000;
+  llvm::ELF::Elf64_Dyn Null{};
+  Null.d_tag = llvm::ELF::DT_NULL;
+  const llvm::ELF::Elf64_Dyn Entries[] = {Strtab, Null};
+  std::vector<uint8_t> ElfBytes = makeDynamicDisplacementTestElf(Text, Entries);
+  ASSERT_FALSE(ElfBytes.empty());
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Insert;
+  Insert.Offset = 0;
+  Insert.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Insert},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  llvm::Expected<ElfView> OutView = ElfView::create(
+      reinterpret_cast<uint8_t *>(Out->getBufferStart()), Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+  llvm::Expected<ElfView::ELFT::DynRange> Dynamic =
+      OutView->file().dynamicEntries();
+  ASSERT_TRUE((bool)Dynamic) << llvm::toString(Dynamic.takeError());
+  ASSERT_EQ(Dynamic->size(), 2u);
+  EXPECT_EQ(Dynamic->begin()->d_un.d_ptr, 0x2008u);
+
+  llvm::ELF::Elf64_Dyn Unknown = Strtab;
+  Unknown.d_tag = 0x70000042;
+  const llvm::ELF::Elf64_Dyn UnknownEntries[] = {Unknown, Null};
+  ElfBytes = makeDynamicDisplacementTestElf(Text, UnknownEntries);
+  ASSERT_FALSE(ElfBytes.empty());
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(
+      *ViewOrErr, S, {Insert}, /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("unknown dynamic tag"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsInvalidExecutableTopology) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(Text.size(), MinInstSize);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(Text);
+  llvm::Expected<ElfView> InitialView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InitialView) << llvm::toString(InitialView.takeError());
+  const ElfView::ELFT::Shdr &Rodata = InitialView->sections()[2];
+  const size_t RodataShdrOffset =
+      reinterpret_cast<const uint8_t *>(&Rodata) - ElfBytes.data();
+  ElfView::ELFT::Shdr ExecutableRodata = Rodata;
+  ExecutableRodata.sh_flags |= llvm::ELF::SHF_EXECINSTR;
+  std::memcpy(ElfBytes.data() + RodataShdrOffset, &ExecutableRodata,
+              sizeof(ExecutableRodata));
+
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  DisplacementEdit Insert;
+  Insert.Offset = 0;
+  Insert.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Insert},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("one executable section"), std::string::npos) << Reason;
+
+  ElfBytes = makeDisplacementTestElf(Text);
+  InitialView = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InitialView) << llvm::toString(InitialView.takeError());
+  const ElfView::ELFT::Shdr &TextShdr = *InitialView->textSection();
+  const size_t TextShdrOffset =
+      reinterpret_cast<const uint8_t *>(&TextShdr) - ElfBytes.data();
+  ElfView::ELFT::Shdr NonExecutableText = TextShdr;
+  NonExecutableText.sh_flags &= ~llvm::ELF::SHF_EXECINSTR;
+  std::memcpy(ElfBytes.data() + TextShdrOffset, &NonExecutableText,
+              sizeof(NonExecutableText));
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(
+      *ViewOrErr, S, {Insert}, /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("allocated executable section"), std::string::npos)
+      << Reason;
+
+  ElfBytes = makeDisplacementTestElf(Text);
+  InitialView = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InitialView) << llvm::toString(InitialView.takeError());
+  const ElfView::ELFT::Shdr &AlignedRodata = InitialView->sections()[2];
+  const size_t AlignedRodataOffset =
+      reinterpret_cast<const uint8_t *>(&AlignedRodata) - ElfBytes.data();
+  ElfView::ELFT::Shdr NonPowerOfTwoSection = AlignedRodata;
+  NonPowerOfTwoSection.sh_addralign = 3;
+  std::memcpy(ElfBytes.data() + AlignedRodataOffset, &NonPowerOfTwoSection,
+              sizeof(NonPowerOfTwoSection));
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(
+      *ViewOrErr, S, {Insert}, /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("section alignment is not a power of two"),
+            std::string::npos)
+      << Reason;
+
+  ElfBytes = makeDisplacementTestElf(Text);
+  InitialView = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InitialView) << llvm::toString(InitialView.takeError());
+  llvm::Expected<ElfView::ELFT::PhdrRange> AlignmentPhdrs =
+      InitialView->file().program_headers();
+  ASSERT_TRUE((bool)AlignmentPhdrs)
+      << llvm::toString(AlignmentPhdrs.takeError());
+  const ElfView::ELFT::Phdr *TextLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *AlignmentPhdrs)
+    if (Phdr.p_type == llvm::ELF::PT_LOAD &&
+        Phdr.p_offset <= InitialView->textOffset() &&
+        Phdr.p_vaddr <= InitialView->textAddr())
+      TextLoad = &Phdr;
+  ASSERT_NE(TextLoad, nullptr);
+  const size_t TextLoadOffset =
+      reinterpret_cast<const uint8_t *>(TextLoad) - ElfBytes.data();
+  ElfView::ELFT::Phdr NonPowerOfTwoSegment = *TextLoad;
+  // 0x280 and 0x1000 are congruent modulo three, so this evaded the old
+  // congruence-only check.
+  NonPowerOfTwoSegment.p_align = 3;
+  std::memcpy(ElfBytes.data() + TextLoadOffset, &NonPowerOfTwoSegment,
+              sizeof(NonPowerOfTwoSegment));
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(
+      *ViewOrErr, S, {Insert}, /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("program-header alignment is not a power of two"),
+            std::string::npos)
+      << Reason;
+
+  ElfBytes = makeDisplacementTestElf(Text);
+  InitialView = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InitialView) << llvm::toString(InitialView.takeError());
+  llvm::Expected<ElfView::ELFT::PhdrRange> Phdrs =
+      InitialView->file().program_headers();
+  ASSERT_TRUE((bool)Phdrs) << llvm::toString(Phdrs.takeError());
+  const ElfView::ELFT::Phdr *TrailingLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *Phdrs)
+    if (Phdr.p_type == llvm::ELF::PT_LOAD &&
+        Phdr.p_offset >= InitialView->textOffset() + InitialView->textSize())
+      TrailingLoad = &Phdr;
+  ASSERT_NE(TrailingLoad, nullptr);
+  const size_t TrailingLoadOffset =
+      reinterpret_cast<const uint8_t *>(TrailingLoad) - ElfBytes.data();
+  ElfView::ELFT::Phdr OverflowingPaddr = *TrailingLoad;
+  OverflowingPaddr.p_paddr = std::numeric_limits<uint64_t>::max();
+  std::memcpy(ElfBytes.data() + TrailingLoadOffset, &OverflowingPaddr,
+              sizeof(OverflowingPaddr));
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+  OutOrErr = tryApplyTextDisplacementToNewBuffer(
+      *ViewOrErr, S, {Insert}, /*RelocateTrailingSections=*/true);
+  ASSERT_FALSE((bool)OutOrErr);
+  Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("program-header address overflows"), std::string::npos)
+      << Reason;
 }
 
 TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {
@@ -2983,12 +3389,200 @@ TEST(TextDisplacement, RejectsTextRelocationSections) {
   EXPECT_NE(Reason.find("relocation section"), std::string::npos);
 }
 
-TEST(TextDisplacement, RejectsDynamicRelocationTargetingText) {
+TEST(TextDisplacement, ProvesCompleteDirectRelocationTableDispatch) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
-  llvm::SmallVector<uint8_t> Text = assembleSingleInst("s_endpgm", S);
-  ASSERT_EQ(Text.size(), MinInstSize);
+  llvm::SmallVector<uint8_t> Text;
+  std::function<void(llvm::StringRef)> Append = [&](llvm::StringRef Assembly) {
+    llvm::SmallVector<uint8_t> Bytes = assembleSingleInst(Assembly, S);
+    EXPECT_FALSE(Bytes.empty()) << Assembly.str();
+    Text.append(Bytes.begin(), Bytes.end());
+  };
+  Append("s_get_pc_i64 s[54:55]");
+  // .text starts at 0x1000 and get_pc returns 0x1004.
+  Append("s_add_nc_u64 s[54:55], s[54:55], 0xffc");
+  Append("s_load_b64 s[0:1], s[54:55], s2");
+  const uint64_t CallOffset = Text.size();
+  Append("s_swap_pc_i64 s[30:31], s[0:1]");
+  const uint64_t TargetOffset = Text.size();
+  Append("s_endpgm");
+
+  std::vector<uint8_t> ElfBytes =
+      makeDisplacementTestElf(Text, /*AddTextRelocation=*/true);
+  llvm::Expected<ElfView> InitialView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InitialView) << llvm::toString(InitialView.takeError());
+
+  const ElfView::ELFT::Shdr *RelaShdr = nullptr;
+  const ElfView::ELFT::Shdr *SymtabShdr = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : InitialView->sections()) {
+    if (Shdr.sh_type == llvm::ELF::SHT_RELA)
+      RelaShdr = &Shdr;
+    if (Shdr.sh_type == llvm::ELF::SHT_SYMTAB)
+      SymtabShdr = &Shdr;
+  }
+  ASSERT_NE(RelaShdr, nullptr);
+  ASSERT_NE(SymtabShdr, nullptr);
+
+  const size_t RelaShdrOffset =
+      reinterpret_cast<const uint8_t *>(RelaShdr) - ElfBytes.data();
+  llvm::ELF::Elf64_Shdr RawRelaShdr;
+  std::memcpy(&RawRelaShdr, ElfBytes.data() + RelaShdrOffset,
+              sizeof(RawRelaShdr));
+  RawRelaShdr.sh_info = 0;
+  std::memcpy(ElfBytes.data() + RelaShdrOffset, &RawRelaShdr,
+              sizeof(RawRelaShdr));
+
+  // Reuse the fixture's .rodata object as a one-slot function table.
+  llvm::ELF::Elf64_Sym TableSymbol;
+  const uint64_t TableSymbolOffset =
+      SymtabShdr->sh_offset + 2 * sizeof(llvm::ELF::Elf64_Sym);
+  std::memcpy(&TableSymbol, ElfBytes.data() + TableSymbolOffset,
+              sizeof(TableSymbol));
+  TableSymbol.st_size = sizeof(uint64_t);
+  std::memcpy(ElfBytes.data() + TableSymbolOffset, &TableSymbol,
+              sizeof(TableSymbol));
+
+  llvm::ELF::Elf64_Rela Rela;
+  Rela.r_offset = TableSymbol.st_value;
+  Rela.r_addend = InitialView->textAddr() + TargetOffset;
+  Rela.setSymbolAndType(/*Symbol=*/0, llvm::ELF::R_AMDGPU_RELATIVE64);
+  std::memcpy(ElfBytes.data() + RawRelaShdr.sh_offset, &Rela, sizeof(Rela));
+
+  llvm::Expected<ElfView> View =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)View) << llvm::toString(View.takeError());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(
+      decodeTextSection(View->textData(), View->textSize(), S, Decoded));
+  llvm::Expected<std::vector<RelocationTableDispatch>> Dispatches =
+      analyzeRelocationTableDispatches(*View, Decoded, S);
+  ASSERT_TRUE((bool)Dispatches) << llvm::toString(Dispatches.takeError());
+  ASSERT_EQ(Dispatches->size(), 1u);
+  EXPECT_EQ((*Dispatches)[0].CallOffset, CallOffset);
+  ASSERT_EQ((*Dispatches)[0].Targets.size(), 1u);
+  EXPECT_EQ((*Dispatches)[0].Targets[0], TargetOffset);
+
+  std::optional<DirectControlFlowInfo> ControlFlow =
+      analyzeDirectControlFlow(*View, Decoded, S);
+  ASSERT_TRUE(ControlFlow.has_value());
+  EXPECT_FALSE(ControlFlow->HasUnresolvedTargets);
+  EXPECT_TRUE(ControlFlow->RelocatableIndirectTransfers.contains(CallOffset));
+  EXPECT_TRUE(ControlFlow->Targets.contains(TargetOffset));
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.OriginalSize = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> Grown =
+      tryApplyTextDisplacementToNewBuffer(*View, S, {Edit},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_TRUE((bool)Grown) << llvm::toString(Grown.takeError());
+
+  // A trailing zero sentinel is part of RCCL's generated table shape and is
+  // admitted, but an unrelocated non-zero slot is not.
+  TableSymbol.st_size = 2 * sizeof(uint64_t);
+  std::memcpy(ElfBytes.data() + TableSymbolOffset, &TableSymbol,
+              sizeof(TableSymbol));
+  llvm::Expected<ElfView> NullTerminatedView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)NullTerminatedView)
+      << llvm::toString(NullTerminatedView.takeError());
+  Dispatches =
+      analyzeRelocationTableDispatches(*NullTerminatedView, Decoded, S);
+  ASSERT_TRUE((bool)Dispatches) << llvm::toString(Dispatches.takeError());
+  ASSERT_EQ(Dispatches->size(), 1u);
+  ASSERT_EQ((*Dispatches)[0].Targets.size(), 1u);
+  EXPECT_EQ((*Dispatches)[0].Targets[0], TargetOffset);
+
+  // A relocation target must be an actual decoded instruction boundary.
+  Rela.r_addend = InitialView->textAddr() + TargetOffset + 1;
+  std::memcpy(ElfBytes.data() + RawRelaShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> InteriorTargetView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InteriorTargetView)
+      << llvm::toString(InteriorTargetView.takeError());
+  Dispatches =
+      analyzeRelocationTableDispatches(*InteriorTargetView, Decoded, S);
+  ASSERT_TRUE((bool)Dispatches) << llvm::toString(Dispatches.takeError());
+  EXPECT_TRUE(Dispatches->empty());
+
+  Rela.r_addend = InitialView->textAddr() + TargetOffset;
+  std::memcpy(ElfBytes.data() + RawRelaShdr.sh_offset, &Rela, sizeof(Rela));
+  const uint64_t NonZero = 1;
+  const uint64_t TableFileOffset =
+      InitialView->sections()[TableSymbol.st_shndx].sh_offset;
+  std::memcpy(ElfBytes.data() + TableFileOffset + sizeof(uint64_t), &NonZero,
+              sizeof(NonZero));
+  llvm::Expected<ElfView> IncompleteView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)IncompleteView)
+      << llvm::toString(IncompleteView.takeError());
+  Dispatches = analyzeRelocationTableDispatches(*IncompleteView, Decoded, S);
+  ASSERT_TRUE((bool)Dispatches) << llvm::toString(Dispatches.takeError());
+  EXPECT_TRUE(Dispatches->empty());
+
+  // A complete relocation set is not a closed-world target proof when the
+  // program can mutate the table after loading.
+  const uint64_t Zero = 0;
+  std::memcpy(ElfBytes.data() + TableFileOffset + sizeof(uint64_t), &Zero,
+              sizeof(Zero));
+  const ElfView::ELFT::Shdr &TableShdr =
+      InitialView->sections()[TableSymbol.st_shndx];
+  const ElfView::ELFT::Shdr OriginalTableShdr = TableShdr;
+  const uint64_t TableShdrOffset =
+      reinterpret_cast<const uint8_t *>(&TableShdr) - ElfBytes.data();
+  ElfView::ELFT::Shdr WritableTableShdr = TableShdr;
+  WritableTableShdr.sh_flags |= llvm::ELF::SHF_WRITE;
+  std::memcpy(ElfBytes.data() + TableShdrOffset, &WritableTableShdr,
+              sizeof(WritableTableShdr));
+  llvm::Expected<ElfView> WritableTableView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)WritableTableView)
+      << llvm::toString(WritableTableView.takeError());
+  Dispatches = analyzeRelocationTableDispatches(*WritableTableView, Decoded, S);
+  ASSERT_TRUE((bool)Dispatches) << llvm::toString(Dispatches.takeError());
+  EXPECT_TRUE(Dispatches->empty());
+
+  // Section flags alone are not a runtime immutability proof. A writable
+  // covering PT_LOAD also invalidates the finite target set.
+  std::memcpy(ElfBytes.data() + TableShdrOffset, &OriginalTableShdr,
+              sizeof(OriginalTableShdr));
+  llvm::Expected<ElfView::ELFT::PhdrRange> Phdrs =
+      InitialView->file().program_headers();
+  ASSERT_TRUE((bool)Phdrs) << llvm::toString(Phdrs.takeError());
+  const ElfView::ELFT::Phdr *TableLoad = nullptr;
+  for (const ElfView::ELFT::Phdr &Phdr : *Phdrs)
+    if (Phdr.p_type == llvm::ELF::PT_LOAD &&
+        Phdr.p_vaddr <= TableSymbol.st_value &&
+        TableSymbol.st_value - Phdr.p_vaddr < Phdr.p_memsz)
+      TableLoad = &Phdr;
+  ASSERT_NE(TableLoad, nullptr);
+  const uint64_t TableLoadOffset =
+      reinterpret_cast<const uint8_t *>(TableLoad) - ElfBytes.data();
+  ElfView::ELFT::Phdr WritableTableLoad = *TableLoad;
+  WritableTableLoad.p_flags |= llvm::ELF::PF_W;
+  std::memcpy(ElfBytes.data() + TableLoadOffset, &WritableTableLoad,
+              sizeof(WritableTableLoad));
+  llvm::Expected<ElfView> WritableLoadView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)WritableLoadView)
+      << llvm::toString(WritableLoadView.takeError());
+  Dispatches = analyzeRelocationTableDispatches(*WritableLoadView, Decoded, S);
+  ASSERT_TRUE((bool)Dispatches) << llvm::toString(Dispatches.takeError());
+  EXPECT_TRUE(Dispatches->empty());
+}
+
+TEST(TextDisplacement, RepairsRcclStyleRelativeFunctionTableRelocation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> End = assembleSingleInst("s_endpgm", S);
+  ASSERT_EQ(End.size(), MinInstSize);
+  Text.append(End.begin(), End.end());
   std::vector<uint8_t> ElfBytes =
       makeDisplacementTestElf(Text, /*AddTextRelocation=*/true);
   llvm::Expected<ElfView> ViewOrErr =
@@ -3036,16 +3630,103 @@ TEST(TextDisplacement, RejectsDynamicRelocationTargetingText) {
   EXPECT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
 
   Rela.setSymbolAndType(/*Symbol=*/0, llvm::ELF::R_AMDGPU_RELATIVE64);
-  Rela.r_addend = NonTextView->textAddr();
+  // A RELATIVE64 addend may point to displaced data, not only code.
+  Rela.r_addend = 0x2000;
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> DataAddendView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)DataAddendView)
+      << llvm::toString(DataAddendView.takeError());
+  OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*DataAddendView, S, {Edit},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> DataAddendOut =
+      std::move(*OutOrErr);
+  llvm::Expected<ElfView> DataAddendOutView = ElfView::create(
+      reinterpret_cast<uint8_t *>(DataAddendOut->getBufferStart()),
+      DataAddendOut->getBufferSize());
+  ASSERT_TRUE((bool)DataAddendOutView)
+      << llvm::toString(DataAddendOutView.takeError());
+  const ElfView::ELFT::Shdr *DataAddendRelaShdr = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : DataAddendOutView->sections())
+    if (Shdr.sh_type == llvm::ELF::SHT_RELA)
+      DataAddendRelaShdr = &Shdr;
+  ASSERT_NE(DataAddendRelaShdr, nullptr);
+  llvm::Expected<ElfView::ELFT::RelaRange> DataAddendRelas =
+      DataAddendOutView->file().relas(*DataAddendRelaShdr);
+  ASSERT_TRUE((bool)DataAddendRelas)
+      << llvm::toString(DataAddendRelas.takeError());
+  ASSERT_EQ(DataAddendRelas->size(), 1u);
+  EXPECT_EQ(DataAddendRelas->begin()->r_offset, 0x2008u);
+  EXPECT_EQ(DataAddendRelas->begin()->r_addend, 0x2008);
+
+  // Model an RCCL function-table slot: the loader writes load_bias plus this
+  // addend into a trailing allocated data object, and the addend names the
+  // second instruction in .text.
+  Rela.r_addend = NonTextView->textAddr() + MinInstSize;
   std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
   llvm::Expected<ElfView> TextAddendView =
       ElfView::create(ElfBytes.data(), ElfBytes.size());
   ASSERT_TRUE((bool)TextAddendView)
       << llvm::toString(TextAddendView.takeError());
-  OutOrErr = tryApplyTextDisplacementToNewBuffer(*TextAddendView, S, {Edit});
+  OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*TextAddendView, S, {Edit},
+                                          /*RelocateTrailingSections=*/true);
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutView =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutView) << llvm::toString(OutView.takeError());
+
+  const ElfView::ELFT::Shdr *OutRelaShdr = nullptr;
+  const ElfView::ELFT::Shdr *OutRodataShdr = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : OutView->sections()) {
+    if (Shdr.sh_type == llvm::ELF::SHT_RELA)
+      OutRelaShdr = &Shdr;
+    llvm::Expected<llvm::StringRef> Name = OutView->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".rodata")
+      OutRodataShdr = &Shdr;
+  }
+  ASSERT_NE(OutRelaShdr, nullptr);
+  ASSERT_NE(OutRodataShdr, nullptr);
+  // Raw growth is four bytes, padded to the trailing section's 8-byte
+  // alignment. Both the relocation place and its defining data section move.
+  EXPECT_EQ(OutRodataShdr->sh_addr, 0x2008u);
+
+  llvm::Expected<ElfView::ELFT::RelaRange> OutRelas =
+      OutView->file().relas(*OutRelaShdr);
+  ASSERT_TRUE((bool)OutRelas) << llvm::toString(OutRelas.takeError());
+  ASSERT_EQ(OutRelas->size(), 1u);
+  EXPECT_EQ(OutRelas->begin()->r_offset, 0x2008u);
+  EXPECT_EQ(OutRelas->begin()->r_addend,
+            static_cast<int64_t>(OutView->textAddr() + 2 * MinInstSize));
+
+  // The descriptor symbol shares the moved allocated section; descriptor
+  // repair must use its shifted address, not the stale pre-growth value.
+  std::vector<KernelDescriptorInfo> KDs = OutView->kernelDescriptors();
+  ASSERT_EQ(KDs.size(), 1u);
+  EXPECT_EQ(KDs[0].VAddr, 0x2008u);
+  EXPECT_EQ(KDs[0].EntryOffset,
+            static_cast<int64_t>(OutView->textAddr() - 0x2008u));
+
+  // The signed ELF field can carry an arbitrary 64-bit address bit pattern.
+  // It must still name a byte covered by exactly one load segment.
+  Rela.r_addend = -1;
+  std::memcpy(ElfBytes.data() + RawShdr.sh_offset, &Rela, sizeof(Rela));
+  llvm::Expected<ElfView> InvalidAddendView =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)InvalidAddendView)
+      << llvm::toString(InvalidAddendView.takeError());
+  OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*InvalidAddendView, S, {Edit},
+                                          /*RelocateTrailingSections=*/true);
   ASSERT_FALSE((bool)OutOrErr);
   Reason = llvm::toString(OutOrErr.takeError());
-  EXPECT_NE(Reason.find("addend references"), std::string::npos) << Reason;
+  EXPECT_NE(Reason.find("outside every PT_LOAD segment"), std::string::npos);
 }
 
 // -- classifyWmmaNops ---------------------------------------------------------

--- a/amd/comgr/test/manual/hotswap-a0-mask/README.md
+++ b/amd/comgr/test/manual/hotswap-a0-mask/README.md
@@ -1,0 +1,41 @@
+# GFX1250 A0 HotSwap Mask Smoke
+
+This directory contains manual B0-code-object inputs for testing the gfx1250
+B0-to-A0 hotswap mask workarounds on an A0 machine.
+
+The rewrite path should be invoked with explicit stepping features:
+
+```bash
+amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+
+amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific-
+```
+
+`b0_mask_rewrite_canary.s` is dispatchable. It stores a sentinel through one
+kernarg pointer and branches around the B0-only mask-test sites. The cold block
+still statically exercises:
+
+- `tensor_load_to_lds` D# Group 1 mask clear.
+- SADDR `cluster_load*` M0 save, low-mask clear, and restore.
+- Off-form `cluster_load` demotion to `global_load`.
+
+Run the rewrite checks with in-tree tools:
+
+```bash
+CLANG=/path/to/build/bin/clang \
+HOTSWAP_REWRITE=/path/to/build/bin/hotswap-rewrite \
+LLVM_OBJDUMP=/path/to/build/bin/llvm-objdump \
+LLVM_READELF=/path/to/build/bin/llvm-readelf \
+./run_rewrite_checks.sh
+```
+
+To also dispatch the rewritten canary on an A0 machine:
+
+```bash
+c++ -std=c++17 run_hsaco_canary.cpp -I/opt/rocm/include \
+  -L/opt/rocm/lib -lhsa-runtime64 -o run_hsaco_canary
+
+RUNNER=$PWD/run_hsaco_canary ./run_rewrite_checks.sh
+```
+
+The runner dispatches `b0_mask_rewrite_canary` from the rewritten HSACO and
+expects output word `0xb0a00001`.

--- a/amd/comgr/test/manual/hotswap-a0-mask/b0_cluster_no_scratch.s
+++ b/amd/comgr/test/manual/hotswap-a0-mask/b0_cluster_no_scratch.s
@@ -1,0 +1,51 @@
+// SADDR cluster_load needs an M0 save/clear/restore trampoline when it remains
+// a cluster load after in-place demotion. With every user-addressable SGPR
+// consumed, hotswap must return ERROR rather than dropping the mandatory mask
+// patch.
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl b0_cluster_no_scratch
+.p2align 8
+.type b0_cluster_no_scratch,@function
+b0_cluster_no_scratch:
+  s_branch .Ldone
+
+.Lcold:
+  s_mov_b32 m0, -1
+  cluster_load_b64 v[0:1], v2, s[4:5]
+  s_wait_loadcnt 0x0
+
+.Ldone:
+  s_endpgm
+.Lend:
+.size b0_cluster_no_scratch, .Lend-b0_cluster_no_scratch
+
+.rodata
+.p2align 8
+.amdhsa_kernel b0_cluster_no_scratch
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 4
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 1
+    - 2
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: b0_cluster_no_scratch
+      .symbol: b0_cluster_no_scratch.kd
+      .sgpr_count: 106
+      .vgpr_count: 4
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+  amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+.end_amdgpu_metadata

--- a/amd/comgr/test/manual/hotswap-a0-mask/b0_mask_rewrite_canary.s
+++ b/amd/comgr/test/manual/hotswap-a0-mask/b0_mask_rewrite_canary.s
@@ -1,0 +1,98 @@
+// Dispatchable B0 canary for gfx1250 A0 hotswap mask validation.
+//
+// The entry path stores a sentinel to the output pointer passed as kernarg 0.
+// The B0-only instructions live in a cold block so the same code object can be
+// safely loaded and dispatched on A0 after rewriting, while still forcing
+// hotswap to patch every mask case in the code object.
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl b0_mask_rewrite_canary
+.p2align 8
+.type b0_mask_rewrite_canary,@function
+b0_mask_rewrite_canary:
+  s_load_b64 s[2:3], s[0:1], 0x0
+  s_wait_kmcnt 0x0
+  s_mov_b32 s14, 0xb0a00001
+  v_mov_b32_e32 v0, 0
+  v_mov_b32_e32 v1, s14
+  global_store_b32 v0, v1, s[2:3] scope:SCOPE_SYS
+  s_wait_storecnt 0x0
+  s_branch .Ldone
+
+.Lcold:
+  s_mov_b32 m0, -1
+
+  // Tensor D# Group 1 is operand 1, so the A0 rewrite must clear s4[15:0].
+  // s4 is read after the tensor op to force save/restore through scratch.
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s12, s4
+
+  // SADDR cluster loads remain cluster loads and must be wrapped with M0
+  // save, low-half clear, and restore.
+  cluster_load_b64 v[0:1], v2, s[4:5]
+  s_wait_loadcnt 0x0
+  cluster_load_async_to_lds_b32 v3, v4, s[6:7]
+  s_wait_loadcnt 0x0
+
+  // Off-form cluster loads should still demote in place to global_load.
+  cluster_load_b32 v5, v[6:7], off
+  s_wait_loadcnt 0x0
+
+.Ldone:
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Lend:
+.size b0_mask_rewrite_canary, .Lend-b0_mask_rewrite_canary
+
+.rodata
+.p2align 8
+.amdhsa_kernel b0_mask_rewrite_canary
+  .amdhsa_kernarg_size 8
+  .amdhsa_user_sgpr_count 2
+  .amdhsa_user_sgpr_kernarg_segment_ptr 1
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 8
+  .amdhsa_next_free_sgpr 24
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 1
+    - 2
+  amdhsa.kernels:
+    - .args:
+        - .address_space: global
+          .offset: 0
+          .size: 8
+          .value_kind: global_buffer
+      .gfx1250_revision: B0
+      .name: b0_mask_rewrite_canary
+      .symbol: b0_mask_rewrite_canary.kd
+      .sgpr_count: 24
+      .vgpr_count: 8
+      .kernarg_segment_size: 8
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+  amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+.end_amdgpu_metadata

--- a/amd/comgr/test/manual/hotswap-a0-mask/b0_tensor_no_scratch.s
+++ b/amd/comgr/test/manual/hotswap-a0-mask/b0_tensor_no_scratch.s
@@ -1,0 +1,49 @@
+// Live tensor_load_to_lds descriptor SGPRs require scratch save/restore around
+// the A0 D# Group 1 mask clear. With every user-addressable SGPR consumed,
+// hotswap must return ERROR rather than dropping the mandatory mask patch.
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.amdhsa_code_object_version 6
+
+.text
+.globl b0_tensor_no_scratch
+.p2align 8
+.type b0_tensor_no_scratch,@function
+b0_tensor_no_scratch:
+  s_branch .Ldone
+
+.Lcold:
+  tensor_load_to_lds s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+
+.Ldone:
+  s_endpgm
+.Lend:
+.size b0_tensor_no_scratch, .Lend-b0_tensor_no_scratch
+
+.rodata
+.p2align 8
+.amdhsa_kernel b0_tensor_no_scratch
+  .amdhsa_wavefront_size32 1
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 106
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 1
+    - 2
+  amdhsa.kernels:
+    - .gfx1250_revision: B0
+      .name: b0_tensor_no_scratch
+      .symbol: b0_tensor_no_scratch.kd
+      .sgpr_count: 106
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .kernarg_segment_align: 8
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .max_flat_workgroup_size: 64
+      .wavefront_size: 32
+  amdhsa.target: amdgcn-amd-amdhsa--gfx1250
+.end_amdgpu_metadata

--- a/amd/comgr/test/manual/hotswap-a0-mask/run_hsaco_canary.cpp
+++ b/amd/comgr/test/manual/hotswap-a0-mask/run_hsaco_canary.cpp
@@ -1,0 +1,246 @@
+#include <hsa/hsa.h>
+#include <hsa/hsa_ext_amd.h>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+constexpr uint32_t Expected = 0xb0a00001u;
+
+void check(hsa_status_t Status, const char *What) {
+  if (Status == HSA_STATUS_SUCCESS)
+    return;
+
+  const char *Text = nullptr;
+  hsa_status_string(Status, &Text);
+  std::fprintf(stderr, "error: %s: %s\n", What, Text ? Text : "unknown");
+  std::exit(1);
+}
+
+struct AgentState {
+  hsa_agent_t Cpu{};
+  hsa_agent_t Gpu{};
+};
+
+hsa_status_t findAgents(hsa_agent_t Agent, void *Data) {
+  AgentState *State = static_cast<AgentState *>(Data);
+  hsa_device_type_t Type;
+  check(hsa_agent_get_info(Agent, HSA_AGENT_INFO_DEVICE, &Type),
+        "hsa_agent_get_info(device)");
+  if (Type == HSA_DEVICE_TYPE_CPU && State->Cpu.handle == 0)
+    State->Cpu = Agent;
+  if (Type == HSA_DEVICE_TYPE_GPU && State->Gpu.handle == 0)
+    State->Gpu = Agent;
+  return HSA_STATUS_SUCCESS;
+}
+
+struct PoolState {
+  hsa_amd_memory_pool_t Kernarg{};
+  hsa_amd_memory_pool_t Fine{};
+};
+
+hsa_status_t findPools(hsa_amd_memory_pool_t Pool, void *Data) {
+  PoolState *State = static_cast<PoolState *>(Data);
+
+  hsa_amd_segment_t Segment;
+  check(hsa_amd_memory_pool_get_info(Pool, HSA_AMD_MEMORY_POOL_INFO_SEGMENT,
+                                     &Segment),
+        "hsa_amd_memory_pool_get_info(segment)");
+  if (Segment != HSA_AMD_SEGMENT_GLOBAL)
+    return HSA_STATUS_SUCCESS;
+
+  uint32_t Flags = 0;
+  check(hsa_amd_memory_pool_get_info(
+            Pool, HSA_AMD_MEMORY_POOL_INFO_GLOBAL_FLAGS, &Flags),
+        "hsa_amd_memory_pool_get_info(global flags)");
+
+  if ((Flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_KERNARG_INIT) &&
+      State->Kernarg.handle == 0)
+    State->Kernarg = Pool;
+  if ((Flags & HSA_AMD_MEMORY_POOL_GLOBAL_FLAG_FINE_GRAINED) &&
+      State->Fine.handle == 0)
+    State->Fine = Pool;
+
+  return HSA_STATUS_SUCCESS;
+}
+
+void queueError(hsa_status_t Status, hsa_queue_t *, void *) {
+  const char *Text = nullptr;
+  hsa_status_string(Status, &Text);
+  std::fprintf(stderr, "queue error: %s\n", Text ? Text : "unknown");
+}
+
+} // namespace
+
+int main(int Argc, char **Argv) {
+  if (Argc < 2 || Argc > 3) {
+    std::fprintf(stderr, "usage: %s <hsaco> [kernel]\n", Argv[0]);
+    return 2;
+  }
+
+  const char *Hsaco = Argv[1];
+  const char *Kernel = Argc == 3 ? Argv[2] : "b0_mask_rewrite_canary";
+
+  check(hsa_init(), "hsa_init");
+
+  AgentState Agents;
+  check(hsa_iterate_agents(findAgents, &Agents), "hsa_iterate_agents");
+  if (Agents.Gpu.handle == 0) {
+    std::fprintf(stderr, "error: no GPU HSA agent found\n");
+    return 1;
+  }
+  if (Agents.Cpu.handle == 0) {
+    std::fprintf(stderr, "error: no CPU HSA agent found\n");
+    return 1;
+  }
+
+  PoolState GpuPools;
+  check(hsa_amd_agent_iterate_memory_pools(Agents.Gpu, findPools, &GpuPools),
+        "hsa_amd_agent_iterate_memory_pools(gpu)");
+  PoolState CpuPools;
+  check(hsa_amd_agent_iterate_memory_pools(Agents.Cpu, findPools, &CpuPools),
+        "hsa_amd_agent_iterate_memory_pools(cpu)");
+
+  hsa_amd_memory_pool_t KernargPool =
+      CpuPools.Kernarg.handle ? CpuPools.Kernarg : GpuPools.Kernarg;
+  if (KernargPool.handle == 0) {
+    std::fprintf(stderr, "error: no kernarg memory pool found\n");
+    return 1;
+  }
+  hsa_amd_memory_pool_t OutputPool =
+      CpuPools.Fine.handle ? CpuPools.Fine : GpuPools.Fine;
+  if (OutputPool.handle == 0) {
+    std::fprintf(stderr, "error: no fine-grained output memory pool found\n");
+    return 1;
+  }
+
+  uint32_t *Output = nullptr;
+  check(hsa_amd_memory_pool_allocate(OutputPool, sizeof(uint32_t), 0,
+                                     reinterpret_cast<void **>(&Output)),
+        "allocate output");
+  *Output = 0;
+
+  struct Kernarg {
+    uint64_t OutputPtr;
+  };
+  Kernarg Args{reinterpret_cast<uint64_t>(Output)};
+
+  void *KernargAddress = nullptr;
+  check(hsa_amd_memory_pool_allocate(KernargPool, sizeof(Kernarg), 0,
+                                     &KernargAddress),
+        "allocate kernarg");
+  std::memcpy(KernargAddress, &Args, sizeof(Args));
+
+  hsa_agent_t AccessAgents[2] = {Agents.Cpu, Agents.Gpu};
+  check(hsa_amd_agents_allow_access(2, AccessAgents, nullptr, Output),
+        "allow output access");
+  check(hsa_amd_agents_allow_access(2, AccessAgents, nullptr, KernargAddress),
+        "allow kernarg access");
+
+  int Fd = open(Hsaco, O_RDONLY);
+  if (Fd < 0) {
+    std::perror("open hsaco");
+    return 1;
+  }
+
+  hsa_code_object_reader_t Reader;
+  check(hsa_code_object_reader_create_from_file(Fd, &Reader),
+        "hsa_code_object_reader_create_from_file");
+
+  hsa_executable_t Executable;
+  check(hsa_executable_create_alt(HSA_PROFILE_FULL,
+                                  HSA_DEFAULT_FLOAT_ROUNDING_MODE_DEFAULT,
+                                  nullptr, &Executable),
+        "hsa_executable_create_alt");
+  check(hsa_executable_load_agent_code_object(Executable, Agents.Gpu, Reader,
+                                              nullptr, nullptr),
+        "hsa_executable_load_agent_code_object");
+  check(hsa_executable_freeze(Executable, nullptr), "hsa_executable_freeze");
+
+  hsa_executable_symbol_t Symbol;
+  check(hsa_executable_get_symbol_by_name(Executable, Kernel, &Agents.Gpu,
+                                          &Symbol),
+        "hsa_executable_get_symbol_by_name");
+
+  uint64_t KernelObject = 0;
+  uint32_t PrivateSize = 0;
+  uint32_t GroupSize = 0;
+  check(hsa_executable_symbol_get_info(
+            Symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_OBJECT, &KernelObject),
+        "get kernel object");
+  check(hsa_executable_symbol_get_info(
+            Symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_PRIVATE_SEGMENT_SIZE,
+            &PrivateSize),
+        "get private segment size");
+  check(hsa_executable_symbol_get_info(
+            Symbol, HSA_EXECUTABLE_SYMBOL_INFO_KERNEL_GROUP_SEGMENT_SIZE,
+            &GroupSize),
+        "get group segment size");
+
+  hsa_queue_t *Queue = nullptr;
+  check(hsa_queue_create(Agents.Gpu, 128, HSA_QUEUE_TYPE_MULTI, queueError,
+                         nullptr, UINT32_MAX, UINT32_MAX, &Queue),
+        "hsa_queue_create");
+
+  hsa_signal_t Signal;
+  check(hsa_signal_create(1, 0, nullptr, &Signal), "hsa_signal_create");
+
+  uint64_t Index = hsa_queue_add_write_index_relaxed(Queue, 1);
+  uint32_t QueueMask = Queue->size - 1;
+  hsa_kernel_dispatch_packet_t *Packet =
+      &reinterpret_cast<hsa_kernel_dispatch_packet_t *>(
+          Queue->base_address)[Index & QueueMask];
+  std::memset(Packet, 0, sizeof(*Packet));
+
+  Packet->setup = 1u << HSA_KERNEL_DISPATCH_PACKET_SETUP_DIMENSIONS;
+  Packet->workgroup_size_x = 1;
+  Packet->workgroup_size_y = 1;
+  Packet->workgroup_size_z = 1;
+  Packet->grid_size_x = 1;
+  Packet->grid_size_y = 1;
+  Packet->grid_size_z = 1;
+  Packet->private_segment_size = PrivateSize;
+  Packet->group_segment_size = GroupSize;
+  Packet->kernel_object = KernelObject;
+  Packet->kernarg_address = KernargAddress;
+  Packet->completion_signal = Signal;
+
+  uint32_t Header = HSA_PACKET_TYPE_KERNEL_DISPATCH;
+  Header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_ACQUIRE_FENCE_SCOPE;
+  Header |= HSA_FENCE_SCOPE_SYSTEM << HSA_PACKET_HEADER_RELEASE_FENCE_SCOPE;
+  __atomic_store_n(reinterpret_cast<uint16_t *>(&Packet->header), Header,
+                   __ATOMIC_RELEASE);
+  hsa_signal_store_release(Queue->doorbell_signal, Index);
+
+  hsa_signal_value_t Done = hsa_signal_wait_acquire(
+      Signal, HSA_SIGNAL_CONDITION_EQ, 0, UINT64_MAX, HSA_WAIT_STATE_BLOCKED);
+  if (Done != 0) {
+    std::fprintf(stderr, "error: dispatch did not complete, signal=%ld\n",
+                 static_cast<long>(Done));
+    return 1;
+  }
+
+  if (*Output != Expected) {
+    std::fprintf(stderr, "error: output 0x%08x != 0x%08x\n", *Output, Expected);
+    return 1;
+  }
+
+  std::printf("PASS: %s wrote 0x%08x\n", Kernel, *Output);
+
+  check(hsa_signal_destroy(Signal), "hsa_signal_destroy");
+  check(hsa_queue_destroy(Queue), "hsa_queue_destroy");
+  check(hsa_executable_destroy(Executable), "hsa_executable_destroy");
+  check(hsa_code_object_reader_destroy(Reader),
+        "hsa_code_object_reader_destroy");
+  close(Fd);
+  check(hsa_amd_memory_pool_free(KernargAddress), "free kernarg");
+  check(hsa_amd_memory_pool_free(Output), "free output");
+  check(hsa_shut_down(), "hsa_shut_down");
+  return 0;
+}

--- a/amd/comgr/test/manual/hotswap-a0-mask/run_rewrite_checks.sh
+++ b/amd/comgr/test/manual/hotswap-a0-mask/run_rewrite_checks.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT="${OUT:-$ROOT/out}"
+CLANG="${CLANG:-clang}"
+HOTSWAP_REWRITE="${HOTSWAP_REWRITE:-hotswap-rewrite}"
+LLVM_OBJDUMP="${LLVM_OBJDUMP:-llvm-objdump}"
+LLVM_READELF="${LLVM_READELF:-llvm-readelf}"
+SOURCE_ISA="amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+"
+TARGET_ISA="amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific-"
+
+mkdir -p "$OUT"
+
+compile_kernel() {
+  local src="$1"
+  local dst="$2"
+  "$CLANG" -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib "$src" -o "$dst"
+}
+
+expect_grep() {
+  local pattern="$1"
+  local file="$2"
+  if ! grep -Eq "$pattern" "$file"; then
+    echo "missing pattern '$pattern' in $file" >&2
+    return 1
+  fi
+}
+
+echo "== compile B0 canary"
+compile_kernel "$ROOT/b0_mask_rewrite_canary.s" \
+  "$OUT/b0_mask_rewrite_canary.b0.hsaco"
+
+echo "== rewrite B0 canary to A0"
+AMD_COMGR_EMIT_VERBOSE_LOGS=1 "$HOTSWAP_REWRITE" \
+  "$OUT/b0_mask_rewrite_canary.b0.hsaco" "$SOURCE_ISA" "$TARGET_ISA" \
+  --output "$OUT/b0_mask_rewrite_canary.a0.hsaco" \
+  >"$OUT/b0_mask_rewrite_canary.rewrite.log" 2>&1
+expect_grep "RESULT: SUCCESS" "$OUT/b0_mask_rewrite_canary.rewrite.log"
+
+"$LLVM_OBJDUMP" -d "$OUT/b0_mask_rewrite_canary.a0.hsaco" \
+  >"$OUT/b0_mask_rewrite_canary.a0.disasm"
+"$LLVM_READELF" --notes "$OUT/b0_mask_rewrite_canary.a0.hsaco" \
+  >"$OUT/b0_mask_rewrite_canary.a0.notes"
+
+echo "== verify patched instructions"
+expect_grep "s_pack_hh_b32_b16 s4, 0, s4" \
+  "$OUT/b0_mask_rewrite_canary.a0.disasm"
+expect_grep "s_mov_b32 s[0-9]+, m0" \
+  "$OUT/b0_mask_rewrite_canary.a0.disasm"
+expect_grep "s_pack_hh_b32_b16 m0, 0, m0" \
+  "$OUT/b0_mask_rewrite_canary.a0.disasm"
+expect_grep "cluster_load_b64" "$OUT/b0_mask_rewrite_canary.a0.disasm"
+expect_grep "cluster_load_async_to_lds_b32" \
+  "$OUT/b0_mask_rewrite_canary.a0.disasm"
+expect_grep "global_load_b32" "$OUT/b0_mask_rewrite_canary.a0.disasm"
+expect_grep ".sgpr_count:[[:space:]]+27" \
+  "$OUT/b0_mask_rewrite_canary.a0.notes"
+
+echo "== verify tensor no-scratch failure"
+compile_kernel "$ROOT/b0_tensor_no_scratch.s" \
+  "$OUT/b0_tensor_no_scratch.b0.hsaco"
+"$HOTSWAP_REWRITE" "$OUT/b0_tensor_no_scratch.b0.hsaco" \
+  "$SOURCE_ISA" "$TARGET_ISA" --expect-status ERROR \
+  >"$OUT/b0_tensor_no_scratch.rewrite.log" 2>&1
+expect_grep "RESULT: ERROR" "$OUT/b0_tensor_no_scratch.rewrite.log"
+
+echo "== verify cluster no-scratch failure"
+compile_kernel "$ROOT/b0_cluster_no_scratch.s" \
+  "$OUT/b0_cluster_no_scratch.b0.hsaco"
+"$HOTSWAP_REWRITE" "$OUT/b0_cluster_no_scratch.b0.hsaco" \
+  "$SOURCE_ISA" "$TARGET_ISA" --expect-status ERROR \
+  >"$OUT/b0_cluster_no_scratch.rewrite.log" 2>&1
+expect_grep "RESULT: ERROR" "$OUT/b0_cluster_no_scratch.rewrite.log"
+
+if [[ -n "${RUNNER:-}" ]]; then
+  echo "== dispatch rewritten canary"
+  "$RUNNER" "$OUT/b0_mask_rewrite_canary.a0.hsaco" \
+    b0_mask_rewrite_canary.kd
+fi
+
+echo "PASS: hotswap A0 mask smoke checks"

--- a/llvm/lib/BinaryFormat/MsgPackDocument.cpp
+++ b/llvm/lib/BinaryFormat/MsgPackDocument.cpp
@@ -297,6 +297,11 @@ bool Document::readFromBlob(
       auto &Map = Stack.back().Node.getMap();
       if (!Stack.back().MapEntry) {
         // Reading a map key.
+        // DocNode's ordering only supports scalar keys. Reject container keys
+        // before inserting them so a one-entry map cannot retain an
+        // unorderable key that asserts during a later lookup.
+        if (Node.isMap() || Node.isArray())
+          return false;
         Stack.back().MapKey = Node;
         Stack.back().MapEntry = &Map[Node];
         continue;

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -486,13 +486,14 @@ DecodeStatus AMDGPUDisassembler::tryDecodeInst(const uint8_t *Table, MCInst &MI,
   SmallString<64> LocalComments;
   raw_svector_ostream LocalCommentStream(LocalComments);
   CommentStream = &LocalCommentStream;
+  HasDecodeError = false;
 
   DecodeStatus Res =
       decodeInstruction(Table, TmpInst, Inst, Address, this, STI);
 
   CommentStream = nullptr;
 
-  if (Res != MCDisassembler::Fail) {
+  if (Res != MCDisassembler::Fail && !HasDecodeError) {
     MI = TmpInst;
     Comments << LocalComments;
     return MCDisassembler::Success;
@@ -835,7 +836,12 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
 
   DecodeStatus Status = MCDisassembler::Success;
 
+  CommentStream = &CS;
+  HasDecodeError = false;
   decodeImmOperands(MI, *MCII);
+  CommentStream = nullptr;
+  if (HasDecodeError)
+    return MCDisassembler::Fail;
 
   if (SIInstrFlags::isDPP(*MCII, MI)) {
     if (isMacDPP(MI))
@@ -1552,7 +1558,9 @@ const char* AMDGPUDisassembler::getRegClassName(unsigned RegClassID) const {
 inline
 MCOperand AMDGPUDisassembler::errOperand(unsigned V,
                                          const Twine& ErrMsg) const {
-  *CommentStream << "Error: " + ErrMsg;
+  HasDecodeError = true;
+  if (CommentStream)
+    *CommentStream << "Error: " + ErrMsg;
 
   // ToDo: add support for error operands to MCInst.h
   // return MCOperand::createError(V);

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.h
@@ -46,6 +46,7 @@ private:
   mutable ArrayRef<uint8_t> Bytes;
   mutable uint64_t Literal;
   mutable bool HasLiteral;
+  mutable bool HasDecodeError = false;
   mutable std::optional<bool> EnableWavefrontSize32;
   unsigned CodeObjectVersion;
   const MCExpr *UCVersionW64Expr;

--- a/llvm/unittests/BinaryFormat/MsgPackDocumentTest.cpp
+++ b/llvm/unittests/BinaryFormat/MsgPackDocumentTest.cpp
@@ -494,6 +494,16 @@ TEST(MsgPackDocument, TestReadMergeMap) {
   ASSERT_EQ(BayS.getInt(), 8);
 }
 
+TEST(MsgPackDocument, RejectsContainerMapKeys) {
+  Document ArrayKeyDoc;
+  EXPECT_FALSE(
+      ArrayKeyDoc.readFromBlob(StringRef("\x81\x90\xc0", 3), /*Multi=*/false));
+
+  Document MapKeyDoc;
+  EXPECT_FALSE(MapKeyDoc.readFromBlob(StringRef("\x81\x80\xc0", 3),
+                                      /*Multi=*/false));
+}
+
 TEST(MsgPackDocument, TestWriteBoolean) {
   Document Doc;
   Doc.getRoot() = true;

--- a/llvm/unittests/MC/AMDGPU/Disassembler.cpp
+++ b/llvm/unittests/MC/AMDGPU/Disassembler.cpp
@@ -64,6 +64,27 @@ TEST(AMDGPUDisassembler, Basic) {
   LLVMDisasmDispose(DCR);
 }
 
+TEST(AMDGPUDisassembler, TruncatedLiteralFails) {
+  LLVMInitializeAMDGPUTargetInfo();
+  LLVMInitializeAMDGPUTargetMC();
+  LLVMInitializeAMDGPUDisassembler();
+
+  uint8_t Bytes[] = {0xff, 0x00, 0x8e, 0xbe};
+  char OutString[100];
+  LLVMDisasmContextRef DCR =
+      LLVMCreateDisasmCPU("amdgcn-amd-amdhsa", "gfx1250", nullptr, 0, nullptr,
+                          symbolLookupCallback);
+
+  // Skip test if AMDGPU not built.
+  if (!DCR)
+    GTEST_SKIP();
+
+  EXPECT_EQ(LLVMDisasmInstruction(DCR, Bytes, sizeof(Bytes), 0, OutString,
+                                  sizeof(OutString)),
+            0U);
+  LLVMDisasmDispose(DCR);
+}
+
 // Check multiple disassemblers in same MCContext.
 TEST(AMDGPUDisassembler, MultiDisassembler) {
   LLVMInitializeAMDGPUTargetInfo();


### PR DESCRIPTION
> [!WARNING]
> **A0 execution validation has not passed yet.**
>
> The translated production code objects were successfully loaded and unloaded
> by HIP on an idle gfx1250 A0 GPU, but no owning rocSOLVER workload or kernel
> was launched. This PR must remain draft until workload-level A0 execution and
> correctness validation are complete.

## Dependencies

This is a stacked draft based on:

- #3552
- #3585 (PC materialization)

Until those dependencies merge, the GitHub diff against `amd-staging` also
includes their commits.

## Summary

When transactional `.text` growth moves an ordinary short branch beyond its
signed 16-bit displacement range, insert a guarded 256-byte branch island:

```asm
island_start:
  s_branch original_boundary
island_entry:
  s_branch displaced_target
  s_nop ...
original_boundary:
```

The original branch targets `island_entry`. Ordinary fallthrough reaches
`island_start` and skips the island, preserving the original path.

The change:

- batches all overflowing branches discovered in one scan;
- preserves later 256-byte kernel-entry alignment;
- reserves distinct instruction boundaries for multiple islands;
- applies only to ordinary `s_branch` and
  `s_cbranch_{scc,vcc,exec}{z,nz}` opcodes;
- preserves fatal repair errors instead of treating them as range-only retries;
- otherwise remains fail-closed.

## Production result

This resolves the two remaining non-unresolved-control-flow displacement
declines:

- `561b43f8975b1a9696f1ae6327a300ea71abc74d300793ce6bdba64191896dee`
  - translated successfully using 9 guarded islands
- `c706a6fcaac0788b03f8ba8788e07bd7888f8721a87053db18594ad0898928c7`
  - translated successfully using 8 guarded islands

Both exact objects were rerun successfully after the opcode whitelist and
fatal-error handling were tightened.

Together with #3552 and the PC-materialization PR, the expected result is
12/28 original short-branch-gateway failures resolved. The remaining 16 are
unresolved-control-flow cases and are intentionally unaffected.

## Testing

- focused transactional branch-island regression, including checks for:
  - source branch to island entry
  - guard branch over the island
  - island branch to the displaced target
- 112 runnable COMGR Hotswap LIT tests passed
- one additional Hotswap test could not run because the matching LLVM build
  lacks `llvm-objcopy` (exit 127), before any Hotswap assertion
- exact translation replay of both production objects above
- A0 HIP module load/unload smoke for both translated objects

## Draft limitations / validation still required

- Execute the owning rocSOLVER workloads on A0 with valid kernel arguments.
- Add backward and unconditional branch-island regressions.
- Add a synthetic multi-island batch regression.
- Add a second aligned kernel entry after an island.
- Test interaction with existing alignment insertions and replacement
  boundaries.
- Rerun the complete 1,231-object corpus on the final integration base.
