### PR TITLE
[comgr][hotswap] Bound finite external PC call targets

### DIFF
--- a/amd/comgr/src/comgr-hotswap-b0a0.cpp
+++ b/amd/comgr/src/comgr-hotswap-b0a0.cpp
@@ -1138,6 +1138,16 @@ struct KnownCallSite {
   MCRegister ReturnRegister;
 };
 
+struct ExternalCallContinuation {
+  size_t InstIndex = 0;
+  uint64_t Continuation = 0;
+};
+
+struct KnownCallSites {
+  SmallVector<KnownCallSite, 4> Local;
+  SmallVector<ExternalCallContinuation, 4> External;
+};
+
 struct BoundedSetPcReturn {
   size_t InstIndex = 0;
   SmallVector<uint64_t, 2> Targets;
@@ -1207,11 +1217,12 @@ getDirectTextTarget(const InternalDecodedInst &DI, const LLVMState &LS,
   return AbsoluteTarget - TextAddr;
 }
 
-static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
+static std::optional<KnownCallSites> collectKnownCallSites(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t TextAddr, uint64_t TextEnd,
     ArrayRef<std::optional<PcMaterializedCallInfo>> MaterializedCalls) {
-  SmallVector<KnownCallSite, 4> Calls;
+  KnownCallSites Calls;
+  uint64_t TextSize = TextEnd - TextAddr;
   for (size_t I = 0; I != Decoded.size(); ++I) {
     const InternalDecodedInst &DI = Decoded[I];
     std::optional<MCRegister> ReturnRegister = getCallReturnRegister(DI, LS);
@@ -1219,21 +1230,55 @@ static std::optional<SmallVector<KnownCallSite, 4>> collectKnownCallSites(
       continue;
 
     std::optional<uint64_t> Target;
+    bool HasFiniteExternalTarget = false;
     if (MaterializedCalls[I]) {
       uint64_t AbsoluteTarget = MaterializedCalls[I]->Target;
       if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
         Target = AbsoluteTarget - TextAddr;
+      else
+        HasFiniteExternalTarget = true;
+    } else if (DI.Inst.getOpcode() == LS.SSwapPcI64Opcode &&
+               DI.Inst.getNumOperands() != 0 &&
+               DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isImm()) {
+      uint64_t AbsoluteTarget = static_cast<uint64_t>(
+          DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).getImm());
+      if (AbsoluteTarget >= TextAddr && AbsoluteTarget < TextEnd)
+        Target = AbsoluteTarget - TextAddr;
+      else
+        HasFiniteExternalTarget = true;
+    } else if (hasPcRelativeOperand(DI, LS)) {
+      std::optional<uint64_t> RelativeTarget =
+          evaluateDirectControlFlowTarget(DI, LS);
+      if (RelativeTarget) {
+        if (*RelativeTarget < TextSize)
+          Target = *RelativeTarget;
+        else
+          HasFiniteExternalTarget = true;
+      }
     } else {
       Target = getDirectTextTarget(DI, LS, TextAddr, TextEnd);
     }
-    if (!Target)
+    if (!Target && !HasFiniteExternalTarget)
       continue;
 
     std::optional<uint64_t> Continuation =
         checkedAddUint64(DI.Offset, DI.Size, "known call continuation address");
     if (!Continuation)
       return std::nullopt;
-    Calls.push_back({I, *Target, *Continuation, *ReturnRegister});
+    // A returning call must have a local, aligned continuation. In
+    // particular, the byte just past the final .text instruction is not a
+    // target inside .text and must never enter DirectControlFlowInfo::Targets.
+    // Reject the complete proof instead of silently treating a malformed or
+    // non-returning call as an ordinary finite call.
+    if (*Continuation >= TextSize || (*Continuation & (MinInstSize - 1)) != 0) {
+      log() << "hotswap: call at 0x" << utohexstr(DI.Offset)
+            << " has no aligned continuation inside .text\n";
+      return std::nullopt;
+    }
+    if (Target)
+      Calls.Local.push_back({I, *Target, *Continuation, *ReturnRegister});
+    if (HasFiniteExternalTarget)
+      Calls.External.push_back({I, *Continuation});
   }
   return Calls;
 }
@@ -1261,6 +1306,7 @@ static bool hasUnprovenFallthroughEntry(
     ArrayRef<InternalDecodedInst> Decoded, const LLVMState &LS,
     uint64_t FunctionBegin, uint64_t ReturnOffset,
     ArrayRef<uint64_t> DeclaredEntries, ArrayRef<KnownCallSite> Calls,
+    ArrayRef<ExternalCallContinuation> ExternalCalls,
     ArrayRef<KnownCallEntry> CallEntries,
     ArrayRef<DirectTextEntry> DirectEntries) {
   if (FunctionBegin == 0)
@@ -1327,6 +1373,17 @@ static bool hasUnprovenFallthroughEntry(
     return true;
   }
 
+  for (const ExternalCallContinuation &Call : ExternalCalls) {
+    uint64_t Source = Decoded[Call.InstIndex].Offset;
+    if (Call.Continuation >= ChainBegin && Call.Continuation < FunctionBegin) {
+      log() << "hotswap: s_set_pc_i64 at 0x" << utohexstr(ReturnOffset)
+            << " is not a bounded return: external call at 0x"
+            << utohexstr(Source) << " returns into the fallthrough chain at 0x"
+            << utohexstr(Call.Continuation) << "\n";
+      return true;
+    }
+  }
+
   ArrayRef<DirectTextEntry>::iterator DirectEntry =
       std::lower_bound(DirectEntries.begin(), DirectEntries.end(), ChainBegin,
                        [](const DirectTextEntry &Indexed, uint64_t Offset) {
@@ -1353,6 +1410,7 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
                            uint64_t TextEnd, ArrayRef<uint64_t> DeclaredEntries,
                            ArrayRef<ElfView::FunctionTextRange> FunctionRanges,
                            ArrayRef<KnownCallSite> Calls,
+                           ArrayRef<ExternalCallContinuation> ExternalCalls,
                            ArrayRef<uint64_t> ExternalEntries) {
   SmallVector<size_t, 2> ReturnIndices;
   for (size_t ReturnIndex = 0; ReturnIndex != Decoded.size(); ++ReturnIndex)
@@ -1446,9 +1504,9 @@ collectBoundedSetPcReturns(ArrayRef<InternalDecodedInst> Decoded,
         continue;
       }
 
-      if (hasUnprovenFallthroughEntry(Decoded, LS, FunctionBegin, Return.Offset,
-                                      SortedDeclaredEntries, Calls, CallEntries,
-                                      DirectEntries))
+      if (hasUnprovenFallthroughEntry(
+              Decoded, LS, FunctionBegin, Return.Offset, SortedDeclaredEntries,
+              Calls, ExternalCalls, CallEntries, DirectEntries))
         continue;
 
       // The link pair must retain the value written by the incoming call
@@ -1638,18 +1696,26 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
   for (size_t I = 0; I != Decoded.size(); ++I)
     MaterializedCalls[I] = matchPcMaterializedCall(Decoded, I, LS, TextAddr);
 
-  std::optional<SmallVector<KnownCallSite, 4>> Calls =
+  std::optional<KnownCallSites> Calls =
       collectKnownCallSites(Decoded, LS, TextAddr, *TextEnd, MaterializedCalls);
   if (!Calls)
     return std::nullopt;
   std::optional<SmallVector<BoundedSetPcReturn, 2>> BoundedReturns =
       collectBoundedSetPcReturns(Decoded, LS, TextAddr, *TextEnd,
-                                 DeclaredEntries, FunctionRanges, *Calls,
-                                 ExternalEntries);
+                                 DeclaredEntries, FunctionRanges, Calls->Local,
+                                 Calls->External, ExternalEntries);
   if (!BoundedReturns)
     return std::nullopt;
 
   DirectControlFlowInfo Info;
+  for (const BoundedSetPcReturn &Return : *BoundedReturns) {
+    for (uint64_t Target : Return.Targets)
+      Info.Targets.insert(Target);
+    Info.BoundedIndirectTransfers.insert(Decoded[Return.InstIndex].Offset);
+  }
+  for (const ExternalCallContinuation &Call : Calls->External)
+    Info.Targets.insert(Call.Continuation);
+
   for (size_t InstIndex = 0; InstIndex != Decoded.size(); ++InstIndex) {
     const InternalDecodedInst &DI = Decoded[InstIndex];
     if ((!LS.MIA->isBranch(DI.Inst) && !LS.MIA->isCall(DI.Inst)) ||
@@ -1695,10 +1761,17 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
       if (*Target >= TextAddr && *Target < *TextEnd) {
         uint64_t RelativeTarget = *Target - TextAddr;
         Info.Targets.insert(RelativeTarget);
-        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg())
+        if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg()) {
+          Info.BoundedIndirectTransfers.insert(DI.Offset);
           log() << "hotswap: resolved PC-materialized call at 0x"
                 << utohexstr(DI.Offset) << " to .text+0x"
                 << utohexstr(RelativeTarget) << "\n";
+        }
+      } else if (DI.Inst.getOperand(DI.Inst.getNumOperands() - 1).isReg()) {
+        Info.BoundedIndirectTransfers.insert(DI.Offset);
+        log() << "hotswap: resolved PC-materialized call at 0x"
+              << utohexstr(DI.Offset) << " to finite external target 0x"
+              << utohexstr(*Target) << "\n";
       }
       continue;
     }
@@ -1711,7 +1784,15 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
             << "; adjacent far trampolines will not be coalesced\n";
       return std::nullopt;
     }
-    Info.Targets.insert(*Target);
+    if (*Target < TextSize) {
+      Info.Targets.insert(*Target);
+    } else if (LS.MIA->isCall(DI.Inst)) {
+      std::optional<uint64_t> Continuation = checkedAddUint64(
+          DI.Offset, DI.Size, "finite external direct call continuation");
+      if (!Continuation)
+        return std::nullopt;
+      Info.Targets.insert(*Continuation);
+    }
   }
   return Info;
 }
@@ -1857,12 +1938,15 @@ collectRelocationProtectedOffsets(ArrayRef<InternalDecodedInst> Decoded,
 /// indirect destination, so leave the complete function in place.
 static DenseSet<uint64_t>
 collectIndirectControlFlowFunctions(ArrayRef<InternalDecodedInst> Decoded,
-                                    const LLVMState &LS, const ElfView &Elf) {
+                                    const LLVMState &LS, const ElfView &Elf,
+                                    const DenseSet<uint64_t> &Bounded) {
   DenseSet<uint64_t> Functions;
   if (!LS.MIA)
     return Functions;
 
   for (const InternalDecodedInst &DI : Decoded) {
+    if (Bounded.contains(DI.Offset))
+      continue;
     if (LS.MIA->isBarrier(DI.Inst) || isEndProgram(DI, LS))
       continue;
     if (!LS.MIA->isIndirectBranch(DI.Inst) &&
@@ -1892,7 +1976,9 @@ expandStraightLineTrampolines(PatchContext &Ctx,
   DenseSet<uint64_t> Protected = collectRelocationProtectedOffsets(
       Ctx.Decoded, Ctx.LS, !Ctx.Config.RunB0A0Patches);
   DenseSet<uint64_t> IndirectControlFlowFunctions =
-      collectIndirectControlFlowFunctions(Ctx.Decoded, Ctx.LS, Ctx.Elf);
+      collectIndirectControlFlowFunctions(
+          Ctx.Decoded, Ctx.LS, Ctx.Elf,
+          Ctx.DirectControlFlow.BoundedIndirectTransfers);
 
   for (size_t I = 0; I != Ctx.OutTrampolines.size(); ++I) {
     if (Ctx.OutTrampolines[I].HasFunctionRange &&

--- a/amd/comgr/src/comgr-hotswap-internal.h
+++ b/amd/comgr/src/comgr-hotswap-internal.h
@@ -1211,6 +1211,10 @@ struct SafeSgprUsageSummary {
 
 struct DirectControlFlowInfo {
   llvm::DenseSet<uint64_t> Targets;
+  // Register-based transfers whose complete finite target set was proven.
+  // These do not make every instruction in their containing function a
+  // potential indirect destination.
+  llvm::DenseSet<uint64_t> BoundedIndirectTransfers;
   bool HasUnresolvedTargets = false;
 };
 
@@ -1409,7 +1413,9 @@ resolveMaterializedPcTarget(llvm::ArrayRef<InternalDecodedInst> Decoded,
 /// bypass that definition. Canonical local-function returns are bounded to
 /// the continuations of calls that preserve the same link register, provided
 /// no interior call, overlapping external alias, or reachable fallthrough can
-/// enter the function without that link definition. \p DeclaredEntries
+/// enter the function without that link definition. A call with one proven
+/// finite target outside .text protects its local continuation without adding
+/// the external address to the local target set. \p DeclaredEntries
 /// contains text-relative function and kernel entry offsets; \p FunctionRanges
 /// supplies the symbol ranges used for the return proof; \p ExternalEntries
 /// identifies externally reachable symbol and kernel entries, including

--- a/amd/comgr/test-lit/hotswap-finite-external-call.s
+++ b/amd/comgr/test-lit/hotswap-finite-external-call.s
@@ -1,0 +1,70 @@
+// COM: A canonical PC-materialized call with one target outside .text has no
+// COM: local destination, but its continuation is a local entry. Proving both
+// COM: facts permits a far required rewrite to use the code-end gateway while
+// COM: preserving the external call's return point.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=LOG %s
+// LOG: hotswap: resolved PC-materialized call
+// LOG-SAME: to finite external target
+// LOG-NOT: hotswap: unresolved call target
+// LOG: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf \
+// RUN:   | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <finite_external_call>:
+// DISASM: s_swap_pc_i64
+// DISASM-NEXT: s_branch
+// DISASM: ds_load_b32 v0, v2 offset:256
+// DISASM-NEXT: ds_load_b32 v1, v2 offset:768
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+.globl finite_external_call
+.p2align 8
+.type finite_external_call,@function
+finite_external_call:
+.Lgetpc:
+  s_get_pc_i64 s[2:3]
+  s_add_nc_u64 s[2:3], s[2:3], 0x100000000
+  s_swap_pc_i64 s[6:7], s[2:3]
+  ds_load_2addr_stride64_b32 v[0:1], v2 offset0:1 offset1:3
+  s_wait_dscnt 0x0
+  s_endpgm
+.size finite_external_call, .-finite_external_call
+
+.fill 20, 1, 0
+.rept 40000
+  s_mov_b32 s10, s11
+.endr
+
+.rodata
+.p2align 8
+.amdhsa_kernel finite_external_call
+  .amdhsa_next_free_vgpr 3
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: finite_external_call
+      .symbol: finite_external_call.kd
+      .sgpr_count: 12
+      .vgpr_count: 3
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-unit/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/HotswapMCTest.cpp
@@ -993,6 +993,79 @@ TEST(CollectDirectBranchTargets, ResolvesProductionPcMaterializedCall) {
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, BoundsFiniteExternalPcMaterializedCall) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+
+  // The exact target is outside this deliberately short .text range. The
+  // external callee may return through the link pair, so the local
+  // continuation remains a protected entry even though the external target
+  // contributes no local offset.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/0x20,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(
+      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
+  EXPECT_TRUE(Info->BoundedIndirectTransfers.contains(Decoded.back().Offset));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalCallContinuationIntoReturnFunction) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_endpgm\n"
+                           "s_get_pc_i64 s[2:3]\n"
+                           "s_add_nc_u64 s[2:3], s[2:3], 0x1000\n"
+                           "s_swap_pc_i64 s[30:31], s[2:3]\n"
+                           "s_nop 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]\n"
+                           "s_endpgm\n"
+                           "s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], -16\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]\n"
+                           "s_endpgm",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 12u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{Decoded[5].Offset,
+                                                 Decoded[8].Offset};
+  llvm::SmallVector<ElfView::FunctionTextRange, 3> FunctionRanges{
+      {Decoded[1].Offset, Decoded[5].Offset},
+      {Decoded[5].Offset, Decoded[7].Offset},
+      {Decoded[8].Offset, Decoded[11].Offset}};
+
+  // The first call has one finite target outside this .text, and returns to
+  // the padding that falls through into the local helper. The later local
+  // call alone would appear to justify the helper's s_set_pc_i64, but the
+  // external continuation is a second link-register provenance and must keep
+  // that return unbounded.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, /*TextSize=*/Bytes.size(), DeclaredEntries,
+      FunctionRanges);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[3].Offset + Decoded[3].Size));
+  EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
 TEST(CollectDirectBranchTargets, RejectsClobberedPcMaterializedCall) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -1147,9 +1220,11 @@ TEST(CollectDirectBranchTargets, BoundsCanonicalSetPcReturn) {
       Decoded, S, /*TextAddr=*/0, /*TextSize=*/0x1000, DeclaredEntries,
       FunctionRanges);
   ASSERT_TRUE(Info);
-  ASSERT_EQ(Info->Targets.size(), 2u);
+  ASSERT_EQ(Info->Targets.size(), 3u);
   EXPECT_TRUE(Info->Targets.contains(0));
   EXPECT_TRUE(Info->Targets.contains(Decoded[1].Offset));
+  EXPECT_TRUE(
+      Info->Targets.contains(Decoded.back().Offset + Decoded.back().Size));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 
@@ -1431,7 +1506,9 @@ TEST(CollectDirectBranchTargets, HandlesImmediateAbsoluteTargetCall) {
       collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
                                  /*TextSize=*/0x40, /*DeclaredEntries=*/{});
   ASSERT_TRUE(OutsideInfo);
-  EXPECT_TRUE(OutsideInfo->Targets.empty());
+  ASSERT_EQ(OutsideInfo->Targets.size(), 1u);
+  EXPECT_TRUE(
+      OutsideInfo->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
   EXPECT_FALSE(OutsideInfo->HasUnresolvedTargets);
 
   std::optional<DirectControlFlowInfo> OverflowInfo =
@@ -1462,6 +1539,105 @@ TEST(CollectDirectBranchTargets, CollectsPcRelativeCall) {
   EXPECT_TRUE(
       Info->Targets.contains(0x200u + Decoded[0].Size + 2 * MinInstSize));
   EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, ProtectsExternalPcRelativeCallContinuation) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  // The encoded target is beyond this deliberately short .text, while the
+  // instruction after the call remains inside .text. The target must not
+  // become a local protection offset, while the return continuation remains
+  // protected.
+  std::optional<DirectControlFlowInfo> Info =
+      collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                 /*TextSize=*/2 * Decoded[0].Size,
+                                 /*DeclaredEntries=*/{});
+  ASSERT_TRUE(Info);
+  ASSERT_EQ(Info->Targets.size(), 1u);
+  EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalPcMaterializedCallContinuationAtTextEnd) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_get_pc_i64 s[0:1]\n"
+                           "s_add_nc_u64 s[0:1], s[0:1], 0x100\n"
+                           "s_swap_pc_i64 s[30:31], s[0:1]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 3u);
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                          /*TextSize=*/Bytes.size(),
+                                          /*DeclaredEntries=*/{}));
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalAbsoluteCallContinuationAtTextEnd) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
+                                          /*TextSize=*/Bytes.size(),
+                                          /*DeclaredEntries=*/{}));
+}
+
+TEST(CollectDirectBranchTargets,
+     RejectsExternalPcRelativeCallContinuationAtTextEnd) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_call_i64 s[30:31], 2", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0,
+                                          /*TextSize=*/Bytes.size(),
+                                          /*DeclaredEntries=*/{}));
+}
+
+TEST(CollectDirectBranchTargets, RejectsInvalidCallContinuationArithmetic) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleSingleInst("s_swap_pc_i64 s[30:31], 0x210", S);
+  ASSERT_FALSE(Bytes.empty());
+
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+
+  Decoded[0].Offset = 1;
+  EXPECT_FALSE(collectDirectBranchTargets(Decoded, S, /*TextAddr=*/0x220,
+                                          /*TextSize=*/0x40,
+                                          /*DeclaredEntries=*/{}));
+
+  Decoded[0].Offset = std::numeric_limits<uint64_t>::max() - 1;
+  EXPECT_FALSE(collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0,
+      /*TextSize=*/std::numeric_limits<uint64_t>::max(),
+      /*DeclaredEntries=*/{}));
 }
 
 TEST(SafeSgprScratchBlock, RejectsRegisterBeyondAddressableLimit) {


### PR DESCRIPTION
## Scope

Bound calls whose complete target is proven but lies outside this object's
`.text`. The external address is not added to the local target set; the local
return continuation is protected. Proven register transfers are recorded
separately so unrelated instructions in the containing function remain
eligible for safe source relocation.

The bounded-return proof also treats an external call continuation entering a
helper's fallthrough chain as a second link-register provenance and rejects
that return conservatively. Immediate absolute, PC-relative, and canonical
get-PC/add register-call forms are covered. A returning finite call fails
closed unless its continuation is aligned and strictly inside `.text`; this
prevents `TextSize` or malformed/overflowed offsets from entering the local
target set.

## Review range

- Base: `amd-staging` at `50d16abb44335104f1f3b8ad8123d0b6aaa7f7d5`
- Head: `f82d55cf79e6de8215445957e7169f06b7a79af8`
- This is a clean four-file feature diff with no cumulative prerequisite
  snapshot.
- ROCm/llvm-project#3598 remains unchanged as the integration reference.

## Validation

- `HotswapMCTests --gtest_filter=CollectDirectBranchTargets.*`: 26/26 passed.
- Full `HotswapMCTests`: 130/130 passed.
- Full supported COMGR LIT: 149/149 passed; 14 unsupported.
- Exact-head ASAN/LeakSanitizer: focused 26/26 and full 130/130 passed with
  `detect_leaks=1:halt_on_error=1:abort_on_error=1`; no sanitizer findings.
- Boundary unit coverage includes `continuation == TextSize` for
  materialized-register, immediate-absolute, and PC-relative external calls,
  plus misalignment and continuation overflow.
- End-to-end LIT proves successful far rewrite, transformed disassembly,
  absence of unresolved-target fallback, and byte-level idempotency.
- `clang-format`, no-added-`auto`, and `git diff --check`: clean.

### Full corpus comparison

- Corpus: 2,685 inputs; 2,558 success and 127 failure.
- Transition matrix versus `amd-staging`: 2,558 `SUCCESS -> SUCCESS`, 127
  `FAILURE -> FAILURE`, zero regressions and zero improvements.
- Evidence on `mi300x`:
  `/home/harsh/hotswap-corpus-20260725-pr3606-f82d55cf-full2685`
- Built `libamd_comgr.so` SHA-256:
  `fe81571b39fd14c052fa5519be8eb7004adedd1c830389339992496d588799e1`
- Manifest SHA-256:
  `076ea013ba466139e76074fcbb31905a5041298e7644f6e8f590bf9353e4f5b9`
- Results SHA-256:
  `67ff61bdcd3553047280f7381dea0ac6d8782eef9ca545724685a7c543122c18`
- Failures SHA-256:
  `f51826f8183ae5b1c5de6b47ad9a88c4f0a25cca0b73c7cc9433a0d2b91aa300`
- Transitions SHA-256:
  `ef79a3b151b11a5f44d5ba811ed03b3b2da60c33ac792bc7e4c26c5658155841`

### `mi400-3` smoke

- Dedicated container: `hotswap-pr-review-root` on
  `ctheliosr-rck-g02-j19-13`; four gfx1250 GPUs visible.
- The installed `/opt/therock/lib/libamd_comgr.so.3.3.0` resolved to the
  exact candidate with SHA-256
  `fe81571b39fd14c052fa5519be8eb7004adedd1c830389339992496d588799e1`.
- Environment:
  `ROCR_VISIBLE_DEVICES=0`, `HSA_HOTSWAP_VERBOSE=1`,
  `AMD_COMGR_HOTSWAP_ENTRY_TRAMPOLINES=0`.
- rocThrust CTest #64 (`merge_key_value.hip`): 1/1 passed; embedded gtests:
  16/16 passed; 7.01 seconds.
- Log:
  `/home/harmenon/logs/hotswap-pr-review-20260725/rocthrust_test64_pr3606_f82d55cf.log`
- Log SHA-256:
  `a3bd0d429be826d4e961298e0474497b5cff2b01eeeab9cfe3a2c33cfdb3605e`

### CI classification

The formatter, primary Linux and Windows builds, Linux and Windows COMGR tests,
SPIR-V translator tests, LLVM SPIR-V codegen tests, compiler/runtime stages,
and documentation build are green. `Linux::release / Test rocm-examples`
failed outside this COMGR change: HIP-Basic built and its 23 tests passed,
then the SPIR-V `Applications/monte_carlo_pi` build could not find
`hipcub/iterator/counting_input_iterator.hpp`. The larger multi-architecture
matrix is still running.

## Remaining draft gate

Publish the instrumented source-coverage report, finish the required CI
classification, and demonstrate this correctness prerequisite's value through
a separately reviewed dependent corpus-reducing slice. Keep this PR draft
until those gates are recorded.
