### PR TITLE
[comgr][hotswap] Remap .eh_frame during text displacement

### DIFF
--- a/amd/comgr/CMakeLists.txt
+++ b/amd/comgr/CMakeLists.txt
@@ -105,6 +105,7 @@ set(SOURCES
   src/comgr-hotswap-b0a0.cpp
   src/comgr-hotswap-profile.cpp
   src/comgr-hotswap-displacement.cpp
+  src/comgr-hotswap-eh-frame.cpp
   src/comgr-hotswap-entry-trampoline.cpp
   src/comgr-hotswap-entry-trampoline-fast.cpp
   src/comgr-hotswap-occupancy.cpp

--- a/amd/comgr/src/comgr-hotswap-displacement.cpp
+++ b/amd/comgr/src/comgr-hotswap-displacement.cpp
@@ -74,8 +74,10 @@ Error validateDebugSections(const ElfView &Elf) {
           Twine(toString(NameOrErr.takeError())));
     }
     StringRef Name = *NameOrErr;
+    if (Name == ".eh_frame")
+      continue;
     if (Name.starts_with(".debug") || Name.starts_with(".zdebug") ||
-        Name == ".eh_frame" || Name == ".eh_frame_hdr") {
+        Name == ".eh_frame_hdr") {
       return makeDisplacementError("debug/unwind section '" + Twine(Name) +
                                    "' requires address remapping");
     }
@@ -760,6 +762,8 @@ Error applyTextDisplacement(const ElfView &Elf, const LLVMState &LS,
 
   if (Error Err =
           rewriteKernelDescriptorEntriesForDisplacement(OutBuf, Elf, Plan))
+    return Err;
+  if (Error Err = remapEhFrameForDisplacement(Elf, Plan, OutBuf))
     return Err;
 
   log() << "hotswap: displacement: grew ELF from " << InputSize << " to "

--- a/amd/comgr/src/comgr-hotswap-eh-frame.cpp
+++ b/amd/comgr/src/comgr-hotswap-eh-frame.cpp
@@ -18,6 +18,7 @@
 
 #include <cstring>
 #include <limits>
+#include <type_traits>
 #include <vector>
 
 using namespace llvm;
@@ -30,10 +31,8 @@ namespace {
 using ELFT = ElfView::ELFT;
 
 struct EhFramePatch {
-  uint64_t LocationOffset;
-  int32_t Location;
-  uint64_t RangeOffset;
-  uint32_t Range;
+  uint64_t Offset;
+  SmallVector<uint8_t, 8> Bytes;
 };
 
 Error makeEhFrameError(const Twine &Msg) {
@@ -96,6 +95,260 @@ bool advancesCfiLocation(const dwarf::CFIProgram &Program) {
     }
   }
   return false;
+}
+
+template <typename T>
+EhFramePatch makeLittleEndianPatch(uint64_t Offset, T Value) {
+  EhFramePatch Patch;
+  Patch.Offset = Offset;
+  Patch.Bytes.resize(sizeof(T));
+  for (unsigned I = 0; I != sizeof(T); ++I)
+    Patch.Bytes[I] = static_cast<uint8_t>(
+        static_cast<std::make_unsigned_t<T>>(Value) >> (I * 8));
+  return Patch;
+}
+
+Expected<uint64_t> mapCfiLocation(const DisplacementPlan &Plan,
+                                  uint64_t OldLocation, uint64_t OldFdeStart,
+                                  uint64_t OldFdeEnd, uint64_t OldTextBegin,
+                                  uint64_t OldTextEnd, uint64_t NewTextBegin) {
+  if (OldLocation < OldFdeStart || OldLocation > OldFdeEnd)
+    return makeEhFrameError(".eh_frame CFI location is outside its FDE range");
+  if (OldLocation < OldTextBegin || OldLocation > OldTextEnd)
+    return makeEhFrameError(".eh_frame CFI location is outside .text");
+
+  uint64_t NewOffset = 0;
+  if (!Plan.mapOffset(OldLocation - OldTextBegin,
+                      DisplacementMapBias::AfterInsertedBytes, NewOffset)) {
+    return makeEhFrameError(
+        ".eh_frame CFI location maps inside a replaced instruction");
+  }
+  if (NewOffset > std::numeric_limits<uint64_t>::max() - NewTextBegin)
+    return makeEhFrameError(".eh_frame CFI location overflows");
+  return NewTextBegin + NewOffset;
+}
+
+Error consumeCfiUleb(DataExtractor &Data, DataExtractor::Cursor &Cursor) {
+  (void)Data.getULEB128(Cursor);
+  if (!Cursor) {
+    consumeError(Cursor.takeError());
+    return makeEhFrameError(".eh_frame has a truncated CFI ULEB128 operand");
+  }
+  return Error::success();
+}
+
+Error consumeCfiSleb(DataExtractor &Data, DataExtractor::Cursor &Cursor) {
+  (void)Data.getSLEB128(Cursor);
+  if (!Cursor) {
+    consumeError(Cursor.takeError());
+    return makeEhFrameError(".eh_frame has a truncated CFI SLEB128 operand");
+  }
+  return Error::success();
+}
+
+Error consumeCfiExpression(DataExtractor &Data, DataExtractor::Cursor &Cursor) {
+  const uint64_t Length = Data.getULEB128(Cursor);
+  if (!Cursor) {
+    consumeError(Cursor.takeError());
+    return makeEhFrameError(".eh_frame has a truncated CFI expression length");
+  }
+  (void)Data.getBytes(Cursor, Length);
+  if (!Cursor) {
+    consumeError(Cursor.takeError());
+    return makeEhFrameError(".eh_frame has a truncated CFI expression");
+  }
+  return Error::success();
+}
+
+Expected<std::vector<EhFramePatch>> remapFdeCfiProgram(
+    StringRef ProgramData, uint64_t ProgramSectionOffset,
+    uint64_t CodeAlignment, const DisplacementPlan &Plan, uint64_t OldFdeStart,
+    uint64_t OldFdeEnd, uint64_t NewFdeStart, uint64_t NewFdeEnd,
+    uint64_t OldTextBegin, uint64_t OldTextEnd, uint64_t NewTextBegin) {
+  if (CodeAlignment == 0)
+    return makeEhFrameError(".eh_frame CFI has zero code alignment");
+
+  DataExtractor Data(ProgramData, /*IsLittleEndian=*/true);
+  DataExtractor::Cursor Cursor(0);
+  uint64_t OldLocation = OldFdeStart;
+  uint64_t NewLocation = NewFdeStart;
+  std::vector<EhFramePatch> Patches;
+
+  auto remapAdvance = [&](uint64_t Operand, uint64_t OperandOffset,
+                          unsigned OperandSize,
+                          uint8_t PrimaryOpcode) -> Error {
+    if (Operand >
+        (std::numeric_limits<uint64_t>::max() - OldLocation) / CodeAlignment) {
+      return makeEhFrameError(".eh_frame CFI advance location overflows");
+    }
+    const uint64_t OldNext = OldLocation + Operand * CodeAlignment;
+    Expected<uint64_t> NewNextOrErr =
+        mapCfiLocation(Plan, OldNext, OldFdeStart, OldFdeEnd, OldTextBegin,
+                       OldTextEnd, NewTextBegin);
+    if (!NewNextOrErr)
+      return NewNextOrErr.takeError();
+    const uint64_t NewNext = *NewNextOrErr;
+    if (NewNext < NewLocation)
+      return makeEhFrameError(".eh_frame CFI location moves backwards");
+    const uint64_t NewDelta = NewNext - NewLocation;
+    if (NewDelta % CodeAlignment != 0) {
+      return makeEhFrameError(
+          ".eh_frame CFI advance is not divisible by its code alignment");
+    }
+    const uint64_t NewOperand = NewDelta / CodeAlignment;
+    const uint64_t MaxOperand = OperandSize == 8
+                                    ? std::numeric_limits<uint64_t>::max()
+                                    : (uint64_t{1} << (OperandSize * 8)) - 1;
+    if (NewOperand > MaxOperand)
+      return makeEhFrameError(
+          ".eh_frame CFI advance no longer fits its encoding");
+
+    if (PrimaryOpcode != 0) {
+      if (NewOperand > 0x3f)
+        return makeEhFrameError(
+            ".eh_frame CFI advance no longer fits DW_CFA_advance_loc");
+      Patches.push_back(makeLittleEndianPatch<uint8_t>(
+          ProgramSectionOffset + OperandOffset,
+          static_cast<uint8_t>(PrimaryOpcode | NewOperand)));
+    } else {
+      EhFramePatch Patch;
+      Patch.Offset = ProgramSectionOffset + OperandOffset;
+      Patch.Bytes.resize(OperandSize);
+      for (unsigned I = 0; I != OperandSize; ++I)
+        Patch.Bytes[I] = static_cast<uint8_t>(NewOperand >> (I * 8));
+      Patches.push_back(std::move(Patch));
+    }
+    OldLocation = OldNext;
+    NewLocation = NewNext;
+    return Error::success();
+  };
+
+  while (Cursor && Cursor.tell() < ProgramData.size()) {
+    const uint64_t OpcodeOffset = Cursor.tell();
+    const uint8_t EncodedOpcode = Data.getU8(Cursor);
+    if (!Cursor)
+      break;
+
+    const uint8_t PrimaryOpcode = EncodedOpcode & 0xc0;
+    if (PrimaryOpcode != 0) {
+      if (PrimaryOpcode == dwarf::DW_CFA_advance_loc) {
+        if (Error Err = remapAdvance(EncodedOpcode & 0x3f, OpcodeOffset, 1,
+                                     dwarf::DW_CFA_advance_loc))
+          return std::move(Err);
+      } else if (PrimaryOpcode == dwarf::DW_CFA_offset) {
+        if (Error Err = consumeCfiUleb(Data, Cursor))
+          return std::move(Err);
+      } else if (PrimaryOpcode != dwarf::DW_CFA_restore) {
+        return makeEhFrameError(".eh_frame has an invalid primary CFI opcode");
+      }
+      continue;
+    }
+
+    switch (EncodedOpcode) {
+    case dwarf::DW_CFA_nop:
+    case dwarf::DW_CFA_remember_state:
+    case dwarf::DW_CFA_restore_state:
+    case dwarf::DW_CFA_GNU_window_save:
+    case dwarf::DW_CFA_AARCH64_negate_ra_state_with_pc:
+      break;
+    case dwarf::DW_CFA_set_loc: {
+      const uint64_t OperandOffset = Cursor.tell();
+      const uint64_t Target = Data.getUnsigned(Cursor, sizeof(uint64_t));
+      if (!Cursor)
+        break;
+      Expected<uint64_t> NewTargetOrErr =
+          mapCfiLocation(Plan, Target, OldFdeStart, OldFdeEnd, OldTextBegin,
+                         OldTextEnd, NewTextBegin);
+      if (!NewTargetOrErr)
+        return NewTargetOrErr.takeError();
+      Patches.push_back(makeLittleEndianPatch<uint64_t>(
+          ProgramSectionOffset + OperandOffset, *NewTargetOrErr));
+      OldLocation = Target;
+      NewLocation = *NewTargetOrErr;
+      break;
+    }
+    case dwarf::DW_CFA_advance_loc1:
+    case dwarf::DW_CFA_advance_loc2:
+    case dwarf::DW_CFA_advance_loc4: {
+      const unsigned OperandSize =
+          EncodedOpcode == dwarf::DW_CFA_advance_loc1   ? 1
+          : EncodedOpcode == dwarf::DW_CFA_advance_loc2 ? 2
+                                                        : 4;
+      const uint64_t OperandOffset = Cursor.tell();
+      const uint64_t Operand = Data.getUnsigned(Cursor, OperandSize);
+      if (!Cursor)
+        break;
+      if (Error Err =
+              remapAdvance(Operand, OperandOffset, OperandSize, /*Primary=*/0))
+        return std::move(Err);
+      break;
+    }
+    case dwarf::DW_CFA_restore_extended:
+    case dwarf::DW_CFA_undefined:
+    case dwarf::DW_CFA_same_value:
+    case dwarf::DW_CFA_def_cfa_register:
+    case dwarf::DW_CFA_def_cfa_offset:
+    case dwarf::DW_CFA_GNU_args_size:
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      break;
+    case dwarf::DW_CFA_def_cfa_offset_sf:
+      if (Error Err = consumeCfiSleb(Data, Cursor))
+        return std::move(Err);
+      break;
+    case dwarf::DW_CFA_LLVM_def_aspace_cfa:
+    case dwarf::DW_CFA_LLVM_def_aspace_cfa_sf:
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      if (EncodedOpcode == dwarf::DW_CFA_LLVM_def_aspace_cfa) {
+        if (Error Err = consumeCfiUleb(Data, Cursor))
+          return std::move(Err);
+      } else if (Error Err = consumeCfiSleb(Data, Cursor)) {
+        return std::move(Err);
+      }
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      break;
+    case dwarf::DW_CFA_offset_extended:
+    case dwarf::DW_CFA_register:
+    case dwarf::DW_CFA_def_cfa:
+    case dwarf::DW_CFA_val_offset:
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      break;
+    case dwarf::DW_CFA_offset_extended_sf:
+    case dwarf::DW_CFA_def_cfa_sf:
+    case dwarf::DW_CFA_val_offset_sf:
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      if (Error Err = consumeCfiSleb(Data, Cursor))
+        return std::move(Err);
+      break;
+    case dwarf::DW_CFA_def_cfa_expression:
+      if (Error Err = consumeCfiExpression(Data, Cursor))
+        return std::move(Err);
+      break;
+    case dwarf::DW_CFA_expression:
+    case dwarf::DW_CFA_val_expression:
+      if (Error Err = consumeCfiUleb(Data, Cursor))
+        return std::move(Err);
+      if (Error Err = consumeCfiExpression(Data, Cursor))
+        return std::move(Err);
+      break;
+    default:
+      return makeEhFrameError(".eh_frame has an unsupported CFI opcode");
+    }
+  }
+
+  if (Error Err = Cursor.takeError()) {
+    consumeError(std::move(Err));
+    return makeEhFrameError(".eh_frame has a truncated CFI instruction");
+  }
+  if (OldLocation > OldFdeEnd || NewLocation > NewFdeEnd)
+    return makeEhFrameError(".eh_frame CFI location exceeds its FDE range");
+  return Patches;
 }
 
 Expected<bool>
@@ -177,9 +430,9 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
                                   WritableMemoryBuffer &OutBuf) {
   // Parse through LLVM so every FDE is tied to its actual CIE instead of
   // guessing a record layout. The fixed-width pcrel|sdata4 address fields can
-  // be rewritten in place. Location-changing CFI is accepted only when its
-  // encoded locations remain valid; changing those instruction streams could
-  // alter record sizes and is outside this remapper's contract.
+  // be rewritten in place. CFI location instructions are also rewritten when
+  // their remapped operand still fits the instruction's existing encoding, so
+  // no record or section needs to change size.
   Expected<const ELFT::Shdr *> OldShdrOrErr = findEhFrameSection(OldElf);
   if (!OldShdrOrErr)
     return OldShdrOrErr.takeError();
@@ -268,6 +521,7 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
   const uint64_t NewTextBegin = OutElfOrErr->textAddr();
 
   std::vector<EhFramePatch> Patches;
+  unsigned RemappedFdeCount = 0;
   for (const dwarf::FrameEntry &Entry : Frame.entries()) {
     if (Entry.getKind() == dwarf::FrameEntry::FK_CIE) {
       const dwarf::CIE &Cie = static_cast<const dwarf::CIE &>(Entry);
@@ -344,15 +598,6 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
       return makeEhFrameError(".eh_frame FDE address range overflows");
     const uint64_t OldEnd = OldStart + OldRange;
 
-    Expected<bool> FdeSetLocOrErr =
-        cfiSetLocationRequiresRemap(Fde.cfis(), Plan, OldTextBegin, OldTextEnd);
-    if (!FdeSetLocOrErr)
-      return FdeSetLocOrErr.takeError();
-    if (*FdeSetLocOrErr) {
-      return makeEhFrameError(
-          ".eh_frame FDE has DW_CFA_set_loc that requires remapping");
-    }
-
     const bool DescribesText =
         OldRange == 0 ? OldStart >= OldTextBegin && OldStart < OldTextEnd
                       : OldEnd > OldTextBegin && OldStart < OldTextEnd;
@@ -416,10 +661,10 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
     if (NewRange > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
       return makeEhFrameError(".eh_frame FDE range overflows sdata4");
     }
-    if (NewRange != OldRange &&
-        (advancesCfiLocation(Cie->cfis()) || advancesCfiLocation(Fde.cfis()))) {
+    if (NewRange != OldRange && advancesCfiLocation(Cie->cfis())) {
       return makeEhFrameError(
-          ".eh_frame FDE has location-changing CFI that requires remapping");
+          ".eh_frame CIE has location-changing CFI that cannot be remapped "
+          "per FDE");
     }
 
     if (NewStartOffset > std::numeric_limits<uint64_t>::max() - NewTextBegin) {
@@ -437,17 +682,56 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
     if (!NewLocationOrErr)
       return NewLocationOrErr.takeError();
 
-    Patches.push_back({OutShdr->sh_offset + LocationOffset, *NewLocationOrErr,
-                       OutShdr->sh_offset + RangeOffset,
-                       static_cast<uint32_t>(NewRange)});
+    uint64_t CfiOffset = RangeOffset + sizeof(uint32_t);
+    if (Cie->getAugmentationString().starts_with("z")) {
+      StringRef AugmentationAndCfi = OldData.slice(CfiOffset, RecordEnd);
+      DataExtractor AugmentationData(AugmentationAndCfi,
+                                     /*IsLittleEndian=*/true);
+      DataExtractor::Cursor Cursor(0);
+      const uint64_t AugmentationLength = AugmentationData.getULEB128(Cursor);
+      if (!Cursor) {
+        consumeError(Cursor.takeError());
+        return makeEhFrameError(
+            ".eh_frame has a truncated FDE augmentation length");
+      }
+      (void)AugmentationData.getBytes(Cursor, AugmentationLength);
+      if (!Cursor) {
+        consumeError(Cursor.takeError());
+        return makeEhFrameError(
+            ".eh_frame has truncated FDE augmentation data");
+      }
+      CfiOffset += Cursor.tell();
+      consumeError(Cursor.takeError());
+    }
+    if (CfiOffset > RecordEnd)
+      return makeEhFrameError(".eh_frame FDE CFI offset is out of bounds");
+
+    Expected<std::vector<EhFramePatch>> CfiPatchesOrErr = remapFdeCfiProgram(
+        OldData.slice(CfiOffset, RecordEnd), CfiOffset,
+        Cie->getCodeAlignmentFactor(), Plan, OldStart, OldEnd, NewStart,
+        NewStart + NewRange, OldTextBegin, OldTextEnd, NewTextBegin);
+    if (!CfiPatchesOrErr)
+      return CfiPatchesOrErr.takeError();
+
+    Patches.push_back(
+        makeLittleEndianPatch<int32_t>(LocationOffset, *NewLocationOrErr));
+    Patches.push_back(makeLittleEndianPatch<uint32_t>(
+        RangeOffset, static_cast<uint32_t>(NewRange)));
+    Patches.insert(Patches.end(),
+                   std::make_move_iterator(CfiPatchesOrErr->begin()),
+                   std::make_move_iterator(CfiPatchesOrErr->end()));
+    ++RemappedFdeCount;
   }
 
   for (const EhFramePatch &Patch : Patches) {
-    std::memcpy(OutData + Patch.LocationOffset, &Patch.Location,
-                sizeof(Patch.Location));
-    std::memcpy(OutData + Patch.RangeOffset, &Patch.Range, sizeof(Patch.Range));
+    if (Patch.Offset > OutShdr->sh_size ||
+        Patch.Bytes.size() > OutShdr->sh_size - Patch.Offset) {
+      return makeEhFrameError(".eh_frame patch is outside the section");
+    }
+    std::memcpy(OutData + OutShdr->sh_offset + Patch.Offset, Patch.Bytes.data(),
+                Patch.Bytes.size());
   }
-  log() << "hotswap: displacement: remapped " << Patches.size()
+  log() << "hotswap: displacement: remapped " << RemappedFdeCount
         << " .eh_frame FDE(s)\n";
   return Error::success();
 }

--- a/amd/comgr/src/comgr-hotswap-eh-frame.cpp
+++ b/amd/comgr/src/comgr-hotswap-eh-frame.cpp
@@ -638,6 +638,12 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
   const uint64_t OldTextBegin = OldElf.textAddr();
   const uint64_t OldTextEnd = OldTextBegin + OldElf.textSize();
   const uint64_t NewTextBegin = OutElfOrErr->textAddr();
+  if (OutElfOrErr->textSize() >
+      std::numeric_limits<uint64_t>::max() - NewTextBegin) {
+    return makeEhFrameError(
+        "displaced .text range overflows while remapping .eh_frame");
+  }
+  const uint64_t NewTextEnd = NewTextBegin + OutElfOrErr->textSize();
 
   std::vector<EhFramePatch> Patches;
   unsigned RemappedFdeCount = 0;
@@ -721,6 +727,13 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
         OldRange == 0 ? OldStart >= OldTextBegin && OldStart < OldTextEnd
                       : OldEnd > OldTextBegin && OldStart < OldTextEnd;
     if (!DescribesText) {
+      const bool OverlapsDisplacedText =
+          OldRange == 0 ? OldStart >= NewTextBegin && OldStart < NewTextEnd
+                        : OldEnd > NewTextBegin && OldStart < NewTextEnd;
+      if (OverlapsDisplacedText) {
+        return makeEhFrameError(
+            ".eh_frame FDE outside old .text overlaps displaced .text");
+      }
       if (OutShdr->sh_addr != OldShdr->sh_addr) {
         return makeEhFrameError("moved .eh_frame has an FDE outside .text");
       }

--- a/amd/comgr/src/comgr-hotswap-eh-frame.cpp
+++ b/amd/comgr/src/comgr-hotswap-eh-frame.cpp
@@ -17,6 +17,7 @@
 #include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
 
 #include <cstring>
+#include <functional>
 #include <limits>
 #include <type_traits>
 #include <vector>
@@ -57,6 +58,123 @@ Expected<const ELFT::Shdr *> findEhFrameSection(const ElfView &Elf) {
     Found = &Shdr;
   }
   return Found;
+}
+
+Expected<uint64_t> amdgpuRelocationWriteWidth(uint32_t Type) {
+  // TODO: Replace this target-internal width mapping when
+  // https://github.com/ROCm/llvm-project/issues/3601 exposes it through LLVM.
+  switch (Type) {
+  case ELF::R_AMDGPU_NONE:
+    return 0;
+  case ELF::R_AMDGPU_REL16:
+    return 2;
+  case ELF::R_AMDGPU_ABS32_LO:
+  case ELF::R_AMDGPU_ABS32_HI:
+  case ELF::R_AMDGPU_REL32:
+  case ELF::R_AMDGPU_ABS32:
+  case ELF::R_AMDGPU_GOTPCREL:
+  case ELF::R_AMDGPU_GOTPCREL32_LO:
+  case ELF::R_AMDGPU_GOTPCREL32_HI:
+  case ELF::R_AMDGPU_REL32_LO:
+  case ELF::R_AMDGPU_REL32_HI:
+    return 4;
+  case ELF::R_AMDGPU_ABS64:
+  case ELF::R_AMDGPU_REL64:
+  case ELF::R_AMDGPU_RELATIVE64:
+    return 8;
+  default:
+    return makeEhFrameError(
+        "dynamic relocation has unknown AMDGPU write width (type " +
+        Twine(Type) + ")");
+  }
+}
+
+Expected<bool> relocationWriteOverlaps(uint64_t Offset, uint64_t Width,
+                                       uint64_t RangeBegin, uint64_t RangeEnd) {
+  if (Width == 0)
+    return false;
+  if (Offset > std::numeric_limits<uint64_t>::max() - Width)
+    return makeEhFrameError("dynamic relocation write range overflows");
+  const uint64_t End = Offset + Width;
+  return Offset < RangeEnd && End > RangeBegin;
+}
+
+Error rejectRelocationsTargetingEhFrame(const ElfView &Elf,
+                                        uint32_t EhFrameIndex,
+                                        uint64_t EhFrameBegin,
+                                        uint64_t EhFrameEnd) {
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    const bool IsRel = Shdr.sh_type == ELF::SHT_REL;
+    const bool IsRela = Shdr.sh_type == ELF::SHT_RELA;
+    const bool IsOpaquePackedRelocation =
+        Shdr.sh_type == ELF::SHT_RELR || Shdr.sh_type == ELF::SHT_ANDROID_REL ||
+        Shdr.sh_type == ELF::SHT_ANDROID_RELA ||
+        Shdr.sh_type == ELF::SHT_ANDROID_RELR || Shdr.sh_type == ELF::SHT_CREL;
+
+    if ((IsRel || IsRela || IsOpaquePackedRelocation) &&
+        Shdr.sh_info == EhFrameIndex) {
+      return makeEhFrameError(".eh_frame relocation records are unsupported");
+    }
+
+    if (IsOpaquePackedRelocation) {
+      if (Shdr.sh_flags & ELF::SHF_ALLOC) {
+        return makeEhFrameError(
+            "allocated packed relocation records cannot be checked for "
+            ".eh_frame targets");
+      }
+      continue;
+    }
+
+    // Section-specific REL/RELA records were handled by sh_info above.
+    // Dynamic relocation sections use sh_info == 0 and absolute virtual
+    // addresses in r_offset, so enumerate them and reject writes that touch
+    // any byte of .eh_frame.
+    if ((!IsRel && !IsRela) || Shdr.sh_info != 0)
+      continue;
+
+    if (IsRela) {
+      Expected<ELFT::RelaRange> RelasOrErr = Elf.file().relas(Shdr);
+      if (!RelasOrErr) {
+        return makeEhFrameError(
+            "failed to read dynamic RELA records while checking .eh_frame: " +
+            Twine(toString(RelasOrErr.takeError())));
+      }
+      for (const ELFT::Rela &Rela : *RelasOrErr) {
+        Expected<uint64_t> WidthOrErr =
+            amdgpuRelocationWriteWidth(Rela.getType(false));
+        if (!WidthOrErr)
+          return WidthOrErr.takeError();
+        Expected<bool> OverlapsOrErr = relocationWriteOverlaps(
+            Rela.r_offset, *WidthOrErr, EhFrameBegin, EhFrameEnd);
+        if (!OverlapsOrErr)
+          return OverlapsOrErr.takeError();
+        if (*OverlapsOrErr) {
+          return makeEhFrameError("dynamic RELA record writes into .eh_frame");
+        }
+      }
+      continue;
+    }
+
+    Expected<ELFT::RelRange> RelsOrErr = Elf.file().rels(Shdr);
+    if (!RelsOrErr) {
+      return makeEhFrameError(
+          "failed to read dynamic REL records while checking .eh_frame: " +
+          Twine(toString(RelsOrErr.takeError())));
+    }
+    for (const ELFT::Rel &Rel : *RelsOrErr) {
+      Expected<uint64_t> WidthOrErr =
+          amdgpuRelocationWriteWidth(Rel.getType(false));
+      if (!WidthOrErr)
+        return WidthOrErr.takeError();
+      Expected<bool> OverlapsOrErr = relocationWriteOverlaps(
+          Rel.r_offset, *WidthOrErr, EhFrameBegin, EhFrameEnd);
+      if (!OverlapsOrErr)
+        return OverlapsOrErr.takeError();
+      if (*OverlapsOrErr)
+        return makeEhFrameError("dynamic REL record writes into .eh_frame");
+    }
+  }
+  return Error::success();
 }
 
 Expected<bool> cfiSetLocationRequiresRemap(const dwarf::CFIProgram &Program,
@@ -174,9 +292,9 @@ Expected<std::vector<EhFramePatch>> remapFdeCfiProgram(
   uint64_t NewLocation = NewFdeStart;
   std::vector<EhFramePatch> Patches;
 
-  auto remapAdvance = [&](uint64_t Operand, uint64_t OperandOffset,
-                          unsigned OperandSize,
-                          uint8_t PrimaryOpcode) -> Error {
+  std::function<Error(uint64_t, uint64_t, unsigned, uint8_t)> RemapAdvance =
+      [&](uint64_t Operand, uint64_t OperandOffset, unsigned OperandSize,
+          uint8_t PrimaryOpcode) -> Error {
     if (Operand >
         (std::numeric_limits<uint64_t>::max() - OldLocation) / CodeAlignment) {
       return makeEhFrameError(".eh_frame CFI advance location overflows");
@@ -232,7 +350,7 @@ Expected<std::vector<EhFramePatch>> remapFdeCfiProgram(
     const uint8_t PrimaryOpcode = EncodedOpcode & 0xc0;
     if (PrimaryOpcode != 0) {
       if (PrimaryOpcode == dwarf::DW_CFA_advance_loc) {
-        if (Error Err = remapAdvance(EncodedOpcode & 0x3f, OpcodeOffset, 1,
+        if (Error Err = RemapAdvance(EncodedOpcode & 0x3f, OpcodeOffset, 1,
                                      dwarf::DW_CFA_advance_loc))
           return std::move(Err);
       } else if (PrimaryOpcode == dwarf::DW_CFA_offset) {
@@ -279,7 +397,7 @@ Expected<std::vector<EhFramePatch>> remapFdeCfiProgram(
       if (!Cursor)
         break;
       if (Error Err =
-              remapAdvance(Operand, OperandOffset, OperandSize, /*Primary=*/0))
+              RemapAdvance(Operand, OperandOffset, OperandSize, /*Primary=*/0))
         return std::move(Err);
       break;
     }
@@ -462,12 +580,13 @@ Error remapEhFrameForDisplacement(const ElfView &OldElf,
   }
   if (!FoundOldEhFrameIndex)
     return makeEhFrameError("failed to resolve .eh_frame section index");
-  for (const ELFT::Shdr &Shdr : OldElf.sections()) {
-    if ((Shdr.sh_type == ELF::SHT_REL || Shdr.sh_type == ELF::SHT_RELA) &&
-        Shdr.sh_info == OldEhFrameIndex) {
-      return makeEhFrameError(".eh_frame relocation records are unsupported");
-    }
-  }
+  if (OldShdr->sh_size >
+      std::numeric_limits<uint64_t>::max() - OldShdr->sh_addr)
+    return makeEhFrameError(".eh_frame virtual address range overflows");
+  if (Error Err = rejectRelocationsTargetingEhFrame(
+          OldElf, OldEhFrameIndex, OldShdr->sh_addr,
+          OldShdr->sh_addr + OldShdr->sh_size))
+    return Err;
 
   uint8_t *OutData = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
   Expected<ElfView> OutElfOrErr =

--- a/amd/comgr/src/comgr-hotswap-eh-frame.cpp
+++ b/amd/comgr/src/comgr-hotswap-eh-frame.cpp
@@ -1,0 +1,456 @@
+//===- comgr-hotswap-eh-frame.cpp - HotSwap unwind remapping ------------===//
+//
+// Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// Validated `.eh_frame` remapping for HotSwap text displacement.
+///
+//===----------------------------------------------------------------------===//
+
+#include "comgr-hotswap-internal.h"
+
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
+
+#include <cstring>
+#include <limits>
+#include <vector>
+
+using namespace llvm;
+
+namespace COMGR {
+namespace hotswap {
+
+namespace {
+
+using ELFT = ElfView::ELFT;
+
+struct EhFramePatch {
+  uint64_t LocationOffset;
+  int32_t Location;
+  uint64_t RangeOffset;
+  uint32_t Range;
+};
+
+Error makeEhFrameError(const Twine &Msg) {
+  std::string Message = Msg.str();
+  log() << "hotswap: displacement unavailable: " << Message << "\n";
+  return createStringError(object::object_error::parse_failed, Message);
+}
+
+Expected<const ELFT::Shdr *> findEhFrameSection(const ElfView &Elf) {
+  const ELFT::Shdr *Found = nullptr;
+  for (const ELFT::Shdr &Shdr : Elf.sections()) {
+    Expected<StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr) {
+      return makeEhFrameError(
+          "failed to read a section name while locating .eh_frame: " +
+          Twine(toString(NameOrErr.takeError())));
+    }
+    if (*NameOrErr != ".eh_frame")
+      continue;
+    if (Found)
+      return makeEhFrameError("ELF contains multiple .eh_frame sections");
+    Found = &Shdr;
+  }
+  return Found;
+}
+
+Expected<bool> cfiSetLocationRequiresRemap(const dwarf::CFIProgram &Program,
+                                           const DisplacementPlan &Plan,
+                                           uint64_t OldTextBegin,
+                                           uint64_t OldTextEnd) {
+  for (const dwarf::CFIProgram::Instruction &Inst : Program) {
+    if (Inst.Opcode != dwarf::DW_CFA_set_loc)
+      continue;
+    if (Inst.Ops.empty())
+      return makeEhFrameError(".eh_frame has malformed DW_CFA_set_loc");
+    const uint64_t OldLocation = Inst.Ops.front();
+    if (OldLocation < OldTextBegin || OldLocation >= OldTextEnd)
+      continue;
+    uint64_t NewOffset = 0;
+    if (!Plan.mapOffset(OldLocation - OldTextBegin,
+                        DisplacementMapBias::AfterInsertedBytes, NewOffset) ||
+        NewOffset != OldLocation - OldTextBegin) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool advancesCfiLocation(const dwarf::CFIProgram &Program) {
+  for (const dwarf::CFIProgram::Instruction &Inst : Program) {
+    switch (Inst.Opcode) {
+    case dwarf::DW_CFA_advance_loc:
+    case dwarf::DW_CFA_advance_loc1:
+    case dwarf::DW_CFA_advance_loc2:
+    case dwarf::DW_CFA_advance_loc4:
+    case dwarf::DW_CFA_MIPS_advance_loc8:
+      return true;
+    default:
+      break;
+    }
+  }
+  return false;
+}
+
+Expected<bool>
+hasUnsupportedAddressExpression(const dwarf::CFIProgram &Program) {
+  for (const dwarf::CFIProgram::Instruction &Inst : Program) {
+    if (!Inst.Expression)
+      continue;
+    for (const DWARFExpression::Operation &Op : *Inst.Expression) {
+      if (Op.isError())
+        return makeEhFrameError(
+            ".eh_frame contains a malformed CFI expression");
+      if (Op.getCode() == dwarf::DW_OP_addr ||
+          Op.getCode() == dwarf::DW_OP_addrx) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+Expected<int32_t> encodePcRelativeSData4(uint64_t Target,
+                                         uint64_t FieldAddress) {
+  if (Target >= FieldAddress) {
+    uint64_t Delta = Target - FieldAddress;
+    if (Delta > static_cast<uint64_t>(std::numeric_limits<int32_t>::max()))
+      return makeEhFrameError(".eh_frame FDE pcrel offset overflows i32");
+    return static_cast<int32_t>(Delta);
+  }
+
+  uint64_t Delta = FieldAddress - Target;
+  const uint64_t NegativeLimit = uint64_t{1}
+                                 << (std::numeric_limits<int32_t>::digits);
+  if (Delta > NegativeLimit)
+    return makeEhFrameError(".eh_frame FDE pcrel offset overflows i32");
+  if (Delta == NegativeLimit)
+    return std::numeric_limits<int32_t>::min();
+  return -static_cast<int32_t>(Delta);
+}
+
+Error validateEhFrameRecordBounds(StringRef Data) {
+  uint64_t Offset = 0;
+  while (Offset < Data.size()) {
+    if (sizeof(uint32_t) > Data.size() - Offset)
+      return makeEhFrameError(".eh_frame has a truncated record length");
+
+    uint32_t RecordLength = 0;
+    std::memcpy(&RecordLength, Data.data() + Offset, sizeof(RecordLength));
+    Offset += sizeof(RecordLength);
+    if (RecordLength == 0) {
+      for (; Offset < Data.size(); ++Offset) {
+        if (Data[Offset] != 0)
+          return makeEhFrameError(
+              ".eh_frame has nonzero data after its terminator");
+      }
+      return Error::success();
+    }
+
+    uint64_t ExtendedLength = RecordLength;
+    if (RecordLength == dwarf::DW_LENGTH_DWARF64) {
+      if (sizeof(uint64_t) > Data.size() - Offset) {
+        return makeEhFrameError(
+            ".eh_frame has a truncated 64-bit record length");
+      }
+      std::memcpy(&ExtendedLength, Data.data() + Offset,
+                  sizeof(ExtendedLength));
+      Offset += sizeof(ExtendedLength);
+    }
+    if (ExtendedLength > Data.size() - Offset)
+      return makeEhFrameError(".eh_frame has a truncated record");
+    Offset += ExtendedLength;
+  }
+  return Error::success();
+}
+
+} // namespace
+
+Error remapEhFrameForDisplacement(const ElfView &OldElf,
+                                  const DisplacementPlan &Plan,
+                                  WritableMemoryBuffer &OutBuf) {
+  // Parse through LLVM so every FDE is tied to its actual CIE instead of
+  // guessing a record layout. The fixed-width pcrel|sdata4 address fields can
+  // be rewritten in place. Location-changing CFI is accepted only when its
+  // encoded locations remain valid; changing those instruction streams could
+  // alter record sizes and is outside this remapper's contract.
+  Expected<const ELFT::Shdr *> OldShdrOrErr = findEhFrameSection(OldElf);
+  if (!OldShdrOrErr)
+    return OldShdrOrErr.takeError();
+  const ELFT::Shdr *OldShdr = *OldShdrOrErr;
+  if (!OldShdr)
+    return Error::success();
+
+  if (OldShdr->sh_offset > OldElf.size() ||
+      OldShdr->sh_size > OldElf.size() - OldShdr->sh_offset) {
+    return makeEhFrameError(".eh_frame is outside the input ELF");
+  }
+  if (OldShdr->sh_type != ELF::SHT_PROGBITS ||
+      !(OldShdr->sh_flags & ELF::SHF_ALLOC) ||
+      (OldShdr->sh_flags & ELF::SHF_COMPRESSED)) {
+    return makeEhFrameError(
+        ".eh_frame must be an allocated, uncompressed SHT_PROGBITS section");
+  }
+
+  uint32_t OldEhFrameIndex = 0;
+  bool FoundOldEhFrameIndex = false;
+  for (const ELFT::Shdr &Shdr : OldElf.sections()) {
+    if (&Shdr == OldShdr) {
+      FoundOldEhFrameIndex = true;
+      break;
+    }
+    ++OldEhFrameIndex;
+  }
+  if (!FoundOldEhFrameIndex)
+    return makeEhFrameError("failed to resolve .eh_frame section index");
+  for (const ELFT::Shdr &Shdr : OldElf.sections()) {
+    if ((Shdr.sh_type == ELF::SHT_REL || Shdr.sh_type == ELF::SHT_RELA) &&
+        Shdr.sh_info == OldEhFrameIndex) {
+      return makeEhFrameError(".eh_frame relocation records are unsupported");
+    }
+  }
+
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(OutBuf.getBufferStart());
+  Expected<ElfView> OutElfOrErr =
+      ElfView::create(OutData, OutBuf.getBufferSize());
+  if (!OutElfOrErr) {
+    return makeEhFrameError(
+        "failed to parse displaced ELF while locating .eh_frame: " +
+        Twine(toString(OutElfOrErr.takeError())));
+  }
+
+  Expected<const ELFT::Shdr *> OutShdrOrErr = findEhFrameSection(*OutElfOrErr);
+  if (!OutShdrOrErr)
+    return OutShdrOrErr.takeError();
+  const ELFT::Shdr *OutShdr = *OutShdrOrErr;
+  if (!OutShdr)
+    return makeEhFrameError(".eh_frame disappeared from displaced ELF");
+  if (OutShdr->sh_size != OldShdr->sh_size)
+    return makeEhFrameError(".eh_frame size changed during displacement");
+  if (OutShdr->sh_type != ELF::SHT_PROGBITS ||
+      !(OutShdr->sh_flags & ELF::SHF_ALLOC) ||
+      (OutShdr->sh_flags & ELF::SHF_COMPRESSED)) {
+    return makeEhFrameError(
+        "displaced .eh_frame is not an allocated, uncompressed SHT_PROGBITS "
+        "section");
+  }
+  if (OutShdr->sh_offset > OutBuf.getBufferSize() ||
+      OutShdr->sh_size > OutBuf.getBufferSize() - OutShdr->sh_offset) {
+    return makeEhFrameError(".eh_frame is outside the displaced ELF");
+  }
+
+  StringRef OldData(
+      reinterpret_cast<const char *>(OldElf.data() + OldShdr->sh_offset),
+      OldShdr->sh_size);
+  if (Error Err = validateEhFrameRecordBounds(OldData))
+    return Err;
+  DWARFDataExtractor Extractor(OldData, /*IsLittleEndian=*/true,
+                               /*AddressSize=*/sizeof(uint64_t));
+  const Triple::ArchType Arch = Triple("amdgcn-amd-amdhsa").getArch();
+  DWARFDebugFrame Frame(Arch, /*IsEH=*/true, OldShdr->sh_addr);
+  if (Error Err = Frame.parse(Extractor)) {
+    return makeEhFrameError("failed to parse .eh_frame: " +
+                            Twine(toString(std::move(Err))));
+  }
+
+  if (OldElf.textSize() >
+      std::numeric_limits<uint64_t>::max() - OldElf.textAddr()) {
+    return makeEhFrameError(".text range overflows while remapping .eh_frame");
+  }
+  const uint64_t OldTextBegin = OldElf.textAddr();
+  const uint64_t OldTextEnd = OldTextBegin + OldElf.textSize();
+  const uint64_t NewTextBegin = OutElfOrErr->textAddr();
+
+  std::vector<EhFramePatch> Patches;
+  for (const dwarf::FrameEntry &Entry : Frame.entries()) {
+    if (Entry.getKind() == dwarf::FrameEntry::FK_CIE) {
+      const dwarf::CIE &Cie = static_cast<const dwarf::CIE &>(Entry);
+      if (Cie.getPersonalityAddress()) {
+        return makeEhFrameError(
+            ".eh_frame personality pointers are unsupported");
+      }
+      Expected<bool> AddressExpressionOrErr =
+          hasUnsupportedAddressExpression(Cie.cfis());
+      if (!AddressExpressionOrErr)
+        return AddressExpressionOrErr.takeError();
+      if (*AddressExpressionOrErr) {
+        return makeEhFrameError(
+            ".eh_frame CFI address expressions are unsupported");
+      }
+      Expected<bool> SetLocOrErr = cfiSetLocationRequiresRemap(
+          Cie.cfis(), Plan, OldTextBegin, OldTextEnd);
+      if (!SetLocOrErr)
+        return SetLocOrErr.takeError();
+      if (*SetLocOrErr) {
+        return makeEhFrameError(
+            ".eh_frame CIE has DW_CFA_set_loc that requires remapping");
+      }
+      continue;
+    }
+    const dwarf::FDE &Fde = static_cast<const dwarf::FDE &>(Entry);
+    const dwarf::CIE *Cie = Fde.getLinkedCIE();
+    if (!Cie)
+      return makeEhFrameError(".eh_frame FDE does not reference a CIE");
+
+    const uint32_t Encoding = Cie->getFDEPointerEncoding();
+    if (Encoding != (dwarf::DW_EH_PE_pcrel | dwarf::DW_EH_PE_sdata4)) {
+      return makeEhFrameError(
+          ".eh_frame FDE pointer encoding is unsupported (expected "
+          "DW_EH_PE_pcrel|DW_EH_PE_sdata4)");
+    }
+    if (Fde.getLSDAAddress())
+      return makeEhFrameError(".eh_frame LSDA pointers are unsupported");
+    Expected<bool> FdeAddressExpressionOrErr =
+        hasUnsupportedAddressExpression(Fde.cfis());
+    if (!FdeAddressExpressionOrErr)
+      return FdeAddressExpressionOrErr.takeError();
+    if (*FdeAddressExpressionOrErr) {
+      return makeEhFrameError(
+          ".eh_frame CFI address expressions are unsupported");
+    }
+
+    const uint64_t RecordOffset = Fde.getOffset();
+    if (RecordOffset > OldShdr->sh_size ||
+        sizeof(uint32_t) > OldShdr->sh_size - RecordOffset) {
+      return makeEhFrameError(".eh_frame FDE header is out of bounds");
+    }
+    uint32_t RecordLength = 0;
+    std::memcpy(&RecordLength, OldData.data() + RecordOffset,
+                sizeof(RecordLength));
+    if (RecordLength == dwarf::DW_LENGTH_DWARF64) {
+      return makeEhFrameError(
+          ".eh_frame uses 64-bit DWARF records (unsupported)");
+    }
+    if (RecordOffset > std::numeric_limits<uint64_t>::max() - 4 ||
+        RecordLength > OldShdr->sh_size - RecordOffset - 4) {
+      return makeEhFrameError(".eh_frame FDE record is out of bounds");
+    }
+    const uint64_t RecordEnd = RecordOffset + 4 + RecordLength;
+    const uint64_t LocationOffset = RecordOffset + 8;
+    const uint64_t RangeOffset = LocationOffset + sizeof(int32_t);
+    if (RangeOffset > RecordEnd || sizeof(uint32_t) > RecordEnd - RangeOffset) {
+      return makeEhFrameError(".eh_frame FDE address fields are truncated");
+    }
+
+    const uint64_t OldStart = Fde.getInitialLocation();
+    const uint64_t OldRange = Fde.getAddressRange();
+    if (OldRange > std::numeric_limits<uint64_t>::max() - OldStart)
+      return makeEhFrameError(".eh_frame FDE address range overflows");
+    const uint64_t OldEnd = OldStart + OldRange;
+
+    Expected<bool> FdeSetLocOrErr =
+        cfiSetLocationRequiresRemap(Fde.cfis(), Plan, OldTextBegin, OldTextEnd);
+    if (!FdeSetLocOrErr)
+      return FdeSetLocOrErr.takeError();
+    if (*FdeSetLocOrErr) {
+      return makeEhFrameError(
+          ".eh_frame FDE has DW_CFA_set_loc that requires remapping");
+    }
+
+    const bool DescribesText =
+        OldRange == 0 ? OldStart >= OldTextBegin && OldStart < OldTextEnd
+                      : OldEnd > OldTextBegin && OldStart < OldTextEnd;
+    if (!DescribesText) {
+      if (OutShdr->sh_addr != OldShdr->sh_addr) {
+        return makeEhFrameError("moved .eh_frame has an FDE outside .text");
+      }
+
+      uint32_t SectionIndex = 0;
+      for (const ELFT::Shdr &OldTargetShdr : OldElf.sections()) {
+        if (OldTargetShdr.sh_size >
+            std::numeric_limits<uint64_t>::max() - OldTargetShdr.sh_addr) {
+          return makeEhFrameError(
+              "section address range overflows while checking .eh_frame");
+        }
+        const uint64_t SectionEnd =
+            OldTargetShdr.sh_addr + OldTargetShdr.sh_size;
+        const bool ContainsFde =
+            OldRange == 0
+                ? OldStart >= OldTargetShdr.sh_addr && OldStart < SectionEnd
+                : OldStart >= OldTargetShdr.sh_addr && OldEnd <= SectionEnd;
+        if (!ContainsFde) {
+          ++SectionIndex;
+          continue;
+        }
+
+        Expected<const ELFT::Shdr *> OutTargetShdrOrErr =
+            OutElfOrErr->file().getSection(SectionIndex);
+        if (!OutTargetShdrOrErr) {
+          return makeEhFrameError(
+              "failed to find displaced section containing an .eh_frame "
+              "FDE: " +
+              Twine(toString(OutTargetShdrOrErr.takeError())));
+        }
+        if ((*OutTargetShdrOrErr)->sh_addr != OldTargetShdr.sh_addr) {
+          return makeEhFrameError(
+              ".eh_frame FDE outside .text targets a moved section");
+        }
+        break;
+      }
+      continue;
+    }
+    if (OldStart < OldTextBegin || OldEnd > OldTextEnd) {
+      return makeEhFrameError(".eh_frame FDE partially overlaps .text");
+    }
+
+    const uint64_t OldStartOffset = OldStart - OldTextBegin;
+    const uint64_t OldEndOffset = OldEnd - OldTextBegin;
+    uint64_t NewStartOffset = 0;
+    uint64_t NewEndOffset = 0;
+    if (!Plan.mapOffset(OldStartOffset,
+                        DisplacementMapBias::BeforeInsertedBytes,
+                        NewStartOffset) ||
+        !Plan.mapOffset(OldEndOffset, DisplacementMapBias::BeforeInsertedBytes,
+                        NewEndOffset) ||
+        NewEndOffset < NewStartOffset) {
+      return makeEhFrameError(".eh_frame FDE range cannot be remapped");
+    }
+
+    const uint64_t NewRange = NewEndOffset - NewStartOffset;
+    if (NewRange > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+      return makeEhFrameError(".eh_frame FDE range overflows sdata4");
+    }
+    if (NewRange != OldRange &&
+        (advancesCfiLocation(Cie->cfis()) || advancesCfiLocation(Fde.cfis()))) {
+      return makeEhFrameError(
+          ".eh_frame FDE has location-changing CFI that requires remapping");
+    }
+
+    if (NewStartOffset > std::numeric_limits<uint64_t>::max() - NewTextBegin) {
+      return makeEhFrameError(".eh_frame FDE start address overflows");
+    }
+    const uint64_t NewStart = NewTextBegin + NewStartOffset;
+    if (NewRange > std::numeric_limits<uint64_t>::max() - NewStart)
+      return makeEhFrameError(".eh_frame FDE end address overflows");
+    if (LocationOffset >
+        std::numeric_limits<uint64_t>::max() - OutShdr->sh_addr) {
+      return makeEhFrameError(".eh_frame FDE field address overflows");
+    }
+    Expected<int32_t> NewLocationOrErr =
+        encodePcRelativeSData4(NewStart, OutShdr->sh_addr + LocationOffset);
+    if (!NewLocationOrErr)
+      return NewLocationOrErr.takeError();
+
+    Patches.push_back({OutShdr->sh_offset + LocationOffset, *NewLocationOrErr,
+                       OutShdr->sh_offset + RangeOffset,
+                       static_cast<uint32_t>(NewRange)});
+  }
+
+  for (const EhFramePatch &Patch : Patches) {
+    std::memcpy(OutData + Patch.LocationOffset, &Patch.Location,
+                sizeof(Patch.Location));
+    std::memcpy(OutData + Patch.RangeOffset, &Patch.Range, sizeof(Patch.Range));
+  }
+  log() << "hotswap: displacement: remapped " << Patches.size()
+        << " .eh_frame FDE(s)\n";
+  return Error::success();
+}
+
+} // namespace hotswap
+} // namespace COMGR

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -381,6 +381,13 @@ private:
   std::vector<DisplacementEdit> Edits;
 };
 
+/// Remap supported `.eh_frame` FDEs after `.text` displacement. The helper
+/// reparses the input unwind table, validates every record before writing, and
+/// updates only the already-private output buffer.
+llvm::Error remapEhFrameForDisplacement(const ElfView &OldElf,
+                                        const DisplacementPlan &Plan,
+                                        llvm::WritableMemoryBuffer &OutBuf);
+
 // Kernel-entry stubs are appended as normal .text growth. Keep each entry on
 // the same 256-byte alignment expected by AMDGPU kernel descriptors.
 static constexpr uint64_t KernelEntryStubStride = 256;

--- a/amd/comgr/test-lit/hotswap-eh-frame-displacement.s
+++ b/amd/comgr/test-lit/hotswap-eh-frame-displacement.s
@@ -1,0 +1,94 @@
+// COM: Exercise the entry-prefix displacement call site on a linked code
+// COM: object with .eh_frame. The FDE must grow with the kernel instead of
+// COM: forcing the appended-stub fallback. A renamed .eh_frame_hdr remains
+// COM: unsupported because its binary-search table would need rebuilding.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %llvm-readelf --section-headers %t.elf | \
+// RUN:   %FileCheck --check-prefix=INPUT-SECTIONS %s
+// INPUT-SECTIONS: .eh_frame
+// RUN: %llvm-objdump --dwarf=frames %t.elf | \
+// RUN:   %FileCheck --check-prefix=INPUT-FRAME %s
+// INPUT-FRAME: FDE cie={{.*}} pc=00001500...0000150c
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --dump %t.out.elf --check-idempotent 2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: displacement: remapped 1 .eh_frame FDE(s)
+// API: hotswap: displacement: grew ELF
+// API: REWRITE: SUCCESS
+// API: IDEMPOTENT: YES
+
+// RUN: %llvm-objdump -d %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <eh_frame_kernel>:
+// DISASM-NEXT: global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+// DISASM-NEXT: v_nop
+// DISASM-NEXT: s_setreg_imm32_b32
+// DISASM-NEXT: s_endpgm
+
+// RUN: %llvm-objdump --dwarf=frames %t.out.elf | \
+// RUN:   %FileCheck --check-prefix=FRAME %s
+// FRAME: .eh_frame contents:
+// FRAME: CIE
+// FRAME: Augmentation:          "zR"
+// FRAME: FDE cie={{.*}} pc=00001500...0000151c
+// FRAME-NOT: invalid
+
+// RUN: %llvm-objcopy --rename-section .eh_frame=.eh_frame_hdr \
+// RUN:   %t.elf %t.hdr.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.hdr.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --entry-trampolines --output %t.hdr.out.elf 2>&1 \
+// RUN:   | %FileCheck --check-prefix=HDR-API %s
+// HDR-API: debug/unwind section '.eh_frame_hdr' requires address remapping
+// HDR-API: using appended entry stubs
+// HDR-API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.hdr.out.elf | \
+// RUN:   %FileCheck --check-prefix=HDR-DISASM %s
+// HDR-DISASM-LABEL: <eh_frame_kernel>:
+// HDR-DISASM-NEXT: s_setreg_imm32_b32
+// HDR-DISASM-NEXT: s_endpgm
+// HDR-DISASM: global_prefetch_b8 v0, s[0:1] scope:SCOPE_SE
+// HDR-DISASM-NEXT: v_nop
+// HDR-DISASM-NEXT: s_get_pc_i64
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.cfi_sections .eh_frame
+.text
+.globl eh_frame_kernel
+.p2align 8
+.type eh_frame_kernel,@function
+eh_frame_kernel:
+  .cfi_startproc
+  s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  s_endpgm
+  .cfi_endproc
+.Leh_frame_kernel_end:
+.size eh_frame_kernel, .Leh_frame_kernel_end-eh_frame_kernel
+
+.rodata
+.p2align 8
+.amdhsa_kernel eh_frame_kernel
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: eh_frame_kernel
+      .symbol: eh_frame_kernel.kd
+      .sgpr_count: 1
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap-eh-frame-displacement.s
+++ b/amd/comgr/test-lit/hotswap-eh-frame-displacement.s
@@ -10,6 +10,7 @@
 // RUN: %llvm-objdump --dwarf=frames %t.elf | \
 // RUN:   %FileCheck --check-prefix=INPUT-FRAME %s
 // INPUT-FRAME: FDE cie={{.*}} pc=00001500...0000150c
+// INPUT-FRAME: DW_CFA_advance_loc: 8 to 0x1508
 
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
@@ -34,6 +35,7 @@
 // FRAME: CIE
 // FRAME: Augmentation:          "zR"
 // FRAME: FDE cie={{.*}} pc=00001500...0000151c
+// FRAME: DW_CFA_advance_loc: 24 to 0x1518
 // FRAME-NOT: invalid
 
 // RUN: %llvm-objcopy --rename-section .eh_frame=.eh_frame_hdr \
@@ -64,6 +66,7 @@
 eh_frame_kernel:
   .cfi_startproc
   s_setreg_imm32_b32 hwreg(HW_REG_WAVE_SCHED_MODE, 0, 2), 2
+  .cfi_undefined 16
   s_endpgm
   .cfi_endproc
 .Leh_frame_kernel_end:

--- a/amd/comgr/test-unit/CMakeLists.txt
+++ b/amd/comgr/test-unit/CMakeLists.txt
@@ -105,6 +105,7 @@ add_executable(HotswapMCTests
   HotswapMCTest.cpp
   ../src/comgr-hotswap-b0a0.cpp
   ../src/comgr-hotswap-displacement.cpp
+  ../src/comgr-hotswap-eh-frame.cpp
   ../src/comgr-hotswap-entry-trampoline.cpp
   ../src/comgr-hotswap-entry-trampoline-fast.cpp
   ../src/comgr-hotswap-elf.cpp
@@ -125,6 +126,7 @@ add_executable(HotswapMCTests
 
 llvm_map_components_to_libnames(COMGR_TEST_UNIT_MC_LIBS
   BinaryFormat
+  DebugInfoDWARF
   MC
   MCDisassembler
   MCParser

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -3258,6 +3258,35 @@ TEST(TextDisplacement, RejectsEhFrameFdePartiallyOverlappingText) {
       << Reason;
 }
 
+TEST(TextDisplacement, RejectsEhFrameFdeSwallowedByTextGrowth) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr + 12, 4, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Edit.ReplacementBytes.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("outside old .text overlaps displaced .text"),
+            std::string::npos)
+      << Reason;
+}
+
 TEST(TextDisplacement, RejectsDynamicRelocationWritesIntoEhFrame) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -20,6 +20,9 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/DebugInfo/DWARF/DWARFDataExtractor.h"
+#include "llvm/DebugInfo/DWARF/DWARFDebugFrame.h"
 #include "llvm/Support/TargetSelect.h"
 #include "gtest/gtest.h"
 
@@ -80,18 +83,24 @@ static uint32_t readDword(const uint8_t *Bytes) {
 
 static uint64_t alignTo8(uint64_t V) { return (V + 7) & ~uint64_t{7}; }
 
+static constexpr uint64_t DisplacementTextAddr = 0x1000;
+static constexpr uint64_t DisplacementEhFrameAddr = 0x3000;
+
 static std::vector<uint8_t> makeDisplacementTestElf(
     llvm::ArrayRef<uint8_t> Text, bool AddTextRelocation = false,
-    bool AddDebugSection = false, bool AddBoundaryTextSymbol = false) {
+    bool AddDebugSection = false, bool AddBoundaryTextSymbol = false,
+    llvm::ArrayRef<uint8_t> EhFrame = {}) {
   using namespace llvm::ELF;
   namespace hsa = llvm::amdhsa;
 
   static constexpr uint64_t ShOff = sizeof(Elf64_Ehdr);
   static constexpr uint64_t PhOff = 0x200;
   static constexpr uint64_t TextOff = 0x280;
-  static constexpr uint64_t TextAddr = 0x1000;
   static constexpr uint64_t RodataAddr = 0x2000;
   static constexpr uint64_t KdBytes = sizeof(hsa::kernel_descriptor_t);
+  const bool AddEhFrame = !EhFrame.empty();
+  const bool AddExtraSection = AddDebugSection || AddEhFrame;
+  assert(!(AddDebugSection && AddEhFrame));
   const uint64_t SymCount = AddBoundaryTextSymbol ? 4 : 3;
 
   const char StrTab[] = "\0kernel\0kernel.kd\0";
@@ -101,6 +110,8 @@ static std::vector<uint8_t> makeDisplacementTestElf(
       "\0.text\0.rodata\0.strtab\0.symtab\0.rela.text\0.shstrtab\0";
   const char ShStrTabDebug[] =
       "\0.text\0.rodata\0.strtab\0.symtab\0.debug_info\0.shstrtab\0";
+  const char ShStrTabEhFrame[] =
+      "\0.text\0.rodata\0.strtab\0.symtab\0.eh_frame\0.shstrtab\0";
 
   const uint64_t RodataOff = alignTo8(TextOff + Text.size());
   const uint64_t StrTabOff = alignTo8(RodataOff + KdBytes);
@@ -108,24 +119,29 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   const uint64_t RelOff =
       AddTextRelocation ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym))
                         : 0;
-  const uint64_t DebugOff =
-      AddDebugSection ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym)) : 0;
+  const uint64_t ExtraOff =
+      AddExtraSection ? alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym)) : 0;
+  const uint64_t ExtraSize = AddDebugSection ? 4 : EhFrame.size();
   const uint64_t ShStrTabOff =
       AddTextRelocation ? alignTo8(RelOff + sizeof(Elf64_Rela))
-      : AddDebugSection ? alignTo8(DebugOff + 4)
+      : AddExtraSection ? alignTo8(ExtraOff + ExtraSize)
                         : alignTo8(SymTabOff + SymCount * sizeof(Elf64_Sym));
   const uint64_t ShStrTabSize = AddTextRelocation ? sizeof(ShStrTabRel)
                                 : AddDebugSection ? sizeof(ShStrTabDebug)
+                                : AddEhFrame      ? sizeof(ShStrTabEhFrame)
                                                   : sizeof(ShStrTabNoRel);
   const uint64_t BufSize = alignTo8(ShStrTabOff + ShStrTabSize + 64);
 
   std::vector<uint8_t> Buf(BufSize, 0);
   const char *ShStrTab = AddTextRelocation ? ShStrTabRel
                          : AddDebugSection ? ShStrTabDebug
+                         : AddEhFrame      ? ShStrTabEhFrame
                                            : ShStrTabNoRel;
   std::memcpy(Buf.data() + ShStrTabOff, ShStrTab, ShStrTabSize);
   std::memcpy(Buf.data() + StrTabOff, StrTab, sizeof(StrTab));
   std::memcpy(Buf.data() + TextOff, Text.data(), Text.size());
+  if (AddEhFrame)
+    std::memcpy(Buf.data() + ExtraOff, EhFrame.data(), EhFrame.size());
 
   Elf64_Ehdr Ehdr = comgr_test::makeElf64Ehdr(EM_AMDGPU);
   Ehdr.e_ident[EI_OSABI] = ELFOSABI_AMDGPU_HSA;
@@ -137,16 +153,16 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   Ehdr.e_phentsize = sizeof(Elf64_Phdr);
   Ehdr.e_phnum = 2;
   Ehdr.e_shentsize = sizeof(Elf64_Shdr);
-  Ehdr.e_shnum = AddTextRelocation || AddDebugSection ? 7 : 6;
-  Ehdr.e_shstrndx = AddTextRelocation || AddDebugSection ? 6 : 5;
+  Ehdr.e_shnum = AddTextRelocation || AddExtraSection ? 7 : 6;
+  Ehdr.e_shstrndx = AddTextRelocation || AddExtraSection ? 6 : 5;
   std::memcpy(Buf.data(), &Ehdr, sizeof(Ehdr));
 
   Elf64_Phdr TextPh{};
   TextPh.p_type = PT_LOAD;
   TextPh.p_flags = PF_R | PF_X;
   TextPh.p_offset = TextOff;
-  TextPh.p_vaddr = TextAddr;
-  TextPh.p_paddr = TextAddr;
+  TextPh.p_vaddr = DisplacementTextAddr;
+  TextPh.p_paddr = DisplacementTextAddr;
   TextPh.p_filesz = Text.size();
   TextPh.p_memsz = Text.size() + 64;
   TextPh.p_align = 8;
@@ -169,7 +185,7 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   TextSh.sh_type = SHT_PROGBITS;
   TextSh.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
   TextSh.sh_offset = TextOff;
-  TextSh.sh_addr = TextAddr;
+  TextSh.sh_addr = DisplacementTextAddr;
   TextSh.sh_size = Text.size();
   TextSh.sh_addralign = 4;
   std::memcpy(Buf.data() + ShOff + 1 * sizeof(Elf64_Shdr), &TextSh,
@@ -204,7 +220,7 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   std::memcpy(Buf.data() + ShOff + 4 * sizeof(Elf64_Shdr), &SymtabSh,
               sizeof(SymtabSh));
 
-  unsigned ShStrIndex = AddTextRelocation || AddDebugSection ? 6 : 5;
+  unsigned ShStrIndex = AddTextRelocation || AddExtraSection ? 6 : 5;
   if (AddTextRelocation) {
     Elf64_Shdr RelaSh{};
     RelaSh.sh_name = 31;
@@ -221,22 +237,37 @@ static std::vector<uint8_t> makeDisplacementTestElf(
     Elf64_Shdr DebugSh{};
     DebugSh.sh_name = 31;
     DebugSh.sh_type = SHT_PROGBITS;
-    DebugSh.sh_offset = DebugOff;
+    DebugSh.sh_offset = ExtraOff;
     DebugSh.sh_size = 4;
     DebugSh.sh_addralign = 1;
     std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &DebugSh,
                 sizeof(DebugSh));
   }
+  if (AddEhFrame) {
+    Elf64_Shdr EhFrameSh{};
+    EhFrameSh.sh_name = 31;
+    EhFrameSh.sh_type = SHT_PROGBITS;
+    EhFrameSh.sh_flags = SHF_ALLOC;
+    EhFrameSh.sh_addr = DisplacementEhFrameAddr;
+    EhFrameSh.sh_offset = ExtraOff;
+    EhFrameSh.sh_size = EhFrame.size();
+    EhFrameSh.sh_addralign = 8;
+    std::memcpy(Buf.data() + ShOff + 5 * sizeof(Elf64_Shdr), &EhFrameSh,
+                sizeof(EhFrameSh));
+  }
 
   Elf64_Shdr ShstrSh{};
-  ShstrSh.sh_name = AddTextRelocation ? 42 : AddDebugSection ? 43 : 31;
+  ShstrSh.sh_name = AddTextRelocation ? 42
+                    : AddDebugSection ? 43
+                    : AddEhFrame      ? 41
+                                      : 31;
   ShstrSh.sh_type = SHT_STRTAB;
   ShstrSh.sh_offset = ShStrTabOff;
   ShstrSh.sh_size = ShStrTabSize;
   std::memcpy(Buf.data() + ShOff + ShStrIndex * sizeof(Elf64_Shdr), &ShstrSh,
               sizeof(ShstrSh));
 
-  int64_t EntryOffset = static_cast<int64_t>(TextAddr - RodataAddr);
+  int64_t EntryOffset = static_cast<int64_t>(DisplacementTextAddr - RodataAddr);
   std::memcpy(
       Buf.data() + RodataOff +
           offsetof(hsa::kernel_descriptor_t, kernel_code_entry_byte_offset),
@@ -246,7 +277,7 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   KernelSym.st_name = 1;
   KernelSym.setBindingAndType(STB_GLOBAL, STT_FUNC);
   KernelSym.st_shndx = 1;
-  KernelSym.st_value = TextAddr;
+  KernelSym.st_value = DisplacementTextAddr;
   KernelSym.st_size = Text.size();
   std::memcpy(Buf.data() + SymTabOff + 1 * sizeof(Elf64_Sym), &KernelSym,
               sizeof(KernelSym));
@@ -264,13 +295,137 @@ static std::vector<uint8_t> makeDisplacementTestElf(
     Elf64_Sym BoundarySym{};
     BoundarySym.setBindingAndType(STB_GLOBAL, STT_FUNC);
     BoundarySym.st_shndx = 1;
-    BoundarySym.st_value = TextAddr;
+    BoundarySym.st_value = DisplacementTextAddr;
     BoundarySym.st_size = MinInstSize;
     std::memcpy(Buf.data() + SymTabOff + 3 * sizeof(Elf64_Sym), &BoundarySym,
                 sizeof(BoundarySym));
   }
 
   return Buf;
+}
+
+struct EhFrameFdeSpec {
+  uint64_t InitialAddress;
+  uint32_t AddressRange;
+  llvm::SmallVector<uint8_t> Cfi;
+};
+
+static std::vector<uint8_t>
+makeEhFrame(llvm::ArrayRef<EhFrameFdeSpec> Fdes,
+            uint8_t PointerEncoding = llvm::dwarf::DW_EH_PE_pcrel |
+                                      llvm::dwarf::DW_EH_PE_sdata4,
+            llvm::ArrayRef<uint8_t> CieCfi = {}) {
+  std::vector<uint8_t> Bytes;
+  const uint8_t DefaultCfi[] = {llvm::dwarf::DW_CFA_nop,
+                                llvm::dwarf::DW_CFA_nop,
+                                llvm::dwarf::DW_CFA_nop};
+  if (CieCfi.empty())
+    CieCfi = DefaultCfi;
+
+  const uint32_t CieLength = 13 + CieCfi.size();
+  const uint32_t CieId = 0;
+  const uint8_t CieFields[] = {
+      1, 'z', 'R', 0, 4, 4, 16, 1, PointerEncoding,
+  };
+  comgr_test::appendBytes(Bytes, &CieLength, sizeof(CieLength));
+  comgr_test::appendBytes(Bytes, &CieId, sizeof(CieId));
+  comgr_test::appendBytes(Bytes, CieFields, sizeof(CieFields));
+  comgr_test::appendBytes(Bytes, CieCfi.data(), CieCfi.size());
+
+  for (const EhFrameFdeSpec &Spec : Fdes) {
+    llvm::ArrayRef<uint8_t> FdeCfi = Spec.Cfi;
+    if (FdeCfi.empty())
+      FdeCfi = DefaultCfi;
+    const uint64_t RecordOffset = Bytes.size();
+    const uint32_t FdeLength = 13 + FdeCfi.size();
+    const uint32_t CiePointer = RecordOffset + sizeof(uint32_t);
+    const uint64_t LocationOffset = RecordOffset + 2 * sizeof(uint32_t);
+    const uint64_t FieldAddress = DisplacementEhFrameAddr + LocationOffset;
+    const int64_t Location = static_cast<int64_t>(Spec.InitialAddress) -
+                             static_cast<int64_t>(FieldAddress);
+    assert(Location >= std::numeric_limits<int32_t>::min() &&
+           Location <= std::numeric_limits<int32_t>::max());
+    const int32_t EncodedLocation = static_cast<int32_t>(Location);
+    const uint8_t AugmentationLength = 0;
+
+    comgr_test::appendBytes(Bytes, &FdeLength, sizeof(FdeLength));
+    comgr_test::appendBytes(Bytes, &CiePointer, sizeof(CiePointer));
+    comgr_test::appendBytes(Bytes, &EncodedLocation, sizeof(EncodedLocation));
+    comgr_test::appendBytes(Bytes, &Spec.AddressRange,
+                            sizeof(Spec.AddressRange));
+    comgr_test::appendBytes(Bytes, &AugmentationLength,
+                            sizeof(AugmentationLength));
+    comgr_test::appendBytes(Bytes, FdeCfi.data(), FdeCfi.size());
+  }
+
+  const uint32_t Terminator = 0;
+  comgr_test::appendBytes(Bytes, &Terminator, sizeof(Terminator));
+  return Bytes;
+}
+
+static std::vector<uint8_t> makeDwarf64FdeEhFrame(const EhFrameFdeSpec &Spec) {
+  std::vector<uint8_t> Bytes = makeEhFrame({});
+  Bytes.resize(Bytes.size() - sizeof(uint32_t));
+
+  const uint64_t RecordOffset = Bytes.size();
+  const uint32_t Dwarf64Marker = llvm::dwarf::DW_LENGTH_DWARF64;
+  const uint64_t FdeLength = 16;
+  const uint32_t CiePointer =
+      RecordOffset + sizeof(uint32_t) + sizeof(uint64_t);
+  const uint64_t LocationOffset =
+      RecordOffset + sizeof(uint32_t) + sizeof(uint64_t) + sizeof(uint32_t);
+  const uint64_t FieldAddress = DisplacementEhFrameAddr + LocationOffset;
+  const int64_t Location = static_cast<int64_t>(Spec.InitialAddress) -
+                           static_cast<int64_t>(FieldAddress);
+  assert(Location >= std::numeric_limits<int32_t>::min() &&
+         Location <= std::numeric_limits<int32_t>::max());
+  const int32_t EncodedLocation = static_cast<int32_t>(Location);
+  const uint8_t Tail[] = {0, llvm::dwarf::DW_CFA_nop, llvm::dwarf::DW_CFA_nop,
+                          llvm::dwarf::DW_CFA_nop};
+
+  comgr_test::appendBytes(Bytes, &Dwarf64Marker, sizeof(Dwarf64Marker));
+  comgr_test::appendBytes(Bytes, &FdeLength, sizeof(FdeLength));
+  comgr_test::appendBytes(Bytes, &CiePointer, sizeof(CiePointer));
+  comgr_test::appendBytes(Bytes, &EncodedLocation, sizeof(EncodedLocation));
+  comgr_test::appendBytes(Bytes, &Spec.AddressRange, sizeof(Spec.AddressRange));
+  comgr_test::appendBytes(Bytes, Tail, sizeof(Tail));
+  const uint32_t Terminator = 0;
+  comgr_test::appendBytes(Bytes, &Terminator, sizeof(Terminator));
+  return Bytes;
+}
+
+static llvm::Expected<std::vector<std::pair<uint64_t, uint64_t>>>
+readEhFrameFdes(const ElfView &Elf) {
+  for (const ElfView::ELFT::Shdr &Shdr : Elf.sections()) {
+    llvm::Expected<llvm::StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr)
+      return NameOrErr.takeError();
+    if (*NameOrErr != ".eh_frame")
+      continue;
+
+    llvm::StringRef Data(
+        reinterpret_cast<const char *>(Elf.data() + Shdr.sh_offset),
+        Shdr.sh_size);
+    llvm::DWARFDataExtractor Extractor(Data, /*IsLittleEndian=*/true,
+                                       /*AddressSize=*/sizeof(uint64_t));
+    const llvm::Triple::ArchType Arch =
+        llvm::Triple("amdgcn-amd-amdhsa").getArch();
+    llvm::DWARFDebugFrame Frame(Arch, /*IsEH=*/true, Shdr.sh_addr);
+    if (llvm::Error Err = Frame.parse(Extractor))
+      return std::move(Err);
+
+    std::vector<std::pair<uint64_t, uint64_t>> Fdes;
+    for (const llvm::dwarf::FrameEntry &Entry : Frame.entries()) {
+      if (Entry.getKind() != llvm::dwarf::FrameEntry::FK_FDE)
+        continue;
+      const llvm::dwarf::FDE &Fde =
+          static_cast<const llvm::dwarf::FDE &>(Entry);
+      Fdes.emplace_back(Fde.getInitialLocation(), Fde.getAddressRange());
+    }
+    return Fdes;
+  }
+  return llvm::createStringError(llvm::object::object_error::parse_failed,
+                                 "missing .eh_frame");
 }
 
 // -- initLLVM ----------------------------------------------------------------
@@ -2485,6 +2640,405 @@ TEST(TextDisplacement, RejectsDebugSectionsUntilAddressesCanBeRemapped) {
   ASSERT_FALSE((bool)OutOrErr);
   std::string Reason = llvm::toString(OutOrErr.takeError());
   EXPECT_NE(Reason.find(".debug_info"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RemapsMultipleEhFrameFdes) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I != 6; ++I)
+    Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  std::vector<EhFrameFdeSpec> Specs = {
+      {DisplacementTextAddr, 8, {}},
+      {DisplacementTextAddr + 8, 12, {}},
+      {0x5000, 4, {}},
+  };
+  std::vector<uint8_t> EhFrame = makeEhFrame(Specs);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  uint64_t OldEhFrameOffset = 0;
+  for (const ElfView::ELFT::Shdr &Shdr : ViewOrErr->sections()) {
+    llvm::Expected<llvm::StringRef> Name =
+        ViewOrErr->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".eh_frame")
+      OldEhFrameOffset = Shdr.sh_offset;
+  }
+  ASSERT_NE(OldEhFrameOffset, 0u);
+
+  DisplacementEdit AtStart;
+  AtStart.Offset = 0;
+  AtStart.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  DisplacementEdit InSecondFde;
+  InSecondFde.Offset = 12;
+  InSecondFde.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S,
+                                          {AtStart, InSecondFde});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutViewOrErr =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutViewOrErr) << llvm::toString(OutViewOrErr.takeError());
+
+  llvm::Expected<std::vector<std::pair<uint64_t, uint64_t>>> FdesOrErr =
+      readEhFrameFdes(*OutViewOrErr);
+  ASSERT_TRUE((bool)FdesOrErr) << llvm::toString(FdesOrErr.takeError());
+  ASSERT_EQ(FdesOrErr->size(), 3u);
+  EXPECT_EQ((*FdesOrErr)[0],
+            std::make_pair(DisplacementTextAddr, uint64_t{12}));
+  EXPECT_EQ((*FdesOrErr)[1],
+            std::make_pair(DisplacementTextAddr + 12, uint64_t{16}));
+  EXPECT_EQ((*FdesOrErr)[2], std::make_pair(uint64_t{0x5000}, uint64_t{4}));
+
+  uint64_t NewEhFrameOffset = 0;
+  for (const ElfView::ELFT::Shdr &Shdr : OutViewOrErr->sections()) {
+    llvm::Expected<llvm::StringRef> Name =
+        OutViewOrErr->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".eh_frame")
+      NewEhFrameOffset = Shdr.sh_offset;
+  }
+  EXPECT_EQ(NewEhFrameOffset, OldEhFrameOffset + 8);
+}
+
+TEST(TextDisplacement, PreservesRelativeCfiWhenFdeMovesUniformly) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I != 5; ++I)
+    Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {
+      DisplacementTextAddr + 8,
+      8,
+      {static_cast<uint8_t>(llvm::dwarf::DW_CFA_advance_loc | 1),
+       llvm::dwarf::DW_CFA_nop, llvm::dwarf::DW_CFA_nop},
+  };
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  uint8_t *OutData = reinterpret_cast<uint8_t *>(Out->getBufferStart());
+  llvm::Expected<ElfView> OutViewOrErr =
+      ElfView::create(OutData, Out->getBufferSize());
+  ASSERT_TRUE((bool)OutViewOrErr) << llvm::toString(OutViewOrErr.takeError());
+  llvm::Expected<std::vector<std::pair<uint64_t, uint64_t>>> FdesOrErr =
+      readEhFrameFdes(*OutViewOrErr);
+  ASSERT_TRUE((bool)FdesOrErr) << llvm::toString(FdesOrErr.takeError());
+  ASSERT_EQ(FdesOrErr->size(), 1u);
+  EXPECT_EQ((*FdesOrErr)[0],
+            std::make_pair(DisplacementTextAddr + 12, uint64_t{8}));
+}
+
+TEST(TextDisplacement, RejectsEhFrameCfiLocationsAcrossGrowth) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I != 3; ++I)
+    Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {
+      DisplacementTextAddr,
+      8,
+      {static_cast<uint8_t>(llvm::dwarf::DW_CFA_advance_loc | 1),
+       llvm::dwarf::DW_CFA_nop, llvm::dwarf::DW_CFA_nop},
+  };
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("location-changing CFI"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsEhFrameSetLocWhoseTargetMoves) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I != 5; ++I)
+    Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> Cfi = {llvm::dwarf::DW_CFA_set_loc};
+  // A location that exactly matches an insertion point moves after the new
+  // bytes even though an FDE boundary at the same address stays before them.
+  const uint64_t SetLocation = DisplacementTextAddr + 8;
+  const uint8_t *SetLocationBytes =
+      reinterpret_cast<const uint8_t *>(&SetLocation);
+  Cfi.append(SetLocationBytes, SetLocationBytes + sizeof(SetLocation));
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, Cfi};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 8;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("DW_CFA_set_loc"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsEhFrameAddressExpression) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> Cfi = {
+      llvm::dwarf::DW_CFA_def_cfa_expression,
+      static_cast<uint8_t>(1 + sizeof(uint64_t)),
+      llvm::dwarf::DW_OP_addr,
+  };
+  const uint64_t ExpressionAddress = DisplacementTextAddr;
+  const uint8_t *ExpressionAddressBytes =
+      reinterpret_cast<const uint8_t *>(&ExpressionAddress);
+  Cfi.append(ExpressionAddressBytes,
+             ExpressionAddressBytes + sizeof(ExpressionAddress));
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, Cfi};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("CFI address expressions"), std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RejectsUnsupportedEhFramePointerEncoding) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame(
+      {Spec}, llvm::dwarf::DW_EH_PE_pcrel | llvm::dwarf::DW_EH_PE_udata4);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("pointer encoding is unsupported"), std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RejectsEhFrameFdeWithoutCie) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  const uint32_t BadCiePointer = 4;
+  std::memcpy(EhFrame.data() + 24, &BadCiePointer, sizeof(BadCiePointer));
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("failed to parse .eh_frame"), std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RejectsTruncatedEhFrameRecords) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  const std::vector<uint8_t> CompleteEhFrame = makeEhFrame({Spec});
+  const size_t TruncationPoints[] = {1, 4, 8, 19, 21, 24, 28, 32, 36, 39};
+
+  for (size_t TruncatedSize : TruncationPoints) {
+    SCOPED_TRACE(TruncatedSize);
+    ASSERT_LT(TruncatedSize, CompleteEhFrame.size());
+    llvm::ArrayRef<uint8_t> TruncatedEhFrame(CompleteEhFrame.data(),
+                                             TruncatedSize);
+    std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+        Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+        /*AddBoundaryTextSymbol=*/false, TruncatedEhFrame);
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(ElfBytes.data(), ElfBytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+    DisplacementEdit Edit;
+    Edit.Offset = 0;
+    Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+    llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+        tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+    ASSERT_FALSE((bool)OutOrErr);
+    std::string Reason = llvm::toString(OutOrErr.takeError());
+    EXPECT_NE(Reason.find(".eh_frame"), std::string::npos) << Reason;
+  }
+}
+
+TEST(TextDisplacement, RejectsDwarf64EhFrameFde) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeDwarf64FdeEhFrame(Spec);
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("64-bit DWARF records"), std::string::npos) << Reason;
+}
+
+TEST(TextDisplacement, RejectsEhFrameFdePartiallyOverlappingText) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 12, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("partially overlaps .text"), std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RejectsCompressedEhFrame) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  const ElfView::ELFT::Shdr *EhShdr = nullptr;
+  for (const ElfView::ELFT::Shdr &Shdr : ViewOrErr->sections()) {
+    llvm::Expected<llvm::StringRef> Name =
+        ViewOrErr->file().getSectionName(Shdr);
+    ASSERT_TRUE((bool)Name) << llvm::toString(Name.takeError());
+    if (*Name == ".eh_frame")
+      EhShdr = &Shdr;
+  }
+  ASSERT_NE(EhShdr, nullptr);
+  const size_t HeaderOffset =
+      reinterpret_cast<const uint8_t *>(EhShdr) - ElfBytes.data();
+  llvm::ELF::Elf64_Shdr RawEhShdr;
+  std::memcpy(&RawEhShdr, ElfBytes.data() + HeaderOffset, sizeof(RawEhShdr));
+  RawEhShdr.sh_flags |= llvm::ELF::SHF_COMPRESSED;
+  std::memcpy(ElfBytes.data() + HeaderOffset, &RawEhShdr, sizeof(RawEhShdr));
+  ViewOrErr = ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find("allocated, uncompressed SHT_PROGBITS"),
+            std::string::npos)
+      << Reason;
 }
 
 TEST(KernelEntryTrampoline, ClampsInstPrefSizeAndAvoidsPrefetchGuard) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -428,6 +428,64 @@ readEhFrameFdes(const ElfView &Elf) {
                                  "missing .eh_frame");
 }
 
+struct EhFrameCfiLocation {
+  uint8_t Opcode;
+  uint64_t Operand;
+};
+
+static llvm::Expected<std::vector<EhFrameCfiLocation>>
+readFirstEhFrameFdeLocations(const ElfView &Elf) {
+  for (const ElfView::ELFT::Shdr &Shdr : Elf.sections()) {
+    llvm::Expected<llvm::StringRef> NameOrErr = Elf.file().getSectionName(Shdr);
+    if (!NameOrErr)
+      return NameOrErr.takeError();
+    if (*NameOrErr != ".eh_frame")
+      continue;
+
+    llvm::StringRef Data(
+        reinterpret_cast<const char *>(Elf.data() + Shdr.sh_offset),
+        Shdr.sh_size);
+    llvm::DWARFDataExtractor Extractor(Data, /*IsLittleEndian=*/true,
+                                       /*AddressSize=*/sizeof(uint64_t));
+    const llvm::Triple::ArchType Arch =
+        llvm::Triple("amdgcn-amd-amdhsa").getArch();
+    llvm::DWARFDebugFrame Frame(Arch, /*IsEH=*/true, Shdr.sh_addr);
+    if (llvm::Error Err = Frame.parse(Extractor))
+      return std::move(Err);
+
+    for (const llvm::dwarf::FrameEntry &Entry : Frame.entries()) {
+      if (Entry.getKind() != llvm::dwarf::FrameEntry::FK_FDE)
+        continue;
+      std::vector<EhFrameCfiLocation> Locations;
+      const llvm::dwarf::FDE &Fde =
+          static_cast<const llvm::dwarf::FDE &>(Entry);
+      for (const llvm::dwarf::CFIProgram::Instruction &Inst : Fde.cfis()) {
+        switch (Inst.Opcode) {
+        case llvm::dwarf::DW_CFA_advance_loc:
+        case llvm::dwarf::DW_CFA_advance_loc1:
+        case llvm::dwarf::DW_CFA_advance_loc2:
+        case llvm::dwarf::DW_CFA_advance_loc4:
+        case llvm::dwarf::DW_CFA_set_loc:
+          if (Inst.Ops.empty()) {
+            return llvm::createStringError(
+                llvm::object::object_error::parse_failed,
+                "location-changing CFI instruction has no operand");
+          }
+          Locations.push_back({Inst.Opcode, Inst.Ops.front()});
+          break;
+        default:
+          break;
+        }
+      }
+      return Locations;
+    }
+    return llvm::createStringError(llvm::object::object_error::parse_failed,
+                                   "missing .eh_frame FDE");
+  }
+  return llvm::createStringError(llvm::object::object_error::parse_failed,
+                                 "missing .eh_frame");
+}
+
 // -- initLLVM ----------------------------------------------------------------
 
 TEST(InitLLVM, ValidGfx1250) {
@@ -2750,7 +2808,7 @@ TEST(TextDisplacement, PreservesRelativeCfiWhenFdeMovesUniformly) {
             std::make_pair(DisplacementTextAddr + 12, uint64_t{8}));
 }
 
-TEST(TextDisplacement, RejectsEhFrameCfiLocationsAcrossGrowth) {
+TEST(TextDisplacement, RemapsCompactEhFrameCfiAdvanceAcrossGrowth) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
@@ -2776,26 +2834,88 @@ TEST(TextDisplacement, RejectsEhFrameCfiLocationsAcrossGrowth) {
   Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
   llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
       tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
-  ASSERT_FALSE((bool)OutOrErr);
-  std::string Reason = llvm::toString(OutOrErr.takeError());
-  EXPECT_NE(Reason.find("location-changing CFI"), std::string::npos) << Reason;
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  llvm::Expected<ElfView> OutViewOrErr = ElfView::create(
+      reinterpret_cast<uint8_t *>(Out->getBufferStart()), Out->getBufferSize());
+  ASSERT_TRUE((bool)OutViewOrErr) << llvm::toString(OutViewOrErr.takeError());
+
+  llvm::Expected<std::vector<EhFrameCfiLocation>> LocationsOrErr =
+      readFirstEhFrameFdeLocations(*OutViewOrErr);
+  ASSERT_TRUE((bool)LocationsOrErr)
+      << llvm::toString(LocationsOrErr.takeError());
+  ASSERT_EQ(LocationsOrErr->size(), 1u);
+  EXPECT_EQ((*LocationsOrErr)[0].Opcode, llvm::dwarf::DW_CFA_advance_loc);
+  EXPECT_EQ((*LocationsOrErr)[0].Operand, 2u);
 }
 
-TEST(TextDisplacement, RejectsEhFrameSetLocWhoseTargetMoves) {
+TEST(TextDisplacement, RemapsFixedWidthEhFrameCfiAdvances) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  struct AdvanceEncoding {
+    uint8_t Opcode;
+    unsigned OperandSize;
+  };
+  const AdvanceEncoding Encodings[] = {
+      {llvm::dwarf::DW_CFA_advance_loc1, 1},
+      {llvm::dwarf::DW_CFA_advance_loc2, 2},
+      {llvm::dwarf::DW_CFA_advance_loc4, 4},
+  };
+  for (const AdvanceEncoding &Encoding : Encodings) {
+    SCOPED_TRACE(Encoding.OperandSize);
+    llvm::SmallVector<uint8_t> Text;
+    for (unsigned I = 0; I != 3; ++I)
+      Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+
+    llvm::SmallVector<uint8_t> Cfi = {Encoding.Opcode};
+    Cfi.append(Encoding.OperandSize, uint8_t{0});
+    Cfi[1] = 1;
+    EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, Cfi};
+    std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+    std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+        Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+        /*AddBoundaryTextSymbol=*/false, EhFrame);
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(ElfBytes.data(), ElfBytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+    DisplacementEdit Edit;
+    Edit.Offset = 0;
+    Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+    llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+        tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+    ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+    std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+    llvm::Expected<ElfView> OutViewOrErr =
+        ElfView::create(reinterpret_cast<uint8_t *>(Out->getBufferStart()),
+                        Out->getBufferSize());
+    ASSERT_TRUE((bool)OutViewOrErr) << llvm::toString(OutViewOrErr.takeError());
+
+    llvm::Expected<std::vector<EhFrameCfiLocation>> LocationsOrErr =
+        readFirstEhFrameFdeLocations(*OutViewOrErr);
+    ASSERT_TRUE((bool)LocationsOrErr)
+        << llvm::toString(LocationsOrErr.takeError());
+    ASSERT_EQ(LocationsOrErr->size(), 1u);
+    EXPECT_EQ((*LocationsOrErr)[0].Opcode, Encoding.Opcode);
+    EXPECT_EQ((*LocationsOrErr)[0].Operand, 2u);
+  }
+}
+
+TEST(TextDisplacement, RemapsMultipleEhFrameCfiAdvancesInSequence) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
 
   llvm::SmallVector<uint8_t> Text;
-  for (unsigned I = 0; I != 5; ++I)
+  for (unsigned I = 0; I != 6; ++I)
     Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
-  llvm::SmallVector<uint8_t> Cfi = {llvm::dwarf::DW_CFA_set_loc};
-  // A location that exactly matches an insertion point moves after the new
-  // bytes even though an FDE boundary at the same address stays before them.
-  const uint64_t SetLocation = DisplacementTextAddr + 8;
-  const uint8_t *SetLocationBytes =
-      reinterpret_cast<const uint8_t *>(&SetLocation);
-  Cfi.append(SetLocationBytes, SetLocationBytes + sizeof(SetLocation));
-  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, Cfi};
+  const uint8_t AdvanceOne =
+      llvm::dwarf::DW_CFA_advance_loc | static_cast<uint8_t>(1);
+  EhFrameFdeSpec Spec = {
+      DisplacementTextAddr,
+      16,
+      {AdvanceOne, AdvanceOne, llvm::dwarf::DW_CFA_nop},
+  };
   std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
   std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
       Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
@@ -2805,13 +2925,97 @@ TEST(TextDisplacement, RejectsEhFrameSetLocWhoseTargetMoves) {
   ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
 
   DisplacementEdit Edit;
-  Edit.Offset = 8;
+  Edit.Offset = 4;
+  Edit.OriginalSize = 4;
+  Edit.ReplacementBytes.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Edit.ReplacementBytes.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  llvm::Expected<ElfView> OutViewOrErr = ElfView::create(
+      reinterpret_cast<uint8_t *>(Out->getBufferStart()), Out->getBufferSize());
+  ASSERT_TRUE((bool)OutViewOrErr) << llvm::toString(OutViewOrErr.takeError());
+
+  llvm::Expected<std::vector<EhFrameCfiLocation>> LocationsOrErr =
+      readFirstEhFrameFdeLocations(*OutViewOrErr);
+  ASSERT_TRUE((bool)LocationsOrErr)
+      << llvm::toString(LocationsOrErr.takeError());
+  ASSERT_EQ(LocationsOrErr->size(), 2u);
+  EXPECT_EQ((*LocationsOrErr)[0].Operand, 1u);
+  EXPECT_EQ((*LocationsOrErr)[1].Operand, 2u);
+}
+
+TEST(TextDisplacement, RemapsEhFrameSetLocWhoseTargetMoves) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I != 6; ++I)
+    Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::SmallVector<uint8_t> Cfi = {llvm::dwarf::DW_CFA_set_loc};
+  const uint64_t SetLocation = DisplacementTextAddr + 8;
+  const uint8_t *SetLocationBytes =
+      reinterpret_cast<const uint8_t *>(&SetLocation);
+  Cfi.append(SetLocationBytes, SetLocationBytes + sizeof(SetLocation));
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 16, Cfi};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 4;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+  std::unique_ptr<llvm::WritableMemoryBuffer> Out = std::move(*OutOrErr);
+  llvm::Expected<ElfView> OutViewOrErr = ElfView::create(
+      reinterpret_cast<uint8_t *>(Out->getBufferStart()), Out->getBufferSize());
+  ASSERT_TRUE((bool)OutViewOrErr) << llvm::toString(OutViewOrErr.takeError());
+
+  llvm::Expected<std::vector<EhFrameCfiLocation>> LocationsOrErr =
+      readFirstEhFrameFdeLocations(*OutViewOrErr);
+  ASSERT_TRUE((bool)LocationsOrErr)
+      << llvm::toString(LocationsOrErr.takeError());
+  ASSERT_EQ(LocationsOrErr->size(), 1u);
+  EXPECT_EQ((*LocationsOrErr)[0].Opcode, llvm::dwarf::DW_CFA_set_loc);
+  EXPECT_EQ((*LocationsOrErr)[0].Operand, DisplacementTextAddr + 12);
+}
+
+TEST(TextDisplacement, RejectsEhFrameCfiAdvanceEncodingOverflow) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  for (unsigned I = 0; I != 65; ++I)
+    Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {
+      DisplacementTextAddr,
+      256,
+      {static_cast<uint8_t>(llvm::dwarf::DW_CFA_advance_loc | 63)},
+  };
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
   Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
   llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
       tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
   ASSERT_FALSE((bool)OutOrErr);
   std::string Reason = llvm::toString(OutOrErr.takeError());
-  EXPECT_NE(Reason.find("DW_CFA_set_loc"), std::string::npos) << Reason;
+  EXPECT_NE(Reason.find("no longer fits DW_CFA_advance_loc"), std::string::npos)
+      << Reason;
 }
 
 TEST(TextDisplacement, RejectsEhFrameAddressExpression) {

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -304,6 +304,65 @@ static std::vector<uint8_t> makeDisplacementTestElf(
   return Buf;
 }
 
+static void addDisplacementTestRelocationSection(
+    std::vector<uint8_t> &ElfBytes, uint32_t SectionType, uint64_t SectionFlags,
+    uint32_t SectionInfo, uint64_t RelocationOffset, uint32_t RelocationType) {
+  using namespace llvm::ELF;
+
+  Elf64_Ehdr Ehdr;
+  std::memcpy(&Ehdr, ElfBytes.data(), sizeof(Ehdr));
+  std::vector<Elf64_Shdr> ExistingShdrs(Ehdr.e_shnum);
+  std::memcpy(ExistingShdrs.data(), ElfBytes.data() + Ehdr.e_shoff,
+              ExistingShdrs.size() * sizeof(Elf64_Shdr));
+
+  const uint64_t RelocationOffsetInFile = alignTo8(ElfBytes.size());
+  Elf64_Shdr RelocationShdr{};
+  RelocationShdr.sh_type = SectionType;
+  RelocationShdr.sh_flags = SectionFlags;
+  RelocationShdr.sh_offset = RelocationOffsetInFile;
+  RelocationShdr.sh_link =
+      SectionType == SHT_REL || SectionType == SHT_RELA ? 4 : 0;
+  RelocationShdr.sh_info = SectionInfo;
+  RelocationShdr.sh_addralign = 8;
+
+  if (SectionType == SHT_RELA) {
+    Elf64_Rela Rela{};
+    Rela.r_offset = RelocationOffset;
+    const uint32_t Symbol = RelocationType == R_AMDGPU_NONE ? 0 : 2;
+    Rela.setSymbolAndType(Symbol, RelocationType);
+    RelocationShdr.sh_size = sizeof(Rela);
+    RelocationShdr.sh_entsize = sizeof(Rela);
+    ElfBytes.resize(RelocationOffsetInFile + sizeof(Rela));
+    std::memcpy(ElfBytes.data() + RelocationOffsetInFile, &Rela, sizeof(Rela));
+  } else if (SectionType == SHT_REL) {
+    Elf64_Rel Rel{};
+    Rel.r_offset = RelocationOffset;
+    const uint32_t Symbol = RelocationType == R_AMDGPU_NONE ? 0 : 2;
+    Rel.setSymbolAndType(Symbol, RelocationType);
+    RelocationShdr.sh_size = sizeof(Rel);
+    RelocationShdr.sh_entsize = sizeof(Rel);
+    ElfBytes.resize(RelocationOffsetInFile + sizeof(Rel));
+    std::memcpy(ElfBytes.data() + RelocationOffsetInFile, &Rel, sizeof(Rel));
+  } else {
+    RelocationShdr.sh_size = sizeof(RelocationOffset);
+    RelocationShdr.sh_entsize = 0;
+    ElfBytes.resize(RelocationOffsetInFile + sizeof(RelocationOffset));
+    std::memcpy(ElfBytes.data() + RelocationOffsetInFile, &RelocationOffset,
+                sizeof(RelocationOffset));
+  }
+
+  Ehdr.e_shoff = alignTo8(ElfBytes.size());
+  ++Ehdr.e_shnum;
+  ElfBytes.resize(Ehdr.e_shoff +
+                  static_cast<uint64_t>(Ehdr.e_shnum) * sizeof(Elf64_Shdr));
+  std::memcpy(ElfBytes.data() + Ehdr.e_shoff, ExistingShdrs.data(),
+              ExistingShdrs.size() * sizeof(Elf64_Shdr));
+  std::memcpy(ElfBytes.data() + Ehdr.e_shoff +
+                  ExistingShdrs.size() * sizeof(Elf64_Shdr),
+              &RelocationShdr, sizeof(RelocationShdr));
+  std::memcpy(ElfBytes.data(), &Ehdr, sizeof(Ehdr));
+}
+
 struct EhFrameFdeSpec {
   uint64_t InitialAddress;
   uint32_t AddressRange;
@@ -3197,6 +3256,151 @@ TEST(TextDisplacement, RejectsEhFrameFdePartiallyOverlappingText) {
   std::string Reason = llvm::toString(OutOrErr.takeError());
   EXPECT_NE(Reason.find("partially overlaps .text"), std::string::npos)
       << Reason;
+}
+
+TEST(TextDisplacement, RejectsDynamicRelocationWritesIntoEhFrame) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+
+  struct RelocationCase {
+    uint32_t SectionType;
+    uint64_t Offset;
+    uint32_t RelocationType;
+  };
+  const RelocationCase Cases[] = {
+      {llvm::ELF::SHT_RELA, DisplacementEhFrameAddr,
+       llvm::ELF::R_AMDGPU_RELATIVE64},
+      {llvm::ELF::SHT_REL, DisplacementEhFrameAddr, llvm::ELF::R_AMDGPU_ABS64},
+      {llvm::ELF::SHT_RELA, DisplacementEhFrameAddr - 4,
+       llvm::ELF::R_AMDGPU_RELATIVE64},
+  };
+
+  for (const RelocationCase &Case : Cases) {
+    SCOPED_TRACE(testing::Message() << "section type " << Case.SectionType
+                                    << ", offset " << Case.Offset);
+    std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+        Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+        /*AddBoundaryTextSymbol=*/false, EhFrame);
+    addDisplacementTestRelocationSection(
+        ElfBytes, Case.SectionType, llvm::ELF::SHF_ALLOC,
+        /*SectionInfo=*/0, Case.Offset, Case.RelocationType);
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(ElfBytes.data(), ElfBytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+    DisplacementEdit Edit;
+    Edit.Offset = 0;
+    Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+    llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+        tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+    ASSERT_FALSE((bool)OutOrErr);
+    std::string Reason = llvm::toString(OutOrErr.takeError());
+    EXPECT_NE(Reason.find("writes into .eh_frame"), std::string::npos)
+        << Reason;
+  }
+}
+
+TEST(TextDisplacement, AllowsNonWritingRelocationAtEhFrameAddress) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  addDisplacementTestRelocationSection(
+      ElfBytes, llvm::ELF::SHT_RELA, llvm::ELF::SHF_ALLOC,
+      /*SectionInfo=*/0, DisplacementEhFrameAddr, llvm::ELF::R_AMDGPU_NONE);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  EXPECT_TRUE((bool)OutOrErr) << llvm::toString(OutOrErr.takeError());
+}
+
+TEST(TextDisplacement, RejectsSectionSpecificEhFrameRelocations) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+      Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+      /*AddBoundaryTextSymbol=*/false, EhFrame);
+  addDisplacementTestRelocationSection(
+      ElfBytes, llvm::ELF::SHT_RELA, /*SectionFlags=*/0,
+      /*SectionInfo=*/5, /*RelocationOffset=*/0, llvm::ELF::R_AMDGPU_ABS64);
+  llvm::Expected<ElfView> ViewOrErr =
+      ElfView::create(ElfBytes.data(), ElfBytes.size());
+  ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+  DisplacementEdit Edit;
+  Edit.Offset = 0;
+  Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+  llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+      tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+  ASSERT_FALSE((bool)OutOrErr);
+  std::string Reason = llvm::toString(OutOrErr.takeError());
+  EXPECT_NE(Reason.find(".eh_frame relocation records are unsupported"),
+            std::string::npos)
+      << Reason;
+}
+
+TEST(TextDisplacement, RejectsAllocatedPackedRelocationsWithEhFrame) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  llvm::SmallVector<uint8_t> Text;
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  Text.append(S.SNopBytes.begin(), S.SNopBytes.end());
+  EhFrameFdeSpec Spec = {DisplacementTextAddr, 8, {}};
+  std::vector<uint8_t> EhFrame = makeEhFrame({Spec});
+  const uint32_t PackedSectionTypes[] = {
+      llvm::ELF::SHT_RELR,         llvm::ELF::SHT_ANDROID_REL,
+      llvm::ELF::SHT_ANDROID_RELA, llvm::ELF::SHT_ANDROID_RELR,
+      llvm::ELF::SHT_CREL,
+  };
+
+  for (uint32_t SectionType : PackedSectionTypes) {
+    SCOPED_TRACE(SectionType);
+    std::vector<uint8_t> ElfBytes = makeDisplacementTestElf(
+        Text, /*AddTextRelocation=*/false, /*AddDebugSection=*/false,
+        /*AddBoundaryTextSymbol=*/false, EhFrame);
+    addDisplacementTestRelocationSection(
+        ElfBytes, SectionType, llvm::ELF::SHF_ALLOC,
+        /*SectionInfo=*/0, DisplacementEhFrameAddr, llvm::ELF::R_AMDGPU_NONE);
+    llvm::Expected<ElfView> ViewOrErr =
+        ElfView::create(ElfBytes.data(), ElfBytes.size());
+    ASSERT_TRUE((bool)ViewOrErr) << llvm::toString(ViewOrErr.takeError());
+
+    DisplacementEdit Edit;
+    Edit.Offset = 0;
+    Edit.ReplacementBytes.assign(S.SNopBytes.begin(), S.SNopBytes.end());
+    llvm::Expected<std::unique_ptr<llvm::WritableMemoryBuffer>> OutOrErr =
+        tryApplyTextDisplacementToNewBuffer(*ViewOrErr, S, {Edit});
+    ASSERT_FALSE((bool)OutOrErr);
+    std::string Reason = llvm::toString(OutOrErr.takeError());
+    EXPECT_NE(Reason.find("packed relocation records"), std::string::npos)
+        << Reason;
+  }
 }
 
 TEST(TextDisplacement, RejectsCompressedEhFrame) {


### PR DESCRIPTION
## Summary

- admit a single allocated, uncompressed `.eh_frame` section to HotSwap text displacement and remap its DWARF32 FDEs in place
- validate CIE/FDE linkage, exact `DW_EH_PE_pcrel|DW_EH_PE_sdata4` encoding, record bounds, augmentation data, relocation absence, expressions, and section ownership
- remap FDE starts/ranges plus compact and fixed-width CFI advances and `DW_CFA_set_loc` without changing record sizes
- fail closed on unsupported pointer encodings, LSDA/personality pointers, address expressions, shared CIE location changes, encoding overflow, partial overlap, and malformed data
- add unit and end-to-end LIT coverage for successful remapping and rejection boundaries

## Scope

This is an independently landable COMGR HotSwap-only split from #3552. It changes only `amd/comgr`; the original #3552 remains unchanged as a reference.

## Review fixes

Post-write review added or corrected:

- complete record-envelope and truncated-field validation before parsing or patching
- CIE linkage and outside-`.text` FDE safety when sections move
- in-place remapping of CFI row locations instead of leaving stale unwind transitions as #3552 did
- compact/fixed-width overflow rejection, sequential CFI state tracking, and `DW_CFA_set_loc` remapping
- the remapped-FDE diagnostic count after byte-granular CFI patches were introduced

## Validation

- MI300X Release: 137/137 `HotswapMCTests`
- MI300X `-DADDRESS_SANITIZER=On`: 137/137 `HotswapMCTests`
- MI300X focused HotSwap LIT: 1/1
- combined split stack at `163a55abbe8a`: 178/178 units and 2/2 displacement LIT tests
- MI300X offline corpus: 2,619 passed, 66 failed, 0 timeouts, 2,155 changed, 464 no-ops
- success and failure path sets exactly match #3552 (zero differences)
- `git diff --check`: clean