### PR TITLE
[test][hotswap] Add gfx1250 B0->A0 code-object benchmark utils

### DIFF
--- a/amd/comgr/utils/hotswap-bench/README.md
+++ b/amd/comgr/utils/hotswap-bench/README.md
@@ -1,0 +1,136 @@
+# HotSwap code-object benchmark
+
+Batch-run the Comgr **HotSwap** gfx1250 B0→A0 rewrite (`hotswap-rewrite`) over a
+directory of AMD GPU code objects (`.hsaco` / `.co`) and tabulate, per object,
+the **CPU time**, **peak RSS**, and **pass/fail/timeout** into a single CSV.
+
+Each object is translated in its own fresh process; Linux `wait4` accounting
+gives that process's user+system CPU and peak resident memory. Work runs in
+parallel for throughput, but rows are always **sorted by input path** before
+writing, so the CSV is deterministic and two runs diff cleanly.
+
+> ⚠️ **Disclaimer — entry trampolines are OFF by default here.** `hotswap-rewrite`
+> itself enables entry trampolines, but the current gfx1250 hotswap path
+> **segfaults on a large fraction of objects** when they are on. For that reason
+> **these scripts default `--entry-trampolines` to OFF.** Pass `--entry-trampolines`
+> only if you specifically want to reproduce the crash (expect many SIGSEGV
+> failures).
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `hotswap_bench.py` | Core runner. Defaults to `*.hsaco`. Fully flag-driven. |
+| `hotswap_bench_all.py` | Thin wrapper: runs **both** `.hsaco` and `.co` with a 5-minute per-file timeout. |
+
+## Prerequisites
+
+- **Linux** (uses `wait4`/`/proc`; the optional memory guard uses `systemd-run` or `choom`).
+- **Python 3.9+** (standard library only — no `pip` deps).
+- A built **`hotswap-rewrite`** binary and **`libamd_comgr.so`** (see below).
+
+## 1. Build the translator
+
+From an llvm-project checkout that contains `amd/comgr`:
+
+```bash
+cd <llvm-project>
+cmake -S llvm -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLVM_ENABLE_PROJECTS="clang;lld" \
+  -DLLVM_TARGETS_TO_BUILD="X86;AMDGPU" \
+  -DLLVM_ENABLE_ASSERTIONS=ON \
+  -DLLVM_EXTERNAL_PROJECTS="device-libs;comgr" \
+  -DLLVM_EXTERNAL_DEVICE_LIBS_SOURCE_DIR="$PWD/amd/device-libs" \
+  -DLLVM_EXTERNAL_COMGR_SOURCE_DIR="$PWD/amd/comgr" \
+  -DCOMGR_BUILD_SHARED_LIBS=ON
+ninja -C build hotswap-rewrite
+```
+
+This produces:
+- `build/tools/comgr/test-lit/hotswap-rewrite`
+- `build/lib/libamd_comgr.so*`
+
+## 2. Variables you need to set
+
+The scripts need to know **where the built tool is**. Set **one** of the
+following (or pass the equivalent flags):
+
+| Variable | Meaning | Required? |
+| --- | --- | --- |
+| `HOTSWAP_BUILD_DIR` | The LLVM **build** directory. The scripts derive `<dir>/tools/comgr/test-lit/hotswap-rewrite` and `<dir>/lib` from it. | **Recommended** |
+| `HOTSWAP_REWRITE` | Explicit path to the `hotswap-rewrite` binary (overrides the above). | Optional |
+| `HOTSWAP_LIBRARY_DIR` | Directory containing `libamd_comgr.so*`. Auto-discovered from the binary if unset. | Optional |
+
+Equivalent command-line flags (take precedence over the env vars):
+`--hotswap <binary>` and `--hotswap-library-dir <dir>`.
+
+Auto-detection: if you run the scripts from **inside** an llvm-project checkout
+that has an in-tree `build/` directory, the binary is found automatically and
+no variable is needed.
+
+The **corpus directory is a positional argument** — your choice. In our runs it
+was `/home/ydeshpan/my_repos/data/hotswap-corpus`.
+
+## 3. Run
+
+```bash
+# point at your build once
+export HOTSWAP_BUILD_DIR=/path/to/llvm-project/build      # or a TheRock amd-llvm build
+
+# all code objects (.hsaco + .co); entry trampolines are OFF by default here,
+# 5-minute timeout, 16-way parallel
+python3 hotswap_bench_all.py /path/to/hotswap-corpus \
+  --jobs 16 \
+  --memory-limit-gb 64 \
+  --csv results.csv
+```
+
+`.hsaco`-only, using the core script directly:
+
+```bash
+export HOTSWAP_BUILD_DIR=/path/to/build
+python3 hotswap_bench.py /path/to/hotswap-corpus --jobs 16 --csv results_hsaco.csv
+```
+
+> To *measure* the entry-trampolines crash instead, add `--entry-trampolines` —
+> expect many `fail` rows with `exit_code = -11` (SIGSEGV).
+
+## Memory safety on shared machines
+
+A parallel run over a large corpus can spike memory. Guard it with **one** of:
+
+- `--memory-limit-gb N` — re-exec inside a **systemd transient scope** with a
+  hard aggregate `MemoryMax=N` GiB cap (`OOMPolicy=kill`); the whole run is
+  killed if it exceeds the cap. Use `--systemd-scope {auto,user,system}`
+  (`auto` picks a user scope when available, else a system scope as root).
+- `--oom-guard` — re-exec under **`choom`** so this run is the preferred OOM
+  victim under memory pressure (no hard cap). Tune with `--oom-score-adj N`.
+
+## Useful flags
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--jobs, -j N` | auto (CPU count) | parallel translations |
+| `--timeout-seconds N` | 900 (`_all`: 300) | per-file wall-clock timeout; 0 disables |
+| `--include-glob GLOB` | `*.hsaco` (`_all`: `*.[hc][so]*`) | which files to pick |
+| `--entry-trampolines` / `--no-entry-trampolines` | **off** | kernel-entry trampoline redirection — default OFF here (see disclaimer); `--entry-trampolines` re-enables it |
+| `--strict-mode` / `--no-strict-mode` | on | fail instead of returning an unpatched object |
+| `--source-isa` / `--target-isa` | `amdgcn-amd-amdhsa--gfx1250` | ISA strings (same = intra-gfx1250 B0→A0) |
+| `--keep-outputs DIR` | discard | retain rewritten `.co` files |
+| `--csv PATH` | see scripts | output CSV path |
+
+## Output CSV columns (one row per code object)
+
+`input_path, filename, input_size, status, exit_code, result, cpu_seconds,
+user_cpu_seconds, system_cpu_seconds, elapsed_seconds, max_rss_kib,
+output_size, spawn_error`
+
+- `status` — `pass` (exit 0), `fail` (non-zero exit), `timeout`, or `spawn_error`.
+- `exit_code` — raw exit code; negative means killed by a signal (e.g. `-11` = SIGSEGV).
+- `result` — the tool's `RESULT:` line (`SUCCESS` / `INVALID_ARGUMENT`) when present.
+- `cpu_seconds` — user + system CPU; `max_rss_kib` — peak resident memory (KiB).
+
+Pass/fail is **exit-code based**: `pass` == the process exited 0. The
+`exit_code` and `result` columns are kept separately so failures (crashes vs.
+graceful errors) can still be distinguished after the fact.

--- a/amd/comgr/utils/hotswap-bench/README.md
+++ b/amd/comgr/utils/hotswap-bench/README.md
@@ -9,12 +9,9 @@ gives that process's user+system CPU and peak resident memory. Work runs in
 parallel for throughput, but rows are always **sorted by input path** before
 writing, so the CSV is deterministic and two runs diff cleanly.
 
-> ⚠️ **Disclaimer — entry trampolines are OFF by default here.** `hotswap-rewrite`
-> itself enables entry trampolines, but the current gfx1250 hotswap path
-> **segfaults on a large fraction of objects** when they are on. For that reason
-> **these scripts default `--entry-trampolines` to OFF.** Pass `--entry-trampolines`
-> only if you specifically want to reproduce the crash (expect many SIGSEGV
-> failures).
+> ⚠️ **Entry trampolines default OFF.** The `--entry-trampolines` flag is
+> considered deprecated and slated for removal, so these scripts default it to
+> off. Pass `--entry-trampolines` only to exercise the old path.
 
 ## Files
 
@@ -48,7 +45,7 @@ ninja -C build hotswap-rewrite
 ```
 
 This produces:
-- `build/tools/comgr/test-lit/hotswap-rewrite`
+- `build/tools/comgr/test-lit/hotswap-rewrite` (or `tools/amd_comgr/test-lit/...`)
 - `build/lib/libamd_comgr.so*`
 
 ## 2. Variables you need to set
@@ -58,7 +55,7 @@ following (or pass the equivalent flags):
 
 | Variable | Meaning | Required? |
 | --- | --- | --- |
-| `HOTSWAP_BUILD_DIR` | The LLVM **build** directory. The scripts derive `<dir>/tools/comgr/test-lit/hotswap-rewrite` and `<dir>/lib` from it. | **Recommended** |
+| `HOTSWAP_BUILD_DIR` | The LLVM **build** directory. The scripts derive the tool from `<dir>/tools/comgr/test-lit/hotswap-rewrite` or `<dir>/tools/amd_comgr/test-lit/hotswap-rewrite` (both comgr and amd_comgr project layouts are probed), and the library from `<dir>/lib`. | **Recommended** |
 | `HOTSWAP_REWRITE` | Explicit path to the `hotswap-rewrite` binary (overrides the above). | Optional |
 | `HOTSWAP_LIBRARY_DIR` | Directory containing `libamd_comgr.so*`. Auto-discovered from the binary if unset. | Optional |
 
@@ -122,15 +119,24 @@ A parallel run over a large corpus can spike memory. Guard it with **one** of:
 
 ## Output CSV columns (one row per code object)
 
-`input_path, filename, input_size, status, exit_code, result, cpu_seconds,
-user_cpu_seconds, system_cpu_seconds, elapsed_seconds, max_rss_kib,
-output_size, spawn_error`
+`input_path, filename, input_size, input_sha256, status, exit_code, result,
+cpu_seconds, user_cpu_seconds, system_cpu_seconds, elapsed_seconds,
+max_rss_kib, output_size, output_sha256, output_is_elf, spawn_error`
 
-- `status` — `pass` (exit 0), `fail` (non-zero exit), `timeout`, or `spawn_error`.
+- `status` — `pass`, `fail`, `timeout`, or `spawn_error`. `pass` requires the
+  process to exit 0 **and** report `RESULT: SUCCESS` **and** write a valid ELF.
 - `exit_code` — raw exit code; negative means killed by a signal (e.g. `-11` = SIGSEGV).
 - `result` — the tool's `RESULT:` line (`SUCCESS` / `INVALID_ARGUMENT`) when present.
+- `input_sha256` / `output_sha256` — content hashes so a clean diff proves the
+  same inputs were measured and detects translation divergence.
+- `output_is_elf` — whether the rewritten object begins with the ELF magic.
 - `cpu_seconds` — user + system CPU; `max_rss_kib` — peak resident memory (KiB).
 
-Pass/fail is **exit-code based**: `pass` == the process exited 0. The
-`exit_code` and `result` columns are kept separately so failures (crashes vs.
-graceful errors) can still be distinguished after the fact.
+## Run metadata sidecar
+
+Alongside the CSV, a `<csv>.meta.json` is written with run-level provenance
+that a per-row diff cannot capture: the effective configuration (ISA,
+strict-mode, entry-trampolines, timeout, jobs, globs), the resolved command
+template, and **identities** (path + size + SHA-256) for `hotswap-rewrite` and
+each `libamd_comgr.so*`. Compare both files to confirm two runs used the same
+binary, library, configuration, and workload.

--- a/amd/comgr/utils/hotswap-bench/README.md
+++ b/amd/comgr/utils/hotswap-bench/README.md
@@ -114,14 +114,16 @@ A parallel run over a large corpus can spike memory. Guard it with **one** of:
 | `--entry-trampolines` / `--no-entry-trampolines` | **off** | kernel-entry trampoline redirection — default OFF here (see disclaimer); `--entry-trampolines` re-enables it |
 | `--strict-mode` / `--no-strict-mode` | on | fail instead of returning an unpatched object |
 | `--source-isa` / `--target-isa` | `amdgcn-amd-amdhsa--gfx1250` | ISA strings (same = intra-gfx1250 B0→A0) |
-| `--keep-outputs DIR` | discard | retain rewritten `.co` files |
+| `--keep-outputs DIR` | discard | retain rewritten `.co` files (input directory structure preserved) |
+| `--resume` | off | resume from `<csv>.partial.jsonl`, skipping already-recorded inputs |
 | `--csv PATH` | see scripts | output CSV path |
 
 ## Output CSV columns (one row per code object)
 
 `input_path, filename, input_size, input_sha256, status, exit_code, result,
 cpu_seconds, user_cpu_seconds, system_cpu_seconds, elapsed_seconds,
-max_rss_kib, output_size, output_sha256, output_is_elf, spawn_error`
+max_rss_kib, output_size, output_sha256, output_is_elf, spawn_error,
+stderr_tail`
 
 - `status` — `pass`, `fail`, `timeout`, or `spawn_error`. `pass` requires the
   process to exit 0 **and** report `RESULT: SUCCESS` **and** write a valid ELF.
@@ -131,6 +133,8 @@ max_rss_kib, output_size, output_sha256, output_is_elf, spawn_error`
   same inputs were measured and detects translation divergence.
 - `output_is_elf` — whether the rewritten object begins with the ELF magic.
 - `cpu_seconds` — user + system CPU; `max_rss_kib` — peak resident memory (KiB).
+- `stderr_tail` — bounded tail of the child's stderr, kept so a crash row
+  retains its assertion/backtrace.
 
 ## Run metadata sidecar
 
@@ -140,3 +144,25 @@ strict-mode, entry-trampolines, timeout, jobs, globs), the resolved command
 template, and **identities** (path + size + SHA-256) for `hotswap-rewrite` and
 each `libamd_comgr.so*`. Compare both files to confirm two runs used the same
 binary, library, configuration, and workload.
+
+## Resilience, interrupts, and resume
+
+Each completed row is appended to `<csv>.partial.jsonl` as it finishes, and the
+final CSV is written atomically (temp file + rename). So if a long run is
+OOM-killed or crashes, the finished work is preserved: re-run with `--resume`
+to skip the inputs already recorded and only translate what's left.
+
+On **Ctrl-C** the runner tears down every active `hotswap-rewrite` process
+group, stops queued work, writes the rows completed so far, and exits 130. The
+checkpoint is deleted automatically once a run finishes completely.
+
+## Tests
+
+`test_hotswap_bench.py` covers result classification, input discovery/exclusions,
+collision-free output naming, timeouts, process-group teardown, the `-j 0`
+parser contract, provenance columns/sidecar, and `--resume`. It uses stub
+executables and temp dirs — no GPU or real `hotswap-rewrite` required:
+
+```bash
+python3 -m unittest -v      # from this directory
+```

--- a/amd/comgr/utils/hotswap-bench/README.md
+++ b/amd/comgr/utils/hotswap-bench/README.md
@@ -111,9 +111,9 @@ A parallel run over a large corpus can spike memory. Guard it with **one** of:
 
 | Flag | Default | Meaning |
 | --- | --- | --- |
-| `--jobs, -j N` | auto (CPU count) | parallel translations |
+| `--jobs, -j N` | `0` (= auto CPU count) | parallel translations; `0` selects the CPU count |
 | `--timeout-seconds N` | 900 (`_all`: 300) | per-file wall-clock timeout; 0 disables |
-| `--include-glob GLOB` | `*.hsaco` (`_all`: `*.[hc][so]*`) | which files to pick |
+| `--include-glob GLOB` | `*.hsaco` (repeatable) | which files to pick; `hotswap_bench_all.py` uses `*.hsaco` + `*.co` |
 | `--entry-trampolines` / `--no-entry-trampolines` | **off** | kernel-entry trampoline redirection — default OFF here (see disclaimer); `--entry-trampolines` re-enables it |
 | `--strict-mode` / `--no-strict-mode` | on | fail instead of returning an unpatched object |
 | `--source-isa` / `--target-isa` | `amdgcn-amd-amdhsa--gfx1250` | ISA strings (same = intra-gfx1250 B0→A0) |

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench.py
@@ -1,0 +1,762 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Run HotSwap gfx1250 B0-to-A0 translation over a directory of .hsaco files
+and tabulate CPU time, peak RSS, and pass/fail into a single CSV.
+
+Each input runs in a fresh process. Linux wait4 resource accounting captures
+user plus system CPU time and peak resident set size for that process.
+
+Inputs are translated in parallel (--jobs) for throughput, but rows are always
+sorted by input path before writing, so the CSV is deterministic regardless of
+completion order and two runs diff cleanly.
+
+Because a parallel run over a large corpus can spike memory, the invocation can
+re-exec itself under a memory guard so it never OOM-kills a shared dev machine:
+  * --memory-limit-gb N wraps the run in a systemd transient scope with a hard
+    aggregate MemoryMax cap (the whole process tree is killed if it exceeds N).
+  * --oom-guard uses choom to bias the kernel OOM killer toward this run, so a
+    machine under memory pressure sacrifices this batch instead of other work.
+
+This is a deliberately simple, single-tool runner that exercises the Comgr
+`hotswap-rewrite` lit binary over a corpus of code objects. Point it at a build
+with $HOTSWAP_REWRITE / $HOTSWAP_BUILD_DIR or the --hotswap flag; see README.md
+in this directory for the full list of variables and steps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import csv
+import functools
+import io
+import os
+import pathlib
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Any, Callable, Sequence
+
+DEFAULT_SOURCE_ISA = "amdgcn-amd-amdhsa--gfx1250"
+DEFAULT_TARGET_ISA = "amdgcn-amd-amdhsa--gfx1250"
+
+# Sentinel set on the re-exec'd child so the memory guard wraps only once.
+GUARD_ENV = "HOTSWAP_HSACO_BENCH_GUARDED"
+
+
+def find_repo_root() -> pathlib.Path | None:
+    """Locate the enclosing llvm-project checkout by walking up until a dir
+    containing amd/comgr is found. Returns None if not inside such a tree."""
+    for parent in pathlib.Path(__file__).resolve().parents:
+        if (parent / "amd" / "comgr").is_dir():
+            return parent
+    return None
+
+
+def first_executable(candidates: Sequence[pathlib.Path | str]) -> str:
+    for candidate in candidates:
+        raw = str(candidate)
+        if "/" not in raw:
+            found = shutil.which(raw)
+            if found:
+                return found
+            continue
+        path = pathlib.Path(raw).expanduser()
+        if path.is_file() and os.access(path, os.X_OK):
+            return str(path.resolve())
+    return ""
+
+
+def default_hotswap() -> str:
+    """Locate the hotswap-rewrite binary. Precedence:
+    1. $HOTSWAP_REWRITE (explicit binary path),
+    2. $HOTSWAP_BUILD_DIR/tools/comgr/test-lit/hotswap-rewrite,
+    3. an in-tree build at <repo-root>/build/tools/comgr/test-lit/hotswap-rewrite,
+    4. `hotswap-rewrite` on PATH.
+    Override at runtime with --hotswap."""
+    candidates: list[pathlib.Path | str] = []
+    if value := os.environ.get("HOTSWAP_REWRITE"):
+        candidates.append(value)
+    if build := os.environ.get("HOTSWAP_BUILD_DIR"):
+        candidates.append(
+            pathlib.Path(build) / "tools" / "comgr" / "test-lit" / "hotswap-rewrite"
+        )
+    if (root := find_repo_root()) is not None:
+        candidates.append(
+            root / "build" / "tools" / "comgr" / "test-lit" / "hotswap-rewrite"
+        )
+    candidates.append("hotswap-rewrite")
+    return first_executable(candidates)
+
+
+def resolve_executable(raw: str, label: str) -> pathlib.Path:
+    if not raw:
+        raise ValueError(f"{label} was not found; pass --{label}")
+    found = raw if "/" in raw else (shutil.which(raw) or "")
+    if not found:
+        raise ValueError(f"{label} executable was not found: {raw}")
+    path = pathlib.Path(found).expanduser().resolve(strict=True)
+    if not path.is_file() or not os.access(path, os.X_OK):
+        raise ValueError(f"{label} is not executable: {path}")
+    return path
+
+
+def discover_library_dirs(binary: pathlib.Path) -> list[pathlib.Path]:
+    for ancestor in list(binary.parents)[:8]:
+        for candidate in (ancestor, ancestor / "lib"):
+            if candidate.is_dir() and any(candidate.glob("libamd_comgr.so*")):
+                return [candidate.resolve()]
+    return []
+
+
+def resolve_library_dirs(
+    raw_directories: Sequence[str], hotswap: pathlib.Path
+) -> list[pathlib.Path]:
+    values = list(raw_directories)
+    if not values and (environment := os.environ.get("HOTSWAP_LIBRARY_DIR")):
+        values.append(environment)
+    if not values:
+        return discover_library_dirs(hotswap)
+    resolved: list[pathlib.Path] = []
+    for raw in values:
+        path = pathlib.Path(raw).expanduser().resolve(strict=True)
+        if not path.is_dir():
+            raise ValueError(f"HotSwap library path is not a directory: {path}")
+        if path not in resolved:
+            resolved.append(path)
+    return resolved
+
+
+def discover_inputs(
+    paths: Sequence[str], recursive: bool, include_glob: str
+) -> list[pathlib.Path]:
+    discovered: set[pathlib.Path] = set()
+    for raw_path in paths:
+        path = pathlib.Path(raw_path).expanduser().resolve(strict=True)
+        if path.is_file():
+            discovered.add(path)
+            continue
+        if not path.is_dir():
+            raise ValueError(f"input is neither a regular file nor directory: {path}")
+        iterator = path.rglob(include_glob) if recursive else path.glob(include_glob)
+        discovered.update(
+            candidate.resolve() for candidate in iterator if candidate.is_file()
+        )
+    return sorted(discovered)
+
+
+def common_root(inputs: Sequence[pathlib.Path]) -> pathlib.Path:
+    if len(inputs) == 1:
+        return inputs[0].parent
+    return pathlib.Path(os.path.commonpath([str(path) for path in inputs]))
+
+
+def terminate_process_group(
+    process: subprocess.Popen[bytes], grace: float
+) -> tuple[int, Any] | None:
+    if process.returncode is not None:
+        return None
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline:
+        try:
+            waited, status, usage = os.wait4(process.pid, os.WNOHANG)
+        except InterruptedError:
+            continue
+        except ChildProcessError:
+            return None
+        if waited:
+            process.returncode = os.waitstatus_to_exitcode(status)
+            return status, usage
+        time.sleep(0.01)
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    return None
+
+
+def timed_process(
+    command: Sequence[str],
+    *,
+    stdout: Any,
+    stderr: Any,
+    environment: dict[str, str],
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    started_ns = time.monotonic_ns()
+    process = subprocess.Popen(
+        list(command),
+        stdout=stdout,
+        stderr=stderr,
+        env=environment,
+        start_new_session=True,
+    )
+    deadline = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
+    timed_out = False
+    status = 0
+    usage = None
+    while True:
+        try:
+            waited, status, usage = os.wait4(process.pid, os.WNOHANG)
+        except InterruptedError:
+            continue
+        if waited:
+            break
+        if deadline is not None and time.monotonic() >= deadline:
+            timed_out = True
+            reaped = terminate_process_group(process, 1.0)
+            if reaped is not None:
+                status, usage = reaped
+            else:
+                try:
+                    _, status, usage = os.wait4(process.pid, 0)
+                except ChildProcessError:
+                    usage = None
+            break
+        time.sleep(0.005)
+
+    if process.returncode is None:
+        process.returncode = os.waitstatus_to_exitcode(status)
+    elapsed_seconds = (time.monotonic_ns() - started_ns) / 1_000_000_000
+    result: dict[str, Any] = {
+        "return_code": process.returncode,
+        "timed_out": timed_out,
+        "elapsed_seconds": elapsed_seconds,
+        "user_cpu_seconds": None,
+        "system_cpu_seconds": None,
+        "cpu_seconds": None,
+        "max_rss_kib": None,
+    }
+    if usage is not None:
+        user_seconds = float(usage.ru_utime)
+        system_seconds = float(usage.ru_stime)
+        result.update(
+            {
+                "user_cpu_seconds": user_seconds,
+                "system_cpu_seconds": system_seconds,
+                "cpu_seconds": user_seconds + system_seconds,
+                "max_rss_kib": int(usage.ru_maxrss),
+            }
+        )
+    return result
+
+
+def hotswap_command(
+    binary: pathlib.Path,
+    source: pathlib.Path,
+    output: pathlib.Path,
+    source_isa: str,
+    target_isa: str,
+    *,
+    entry_trampolines: bool,
+    strict_mode: bool,
+) -> list[str]:
+    command = [str(binary), str(source), source_isa, target_isa, "--output", str(output)]
+    if entry_trampolines:
+        command.append("--entry-trampolines")
+    if strict_mode:
+        command.append("--strict-mode")
+    return command
+
+
+def run_one(
+    *,
+    source: pathlib.Path,
+    hotswap: pathlib.Path,
+    library_dirs: Sequence[pathlib.Path],
+    source_isa: str,
+    target_isa: str,
+    entry_trampolines: bool,
+    strict_mode: bool,
+    timeout_seconds: float,
+    outputs_dir: pathlib.Path | None,
+    input_root: pathlib.Path,
+) -> dict[str, Any]:
+    relative = os.path.relpath(source, input_root)
+    try:
+        input_size = source.stat().st_size
+    except OSError:
+        input_size = None
+
+    if outputs_dir is not None:
+        outputs_dir.mkdir(parents=True, exist_ok=True)
+        safe = relative.replace(os.sep, "__")
+        output = outputs_dir / f"{safe}.co"
+        cleanup = False
+    else:
+        handle, temporary = tempfile.mkstemp(suffix=".co", prefix="hotswap-")
+        os.close(handle)
+        output = pathlib.Path(temporary)
+        cleanup = True
+    output.unlink(missing_ok=True)
+
+    environment = dict(os.environ)
+    environment["LC_ALL"] = "C"
+    if library_dirs:
+        previous = environment.get("LD_LIBRARY_PATH")
+        prefix = os.pathsep.join(str(path) for path in library_dirs)
+        environment["LD_LIBRARY_PATH"] = (
+            prefix + os.pathsep + previous if previous else prefix
+        )
+
+    command = hotswap_command(
+        hotswap,
+        source,
+        output,
+        source_isa,
+        target_isa,
+        entry_trampolines=entry_trampolines,
+        strict_mode=strict_mode,
+    )
+
+    stdout_buffer = io.BytesIO()
+    with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+        try:
+            process_result = timed_process(
+                command,
+                stdout=stdout_file,
+                stderr=stderr_file,
+                environment=environment,
+                timeout_seconds=timeout_seconds,
+            )
+            spawn_error = None
+        except OSError as error:
+            process_result = {
+                "return_code": None,
+                "timed_out": False,
+                "elapsed_seconds": 0.0,
+                "user_cpu_seconds": None,
+                "system_cpu_seconds": None,
+                "cpu_seconds": None,
+                "max_rss_kib": None,
+            }
+            spawn_error = str(error)
+        stdout_file.seek(0)
+        stdout_buffer.write(stdout_file.read())
+
+    result_line = ""
+    for line in stdout_buffer.getvalue().decode("utf-8", "replace").splitlines():
+        if line.startswith("RESULT:"):
+            result_line = line.split(":", 1)[1].strip()
+            break
+
+    output_size = output.stat().st_size if output.is_file() else None
+
+    if spawn_error is not None:
+        status = "spawn_error"
+    elif process_result["timed_out"]:
+        status = "timeout"
+    elif process_result["return_code"] == 0:
+        status = "pass"
+    else:
+        status = "fail"
+
+    if cleanup:
+        output.unlink(missing_ok=True)
+
+    return {
+        "input_path": relative,
+        "filename": source.name,
+        "input_size": input_size,
+        "status": status,
+        "exit_code": process_result["return_code"],
+        "result": result_line,
+        "cpu_seconds": process_result["cpu_seconds"],
+        "user_cpu_seconds": process_result["user_cpu_seconds"],
+        "system_cpu_seconds": process_result["system_cpu_seconds"],
+        "elapsed_seconds": process_result["elapsed_seconds"],
+        "max_rss_kib": process_result["max_rss_kib"],
+        "output_size": output_size,
+        "spawn_error": spawn_error,
+    }
+
+
+CSV_FIELDS = [
+    "input_path",
+    "filename",
+    "input_size",
+    "status",
+    "exit_code",
+    "result",
+    "cpu_seconds",
+    "user_cpu_seconds",
+    "system_cpu_seconds",
+    "elapsed_seconds",
+    "max_rss_kib",
+    "output_size",
+    "spawn_error",
+]
+
+
+def write_csv(path: pathlib.Path, rows: Sequence[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=CSV_FIELDS, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def nonnegative_float(value: str) -> float:
+    parsed = float(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
+    return parsed
+
+
+def positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def apply_oom_score_adj(value: int) -> None:
+    """Bias the kernel OOM killer toward this process tree. Children inherit
+    oom_score_adj across fork/exec, so setting it here covers every worker and
+    hotswap-rewrite descendant. Best-effort: warn but continue on failure."""
+    try:
+        with open("/proc/self/oom_score_adj", "w", encoding="ascii") as stream:
+            stream.write(f"{value}\n")
+    except OSError as error:
+        print(
+            f"warning: could not set oom_score_adj={value}: {error}",
+            file=sys.stderr,
+        )
+
+
+def user_systemd_manager_available() -> bool:
+    systemctl = shutil.which("systemctl")
+    if not systemctl:
+        return False
+    return (
+        subprocess.run(
+            [systemctl, "--user", "show-environment"], capture_output=True
+        ).returncode
+        == 0
+    )
+
+
+def choose_systemd_scope(preference: str) -> str:
+    """Resolve the systemd scope to use for the memory cap. 'auto' prefers a
+    user scope, falling back to a system scope when running as root."""
+    if preference == "user":
+        if not user_systemd_manager_available():
+            raise ValueError(
+                "--systemd-scope user requires an accessible systemd user "
+                "manager; start a systemd user session or use "
+                "--systemd-scope system/auto"
+            )
+        return "user"
+    if preference == "system":
+        if os.geteuid() != 0:
+            raise ValueError(
+                "--systemd-scope system needs root (or interactive polkit "
+                "auth); run as root or use --systemd-scope user"
+            )
+        return "system"
+    # auto
+    if user_systemd_manager_available():
+        return "user"
+    if os.geteuid() == 0:
+        return "system"
+    raise ValueError(
+        "no usable systemd scope: no user manager and not root for a system "
+        "scope. Start a systemd user session, run as root, or use --oom-guard"
+    )
+
+
+def reexec_under_memory_guard(args: argparse.Namespace) -> None:
+    """If a memory guard was requested and is not already active, replace this
+    process with one wrapped by systemd-run (hard aggregate cap) or choom (OOM
+    victim bias). Returns normally when no wrapping is needed."""
+    if os.environ.get(GUARD_ENV) == "1":
+        return
+    if not args.memory_limit_gb and not args.oom_guard:
+        return
+    if args.memory_limit_gb and args.oom_guard:
+        raise ValueError("use only one of --memory-limit-gb or --oom-guard")
+
+    child = [sys.executable, str(pathlib.Path(sys.argv[0]).resolve()), *sys.argv[1:]]
+
+    if args.memory_limit_gb:
+        systemd_run = shutil.which("systemd-run")
+        if not systemd_run:
+            raise ValueError("--memory-limit-gb requires systemd-run")
+        scope = choose_systemd_scope(args.systemd_scope)
+        # A transient scope puts this runner, every worker, and every
+        # hotswap-rewrite descendant in one cgroup, so MemoryMax applies to
+        # their aggregate memory and OOMPolicy=kill takes down the whole scope
+        # if the cap is hit. OOMScoreAdjust is not a valid scope property (a
+        # scope adopts existing processes rather than spawning them), so the
+        # global-pressure victim bias is applied later via /proc/self.
+        wrapper = [systemd_run]
+        if scope == "user":
+            wrapper.append("--user")
+        wrapper += [
+            "--scope",
+            "--quiet",
+            "--collect",
+            "--property=OOMPolicy=kill",
+            f"--property=MemoryMax={args.memory_limit_gb}G",
+            "--",
+        ]
+        print(
+            f"re-exec under systemd {scope} scope: "
+            f"MemoryMax={args.memory_limit_gb}G, OOMPolicy=kill",
+            file=sys.stderr,
+        )
+    else:
+        choom = shutil.which("choom")
+        if not choom:
+            raise ValueError("--oom-guard requires the choom tool (util-linux)")
+        wrapper = [choom, "-n", str(args.oom_score_adj), "--"]
+        print(
+            f"re-exec under choom: oom_score_adj={args.oom_score_adj} "
+            "(preferred OOM victim; no hard cap)",
+            file=sys.stderr,
+        )
+
+    os.environ[GUARD_ENV] = "1"
+    os.execvp(wrapper[0], wrapper + child)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help=".hsaco files or directories to scan",
+    )
+    parser.add_argument(
+        "--csv",
+        default="hotswap_hsaco_bench.csv",
+        help="output CSV path (default: hotswap_hsaco_bench.csv)",
+    )
+    parser.add_argument(
+        "--hotswap",
+        default=default_hotswap(),
+        help="hotswap-rewrite executable (default: auto-detected)",
+    )
+    parser.add_argument(
+        "--hotswap-library-dir",
+        action="append",
+        default=[],
+        help="prepend a directory to LD_LIBRARY_PATH for hotswap; repeatable",
+    )
+    parser.add_argument("--source-isa", default=DEFAULT_SOURCE_ISA)
+    parser.add_argument("--target-isa", default=DEFAULT_TARGET_ISA)
+    parser.add_argument(
+        "--entry-trampolines",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "pass --entry-trampolines to hotswap-rewrite (default: OFF; the "
+            "gfx1250 path currently segfaults with trampolines on)"
+        ),
+    )
+    parser.add_argument(
+        "--strict-mode",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="pass --strict-mode to hotswap-rewrite (default: true)",
+    )
+    parser.add_argument(
+        "--include-glob",
+        default="*.hsaco",
+        help="filename glob within directories (default: *.hsaco)",
+    )
+    parser.add_argument(
+        "--recursive",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="recurse into input directories (default: true)",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=nonnegative_float,
+        default=900.0,
+        help="per-input timeout; zero disables (default: 900)",
+    )
+    parser.add_argument(
+        "--jobs",
+        "-j",
+        type=positive_int,
+        default=0,
+        help="parallel translations; zero auto-detects CPU count (default: auto)",
+    )
+    parser.add_argument(
+        "--memory-limit-gb",
+        type=positive_int,
+        default=0,
+        help=(
+            "re-exec under a systemd transient scope with this hard aggregate "
+            "MemoryMax cap in GiB (whole run is killed if exceeded)"
+        ),
+    )
+    parser.add_argument(
+        "--systemd-scope",
+        choices=("auto", "user", "system"),
+        default="auto",
+        help=(
+            "systemd scope for --memory-limit-gb; auto uses a user scope when "
+            "available, else a system scope as root (default: auto)"
+        ),
+    )
+    parser.add_argument(
+        "--oom-guard",
+        action="store_true",
+        help=(
+            "re-exec under choom so this run is the preferred OOM victim under "
+            "memory pressure (no hard cap; mutually exclusive with "
+            "--memory-limit-gb)"
+        ),
+    )
+    parser.add_argument(
+        "--oom-score-adj",
+        type=int,
+        default=1000,
+        help="oom_score_adj passed to choom by --oom-guard (default: 1000)",
+    )
+    parser.add_argument(
+        "--keep-outputs",
+        metavar="DIR",
+        default=None,
+        help="retain rewritten code objects in DIR (default: discard)",
+    )
+    parser.add_argument("--quiet", action="store_true")
+    return parser
+
+
+def execute_all(
+    sources: Sequence[pathlib.Path],
+    worker: Callable[..., dict[str, Any]],
+    jobs: int,
+    quiet: bool,
+) -> tuple[list[dict[str, Any]], dict[str, int], bool]:
+    """Run worker over every source, optionally in parallel. Completion order
+    is arbitrary; the caller sorts before writing so output stays deterministic.
+    Returns (rows, status_counts, interrupted)."""
+    total = len(sources)
+    rows: list[dict[str, Any]] = []
+    counts: dict[str, int] = {}
+    interrupted = False
+
+    def record(row: dict[str, Any]) -> None:
+        rows.append(row)
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
+        if not quiet:
+            cpu = row["cpu_seconds"]
+            rss = row["max_rss_kib"]
+            cpu_text = "n/a" if cpu is None else f"{cpu:.4f}s"
+            rss_text = "n/a" if rss is None else f"{rss / 1024:.1f}MiB"
+            print(
+                f"[{len(rows)}/{total}] {row['status']:<11} "
+                f"cpu={cpu_text} rss={rss_text} {row['input_path']}",
+                flush=True,
+            )
+
+    if jobs == 1:
+        try:
+            for source in sources:
+                record(worker(source=source))
+        except KeyboardInterrupt:
+            interrupted = True
+            print("interrupted; writing partial CSV", file=sys.stderr)
+        return rows, counts, interrupted
+
+    # Each worker runs in its own process, so at most one hotswap-rewrite child
+    # exists per process at a time; this keeps the wait4 accounting isolated and
+    # avoids cross-thread reaping races.
+    with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as executor:
+        futures = {
+            executor.submit(worker, source=source): source for source in sources
+        }
+        try:
+            for future in concurrent.futures.as_completed(futures):
+                record(future.result())
+        except KeyboardInterrupt:
+            interrupted = True
+            print(
+                "interrupted; cancelling remaining work and writing partial CSV",
+                file=sys.stderr,
+            )
+            for future in futures:
+                future.cancel()
+    return rows, counts, interrupted
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        # May replace this process (systemd-run / choom); returns if no guard.
+        reexec_under_memory_guard(args)
+        hotswap = resolve_executable(args.hotswap, "hotswap")
+        library_dirs = resolve_library_dirs(args.hotswap_library_dir, hotswap)
+        sources = discover_inputs(args.inputs, args.recursive, args.include_glob)
+        if not sources:
+            raise ValueError(f"no files matching {args.include_glob!r} were found")
+    except (OSError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+
+    # systemd scopes cannot set OOMScoreAdjust, so apply the victim bias here;
+    # choom already applies it for the --oom-guard path.
+    if args.memory_limit_gb:
+        apply_oom_score_adj(args.oom_score_adj)
+
+    jobs = args.jobs if args.jobs else (os.cpu_count() or 1)
+    input_root = common_root(sources)
+    outputs_dir = (
+        pathlib.Path(args.keep_outputs).expanduser().resolve()
+        if args.keep_outputs
+        else None
+    )
+    if not args.quiet:
+        print(f"hotswap-rewrite: {hotswap}", file=sys.stderr)
+        if library_dirs:
+            print(
+                "LD_LIBRARY_PATH += "
+                + os.pathsep.join(str(path) for path in library_dirs),
+                file=sys.stderr,
+            )
+        print(
+            f"inputs: {len(sources)} file(s) under {input_root}; jobs={jobs}",
+            file=sys.stderr,
+        )
+
+    worker = functools.partial(
+        run_one,
+        hotswap=hotswap,
+        library_dirs=library_dirs,
+        source_isa=args.source_isa,
+        target_isa=args.target_isa,
+        entry_trampolines=args.entry_trampolines,
+        strict_mode=args.strict_mode,
+        timeout_seconds=args.timeout_seconds,
+        outputs_dir=outputs_dir,
+        input_root=input_root,
+    )
+    rows, counts, interrupted = execute_all(sources, worker, jobs, args.quiet)
+
+    rows.sort(key=lambda value: value["input_path"])
+    csv_path = pathlib.Path(args.csv).expanduser().resolve()
+    write_csv(csv_path, rows)
+
+    summary = ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
+    print(f"wrote {len(rows)} row(s) to {csv_path} ({summary})", file=sys.stderr)
+    if interrupted:
+        return 130
+    return 0 if counts.get("pass", 0) == len(rows) and rows else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench.py
@@ -133,7 +133,7 @@ def resolve_library_dirs(
 
 
 def discover_inputs(
-    paths: Sequence[str], recursive: bool, include_glob: str
+    paths: Sequence[str], recursive: bool, include_globs: Sequence[str]
 ) -> list[pathlib.Path]:
     discovered: set[pathlib.Path] = set()
     for raw_path in paths:
@@ -143,10 +143,13 @@ def discover_inputs(
             continue
         if not path.is_dir():
             raise ValueError(f"input is neither a regular file nor directory: {path}")
-        iterator = path.rglob(include_glob) if recursive else path.glob(include_glob)
-        discovered.update(
-            candidate.resolve() for candidate in iterator if candidate.is_file()
-        )
+        for include_glob in include_globs:
+            iterator = (
+                path.rglob(include_glob) if recursive else path.glob(include_glob)
+            )
+            discovered.update(
+                candidate.resolve() for candidate in iterator if candidate.is_file()
+            )
     return sorted(discovered)
 
 
@@ -288,9 +291,11 @@ def run_one(
         input_size = None
 
     if outputs_dir is not None:
-        outputs_dir.mkdir(parents=True, exist_ok=True)
-        safe = relative.replace(os.sep, "__")
-        output = outputs_dir / f"{safe}.co"
+        # Preserve the input's relative directory structure so retained outputs
+        # map 1:1 to inputs; flattening separators to "__" would collide (e.g.
+        # a/b.hsaco and a__b.hsaco) and race under parallel workers.
+        output = outputs_dir / f"{relative}.co"
+        output.parent.mkdir(parents=True, exist_ok=True)
         cleanup = False
     else:
         handle, temporary = tempfile.mkstemp(suffix=".co", prefix="hotswap-")
@@ -349,16 +354,28 @@ def run_one(
             result_line = line.split(":", 1)[1].strip()
             break
 
-    output_size = output.stat().st_size if output.is_file() else None
+    output_size: int | None = None
+    output_is_elf = False
+    if output.is_file():
+        output_size = output.stat().st_size
+        try:
+            with output.open("rb") as stream:
+                output_is_elf = stream.read(4) == b"\x7fELF"
+        except OSError:
+            output_is_elf = False
 
     if spawn_error is not None:
         status = "spawn_error"
     elif process_result["timed_out"]:
         status = "timeout"
-    elif process_result["return_code"] == 0:
-        status = "pass"
-    else:
+    elif process_result["return_code"] != 0:
         status = "fail"
+    elif result_line != "SUCCESS" or not output_is_elf:
+        # Exit 0 but the rewrite did not report SUCCESS or wrote no valid ELF
+        # (e.g. INVALID_ARGUMENT); not a successful translation.
+        status = "fail"
+    else:
+        status = "pass"
 
     if cleanup:
         output.unlink(missing_ok=True)
@@ -416,6 +433,13 @@ def positive_int(value: str) -> int:
     parsed = int(value)
     if parsed <= 0:
         raise argparse.ArgumentTypeError("must be greater than zero")
+    return parsed
+
+
+def nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be nonnegative")
     return parsed
 
 
@@ -571,8 +595,14 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--include-glob",
-        default="*.hsaco",
-        help="filename glob within directories (default: *.hsaco)",
+        action="append",
+        default=None,
+        metavar="GLOB",
+        help=(
+            "filename glob within directories; repeatable (default: *.hsaco). "
+            "Match extensions explicitly, e.g. "
+            "--include-glob '*.hsaco' --include-glob '*.co'"
+        ),
     )
     parser.add_argument(
         "--recursive",
@@ -589,9 +619,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--jobs",
         "-j",
-        type=positive_int,
+        type=nonnegative_int,
         default=0,
-        help="parallel translations; zero auto-detects CPU count (default: auto)",
+        help="parallel translations; 0 auto-detects CPU count (default: 0)",
     )
     parser.add_argument(
         "--memory-limit-gb",
@@ -701,9 +731,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         reexec_under_memory_guard(args)
         hotswap = resolve_executable(args.hotswap, "hotswap")
         library_dirs = resolve_library_dirs(args.hotswap_library_dir, hotswap)
-        sources = discover_inputs(args.inputs, args.recursive, args.include_glob)
+        include_globs = args.include_glob or ["*.hsaco"]
+        sources = discover_inputs(args.inputs, args.recursive, include_globs)
         if not sources:
-            raise ValueError(f"no files matching {args.include_glob!r} were found")
+            raise ValueError(f"no files matching {include_globs!r} were found")
     except (OSError, ValueError) as error:
         print(f"error: {error}", file=sys.stderr)
         return 2

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench.py
@@ -54,9 +54,55 @@ GUARD_ENV = "HOTSWAP_HSACO_BENCH_GUARDED"
 
 METADATA_SCHEMA_VERSION = 1
 
+# Bounded amount of a failed translation's stderr retained per row.
+STDERR_TAIL_BYTES = 4096
+
 
 def utc_now() -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def read_tail(stream: Any, limit: int) -> str:
+    """Return the last `limit` bytes of a binary file object as text."""
+    try:
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell()
+        stream.seek(max(0, size - limit))
+        data = stream.read()
+    except OSError:
+        return ""
+    text = data.decode("utf-8", "replace").strip()
+    if size > limit:
+        text = "...(truncated)...\n" + text
+    return text
+
+
+def append_jsonl(path: pathlib.Path, record: dict[str, Any]) -> None:
+    """Append one result record as a JSON line, flushed so it survives an
+    abrupt process death (e.g. an OOM kill) for later --resume."""
+    with path.open("a", encoding="utf-8") as stream:
+        stream.write(json.dumps(record, separators=(",", ":")))
+        stream.write("\n")
+        stream.flush()
+
+
+def read_jsonl(path: pathlib.Path) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    if not path.exists():
+        return records
+    with path.open("r", encoding="utf-8") as stream:
+        for line in stream:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                value = json.loads(line)
+            except json.JSONDecodeError:
+                # Tolerate a torn final line from an interrupted write.
+                continue
+            if isinstance(value, dict) and "input_path" in value:
+                records.append(value)
+    return records
 
 
 def sha256_file(path: pathlib.Path) -> str | None:
@@ -246,25 +292,32 @@ def timed_process(
     timed_out = False
     status = 0
     usage = None
-    while True:
-        try:
-            waited, status, usage = os.wait4(process.pid, os.WNOHANG)
-        except InterruptedError:
-            continue
-        if waited:
-            break
-        if deadline is not None and time.monotonic() >= deadline:
-            timed_out = True
-            reaped = terminate_process_group(process, 1.0)
-            if reaped is not None:
-                status, usage = reaped
-            else:
-                try:
-                    _, status, usage = os.wait4(process.pid, 0)
-                except ChildProcessError:
-                    usage = None
-            break
-        time.sleep(0.005)
+    try:
+        while True:
+            try:
+                waited, status, usage = os.wait4(process.pid, os.WNOHANG)
+            except InterruptedError:
+                continue
+            if waited:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                timed_out = True
+                reaped = terminate_process_group(process, 1.0)
+                if reaped is not None:
+                    status, usage = reaped
+                else:
+                    try:
+                        _, status, usage = os.wait4(process.pid, 0)
+                    except ChildProcessError:
+                        usage = None
+                break
+            time.sleep(0.005)
+    except KeyboardInterrupt:
+        # The child runs in its own session/process group, so a terminal SIGINT
+        # does not reach it; tear it (and any descendants) down explicitly
+        # before propagating the interrupt.
+        terminate_process_group(process, 1.0)
+        raise
 
     if process.returncode is None:
         process.returncode = os.waitstatus_to_exitcode(status)
@@ -364,6 +417,7 @@ def run_one(
     )
 
     stdout_buffer = io.BytesIO()
+    stderr_tail = ""
     with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
         try:
             process_result = timed_process(
@@ -387,6 +441,9 @@ def run_one(
             spawn_error = str(error)
         stdout_file.seek(0)
         stdout_buffer.write(stdout_file.read())
+        # Keep a bounded stderr tail so crash diagnostics (asserts, backtraces)
+        # are retained without unbounded CSV growth.
+        stderr_tail = read_tail(stderr_file, STDERR_TAIL_BYTES)
 
     result_line = ""
     for line in stdout_buffer.getvalue().decode("utf-8", "replace").splitlines():
@@ -441,6 +498,7 @@ def run_one(
         "output_sha256": output_sha256,
         "output_is_elf": output_is_elf,
         "spawn_error": spawn_error,
+        "stderr_tail": stderr_tail,
     }
 
 
@@ -461,15 +519,25 @@ CSV_FIELDS = [
     "output_sha256",
     "output_is_elf",
     "spawn_error",
+    "stderr_tail",
 ]
 
 
 def write_csv(path: pathlib.Path, rows: Sequence[dict[str, Any]]) -> None:
+    # Write to a sibling temp file and atomically rename, so a crash mid-write
+    # never leaves a truncated CSV in place.
     path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("w", encoding="utf-8", newline="") as stream:
-        writer = csv.DictWriter(stream, fieldnames=CSV_FIELDS, extrasaction="ignore")
-        writer.writeheader()
-        writer.writerows(rows)
+    tmp = path.with_name(f".{path.name}.tmp.{os.getpid()}")
+    try:
+        with tmp.open("w", encoding="utf-8", newline="") as stream:
+            writer = csv.DictWriter(
+                stream, fieldnames=CSV_FIELDS, extrasaction="ignore"
+            )
+            writer.writeheader()
+            writer.writerows(rows)
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def write_run_metadata(
@@ -776,6 +844,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="retain rewritten code objects in DIR (default: discard)",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "resume from a prior run's <csv>.partial.jsonl checkpoint, skipping "
+            "inputs already recorded (assumes the same inputs and configuration)"
+        ),
+    )
     parser.add_argument("--quiet", action="store_true")
     return parser
 
@@ -785,25 +861,31 @@ def execute_all(
     worker: Callable[..., dict[str, Any]],
     jobs: int,
     quiet: bool,
-) -> tuple[list[dict[str, Any]], dict[str, int], bool]:
+    *,
+    checkpoint_path: pathlib.Path | None = None,
+    total: int | None = None,
+    start_index: int = 0,
+) -> tuple[list[dict[str, Any]], bool]:
     """Run worker over every source, optionally in parallel. Completion order
     is arbitrary; the caller sorts before writing so output stays deterministic.
-    Returns (rows, status_counts, interrupted)."""
-    total = len(sources)
+    Each completed row is appended to checkpoint_path (if given) as it finishes,
+    so an OOM/crash mid-run is recoverable with --resume.
+    Returns (rows, interrupted)."""
+    overall_total = len(sources) if total is None else total
     rows: list[dict[str, Any]] = []
-    counts: dict[str, int] = {}
     interrupted = False
 
     def record(row: dict[str, Any]) -> None:
         rows.append(row)
-        counts[row["status"]] = counts.get(row["status"], 0) + 1
+        if checkpoint_path is not None:
+            append_jsonl(checkpoint_path, row)
         if not quiet:
             cpu = row["cpu_seconds"]
             rss = row["max_rss_kib"]
             cpu_text = "n/a" if cpu is None else f"{cpu:.4f}s"
             rss_text = "n/a" if rss is None else f"{rss / 1024:.1f}MiB"
             print(
-                f"[{len(rows)}/{total}] {row['status']:<11} "
+                f"[{start_index + len(rows)}/{overall_total}] {row['status']:<11} "
                 f"cpu={cpu_text} rss={rss_text} {row['input_path']}",
                 flush=True,
             )
@@ -814,28 +896,46 @@ def execute_all(
                 record(worker(source=source))
         except KeyboardInterrupt:
             interrupted = True
-            print("interrupted; writing partial CSV", file=sys.stderr)
-        return rows, counts, interrupted
+            print("interrupted; writing partial results", file=sys.stderr)
+        return rows, interrupted
 
     # Each worker runs in its own process, so at most one hotswap-rewrite child
     # exists per process at a time; this keeps the wait4 accounting isolated and
-    # avoids cross-thread reaping races.
-    with concurrent.futures.ProcessPoolExecutor(max_workers=jobs) as executor:
+    # avoids cross-process reaping races.
+    executor = concurrent.futures.ProcessPoolExecutor(max_workers=jobs)
+    recorded: set[concurrent.futures.Future] = set()
+    try:
         futures = {
             executor.submit(worker, source=source): source for source in sources
         }
         try:
             for future in concurrent.futures.as_completed(futures):
-                record(future.result())
+                row = future.result()
+                recorded.add(future)
+                record(row)
         except KeyboardInterrupt:
             interrupted = True
             print(
-                "interrupted; cancelling remaining work and writing partial CSV",
+                "interrupted; stopping workers and writing partial results",
                 file=sys.stderr,
             )
             for future in futures:
                 future.cancel()
-    return rows, counts, interrupted
+            # Salvage any rows that finished before the interrupt but were not
+            # yet recorded by the as_completed loop.
+            for future in futures:
+                if future in recorded or future.cancelled() or not future.done():
+                    continue
+                try:
+                    record(future.result())
+                except BaseException:
+                    pass
+    finally:
+        # Do not block on still-running children when interrupted; each worker's
+        # timed_process already tears down its own hotswap-rewrite process group
+        # on SIGINT.
+        executor.shutdown(wait=not interrupted, cancel_futures=True)
+    return rows, interrupted
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -890,10 +990,43 @@ def main(argv: Sequence[str] | None = None) -> int:
         outputs_dir=outputs_dir,
         input_root=input_root,
     )
-    rows, counts, interrupted = execute_all(sources, worker, jobs, args.quiet)
 
-    rows.sort(key=lambda value: value["input_path"])
     csv_path = pathlib.Path(args.csv).expanduser().resolve()
+    checkpoint_path = csv_path.with_name(csv_path.name + ".partial.jsonl")
+
+    # Resume: reuse rows already recorded in the checkpoint and only run the
+    # inputs that are still missing.
+    done_rows: list[dict[str, Any]] = []
+    if args.resume:
+        done_rows = read_jsonl(checkpoint_path)
+        done_paths = {row["input_path"] for row in done_rows}
+        remaining = [
+            source
+            for source in sources
+            if os.path.relpath(source, input_root) not in done_paths
+        ]
+        if not args.quiet:
+            print(
+                f"resume: {len(done_rows)} already done, "
+                f"{len(remaining)} remaining",
+                file=sys.stderr,
+            )
+    else:
+        checkpoint_path.unlink(missing_ok=True)
+        remaining = list(sources)
+
+    new_rows, interrupted = execute_all(
+        remaining,
+        worker,
+        jobs,
+        args.quiet,
+        checkpoint_path=checkpoint_path,
+        total=len(sources),
+        start_index=len(done_rows),
+    )
+
+    rows = done_rows + new_rows
+    rows.sort(key=lambda value: value["input_path"])
     write_csv(csv_path, rows)
     meta_path = write_run_metadata(
         csv_path,
@@ -906,11 +1039,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         input_count=len(sources),
     )
 
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row["status"]] = counts.get(row["status"], 0) + 1
     summary = ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
     print(f"wrote {len(rows)} row(s) to {csv_path} ({summary})", file=sys.stderr)
     print(f"wrote run metadata to {meta_path}", file=sys.stderr)
+
     if interrupted:
+        print(
+            f"interrupted; resume with: --resume --csv {csv_path}",
+            file=sys.stderr,
+        )
         return 130
+    # Full run finished: the checkpoint is now redundant with the CSV.
+    checkpoint_path.unlink(missing_ok=True)
     return 0 if counts.get("pass", 0) == len(rows) and rows else 1
 
 

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Advanced Micro Devices, Inc.
-# SPDX-License-Identifier: MIT
+# Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+# amd/comgr/LICENSE.TXT in this repository for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Run HotSwap gfx1250 B0-to-A0 translation over a directory of .hsaco files
 and tabulate CPU time, peak RSS, and pass/fail into a single CSV.
@@ -30,8 +31,11 @@ from __future__ import annotations
 import argparse
 import concurrent.futures
 import csv
+import datetime
 import functools
+import hashlib
 import io
+import json
 import os
 import pathlib
 import shutil
@@ -47,6 +51,32 @@ DEFAULT_TARGET_ISA = "amdgcn-amd-amdhsa--gfx1250"
 
 # Sentinel set on the re-exec'd child so the memory guard wraps only once.
 GUARD_ENV = "HOTSWAP_HSACO_BENCH_GUARDED"
+
+METADATA_SCHEMA_VERSION = 1
+
+
+def utc_now() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def sha256_file(path: pathlib.Path) -> str | None:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def file_identity(path: pathlib.Path) -> dict[str, Any] | None:
+    """Return {path, size, sha256} for a file, or None if it can't be read."""
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return None
+    return {"path": str(path), "size": size, "sha256": sha256_file(path)}
 
 
 def find_repo_root() -> pathlib.Path | None:
@@ -72,24 +102,33 @@ def first_executable(candidates: Sequence[pathlib.Path | str]) -> str:
     return ""
 
 
+# hotswap-rewrite lands under one of these subpaths of an LLVM build dir,
+# depending on the comgr external-project name (comgr vs amd_comgr).
+HOTSWAP_BUILD_SUBPATHS = (
+    ("tools", "comgr", "test-lit", "hotswap-rewrite"),
+    ("tools", "amd_comgr", "test-lit", "hotswap-rewrite"),
+)
+
+
+def build_dir_candidates(build_dir: pathlib.Path) -> list[pathlib.Path]:
+    return [build_dir.joinpath(*subpath) for subpath in HOTSWAP_BUILD_SUBPATHS]
+
+
 def default_hotswap() -> str:
     """Locate the hotswap-rewrite binary. Precedence:
     1. $HOTSWAP_REWRITE (explicit binary path),
-    2. $HOTSWAP_BUILD_DIR/tools/comgr/test-lit/hotswap-rewrite,
-    3. an in-tree build at <repo-root>/build/tools/comgr/test-lit/hotswap-rewrite,
+    2. $HOTSWAP_BUILD_DIR/tools/{comgr,amd_comgr}/test-lit/hotswap-rewrite,
+    3. an in-tree build at <repo-root>/build/tools/{comgr,amd_comgr}/test-lit/...,
     4. `hotswap-rewrite` on PATH.
+    Both the `comgr` and `amd_comgr` external-project layouts are probed.
     Override at runtime with --hotswap."""
     candidates: list[pathlib.Path | str] = []
     if value := os.environ.get("HOTSWAP_REWRITE"):
         candidates.append(value)
     if build := os.environ.get("HOTSWAP_BUILD_DIR"):
-        candidates.append(
-            pathlib.Path(build) / "tools" / "comgr" / "test-lit" / "hotswap-rewrite"
-        )
+        candidates.extend(build_dir_candidates(pathlib.Path(build)))
     if (root := find_repo_root()) is not None:
-        candidates.append(
-            root / "build" / "tools" / "comgr" / "test-lit" / "hotswap-rewrite"
-        )
+        candidates.extend(build_dir_candidates(root / "build"))
     candidates.append("hotswap-rewrite")
     return first_executable(candidates)
 
@@ -289,6 +328,7 @@ def run_one(
         input_size = source.stat().st_size
     except OSError:
         input_size = None
+    input_sha256 = sha256_file(source)
 
     if outputs_dir is not None:
         # Preserve the input's relative directory structure so retained outputs
@@ -356,6 +396,7 @@ def run_one(
 
     output_size: int | None = None
     output_is_elf = False
+    output_sha256: str | None = None
     if output.is_file():
         output_size = output.stat().st_size
         try:
@@ -363,6 +404,9 @@ def run_one(
                 output_is_elf = stream.read(4) == b"\x7fELF"
         except OSError:
             output_is_elf = False
+        # Hash the output before it is cleaned up so translation divergence is
+        # detectable across runs.
+        output_sha256 = sha256_file(output)
 
     if spawn_error is not None:
         status = "spawn_error"
@@ -384,6 +428,7 @@ def run_one(
         "input_path": relative,
         "filename": source.name,
         "input_size": input_size,
+        "input_sha256": input_sha256,
         "status": status,
         "exit_code": process_result["return_code"],
         "result": result_line,
@@ -393,6 +438,8 @@ def run_one(
         "elapsed_seconds": process_result["elapsed_seconds"],
         "max_rss_kib": process_result["max_rss_kib"],
         "output_size": output_size,
+        "output_sha256": output_sha256,
+        "output_is_elf": output_is_elf,
         "spawn_error": spawn_error,
     }
 
@@ -401,6 +448,7 @@ CSV_FIELDS = [
     "input_path",
     "filename",
     "input_size",
+    "input_sha256",
     "status",
     "exit_code",
     "result",
@@ -410,6 +458,8 @@ CSV_FIELDS = [
     "elapsed_seconds",
     "max_rss_kib",
     "output_size",
+    "output_sha256",
+    "output_is_elf",
     "spawn_error",
 ]
 
@@ -420,6 +470,70 @@ def write_csv(path: pathlib.Path, rows: Sequence[dict[str, Any]]) -> None:
         writer = csv.DictWriter(stream, fieldnames=CSV_FIELDS, extrasaction="ignore")
         writer.writeheader()
         writer.writerows(rows)
+
+
+def write_run_metadata(
+    csv_path: pathlib.Path,
+    *,
+    hotswap: pathlib.Path,
+    library_dirs: Sequence[pathlib.Path],
+    args: argparse.Namespace,
+    jobs: int,
+    include_globs: Sequence[str],
+    input_root: pathlib.Path,
+    input_count: int,
+) -> pathlib.Path:
+    """Persist run-level provenance to <csv>.meta.json so two runs can be
+    checked for the same tool, library, configuration, and workload scope
+    (things a per-row CSV diff cannot by itself guarantee)."""
+    libraries: list[dict[str, Any]] = []
+    for directory in library_dirs:
+        for lib in sorted(directory.glob("libamd_comgr.so*")):
+            if lib.is_file() and not lib.is_symlink():
+                identity = file_identity(lib)
+                if identity is not None:
+                    libraries.append(identity)
+
+    command_template = hotswap_command(
+        hotswap,
+        pathlib.Path("INPUT"),
+        pathlib.Path("OUTPUT.co"),
+        args.source_isa,
+        args.target_isa,
+        entry_trampolines=args.entry_trampolines,
+        strict_mode=args.strict_mode,
+    )
+
+    metadata = {
+        "schema_version": METADATA_SCHEMA_VERSION,
+        "generated_at": utc_now(),
+        "tool": {
+            "hotswap_rewrite": file_identity(hotswap),
+            "libraries": libraries,
+        },
+        "config": {
+            "source_isa": args.source_isa,
+            "target_isa": args.target_isa,
+            "entry_trampolines": args.entry_trampolines,
+            "strict_mode": args.strict_mode,
+            "timeout_seconds": args.timeout_seconds,
+            "jobs": jobs,
+            "include_globs": list(include_globs),
+            "recursive": args.recursive,
+            "memory_limit_gb": args.memory_limit_gb or None,
+            "oom_guard": args.oom_guard,
+        },
+        "command_template": command_template,
+        "input_root": str(input_root),
+        "input_count": input_count,
+    }
+
+    meta_path = csv_path.with_name(csv_path.name + ".meta.json")
+    meta_path.parent.mkdir(parents=True, exist_ok=True)
+    with meta_path.open("w", encoding="utf-8") as stream:
+        json.dump(metadata, stream, indent=2, sort_keys=True)
+        stream.write("\n")
+    return meta_path
 
 
 def nonnegative_float(value: str) -> float:
@@ -781,9 +895,20 @@ def main(argv: Sequence[str] | None = None) -> int:
     rows.sort(key=lambda value: value["input_path"])
     csv_path = pathlib.Path(args.csv).expanduser().resolve()
     write_csv(csv_path, rows)
+    meta_path = write_run_metadata(
+        csv_path,
+        hotswap=hotswap,
+        library_dirs=library_dirs,
+        args=args,
+        jobs=jobs,
+        include_globs=include_globs,
+        input_root=input_root,
+        input_count=len(sources),
+    )
 
     summary = ", ".join(f"{status}={count}" for status, count in sorted(counts.items()))
     print(f"wrote {len(rows)} row(s) to {csv_path} ({summary})", file=sys.stderr)
+    print(f"wrote run metadata to {meta_path}", file=sys.stderr)
     if interrupted:
         return 130
     return 0 if counts.get("pass", 0) == len(rows) and rows else 1

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench_all.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench_all.py
@@ -34,19 +34,26 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
 import hotswap_bench as bench  # noqa: E402
 
-# Defaults injected only when the flag is not already supplied by the caller.
-DEFAULTS: dict[str, str] = {
-    "--include-glob": "*.[hc][so]*",
-    "--timeout-seconds": "300",
-    "--csv": "hotswap_bench_all.csv",
-}
+# Each group: (flag names that mark it as caller-supplied, tokens to append
+# when none of those flags are present). Extensions are matched explicitly so
+# stray files like results.csv, header.host, or backup.hsaco.bak are ignored.
+DEFAULT_GROUPS: list[tuple[tuple[str, ...], list[str]]] = [
+    (("--include-glob",), ["--include-glob", "*.hsaco", "--include-glob", "*.co"]),
+    (("--timeout-seconds",), ["--timeout-seconds", "300"]),
+    (("--csv",), ["--csv", "hotswap_bench_all.csv"]),
+]
 
 
 def apply_defaults(argv: list[str]) -> list[str]:
     result = list(argv)
-    for flag, value in DEFAULTS.items():
-        if not any(arg == flag or arg.startswith(flag + "=") for arg in result):
-            result += [flag, value]
+    for flags, tokens in DEFAULT_GROUPS:
+        present = any(
+            arg == flag or arg.startswith(flag + "=")
+            for arg in result
+            for flag in flags
+        )
+        if not present:
+            result += tokens
     return result
 
 

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench_all.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench_all.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) 2026 Advanced Micro Devices, Inc.
-# SPDX-License-Identifier: MIT
+# Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+# amd/comgr/LICENSE.TXT in this repository for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 """Run HotSwap gfx1250 B0-to-A0 translation over ALL code objects (.hsaco AND
 .co) in a directory, with a 5-minute per-file timeout.

--- a/amd/comgr/utils/hotswap-bench/hotswap_bench_all.py
+++ b/amd/comgr/utils/hotswap-bench/hotswap_bench_all.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+"""Run HotSwap gfx1250 B0-to-A0 translation over ALL code objects (.hsaco AND
+.co) in a directory, with a 5-minute per-file timeout.
+
+This is a thin convenience wrapper around hotswap_bench.py that changes only
+the defaults:
+  * --include-glob matches both .co and .hsaco,
+  * --timeout-seconds is 300 (5 minutes),
+  * --csv defaults to hotswap_bench_all.csv.
+
+The translator binary and its library are resolved by hotswap_bench.py itself
+(via $HOTSWAP_REWRITE / $HOTSWAP_BUILD_DIR / --hotswap; see README.md), so this
+wrapper stays free of any machine-specific paths.
+
+Every other flag (--jobs, --memory-limit-gb, --oom-guard, --source-isa, ...) is
+inherited from hotswap_bench.py and can be overridden on the command line;
+anything passed explicitly wins over these defaults.
+
+Example:
+  HOTSWAP_BUILD_DIR=/path/to/build \\
+    python3 hotswap_bench_all.py /path/to/corpus --jobs 16 --memory-limit-gb 64
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+# Make the sibling module importable regardless of the caller's working dir.
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import hotswap_bench as bench  # noqa: E402
+
+# Defaults injected only when the flag is not already supplied by the caller.
+DEFAULTS: dict[str, str] = {
+    "--include-glob": "*.[hc][so]*",
+    "--timeout-seconds": "300",
+    "--csv": "hotswap_bench_all.csv",
+}
+
+
+def apply_defaults(argv: list[str]) -> list[str]:
+    result = list(argv)
+    for flag, value in DEFAULTS.items():
+        if not any(arg == flag or arg.startswith(flag + "=") for arg in result):
+            result += [flag, value]
+    return result
+
+
+def main() -> int:
+    # Rewrite sys.argv in place so hotswap_bench's argument parsing and its
+    # memory-guard re-exec (which reads sys.argv) both see the same values.
+    sys.argv = [sys.argv[0], *apply_defaults(sys.argv[1:])]
+    return bench.main()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/amd/comgr/utils/hotswap-bench/test_hotswap_bench.py
+++ b/amd/comgr/utils/hotswap-bench/test_hotswap_bench.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+# Part of Comgr, under the Apache License v2.0 with LLVM Exceptions. See
+# amd/comgr/LICENSE.TXT in this repository for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+"""Unit tests for hotswap_bench.py.
+
+These use small stub executables and temporary directories so the whole suite
+runs without a GPU or a real hotswap-rewrite / libamd_comgr.so. Run with:
+
+    python3 -m unittest -v          # from this directory
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import hotswap_bench as bench  # noqa: E402
+
+# Stub bodies emulating hotswap-rewrite behaviours. Each writes to --output
+# and/or prints a RESULT: line as the real driver would.
+STUB_SUCCESS = """
+import sys
+args = sys.argv[1:]
+out = args[args.index("--output") + 1] if "--output" in args else None
+if out:
+    with open(out, "wb") as handle:
+        handle.write(b"\\x7fELFstub-output")
+print("RESULT: SUCCESS")
+"""
+
+STUB_NO_RESULT = """
+raise SystemExit(0)
+"""
+
+STUB_INVALID_ARGUMENT = """
+print("RESULT: INVALID_ARGUMENT")
+raise SystemExit(0)
+"""
+
+STUB_FAIL = """
+import sys
+print("boom: assertion failed in rewrite", file=sys.stderr)
+print("FAILED: unexpected error status ERROR")
+raise SystemExit(1)
+"""
+
+STUB_SLEEP = """
+import time
+time.sleep(30)
+"""
+
+
+def make_stub(directory: pathlib.Path, name: str, body: str) -> pathlib.Path:
+    path = directory / name
+    path.write_text("#!/usr/bin/env python3\n" + body)
+    path.chmod(0o755)
+    return path
+
+
+class TempCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def run_one(self, stub_body: str, source: pathlib.Path, **overrides):
+        stub = make_stub(self.tmp, "stub", stub_body)
+        kwargs = dict(
+            source=source,
+            hotswap=stub,
+            library_dirs=[],
+            source_isa="amdgcn-amd-amdhsa--gfx1250",
+            target_isa="amdgcn-amd-amdhsa--gfx1250",
+            entry_trampolines=False,
+            strict_mode=True,
+            timeout_seconds=30.0,
+            outputs_dir=None,
+            input_root=source.parent,
+        )
+        kwargs.update(overrides)
+        return bench.run_one(**kwargs)
+
+
+class ClassificationTests(TempCase):
+    def _input(self, name: str = "a.hsaco", data: bytes = b"input-bytes"):
+        path = self.tmp / name
+        path.write_bytes(data)
+        return path
+
+    def test_success_is_pass_with_hashes(self):
+        row = self.run_one(STUB_SUCCESS, self._input())
+        self.assertEqual(row["status"], "pass")
+        self.assertEqual(row["result"], "SUCCESS")
+        self.assertTrue(row["output_is_elf"])
+        self.assertTrue(row["input_sha256"])
+        self.assertTrue(row["output_sha256"])
+
+    def test_exit0_without_result_or_output_is_fail(self):
+        row = self.run_one(STUB_NO_RESULT, self._input())
+        self.assertEqual(row["status"], "fail")
+        self.assertEqual(row["exit_code"], 0)
+        self.assertFalse(row["output_is_elf"])
+
+    def test_invalid_argument_is_fail(self):
+        row = self.run_one(STUB_INVALID_ARGUMENT, self._input())
+        self.assertEqual(row["status"], "fail")
+        self.assertEqual(row["result"], "INVALID_ARGUMENT")
+
+    def test_nonzero_exit_is_fail_and_keeps_stderr_tail(self):
+        row = self.run_one(STUB_FAIL, self._input())
+        self.assertEqual(row["status"], "fail")
+        self.assertEqual(row["exit_code"], 1)
+        self.assertIn("assertion failed", row["stderr_tail"])
+
+    def test_timeout(self):
+        row = self.run_one(STUB_SLEEP, self._input(), timeout_seconds=1.0)
+        self.assertEqual(row["status"], "timeout")
+
+
+class DiscoveryTests(TempCase):
+    def test_matches_only_requested_extensions(self):
+        corpus = self.tmp / "corpus"
+        (corpus / "sub").mkdir(parents=True)
+        for name in ("a.hsaco", "b.co", "sub/c.hsaco"):
+            (corpus / name).write_bytes(b"x")
+        # Stray files that a broad glob would wrongly pick up.
+        for name in ("results.csv", "header.host", "backup.hsaco.bak"):
+            (corpus / name).write_bytes(b"x")
+
+        found = bench.discover_inputs([str(corpus)], True, ["*.hsaco", "*.co"])
+        relative = sorted(str(p.relative_to(corpus)) for p in found)
+        self.assertEqual(relative, ["a.hsaco", "b.co", "sub/c.hsaco"])
+
+
+class OutputNamingTests(TempCase):
+    def test_keep_outputs_is_collision_free(self):
+        root = self.tmp / "corpus"
+        (root / "a").mkdir(parents=True)
+        nested = root / "a" / "b.hsaco"
+        flat = root / "a__b.hsaco"
+        nested.write_bytes(b"n")
+        flat.write_bytes(b"f")
+        outputs = self.tmp / "outputs"
+
+        row_nested = self.run_one(
+            STUB_SUCCESS, nested, outputs_dir=outputs, input_root=root
+        )
+        row_flat = self.run_one(
+            STUB_SUCCESS, flat, outputs_dir=outputs, input_root=root
+        )
+        self.assertEqual(row_nested["status"], "pass")
+        self.assertEqual(row_flat["status"], "pass")
+        self.assertTrue((outputs / "a" / "b.hsaco.co").is_file())
+        self.assertTrue((outputs / "a__b.hsaco.co").is_file())
+
+
+class ParserTests(unittest.TestCase):
+    def test_jobs_zero_accepted(self):
+        args = bench.build_parser().parse_args(["input", "-j", "0"])
+        self.assertEqual(args.jobs, 0)
+
+    def test_jobs_negative_rejected(self):
+        with self.assertRaises(SystemExit):
+            bench.build_parser().parse_args(["input", "-j", "-1"])
+
+    def test_entry_trampolines_default_off(self):
+        args = bench.build_parser().parse_args(["input"])
+        self.assertFalse(args.entry_trampolines)
+
+
+class ProcessGroupTests(unittest.TestCase):
+    def test_terminate_process_group_kills_child(self):
+        process = subprocess.Popen(["sleep", "30"], start_new_session=True)
+        try:
+            bench.terminate_process_group(process, 1.0)
+            self.assertIsNotNone(process.returncode)
+        finally:
+            if process.returncode is None:
+                process.kill()
+                process.wait()
+
+
+class MainTests(TempCase):
+    def _corpus(self):
+        corpus = self.tmp / "corpus"
+        corpus.mkdir()
+        (corpus / "b.co").write_bytes(b"bbbb")
+        (corpus / "a.hsaco").write_bytes(b"aaaa")
+        return corpus
+
+    def _read_csv(self, path: pathlib.Path):
+        import csv
+
+        with path.open(newline="") as handle:
+            return list(csv.DictReader(handle))
+
+    def test_end_to_end_csv_sorted_with_provenance_and_sidecar(self):
+        stub = make_stub(self.tmp, "stub", STUB_SUCCESS)
+        corpus = self._corpus()
+        csv_path = self.tmp / "out.csv"
+        code = bench.main(
+            [
+                str(corpus),
+                "--hotswap",
+                str(stub),
+                "--include-glob",
+                "*.hsaco",
+                "--include-glob",
+                "*.co",
+                "-j",
+                "1",
+                "--csv",
+                str(csv_path),
+                "--quiet",
+            ]
+        )
+        self.assertEqual(code, 0)
+        rows = self._read_csv(csv_path)
+        # Deterministic sort by input_path.
+        self.assertEqual([r["input_path"] for r in rows], ["a.hsaco", "b.co"])
+        self.assertTrue(all(r["input_sha256"] for r in rows))
+        self.assertTrue(all(r["output_sha256"] for r in rows))
+        # Sidecar with tool identity.
+        meta = json.loads((self.tmp / "out.csv.meta.json").read_text())
+        self.assertEqual(meta["tool"]["hotswap_rewrite"]["path"], str(stub))
+        self.assertIn("sha256", meta["tool"]["hotswap_rewrite"])
+        # Checkpoint removed after a complete run.
+        self.assertFalse((self.tmp / "out.csv.partial.jsonl").exists())
+
+    def test_resume_skips_recorded_inputs(self):
+        stub = make_stub(self.tmp, "stub", STUB_SUCCESS)
+        corpus = self._corpus()
+        csv_path = self.tmp / "out.csv"
+        checkpoint = self.tmp / "out.csv.partial.jsonl"
+        # Seed a.hsaco as already done with a sentinel result so we can tell it
+        # was reused rather than re-run.
+        seeded = {
+            "input_path": "a.hsaco",
+            "filename": "a.hsaco",
+            "status": "pass",
+            "result": "SEEDED",
+        }
+        bench.append_jsonl(checkpoint, seeded)
+
+        code = bench.main(
+            [
+                str(corpus),
+                "--hotswap",
+                str(stub),
+                "--include-glob",
+                "*.hsaco",
+                "--include-glob",
+                "*.co",
+                "-j",
+                "1",
+                "--resume",
+                "--csv",
+                str(csv_path),
+                "--quiet",
+            ]
+        )
+        self.assertEqual(code, 0)
+        rows = {r["input_path"]: r for r in self._read_csv(csv_path)}
+        self.assertEqual(set(rows), {"a.hsaco", "b.co"})
+        # a.hsaco came from the checkpoint (sentinel), b.co was actually run.
+        self.assertEqual(rows["a.hsaco"]["result"], "SEEDED")
+        self.assertEqual(rows["b.co"]["result"], "SUCCESS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Adds `amd/comgr/utils/hotswap-bench/` — tooling to batch-run the Comgr
**HotSwap** gfx1250 B0→A0 rewrite (`hotswap-rewrite`) over a directory of AMD
GPU code objects (`.hsaco` / `.co`) and tabulate, per object, **CPU time**,
**peak RSS**, and **pass/fail/timeout** into a single CSV.
Motivated by validating the hotswap rewrite across a large real-world corpus of
code objects and comparing behavior across builds/branches.
## What's included
- **`hotswap_bench.py`** — core runner. Each object is translated in its own
  fresh process; Linux `wait4` gives that process's user+system CPU and peak
  RSS. Work runs in parallel (`--jobs`), but rows are always **sorted by input
  path** before writing, so the CSV is deterministic and two runs diff cleanly.
- **`hotswap_bench_all.py`** — thin wrapper that runs **both** `.hsaco` and
  `.co` with a 5-minute per-file timeout.
- **`README.md`** — build steps, required variables, usage, flags, CSV schema.
## Notable design points
- **Tool/library discovery** via `$HOTSWAP_REWRITE` / `$HOTSWAP_BUILD_DIR` /
  `--hotswap` / in-tree `build/` auto-detection — no hardcoded paths.
- **Memory safety** for shared machines: `--memory-limit-gb N` re-execs under a
  systemd transient scope with a hard `MemoryMax` cap (`OOMPolicy=kill`), or
  `--oom-guard` uses `choom` to bias the OOM killer toward this run.
- **Pass/fail is exit-code based**; `exit_code` and the tool's `RESULT:` line
  are kept as separate columns so crashes vs. graceful errors stay distinguishable.
## ⚠️ Entry trampolines default OFF
`hotswap-rewrite` enables entry trampolines by default, but the current gfx1250
path **segfaults on a large fraction of objects** when they are on. These
scripts therefore default `--entry-trampolines` to **off**. Observed on a
~2,685-object corpus:
| Config | pass | fail | timeout |
|---|---:|---:|---:|
| entry-trampolines **on** | 1,847 | 835 (734 SIGSEGV + 101 exit-1) | 3 |
| entry-trampolines **off** | 2,560 | 122 (exit-1) | 3 |
Disabling trampolines eliminated all 734 segfaults with **zero regressions**.
Pass `--entry-trampolines` explicitly to reproduce the crash.
## Usage
```bash
export HOTSWAP_BUILD_DIR=/path/to/llvm-project/build
python3 amd/comgr/utils/hotswap-bench/hotswap_bench_all.py /path/to/corpus \
  --jobs 16 --memory-limit-gb 64 --csv results.csv