### PR TITLE
[comgr][hotswap] Lower M32 scale16 WMMA exactly

### DIFF
--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1425,14 +1425,6 @@ bool physicalVgprRangeFitsOneBank(unsigned Base, unsigned Width,
 bool isVectorRegisterOrAlias(llvm::MCRegister Reg,
                              const llvm::MCRegisterInfo &MRI);
 
-/// Return true only for the complete observed gfx1250 B0 legacy-VOP3 scalar
-/// source encoding that the A0 MC decoder reports as two unknown dwords.
-bool isLegacyB0Vop3ScalarSourceEncoding(uint32_t Word0, uint32_t Word1);
-
-/// Match the complete legacy B0 pair at Decoded[HeadIndex]. A known control
-/// flow entry into the decoder-created continuation dword rejects the pair.
-bool isUndecodedB0Vop3ScalarSourcePair(const PatchContext &Ctx,
-                                       size_t HeadIndex);
 enum class VgprMsbOperand : unsigned {
   Src0 = 0,
   Src1 = 2,

--- a/amd/comgr/src/hotswap/rewriter/internal.h
+++ b/amd/comgr/src/hotswap/rewriter/internal.h
@@ -1390,6 +1390,49 @@ struct PatchContext {
   bool HasUnresolvedPendingTrampoline = false;
 };
 
+/// One node in the all-path proof that an incoming physical VGPR value is
+/// killed before it can be observed. Opaque nodes and unsafe exits observe
+/// every still-live value conservatively. A safe terminal (s_endpgm or the
+/// patched site on a later loop iteration) observes none.
+struct ForwardVgprProofNode {
+  llvm::BitVector Uses;
+  llvm::BitVector FullDefs;
+  llvm::SmallVector<size_t, 2> Successors;
+  bool Opaque = false;
+  bool HasUnsafeExit = false;
+  bool SafeTerminal = false;
+
+  explicit ForwardVgprProofNode(unsigned MaxVgprs = 0)
+      : Uses(MaxVgprs), FullDefs(MaxVgprs) {}
+};
+
+/// Return physical VGPR values whose incoming contents are killed on every
+/// path before a use, opaque instruction, unsafe exit, or non-killing cycle.
+/// Malformed graph inputs fail closed with std::nullopt.
+std::optional<llvm::BitVector>
+computeForwardDeadVgprs(llvm::ArrayRef<ForwardVgprProofNode> Nodes,
+                        size_t EntryNode, unsigned MaxVgprs);
+
+/// True when [Base, Base + Width) is non-empty, within MaxVgprs, and does not
+/// cross one of gfx1250's 256-register physical VGPR banks.
+bool physicalVgprRangeFitsOneBank(unsigned Base, unsigned Width,
+                                  unsigned MaxVgprs);
+
+/// Return true when \p Reg or one of its aliases belongs to a physical vector
+/// register file. Physical-VGPR proofs use this after encoded-range recovery
+/// fails: a true result must invalidate the proof rather than silently treating
+/// the operand as scalar.
+bool isVectorRegisterOrAlias(llvm::MCRegister Reg,
+                             const llvm::MCRegisterInfo &MRI);
+
+/// Return true only for the complete observed gfx1250 B0 legacy-VOP3 scalar
+/// source encoding that the A0 MC decoder reports as two unknown dwords.
+bool isLegacyB0Vop3ScalarSourceEncoding(uint32_t Word0, uint32_t Word1);
+
+/// Match the complete legacy B0 pair at Decoded[HeadIndex]. A known control
+/// flow entry into the decoder-created continuation dword rejects the pair.
+bool isUndecodedB0Vop3ScalarSourcePair(const PatchContext &Ctx,
+                                       size_t HeadIndex);
 enum class VgprMsbOperand : unsigned {
   Src0 = 0,
   Src1 = 2,
@@ -1412,6 +1455,13 @@ void ensureVgprMsbModes(PatchContext &Ctx);
 /// prevents object-wide analysis.
 [[nodiscard]] std::optional<unsigned>
 getLocallyEstablishedVgprMsbMode(PatchContext &Ctx, size_t Idx);
+
+/// Apply one instruction's persistent VGPR-MSB transfer to an exact packed
+/// mode. Returns VgprMsbUnknown when the incoming state or the instruction's
+/// MODE effect is ambiguous; an exact setter can recover an exact mode.
+int16_t transferExactVgprMsbMode(int16_t Incoming,
+                                 const InternalDecodedInst &DI,
+                                 const LLVMState &LS);
 
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand);
 void setVgprMsbBank(unsigned &Mode, VgprMsbOperand Operand, unsigned Bank);

--- a/amd/comgr/src/hotswap/rewriter/patch-wmma-scale16.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-wmma-scale16.cpp
@@ -51,8 +51,11 @@
 /// returns an error instead of a miscompile. A loud failure beats silent wrong
 /// results.
 ///
-/// The 32x16x128_f4 (M=32) variant also needs an M-split; it is not lowered
-/// exactly yet and fails closed.
+/// The 32x16x128_f4 (M=32) variant is split into two M=16 halves, and each
+/// resulting half is K-split as above, for four exact block-32 WMMAs total.
+/// Scratch reuse inside a fully allocated kernel is allowed only when exact
+/// all-path physical-register liveness proves each of its four scratch values
+/// dead.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -62,9 +65,12 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Twine.h"
+#include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <algorithm>
+#include <array>
+#include <functional>
 #include <initializer_list>
 
 using namespace llvm;
@@ -80,6 +86,12 @@ static constexpr unsigned VOP3PXSize = 16;
 // AMDGPU SRC operand encoding: VGPRs are 256 + N. VgprBankSize comes from
 // internal.h so the DS and Scale16 rewrites share one bank definition.
 static constexpr unsigned VgprEncBase = 256;
+
+bool physicalVgprRangeFitsOneBank(unsigned Base, unsigned Width,
+                                  unsigned MaxVgprs) {
+  return Width != 0 && Base < MaxVgprs && Width <= MaxVgprs - Base &&
+         Base / VgprBankSize == (Base + Width - 1) / VgprBankSize;
+}
 
 static std::string vgprName(unsigned N) { return ("v" + Twine(N)).str(); }
 
@@ -294,9 +306,8 @@ static SmallVector<uint8_t> rewriteScale16ToScale(const uint8_t *OrigRaw,
 
 using VgprBankRequirement = std::pair<VgprMsbOperand, unsigned>;
 
-static void
-emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
-                    std::initializer_list<VgprBankRequirement> Requirements) {
+static void emitModeForOperands(raw_string_ostream &OS, unsigned &CurrentMode,
+                                ArrayRef<VgprBankRequirement> Requirements) {
   unsigned NewMode = CurrentMode;
   for (const VgprBankRequirement &Requirement : Requirements)
     setVgprMsbBank(NewMode, Requirement.first, Requirement.second);
@@ -558,6 +569,792 @@ static uint32_t failClosed(PatchContext &Ctx, const InternalDecodedInst &DI,
         << "; refusing to return a miscompiled code object.\n";
   Ctx.RequiredPatchFailed = true;
   return 0;
+}
+
+static void emitScalePairSplitInPlace(raw_string_ostream &OS, unsigned Lo,
+                                      unsigned Hi, unsigned Tmp,
+                                      unsigned &CurrentMode) {
+  unsigned PairBank = Lo / VgprBankSize;
+  unsigned TmpBank = Tmp / VgprBankSize;
+  emitVgprCopy(OS, Tmp, Lo, /*W=*/1, CurrentMode);
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, PairBank},
+                       {VgprMsbOperand::Src0, TmpBank},
+                       {VgprMsbOperand::Src1, PairBank}});
+  OS << "v_perm_b32 " << encodedVgprName(Lo) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x06040200\n";
+  OS << "v_perm_b32 " << encodedVgprName(Hi) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x07050301\n";
+}
+
+static void emitScalePairRestoreInPlace(raw_string_ostream &OS, unsigned Lo,
+                                        unsigned Hi, unsigned Tmp,
+                                        unsigned &CurrentMode) {
+  unsigned PairBank = Lo / VgprBankSize;
+  unsigned TmpBank = Tmp / VgprBankSize;
+  emitVgprCopy(OS, Tmp, Lo, /*W=*/1, CurrentMode);
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Dst, PairBank},
+                       {VgprMsbOperand::Src0, TmpBank},
+                       {VgprMsbOperand::Src1, PairBank}});
+  OS << "v_perm_b32 " << encodedVgprName(Lo) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x05010400\n";
+  OS << "v_perm_b32 " << encodedVgprName(Hi) << ", " << encodedVgprName(Tmp)
+     << ", " << encodedVgprName(Hi) << ", 0x07030602\n";
+}
+
+static void emitMaskVgprsInPlace(raw_string_ostream &OS, bool KeepLow,
+                                 unsigned Base, unsigned W, unsigned SubW,
+                                 unsigned &CurrentMode) {
+  for (unsigned I = 0; I != W; ++I) {
+    bool IsLow = ((I / SubW) % 2) == 0;
+    if (IsLow == KeepLow)
+      continue;
+    unsigned Physical = Base + I;
+    emitModeForOperands(OS, CurrentMode,
+                        {{VgprMsbOperand::Dst, Physical / VgprBankSize}});
+    OS << "v_mov_b32 " << encodedVgprName(Physical) << ", 0\n";
+  }
+}
+
+struct Scale32PrintedAsm {
+  std::string Operands[6]; // dst, matrix A/B, src2, scale A/B
+  std::string ModifierSuffix;
+};
+
+// Parse the six positional operands of the M=32 scaled WMMA while preserving
+// the printer's exact inline-immediate spelling and modifier ordering.
+static std::optional<Scale32PrintedAsm>
+parseScale32PrintedAsm(PatchContext &Ctx, const InternalDecodedInst &DI) {
+  SmallString<256> Buf;
+  raw_svector_ostream OS(Buf);
+  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
+                         OS);
+  StringRef S = StringRef(Buf).trim();
+  size_t MnemEnd = S.find_first_of(" \t");
+  if (MnemEnd == StringRef::npos)
+    return std::nullopt;
+
+  Scale32PrintedAsm Result;
+  StringRef Rest = S.substr(MnemEnd).ltrim();
+  for (unsigned I = 0; I != 5; ++I) {
+    size_t Comma = Rest.find(',');
+    if (Comma == StringRef::npos)
+      return std::nullopt;
+    Result.Operands[I] = Rest.substr(0, Comma).trim().str();
+    Rest = Rest.substr(Comma + 1).ltrim();
+  }
+  size_t ModBegin = Rest.find_first_of(" \t");
+  if (ModBegin == StringRef::npos) {
+    Result.Operands[5] = Rest.str();
+  } else {
+    Result.Operands[5] = Rest.substr(0, ModBegin).str();
+    Result.ModifierSuffix = Rest.substr(ModBegin).str();
+  }
+  return Result;
+}
+
+static SmallVector<StringRef, 8> tokenizeScaleModifiers(StringRef Suffix) {
+  SmallVector<StringRef, 8> Result;
+  StringRef Rest = Suffix.ltrim();
+  while (!Rest.empty()) {
+    size_t Space = Rest.find_first_of(" \t");
+    if (Space == StringRef::npos) {
+      Result.push_back(Rest);
+      break;
+    }
+    Result.push_back(Rest.substr(0, Space));
+    Rest = Rest.substr(Space + 1).ltrim();
+  }
+  return Result;
+}
+
+static bool parsePackedScaleModifier(StringRef Token, StringRef Name,
+                                     std::array<StringRef, 3> &Bits) {
+  if (!Token.starts_with(Name) || !Token.ends_with("]"))
+    return false;
+  Token = Token.drop_front(Name.size());
+  if (!Token.starts_with(":["))
+    return false;
+  SmallVector<StringRef, 3> Parts;
+  Token.drop_front(2).drop_back(1).split(Parts, ",");
+  if (Parts.size() != 3)
+    return false;
+  for (unsigned I = 0; I != 3; ++I) {
+    Bits[I] = Parts[I].trim();
+    if (Bits[I] != "0" && Bits[I] != "1")
+      return false;
+  }
+  return true;
+}
+
+static bool isKnownScale32Modifier(StringRef Token) {
+  if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse" ||
+      Token == "matrix_a_scale:MATRIX_SCALE_ROW1" ||
+      Token == "matrix_b_scale:MATRIX_SCALE_ROW1" ||
+      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E8" ||
+      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E5M3" ||
+      Token == "matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3" ||
+      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E8" ||
+      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E5M3" ||
+      Token == "matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3")
+    return true;
+  std::array<StringRef, 3> Bits;
+  return parsePackedScaleModifier(Token, "neg_lo", Bits) ||
+         parsePackedScaleModifier(Token, "neg_hi", Bits);
+}
+
+// The split changes both matrix register layout and the K-pass accumulator.
+// Reuse promises therefore no longer describe the generated sequence and are
+// removed. On each high-K pass src2 is the low-pass result, not the original
+// C, so clear the src2 neg/abs bit instead of applying C's modifier twice.
+static std::optional<std::string>
+transformScale32ModifierSuffix(StringRef Suffix, bool HighKPass) {
+  std::string Result;
+  for (StringRef Token : tokenizeScaleModifiers(Suffix)) {
+    if (!isKnownScale32Modifier(Token)) {
+      log() << "hotswap: error: wmma_scale16: unsupported M=32 modifier token "
+               "\""
+            << Token << "\"\n";
+      return std::nullopt;
+    }
+    if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse")
+      continue;
+
+    std::array<StringRef, 3> Bits;
+    if (HighKPass && (parsePackedScaleModifier(Token, "neg_lo", Bits) ||
+                      parsePackedScaleModifier(Token, "neg_hi", Bits))) {
+      if (Bits[0] == "0" && Bits[1] == "0")
+        continue;
+      StringRef Name = Token.take_front(Token.find(':'));
+      Result += (" " + Name + ":[" + Bits[0] + "," + Bits[1] + ",0]").str();
+      continue;
+    }
+    Result += ' ';
+    Result += Token.str();
+  }
+  return Result;
+}
+
+static std::string encodedVgprRange(unsigned PhysicalBase, unsigned Width) {
+  assert(Width > 0);
+  unsigned EncodedBase = PhysicalBase % VgprBankSize;
+  return formatv("v[{0}:{1}]", EncodedBase, EncodedBase + Width - 1).str();
+}
+
+static void emitScale32Half(raw_string_ostream &OS, unsigned DstBase,
+                            unsigned MatrixABase, unsigned MatrixBBase,
+                            StringRef Src2, unsigned ScaleAReg,
+                            unsigned ScaleBReg, StringRef ModifierSuffix) {
+  OS << "v_wmma_scale_f32_16x16x128_f8f6f4 " << encodedVgprRange(DstBase, 8)
+     << ", " << encodedVgprRange(MatrixABase, 8) << ", "
+     << encodedVgprRange(MatrixBBase, 8) << ", " << Src2 << ", "
+     << encodedVgprName(ScaleAReg) << ", " << encodedVgprName(ScaleBReg)
+     << " matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4"
+     << ModifierSuffix << "\n";
+}
+
+// Prefer one exact-liveness-proven dead block inside the kernel's declared
+// allocation. Fully allocated production kernels often have no above-KD
+// headroom even though a particular WMMA site has a large dead interval.
+// Search high-to-low within each physical bank so every generated range keeps
+// one VGPR-MSB setting. Fall back to the allocator's normal above-KD growth.
+static std::optional<unsigned>
+allocContiguousDeadOrAboveInBank(VgprAllocator &Alloc, unsigned Count,
+                                 unsigned Align, unsigned BankSize,
+                                 bool AllowDeadReuse) {
+  if (Count == 0 || Count > BankSize || Align == 0)
+    return std::nullopt;
+
+  if (AllowDeadReuse) {
+    unsigned BankCount = (Alloc.KdAllocatedVgprs + BankSize - 1) / BankSize;
+    for (unsigned ReverseBank = BankCount; ReverseBank != 0; --ReverseBank) {
+      unsigned Bank = ReverseBank - 1;
+      unsigned BankBegin = Bank * BankSize;
+      unsigned BankEnd = std::min(Alloc.KdAllocatedVgprs, BankBegin + BankSize);
+      if (BankEnd < BankBegin + Count)
+        continue;
+
+      unsigned Base = BankEnd - Count;
+      Base -= Base % Align;
+      while (Base >= BankBegin) {
+        bool AllDead = true;
+        for (unsigned V = Base; V != Base + Count; ++V) {
+          if (V >= static_cast<unsigned>(Alloc.LiveAtPoint.size()) ||
+              Alloc.LiveAtPoint.test(V)) {
+            AllDead = false;
+            break;
+          }
+        }
+        if (AllDead) {
+          Alloc.LiveAtPoint.set(Base, Base + Count);
+          return Base;
+        }
+        if (Base < BankBegin + Align)
+          break;
+        Base -= Align;
+      }
+    }
+  }
+  return Alloc.allocContiguousAboveKdInBank(Count, Align, BankSize);
+}
+
+static bool rangesOverlap(unsigned ABase, unsigned AWidth, unsigned BBase,
+                          unsigned BWidth) {
+  return ABase < BBase + BWidth && BBase < ABase + AWidth;
+}
+
+static bool sameRange(unsigned ABase, unsigned AWidth, unsigned BBase,
+                      unsigned BWidth) {
+  return ABase == BBase && AWidth == BWidth;
+}
+
+static void reserveVgprRange(VgprAllocator &Alloc, unsigned Base,
+                             unsigned Width) {
+  assert(Width > 0 && Base <= Alloc.LiveAtPoint.size() &&
+         Width <= Alloc.LiveAtPoint.size() - Base);
+  Alloc.LiveAtPoint.set(Base, Base + Width);
+}
+
+struct EncodedVgprRange {
+  unsigned Base = 0;
+  unsigned Width = 0;
+  bool FullDwords = false;
+};
+
+static std::optional<unsigned> parseScalarVgprName(StringRef Name,
+                                                   bool &IsPartial) {
+  IsPartial = false;
+  if (!Name.consume_front("VGPR"))
+    return std::nullopt;
+  size_t Digits = Name.find_first_not_of("0123456789");
+  StringRef Number = Digits == StringRef::npos ? Name : Name.take_front(Digits);
+  unsigned Index = 0;
+  if (Number.empty() || Number.getAsInteger(10, Index))
+    return std::nullopt;
+  if (Digits == StringRef::npos)
+    return Index;
+  StringRef Suffix = Name.drop_front(Digits);
+  if (Suffix == "_LO16" || Suffix == "_HI16") {
+    IsPartial = true;
+    return Index;
+  }
+  return std::nullopt;
+}
+
+// Convert an explicit MC VGPR or VGPR tuple to its encoded v0..v255 interval.
+// True16 operands are identified but never accepted as a full-value kill.
+static std::optional<EncodedVgprRange>
+getEncodedVgprRange(MCRegister Reg, const MCRegisterInfo &MRI) {
+  if (!Reg)
+    return std::nullopt;
+
+  bool IsPartial = false;
+  if (std::optional<unsigned> Scalar =
+          parseScalarVgprName(MRI.getName(Reg), IsPartial))
+    return EncodedVgprRange{*Scalar, 1, !IsPartial};
+
+  SmallVector<unsigned, 16> Scalars;
+  for (MCPhysReg Sub : MRI.subregs(Reg)) {
+    bool SubPartial = false;
+    std::optional<unsigned> Index =
+        parseScalarVgprName(MRI.getName(Sub), SubPartial);
+    if (Index && !SubPartial)
+      Scalars.push_back(*Index);
+  }
+  if (Scalars.empty())
+    return std::nullopt;
+  llvm::sort(Scalars);
+  Scalars.erase(std::unique(Scalars.begin(), Scalars.end()), Scalars.end());
+  for (unsigned I = 1; I != Scalars.size(); ++I)
+    if (Scalars[I] != Scalars.front() + I)
+      return std::nullopt;
+  return EncodedVgprRange{Scalars.front(),
+                          static_cast<unsigned>(Scalars.size()), true};
+}
+
+bool isVectorRegisterOrAlias(MCRegister Reg, const MCRegisterInfo &MRI) {
+  if (!Reg)
+    return false;
+  for (MCRegAliasIterator Alias(Reg, &MRI, /*IncludeSelf=*/true);
+       Alias.isValid(); ++Alias) {
+    StringRef Name = MRI.getName(*Alias);
+    if (Name.contains("VGPR") || Name.contains("AGPR"))
+      return true;
+  }
+  return false;
+}
+
+static bool setPhysicalVgprRange(BitVector &Out, const EncodedVgprRange &Range,
+                                 unsigned Bank, unsigned MaxVgprs) {
+  if (Range.Width == 0 || Range.Base >= VgprBankSize ||
+      Range.Width > VgprBankSize - Range.Base)
+    return false;
+  unsigned Base = Range.Base + Bank * VgprBankSize;
+  if (Base >= MaxVgprs || Range.Width > MaxVgprs - Base)
+    return false;
+  Out.set(Base, Base + Range.Width);
+  return true;
+}
+
+struct PhysicalVgprAccess {
+  BitVector Uses;
+  BitVector FullDefs;
+  bool Valid = true;
+
+  explicit PhysicalVgprAccess(unsigned MaxVgprs)
+      : Uses(MaxVgprs), FullDefs(MaxVgprs) {}
+};
+
+// The M=32 Scale16 MC layout is mirrored and runtime-validated by the
+// lowering below. Matrix A uses src0, matrix B uses src1, and the accumulator
+// uses src2. Scale-prefix VGPR operands ignore VGPR-MSB and use bank zero.
+// Other instruction layouts remain conservative-all-banks unless their role
+// is structurally unambiguous.
+static constexpr unsigned M32MatrixAOperand = 1;
+static constexpr unsigned M32MatrixBOperand = 2;
+static constexpr unsigned M32AccumulatorOperand = 4;
+static constexpr unsigned M32ScaleAOperand = 5;
+static constexpr unsigned M32ScaleBOperand = 6;
+
+static std::optional<VgprMsbOperand>
+getExactSourceRole(const InternalDecodedInst &DI, unsigned OperandIndex,
+                   unsigned NumDefs) {
+  if (DI.Mnemonic == "v_wmma_scale16_f32_32x16x128_f4") {
+    switch (OperandIndex) {
+    case M32MatrixAOperand:
+      return VgprMsbOperand::Src0;
+    case M32MatrixBOperand:
+      return VgprMsbOperand::Src1;
+    case M32AccumulatorOperand:
+      return VgprMsbOperand::Src2;
+    default:
+      return std::nullopt;
+    }
+  }
+  if (StringRef(DI.Mnemonic).starts_with("ds_") && OperandIndex == NumDefs)
+    return VgprMsbOperand::Src0;
+  return std::nullopt;
+}
+
+// Resolve every explicit access through the exact persistent VGPR-MSB mode.
+// Sources with a validated architectural role use that role's bank. Every
+// other source maps through the union of src0/src1/src2 banks, which can only
+// add uses, never hide one. Explicit full-width definitions use the
+// architectural dst bank. Tied definitions are reads of their incoming
+// destination. Implicit/partial VGPR operands cannot prove a kill and
+// conservatively block the encoded range in every bank.
+static PhysicalVgprAccess getPhysicalVgprAccess(const InternalDecodedInst &DI,
+                                                const LLVMState &LS,
+                                                unsigned Mode,
+                                                unsigned MaxVgprs) {
+  PhysicalVgprAccess Result(MaxVgprs);
+  const MCInstrDesc &Desc = LS.MCII->get(DI.Inst.getOpcode());
+  const MCRegisterInfo &MRI = *LS.MRI;
+  unsigned DstBank = getVgprMsbBank(Mode, VgprMsbOperand::Dst);
+  SmallVector<unsigned, 3> SrcBanks = {
+      getVgprMsbBank(Mode, VgprMsbOperand::Src0),
+      getVgprMsbBank(Mode, VgprMsbOperand::Src1),
+      getVgprMsbBank(Mode, VgprMsbOperand::Src2)};
+  llvm::sort(SrcBanks);
+  SrcBanks.erase(std::unique(SrcBanks.begin(), SrcBanks.end()), SrcBanks.end());
+
+  std::function<void(const EncodedVgprRange &)> AddEveryBankUse =
+      [&](const EncodedVgprRange &Range) {
+        for (unsigned Bank = 0; Bank * VgprBankSize < MaxVgprs; ++Bank)
+          if (!setPhysicalVgprRange(Result.Uses, Range, Bank, MaxVgprs))
+            Result.Valid = false;
+      };
+
+  unsigned NumDefs = Desc.getNumDefs();
+  for (unsigned I = 0, E = DI.Inst.getNumOperands(); I != E; ++I) {
+    const MCOperand &Op = DI.Inst.getOperand(I);
+    if (!Op.isReg() || !Op.getReg())
+      continue;
+    std::optional<EncodedVgprRange> Range =
+        getEncodedVgprRange(MCRegister(Op.getReg()), MRI);
+    if (!Range) {
+      if (isVectorRegisterOrAlias(MCRegister(Op.getReg()), MRI))
+        Result.Valid = false;
+      continue;
+    }
+
+    bool IsDef = I < NumDefs;
+    if (!IsDef) {
+      if (DI.Mnemonic == "v_wmma_scale16_f32_32x16x128_f4" &&
+          (I == M32ScaleAOperand || I == M32ScaleBOperand)) {
+        if (!setPhysicalVgprRange(Result.Uses, *Range, /*Bank=*/0, MaxVgprs))
+          Result.Valid = false;
+        continue;
+      }
+      if (std::optional<VgprMsbOperand> Role =
+              getExactSourceRole(DI, I, NumDefs)) {
+        unsigned Bank = getVgprMsbBank(Mode, *Role);
+        if (!setPhysicalVgprRange(Result.Uses, *Range, Bank, MaxVgprs))
+          Result.Valid = false;
+      } else {
+        for (unsigned Bank : SrcBanks)
+          if (!setPhysicalVgprRange(Result.Uses, *Range, Bank, MaxVgprs))
+            Result.Valid = false;
+      }
+      continue;
+    }
+
+    int TiedTo = Desc.getOperandConstraint(I, MCOI::TIED_TO);
+    if (TiedTo >= 0) {
+      if (!setPhysicalVgprRange(Result.Uses, *Range, DstBank, MaxVgprs))
+        Result.Valid = false;
+    }
+    if (!Range->FullDwords) {
+      AddEveryBankUse(*Range);
+      continue;
+    }
+    if (!setPhysicalVgprRange(Result.FullDefs, *Range, DstBank, MaxVgprs))
+      Result.Valid = false;
+  }
+
+  for (MCPhysReg Implicit : Desc.implicit_uses()) {
+    std::optional<EncodedVgprRange> Range =
+        getEncodedVgprRange(MCRegister(Implicit), MRI);
+    if (Range)
+      AddEveryBankUse(*Range);
+    else if (isVectorRegisterOrAlias(MCRegister(Implicit), MRI))
+      Result.Valid = false;
+  }
+  for (MCPhysReg Implicit : Desc.implicit_defs()) {
+    std::optional<EncodedVgprRange> Range =
+        getEncodedVgprRange(MCRegister(Implicit), MRI);
+    if (Range)
+      AddEveryBankUse(*Range);
+    else if (isVectorRegisterOrAlias(MCRegister(Implicit), MRI))
+      Result.Valid = false;
+  }
+  return Result;
+}
+
+static bool hasDynamicVgprAddressing(ArrayRef<InternalDecodedInst> Decoded,
+                                     size_t Begin, size_t End) {
+  for (size_t I = Begin; I != End; ++I) {
+    StringRef Mnemonic = Decoded[I].Mnemonic;
+    if (Mnemonic.contains("movrel") || Mnemonic.contains("gpr_idx") ||
+        Mnemonic.starts_with("s_setreg"))
+      return true;
+  }
+  return false;
+}
+
+std::optional<BitVector>
+computeForwardDeadVgprs(ArrayRef<ForwardVgprProofNode> Nodes, size_t EntryNode,
+                        unsigned MaxVgprs) {
+  if (Nodes.empty() || EntryNode >= Nodes.size() || MaxVgprs == 0)
+    return std::nullopt;
+  for (const ForwardVgprProofNode &Node : Nodes) {
+    if (Node.Uses.size() != MaxVgprs || Node.FullDefs.size() != MaxVgprs)
+      return std::nullopt;
+    for (size_t Successor : Node.Successors)
+      if (Successor >= Nodes.size())
+        return std::nullopt;
+  }
+
+  std::vector<BitVector> AliveAt(Nodes.size(), BitVector(MaxVgprs));
+  AliveAt[EntryNode].set();
+  BitVector Unsafe(MaxVgprs);
+  SmallVector<size_t, 64> Worklist;
+  Worklist.push_back(EntryNode);
+
+  while (!Worklist.empty()) {
+    size_t Index = Worklist.pop_back_val();
+    BitVector Alive = AliveAt[Index];
+    if (Alive.none())
+      continue;
+
+    const ForwardVgprProofNode &Node = Nodes[Index];
+    if (Node.Opaque) {
+      Unsafe |= Alive;
+      continue;
+    }
+
+    BitVector UsedAlive = Alive;
+    UsedAlive &= Node.Uses;
+    Unsafe |= UsedAlive;
+    Alive.reset(Node.Uses);
+    Alive.reset(Node.FullDefs);
+
+    if (Node.HasUnsafeExit)
+      Unsafe |= Alive;
+    if (Node.Successors.empty()) {
+      if (!Node.SafeTerminal)
+        Unsafe |= Alive;
+      continue;
+    }
+
+    for (size_t Successor : Node.Successors) {
+      BitVector NewBits = Alive;
+      NewBits.reset(AliveAt[Successor]);
+      if (NewBits.none())
+        continue;
+      AliveAt[Successor] |= Alive;
+      Worklist.push_back(Successor);
+    }
+  }
+
+  // A value that can circulate around a cycle without a use or full kill is
+  // not accepted as scratch. Detect such cycles in the per-value subgraph:
+  // Kahn removal leaves exactly the nodes belonging to, or fed only by, a
+  // surviving cycle. This is intentionally conservative for non-terminating
+  // paths and makes loop handling independent of worklist visitation order.
+  SmallVector<unsigned, 64> InDegree(Nodes.size());
+  SmallVector<size_t, 64> Queue;
+  BitVector Included(Nodes.size());
+  for (unsigned V = 0; V != MaxVgprs; ++V) {
+    if (Unsafe.test(V))
+      continue;
+    Included.reset();
+    unsigned IncludedCount = 0;
+    for (size_t I = 0; I != Nodes.size(); ++I) {
+      const ForwardVgprProofNode &Node = Nodes[I];
+      if (AliveAt[I].test(V) && !Node.Opaque && !Node.Uses.test(V) &&
+          !Node.FullDefs.test(V)) {
+        Included.set(I);
+        ++IncludedCount;
+      }
+    }
+    if (IncludedCount == 0)
+      continue;
+
+    llvm::fill(InDegree, 0);
+    for (int I = Included.find_first(); I >= 0; I = Included.find_next(I))
+      for (size_t Successor : Nodes[static_cast<size_t>(I)].Successors)
+        if (Included.test(Successor))
+          ++InDegree[Successor];
+    Queue.clear();
+    for (int I = Included.find_first(); I >= 0; I = Included.find_next(I))
+      if (InDegree[static_cast<size_t>(I)] == 0)
+        Queue.push_back(static_cast<size_t>(I));
+
+    unsigned Removed = 0;
+    while (!Queue.empty()) {
+      size_t I = Queue.pop_back_val();
+      ++Removed;
+      for (size_t Successor : Nodes[I].Successors)
+        if (Included.test(Successor) && --InDegree[Successor] == 0)
+          Queue.push_back(Successor);
+    }
+    if (Removed != IncludedCount)
+      Unsafe.set(V);
+  }
+
+  BitVector Safe(MaxVgprs);
+  Safe.set();
+  Safe.reset(Unsafe);
+  return Safe;
+}
+
+struct ScaleForwardGraph {
+  std::vector<ForwardVgprProofNode> Nodes;
+  std::vector<size_t> GlobalIndices;
+  std::vector<int16_t> ModeBefore;
+  BitVector UndecodedVop3Heads;
+  size_t EntryNode = 0;
+};
+
+// The B0 f4gemm object contains a legacy VOP3 opcode that the A0 gfx1250 MC
+// decoder intentionally does not recognize. The failed decode advances only
+// one dword, so its second dword appears as a separate unknown instruction.
+//
+// Recognize only the exact observed encoding:
+//   * legacy VOP3 major 0x34 and opcode 0x31;
+//   * vdst encoding zero, with only the observed bit-14 modifier variation;
+//   * scalar source encodings, in either observed second-dword spelling.
+//
+// We do not assign the unknown opcode semantics. Instead, conservatively model
+// encoded v0 as a use in every physical bank (so it cannot be scratch), model
+// no kill, and skip the split continuation dword. This is enough to traverse
+// the instruction without relying on whether opcode 0x31 has a vector or
+// scalar destination on B0.
+static bool recognizeUndecodedB0Vop3ScalarSources(PatchContext &Ctx,
+                                                  size_t Global,
+                                                  unsigned MaxVgprs,
+                                                  BitVector &ConservativeUses) {
+  if (!isUndecodedB0Vop3ScalarSourcePair(Ctx, Global))
+    return false;
+
+  for (unsigned Physical = 0; Physical < MaxVgprs; Physical += VgprBankSize)
+    ConservativeUses.set(Physical);
+  return true;
+}
+
+static std::optional<ScaleForwardGraph>
+buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
+                       unsigned MaxVgprs) {
+  if (!Ctx.LS.MIA || !Ctx.LS.MCII || !Ctx.LS.MRI ||
+      SiteIdx >= Ctx.Decoded.size())
+    return std::nullopt;
+
+  std::optional<ElfView::FunctionTextRange> Owner =
+      Ctx.Elf.findFunctionTextRangeAtOffset(Ctx.Decoded[SiteIdx].Offset);
+  if (!Owner || SiteIdx + 1 >= Ctx.Decoded.size())
+    return std::nullopt;
+
+  size_t BeginIndex = SiteIdx;
+  while (BeginIndex > 0 && Ctx.Decoded[BeginIndex - 1].Offset >= Owner->Begin)
+    --BeginIndex;
+  size_t EndIndex = SiteIdx + 1;
+  while (EndIndex < Ctx.Decoded.size() &&
+         Ctx.Decoded[EndIndex].Offset < Owner->End)
+    ++EndIndex;
+  if (BeginIndex == EndIndex || SiteIdx + 1 >= EndIndex)
+    return std::nullopt;
+
+  ScaleForwardGraph Graph;
+  size_t Count = EndIndex - BeginIndex;
+  Graph.Nodes.reserve(Count);
+  Graph.GlobalIndices.reserve(Count);
+  for (size_t I = BeginIndex; I != EndIndex; ++I) {
+    Graph.Nodes.emplace_back(MaxVgprs);
+    Graph.GlobalIndices.push_back(I);
+  }
+  Graph.UndecodedVop3Heads.resize(Count);
+  Graph.EntryNode = SiteIdx + 1 - BeginIndex;
+
+  DenseMap<uint64_t, size_t> IndexAtOffset;
+  for (size_t Local = 0; Local != Count; ++Local)
+    IndexAtOffset[Ctx.Decoded[Graph.GlobalIndices[Local]].Offset] = Local;
+
+  std::function<void(size_t)> AddFallthrough = [&](size_t Local) {
+    if (Local + 1 < Count)
+      Graph.Nodes[Local].Successors.push_back(Local + 1);
+    else
+      Graph.Nodes[Local].HasUnsafeExit = true;
+  };
+
+  for (size_t Local = 0; Local != Count; ++Local) {
+    size_t Global = Graph.GlobalIndices[Local];
+    const InternalDecodedInst &DI = Ctx.Decoded[Global];
+    ForwardVgprProofNode &Node = Graph.Nodes[Local];
+
+    // A later loop iteration reaches the replacement itself. Scratch excludes
+    // every original operand, and the replacement defines its scratch before
+    // reading it, so no incoming scratch value can be observed there.
+    if (Global == SiteIdx) {
+      Node.SafeTerminal = true;
+      continue;
+    }
+    if (!DI.DecodeSucceeded && recognizeUndecodedB0Vop3ScalarSources(
+                                   Ctx, Global, MaxVgprs, Node.Uses)) {
+      if (Local + 2 >= Count)
+        Node.HasUnsafeExit = true;
+      else
+        Node.Successors.push_back(Local + 2);
+      Graph.UndecodedVop3Heads.set(Local);
+      continue;
+    }
+    if (!DI.DecodeSucceeded ||
+        hasDynamicVgprAddressing(Ctx.Decoded, Global, Global + 1)) {
+      Node.Opaque = true;
+      continue;
+    }
+    if (DI.Inst.getOpcode() == Ctx.LS.SEndPgmOpcode ||
+        DI.Inst.getOpcode() == Ctx.LS.SEndPgmSavedOpcode) {
+      Node.SafeTerminal = true;
+      continue;
+    }
+    if (Ctx.LS.MIA->isCall(DI.Inst) || Ctx.LS.MIA->isIndirectBranch(DI.Inst) ||
+        Ctx.LS.MIA->isReturn(DI.Inst)) {
+      Node.Opaque = true;
+      continue;
+    }
+    if (Ctx.LS.MIA->isBranch(DI.Inst)) {
+      uint64_t Target = 0;
+      if (!Ctx.LS.MIA->evaluateBranch(DI.Inst, DI.Offset, DI.Size, Target)) {
+        Node.Opaque = true;
+        continue;
+      }
+      DenseMap<uint64_t, size_t>::const_iterator TargetIt =
+          IndexAtOffset.find(Target);
+      if (TargetIt == IndexAtOffset.end())
+        Node.HasUnsafeExit = true;
+      else
+        Node.Successors.push_back(TargetIt->second);
+      if (Ctx.LS.MIA->isConditionalBranch(DI.Inst))
+        AddFallthrough(Local);
+      else if (!Ctx.LS.MIA->isUnconditionalBranch(DI.Inst))
+        Node.Opaque = true;
+      continue;
+    }
+    if (Ctx.LS.MIA->mayAffectControlFlow(DI.Inst, *Ctx.LS.MRI)) {
+      Node.Opaque = true;
+      continue;
+    }
+    AddFallthrough(Local);
+  }
+
+  Graph.ModeBefore.assign(Count, VgprMsbUnreachable);
+  Graph.ModeBefore[Graph.EntryNode] = static_cast<int16_t>(EntryMode & 0xff);
+  SmallVector<size_t, 64> Worklist;
+  Worklist.push_back(Graph.EntryNode);
+  for (size_t Next = 0; Next != Worklist.size(); ++Next) {
+    size_t Local = Worklist[Next];
+    const ForwardVgprProofNode &Node = Graph.Nodes[Local];
+    if (Node.Opaque || Node.SafeTerminal)
+      continue;
+    int16_t Out = Graph.UndecodedVop3Heads.test(Local)
+                      ? Graph.ModeBefore[Local]
+                      : transferExactVgprMsbMode(
+                            Graph.ModeBefore[Local],
+                            Ctx.Decoded[Graph.GlobalIndices[Local]], Ctx.LS);
+    for (size_t Successor : Node.Successors) {
+      int16_t Old = Graph.ModeBefore[Successor];
+      int16_t Merged = Old == VgprMsbUnreachable ? Out
+                       : Old == Out              ? Old
+                                                 : VgprMsbUnknown;
+      if (Merged != Old) {
+        Graph.ModeBefore[Successor] = Merged;
+        Worklist.push_back(Successor);
+      }
+    }
+  }
+  return Graph;
+}
+
+// Return physical VGPR values whose incoming contents cannot be observed on
+// any continuation path after SiteIdx. This deliberately does not consume the
+// generic LivenessInfo: its weak in-tree implementation is encoded-v0..v255
+// conservative liveness, not a proof over gfx1250's four physical banks.
+static std::optional<BitVector>
+computeForwardDeadPhysicalVgprs(PatchContext &Ctx, size_t SiteIdx,
+                                unsigned EntryMode, unsigned MaxVgprs) {
+  if (Ctx.DirectControlFlow.HasUnresolvedTargets ||
+      Ctx.DirectControlFlow.HasUnboundedIndirectEntries || !Ctx.LS.MIA ||
+      !Ctx.LS.MCII || !Ctx.LS.MRI || SiteIdx >= Ctx.Decoded.size())
+    return std::nullopt;
+
+  std::optional<ScaleForwardGraph> Graph =
+      buildScaleForwardGraph(Ctx, SiteIdx, EntryMode, MaxVgprs);
+  if (!Graph)
+    return std::nullopt;
+
+  for (size_t Local = 0; Local != Graph->Nodes.size(); ++Local) {
+    ForwardVgprProofNode &Node = Graph->Nodes[Local];
+    if (Node.Opaque || Node.SafeTerminal)
+      continue;
+    if (Graph->UndecodedVop3Heads.test(Local))
+      continue;
+
+    int16_t Mode = Graph->ModeBefore[Local];
+    if (Mode == VgprMsbUnreachable)
+      continue;
+    unsigned AccessMode = Mode >= 0 ? static_cast<unsigned>(Mode) : 0;
+    PhysicalVgprAccess Access = getPhysicalVgprAccess(
+        Ctx.Decoded[Graph->GlobalIndices[Local]], Ctx.LS, AccessMode, MaxVgprs);
+    if (!Access.Valid)
+      return std::nullopt;
+    if (Mode < 0 && (Access.Uses.any() || Access.FullDefs.any()))
+      return std::nullopt;
+    Node.Uses = std::move(Access.Uses);
+    Node.FullDefs = std::move(Access.FullDefs);
+  }
+  return computeForwardDeadVgprs(Graph->Nodes, Graph->EntryNode, MaxVgprs);
 }
 
 // ---------------------------------------------------------------------------
@@ -896,6 +1693,331 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 }
 
 // ---------------------------------------------------------------------------
+// v_wmma_scale16_f32_32x16x128_f4 -> exact M+K split
+// ---------------------------------------------------------------------------
+
+static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
+
+  if (DI.Size != VOP3PXSize)
+    return failClosed(Ctx, DI, "unexpected instruction size " + Twine(DI.Size));
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    if (T.OriginalOffset == DI.Offset)
+      return 0;
+
+  const uint8_t *Raw = Ctx.Text + DI.Offset;
+  std::optional<unsigned> ScaleABase =
+      decodeVgprEncoding(extractScaleSrc0(Raw));
+  std::optional<unsigned> ScaleBBase =
+      decodeVgprEncoding(extractScaleSrc1(Raw));
+  if (!ScaleABase || !ScaleBBase)
+    return failClosed(Ctx, DI, "non-VGPR block-16 scale operand");
+
+  std::optional<unsigned> ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode)
+    ActiveMode = getLocallyEstablishedVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode) {
+    std::string Detail = "cannot determine active VGPR-MSB mode";
+    if (Ctx.DirectControlFlow.HasUnresolvedTargets)
+      Detail += " (unresolved control-flow target)";
+    if (Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
+      Detail += " (unbounded indirect entry)";
+    return failClosed(Ctx, DI, Detail);
+  }
+
+  std::optional<Scale32PrintedAsm> Printed = parseScale32PrintedAsm(Ctx, DI);
+  if (!Printed)
+    return failClosed(Ctx, DI, "could not parse canonical instruction");
+  std::optional<std::string> LowSuffix =
+      transformScale32ModifierSuffix(Printed->ModifierSuffix,
+                                     /*HighKPass=*/false);
+  std::optional<std::string> HighSuffix =
+      transformScale32ModifierSuffix(Printed->ModifierSuffix,
+                                     /*HighKPass=*/true);
+  if (!LowSuffix || !HighSuffix)
+    return failClosed(Ctx, DI, "unsupported modifier combination");
+
+  std::optional<VgprRange> DRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/0);
+  std::optional<VgprRange> ARange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/1);
+  std::optional<VgprRange> BRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/2);
+  if (!DRange || !ARange || !BRange || DRange->Width != 16 ||
+      ARange->Width != 16 || BRange->Width != 8)
+    return failClosed(Ctx, DI, "unexpected M=32 matrix operand widths/layout");
+
+  // The M=32 profile mirrors the common VOP3P layout in its first five MC
+  // operands: vdst, src0, src1, src2 modifiers, src2. Validate that mirror at
+  // runtime so a TableGen layout change fails closed.
+  if (DI.Inst.getNumOperands() < 5)
+    return failClosed(Ctx, DI, "truncated M=32 MC operand layout");
+  const MCOperand &Src2Op = DI.Inst.getOperand(4);
+  bool Src2IsImm = Src2Op.isImm();
+  std::optional<VgprRange> CRange;
+  if (Src2Op.isReg())
+    CRange = matrixOperandRange(Ctx, DI, /*OperandIndex=*/3);
+  else if (!Src2IsImm)
+    return failClosed(Ctx, DI, "unsupported non-VGPR/non-immediate src2");
+  if (CRange && CRange->Width != 16)
+    return failClosed(Ctx, DI, "src2 and destination widths differ");
+  if (!Src2IsImm && !CRange)
+    return failClosed(Ctx, DI, "could not determine src2 VGPR range");
+
+  unsigned Src0Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned Src1Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned Src2Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2);
+  unsigned DstBank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+
+  unsigned DBase = DRange->Base + DstBank * VgprBankSize;
+  unsigned ABase = ARange->Base + Src0Bank * VgprBankSize;
+  unsigned BBase = BRange->Base + Src1Bank * VgprBankSize;
+  unsigned CBase = CRange ? CRange->Base + Src2Bank * VgprBankSize : 0;
+  unsigned ScaleALo = *ScaleABase;
+  unsigned ScaleAHi = ScaleALo + 1;
+  unsigned ScaleBLo = *ScaleBBase;
+  unsigned ScaleBHi = ScaleBLo + 1;
+
+  if (!physicalVgprRangeFitsOneBank(DBase, 16, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(ABase, 16, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(BBase, 8, Ctx.Config.MaxVgprs) ||
+      (CRange &&
+       !physicalVgprRangeFitsOneBank(CBase, 16, Ctx.Config.MaxVgprs)) ||
+      !physicalVgprRangeFitsOneBank(ScaleALo, 2, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(ScaleBLo, 2, Ctx.Config.MaxVgprs))
+    return failClosed(Ctx, DI,
+                      "M=32 operand exceeds or crosses a physical VGPR bank");
+
+  // The split reads A in stages after its first D-half write. The fused source
+  // instruction reads all of A before writing D, so any D/A overlap would
+  // otherwise let the replacement destroy a later A read.
+  if (rangesOverlap(DBase, 16, ABase, 16))
+    return failClosed(Ctx, DI,
+                      "destination overlaps matrix A across staged reads");
+  if (rangesOverlap(DBase, 16, BBase, 8))
+    return failClosed(Ctx, DI,
+                      "destination overlaps matrix B across staged reads");
+  if (rangesOverlap(ABase, 16, BBase, 8))
+    return failClosed(Ctx, DI,
+                      "matrix A overlaps matrix B during in-place masking");
+
+  // Exact D==C is the ordinary in-place accumulator form. A disjoint C is
+  // likewise safe. Reject partial/cross-half overlap: writing DLo could
+  // otherwise destroy CHi before the second low-K pass consumes it.
+  if (CRange && rangesOverlap(DBase, 16, CBase, 16) &&
+      !sameRange(DBase, 16, CBase, 16))
+    return failClosed(Ctx, DI,
+                      "partial destination/src2 overlap across staged reads");
+
+  std::function<bool(unsigned, unsigned)> ScaleOverlaps = [&](unsigned Base,
+                                                              unsigned Width) {
+    return rangesOverlap(ScaleALo, 2, Base, Width) ||
+           rangesOverlap(ScaleBLo, 2, Base, Width);
+  };
+  if (ScaleOverlaps(DBase, 16) || ScaleOverlaps(ABase, 16) ||
+      ScaleOverlaps(BBase, 8) || (CRange && ScaleOverlaps(CBase, 16)) ||
+      rangesOverlap(ScaleALo, 2, ScaleBLo, 2))
+    return failClosed(
+        Ctx, DI,
+        "scale pair overlaps a staged matrix operand or the other scale");
+  if (CRange && rangesOverlap(ABase, 16, CBase, 16))
+    return failClosed(Ctx, DI,
+                      "matrix A overlaps src2 during in-place masking");
+
+  std::string KernelName =
+      Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
+  std::optional<unsigned> KdVgprs = Ctx.Elf.getKernelVgprCount(
+      KernelName, getKernelVgprGranuleSize(Ctx, KernelName));
+  unsigned KdCount = KdVgprs.value_or(Ctx.Config.MaxVgprs);
+  VgprAllocator Alloc(Ctx.Liveness.liveBefore(Idx), KdCount,
+                      Ctx.Config.MaxVgprs);
+
+  // Replace generic encoded-register liveness with a physical-bank all-path
+  // proof when available. An unset bit is the only state the in-KD allocator
+  // accepts; failure leaves the allocator conservative-all-live and therefore
+  // permits only ordinary above-KD growth.
+  std::optional<BitVector> ForwardDead = computeForwardDeadPhysicalVgprs(
+      Ctx, Idx, *ActiveMode, Ctx.Config.MaxVgprs);
+  if (ForwardDead) {
+    for (int V = ForwardDead->find_first(); V >= 0;
+         V = ForwardDead->find_next(V))
+      Alloc.LiveAtPoint.reset(static_cast<unsigned>(V));
+    unsigned BestBase = 0;
+    unsigned BestWidth = 0;
+    for (unsigned BankBase = 0; BankBase < Ctx.Config.MaxVgprs;
+         BankBase += VgprBankSize) {
+      unsigned BankEnd = std::min(Ctx.Config.MaxVgprs, BankBase + VgprBankSize);
+      for (unsigned V = BankBase; V != BankEnd;) {
+        if (!ForwardDead->test(V)) {
+          ++V;
+          continue;
+        }
+        unsigned Begin = V;
+        while (V != BankEnd && ForwardDead->test(V))
+          ++V;
+        if (V - Begin > BestWidth) {
+          BestBase = Begin;
+          BestWidth = V - Begin;
+        }
+      }
+    }
+    log() << "hotswap: wmma_scale16: physical forward-dead proof at offset 0x"
+          << utohexstr(DI.Offset) << " found " << ForwardDead->count()
+          << " VGPRs; longest single-bank run ";
+    if (BestWidth)
+      log() << "v" << BestBase << ":" << (BestBase + BestWidth - 1) << " ("
+            << BestWidth << ")\n";
+    else
+      log() << "<none>\n";
+  } else {
+    log() << "hotswap: wmma_scale16: physical forward-dead proof unavailable "
+             "at offset 0x"
+          << utohexstr(DI.Offset) << "\n";
+  }
+
+  // Liveness describes values entering the original instruction. Its
+  // destination can therefore appear dead even though every replacement
+  // writes it, and tied/overlapping inputs need the same protection. Reserve
+  // every physical VGPR range decoded from the original instruction before
+  // considering an in-KD scratch block.
+  reserveVgprRange(Alloc, DBase, 16);
+  reserveVgprRange(Alloc, ABase, 16);
+  reserveVgprRange(Alloc, BBase, 8);
+  if (CRange)
+    reserveVgprRange(Alloc, CBase, 16);
+  reserveVgprRange(Alloc, ScaleALo, 2);
+  reserveVgprRange(Alloc, ScaleBLo, 2);
+
+  // Masking one eight-register FP4 A half overwrites exactly four registers.
+  // Preserve only those four values, not the four already-retained values.
+  // The first save slot doubles as the reversible scale-pair permutation
+  // temporary before the first A save and after the final A restore. Low-K
+  // runs for both M halves before high-K, so the same four slots serve all four
+  // WMMAs. Matrix B stays in place.
+  constexpr unsigned MatrixHalfWidth = 8;
+  constexpr unsigned SavedARegCount = MatrixHalfWidth / 2;
+  constexpr unsigned ScratchCount = SavedARegCount;
+  std::array<unsigned, SavedARegCount> SavedARegs;
+  for (unsigned &Reg : SavedARegs) {
+    std::optional<unsigned> Allocated = allocContiguousDeadOrAboveInBank(
+        Alloc, /*Count=*/1, /*Align=*/1, VgprBankSize, ForwardDead.has_value());
+    if (!Allocated)
+      return failClosed(Ctx, DI,
+                        "fewer than four dead/above-KD VGPRs for exact M+K "
+                        "split");
+    Reg = *Allocated;
+  }
+  unsigned TmpReg = SavedARegs.front();
+
+  std::string ReplacementAsm;
+  raw_string_ostream OS(ReplacementAsm);
+  unsigned CurrentMode = *ActiveMode;
+  emitScalePairSplitInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
+  emitScalePairSplitInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+
+  int HazardNops = classifyWmmaNops("v_wmma_scale_f32_16x16x128_f8f6f4").A0Nops;
+  std::function<void()> EmitHazardNops = [&] {
+    for (int I = 0; I != HazardNops; ++I)
+      OS << "v_nop\n";
+  };
+
+  for (bool HighK : {false, true}) {
+    for (unsigned MHalf = 0; MHalf != 2; ++MHalf) {
+      unsigned OriginalAHalf = ABase + MHalf * MatrixHalfWidth;
+      unsigned DstHalf = DBase + MHalf * MatrixHalfWidth;
+      unsigned ABank = OriginalAHalf / VgprBankSize;
+      unsigned BBank = BBase / VgprBankSize;
+
+      unsigned SavedIndex = 0;
+      for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
+        bool IsLow = ((I / 2) % 2) == 0;
+        if (IsLow == !HighK)
+          continue;
+        unsigned Saved = SavedARegs[SavedIndex++];
+        emitVgprCopy(OS, Saved, OriginalAHalf + I, /*W=*/1, CurrentMode);
+      }
+      assert(SavedIndex == SavedARegCount);
+      emitMaskVgprsInPlace(OS, /*KeepLow=*/!HighK, OriginalAHalf,
+                           MatrixHalfWidth, /*SubW=*/2, CurrentMode);
+
+      SmallVector<VgprBankRequirement, 4> WmmaMode = {
+          {VgprMsbOperand::Dst, DstHalf / VgprBankSize},
+          {VgprMsbOperand::Src0, ABank},
+          {VgprMsbOperand::Src1, BBank}};
+      std::string Src2;
+      if (HighK) {
+        WmmaMode.push_back({VgprMsbOperand::Src2, DstHalf / VgprBankSize});
+        Src2 = encodedVgprRange(DstHalf, MatrixHalfWidth);
+      } else if (CRange) {
+        unsigned CHalf = CBase + MHalf * MatrixHalfWidth;
+        WmmaMode.push_back({VgprMsbOperand::Src2, CHalf / VgprBankSize});
+        Src2 = encodedVgprRange(CHalf, MatrixHalfWidth);
+      } else {
+        Src2 = Printed->Operands[3];
+      }
+      emitModeForOperands(OS, CurrentMode, WmmaMode);
+      emitScale32Half(OS, DstHalf, OriginalAHalf, BBase, Src2,
+                      HighK ? ScaleAHi : ScaleALo, HighK ? ScaleBHi : ScaleBLo,
+                      HighK ? *HighSuffix : *LowSuffix);
+
+      EmitHazardNops();
+      SavedIndex = 0;
+      for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
+        bool IsLow = ((I / 2) % 2) == 0;
+        if (IsLow == !HighK)
+          continue;
+        unsigned Saved = SavedARegs[SavedIndex++];
+        emitVgprCopy(OS, OriginalAHalf + I, Saved, /*W=*/1, CurrentMode);
+      }
+      assert(SavedIndex == SavedARegCount);
+    }
+  }
+
+  emitScalePairRestoreInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
+  emitScalePairRestoreInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Src0,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0)},
+                       {VgprMsbOperand::Src1,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1)},
+                       {VgprMsbOperand::Src2,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2)},
+                       {VgprMsbOperand::Dst,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst)}});
+
+  SmallVector<uint8_t> Replacement =
+      assembleInstructions(ReplacementAsm, Ctx.LS);
+  if (Replacement.empty())
+    return failClosed(Ctx, DI, "M+K split assembly failed");
+
+  unsigned Extra = Alloc.extraVgprsNeeded();
+  if (checkKernelVgprBump(Ctx, KernelName, Extra, PatchRequirement::Required) !=
+      VgprBumpDecision::Apply)
+    return 0;
+  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
+    return failClosed(Ctx, DI, "M+K split trampoline emission failed");
+
+  KernelPatchStats &Stats = Ctx.KernelStats[KernelName];
+  Stats.ExtraVgprs = std::max(Stats.ExtraVgprs, Extra);
+  if (Extra == 0)
+    Stats.ScratchReused += ScratchCount;
+  Stats.ScratchAboveKd += Extra;
+  ScratchPatchInfo Info;
+  Info.Offset = DI.Offset;
+  Info.ScratchRegs.resize(Ctx.Config.MaxVgprs);
+  for (unsigned Reg : SavedARegs)
+    Info.ScratchRegs.set(Reg);
+  Ctx.OutScratchPatches.push_back(std::move(Info));
+
+  log() << "hotswap: wmma_scale16: exact M+K split at offset 0x"
+        << utohexstr(DI.Offset) << " (D=v" << DBase << ":" << (DBase + 15)
+        << ", A=v" << ABase << ":" << (ABase + 15) << ", B=v" << BBase << ":"
+        << (BBase + 7) << ", four saved-A VGPRs, tmp=v" << TmpReg << ", +"
+        << Extra << " vgpr, 4 WMMAs, " << Replacement.size() << " bytes)\n";
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
 // patchWmmaScale16 -- dispatch
 // ---------------------------------------------------------------------------
 
@@ -904,9 +2026,10 @@ static uint32_t applyWmmaScale16PatchesImpl(PatchContext &Ctx, size_t Idx) {
 
   if (Mnem == "v_wmma_scale16_f32_16x16x128_f8f6f4")
     return patchWmmaScale16_16x16(Ctx, Idx);
+  if (Mnem == "v_wmma_scale16_f32_32x16x128_f4")
+    return patchWmmaScale16_32x16(Ctx, Idx);
 
-  // The M=32 FP4 form needs an M-split in addition to the K-split; not yet
-  // lowered exactly, so fail closed rather than miscompile.
+  // Any other block-16 scaled variant still has no exact lowering.
   if (Mnem.starts_with("v_wmma_scale16_f32_"))
     return failClosed(Ctx, Ctx.Decoded[Idx],
                       "block-16 scaled variant has no exact lowering yet");

--- a/amd/comgr/src/hotswap/rewriter/patch-wmma-scale16.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-wmma-scale16.cpp
@@ -1,4 +1,4 @@
-//===- patch-wmma-scale16.cpp - WMMA Scale16 decomposition ----------------===//
+//===- patch-wmma-scale16.cpp - Scaled WMMA decomposition -----------------===//
 //
 // Part of Comgr, under the Apache License v2.0 with LLVM Exceptions.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
@@ -6,9 +6,10 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// Lowers block-16 scaled WMMA (v_wmma_scale16_f32_*) for gfx1250 hardware that
-/// only has block-32 scaled WMMA (v_wmma_scale_f32_*). Done exactly, or failing
-/// closed when it cannot be applied.
+/// Lowers scaled WMMA variants that exist on gfx1250 B0 but not A0. This
+/// includes block-16 scaled WMMA (v_wmma_scale16_f32_*) and the M=32 regular
+/// scale form (v_wmma_scale_f32_32x16x128_f4). Done exactly, or failing closed
+/// when it cannot be applied.
 ///
 /// A block-32 op applies one (scaleA, scaleB) pair across all 32 K-elements of
 /// a block, so it cannot honor both block-16 sub-scales of that block at once.
@@ -523,100 +524,6 @@ matrixOperandRange(PatchContext &Ctx, const InternalDecodedInst &DI,
   return VgprRange{Lo, Hi - Lo + 1};
 }
 
-// Matrix-A K-subblock masking scheme, chosen by the matrix-A data format.
-// The K-split must isolate each 16-K subblock, and how a subblock maps to
-// lanes/VGPRs is format-dependent:
-//   * FP8/BF8: subblocks split by wave lane  -> Lane mask.
-//   * FP6/BF6: subblocks split by VGPR index -> Vgpr select, 3 VGPRs/subblock.
-//   * FP4    : subblocks split by VGPR index -> Vgpr select, 2 VGPRs/subblock.
-enum class AMaskScheme { Lane, Vgpr };
-struct AMaskPlan {
-  AMaskScheme Scheme;
-  unsigned SubW; // VGPRs per 16-K subblock (Vgpr scheme only)
-};
-
-// Parse "matrix_a_fmt:MATRIX_FMT_<fmt>" from the printer's canonical form and
-// map it to a masking plan. FP8 is the default when the modifier is omitted.
-static std::optional<AMaskPlan> matrixAMaskPlan(PatchContext &Ctx,
-                                                const InternalDecodedInst &DI) {
-  SmallString<256> Buf;
-  raw_svector_ostream OS(Buf);
-  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
-                         OS);
-  StringRef S(Buf);
-  StringRef Key = "matrix_a_fmt:MATRIX_FMT_";
-  StringRef Fmt = "FP8"; // omitted modifier => default FP8
-  size_t P = S.find(Key);
-  if (P != StringRef::npos) {
-    StringRef R = S.substr(P + Key.size());
-    size_t E = R.find_first_of(" \t\r\n");
-    Fmt = (E == StringRef::npos) ? R : R.substr(0, E);
-  }
-  if (Fmt == "FP8" || Fmt == "BF8")
-    return AMaskPlan{AMaskScheme::Lane, /*SubW=*/4};
-  if (Fmt == "FP6" || Fmt == "BF6")
-    return AMaskPlan{AMaskScheme::Vgpr, /*SubW=*/3};
-  if (Fmt == "FP4")
-    return AMaskPlan{AMaskScheme::Vgpr, /*SubW=*/2};
-  return std::nullopt; // unknown format -> caller fails closed
-}
-
-// Fail the whole rewrite closed rather than emit a miscompile.
-static uint32_t failClosed(PatchContext &Ctx, const InternalDecodedInst &DI,
-                           const Twine &Why) {
-  log() << "hotswap: error: wmma_scale16: " << DI.Mnemonic << " at offset 0x"
-        << utohexstr(DI.Offset) << ": " << Why
-        << "; refusing to return a miscompiled code object.\n";
-  Ctx.RequiredPatchFailed = true;
-  return 0;
-}
-
-static void emitScalePairSplitInPlace(raw_string_ostream &OS, unsigned Lo,
-                                      unsigned Hi, unsigned Tmp,
-                                      unsigned &CurrentMode) {
-  unsigned PairBank = Lo / VgprBankSize;
-  unsigned TmpBank = Tmp / VgprBankSize;
-  emitVgprCopy(OS, Tmp, Lo, /*W=*/1, CurrentMode);
-  emitModeForOperands(OS, CurrentMode,
-                      {{VgprMsbOperand::Dst, PairBank},
-                       {VgprMsbOperand::Src0, TmpBank},
-                       {VgprMsbOperand::Src1, PairBank}});
-  OS << "v_perm_b32 " << encodedVgprName(Lo) << ", " << encodedVgprName(Tmp)
-     << ", " << encodedVgprName(Hi) << ", 0x06040200\n";
-  OS << "v_perm_b32 " << encodedVgprName(Hi) << ", " << encodedVgprName(Tmp)
-     << ", " << encodedVgprName(Hi) << ", 0x07050301\n";
-}
-
-static void emitScalePairRestoreInPlace(raw_string_ostream &OS, unsigned Lo,
-                                        unsigned Hi, unsigned Tmp,
-                                        unsigned &CurrentMode) {
-  unsigned PairBank = Lo / VgprBankSize;
-  unsigned TmpBank = Tmp / VgprBankSize;
-  emitVgprCopy(OS, Tmp, Lo, /*W=*/1, CurrentMode);
-  emitModeForOperands(OS, CurrentMode,
-                      {{VgprMsbOperand::Dst, PairBank},
-                       {VgprMsbOperand::Src0, TmpBank},
-                       {VgprMsbOperand::Src1, PairBank}});
-  OS << "v_perm_b32 " << encodedVgprName(Lo) << ", " << encodedVgprName(Tmp)
-     << ", " << encodedVgprName(Hi) << ", 0x05010400\n";
-  OS << "v_perm_b32 " << encodedVgprName(Hi) << ", " << encodedVgprName(Tmp)
-     << ", " << encodedVgprName(Hi) << ", 0x07030602\n";
-}
-
-static void emitMaskVgprsInPlace(raw_string_ostream &OS, bool KeepLow,
-                                 unsigned Base, unsigned W, unsigned SubW,
-                                 unsigned &CurrentMode) {
-  for (unsigned I = 0; I != W; ++I) {
-    bool IsLow = ((I / SubW) % 2) == 0;
-    if (IsLow == KeepLow)
-      continue;
-    unsigned Physical = Base + I;
-    emitModeForOperands(OS, CurrentMode,
-                        {{VgprMsbOperand::Dst, Physical / VgprBankSize}});
-    OS << "v_mov_b32 " << encodedVgprName(Physical) << ", 0\n";
-  }
-}
-
 struct Scale32PrintedAsm {
   std::string Operands[6]; // dst, matrix A/B, src2, scale A/B
   std::string ModifierSuffix;
@@ -736,6 +643,25 @@ transformScale32ModifierSuffix(StringRef Suffix, bool HighKPass) {
   return Result;
 }
 
+static std::optional<std::string>
+transformRegularScaleM32ModifierSuffix(StringRef Suffix, bool HighMHalf) {
+  std::string Result =
+      HighMHalf ? " matrix_a_scale:MATRIX_SCALE_ROW1" : std::string();
+  for (StringRef Token : tokenizeScaleModifiers(Suffix)) {
+    if (!isKnownScale32Modifier(Token)) {
+      log() << "hotswap: error: wmma_scale: unsupported M=32 modifier token \""
+            << Token << "\"\n";
+      return std::nullopt;
+    }
+    if (Token == "matrix_a_reuse" || Token == "matrix_b_reuse" ||
+        Token == "matrix_a_scale:MATRIX_SCALE_ROW1")
+      continue;
+    Result += ' ';
+    Result += Token.str();
+  }
+  return Result;
+}
+
 static std::string encodedVgprRange(unsigned PhysicalBase, unsigned Width) {
   assert(Width > 0);
   unsigned EncodedBase = PhysicalBase % VgprBankSize;
@@ -754,34 +680,41 @@ static void emitScale32Half(raw_string_ostream &OS, unsigned DstBase,
      << ModifierSuffix << "\n";
 }
 
-// Prefer one exact-liveness-proven dead block inside the kernel's declared
-// allocation. Fully allocated production kernels often have no above-KD
-// headroom even though a particular WMMA site has a large dead interval.
-// Search high-to-low within each physical bank so every generated range keeps
-// one VGPR-MSB setting. Fall back to the allocator's normal above-KD growth.
+static void emitRegularScaleMHalf(raw_string_ostream &OS, unsigned DstBase,
+                                  unsigned MatrixABase, unsigned MatrixBBase,
+                                  StringRef Src2, StringRef ScaleA,
+                                  StringRef ScaleB, StringRef ModifierSuffix) {
+  OS << "v_wmma_scale_f32_16x16x128_f8f6f4 " << encodedVgprRange(DstBase, 8)
+     << ", " << encodedVgprRange(MatrixABase, 8) << ", "
+     << encodedVgprRange(MatrixBBase, 8) << ", " << Src2 << ", " << ScaleA
+     << ", " << ScaleB
+     << " matrix_a_fmt:MATRIX_FMT_FP4 matrix_b_fmt:MATRIX_FMT_FP4"
+     << ModifierSuffix << "\n";
+}
+
+// Prefer one exact-liveness-proven dead block in bank zero. Scale-prefix
+// operands ignore VGPR-MSB, so every generated scale and the masked-A copy
+// must be directly addressable there. Fall back to above-KD growth only while
+// it still fits in bank zero.
 static std::optional<unsigned>
-allocContiguousDeadOrAboveInBank(VgprAllocator &Alloc, unsigned Count,
-                                 unsigned Align, unsigned BankSize,
-                                 bool AllowDeadReuse) {
-  if (Count == 0 || Count > BankSize || Align == 0)
+allocContiguousDeadOrAboveLowBank(VgprAllocator &Alloc, unsigned Count,
+                                  unsigned Align, bool AllowDeadReuse,
+                                  bool AllowAboveKd) {
+  unsigned LowBankLimit =
+      std::min({VgprBankSize, Alloc.MaxVgprs,
+                static_cast<unsigned>(Alloc.LiveAtPoint.size())});
+  if (Count == 0 || Count > LowBankLimit || Align == 0)
     return std::nullopt;
 
   if (AllowDeadReuse) {
-    unsigned BankCount = (Alloc.KdAllocatedVgprs + BankSize - 1) / BankSize;
-    for (unsigned ReverseBank = BankCount; ReverseBank != 0; --ReverseBank) {
-      unsigned Bank = ReverseBank - 1;
-      unsigned BankBegin = Bank * BankSize;
-      unsigned BankEnd = std::min(Alloc.KdAllocatedVgprs, BankBegin + BankSize);
-      if (BankEnd < BankBegin + Count)
-        continue;
-
+    unsigned BankEnd = std::min(Alloc.KdAllocatedVgprs, LowBankLimit);
+    if (BankEnd >= Count) {
       unsigned Base = BankEnd - Count;
       Base -= Base % Align;
-      while (Base >= BankBegin) {
+      while (true) {
         bool AllDead = true;
         for (unsigned V = Base; V != Base + Count; ++V) {
-          if (V >= static_cast<unsigned>(Alloc.LiveAtPoint.size()) ||
-              Alloc.LiveAtPoint.test(V)) {
+          if (Alloc.LiveAtPoint.test(V)) {
             AllDead = false;
             break;
           }
@@ -790,13 +723,22 @@ allocContiguousDeadOrAboveInBank(VgprAllocator &Alloc, unsigned Count,
           Alloc.LiveAtPoint.set(Base, Base + Count);
           return Base;
         }
-        if (Base < BankBegin + Align)
+        if (Base < Align)
           break;
         Base -= Align;
       }
     }
   }
-  return Alloc.allocContiguousAboveKdInBank(Count, Align, BankSize);
+
+  if (!AllowAboveKd)
+    return std::nullopt;
+
+  unsigned AboveBase = Alloc.NextAboveKd;
+  if (AboveBase % Align != 0)
+    AboveBase += Align - AboveBase % Align;
+  if (AboveBase + Count > LowBankLimit)
+    return std::nullopt;
+  return Alloc.allocContiguousAboveKdInBank(Count, Align, VgprBankSize);
 }
 
 static bool rangesOverlap(unsigned ABase, unsigned AWidth, unsigned BBase,
@@ -1357,6 +1299,64 @@ computeForwardDeadPhysicalVgprs(PatchContext &Ctx, size_t SiteIdx,
   return computeForwardDeadVgprs(Graph->Nodes, Graph->EntryNode, MaxVgprs);
 }
 
+// Matrix-A K-subblock masking scheme, chosen by the matrix-A data format.
+// The K-split must isolate each 16-K subblock, and how a subblock maps to
+// lanes/VGPRs is format-dependent:
+//   * FP8/BF8: subblocks split by wave lane  -> Lane mask.
+//   * FP6/BF6: subblocks split by VGPR index -> Vgpr select, 3 VGPRs/subblock.
+//   * FP4    : subblocks split by VGPR index -> Vgpr select, 2 VGPRs/subblock.
+enum class AMaskScheme { Lane, Vgpr };
+struct AMaskPlan {
+  AMaskScheme Scheme;
+  unsigned SubW; // VGPRs per 16-K subblock (Vgpr scheme only)
+};
+
+// Parse "matrix_a_fmt:MATRIX_FMT_<fmt>" from the printer's canonical form and
+// map it to a masking plan. FP8 is the default when the modifier is omitted.
+static std::optional<AMaskPlan> matrixAMaskPlan(PatchContext &Ctx,
+                                                const InternalDecodedInst &DI) {
+  SmallString<256> Buf;
+  raw_svector_ostream OS(Buf);
+  Ctx.LS.MCIP->printInst(&DI.Inst, /*Address=*/0, /*Annot=*/"", *Ctx.LS.STI,
+                         OS);
+  StringRef S(Buf);
+  StringRef Key = "matrix_a_fmt:MATRIX_FMT_";
+  StringRef Fmt = "FP8"; // omitted modifier => default FP8
+  size_t P = S.find(Key);
+  if (P != StringRef::npos) {
+    StringRef R = S.substr(P + Key.size());
+    size_t E = R.find_first_of(" \t\r\n");
+    Fmt = (E == StringRef::npos) ? R : R.substr(0, E);
+  }
+  if (Fmt == "FP8" || Fmt == "BF8")
+    return AMaskPlan{AMaskScheme::Lane, /*SubW=*/4};
+  if (Fmt == "FP6" || Fmt == "BF6")
+    return AMaskPlan{AMaskScheme::Vgpr, /*SubW=*/3};
+  if (Fmt == "FP4")
+    return AMaskPlan{AMaskScheme::Vgpr, /*SubW=*/2};
+  return std::nullopt; // unknown format -> caller fails closed
+}
+
+// Fail the whole rewrite closed rather than emit a miscompile.
+static uint32_t failClosed(PatchContext &Ctx, const InternalDecodedInst &DI,
+                           const Twine &Why) {
+  log() << "hotswap: error: wmma_scale16: " << DI.Mnemonic << " at offset 0x"
+        << utohexstr(DI.Offset) << ": " << Why
+        << "; refusing to return a miscompiled code object.\n";
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
+static uint32_t failRegularScaleM32Closed(PatchContext &Ctx,
+                                          const InternalDecodedInst &DI,
+                                          const Twine &Why) {
+  log() << "hotswap: error: wmma_scale: " << DI.Mnemonic << " at offset 0x"
+        << utohexstr(DI.Offset) << ": " << Why
+        << "; refusing to return a miscompiled code object.\n";
+  Ctx.RequiredPatchFailed = true;
+  return 0;
+}
+
 // ---------------------------------------------------------------------------
 // v_wmma_scale16_f32_16x16x128_f8f6f4 -> exact K-split
 // ---------------------------------------------------------------------------
@@ -1693,6 +1693,203 @@ static uint32_t patchWmmaScale16_16x16(PatchContext &Ctx, size_t Idx) {
 }
 
 // ---------------------------------------------------------------------------
+// v_wmma_scale_f32_32x16x128_f4 -> exact M split
+// ---------------------------------------------------------------------------
+
+static uint32_t patchWmmaScale_32x16(PatchContext &Ctx, size_t Idx) {
+  const InternalDecodedInst &DI = Ctx.Decoded[Idx];
+
+  if (DI.Size != VOP3PXSize)
+    return failRegularScaleM32Closed(
+        Ctx, DI, "unexpected instruction size " + Twine(DI.Size));
+  for (const Trampoline &T : Ctx.OutTrampolines)
+    if (T.OriginalOffset == DI.Offset)
+      return 0;
+
+  std::optional<unsigned> ActiveMode = getActiveVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode)
+    ActiveMode = getLocallyEstablishedVgprMsbMode(Ctx, Idx);
+  if (!ActiveMode) {
+    std::string Detail = "cannot determine active VGPR-MSB mode";
+    if (Ctx.DirectControlFlow.HasUnresolvedTargets)
+      Detail += " (unresolved control-flow target)";
+    if (Ctx.DirectControlFlow.HasUnboundedIndirectEntries)
+      Detail += " (unbounded indirect entry)";
+    return failRegularScaleM32Closed(Ctx, DI, Detail);
+  }
+
+  std::optional<Scale32PrintedAsm> Printed = parseScale32PrintedAsm(Ctx, DI);
+  if (!Printed)
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "could not parse canonical instruction");
+  std::optional<std::string> LowModifierSuffix =
+      transformRegularScaleM32ModifierSuffix(Printed->ModifierSuffix,
+                                             /*HighMHalf=*/false);
+  std::optional<std::string> HighModifierSuffix =
+      transformRegularScaleM32ModifierSuffix(Printed->ModifierSuffix,
+                                             /*HighMHalf=*/true);
+  if (!LowModifierSuffix || !HighModifierSuffix)
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "unsupported modifier combination");
+
+  std::optional<VgprRange> DRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/0);
+  std::optional<VgprRange> ARange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/1);
+  std::optional<VgprRange> BRange =
+      matrixOperandRange(Ctx, DI, /*OperandIndex=*/2);
+  if (!DRange || !ARange || !BRange || DRange->Width != 16 ||
+      ARange->Width != 16 || BRange->Width != 8)
+    return failRegularScaleM32Closed(
+        Ctx, DI, "unexpected M=32 matrix operand widths/layout");
+
+  if (DI.Inst.getNumOperands() < 7)
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "truncated M=32 MC operand layout");
+  const MCOperand &Src2Op = DI.Inst.getOperand(4);
+  bool Src2IsImm = Src2Op.isImm();
+  std::optional<VgprRange> CRange;
+  if (Src2Op.isReg())
+    CRange = matrixOperandRange(Ctx, DI, /*OperandIndex=*/3);
+  else if (!Src2IsImm)
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "unsupported non-VGPR/non-immediate src2");
+  if (CRange && CRange->Width != 16)
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "src2 and destination widths differ");
+  if (!Src2IsImm && !CRange)
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "could not determine src2 VGPR range");
+
+  unsigned Src0Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0);
+  unsigned Src1Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1);
+  unsigned Src2Bank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2);
+  unsigned DstBank = getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst);
+
+  unsigned DBase = DRange->Base + DstBank * VgprBankSize;
+  unsigned ABase = ARange->Base + Src0Bank * VgprBankSize;
+  unsigned BBase = BRange->Base + Src1Bank * VgprBankSize;
+  unsigned CBase = CRange ? CRange->Base + Src2Bank * VgprBankSize : 0;
+
+  if (!physicalVgprRangeFitsOneBank(DBase, 16, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(ABase, 16, Ctx.Config.MaxVgprs) ||
+      !physicalVgprRangeFitsOneBank(BBase, 8, Ctx.Config.MaxVgprs) ||
+      (CRange && !physicalVgprRangeFitsOneBank(CBase, 16, Ctx.Config.MaxVgprs)))
+    return failRegularScaleM32Closed(
+        Ctx, DI, "M=32 operand exceeds or crosses a physical VGPR bank");
+
+  if (rangesOverlap(DBase, 16, ABase, 16))
+    return failRegularScaleM32Closed(
+        Ctx, DI, "destination overlaps matrix A across staged reads");
+  if (rangesOverlap(DBase, 16, BBase, 8))
+    return failRegularScaleM32Closed(
+        Ctx, DI, "destination overlaps matrix B across staged reads");
+  if (CRange && rangesOverlap(DBase, 16, CBase, 16) &&
+      !sameRange(DBase, 16, CBase, 16))
+    return failRegularScaleM32Closed(
+        Ctx, DI, "partial destination/src2 overlap across staged reads");
+
+  for (unsigned OperandIndex : {5u, 6u}) {
+    const MCOperand &ScaleOp = DI.Inst.getOperand(OperandIndex);
+    if (!ScaleOp.isReg() || !ScaleOp.getReg())
+      return failRegularScaleM32Closed(Ctx, DI, "non-register scale operand");
+    std::optional<EncodedVgprRange> ScaleRange =
+        getEncodedVgprRange(MCRegister(ScaleOp.getReg()), *Ctx.LS.MRI);
+    if (!ScaleRange) {
+      if (isVectorRegisterOrAlias(MCRegister(ScaleOp.getReg()), *Ctx.LS.MRI))
+        return failRegularScaleM32Closed(Ctx, DI,
+                                         "unsupported vector scale operand");
+      continue;
+    }
+    if (!ScaleRange->FullDwords || ScaleRange->Width != 1 ||
+        ScaleRange->Base >= Ctx.Config.MaxVgprs)
+      return failRegularScaleM32Closed(Ctx, DI,
+                                       "unsupported VGPR scale operand");
+    if (rangesOverlap(DBase, 16, ScaleRange->Base, ScaleRange->Width))
+      return failRegularScaleM32Closed(Ctx, DI,
+                                       "destination overlaps a scale operand");
+  }
+
+  std::string ReplacementAsm;
+  raw_string_ostream OS(ReplacementAsm);
+  unsigned CurrentMode = *ActiveMode;
+  constexpr unsigned MatrixHalfWidth = 8;
+  int HazardNops = classifyWmmaNops("v_wmma_scale_f32_16x16x128_f8f6f4").A0Nops;
+
+  for (unsigned MHalf = 0; MHalf != 2; ++MHalf) {
+    unsigned DstHalf = DBase + MHalf * MatrixHalfWidth;
+    unsigned AHalf = ABase + MHalf * MatrixHalfWidth;
+    SmallVector<VgprBankRequirement, 4> WmmaMode = {
+        {VgprMsbOperand::Dst, DstHalf / VgprBankSize},
+        {VgprMsbOperand::Src0, AHalf / VgprBankSize},
+        {VgprMsbOperand::Src1, BBase / VgprBankSize}};
+    std::string Src2;
+    if (CRange) {
+      unsigned CHalf = CBase + MHalf * MatrixHalfWidth;
+      WmmaMode.push_back({VgprMsbOperand::Src2, CHalf / VgprBankSize});
+      Src2 = encodedVgprRange(CHalf, MatrixHalfWidth);
+    } else {
+      Src2 = Printed->Operands[3];
+    }
+
+    emitModeForOperands(OS, CurrentMode, WmmaMode);
+    emitRegularScaleMHalf(OS, DstHalf, AHalf, BBase, Src2, Printed->Operands[4],
+                          Printed->Operands[5],
+                          MHalf == 0 ? *LowModifierSuffix
+                                     : *HighModifierSuffix);
+    for (int I = 0; I != HazardNops; ++I)
+      OS << "v_nop\n";
+  }
+
+  emitModeForOperands(OS, CurrentMode,
+                      {{VgprMsbOperand::Src0,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0)},
+                       {VgprMsbOperand::Src1,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src1)},
+                       {VgprMsbOperand::Src2,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src2)},
+                       {VgprMsbOperand::Dst,
+                        getVgprMsbBank(*ActiveMode, VgprMsbOperand::Dst)}});
+
+  SmallVector<uint8_t> Replacement =
+      assembleInstructions(ReplacementAsm, Ctx.LS);
+  if (Replacement.empty())
+    return failRegularScaleM32Closed(Ctx, DI, "M split assembly failed");
+
+  std::vector<InternalDecodedInst> ReplacementDecoded;
+  if (!decodeTextSection(Replacement.data(), Replacement.size(), Ctx.LS,
+                         ReplacementDecoded))
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "could not decode assembled M split");
+  unsigned ScaledWmmas = 0;
+  for (const InternalDecodedInst &ReplacementInst : ReplacementDecoded) {
+    if (ReplacementInst.Mnemonic != "v_wmma_scale_f32_16x16x128_f8f6f4")
+      continue;
+    if (ReplacementInst.Size != VOP3PXSize ||
+        ReplacementInst.Offset > Replacement.size() ||
+        VOP3PXSize > Replacement.size() - ReplacementInst.Offset)
+      return failRegularScaleM32Closed(
+          Ctx, DI, "invalid assembled scaled-WMMA boundary");
+    patchScaleSrc2(Replacement.data() + ReplacementInst.Offset);
+    ++ScaledWmmas;
+  }
+  if (ScaledWmmas != 2)
+    return failRegularScaleM32Closed(
+        Ctx, DI, "assembled M split did not contain exactly two scaled WMMAs");
+
+  if (!emitToTrampoline(Ctx, DI.Offset, DI.Size, Replacement))
+    return failRegularScaleM32Closed(Ctx, DI,
+                                     "M split trampoline emission failed");
+
+  Ctx.RequiredPatchApplied = true;
+  log() << "hotswap: wmma_scale: exact M split at offset 0x"
+        << utohexstr(DI.Offset) << " (D=v" << DBase << ":" << (DBase + 15)
+        << ", A=v" << ABase << ":" << (ABase + 15) << ", B=v" << BBase << ":"
+        << (BBase + 7) << ", 2 WMMAs, " << Replacement.size() << " bytes)\n";
+  return 1;
+}
+
+// ---------------------------------------------------------------------------
 // v_wmma_scale16_f32_32x16x128_f4 -> exact M+K split
 // ---------------------------------------------------------------------------
 
@@ -1736,6 +1933,21 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
                                      /*HighKPass=*/true);
   if (!LowSuffix || !HighSuffix)
     return failClosed(Ctx, DI, "unsupported modifier combination");
+  std::optional<std::string> LowKLowMSuffix =
+      transformRegularScaleM32ModifierSuffix(*LowSuffix,
+                                             /*HighMHalf=*/false);
+  std::optional<std::string> LowKHighMSuffix =
+      transformRegularScaleM32ModifierSuffix(*LowSuffix,
+                                             /*HighMHalf=*/true);
+  std::optional<std::string> HighKLowMSuffix =
+      transformRegularScaleM32ModifierSuffix(*HighSuffix,
+                                             /*HighMHalf=*/false);
+  std::optional<std::string> HighKHighMSuffix =
+      transformRegularScaleM32ModifierSuffix(*HighSuffix,
+                                             /*HighMHalf=*/true);
+  if (!LowKLowMSuffix || !LowKHighMSuffix || !HighKLowMSuffix ||
+      !HighKHighMSuffix)
+    return failClosed(Ctx, DI, "unsupported M-half modifier combination");
 
   std::optional<VgprRange> DRange =
       matrixOperandRange(Ctx, DI, /*OperandIndex=*/0);
@@ -1798,8 +2010,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
     return failClosed(Ctx, DI,
                       "destination overlaps matrix B across staged reads");
   if (rangesOverlap(ABase, 16, BBase, 8))
-    return failClosed(Ctx, DI,
-                      "matrix A overlaps matrix B during in-place masking");
+    return failClosed(Ctx, DI, "matrix A overlaps matrix B");
 
   // Exact D==C is the ordinary in-place accumulator form. A disjoint C is
   // likewise safe. Reject partial/cross-half overlap: writing DLo could
@@ -1821,8 +2032,7 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
         Ctx, DI,
         "scale pair overlaps a staged matrix operand or the other scale");
   if (CRange && rangesOverlap(ABase, 16, CBase, 16))
-    return failClosed(Ctx, DI,
-                      "matrix A overlaps src2 during in-place masking");
+    return failClosed(Ctx, DI, "matrix A overlaps src2");
 
   std::string KernelName =
       Ctx.Elf.findKernelAtAddress(DI.Offset + Ctx.Elf.textAddr());
@@ -1888,32 +2098,83 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   reserveVgprRange(Alloc, ScaleALo, 2);
   reserveVgprRange(Alloc, ScaleBLo, 2);
 
-  // Masking one eight-register FP4 A half overwrites exactly four registers.
-  // Preserve only those four values, not the four already-retained values.
-  // The first save slot doubles as the reversible scale-pair permutation
-  // temporary before the first A save and after the final A restore. Low-K
-  // runs for both M halves before high-K, so the same four slots serve all four
-  // WMMAs. Matrix B stays in place.
+  // Keep the masked A half and all generated scale operands in bank zero. The
+  // original A and Scale16 pairs remain untouched throughout the lowering.
+  // Prefer one contiguous 13-register dead block, but do not require it:
+  // rocJITu's schedule only needs masked A to be contiguous. The four scales
+  // and one temporary can use independent dead low-bank slots. This avoids a
+  // kernel VGPR bump when the low bank has enough dead registers but no
+  // 13-register run.
   constexpr unsigned MatrixHalfWidth = 8;
-  constexpr unsigned SavedARegCount = MatrixHalfWidth / 2;
-  constexpr unsigned ScratchCount = SavedARegCount;
-  std::array<unsigned, SavedARegCount> SavedARegs;
-  for (unsigned &Reg : SavedARegs) {
-    std::optional<unsigned> Allocated = allocContiguousDeadOrAboveInBank(
-        Alloc, /*Count=*/1, /*Align=*/1, VgprBankSize, ForwardDead.has_value());
-    if (!Allocated)
-      return failClosed(Ctx, DI,
-                        "fewer than four dead/above-KD VGPRs for exact M+K "
-                        "split");
-    Reg = *Allocated;
+  constexpr unsigned ScaleScratchCount = 4;
+  constexpr unsigned ScalarScratchCount = ScaleScratchCount + 1;
+  constexpr unsigned ScratchCount = MatrixHalfWidth + ScaleScratchCount + 1;
+  unsigned MaskedABase = 0;
+  std::array<unsigned, ScalarScratchCount> ScalarScratchRegs = {};
+
+  VgprAllocator ScratchAlloc = Alloc;
+  std::optional<unsigned> FullScratch = allocContiguousDeadOrAboveLowBank(
+      ScratchAlloc, ScratchCount, /*Align=*/2, ForwardDead.has_value(),
+      /*AllowAboveKd=*/false);
+  if (FullScratch) {
+    MaskedABase = *FullScratch;
+    for (unsigned I = 0; I != ScalarScratchCount; ++I)
+      ScalarScratchRegs[I] = MaskedABase + MatrixHalfWidth + I;
+    Alloc = std::move(ScratchAlloc);
+  } else {
+    ScratchAlloc = Alloc;
+    std::optional<unsigned> MaskedA = allocContiguousDeadOrAboveLowBank(
+        ScratchAlloc, MatrixHalfWidth, /*Align=*/2, ForwardDead.has_value(),
+        /*AllowAboveKd=*/false);
+    bool SplitScratchComplete = MaskedA.has_value();
+    if (MaskedA)
+      MaskedABase = *MaskedA;
+    for (unsigned I = 0; SplitScratchComplete && I != ScalarScratchCount; ++I) {
+      std::optional<unsigned> Scalar = allocContiguousDeadOrAboveLowBank(
+          ScratchAlloc, /*Count=*/1, /*Align=*/1, ForwardDead.has_value(),
+          /*AllowAboveKd=*/false);
+      if (!Scalar) {
+        SplitScratchComplete = false;
+        break;
+      }
+      ScalarScratchRegs[I] = *Scalar;
+    }
+
+    if (SplitScratchComplete) {
+      Alloc = std::move(ScratchAlloc);
+    } else {
+      ScratchAlloc = Alloc;
+      FullScratch = allocContiguousDeadOrAboveLowBank(
+          ScratchAlloc, ScratchCount, /*Align=*/2, ForwardDead.has_value(),
+          /*AllowAboveKd=*/true);
+      if (!FullScratch)
+        return failClosed(
+            Ctx, DI,
+            "no bank-zero masked-A block and five scalar scratch VGPRs");
+      MaskedABase = *FullScratch;
+      for (unsigned I = 0; I != ScalarScratchCount; ++I)
+        ScalarScratchRegs[I] = MaskedABase + MatrixHalfWidth + I;
+      Alloc = std::move(ScratchAlloc);
+    }
   }
-  unsigned TmpReg = SavedARegs.front();
+
+  unsigned ScaleALoReg = ScalarScratchRegs[0];
+  unsigned ScaleBLoReg = ScalarScratchRegs[1];
+  unsigned ScaleAHiReg = ScalarScratchRegs[2];
+  unsigned ScaleBHiReg = ScalarScratchRegs[3];
+  unsigned TmpReg = ScalarScratchRegs[4];
 
   std::string ReplacementAsm;
   raw_string_ostream OS(ReplacementAsm);
   unsigned CurrentMode = *ActiveMode;
-  emitScalePairSplitInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
-  emitScalePairSplitInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
+  emitGatherEven(OS, ScaleALo, ScaleAHi, ScaleALoReg, TmpReg,
+                 /*ScratchBank=*/0, CurrentMode);
+  emitGatherEven(OS, ScaleBLo, ScaleBHi, ScaleBLoReg, TmpReg,
+                 /*ScratchBank=*/0, CurrentMode);
+  emitGatherOdd(OS, ScaleALo, ScaleAHi, ScaleAHiReg, TmpReg,
+                /*ScratchBank=*/0, CurrentMode);
+  emitGatherOdd(OS, ScaleBLo, ScaleBHi, ScaleBHiReg, TmpReg,
+                /*ScratchBank=*/0, CurrentMode);
 
   int HazardNops = classifyWmmaNops("v_wmma_scale_f32_16x16x128_f8f6f4").A0Nops;
   std::function<void()> EmitHazardNops = [&] {
@@ -1921,28 +2182,19 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
       OS << "v_nop\n";
   };
 
-  for (bool HighK : {false, true}) {
-    for (unsigned MHalf = 0; MHalf != 2; ++MHalf) {
+  for (unsigned MHalf = 0; MHalf != 2; ++MHalf) {
+    for (bool HighK : {false, true}) {
       unsigned OriginalAHalf = ABase + MHalf * MatrixHalfWidth;
       unsigned DstHalf = DBase + MHalf * MatrixHalfWidth;
-      unsigned ABank = OriginalAHalf / VgprBankSize;
       unsigned BBank = BBase / VgprBankSize;
 
-      unsigned SavedIndex = 0;
-      for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
-        bool IsLow = ((I / 2) % 2) == 0;
-        if (IsLow == !HighK)
-          continue;
-        unsigned Saved = SavedARegs[SavedIndex++];
-        emitVgprCopy(OS, Saved, OriginalAHalf + I, /*W=*/1, CurrentMode);
-      }
-      assert(SavedIndex == SavedARegCount);
-      emitMaskVgprsInPlace(OS, /*KeepLow=*/!HighK, OriginalAHalf,
-                           MatrixHalfWidth, /*SubW=*/2, CurrentMode);
+      emitVgprSelectCopy(OS, /*KeepLow=*/!HighK, MaskedABase, OriginalAHalf,
+                         MatrixHalfWidth, /*SubW=*/2, /*ScratchBank=*/0,
+                         CurrentMode);
 
       SmallVector<VgprBankRequirement, 4> WmmaMode = {
           {VgprMsbOperand::Dst, DstHalf / VgprBankSize},
-          {VgprMsbOperand::Src0, ABank},
+          {VgprMsbOperand::Src0, 0},
           {VgprMsbOperand::Src1, BBank}};
       std::string Src2;
       if (HighK) {
@@ -1956,25 +2208,17 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
         Src2 = Printed->Operands[3];
       }
       emitModeForOperands(OS, CurrentMode, WmmaMode);
-      emitScale32Half(OS, DstHalf, OriginalAHalf, BBase, Src2,
-                      HighK ? ScaleAHi : ScaleALo, HighK ? ScaleBHi : ScaleBLo,
-                      HighK ? *HighSuffix : *LowSuffix);
+      const std::string &HalfSuffix =
+          HighK ? (MHalf == 0 ? *HighKLowMSuffix : *HighKHighMSuffix)
+                : (MHalf == 0 ? *LowKLowMSuffix : *LowKHighMSuffix);
+      emitScale32Half(OS, DstHalf, MaskedABase, BBase, Src2,
+                      HighK ? ScaleAHiReg : ScaleALoReg,
+                      HighK ? ScaleBHiReg : ScaleBLoReg, HalfSuffix);
 
       EmitHazardNops();
-      SavedIndex = 0;
-      for (unsigned I = 0; I != MatrixHalfWidth; ++I) {
-        bool IsLow = ((I / 2) % 2) == 0;
-        if (IsLow == !HighK)
-          continue;
-        unsigned Saved = SavedARegs[SavedIndex++];
-        emitVgprCopy(OS, OriginalAHalf + I, Saved, /*W=*/1, CurrentMode);
-      }
-      assert(SavedIndex == SavedARegCount);
     }
   }
 
-  emitScalePairRestoreInPlace(OS, ScaleALo, ScaleAHi, TmpReg, CurrentMode);
-  emitScalePairRestoreInPlace(OS, ScaleBLo, ScaleBHi, TmpReg, CurrentMode);
   emitModeForOperands(OS, CurrentMode,
                       {{VgprMsbOperand::Src0,
                         getVgprMsbBank(*ActiveMode, VgprMsbOperand::Src0)},
@@ -2005,15 +2249,19 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
   ScratchPatchInfo Info;
   Info.Offset = DI.Offset;
   Info.ScratchRegs.resize(Ctx.Config.MaxVgprs);
-  for (unsigned Reg : SavedARegs)
+  Info.ScratchRegs.set(MaskedABase, MaskedABase + MatrixHalfWidth);
+  for (unsigned Reg : ScalarScratchRegs)
     Info.ScratchRegs.set(Reg);
   Ctx.OutScratchPatches.push_back(std::move(Info));
 
   log() << "hotswap: wmma_scale16: exact M+K split at offset 0x"
         << utohexstr(DI.Offset) << " (D=v" << DBase << ":" << (DBase + 15)
         << ", A=v" << ABase << ":" << (ABase + 15) << ", B=v" << BBase << ":"
-        << (BBase + 7) << ", four saved-A VGPRs, tmp=v" << TmpReg << ", +"
-        << Extra << " vgpr, 4 WMMAs, " << Replacement.size() << " bytes)\n";
+        << (BBase + 7) << ", masked-A=v" << MaskedABase << ":"
+        << (MaskedABase + MatrixHalfWidth - 1) << ", scales=v" << ScaleALoReg
+        << ",v" << ScaleBLoReg << ",v" << ScaleAHiReg << ",v" << ScaleBHiReg
+        << ", tmp=v" << TmpReg << ", +" << Extra << " vgpr, 4 WMMAs, "
+        << Replacement.size() << " bytes)\n";
   return 1;
 }
 
@@ -2024,12 +2272,13 @@ static uint32_t patchWmmaScale16_32x16(PatchContext &Ctx, size_t Idx) {
 static uint32_t applyWmmaScale16PatchesImpl(PatchContext &Ctx, size_t Idx) {
   StringRef Mnem(Ctx.Decoded[Idx].Mnemonic);
 
+  if (Mnem == "v_wmma_scale_f32_32x16x128_f4")
+    return patchWmmaScale_32x16(Ctx, Idx);
   if (Mnem == "v_wmma_scale16_f32_16x16x128_f8f6f4")
     return patchWmmaScale16_16x16(Ctx, Idx);
   if (Mnem == "v_wmma_scale16_f32_32x16x128_f4")
     return patchWmmaScale16_32x16(Ctx, Idx);
 
-  // Any other block-16 scaled variant still has no exact lowering.
   if (Mnem.starts_with("v_wmma_scale16_f32_"))
     return failClosed(Ctx, Ctx.Decoded[Idx],
                       "block-16 scaled variant has no exact lowering yet");

--- a/amd/comgr/src/hotswap/rewriter/patch-wmma-scale16.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-wmma-scale16.cpp
@@ -1096,35 +1096,8 @@ struct ScaleForwardGraph {
   std::vector<ForwardVgprProofNode> Nodes;
   std::vector<size_t> GlobalIndices;
   std::vector<int16_t> ModeBefore;
-  BitVector UndecodedVop3Heads;
   size_t EntryNode = 0;
 };
-
-// The B0 f4gemm object contains a legacy VOP3 opcode that the A0 gfx1250 MC
-// decoder intentionally does not recognize. The failed decode advances only
-// one dword, so its second dword appears as a separate unknown instruction.
-//
-// Recognize only the exact observed encoding:
-//   * legacy VOP3 major 0x34 and opcode 0x31;
-//   * vdst encoding zero, with only the observed bit-14 modifier variation;
-//   * scalar source encodings, in either observed second-dword spelling.
-//
-// We do not assign the unknown opcode semantics. Instead, conservatively model
-// encoded v0 as a use in every physical bank (so it cannot be scratch), model
-// no kill, and skip the split continuation dword. This is enough to traverse
-// the instruction without relying on whether opcode 0x31 has a vector or
-// scalar destination on B0.
-static bool recognizeUndecodedB0Vop3ScalarSources(PatchContext &Ctx,
-                                                  size_t Global,
-                                                  unsigned MaxVgprs,
-                                                  BitVector &ConservativeUses) {
-  if (!isUndecodedB0Vop3ScalarSourcePair(Ctx, Global))
-    return false;
-
-  for (unsigned Physical = 0; Physical < MaxVgprs; Physical += VgprBankSize)
-    ConservativeUses.set(Physical);
-  return true;
-}
 
 static std::optional<ScaleForwardGraph>
 buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
@@ -1156,7 +1129,6 @@ buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
     Graph.Nodes.emplace_back(MaxVgprs);
     Graph.GlobalIndices.push_back(I);
   }
-  Graph.UndecodedVop3Heads.resize(Count);
   Graph.EntryNode = SiteIdx + 1 - BeginIndex;
 
   DenseMap<uint64_t, size_t> IndexAtOffset;
@@ -1180,15 +1152,6 @@ buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
     // reading it, so no incoming scratch value can be observed there.
     if (Global == SiteIdx) {
       Node.SafeTerminal = true;
-      continue;
-    }
-    if (!DI.DecodeSucceeded && recognizeUndecodedB0Vop3ScalarSources(
-                                   Ctx, Global, MaxVgprs, Node.Uses)) {
-      if (Local + 2 >= Count)
-        Node.HasUnsafeExit = true;
-      else
-        Node.Successors.push_back(Local + 2);
-      Graph.UndecodedVop3Heads.set(Local);
       continue;
     }
     if (!DI.DecodeSucceeded ||
@@ -1240,11 +1203,9 @@ buildScaleForwardGraph(PatchContext &Ctx, size_t SiteIdx, unsigned EntryMode,
     const ForwardVgprProofNode &Node = Graph.Nodes[Local];
     if (Node.Opaque || Node.SafeTerminal)
       continue;
-    int16_t Out = Graph.UndecodedVop3Heads.test(Local)
-                      ? Graph.ModeBefore[Local]
-                      : transferExactVgprMsbMode(
-                            Graph.ModeBefore[Local],
-                            Ctx.Decoded[Graph.GlobalIndices[Local]], Ctx.LS);
+    int16_t Out = transferExactVgprMsbMode(
+        Graph.ModeBefore[Local], Ctx.Decoded[Graph.GlobalIndices[Local]],
+        Ctx.LS);
     for (size_t Successor : Node.Successors) {
       int16_t Old = Graph.ModeBefore[Successor];
       int16_t Merged = Old == VgprMsbUnreachable ? Out
@@ -1279,8 +1240,6 @@ computeForwardDeadPhysicalVgprs(PatchContext &Ctx, size_t SiteIdx,
   for (size_t Local = 0; Local != Graph->Nodes.size(); ++Local) {
     ForwardVgprProofNode &Node = Graph->Nodes[Local];
     if (Node.Opaque || Node.SafeTerminal)
-      continue;
-    if (Graph->UndecodedVop3Heads.test(Local))
       continue;
 
     int16_t Mode = Graph->ModeBefore[Local];

--- a/amd/comgr/src/hotswap/rewriter/patch-wmma-split.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-wmma-split.cpp
@@ -72,7 +72,6 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/Endian.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1132,46 +1131,6 @@ buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
 
 } // anonymous namespace
 
-bool isLegacyB0Vop3ScalarSourceEncoding(uint32_t Word0, uint32_t Word1) {
-  // TODO(https://github.com/ROCm/llvm-project/issues/3638): Replace this
-  // exact B0 encoding exception with an installed AMDGPU MC classifier.
-  constexpr unsigned Vop3MajorShift = 26;
-  constexpr uint32_t Vop3MajorMask = 0x3fu << Vop3MajorShift;
-  constexpr uint32_t LegacyVop3Major = 0x34u << Vop3MajorShift;
-  constexpr unsigned Vop3OpcodeShift = 16;
-  constexpr uint32_t Vop3OpcodeMask = 0x3ffu << Vop3OpcodeShift;
-  constexpr uint32_t LegacyVop3Opcode = 0x31u << Vop3OpcodeShift;
-  constexpr uint32_t Vop3VdstMask = 0xffu;
-  constexpr uint32_t ObservedModifierMask = 1u << 14;
-  constexpr uint32_t RequiredWord0 = LegacyVop3Major | LegacyVop3Opcode;
-  constexpr uint32_t FixedWord0Mask =
-      ~(ObservedModifierMask) | Vop3MajorMask | Vop3OpcodeMask | Vop3VdstMask;
-  constexpr uint32_t AlternateScalarSourceEncoding = 1u << 20;
-
-  return (Word0 & FixedWord0Mask) == RequiredWord0 &&
-         (Word1 == 0 || Word1 == AlternateScalarSourceEncoding);
-}
-
-bool isUndecodedB0Vop3ScalarSourcePair(const PatchContext &Ctx,
-                                       size_t HeadIndex) {
-  if (HeadIndex + 1 >= Ctx.Decoded.size())
-    return false;
-  const InternalDecodedInst &Head = Ctx.Decoded[HeadIndex];
-  const InternalDecodedInst &Tail = Ctx.Decoded[HeadIndex + 1];
-  if (Head.DecodeSucceeded || Tail.DecodeSucceeded ||
-      Head.Size != MinInstSize || Tail.Size != MinInstSize ||
-      Tail.Offset != Head.Offset + MinInstSize || Head.Offset > Ctx.TextSize ||
-      2 * MinInstSize > Ctx.TextSize - Head.Offset)
-    return false;
-
-  uint32_t Word0 = support::endian::read32le(Ctx.Text + Head.Offset);
-  uint32_t Word1 =
-      support::endian::read32le(Ctx.Text + Head.Offset + MinInstSize);
-  if (!isLegacyB0Vop3ScalarSourceEncoding(Word0, Word1))
-    return false;
-  return !Ctx.DirectControlFlow.Targets.contains(Tail.Offset) &&
-         !llvm::is_contained(Ctx.DeclaredEntries, Tail.Offset);
-}
 void ensureVgprMsbModes(PatchContext &Ctx) {
   if (Ctx.VgprMsbModeBefore.empty())
     computeVgprMsbModes(Ctx);
@@ -1196,15 +1155,6 @@ std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
       if (Entry == Current.Offset)
         return std::nullopt;
 
-    // The A0 decoder represents the exact B0 legacy-VOP3 pair as two unknown
-    // dwords. It cannot change MODE, so a straight-line local dominance scan
-    // may step over the complete pair. The shared classifier also rejects a
-    // known entry into its continuation dword.
-    if (Idx >= 2 && isUndecodedB0Vop3ScalarSourcePair(Ctx, Idx - 2)) {
-      Idx -= 2;
-      continue;
-    }
-
     if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(Prev, Ctx.LS))
       return Mode;
 
@@ -1228,6 +1178,7 @@ int16_t transferExactVgprMsbMode(int16_t Incoming,
                     : unknownVgprMsbState();
   return exactVgprMsbMode(transferVgprMsbState(State, DI, LS));
 }
+
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand) {
   return getVgprMsbs(Mode, Operand);
 }

--- a/amd/comgr/src/hotswap/rewriter/patch-wmma-split.cpp
+++ b/amd/comgr/src/hotswap/rewriter/patch-wmma-split.cpp
@@ -72,6 +72,7 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Endian.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -1131,6 +1132,46 @@ buildSplit32x16Asm(StringRef Replacement, const PrintedAsm &P, const WmmaOps &R,
 
 } // anonymous namespace
 
+bool isLegacyB0Vop3ScalarSourceEncoding(uint32_t Word0, uint32_t Word1) {
+  // TODO(https://github.com/ROCm/llvm-project/issues/3638): Replace this
+  // exact B0 encoding exception with an installed AMDGPU MC classifier.
+  constexpr unsigned Vop3MajorShift = 26;
+  constexpr uint32_t Vop3MajorMask = 0x3fu << Vop3MajorShift;
+  constexpr uint32_t LegacyVop3Major = 0x34u << Vop3MajorShift;
+  constexpr unsigned Vop3OpcodeShift = 16;
+  constexpr uint32_t Vop3OpcodeMask = 0x3ffu << Vop3OpcodeShift;
+  constexpr uint32_t LegacyVop3Opcode = 0x31u << Vop3OpcodeShift;
+  constexpr uint32_t Vop3VdstMask = 0xffu;
+  constexpr uint32_t ObservedModifierMask = 1u << 14;
+  constexpr uint32_t RequiredWord0 = LegacyVop3Major | LegacyVop3Opcode;
+  constexpr uint32_t FixedWord0Mask =
+      ~(ObservedModifierMask) | Vop3MajorMask | Vop3OpcodeMask | Vop3VdstMask;
+  constexpr uint32_t AlternateScalarSourceEncoding = 1u << 20;
+
+  return (Word0 & FixedWord0Mask) == RequiredWord0 &&
+         (Word1 == 0 || Word1 == AlternateScalarSourceEncoding);
+}
+
+bool isUndecodedB0Vop3ScalarSourcePair(const PatchContext &Ctx,
+                                       size_t HeadIndex) {
+  if (HeadIndex + 1 >= Ctx.Decoded.size())
+    return false;
+  const InternalDecodedInst &Head = Ctx.Decoded[HeadIndex];
+  const InternalDecodedInst &Tail = Ctx.Decoded[HeadIndex + 1];
+  if (Head.DecodeSucceeded || Tail.DecodeSucceeded ||
+      Head.Size != MinInstSize || Tail.Size != MinInstSize ||
+      Tail.Offset != Head.Offset + MinInstSize || Head.Offset > Ctx.TextSize ||
+      2 * MinInstSize > Ctx.TextSize - Head.Offset)
+    return false;
+
+  uint32_t Word0 = support::endian::read32le(Ctx.Text + Head.Offset);
+  uint32_t Word1 =
+      support::endian::read32le(Ctx.Text + Head.Offset + MinInstSize);
+  if (!isLegacyB0Vop3ScalarSourceEncoding(Word0, Word1))
+    return false;
+  return !Ctx.DirectControlFlow.Targets.contains(Tail.Offset) &&
+         !llvm::is_contained(Ctx.DeclaredEntries, Tail.Offset);
+}
 void ensureVgprMsbModes(PatchContext &Ctx) {
   if (Ctx.VgprMsbModeBefore.empty())
     computeVgprMsbModes(Ctx);
@@ -1155,6 +1196,15 @@ std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
       if (Entry == Current.Offset)
         return std::nullopt;
 
+    // The A0 decoder represents the exact B0 legacy-VOP3 pair as two unknown
+    // dwords. It cannot change MODE, so a straight-line local dominance scan
+    // may step over the complete pair. The shared classifier also rejects a
+    // known entry into its continuation dword.
+    if (Idx >= 2 && isUndecodedB0Vop3ScalarSourcePair(Ctx, Idx - 2)) {
+      Idx -= 2;
+      continue;
+    }
+
     if (std::optional<unsigned> Mode = getExactVgprMsbModeWritten(Prev, Ctx.LS))
       return Mode;
 
@@ -1170,6 +1220,14 @@ std::optional<unsigned> getLocallyEstablishedVgprMsbMode(PatchContext &Ctx,
   return std::nullopt;
 }
 
+int16_t transferExactVgprMsbMode(int16_t Incoming,
+                                 const InternalDecodedInst &DI,
+                                 const LLVMState &LS) {
+  VgprMsbState State =
+      Incoming >= 0 ? vgprMsbStateFromMode(static_cast<unsigned>(Incoming))
+                    : unknownVgprMsbState();
+  return exactVgprMsbMode(transferVgprMsbState(State, DI, LS));
+}
 unsigned getVgprMsbBank(unsigned Mode, VgprMsbOperand Operand) {
   return getVgprMsbs(Mode, Operand);
 }

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-legacy-mc.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-trampoline-tensor-legacy-mc.s
@@ -1,0 +1,222 @@
+// COM: Verify that the LLVM MC legacy gfx1250 tensor records are consumed by
+// COM: the existing HotSwap tensor path. Loads use the established descriptor
+// COM: mask wrapper. Stores retain one 12-byte boundary and their canonical
+// COM: scalar operands, but do not receive the load-only wrapper.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+
+// RUN: %llvm-objdump -d %t.elf | %FileCheck --check-prefix=INPUT %s
+// INPUT-LABEL: <legacy_load_d2>:
+// INPUT: tensor_load_to_lds s[0:3], s[4:11]
+// INPUT-NEXT: s_mov_b32 s0, s4
+// INPUT-LABEL: <legacy_load_d4>:
+// INPUT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
+// INPUT-NEXT: s_endpgm
+// INPUT-LABEL: <legacy_store_d2>:
+// INPUT: tensor_store_from_lds s[0:3], s[4:11]
+// INPUT-NEXT: s_mov_b32 s0, s4
+// INPUT-NEXT: s_endpgm
+// INPUT-LABEL: <legacy_store_d4>:
+// INPUT: tensor_store_from_lds s[0:3], s[4:11], s[12:15], s[16:19]
+// INPUT-NEXT: s_mov_b32 s0, s4
+// INPUT-NEXT: s_endpgm
+
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --output %t.out.elf \
+// RUN:   2>&1 \
+// RUN:   | %FileCheck --check-prefix=API %s
+// API: hotswap: tensor_load_to_lds: s4 live, save/restore via s{{[0-9]+}}
+// API: hotswap: tensor_load_to_lds: s4 dead, no save/restore needed
+// API-NOT: tensor_store_from_lds
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-readelf -h %t.out.elf | %FileCheck --check-prefix=ELF %s
+// ELF: Class:                             ELF64
+// ELF: Machine:                           EM_AMDGPU
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=OUTPUT %s
+// OUTPUT-LABEL: <legacy_load_d2>:
+// OUTPUT: s_branch
+// OUTPUT: s_mov_b32 s0, s4
+// OUTPUT: s_endpgm
+// OUTPUT: s_mov_b32 [[SCRATCH:s[0-9]+]], s4
+// OUTPUT-NEXT: s_pack_hh_b32_b16 s4, 0, s4
+// OUTPUT-NEXT: tensor_load_to_lds s[0:3], s[4:11]
+// OUTPUT-NEXT: s_mov_b32 s4, [[SCRATCH]]
+// OUTPUT-NEXT: s_branch
+
+// OUTPUT-LABEL: <legacy_load_d4>:
+// OUTPUT: s_branch
+// OUTPUT: s_endpgm
+// OUTPUT: s_pack_hh_b32_b16 s4, 0, s4
+// OUTPUT-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
+// OUTPUT-NEXT: s_branch
+
+// OUTPUT-LABEL: <legacy_store_d2>:
+// OUTPUT-NOT: s_pack_hh_b32_b16
+// OUTPUT-NOT: s_branch
+// OUTPUT: tensor_store_from_lds s[0:3], s[4:11]
+// OUTPUT-NEXT: s_mov_b32 s0, s4
+// OUTPUT-NEXT: s_endpgm
+
+// OUTPUT-LABEL: <legacy_store_d4>:
+// OUTPUT-NOT: s_pack_hh_b32_b16
+// OUTPUT-NOT: s_branch
+// OUTPUT: tensor_store_from_lds s[0:3], s[4:11], s[12:15], s[16:19]
+// OUTPUT-NEXT: s_mov_b32 s0, s4
+// OUTPUT-NEXT: s_endpgm
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --strict-mode --check-idempotent \
+// RUN:   | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl legacy_load_d2
+.p2align 8
+.type legacy_load_d2,@function
+legacy_load_d2:
+  tensor_load_to_lds_gfx1250_legacy s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Llegacy_load_d2_end:
+.size legacy_load_d2, .Llegacy_load_d2_end-legacy_load_d2
+
+.globl legacy_load_d4
+.p2align 8
+.type legacy_load_d4,@function
+legacy_load_d4:
+  tensor_load_to_lds_gfx1250_legacy s[0:3], s[4:11], s[12:15], s[16:19]
+  s_endpgm
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+  s_nop 0
+.Llegacy_load_d4_end:
+.size legacy_load_d4, .Llegacy_load_d4_end-legacy_load_d4
+
+.globl legacy_store_d2
+.p2align 8
+.type legacy_store_d2,@function
+legacy_store_d2:
+  tensor_store_from_lds_gfx1250_legacy s[0:3], s[4:11]
+  s_mov_b32 s0, s4
+  s_endpgm
+.Llegacy_store_d2_end:
+.size legacy_store_d2, .Llegacy_store_d2_end-legacy_store_d2
+
+.globl legacy_store_d4
+.p2align 8
+.type legacy_store_d4,@function
+legacy_store_d4:
+  tensor_store_from_lds_gfx1250_legacy s[0:3], s[4:11], s[12:15], s[16:19]
+  s_mov_b32 s0, s4
+  s_endpgm
+.Llegacy_store_d4_end:
+.size legacy_store_d4, .Llegacy_store_d4_end-legacy_store_d4
+
+.rodata
+.p2align 8
+.amdhsa_kernel legacy_load_d2
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel legacy_load_d4
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 20
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel legacy_store_d2
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 12
+.end_amdhsa_kernel
+
+.p2align 8
+.amdhsa_kernel legacy_store_d4
+  .amdhsa_next_free_vgpr 1
+  .amdhsa_next_free_sgpr 20
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: legacy_load_d2
+      .symbol: legacy_load_d2.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: legacy_load_d4
+      .symbol: legacy_load_d4.kd
+      .sgpr_count: 20
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: legacy_store_d2
+      .symbol: legacy_store_d2.kd
+      .sgpr_count: 12
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+    - .name: legacy_store_d4
+      .symbol: legacy_store_d4.kd
+      .sgpr_count: 20
+      .vgpr_count: 1
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 64
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale-32x16.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale-32x16.s
@@ -1,0 +1,70 @@
+// Test the regular block-32 scaled M=32 lowering used by ROCM-28594.
+//
+// The source operation is B0-only. A0 supports the M=16 regular-scale form,
+// so the replacement splits only M and preserves the original block-32 scale
+// operands for both halves.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: wmma_scale: exact M split
+// API-SAME: 2 WMMAs
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_scale_32x16>:
+// DISASM-NOT: v_wmma_scale_f32_32x16x128_f4
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM-NOT: matrix_a_reuse
+// DISASM-NOT: matrix_b_reuse
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}matrix_a_scale:MATRIX_SCALE_ROW1{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl test_wmma_scale_32x16
+.p2align 8
+.type test_wmma_scale_32x16,@function
+test_wmma_scale_32x16:
+  v_wmma_scale_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v40, v42 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E8 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E8 matrix_a_reuse matrix_b_reuse neg_lo:[0,0,1]
+  s_endpgm
+.Ltest_wmma_scale_32x16_end:
+.size test_wmma_scale_32x16, .Ltest_wmma_scale_32x16_end-test_wmma_scale_32x16
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale_32x16
+  .amdhsa_next_free_vgpr 43
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale_32x16
+      .symbol: test_wmma_scale_32x16.kd
+      .sgpr_count: 2
+      .vgpr_count: 43
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-bank-zero.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-bank-zero.s
@@ -14,19 +14,24 @@
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-NOT: v_wmma_scale16
-// DISASM: v_mov_b32_e32 v[[TMP:[0-9]+]]{{.*}}, v40
+// DISASM-NOT: v_perm_b32
 // DISASM: s_wait_xcnt 0x0
 // DISASM-NEXT: s_set_vgpr_msb
-// DISASM: v_perm_b32 v40, v[[TMP]]{{.*}}, v41, 0x6040200
-// DISASM: v_mov_b32_e32 v[[TMP]]{{.*}}, v42
+// DISASM-NEXT: v_and_b32{{(_e32)?}} v250, 0xff, v40
 // DISASM: s_wait_xcnt 0x0
 // DISASM-NEXT: s_set_vgpr_msb
-// DISASM: v_perm_b32 v42, v[[TMP]]{{.*}}, v43, 0x6040200
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v40, v42
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v41, v43
+// DISASM: v_bfe_u32 v254, v40, 16, 8
+// DISASM: v_bfe_u32 v252, v40, 8, 8
+// DISASM: s_wait_xcnt 0x0
+// DISASM-NEXT: s_set_vgpr_msb
+// DISASM-NEXT: v_mov_b32{{(_e32)?}} v242, v16{{.*}}v272
+// DISASM: s_wait_xcnt 0x0
+// DISASM-NEXT: s_set_vgpr_msb
+// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[242:249], {{.*}}, v[0:7], v250, v251
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[242:249], {{.*}}, v[0:7], v252, v253
 //
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, 1.0, v40, v42{{.*}}neg_hi:[0,0,1]
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v[0:7], v41, v43
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, 1.0, v56, v57{{.*}}neg_hi:[0,0,1]
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v[0:7], v58, v59
 // DISASM-NOT: neg_hi
 // DISASM: v_nop
 

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-bank-zero.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-bank-zero.s
@@ -1,0 +1,100 @@
+// COM: M=32 Scale16 prefix operands always address bank-zero VGPRs even when
+// COM: matrix SRC0/SRC1 select nonzero physical banks through VGPR-MSB. Every
+// COM: generated mode transition must also drain XCNT before remapping VGPRs.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: wmma_scale16: exact M+K split
+// API: wmma_scale16: exact M+K split
+// API-NOT: error:
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-NOT: v_wmma_scale16
+// DISASM: v_mov_b32_e32 v[[TMP:[0-9]+]]{{.*}}, v40
+// DISASM: s_wait_xcnt 0x0
+// DISASM-NEXT: s_set_vgpr_msb
+// DISASM: v_perm_b32 v40, v[[TMP]]{{.*}}, v41, 0x6040200
+// DISASM: v_mov_b32_e32 v[[TMP]]{{.*}}, v42
+// DISASM: s_wait_xcnt 0x0
+// DISASM-NEXT: s_set_vgpr_msb
+// DISASM: v_perm_b32 v42, v[[TMP]]{{.*}}, v43, 0x6040200
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v40, v42
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v41, v43
+//
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, 1.0, v40, v42{{.*}}neg_hi:[0,0,1]
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 {{.*}}, v[0:7], v41, v43
+// DISASM-NOT: neg_hi
+// DISASM: v_nop
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.globl test_m32_scale_bank_zero
+.p2align 8
+.type test_m32_scale_bank_zero,@function
+test_m32_scale_bank_zero:
+  s_set_vgpr_msb 0x5
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43] matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  s_endpgm
+.Ltest_m32_scale_bank_zero_end:
+.size test_m32_scale_bank_zero, .Ltest_m32_scale_bank_zero_end-test_m32_scale_bank_zero
+
+.globl test_m32_immediate_neg_hi
+.p2align 8
+.type test_m32_immediate_neg_hi,@function
+test_m32_immediate_neg_hi:
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], 1.0, v[40:41], v[42:43] matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3 neg_hi:[0,0,1]
+  s_endpgm
+.Ltest_m32_immediate_neg_hi_end:
+.size test_m32_immediate_neg_hi, .Ltest_m32_immediate_neg_hi_end-test_m32_immediate_neg_hi
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_m32_scale_bank_zero
+  .amdhsa_next_free_vgpr 304
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_m32_immediate_neg_hi
+  .amdhsa_next_free_vgpr 44
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_m32_scale_bank_zero
+      .symbol: test_m32_scale_bank_zero.kd
+      .sgpr_count: 2
+      .vgpr_count: 304
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_m32_immediate_neg_hi
+      .symbol: test_m32_immediate_neg_hi.kd
+      .sgpr_count: 2
+      .vgpr_count: 44
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-refuse.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-refuse.s
@@ -1,40 +1,102 @@
-// COM: Fail-closed gate for the 32x16 FP4 block-16 scaled WMMA. The M=32 form
-// COM: needs an M-split on top of the K-split and has no exact lowering yet,
-// COM: so the rewrite refuses it: any unlowerable v_wmma_scale16_f32_* makes the
-// COM: rewrite return an error instead of emitting a wrong code object.
+// COM: Fail-closed overlap gates for the staged M+K lowering. Each variant is
+// COM: assembled into its own object so every rejection is exercised
+// COM: independently.
 
-// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=1 %s -o %t.da.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.da.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=D-A %s
+// D-A: destination overlaps matrix A
+// D-A: RESULT: ERROR
 
-// COM: Default mode: presence of the unlowerable form fails the rewrite.
-// RUN: hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --expect-status ERROR \
-// RUN:   | %FileCheck --check-prefix=REFUSE %s
-// REFUSE: RESULT: ERROR
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=2 %s -o %t.db.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.db.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=D-B %s
+// D-B: destination overlaps matrix B
+// D-B: RESULT: ERROR
 
-// COM: Strict mode: same fail-closed result.
-// RUN: hotswap-rewrite %t.elf \
-// RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \
-// RUN:   --strict-mode --expect-status ERROR \
-// RUN:   | %FileCheck --check-prefix=REFUSE %s
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=3 %s -o %t.ab.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ab.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=A-B %s
+// A-B: matrix A overlaps matrix B
+// A-B: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=4 %s -o %t.dc.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.dc.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=D-C %s
+// D-C: partial destination/src2 overlap
+// D-C: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=5 %s -o %t.ac.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.ac.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=A-C %s
+// A-C: matrix A overlaps src2
+// A-C: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=6 %s -o %t.scale-matrix.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.scale-matrix.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SCALE %s
+// SCALE: scale pair overlaps a staged matrix operand
+// SCALE: RESULT: ERROR
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib \
+// RUN:   -Wa,-defsym,CASE=7 %s -o %t.scale-scale.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite \
+// RUN:   %t.scale-scale.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --expect-status ERROR 2>&1 | %FileCheck --check-prefix=SCALE %s
 
 .amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
 .text
 
-// --- Scale16 32x16 FP4 (block-16) -> refuse (fail closed) ---
-.globl test_wmma_scale16_32x16
+.globl test_wmma_scale16_32x16_refuse
 .p2align 8
-.type test_wmma_scale16_32x16,@function
-test_wmma_scale16_32x16:
-  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43]
+.type test_wmma_scale16_32x16_refuse,@function
+test_wmma_scale16_32x16_refuse:
+.if CASE == 1
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[8:23], v[32:39], v[0:15], v[40:41], v[42:43]
+.elseif CASE == 2
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[8:15], v[0:15], v[40:41], v[42:43]
+.elseif CASE == 3
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[24:31], v[0:15], v[40:41], v[42:43]
+.elseif CASE == 4
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[24:39], v[40:47], v[8:23], v[48:49], v[50:51]
+.elseif CASE == 5
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[16:31], v[40:41], v[42:43]
+.elseif CASE == 6
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[16:17], v[42:43]
+.elseif CASE == 7
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[40:41]
+.else
+  .error "unknown CASE"
+.endif
   s_endpgm
-.Ltest_wmma_scale16_32x16_end:
-.size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16
+.Ltest_wmma_scale16_32x16_refuse_end:
+.size test_wmma_scale16_32x16_refuse, .Ltest_wmma_scale16_32x16_refuse_end-test_wmma_scale16_32x16_refuse
 
 .rodata
 .p2align 8
-.amdhsa_kernel test_wmma_scale16_32x16
-  .amdhsa_next_free_vgpr 44
+.amdhsa_kernel test_wmma_scale16_32x16_refuse
+  .amdhsa_next_free_vgpr 52
   .amdhsa_next_free_sgpr 2
   .amdhsa_wavefront_size32 1
 .end_amdhsa_kernel
@@ -44,10 +106,10 @@ test_wmma_scale16_32x16:
     - 3
     - 0
   amdhsa.kernels:
-    - .name: test_wmma_scale16_32x16
-      .symbol: test_wmma_scale16_32x16.kd
+    - .name: test_wmma_scale16_32x16_refuse
+      .symbol: test_wmma_scale16_32x16_refuse.kd
       .sgpr_count: 2
-      .vgpr_count: 44
+      .vgpr_count: 52
       .kernarg_segment_size: 0
       .group_segment_fixed_size: 0
       .private_segment_fixed_size: 0

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-split-scratch.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16-split-scratch.s
@@ -1,0 +1,106 @@
+// COM: The M=32 Scale16 lowering does not require all 13 scratch VGPRs to be
+// COM: contiguous. This fixture exposes one eight-register dead run for masked
+// COM: A plus five separate dead low-bank registers for generated scales and
+// COM: the gather temporary. The kernel is already at a metadata digit
+// COM: boundary, so unnecessary growth would also make the rewrite fail.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: wmma_scale16: exact M+K split
+// API-SAME: masked-A=v120:127
+// API-SAME: scales=v119,v118,v117,v115, tmp=v114, +0 vgpr, 4 WMMAs
+// API-NOT: updating AMDGPU metadata changes note size
+// API-NOT: error:
+// API: liveness: kernel test_wmma_scale16_32x16_split_scratch:
+// API-SAME: vgprs_before=128, vgprs_after=128
+// API-SAME: scratch_reused=13, scratch_above_kd=0
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_scale16_32x16_split_scratch>:
+// DISASM-NOT: v_wmma_scale16
+// DISASM: s_branch
+// DISASM: s_endpgm
+// DISASM: v_and_b32{{(_e32)?}} v119, 0xff, v64
+// DISASM: v_and_b32{{(_e32)?}} v118, 0xff, v46
+// DISASM: v_bfe_u32 v117, v64, 8, 8
+// DISASM: v_bfe_u32 v115, v46, 8, 8
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[16:23], v[120:127], v[34:41], 0, v119, v118
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[16:23], v[120:127], v[34:41], v[16:23], v117, v115
+// DISASM-NOT: v_wmma_scale16
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+.macro opaque_b0_vop3
+  .long 0xd0310000
+  .long 0x00100000
+  v_cmp_ge_u16_e32 vcc_lo, s32, v18.l
+.endm
+
+.globl test_wmma_scale16_32x16_split_scratch
+.p2align 8
+.type test_wmma_scale16_32x16_split_scratch,@function
+test_wmma_scale16_32x16_split_scratch:
+  s_set_vgpr_msb 0
+  opaque_b0_vop3
+  v_wmma_scale16_f32_32x16x128_f4 v[16:31], v[0:15], v[34:41], 0, v[64:65], v[46:47] matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  opaque_b0_vop3
+  // Keep one register live in every otherwise available 13-register interval.
+  v_mov_b32 v0, v48
+  v_mov_b32 v0, v60
+  v_mov_b32 v0, v72
+  v_mov_b32 v0, v84
+  v_mov_b32 v0, v96
+  v_mov_b32 v0, v108
+  v_mov_b32 v0, v116
+  v_mov_b32 v117, 0
+  v_mov_b32 v118, 0
+  v_mov_b32 v119, 0
+  v_mov_b32 v120, 0
+  v_mov_b32 v121, 0
+  v_mov_b32 v122, 0
+  v_mov_b32 v123, 0
+  v_mov_b32 v124, 0
+  v_mov_b32 v125, 0
+  v_mov_b32 v126, 0
+  v_mov_b32 v127, 0
+  v_mov_b32 v61, 0
+  v_mov_b32 v53, 0
+  s_endpgm
+.Ltest_wmma_scale16_32x16_split_scratch_end:
+.size test_wmma_scale16_32x16_split_scratch, .Ltest_wmma_scale16_32x16_split_scratch_end-test_wmma_scale16_32x16_split_scratch
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_32x16_split_scratch
+  .amdhsa_next_free_vgpr 128
+  .amdhsa_next_free_sgpr 34
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_32x16_split_scratch
+      .symbol: test_wmma_scale16_32x16_split_scratch.kd
+      .sgpr_count: 34
+      .vgpr_count: 128
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16.s
@@ -1,0 +1,146 @@
+// COM: Exact decomposition of the corpus's M=32 FP4 block-16 scaled WMMA.
+// COM: The schedule is low-M/low-K, high-M/low-K, low-M/high-K,
+// COM: high-M/high-K. The low passes read the original C halves and even scale
+// COM: bytes; the high passes accumulate from D and use odd scale bytes. Only
+// COM: the four A registers overwritten by each FP4 mask are saved, and the
+// COM: first save slot is reused as the reversible scale-pair permutation
+// COM: temporary.
+
+// RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
+// RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific+ \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
+// API: physical forward-dead proof at offset
+// API-SAME: found 4 VGPRs
+// API: wmma_scale16: exact M+K split
+// API-SAME: four saved-A VGPRs, tmp=v55, +0 vgpr, 4 WMMAs
+// API-NOT: error:
+// API: liveness: kernel test_wmma_scale16_32x16:
+// API-SAME: scratch_reused=4, scratch_above_kd=0
+// API: RESULT: SUCCESS
+
+// RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
+// DISASM-LABEL: <test_wmma_scale16_32x16>:
+// DISASM-NOT: v_wmma_scale16
+// DISASM: s_branch
+// DISASM: s_endpgm
+//
+// COM: Forward byte split and its exact inverse. These selectors implement
+// COM: [0,2,4,6] / [1,3,5,7], then restore the two original dwords exactly.
+// DISASM: v_mov_b32_e32 v[[TMP:[0-9]+]], v40
+// DISASM-NEXT: v_perm_b32 v40, v[[TMP]], v41, 0x6040200
+// DISASM-NEXT: v_perm_b32 v41, v[[TMP]], v41, 0x7050301
+// DISASM: v_mov_b32_e32 v[[TMP]], v42
+// DISASM-NEXT: v_perm_b32 v42, v[[TMP]], v43, 0x6040200
+// DISASM-NEXT: v_perm_b32 v43, v[[TMP]], v43, 0x7050301
+//
+// COM: D==C, low-low-high-high order. Reuse hints are stripped, and the
+// COM: original C modifier appears only on the two low-K passes.
+// DISASM-NOT: matrix_a_reuse
+// DISASM-NOT: matrix_b_reuse
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v41, v43{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NOT: neg_lo
+// DISASM: v_nop
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v41, v43{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM-NOT: neg_lo
+// DISASM: v_nop
+// DISASM: v_mov_b32_e32 v[[TMP]], v40
+// DISASM-NEXT: v_perm_b32 v40, v[[TMP]], v41, 0x5010400
+// DISASM-NEXT: v_perm_b32 v41, v[[TMP]], v41, 0x7030602
+// DISASM: v_mov_b32_e32 v[[TMP]], v42
+// DISASM-NEXT: v_perm_b32 v42, v[[TMP]], v43, 0x5010400
+// DISASM-NEXT: v_perm_b32 v43, v[[TMP]], v43, 0x7030602
+//
+// COM: The second lowering permits matrix B to overlap C. Its first low pass
+// COM: therefore has the same v[32:39] range in src1 and src2.
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[32:39], v48, v50
+// DISASM-NOT: v_wmma_scale16
+
+// RUN: hotswap-rewrite %t.out.elf \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
+// RUN:   --check-idempotent | %FileCheck --check-prefix=IDEM %s
+// IDEM: IDEMPOTENT: YES
+
+.amdgcn_target "amdgcn-amd-amdhsa--gfx1250"
+.text
+
+// Reduced opaque sequence from the f4gemm corpus. The A0 decoder splits this
+// legacy B0 VOP3 into two unknown dwords. The sequence before the WMMA tests
+// local MODE recovery; the sequence after it tests forward physical liveness.
+.macro opaque_b0_vop3
+  .long 0xd0310000
+  .long 0x00100000
+  v_cmp_ge_u16_e32 vcc_lo, s32, v18.l
+.endm
+
+.globl test_wmma_scale16_32x16
+.p2align 8
+.type test_wmma_scale16_32x16,@function
+test_wmma_scale16_32x16:
+  s_set_vgpr_msb 0
+  opaque_b0_vop3
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[0:15], v[40:41], v[42:43] matrix_a_scale:MATRIX_SCALE_ROW1 matrix_b_scale:MATRIX_SCALE_ROW1 matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_a_reuse matrix_b_reuse neg_lo:[0,0,1]
+  opaque_b0_vop3
+  v_mov_b32 v52, 0
+  v_mov_b32 v53, 0
+  v_mov_b32 v54, 0
+  v_mov_b32 v55, 0
+  s_branch test_wmma_scale16_32x16_bc_overlap
+.Ltest_wmma_scale16_32x16_end:
+.size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16
+
+.globl test_wmma_scale16_32x16_bc_overlap
+.p2align 8
+.type test_wmma_scale16_32x16_bc_overlap,@function
+test_wmma_scale16_32x16_bc_overlap:
+  v_wmma_scale16_f32_32x16x128_f4 v[0:15], v[16:31], v[32:39], v[32:47], v[48:49], v[50:51] matrix_a_scale_fmt:MATRIX_SCALE_FMT_E4M3 matrix_b_scale_fmt:MATRIX_SCALE_FMT_E4M3
+  s_endpgm
+.Ltest_wmma_scale16_32x16_bc_overlap_end:
+.size test_wmma_scale16_32x16_bc_overlap, .Ltest_wmma_scale16_32x16_bc_overlap_end-test_wmma_scale16_32x16_bc_overlap
+
+.rodata
+.p2align 8
+.amdhsa_kernel test_wmma_scale16_32x16
+  .amdhsa_next_free_vgpr 1024
+  .amdhsa_next_free_sgpr 34
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdhsa_kernel test_wmma_scale16_32x16_bc_overlap
+  .amdhsa_next_free_vgpr 52
+  .amdhsa_next_free_sgpr 2
+  .amdhsa_wavefront_size32 1
+.end_amdhsa_kernel
+
+.amdgpu_metadata
+  amdhsa.version:
+    - 3
+    - 0
+  amdhsa.kernels:
+    - .name: test_wmma_scale16_32x16
+      .symbol: test_wmma_scale16_32x16.kd
+      .sgpr_count: 34
+      .vgpr_count: 1024
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+    - .name: test_wmma_scale16_32x16_bc_overlap
+      .symbol: test_wmma_scale16_32x16_bc_overlap.kd
+      .sgpr_count: 2
+      .vgpr_count: 52
+      .kernarg_segment_size: 0
+      .group_segment_fixed_size: 0
+      .private_segment_fixed_size: 0
+      .kernarg_segment_align: 8
+      .wavefront_size: 32
+      .max_flat_workgroup_size: 256
+.end_amdgpu_metadata

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-32x16.s
@@ -1,10 +1,7 @@
 // COM: Exact decomposition of the corpus's M=32 FP4 block-16 scaled WMMA.
-// COM: The schedule is low-M/low-K, high-M/low-K, low-M/high-K,
-// COM: high-M/high-K. The low passes read the original C halves and even scale
-// COM: bytes; the high passes accumulate from D and use odd scale bytes. Only
-// COM: the four A registers overwritten by each FP4 mask are saved, and the
-// COM: first save slot is reused as the reversible scale-pair permutation
-// COM: temporary.
+// COM: One 13-VGPR bank-zero block holds an eight-register masked-A half, four
+// COM: gathered scale values, and one temporary. The schedule is M0 low/high,
+// COM: then M1 low/high. Original A and Scale16 tuples are never modified.
 
 // RUN: %clang -target amdgcn-amd-amdhsa -mcpu=gfx1250 -nostdlib %s -o %t.elf
 // RUN: env AMD_COMGR_EMIT_VERBOSE_LOGS=1 hotswap-rewrite %t.elf \
@@ -12,12 +9,12 @@
 // RUN:   amdgcn-amd-amdhsa--gfx1250:gfx1250-b0-specific- \
 // RUN:   --output %t.out.elf 2>&1 | %FileCheck --check-prefix=API %s
 // API: physical forward-dead proof at offset
-// API-SAME: found 4 VGPRs
+// API-SAME: found 13 VGPRs
 // API: wmma_scale16: exact M+K split
-// API-SAME: four saved-A VGPRs, tmp=v55, +0 vgpr, 4 WMMAs
+// API-SAME: masked-A=v52:59, scales=v60,v61,v62,v63, tmp=v64, +0 vgpr, 4 WMMAs
 // API-NOT: error:
 // API: liveness: kernel test_wmma_scale16_32x16:
-// API-SAME: scratch_reused=4, scratch_above_kd=0
+// API-SAME: scratch_reused=13, scratch_above_kd=0
 // API: RESULT: SUCCESS
 
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
@@ -26,39 +23,41 @@
 // DISASM: s_branch
 // DISASM: s_endpgm
 //
-// COM: Forward byte split and its exact inverse. These selectors implement
-// COM: [0,2,4,6] / [1,3,5,7], then restore the two original dwords exactly.
-// DISASM: v_mov_b32_e32 v[[TMP:[0-9]+]], v40
-// DISASM-NEXT: v_perm_b32 v40, v[[TMP]], v41, 0x6040200
-// DISASM-NEXT: v_perm_b32 v41, v[[TMP]], v41, 0x7050301
-// DISASM: v_mov_b32_e32 v[[TMP]], v42
-// DISASM-NEXT: v_perm_b32 v42, v[[TMP]], v43, 0x6040200
-// DISASM-NEXT: v_perm_b32 v43, v[[TMP]], v43, 0x7050301
+// COM: Even/odd byte gathers land in dedicated low-bank scale registers.
+// COM: The original scale pairs remain read-only; no reversible v_perm
+// COM: mutation/restore sequence is emitted.
+// DISASM-NOT: v_perm_b32
+// DISASM: v_and_b32{{(_e32)?}} v60, 0xff, v40
+// DISASM: v_and_b32{{(_e32)?}} v61, 0xff, v42
+// DISASM: v_bfe_u32 v62, v40, 8, 8
+// DISASM: v_bfe_u32 v63, v42, 8, 8
 //
-// COM: D==C, low-low-high-high order. Reuse hints are stripped, and the
+// COM: D==C, M0 low/high then M1 low/high. Reuse hints are stripped, and the
 // COM: original C modifier appears only on the two low-K passes.
 // DISASM-NOT: matrix_a_reuse
 // DISASM-NOT: matrix_b_reuse
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
+// DISASM: v_mov_b32{{(_e32)?}} v52, v16
+// DISASM: v_mov_b32{{(_e32)?}} v54, 0
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[52:59], v[32:39], v[0:7], v60, v61{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
 // DISASM: v_nop
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v40, v42{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}neg_lo:[0,0,1]
-// DISASM: v_nop
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[0:7], v41, v43{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM: v_mov_b32{{(_e32)?}} v52, 0
+// DISASM: v_mov_b32{{(_e32)?}} v54, v18
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[52:59], v[32:39], v[0:7], v62, v63{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
 // DISASM-NOT: neg_lo
 // DISASM: v_nop
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[24:31], v[32:39], v[8:15], v41, v43{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4
+// DISASM: v_mov_b32{{(_e32)?}} v52, v24
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[52:59], v[32:39], v[8:15], v60, v61{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}matrix_a_scale:MATRIX_SCALE_ROW1{{.*}}neg_lo:[0,0,1]
+// DISASM: v_nop
+// DISASM: v_mov_b32{{(_e32)?}} v52, 0
+// DISASM: v_mov_b32{{(_e32)?}} v54, v26
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[8:15], v[52:59], v[32:39], v[8:15], v62, v63{{.*}}matrix_a_fmt:MATRIX_FMT_FP4{{.*}}matrix_b_fmt:MATRIX_FMT_FP4{{.*}}matrix_a_scale:MATRIX_SCALE_ROW1
 // DISASM-NOT: neg_lo
 // DISASM: v_nop
-// DISASM: v_mov_b32_e32 v[[TMP]], v40
-// DISASM-NEXT: v_perm_b32 v40, v[[TMP]], v41, 0x5010400
-// DISASM-NEXT: v_perm_b32 v41, v[[TMP]], v41, 0x7030602
-// DISASM: v_mov_b32_e32 v[[TMP]], v42
-// DISASM-NEXT: v_perm_b32 v42, v[[TMP]], v43, 0x5010400
-// DISASM-NEXT: v_perm_b32 v43, v[[TMP]], v43, 0x7030602
+// DISASM-NOT: v_perm_b32
 //
 // COM: The second lowering permits matrix B to overlap C. Its first low pass
 // COM: therefore has the same v[32:39] range in src1 and src2.
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[16:23], v[32:39], v[32:39], v48, v50
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[0:7], v[64:71], v[32:39], v[32:39], v72, v73
 // DISASM-NOT: v_wmma_scale16
 
 // RUN: hotswap-rewrite %t.out.elf \
@@ -91,6 +90,15 @@ test_wmma_scale16_32x16:
   v_mov_b32 v53, 0
   v_mov_b32 v54, 0
   v_mov_b32 v55, 0
+  v_mov_b32 v56, 0
+  v_mov_b32 v57, 0
+  v_mov_b32 v58, 0
+  v_mov_b32 v59, 0
+  v_mov_b32 v60, 0
+  v_mov_b32 v61, 0
+  v_mov_b32 v62, 0
+  v_mov_b32 v63, 0
+  v_mov_b32 v64, 0
   s_branch test_wmma_scale16_32x16_bc_overlap
 .Ltest_wmma_scale16_32x16_end:
 .size test_wmma_scale16_32x16, .Ltest_wmma_scale16_32x16_end-test_wmma_scale16_32x16

--- a/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-large-vgpr-count.s
+++ b/amd/comgr/test-lit/hotswap/rewriter/hotswap-wmma-scale16-large-vgpr-count.s
@@ -16,37 +16,21 @@
 // RUN: %llvm-objdump -d %t.out.elf | %FileCheck --check-prefix=DISASM %s
 // DISASM-LABEL: <test_wmma_scale16_large_vgpr_count>:
 // DISASM-NOT: v_wmma_scale16
-// COM: Masked A and generated scale operands share a preserved bank-zero
-// COM: block. Matrix B remains in above-KD scratch. Each WMMA consumes the
-// COM: exact low-bank values produced by its gather.
-// DISASM: v_and_b32_e32 [[LO_A:v[0-9]+]], 0xff, v0{{[[:space:]]+//}}
-// DISASM: v_and_b32_e32 [[LO_B:v[0-9]+]], 0xff, v18{{[[:space:]]+//}}
-// DISASM: v_bfe_u32 [[HI_A:v[0-9]+]], v0, 8, 8
-// DISASM: v_bfe_u32 [[HI_B:v[0-9]+]], v18, 8, 8
-// DISASM: v_lshl_or_b32 [[HI_B]], {{.*}}, 24, [[HI_B]]
+// DISASM: v_mov_b32_e32 v176 /*v688*/, v2
+// DISASM: v_mov_b32_e32 v191 /*v703*/, v255
 // DISASM-NEXT: s_wait_xcnt 0x0
 // DISASM-NEXT: s_set_vgpr_msb {{.*}}
-// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, 0, [[LO_A]], [[LO_B]]
-// DISASM: v_mov_b32_e32 v9, v181
-// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, v[38:45], [[HI_A]], [[HI_B]]
+// DISASM-NEXT: v_mov_b32_e32 v192 /*v704*/, v0 /*v256*/
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, 0, v10, v11
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, v[38:45], v12, v13
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_wait_xcnt 0x0
-// DISASM-NEXT: s_set_vgpr_msb 0x80a
-// DISASM-NEXT: v_mov_b32_e32 v2, v176 /*v688*/
-// DISASM: v_and_b32_e32 [[LO_A_2:v[0-9]+]], 0xff, v0{{[[:space:]]+//}}
-// DISASM: v_and_b32_e32 [[LO_B_2:v[0-9]+]], 0xff, v18{{[[:space:]]+//}}
-// DISASM: v_bfe_u32 [[HI_A_2:v[0-9]+]], v0, 8, 8
-// DISASM: v_bfe_u32 [[HI_B_2:v[0-9]+]], v18, 8, 8
-// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, 0, [[LO_A_2]], [[LO_B_2]]
-// DISASM: v_mov_b32_e32 v9, v181
-// DISASM-NEXT: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, v[38:45], [[HI_A_2]], [[HI_B_2]]
+// DISASM: v_mov_b32_e32 v2, v176 /*v688*/
+// DISASM: s_set_vgpr_msb 0xa00
+// DISASM: v_mov_b32_e32 v176 /*v688*/, v2
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, 0, v10, v11
+// DISASM: v_wmma_scale_f32_16x16x128_f8f6f4 v[38:45], v[2:9], v[190:197] /*v[702:709]*/, v[38:45], v12, v13
 // DISASM-NEXT: v_nop
-// DISASM-NEXT: s_wait_xcnt 0x0
-// DISASM-NEXT: s_set_vgpr_msb 0x80a
-// DISASM-NEXT: v_mov_b32_e32 v2, v176 /*v688*/
-// DISASM: v_mov_b32_e32 v14, v188 /*v700*/
-// DISASM-NEXT: s_wait_xcnt 0x0
-// DISASM-NEXT: s_set_vgpr_msb 0xa00
+// DISASM: v_mov_b32_e32 v2, v176 /*v688*/
 
 // RUN: hotswap-rewrite %t.out.elf \
 // RUN:   amdgcn-amd-amdhsa--gfx1250 amdgcn-amd-amdhsa--gfx1250 \

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -2983,6 +2983,240 @@ TEST(SafeSgprScratchBlock, CommitRejectsObjectWithoutKernelDescriptor) {
       commitSafeSgprScratchBlock(Ctx, /*TextOffset=*/0, Block, "unit test"));
 }
 
+TEST(ForwardDeadVgprs, OpaqueBeforeKillRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Opaque = true;
+  Nodes[1].FullDefs.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, KillBeforeOpaqueAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].FullDefs.set(Candidate);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Opaque = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, ExternalExitBeforeKillRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].HasUnsafeExit = true;
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].FullDefs.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, KillBeforeExternalExitAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].FullDefs.set(Candidate);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].HasUnsafeExit = true;
+  Nodes[1].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, OneUseBeforeKillBranchRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[0].Successors.push_back(2);
+  Nodes[1].Uses.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+  Nodes[2].FullDefs.set(Candidate);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, AllBranchesKillAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[0].Successors.push_back(2);
+  Nodes[1].FullDefs.set(Candidate);
+  Nodes[1].SafeTerminal = true;
+  Nodes[2].FullDefs.set(Candidate);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, LoopPathWithoutKillRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Successors.push_back(0);
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, LoopWithFullKillAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  Nodes.emplace_back(MaxVgprs);
+  Nodes[0].FullDefs.set(Candidate);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Successors.push_back(0);
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, BackedgeUseBeforePatchedSiteRejects) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Uses.set(Candidate);
+  Nodes[1].Successors.push_back(2);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, BackedgeWithoutUseToPatchedSiteAccepts) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  for (unsigned I = 0; I != 3; ++I)
+    Nodes.emplace_back(MaxVgprs);
+  Nodes[0].Successors.push_back(1);
+  Nodes[1].Successors.push_back(2);
+  Nodes[2].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_TRUE(Safe->test(Candidate));
+}
+
+TEST(ForwardDeadVgprs, PartialDefinitionIsUseNotKill) {
+  constexpr unsigned MaxVgprs = 8;
+  constexpr unsigned Candidate = 3;
+  std::vector<ForwardVgprProofNode> Nodes;
+  Nodes.emplace_back(MaxVgprs);
+  // Partial/tied definitions consume the incoming full dword and therefore
+  // belong in Uses, never FullDefs.
+  Nodes[0].Uses.set(Candidate);
+  Nodes[0].SafeTerminal = true;
+
+  std::optional<llvm::BitVector> Safe =
+      computeForwardDeadVgprs(Nodes, /*EntryNode=*/0, MaxVgprs);
+  ASSERT_TRUE(Safe);
+  EXPECT_FALSE(Safe->test(Candidate));
+}
+
+TEST(WmmaScale16, PhysicalVgprRangeMustFitOneBank) {
+  EXPECT_TRUE(physicalVgprRangeFitsOneBank(0, 16, 1024));
+  EXPECT_TRUE(physicalVgprRangeFitsOneBank(248, 8, 1024));
+  EXPECT_TRUE(physicalVgprRangeFitsOneBank(1016, 8, 1024));
+
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(0, 0, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(249, 8, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(255, 2, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(1017, 8, 1024));
+  EXPECT_FALSE(physicalVgprRangeFitsOneBank(1024, 1, 1024));
+}
+
+TEST(WmmaScale16, LegacyB0Vop3ScalarSourceEncodingIsExact) {
+  constexpr uint32_t ObservedWord0 = 0xd0310000u;
+  constexpr uint32_t ObservedAlternateSourceWord = 1u << 20;
+  constexpr uint32_t AllowedModifier = 1u << 14;
+
+  EXPECT_TRUE(isLegacyB0Vop3ScalarSourceEncoding(ObservedWord0, 0));
+  EXPECT_TRUE(isLegacyB0Vop3ScalarSourceEncoding(
+      ObservedWord0 | AllowedModifier, ObservedAlternateSourceWord));
+
+  EXPECT_FALSE(isLegacyB0Vop3ScalarSourceEncoding(ObservedWord0 | 1u, 0));
+  EXPECT_FALSE(
+      isLegacyB0Vop3ScalarSourceEncoding(ObservedWord0 ^ (1u << 16), 0));
+  EXPECT_FALSE(isLegacyB0Vop3ScalarSourceEncoding(
+      ObservedWord0, ObservedAlternateSourceWord | 1u));
+}
+
+TEST(WmmaScale16, UnrecognizedVectorRegisterCannotDisappearFromProof) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+  ASSERT_NE(S.MRI, nullptr);
+
+  auto FindRegister = [&](llvm::StringRef Name) {
+    for (unsigned Reg = 1; Reg != S.MRI->getNumRegs(); ++Reg)
+      if (Name == S.MRI->getName(Reg))
+        return llvm::MCRegister(Reg);
+    return llvm::MCRegister();
+  };
+
+  // AGPRs are vector registers but are deliberately not representable as an
+  // encoded v0..v255 range. Such an operand must invalidate the physical-VGPR
+  // proof; it cannot be ignored like a scalar register.
+  llvm::MCRegister Agpr0 = FindRegister("AGPR0");
+  llvm::MCRegister Sgpr0 = FindRegister("SGPR0");
+  ASSERT_TRUE(Agpr0);
+  ASSERT_TRUE(Sgpr0);
+  EXPECT_TRUE(isVectorRegisterOrAlias(Agpr0, *S.MRI));
+  EXPECT_FALSE(isVectorRegisterOrAlias(Sgpr0, *S.MRI));
+}
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64}, {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -24,6 +24,8 @@
 #include "gtest/gtest.h"
 
 #include <cstring>
+#include <functional>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <vector>
@@ -3200,12 +3202,13 @@ TEST(WmmaScale16, UnrecognizedVectorRegisterCannotDisappearFromProof) {
   ASSERT_TRUE(S.Valid);
   ASSERT_NE(S.MRI, nullptr);
 
-  auto FindRegister = [&](llvm::StringRef Name) {
-    for (unsigned Reg = 1; Reg != S.MRI->getNumRegs(); ++Reg)
-      if (Name == S.MRI->getName(Reg))
-        return llvm::MCRegister(Reg);
-    return llvm::MCRegister();
-  };
+  std::function<llvm::MCRegister(llvm::StringRef)> FindRegister =
+      [&](llvm::StringRef Name) {
+        for (unsigned Reg = 1; Reg != S.MRI->getNumRegs(); ++Reg)
+          if (Name == S.MRI->getName(Reg))
+            return llvm::MCRegister(Reg);
+        return llvm::MCRegister();
+      };
 
   // AGPRs are vector registers but are deliberately not representable as an
   // encoded v0..v255 range. Such an operand must invalidate the physical-VGPR

--- a/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
+++ b/amd/comgr/test-unit/hotswap/rewriter/HotswapMCTest.cpp
@@ -1473,6 +1473,23 @@ TEST(CollectDirectBranchTargets, RejectsUndecodedMaterializationSlot) {
   EXPECT_TRUE(Info->HasUnresolvedTargets);
 }
 
+TEST(CollectDirectBranchTargets, UndecodedScalarClassRemainsUnbounded) {
+  LLVMState S = initLLVM(makeGfx1250Ident());
+  ASSERT_TRUE(S.Valid);
+
+  const uint8_t Bytes[] = {0xff, 0xff, 0xff, 0xff};
+  std::vector<InternalDecodedInst> Decoded;
+  ASSERT_TRUE(decodeTextSection(Bytes, sizeof(Bytes), S, Decoded));
+  ASSERT_EQ(Decoded.size(), 1u);
+  ASSERT_FALSE(Decoded.front().DecodeSucceeded);
+
+  std::optional<DirectControlFlowInfo> Info = collectDirectBranchTargets(
+      Decoded, S, /*TextAddr=*/0, sizeof(Bytes), /*DeclaredEntries=*/{0},
+      /*FunctionRanges=*/{}, /*ExternalEntries=*/{}, Bytes);
+  ASSERT_TRUE(Info);
+  EXPECT_TRUE(Info->HasUnboundedIndirectEntries);
+}
+
 TEST(CollectDirectBranchTargets, RejectsUnboundedIndirectEntry) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -3181,22 +3198,6 @@ TEST(WmmaScale16, PhysicalVgprRangeMustFitOneBank) {
   EXPECT_FALSE(physicalVgprRangeFitsOneBank(1024, 1, 1024));
 }
 
-TEST(WmmaScale16, LegacyB0Vop3ScalarSourceEncodingIsExact) {
-  constexpr uint32_t ObservedWord0 = 0xd0310000u;
-  constexpr uint32_t ObservedAlternateSourceWord = 1u << 20;
-  constexpr uint32_t AllowedModifier = 1u << 14;
-
-  EXPECT_TRUE(isLegacyB0Vop3ScalarSourceEncoding(ObservedWord0, 0));
-  EXPECT_TRUE(isLegacyB0Vop3ScalarSourceEncoding(
-      ObservedWord0 | AllowedModifier, ObservedAlternateSourceWord));
-
-  EXPECT_FALSE(isLegacyB0Vop3ScalarSourceEncoding(ObservedWord0 | 1u, 0));
-  EXPECT_FALSE(
-      isLegacyB0Vop3ScalarSourceEncoding(ObservedWord0 ^ (1u << 16), 0));
-  EXPECT_FALSE(isLegacyB0Vop3ScalarSourceEncoding(
-      ObservedWord0, ObservedAlternateSourceWord | 1u));
-}
-
 TEST(WmmaScale16, UnrecognizedVectorRegisterCannotDisappearFromProof) {
   LLVMState S = initLLVM(makeGfx1250Ident());
   ASSERT_TRUE(S.Valid);
@@ -3220,6 +3221,7 @@ TEST(WmmaScale16, UnrecognizedVectorRegisterCannotDisappearFromProof) {
   EXPECT_TRUE(isVectorRegisterOrAlias(Agpr0, *S.MRI));
   EXPECT_FALSE(isVectorRegisterOrAlias(Sgpr0, *S.MRI));
 }
+
 TEST(FindNearestSled, RejectsOverflowingHeadroom) {
   std::vector<NopSled> Sleds = {{0, 64, 60, 0, 64}, {100, 128, 100, 100, 128}};
   EXPECT_EQ(findNearestSled(Sleds, 0, std::numeric_limits<uint64_t>::max()),

--- a/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
+++ b/llvm/lib/Target/AMDGPU/Disassembler/AMDGPUDisassembler.cpp
@@ -833,6 +833,24 @@ DecodeStatus AMDGPUDisassembler::getInstruction(MCInst &MI, uint64_t &Size,
     return MCDisassembler::Fail;
   } while (false);
 
+  // Present legacy tensor encodings through the canonical MC opcode model.
+  switch (MI.getOpcode()) {
+  case AMDGPU::TENSOR_LOAD_TO_LDS_d2_gfx1250_legacy:
+    MI.setOpcode(AMDGPU::TENSOR_LOAD_TO_LDS_d2_gfx1250);
+    break;
+  case AMDGPU::TENSOR_LOAD_TO_LDS_d4_gfx1250_legacy:
+    MI.setOpcode(AMDGPU::TENSOR_LOAD_TO_LDS_d4_gfx1250);
+    break;
+  case AMDGPU::TENSOR_STORE_FROM_LDS_d2_gfx1250_legacy:
+    MI.setOpcode(AMDGPU::TENSOR_STORE_FROM_LDS_d2_gfx1250);
+    break;
+  case AMDGPU::TENSOR_STORE_FROM_LDS_d4_gfx1250_legacy:
+    MI.setOpcode(AMDGPU::TENSOR_STORE_FROM_LDS_d4_gfx1250);
+    break;
+  default:
+    break;
+  }
+
   DecodeStatus Status = MCDisassembler::Success;
 
   decodeImmOperands(MI, *MCII);

--- a/llvm/lib/Target/AMDGPU/MIMGInstructions.td
+++ b/llvm/lib/Target/AMDGPU/MIMGInstructions.td
@@ -2241,6 +2241,15 @@ class VIMAGE_TENSOR_Real <bits<8> op, VIMAGE_TENSOR_Pseudo ps, string opName = p
   let dim = 1;   // sp3
 }
 
+class VIMAGE_TENSOR_Legacy_Real <bits<8> op, VIMAGE_TENSOR_Pseudo ps,
+                                 string opName> :
+  VIMAGE_TENSOR_Real<op, ps, opName> {
+  let dmask = 0;
+  let dim = 0;
+  // Legacy tensor encodings use zero in the otherwise unused vaddr4 field.
+  let vaddr4 = 0;
+}
+
 multiclass VIMAGE_TENSOR_Real_gfx1250<bits<8> op> {
   let AssemblerPredicate = isGFX125xOnly, DecoderNamespace = "GFX1250" in {
     foreach DSuffix = ["_d2", "_d4"] in {
@@ -2251,5 +2260,21 @@ multiclass VIMAGE_TENSOR_Real_gfx1250<bits<8> op> {
   }
 }
 
-defm TENSOR_LOAD_TO_LDS    : VIMAGE_TENSOR_Real_gfx1250<0xc4>;
-defm TENSOR_STORE_FROM_LDS : VIMAGE_TENSOR_Real_gfx1250<0xc5>;
+multiclass VIMAGE_TENSOR_Legacy_Real_gfx1250<bits<8> op, string opName> {
+  let AssemblerPredicate = isGFX125xOnly, DecoderNamespace = "GFX1250" in {
+    foreach DSuffix = ["_d2", "_d4"] in {
+      defvar ps = !cast<VIMAGE_TENSOR_Pseudo>(NAME # DSuffix);
+      def DSuffix # _gfx1250_legacy :
+        VIMAGE_TENSOR_Legacy_Real<op, ps, opName>;
+    }
+  }
+}
+
+defm TENSOR_LOAD_TO_LDS :
+  VIMAGE_TENSOR_Real_gfx1250<0xc4>,
+  VIMAGE_TENSOR_Legacy_Real_gfx1250<0xc4,
+    "tensor_load_to_lds_gfx1250_legacy">;
+defm TENSOR_STORE_FROM_LDS :
+  VIMAGE_TENSOR_Real_gfx1250<0xc5>,
+  VIMAGE_TENSOR_Legacy_Real_gfx1250<0xc5,
+    "tensor_store_from_lds_gfx1250_legacy">;

--- a/llvm/test/MC/AMDGPU/gfx1250_asm_vimage_legacy.s
+++ b/llvm/test/MC/AMDGPU/gfx1250_asm_vimage_legacy.s
@@ -1,0 +1,42 @@
+// RUN: llvm-mc -triple=amdgpu12.50 -mattr=+gfx1250-b0-specific -show-encoding %s | FileCheck --check-prefix=ENC %s
+// RUN: llvm-mc -triple=amdgpu12.50 -mattr=-gfx1250-b0-specific -show-encoding %s | FileCheck --check-prefix=ENC %s
+// RUN: llvm-mc -triple=amdgpu12.50 -mattr=+gfx1250-b0-specific -show-encoding %s | %extract-encodings | llvm-mc -triple=amdgpu12.50 -mattr=+gfx1250-b0-specific -disassemble -show-encoding | FileCheck --check-prefix=DIS --implicit-check-not=v_illegal --implicit-check-not=v_cmp_ge_u16_e32 %s
+// RUN: llvm-mc -triple=amdgpu12.50 -mattr=-gfx1250-b0-specific -show-encoding %s | %extract-encodings | llvm-mc -triple=amdgpu12.50 -mattr=-gfx1250-b0-specific -disassemble -show-encoding | FileCheck --check-prefix=DIS --implicit-check-not=v_illegal --implicit-check-not=v_cmp_ge_u16_e32 %s
+// RUN: llvm-mc -triple=amdgpu12.50 -mattr=+gfx1250-b0-specific -show-encoding %s | %extract-encodings | llvm-mc -triple=amdgpu12.50 -mattr=+gfx1250-b0-specific -disassemble -show-inst | FileCheck --check-prefix=MCINST %s
+// RUN: llvm-mc -triple=amdgpu12.50 -mattr=-gfx1250-b0-specific -show-encoding %s | %extract-encodings | llvm-mc -triple=amdgpu12.50 -mattr=-gfx1250-b0-specific -disassemble -show-inst | FileCheck --check-prefix=MCINST %s
+
+tensor_load_to_lds_gfx1250_legacy s[0:3], s[4:11]
+// ENC: tensor_load_to_lds_gfx1250_legacy s[0:3], s[4:11] ; encoding: [0x00,0x00,0x31,0xd0,0x00,0x00,0x00,0x00,0x00,0x04,0x7c,0x7c]
+// DIS: tensor_load_to_lds s[0:3], s[4:11] ; encoding: [0x01,0x00,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x7c,0x7c]
+// MCINST: <MCInst #{{[0-9]+}} TENSOR_LOAD_TO_LDS_d2_gfx1250
+
+tensor_load_to_lds_gfx1250_legacy s[0:3], s[4:11], s[12:15], s[16:19]
+// ENC: tensor_load_to_lds_gfx1250_legacy s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x00,0x00,0x31,0xd0,0x00,0x00,0x00,0x00,0x00,0x04,0x0c,0x10]
+// DIS-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x01,0x00,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x0c,0x10]
+// MCINST: <MCInst #{{[0-9]+}} TENSOR_LOAD_TO_LDS_d4_gfx1250
+
+tensor_store_from_lds_gfx1250_legacy s[0:3], s[4:11]
+// ENC: tensor_store_from_lds_gfx1250_legacy s[0:3], s[4:11] ; encoding: [0x00,0x40,0x31,0xd0,0x00,0x00,0x00,0x00,0x00,0x04,0x7c,0x7c]
+// DIS-NEXT: tensor_store_from_lds s[0:3], s[4:11] ; encoding: [0x01,0x40,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x7c,0x7c]
+// MCINST: <MCInst #{{[0-9]+}} TENSOR_STORE_FROM_LDS_d2_gfx1250
+
+tensor_store_from_lds_gfx1250_legacy s[0:3], s[4:11], s[12:15], s[16:19]
+// ENC: tensor_store_from_lds_gfx1250_legacy s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x00,0x40,0x31,0xd0,0x00,0x00,0x00,0x00,0x00,0x04,0x0c,0x10]
+// DIS-NEXT: tensor_store_from_lds s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x01,0x40,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x0c,0x10]
+// MCINST: <MCInst #{{[0-9]+}} TENSOR_STORE_FROM_LDS_d4_gfx1250
+
+tensor_load_to_lds s[0:3], s[4:11]
+// ENC: tensor_load_to_lds s[0:3], s[4:11] ; encoding: [0x01,0x00,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x7c,0x7c]
+// DIS-NEXT: tensor_load_to_lds s[0:3], s[4:11] ; encoding: [0x01,0x00,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x7c,0x7c]
+
+tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19]
+// ENC: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x01,0x00,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x0c,0x10]
+// DIS-NEXT: tensor_load_to_lds s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x01,0x00,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x0c,0x10]
+
+tensor_store_from_lds s[0:3], s[4:11]
+// ENC: tensor_store_from_lds s[0:3], s[4:11] ; encoding: [0x01,0x40,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x7c,0x7c]
+// DIS-NEXT: tensor_store_from_lds s[0:3], s[4:11] ; encoding: [0x01,0x40,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x7c,0x7c]
+
+tensor_store_from_lds s[0:3], s[4:11], s[12:15], s[16:19]
+// ENC: tensor_store_from_lds s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x01,0x40,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x0c,0x10]
+// DIS-NEXT: tensor_store_from_lds s[0:3], s[4:11], s[12:15], s[16:19] ; encoding: [0x01,0x40,0x71,0xd0,0x00,0x00,0x00,0x7c,0x00,0x04,0x0c,0x10]


### PR DESCRIPTION
## Scope

Lower M32 block-16 scale16 WMMA exactly through four block-32 operations with conservative overlap and continuation-liveness checks.

## Review fixes

The review repair commits on this branch:

- keep scale-prefix operands in physical VGPR bank 0 while selecting matrix operands from their A/B banks;
- drain XCNT immediately before every generated VGPR-bank mode change;
- centralize the fail-closed legacy-B0 VOP3 scalar-source classifier and add positive/near-miss coverage;
- add focused displacement-aware LIT coverage for nonzero matrix banks, bank-zero scale operands, XCNT waits, immediate C, `neg_hi`, and A0-to-A0 idempotence.

The temporary exact encoding classifier is tracked by ROCm/llvm-project#3638 so it can be replaced by an installed MC/TargetParser API.

## Review range and dependencies

- Historical clean fork PR for the original feature: https://github.com/harsh-amd/llvm-project/pull/15
- Original exact logical source commit: `3c9a16b20ea0f5a99563b33c41b7e8f64792994e`
- Review repair commits: `dc80021da911b5d1f4be07182c436784122e1daf` and `a655e97001fbaf18ab48cffe2d162d45fed0282f`

The dependency audit found that this feature is **not buildable on #3577 alone**. It also consumes the finite-indirect-control-flow API represented by #3610, the current/final liveness API represented by #3618, and bank-aware helper changes from the larger cumulative stack. The clean-fork base currently imports that broader stack, so this upstream Files changed view remains cumulative.

## Review status

Draft and not ready to merge. The branch must be reduced to a complete, explicit, buildable prerequisite chain after those dependencies settle. Do not merge the cumulative snapshot.

ROCm/llvm-project#3598 remains unchanged as the immutable 2,685/2,685 integration reference; that historical result is not a corpus qualification claim for this repaired head.

## Validation of repaired cumulative head

- Release/assertions focused build: PASS
- `HotswapMCTests`: 214/214 PASS
- focused M32 bank-zero/XCNT LIT test: 1/1 PASS
- formatting and `git diff --check`: PASS

Full `check-comgr`, ASAN, baseline/candidate corpus comparison, and MI400-3 qualification were intentionally not started because the review/dependency/scope gate remains unresolved. They are required after the PR is made independently reviewable and buildable.
