### PR TITLE
[comgr][hotswap] Bound symbol-less return inference memory

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -3250,14 +3250,6 @@ static BitVector computeFiniteControlFlowReachability(
   return Reachable;
 }
 
-struct SymbolLessReturnRegion {
-  uint64_t Entry = 0;
-  MCRegister LinkRegister;
-  SmallVector<size_t, 16> Instructions;
-  SmallVector<size_t, 2> Returns;
-  SmallVector<uint64_t, 8> Continuations;
-};
-
 static bool instructionMayFallThrough(const InternalDecodedInst &DI,
                                       const LLVMState &LS) {
   if (!DI.DecodeSucceeded)
@@ -3301,11 +3293,27 @@ static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
     Groups[Inserted.first->second].Continuations.push_back(Call.Continuation);
   }
 
+  DenseSet<uint64_t> RejectedRegionEntries;
+  RejectedRegionEntries.insert(DeclaredEntries.begin(), DeclaredEntries.end());
+  RejectedRegionEntries.insert(ExternalEntries.begin(), ExternalEntries.end());
+  size_t RetainedGroups = 0;
+  for (size_t I = 0; I != Groups.size(); ++I) {
+    if (RejectedRegionEntries.contains(Groups[I].Entry))
+      continue;
+    if (RetainedGroups != I)
+      Groups[RetainedGroups] = std::move(Groups[I]);
+    ++RetainedGroups;
+  }
+  Groups.resize(RetainedGroups);
+  if (Groups.empty())
+    return {};
+
   DenseMap<uint64_t, size_t> OffsetToIndex;
   for (size_t I = 0; I != Decoded.size(); ++I)
     OffsetToIndex.try_emplace(Decoded[I].Offset, I);
 
   SmallVector<SymbolLessReturnRegion, 8> Regions;
+  std::vector<int64_t> RegionOwner;
   for (CallGroup &Group : Groups) {
     DenseMap<uint64_t, size_t>::const_iterator Entry =
         OffsetToIndex.find(Group.Entry);
@@ -3517,28 +3525,59 @@ static SmallVector<SymbolLessReturnRegion, 8> collectSymbolLessReturnRegions(
       if (!Safe)
         break;
     }
-    if (Safe)
-      Regions.push_back(std::move(Region));
+    if (!Safe)
+      continue;
+    if (RegionOwner.empty())
+      RegionOwner.assign(Decoded.size(), -1);
+    if (!claimSymbolLessReturnRegion(Regions, RegionOwner, std::move(Region)))
+      continue;
   }
 
-  // Two independently inferred call entries may not claim a shared body.
-  BitVector Claimed(Decoded.size());
-  BitVector Overlap(Regions.size());
-  for (size_t I = 0; I != Regions.size(); ++I)
-    for (size_t InstIndex : Regions[I].Instructions) {
-      if (Claimed.test(InstIndex)) {
-        Overlap.set(I);
-        for (size_t J = 0; J != I; ++J)
-          if (llvm::is_contained(Regions[J].Instructions, InstIndex))
-            Overlap.set(J);
-      }
-      Claimed.set(InstIndex);
-    }
   SmallVector<SymbolLessReturnRegion, 8> Disjoint;
-  for (size_t I = 0; I != Regions.size(); ++I)
-    if (!Overlap.test(I))
-      Disjoint.push_back(std::move(Regions[I]));
+  for (SymbolLessReturnRegion &Region : Regions)
+    if (!Region.Instructions.empty())
+      Disjoint.push_back(std::move(Region));
   return Disjoint;
+}
+
+bool claimSymbolLessReturnRegion(
+    SmallVectorImpl<SymbolLessReturnRegion> &Regions,
+    std::vector<int64_t> &RegionOwner, SymbolLessReturnRegion Region) {
+  assert(!Region.Instructions.empty());
+  assert(Regions.size() <=
+         static_cast<size_t>(std::numeric_limits<int64_t>::max()));
+
+  bool Overlaps = false;
+  SmallVector<size_t, 4> OverlappingOwners;
+  for (size_t InstIndex : Region.Instructions) {
+    assert(InstIndex < RegionOwner.size());
+    int64_t Owner = RegionOwner[InstIndex];
+    if (Owner == -1)
+      continue;
+    Overlaps = true;
+    if (Owner >= 0 &&
+        !llvm::is_contained(OverlappingOwners, static_cast<size_t>(Owner)))
+      OverlappingOwners.push_back(static_cast<size_t>(Owner));
+  }
+  if (Overlaps) {
+    for (size_t Owner : OverlappingOwners) {
+      assert(Owner < Regions.size());
+      for (size_t InstIndex : Regions[Owner].Instructions) {
+        assert(InstIndex < RegionOwner.size());
+        RegionOwner[InstIndex] = -2;
+      }
+      Regions[Owner] = SymbolLessReturnRegion{};
+    }
+    for (size_t InstIndex : Region.Instructions)
+      RegionOwner[InstIndex] = -2;
+    return false;
+  }
+
+  size_t Owner = Regions.size();
+  for (size_t InstIndex : Region.Instructions)
+    RegionOwner[InstIndex] = static_cast<int64_t>(Owner);
+  Regions.push_back(std::move(Region));
+  return true;
 }
 
 struct FiniteControlFlowAudit {

--- a/amd/comgr/src/hotswap/rewriter/b0a0.cpp
+++ b/amd/comgr/src/hotswap/rewriter/b0a0.cpp
@@ -3555,18 +3555,22 @@ bool claimSymbolLessReturnRegion(
     if (Owner == -1)
       continue;
     Overlaps = true;
-    if (Owner >= 0 &&
-        !llvm::is_contained(OverlappingOwners, static_cast<size_t>(Owner)))
+    if (Owner >= 0)
       OverlappingOwners.push_back(static_cast<size_t>(Owner));
   }
   if (Overlaps) {
+    llvm::sort(OverlappingOwners);
+    OverlappingOwners.erase(
+        std::unique(OverlappingOwners.begin(), OverlappingOwners.end()),
+        OverlappingOwners.end());
     for (size_t Owner : OverlappingOwners) {
       assert(Owner < Regions.size());
       for (size_t InstIndex : Regions[Owner].Instructions) {
         assert(InstIndex < RegionOwner.size());
         RegionOwner[InstIndex] = -2;
       }
-      Regions[Owner] = SymbolLessReturnRegion{};
+      SymbolLessReturnRegion Empty;
+      std::swap(Regions[Owner], Empty);
     }
     for (size_t InstIndex : Region.Instructions)
       RegionOwner[InstIndex] = -2;

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1310,6 +1310,14 @@ struct DirectControlFlowInfo {
   bool HasUnresolvedTargets = false;
 };
 
+struct SymbolLessReturnRegion {
+  uint64_t Entry = 0;
+  llvm::MCRegister LinkRegister;
+  llvm::SmallVector<size_t, 16> Instructions;
+  llvm::SmallVector<size_t, 2> Returns;
+  llvm::SmallVector<uint64_t, 8> Continuations;
+};
+
 // Per-instruction persistent gfx1250 VGPR-MSB mode (packed src0/src1/src2/dst,
 // two bits each, values 0-255) recovered by the WMMA split pass's
 // whole-function CFG fixed point. The sentinels distinguish "not analyzed",
@@ -1636,6 +1644,16 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
     llvm::ArrayRef<ElfView::FunctionTextRange> FunctionRanges = {},
     llvm::ArrayRef<uint64_t> ExternalEntries = {},
     llvm::ArrayRef<uint8_t> Text = {});
+
+/// Claim \p Region in the streaming symbol-less ownership map. An overlap
+/// invalidates every active owner in the component and leaves -2 tombstones
+/// for both the old and new instructions, so later transitive overlaps remain
+/// rejected after the invalid regions' instruction vectors are released.
+/// \p RegionOwner must be sized for the decoded instructions and initially
+/// contain -1 in every entry.
+[[nodiscard]] bool claimSymbolLessReturnRegion(
+    llvm::SmallVectorImpl<SymbolLessReturnRegion> &Regions,
+    std::vector<int64_t> &RegionOwner, SymbolLessReturnRegion Region);
 
 /// Return whether \p DI consumes the incoming value of \p Register, including
 /// explicit read/modify/write destinations represented by MC tied-operand

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1650,7 +1650,8 @@ std::optional<DirectControlFlowInfo> collectDirectBranchTargets(
 /// for both the old and new instructions, so later transitive overlaps remain
 /// rejected after the invalid regions' instruction vectors are released.
 /// \p RegionOwner must be sized for the decoded instructions and initially
-/// contain -1 in every entry.
+/// contain -1 in every entry. \p Region.Instructions must be nonempty, contain
+/// unique indices, and refer only to entries in \p RegionOwner.
 [[nodiscard]] bool claimSymbolLessReturnRegion(
     llvm::SmallVectorImpl<SymbolLessReturnRegion> &Regions,
     std::vector<int64_t> &RegionOwner, SymbolLessReturnRegion Region);

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -1108,20 +1108,45 @@ TEST(SymbolLessReturnRegionOwnership, RejectsTransitiveTombstoneOverlap) {
   llvm::SmallVector<SymbolLessReturnRegion, 4> Regions;
   std::vector<int64_t> RegionOwner(5, -1);
 
-  EXPECT_TRUE(claimSymbolLessReturnRegion(
-      Regions, RegionOwner, makeSymbolLessReturnRegion({0, 1})));
-  EXPECT_FALSE(claimSymbolLessReturnRegion(
-      Regions, RegionOwner, makeSymbolLessReturnRegion({1, 2})));
-  EXPECT_FALSE(claimSymbolLessReturnRegion(
-      Regions, RegionOwner, makeSymbolLessReturnRegion({2, 3})));
-  EXPECT_TRUE(claimSymbolLessReturnRegion(
-      Regions, RegionOwner, makeSymbolLessReturnRegion({4})));
+  EXPECT_TRUE(claimSymbolLessReturnRegion(Regions, RegionOwner,
+                                          makeSymbolLessReturnRegion({0, 1})));
+  EXPECT_FALSE(claimSymbolLessReturnRegion(Regions, RegionOwner,
+                                           makeSymbolLessReturnRegion({1, 2})));
+  EXPECT_FALSE(claimSymbolLessReturnRegion(Regions, RegionOwner,
+                                           makeSymbolLessReturnRegion({2, 3})));
+  EXPECT_TRUE(claimSymbolLessReturnRegion(Regions, RegionOwner,
+                                          makeSymbolLessReturnRegion({4})));
 
   ASSERT_EQ(Regions.size(), 2u);
   EXPECT_TRUE(Regions[0].Instructions.empty());
   ASSERT_EQ(Regions[1].Instructions.size(), 1u);
   EXPECT_EQ(Regions[1].Instructions.front(), 4u);
   EXPECT_EQ(RegionOwner, (std::vector<int64_t>{-2, -2, -2, -2, 1}));
+}
+
+TEST(SymbolLessReturnRegionOwnership, ReleasesInvalidatedBackingStorage) {
+  llvm::SmallVector<SymbolLessReturnRegion, 4> Regions;
+  std::vector<int64_t> RegionOwner(65, -1);
+
+  SymbolLessReturnRegion HeapBacked =
+      makeSequentialSymbolLessReturnRegion(/*Begin=*/0, /*Count=*/64);
+  HeapBacked.Returns.resize(8);
+  HeapBacked.Continuations.resize(16);
+  SymbolLessReturnRegion Empty;
+  ASSERT_GT(HeapBacked.Instructions.capacity(), Empty.Instructions.capacity());
+  ASSERT_GT(HeapBacked.Returns.capacity(), Empty.Returns.capacity());
+  ASSERT_GT(HeapBacked.Continuations.capacity(),
+            Empty.Continuations.capacity());
+  ASSERT_TRUE(
+      claimSymbolLessReturnRegion(Regions, RegionOwner, std::move(HeapBacked)));
+  ASSERT_FALSE(claimSymbolLessReturnRegion(
+      Regions, RegionOwner, makeSymbolLessReturnRegion({63, 64})));
+
+  ASSERT_EQ(Regions.size(), 1u);
+  EXPECT_LE(Regions[0].Instructions.capacity(), Empty.Instructions.capacity());
+  EXPECT_LE(Regions[0].Returns.capacity(), Empty.Returns.capacity());
+  EXPECT_LE(Regions[0].Continuations.capacity(),
+            Empty.Continuations.capacity());
 }
 
 TEST(SymbolLessReturnRegionOwnership,
@@ -1139,15 +1164,15 @@ TEST(SymbolLessReturnRegionOwnership,
         Regions, RegionOwner,
         makeSequentialSymbolLessReturnRegion(Base, RegionWidth)))
         << I;
-    ASSERT_FALSE(claimSymbolLessReturnRegion(
-        Regions, RegionOwner,
-        makeSequentialSymbolLessReturnRegion(Base + RegionWidth - 1,
-                                              RegionWidth)))
+    ASSERT_FALSE(
+        claimSymbolLessReturnRegion(Regions, RegionOwner,
+                                    makeSequentialSymbolLessReturnRegion(
+                                        Base + RegionWidth - 1, RegionWidth)))
         << I;
     ASSERT_FALSE(claimSymbolLessReturnRegion(
         Regions, RegionOwner,
         makeSequentialSymbolLessReturnRegion(Base + 2 * RegionWidth - 2,
-                                              RegionWidth)))
+                                             RegionWidth)))
         << I;
   }
 

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -23,7 +23,9 @@
 #include "llvm/Support/TargetSelect.h"
 #include "gtest/gtest.h"
 
+#include <algorithm>
 #include <cstring>
+#include <initializer_list>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -69,6 +71,22 @@ static TargetIdentifier makeGfx1250Ident() {
   TI.Environ = "";
   TI.Processor = "gfx1250";
   return TI;
+}
+
+static SymbolLessReturnRegion
+makeSymbolLessReturnRegion(std::initializer_list<size_t> Instructions) {
+  SymbolLessReturnRegion Region;
+  Region.Instructions.append(Instructions.begin(), Instructions.end());
+  return Region;
+}
+
+static SymbolLessReturnRegion
+makeSequentialSymbolLessReturnRegion(size_t Begin, size_t Count) {
+  SymbolLessReturnRegion Region;
+  Region.Instructions.reserve(Count);
+  for (size_t I = 0; I != Count; ++I)
+    Region.Instructions.push_back(Begin + I);
+  return Region;
 }
 
 static std::vector<InternalDecodedInst>
@@ -1084,6 +1102,62 @@ TEST(CollectDirectBranchTargets, MarksRegisterTargetCallUnresolved) {
   EXPECT_TRUE(Info->Targets.empty());
   EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
   EXPECT_TRUE(Info->HasUnresolvedTargets);
+}
+
+TEST(SymbolLessReturnRegionOwnership, RejectsTransitiveTombstoneOverlap) {
+  llvm::SmallVector<SymbolLessReturnRegion, 4> Regions;
+  std::vector<int64_t> RegionOwner(5, -1);
+
+  EXPECT_TRUE(claimSymbolLessReturnRegion(
+      Regions, RegionOwner, makeSymbolLessReturnRegion({0, 1})));
+  EXPECT_FALSE(claimSymbolLessReturnRegion(
+      Regions, RegionOwner, makeSymbolLessReturnRegion({1, 2})));
+  EXPECT_FALSE(claimSymbolLessReturnRegion(
+      Regions, RegionOwner, makeSymbolLessReturnRegion({2, 3})));
+  EXPECT_TRUE(claimSymbolLessReturnRegion(
+      Regions, RegionOwner, makeSymbolLessReturnRegion({4})));
+
+  ASSERT_EQ(Regions.size(), 2u);
+  EXPECT_TRUE(Regions[0].Instructions.empty());
+  ASSERT_EQ(Regions[1].Instructions.size(), 1u);
+  EXPECT_EQ(Regions[1].Instructions.front(), 4u);
+  EXPECT_EQ(RegionOwner, (std::vector<int64_t>{-2, -2, -2, -2, 1}));
+}
+
+TEST(SymbolLessReturnRegionOwnership,
+     ScalesAcrossManyTransitiveTombstoneComponents) {
+  constexpr size_t ComponentCount = 1 << 14;
+  constexpr size_t RegionWidth = 64;
+  constexpr size_t ComponentWidth = 3 * RegionWidth - 2;
+  std::vector<int64_t> RegionOwner(ComponentCount * ComponentWidth, -1);
+  llvm::SmallVector<SymbolLessReturnRegion, 8> Regions;
+  Regions.reserve(ComponentCount);
+
+  for (size_t I = 0; I != ComponentCount; ++I) {
+    size_t Base = I * ComponentWidth;
+    ASSERT_TRUE(claimSymbolLessReturnRegion(
+        Regions, RegionOwner,
+        makeSequentialSymbolLessReturnRegion(Base, RegionWidth)))
+        << I;
+    ASSERT_FALSE(claimSymbolLessReturnRegion(
+        Regions, RegionOwner,
+        makeSequentialSymbolLessReturnRegion(Base + RegionWidth - 1,
+                                              RegionWidth)))
+        << I;
+    ASSERT_FALSE(claimSymbolLessReturnRegion(
+        Regions, RegionOwner,
+        makeSequentialSymbolLessReturnRegion(Base + 2 * RegionWidth - 2,
+                                              RegionWidth)))
+        << I;
+  }
+
+  ASSERT_EQ(Regions.size(), ComponentCount);
+  EXPECT_TRUE(std::all_of(Regions.begin(), Regions.end(),
+                          [](const SymbolLessReturnRegion &Region) {
+                            return Region.Instructions.empty();
+                          }));
+  EXPECT_TRUE(std::all_of(RegionOwner.begin(), RegionOwner.end(),
+                          [](int64_t Owner) { return Owner == -2; }));
 }
 
 TEST(CollectDirectBranchTargets,
@@ -2560,6 +2634,39 @@ TEST(CollectDirectBranchTargets, BoundsTwoIndependentSymbolLessReturnRegions) {
   EXPECT_TRUE(Info->Targets.contains(Decoded[0].Offset + Decoded[0].Size));
   EXPECT_TRUE(Info->Targets.contains(Decoded[2].Offset + Decoded[2].Size));
   EXPECT_FALSE(Info->HasUnboundedIndirectEntries);
+  EXPECT_FALSE(Info->HasUnresolvedTargets);
+}
+
+TEST(CollectDirectBranchTargets, RejectsOverlappingSymbolLessReturnRegions) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  llvm::SmallVector<uint8_t> Bytes =
+      assembleInstructions("s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_call_i64 s[30:31], 5\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_endpgm\n"
+                           "s_branch 2\n"
+                           "s_endpgm\n"
+                           "s_branch 0\n"
+                           "s_nop 0\n"
+                           "s_set_pc_i64 s[30:31]",
+                           S);
+  ASSERT_FALSE(Bytes.empty());
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes.data(), Bytes.size(), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 11u);
+  llvm::SmallVector<uint64_t, 2> DeclaredEntries{0, Decoded[2].Offset};
+
+  // The two distinct call entries use the same link pair but converge on one
+  // return tail. Neither provisional region owns that shared body uniquely,
+  // so the streaming overlap audit must reject both.
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, Bytes.size(), DeclaredEntries);
+  ASSERT_TRUE(Info);
+  EXPECT_FALSE(Info->BoundedIndirectTransfers.contains(Decoded[10].Offset));
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
   EXPECT_FALSE(Info->HasUnresolvedTargets);
 }
 


### PR DESCRIPTION
## Scope

Bound symbol-less return-inference memory without changing the accepted fixed-point result.

## Clean review range

- Clean fork PR: https://github.com/harsh-amd/llvm-project/pull/9
- Exact #3598 source commit(s): bb63ba0c
- Depends on finite fixed-point control-flow proof.

## Review status

Draft for early review. GitHub cannot base an upstream ROCm PR on a branch in the fork, so the Files changed view is temporarily cumulative with unmerged prerequisites. Review the clean fork PR and exact source commits linked above. This branch will be rebased and reduced after dependencies land; do not merge the cumulative snapshot.

ROCm/llvm-project#3598 remains unchanged as the immutable 2,685/2,685 integration reference.

## Validation provenance

The source commits are exact ancestors of corpus-tested ab3cdd61. The cumulative integration passed 2,685/2,685 corpus paths, 213/213 HotswapMCTests, and COMGR lit with 168 passed, 14 unsupported, and 0 failed. Standalone current-staging formatting, focused tests, CI, and the appropriate corpus transition gate are required before this draft becomes ready.