### PR TITLE
Reland "[Clang] Enable -Wunused-template under -Wall" (#208001)

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1370,7 +1370,7 @@ def Conversion
 def Unused : DiagGroup<"unused",
                        [UnusedArgument, UnusedFunction, UnusedLabel,
                         // UnusedParameter, (matches GCC's behavior)
-                        // UnusedTemplate, (clean-up libc++ before enabling)
+                        UnusedTemplate,
                         // UnusedMemberFunction, (clean-up llvm before enabling)
                         UnusedPrivateField, UnusedLambdaCapture,
                         UnusedLocalTypedef, UnusedValue, UnusedVariable,

--- a/clang/test/Misc/warning-wall.c
+++ b/clang/test/Misc/warning-wall.c
@@ -73,6 +73,8 @@ CHECK-NEXT:      -Wunused-argument
 CHECK-NEXT:      -Wunused-function
 CHECK-NEXT:        -Wunneeded-internal-declaration
 CHECK-NEXT:      -Wunused-label
+CHECK-NEXT:      -Wunused-template
+CHECK-NEXT:        -Wunneeded-internal-declaration
 CHECK-NEXT:      -Wunused-private-field
 CHECK-NEXT:      -Wunused-lambda-capture
 CHECK-NEXT:      -Wunused-local-typedef

--- a/clang/test/SemaCXX/warn-func-not-needed.cpp
+++ b/clang/test/SemaCXX/warn-func-not-needed.cpp
@@ -10,7 +10,7 @@ void foo() {
 }
 
 namespace test1_template {
-template <typename T> static void f() {}
+template <typename T> static void f() {} // expected-warning {{unused function template}}
 template <> void f<int>() {} // expected-warning {{function 'f<int>' is not needed and will not be emitted}}
 template <typename T>
 void foo() {

--- a/clang/test/SemaCXX/warn-variable-not-needed.cpp
+++ b/clang/test/SemaCXX/warn-variable-not-needed.cpp
@@ -4,7 +4,7 @@ namespace test1 {
   static int abc = 42; // expected-warning {{variable 'abc' is not needed and will not be emitted}}
 
   namespace {
-  template <typename T> int abc_template = 0;
+  template <typename T> int abc_template = 0; // expected-warning {{unused variable template}}
   template <> int abc_template<int> = 0; // expected-warning {{variable 'abc_template<int>' is not needed and will not be emitted}}
   }                                      // namespace
   template <typename T>


### PR DESCRIPTION
Reland of #206123, which was reverted in #207848.

What has changed since:

- flang-rt occurrences are fixed in #207979 
- openmp had one more occurrence which is fixed in #207983 
- The remaining -Wunused-template hits anywhere in CI logs are the tsan Go runtime warnings, which are warnings only (buildgo.sh does not use -Werror on Linux)

Marked as draft until #207979  and #207983  land.

Closes #202945


